### PR TITLE
[codex] Harden schema traversal limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ condensed series summaries instead of full per-patch history.
 
 ### Changed
 
+- **Schema traversal hardening (#2202).** Runtime schema canonicalization,
+  JSON Schema/OpenAPI export, validation, runtime parameter assertions,
+  sub-agent return-schema validation, and JSON-stream schema setup now share
+  explicit traversal limits: 128 nested schema nodes and 256 local `$ref`
+  expansions. Cyclic local references such as `$ref: "#"` now fail
+  deterministically with a Harn-level schema error instead of relying on Rust
+  stack depth.
 - **Bridge inject mode `wait_for_completion` renamed to `audit_only`
   (#2212).** The previous name was a footgun: reminders queued with this
   mode drain at `loop_exit` and land in the transcript audit, but the

--- a/conformance/tests/types/schema_limits.expected
+++ b/conformance/tests/types/schema_limits.expected
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/conformance/tests/types/schema_limits.harn
+++ b/conformance/tests/types/schema_limits.harn
@@ -1,0 +1,13 @@
+pipeline test(task) {
+  let self_ref = {"$ref": "#"}
+  let from_json = try {
+    schema_from_json_schema(self_ref)
+  }
+  __io_println(is_err(from_json))
+  __io_println(contains(to_string(unwrap_err(from_json)), "cyclic schema reference"))
+  let checked = schema_check("ok", self_ref)
+  __io_println(is_err(checked))
+  __io_println(contains(unwrap_err(checked).message, "cyclic schema reference"))
+  let normal = {type: "dict", properties: {node: {type: "string"}}}
+  __io_println(schema_is({node: "ok"}, normal))
+}

--- a/crates/harn-vm/src/schema/api.rs
+++ b/crates/harn-vm/src/schema/api.rs
@@ -102,19 +102,17 @@ pub(crate) fn schema_assert_param(
 pub(crate) fn schema_to_json_schema_value(schema: &VmValue) -> Result<VmValue, VmError> {
     let normalized = canonicalize_schema_value(schema)
         .map_err(|error| VmError::Thrown(VmValue::String(Rc::from(error))))?;
-    Ok(super::json_to_vm_value(&canonical_to_json_schema(
-        &normalized,
-        false,
-    )))
+    let json_schema = canonical_to_json_schema(&normalized, false)
+        .map_err(|error| VmError::Thrown(VmValue::String(Rc::from(error))))?;
+    Ok(super::json_to_vm_value(&json_schema))
 }
 
 pub(crate) fn schema_to_openapi_schema_value(schema: &VmValue) -> Result<VmValue, VmError> {
     let normalized = canonicalize_schema_value(schema)
         .map_err(|error| VmError::Thrown(VmValue::String(Rc::from(error))))?;
-    Ok(super::json_to_vm_value(&canonical_to_json_schema(
-        &normalized,
-        true,
-    )))
+    let json_schema = canonical_to_json_schema(&normalized, true)
+        .map_err(|error| VmError::Thrown(VmValue::String(Rc::from(error))))?;
+    Ok(super::json_to_vm_value(&json_schema))
 }
 
 pub(crate) fn schema_from_json_schema_value(schema: &VmValue) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/schema/canonicalize.rs
+++ b/crates/harn-vm/src/schema/canonicalize.rs
@@ -1,23 +1,29 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::rc::Rc;
 
 use crate::value::VmValue;
 
+use super::limits::{with_schema_depth, SchemaTraversal};
 use super::type_check::schema_type_name;
 use super::{schema_bool, schema_i64, schema_number, vm_value_to_serde_json};
 
-pub(super) fn resolve_canonical_ref(
+pub(super) fn resolve_canonical_ref_with_path(
     root_schema: &BTreeMap<String, VmValue>,
     pointer: &str,
-) -> Option<BTreeMap<String, VmValue>> {
+) -> Option<(String, BTreeMap<String, VmValue>)> {
+    if !pointer.starts_with('#') {
+        return None;
+    }
     let stripped = pointer.trim_start_matches('#').trim_start_matches('/');
     if stripped.is_empty() {
-        return Some(root_schema.clone());
+        return Some(("#".to_string(), root_schema.clone()));
     }
 
     let mut current = VmValue::Dict(Rc::new(root_schema.clone()));
+    let mut normalized_segments = Vec::new();
     for segment in stripped.split('/') {
         let decoded = segment.replace("~1", "/").replace("~0", "~");
+        normalized_segments.push(encode_json_pointer_segment(&decoded));
         current = match current {
             VmValue::Dict(ref map) => map.get(&decoded)?.clone(),
             VmValue::List(ref list) => {
@@ -27,20 +33,46 @@ pub(super) fn resolve_canonical_ref(
             _ => return None,
         };
     }
-    current.as_dict().cloned()
+    current
+        .as_dict()
+        .cloned()
+        .map(|schema| (format!("#/{}", normalized_segments.join("/")), schema))
+}
+
+fn encode_json_pointer_segment(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
 }
 
 pub(super) fn canonicalize_schema_value(schema: &VmValue) -> Result<VmValue, String> {
-    let schema_dict = schema
-        .as_dict()
-        .ok_or_else(|| "schema must be a dict".to_string())?;
-    Ok(VmValue::Dict(Rc::new(canonicalize_schema_dict(
-        schema_dict,
-    )?)))
+    let mut traversal = SchemaTraversal::new();
+    let normalized = canonicalize_schema_value_with(schema, &mut traversal)?;
+    if traversal.saw_ref() {
+        let root = normalized
+            .as_dict()
+            .ok_or_else(|| "schema must be a dict".to_string())?;
+        validate_canonical_ref_graph(root)?;
+    }
+    Ok(normalized)
+}
+
+fn canonicalize_schema_value_with(
+    schema: &VmValue,
+    traversal: &mut SchemaTraversal,
+) -> Result<VmValue, String> {
+    with_schema_depth(traversal, |traversal| {
+        let schema_dict = schema
+            .as_dict()
+            .ok_or_else(|| "schema must be a dict".to_string())?;
+        Ok(VmValue::Dict(Rc::new(canonicalize_schema_dict(
+            schema_dict,
+            traversal,
+        )?)))
+    })
 }
 
 fn canonicalize_schema_dict(
     schema: &BTreeMap<String, VmValue>,
+    traversal: &mut SchemaTraversal,
 ) -> Result<BTreeMap<String, VmValue>, String> {
     let mut out = BTreeMap::new();
 
@@ -61,19 +93,26 @@ fn canonicalize_schema_dict(
     }
 
     if let Some(reference) = schema.get("$ref") {
+        traversal.mark_ref();
         out.insert("$ref".to_string(), reference.clone());
     }
 
     if let Some(properties) = schema.get("properties").and_then(VmValue::as_dict) {
         let mut next = BTreeMap::new();
         for (key, value) in properties {
-            next.insert(key.clone(), canonicalize_schema_value(value)?);
+            next.insert(
+                key.clone(),
+                canonicalize_schema_value_with(value, traversal)?,
+            );
         }
         out.insert("properties".to_string(), VmValue::Dict(Rc::new(next)));
     }
 
     if let Some(items) = schema.get("items") {
-        out.insert("items".to_string(), canonicalize_schema_value(items)?);
+        out.insert(
+            "items".to_string(),
+            canonicalize_schema_value_with(items, traversal)?,
+        );
     }
 
     if let Some(additional) = schema
@@ -87,7 +126,7 @@ fn canonicalize_schema_dict(
             VmValue::Dict(_) => {
                 out.insert(
                     "additional_properties".to_string(),
-                    canonicalize_schema_value(additional)?,
+                    canonicalize_schema_value_with(additional, traversal)?,
                 );
             }
             _ => {}
@@ -137,7 +176,7 @@ fn canonicalize_schema_dict(
     if let Some(definitions) = schema.get("definitions").and_then(VmValue::as_dict) {
         out.insert(
             "definitions".to_string(),
-            VmValue::Dict(Rc::new(canonicalize_schema_map(definitions)?)),
+            VmValue::Dict(Rc::new(canonicalize_schema_map(definitions, traversal)?)),
         );
     }
 
@@ -146,7 +185,7 @@ fn canonicalize_schema_dict(
         if let Some(schemas) = components.get("schemas").and_then(VmValue::as_dict) {
             next_components.insert(
                 "schemas".to_string(),
-                VmValue::Dict(Rc::new(canonicalize_schema_map(schemas)?)),
+                VmValue::Dict(Rc::new(canonicalize_schema_map(schemas, traversal)?)),
             );
         }
         out.insert(
@@ -160,11 +199,17 @@ fn canonicalize_schema_dict(
         .or_else(|| schema.get("oneOf"))
         .or_else(|| schema.get("anyOf"))
     {
-        out.insert("union".to_string(), canonicalize_schema_list(union)?);
+        out.insert(
+            "union".to_string(),
+            canonicalize_schema_list(union, traversal)?,
+        );
     }
 
     if let Some(all_of) = schema.get("all_of").or_else(|| schema.get("allOf")) {
-        out.insert("all_of".to_string(), canonicalize_schema_list(all_of)?);
+        out.insert(
+            "all_of".to_string(),
+            canonicalize_schema_list(all_of, traversal)?,
+        );
     }
 
     match schema.get("type") {
@@ -208,24 +253,198 @@ fn canonicalize_schema_dict(
 
 fn canonicalize_schema_map(
     source: &BTreeMap<String, VmValue>,
+    traversal: &mut SchemaTraversal,
 ) -> Result<BTreeMap<String, VmValue>, String> {
     let mut next = BTreeMap::new();
     for (key, value) in source {
-        next.insert(key.clone(), canonicalize_schema_value(value)?);
+        next.insert(
+            key.clone(),
+            canonicalize_schema_value_with(value, traversal)?,
+        );
     }
     Ok(next)
 }
 
-fn canonicalize_schema_list(value: &VmValue) -> Result<VmValue, String> {
+fn canonicalize_schema_list(
+    value: &VmValue,
+    traversal: &mut SchemaTraversal,
+) -> Result<VmValue, String> {
     let list = match value {
         VmValue::List(list) => list,
         _ => return Err("schema union/all_of must be a list".to_string()),
     };
     Ok(VmValue::List(Rc::new(
         list.iter()
-            .map(canonicalize_schema_value)
+            .map(|value| canonicalize_schema_value_with(value, traversal))
             .collect::<Result<Vec<_>, _>>()?,
     )))
+}
+
+fn validate_canonical_ref_graph(root_schema: &BTreeMap<String, VmValue>) -> Result<(), String> {
+    let mut traversal = SchemaTraversal::new();
+    let mut stack = Vec::new();
+    let mut checked = BTreeSet::new();
+    validate_ref_graph_dict(
+        root_schema,
+        root_schema,
+        "#",
+        &mut traversal,
+        &mut stack,
+        &mut checked,
+    )
+}
+
+fn validate_ref_graph_dict(
+    schema: &BTreeMap<String, VmValue>,
+    root_schema: &BTreeMap<String, VmValue>,
+    pointer: &str,
+    traversal: &mut SchemaTraversal,
+    stack: &mut Vec<String>,
+    checked: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    if checked.contains(pointer) {
+        return Ok(());
+    }
+    if let Some(index) = stack.iter().position(|entry| entry == pointer) {
+        let mut cycle = stack[index..].to_vec();
+        cycle.push(pointer.to_string());
+        return Err(format!("cyclic schema reference: {}", cycle.join(" -> ")));
+    }
+
+    with_schema_depth(traversal, |traversal| {
+        stack.push(pointer.to_string());
+
+        let result =
+            validate_ref_graph_dict_inner(schema, root_schema, pointer, traversal, stack, checked);
+
+        stack.pop();
+        if result.is_ok() {
+            checked.insert(pointer.to_string());
+        }
+        result
+    })
+}
+
+fn validate_ref_graph_dict_inner(
+    schema: &BTreeMap<String, VmValue>,
+    root_schema: &BTreeMap<String, VmValue>,
+    pointer: &str,
+    traversal: &mut SchemaTraversal,
+    stack: &mut Vec<String>,
+    checked: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    if let Some(VmValue::String(reference)) = schema.get("$ref") {
+        traversal.expand_ref()?;
+        if let Some((target_pointer, target_schema)) =
+            resolve_canonical_ref_with_path(root_schema, reference)
+        {
+            validate_ref_graph_dict(
+                &target_schema,
+                root_schema,
+                &target_pointer,
+                traversal,
+                stack,
+                checked,
+            )?;
+        }
+    }
+
+    if let Some(VmValue::Dict(properties)) = schema.get("properties") {
+        for (name, child) in properties.iter() {
+            validate_ref_graph_value(
+                child,
+                root_schema,
+                &format!("{pointer}/properties/{}", encode_json_pointer_segment(name)),
+                traversal,
+                stack,
+                checked,
+            )?;
+        }
+    }
+    if let Some(items) = schema.get("items") {
+        validate_ref_graph_value(
+            items,
+            root_schema,
+            &format!("{pointer}/items"),
+            traversal,
+            stack,
+            checked,
+        )?;
+    }
+    if let Some(extra) = schema.get("additional_properties") {
+        validate_ref_graph_value(
+            extra,
+            root_schema,
+            &format!("{pointer}/additional_properties"),
+            traversal,
+            stack,
+            checked,
+        )?;
+    }
+    for key in ["union", "all_of"] {
+        if let Some(VmValue::List(branches)) = schema.get(key) {
+            for (index, branch) in branches.iter().enumerate() {
+                validate_ref_graph_value(
+                    branch,
+                    root_schema,
+                    &format!("{pointer}/{key}/{index}"),
+                    traversal,
+                    stack,
+                    checked,
+                )?;
+            }
+        }
+    }
+    if let Some(VmValue::Dict(definitions)) = schema.get("definitions") {
+        for (name, child) in definitions.iter() {
+            validate_ref_graph_value(
+                child,
+                root_schema,
+                &format!(
+                    "{pointer}/definitions/{}",
+                    encode_json_pointer_segment(name)
+                ),
+                traversal,
+                stack,
+                checked,
+            )?;
+        }
+    }
+    if let Some(schemas) = schema
+        .get("components")
+        .and_then(VmValue::as_dict)
+        .and_then(|components| components.get("schemas"))
+        .and_then(VmValue::as_dict)
+    {
+        for (name, child) in schemas.iter() {
+            validate_ref_graph_value(
+                child,
+                root_schema,
+                &format!(
+                    "{pointer}/components/schemas/{}",
+                    encode_json_pointer_segment(name)
+                ),
+                traversal,
+                stack,
+                checked,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_ref_graph_value(
+    value: &VmValue,
+    root_schema: &BTreeMap<String, VmValue>,
+    pointer: &str,
+    traversal: &mut SchemaTraversal,
+    stack: &mut Vec<String>,
+    checked: &mut BTreeSet<String>,
+) -> Result<(), String> {
+    let Some(schema) = value.as_dict() else {
+        return Ok(());
+    };
+    validate_ref_graph_dict(schema, root_schema, pointer, traversal, stack, checked)
 }
 
 fn normalize_string_list(value: &VmValue) -> VmValue {
@@ -252,219 +471,243 @@ fn normalize_type_name(type_name: &str) -> String {
     }
 }
 
-pub(super) fn canonical_to_json_schema(schema: &VmValue, openapi_style: bool) -> serde_json::Value {
-    let schema_dict = match schema.as_dict() {
-        Some(dict) => dict,
-        None => return serde_json::json!({}),
-    };
-    let mut out = serde_json::Map::new();
+pub(super) fn canonical_to_json_schema(
+    schema: &VmValue,
+    openapi_style: bool,
+) -> Result<serde_json::Value, String> {
+    let mut traversal = SchemaTraversal::new();
+    canonical_to_json_schema_with(schema, openapi_style, &mut traversal)
+}
 
-    if let Some(reference) = schema_dict.get("$ref").and_then(|value| match value {
-        VmValue::String(value) => Some(value.to_string()),
-        _ => None,
-    }) {
-        out.insert("$ref".to_string(), serde_json::Value::String(reference));
-    }
-
-    if let Some(type_name) = schema_type_name(schema_dict) {
-        match type_name {
-            "set" => {
-                out.insert(
-                    "type".to_string(),
-                    serde_json::Value::String("array".into()),
-                );
-                out.insert("uniqueItems".to_string(), serde_json::Value::Bool(true));
-            }
-            "closure" => {
-                out.insert(
-                    "type".to_string(),
-                    serde_json::Value::String("string".into()),
-                );
-                out.insert(
-                    "x-harn-type".to_string(),
-                    serde_json::Value::String("closure".into()),
-                );
-            }
-            "builtin" => {
-                out.insert(
-                    "type".to_string(),
-                    serde_json::Value::String("string".into()),
-                );
-                out.insert(
-                    "x-harn-type".to_string(),
-                    serde_json::Value::String("builtin".into()),
-                );
-            }
-            other => {
-                out.insert("type".to_string(), json_type_for_harn(other));
-            }
-        }
-    }
-
-    if let Some(min) = schema_number(schema_dict, "min") {
-        out.insert("minimum".to_string(), serde_json::json!(min));
-    }
-    if let Some(max) = schema_number(schema_dict, "max") {
-        out.insert("maximum".to_string(), serde_json::json!(max));
-    }
-    if let Some(min_length) = schema_i64(schema_dict, "min_length") {
-        out.insert("minLength".to_string(), serde_json::json!(min_length));
-    }
-    if let Some(max_length) = schema_i64(schema_dict, "max_length") {
-        out.insert("maxLength".to_string(), serde_json::json!(max_length));
-    }
-    if let Some(min_items) = schema_i64(schema_dict, "min_items") {
-        out.insert("minItems".to_string(), serde_json::json!(min_items));
-    }
-    if let Some(max_items) = schema_i64(schema_dict, "max_items") {
-        out.insert("maxItems".to_string(), serde_json::json!(max_items));
-    }
-    if let Some(VmValue::String(pattern)) = schema_dict.get("pattern") {
-        out.insert(
-            "pattern".to_string(),
-            serde_json::Value::String(pattern.to_string()),
-        );
-    }
-    if let Some(default) = schema_dict.get("default") {
-        out.insert("default".to_string(), vm_value_to_serde_json(default));
-    }
-    if let Some(const_value) = schema_dict.get("const") {
-        out.insert("const".to_string(), vm_value_to_serde_json(const_value));
-    }
-    if let Some(VmValue::List(enum_values)) = schema_dict.get("enum") {
-        out.insert(
-            "enum".to_string(),
-            serde_json::Value::Array(enum_values.iter().map(vm_value_to_serde_json).collect()),
-        );
-    }
-    if let Some(VmValue::Dict(item_schema)) = schema_dict.get("items") {
-        out.insert(
-            "items".to_string(),
-            canonical_to_json_schema(&VmValue::Dict(item_schema.clone()), openapi_style),
-        );
-    }
-    if let Some(VmValue::Dict(properties)) = schema_dict.get("properties") {
-        let mut props = serde_json::Map::new();
-        for (name, child) in properties.iter() {
-            props.insert(name.clone(), canonical_to_json_schema(child, openapi_style));
-        }
-        out.insert("properties".to_string(), serde_json::Value::Object(props));
-    }
-    if let Some(VmValue::List(required)) = schema_dict.get("required") {
-        out.insert(
-            "required".to_string(),
-            serde_json::Value::Array(
-                required
-                    .iter()
-                    .map(|value| serde_json::Value::String(value.display()))
-                    .collect(),
-            ),
-        );
-    }
-    if let Some(extra) = schema_dict.get("additional_properties") {
-        let exported = match extra {
-            VmValue::Bool(value) => serde_json::Value::Bool(*value),
-            VmValue::Dict(_) => canonical_to_json_schema(extra, openapi_style),
-            _ => serde_json::Value::Bool(true),
+fn canonical_to_json_schema_with(
+    schema: &VmValue,
+    openapi_style: bool,
+    traversal: &mut SchemaTraversal,
+) -> Result<serde_json::Value, String> {
+    with_schema_depth(traversal, |traversal| {
+        let schema_dict = match schema.as_dict() {
+            Some(dict) => dict,
+            None => return Ok(serde_json::json!({})),
         };
-        out.insert("additionalProperties".to_string(), exported);
-    }
-    if let Some(VmValue::List(union_schemas)) = schema_dict.get("union") {
-        let mut branches = union_schemas
-            .iter()
-            .map(|value| canonical_to_json_schema(value, openapi_style))
-            .collect::<Vec<_>>();
-        if openapi_style && branches.len() == 2 {
-            let null_index = branches.iter().position(|value| value == "null");
-            if let Some(null_index) = null_index {
-                let other_index = if null_index == 0 { 1 } else { 0 };
-                if let Some(other_type) = branches[other_index].as_object_mut() {
-                    other_type.insert("nullable".to_string(), serde_json::Value::Bool(true));
-                    return serde_json::Value::Object(other_type.clone());
+        let mut out = serde_json::Map::new();
+
+        if let Some(reference) = schema_dict.get("$ref").and_then(|value| match value {
+            VmValue::String(value) => Some(value.to_string()),
+            _ => None,
+        }) {
+            out.insert("$ref".to_string(), serde_json::Value::String(reference));
+        }
+
+        if let Some(type_name) = schema_type_name(schema_dict) {
+            match type_name {
+                "set" => {
+                    out.insert(
+                        "type".to_string(),
+                        serde_json::Value::String("array".into()),
+                    );
+                    out.insert("uniqueItems".to_string(), serde_json::Value::Bool(true));
+                }
+                "closure" => {
+                    out.insert(
+                        "type".to_string(),
+                        serde_json::Value::String("string".into()),
+                    );
+                    out.insert(
+                        "x-harn-type".to_string(),
+                        serde_json::Value::String("closure".into()),
+                    );
+                }
+                "builtin" => {
+                    out.insert(
+                        "type".to_string(),
+                        serde_json::Value::String("string".into()),
+                    );
+                    out.insert(
+                        "x-harn-type".to_string(),
+                        serde_json::Value::String("builtin".into()),
+                    );
+                }
+                other => {
+                    out.insert("type".to_string(), json_type_for_harn(other));
                 }
             }
         }
-        out.insert("oneOf".to_string(), serde_json::Value::Array(branches));
-    }
-    if let Some(VmValue::List(all_of)) = schema_dict.get("all_of") {
-        out.insert(
-            "allOf".to_string(),
-            serde_json::Value::Array(
-                all_of
-                    .iter()
-                    .map(|value| canonical_to_json_schema(value, openapi_style))
-                    .collect(),
-            ),
-        );
-    }
 
-    if schema_bool(schema_dict, "nullable") {
-        if openapi_style {
-            out.insert("nullable".to_string(), serde_json::Value::Bool(true));
-        } else if let Some(existing) = out.remove("type") {
+        if let Some(min) = schema_number(schema_dict, "min") {
+            out.insert("minimum".to_string(), serde_json::json!(min));
+        }
+        if let Some(max) = schema_number(schema_dict, "max") {
+            out.insert("maximum".to_string(), serde_json::json!(max));
+        }
+        if let Some(min_length) = schema_i64(schema_dict, "min_length") {
+            out.insert("minLength".to_string(), serde_json::json!(min_length));
+        }
+        if let Some(max_length) = schema_i64(schema_dict, "max_length") {
+            out.insert("maxLength".to_string(), serde_json::json!(max_length));
+        }
+        if let Some(min_items) = schema_i64(schema_dict, "min_items") {
+            out.insert("minItems".to_string(), serde_json::json!(min_items));
+        }
+        if let Some(max_items) = schema_i64(schema_dict, "max_items") {
+            out.insert("maxItems".to_string(), serde_json::json!(max_items));
+        }
+        if let Some(VmValue::String(pattern)) = schema_dict.get("pattern") {
             out.insert(
-                "type".to_string(),
-                serde_json::Value::Array(vec![existing, serde_json::Value::String("null".into())]),
+                "pattern".to_string(),
+                serde_json::Value::String(pattern.to_string()),
             );
         }
-    }
-
-    if let Some(VmValue::Dict(definitions)) = schema_dict.get("definitions") {
-        out.insert(
-            "definitions".to_string(),
-            serde_json::Value::Object(
-                definitions
-                    .iter()
-                    .map(|(name, child)| {
-                        (name.clone(), canonical_to_json_schema(child, openapi_style))
-                    })
-                    .collect(),
-            ),
-        );
-    }
-    if let Some(VmValue::Dict(components)) = schema_dict.get("components") {
-        let mut next_components = serde_json::Map::new();
-        for (key, value) in components.iter() {
-            if key == "schemas" {
-                let schema_map = value.as_dict().cloned().unwrap_or_default();
-                next_components.insert(
-                    "schemas".to_string(),
-                    serde_json::Value::Object(
-                        schema_map
-                            .iter()
-                            .map(|(name, child)| {
-                                (name.clone(), canonical_to_json_schema(child, openapi_style))
-                            })
-                            .collect(),
-                    ),
+        if let Some(default) = schema_dict.get("default") {
+            out.insert("default".to_string(), vm_value_to_serde_json(default));
+        }
+        if let Some(const_value) = schema_dict.get("const") {
+            out.insert("const".to_string(), vm_value_to_serde_json(const_value));
+        }
+        if let Some(VmValue::List(enum_values)) = schema_dict.get("enum") {
+            out.insert(
+                "enum".to_string(),
+                serde_json::Value::Array(enum_values.iter().map(vm_value_to_serde_json).collect()),
+            );
+        }
+        if let Some(VmValue::Dict(item_schema)) = schema_dict.get("items") {
+            out.insert(
+                "items".to_string(),
+                canonical_to_json_schema_with(
+                    &VmValue::Dict(item_schema.clone()),
+                    openapi_style,
+                    traversal,
+                )?,
+            );
+        }
+        if let Some(VmValue::Dict(properties)) = schema_dict.get("properties") {
+            let mut props = serde_json::Map::new();
+            for (name, child) in properties.iter() {
+                props.insert(
+                    name.clone(),
+                    canonical_to_json_schema_with(child, openapi_style, traversal)?,
                 );
-            } else {
-                next_components.insert(key.clone(), vm_value_to_serde_json(value));
+            }
+            out.insert("properties".to_string(), serde_json::Value::Object(props));
+        }
+        if let Some(VmValue::List(required)) = schema_dict.get("required") {
+            out.insert(
+                "required".to_string(),
+                serde_json::Value::Array(
+                    required
+                        .iter()
+                        .map(|value| serde_json::Value::String(value.display()))
+                        .collect(),
+                ),
+            );
+        }
+        if let Some(extra) = schema_dict.get("additional_properties") {
+            let exported = match extra {
+                VmValue::Bool(value) => serde_json::Value::Bool(*value),
+                VmValue::Dict(_) => canonical_to_json_schema_with(extra, openapi_style, traversal)?,
+                _ => serde_json::Value::Bool(true),
+            };
+            out.insert("additionalProperties".to_string(), exported);
+        }
+        if let Some(VmValue::List(union_schemas)) = schema_dict.get("union") {
+            let mut branches = union_schemas
+                .iter()
+                .map(|value| canonical_to_json_schema_with(value, openapi_style, traversal))
+                .collect::<Result<Vec<_>, _>>()?;
+            if openapi_style && branches.len() == 2 {
+                let null_index = branches.iter().position(|value| value == "null");
+                if let Some(null_index) = null_index {
+                    let other_index = if null_index == 0 { 1 } else { 0 };
+                    if let Some(other_type) = branches[other_index].as_object_mut() {
+                        other_type.insert("nullable".to_string(), serde_json::Value::Bool(true));
+                        return Ok(serde_json::Value::Object(other_type.clone()));
+                    }
+                }
+            }
+            out.insert("oneOf".to_string(), serde_json::Value::Array(branches));
+        }
+        if let Some(VmValue::List(all_of)) = schema_dict.get("all_of") {
+            out.insert(
+                "allOf".to_string(),
+                serde_json::Value::Array(
+                    all_of
+                        .iter()
+                        .map(|value| canonical_to_json_schema_with(value, openapi_style, traversal))
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+            );
+        }
+
+        if schema_bool(schema_dict, "nullable") {
+            if openapi_style {
+                out.insert("nullable".to_string(), serde_json::Value::Bool(true));
+            } else if let Some(existing) = out.remove("type") {
+                out.insert(
+                    "type".to_string(),
+                    serde_json::Value::Array(vec![
+                        existing,
+                        serde_json::Value::String("null".into()),
+                    ]),
+                );
             }
         }
-        out.insert(
-            "components".to_string(),
-            serde_json::Value::Object(next_components),
-        );
-    }
 
-    for key in [
-        "title",
-        "description",
-        "format",
-        "deprecated",
-        "readOnly",
-        "writeOnly",
-        "example",
-        "examples",
-        "x-harn-type",
-    ] {
-        if let Some(value) = schema_dict.get(key) {
-            out.insert(key.to_string(), vm_value_to_serde_json(value));
+        if let Some(VmValue::Dict(definitions)) = schema_dict.get("definitions") {
+            let mut exported = serde_json::Map::new();
+            for (name, child) in definitions.iter() {
+                exported.insert(
+                    name.clone(),
+                    canonical_to_json_schema_with(child, openapi_style, traversal)?,
+                );
+            }
+            out.insert(
+                "definitions".to_string(),
+                serde_json::Value::Object(exported),
+            );
         }
-    }
+        if let Some(VmValue::Dict(components)) = schema_dict.get("components") {
+            let mut next_components = serde_json::Map::new();
+            for (key, value) in components.iter() {
+                if key == "schemas" {
+                    let schema_map = value.as_dict().cloned().unwrap_or_default();
+                    let mut exported_schemas = serde_json::Map::new();
+                    for (name, child) in schema_map.iter() {
+                        exported_schemas.insert(
+                            name.clone(),
+                            canonical_to_json_schema_with(child, openapi_style, traversal)?,
+                        );
+                    }
+                    next_components.insert(
+                        "schemas".to_string(),
+                        serde_json::Value::Object(exported_schemas),
+                    );
+                } else {
+                    next_components.insert(key.clone(), vm_value_to_serde_json(value));
+                }
+            }
+            out.insert(
+                "components".to_string(),
+                serde_json::Value::Object(next_components),
+            );
+        }
 
-    serde_json::Value::Object(out)
+        for key in [
+            "title",
+            "description",
+            "format",
+            "deprecated",
+            "readOnly",
+            "writeOnly",
+            "example",
+            "examples",
+            "x-harn-type",
+        ] {
+            if let Some(value) = schema_dict.get(key) {
+                out.insert(key.to_string(), vm_value_to_serde_json(value));
+            }
+        }
+
+        Ok(serde_json::Value::Object(out))
+    })
 }
 
 fn json_type_for_harn(type_name: &str) -> serde_json::Value {

--- a/crates/harn-vm/src/schema/limits.rs
+++ b/crates/harn-vm/src/schema/limits.rs
@@ -1,0 +1,77 @@
+pub(super) const DEFAULT_SCHEMA_MAX_DEPTH: usize = 128;
+pub(super) const DEFAULT_SCHEMA_MAX_REF_EXPANSIONS: usize = 256;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct SchemaLimits {
+    pub(super) max_depth: usize,
+    pub(super) max_ref_expansions: usize,
+}
+
+impl Default for SchemaLimits {
+    fn default() -> Self {
+        Self {
+            max_depth: DEFAULT_SCHEMA_MAX_DEPTH,
+            max_ref_expansions: DEFAULT_SCHEMA_MAX_REF_EXPANSIONS,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SchemaTraversal {
+    limits: SchemaLimits,
+    depth: usize,
+    ref_expansions: usize,
+    saw_ref: bool,
+}
+
+impl SchemaTraversal {
+    pub(super) fn new() -> Self {
+        Self {
+            limits: SchemaLimits::default(),
+            depth: 0,
+            ref_expansions: 0,
+            saw_ref: false,
+        }
+    }
+
+    pub(super) fn enter_schema(&mut self) -> Result<(), String> {
+        if self.depth >= self.limits.max_depth {
+            return Err(format!("schema depth exceeded ({})", self.limits.max_depth));
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    pub(super) fn exit_schema(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
+    }
+
+    pub(super) fn expand_ref(&mut self) -> Result<(), String> {
+        self.ref_expansions += 1;
+        if self.ref_expansions > self.limits.max_ref_expansions {
+            return Err(format!(
+                "schema $ref expansion limit exceeded ({})",
+                self.limits.max_ref_expansions
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn mark_ref(&mut self) {
+        self.saw_ref = true;
+    }
+
+    pub(super) fn saw_ref(&self) -> bool {
+        self.saw_ref
+    }
+}
+
+pub(super) fn with_schema_depth<T>(
+    traversal: &mut SchemaTraversal,
+    f: impl FnOnce(&mut SchemaTraversal) -> Result<T, String>,
+) -> Result<T, String> {
+    traversal.enter_schema()?;
+    let result = f(traversal);
+    traversal.exit_schema();
+    result
+}

--- a/crates/harn-vm/src/schema/mod.rs
+++ b/crates/harn-vm/src/schema/mod.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 
 mod api;
 mod canonicalize;
+mod limits;
 mod result;
 mod transform;
 mod type_check;

--- a/crates/harn-vm/src/schema/tests.rs
+++ b/crates/harn-vm/src/schema/tests.rs
@@ -4,8 +4,12 @@ use std::rc::Rc;
 use crate::value::VmValue;
 
 use super::canonicalize::canonicalize_schema_value;
+use super::limits::{DEFAULT_SCHEMA_MAX_DEPTH, DEFAULT_SCHEMA_MAX_REF_EXPANSIONS};
 use super::transform::{merge_schema_dicts, schema_partial_dict};
-use super::{schema_is_value, schema_result_value, schema_to_openapi_schema_value};
+use super::validate::{validate_schema_value, ValidationOptions};
+use super::{
+    schema_assert_param, schema_is_value, schema_result_value, schema_to_openapi_schema_value,
+};
 
 fn s(v: &str) -> VmValue {
     VmValue::String(Rc::from(v))
@@ -21,6 +25,51 @@ fn make_vm_dict(pairs: Vec<(&str, VmValue)>) -> VmValue {
 
 fn make_list(items: Vec<VmValue>) -> VmValue {
     VmValue::List(Rc::new(items))
+}
+
+fn assert_schema_error_contains(schema: &VmValue, expected: &str) {
+    match canonicalize_schema_value(schema) {
+        Ok(value) => panic!("expected schema error containing {expected:?}, got {value:?}"),
+        Err(error) => assert!(
+            error.contains(expected),
+            "expected schema error containing {expected:?}, got {error:?}"
+        ),
+    }
+}
+
+fn deep_properties_schema(depth: usize) -> VmValue {
+    let mut schema = make_vm_dict(vec![("type", s("string"))]);
+    for _ in 0..depth {
+        schema = make_vm_dict(vec![
+            ("type", s("dict")),
+            ("properties", make_vm_dict(vec![("node", schema)])),
+        ]);
+    }
+    schema
+}
+
+fn deep_items_schema(depth: usize) -> VmValue {
+    let mut schema = make_vm_dict(vec![("type", s("string"))]);
+    for _ in 0..depth {
+        schema = make_vm_dict(vec![("type", s("list")), ("items", schema)]);
+    }
+    schema
+}
+
+fn deep_node_value(depth: usize) -> VmValue {
+    let mut value = s("ok");
+    for _ in 0..depth {
+        value = make_vm_dict(vec![("node", value)]);
+    }
+    value
+}
+
+fn deep_list_value(depth: usize) -> VmValue {
+    let mut value = s("ok");
+    for _ in 0..depth {
+        value = make_list(vec![value]);
+    }
+    value
 }
 
 #[test]
@@ -46,6 +95,128 @@ fn normalize_json_schema_types() {
             .unwrap()
             .display(),
         "string"
+    );
+}
+
+#[test]
+fn direct_self_ref_schema_is_rejected() {
+    let schema = make_vm_dict(vec![("$ref", s("#"))]);
+    assert_schema_error_contains(&schema, "cyclic schema reference: # -> #");
+}
+
+#[test]
+fn two_node_ref_cycle_is_rejected() {
+    let schema = make_vm_dict(vec![(
+        "definitions",
+        make_vm_dict(vec![
+            ("A", make_vm_dict(vec![("$ref", s("#/definitions/B"))])),
+            ("B", make_vm_dict(vec![("$ref", s("#/definitions/A"))])),
+        ]),
+    )]);
+
+    assert_schema_error_contains(
+        &schema,
+        "cyclic schema reference: #/definitions/A -> #/definitions/B -> #/definitions/A",
+    );
+}
+
+#[test]
+fn deep_properties_schema_is_rejected_at_depth_limit() {
+    let schema = deep_properties_schema(DEFAULT_SCHEMA_MAX_DEPTH + 1);
+    assert_schema_error_contains(&schema, "schema depth exceeded (128)");
+}
+
+#[test]
+fn deep_items_schema_is_rejected_at_depth_limit() {
+    let schema = deep_items_schema(DEFAULT_SCHEMA_MAX_DEPTH + 1);
+    assert_schema_error_contains(&schema, "schema depth exceeded (128)");
+}
+
+#[test]
+fn many_refs_are_rejected_at_expansion_limit() {
+    let mut properties = BTreeMap::new();
+    for index in 0..=DEFAULT_SCHEMA_MAX_REF_EXPANSIONS {
+        properties.insert(
+            format!("p{index}"),
+            make_vm_dict(vec![("$ref", s("#/definitions/String"))]),
+        );
+    }
+
+    let schema = make_vm_dict(vec![
+        ("type", s("dict")),
+        ("properties", VmValue::Dict(Rc::new(properties))),
+        (
+            "definitions",
+            make_vm_dict(vec![("String", make_vm_dict(vec![("type", s("string"))]))]),
+        ),
+    ]);
+
+    assert_schema_error_contains(&schema, "schema $ref expansion limit exceeded (256)");
+}
+
+#[test]
+fn normal_nested_schema_within_limit_still_passes() {
+    let schema = deep_properties_schema(8);
+    let data = deep_node_value(8);
+    assert!(schema_is_value(&data, &schema).unwrap());
+}
+
+#[test]
+fn validation_depth_limit_returns_error_without_panicking() {
+    let schema = deep_items_schema(DEFAULT_SCHEMA_MAX_DEPTH + 1);
+    let data = deep_list_value(DEFAULT_SCHEMA_MAX_DEPTH + 1);
+    let result = validate_schema_value(
+        &data,
+        &schema,
+        ValidationOptions {
+            apply_defaults: false,
+            numeric_compat: false,
+        },
+    );
+
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|error| error.contains("schema depth exceeded (128)")),
+        "expected depth-limit error, got {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn validation_ref_cycle_returns_error_without_panicking() {
+    let schema = make_vm_dict(vec![("$ref", s("#"))]);
+    let result = validate_schema_value(
+        &s("ok"),
+        &schema,
+        ValidationOptions {
+            apply_defaults: false,
+            numeric_compat: false,
+        },
+    );
+
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|error| error.contains("cyclic schema reference: # -> #")),
+        "expected cyclic-ref error, got {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn runtime_param_schema_cycles_are_rejected() {
+    let schema = make_vm_dict(vec![("$ref", s("#"))]);
+    let error = schema_assert_param(&s("ok"), "payload", &schema)
+        .expect_err("cyclic parameter schema must be rejected");
+
+    assert!(
+        error
+            .to_string()
+            .contains("cyclic schema reference: # -> #"),
+        "expected cyclic-ref error, got {error:?}"
     );
 }
 

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -5,7 +5,8 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::value::{values_equal, StructLayout, VmValue};
 
-use super::canonicalize::resolve_canonical_ref;
+use super::canonicalize::resolve_canonical_ref_with_path;
+use super::limits::SchemaTraversal;
 use super::result::ValidationResult;
 use super::type_check::{
     actual_value_type, schema_expected_label, schema_is_object_like, schema_type_name,
@@ -64,7 +65,22 @@ pub(super) fn validate_schema_value(
 ) -> ValidationResult {
     let root = schema.as_dict().cloned().unwrap_or_default();
     let schema_dict = schema.as_dict().cloned().unwrap_or_default();
-    validate_against_schema(data, &schema_dict, &root, "", options)
+    let mut context = ValidationContext::new();
+    validate_against_schema(data, &schema_dict, &root, "", options, &mut context)
+}
+
+struct ValidationContext {
+    traversal: SchemaTraversal,
+    ref_stack: Vec<String>,
+}
+
+impl ValidationContext {
+    fn new() -> Self {
+        Self {
+            traversal: SchemaTraversal::new(),
+            ref_stack: Vec::new(),
+        }
+    }
 }
 
 fn validate_against_schema(
@@ -73,11 +89,48 @@ fn validate_against_schema(
     root_schema: &BTreeMap<String, VmValue>,
     path: &str,
     options: ValidationOptions,
+    context: &mut ValidationContext,
+) -> ValidationResult {
+    if let Err(error) = context.traversal.enter_schema() {
+        return validation_limit_error(value, path, error);
+    }
+    let result = validate_against_schema_inner(value, schema, root_schema, path, options, context);
+    context.traversal.exit_schema();
+    result
+}
+
+fn validate_against_schema_inner(
+    value: &VmValue,
+    schema: &BTreeMap<String, VmValue>,
+    root_schema: &BTreeMap<String, VmValue>,
+    path: &str,
+    options: ValidationOptions,
+    context: &mut ValidationContext,
 ) -> ValidationResult {
     if let Some(VmValue::String(pointer)) = schema.get("$ref") {
-        match resolve_canonical_ref(root_schema, pointer) {
-            Some(resolved) => {
-                return validate_against_schema(value, &resolved, root_schema, path, options);
+        if let Err(error) = context.traversal.expand_ref() {
+            return validation_limit_error(value, path, error);
+        }
+        match resolve_canonical_ref_with_path(root_schema, pointer) {
+            Some((resolved_pointer, resolved)) => {
+                if let Some(index) = context
+                    .ref_stack
+                    .iter()
+                    .position(|entry| entry == &resolved_pointer)
+                {
+                    let mut cycle = context.ref_stack[index..].to_vec();
+                    cycle.push(resolved_pointer);
+                    return validation_limit_error(
+                        value,
+                        path,
+                        format!("cyclic schema reference: {}", cycle.join(" -> ")),
+                    );
+                }
+                context.ref_stack.push(resolved_pointer);
+                let result =
+                    validate_against_schema(value, &resolved, root_schema, path, options, context);
+                context.ref_stack.pop();
+                return result;
             }
             None => {
                 return ValidationResult {
@@ -121,8 +174,14 @@ fn validate_against_schema(
             let Some(branch_dict) = branch.as_dict() else {
                 continue;
             };
-            let branch_result =
-                validate_against_schema(&normalized, branch_dict, root_schema, path, options);
+            let branch_result = validate_against_schema(
+                &normalized,
+                branch_dict,
+                root_schema,
+                path,
+                options,
+                context,
+            );
             normalized = branch_result.value;
             errors.extend(branch_result.errors);
         }
@@ -133,7 +192,7 @@ fn validate_against_schema(
         for branch in union_schemas.iter() {
             if let Some(dict) = branch.as_dict() {
                 let branch_result =
-                    validate_against_schema(value, dict, root_schema, path, options);
+                    validate_against_schema(value, dict, root_schema, path, options, context);
                 if branch_result.errors.is_empty() {
                     matched = Some(branch_result.value);
                     break;
@@ -168,14 +227,21 @@ fn validate_against_schema(
     match &normalized {
         VmValue::Dict(map) => {
             let (next_value, next_errors) =
-                validate_object_fields(map, None, schema, root_schema, path, options);
+                validate_object_fields(map, None, schema, root_schema, path, options, context);
             normalized = next_value;
             errors.extend(next_errors);
         }
         VmValue::StructInstance { layout, .. } => {
             let fields = normalized.struct_fields_map().unwrap_or_default();
-            let (next_value, next_errors) =
-                validate_object_fields(&fields, Some(layout), schema, root_schema, path, options);
+            let (next_value, next_errors) = validate_object_fields(
+                &fields,
+                Some(layout),
+                schema,
+                root_schema,
+                path,
+                options,
+                context,
+            );
             normalized = next_value;
             errors.extend(next_errors);
         }
@@ -209,6 +275,7 @@ fn validate_against_schema(
                         root_schema,
                         &index_path(path, i),
                         options,
+                        context,
                     );
                     if child.errors.is_empty() {
                         normalized_items.push(child.value);
@@ -300,6 +367,13 @@ fn validate_against_schema(
     }
 }
 
+fn validation_limit_error(value: &VmValue, path: &str, error: String) -> ValidationResult {
+    ValidationResult {
+        value: value.clone(),
+        errors: vec![format!("at {}: {}", location_label(path), error)],
+    }
+}
+
 fn validate_object_fields(
     fields: &BTreeMap<String, VmValue>,
     struct_layout: Option<&StructLayout>,
@@ -307,6 +381,7 @@ fn validate_object_fields(
     root_schema: &BTreeMap<String, VmValue>,
     path: &str,
     options: ValidationOptions,
+    context: &mut ValidationContext,
 ) -> (VmValue, Vec<String>) {
     let mut errors = Vec::new();
     let mut merged = fields.clone();
@@ -349,6 +424,7 @@ fn validate_object_fields(
                         root_schema,
                         &child_path,
                         options,
+                        context,
                     );
                     if child.errors.is_empty() {
                         merged.insert(key.clone(), child.value);
@@ -364,6 +440,7 @@ fn validate_object_fields(
                             root_schema,
                             &child_path,
                             options,
+                            context,
                         );
                         if child.errors.is_empty() {
                             merged.insert(key.clone(), child.value);
@@ -400,6 +477,7 @@ fn validate_object_fields(
                     root_schema,
                     &child_path(path, key),
                     options,
+                    context,
                 );
                 if child.errors.is_empty() {
                     merged.insert(key.clone(), child.value);
@@ -485,9 +563,78 @@ pub(super) fn first_param_validation_error(
     param_name: &str,
     options: ValidationOptions,
 ) -> Option<String> {
+    let mut context = ValidationContext::new();
+    first_param_validation_error_inner(
+        value,
+        schema,
+        root_schema,
+        param_name,
+        options,
+        &mut context,
+    )
+}
+
+fn first_param_validation_error_inner(
+    value: &VmValue,
+    schema: &BTreeMap<String, VmValue>,
+    root_schema: &BTreeMap<String, VmValue>,
+    param_name: &str,
+    options: ValidationOptions,
+    context: &mut ValidationContext,
+) -> Option<String> {
+    if let Err(error) = context.traversal.enter_schema() {
+        return Some(format!("parameter '{}': {}", param_name, error));
+    }
+    let result =
+        first_param_validation_error_body(value, schema, root_schema, param_name, options, context);
+    context.traversal.exit_schema();
+    result
+}
+
+fn first_param_validation_error_body(
+    value: &VmValue,
+    schema: &BTreeMap<String, VmValue>,
+    root_schema: &BTreeMap<String, VmValue>,
+    param_name: &str,
+    options: ValidationOptions,
+    context: &mut ValidationContext,
+) -> Option<String> {
     if let Some(VmValue::String(pointer)) = schema.get("$ref") {
-        let resolved = resolve_canonical_ref(root_schema, pointer)?;
-        return first_param_validation_error(value, &resolved, root_schema, param_name, options);
+        if let Err(error) = context.traversal.expand_ref() {
+            return Some(format!("parameter '{}': {}", param_name, error));
+        }
+        let Some((resolved_pointer, resolved)) =
+            resolve_canonical_ref_with_path(root_schema, pointer)
+        else {
+            return Some(format!(
+                "parameter '{}': unresolved schema reference '{}'",
+                param_name, pointer
+            ));
+        };
+        if let Some(index) = context
+            .ref_stack
+            .iter()
+            .position(|entry| entry == &resolved_pointer)
+        {
+            let mut cycle = context.ref_stack[index..].to_vec();
+            cycle.push(resolved_pointer);
+            return Some(format!(
+                "parameter '{}': cyclic schema reference: {}",
+                param_name,
+                cycle.join(" -> ")
+            ));
+        }
+        context.ref_stack.push(resolved_pointer);
+        let result = first_param_validation_error_inner(
+            value,
+            &resolved,
+            root_schema,
+            param_name,
+            options,
+            context,
+        );
+        context.ref_stack.pop();
+        return result;
     }
 
     if matches!(value, VmValue::Nil) && schema_bool(schema, "nullable") {
@@ -497,9 +644,14 @@ pub(super) fn first_param_validation_error(
     if let Some(VmValue::List(branches)) = schema.get("all_of") {
         for branch in branches.iter() {
             let branch_dict = branch.as_dict()?;
-            if let Some(error) =
-                first_param_validation_error(value, branch_dict, root_schema, param_name, options)
-            {
+            if let Some(error) = first_param_validation_error_inner(
+                value,
+                branch_dict,
+                root_schema,
+                param_name,
+                options,
+                context,
+            ) {
                 return Some(error);
             }
         }
@@ -509,7 +661,14 @@ pub(super) fn first_param_validation_error(
     if let Some(VmValue::List(branches)) = schema.get("union") {
         for branch in branches.iter() {
             let branch_dict = branch.as_dict()?;
-            first_param_validation_error(value, branch_dict, root_schema, param_name, options)?;
+            first_param_validation_error_inner(
+                value,
+                branch_dict,
+                root_schema,
+                param_name,
+                options,
+                context,
+            )?;
         }
         return Some(format!(
             "parameter '{}' expected {}, got {} ({})",
@@ -536,7 +695,7 @@ pub(super) fn first_param_validation_error(
                 ));
             }
         };
-        return first_object_param_error(fields, schema, root_schema, param_name, options);
+        return first_object_param_error(fields, schema, root_schema, param_name, options, context);
     }
 
     if let Some(expected_type) = schema_type_name(schema) {
@@ -551,7 +710,7 @@ pub(super) fn first_param_validation_error(
         }
     }
 
-    let result = validate_against_schema(value, schema, root_schema, "root", options);
+    let result = validate_against_schema(value, schema, root_schema, "root", options, context);
     if result.errors.is_empty() {
         None
     } else {
@@ -577,6 +736,7 @@ fn first_object_param_error(
     root_schema: &BTreeMap<String, VmValue>,
     param_name: &str,
     options: ValidationOptions,
+    context: &mut ValidationContext,
 ) -> Option<String> {
     let mut known_keys = std::collections::BTreeSet::new();
 
@@ -629,12 +789,13 @@ fn first_object_param_error(
                 match prop_value {
                     VmValue::Dict(_) | VmValue::StructInstance { .. } => {
                         let child_param = format!("{param_name}.{key}");
-                        if let Some(error) = first_param_validation_error(
+                        if let Some(error) = first_param_validation_error_inner(
                             prop_value,
                             prop_schema_dict,
                             root_schema,
                             &child_param,
                             options,
+                            context,
                         ) {
                             return Some(error);
                         }
@@ -664,12 +825,13 @@ fn first_object_param_error(
             }
 
             let child_param = format!("{param_name}.{key}");
-            if let Some(error) = first_param_validation_error(
+            if let Some(error) = first_param_validation_error_inner(
                 prop_value,
                 prop_schema_dict,
                 root_schema,
                 &child_param,
                 options,
+                context,
             ) {
                 return Some(error);
             }
@@ -696,12 +858,13 @@ fn first_object_param_error(
                     match value {
                         VmValue::Dict(_) | VmValue::StructInstance { .. } => {
                             let child_param = format!("{param_name}.{key}");
-                            if let Some(error) = first_param_validation_error(
+                            if let Some(error) = first_param_validation_error_inner(
                                 value,
                                 extra_schema,
                                 root_schema,
                                 &child_param,
                                 options,
+                                context,
                             ) {
                                 return Some(error);
                             }
@@ -731,12 +894,13 @@ fn first_object_param_error(
                 }
 
                 let child_param = format!("{param_name}.{key}");
-                if let Some(error) = first_param_validation_error(
+                if let Some(error) = first_param_validation_error_inner(
                     value,
                     extra_schema,
                     root_schema,
                     &child_param,
                     options,
+                    context,
                 ) {
                     return Some(error);
                 }

--- a/crates/harn-vm/src/stdlib/json_stream.rs
+++ b/crates/harn-vm/src/stdlib/json_stream.rs
@@ -857,10 +857,29 @@ mod tests {
     }
 
     fn call(name: &str, args: Vec<VmValue>) -> VmValue {
+        call_result(name, args).unwrap()
+    }
+
+    fn call_result(name: &str, args: Vec<VmValue>) -> Result<VmValue, VmError> {
         let mut vm = Vm::new();
         register_json_stream_builtins(&mut vm);
         let builtin = vm.builtins.get(name).unwrap().clone();
-        builtin(&args, &mut String::new()).unwrap()
+        builtin(&args, &mut String::new())
+    }
+
+    #[test]
+    fn stream_validator_rejects_cyclic_schema_at_create() {
+        reset_json_stream_state();
+        let schema = dict([("$ref", string("#"))]);
+        let error = call_result("__json_stream_validator", vec![schema])
+            .expect_err("cyclic schema must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cyclic schema reference: # -> #"),
+            "expected cyclic schema reference error, got {error:?}"
+        );
     }
 
     #[test]

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -126,6 +126,12 @@ JSON Schema / OpenAPI Schema Object spellings such as `object`, `array`,
 `minItems`, `maxItems`, and `additionalProperties`, normalizing them into the
 same internal form.
 
+Schema traversal is bounded before validation runs: canonicalization, JSON
+Schema/OpenAPI export, runtime validation, and JSON-stream schema setup reject
+schemas deeper than 128 nested schema nodes, more than 256 `$ref` expansions,
+or cyclic local `$ref` graphs. These failures surface as regular Harn schema
+errors such as `schema depth exceeded (128)` or `cyclic schema reference: # -> #`.
+
 Supported canonical keys:
 
 | Key | Type | Description |


### PR DESCRIPTION
## Summary
- Add shared schema traversal limits for canonicalization, export, and validation.
- Reject cyclic local `$ref` graphs, excessive `$ref` expansion, and overly deep `properties`/`items` schemas with clean errors.
- Apply the same guardrails to schema builtins, `__assert_schema` parameter checks, sub-agent return schemas, and JSON stream validator setup.
- Document the limits and add conformance coverage for the schema builtins.

## Validation
- `cargo fmt --check`
- `cargo test -p harn-vm schema:: --lib`
- `cargo test -p harn-vm stdlib::json_stream --lib`
- `cargo run --bin harn -- test conformance --filter schema_`
- `cargo run --bin harn -- test conformance --filter json_stream`
- `make lint-test-patterns`
- pre-push targeted checks

Closes #2202