### PR TITLE
Add context-engineering eval runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **Reusable context-engineering eval primitives (#2195).** Added
+  `harn eval context` plus portable `harn.context_eval.manifest.v1` and
+  `harn.context_eval.report.v1` shapes for deterministic pack, projection,
+  compaction, and tool-disclosure experiments. The smoke manifest exercises
+  three tasks across three context modes and writes stable JSON/JSONL/Markdown
+  artifacts that hosted eval tooling and downstream products can ingest.
 - **First-class compaction instructions (#2190).** Manual session compaction,
   transcript auto-compaction, host-triggered compaction, and `agent_loop`
   auto-compaction now accept a typed `CompactionPolicy` with optional

--- a/crates/harn-cli/src/cli/eval.rs
+++ b/crates/harn-cli/src/cli/eval.rs
@@ -49,10 +49,24 @@ pub struct EvalArgs {
 pub enum EvalCommand {
     /// Benchmark coding-agent fixtures across providers and tool formats.
     CodingAgent(EvalCodingAgentArgs),
+    /// Run deterministic context-engineering modes over task fixtures.
+    Context(EvalContextArgs),
     /// Render and optionally run a `.harn.prompt` across a fleet of models.
     Prompt(EvalPromptArgs),
     /// Run tool-call accuracy, latency, and cost evals over a dataset.
     ToolCalls(EvalToolCallsArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct EvalContextArgs {
+    /// Context eval manifest JSON or TOML.
+    pub manifest: PathBuf,
+    /// Output directory for summary.json, per_run.jsonl, and summary.md.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+    /// Print the aggregate summary JSON to stdout.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -96,8 +96,8 @@ pub(crate) use dump::{
     DumpTriggerQuickrefArgs,
 };
 pub use eval::{
-    EvalArgs, EvalCodingAgentArgs, EvalCommand, EvalPromptArgs, EvalPromptMode, EvalPromptOutput,
-    EvalToolCallsArgs, EvalToolCallsCommand, EvalToolCallsRegressionArgs,
+    EvalArgs, EvalCodingAgentArgs, EvalCommand, EvalContextArgs, EvalPromptArgs, EvalPromptMode,
+    EvalPromptOutput, EvalToolCallsArgs, EvalToolCallsCommand, EvalToolCallsRegressionArgs,
 };
 pub(crate) use explain::{CatalogFormat, ExplainArgs};
 pub(crate) use fix::{FixArgs, HarnessThreadingMode};

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -306,6 +306,35 @@ fn test_parses_eval_tool_calls_args() {
 }
 
 #[test]
+fn test_parses_eval_context_args() {
+    let cli = Cli::parse_from([
+        "harn",
+        "eval",
+        "context",
+        "examples/evals/context-engineering-smoke.json",
+        "--output",
+        ".harn-runs/context-eval/smoke",
+        "--json",
+    ]);
+
+    let Command::Eval(args) = cli.command.unwrap() else {
+        panic!("expected eval command");
+    };
+    let Some(EvalCommand::Context(context)) = args.command else {
+        panic!("expected context command");
+    };
+    assert_eq!(
+        context.manifest,
+        PathBuf::from("examples/evals/context-engineering-smoke.json")
+    );
+    assert_eq!(
+        context.output,
+        Some(PathBuf::from(".harn-runs/context-eval/smoke"))
+    );
+    assert!(context.json);
+}
+
+#[test]
 fn test_parses_run_yes_flag() {
     let cli = Cli::parse_from(["harn", "run", "--yes", "main.harn"]);
 

--- a/crates/harn-cli/src/commands/eval_context.rs
+++ b/crates/harn-cli/src/commands/eval_context.rs
@@ -1,0 +1,135 @@
+//! `harn eval context` — deterministic context-engineering mode runner.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use harn_vm::orchestration::{
+    context_eval_default_output_dir, evaluate_context_eval_manifest, load_context_eval_manifest,
+    ContextEvalReport, ContextEvalRunReport,
+};
+
+use crate::cli::EvalContextArgs;
+
+pub fn run(args: EvalContextArgs) -> i32 {
+    let manifest = match load_context_eval_manifest(&args.manifest) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    let report = match evaluate_context_eval_manifest(&manifest) {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+
+    let output_dir = args.output.unwrap_or_else(context_eval_default_output_dir);
+    if let Err(error) = fs::create_dir_all(&output_dir) {
+        eprintln!("error: failed to create {}: {error}", output_dir.display());
+        return 1;
+    }
+    if let Err(error) = write_outputs(&output_dir, &report) {
+        eprintln!("error: failed to write context eval outputs: {error}");
+        return 1;
+    }
+    eprintln!(
+        "wrote {}, {}, and {}",
+        output_dir.join("summary.json").display(),
+        output_dir.join("per_run.jsonl").display(),
+        output_dir.join("summary.md").display()
+    );
+    if args.json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(payload) => println!("{payload}"),
+            Err(error) => {
+                eprintln!("error: failed to serialize context eval summary: {error}");
+                return 1;
+            }
+        }
+    } else {
+        println!(
+            "context eval: {}/{} passed, mean_correctness={:.2}, mean_tool_quality={:.2}",
+            report.passed_runs,
+            report.total_runs,
+            report.aggregate.mean_final_correctness,
+            report.aggregate.mean_tool_call_quality
+        );
+    }
+
+    if report.pass {
+        0
+    } else {
+        1
+    }
+}
+
+fn write_outputs(output_dir: &Path, report: &ContextEvalReport) -> Result<(), String> {
+    write_json(output_dir.join("summary.json"), report)?;
+    write_jsonl(output_dir.join("per_run.jsonl"), &report.runs)?;
+    fs::write(output_dir.join("summary.md"), render_markdown(report))
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn write_json(path: PathBuf, report: &ContextEvalReport) -> Result<(), String> {
+    let payload = serde_json::to_string_pretty(report).map_err(|error| error.to_string())?;
+    fs::write(path, payload).map_err(|error| error.to_string())
+}
+
+fn write_jsonl(path: PathBuf, runs: &[ContextEvalRunReport]) -> Result<(), String> {
+    let mut file = fs::File::create(path).map_err(|error| error.to_string())?;
+    for run in runs {
+        let line = serde_json::to_string(run).map_err(|error| error.to_string())?;
+        file.write_all(line.as_bytes())
+            .map_err(|error| error.to_string())?;
+        file.write_all(b"\n").map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn render_markdown(report: &ContextEvalReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Context Eval: {}\n\n",
+        report
+            .manifest_name
+            .as_deref()
+            .unwrap_or(report.manifest_id.as_str())
+    ));
+    out.push_str(&format!(
+        "- status: {}\n- runs: {}/{} passed\n- mean correctness: {:.4}\n- mean tool quality: {:.4}\n- input tokens: {}\n- output tokens: {}\n- cost USD: {:.6}\n\n",
+        if report.pass { "PASS" } else { "FAIL" },
+        report.passed_runs,
+        report.total_runs,
+        report.aggregate.mean_final_correctness,
+        report.aggregate.mean_tool_call_quality,
+        report.aggregate.total_input_tokens,
+        report.aggregate.total_output_tokens,
+        report.aggregate.total_cost_usd,
+    ));
+    out.push_str("| task | mode | pass | correctness | tools | reads before edit | input tokens | compactions | cache key |\n");
+    out.push_str("|---|---|---:|---:|---:|---:|---:|---:|---|\n");
+    for run in &report.runs {
+        out.push_str(&format!(
+            "| {} | {} | {} | {:.4} | {:.4} | {} | {} | {} | `{}` |\n",
+            escape_md(&run.task_id),
+            escape_md(&run.mode_id),
+            if run.passed { "yes" } else { "no" },
+            run.final_correctness.score,
+            run.tool_call_quality.score,
+            run.reads_before_first_edit,
+            run.input_tokens,
+            run.compaction_count,
+            run.cache.key,
+        ));
+    }
+    out
+}
+
+fn escape_md(value: &str) -> String {
+    value.replace('|', "\\|")
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod dump_highlight_keywords;
 pub(crate) mod dump_protocol_artifacts;
 pub(crate) mod dump_trigger_quickref;
 pub mod eval_coding_agent;
+pub mod eval_context;
 pub(crate) mod eval_model_selector;
 pub mod eval_prompt;
 pub(crate) mod eval_prompt_context;

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1115,6 +1115,12 @@ async fn async_main() {
                     process::exit(code);
                 }
             }
+            Some(EvalCommand::Context(context_args)) => {
+                let code = commands::eval_context::run(context_args);
+                if code != 0 {
+                    process::exit(code);
+                }
+            }
             Some(EvalCommand::Prompt(prompt_args)) => {
                 let code = commands::eval_prompt::run(prompt_args).await;
                 if code != 0 {

--- a/crates/harn-cli/tests/eval_context_cli.rs
+++ b/crates/harn-cli/tests/eval_context_cli.rs
@@ -1,0 +1,49 @@
+//! In-process coverage for `harn eval context`.
+
+use std::fs;
+use std::path::Path;
+
+use harn_cli::cli::EvalContextArgs;
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate lives under crates/harn-cli")
+}
+
+#[test]
+fn context_smoke_manifest_writes_stable_report_artifacts() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = tmp.path().join("context-eval");
+    let manifest = workspace_root().join("examples/evals/context-engineering-smoke.json");
+    let args = EvalContextArgs {
+        manifest,
+        output: Some(output.clone()),
+        json: false,
+    };
+
+    let exit = harn_cli::commands::eval_context::run(args);
+    assert_eq!(exit, 0, "context eval smoke fixture should pass");
+
+    let summary_raw = fs::read_to_string(output.join("summary.json")).expect("summary exists");
+    let summary: serde_json::Value =
+        serde_json::from_str(&summary_raw).expect("summary parses as JSON");
+    assert_eq!(summary["_type"], "harn.context_eval.report.v1");
+    assert_eq!(summary["schema_version"], 1);
+    assert_eq!(summary["pass"], true);
+    assert_eq!(summary["total_runs"], 9);
+    assert_eq!(summary["passed_runs"], 9);
+    assert_eq!(summary["failed_runs"], 0);
+    let runs = summary["runs"].as_array().expect("runs are present");
+    assert_eq!(runs.len(), 9);
+    assert!(
+        runs.iter()
+            .all(|run| run["cache"]["deterministic_order"] == true),
+        "reports must be stable enough for hosted ingestion and diffing",
+    );
+
+    let per_run = fs::read_to_string(output.join("per_run.jsonl")).expect("per-run JSONL exists");
+    assert_eq!(per_run.lines().count(), 9);
+    assert!(output.join("summary.md").exists());
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -146,6 +146,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/context/maintenance.harn"),
     },
     StdlibSource {
+        module: "context/eval",
+        source: include_str!("stdlib/context/eval.harn"),
+    },
+    StdlibSource {
         module: "runtime",
         source: include_str!("stdlib/stdlib_runtime.harn"),
     },
@@ -1015,6 +1019,7 @@ mod tests {
         for module in [
             "context",
             "context/maintenance",
+            "context/eval",
             "edit",
             "artifact/web",
             "command",

--- a/crates/harn-stdlib/src/stdlib/context/eval.harn
+++ b/crates/harn-stdlib/src/stdlib/context/eval.harn
@@ -1,0 +1,178 @@
+/**
+ * std/context/eval - helpers for Harn context-engineering eval manifests.
+ *
+ * The CLI runner owns execution. These helpers keep Harn-authored fixtures,
+ * package evals, and host UI code aligned on the same portable data shape.
+ */
+import { filter_nil } from "std/collections"
+
+let CONTEXT_EVAL_MANIFEST_SCHEMA = "harn.context_eval.manifest.v1"
+
+let CONTEXT_EVAL_REPORT_SCHEMA = "harn.context_eval.report.v1"
+
+let CONTEXT_EVAL_VERSION = 1
+
+fn __context_eval_text(value) {
+  if value == nil {
+    return ""
+  }
+  return trim(to_string(value))
+}
+
+fn __context_eval_required_text(value, field) {
+  let text = __context_eval_text(value)
+  if text == "" {
+    throw "std/context/eval: " + field + " is required"
+  }
+  return text
+}
+
+fn __context_eval_list(value, field) {
+  if value == nil {
+    return []
+  }
+  if type_of(value) != "list" {
+    throw "std/context/eval: " + field + " must be a list"
+  }
+  return value
+}
+
+fn __context_eval_string_list(value, field) {
+  var out = []
+  for item in __context_eval_list(value, field) {
+    let text = __context_eval_text(item)
+    if text != "" && !out.contains(text) {
+      out = out.push(text)
+    }
+  }
+  return out.sort()
+}
+
+/**
+ * Build a context-eval mode declaration.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: context_eval_mode("pack", "hud_pack", {budget_tokens: 1600})
+ */
+pub fn context_eval_mode(id: string, kind = nil, options = nil) {
+  let opts = options ?? {}
+  let mode_id = __context_eval_required_text(id, "mode id")
+  let mode_kind = __context_eval_text(kind ?? opts?.kind ?? mode_id)
+  return filter_nil(
+    opts
+      + {
+      id: mode_id,
+      kind: if mode_kind == "" {
+        mode_id
+      } else {
+        mode_kind
+      },
+      name: opts?.name,
+      description: opts?.description,
+      artifact_ids: __context_eval_string_list(opts?.artifact_ids ?? opts?.artifacts, "artifact_ids"),
+      include_artifact_kinds: __context_eval_string_list(
+        opts?.include_artifact_kinds ?? opts?.include_kinds,
+        "include_artifact_kinds",
+      ),
+      exclude_artifact_kinds: __context_eval_string_list(
+        opts?.exclude_artifact_kinds ?? opts?.exclude_kinds,
+        "exclude_artifact_kinds",
+      ),
+      budget_tokens: opts?.budget_tokens ?? opts?.max_tokens,
+      assemble_strategy: opts?.assemble_strategy ?? opts?.strategy,
+      dedup: opts?.dedup,
+      projection_policy: opts?.projection_policy ?? opts?.projection,
+      transcript_keep_last: opts?.transcript_keep_last ?? opts?.keep_last,
+      tool_disclosure: opts?.tool_disclosure,
+      tool_allowlist: __context_eval_string_list(opts?.tool_allowlist ?? opts?.tools, "tool_allowlist"),
+      expected_cache_hit: opts?.expected_cache_hit,
+      cache_namespace: opts?.cache_namespace,
+      compaction_policy: opts?.compaction_policy,
+      preprocessing: opts?.preprocessing ?? "deterministic",
+      metadata: opts?.metadata ?? {},
+    },
+  )
+}
+
+/**
+ * Build a context-eval task declaration.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: context_eval_task("incident", "Find the failing service", {artifacts: []})
+ */
+pub fn context_eval_task(id: string, objective: string, options = nil) {
+  let opts = options ?? {}
+  let task_id = __context_eval_required_text(id, "task id")
+  let task_objective = __context_eval_required_text(objective, "objective")
+  let expected = opts?.expected ?? {}
+  return filter_nil(
+    opts
+      + {
+      id: task_id,
+      name: opts?.name,
+      objective: task_objective,
+      reference_answer: opts?.reference_answer,
+      artifacts: __context_eval_list(opts?.artifacts, "artifacts"),
+      transcript: __context_eval_list(opts?.transcript, "transcript"),
+      tools: __context_eval_list(opts?.tools, "tools"),
+      tool_events: __context_eval_list(opts?.tool_events, "tool_events"),
+      expected: expected
+        + {
+        required_terms: __context_eval_string_list(expected?.required_terms ?? opts?.required_terms, "required_terms"),
+        expected_artifact_ids: __context_eval_string_list(
+          expected?.expected_artifact_ids ?? opts?.expected_artifact_ids,
+          "expected_artifact_ids",
+        ),
+        expected_tools: __context_eval_string_list(expected?.expected_tools ?? opts?.expected_tools, "expected_tools"),
+        max_input_tokens: expected?.max_input_tokens ?? opts?.max_input_tokens,
+      },
+      observed: opts?.observed ?? {},
+      mode_observations: opts?.mode_observations ?? {},
+      metadata: opts?.metadata ?? {},
+    },
+  )
+}
+
+/**
+ * Build a portable context-eval manifest for `harn eval context`.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: context_eval_manifest(tasks, modes, {id: "repo-context-smoke"})
+ */
+pub fn context_eval_manifest(tasks = [], modes = [], options = nil) {
+  let opts = options ?? {}
+  return filter_nil(
+    {
+      _type: CONTEXT_EVAL_MANIFEST_SCHEMA,
+      version: CONTEXT_EVAL_VERSION,
+      id: __context_eval_text(opts?.id ?? "context-eval"),
+      name: opts?.name,
+      description: opts?.description,
+      modes: __context_eval_list(modes, "modes"),
+      tasks: __context_eval_list(tasks, "tasks"),
+      metadata: opts?.metadata ?? {},
+    },
+  )
+}
+
+/**
+ * Return the report schema id consumed by harn-cloud and local host UIs.
+ *
+ * @effects: []
+ * @allocation: stack
+ * @errors: []
+ * @api_stability: stable
+ * @example: context_eval_report_schema()
+ */
+pub fn context_eval_report_schema() {
+  return CONTEXT_EVAL_REPORT_SCHEMA
+}

--- a/crates/harn-vm/src/orchestration/context_eval.rs
+++ b/crates/harn-vm/src/orchestration/context_eval.rs
@@ -1,0 +1,1218 @@
+//! Deterministic context-engineering eval primitives.
+//!
+//! The runner measures whether a task has enough projected context, transcript
+//! state, and tool disclosure to be answerable under a named context mode. It
+//! intentionally does not call an LLM by default; live/model preprocessing can
+//! be layered on top by hosts while keeping this report shape stable.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+
+use super::{
+    assemble_context, estimate_chunk_tokens, render_assembled_chunks, ArtifactRecord,
+    AssembleDedup, AssembleOptions, AssembleStrategy,
+};
+use crate::value::VmError;
+
+pub const CONTEXT_EVAL_SCHEMA_VERSION: u32 = 1;
+pub const CONTEXT_EVAL_MANIFEST_TYPE: &str = "harn.context_eval.manifest.v1";
+pub const CONTEXT_EVAL_REPORT_TYPE: &str = "harn.context_eval.report.v1";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalManifest {
+    #[serde(rename = "_type")]
+    pub type_name: String,
+    pub version: u32,
+    pub id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub modes: Vec<ContextEvalMode>,
+    pub tasks: Vec<ContextEvalTask>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalMode {
+    pub id: String,
+    pub name: Option<String>,
+    pub kind: String,
+    pub description: Option<String>,
+    #[serde(default, alias = "artifact-ids")]
+    pub artifact_ids: Vec<String>,
+    #[serde(default, alias = "include-artifact-kinds")]
+    pub include_artifact_kinds: Vec<String>,
+    #[serde(default, alias = "exclude-artifact-kinds")]
+    pub exclude_artifact_kinds: Vec<String>,
+    #[serde(default, alias = "budget-tokens")]
+    pub budget_tokens: Option<usize>,
+    #[serde(default, alias = "assemble-strategy")]
+    pub assemble_strategy: Option<String>,
+    pub dedup: Option<String>,
+    #[serde(default, alias = "microcompact-threshold")]
+    pub microcompact_threshold: Option<usize>,
+    #[serde(default, alias = "semantic-overlap")]
+    pub semantic_overlap: Option<f64>,
+    #[serde(default, alias = "projection-policy")]
+    pub projection_policy: Option<String>,
+    #[serde(default, alias = "transcript-keep-last")]
+    pub transcript_keep_last: Option<usize>,
+    #[serde(default, alias = "tool-disclosure")]
+    pub tool_disclosure: Option<String>,
+    #[serde(default, alias = "tool-allowlist")]
+    pub tool_allowlist: Vec<String>,
+    #[serde(default, alias = "expected-cache-hit")]
+    pub expected_cache_hit: Option<bool>,
+    #[serde(default, alias = "cache-namespace")]
+    pub cache_namespace: Option<String>,
+    #[serde(default, alias = "compaction-policy")]
+    pub compaction_policy: Option<JsonValue>,
+    pub preprocessing: Option<String>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalTask {
+    pub id: String,
+    pub name: Option<String>,
+    pub objective: String,
+    #[serde(default, alias = "reference-answer")]
+    pub reference_answer: Option<String>,
+    pub artifacts: Vec<ArtifactRecord>,
+    pub transcript: Vec<ContextEvalTranscriptMessage>,
+    pub tools: Vec<ContextEvalTool>,
+    #[serde(default, alias = "tool-events")]
+    pub tool_events: Vec<ContextEvalToolEvent>,
+    pub expected: ContextEvalExpected,
+    pub observed: ContextEvalObserved,
+    #[serde(default, alias = "mode-observations")]
+    pub mode_observations: BTreeMap<String, ContextEvalObserved>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalTranscriptMessage {
+    pub role: String,
+    pub content: String,
+    #[serde(default, alias = "estimated-tokens")]
+    pub estimated_tokens: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalTool {
+    pub name: String,
+    pub description: Option<String>,
+    pub capability: Option<String>,
+    pub deterministic: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalToolEvent {
+    pub order: Option<usize>,
+    pub name: String,
+    pub phase: Option<String>,
+    pub success: Option<bool>,
+    pub quality: Option<String>,
+    pub recovery: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalExpected {
+    #[serde(default, alias = "required-terms")]
+    pub required_terms: Vec<String>,
+    #[serde(default, alias = "expected-artifact-ids")]
+    pub expected_artifact_ids: Vec<String>,
+    #[serde(default, alias = "expected-tools")]
+    pub expected_tools: Vec<String>,
+    #[serde(default, alias = "max-input-tokens")]
+    pub max_input_tokens: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalObserved {
+    #[serde(default, alias = "final-response")]
+    pub final_response: Option<String>,
+    #[serde(default, alias = "latency-ms")]
+    pub latency_ms: Option<u64>,
+    #[serde(default, alias = "input-tokens")]
+    pub input_tokens: Option<usize>,
+    #[serde(default, alias = "output-tokens")]
+    pub output_tokens: Option<usize>,
+    #[serde(default, alias = "cost-usd")]
+    pub cost_usd: Option<f64>,
+    #[serde(default, alias = "cache-hit")]
+    pub cache_hit: Option<bool>,
+    #[serde(default, alias = "compaction-count")]
+    pub compaction_count: Option<usize>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalReport {
+    #[serde(rename = "_type")]
+    pub type_name: String,
+    pub schema_version: u32,
+    pub manifest_id: String,
+    pub manifest_name: Option<String>,
+    pub pass: bool,
+    pub total_runs: usize,
+    pub passed_runs: usize,
+    pub failed_runs: usize,
+    pub total_tasks: usize,
+    pub total_modes: usize,
+    pub aggregate: ContextEvalAggregate,
+    pub modes: Vec<ContextEvalModeSummary>,
+    pub tasks: Vec<ContextEvalTaskSummary>,
+    pub runs: Vec<ContextEvalRunReport>,
+    pub metadata: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalAggregate {
+    pub mean_final_correctness: f64,
+    pub mean_tool_call_quality: f64,
+    pub total_latency_ms: u64,
+    pub total_input_tokens: usize,
+    pub total_output_tokens: usize,
+    pub total_cost_usd: f64,
+    pub total_compaction_count: usize,
+    pub total_error_recovery_count: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalModeSummary {
+    pub id: String,
+    pub kind: String,
+    pub projection_policy: String,
+    pub tool_disclosure: String,
+    pub preprocessing: ContextEvalPreprocessing,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalPreprocessing {
+    pub mode: String,
+    pub llm_enabled: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalTaskSummary {
+    pub id: String,
+    pub name: Option<String>,
+    pub required_terms: Vec<String>,
+    pub expected_artifact_ids: Vec<String>,
+    pub expected_tools: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalRunReport {
+    pub run_id: String,
+    pub task_id: String,
+    pub mode_id: String,
+    pub mode_kind: String,
+    pub status: String,
+    pub passed: bool,
+    pub final_correctness: ContextEvalCorrectness,
+    pub reads_before_first_edit: usize,
+    pub tool_call_quality: ContextEvalToolQuality,
+    pub latency_ms: u64,
+    pub input_tokens: usize,
+    pub output_tokens: usize,
+    pub cost_usd: f64,
+    pub compaction_count: usize,
+    pub projection: ContextEvalProjectionReport,
+    pub context: ContextEvalContextReport,
+    pub cache: ContextEvalCacheReport,
+    pub error_recovery_count: usize,
+    pub preprocessing: ContextEvalPreprocessing,
+    pub failures: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalCorrectness {
+    pub passed: bool,
+    pub score: f64,
+    pub required_terms_present: Vec<String>,
+    pub required_terms_missing: Vec<String>,
+    pub expected_artifact_ids_present: Vec<String>,
+    pub expected_artifact_ids_missing: Vec<String>,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct ContextEvalToolQuality {
+    pub score: f64,
+    pub expected_tools: Vec<String>,
+    pub observed_tools: Vec<String>,
+    pub matched_tools: Vec<String>,
+    pub missing_tools: Vec<String>,
+    pub unnecessary_tools: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalProjectionReport {
+    pub policy: String,
+    pub source_message_count: usize,
+    pub retained_message_count: usize,
+    pub retained_tokens: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalContextReport {
+    pub projection_policy: String,
+    pub tool_disclosure: String,
+    pub artifact_count: usize,
+    pub selected_artifact_ids: Vec<String>,
+    pub dropped_artifact_ids: Vec<String>,
+    pub rendered_bytes: usize,
+    pub rendered_tokens: usize,
+    pub budget_tokens: usize,
+    pub assemble_strategy: String,
+    pub dedup: String,
+    pub exposed_tools: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ContextEvalCacheReport {
+    pub namespace: String,
+    pub key: String,
+    pub stable_input_hash: String,
+    pub deterministic_order: bool,
+    pub hit: Option<bool>,
+}
+
+struct PreparedModeRun {
+    artifacts: Vec<ArtifactRecord>,
+    rendered_context: String,
+    selected_artifact_ids: Vec<String>,
+    dropped_artifact_ids: Vec<String>,
+    projection: ContextEvalProjectionReport,
+    transcript_text: String,
+    exposed_tools: Vec<String>,
+    visible_tool_events: Vec<ContextEvalToolEvent>,
+}
+
+pub fn load_context_eval_manifest(path: &Path) -> Result<ContextEvalManifest, VmError> {
+    let content = std::fs::read_to_string(path).map_err(|error| {
+        VmError::Runtime(format!("failed to read context eval manifest: {error}"))
+    })?;
+    let mut manifest: ContextEvalManifest =
+        if path.extension().and_then(|ext| ext.to_str()) == Some("toml") {
+            toml::from_str(&content).map_err(|error| {
+                VmError::Runtime(format!("failed to parse context eval TOML: {error}"))
+            })?
+        } else {
+            serde_json::from_str(&content).map_err(|error| {
+                VmError::Runtime(format!("failed to parse context eval JSON: {error}"))
+            })?
+        };
+    normalize_context_eval_manifest(&mut manifest)?;
+    Ok(manifest)
+}
+
+pub fn evaluate_context_eval_manifest(
+    manifest: &ContextEvalManifest,
+) -> Result<ContextEvalReport, VmError> {
+    let mut manifest = manifest.clone();
+    normalize_context_eval_manifest(&mut manifest)?;
+
+    let modes = manifest
+        .modes
+        .iter()
+        .map(|mode| ContextEvalModeSummary {
+            id: mode.id.clone(),
+            kind: mode_kind(mode),
+            projection_policy: projection_policy(mode),
+            tool_disclosure: tool_disclosure(mode),
+            preprocessing: preprocessing_report(mode),
+        })
+        .collect::<Vec<_>>();
+    let tasks = manifest
+        .tasks
+        .iter()
+        .map(|task| ContextEvalTaskSummary {
+            id: task.id.clone(),
+            name: task.name.clone(),
+            required_terms: sorted_strings(&task.expected.required_terms),
+            expected_artifact_ids: sorted_strings(&task.expected.expected_artifact_ids),
+            expected_tools: sorted_strings(&task.expected.expected_tools),
+        })
+        .collect::<Vec<_>>();
+
+    let mut runs = Vec::new();
+    for task in &manifest.tasks {
+        for mode in &manifest.modes {
+            runs.push(evaluate_task_mode(task, mode)?);
+        }
+    }
+
+    let total_runs = runs.len();
+    let passed_runs = runs.iter().filter(|run| run.passed).count();
+    let failed_runs = total_runs.saturating_sub(passed_runs);
+    let aggregate = aggregate_runs(&runs);
+    Ok(ContextEvalReport {
+        type_name: CONTEXT_EVAL_REPORT_TYPE.to_string(),
+        schema_version: CONTEXT_EVAL_SCHEMA_VERSION,
+        manifest_id: manifest.id,
+        manifest_name: manifest.name,
+        pass: failed_runs == 0,
+        total_runs,
+        passed_runs,
+        failed_runs,
+        total_tasks: tasks.len(),
+        total_modes: modes.len(),
+        aggregate,
+        modes,
+        tasks,
+        runs,
+        metadata: manifest.metadata,
+    })
+}
+
+fn normalize_context_eval_manifest(manifest: &mut ContextEvalManifest) -> Result<(), VmError> {
+    if manifest.type_name.is_empty() {
+        manifest.type_name = CONTEXT_EVAL_MANIFEST_TYPE.to_string();
+    }
+    if manifest.type_name != CONTEXT_EVAL_MANIFEST_TYPE {
+        return Err(VmError::Runtime(format!(
+            "context eval manifest _type must be {CONTEXT_EVAL_MANIFEST_TYPE}"
+        )));
+    }
+    if manifest.version == 0 {
+        manifest.version = CONTEXT_EVAL_SCHEMA_VERSION;
+    }
+    if manifest.version != CONTEXT_EVAL_SCHEMA_VERSION {
+        return Err(VmError::Runtime(format!(
+            "context eval manifest version must be {CONTEXT_EVAL_SCHEMA_VERSION}"
+        )));
+    }
+    if manifest.id.trim().is_empty() {
+        manifest.id = "context-eval".to_string();
+    }
+    if manifest.modes.is_empty() {
+        return Err(VmError::Runtime(
+            "context eval manifest must declare at least one mode".to_string(),
+        ));
+    }
+    if manifest.tasks.is_empty() {
+        return Err(VmError::Runtime(
+            "context eval manifest must declare at least one task".to_string(),
+        ));
+    }
+    let mut mode_ids = BTreeSet::new();
+    for (index, mode) in manifest.modes.iter_mut().enumerate() {
+        if mode.id.trim().is_empty() {
+            mode.id = format!("mode_{}", index + 1);
+        }
+        if !mode_ids.insert(mode.id.clone()) {
+            return Err(VmError::Runtime(format!(
+                "context eval manifest has duplicate mode id '{}'",
+                mode.id
+            )));
+        }
+        if mode.kind.trim().is_empty() {
+            mode.kind = mode.id.clone();
+        }
+    }
+    let mut task_ids = BTreeSet::new();
+    for (index, task) in manifest.tasks.iter_mut().enumerate() {
+        if task.id.trim().is_empty() {
+            task.id = format!("task_{}", index + 1);
+        }
+        if !task_ids.insert(task.id.clone()) {
+            return Err(VmError::Runtime(format!(
+                "context eval manifest has duplicate task id '{}'",
+                task.id
+            )));
+        }
+        if task.objective.trim().is_empty() {
+            return Err(VmError::Runtime(format!(
+                "context eval task '{}' must declare objective",
+                task.id
+            )));
+        }
+        for (artifact_index, artifact) in task.artifacts.iter_mut().enumerate() {
+            normalize_eval_artifact(artifact, &task.id, artifact_index);
+        }
+        task.tools.sort_by(|left, right| left.name.cmp(&right.name));
+        task.tool_events.sort_by(|left, right| {
+            left.order
+                .unwrap_or(usize::MAX)
+                .cmp(&right.order.unwrap_or(usize::MAX))
+                .then_with(|| left.name.cmp(&right.name))
+        });
+    }
+    Ok(())
+}
+
+fn normalize_eval_artifact(artifact: &mut ArtifactRecord, task_id: &str, index: usize) {
+    if artifact.type_name.is_empty() {
+        artifact.type_name = "artifact".to_string();
+    }
+    if artifact.id.trim().is_empty() {
+        artifact.id = format!("{task_id}_artifact_{}", index + 1);
+    }
+    if artifact.kind.trim().is_empty() {
+        artifact.kind = "artifact".to_string();
+    }
+    if artifact.created_at.trim().is_empty() {
+        artifact.created_at = "1970-01-01T00:00:00Z".to_string();
+    }
+    if artifact.estimated_tokens.is_none() {
+        artifact.estimated_tokens = artifact
+            .text
+            .as_ref()
+            .map(|text| ((text.len() as f64) / 4.0).ceil() as usize);
+    }
+    if artifact.priority.is_none() {
+        artifact.priority = Some(40);
+    }
+}
+
+fn evaluate_task_mode(
+    task: &ContextEvalTask,
+    mode: &ContextEvalMode,
+) -> Result<ContextEvalRunReport, VmError> {
+    let prepared = prepare_mode_run(task, mode)?;
+    let mode_id = mode.id.clone();
+    let mode_kind = mode_kind(mode);
+    let observed = task
+        .mode_observations
+        .get(&mode_id)
+        .unwrap_or(&task.observed);
+    let visible_input = visible_input(task, &prepared);
+    let (final_surface, correctness_source) = observed
+        .final_response
+        .as_ref()
+        .map(|response| (response.as_str(), "final_response"))
+        .unwrap_or_else(|| (visible_input.as_str(), "context_projection"));
+    let final_correctness = score_correctness(
+        &task.expected,
+        final_surface,
+        &prepared.selected_artifact_ids,
+        correctness_source,
+    );
+    let tool_call_quality =
+        score_tools(&task.expected.expected_tools, &prepared.visible_tool_events);
+    let reads_before_first_edit = reads_before_first_edit(&prepared.visible_tool_events);
+    let error_recovery_count = error_recovery_count(&prepared.visible_tool_events);
+    let input_tokens = observed
+        .input_tokens
+        .unwrap_or_else(|| estimate_chunk_tokens(&visible_input));
+    let output_tokens = observed
+        .output_tokens
+        .or_else(|| {
+            task.reference_answer
+                .as_ref()
+                .map(|text| estimate_chunk_tokens(text))
+        })
+        .unwrap_or(0);
+    let compaction_count = observed.compaction_count.unwrap_or(0) + mode_compaction_count(mode);
+    let latency_ms = observed.latency_ms.unwrap_or(0);
+    let cost_usd = observed.cost_usd.unwrap_or(0.0);
+    let mut failures = Vec::new();
+    if !final_correctness.required_terms_missing.is_empty() {
+        failures.push(format!(
+            "missing required terms: {}",
+            final_correctness.required_terms_missing.join(", ")
+        ));
+    }
+    if !final_correctness.expected_artifact_ids_missing.is_empty() {
+        failures.push(format!(
+            "missing expected artifacts: {}",
+            final_correctness.expected_artifact_ids_missing.join(", ")
+        ));
+    }
+    if !tool_call_quality.missing_tools.is_empty() {
+        failures.push(format!(
+            "missing expected tools: {}",
+            tool_call_quality.missing_tools.join(", ")
+        ));
+    }
+    if let Some(max) = task.expected.max_input_tokens {
+        if input_tokens > max {
+            failures.push(format!("input tokens {input_tokens} exceed max {max}"));
+        }
+    }
+    let passed = failures.is_empty();
+    let stable_input_hash = stable_hash(&[
+        task.id.as_str(),
+        mode.id.as_str(),
+        &prepared.selected_artifact_ids.join("\n"),
+        prepared.rendered_context.as_str(),
+        prepared.transcript_text.as_str(),
+        &prepared.exposed_tools.join("\n"),
+    ]);
+    let cache_namespace = mode
+        .cache_namespace
+        .clone()
+        .unwrap_or_else(|| "harn.context_eval".to_string());
+    Ok(ContextEvalRunReport {
+        run_id: format!("{}__{}", task.id, mode.id),
+        task_id: task.id.clone(),
+        mode_id,
+        mode_kind,
+        status: if passed { "pass" } else { "fail" }.to_string(),
+        passed,
+        final_correctness,
+        reads_before_first_edit,
+        tool_call_quality,
+        latency_ms,
+        input_tokens,
+        output_tokens,
+        cost_usd,
+        compaction_count,
+        projection: prepared.projection,
+        context: ContextEvalContextReport {
+            projection_policy: projection_policy(mode),
+            tool_disclosure: tool_disclosure(mode),
+            artifact_count: prepared.artifacts.len(),
+            selected_artifact_ids: prepared.selected_artifact_ids,
+            dropped_artifact_ids: prepared.dropped_artifact_ids,
+            rendered_bytes: prepared.rendered_context.len(),
+            rendered_tokens: estimate_chunk_tokens(&prepared.rendered_context),
+            budget_tokens: mode_budget_tokens(mode),
+            assemble_strategy: assemble_strategy(mode)?.as_str().to_string(),
+            dedup: assemble_dedup(mode)?.as_str().to_string(),
+            exposed_tools: prepared.exposed_tools,
+        },
+        cache: ContextEvalCacheReport {
+            namespace: cache_namespace.clone(),
+            key: format!("{}:{}", cache_namespace, &stable_input_hash[..32]),
+            stable_input_hash,
+            deterministic_order: true,
+            hit: mode.expected_cache_hit.or(observed.cache_hit),
+        },
+        error_recovery_count,
+        preprocessing: preprocessing_report(mode),
+        failures,
+    })
+}
+
+fn prepare_mode_run(
+    task: &ContextEvalTask,
+    mode: &ContextEvalMode,
+) -> Result<PreparedModeRun, VmError> {
+    let filtered = filter_artifacts(task, mode);
+    let options = AssembleOptions {
+        budget_tokens: mode_budget_tokens(mode),
+        dedup: assemble_dedup(mode)?,
+        strategy: assemble_strategy(mode)?,
+        query: Some(task.objective.clone()),
+        microcompact_threshold: mode.microcompact_threshold.unwrap_or(2_000),
+        semantic_overlap: mode.semantic_overlap.unwrap_or(0.85),
+    };
+    let assembled = assemble_context(&filtered, &options, None);
+    let selected_artifact_ids = sorted_strings(
+        &assembled
+            .included
+            .iter()
+            .map(|item| item.artifact_id.clone())
+            .collect::<Vec<_>>(),
+    );
+    let dropped_artifact_ids = sorted_strings(
+        &assembled
+            .dropped
+            .iter()
+            .map(|item| item.artifact_id.clone())
+            .collect::<Vec<_>>(),
+    );
+    let rendered_context = if assembled.chunks.is_empty() {
+        String::new()
+    } else {
+        render_assembled_chunks(&assembled)
+    };
+    let (projection, transcript_text) = project_transcript(task, mode);
+    let exposed_tools = exposed_tools(task, mode);
+    let visible_tool_events = visible_tool_events(task, &exposed_tools, mode);
+    Ok(PreparedModeRun {
+        artifacts: filtered,
+        rendered_context,
+        selected_artifact_ids,
+        dropped_artifact_ids,
+        projection,
+        transcript_text,
+        exposed_tools,
+        visible_tool_events,
+    })
+}
+
+fn filter_artifacts(task: &ContextEvalTask, mode: &ContextEvalMode) -> Vec<ArtifactRecord> {
+    if mode_kind(mode) == "cold" || mode_budget_tokens(mode) == 0 {
+        return Vec::new();
+    }
+    let include_ids: BTreeSet<&str> = mode.artifact_ids.iter().map(String::as_str).collect();
+    let include_kinds: BTreeSet<&str> = mode
+        .include_artifact_kinds
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let exclude_kinds: BTreeSet<&str> = mode
+        .exclude_artifact_kinds
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let kind = mode_kind(mode);
+    task.artifacts
+        .iter()
+        .filter(|artifact| include_ids.is_empty() || include_ids.contains(artifact.id.as_str()))
+        .filter(|artifact| {
+            include_kinds.is_empty()
+                || include_kinds.contains(artifact.kind.as_str())
+                || include_kinds.contains(
+                    artifact
+                        .metadata
+                        .get("context_tier")
+                        .and_then(JsonValue::as_str)
+                        .unwrap_or(""),
+                )
+        })
+        .filter(|artifact| !exclude_kinds.contains(artifact.kind.as_str()))
+        .filter(|artifact| {
+            default_mode_allows_artifact(
+                &kind,
+                artifact,
+                include_ids.is_empty() && include_kinds.is_empty(),
+            )
+        })
+        .cloned()
+        .collect()
+}
+
+fn default_mode_allows_artifact(
+    kind: &str,
+    artifact: &ArtifactRecord,
+    using_default_filter: bool,
+) -> bool {
+    if !using_default_filter {
+        return true;
+    }
+    match kind {
+        "cold" => false,
+        "scanned" => artifact_matches_tier(artifact, &["scan", "scanned", "tier1_scan"]),
+        "enriched" => artifact_matches_tier(
+            artifact,
+            &[
+                "scan",
+                "scanned",
+                "tier1_scan",
+                "enrichment",
+                "enriched",
+                "tier2_enrichment",
+            ],
+        ),
+        _ => true,
+    }
+}
+
+fn artifact_matches_tier(artifact: &ArtifactRecord, labels: &[&str]) -> bool {
+    labels.iter().any(|label| {
+        artifact.kind == *label
+            || artifact
+                .metadata
+                .get("context_tier")
+                .and_then(JsonValue::as_str)
+                == Some(*label)
+    })
+}
+
+fn project_transcript(
+    task: &ContextEvalTask,
+    mode: &ContextEvalMode,
+) -> (ContextEvalProjectionReport, String) {
+    let policy = projection_policy(mode);
+    let keep_last = mode.transcript_keep_last.unwrap_or(match policy.as_str() {
+        "none" => 0,
+        "summary" | "compacted" => 1,
+        "last_n" | "projected" => 2,
+        _ => task.transcript.len(),
+    });
+    let retained: Vec<&ContextEvalTranscriptMessage> = match policy.as_str() {
+        "none" => Vec::new(),
+        "full" => task.transcript.iter().collect(),
+        "summary" | "compacted" | "last_n" | "projected" => task
+            .transcript
+            .iter()
+            .rev()
+            .take(keep_last)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect(),
+        _ => task.transcript.iter().collect(),
+    };
+    let transcript_text = retained
+        .iter()
+        .map(|message| format!("{}: {}", message.role, message.content))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let retained_tokens = retained
+        .iter()
+        .map(|message| {
+            message
+                .estimated_tokens
+                .unwrap_or_else(|| estimate_chunk_tokens(&message.content))
+        })
+        .sum();
+    (
+        ContextEvalProjectionReport {
+            policy,
+            source_message_count: task.transcript.len(),
+            retained_message_count: retained.len(),
+            retained_tokens,
+        },
+        transcript_text,
+    )
+}
+
+fn exposed_tools(task: &ContextEvalTask, mode: &ContextEvalMode) -> Vec<String> {
+    let disclosure = tool_disclosure(mode);
+    let allowlist: BTreeSet<&str> = mode.tool_allowlist.iter().map(String::as_str).collect();
+    let mut names = match disclosure.as_str() {
+        "none" => Vec::new(),
+        "full" => task.tools.iter().map(|tool| tool.name.clone()).collect(),
+        "limited" | "tool_search_limited" => task
+            .tools
+            .iter()
+            .filter(|tool| allowlist.contains(tool.name.as_str()))
+            .map(|tool| tool.name.clone())
+            .collect(),
+        _ => task.tools.iter().map(|tool| tool.name.clone()).collect(),
+    };
+    if disclosure == "tool_search_limited" && !names.iter().any(|name| name == "tool_search") {
+        names.push("tool_search".to_string());
+    }
+    sorted_strings(&names)
+}
+
+fn visible_tool_events(
+    task: &ContextEvalTask,
+    exposed_tools: &[String],
+    mode: &ContextEvalMode,
+) -> Vec<ContextEvalToolEvent> {
+    if tool_disclosure(mode) == "full" {
+        return task.tool_events.clone();
+    }
+    let exposed: BTreeSet<&str> = exposed_tools.iter().map(String::as_str).collect();
+    task.tool_events
+        .iter()
+        .filter(|event| exposed.contains(event.name.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn visible_input(task: &ContextEvalTask, prepared: &PreparedModeRun) -> String {
+    [
+        task.objective.as_str(),
+        prepared.rendered_context.as_str(),
+        prepared.transcript_text.as_str(),
+        &prepared.exposed_tools.join("\n"),
+    ]
+    .into_iter()
+    .filter(|part| !part.trim().is_empty())
+    .collect::<Vec<_>>()
+    .join("\n\n")
+}
+
+fn score_correctness(
+    expected: &ContextEvalExpected,
+    surface: &str,
+    selected_artifact_ids: &[String],
+    source: &str,
+) -> ContextEvalCorrectness {
+    let lower_surface = surface.to_ascii_lowercase();
+    let mut present_terms = Vec::new();
+    let mut missing_terms = Vec::new();
+    for term in sorted_strings(&expected.required_terms) {
+        if lower_surface.contains(&term.to_ascii_lowercase()) {
+            present_terms.push(term);
+        } else {
+            missing_terms.push(term);
+        }
+    }
+    let selected: BTreeSet<&str> = selected_artifact_ids.iter().map(String::as_str).collect();
+    let mut present_artifacts = Vec::new();
+    let mut missing_artifacts = Vec::new();
+    for id in sorted_strings(&expected.expected_artifact_ids) {
+        if selected.contains(id.as_str()) {
+            present_artifacts.push(id);
+        } else {
+            missing_artifacts.push(id);
+        }
+    }
+    let term_score = fraction(
+        present_terms.len(),
+        present_terms.len() + missing_terms.len(),
+    );
+    let artifact_score = fraction(
+        present_artifacts.len(),
+        present_artifacts.len() + missing_artifacts.len(),
+    );
+    let score = if expected.required_terms.is_empty() && expected.expected_artifact_ids.is_empty() {
+        1.0
+    } else if expected.required_terms.is_empty() || expected.expected_artifact_ids.is_empty() {
+        term_score.max(artifact_score)
+    } else {
+        (term_score + artifact_score) / 2.0
+    };
+    ContextEvalCorrectness {
+        passed: missing_terms.is_empty() && missing_artifacts.is_empty(),
+        score: round4(score),
+        required_terms_present: present_terms,
+        required_terms_missing: missing_terms,
+        expected_artifact_ids_present: present_artifacts,
+        expected_artifact_ids_missing: missing_artifacts,
+        source: source.to_string(),
+    }
+}
+
+fn score_tools(
+    expected_tools: &[String],
+    events: &[ContextEvalToolEvent],
+) -> ContextEvalToolQuality {
+    let expected = sorted_strings(expected_tools);
+    let expected_set: BTreeSet<&str> = expected.iter().map(String::as_str).collect();
+    let observed = sorted_strings(
+        &events
+            .iter()
+            .map(|event| event.name.clone())
+            .collect::<Vec<_>>(),
+    );
+    let observed_set: BTreeSet<&str> = observed.iter().map(String::as_str).collect();
+    let matched_tools = expected
+        .iter()
+        .filter(|tool| observed_set.contains(tool.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing_tools = expected
+        .iter()
+        .filter(|tool| !observed_set.contains(tool.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let unnecessary_tools = observed
+        .iter()
+        .filter(|tool| !expected_set.contains(tool.as_str()) && !is_edit_tool(tool))
+        .cloned()
+        .collect::<Vec<_>>();
+    let denominator = expected.len() + unnecessary_tools.len();
+    let score = if denominator == 0 {
+        1.0
+    } else {
+        matched_tools.len() as f64 / denominator as f64
+    };
+    ContextEvalToolQuality {
+        score: round4(score),
+        expected_tools: expected,
+        observed_tools: observed,
+        matched_tools,
+        missing_tools,
+        unnecessary_tools,
+    }
+}
+
+fn reads_before_first_edit(events: &[ContextEvalToolEvent]) -> usize {
+    let mut reads = 0;
+    for event in events {
+        if is_edit_event(event) {
+            break;
+        }
+        if is_read_event(event) {
+            reads += 1;
+        }
+    }
+    reads
+}
+
+fn error_recovery_count(events: &[ContextEvalToolEvent]) -> usize {
+    events
+        .iter()
+        .filter(|event| {
+            event.recovery == Some(true)
+                || event
+                    .phase
+                    .as_deref()
+                    .is_some_and(|phase| phase.contains("recovery") || phase.contains("error"))
+                || event.quality.as_deref() == Some("recovery")
+        })
+        .count()
+}
+
+fn aggregate_runs(runs: &[ContextEvalRunReport]) -> ContextEvalAggregate {
+    let total = runs.len();
+    let mean_final_correctness = mean(total, runs.iter().map(|run| run.final_correctness.score));
+    let mean_tool_call_quality = mean(total, runs.iter().map(|run| run.tool_call_quality.score));
+    ContextEvalAggregate {
+        mean_final_correctness,
+        mean_tool_call_quality,
+        total_latency_ms: runs.iter().map(|run| run.latency_ms).sum(),
+        total_input_tokens: runs.iter().map(|run| run.input_tokens).sum(),
+        total_output_tokens: runs.iter().map(|run| run.output_tokens).sum(),
+        total_cost_usd: round6(runs.iter().map(|run| run.cost_usd).sum()),
+        total_compaction_count: runs.iter().map(|run| run.compaction_count).sum(),
+        total_error_recovery_count: runs.iter().map(|run| run.error_recovery_count).sum(),
+    }
+}
+
+fn mode_kind(mode: &ContextEvalMode) -> String {
+    let value = mode.kind.trim();
+    if value.is_empty() {
+        mode.id.clone()
+    } else {
+        value.to_string()
+    }
+}
+
+fn mode_budget_tokens(mode: &ContextEvalMode) -> usize {
+    mode.budget_tokens
+        .unwrap_or_else(|| match mode_kind(mode).as_str() {
+            "cold" => 0,
+            "scanned" => 800,
+            "enriched" => 1_200,
+            "hud_pack" | "projected" | "compacted" | "tool_search_limited" => 1_600,
+            "full" => 64_000,
+            _ => 8_000,
+        })
+}
+
+fn assemble_strategy(mode: &ContextEvalMode) -> Result<AssembleStrategy, VmError> {
+    mode.assemble_strategy
+        .as_deref()
+        .map(AssembleStrategy::parse)
+        .transpose()
+        .map_err(VmError::Runtime)
+        .map(|value| value.unwrap_or(AssembleStrategy::Relevance))
+}
+
+fn assemble_dedup(mode: &ContextEvalMode) -> Result<AssembleDedup, VmError> {
+    mode.dedup
+        .as_deref()
+        .map(AssembleDedup::parse)
+        .transpose()
+        .map_err(VmError::Runtime)
+        .map(|value| value.unwrap_or(AssembleDedup::Chunked))
+}
+
+fn projection_policy(mode: &ContextEvalMode) -> String {
+    mode.projection_policy
+        .clone()
+        .unwrap_or_else(|| match mode_kind(mode).as_str() {
+            "cold" | "scanned" | "enriched" | "hud_pack" | "tool_search_limited" => {
+                "none".to_string()
+            }
+            "projected" => "last_n".to_string(),
+            "compacted" => "compacted".to_string(),
+            "full" => "full".to_string(),
+            _ => "none".to_string(),
+        })
+}
+
+fn tool_disclosure(mode: &ContextEvalMode) -> String {
+    mode.tool_disclosure
+        .clone()
+        .unwrap_or_else(|| match mode_kind(mode).as_str() {
+            "cold" | "scanned" | "enriched" | "hud_pack" => "none".to_string(),
+            "tool_search_limited" => "tool_search_limited".to_string(),
+            "full" => "full".to_string(),
+            _ => "limited".to_string(),
+        })
+}
+
+fn preprocessing_report(mode: &ContextEvalMode) -> ContextEvalPreprocessing {
+    let preprocessing = mode
+        .preprocessing
+        .clone()
+        .unwrap_or_else(|| "deterministic".to_string());
+    ContextEvalPreprocessing {
+        llm_enabled: preprocessing == "llm",
+        mode: preprocessing,
+    }
+}
+
+fn mode_compaction_count(mode: &ContextEvalMode) -> usize {
+    usize::from(mode_kind(mode) == "compacted" || mode.compaction_policy.is_some())
+}
+
+fn is_read_event(event: &ContextEvalToolEvent) -> bool {
+    event
+        .phase
+        .as_deref()
+        .is_some_and(|phase| phase == "read" || phase == "scan")
+        || event.name.starts_with("read")
+        || event.name.starts_with("search")
+        || event.name.starts_with("list")
+}
+
+fn is_edit_event(event: &ContextEvalToolEvent) -> bool {
+    event
+        .phase
+        .as_deref()
+        .is_some_and(|phase| phase == "edit" || phase == "write" || phase == "mutation")
+        || is_edit_tool(&event.name)
+}
+
+fn is_edit_tool(name: &str) -> bool {
+    name.starts_with("edit")
+        || name.starts_with("write")
+        || name.starts_with("apply")
+        || name.contains("patch")
+}
+
+fn fraction(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        1.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
+}
+
+fn mean(total: usize, values: impl Iterator<Item = f64>) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        round4(values.sum::<f64>() / total as f64)
+    }
+}
+
+fn sorted_strings(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn stable_hash(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update((part.len() as u64).to_le_bytes());
+        hasher.update(part.as_bytes());
+    }
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn round4(value: f64) -> f64 {
+    (value * 10_000.0).round() / 10_000.0
+}
+
+fn round6(value: f64) -> f64 {
+    (value * 1_000_000.0).round() / 1_000_000.0
+}
+
+pub fn context_eval_default_output_dir() -> PathBuf {
+    PathBuf::from(".harn-runs/context-eval/latest")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact(id: &str, kind: &str, text: &str) -> ArtifactRecord {
+        ArtifactRecord {
+            type_name: "artifact".to_string(),
+            id: id.to_string(),
+            kind: kind.to_string(),
+            title: Some(id.to_string()),
+            text: Some(text.to_string()),
+            data: None,
+            source: Some("fixture".to_string()),
+            created_at: "2026-05-23T00:00:00Z".to_string(),
+            freshness: Some("fresh".to_string()),
+            priority: Some(80),
+            lineage: Vec::new(),
+            relevance: Some(1.0),
+            estimated_tokens: None,
+            stage: None,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn context_eval_scores_modes_deterministically() {
+        let manifest = ContextEvalManifest {
+            type_name: CONTEXT_EVAL_MANIFEST_TYPE.to_string(),
+            version: 1,
+            id: "smoke".to_string(),
+            modes: vec![
+                ContextEvalMode {
+                    id: "cold".to_string(),
+                    kind: "cold".to_string(),
+                    ..Default::default()
+                },
+                ContextEvalMode {
+                    id: "pack".to_string(),
+                    kind: "hud_pack".to_string(),
+                    artifact_ids: vec!["runbook".to_string()],
+                    tool_disclosure: Some("limited".to_string()),
+                    tool_allowlist: vec!["read_file".to_string()],
+                    ..Default::default()
+                },
+            ],
+            tasks: vec![ContextEvalTask {
+                id: "task".to_string(),
+                objective: "Find the rollback command".to_string(),
+                artifacts: vec![artifact(
+                    "runbook",
+                    "context_pack",
+                    "Use deploy rollback now.",
+                )],
+                tools: vec![ContextEvalTool {
+                    name: "read_file".to_string(),
+                    ..Default::default()
+                }],
+                tool_events: vec![ContextEvalToolEvent {
+                    order: Some(1),
+                    name: "read_file".to_string(),
+                    phase: Some("read".to_string()),
+                    success: Some(true),
+                    quality: Some("useful".to_string()),
+                    recovery: None,
+                }],
+                expected: ContextEvalExpected {
+                    required_terms: vec!["deploy rollback".to_string()],
+                    expected_artifact_ids: vec!["runbook".to_string()],
+                    expected_tools: vec!["read_file".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let report = evaluate_context_eval_manifest(&manifest).expect("context eval succeeds");
+        assert_eq!(report.total_runs, 2);
+        assert_eq!(report.passed_runs, 1);
+        assert!(!report.runs[0].passed);
+        assert!(report.runs[1].passed);
+        assert_eq!(report.runs[1].reads_before_first_edit, 1);
+        assert_eq!(report.runs[1].tool_call_quality.score, 1.0);
+        assert_eq!(report.runs[1].cache.stable_input_hash.len(), 64);
+    }
+}

--- a/crates/harn-vm/src/orchestration/mod.rs
+++ b/crates/harn-vm/src/orchestration/mod.rs
@@ -95,6 +95,9 @@ mod workflow_test_fixtures;
 mod records;
 pub use records::*;
 
+mod context_eval;
+pub use context_eval::*;
+
 mod merge_captain_audit;
 pub use merge_captain_audit::*;
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1318,12 +1318,14 @@ harn eval evals/regression.json
 harn eval harn.eval.toml
 harn eval evals/clarifying-question.json
 harn eval --llm-mock fixtures.jsonl --structural-experiment doubled_prompt pipeline.harn
+harn eval context examples/evals/context-engineering-smoke.json \
+    --output target/context-eval --json
 harn eval prompt examples/coding-agent-system.harn.prompt \
     --fleet claude-opus-4-7,gpt-5,gemini-2.5-pro,qwen3.5,ollama:qwen3.5 \
     --bindings examples/coding-agent-system.bindings.json
 ```
 
-`harn eval` accepts five inputs:
+The legacy `harn eval <path>` entrypoint accepts five inputs:
 
 - a single run record JSON file
 - a directory of run record JSON files
@@ -1351,6 +1353,31 @@ the pipeline twice in isolated temp run directories: once as the baseline and
 once with `HARN_STRUCTURAL_EXPERIMENT=<spec>`. The CLI then evaluates both run
 sets against their embedded replay fixtures and prints a paired A/B summary.
 Use `--llm-mock <fixture.jsonl>` to keep the two runs deterministic.
+
+### harn eval context
+
+Run deterministic context-engineering evals over task fixtures and named
+context modes:
+
+```bash
+harn eval context examples/evals/context-engineering-smoke.json \
+    --output target/context-eval --json
+```
+
+The manifest uses `_type = "harn.context_eval.manifest.v1"` and can be JSON
+or TOML. It declares tasks, artifacts, transcript snippets, tool disclosures,
+expected terms/artifacts/tools, and modes such as HUD packs, projections,
+compaction, or limited tool disclosure. The local runner does not call an LLM;
+it scores whether each mode exposes enough deterministic context for the task
+and writes:
+
+- `summary.json`: a `harn.context_eval.report.v1` aggregate report
+- `per_run.jsonl`: one machine-readable record per task/mode run
+- `summary.md`: a compact human-readable table
+
+The report schema is checked into
+`spec/schemas/context-eval-report.v1.schema.json` so hosted evaluators,
+dashboards, and downstream products can ingest the same local artifacts.
 
 ### harn eval prompt
 

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -267,6 +267,20 @@ such as `model`, `provider`, and token counts when present.
 `harn eval` supports the default replay fixture flow plus an explicit
 clarifying-question kind for ambiguous tasks.
 
+`harn eval context <manifest>` supports deterministic context-engineering
+fixtures for pack, projection, compaction, and tool-disclosure experiments. A
+manifest declares task fixtures and one or more context modes; the runner scores
+each task/mode pair without model calls and writes stable local artifacts:
+`summary.json`, `per_run.jsonl`, and `summary.md`. Use the builders in
+`std/context/eval` when authoring manifests from Harn code, and use
+`spec/schemas/context-eval-report.v1.schema.json` when ingesting
+`harn.context_eval.report.v1` reports from hosted systems or downstream UIs.
+
+```bash
+harn eval context examples/evals/context-engineering-smoke.json \
+  --output target/context-eval --json
+```
+
 ## Eval packs
 
 Portable eval packs live in `harn.eval.toml` or another TOML file listed in

--- a/examples/evals/context-engineering-smoke.json
+++ b/examples/evals/context-engineering-smoke.json
@@ -1,0 +1,286 @@
+{
+  "_type": "harn.context_eval.manifest.v1",
+  "version": 1,
+  "id": "context-engineering-smoke",
+  "name": "Context Engineering Smoke",
+  "description": "Three deterministic tasks projected through reusable context modes.",
+  "modes": [
+    {
+      "id": "hud-pack",
+      "kind": "hud_pack",
+      "budget_tokens": 900,
+      "assemble_strategy": "relevance",
+      "dedup": "chunked",
+      "tool_disclosure": "full",
+      "cache_namespace": "harn.context_eval.smoke"
+    },
+    {
+      "id": "compacted",
+      "kind": "compacted",
+      "budget_tokens": 900,
+      "assemble_strategy": "relevance",
+      "dedup": "chunked",
+      "projection_policy": "compacted",
+      "transcript_keep_last": 1,
+      "tool_disclosure": "full",
+      "compaction_policy": {
+        "mode": "eval",
+        "scope": "summary",
+        "preserve": ["current blocker", "verification command"]
+      },
+      "cache_namespace": "harn.context_eval.smoke"
+    },
+    {
+      "id": "tool-search-limited",
+      "kind": "tool_search_limited",
+      "budget_tokens": 900,
+      "assemble_strategy": "relevance",
+      "dedup": "chunked",
+      "tool_disclosure": "tool_search_limited",
+      "tool_allowlist": ["read_file", "search_files", "search_logs"],
+      "cache_namespace": "harn.context_eval.smoke",
+      "expected_cache_hit": true
+    }
+  ],
+  "tasks": [
+    {
+      "id": "payments-incident",
+      "name": "Payments Incident",
+      "objective": "Identify the likely failing service and first verification step for checkout error 524.",
+      "reference_answer": "Check payments-api saturation and verify with search_logs before changing deploy state.",
+      "artifacts": [
+        {
+          "_type": "artifact",
+          "id": "payments-runbook",
+          "kind": "context_pack",
+          "title": "Payments error 524 runbook",
+          "text": "Checkout error 524 usually points at payments-api saturation behind the edge proxy. First verification step: run search_logs for payments-api timeout spikes before changing deploy state.",
+          "source": "examples/evals/payments-runbook.md",
+          "created_at": "2026-05-23T00:00:00Z",
+          "freshness": "fresh",
+          "priority": 90,
+          "metadata": {
+            "context_tier": "pack"
+          }
+        },
+        {
+          "_type": "artifact",
+          "id": "payments-noise",
+          "kind": "transcript_summary",
+          "title": "Old gateway note",
+          "text": "Legacy gateway retries were removed last quarter and should not drive current checkout triage.",
+          "source": "examples/evals/old-note.md",
+          "created_at": "2026-04-01T00:00:00Z",
+          "freshness": "stale",
+          "priority": 20
+        }
+      ],
+      "transcript": [
+        {
+          "role": "user",
+          "content": "Checkout is returning 524s in production."
+        },
+        {
+          "role": "assistant",
+          "content": "Current blocker is confirming whether payments-api is saturated."
+        }
+      ],
+      "tools": [
+        {
+          "name": "search_logs",
+          "description": "Search production logs",
+          "deterministic": true
+        },
+        {
+          "name": "read_file",
+          "description": "Read repo files",
+          "deterministic": true
+        },
+        {
+          "name": "apply_patch",
+          "description": "Apply file edits",
+          "deterministic": true
+        }
+      ],
+      "tool_events": [
+        {
+          "order": 1,
+          "name": "search_logs",
+          "phase": "read",
+          "success": true,
+          "quality": "useful"
+        },
+        {
+          "order": 2,
+          "name": "apply_patch",
+          "phase": "edit",
+          "success": true
+        }
+      ],
+      "expected": {
+        "required_terms": ["payments-api", "search_logs", "error 524"],
+        "expected_artifact_ids": ["payments-runbook"],
+        "expected_tools": ["search_logs"]
+      },
+      "observed": {
+        "latency_ms": 1800,
+        "output_tokens": 36,
+        "cost_usd": 0.0004
+      }
+    },
+    {
+      "id": "release-prep",
+      "name": "Release Prep",
+      "objective": "Find the command sequence for a patch release gate dry run.",
+      "reference_answer": "Run release_gate.sh full --bump patch --dry-run before opening the bump PR.",
+      "artifacts": [
+        {
+          "_type": "artifact",
+          "id": "release-checklist",
+          "kind": "context_pack",
+          "title": "Release checklist",
+          "text": "Patch release prep starts with ./scripts/release_gate.sh full --bump patch --dry-run. Only after that passes should the release_ship bump patch PR be opened.",
+          "source": "AGENTS.md",
+          "created_at": "2026-05-23T00:00:00Z",
+          "freshness": "fresh",
+          "priority": 95,
+          "metadata": {
+            "context_tier": "pack"
+          }
+        }
+      ],
+      "transcript": [
+        {
+          "role": "user",
+          "content": "Prepare a patch release but do not publish yet."
+        },
+        {
+          "role": "assistant",
+          "content": "Verification command is the dry-run release gate."
+        }
+      ],
+      "tools": [
+        {
+          "name": "read_file",
+          "description": "Read repo files",
+          "deterministic": true
+        },
+        {
+          "name": "apply_patch",
+          "description": "Apply file edits",
+          "deterministic": true
+        }
+      ],
+      "tool_events": [
+        {
+          "order": 1,
+          "name": "read_file",
+          "phase": "read",
+          "success": true,
+          "quality": "useful"
+        },
+        {
+          "order": 2,
+          "name": "apply_patch",
+          "phase": "edit",
+          "success": true
+        }
+      ],
+      "expected": {
+        "required_terms": ["release_gate.sh", "bump patch", "dry-run"],
+        "expected_artifact_ids": ["release-checklist"],
+        "expected_tools": ["read_file"]
+      },
+      "observed": {
+        "latency_ms": 1400,
+        "output_tokens": 30,
+        "cost_usd": 0.0003
+      }
+    },
+    {
+      "id": "flaky-test",
+      "name": "Flaky Test Audit",
+      "objective": "Name the deterministic pattern that should replace sleep-based orchestration tests.",
+      "reference_answer": "Use tokio::time::pause/advance or EventLog::subscribe instead of sleep polling.",
+      "artifacts": [
+        {
+          "_type": "artifact",
+          "id": "testing-guidance",
+          "kind": "context_pack",
+          "title": "Deterministic orchestration testing",
+          "text": "Do not add std::thread::sleep, tokio::time::sleep, Instant::now polling loops, SystemTime::now, or short recv_timeout calls to tests. Prefer tokio::time::pause()/advance(), EventLog::subscribe(), or OrchestratorHarness.",
+          "source": "AGENTS.md",
+          "created_at": "2026-05-23T00:00:00Z",
+          "freshness": "fresh",
+          "priority": 100,
+          "metadata": {
+            "context_tier": "pack"
+          }
+        }
+      ],
+      "transcript": [
+        {
+          "role": "user",
+          "content": "This orchestration test flakes in CI."
+        },
+        {
+          "role": "assistant",
+          "content": "Current blocker is replacing wall-clock polling with a deterministic event source."
+        }
+      ],
+      "tools": [
+        {
+          "name": "search_files",
+          "description": "Search repo files",
+          "deterministic": true
+        },
+        {
+          "name": "read_file",
+          "description": "Read repo files",
+          "deterministic": true
+        },
+        {
+          "name": "apply_patch",
+          "description": "Apply file edits",
+          "deterministic": true
+        }
+      ],
+      "tool_events": [
+        {
+          "order": 1,
+          "name": "search_files",
+          "phase": "read",
+          "success": true,
+          "quality": "useful"
+        },
+        {
+          "order": 2,
+          "name": "read_file",
+          "phase": "read",
+          "success": true,
+          "quality": "useful"
+        },
+        {
+          "order": 3,
+          "name": "apply_patch",
+          "phase": "edit",
+          "success": true
+        }
+      ],
+      "expected": {
+        "required_terms": ["tokio::time::pause", "EventLog::subscribe", "OrchestratorHarness"],
+        "expected_artifact_ids": ["testing-guidance"],
+        "expected_tools": ["search_files", "read_file"]
+      },
+      "observed": {
+        "latency_ms": 1600,
+        "output_tokens": 34,
+        "cost_usd": 0.0003
+      }
+    }
+  ],
+  "metadata": {
+    "issue": "2195",
+    "consumer_schema": "harn.context_eval.report.v1"
+  }
+}

--- a/spec/schemas/context-eval-report.v1.schema.json
+++ b/spec/schemas/context-eval-report.v1.schema.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/context-eval-report.v1.schema.json",
+  "title": "Harn context eval report v1",
+  "type": "object",
+  "required": [
+    "_type",
+    "schema_version",
+    "manifest_id",
+    "pass",
+    "total_runs",
+    "passed_runs",
+    "failed_runs",
+    "total_tasks",
+    "total_modes",
+    "aggregate",
+    "modes",
+    "tasks",
+    "runs"
+  ],
+  "properties": {
+    "_type": { "const": "harn.context_eval.report.v1" },
+    "schema_version": { "const": 1 },
+    "manifest_id": { "type": "string" },
+    "manifest_name": { "type": ["string", "null"] },
+    "pass": { "type": "boolean" },
+    "total_runs": { "type": "integer", "minimum": 0 },
+    "passed_runs": { "type": "integer", "minimum": 0 },
+    "failed_runs": { "type": "integer", "minimum": 0 },
+    "total_tasks": { "type": "integer", "minimum": 0 },
+    "total_modes": { "type": "integer", "minimum": 0 },
+    "aggregate": {
+      "type": "object",
+      "required": [
+        "mean_final_correctness",
+        "mean_tool_call_quality",
+        "total_latency_ms",
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_cost_usd",
+        "total_compaction_count",
+        "total_error_recovery_count"
+      ],
+      "properties": {
+        "mean_final_correctness": { "type": "number", "minimum": 0, "maximum": 1 },
+        "mean_tool_call_quality": { "type": "number", "minimum": 0, "maximum": 1 },
+        "total_latency_ms": { "type": "integer", "minimum": 0 },
+        "total_input_tokens": { "type": "integer", "minimum": 0 },
+        "total_output_tokens": { "type": "integer", "minimum": 0 },
+        "total_cost_usd": { "type": "number", "minimum": 0 },
+        "total_compaction_count": { "type": "integer", "minimum": 0 },
+        "total_error_recovery_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "modes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/mode" }
+    },
+    "tasks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/task" }
+    },
+    "runs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/run" }
+    },
+    "metadata": { "type": "object" }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "mode": {
+      "type": "object",
+      "required": ["id", "kind", "projection_policy", "tool_disclosure", "preprocessing"],
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string" },
+        "projection_policy": { "type": "string" },
+        "tool_disclosure": { "type": "string" },
+        "preprocessing": { "$ref": "#/$defs/preprocessing" }
+      },
+      "additionalProperties": true
+    },
+    "task": {
+      "type": "object",
+      "required": ["id", "required_terms", "expected_artifact_ids", "expected_tools"],
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": ["string", "null"] },
+        "required_terms": { "type": "array", "items": { "type": "string" } },
+        "expected_artifact_ids": { "type": "array", "items": { "type": "string" } },
+        "expected_tools": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "run": {
+      "type": "object",
+      "required": [
+        "run_id",
+        "task_id",
+        "mode_id",
+        "mode_kind",
+        "status",
+        "passed",
+        "final_correctness",
+        "reads_before_first_edit",
+        "tool_call_quality",
+        "latency_ms",
+        "input_tokens",
+        "output_tokens",
+        "cost_usd",
+        "compaction_count",
+        "projection",
+        "context",
+        "cache",
+        "error_recovery_count",
+        "preprocessing",
+        "failures"
+      ],
+      "properties": {
+        "run_id": { "type": "string" },
+        "task_id": { "type": "string" },
+        "mode_id": { "type": "string" },
+        "mode_kind": { "type": "string" },
+        "status": { "enum": ["pass", "fail"] },
+        "passed": { "type": "boolean" },
+        "final_correctness": { "$ref": "#/$defs/final_correctness" },
+        "reads_before_first_edit": { "type": "integer", "minimum": 0 },
+        "tool_call_quality": { "$ref": "#/$defs/tool_call_quality" },
+        "latency_ms": { "type": "integer", "minimum": 0 },
+        "input_tokens": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "cost_usd": { "type": "number", "minimum": 0 },
+        "compaction_count": { "type": "integer", "minimum": 0 },
+        "projection": { "$ref": "#/$defs/projection" },
+        "context": { "$ref": "#/$defs/context" },
+        "cache": { "$ref": "#/$defs/cache" },
+        "error_recovery_count": { "type": "integer", "minimum": 0 },
+        "preprocessing": { "$ref": "#/$defs/preprocessing" },
+        "failures": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "final_correctness": {
+      "type": "object",
+      "required": [
+        "passed",
+        "score",
+        "required_terms_present",
+        "required_terms_missing",
+        "expected_artifact_ids_present",
+        "expected_artifact_ids_missing",
+        "source"
+      ],
+      "properties": {
+        "passed": { "type": "boolean" },
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "required_terms_present": { "type": "array", "items": { "type": "string" } },
+        "required_terms_missing": { "type": "array", "items": { "type": "string" } },
+        "expected_artifact_ids_present": { "type": "array", "items": { "type": "string" } },
+        "expected_artifact_ids_missing": { "type": "array", "items": { "type": "string" } },
+        "source": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "tool_call_quality": {
+      "type": "object",
+      "required": [
+        "score",
+        "expected_tools",
+        "observed_tools",
+        "matched_tools",
+        "missing_tools",
+        "unnecessary_tools"
+      ],
+      "properties": {
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "expected_tools": { "type": "array", "items": { "type": "string" } },
+        "observed_tools": { "type": "array", "items": { "type": "string" } },
+        "matched_tools": { "type": "array", "items": { "type": "string" } },
+        "missing_tools": { "type": "array", "items": { "type": "string" } },
+        "unnecessary_tools": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "projection": {
+      "type": "object",
+      "required": ["policy", "source_message_count", "retained_message_count", "retained_tokens"],
+      "properties": {
+        "policy": { "type": "string" },
+        "source_message_count": { "type": "integer", "minimum": 0 },
+        "retained_message_count": { "type": "integer", "minimum": 0 },
+        "retained_tokens": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "context": {
+      "type": "object",
+      "required": [
+        "projection_policy",
+        "tool_disclosure",
+        "artifact_count",
+        "selected_artifact_ids",
+        "dropped_artifact_ids",
+        "rendered_bytes",
+        "rendered_tokens",
+        "budget_tokens",
+        "assemble_strategy",
+        "dedup",
+        "exposed_tools"
+      ],
+      "properties": {
+        "projection_policy": { "type": "string" },
+        "tool_disclosure": { "type": "string" },
+        "artifact_count": { "type": "integer", "minimum": 0 },
+        "selected_artifact_ids": { "type": "array", "items": { "type": "string" } },
+        "dropped_artifact_ids": { "type": "array", "items": { "type": "string" } },
+        "rendered_bytes": { "type": "integer", "minimum": 0 },
+        "rendered_tokens": { "type": "integer", "minimum": 0 },
+        "budget_tokens": { "type": "integer", "minimum": 0 },
+        "assemble_strategy": { "type": "string" },
+        "dedup": { "type": "string" },
+        "exposed_tools": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "cache": {
+      "type": "object",
+      "required": ["namespace", "key", "stable_input_hash", "deterministic_order", "hit"],
+      "properties": {
+        "namespace": { "type": "string" },
+        "key": { "type": "string" },
+        "stable_input_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "deterministic_order": { "type": "boolean" },
+        "hit": { "type": ["boolean", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "preprocessing": {
+      "type": "object",
+      "required": ["mode", "llm_enabled"],
+      "properties": {
+        "mode": { "type": "string" },
+        "llm_enabled": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `harn eval context` for deterministic context-engineering eval manifests and stable JSON/JSONL/Markdown report artifacts.
- Add VM primitives, stdlib manifest builders, a report JSON schema, and a 3-task x 3-mode smoke manifest covering packs, compaction/projection, and tool disclosure.
- Document the CLI path and report ingestion contract for hosted evals and downstream consumers.

Closes #2195.

## Verification

- `cargo test -p harn-vm context_eval_scores_modes_deterministically`
- `cargo test -p harn-cli test_parses_eval_context_args`
- `cargo test -p harn-cli --test eval_context_cli`
- `cargo test -p harn-stdlib key_stdlib_modules_resolve`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/context/eval.harn`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/context/eval.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/context/eval.harn`
- `cargo run --quiet --bin harn -- eval context examples/evals/context-engineering-smoke.json --output /tmp/harn-context-eval-smoke --json`
- AJV validation of `/tmp/harn-context-eval-smoke/summary.json` against `spec/schemas/context-eval-report.v1.schema.json`
- `make lint-test-patterns`
- `make test` after rebasing on `origin/main` (`4969 passed, 2 skipped`)
- pre-commit hook: Rust/Harn format, Harn lint, Rust prompt prose ratchet, changed-package clippy, highlight keyword check, markdown lint
- pre-push hook: targeted package checks, affected Harn fmt/lint, markdown lint, highlight keyword check, changelog guard
