### PR TITLE
MCP RC artifacts: pin DRAFT-2026-v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -262,6 +262,11 @@ check-protocol-artifacts:
 	@echo "=== Checking Harn protocol artifacts are up to date ==="
 	@cargo run --quiet -p harn-cli -- dump-protocol-artifacts --check
 	@echo "    Harn protocol artifacts OK."
+
+check-burin-protocol-artifacts:
+	@echo "=== Checking Burin Code vendored protocol bindings match Harn ==="
+	@python3 scripts/check_burin_protocol_bindings.py --required
+	@echo "    Burin protocol bindings OK."
 
 # Round-trip the published JSON fixture through the Python and Go protocol
 # bindings to catch wire-vocabulary drift before downstream consumers vendor

--- a/conformance/protocols/README.md
+++ b/conformance/protocols/README.md
@@ -85,3 +85,10 @@ cargo test -p harn-serve protocol_conformance_
 Adapter-generated fixture tests print the expected and actual JSON arrays when
 they drift, so CI failures should point directly at the checked-in fixture that
 needs to be refreshed or the adapter behavior that changed unexpectedly.
+
+The MCP `DRAFT-2026-v1` profile is intentionally checked in beside the stable
+`2025-11-25` profile. It covers RC artifact shapes only: per-request metadata,
+Streamable HTTP routing headers, `server/discover`, cache hints,
+input-required results, unsupported-version errors, and JSON Schema 2020-12
+tool schemas. Runtime support remains opt-in until the final `2026-07-28`
+specification lands.

--- a/conformance/protocols/fixtures/mcp/draft_2026_v1_core.valid.json
+++ b/conformance/protocols/fixtures/mcp/draft_2026_v1_core.valid.json
@@ -1,0 +1,133 @@
+{
+  "name": "mcp.draft_2026_v1.core",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-draft-2026-v1.schema.json",
+  "expect": "valid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "server/discover",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {
+            "name": "harn-fixture-client",
+            "version": "0.1.0"
+          },
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "resultType": "complete",
+        "supportedVersions": ["DRAFT-2026-v1", "2025-11-25"],
+        "capabilities": {
+          "tools": {}
+        },
+        "serverInfo": {
+          "name": "harn-fixture-server",
+          "version": "0.1.0"
+        },
+        "instructions": "Prefer 2025-11-25 unless RC support is explicitly enabled."
+      }
+    },
+    {
+      "MCP-Protocol-Version": "DRAFT-2026-v1",
+      "Mcp-Method": "tools/call",
+      "Mcp-Name": "echo"
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "tools/list",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {
+            "name": "harn-fixture-client",
+            "version": "0.1.0"
+          },
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "resultType": "complete",
+        "ttlMs": 30000,
+        "cacheScope": "private",
+        "tools": [
+          {
+            "name": "echo",
+            "title": "Echo",
+            "description": "Echoes a string.",
+            "inputSchema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": ["message"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "result": {
+        "resultType": "input_required",
+        "requestState": "opaque-server-state",
+        "inputRequests": {
+          "confirm": {
+            "method": "elicitation/create",
+            "params": {
+              "mode": "form",
+              "message": "Confirm the tool call.",
+              "requestedSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "confirmed": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["confirmed"]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 4,
+      "error": {
+        "code": -32004,
+        "message": "Unsupported protocol version",
+        "data": {
+          "requested": "DRAFT-2026-v0",
+          "supported": ["DRAFT-2026-v1", "2025-11-25"]
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "DRAFT-2026-v1",
+    "family": "rc-core",
+    "case": "discover-metadata-cache-input-required-unsupported-version",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Pins the MCP RC helper surface Harn publishes before runtime behavior opts in: request metadata, standard HTTP headers, server/discover, cache hints, input-required results, unsupported-version errors, and JSON Schema 2020-12 tool schemas."
+    }
+  }
+}

--- a/conformance/protocols/fixtures/mcp/draft_2026_v1_missing_metadata.invalid.json
+++ b/conformance/protocols/fixtures/mcp/draft_2026_v1_missing_metadata.invalid.json
@@ -1,0 +1,44 @@
+{
+  "name": "mcp.draft_2026_v1.missing_metadata",
+  "protocol": "mcp",
+  "schema": "schemas/mcp-draft-2026-v1.schema.json",
+  "expect": "invalid",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "tools/list",
+      "params": {
+        "cursor": "page-2"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "resultType": "input_required"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "error": {
+        "code": -32004,
+        "message": "version unsupported",
+        "data": {
+          "requested": "DRAFT-2026-v0",
+          "supported": ["DRAFT-2026-v1"]
+        }
+      }
+    }
+  ],
+  "matrix": {
+    "version": "DRAFT-2026-v1",
+    "family": "rc-core",
+    "case": "missing-required-metadata-and-result-discriminants",
+    "source": {
+      "kind": "hand_authored",
+      "description": "Negative coverage for required per-request metadata, input-required continuation state, and the unsupported-version error message pinned by the RC profile."
+    }
+  }
+}

--- a/conformance/protocols/schemas/mcp-draft-2026-v1.schema.json
+++ b/conformance/protocols/schemas/mcp-draft-2026-v1.schema.json
@@ -1,0 +1,3988 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/conformance/protocols/mcp-draft-2026-v1.schema.json",
+  "title": "Harn MCP DRAFT-2026-v1 adapter profile",
+  "description": "Pinned Harn adapter profile derived from modelcontextprotocol/modelcontextprotocol schema/draft/schema.json for the MCP DRAFT-2026-v1 release-candidate wire surface. Runtime support remains opt-in until the final 2026-07-28 specification lands.",
+  "x-harn-provenance": {
+    "protocol": "mcp",
+    "upstream_version": "DRAFT-2026-v1",
+    "upstream_source_url": "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json",
+    "upstream_spec_url": "https://modelcontextprotocol.io/specification/draft",
+    "retrieved_at": "2026-05-23",
+    "refresh_command": "curl -fsSL https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json",
+    "profile_note": "The upstream draft schema is definitions-only; this profile supplies a root over the DRAFT-2026-v1 request, response, notification, standard HTTP header, metadata, cache hint, input-required, and unsupported-version shapes Harn publishes for downstream implementers. The stable runtime protocol version remains 2025-11-25 unless an implementation explicitly opts into the RC."
+  },
+  "anyOf": [
+    {
+      "$ref": "#/$defs/ClientRequest"
+    },
+    {
+      "$ref": "#/$defs/DiscoverResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListResourcesResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListResourceTemplatesResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ReadResourceResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListPromptsResultResponse"
+    },
+    {
+      "$ref": "#/$defs/GetPromptResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListToolsResultResponse"
+    },
+    {
+      "$ref": "#/$defs/CallToolResultResponse"
+    },
+    {
+      "$ref": "#/$defs/CompleteResultResponse"
+    },
+    {
+      "$ref": "#/$defs/UnsupportedProtocolVersionError"
+    },
+    {
+      "$ref": "#/$defs/MissingRequiredClientCapabilityError"
+    },
+    {
+      "$ref": "#/$defs/ProgressNotification"
+    },
+    {
+      "$ref": "#/$defs/LoggingMessageNotification"
+    },
+    {
+      "$ref": "#/$defs/ToolListChangedNotification"
+    },
+    {
+      "$ref": "#/$defs/ResourceListChangedNotification"
+    },
+    {
+      "$ref": "#/$defs/ResourceUpdatedNotification"
+    },
+    {
+      "$ref": "#/$defs/PromptListChangedNotification"
+    },
+    {
+      "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
+    },
+    {
+      "$ref": "#/$defs/MCPHttpHeaders"
+    }
+  ],
+  "$defs": {
+    "Annotations": {
+      "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+      "properties": {
+        "audience": {
+          "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+          "items": {
+            "$ref": "#/$defs/Role"
+          },
+          "type": "array"
+        },
+        "lastModified": {
+          "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "AudioContent": {
+      "description": "Audio provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded audio data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the audio. Different providers may support different audio types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "audio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "BaseMetadata": {
+      "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "BlobResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "blob": {
+          "description": "A base64-encoded string representing the binary data of the item.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blob",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "BooleanSchema": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "boolean",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "CacheableResult": {
+      "description": "A result that supports a time-to-live (TTL) hint for client-side caching.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "CallToolRequest": {
+      "description": "Used by the client to invoke a tool provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/call",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CallToolRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CallToolRequestParams": {
+      "description": "Parameters for a `tools/call` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {},
+          "description": "Arguments to use for the tool call.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the tool.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "CallToolResult": {
+      "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "description": "A list of content objects that represent the unstructured result of the tool call.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+          "type": "boolean"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "structuredContent": {
+          "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
+        }
+      },
+      "required": [
+        "content",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CallToolResultResponse": {
+      "description": "A successful response from the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/CallToolResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "CancelledNotification": {
+      "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/cancelled",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CancelledNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CancelledNotificationParams": {
+      "description": "Parameters for a `notifications/cancelled` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "reason": {
+          "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+          "type": "string"
+        },
+        "requestId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+        }
+      },
+      "type": "object"
+    },
+    "ClientCapabilities": {
+      "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+      "properties": {
+        "elicitation": {
+          "description": "Present if the client supports elicitation from the server.",
+          "properties": {
+            "form": {
+              "$ref": "#/$defs/JSONObject"
+            },
+            "url": {
+              "$ref": "#/$defs/JSONObject"
+            }
+          },
+          "type": "object"
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the client supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.",
+          "type": "object"
+        },
+        "roots": {
+          "description": "Present if the client supports listing roots.",
+          "properties": {},
+          "type": "object"
+        },
+        "sampling": {
+          "description": "Present if the client supports sampling from an LLM.",
+          "properties": {
+            "context": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
+            },
+            "tools": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ClientNotification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CancelledNotification"
+        },
+        {
+          "$ref": "#/$defs/ProgressNotification"
+        }
+      ]
+    },
+    "ClientRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DiscoverRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesRequest"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceRequest"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsListenRequest"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsRequest"
+        },
+        {
+          "$ref": "#/$defs/GetPromptRequest"
+        },
+        {
+          "$ref": "#/$defs/ListToolsRequest"
+        },
+        {
+          "$ref": "#/$defs/CallToolRequest"
+        },
+        {
+          "$ref": "#/$defs/CompleteRequest"
+        }
+      ]
+    },
+    "ClientResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "CompleteRequest": {
+      "description": "A request from the client to the server, to ask for completion options.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "completion/complete",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CompleteRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CompleteRequestParams": {
+      "description": "Parameters for a `completion/complete` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "argument": {
+          "description": "The argument's information",
+          "properties": {
+            "name": {
+              "description": "The name of the argument",
+              "type": "string"
+            },
+            "value": {
+              "description": "The value of the argument to use for completion matching.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "value"
+          ],
+          "type": "object"
+        },
+        "context": {
+          "description": "Additional, optional context for completions",
+          "properties": {
+            "arguments": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Previously-resolved variables in a URI template or prompt.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptReference"
+            },
+            {
+              "$ref": "#/$defs/ResourceTemplateReference"
+            }
+          ]
+        }
+      },
+      "required": [
+        "_meta",
+        "argument",
+        "ref"
+      ],
+      "type": "object"
+    },
+    "CompleteResult": {
+      "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "completion": {
+          "properties": {
+            "hasMore": {
+              "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+              "type": "boolean"
+            },
+            "total": {
+              "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+              "type": "integer"
+            },
+            "values": {
+              "description": "An array of completion values. Must not exceed 100 items.",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100,
+              "type": "array"
+            }
+          },
+          "required": [
+            "values"
+          ],
+          "type": "object"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "completion",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CompleteResultResponse": {
+      "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ResourceLink"
+        },
+        {
+          "$ref": "#/$defs/EmbeddedResource"
+        }
+      ]
+    },
+    "CreateMessageRequest": {
+      "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+      "properties": {
+        "method": {
+          "const": "sampling/createMessage",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CreateMessageRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CreateMessageRequestParams": {
+      "description": "Parameters for a `sampling/createMessage` request.",
+      "properties": {
+        "includeContext": {
+          "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. Values `\"thisServer\"` and `\"allServers\"` are soft-deprecated. Servers SHOULD only use these values if the client\ndeclares {@link ClientCapabilities.sampling.context}. These values may be removed in future spec releases.",
+          "enum": [
+            "allServers",
+            "none",
+            "thisServer"
+          ],
+          "type": "string"
+        },
+        "maxTokens": {
+          "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+          "type": "integer"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/SamplingMessage"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+        },
+        "modelPreferences": {
+          "$ref": "#/$defs/ModelPreferences",
+          "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+        },
+        "stopSequences": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "systemPrompt": {
+          "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+          "type": "string"
+        },
+        "temperature": {
+          "type": "number"
+        },
+        "toolChoice": {
+          "$ref": "#/$defs/ToolChoice",
+          "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+        },
+        "tools": {
+          "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "maxTokens",
+        "messages"
+      ],
+      "type": "object"
+    },
+    "CreateMessageResult": {
+      "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "model": {
+          "description": "The name of the model that generated the message.",
+          "type": "string"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        },
+        "stopReason": {
+          "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "model",
+        "role"
+      ],
+      "type": "object"
+    },
+    "Cursor": {
+      "description": "An opaque token used to represent a cursor for pagination.",
+      "type": "string"
+    },
+    "DiscoverRequest": {
+      "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "server/discover",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "DiscoverResult": {
+      "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ServerCapabilities",
+          "description": "The capabilities of the server."
+        },
+        "instructions": {
+          "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "serverInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Information about the server software implementation."
+        },
+        "supportedVersions": {
+          "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "capabilities",
+        "resultType",
+        "serverInfo",
+        "supportedVersions"
+      ],
+      "type": "object"
+    },
+    "DiscoverResultResponse": {
+      "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/DiscoverResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ElicitRequest": {
+      "description": "A request from the server to elicit additional information from the user via the client.",
+      "properties": {
+        "method": {
+          "const": "elicitation/create",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ElicitRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestFormParams": {
+      "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user describing what information is being requested.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "form",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "requestedSchema": {
+          "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "properties": {
+              "additionalProperties": {
+                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "properties",
+            "type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "message",
+        "requestedSchema"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestParams": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ElicitRequestFormParams"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequestURLParams"
+        }
+      ],
+      "description": "The parameters for a request to elicit additional information from the user via the client."
+    },
+    "ElicitRequestURLParams": {
+      "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+      "properties": {
+        "elicitationId": {
+          "description": "The ID of the elicitation, which must be unique within the context of the server.\nThe client MUST treat this ID as an opaque value.",
+          "type": "string"
+        },
+        "message": {
+          "description": "The message to present to the user explaining why the interaction is needed.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "url",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL that the user should navigate to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "elicitationId",
+        "message",
+        "mode",
+        "url"
+      ],
+      "type": "object"
+    },
+    "ElicitResult": {
+      "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
+      "properties": {
+        "action": {
+          "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
+          "enum": [
+            "accept",
+            "cancel",
+            "decline"
+          ],
+          "type": "string"
+        },
+        "content": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": [
+                  "string",
+                  "integer",
+                  "boolean"
+                ]
+              }
+            ]
+          },
+          "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "ElicitationCompleteNotification": {
+      "description": "An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/elicitation/complete",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "elicitationId": {
+              "description": "The ID of the elicitation that completed.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "elicitationId"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "EmbeddedResource": {
+      "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "resource": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextResourceContents"
+            },
+            {
+              "$ref": "#/$defs/BlobResourceContents"
+            }
+          ]
+        },
+        "type": {
+          "const": "resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resource",
+        "type"
+      ],
+      "type": "object"
+    },
+    "EmptyResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "EnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ]
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequest": {
+      "description": "Used by the client to get a prompt provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/get",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/GetPromptRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequestParams": {
+      "description": "Parameters for a `prompts/get` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments to use for templating the prompt.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the prompt or prompt template.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "GetPromptResult": {
+      "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "description": {
+          "description": "An optional description for the prompt.",
+          "type": "string"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/PromptMessage"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "messages",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "GetPromptResultResponse": {
+      "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/GetPromptResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+          "format": "uri",
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "dark",
+            "light"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Icons": {
+      "description": "Base interface to add `icons` property.",
+      "properties": {
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ImageContent": {
+      "description": "An image provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded image data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the image. Different providers may support different image types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Implementation": {
+      "description": "Describes the MCP implementation.",
+      "properties": {
+        "description": {
+          "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of this implementation.",
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "An optional URL of the website for this implementation.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "type": "object"
+    },
+    "InputRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageRequest"
+        },
+        {
+          "$ref": "#/$defs/ListRootsRequest"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequest"
+        }
+      ]
+    },
+    "InputRequests": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputRequest"
+      },
+      "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
+      "type": "object"
+    },
+    "InputRequiredResult": {
+      "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "inputRequests": {
+          "$ref": "#/$defs/InputRequests"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "resultType": {
+          "const": "input_required",
+          "type": "string",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "inputRequests"
+          ]
+        },
+        {
+          "required": [
+            "requestState"
+          ]
+        }
+      ]
+    },
+    "InputResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageResult"
+        },
+        {
+          "$ref": "#/$defs/ListRootsResult"
+        },
+        {
+          "$ref": "#/$defs/ElicitResult"
+        }
+      ]
+    },
+    "InputResponseRequestParams": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "InputResponses": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputResponse"
+      },
+      "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
+      "type": "object"
+    },
+    "InternalError": {
+      "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
+      "properties": {
+        "code": {
+          "const": -32603,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidParamsError": {
+      "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
+      "properties": {
+        "code": {
+          "const": -32602,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidRequestError": {
+      "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
+      "properties": {
+        "code": {
+          "const": -32600,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "JSONArray": {
+      "items": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "array"
+    },
+    "JSONObject": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "object"
+    },
+    "JSONRPCErrorResponse": {
+      "description": "A response to a request that indicates an error occurred.",
+      "properties": {
+        "error": {
+          "$ref": "#/$defs/Error"
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "JSONRPCMessage": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCRequest"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCNotification"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
+    },
+    "JSONRPCNotification": {
+      "description": "A notification which does not expect a response.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCRequest": {
+      "description": "A request that expects a response.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "A response to a request, containing either the result or error."
+    },
+    "JSONRPCResultResponse": {
+      "description": "A successful (non-error) response to a request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/Result"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "JSONValue": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONObject"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JSONValue"
+          },
+          "type": "array"
+        },
+        {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    "LegacyTitledEnumSchema": {
+      "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enumNames": {
+          "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ListPromptsRequest": {
+      "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResult": {
+      "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "prompts": {
+          "items": {
+            "$ref": "#/$defs/Prompt"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "prompts",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResultResponse": {
+      "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListPromptsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesRequest": {
+      "description": "Sent from the client to request a list of resource templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/templates/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResult": {
+      "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resourceTemplates": {
+          "items": {
+            "$ref": "#/$defs/ResourceTemplate"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resourceTemplates",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourcesRequest": {
+      "description": "Sent from the client to request a list of resources the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResult": {
+      "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resources": {
+          "items": {
+            "$ref": "#/$defs/Resource"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resources",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourcesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListRootsRequest": {
+      "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+      "properties": {
+        "method": {
+          "const": "roots/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RequestParams"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "ListRootsResult": {
+      "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
+      "properties": {
+        "roots": {
+          "items": {
+            "$ref": "#/$defs/Root"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roots"
+      ],
+      "type": "object"
+    },
+    "ListToolsRequest": {
+      "description": "Sent from the client to request a list of tools the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListToolsResult": {
+      "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "tools": {
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "tools",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListToolsResultResponse": {
+      "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListToolsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "LoggingLevel": {
+      "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+      "enum": [
+        "alert",
+        "critical",
+        "debug",
+        "emergency",
+        "error",
+        "info",
+        "notice",
+        "warning"
+      ],
+      "type": "string"
+    },
+    "LoggingMessageNotification": {
+      "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/message",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoggingMessageNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "LoggingMessageNotificationParams": {
+      "description": "Parameters for a `notifications/message` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "data": {
+          "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+        },
+        "level": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The severity of this log message."
+        },
+        "logger": {
+          "description": "An optional name of the logger issuing this message.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "level"
+      ],
+      "type": "object"
+    },
+    "MetaObject": {
+      "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
+      "type": "object"
+    },
+    "MethodNotFoundError": {
+      "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, this error is returned when a request is made for a method that requires a capability that has not been declared. This can occur in either direction:\n\n- A server returning this error when the client requests a capability it doesn't support (e.g., requesting completions when the `completions` capability was not advertised)\n- A client returning this error when the server requests a capability it doesn't support (e.g., requesting roots when the client did not declare the `roots` capability)",
+      "properties": {
+        "code": {
+          "const": -32601,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "MissingRequiredClientCapabilityError": {
+      "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32003,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requiredCapabilities": {
+                      "$ref": "#/$defs/ClientCapabilities",
+                      "description": "The capabilities the server requires from the client to process this request."
+                    }
+                  },
+                  "required": [
+                    "requiredCapabilities"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "code",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "ModelHint": {
+      "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+      "properties": {
+        "name": {
+          "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ModelPreferences": {
+      "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+      "properties": {
+        "costPriority": {
+          "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "hints": {
+          "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+          "items": {
+            "$ref": "#/$defs/ModelHint"
+          },
+          "type": "array"
+        },
+        "intelligencePriority": {
+          "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "speedPriority": {
+          "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "MultiSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        }
+      ]
+    },
+    "Notification": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "NotificationParams": {
+      "description": "Common params for any notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        }
+      },
+      "type": "object"
+    },
+    "NumberSchema": {
+      "properties": {
+        "default": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "maximum": {
+          "type": "integer"
+        },
+        "minimum": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "integer",
+            "number"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequest": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequestParams": {
+      "description": "Common params for paginated requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "cursor": {
+          "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "PaginatedResult": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ParseError": {
+      "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
+      "properties": {
+        "code": {
+          "const": -32700,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "PrimitiveSchemaDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StringSchema"
+        },
+        {
+          "$ref": "#/$defs/NumberSchema"
+        },
+        {
+          "$ref": "#/$defs/BooleanSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ],
+      "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+    },
+    "ProgressNotification": {
+      "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/progress",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ProgressNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ProgressNotificationParams": {
+      "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "message": {
+          "description": "An optional message describing the current progress.",
+          "type": "string"
+        },
+        "progress": {
+          "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+          "type": "number"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+        },
+        "total": {
+          "description": "Total number of items to process (or total progress required), if known.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "progress",
+        "progressToken"
+      ],
+      "type": "object"
+    },
+    "ProgressToken": {
+      "description": "A progress token, used to associate progress notifications with the original request.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "Prompt": {
+      "description": "A prompt or prompt template that the server offers.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "arguments": {
+          "description": "A list of arguments to use for templating the prompt.",
+          "items": {
+            "$ref": "#/$defs/PromptArgument"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "An optional description of what this prompt provides",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptArgument": {
+      "description": "Describes an argument that a prompt can accept.",
+      "properties": {
+        "description": {
+          "description": "A human-readable description of the argument.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether this argument must be provided.",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/prompts/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "PromptMessage": {
+      "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
+      "properties": {
+        "content": {
+          "$ref": "#/$defs/ContentBlock"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "PromptReference": {
+      "description": "Identifies a prompt.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "ref/prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequest": {
+      "description": "Sent from the client to the server, to read a specific resource URI.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/read",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ReadResourceRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequestParams": {
+      "description": "Parameters for a `resources/read` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResult": {
+      "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "contents": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TextResourceContents"
+              },
+              {
+                "$ref": "#/$defs/BlobResourceContents"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "contents",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResultResponse": {
+      "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/ReadResourceResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "Request": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "RequestId": {
+      "description": "A uniquely identifying ID for a request in JSON-RPC.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "RequestMetaObject": {
+      "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/clientCapabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Identifies the client software making the request. Required.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional."
+        },
+        "io.modelcontextprotocol/logLevel": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
+        },
+        "io.modelcontextprotocol/protocolVersion": {
+          "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
+          "type": "string",
+          "const": "DRAFT-2026-v1"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+        }
+      },
+      "required": [
+        "io.modelcontextprotocol/clientCapabilities",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/protocolVersion"
+      ],
+      "type": "object"
+    },
+    "RequestParams": {
+      "description": "Common params for any request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "Resource": {
+      "description": "A known resource that the server is capable of reading.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceContents": {
+      "description": "The contents of a specific resource or sub-resource.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceLink": {
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "resource_link",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ResourceRequestParams": {
+      "description": "Common params for resource-related requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplate": {
+      "description": "A template description for resources available on the server.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uriTemplate": {
+          "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uriTemplate"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplateReference": {
+      "description": "A reference to a resource or resource template definition.",
+      "properties": {
+        "type": {
+          "const": "ref/resource",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI or URI template of the resource.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotification": {
+      "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/updated",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotificationParams": {
+      "description": "Parameters for a `notifications/resources/updated` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "Result": {
+      "additionalProperties": {},
+      "description": "Common result fields.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ResultType": {
+      "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
+      "enum": [
+        "complete",
+        "input_required"
+      ],
+      "type": "string"
+    },
+    "Role": {
+      "description": "The sender or recipient of messages and data in a conversation.",
+      "enum": [
+        "assistant",
+        "user"
+      ],
+      "type": "string"
+    },
+    "Root": {
+      "description": "Represents a root directory or file that the server can operate on.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "name": {
+          "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "SamplingMessage": {
+      "description": "Describes a message issued to or received from an LLM API.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "SamplingMessageContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ToolUseContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultContent"
+        }
+      ]
+    },
+    "ServerCapabilities": {
+      "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+      "properties": {
+        "completions": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports argument autocompletion suggestions."
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the server supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/apps\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.",
+          "type": "object"
+        },
+        "logging": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports sending log messages to the client."
+        },
+        "prompts": {
+          "description": "Present if the server offers any prompt templates.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the prompt list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "description": "Present if the server offers any resources to read.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the resource list.",
+              "type": "boolean"
+            },
+            "subscribe": {
+              "description": "Whether this server supports subscribing to resource updates.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "tools": {
+          "description": "Present if the server offers any tools to call.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the tool list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ServerNotification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CancelledNotification"
+        },
+        {
+          "$ref": "#/$defs/ProgressNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceUpdatedNotification"
+        },
+        {
+          "$ref": "#/$defs/PromptListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/ToolListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/LoggingMessageNotification"
+        },
+        {
+          "$ref": "#/$defs/ElicitationCompleteNotification"
+        }
+      ]
+    },
+    "ServerResult": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Result"
+        },
+        {
+          "$ref": "#/$defs/InputRequiredResult"
+        },
+        {
+          "$ref": "#/$defs/DiscoverResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceResult"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsResult"
+        },
+        {
+          "$ref": "#/$defs/GetPromptResult"
+        },
+        {
+          "$ref": "#/$defs/ListToolsResult"
+        },
+        {
+          "$ref": "#/$defs/CallToolResult"
+        },
+        {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      ]
+    },
+    "SingleSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        }
+      ]
+    },
+    "StringSchema": {
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "date",
+            "date-time",
+            "email",
+            "uri"
+          ],
+          "type": "string"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "SubscriptionFilter": {
+      "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
+      "properties": {
+        "promptsListChanged": {
+          "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
+          "type": "boolean"
+        },
+        "resourceSubscriptions": {
+          "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourcesListChanged": {
+          "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
+          "type": "boolean"
+        },
+        "toolsListChanged": {
+          "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotification": {
+      "description": "Sent by the server as the first message on a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream to acknowledge\nthat the subscription has been established and to report which notification\ntypes it agreed to honor.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/subscriptions/acknowledged",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotificationParams": {
+      "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
+        }
+      },
+      "required": [
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequest": {
+      "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "subscriptions/listen",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsListenRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequestParams": {
+      "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
+        }
+      },
+      "required": [
+        "_meta",
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "TextContent": {
+      "description": "Text provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "text": {
+          "description": "The text content of the message.",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "text": {
+          "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for array items with enum options and display labels.",
+          "properties": {
+            "anyOf": {
+              "description": "Array of enum options with values and display labels.",
+              "items": {
+                "properties": {
+                  "const": {
+                    "description": "The constant enum value.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Display title for this option.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "const",
+                  "title"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "anyOf"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "oneOf": {
+          "description": "Array of enum options with values and display labels.",
+          "items": {
+            "properties": {
+              "const": {
+                "description": "The enum value.",
+                "type": "string"
+              },
+              "title": {
+                "description": "Display label for this option.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "const",
+              "title"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "oneOf",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Tool": {
+      "description": "Definition for a tool the client can call.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/ToolAnnotations",
+          "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
+        },
+        "description": {
+          "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "inputSchema": {
+          "additionalProperties": {},
+          "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "outputSchema": {
+          "additionalProperties": {},
+          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "inputSchema",
+        "name"
+      ],
+      "type": "object"
+    },
+    "ToolAnnotations": {
+      "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
+      "properties": {
+        "destructiveHint": {
+          "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+          "type": "boolean"
+        },
+        "idempotentHint": {
+          "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+          "type": "boolean"
+        },
+        "openWorldHint": {
+          "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+          "type": "boolean"
+        },
+        "readOnlyHint": {
+          "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "A human-readable title for the tool.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolChoice": {
+      "description": "Controls tool selection behavior for sampling requests.",
+      "properties": {
+        "mode": {
+          "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+          "enum": [
+            "auto",
+            "none",
+            "required"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/tools/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ToolResultContent": {
+      "description": "The result of a tool use, provided by the user back to the assistant.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
+        },
+        "content": {
+          "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+          "type": "boolean"
+        },
+        "structuredContent": {
+          "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
+        },
+        "toolUseId": {
+          "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_result",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "toolUseId",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ToolUseContent": {
+      "description": "A request from the assistant to call a tool.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+        },
+        "id": {
+          "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+          "type": "string"
+        },
+        "input": {
+          "additionalProperties": {},
+          "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The name of the tool to call.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_use",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "input",
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UnsupportedProtocolVersionError": {
+      "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32004,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requested": {
+                      "description": "The protocol version that was requested by the client.",
+                      "type": "string"
+                    },
+                    "supported": {
+                      "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "requested",
+                    "supported"
+                  ],
+                  "type": "object"
+                },
+                "message": {
+                  "const": "Unsupported protocol version",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "code",
+                "data",
+                "message"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for the array items.",
+          "properties": {
+            "enum": {
+              "description": "Array of enum values to choose from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "enum": {
+          "description": "Array of enum values to choose from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    },
+    "MCPHttpHeaders": {
+      "description": "Standard MCP Streamable HTTP headers for the DRAFT-2026-v1 profile. Mcp-Name is required when the routed method targets a named tool, prompt, or resource.",
+      "type": "object",
+      "required": [
+        "MCP-Protocol-Version",
+        "Mcp-Method"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "MCP-Protocol-Version": {
+          "const": "DRAFT-2026-v1",
+          "type": "string"
+        },
+        "Mcp-Method": {
+          "enum": [
+            "server/discover",
+            "tools/list",
+            "tools/call",
+            "resources/list",
+            "resources/read",
+            "resources/templates/list",
+            "prompts/list",
+            "prompts/get",
+            "completion/complete"
+          ],
+          "type": "string"
+        },
+        "Mcp-Name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -80,7 +80,12 @@ const A2A_TASK_STATES: &[&str] = &[
 ];
 const A2A_TASK_EVENT_TYPES: &[&str] = &["status", "message", "worker_update"];
 
+const MCP_DRAFT_PROTOCOL_VERSION: &str = "DRAFT-2026-v1";
+const MCP_FINAL_2026_PROTOCOL_VERSION: &str = "2026-07-28";
+const MCP_JSON_SCHEMA_2020_12_DIALECT: &str = "https://json-schema.org/draft/2020-12/schema";
+const MCP_PROTOCOL_VERSIONS: &[&str] = &[MCP_DRAFT_PROTOCOL_VERSION, MCP_PROTOCOL_VERSION];
 const MCP_METHODS: &[&str] = &[
+    "server/discover",
     "initialize",
     "tools/list",
     "tools/call",
@@ -96,6 +101,28 @@ const MCP_METHODS: &[&str] = &[
     "notifications/initialized",
     "notifications/message",
 ];
+const MCP_REQUIRED_METADATA_KEYS: &[&str] = &[
+    "io.modelcontextprotocol/protocolVersion",
+    "io.modelcontextprotocol/clientInfo",
+    "io.modelcontextprotocol/clientCapabilities",
+];
+const MCP_METADATA_KEYS: &[&str] = &[
+    "io.modelcontextprotocol/protocolVersion",
+    "io.modelcontextprotocol/clientInfo",
+    "io.modelcontextprotocol/clientCapabilities",
+    "io.modelcontextprotocol/logLevel",
+    "progressToken",
+    "traceparent",
+    "tracestate",
+    "baggage",
+];
+const MCP_STANDARD_HTTP_HEADERS: &[&str] = &["MCP-Protocol-Version", "Mcp-Method", "Mcp-Name"];
+const MCP_CACHE_RESULT_FIELDS: &[&str] = &["ttlMs", "cacheScope"];
+const MCP_CACHE_SCOPES: &[&str] = &["private", "public"];
+const MCP_RESULT_TYPES: &[&str] = &["complete", "input_required"];
+const MCP_INPUT_REQUIRED_RESULT_TYPE: &str = "input_required";
+const MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE: i32 = -32004;
+const MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE: &str = "Unsupported protocol version";
 const MCP_LOGGING_LEVELS: &[&str] = &[
     "debug",
     "info",
@@ -122,6 +149,11 @@ const SCHEMA_COPIES: &[SchemaCopy] = &[
         protocol: "mcp",
         source: "conformance/protocols/schemas/mcp-2025-11-25.schema.json",
         artifact: "schemas/mcp-2025-11-25.schema.json",
+    },
+    SchemaCopy {
+        protocol: "mcp",
+        source: "conformance/protocols/schemas/mcp-draft-2026-v1.schema.json",
+        artifact: "schemas/mcp-draft-2026-v1.schema.json",
     },
 ];
 
@@ -316,7 +348,23 @@ fn generate_manifest() -> Result<String, String> {
         },
         "mcp": {
             "protocolVersion": MCP_PROTOCOL_VERSION,
+            "stableProtocolVersion": MCP_PROTOCOL_VERSION,
+            "draftProtocolVersion": MCP_DRAFT_PROTOCOL_VERSION,
+            "final2026ProtocolVersion": MCP_FINAL_2026_PROTOCOL_VERSION,
+            "protocolVersions": MCP_PROTOCOL_VERSIONS,
+            "jsonSchemaDialect": MCP_JSON_SCHEMA_2020_12_DIALECT,
             "methods": MCP_METHODS,
+            "requiredRequestMetadataKeys": MCP_REQUIRED_METADATA_KEYS,
+            "metadataKeys": MCP_METADATA_KEYS,
+            "standardHttpHeaders": MCP_STANDARD_HTTP_HEADERS,
+            "cacheResultFields": MCP_CACHE_RESULT_FIELDS,
+            "cacheScopes": MCP_CACHE_SCOPES,
+            "resultTypes": MCP_RESULT_TYPES,
+            "inputRequiredResultType": MCP_INPUT_REQUIRED_RESULT_TYPE,
+            "unsupportedProtocolVersionError": {
+                "code": MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE,
+                "message": MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE,
+            },
             "loggingLevels": MCP_LOGGING_LEVELS,
         },
         "receipts": {
@@ -367,6 +415,9 @@ fn generate_readme() -> String {
            profile (`{acp}`).\n\
          - `schemas/a2a-0.3.0.schema.json`: Harn's A2A schema profile (`{a2a}`).\n\
          - `schemas/mcp-2025-11-25.schema.json`: Harn's MCP schema profile (`{mcp}`).\n\
+         - `schemas/mcp-draft-2026-v1.schema.json`: Harn's opt-in MCP RC schema\n\
+           profile (`{mcp_draft}`), pinned beside the stable profile until the\n\
+           final `2026-07-28` specification lands.\n\
          - `schemas/tool-call-receipt.schema.json`: Harn's typed, privacy-preserving\n\
            `ToolCallReceipt` schema for audited tool calls.\n\
          - `harn-protocol.ts`: TypeScript definitions for ACP session updates,\n\
@@ -384,6 +435,7 @@ fn generate_readme() -> String {
         acp = ACP_SCHEMA_COMPATIBILITY,
         a2a = A2A_PROTOCOL_VERSION,
         mcp = MCP_PROTOCOL_VERSION,
+        mcp_draft = MCP_DRAFT_PROTOCOL_VERSION,
     )
 }
 
@@ -392,6 +444,30 @@ fn generate_typescript() -> String {
     out.push_str("export const HARN_PROTOCOL_ARTIFACT_VERSION = ");
     out.push_str(&json_string_literal(env!("CARGO_PKG_VERSION")));
     out.push_str("\n\n");
+    for (name, value) in [
+        ("MCP_PROTOCOL_VERSION", MCP_PROTOCOL_VERSION),
+        ("MCP_STABLE_PROTOCOL_VERSION", MCP_PROTOCOL_VERSION),
+        ("MCP_DRAFT_PROTOCOL_VERSION", MCP_DRAFT_PROTOCOL_VERSION),
+        (
+            "MCP_FINAL_2026_PROTOCOL_VERSION",
+            MCP_FINAL_2026_PROTOCOL_VERSION,
+        ),
+        (
+            "MCP_JSON_SCHEMA_2020_12_DIALECT",
+            MCP_JSON_SCHEMA_2020_12_DIALECT,
+        ),
+    ] {
+        out.push_str("export const ");
+        out.push_str(name);
+        out.push_str(" = ");
+        out.push_str(&json_string_literal(value));
+        out.push('\n');
+    }
+    out.push_str(&format!(
+        "export const MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR = {{ code: {}, message: {} }} as const\n\n",
+        MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE,
+        json_string_literal(MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE)
+    ));
     out.push_str(&ts_array(
         "ACP_AGENT_METHODS",
         ACP_AGENT_METHODS,
@@ -481,7 +557,42 @@ fn generate_typescript() -> String {
         A2A_TASK_EVENT_TYPES,
         "A2ATaskEventType",
     ));
+    out.push_str(&ts_array(
+        "MCP_PROTOCOL_VERSIONS",
+        MCP_PROTOCOL_VERSIONS,
+        "MCPProtocolVersion",
+    ));
     out.push_str(&ts_array("MCP_METHODS", MCP_METHODS, "MCPMethod"));
+    out.push_str(&ts_array(
+        "MCP_REQUIRED_METADATA_KEYS",
+        MCP_REQUIRED_METADATA_KEYS,
+        "MCPRequiredMetadataKey",
+    ));
+    out.push_str(&ts_array(
+        "MCP_METADATA_KEYS",
+        MCP_METADATA_KEYS,
+        "MCPMetadataKey",
+    ));
+    out.push_str(&ts_array(
+        "MCP_STANDARD_HTTP_HEADERS",
+        MCP_STANDARD_HTTP_HEADERS,
+        "MCPStandardHTTPHeader",
+    ));
+    out.push_str(&ts_array(
+        "MCP_CACHE_RESULT_FIELDS",
+        MCP_CACHE_RESULT_FIELDS,
+        "MCPCacheResultField",
+    ));
+    out.push_str(&ts_array(
+        "MCP_CACHE_SCOPES",
+        MCP_CACHE_SCOPES,
+        "MCPCacheScope",
+    ));
+    out.push_str(&ts_array(
+        "MCP_RESULT_TYPES",
+        MCP_RESULT_TYPES,
+        "MCPResultType",
+    ));
     out.push_str(&ts_array(
         "MCP_LOGGING_LEVELS",
         MCP_LOGGING_LEVELS,
@@ -744,12 +855,75 @@ export type A2ATaskEvent =
   | { type: "message" | "worker_update"; taskId: string; message?: A2AMessage }
   | { statusUpdate: { taskId: string; contextId?: string | null; status: A2ATaskStatus } }
 
+export type MCPJsonSchema202012 = ACPObject
+
+export interface MCPImplementation {
+  name: string
+  version: string
+  title?: string
+  description?: string
+  websiteUrl?: string
+}
+
+export interface MCPRequestMeta {
+  "io.modelcontextprotocol/protocolVersion": MCPProtocolVersion | string
+  "io.modelcontextprotocol/clientInfo": MCPImplementation
+  "io.modelcontextprotocol/clientCapabilities": ACPObject
+  "io.modelcontextprotocol/logLevel"?: MCPLoggingLevel
+  progressToken?: string | number
+  traceparent?: string
+  tracestate?: string
+  baggage?: string
+  [key: string]: ACPValue | MCPImplementation | undefined
+}
+
+export interface MCPHTTPHeaders {
+  "MCP-Protocol-Version": MCPProtocolVersion | string
+  "Mcp-Method": MCPMethod | string
+  "Mcp-Name"?: string
+  [header: string]: string | undefined
+}
+
+export interface MCPCacheHints {
+  ttlMs: number
+  cacheScope: MCPCacheScope
+}
+
+export interface MCPDiscoverResult {
+  resultType: "complete"
+  supportedVersions: (MCPProtocolVersion | string)[]
+  capabilities: ACPObject
+  serverInfo: MCPImplementation
+  instructions?: string
+  _meta?: ACPObject
+}
+
+export interface MCPInputRequiredResult {
+  resultType: "input_required"
+  inputRequests?: Record<string, ACPObject>
+  requestState?: string
+  _meta?: ACPObject
+}
+
+export interface MCPUnsupportedProtocolVersionError {
+  jsonrpc: "2.0"
+  id?: JsonRpcId
+  error: {
+    code: typeof MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR.code
+    message: typeof MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR.message
+    data: {
+      requested: string
+      supported: (MCPProtocolVersion | string)[]
+    }
+  }
+}
+
 export interface MCPTool {
   name: string
   title?: string
   description?: string
-  inputSchema: ACPObject
-  outputSchema?: ACPObject
+  inputSchema: MCPJsonSchema202012
+  outputSchema?: MCPJsonSchema202012
   annotations?: ACPObject
 }
 
@@ -807,6 +981,49 @@ fn generate_swift() -> String {
     out.push_str(&format!(
         "    public static let harnAgentEventMethod = {}\n",
         json_string_literal(HARN_AGENT_EVENT_METHOD)
+    ));
+    for (name, value) in [
+        ("mcpProtocolVersion", MCP_PROTOCOL_VERSION),
+        ("mcpStableProtocolVersion", MCP_PROTOCOL_VERSION),
+        ("mcpDraftProtocolVersion", MCP_DRAFT_PROTOCOL_VERSION),
+        (
+            "mcpFinal2026ProtocolVersion",
+            MCP_FINAL_2026_PROTOCOL_VERSION,
+        ),
+        (
+            "mcpJsonSchema202012Dialect",
+            MCP_JSON_SCHEMA_2020_12_DIALECT,
+        ),
+    ] {
+        out.push_str(&format!(
+            "    public static let {name} = {}\n",
+            json_string_literal(value)
+        ));
+    }
+    out.push_str(&format!(
+        "    public static let mcpUnsupportedProtocolVersionErrorCode = {}\n",
+        MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+    ));
+    out.push_str(&format!(
+        "    public static let mcpUnsupportedProtocolVersionErrorMessage = {}\n",
+        json_string_literal(MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE)
+    ));
+    out.push_str(&swift_string_array(
+        "mcpProtocolVersions",
+        MCP_PROTOCOL_VERSIONS,
+    ));
+    out.push_str(&swift_string_array(
+        "mcpRequiredMetadataKeys",
+        MCP_REQUIRED_METADATA_KEYS,
+    ));
+    out.push_str(&swift_string_array("mcpMetadataKeys", MCP_METADATA_KEYS));
+    out.push_str(&swift_string_array(
+        "mcpStandardHTTPHeaders",
+        MCP_STANDARD_HTTP_HEADERS,
+    ));
+    out.push_str(&swift_string_array(
+        "mcpCacheResultFields",
+        MCP_CACHE_RESULT_FIELDS,
     ));
     out.push_str(&swift_string_array(
         "acpSessionUpdateExtensions",
@@ -886,6 +1103,14 @@ fn generate_swift() -> String {
         &strs_to_strings(A2A_TASK_EVENT_TYPES),
     ));
     out.push_str(&swift_enum("HarnMCPMethod", &strs_to_strings(MCP_METHODS)));
+    out.push_str(&swift_enum(
+        "HarnMCPCacheScope",
+        &strs_to_strings(MCP_CACHE_SCOPES),
+    ));
+    out.push_str(&swift_enum(
+        "HarnMCPResultType",
+        &strs_to_strings(MCP_RESULT_TYPES),
+    ));
     out.push_str(&swift_enum(
         "HarnMCPLoggingLevel",
         &strs_to_strings(MCP_LOGGING_LEVELS),
@@ -1513,12 +1738,104 @@ public struct HarnA2ATask: Codable, Sendable, Equatable {
     public var metadata: HarnACPObject?
 }
 
+public typealias HarnMCPJsonSchema202012 = HarnACPObject
+
+public struct HarnMCPImplementation: Codable, Sendable, Equatable {
+    public var name: String
+    public var version: String
+    public var title: String?
+    public var description: String?
+    public var websiteUrl: String?
+}
+
+public struct HarnMCPRequestMeta: Codable, Sendable, Equatable {
+    public var protocolVersion: String
+    public var clientInfo: HarnMCPImplementation
+    public var clientCapabilities: HarnACPObject
+    public var logLevel: HarnMCPLoggingLevel?
+    public var progressToken: HarnACPValue?
+    public var traceparent: String?
+    public var tracestate: String?
+    public var baggage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case protocolVersion = "io.modelcontextprotocol/protocolVersion"
+        case clientInfo = "io.modelcontextprotocol/clientInfo"
+        case clientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+        case logLevel = "io.modelcontextprotocol/logLevel"
+        case progressToken
+        case traceparent
+        case tracestate
+        case baggage
+    }
+}
+
+public struct HarnMCPHTTPHeaders: Codable, Sendable, Equatable {
+    public var protocolVersion: String
+    public var method: String
+    public var name: String?
+
+    enum CodingKeys: String, CodingKey {
+        case protocolVersion = "MCP-Protocol-Version"
+        case method = "Mcp-Method"
+        case name = "Mcp-Name"
+    }
+}
+
+public struct HarnMCPCacheHints: Codable, Sendable, Equatable {
+    public var ttlMs: Int
+    public var cacheScope: HarnMCPCacheScope
+}
+
+public struct HarnMCPDiscoverResult: Codable, Sendable, Equatable {
+    public var resultType: HarnMCPResultType
+    public var supportedVersions: [String]
+    public var capabilities: HarnACPObject
+    public var serverInfo: HarnMCPImplementation
+    public var instructions: String?
+    public var meta: HarnACPObject?
+
+    enum CodingKeys: String, CodingKey {
+        case resultType
+        case supportedVersions
+        case capabilities
+        case serverInfo
+        case instructions
+        case meta = "_meta"
+    }
+}
+
+public struct HarnMCPInputRequiredResult: Codable, Sendable, Equatable {
+    public var resultType: HarnMCPResultType
+    public var inputRequests: HarnACPObject?
+    public var requestState: String?
+    public var meta: HarnACPObject?
+
+    enum CodingKeys: String, CodingKey {
+        case resultType
+        case inputRequests
+        case requestState
+        case meta = "_meta"
+    }
+}
+
+public struct HarnMCPUnsupportedProtocolVersionErrorData: Codable, Sendable, Equatable {
+    public var requested: String
+    public var supported: [String]
+}
+
+public struct HarnMCPUnsupportedProtocolVersionError: Codable, Sendable, Equatable {
+    public var jsonrpc: String
+    public var id: HarnJsonRpcId?
+    public var error: HarnACPError
+}
+
 public struct HarnMCPTool: Codable, Sendable, Equatable {
     public var name: String
     public var title: String?
     public var description: String?
-    public var inputSchema: HarnACPObject
-    public var outputSchema: HarnACPObject?
+    public var inputSchema: HarnMCPJsonSchema202012
+    public var outputSchema: HarnMCPJsonSchema202012?
     public var annotations: HarnACPObject?
 }
 
@@ -1580,9 +1897,31 @@ fn generate_python() -> String {
         ("ACP_SCHEMA_COMPATIBILITY", ACP_SCHEMA_COMPATIBILITY),
         ("A2A_PROTOCOL_VERSION", A2A_PROTOCOL_VERSION),
         ("MCP_PROTOCOL_VERSION", MCP_PROTOCOL_VERSION),
+        ("MCP_STABLE_PROTOCOL_VERSION", MCP_PROTOCOL_VERSION),
+        ("MCP_DRAFT_PROTOCOL_VERSION", MCP_DRAFT_PROTOCOL_VERSION),
+        (
+            "MCP_FINAL_2026_PROTOCOL_VERSION",
+            MCP_FINAL_2026_PROTOCOL_VERSION,
+        ),
+        (
+            "MCP_JSON_SCHEMA_2020_12_DIALECT",
+            MCP_JSON_SCHEMA_2020_12_DIALECT,
+        ),
+        (
+            "MCP_INPUT_REQUIRED_RESULT_TYPE",
+            MCP_INPUT_REQUIRED_RESULT_TYPE,
+        ),
+        (
+            "MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE",
+            MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE,
+        ),
     ] {
         out.push_str(&format!("{name}: str = {}\n", json_string_literal(value)));
     }
+    out.push_str(&format!(
+        "MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE: int = {}\n",
+        MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+    ));
     out.push('\n');
 
     out.push_str(&py_const_tuple("ACP_AGENT_METHODS", ACP_AGENT_METHODS));
@@ -1647,7 +1986,26 @@ fn generate_python() -> String {
         "A2A_TASK_EVENT_TYPES",
         A2A_TASK_EVENT_TYPES,
     ));
+    out.push_str(&py_const_tuple(
+        "MCP_PROTOCOL_VERSIONS",
+        MCP_PROTOCOL_VERSIONS,
+    ));
     out.push_str(&py_const_tuple("MCP_METHODS", MCP_METHODS));
+    out.push_str(&py_const_tuple(
+        "MCP_REQUIRED_METADATA_KEYS",
+        MCP_REQUIRED_METADATA_KEYS,
+    ));
+    out.push_str(&py_const_tuple("MCP_METADATA_KEYS", MCP_METADATA_KEYS));
+    out.push_str(&py_const_tuple(
+        "MCP_STANDARD_HTTP_HEADERS",
+        MCP_STANDARD_HTTP_HEADERS,
+    ));
+    out.push_str(&py_const_tuple(
+        "MCP_CACHE_RESULT_FIELDS",
+        MCP_CACHE_RESULT_FIELDS,
+    ));
+    out.push_str(&py_const_tuple("MCP_CACHE_SCOPES", MCP_CACHE_SCOPES));
+    out.push_str(&py_const_tuple("MCP_RESULT_TYPES", MCP_RESULT_TYPES));
     out.push_str(&py_const_tuple("MCP_LOGGING_LEVELS", MCP_LOGGING_LEVELS));
 
     out.push_str(&py_str_enum("ACPAgentMethod", ACP_AGENT_METHODS));
@@ -1684,6 +2042,8 @@ fn generate_python() -> String {
     ));
     out.push_str(&py_str_enum("A2ATaskState", A2A_TASK_STATES));
     out.push_str(&py_str_enum("A2ATaskEventType", A2A_TASK_EVENT_TYPES));
+    out.push_str(&py_str_enum("MCPCacheScope", MCP_CACHE_SCOPES));
+    out.push_str(&py_str_enum("MCPResultType", MCP_RESULT_TYPES));
     out.push_str(&py_str_enum("MCPLoggingLevel", MCP_LOGGING_LEVELS));
 
     out.push_str(PYTHON_TYPE_DEFINITIONS);
@@ -1939,13 +2299,64 @@ class A2ATask(_HarnDataclass):
     metadata: Optional[JsonObject] = None
 
 
+MCPJsonSchema202012 = JsonObject
+MCPRequestMeta = JsonObject
+MCPHTTPHeaders = Dict[str, str]
+
+
+@dataclass
+class MCPImplementation(_HarnDataclass):
+    name: str
+    version: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    websiteUrl: Optional[str] = None
+
+
+@dataclass
+class MCPCacheHints(_HarnDataclass):
+    ttlMs: int
+    cacheScope: str
+
+
+@dataclass
+class MCPDiscoverResult(_HarnDataclass):
+    resultType: str
+    supportedVersions: List[str]
+    capabilities: JsonObject
+    serverInfo: MCPImplementation
+    instructions: Optional[str] = None
+    _meta: Optional[JsonObject] = None
+
+
+@dataclass
+class MCPInputRequiredResult(_HarnDataclass):
+    resultType: str
+    inputRequests: Optional[JsonObject] = None
+    requestState: Optional[str] = None
+    _meta: Optional[JsonObject] = None
+
+
+@dataclass
+class MCPUnsupportedProtocolVersionErrorData(_HarnDataclass):
+    requested: str
+    supported: List[str]
+
+
+@dataclass
+class MCPUnsupportedProtocolVersionError(_HarnDataclass):
+    error: ACPError
+    id: JsonRpcId = None
+    jsonrpc: str = "2.0"
+
+
 @dataclass
 class MCPTool(_HarnDataclass):
     name: str
-    inputSchema: JsonObject
+    inputSchema: MCPJsonSchema202012
     title: Optional[str] = None
     description: Optional[str] = None
-    outputSchema: Optional[JsonObject] = None
+    outputSchema: Optional[MCPJsonSchema202012] = None
     annotations: Optional[JsonObject] = None
 
 
@@ -1982,6 +2393,13 @@ fn python_public_names() -> Vec<String> {
         "ACP_SCHEMA_COMPATIBILITY",
         "A2A_PROTOCOL_VERSION",
         "MCP_PROTOCOL_VERSION",
+        "MCP_STABLE_PROTOCOL_VERSION",
+        "MCP_DRAFT_PROTOCOL_VERSION",
+        "MCP_FINAL_2026_PROTOCOL_VERSION",
+        "MCP_JSON_SCHEMA_2020_12_DIALECT",
+        "MCP_INPUT_REQUIRED_RESULT_TYPE",
+        "MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE",
+        "MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE",
         "ACP_AGENT_METHODS",
         "ACP_CLIENT_METHODS",
         "ACP_AGENT_NOTIFICATIONS",
@@ -2001,7 +2419,14 @@ fn python_public_names() -> Vec<String> {
         "A2A_METHODS",
         "A2A_TASK_STATES",
         "A2A_TASK_EVENT_TYPES",
+        "MCP_PROTOCOL_VERSIONS",
         "MCP_METHODS",
+        "MCP_REQUIRED_METADATA_KEYS",
+        "MCP_METADATA_KEYS",
+        "MCP_STANDARD_HTTP_HEADERS",
+        "MCP_CACHE_RESULT_FIELDS",
+        "MCP_CACHE_SCOPES",
+        "MCP_RESULT_TYPES",
         "MCP_LOGGING_LEVELS",
         "ACPAgentMethod",
         "ACPClientMethod",
@@ -2016,6 +2441,8 @@ fn python_public_names() -> Vec<String> {
         "ToolCallReceiptExecutor",
         "A2ATaskState",
         "A2ATaskEventType",
+        "MCPCacheScope",
+        "MCPResultType",
         "MCPLoggingLevel",
         "ACPError",
         "ACPRequest",
@@ -2037,6 +2464,15 @@ fn python_public_names() -> Vec<String> {
         "A2AMessage",
         "A2ATaskStatus",
         "A2ATask",
+        "MCPJsonSchema202012",
+        "MCPRequestMeta",
+        "MCPHTTPHeaders",
+        "MCPImplementation",
+        "MCPCacheHints",
+        "MCPDiscoverResult",
+        "MCPInputRequiredResult",
+        "MCPUnsupportedProtocolVersionErrorData",
+        "MCPUnsupportedProtocolVersionError",
         "MCPTool",
         "MCPResource",
         "MCPResourceTemplate",
@@ -2161,6 +2597,36 @@ fn generate_go() -> String {
             "MCPProtocolVersion",
             MCP_PROTOCOL_VERSION,
         ),
+        (
+            "// MCPStableProtocolVersion is the stable MCP protocol version Harn implements at runtime.\n",
+            "MCPStableProtocolVersion",
+            MCP_PROTOCOL_VERSION,
+        ),
+        (
+            "// MCPDraftProtocolVersion is the opt-in MCP release-candidate profile identity.\n",
+            "MCPDraftProtocolVersion",
+            MCP_DRAFT_PROTOCOL_VERSION,
+        ),
+        (
+            "// MCPFinal2026ProtocolVersion is the scheduled final identity for the RC profile.\n",
+            "MCPFinal2026ProtocolVersion",
+            MCP_FINAL_2026_PROTOCOL_VERSION,
+        ),
+        (
+            "// MCPJSONSchema202012Dialect is the JSON Schema dialect used by the MCP RC artifact profile.\n",
+            "MCPJSONSchema202012Dialect",
+            MCP_JSON_SCHEMA_2020_12_DIALECT,
+        ),
+        (
+            "// MCPInputRequiredResultType is the resultType discriminator for multi round-trip requests.\n",
+            "MCPInputRequiredResultType",
+            MCP_INPUT_REQUIRED_RESULT_TYPE,
+        ),
+        (
+            "// MCPUnsupportedProtocolVersionErrorMessage is the standard message for unsupported versions.\n",
+            "MCPUnsupportedProtocolVersionErrorMessage",
+            MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE,
+        ),
     ] {
         out.push_str(doc);
         out.push_str(&format!(
@@ -2168,6 +2634,10 @@ fn generate_go() -> String {
             json_string_literal(value)
         ));
     }
+    out.push_str(&format!(
+        "// MCPUnsupportedProtocolVersionErrorCode is the JSON-RPC server error for unsupported versions.\nconst MCPUnsupportedProtocolVersionErrorCode = {}\n\n",
+        MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE
+    ));
 
     out.push_str(&go_typed_array(
         "ACPAgentMethod",
@@ -2250,7 +2720,22 @@ fn generate_go() -> String {
         "A2ATaskEventTypes",
         A2A_TASK_EVENT_TYPES,
     ));
+    out.push_str(&go_typed_array(
+        "MCPProtocolVersionValue",
+        "MCPProtocolVersions",
+        MCP_PROTOCOL_VERSIONS,
+    ));
     out.push_str(&go_typed_array("MCPMethod", "MCPMethods", MCP_METHODS));
+    out.push_str(&go_typed_array(
+        "MCPCacheScope",
+        "MCPCacheScopes",
+        MCP_CACHE_SCOPES,
+    ));
+    out.push_str(&go_typed_array(
+        "MCPResultType",
+        "MCPResultTypes",
+        MCP_RESULT_TYPES,
+    ));
     out.push_str(&go_typed_array(
         "MCPLoggingLevel",
         "MCPLoggingLevels",
@@ -2265,6 +2750,19 @@ fn generate_go() -> String {
         HARN_CONTENT_EXTENSION_FIELDS,
     ));
     out.push_str(&go_string_array("A2AMethods", A2A_METHODS));
+    out.push_str(&go_string_array(
+        "MCPRequiredMetadataKeys",
+        MCP_REQUIRED_METADATA_KEYS,
+    ));
+    out.push_str(&go_string_array("MCPMetadataKeys", MCP_METADATA_KEYS));
+    out.push_str(&go_string_array(
+        "MCPStandardHTTPHeaders",
+        MCP_STANDARD_HTTP_HEADERS,
+    ));
+    out.push_str(&go_string_array(
+        "MCPCacheResultFields",
+        MCP_CACHE_RESULT_FIELDS,
+    ));
 
     out.push_str(GO_TYPE_DEFINITIONS);
     out
@@ -2516,14 +3014,84 @@ type A2ATask struct {
 	Metadata  JSONObject        `json:"metadata,omitempty"`
 }
 
+// MCPJSONSchema202012 is the JSON Schema dialect surface used by the MCP RC
+// tool input/output schema profile.
+type MCPJSONSchema202012 = JSONObject
+
+// MCPImplementation describes an MCP client or server implementation.
+type MCPImplementation struct {
+	Name        string  `json:"name"`
+	Version     string  `json:"version"`
+	Title       *string `json:"title,omitempty"`
+	Description *string `json:"description,omitempty"`
+	WebsiteURL  *string `json:"websiteUrl,omitempty"`
+}
+
+// MCPRequestMeta is the per-request metadata required by the MCP RC profile.
+type MCPRequestMeta struct {
+	ProtocolVersion    string            `json:"io.modelcontextprotocol/protocolVersion"`
+	ClientInfo         MCPImplementation `json:"io.modelcontextprotocol/clientInfo"`
+	ClientCapabilities JSONObject        `json:"io.modelcontextprotocol/clientCapabilities"`
+	LogLevel           *MCPLoggingLevel  `json:"io.modelcontextprotocol/logLevel,omitempty"`
+	ProgressToken      json.RawMessage   `json:"progressToken,omitempty"`
+	Traceparent        *string           `json:"traceparent,omitempty"`
+	Tracestate         *string           `json:"tracestate,omitempty"`
+	Baggage            *string           `json:"baggage,omitempty"`
+}
+
+// MCPHTTPHeaders names the HTTP headers used by the MCP RC Streamable HTTP profile.
+type MCPHTTPHeaders struct {
+	ProtocolVersion string  `json:"MCP-Protocol-Version"`
+	Method          string  `json:"Mcp-Method"`
+	Name            *string `json:"Mcp-Name,omitempty"`
+}
+
+// MCPCacheHints captures the RC ttlMs/cacheScope cache fields.
+type MCPCacheHints struct {
+	TTLMS      uint64        `json:"ttlMs"`
+	CacheScope MCPCacheScope `json:"cacheScope"`
+}
+
+// MCPDiscoverResult is the result returned by server/discover.
+type MCPDiscoverResult struct {
+	ResultType        MCPResultType     `json:"resultType"`
+	SupportedVersions []string          `json:"supportedVersions"`
+	Capabilities      JSONObject        `json:"capabilities"`
+	ServerInfo        MCPImplementation `json:"serverInfo"`
+	Instructions      *string           `json:"instructions,omitempty"`
+	Meta              JSONObject        `json:"_meta,omitempty"`
+}
+
+// MCPInputRequiredResult carries server-to-client requests for multi round-trip calls.
+type MCPInputRequiredResult struct {
+	ResultType    MCPResultType `json:"resultType"`
+	InputRequests JSONObject    `json:"inputRequests,omitempty"`
+	RequestState  *string       `json:"requestState,omitempty"`
+	Meta          JSONObject    `json:"_meta,omitempty"`
+}
+
+// MCPUnsupportedProtocolVersionErrorData is the typed data payload for -32004.
+type MCPUnsupportedProtocolVersionErrorData struct {
+	Requested string   `json:"requested"`
+	Supported []string `json:"supported"`
+}
+
+// MCPUnsupportedProtocolVersionError is the JSON-RPC error response shape for
+// an unsupported MCP protocol version.
+type MCPUnsupportedProtocolVersionError struct {
+	JSONRPC string    `json:"jsonrpc"`
+	ID      JSONRPCID `json:"id,omitempty"`
+	Error   ACPError  `json:"error"`
+}
+
 // MCPTool is the MCP `tools/list` entry.
 type MCPTool struct {
-	Name         string     `json:"name"`
-	Title        *string    `json:"title,omitempty"`
-	Description  *string    `json:"description,omitempty"`
-	InputSchema  JSONObject `json:"inputSchema"`
-	OutputSchema JSONObject `json:"outputSchema,omitempty"`
-	Annotations  JSONObject `json:"annotations,omitempty"`
+	Name         string              `json:"name"`
+	Title        *string             `json:"title,omitempty"`
+	Description  *string             `json:"description,omitempty"`
+	InputSchema  MCPJSONSchema202012 `json:"inputSchema"`
+	OutputSchema MCPJSONSchema202012 `json:"outputSchema,omitempty"`
+	Annotations  JSONObject          `json:"annotations,omitempty"`
 }
 
 // MCPResource is the MCP `resources/list` entry.
@@ -2716,7 +3284,49 @@ fn generate_round_trip_fixture() -> Result<String, String> {
         "name": "echo",
         "title": "Echo",
         "description": "Echoes input",
-        "inputSchema": {"type": "object", "properties": {"x": {"type": "string"}}}
+        "inputSchema": {
+            "$schema": MCP_JSON_SCHEMA_2020_12_DIALECT,
+            "type": "object",
+            "properties": {"x": {"type": "string"}}
+        }
+    });
+    let mcp_discover_result = json!({
+        "resultType": "complete",
+        "supportedVersions": MCP_PROTOCOL_VERSIONS,
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": "harn", "version": env!("CARGO_PKG_VERSION")},
+        "instructions": "Use the stable MCP version unless the RC is explicitly enabled.",
+    });
+    let mcp_input_required_result = json!({
+        "resultType": MCP_INPUT_REQUIRED_RESULT_TYPE,
+        "requestState": "opaque-state",
+        "inputRequests": {
+            "confirm": {
+                "method": "elicitation/create",
+                "params": {
+                    "message": "Confirm the action",
+                    "mode": "form",
+                    "requestedSchema": {
+                        "$schema": MCP_JSON_SCHEMA_2020_12_DIALECT,
+                        "type": "object",
+                        "properties": {"confirmed": {"type": "boolean"}},
+                        "required": ["confirmed"],
+                    }
+                }
+            }
+        }
+    });
+    let mcp_unsupported_version_error = json!({
+        "jsonrpc": "2.0",
+        "id": 19,
+        "error": {
+            "code": MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE,
+            "message": MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE,
+            "data": {
+                "requested": "DRAFT-2026-v0",
+                "supported": MCP_PROTOCOL_VERSIONS,
+            }
+        }
     });
 
     let fixture = json!({
@@ -2731,6 +3341,9 @@ fn generate_round_trip_fixture() -> Result<String, String> {
         },
         "a2aTask": a2a_task,
         "mcpTool": mcp_tool,
+        "mcpDiscoverResult": mcp_discover_result,
+        "mcpInputRequiredResult": mcp_input_required_result,
+        "mcpUnsupportedProtocolVersionError": mcp_unsupported_version_error,
         "toolCallReceipt": tool_call_receipt,
     });
 
@@ -3001,6 +3614,16 @@ mod tests {
     fn generated_types_include_harn_wire_vocabularies() {
         let ts = generate_typescript();
         assert!(ts.contains("export type JsonRpcId = number | string | null"));
+        assert!(ts.contains("export const MCP_DRAFT_PROTOCOL_VERSION = \"DRAFT-2026-v1\""));
+        assert!(ts.contains("export interface MCPRequestMeta"));
+        assert!(ts.contains("export interface MCPDiscoverResult"));
+        assert!(ts.contains("export interface MCPInputRequiredResult"));
+        assert!(ts.contains("MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR"));
+        assert!(ts.contains("server/discover"));
+        assert!(ts.contains("io.modelcontextprotocol/protocolVersion"));
+        assert!(ts.contains("MCP-Protocol-Version"));
+        assert!(ts.contains("ttlMs"));
+        assert!(ts.contains("cacheScope"));
         assert!(ts.contains("sessionClose: \"session/close\""));
         assert!(ts.contains("@deprecated Use session/close; session/stop will be removed"));
         for value in HARN_SESSION_UPDATE_EXTENSIONS
@@ -3012,6 +3635,15 @@ mod tests {
         }
         let swift = generate_swift();
         assert!(swift.contains("public enum HarnACPAgentMethod"));
+        assert!(swift.contains("mcpDraftProtocolVersion = \"DRAFT-2026-v1\""));
+        assert!(swift.contains("public struct HarnMCPRequestMeta"));
+        assert!(swift.contains("public struct HarnMCPDiscoverResult"));
+        assert!(swift.contains("public struct HarnMCPInputRequiredResult"));
+        assert!(swift.contains("HarnMCPUnsupportedProtocolVersionError"));
+        assert!(
+            swift.contains("case protocolVersion = \"io.modelcontextprotocol/protocolVersion\"")
+        );
+        assert!(swift.contains("case protocolVersion = \"MCP-Protocol-Version\""));
         assert!(swift.contains("case sessionClose = \"session/close\""));
         assert!(swift.contains("@available(*, deprecated"));
         assert!(swift.contains("public static let allCases: [Self]"));
@@ -3047,6 +3679,11 @@ mod tests {
     #[test]
     fn generated_python_includes_harn_wire_vocabularies() {
         let py = generate_python();
+        assert!(py.contains("MCP_DRAFT_PROTOCOL_VERSION: str = \"DRAFT-2026-v1\""));
+        assert!(py.contains("MCP_REQUIRED_METADATA_KEYS: tuple"));
+        assert!(py.contains("class MCPDiscoverResult(_HarnDataclass):"));
+        assert!(py.contains("class MCPInputRequiredResult(_HarnDataclass):"));
+        assert!(py.contains("class MCPCacheScope(str, Enum):"));
         assert!(py.contains("class ACPSessionUpdate(str, Enum):"));
         assert!(py.contains("class HarnToolCallErrorCategory(str, Enum):"));
         assert!(py.contains("class HarnWorkerStatus(str, Enum):"));
@@ -3070,6 +3707,11 @@ mod tests {
     fn generated_go_includes_harn_wire_vocabularies() {
         let go = generate_go();
         assert!(go.contains("package harnprotocol"));
+        assert!(go.contains("const MCPDraftProtocolVersion = \"DRAFT-2026-v1\""));
+        assert!(go.contains("type MCPRequestMeta struct"));
+        assert!(go.contains("type MCPDiscoverResult struct"));
+        assert!(go.contains("type MCPInputRequiredResult struct"));
+        assert!(go.contains("MCPUnsupportedProtocolVersionErrorCode"));
         assert!(go.contains("type JSONRPCID struct"));
         assert!(go.contains("type ACPSessionUpdateNotification struct"));
         assert!(go.contains("func IsRequest(envelope map[string]json.RawMessage)"));
@@ -3111,6 +3753,18 @@ mod tests {
             json!("composition_child_call")
         );
         assert_eq!(fixture["a2aTask"]["status"]["state"], json!("working"));
+        assert_eq!(
+            fixture["mcpDiscoverResult"]["supportedVersions"][0],
+            json!(MCP_DRAFT_PROTOCOL_VERSION)
+        );
+        assert_eq!(
+            fixture["mcpInputRequiredResult"]["resultType"],
+            json!(MCP_INPUT_REQUIRED_RESULT_TYPE)
+        );
+        assert_eq!(
+            fixture["mcpUnsupportedProtocolVersionError"]["error"]["code"],
+            json!(MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE)
+        );
         assert_eq!(fixture["toolCallReceipt"]["schema_version"], json!(1));
     }
 
@@ -3124,6 +3778,18 @@ mod tests {
         assert_eq!(
             manifest["bindings"]["typescript"]["stability"],
             json!("stable")
+        );
+        assert_eq!(
+            manifest["mcp"]["draftProtocolVersion"],
+            json!("DRAFT-2026-v1")
+        );
+        assert_eq!(
+            manifest["mcp"]["unsupportedProtocolVersionError"]["code"],
+            json!(MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE)
+        );
+        assert_eq!(
+            manifest["mcp"]["jsonSchemaDialect"],
+            json!(MCP_JSON_SCHEMA_2020_12_DIALECT)
         );
         assert_eq!(manifest["bindings"]["python"]["stability"], json!("stable"));
         assert_eq!(manifest["bindings"]["go"]["stability"], json!("stable"));

--- a/docs/src/protocol-artifacts.md
+++ b/docs/src/protocol-artifacts.md
@@ -21,7 +21,9 @@ The generated contract includes:
   block enumerating the published TypeScript, Swift, Python, and Go modules
   with their stability tier and (for Go) the canonical module path.
 - `schemas/*.schema.json`: stable copies of the ACP, A2A, and MCP adapter
-  profiles validated by `harn test protocols`.
+  profiles validated by `harn test protocols`. MCP publishes both the stable
+  `2025-11-25` profile and the opt-in `DRAFT-2026-v1` RC profile so
+  downstreams can prepare without changing runtime negotiation behavior.
 - `harn-protocol.ts`: TypeScript bindings for JSON-RPC messages, ACP
   `session/update`, Harn tool lifecycle metadata, A2A task events, and MCP
   tool/resource/prompt metadata.
@@ -42,6 +44,14 @@ The generated contract includes:
   envelopes plus an A2A task and an MCP tool entry. `make check-bindings`
   decodes and re-encodes these through the Python and Go bindings on every
   CI run, catching wire-vocabulary drift before downstream consumers see it.
+
+MCP RC helpers include `DRAFT-2026-v1`, the final scheduled
+`2026-07-28` identity, required request `_meta` keys, standard Streamable HTTP
+headers (`MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`), `server/discover`,
+`ttlMs`/`cacheScope` cache hints, `input_required` results, the `-32004`
+unsupported-version error, and the JSON Schema 2020-12 dialect URL. The RC
+profile is data-only until the final spec lands; servers and clients should
+opt in explicitly instead of assuming Harn's stable MCP runtime negotiates it.
 
 ## Stability
 
@@ -86,6 +96,15 @@ import `spec/protocol-artifacts/python/harn_protocol.py` (e.g. by vendoring
 the file or pinning the artifact directory) and the
 `harnprotocol` Go module under `spec/protocol-artifacts/go/harnprotocol`
 respectively.
+
+Cross-repo release jobs can run:
+
+```sh
+BURIN_CODE_ROOT=/path/to/burin-code make check-burin-protocol-artifacts
+```
+
+to fail when Burin Code's vendored Swift or TypeScript protocol bindings drift
+from the Harn source artifacts.
 
 For ACP, clients should still follow the wire namespacing rules in
 [Bridge protocol](./bridge-protocol.md): canonical ACP fields remain at the

--- a/scripts/check_burin_protocol_bindings.py
+++ b/scripts/check_burin_protocol_bindings.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Compare Burin Code's vendored Harn protocol bindings with this checkout.
+
+The Harn repo is the source of truth for the generated Swift and TypeScript
+protocol artifacts Burin Code vendors. This check intentionally accepts an
+explicit Burin checkout path so Harn CI can run without a sibling repository,
+while release and cross-repo jobs can fail fast on drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ARTIFACTS = REPO_ROOT / "spec" / "protocol-artifacts"
+
+TARGETS = (
+    (
+        ARTIFACTS / "HarnProtocol.swift",
+        Path("Sources/BurinCore/ACP/HarnProtocol.generated.swift"),
+    ),
+    (
+        ARTIFACTS / "harn-protocol.ts",
+        Path("tui/src/generated/harn-protocol.ts"),
+    ),
+)
+
+
+def normalize(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def discover_burin_root() -> Path | None:
+    env = os.environ.get("BURIN_CODE_ROOT")
+    if env:
+        return Path(env).expanduser()
+    candidate = Path.home() / "projects" / "burin-code"
+    if candidate.is_dir():
+        return candidate
+    return None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--burin-root",
+        type=Path,
+        default=None,
+        help="Path to a burin-code checkout. Defaults to BURIN_CODE_ROOT or ~/projects/burin-code.",
+    )
+    parser.add_argument(
+        "--required",
+        action="store_true",
+        help="Fail when no Burin checkout can be found instead of skipping.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    burin_root = (args.burin_root or discover_burin_root())
+    if burin_root is None or not burin_root.is_dir():
+        if args.required:
+            print("error: Burin Code checkout not found", file=sys.stderr)
+            return 1
+        print("skipping Burin protocol binding drift check (no Burin Code checkout found)")
+        return 0
+
+    stale: list[str] = []
+    for source, destination_relative in TARGETS:
+        destination = burin_root / destination_relative
+        if not destination.is_file():
+            stale.append(f"{destination_relative} (missing)")
+            continue
+        if normalize(source.read_text()) != normalize(destination.read_text()):
+            stale.append(str(destination_relative))
+
+    if stale:
+        print(
+            f"error: Burin Code protocol bindings diverge from {ARTIFACTS}:",
+            file=sys.stderr,
+        )
+        for path in stale:
+            print(f"  {path}", file=sys.stderr)
+        print(
+            "hint: regenerate Burin's vendored bindings from this Harn checkout or the matching Harn release.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Burin protocol bindings match {ARTIFACTS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_protocol_bindings.py
+++ b/scripts/check_protocol_bindings.py
@@ -71,6 +71,17 @@ def main() -> int:
         ),
         ("A2ATask", fixture["a2aTask"], hp.A2ATask),
         ("MCPTool", fixture["mcpTool"], hp.MCPTool),
+        ("MCPDiscoverResult", fixture["mcpDiscoverResult"], hp.MCPDiscoverResult),
+        (
+            "MCPInputRequiredResult",
+            fixture["mcpInputRequiredResult"],
+            hp.MCPInputRequiredResult,
+        ),
+        (
+            "MCPUnsupportedProtocolVersionError",
+            fixture["mcpUnsupportedProtocolVersionError"],
+            hp.MCPUnsupportedProtocolVersionError,
+        ),
         ("ToolCallReceipt", fixture["toolCallReceipt"], hp.ToolCallReceipt),
     ]
     for label, payload, cls in cases:

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -7,6 +7,41 @@ public enum HarnProtocolConstants {
     public static let artifactVersion = "0.8.34"
     public static let acpSchemaCompatibility = "agentclientprotocol/agent-client-protocol schema v0.12.2"
     public static let harnAgentEventMethod = "_harn/agentEvent"
+    public static let mcpProtocolVersion = "2025-11-25"
+    public static let mcpStableProtocolVersion = "2025-11-25"
+    public static let mcpDraftProtocolVersion = "DRAFT-2026-v1"
+    public static let mcpFinal2026ProtocolVersion = "2026-07-28"
+    public static let mcpJsonSchema202012Dialect = "https://json-schema.org/draft/2020-12/schema"
+    public static let mcpUnsupportedProtocolVersionErrorCode = -32004
+    public static let mcpUnsupportedProtocolVersionErrorMessage = "Unsupported protocol version"
+    public static let mcpProtocolVersions: [String] = [
+        "DRAFT-2026-v1",
+        "2025-11-25",
+    ]
+    public static let mcpRequiredMetadataKeys: [String] = [
+        "io.modelcontextprotocol/protocolVersion",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/clientCapabilities",
+    ]
+    public static let mcpMetadataKeys: [String] = [
+        "io.modelcontextprotocol/protocolVersion",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/clientCapabilities",
+        "io.modelcontextprotocol/logLevel",
+        "progressToken",
+        "traceparent",
+        "tracestate",
+        "baggage",
+    ]
+    public static let mcpStandardHTTPHeaders: [String] = [
+        "MCP-Protocol-Version",
+        "Mcp-Method",
+        "Mcp-Name",
+    ]
+    public static let mcpCacheResultFields: [String] = [
+        "ttlMs",
+        "cacheScope",
+    ]
     public static let acpSessionUpdateExtensions: [String] = [
         "available_commands_update",
         "fs_watch",
@@ -377,6 +412,7 @@ public enum HarnA2ATaskEventType: String, Codable, Sendable, CaseIterable {
 }
 
 public enum HarnMCPMethod: String, Codable, Sendable, CaseIterable {
+    case serverDiscover = "server/discover"
     case initialize = "initialize"
     case toolsList = "tools/list"
     case toolsCall = "tools/call"
@@ -393,6 +429,7 @@ public enum HarnMCPMethod: String, Codable, Sendable, CaseIterable {
     case notificationsMessage = "notifications/message"
 
     public static let allCases: [Self] = [
+        "server/discover",
         "initialize",
         "tools/list",
         "tools/call",
@@ -407,6 +444,26 @@ public enum HarnMCPMethod: String, Codable, Sendable, CaseIterable {
         "elicitation/create",
         "notifications/initialized",
         "notifications/message",
+    ].map { Self(rawValue: $0)! }
+}
+
+public enum HarnMCPCacheScope: String, Codable, Sendable, CaseIterable {
+    case private = "private"
+    case public = "public"
+
+    public static let allCases: [Self] = [
+        "private",
+        "public",
+    ].map { Self(rawValue: $0)! }
+}
+
+public enum HarnMCPResultType: String, Codable, Sendable, CaseIterable {
+    case complete = "complete"
+    case inputRequired = "input_required"
+
+    public static let allCases: [Self] = [
+        "complete",
+        "input_required",
     ].map { Self(rawValue: $0)! }
 }
 
@@ -1053,12 +1110,104 @@ public struct HarnA2ATask: Codable, Sendable, Equatable {
     public var metadata: HarnACPObject?
 }
 
+public typealias HarnMCPJsonSchema202012 = HarnACPObject
+
+public struct HarnMCPImplementation: Codable, Sendable, Equatable {
+    public var name: String
+    public var version: String
+    public var title: String?
+    public var description: String?
+    public var websiteUrl: String?
+}
+
+public struct HarnMCPRequestMeta: Codable, Sendable, Equatable {
+    public var protocolVersion: String
+    public var clientInfo: HarnMCPImplementation
+    public var clientCapabilities: HarnACPObject
+    public var logLevel: HarnMCPLoggingLevel?
+    public var progressToken: HarnACPValue?
+    public var traceparent: String?
+    public var tracestate: String?
+    public var baggage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case protocolVersion = "io.modelcontextprotocol/protocolVersion"
+        case clientInfo = "io.modelcontextprotocol/clientInfo"
+        case clientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+        case logLevel = "io.modelcontextprotocol/logLevel"
+        case progressToken
+        case traceparent
+        case tracestate
+        case baggage
+    }
+}
+
+public struct HarnMCPHTTPHeaders: Codable, Sendable, Equatable {
+    public var protocolVersion: String
+    public var method: String
+    public var name: String?
+
+    enum CodingKeys: String, CodingKey {
+        case protocolVersion = "MCP-Protocol-Version"
+        case method = "Mcp-Method"
+        case name = "Mcp-Name"
+    }
+}
+
+public struct HarnMCPCacheHints: Codable, Sendable, Equatable {
+    public var ttlMs: Int
+    public var cacheScope: HarnMCPCacheScope
+}
+
+public struct HarnMCPDiscoverResult: Codable, Sendable, Equatable {
+    public var resultType: HarnMCPResultType
+    public var supportedVersions: [String]
+    public var capabilities: HarnACPObject
+    public var serverInfo: HarnMCPImplementation
+    public var instructions: String?
+    public var meta: HarnACPObject?
+
+    enum CodingKeys: String, CodingKey {
+        case resultType
+        case supportedVersions
+        case capabilities
+        case serverInfo
+        case instructions
+        case meta = "_meta"
+    }
+}
+
+public struct HarnMCPInputRequiredResult: Codable, Sendable, Equatable {
+    public var resultType: HarnMCPResultType
+    public var inputRequests: HarnACPObject?
+    public var requestState: String?
+    public var meta: HarnACPObject?
+
+    enum CodingKeys: String, CodingKey {
+        case resultType
+        case inputRequests
+        case requestState
+        case meta = "_meta"
+    }
+}
+
+public struct HarnMCPUnsupportedProtocolVersionErrorData: Codable, Sendable, Equatable {
+    public var requested: String
+    public var supported: [String]
+}
+
+public struct HarnMCPUnsupportedProtocolVersionError: Codable, Sendable, Equatable {
+    public var jsonrpc: String
+    public var id: HarnJsonRpcId?
+    public var error: HarnACPError
+}
+
 public struct HarnMCPTool: Codable, Sendable, Equatable {
     public var name: String
     public var title: String?
     public var description: String?
-    public var inputSchema: HarnACPObject
-    public var outputSchema: HarnACPObject?
+    public var inputSchema: HarnMCPJsonSchema202012
+    public var outputSchema: HarnMCPJsonSchema202012?
     public var annotations: HarnACPObject?
 }
 

--- a/spec/protocol-artifacts/README.md
+++ b/spec/protocol-artifacts/README.md
@@ -28,6 +28,9 @@ extension fields, and generated binding vocabulary.
 profile (`agentclientprotocol/agent-client-protocol schema v0.12.2`).
 - `schemas/a2a-0.3.0.schema.json`: Harn's A2A schema profile (`0.3.0`).
 - `schemas/mcp-2025-11-25.schema.json`: Harn's MCP schema profile (`2025-11-25`).
+- `schemas/mcp-draft-2026-v1.schema.json`: Harn's opt-in MCP RC schema
+profile (`DRAFT-2026-v1`), pinned beside the stable profile until the
+final `2026-07-28` specification lands.
 - `schemas/tool-call-receipt.schema.json`: Harn's typed, privacy-preserving
 `ToolCallReceipt` schema for audited tool calls.
 - `harn-protocol.ts`: TypeScript definitions for ACP session updates,

--- a/spec/protocol-artifacts/fixtures/round_trip.json
+++ b/spec/protocol-artifacts/fixtures/round_trip.json
@@ -99,9 +99,50 @@
     }
   },
   "harnAgentEventMethod": "_harn/agentEvent",
+  "mcpDiscoverResult": {
+    "capabilities": {
+      "tools": {}
+    },
+    "instructions": "Use the stable MCP version unless the RC is explicitly enabled.",
+    "resultType": "complete",
+    "serverInfo": {
+      "name": "harn",
+      "version": "0.8.34"
+    },
+    "supportedVersions": [
+      "DRAFT-2026-v1",
+      "2025-11-25"
+    ]
+  },
+  "mcpInputRequiredResult": {
+    "inputRequests": {
+      "confirm": {
+        "method": "elicitation/create",
+        "params": {
+          "message": "Confirm the action",
+          "mode": "form",
+          "requestedSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+              "confirmed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "confirmed"
+            ],
+            "type": "object"
+          }
+        }
+      }
+    },
+    "requestState": "opaque-state",
+    "resultType": "input_required"
+  },
   "mcpTool": {
     "description": "Echoes input",
     "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "x": {
           "type": "string"
@@ -111,6 +152,21 @@
     },
     "name": "echo",
     "title": "Echo"
+  },
+  "mcpUnsupportedProtocolVersionError": {
+    "error": {
+      "code": -32004,
+      "data": {
+        "requested": "DRAFT-2026-v0",
+        "supported": [
+          "DRAFT-2026-v1",
+          "2025-11-25"
+        ]
+      },
+      "message": "Unsupported protocol version"
+    },
+    "id": 19,
+    "jsonrpc": "2.0"
   },
   "toolCallReceipt": {
     "args_hash": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -24,6 +24,27 @@ const A2AProtocolVersion = "0.3.0"
 // MCPProtocolVersion is the MCP protocol version Harn implements.
 const MCPProtocolVersion = "2025-11-25"
 
+// MCPStableProtocolVersion is the stable MCP protocol version Harn implements at runtime.
+const MCPStableProtocolVersion = "2025-11-25"
+
+// MCPDraftProtocolVersion is the opt-in MCP release-candidate profile identity.
+const MCPDraftProtocolVersion = "DRAFT-2026-v1"
+
+// MCPFinal2026ProtocolVersion is the scheduled final identity for the RC profile.
+const MCPFinal2026ProtocolVersion = "2026-07-28"
+
+// MCPJSONSchema202012Dialect is the JSON Schema dialect used by the MCP RC artifact profile.
+const MCPJSONSchema202012Dialect = "https://json-schema.org/draft/2020-12/schema"
+
+// MCPInputRequiredResultType is the resultType discriminator for multi round-trip requests.
+const MCPInputRequiredResultType = "input_required"
+
+// MCPUnsupportedProtocolVersionErrorMessage is the standard message for unsupported versions.
+const MCPUnsupportedProtocolVersionErrorMessage = "Unsupported protocol version"
+
+// MCPUnsupportedProtocolVersionErrorCode is the JSON-RPC server error for unsupported versions.
+const MCPUnsupportedProtocolVersionErrorCode = -32004
+
 // ACPAgentMethod is the typed alias for the ACPAgentMethods wire vocabulary.
 type ACPAgentMethod = string
 
@@ -278,11 +299,21 @@ var A2ATaskEventTypes = []A2ATaskEventType{
 	"worker_update",
 }
 
+// MCPProtocolVersionValue is the typed alias for the MCPProtocolVersions wire vocabulary.
+type MCPProtocolVersionValue = string
+
+// MCPProtocolVersions enumerates every wire value Harn currently emits for MCPProtocolVersionValue.
+var MCPProtocolVersions = []MCPProtocolVersionValue{
+	"DRAFT-2026-v1",
+	"2025-11-25",
+}
+
 // MCPMethod is the typed alias for the MCPMethods wire vocabulary.
 type MCPMethod = string
 
 // MCPMethods enumerates every wire value Harn currently emits for MCPMethod.
 var MCPMethods = []MCPMethod{
+	"server/discover",
 	"initialize",
 	"tools/list",
 	"tools/call",
@@ -297,6 +328,24 @@ var MCPMethods = []MCPMethod{
 	"elicitation/create",
 	"notifications/initialized",
 	"notifications/message",
+}
+
+// MCPCacheScope is the typed alias for the MCPCacheScopes wire vocabulary.
+type MCPCacheScope = string
+
+// MCPCacheScopes enumerates every wire value Harn currently emits for MCPCacheScope.
+var MCPCacheScopes = []MCPCacheScope{
+	"private",
+	"public",
+}
+
+// MCPResultType is the typed alias for the MCPResultTypes wire vocabulary.
+type MCPResultType = string
+
+// MCPResultTypes enumerates every wire value Harn currently emits for MCPResultType.
+var MCPResultTypes = []MCPResultType{
+	"complete",
+	"input_required",
 }
 
 // MCPLoggingLevel is the typed alias for the MCPLoggingLevels wire vocabulary.
@@ -344,6 +393,38 @@ var A2AMethods = []string{
 	"tasks/pushNotificationConfig/list",
 	"tasks/pushNotificationConfig/delete",
 	"agent/getAuthenticatedExtendedCard",
+}
+
+// MCPRequiredMetadataKeys enumerates the wire values Harn currently emits.
+var MCPRequiredMetadataKeys = []string{
+	"io.modelcontextprotocol/protocolVersion",
+	"io.modelcontextprotocol/clientInfo",
+	"io.modelcontextprotocol/clientCapabilities",
+}
+
+// MCPMetadataKeys enumerates the wire values Harn currently emits.
+var MCPMetadataKeys = []string{
+	"io.modelcontextprotocol/protocolVersion",
+	"io.modelcontextprotocol/clientInfo",
+	"io.modelcontextprotocol/clientCapabilities",
+	"io.modelcontextprotocol/logLevel",
+	"progressToken",
+	"traceparent",
+	"tracestate",
+	"baggage",
+}
+
+// MCPStandardHTTPHeaders enumerates the wire values Harn currently emits.
+var MCPStandardHTTPHeaders = []string{
+	"MCP-Protocol-Version",
+	"Mcp-Method",
+	"Mcp-Name",
+}
+
+// MCPCacheResultFields enumerates the wire values Harn currently emits.
+var MCPCacheResultFields = []string{
+	"ttlMs",
+	"cacheScope",
 }
 
 // JSONValue is the Go counterpart of the TypeScript ACPValue / Python JsonValue
@@ -592,14 +673,84 @@ type A2ATask struct {
 	Metadata  JSONObject        `json:"metadata,omitempty"`
 }
 
+// MCPJSONSchema202012 is the JSON Schema dialect surface used by the MCP RC
+// tool input/output schema profile.
+type MCPJSONSchema202012 = JSONObject
+
+// MCPImplementation describes an MCP client or server implementation.
+type MCPImplementation struct {
+	Name        string  `json:"name"`
+	Version     string  `json:"version"`
+	Title       *string `json:"title,omitempty"`
+	Description *string `json:"description,omitempty"`
+	WebsiteURL  *string `json:"websiteUrl,omitempty"`
+}
+
+// MCPRequestMeta is the per-request metadata required by the MCP RC profile.
+type MCPRequestMeta struct {
+	ProtocolVersion    string            `json:"io.modelcontextprotocol/protocolVersion"`
+	ClientInfo         MCPImplementation `json:"io.modelcontextprotocol/clientInfo"`
+	ClientCapabilities JSONObject        `json:"io.modelcontextprotocol/clientCapabilities"`
+	LogLevel           *MCPLoggingLevel  `json:"io.modelcontextprotocol/logLevel,omitempty"`
+	ProgressToken      json.RawMessage   `json:"progressToken,omitempty"`
+	Traceparent        *string           `json:"traceparent,omitempty"`
+	Tracestate         *string           `json:"tracestate,omitempty"`
+	Baggage            *string           `json:"baggage,omitempty"`
+}
+
+// MCPHTTPHeaders names the HTTP headers used by the MCP RC Streamable HTTP profile.
+type MCPHTTPHeaders struct {
+	ProtocolVersion string  `json:"MCP-Protocol-Version"`
+	Method          string  `json:"Mcp-Method"`
+	Name            *string `json:"Mcp-Name,omitempty"`
+}
+
+// MCPCacheHints captures the RC ttlMs/cacheScope cache fields.
+type MCPCacheHints struct {
+	TTLMS      uint64        `json:"ttlMs"`
+	CacheScope MCPCacheScope `json:"cacheScope"`
+}
+
+// MCPDiscoverResult is the result returned by server/discover.
+type MCPDiscoverResult struct {
+	ResultType        MCPResultType     `json:"resultType"`
+	SupportedVersions []string          `json:"supportedVersions"`
+	Capabilities      JSONObject        `json:"capabilities"`
+	ServerInfo        MCPImplementation `json:"serverInfo"`
+	Instructions      *string           `json:"instructions,omitempty"`
+	Meta              JSONObject        `json:"_meta,omitempty"`
+}
+
+// MCPInputRequiredResult carries server-to-client requests for multi round-trip calls.
+type MCPInputRequiredResult struct {
+	ResultType    MCPResultType `json:"resultType"`
+	InputRequests JSONObject    `json:"inputRequests,omitempty"`
+	RequestState  *string       `json:"requestState,omitempty"`
+	Meta          JSONObject    `json:"_meta,omitempty"`
+}
+
+// MCPUnsupportedProtocolVersionErrorData is the typed data payload for -32004.
+type MCPUnsupportedProtocolVersionErrorData struct {
+	Requested string   `json:"requested"`
+	Supported []string `json:"supported"`
+}
+
+// MCPUnsupportedProtocolVersionError is the JSON-RPC error response shape for
+// an unsupported MCP protocol version.
+type MCPUnsupportedProtocolVersionError struct {
+	JSONRPC string    `json:"jsonrpc"`
+	ID      JSONRPCID `json:"id,omitempty"`
+	Error   ACPError  `json:"error"`
+}
+
 // MCPTool is the MCP `tools/list` entry.
 type MCPTool struct {
-	Name         string     `json:"name"`
-	Title        *string    `json:"title,omitempty"`
-	Description  *string    `json:"description,omitempty"`
-	InputSchema  JSONObject `json:"inputSchema"`
-	OutputSchema JSONObject `json:"outputSchema,omitempty"`
-	Annotations  JSONObject `json:"annotations,omitempty"`
+	Name         string              `json:"name"`
+	Title        *string             `json:"title,omitempty"`
+	Description  *string             `json:"description,omitempty"`
+	InputSchema  MCPJSONSchema202012 `json:"inputSchema"`
+	OutputSchema MCPJSONSchema202012 `json:"outputSchema,omitempty"`
+	Annotations  JSONObject          `json:"annotations,omitempty"`
 }
 
 // MCPResource is the MCP `resources/list` entry.

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol_test.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol_test.go
@@ -236,6 +236,63 @@ func TestRoundTripFixture(t *testing.T) {
 		assertRoundTrip(t, "MCPTool", raw, out)
 	})
 
+	t.Run("MCPDiscoverResult", func(t *testing.T) {
+		raw, ok := fixture["mcpDiscoverResult"]
+		if !ok {
+			t.Fatal("fixture missing mcpDiscoverResult")
+		}
+		var result MCPDiscoverResult
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("decode mcp discover result: %v", err)
+		}
+		if len(result.SupportedVersions) == 0 || result.SupportedVersions[0] != MCPDraftProtocolVersion {
+			t.Fatalf("expected first supported version %q, got %#v", MCPDraftProtocolVersion, result.SupportedVersions)
+		}
+		out, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("encode mcp discover result: %v", err)
+		}
+		assertRoundTrip(t, "MCPDiscoverResult", raw, out)
+	})
+
+	t.Run("MCPInputRequiredResult", func(t *testing.T) {
+		raw, ok := fixture["mcpInputRequiredResult"]
+		if !ok {
+			t.Fatal("fixture missing mcpInputRequiredResult")
+		}
+		var result MCPInputRequiredResult
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("decode mcp input-required result: %v", err)
+		}
+		if result.ResultType != MCPInputRequiredResultType {
+			t.Fatalf("expected resultType=%q, got %q", MCPInputRequiredResultType, result.ResultType)
+		}
+		out, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("encode mcp input-required result: %v", err)
+		}
+		assertRoundTrip(t, "MCPInputRequiredResult", raw, out)
+	})
+
+	t.Run("MCPUnsupportedProtocolVersionError", func(t *testing.T) {
+		raw, ok := fixture["mcpUnsupportedProtocolVersionError"]
+		if !ok {
+			t.Fatal("fixture missing mcpUnsupportedProtocolVersionError")
+		}
+		var response MCPUnsupportedProtocolVersionError
+		if err := json.Unmarshal(raw, &response); err != nil {
+			t.Fatalf("decode mcp unsupported-version error: %v", err)
+		}
+		if response.Error.Code != MCPUnsupportedProtocolVersionErrorCode {
+			t.Fatalf("expected code=%d, got %d", MCPUnsupportedProtocolVersionErrorCode, response.Error.Code)
+		}
+		out, err := json.Marshal(response)
+		if err != nil {
+			t.Fatalf("encode mcp unsupported-version error: %v", err)
+		}
+		assertRoundTrip(t, "MCPUnsupportedProtocolVersionError", raw, out)
+	})
+
 	t.Run("ToolCallReceipt", func(t *testing.T) {
 		raw, ok := fixture["toolCallReceipt"]
 		if !ok {
@@ -353,7 +410,10 @@ func TestVocabulariesArePopulated(t *testing.T) {
 		{"ToolCallReceiptExecutors", ToolCallReceiptExecutors},
 		{"A2ATaskStates", A2ATaskStates},
 		{"A2ATaskEventTypes", A2ATaskEventTypes},
+		{"MCPProtocolVersions", MCPProtocolVersions},
 		{"MCPMethods", MCPMethods},
+		{"MCPCacheScopes", MCPCacheScopes},
+		{"MCPResultTypes", MCPResultTypes},
 	}
 	for _, check := range checks {
 		if len(check.values) == 0 {

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -3,6 +3,13 @@
 
 export const HARN_PROTOCOL_ARTIFACT_VERSION = "0.8.34"
 
+export const MCP_PROTOCOL_VERSION = "2025-11-25"
+export const MCP_STABLE_PROTOCOL_VERSION = "2025-11-25"
+export const MCP_DRAFT_PROTOCOL_VERSION = "DRAFT-2026-v1"
+export const MCP_FINAL_2026_PROTOCOL_VERSION = "2026-07-28"
+export const MCP_JSON_SCHEMA_2020_12_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+export const MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR = { code: -32004, message: "Unsupported protocol version" } as const
+
 export const ACP_AGENT_METHODS = [
   "initialize",
   "session/inject",
@@ -226,7 +233,14 @@ export const A2A_TASK_EVENT_TYPES = [
 ] as const
 export type A2ATaskEventType = (typeof A2A_TASK_EVENT_TYPES)[number]
 
+export const MCP_PROTOCOL_VERSIONS = [
+  "DRAFT-2026-v1",
+  "2025-11-25",
+] as const
+export type MCPProtocolVersion = (typeof MCP_PROTOCOL_VERSIONS)[number]
+
 export const MCP_METHODS = [
+  "server/discover",
   "initialize",
   "tools/list",
   "tools/call",
@@ -243,6 +257,50 @@ export const MCP_METHODS = [
   "notifications/message",
 ] as const
 export type MCPMethod = (typeof MCP_METHODS)[number]
+
+export const MCP_REQUIRED_METADATA_KEYS = [
+  "io.modelcontextprotocol/protocolVersion",
+  "io.modelcontextprotocol/clientInfo",
+  "io.modelcontextprotocol/clientCapabilities",
+] as const
+export type MCPRequiredMetadataKey = (typeof MCP_REQUIRED_METADATA_KEYS)[number]
+
+export const MCP_METADATA_KEYS = [
+  "io.modelcontextprotocol/protocolVersion",
+  "io.modelcontextprotocol/clientInfo",
+  "io.modelcontextprotocol/clientCapabilities",
+  "io.modelcontextprotocol/logLevel",
+  "progressToken",
+  "traceparent",
+  "tracestate",
+  "baggage",
+] as const
+export type MCPMetadataKey = (typeof MCP_METADATA_KEYS)[number]
+
+export const MCP_STANDARD_HTTP_HEADERS = [
+  "MCP-Protocol-Version",
+  "Mcp-Method",
+  "Mcp-Name",
+] as const
+export type MCPStandardHTTPHeader = (typeof MCP_STANDARD_HTTP_HEADERS)[number]
+
+export const MCP_CACHE_RESULT_FIELDS = [
+  "ttlMs",
+  "cacheScope",
+] as const
+export type MCPCacheResultField = (typeof MCP_CACHE_RESULT_FIELDS)[number]
+
+export const MCP_CACHE_SCOPES = [
+  "private",
+  "public",
+] as const
+export type MCPCacheScope = (typeof MCP_CACHE_SCOPES)[number]
+
+export const MCP_RESULT_TYPES = [
+  "complete",
+  "input_required",
+] as const
+export type MCPResultType = (typeof MCP_RESULT_TYPES)[number]
 
 export const MCP_LOGGING_LEVELS = [
   "debug",
@@ -511,12 +569,75 @@ export type A2ATaskEvent =
   | { type: "message" | "worker_update"; taskId: string; message?: A2AMessage }
   | { statusUpdate: { taskId: string; contextId?: string | null; status: A2ATaskStatus } }
 
+export type MCPJsonSchema202012 = ACPObject
+
+export interface MCPImplementation {
+  name: string
+  version: string
+  title?: string
+  description?: string
+  websiteUrl?: string
+}
+
+export interface MCPRequestMeta {
+  "io.modelcontextprotocol/protocolVersion": MCPProtocolVersion | string
+  "io.modelcontextprotocol/clientInfo": MCPImplementation
+  "io.modelcontextprotocol/clientCapabilities": ACPObject
+  "io.modelcontextprotocol/logLevel"?: MCPLoggingLevel
+  progressToken?: string | number
+  traceparent?: string
+  tracestate?: string
+  baggage?: string
+  [key: string]: ACPValue | MCPImplementation | undefined
+}
+
+export interface MCPHTTPHeaders {
+  "MCP-Protocol-Version": MCPProtocolVersion | string
+  "Mcp-Method": MCPMethod | string
+  "Mcp-Name"?: string
+  [header: string]: string | undefined
+}
+
+export interface MCPCacheHints {
+  ttlMs: number
+  cacheScope: MCPCacheScope
+}
+
+export interface MCPDiscoverResult {
+  resultType: "complete"
+  supportedVersions: (MCPProtocolVersion | string)[]
+  capabilities: ACPObject
+  serverInfo: MCPImplementation
+  instructions?: string
+  _meta?: ACPObject
+}
+
+export interface MCPInputRequiredResult {
+  resultType: "input_required"
+  inputRequests?: Record<string, ACPObject>
+  requestState?: string
+  _meta?: ACPObject
+}
+
+export interface MCPUnsupportedProtocolVersionError {
+  jsonrpc: "2.0"
+  id?: JsonRpcId
+  error: {
+    code: typeof MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR.code
+    message: typeof MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR.message
+    data: {
+      requested: string
+      supported: (MCPProtocolVersion | string)[]
+    }
+  }
+}
+
 export interface MCPTool {
   name: string
   title?: string
   description?: string
-  inputSchema: ACPObject
-  outputSchema?: ACPObject
+  inputSchema: MCPJsonSchema202012
+  outputSchema?: MCPJsonSchema202012
   annotations?: ACPObject
 }
 

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -221,6 +221,18 @@
   "checkCommand": "make check-protocol-artifacts",
   "generatedBy": "harn dump-protocol-artifacts",
   "mcp": {
+    "cacheResultFields": [
+      "ttlMs",
+      "cacheScope"
+    ],
+    "cacheScopes": [
+      "private",
+      "public"
+    ],
+    "draftProtocolVersion": "DRAFT-2026-v1",
+    "final2026ProtocolVersion": "2026-07-28",
+    "inputRequiredResultType": "input_required",
+    "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
     "loggingLevels": [
       "debug",
       "info",
@@ -231,7 +243,18 @@
       "alert",
       "emergency"
     ],
+    "metadataKeys": [
+      "io.modelcontextprotocol/protocolVersion",
+      "io.modelcontextprotocol/clientInfo",
+      "io.modelcontextprotocol/clientCapabilities",
+      "io.modelcontextprotocol/logLevel",
+      "progressToken",
+      "traceparent",
+      "tracestate",
+      "baggage"
+    ],
     "methods": [
+      "server/discover",
       "initialize",
       "tools/list",
       "tools/call",
@@ -247,7 +270,30 @@
       "notifications/initialized",
       "notifications/message"
     ],
-    "protocolVersion": "2025-11-25"
+    "protocolVersion": "2025-11-25",
+    "protocolVersions": [
+      "DRAFT-2026-v1",
+      "2025-11-25"
+    ],
+    "requiredRequestMetadataKeys": [
+      "io.modelcontextprotocol/protocolVersion",
+      "io.modelcontextprotocol/clientInfo",
+      "io.modelcontextprotocol/clientCapabilities"
+    ],
+    "resultTypes": [
+      "complete",
+      "input_required"
+    ],
+    "stableProtocolVersion": "2025-11-25",
+    "standardHttpHeaders": [
+      "MCP-Protocol-Version",
+      "Mcp-Method",
+      "Mcp-Name"
+    ],
+    "unsupportedProtocolVersionError": {
+      "code": -32004,
+      "message": "Unsupported protocol version"
+    }
   },
   "receipts": {
     "toolCallReceiptExecutors": [
@@ -309,6 +355,20 @@
         "upstream_version": "2025-11-25"
       },
       "source": "conformance/protocols/schemas/mcp-2025-11-25.schema.json"
+    },
+    {
+      "artifact": "schemas/mcp-draft-2026-v1.schema.json",
+      "protocol": "mcp",
+      "provenance": {
+        "profile_note": "The upstream draft schema is definitions-only; this profile supplies a root over the DRAFT-2026-v1 request, response, notification, standard HTTP header, metadata, cache hint, input-required, and unsupported-version shapes Harn publishes for downstream implementers. The stable runtime protocol version remains 2025-11-25 unless an implementation explicitly opts into the RC.",
+        "protocol": "mcp",
+        "refresh_command": "curl -fsSL https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json",
+        "retrieved_at": "2026-05-23",
+        "upstream_source_url": "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json",
+        "upstream_spec_url": "https://modelcontextprotocol.io/specification/draft",
+        "upstream_version": "DRAFT-2026-v1"
+      },
+      "source": "conformance/protocols/schemas/mcp-draft-2026-v1.schema.json"
     },
     {
       "artifact": "schemas/tool-call-receipt.schema.json",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -21,6 +21,13 @@ __all__ = [
     "ACP_SCHEMA_COMPATIBILITY",
     "A2A_PROTOCOL_VERSION",
     "MCP_PROTOCOL_VERSION",
+    "MCP_STABLE_PROTOCOL_VERSION",
+    "MCP_DRAFT_PROTOCOL_VERSION",
+    "MCP_FINAL_2026_PROTOCOL_VERSION",
+    "MCP_JSON_SCHEMA_2020_12_DIALECT",
+    "MCP_INPUT_REQUIRED_RESULT_TYPE",
+    "MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE",
+    "MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE",
     "ACP_AGENT_METHODS",
     "ACP_CLIENT_METHODS",
     "ACP_AGENT_NOTIFICATIONS",
@@ -40,7 +47,14 @@ __all__ = [
     "A2A_METHODS",
     "A2A_TASK_STATES",
     "A2A_TASK_EVENT_TYPES",
+    "MCP_PROTOCOL_VERSIONS",
     "MCP_METHODS",
+    "MCP_REQUIRED_METADATA_KEYS",
+    "MCP_METADATA_KEYS",
+    "MCP_STANDARD_HTTP_HEADERS",
+    "MCP_CACHE_RESULT_FIELDS",
+    "MCP_CACHE_SCOPES",
+    "MCP_RESULT_TYPES",
     "MCP_LOGGING_LEVELS",
     "ACPAgentMethod",
     "ACPClientMethod",
@@ -55,6 +69,8 @@ __all__ = [
     "ToolCallReceiptExecutor",
     "A2ATaskState",
     "A2ATaskEventType",
+    "MCPCacheScope",
+    "MCPResultType",
     "MCPLoggingLevel",
     "ACPError",
     "ACPRequest",
@@ -76,6 +92,15 @@ __all__ = [
     "A2AMessage",
     "A2ATaskStatus",
     "A2ATask",
+    "MCPJsonSchema202012",
+    "MCPRequestMeta",
+    "MCPHTTPHeaders",
+    "MCPImplementation",
+    "MCPCacheHints",
+    "MCPDiscoverResult",
+    "MCPInputRequiredResult",
+    "MCPUnsupportedProtocolVersionErrorData",
+    "MCPUnsupportedProtocolVersionError",
     "MCPTool",
     "MCPResource",
     "MCPResourceTemplate",
@@ -93,6 +118,13 @@ HARN_AGENT_EVENT_METHOD: str = "_harn/agentEvent"
 ACP_SCHEMA_COMPATIBILITY: str = "agentclientprotocol/agent-client-protocol schema v0.12.2"
 A2A_PROTOCOL_VERSION: str = "0.3.0"
 MCP_PROTOCOL_VERSION: str = "2025-11-25"
+MCP_STABLE_PROTOCOL_VERSION: str = "2025-11-25"
+MCP_DRAFT_PROTOCOL_VERSION: str = "DRAFT-2026-v1"
+MCP_FINAL_2026_PROTOCOL_VERSION: str = "2026-07-28"
+MCP_JSON_SCHEMA_2020_12_DIALECT: str = "https://json-schema.org/draft/2020-12/schema"
+MCP_INPUT_REQUIRED_RESULT_TYPE: str = "input_required"
+MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE: str = "Unsupported protocol version"
+MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE: int = -32004
 
 ACP_AGENT_METHODS: tuple = (
     "initialize",
@@ -294,7 +326,12 @@ A2A_TASK_EVENT_TYPES: tuple = (
     "message",
     "worker_update",
 )
+MCP_PROTOCOL_VERSIONS: tuple = (
+    "DRAFT-2026-v1",
+    "2025-11-25",
+)
 MCP_METHODS: tuple = (
+    "server/discover",
     "initialize",
     "tools/list",
     "tools/call",
@@ -309,6 +346,38 @@ MCP_METHODS: tuple = (
     "elicitation/create",
     "notifications/initialized",
     "notifications/message",
+)
+MCP_REQUIRED_METADATA_KEYS: tuple = (
+    "io.modelcontextprotocol/protocolVersion",
+    "io.modelcontextprotocol/clientInfo",
+    "io.modelcontextprotocol/clientCapabilities",
+)
+MCP_METADATA_KEYS: tuple = (
+    "io.modelcontextprotocol/protocolVersion",
+    "io.modelcontextprotocol/clientInfo",
+    "io.modelcontextprotocol/clientCapabilities",
+    "io.modelcontextprotocol/logLevel",
+    "progressToken",
+    "traceparent",
+    "tracestate",
+    "baggage",
+)
+MCP_STANDARD_HTTP_HEADERS: tuple = (
+    "MCP-Protocol-Version",
+    "Mcp-Method",
+    "Mcp-Name",
+)
+MCP_CACHE_RESULT_FIELDS: tuple = (
+    "ttlMs",
+    "cacheScope",
+)
+MCP_CACHE_SCOPES: tuple = (
+    "private",
+    "public",
+)
+MCP_RESULT_TYPES: tuple = (
+    "complete",
+    "input_required",
 )
 MCP_LOGGING_LEVELS: tuple = (
     "debug",
@@ -463,6 +532,16 @@ class A2ATaskEventType(str, Enum):
     STATUS = "status"
     MESSAGE = "message"
     WORKER_UPDATE = "worker_update"
+
+
+class MCPCacheScope(str, Enum):
+    PRIVATE = "private"
+    PUBLIC = "public"
+
+
+class MCPResultType(str, Enum):
+    COMPLETE = "complete"
+    INPUT_REQUIRED = "input_required"
 
 
 class MCPLoggingLevel(str, Enum):
@@ -723,13 +802,64 @@ class A2ATask(_HarnDataclass):
     metadata: Optional[JsonObject] = None
 
 
+MCPJsonSchema202012 = JsonObject
+MCPRequestMeta = JsonObject
+MCPHTTPHeaders = Dict[str, str]
+
+
+@dataclass
+class MCPImplementation(_HarnDataclass):
+    name: str
+    version: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    websiteUrl: Optional[str] = None
+
+
+@dataclass
+class MCPCacheHints(_HarnDataclass):
+    ttlMs: int
+    cacheScope: str
+
+
+@dataclass
+class MCPDiscoverResult(_HarnDataclass):
+    resultType: str
+    supportedVersions: List[str]
+    capabilities: JsonObject
+    serverInfo: MCPImplementation
+    instructions: Optional[str] = None
+    _meta: Optional[JsonObject] = None
+
+
+@dataclass
+class MCPInputRequiredResult(_HarnDataclass):
+    resultType: str
+    inputRequests: Optional[JsonObject] = None
+    requestState: Optional[str] = None
+    _meta: Optional[JsonObject] = None
+
+
+@dataclass
+class MCPUnsupportedProtocolVersionErrorData(_HarnDataclass):
+    requested: str
+    supported: List[str]
+
+
+@dataclass
+class MCPUnsupportedProtocolVersionError(_HarnDataclass):
+    error: ACPError
+    id: JsonRpcId = None
+    jsonrpc: str = "2.0"
+
+
 @dataclass
 class MCPTool(_HarnDataclass):
     name: str
-    inputSchema: JsonObject
+    inputSchema: MCPJsonSchema202012
     title: Optional[str] = None
     description: Optional[str] = None
-    outputSchema: Optional[JsonObject] = None
+    outputSchema: Optional[MCPJsonSchema202012] = None
     annotations: Optional[JsonObject] = None
 
 

--- a/spec/protocol-artifacts/schemas/mcp-draft-2026-v1.schema.json
+++ b/spec/protocol-artifacts/schemas/mcp-draft-2026-v1.schema.json
@@ -1,0 +1,3988 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/conformance/protocols/mcp-draft-2026-v1.schema.json",
+  "title": "Harn MCP DRAFT-2026-v1 adapter profile",
+  "description": "Pinned Harn adapter profile derived from modelcontextprotocol/modelcontextprotocol schema/draft/schema.json for the MCP DRAFT-2026-v1 release-candidate wire surface. Runtime support remains opt-in until the final 2026-07-28 specification lands.",
+  "x-harn-provenance": {
+    "protocol": "mcp",
+    "upstream_version": "DRAFT-2026-v1",
+    "upstream_source_url": "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json",
+    "upstream_spec_url": "https://modelcontextprotocol.io/specification/draft",
+    "retrieved_at": "2026-05-23",
+    "refresh_command": "curl -fsSL https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/schema/draft/schema.json",
+    "profile_note": "The upstream draft schema is definitions-only; this profile supplies a root over the DRAFT-2026-v1 request, response, notification, standard HTTP header, metadata, cache hint, input-required, and unsupported-version shapes Harn publishes for downstream implementers. The stable runtime protocol version remains 2025-11-25 unless an implementation explicitly opts into the RC."
+  },
+  "anyOf": [
+    {
+      "$ref": "#/$defs/ClientRequest"
+    },
+    {
+      "$ref": "#/$defs/DiscoverResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListResourcesResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListResourceTemplatesResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ReadResourceResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListPromptsResultResponse"
+    },
+    {
+      "$ref": "#/$defs/GetPromptResultResponse"
+    },
+    {
+      "$ref": "#/$defs/ListToolsResultResponse"
+    },
+    {
+      "$ref": "#/$defs/CallToolResultResponse"
+    },
+    {
+      "$ref": "#/$defs/CompleteResultResponse"
+    },
+    {
+      "$ref": "#/$defs/UnsupportedProtocolVersionError"
+    },
+    {
+      "$ref": "#/$defs/MissingRequiredClientCapabilityError"
+    },
+    {
+      "$ref": "#/$defs/ProgressNotification"
+    },
+    {
+      "$ref": "#/$defs/LoggingMessageNotification"
+    },
+    {
+      "$ref": "#/$defs/ToolListChangedNotification"
+    },
+    {
+      "$ref": "#/$defs/ResourceListChangedNotification"
+    },
+    {
+      "$ref": "#/$defs/ResourceUpdatedNotification"
+    },
+    {
+      "$ref": "#/$defs/PromptListChangedNotification"
+    },
+    {
+      "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
+    },
+    {
+      "$ref": "#/$defs/MCPHttpHeaders"
+    }
+  ],
+  "$defs": {
+    "Annotations": {
+      "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+      "properties": {
+        "audience": {
+          "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+          "items": {
+            "$ref": "#/$defs/Role"
+          },
+          "type": "array"
+        },
+        "lastModified": {
+          "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "AudioContent": {
+      "description": "Audio provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded audio data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the audio. Different providers may support different audio types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "audio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "BaseMetadata": {
+      "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "BlobResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "blob": {
+          "description": "A base64-encoded string representing the binary data of the item.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blob",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "BooleanSchema": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "boolean",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "CacheableResult": {
+      "description": "A result that supports a time-to-live (TTL) hint for client-side caching.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "CallToolRequest": {
+      "description": "Used by the client to invoke a tool provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/call",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CallToolRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CallToolRequestParams": {
+      "description": "Parameters for a `tools/call` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {},
+          "description": "Arguments to use for the tool call.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the tool.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "CallToolResult": {
+      "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "description": "A list of content objects that represent the unstructured result of the tool call.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+          "type": "boolean"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "structuredContent": {
+          "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
+        }
+      },
+      "required": [
+        "content",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CallToolResultResponse": {
+      "description": "A successful response from the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/CallToolResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "CancelledNotification": {
+      "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/cancelled",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CancelledNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CancelledNotificationParams": {
+      "description": "Parameters for a `notifications/cancelled` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "reason": {
+          "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+          "type": "string"
+        },
+        "requestId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+        }
+      },
+      "type": "object"
+    },
+    "ClientCapabilities": {
+      "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+      "properties": {
+        "elicitation": {
+          "description": "Present if the client supports elicitation from the server.",
+          "properties": {
+            "form": {
+              "$ref": "#/$defs/JSONObject"
+            },
+            "url": {
+              "$ref": "#/$defs/JSONObject"
+            }
+          },
+          "type": "object"
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the client supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.",
+          "type": "object"
+        },
+        "roots": {
+          "description": "Present if the client supports listing roots.",
+          "properties": {},
+          "type": "object"
+        },
+        "sampling": {
+          "description": "Present if the client supports sampling from an LLM.",
+          "properties": {
+            "context": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
+            },
+            "tools": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ClientNotification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CancelledNotification"
+        },
+        {
+          "$ref": "#/$defs/ProgressNotification"
+        }
+      ]
+    },
+    "ClientRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DiscoverRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesRequest"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceRequest"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsListenRequest"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsRequest"
+        },
+        {
+          "$ref": "#/$defs/GetPromptRequest"
+        },
+        {
+          "$ref": "#/$defs/ListToolsRequest"
+        },
+        {
+          "$ref": "#/$defs/CallToolRequest"
+        },
+        {
+          "$ref": "#/$defs/CompleteRequest"
+        }
+      ]
+    },
+    "ClientResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "CompleteRequest": {
+      "description": "A request from the client to the server, to ask for completion options.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "completion/complete",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CompleteRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CompleteRequestParams": {
+      "description": "Parameters for a `completion/complete` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "argument": {
+          "description": "The argument's information",
+          "properties": {
+            "name": {
+              "description": "The name of the argument",
+              "type": "string"
+            },
+            "value": {
+              "description": "The value of the argument to use for completion matching.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "value"
+          ],
+          "type": "object"
+        },
+        "context": {
+          "description": "Additional, optional context for completions",
+          "properties": {
+            "arguments": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Previously-resolved variables in a URI template or prompt.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptReference"
+            },
+            {
+              "$ref": "#/$defs/ResourceTemplateReference"
+            }
+          ]
+        }
+      },
+      "required": [
+        "_meta",
+        "argument",
+        "ref"
+      ],
+      "type": "object"
+    },
+    "CompleteResult": {
+      "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "completion": {
+          "properties": {
+            "hasMore": {
+              "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+              "type": "boolean"
+            },
+            "total": {
+              "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+              "type": "integer"
+            },
+            "values": {
+              "description": "An array of completion values. Must not exceed 100 items.",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100,
+              "type": "array"
+            }
+          },
+          "required": [
+            "values"
+          ],
+          "type": "object"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "completion",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CompleteResultResponse": {
+      "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ResourceLink"
+        },
+        {
+          "$ref": "#/$defs/EmbeddedResource"
+        }
+      ]
+    },
+    "CreateMessageRequest": {
+      "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+      "properties": {
+        "method": {
+          "const": "sampling/createMessage",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CreateMessageRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CreateMessageRequestParams": {
+      "description": "Parameters for a `sampling/createMessage` request.",
+      "properties": {
+        "includeContext": {
+          "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. Values `\"thisServer\"` and `\"allServers\"` are soft-deprecated. Servers SHOULD only use these values if the client\ndeclares {@link ClientCapabilities.sampling.context}. These values may be removed in future spec releases.",
+          "enum": [
+            "allServers",
+            "none",
+            "thisServer"
+          ],
+          "type": "string"
+        },
+        "maxTokens": {
+          "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+          "type": "integer"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/SamplingMessage"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+        },
+        "modelPreferences": {
+          "$ref": "#/$defs/ModelPreferences",
+          "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+        },
+        "stopSequences": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "systemPrompt": {
+          "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+          "type": "string"
+        },
+        "temperature": {
+          "type": "number"
+        },
+        "toolChoice": {
+          "$ref": "#/$defs/ToolChoice",
+          "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+        },
+        "tools": {
+          "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "maxTokens",
+        "messages"
+      ],
+      "type": "object"
+    },
+    "CreateMessageResult": {
+      "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "model": {
+          "description": "The name of the model that generated the message.",
+          "type": "string"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        },
+        "stopReason": {
+          "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "model",
+        "role"
+      ],
+      "type": "object"
+    },
+    "Cursor": {
+      "description": "An opaque token used to represent a cursor for pagination.",
+      "type": "string"
+    },
+    "DiscoverRequest": {
+      "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "server/discover",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "DiscoverResult": {
+      "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ServerCapabilities",
+          "description": "The capabilities of the server."
+        },
+        "instructions": {
+          "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "serverInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Information about the server software implementation."
+        },
+        "supportedVersions": {
+          "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "capabilities",
+        "resultType",
+        "serverInfo",
+        "supportedVersions"
+      ],
+      "type": "object"
+    },
+    "DiscoverResultResponse": {
+      "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/DiscoverResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ElicitRequest": {
+      "description": "A request from the server to elicit additional information from the user via the client.",
+      "properties": {
+        "method": {
+          "const": "elicitation/create",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ElicitRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestFormParams": {
+      "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user describing what information is being requested.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "form",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "requestedSchema": {
+          "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "properties": {
+              "additionalProperties": {
+                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "properties",
+            "type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "message",
+        "requestedSchema"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestParams": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ElicitRequestFormParams"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequestURLParams"
+        }
+      ],
+      "description": "The parameters for a request to elicit additional information from the user via the client."
+    },
+    "ElicitRequestURLParams": {
+      "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+      "properties": {
+        "elicitationId": {
+          "description": "The ID of the elicitation, which must be unique within the context of the server.\nThe client MUST treat this ID as an opaque value.",
+          "type": "string"
+        },
+        "message": {
+          "description": "The message to present to the user explaining why the interaction is needed.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "url",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL that the user should navigate to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "elicitationId",
+        "message",
+        "mode",
+        "url"
+      ],
+      "type": "object"
+    },
+    "ElicitResult": {
+      "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
+      "properties": {
+        "action": {
+          "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
+          "enum": [
+            "accept",
+            "cancel",
+            "decline"
+          ],
+          "type": "string"
+        },
+        "content": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": [
+                  "string",
+                  "integer",
+                  "boolean"
+                ]
+              }
+            ]
+          },
+          "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "ElicitationCompleteNotification": {
+      "description": "An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/elicitation/complete",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "elicitationId": {
+              "description": "The ID of the elicitation that completed.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "elicitationId"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "EmbeddedResource": {
+      "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "resource": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextResourceContents"
+            },
+            {
+              "$ref": "#/$defs/BlobResourceContents"
+            }
+          ]
+        },
+        "type": {
+          "const": "resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resource",
+        "type"
+      ],
+      "type": "object"
+    },
+    "EmptyResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "EnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ]
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequest": {
+      "description": "Used by the client to get a prompt provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/get",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/GetPromptRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequestParams": {
+      "description": "Parameters for a `prompts/get` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments to use for templating the prompt.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the prompt or prompt template.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "GetPromptResult": {
+      "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "description": {
+          "description": "An optional description for the prompt.",
+          "type": "string"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/PromptMessage"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "messages",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "GetPromptResultResponse": {
+      "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/GetPromptResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+          "format": "uri",
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "dark",
+            "light"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Icons": {
+      "description": "Base interface to add `icons` property.",
+      "properties": {
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ImageContent": {
+      "description": "An image provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded image data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the image. Different providers may support different image types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Implementation": {
+      "description": "Describes the MCP implementation.",
+      "properties": {
+        "description": {
+          "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of this implementation.",
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "An optional URL of the website for this implementation.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "type": "object"
+    },
+    "InputRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageRequest"
+        },
+        {
+          "$ref": "#/$defs/ListRootsRequest"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequest"
+        }
+      ]
+    },
+    "InputRequests": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputRequest"
+      },
+      "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
+      "type": "object"
+    },
+    "InputRequiredResult": {
+      "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "inputRequests": {
+          "$ref": "#/$defs/InputRequests"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "resultType": {
+          "const": "input_required",
+          "type": "string",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "inputRequests"
+          ]
+        },
+        {
+          "required": [
+            "requestState"
+          ]
+        }
+      ]
+    },
+    "InputResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageResult"
+        },
+        {
+          "$ref": "#/$defs/ListRootsResult"
+        },
+        {
+          "$ref": "#/$defs/ElicitResult"
+        }
+      ]
+    },
+    "InputResponseRequestParams": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "InputResponses": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputResponse"
+      },
+      "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
+      "type": "object"
+    },
+    "InternalError": {
+      "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
+      "properties": {
+        "code": {
+          "const": -32603,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidParamsError": {
+      "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
+      "properties": {
+        "code": {
+          "const": -32602,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidRequestError": {
+      "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
+      "properties": {
+        "code": {
+          "const": -32600,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "JSONArray": {
+      "items": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "array"
+    },
+    "JSONObject": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "object"
+    },
+    "JSONRPCErrorResponse": {
+      "description": "A response to a request that indicates an error occurred.",
+      "properties": {
+        "error": {
+          "$ref": "#/$defs/Error"
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "JSONRPCMessage": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCRequest"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCNotification"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
+    },
+    "JSONRPCNotification": {
+      "description": "A notification which does not expect a response.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCRequest": {
+      "description": "A request that expects a response.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "A response to a request, containing either the result or error."
+    },
+    "JSONRPCResultResponse": {
+      "description": "A successful (non-error) response to a request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/Result"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "JSONValue": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONObject"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JSONValue"
+          },
+          "type": "array"
+        },
+        {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    "LegacyTitledEnumSchema": {
+      "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enumNames": {
+          "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ListPromptsRequest": {
+      "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResult": {
+      "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "prompts": {
+          "items": {
+            "$ref": "#/$defs/Prompt"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "prompts",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResultResponse": {
+      "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListPromptsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesRequest": {
+      "description": "Sent from the client to request a list of resource templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/templates/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResult": {
+      "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resourceTemplates": {
+          "items": {
+            "$ref": "#/$defs/ResourceTemplate"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resourceTemplates",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourcesRequest": {
+      "description": "Sent from the client to request a list of resources the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResult": {
+      "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resources": {
+          "items": {
+            "$ref": "#/$defs/Resource"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resources",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourcesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListRootsRequest": {
+      "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+      "properties": {
+        "method": {
+          "const": "roots/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RequestParams"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "ListRootsResult": {
+      "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
+      "properties": {
+        "roots": {
+          "items": {
+            "$ref": "#/$defs/Root"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roots"
+      ],
+      "type": "object"
+    },
+    "ListToolsRequest": {
+      "description": "Sent from the client to request a list of tools the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListToolsResult": {
+      "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "tools": {
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "tools",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListToolsResultResponse": {
+      "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListToolsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "LoggingLevel": {
+      "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+      "enum": [
+        "alert",
+        "critical",
+        "debug",
+        "emergency",
+        "error",
+        "info",
+        "notice",
+        "warning"
+      ],
+      "type": "string"
+    },
+    "LoggingMessageNotification": {
+      "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/message",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoggingMessageNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "LoggingMessageNotificationParams": {
+      "description": "Parameters for a `notifications/message` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "data": {
+          "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+        },
+        "level": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The severity of this log message."
+        },
+        "logger": {
+          "description": "An optional name of the logger issuing this message.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "level"
+      ],
+      "type": "object"
+    },
+    "MetaObject": {
+      "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
+      "type": "object"
+    },
+    "MethodNotFoundError": {
+      "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, this error is returned when a request is made for a method that requires a capability that has not been declared. This can occur in either direction:\n\n- A server returning this error when the client requests a capability it doesn't support (e.g., requesting completions when the `completions` capability was not advertised)\n- A client returning this error when the server requests a capability it doesn't support (e.g., requesting roots when the client did not declare the `roots` capability)",
+      "properties": {
+        "code": {
+          "const": -32601,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "MissingRequiredClientCapabilityError": {
+      "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32003,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requiredCapabilities": {
+                      "$ref": "#/$defs/ClientCapabilities",
+                      "description": "The capabilities the server requires from the client to process this request."
+                    }
+                  },
+                  "required": [
+                    "requiredCapabilities"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "code",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "ModelHint": {
+      "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+      "properties": {
+        "name": {
+          "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ModelPreferences": {
+      "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+      "properties": {
+        "costPriority": {
+          "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "hints": {
+          "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+          "items": {
+            "$ref": "#/$defs/ModelHint"
+          },
+          "type": "array"
+        },
+        "intelligencePriority": {
+          "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "speedPriority": {
+          "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "MultiSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        }
+      ]
+    },
+    "Notification": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "NotificationParams": {
+      "description": "Common params for any notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        }
+      },
+      "type": "object"
+    },
+    "NumberSchema": {
+      "properties": {
+        "default": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "maximum": {
+          "type": "integer"
+        },
+        "minimum": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "integer",
+            "number"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequest": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequestParams": {
+      "description": "Common params for paginated requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "cursor": {
+          "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "PaginatedResult": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ParseError": {
+      "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
+      "properties": {
+        "code": {
+          "const": -32700,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "PrimitiveSchemaDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StringSchema"
+        },
+        {
+          "$ref": "#/$defs/NumberSchema"
+        },
+        {
+          "$ref": "#/$defs/BooleanSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ],
+      "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+    },
+    "ProgressNotification": {
+      "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/progress",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ProgressNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ProgressNotificationParams": {
+      "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "message": {
+          "description": "An optional message describing the current progress.",
+          "type": "string"
+        },
+        "progress": {
+          "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+          "type": "number"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+        },
+        "total": {
+          "description": "Total number of items to process (or total progress required), if known.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "progress",
+        "progressToken"
+      ],
+      "type": "object"
+    },
+    "ProgressToken": {
+      "description": "A progress token, used to associate progress notifications with the original request.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "Prompt": {
+      "description": "A prompt or prompt template that the server offers.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "arguments": {
+          "description": "A list of arguments to use for templating the prompt.",
+          "items": {
+            "$ref": "#/$defs/PromptArgument"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "An optional description of what this prompt provides",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptArgument": {
+      "description": "Describes an argument that a prompt can accept.",
+      "properties": {
+        "description": {
+          "description": "A human-readable description of the argument.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether this argument must be provided.",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/prompts/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "PromptMessage": {
+      "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
+      "properties": {
+        "content": {
+          "$ref": "#/$defs/ContentBlock"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "PromptReference": {
+      "description": "Identifies a prompt.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "ref/prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequest": {
+      "description": "Sent from the client to the server, to read a specific resource URI.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/read",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ReadResourceRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequestParams": {
+      "description": "Parameters for a `resources/read` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResult": {
+      "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "contents": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TextResourceContents"
+              },
+              {
+                "$ref": "#/$defs/BlobResourceContents"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "contents",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResultResponse": {
+      "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/ReadResourceResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "Request": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "RequestId": {
+      "description": "A uniquely identifying ID for a request in JSON-RPC.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "RequestMetaObject": {
+      "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/clientCapabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Identifies the client software making the request. Required.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional."
+        },
+        "io.modelcontextprotocol/logLevel": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
+        },
+        "io.modelcontextprotocol/protocolVersion": {
+          "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
+          "type": "string",
+          "const": "DRAFT-2026-v1"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+        }
+      },
+      "required": [
+        "io.modelcontextprotocol/clientCapabilities",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/protocolVersion"
+      ],
+      "type": "object"
+    },
+    "RequestParams": {
+      "description": "Common params for any request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "Resource": {
+      "description": "A known resource that the server is capable of reading.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceContents": {
+      "description": "The contents of a specific resource or sub-resource.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceLink": {
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "resource_link",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ResourceRequestParams": {
+      "description": "Common params for resource-related requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplate": {
+      "description": "A template description for resources available on the server.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uriTemplate": {
+          "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uriTemplate"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplateReference": {
+      "description": "A reference to a resource or resource template definition.",
+      "properties": {
+        "type": {
+          "const": "ref/resource",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI or URI template of the resource.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotification": {
+      "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/updated",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotificationParams": {
+      "description": "Parameters for a `notifications/resources/updated` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "Result": {
+      "additionalProperties": {},
+      "description": "Common result fields.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "resultType": {
+          "$ref": "#/$defs/ResultType",
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`."
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ResultType": {
+      "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
+      "enum": [
+        "complete",
+        "input_required"
+      ],
+      "type": "string"
+    },
+    "Role": {
+      "description": "The sender or recipient of messages and data in a conversation.",
+      "enum": [
+        "assistant",
+        "user"
+      ],
+      "type": "string"
+    },
+    "Root": {
+      "description": "Represents a root directory or file that the server can operate on.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "name": {
+          "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "SamplingMessage": {
+      "description": "Describes a message issued to or received from an LLM API.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "SamplingMessageContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ToolUseContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultContent"
+        }
+      ]
+    },
+    "ServerCapabilities": {
+      "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+      "properties": {
+        "completions": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports argument autocompletion suggestions."
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the server supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/apps\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.",
+          "type": "object"
+        },
+        "logging": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports sending log messages to the client."
+        },
+        "prompts": {
+          "description": "Present if the server offers any prompt templates.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the prompt list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "description": "Present if the server offers any resources to read.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the resource list.",
+              "type": "boolean"
+            },
+            "subscribe": {
+              "description": "Whether this server supports subscribing to resource updates.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "tools": {
+          "description": "Present if the server offers any tools to call.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the tool list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ServerNotification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CancelledNotification"
+        },
+        {
+          "$ref": "#/$defs/ProgressNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceUpdatedNotification"
+        },
+        {
+          "$ref": "#/$defs/PromptListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/ToolListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/LoggingMessageNotification"
+        },
+        {
+          "$ref": "#/$defs/ElicitationCompleteNotification"
+        }
+      ]
+    },
+    "ServerResult": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Result"
+        },
+        {
+          "$ref": "#/$defs/InputRequiredResult"
+        },
+        {
+          "$ref": "#/$defs/DiscoverResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceResult"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsResult"
+        },
+        {
+          "$ref": "#/$defs/GetPromptResult"
+        },
+        {
+          "$ref": "#/$defs/ListToolsResult"
+        },
+        {
+          "$ref": "#/$defs/CallToolResult"
+        },
+        {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      ]
+    },
+    "SingleSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        }
+      ]
+    },
+    "StringSchema": {
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "date",
+            "date-time",
+            "email",
+            "uri"
+          ],
+          "type": "string"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "SubscriptionFilter": {
+      "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
+      "properties": {
+        "promptsListChanged": {
+          "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
+          "type": "boolean"
+        },
+        "resourceSubscriptions": {
+          "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourcesListChanged": {
+          "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
+          "type": "boolean"
+        },
+        "toolsListChanged": {
+          "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotification": {
+      "description": "Sent by the server as the first message on a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream to acknowledge\nthat the subscription has been established and to report which notification\ntypes it agreed to honor.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/subscriptions/acknowledged",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotificationParams": {
+      "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
+        }
+      },
+      "required": [
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequest": {
+      "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "subscriptions/listen",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsListenRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequestParams": {
+      "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
+        }
+      },
+      "required": [
+        "_meta",
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "TextContent": {
+      "description": "Text provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "text": {
+          "description": "The text content of the message.",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "text": {
+          "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for array items with enum options and display labels.",
+          "properties": {
+            "anyOf": {
+              "description": "Array of enum options with values and display labels.",
+              "items": {
+                "properties": {
+                  "const": {
+                    "description": "The constant enum value.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Display title for this option.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "const",
+                  "title"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "anyOf"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "oneOf": {
+          "description": "Array of enum options with values and display labels.",
+          "items": {
+            "properties": {
+              "const": {
+                "description": "The enum value.",
+                "type": "string"
+              },
+              "title": {
+                "description": "Display label for this option.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "const",
+              "title"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "oneOf",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Tool": {
+      "description": "Definition for a tool the client can call.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/ToolAnnotations",
+          "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
+        },
+        "description": {
+          "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "inputSchema": {
+          "additionalProperties": {},
+          "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "outputSchema": {
+          "additionalProperties": {},
+          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "inputSchema",
+        "name"
+      ],
+      "type": "object"
+    },
+    "ToolAnnotations": {
+      "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
+      "properties": {
+        "destructiveHint": {
+          "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+          "type": "boolean"
+        },
+        "idempotentHint": {
+          "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+          "type": "boolean"
+        },
+        "openWorldHint": {
+          "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+          "type": "boolean"
+        },
+        "readOnlyHint": {
+          "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "A human-readable title for the tool.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolChoice": {
+      "description": "Controls tool selection behavior for sampling requests.",
+      "properties": {
+        "mode": {
+          "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+          "enum": [
+            "auto",
+            "none",
+            "required"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/tools/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ToolResultContent": {
+      "description": "The result of a tool use, provided by the user back to the assistant.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
+        },
+        "content": {
+          "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+          "type": "boolean"
+        },
+        "structuredContent": {
+          "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
+        },
+        "toolUseId": {
+          "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_result",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "toolUseId",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ToolUseContent": {
+      "description": "A request from the assistant to call a tool.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+        },
+        "id": {
+          "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+          "type": "string"
+        },
+        "input": {
+          "additionalProperties": {},
+          "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The name of the tool to call.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_use",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "input",
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UnsupportedProtocolVersionError": {
+      "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32004,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requested": {
+                      "description": "The protocol version that was requested by the client.",
+                      "type": "string"
+                    },
+                    "supported": {
+                      "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "requested",
+                    "supported"
+                  ],
+                  "type": "object"
+                },
+                "message": {
+                  "const": "Unsupported protocol version",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "code",
+                "data",
+                "message"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for the array items.",
+          "properties": {
+            "enum": {
+              "description": "Array of enum values to choose from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "enum": {
+          "description": "Array of enum values to choose from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    },
+    "MCPHttpHeaders": {
+      "description": "Standard MCP Streamable HTTP headers for the DRAFT-2026-v1 profile. Mcp-Name is required when the routed method targets a named tool, prompt, or resource.",
+      "type": "object",
+      "required": [
+        "MCP-Protocol-Version",
+        "Mcp-Method"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "MCP-Protocol-Version": {
+          "const": "DRAFT-2026-v1",
+          "type": "string"
+        },
+        "Mcp-Method": {
+          "enum": [
+            "server/discover",
+            "tools/list",
+            "tools/call",
+            "resources/list",
+            "resources/read",
+            "resources/templates/list",
+            "prompts/list",
+            "prompts/get",
+            "completion/complete"
+          ],
+          "type": "string"
+        },
+        "Mcp-Name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the opt-in MCP `DRAFT-2026-v1` schema profile beside the stable `2025-11-25` profile
- generate shared MCP RC helpers across TypeScript, Swift, Python, and Go bindings plus round-trip fixtures
- document RC opt-in behavior and add a Burin vendored Swift/TS drift check

Closes #2183

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `CARGO_TARGET_DIR=/tmp/harn-target-2183 CARGO_BUILD_JOBS=4 make check-protocol-artifacts`
- `make check-bindings`
- `python3 -m py_compile scripts/check_burin_protocol_bindings.py scripts/check_protocol_bindings.py`
- `CARGO_TARGET_DIR=/tmp/harn-target-2183 CARGO_BUILD_JOBS=4 cargo test -p harn-cli dump_protocol_artifacts --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2183 CARGO_BUILD_JOBS=4 HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- test protocols`
- pre-commit hook: full workspace clippy, markdownlint, CI ratchets
- pre-push hook: targeted local checks, markdownlint

## Notes
- `python3 scripts/check_burin_protocol_bindings.py --burin-root /Users/ksinder/projects/burin-code --required` currently reports the expected Burin vendored Swift/TS drift until Burin vendors this Harn artifact set.
