### PR TITLE
Add hard transcript budgets for agent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ condensed series summaries instead of full per-patch history.
   the session's bridge without going through ACP. Returns the reminder
   id; mode defaults to `audit_only` and accepts the same delivery modes
   as `session/remind`.
+- **Hard per-session transcript budgets (#2205).** First-class agent sessions
+  now enforce retained message and event caps through the session store itself,
+  independent of optional auto-compaction. Budget pressure rejects by default or
+  applies an explicit trim/compact recovery policy, records
+  `transcript_budget` audit metadata, and exposes the last budget action in
+  session snapshots for host UIs.
 
 ### Changed
 

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -30,6 +30,79 @@ use crate::value::VmValue;
 /// least-recently-accessed session is evicted on the next `open`.
 pub const DEFAULT_SESSION_CAP: usize = 128;
 
+/// Default cap on retained prompt-visible messages per session. The
+/// limit is intentionally high enough for normal long-running agents
+/// while still bounding accidental unbounded growth.
+pub const DEFAULT_TRANSCRIPT_MESSAGE_CAP: usize = 4096;
+
+/// Default cap on retained transcript audit events per session. Events
+/// include message-derived entries plus orchestration lifecycle records.
+pub const DEFAULT_TRANSCRIPT_EVENT_CAP: usize = 32768;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TranscriptBudgetRecovery {
+    Reject,
+    Trim { keep_last: usize },
+    Compact { keep_last: usize },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionTranscriptBudgetPolicy {
+    pub max_messages: usize,
+    pub max_events: usize,
+    pub max_approx_bytes: Option<usize>,
+    pub recovery: TranscriptBudgetRecovery,
+}
+
+impl SessionTranscriptBudgetPolicy {
+    pub fn reject(max_messages: usize, max_events: usize) -> Self {
+        Self {
+            max_messages: max_messages.max(1),
+            max_events: max_events.max(1),
+            max_approx_bytes: None,
+            recovery: TranscriptBudgetRecovery::Reject,
+        }
+    }
+
+    pub fn trim(max_messages: usize, max_events: usize, keep_last: usize) -> Self {
+        Self {
+            max_messages: max_messages.max(1),
+            max_events: max_events.max(1),
+            max_approx_bytes: None,
+            recovery: TranscriptBudgetRecovery::Trim { keep_last },
+        }
+    }
+
+    pub fn compact(max_messages: usize, max_events: usize, keep_last: usize) -> Self {
+        Self {
+            max_messages: max_messages.max(1),
+            max_events: max_events.max(1),
+            max_approx_bytes: None,
+            recovery: TranscriptBudgetRecovery::Compact { keep_last },
+        }
+    }
+
+    pub fn with_max_approx_bytes(mut self, max_approx_bytes: Option<usize>) -> Self {
+        self.max_approx_bytes = max_approx_bytes.map(|limit| limit.max(1));
+        self
+    }
+
+    fn normalized(&self) -> Self {
+        Self {
+            max_messages: self.max_messages.max(1),
+            max_events: self.max_events.max(1),
+            max_approx_bytes: self.max_approx_bytes.map(|limit| limit.max(1)),
+            recovery: self.recovery.clone(),
+        }
+    }
+}
+
+impl Default for SessionTranscriptBudgetPolicy {
+    fn default() -> Self {
+        Self::reject(DEFAULT_TRANSCRIPT_MESSAGE_CAP, DEFAULT_TRANSCRIPT_EVENT_CAP)
+    }
+}
+
 pub struct SessionState {
     pub id: String,
     pub transcript: VmValue,
@@ -65,6 +138,8 @@ pub struct SessionState {
     /// the route's native thinking shape. Exposed over ACP as
     /// `session/set_config_option(configId="thought_level")`.
     pub pinned_reasoning_policy: Option<String>,
+    pub transcript_budget_policy: SessionTranscriptBudgetPolicy,
+    pub last_transcript_budget_action: Option<serde_json::Value>,
 }
 
 impl SessionState {
@@ -85,6 +160,8 @@ impl SessionState {
             system_prompt: None,
             pinned_model: None,
             pinned_reasoning_policy: None,
+            transcript_budget_policy: default_transcript_budget_policy(),
+            last_transcript_budget_action: None,
         }
     }
 }
@@ -112,6 +189,8 @@ pub struct ReminderInjectionReport {
 thread_local! {
     static SESSIONS: RefCell<HashMap<String, SessionState>> = RefCell::new(HashMap::new());
     static SESSION_CAP: Cell<usize> = const { Cell::new(DEFAULT_SESSION_CAP) };
+    static DEFAULT_TRANSCRIPT_BUDGET_POLICY: RefCell<SessionTranscriptBudgetPolicy> =
+        RefCell::new(SessionTranscriptBudgetPolicy::default());
     static CURRENT_SESSION_STACK: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
     static CURRENT_TOOL_CALL_STACK: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 }
@@ -159,11 +238,57 @@ pub fn session_cap() -> usize {
     SESSION_CAP.with(|c| c.get())
 }
 
+pub fn set_default_transcript_budget_policy(policy: SessionTranscriptBudgetPolicy) {
+    DEFAULT_TRANSCRIPT_BUDGET_POLICY.with(|cell| {
+        *cell.borrow_mut() = policy.normalized();
+    });
+}
+
+pub fn reset_default_transcript_budget_policy() {
+    set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::default());
+}
+
+pub fn default_transcript_budget_policy() -> SessionTranscriptBudgetPolicy {
+    DEFAULT_TRANSCRIPT_BUDGET_POLICY.with(|cell| cell.borrow().clone())
+}
+
+pub fn transcript_budget_policy(id: &str) -> Option<SessionTranscriptBudgetPolicy> {
+    SESSIONS.with(|s| {
+        s.borrow()
+            .get(id)
+            .map(|state| state.transcript_budget_policy.clone())
+    })
+}
+
+pub fn set_transcript_budget_policy(
+    id: &str,
+    policy: SessionTranscriptBudgetPolicy,
+) -> Result<(), String> {
+    SESSIONS.with(|s| {
+        let mut map = s.borrow_mut();
+        let Some(state) = map.get_mut(id) else {
+            return Err(format!("agent session '{id}' does not exist"));
+        };
+        let previous = state.transcript_budget_policy.clone();
+        let previous_action = state.last_transcript_budget_action.clone();
+        state.transcript_budget_policy = policy.normalized();
+        let candidate = state.transcript.clone();
+        if let Err(error) = apply_transcript_with_budget(state, candidate, "policy_update") {
+            state.transcript_budget_policy = previous;
+            state.last_transcript_budget_action = previous_action;
+            return Err(error);
+        }
+        state.last_accessed = Instant::now();
+        Ok(())
+    })
+}
+
 /// Clear the session store. Wired into `reset_llm_state` for test isolation.
 pub fn reset_session_store() {
     SESSIONS.with(|s| s.borrow_mut().clear());
     CURRENT_SESSION_STACK.with(|stack| stack.borrow_mut().clear());
     CURRENT_TOOL_CALL_STACK.with(|stack| stack.borrow_mut().clear());
+    reset_default_transcript_budget_policy();
 }
 
 pub(crate) fn push_current_session(id: String) {
@@ -463,6 +588,7 @@ pub fn reset_transcript(id: &str) -> bool {
         state.transcript = empty_transcript(id);
         state.tool_format = None;
         state.system_prompt = None;
+        state.last_transcript_budget_action = None;
         state.last_accessed = Instant::now();
         true
     })
@@ -481,6 +607,8 @@ pub fn fork(src_id: &str, dst_id: Option<String>) -> Option<String> {
         src_system_prompt,
         src_pinned_model,
         src_pinned_reasoning_policy,
+        src_transcript_budget_policy,
+        src_last_transcript_budget_action,
         dst,
     ) = SESSIONS.with(|s| {
         let mut map = s.borrow_mut();
@@ -494,6 +622,8 @@ pub fn fork(src_id: &str, dst_id: Option<String>) -> Option<String> {
             src.system_prompt.clone(),
             src.pinned_model.clone(),
             src.pinned_reasoning_policy.clone(),
+            src.transcript_budget_policy.clone(),
+            src.last_transcript_budget_action.clone(),
             dst,
         ))
     })?;
@@ -507,10 +637,24 @@ pub fn fork(src_id: &str, dst_id: Option<String>) -> Option<String> {
             state.system_prompt = src_system_prompt;
             state.pinned_model = src_pinned_model;
             state.pinned_reasoning_policy = src_pinned_reasoning_policy;
+            state.transcript_budget_policy = src_transcript_budget_policy;
+            state.last_transcript_budget_action = src_last_transcript_budget_action;
             state.last_accessed = Instant::now();
         }
         update_lineage(&mut map, src_id, &dst, None);
     });
+    let budget_ok = SESSIONS.with(|s| {
+        let mut map = s.borrow_mut();
+        let Some(state) = map.get_mut(&dst) else {
+            return false;
+        };
+        let candidate = state.transcript.clone();
+        apply_transcript_with_budget(state, candidate, "fork").is_ok()
+    });
+    if !budget_ok {
+        close(&dst);
+        return None;
+    }
     // open_or_create evicts BEFORE inserting, so the dst slot is
     // guaranteed once we get here. The existence check is cheap
     // insurance against a future refactor that breaks that invariant.
@@ -550,11 +694,12 @@ pub fn truncate(id: &str, keep_first: usize) -> Option<SessionTruncateResult> {
     SESSIONS.with(|s| {
         let mut map = s.borrow_mut();
         let state = map.get_mut(id)?;
-        Some(truncate_state(state, keep_first))
+        let result = truncate_state(state, keep_first)?;
+        Some(result)
     })
 }
 
-fn truncate_state(state: &mut SessionState, keep_first: usize) -> SessionTruncateResult {
+fn truncate_state(state: &mut SessionState, keep_first: usize) -> Option<SessionTruncateResult> {
     let dict = state
         .transcript
         .as_dict()
@@ -595,14 +740,14 @@ fn truncate_state(state: &mut SessionState, keep_first: usize) -> SessionTruncat
         );
         next.insert("messages".to_string(), VmValue::List(Rc::new(retained)));
         next.remove("summary");
-        state.transcript = VmValue::Dict(Rc::new(next));
+        apply_transcript_with_budget(state, VmValue::Dict(Rc::new(next)), "truncate").ok()?;
     }
     state.last_accessed = Instant::now();
-    SessionTruncateResult {
+    Some(SessionTruncateResult {
         kept_turn_count,
         removed_turn_count,
         new_tip_turn_id,
-    }
+    })
 }
 
 /// Retain only the last `keep_last` messages in the session transcript.
@@ -627,7 +772,7 @@ pub fn trim(id: &str, keep_last: usize) -> Option<usize> {
             )),
         );
         next.insert("messages".to_string(), VmValue::List(Rc::new(retained)));
-        state.transcript = VmValue::Dict(Rc::new(next));
+        apply_transcript_with_budget(state, VmValue::Dict(Rc::new(next)), "trim").ok()?;
         state.last_accessed = Instant::now();
         Some(kept)
     })
@@ -665,8 +810,7 @@ pub fn inject_message(id: &str, message: VmValue) -> Result<(), String> {
             _ => crate::llm::helpers::transcript_events_from_messages(&messages),
         };
         let new_message = VmValue::Dict(Rc::new(msg_dict));
-        emit_identified_user_message_event(id, &new_message);
-        emit_llm_message_event(id, messages.len(), &new_message);
+        let message_index = messages.len();
         events.push(crate::llm::helpers::transcript_event_from_message(
             &new_message,
         ));
@@ -674,7 +818,16 @@ pub fn inject_message(id: &str, message: VmValue) -> Result<(), String> {
         let mut next = dict;
         next.insert("events".to_string(), VmValue::List(Rc::new(events)));
         next.insert("messages".to_string(), VmValue::List(Rc::new(messages)));
-        state.transcript = VmValue::Dict(Rc::new(next));
+        let persisted_message = next
+            .get("messages")
+            .and_then(|value| match value {
+                VmValue::List(list) => list.get(message_index).cloned(),
+                _ => None,
+            })
+            .unwrap_or(VmValue::Nil);
+        apply_transcript_with_budget(state, VmValue::Dict(Rc::new(next)), "inject_message")?;
+        emit_identified_user_message_event(id, &persisted_message);
+        emit_llm_message_event(id, message_index, &persisted_message);
         state.last_accessed = Instant::now();
         Ok(())
     })
@@ -716,6 +869,396 @@ fn user_message_content_blocks(content: &serde_json::Value) -> Vec<serde_json::V
             "type": "text",
             "text": other.to_string(),
         })],
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TranscriptBudgetUsage {
+    message_count: usize,
+    event_count: usize,
+    approx_bytes: Option<usize>,
+}
+
+fn transcript_messages_from_dict(dict: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+    match dict.get("messages") {
+        Some(VmValue::List(list)) => list.iter().cloned().collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn transcript_events_from_dict(dict: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+    match dict.get("events") {
+        Some(VmValue::List(list)) => list.iter().cloned().collect(),
+        _ => {
+            let messages = transcript_messages_from_dict(dict);
+            crate::llm::helpers::transcript_events_from_messages(&messages)
+        }
+    }
+}
+
+fn transcript_usage(transcript: &VmValue, include_bytes: bool) -> TranscriptBudgetUsage {
+    let Some(dict) = transcript.as_dict() else {
+        return TranscriptBudgetUsage {
+            message_count: 0,
+            event_count: 0,
+            approx_bytes: include_bytes.then_some(0),
+        };
+    };
+    let approx_bytes = if include_bytes {
+        serde_json::to_vec(&crate::llm::helpers::vm_value_to_json(transcript))
+            .map(|bytes| bytes.len())
+            .ok()
+            .or(Some(usize::MAX))
+    } else {
+        None
+    };
+    TranscriptBudgetUsage {
+        message_count: transcript_messages_from_dict(dict).len(),
+        event_count: transcript_events_from_dict(dict).len(),
+        approx_bytes,
+    }
+}
+
+fn transcript_budget_exceeded_reason(
+    usage: &TranscriptBudgetUsage,
+    policy: &SessionTranscriptBudgetPolicy,
+) -> Option<&'static str> {
+    if usage.message_count > policy.max_messages {
+        return Some("message_count");
+    }
+    if usage.event_count > policy.max_events {
+        return Some("event_count");
+    }
+    if let (Some(bytes), Some(limit)) = (usage.approx_bytes, policy.max_approx_bytes) {
+        if bytes > limit {
+            return Some("approx_bytes");
+        }
+    }
+    None
+}
+
+fn transcript_budget_usage_json(usage: &TranscriptBudgetUsage) -> serde_json::Value {
+    serde_json::json!({
+        "messages": usage.message_count,
+        "events": usage.event_count,
+        "approx_bytes": usage.approx_bytes,
+    })
+}
+
+fn transcript_budget_policy_json(policy: &SessionTranscriptBudgetPolicy) -> serde_json::Value {
+    let recovery = match &policy.recovery {
+        TranscriptBudgetRecovery::Reject => serde_json::json!({"action": "reject"}),
+        TranscriptBudgetRecovery::Trim { keep_last } => {
+            serde_json::json!({"action": "trim", "keep_last": keep_last})
+        }
+        TranscriptBudgetRecovery::Compact { keep_last } => {
+            serde_json::json!({"action": "compact", "keep_last": keep_last})
+        }
+    };
+    serde_json::json!({
+        "max_messages": policy.max_messages,
+        "max_events": policy.max_events,
+        "max_approx_bytes": policy.max_approx_bytes,
+        "recovery": recovery,
+    })
+}
+
+fn transcript_budget_recovery_name(recovery: &TranscriptBudgetRecovery) -> &'static str {
+    match recovery {
+        TranscriptBudgetRecovery::Reject => "reject",
+        TranscriptBudgetRecovery::Trim { .. } => "trim",
+        TranscriptBudgetRecovery::Compact { .. } => "compact",
+    }
+}
+
+fn transcript_budget_error(
+    state: &SessionState,
+    policy: &SessionTranscriptBudgetPolicy,
+    usage: &TranscriptBudgetUsage,
+    reason: &str,
+) -> String {
+    let byte_suffix = match (usage.approx_bytes, policy.max_approx_bytes) {
+        (Some(bytes), Some(limit)) => format!(", approx_bytes {bytes}/{limit}"),
+        _ => String::new(),
+    };
+    format!(
+        "transcript budget exceeded for session '{}': {reason} (messages {}/{}, events {}/{}{}; recovery={})",
+        state.id,
+        usage.message_count,
+        policy.max_messages,
+        usage.event_count,
+        policy.max_events,
+        byte_suffix,
+        transcript_budget_recovery_name(&policy.recovery),
+    )
+}
+
+fn transcript_budget_audit_json(
+    action: &str,
+    source: &str,
+    reason: &str,
+    policy: &SessionTranscriptBudgetPolicy,
+    usage_before: &TranscriptBudgetUsage,
+    usage_attempted: &TranscriptBudgetUsage,
+    usage_after: &TranscriptBudgetUsage,
+) -> serde_json::Value {
+    serde_json::json!({
+        "action": action,
+        "source": source,
+        "reason": reason,
+        "policy": transcript_budget_policy_json(policy),
+        "usage_before": transcript_budget_usage_json(usage_before),
+        "usage_attempted": transcript_budget_usage_json(usage_attempted),
+        "usage_after": transcript_budget_usage_json(usage_after),
+        "removed_messages": usage_attempted.message_count.saturating_sub(usage_after.message_count),
+        "removed_events": usage_attempted.event_count.saturating_sub(usage_after.event_count),
+    })
+}
+
+fn transcript_budget_event(audit: &serde_json::Value) -> VmValue {
+    let action = audit
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("enforced");
+    crate::llm::helpers::transcript_event(
+        "transcript_budget",
+        "system",
+        "internal",
+        &format!("Transcript budget {action}."),
+        Some(audit.clone()),
+    )
+}
+
+fn append_event_to_transcript(transcript: VmValue, event: VmValue) -> VmValue {
+    let Some(dict) = transcript.as_dict() else {
+        return transcript;
+    };
+    let mut next = dict.clone();
+    let mut events = transcript_events_from_dict(&next);
+    events.push(event);
+    next.insert("events".to_string(), VmValue::List(Rc::new(events)));
+    VmValue::Dict(Rc::new(next))
+}
+
+fn summary_message_vm(summary: &str) -> VmValue {
+    crate::stdlib::json_to_vm_value(&summary_message_json(summary))
+}
+
+fn tail_message_capacity(
+    policy: &SessionTranscriptBudgetPolicy,
+    reserve_audit_event: bool,
+) -> usize {
+    let event_capacity = if reserve_audit_event {
+        policy.max_events.saturating_sub(1)
+    } else {
+        policy.max_events
+    };
+    policy.max_messages.min(event_capacity)
+}
+
+fn trim_transcript_for_budget(
+    transcript: &VmValue,
+    policy: &SessionTranscriptBudgetPolicy,
+    keep_last: usize,
+) -> VmValue {
+    let dict = transcript.as_dict().cloned().unwrap_or_else(BTreeMap::new);
+    let messages = transcript_messages_from_dict(&dict);
+    let keep = keep_last.min(tail_message_capacity(policy, true));
+    let start = messages.len().saturating_sub(keep);
+    let retained: Vec<VmValue> = messages.into_iter().skip(start).collect();
+    let mut next = dict;
+    next.insert(
+        "events".to_string(),
+        VmValue::List(Rc::new(
+            crate::llm::helpers::transcript_events_from_messages(&retained),
+        )),
+    );
+    next.insert("messages".to_string(), VmValue::List(Rc::new(retained)));
+    next.remove("summary");
+    VmValue::Dict(Rc::new(next))
+}
+
+fn compact_transcript_for_budget(
+    transcript: &VmValue,
+    policy: &SessionTranscriptBudgetPolicy,
+    keep_last: usize,
+    reason: &str,
+) -> VmValue {
+    let dict = transcript.as_dict().cloned().unwrap_or_else(BTreeMap::new);
+    let messages = transcript_messages_from_dict(&dict);
+    let message_capacity = tail_message_capacity(policy, true);
+    let mut retained = Vec::new();
+    let mut summary = None;
+
+    if messages.len() > message_capacity {
+        if message_capacity > 0 {
+            let tail_keep = keep_last.min(message_capacity.saturating_sub(1));
+            let archived = messages.len().saturating_sub(tail_keep);
+            let summary_text = format!(
+                "[auto-compacted {archived} older message(s) under transcript budget]\nSession transcript exceeded the {reason} budget; retained the most recent {tail_keep} message(s)."
+            );
+            retained.push(summary_message_vm(&summary_text));
+            retained.extend(messages.into_iter().skip(archived).take(tail_keep));
+            summary = Some(summary_text);
+        }
+    } else {
+        retained = messages;
+    }
+
+    let mut next = dict;
+    next.insert(
+        "events".to_string(),
+        VmValue::List(Rc::new(
+            crate::llm::helpers::transcript_events_from_messages(&retained),
+        )),
+    );
+    next.insert("messages".to_string(), VmValue::List(Rc::new(retained)));
+    if let Some(summary) = summary {
+        next.insert("summary".to_string(), VmValue::String(Rc::from(summary)));
+    } else {
+        next.remove("summary");
+    }
+    VmValue::Dict(Rc::new(next))
+}
+
+fn recovered_transcript_with_audit(
+    recovered: VmValue,
+    action: &str,
+    source: &str,
+    reason: &str,
+    policy: &SessionTranscriptBudgetPolicy,
+    usage_before: &TranscriptBudgetUsage,
+    usage_attempted: &TranscriptBudgetUsage,
+    include_bytes: bool,
+) -> (VmValue, serde_json::Value, TranscriptBudgetUsage) {
+    let usage_after_without_audit = transcript_usage(&recovered, include_bytes);
+    let initial_audit = transcript_budget_audit_json(
+        action,
+        source,
+        reason,
+        policy,
+        usage_before,
+        usage_attempted,
+        &usage_after_without_audit,
+    );
+    let with_initial_audit =
+        append_event_to_transcript(recovered.clone(), transcript_budget_event(&initial_audit));
+    let usage_after = transcript_usage(&with_initial_audit, include_bytes);
+    let audit = transcript_budget_audit_json(
+        action,
+        source,
+        reason,
+        policy,
+        usage_before,
+        usage_attempted,
+        &usage_after,
+    );
+    let with_audit = append_event_to_transcript(recovered, transcript_budget_event(&audit));
+    let usage_after = transcript_usage(&with_audit, include_bytes);
+    (with_audit, audit, usage_after)
+}
+
+fn apply_transcript_with_budget(
+    state: &mut SessionState,
+    candidate: VmValue,
+    source: &str,
+) -> Result<(), String> {
+    let policy = state.transcript_budget_policy.normalized();
+    let include_bytes = policy.max_approx_bytes.is_some();
+    let usage_before = transcript_usage(&state.transcript, include_bytes);
+    let usage_attempted = transcript_usage(&candidate, include_bytes);
+    let Some(reason) = transcript_budget_exceeded_reason(&usage_attempted, &policy) else {
+        state.transcript = candidate;
+        return Ok(());
+    };
+
+    match policy.recovery.clone() {
+        TranscriptBudgetRecovery::Reject => {
+            let audit = transcript_budget_audit_json(
+                "rejected",
+                source,
+                reason,
+                &policy,
+                &usage_before,
+                &usage_attempted,
+                &usage_before,
+            );
+            state.last_transcript_budget_action = Some(audit);
+            Err(transcript_budget_error(
+                state,
+                &policy,
+                &usage_attempted,
+                reason,
+            ))
+        }
+        TranscriptBudgetRecovery::Trim { keep_last } => {
+            let recovered = trim_transcript_for_budget(&candidate, &policy, keep_last);
+            let (with_audit, audit, usage_after) = recovered_transcript_with_audit(
+                recovered,
+                "trimmed",
+                source,
+                reason,
+                &policy,
+                &usage_before,
+                &usage_attempted,
+                include_bytes,
+            );
+            if transcript_budget_exceeded_reason(&usage_after, &policy).is_some() {
+                let rejected = transcript_budget_audit_json(
+                    "rejected",
+                    source,
+                    reason,
+                    &policy,
+                    &usage_before,
+                    &usage_attempted,
+                    &usage_after,
+                );
+                state.last_transcript_budget_action = Some(rejected);
+                return Err(transcript_budget_error(
+                    state,
+                    &policy,
+                    &usage_after,
+                    reason,
+                ));
+            }
+            state.last_transcript_budget_action = Some(audit);
+            state.transcript = with_audit;
+            Ok(())
+        }
+        TranscriptBudgetRecovery::Compact { keep_last } => {
+            let recovered = compact_transcript_for_budget(&candidate, &policy, keep_last, reason);
+            let (with_audit, audit, usage_after) = recovered_transcript_with_audit(
+                recovered,
+                "compacted",
+                source,
+                reason,
+                &policy,
+                &usage_before,
+                &usage_attempted,
+                include_bytes,
+            );
+            if transcript_budget_exceeded_reason(&usage_after, &policy).is_some() {
+                let rejected = transcript_budget_audit_json(
+                    "rejected",
+                    source,
+                    reason,
+                    &policy,
+                    &usage_before,
+                    &usage_attempted,
+                    &usage_after,
+                );
+                state.last_transcript_budget_action = Some(rejected);
+                return Err(transcript_budget_error(
+                    state,
+                    &policy,
+                    &usage_after,
+                    reason,
+                ));
+            }
+            state.last_transcript_budget_action = Some(audit);
+            state.transcript = with_audit;
+            Ok(())
+        }
     }
 }
 
@@ -789,7 +1332,7 @@ pub fn seed_from_messages(
             );
         }
         let vm_messages = crate::llm::helpers::json_messages_to_vm(messages);
-        state.transcript = crate::llm::helpers::new_transcript_with(
+        let candidate = crate::llm::helpers::new_transcript_with(
             Some(resolved.clone()),
             vm_messages,
             None,
@@ -797,6 +1340,7 @@ pub fn seed_from_messages(
                 metadata,
             ))),
         );
+        apply_transcript_with_budget(state, candidate, "seed_from_messages")?;
         state.last_accessed = Instant::now();
         Ok(resolved)
     })
@@ -882,13 +1426,19 @@ pub fn prompt_state_json(id: &str) -> SessionPromptState {
 
 /// Overwrite the transcript for this session. Used by `agent_loop` on
 /// exit to persist the synthesized transcript.
-pub fn store_transcript(id: &str, transcript: VmValue) {
+pub fn store_transcript(id: &str, transcript: VmValue) -> Result<(), String> {
     SESSIONS.with(|s| {
-        if let Some(state) = s.borrow_mut().get_mut(id) {
-            state.transcript = transcript_with_session_metadata(transcript, state);
-            state.last_accessed = Instant::now();
-        }
-    });
+        let mut map = s.borrow_mut();
+        let Some(state) = map.get_mut(id) else {
+            return Err(format!(
+                "agent_session_store_transcript: unknown session id '{id}'"
+            ));
+        };
+        let transcript = transcript_with_session_metadata(transcript, state);
+        apply_transcript_with_budget(state, transcript, "store_transcript")?;
+        state.last_accessed = Instant::now();
+        Ok(())
+    })
 }
 
 /// Remove malformed reminder events after their drop audit has been emitted.
@@ -930,7 +1480,11 @@ pub fn prune_invalid_reminder_events(id: &str) -> usize {
         if pruned > 0 {
             let mut next = dict;
             next.insert("events".to_string(), VmValue::List(Rc::new(kept)));
-            state.transcript = VmValue::Dict(Rc::new(next));
+            let _ = apply_transcript_with_budget(
+                state,
+                VmValue::Dict(Rc::new(next)),
+                "prune_invalid_reminder_events",
+            );
             state.last_accessed = Instant::now();
         }
         pruned
@@ -952,7 +1506,7 @@ pub fn apply_reminder_post_turn(id: &str, turn: i64) -> Result<serde_json::Value
         let report = crate::llm::helpers::apply_reminder_post_turn(&state.transcript, turn);
         if report.decremented_count > 0 || !report.expired.is_empty() {
             if let Some(next) = report.transcript.clone() {
-                state.transcript = next;
+                apply_transcript_with_budget(state, next, "apply_reminder_post_turn")?;
             }
             state.last_accessed = Instant::now();
         }
@@ -1039,7 +1593,7 @@ pub fn inject_reminder(
         events.push(crate::llm::helpers::transcript_reminder_event(&reminder));
         let mut next = dict;
         next.insert("events".to_string(), VmValue::List(Rc::new(events)));
-        state.transcript = VmValue::Dict(Rc::new(next));
+        apply_transcript_with_budget(state, VmValue::Dict(Rc::new(next)), "inject_reminder")?;
         state.last_accessed = Instant::now();
         Ok(())
     })?;
@@ -1112,7 +1666,7 @@ pub fn append_event(id: &str, event: VmValue) -> Result<(), String> {
         events.push(event);
         let mut next = dict;
         next.insert("events".to_string(), VmValue::List(Rc::new(events)));
-        state.transcript = VmValue::Dict(Rc::new(next));
+        apply_transcript_with_budget(state, VmValue::Dict(Rc::new(next)), "append_event")?;
         state.last_accessed = Instant::now();
         Ok(())
     })
@@ -1120,8 +1674,8 @@ pub fn append_event(id: &str, event: VmValue) -> Result<(), String> {
 
 /// Replace the transcript's message list wholesale. Used by the
 /// in-loop compaction path, which operates on JSON messages.
-pub fn replace_messages(id: &str, messages: &[serde_json::Value]) {
-    replace_messages_with_summary(id, messages, None);
+pub fn replace_messages(id: &str, messages: &[serde_json::Value]) -> Result<(), String> {
+    replace_messages_with_summary(id, messages, None)
 }
 
 /// Replace the transcript's message list and optionally update the
@@ -1132,11 +1686,13 @@ pub fn replace_messages_with_summary(
     id: &str,
     messages: &[serde_json::Value],
     summary: Option<&str>,
-) {
+) -> Result<(), String> {
     SESSIONS.with(|s| {
         let mut map = s.borrow_mut();
         let Some(state) = map.get_mut(id) else {
-            return;
+            return Err(format!(
+                "agent_session_replace_messages: unknown session id '{id}'"
+            ));
         };
         let dict = state
             .transcript
@@ -1160,10 +1716,13 @@ pub fn replace_messages_with_summary(
                 "summary".to_string(),
                 VmValue::String(Rc::from(summary.to_string())),
             );
+        } else {
+            next.remove("summary");
         }
-        state.transcript = VmValue::Dict(Rc::new(next));
+        apply_transcript_with_budget(state, VmValue::Dict(Rc::new(next)), "replace_messages")?;
         state.last_accessed = Instant::now();
-    });
+        Ok(())
+    })
 }
 
 pub fn append_subscriber(id: &str, callback: VmValue) {
@@ -1293,7 +1852,7 @@ pub fn record_system_prompt(id: &str, system_prompt: &str) -> Result<(), String>
             ));
             next.insert("events".to_string(), VmValue::List(Rc::new(events)));
         }
-        state.transcript = VmValue::Dict(Rc::new(next));
+        apply_transcript_with_budget(state, VmValue::Dict(Rc::new(next)), "record_system_prompt")?;
         state.last_accessed = Instant::now();
         Ok(())
     })
@@ -1441,6 +2000,20 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
             crate::stdlib::json_to_vm_value(&crate::llm::helpers::system_prompt_metadata(
                 system_prompt,
             )),
+        );
+    }
+    if let Some(last_action) = state.last_transcript_budget_action.as_ref() {
+        let usage = transcript_usage(
+            &VmValue::Dict(Rc::new(next.clone())),
+            state.transcript_budget_policy.max_approx_bytes.is_some(),
+        );
+        metadata.insert(
+            "transcript_budget".to_string(),
+            crate::stdlib::json_to_vm_value(&serde_json::json!({
+                "policy": transcript_budget_policy_json(&state.transcript_budget_policy.normalized()),
+                "usage": transcript_budget_usage_json(&usage),
+                "last_action": last_action,
+            })),
         );
     }
     if !metadata.is_empty() {

--- a/crates/harn-vm/src/agent_sessions_tests.rs
+++ b/crates/harn-vm/src/agent_sessions_tests.rs
@@ -52,6 +52,29 @@ fn event_count_by_kind(id: &str, expected_kind: &str) -> usize {
         .unwrap_or(0)
 }
 
+fn event_count(id: &str) -> usize {
+    snapshot(id)
+        .and_then(|snapshot| snapshot.as_dict().cloned())
+        .and_then(|dict| dict.get("events").cloned())
+        .and_then(|events| match events {
+            VmValue::List(events) => Some(events.len()),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+fn budget_metadata(id: &str) -> serde_json::Value {
+    snapshot(id)
+        .map(|value| crate::llm::helpers::vm_value_to_json(&value))
+        .and_then(|value| value.get("metadata").cloned())
+        .and_then(|metadata| metadata.get("transcript_budget").cloned())
+        .expect("transcript budget metadata")
+}
+
+fn simple_event(kind: &str) -> VmValue {
+    crate::llm::helpers::transcript_event(kind, "system", "internal", "", None)
+}
+
 struct CapturingSink(Arc<Mutex<Vec<AgentEvent>>>);
 
 impl AgentEventSink for CapturingSink {
@@ -61,6 +84,111 @@ impl AgentEventSink for CapturingSink {
             .expect("capture sink poisoned")
             .push(event.clone());
     }
+}
+
+#[test]
+fn transcript_budget_rejects_message_count_growth() {
+    reset_session_store();
+    set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::reject(2, 16));
+    let id = open_or_create(Some("budget-message-reject".into()));
+
+    inject_message(&id, make_msg("user", "one")).unwrap();
+    inject_message(&id, make_msg("assistant", "two")).unwrap();
+    let error = inject_message(&id, make_msg("user", "three")).unwrap_err();
+
+    assert!(error.contains("message_count"), "{error}");
+    assert_eq!(message_count(&id), 2);
+    assert_eq!(event_count_by_kind(&id, "transcript_budget"), 0);
+    let metadata = budget_metadata(&id);
+    assert_eq!(metadata["last_action"]["action"], "rejected");
+    assert_eq!(metadata["last_action"]["reason"], "message_count");
+    assert_eq!(metadata["usage"]["messages"], 2);
+
+    reset_default_transcript_budget_policy();
+    reset_session_store();
+}
+
+#[test]
+fn transcript_budget_rejects_event_count_growth() {
+    reset_session_store();
+    set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::reject(16, 2));
+    let id = open_or_create(Some("budget-event-reject".into()));
+
+    append_event(&id, simple_event("audit_one")).unwrap();
+    append_event(&id, simple_event("audit_two")).unwrap();
+    let error = append_event(&id, simple_event("audit_three")).unwrap_err();
+
+    assert!(error.contains("event_count"), "{error}");
+    assert_eq!(event_count(&id), 2);
+    let metadata = budget_metadata(&id);
+    assert_eq!(metadata["last_action"]["action"], "rejected");
+    assert_eq!(metadata["last_action"]["reason"], "event_count");
+    assert_eq!(metadata["usage"]["events"], 2);
+
+    reset_default_transcript_budget_policy();
+    reset_session_store();
+}
+
+#[test]
+fn transcript_budget_compaction_recovers_and_preserves_prompt_state() {
+    reset_session_store();
+    set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::compact(3, 4, 1));
+    let id = open_or_create(Some("budget-compact-recover".into()));
+
+    inject_message(&id, make_msg("user", "one")).unwrap();
+    inject_message(&id, make_msg("assistant", "two")).unwrap();
+    inject_message(&id, make_msg("user", "three")).unwrap();
+    inject_message(&id, make_msg("assistant", "four")).unwrap();
+
+    assert!(message_count(&id) <= 3);
+    assert!(event_count(&id) <= 4);
+    assert_eq!(event_count_by_kind(&id, "transcript_budget"), 1);
+    let snapshot = snapshot(&id).expect("session snapshot");
+    let snapshot_json = crate::llm::helpers::vm_value_to_json(&snapshot);
+    let summary = snapshot_json["summary"]
+        .as_str()
+        .expect("budget compaction summary");
+    assert!(summary.contains("auto-compacted 3 older message(s)"));
+    let metadata = budget_metadata(&id);
+    assert_eq!(metadata["last_action"]["action"], "compacted");
+    assert_eq!(metadata["last_action"]["reason"], "message_count");
+
+    let prompt = prompt_state_json(&id);
+    assert_eq!(prompt.summary.as_deref(), Some(summary));
+    assert_eq!(
+        prompt
+            .messages
+            .first()
+            .and_then(|msg| msg["content"].as_str()),
+        Some(summary)
+    );
+
+    reset_default_transcript_budget_policy();
+    reset_session_store();
+}
+
+#[test]
+fn fork_preserves_transcript_budget_metadata() {
+    reset_session_store();
+    set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::compact(3, 4, 1));
+    let parent = open_or_create(Some("budget-fork-parent".into()));
+    inject_message(&parent, make_msg("user", "one")).unwrap();
+    inject_message(&parent, make_msg("assistant", "two")).unwrap();
+    inject_message(&parent, make_msg("user", "three")).unwrap();
+    inject_message(&parent, make_msg("assistant", "four")).unwrap();
+
+    let child = fork(&parent, Some("budget-fork-child".into())).expect("fork");
+
+    assert_eq!(message_count(&child), message_count(&parent));
+    assert_eq!(event_count_by_kind(&child, "transcript_budget"), 1);
+    let metadata = budget_metadata(&child);
+    assert_eq!(metadata["policy"]["max_messages"], 3);
+    assert_eq!(metadata["policy"]["max_events"], 4);
+    assert_eq!(metadata["last_action"]["action"], "compacted");
+    assert_eq!(parent_id(&child).as_deref(), Some(parent.as_str()));
+
+    reset_default_transcript_budget_policy();
+    reset_session_store();
 }
 
 #[test]
@@ -392,7 +520,8 @@ fn truncate_to_zero_clears_messages_events_and_stale_summary() {
             serde_json::json!({"role": "assistant", "content": "after"}),
         ],
         Some("summary that mentions removed turns"),
-    );
+    )
+    .unwrap();
 
     let result = truncate(&id, 0).expect("truncate result");
     assert_eq!(result.kept_turn_count, 0);
@@ -406,6 +535,30 @@ fn truncate_to_zero_clears_messages_events_and_stale_summary() {
         !dict.contains_key("summary"),
         "truncating away summarized turns must not leave stale prompt summary"
     );
+    reset_session_store();
+}
+
+#[test]
+fn replace_messages_without_summary_clears_stale_summary() {
+    reset_session_store();
+    let id = open_or_create(Some("replace-clears-summary".into()));
+    replace_messages_with_summary(
+        &id,
+        &[serde_json::json!({"role": "user", "content": "before"})],
+        Some("old compacted summary"),
+    )
+    .unwrap();
+
+    replace_messages(
+        &id,
+        &[serde_json::json!({"role": "assistant", "content": "after"})],
+    )
+    .unwrap();
+
+    let prompt = prompt_state_json(&id);
+    assert_eq!(prompt.summary, None);
+    assert_eq!(prompt.messages.len(), 1);
+    assert_eq!(prompt.messages[0]["content"], "after");
     reset_session_store();
 }
 
@@ -499,7 +652,7 @@ fn branch_event_index_counts_non_message_events() {
             ])),
         ),
     ])));
-    store_transcript(&src, transcript);
+    store_transcript(&src, transcript).unwrap();
 
     let dst = fork_at(&src, 2, Some("branch-event-index-child".into())).expect("fork_at");
     assert_eq!(
@@ -539,7 +692,7 @@ fn prompt_state_prepends_summary_message_when_missing_from_messages() {
         Vec::new(),
         Some("active"),
     );
-    store_transcript(&session, transcript);
+    store_transcript(&session, transcript).unwrap();
 
     let prompt = prompt_state_json(&session);
     assert_eq!(

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -362,8 +362,8 @@ fn agent_inject_feedback_builtin(args: &[VmValue], _out: &mut String) -> Result<
             ))
         }
     };
-    let _ =
-        crate::agent_sessions::inject_message(&session_id, agent_feedback_message(&kind, &content));
+    crate::agent_sessions::inject_message(&session_id, agent_feedback_message(&kind, &content))
+        .map_err(VmError::Runtime)?;
     Ok(VmValue::Nil)
 }
 

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -313,7 +313,8 @@ async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError>
         "role": "user",
         "content": initial_user_content(&opts_map, &message),
     });
-    let _ = crate::agent_sessions::inject_message(&resolved, json_to_vm(&user_msg));
+    crate::agent_sessions::inject_message(&resolved, json_to_vm(&user_msg))
+        .map_err(VmError::Runtime)?;
 
     let session = AgentHostSession {
         session_id: resolved.clone(),
@@ -585,7 +586,8 @@ async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmEr
                 "error": error,
             })),
         );
-        let _ = crate::agent_sessions::append_event(&session_id, transcript_event);
+        crate::agent_sessions::append_event(&session_id, transcript_event)
+            .map_err(VmError::Runtime)?;
     }
     let snapshot = crate::agent_sessions::transcript(&session_id);
     let transcript_json = snapshot
@@ -759,6 +761,11 @@ fn host_agent_session_record_assistant_builtin(
         .iter()
         .map(vm_to_json)
         .collect::<Vec<_>>();
+    crate::agent_sessions::inject_message(
+        &session_id,
+        assistant_message_from_llm_result(&llm_result),
+    )
+    .map_err(VmError::Runtime)?;
     let _ = with_session(&session_id, HOST_SESSION_RECORD_ASSISTANT, |session| {
         session.tool_calls.extend(calls_json);
         if !provider.is_empty() {
@@ -769,10 +776,6 @@ fn host_agent_session_record_assistant_builtin(
         }
         Ok(())
     });
-    let _ = crate::agent_sessions::inject_message(
-        &session_id,
-        assistant_message_from_llm_result(&llm_result),
-    );
     Ok(VmValue::Nil)
 }
 
@@ -908,14 +911,15 @@ fn host_agent_session_record_tool_results_builtin(
                     "",
                     Some(plan_metadata.clone()),
                 );
-                let _ = crate::agent_sessions::append_event(&session_id, event);
+                crate::agent_sessions::append_event(&session_id, event)
+                    .map_err(VmError::Runtime)?;
                 super::agent_runtime::emit_agent_event_sync(&AgentEvent::Plan {
                     session_id: session_id.clone(),
                     plan: plan_value,
                 });
             }
         }
-        let _ = crate::agent_sessions::inject_message(
+        crate::agent_sessions::inject_message(
             &session_id,
             tool_result_message_for_provider(
                 &provider,
@@ -925,7 +929,8 @@ fn host_agent_session_record_tool_results_builtin(
                 &tool_call_id,
                 &observation,
             ),
-        );
+        )
+        .map_err(VmError::Runtime)?;
     }
     let _ = with_session(&session_id, HOST_SESSION_RECORD_TOOL_RESULTS, |session| {
         session.successful_tools.extend(successful);
@@ -985,7 +990,7 @@ fn host_agent_session_record_usage_builtin(
         }
         Ok((session.tokens_used, session.cost_used))
     })?;
-    let _ = crate::agent_sessions::append_event(
+    crate::agent_sessions::append_event(
         &session_id,
         crate::llm::helpers::transcript_event(
             "llm_call",
@@ -1000,7 +1005,8 @@ fn host_agent_session_record_usage_builtin(
                 "cost_usd": cost,
             })),
         ),
-    );
+    )
+    .map_err(VmError::Runtime)?;
     let mut out = BTreeMap::new();
     out.insert("tokens_used".to_string(), VmValue::Int(totals.0));
     out.insert("cost_usd".to_string(), VmValue::Float(totals.1));
@@ -1061,10 +1067,11 @@ fn host_agent_session_inject_feedback_builtin(
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     let kind = args.get(1).map(|v| v.display()).unwrap_or_default();
     let content = args.get(2).map(|v| v.display()).unwrap_or_default();
-    let _ = crate::agent_sessions::inject_message(
+    crate::agent_sessions::inject_message(
         &session_id,
         super::agent_config::agent_feedback_message(&kind, &content),
-    );
+    )
+    .map_err(VmError::Runtime)?;
     Ok(VmValue::Nil)
 }
 
@@ -1184,7 +1191,7 @@ fn host_agent_session_record_skill_event_builtin(
         &text,
         Some(metadata_json.clone()),
     );
-    let _ = crate::agent_sessions::append_event(&session_id, event);
+    crate::agent_sessions::append_event(&session_id, event).map_err(VmError::Runtime)?;
 
     let name = metadata_json
         .get("name")
@@ -1274,7 +1281,8 @@ fn host_agent_session_replace_messages_builtin(
         &session_id,
         &messages_json,
         summary.as_deref(),
-    );
+    )
+    .map_err(VmError::Runtime)?;
     Ok(VmValue::Nil)
 }
 
@@ -1337,7 +1345,10 @@ async fn host_agent_emit_event(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         };
         let transcript_event =
             super::helpers::transcript_event(&event_type, role, "internal", "", Some(payload));
-        let _ = crate::agent_sessions::append_event(&session_id, transcript_event);
+        if crate::agent_sessions::exists(&session_id) {
+            crate::agent_sessions::append_event(&session_id, transcript_event)
+                .map_err(VmError::Runtime)?;
+        }
     }
     crate::llm::agent_runtime::emit_agent_event(&event).await;
     Ok(VmValue::Nil)
@@ -1578,7 +1589,7 @@ fn host_agent_record_native_tool_fallback_builtin(
         "",
         Some(payload_json),
     );
-    let _ = crate::agent_sessions::append_event(&session_id, event);
+    crate::agent_sessions::append_event(&session_id, event).map_err(VmError::Runtime)?;
     Ok(VmValue::Nil)
 }
 
@@ -1652,7 +1663,7 @@ fn host_agent_record_compaction_builtin(
         "",
         Some(payload_json),
     );
-    let _ = crate::agent_sessions::append_event(&session_id, event);
+    crate::agent_sessions::append_event(&session_id, event).map_err(VmError::Runtime)?;
     crate::llm::emit_live_agent_event_sync(&crate::agent_events::AgentEvent::TranscriptCompacted {
         session_id,
         mode,
@@ -1857,12 +1868,12 @@ async fn drain_bridge_injections_for_checkpoint(
     session_id: &str,
     bridge: &crate::bridge::HostBridge,
     checkpoint: crate::bridge::DeliveryCheckpoint,
-) -> (usize, Option<&'static str>) {
+) -> Result<(usize, Option<&'static str>), VmError> {
     let queued = bridge
         .take_queued_transcript_injections_for(checkpoint)
         .await;
     if queued.is_empty() {
-        return (0, None);
+        return Ok((0, None));
     }
     let mut saw_user_message = false;
     let mut saw_reminder = false;
@@ -1870,30 +1881,32 @@ async fn drain_bridge_injections_for_checkpoint(
     for injection in queued {
         match injection {
             crate::bridge::QueuedTranscriptInjection::User(message) => {
-                saw_user_message = true;
-                delivered += 1;
-                let _ = crate::agent_sessions::inject_message(
+                crate::agent_sessions::inject_message(
                     session_id,
                     json_to_vm(&serde_json::json!({
                         "role": "user",
                         "content": message.transcript_content,
                         "messageId": message.message_id,
                     })),
-                );
+                )
+                .map_err(VmError::Runtime)?;
+                saw_user_message = true;
+                delivered += 1;
             }
             crate::bridge::QueuedTranscriptInjection::Reminder(reminder) => {
+                crate::agent_sessions::inject_reminder(session_id, reminder.reminder)
+                    .map_err(VmError::Runtime)?;
                 saw_reminder = true;
                 delivered += 1;
-                let _ = crate::agent_sessions::inject_reminder(session_id, reminder.reminder);
             }
         }
     }
     if saw_user_message {
-        (delivered, Some("message"))
+        Ok((delivered, Some("message")))
     } else if saw_reminder {
-        (delivered, Some("reminder"))
+        Ok((delivered, Some("reminder")))
     } else {
-        (delivered, None)
+        Ok((delivered, None))
     }
 }
 
@@ -1908,13 +1921,13 @@ async fn daemon_checkpoint_drain(
     session_id: &str,
     bridge: &crate::bridge::HostBridge,
     kind: &'static str,
-) -> (usize, Option<&'static str>) {
+) -> Result<(usize, Option<&'static str>), VmError> {
     let (delivered, reason) = drain_bridge_injections_for_checkpoint(
         session_id,
         bridge,
         crate::bridge::DeliveryCheckpoint::InterruptImmediate,
     )
-    .await;
+    .await?;
     let event = crate::agent_events::AgentEvent::LoopCheckpoint {
         session_id: session_id.to_string(),
         iteration: 0,
@@ -1924,7 +1937,7 @@ async fn daemon_checkpoint_drain(
         dispatch_skipped: false,
     };
     super::agent_runtime::emit_agent_event(&event).await;
-    (delivered, reason)
+    Ok((delivered, reason))
 }
 
 /// Push a system-reminder onto the session's host bridge queue. The
@@ -1989,7 +2002,7 @@ async fn host_agent_session_drain_bridge_injections(
         })));
     };
     let (delivered, reason) =
-        drain_bridge_injections_for_checkpoint(&session_id, &bridge, checkpoint).await;
+        drain_bridge_injections_for_checkpoint(&session_id, &bridge, checkpoint).await?;
     Ok(json_to_vm(&serde_json::json!({
         "delivered": delivered,
         "reason": reason.unwrap_or("none"),
@@ -2015,7 +2028,7 @@ async fn host_agent_daemon_wait(args: Vec<VmValue>) -> Result<VmValue, VmError> 
             bridge.set_daemon_idle(false);
             return Ok(json_to_vm(&serde_json::json!({"reason": "resume"})));
         }
-        let (_, reason) = daemon_checkpoint_drain(&session_id, bridge, "daemon_idle_pre").await;
+        let (_, reason) = daemon_checkpoint_drain(&session_id, bridge, "daemon_idle_pre").await?;
         if let Some(reason) = reason {
             bridge.set_daemon_idle(false);
             return Ok(json_to_vm(&serde_json::json!({"reason": reason})));
@@ -2027,7 +2040,7 @@ async fn host_agent_daemon_wait(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     }
 
     if let Some(bridge) = bridge.as_ref() {
-        let (_, reason) = daemon_checkpoint_drain(&session_id, bridge, "daemon_idle_post").await;
+        let (_, reason) = daemon_checkpoint_drain(&session_id, bridge, "daemon_idle_post").await?;
         if let Some(reason) = reason {
             bridge.set_daemon_idle(false);
             return Ok(json_to_vm(&serde_json::json!({"reason": reason})));

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -658,7 +658,8 @@ async fn agent_session_compact_builtin(args: Vec<VmValue>) -> Result<VmValue, Vm
         let archived_messages = original_message_count
             .saturating_sub(messages.len())
             .saturating_add(1);
-        agent_sessions::replace_messages_with_summary(&id, &messages, Some(&summary));
+        agent_sessions::replace_messages_with_summary(&id, &messages, Some(&summary))
+            .map_err(err)?;
         record_agent_session_compaction(
             &id,
             &config,
@@ -666,9 +667,9 @@ async fn agent_session_compact_builtin(args: Vec<VmValue>) -> Result<VmValue, Vm
             estimated_tokens_before,
             estimated_tokens_after,
             summary.len(),
-        );
+        )?;
     } else {
-        agent_sessions::replace_messages(&id, &messages);
+        agent_sessions::replace_messages(&id, &messages).map_err(err)?;
     }
     Ok(VmValue::Int(kept as i64))
 }
@@ -767,7 +768,7 @@ fn record_agent_session_compaction(
     estimated_tokens_before: usize,
     estimated_tokens_after: usize,
     new_summary_len: usize,
-) {
+) -> Result<(), VmError> {
     let mut metadata = serde_json::json!({
         "mode": "host",
         "strategy": &config.policy_strategy,
@@ -791,7 +792,7 @@ fn record_agent_session_compaction(
         "",
         Some(metadata.clone()),
     );
-    let _ = agent_sessions::append_event(id, event);
+    agent_sessions::append_event(id, event).map_err(err)?;
     crate::llm::emit_live_agent_event_sync(&crate::agent_events::AgentEvent::TranscriptCompacted {
         session_id: id.to_string(),
         mode: "host".to_string(),
@@ -804,6 +805,7 @@ fn record_agent_session_compaction(
         instruction_source: config.policy.instruction_source().map(str::to_string),
         compaction_policy: config.policy.metadata_json(),
     });
+    Ok(())
 }
 
 fn compact_usize_opt(

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -113,27 +113,33 @@ pub(in super::super) fn ensure_worker_config_session_ids(
     }
 }
 
-fn restore_worker_transcript(config: &WorkerConfig, transcript: Option<&VmValue>) {
+fn restore_worker_transcript(
+    config: &WorkerConfig,
+    transcript: Option<&VmValue>,
+) -> Result<(), VmError> {
     let Some(transcript) = transcript.cloned() else {
         if let WorkerConfig::SubAgent { spec } = config {
             crate::agent_sessions::open_or_create(Some(spec.session_id.clone()));
             crate::agent_sessions::reset_transcript(&spec.session_id);
         }
-        return;
+        return Ok(());
     };
     match config {
         WorkerConfig::Stage { node, .. } => {
             if let Some(session_id) = worker_stage_session_id(node) {
                 crate::agent_sessions::open_or_create(Some(session_id.clone()));
-                crate::agent_sessions::store_transcript(&session_id, transcript);
+                crate::agent_sessions::store_transcript(&session_id, transcript)
+                    .map_err(VmError::Runtime)?;
             }
         }
         WorkerConfig::SubAgent { spec } => {
             crate::agent_sessions::open_or_create(Some(spec.session_id.clone()));
-            crate::agent_sessions::store_transcript(&spec.session_id, transcript);
+            crate::agent_sessions::store_transcript(&spec.session_id, transcript)
+                .map_err(VmError::Runtime)?;
         }
         WorkerConfig::Workflow { .. } => {}
     }
+    Ok(())
 }
 
 async fn call_worker_harn_export(
@@ -153,7 +159,7 @@ async fn execute_worker_config(
     audit: MutationSessionRecord,
 ) -> Result<WorkerExecutionResult, VmError> {
     ensure_worker_worktree(&worker_id, &mut execution)?;
-    restore_worker_transcript(&config, prior_transcript.as_ref());
+    restore_worker_transcript(&config, prior_transcript.as_ref())?;
     let execution_record = execution_record(&execution);
     crate::stdlib::process::set_thread_execution_context(Some(execution_record.clone()));
     let parent_run_id = audit.run_id.clone();

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2296,6 +2296,10 @@ Lifecycle builtins (all hard-error on unknown ids except `exists`,
   `transcript_auto_compact`, and errors on unknown option keys.
 - `agent_session_length(id)` / `_snapshot(id)` / `_ancestry(id)` for read-only inspection.
 
+Session snapshots include `metadata.transcript_budget` after hard retention
+budget pressure. `last_action` records whether Harn rejected, trimmed, or
+compacted the transcript, along with before/after message and event counts.
+
 ### Daemon wrappers
 
 Use the daemon stdlib wrappers when you want a first-class handle around

--- a/docs/src/transcript-architecture.md
+++ b/docs/src/transcript-architecture.md
@@ -59,6 +59,13 @@ Rules:
   continuations that omit all new system prompt fields.
 - Message blocks should reference assets by `asset_id` instead of embedding base64 when persistence matters.
 - Compaction should summarize archived text while retaining asset descriptors and recent multimodal turns.
+- First-class sessions enforce hard transcript retention budgets independent of
+  optional auto-compaction. The runtime caps retained message count, event count,
+  and any configured approximate byte budget; budget pressure either rejects the
+  mutation or applies the explicit session recovery policy. Recovery writes a
+  `transcript_budget` audit event, and session snapshots expose
+  `metadata.transcript_budget.last_action` so hosts can explain why context was
+  trimmed or compacted.
 
 Persistence split:
 


### PR DESCRIPTION
## Summary
- add hard per-session transcript budget policy for message, event, and optional approximate-byte caps
- enforce budgets across session mutations, host transcript writes, compaction, worker restore, forks, reminders, and bridge injections
- surface transcript budget policy/usage/last action metadata and document the host-facing contract

## Verification
- cargo fmt --all -- --check
- cargo test -p harn-vm agent_sessions
- cargo test -p harn-vm --test agent_loop_steering_seams
- cargo clippy -p harn-vm --all-targets -- -D warnings
- cargo run --quiet --bin harn -- test conformance --filter agent_sessions
- cargo run --quiet --bin harn -- test conformance --filter agent_session_compact
- make lint-test-patterns
- make check-docs-snippets
- pre-commit hook
- pre-push hook

Closes #2205