### PR TITLE
Add typed stdlib shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ condensed series summaries instead of full per-patch history.
   catalog bindings now expose `preferred_tool_format`, `tool_mode_parity`, and
   optional parity notes. Presets use that data to route known unreliable native
   tool modes to text tools without provider-specific branches.
+- **Stdlib typed shape audit (#2193).** High-value stdlib helpers now expose
+  reusable type aliases for their public record contracts instead of leaving
+  callers to pass free-form dicts. The pass covers run artifacts, calendar,
+  UI resource envelopes, waitpoints, replay corrections, tool registries, and
+  trigger helper plans while preserving raw provider payload envelopes where
+  hosts own the external schema.
 - **Bridge inject mode `wait_for_completion` renamed to `audit_only`
   (#2212).** The previous name was a footgun: reminders queued with this
   mode drain at `loop_exit` and land in the transcript audit, but the

--- a/conformance/tests/integration/tool_define_many.harn
+++ b/conformance/tests/integration/tool_define_many.harn
@@ -1,30 +1,28 @@
-import { tool_define_many, tool_registry_from } from "std/tools"
+import "std/tools"
 
 pipeline test(task) {
-  let registry = tool_define_many(
-    tool_registry(),
-    [
-      {
-        name: "search_code",
-        description: "Search code",
-        parameters: {query: {type: "string"}},
-        handler: { args -> "search:" + args.query },
+  let specs: list<ToolDefinitionSpec> = [
+    {
+      name: "search_code",
+      description: "Search code",
+      parameters: {query: {type: "string"}},
+      handler: { args -> "search:" + args.query },
+    },
+    {
+      name: "read_file",
+      description: "Read file",
+      config: {
+        parameters: {path: {type: "string"}},
+        returns: {type: "string"},
+        handler: { args -> "read:" + args.path },
       },
-      {
-        name: "read_file",
-        description: "Read file",
-        config: {
-          parameters: {path: {type: "string"}},
-          returns: {type: "string"},
-          handler: { args -> "read:" + args.path },
-        },
-      },
-    ],
-  )
+    },
+  ]
+  let registry: ToolRegistry = tool_define_many(tool_registry(), specs)
   assert(tool_count(registry) == 2, "tool_define_many registers both tools")
   assert(tool_find(registry, "search_code").parameters.query.type == "string", "inline config works")
   assert(tool_find(registry, "read_file").outputSchema.type == "string", "nested config works")
-  let fresh = tool_registry_from([{name: "one", desc: "One tool", parameters: {}, handler: { _ -> "ok" }}])
+  let fresh: ToolRegistry = tool_registry_from([{name: "one", desc: "One tool", parameters: {}, handler: { _ -> "ok" }}])
   assert(tool_count(fresh) == 1, "tool_registry_from creates a registry")
   log("tool_define_many tests passed")
 }

--- a/conformance/tests/stdlib/calendar_boundaries.harn
+++ b/conformance/tests/stdlib/calendar_boundaries.harn
@@ -1,25 +1,16 @@
-import {
-  date_range,
-  end_of_month,
-  iso_week,
-  next_weekday,
-  previous_weekday,
-  quarter,
-  start_of_month,
-  start_of_quarter,
-  start_of_week,
-} from "std/calendar"
+import "std/calendar"
 
 pipeline default() {
   let jan1 = date_parse("2021-01-01T12:34:56Z")
-  let week = iso_week(jan1)
+  let week: CalendarIsoWeek = iso_week(jan1)
   __io_println(to_string(week.year) + "-W" + to_string(week.week))
   __io_println(quarter(date_parse("2024-02-29T12:00:00Z")))
   __io_println(date_to_zone(start_of_week(jan1), "UTC"))
   __io_println(date_to_zone(start_of_month(date_parse("2024-02-29T12:00:00Z")), "UTC"))
   __io_println(date_to_zone(end_of_month(date_parse("2024-02-29T12:00:00Z")), "UTC"))
   __io_println(date_to_zone(start_of_quarter(date_parse("2024-05-15T12:00:00Z")), "UTC"))
-  let range = date_range("2024-02-27", "2024-03-02", "day", "UTC")
+  let range_options: CalendarDateRangeOptions = {max_items: 10}
+  let range: list<CalendarTimestamp> = date_range("2024-02-27", "2024-03-02", "day", "UTC", range_options)
   __io_println(len(range))
   __io_println(date_format(range[2], "%Y-%m-%d", "UTC"))
   __io_println(date_format(next_weekday("2024-02-29", "monday", "UTC"), "%Y-%m-%d", "UTC"))

--- a/conformance/tests/stdlib/calendar_business_days.expected
+++ b/conformance/tests/stdlib/calendar_business_days.expected
@@ -8,4 +8,5 @@ false
 true
 after_window
 false
+false
 true

--- a/conformance/tests/stdlib/calendar_business_days.harn
+++ b/conformance/tests/stdlib/calendar_business_days.harn
@@ -1,13 +1,4 @@
-import {
-  add_business_days,
-  business_days_between,
-  business_window,
-  holidays,
-  is_business_day,
-  is_business_time,
-  is_holiday,
-  next_business_day,
-} from "std/calendar"
+import "std/calendar"
 
 pipeline default() {
   let calendar = "US-FEDERAL"
@@ -21,11 +12,14 @@ pipeline default() {
   __io_println(business_days_between("2026-07-01", "2026-07-08", calendar, timezone))
   __io_println(holidays(2026, calendar)[5].date)
   __io_println(len(holidays(2020, calendar)))
-  let options = {timezone: timezone, start: "09:00", end: "17:00"}
+  let options: CalendarBusinessWindowOptions = {timezone: timezone, start: "09:00", end: "17:00"}
   __io_println(is_business_time(date_parse("2026-07-06T14:00:00-04:00"), calendar, options))
-  __io_println(business_window(date_parse("2026-07-06T22:00:00Z"), calendar, options).reason)
-  let custom = {timezone: "UTC", holidays: ["2026-01-02"]}
+  let window: CalendarBusinessWindow = business_window(date_parse("2026-07-06T22:00:00Z"), calendar, options)
+  __io_println(window.reason)
+  let custom: CalendarBusinessCalendar = {timezone: "UTC", holidays: ["2026-01-02"]}
   __io_println(is_business_day("2026-01-02", custom))
+  let custom_weekend: CalendarBusinessCalendar = {timezone: "UTC", weekends: [5]}
+  __io_println(is_business_day("2026-01-02", custom_weekend))
   let unsupported = try {
     is_business_day("2026-01-02", "ZZ")
   }

--- a/conformance/tests/stdlib/calendar_country_lookup.harn
+++ b/conformance/tests/stdlib/calendar_country_lookup.harn
@@ -1,17 +1,22 @@
-import {
-  countries,
-  country_info,
-  country_timezones,
-  default_timezone_for_country,
-} from "std/calendar"
+import "std/calendar"
 
 pipeline default() {
-  let us = country_info("us")
+  let us: CalendarCountry = country_info("us")
+    ?? {
+    code: "US",
+    name: "missing",
+    timezones: [],
+    default_timezone_ambiguous: true,
+    currency_code: "USD",
+    currency_name: "United States dollar",
+    holiday_calendars: [],
+  }
   __io_println(us.name)
   __io_println(us.default_timezone == nil)
   __io_println(country_timezones("US")[0])
   __io_println(default_timezone_for_country("GB"))
   __io_println(default_timezone_for_country("US") == nil)
   __io_println(country_info("ZZ") == nil)
-  __io_println(countries().find({ country -> country.code == "JP" }).currency_code)
+  let all_countries: list<CalendarCountry> = countries()
+  __io_println(all_countries.find({ country -> country.code == "JP" }).currency_code)
 }

--- a/conformance/tests/stdlib/run_artifacts.harn
+++ b/conformance/tests/stdlib/run_artifacts.harn
@@ -1,24 +1,15 @@
-import {
-  run_artifact_path,
-  run_artifact_read_json,
-  run_artifact_read_text,
-  run_artifact_transcript_dir,
-  run_artifact_transcript_path,
-  run_artifact_write_json,
-  run_artifact_write_text,
-  run_artifacts_from_dir,
-  run_artifacts_list,
-  run_artifacts_open,
-} from "std/run_artifacts"
+import "std/run_artifacts"
 
 pipeline test(task) {
   let root = path_join(harness.fs.temp_dir(), "harn-run-artifacts-" + uuid_v7())
-  let run = run_artifacts_open("eval", {root: root, run_id: "run-a"})
+  let open_options: RunArtifactsOpenOptions = {root: root, run_id: "run-a"}
+  let run: RunArtifactsRun = run_artifacts_open("eval", open_options)
+  let paths: RunArtifactPaths = run.paths
   __io_println(run.kind)
   __io_println(run.run_id)
   __io_println(run.root == path_normalize(root))
   __io_println(harness.fs.exists(run.dir))
-  __io_println(path_relative_to(run.paths.facts, run.dir))
+  __io_println(path_relative_to(paths.facts, run.dir))
   run_artifact_write_json(run, "facts.json", {status: "ok", count: 2}, {pretty: true})
   let facts = run_artifact_read_json(run, "facts.json")
   __io_println(facts.status)
@@ -30,7 +21,7 @@ pipeline test(task) {
   __io_println(run_artifact_read_text(run, "review.md", "") == "hello\n")
   __io_println(path_relative_to(run_artifact_transcript_dir(run), run.dir))
   __io_println(path_relative_to(run_artifact_transcript_path(run, "chat-llm"), run.dir))
-  let reopened = run_artifacts_from_dir("eval", run.dir)
+  let reopened: RunArtifactsRun = run_artifacts_from_dir("eval", run.dir)
   __io_println(reopened.run_id)
   __io_println(path_relative_to(reopened.paths.agent_result, reopened.dir))
   let escaped = try {
@@ -44,7 +35,7 @@ pipeline test(task) {
   __io_println(len(run_artifacts_list("eval", {root: empty_root})) == 0)
   let run_b = run_artifacts_open("eval", {root: root, run_id: "run-b"})
   run_artifact_write_json(run_b, "facts.json", {status: "ok"})
-  let listed = run_artifacts_list("eval", {root: root, limit: 10})
+  let listed: list<RunArtifactsRun> = run_artifacts_list("eval", {root: root, limit: 10})
   __io_println(len(listed))
   __io_println(listed[0].modified >= listed[1].modified)
   __io_println(len(run_artifacts_list("eval", {root: root, limit: 1})))

--- a/conformance/tests/stdlib/ui_resource.harn
+++ b/conformance/tests/stdlib/ui_resource.harn
@@ -1,33 +1,15 @@
-import {
-  ui_context_update_envelope,
-  ui_host_capabilities,
-  ui_host_supports_apps,
-  ui_resource,
-  ui_resource_csp_header,
-  ui_resource_sandbox_attr,
-  ui_select_for_host,
-  ui_structured_fallback,
-  ui_tool_call_envelope,
-  ui_tool_meta,
-  ui_tool_meta_to_mcp,
-  ui_tool_result,
-  ui_tool_result_validate,
-} from "std/ui_resource"
+import "std/ui_resource"
 
 pipeline default() {
   let dashboard_html = "<!doctype html><html><head><style>.tile { padding: 12px; }</style></head><body><main><h1>KPIs</h1><pre>signups=42 churn=3</pre><script>const initial = window.openInitialData; const summary = document.getElementById('summary');</script></main></body></html>"
-  let resource = ui_resource(
-    "ui://harn-dashboard/kpis@v1",
-    "KPIs dashboard",
-    dashboard_html,
-    {
-      description: "Weekly KPI tiles",
-      permissions: ["tools/call", "context/update"],
-      capabilities: ["tools/call", "context/update", "context/read"],
-      version: "2026-05-11",
-      meta: {owner: "growth-team"},
-    },
-  )
+  let resource_options: UiResourceOptions = {
+    description: "Weekly KPI tiles",
+    permissions: ["tools/call", "context/update"],
+    capabilities: ["tools/call", "context/update", "context/read"],
+    version: "2026-05-11",
+    meta: {owner: "growth-team"},
+  }
+  let resource: UiResource = ui_resource("ui://harn-dashboard/kpis@v1", "KPIs dashboard", dashboard_html, resource_options)
   __io_println(resource.schema)
   __io_println(resource.mime_type)
   __io_println(resource.profile)
@@ -36,7 +18,8 @@ pipeline default() {
   __io_println(resource.validation.ok)
   __io_println(resource.content_sha256.starts_with("sha256:"))
   __io_println(len(resource.permissions))
-  let meta = ui_tool_meta(resource, {visibility: "app_only", initial_view: {tab: "signups"}})
+  let meta_options: UiToolMetaOptions = {visibility: "app_only", initial_view: {tab: "signups"}}
+  let meta: UiToolMeta = ui_tool_meta(resource, meta_options)
   let mcp_meta = ui_tool_meta_to_mcp(meta)
   __io_println(meta.schema)
   __io_println(mcp_meta.ui.resourceUri)
@@ -47,10 +30,8 @@ pipeline default() {
   __io_println(csp_header.contains("connect-src 'none'"))
   let sandbox_attr = ui_resource_sandbox_attr(resource.csp)
   __io_println(sandbox_attr)
-  let result = ui_tool_result(
-    resource,
-    {structured_fallback: ui_structured_fallback({signups: 42, churn: 3}, {text: "signups=42 churn=3"})},
-  )
+  let result_options: UiToolResultOptions = {structured_fallback: ui_structured_fallback({signups: 42, churn: 3}, {text: "signups=42 churn=3"})}
+  let result: UiToolResult = ui_tool_result(resource, result_options)
   __io_println(result.schema)
   __io_println(result.text_fallback.content.contains("KPIs"))
   __io_println(result.text_fallback.content.contains("signups=42 churn=3"))
@@ -70,7 +51,7 @@ pipeline default() {
   let mcp_caps = ui_host_supports_apps({apps: {enabled: true, profiles: ["mcp-app", "openai-app"]}})
   let custom_only = ui_host_supports_apps({apps: true, profiles: ["custom-app"]})
   let null_caps = ui_host_supports_apps(nil)
-  let normalized = ui_host_capabilities({apps: {enabled: true, profiles: ["mcp-app"], bridges: ["postMessage"]}})
+  let normalized: UiHostCapabilities = ui_host_capabilities({apps: {enabled: true, profiles: ["mcp-app"], bridges: ["postMessage"]}})
   __io_println(openai_caps)
   __io_println(no_apps)
   __io_println(mcp_caps)
@@ -78,12 +59,12 @@ pipeline default() {
   __io_println(null_caps)
   __io_println(normalized.profiles)
   __io_println(normalized.bridges)
-  let call = ui_tool_call_envelope("dashboard.refresh", {window: "7d"}, {id: "call-1"})
+  let call: UiToolCallEnvelope = ui_tool_call_envelope("dashboard.refresh", {window: "7d"}, {id: "call-1"})
   __io_println(call.jsonrpc)
   __io_println(call.method)
   __io_println(call.params.name)
   __io_println(call.params.arguments.window)
-  let ctx_update = ui_context_update_envelope("selection", {tile: "signups"}, {id: "ctx-1"})
+  let ctx_update: UiContextUpdateEnvelope = ui_context_update_envelope("selection", {tile: "signups"}, {id: "ctx-1"})
   __io_println(ctx_update.method)
   __io_println(ctx_update.params.key)
   __io_println(ctx_update.params.model_visible)

--- a/conformance/tests/stdlib/waitpoint_fan_in.harn
+++ b/conformance/tests/stdlib/waitpoint_fan_in.harn
@@ -1,7 +1,7 @@
-import { complete, create, wait } from "std/waitpoint"
+import "std/waitpoint"
 
 pipeline test(task) {
-  let wp = create("fan-in-" + uuid())
+  let wp: Waitpoint = create("fan-in-" + uuid())
   let first = spawn {
     wait(wp).value + "-1"
   }

--- a/conformance/tests/stdlib/waitpoint_fan_out.harn
+++ b/conformance/tests/stdlib/waitpoint_fan_out.harn
@@ -1,7 +1,7 @@
-import { complete, create, wait } from "std/waitpoint"
+import "std/waitpoint"
 
 pipeline test(task) {
-  let points = [
+  let points: list<Waitpoint> = [
     create("fan-out-1"),
     create("fan-out-2"),
     create("fan-out-3"),

--- a/conformance/tests/trust_graph/corrections_policy_adapts.harn
+++ b/conformance/tests/trust_graph/corrections_policy_adapts.harn
@@ -4,20 +4,20 @@ pipeline test(task) {
   let unique = uuid_v7()
   let actor_id = "correction-policy-" + unique
   let action = "github.issue.opened"
-  let correction_id: CorrectionId = record(
-    {
-      actor_id: actor_id,
-      action: action,
-      from_decision: {actor_id: actor_id, action: action, outcome: "success"},
-      to_decision: {outcome: "denied"},
-      reason: "operator corrected unsafe routing",
-      applied_by: "maintainer-1",
-      scope: "this_persona",
-      trace_id: "trace-" + unique,
-      step: "outcome",
-      evidence_refs: [{kind: "trigger_replay", event_id: "evt-" + unique}],
-    },
-  )
+  let evidence: CorrectionEvidenceRef = {kind: "trigger_replay", event_id: "evt-" + unique}
+  let correction: CorrectionInput = {
+    actor_id: actor_id,
+    action: action,
+    from_decision: {actor_id: actor_id, action: action, outcome: "success"},
+    to_decision: {outcome: "denied"},
+    reason: "operator corrected unsafe routing",
+    applied_by: "maintainer-1",
+    scope: "this_persona",
+    trace_id: "trace-" + unique,
+    step: "outcome",
+    evidence_refs: [evidence],
+  }
+  let correction_id: CorrectionId = record(correction)
   let records: list<CorrectionRecord> = query({actor_id: actor_id, action: action})
   let policy: CapabilityPolicy = trust.policy_for(actor_id)
   __io_println(correction_id != "")

--- a/crates/harn-stdlib/src/stdlib/stdlib_calendar.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_calendar.harn
@@ -1,6 +1,112 @@
-// std/calendar — civil date, timezone, country, and business-calendar helpers.
-//
-// Import with: import { add_business_days, country_info, start_of_week } from "std/calendar"
+/**
+ * std/calendar — civil date, timezone, country, and business-calendar helpers.
+ *
+ * Import with: import { add_business_days, country_info, start_of_week } from "std/calendar"
+ */
+type CalendarInstant = int | float | string | dict
+
+type CalendarTimestamp = int | float
+
+type CalendarUnit = "day" | "week" | "month" | "quarter" | "year"
+
+type CalendarBoundaryEdge = "start" | "end"
+
+type CalendarDisambiguation = "earlier" | "later" | "reject"
+
+type CalendarWeekday = int | string
+
+type CalendarWeekends = list<int> | list<string> | list<CalendarWeekday>
+
+type CalendarParts = {
+  year: int,
+  month: int,
+  day: int,
+  hour: int,
+  minute: int,
+  second: int,
+  weekday: int,
+  iso_weekday: int,
+  iso_week: int,
+  iso_week_year: int,
+  ordinal: int,
+  quarter: int,
+  timezone: string,
+  offset_seconds: int,
+  timestamp: CalendarTimestamp,
+  iso8601: string,
+  date: string,
+}
+
+type CalendarIsoWeek = {year: int, week: int}
+
+type CalendarLocalDateTime = {
+  year: int,
+  month: int,
+  day: int,
+  hour?: int,
+  minute?: int,
+  second?: int,
+}
+
+type CalendarDateRangeOptions = {
+  max_items?: int,
+  include_end?: bool,
+  disambiguation?: CalendarDisambiguation,
+}
+
+type CalendarCountry = {
+  code: string,
+  name: string,
+  timezones: list<string>,
+  default_timezone?: string,
+  default_timezone_ambiguous: bool,
+  currency_code: string,
+  currency_name: string,
+  holiday_calendars: list<string>,
+}
+
+type CalendarHolidayCalendarInfo = {
+  name: string,
+  country: string,
+  timezone: string,
+  description: string,
+}
+
+type CalendarHoliday = {date: string, actual_date: string, name: string, observed: bool}
+
+type CalendarCustomHoliday = string | {date: string, name?: string}
+
+type CalendarCustomHolidays = list<string> | list<{date: string, name?: string}> | list<CalendarCustomHoliday>
+
+type CalendarBusinessCalendar = string | {
+  name?: string,
+  timezone?: string,
+  weekends?: CalendarWeekends,
+  holiday_calendar?: string,
+  holidays?: CalendarCustomHolidays,
+}
+
+type CalendarBusinessWindowOptions = {
+  timezone?: string,
+  start?: string,
+  start_hour?: int,
+  end?: string,
+  end_hour?: int,
+}
+
+type CalendarBusinessWindowReason = "inside" | "non_business_day" | "before_window" | "after_window"
+
+type CalendarBusinessWindow = {
+  inside: bool,
+  business_day: bool,
+  reason: CalendarBusinessWindowReason,
+  timezone: string,
+  calendar: string,
+  local_date: string,
+  starts_at: CalendarTimestamp,
+  ends_at: CalendarTimestamp,
+}
+
 /**
  * Return timezone-local calendar fields, including ISO week and quarter.
  *
@@ -10,7 +116,7 @@
  * @api_stability: stable
  * @example: parts(timestamp, timezone)
  */
-pub fn parts(timestamp, timezone: string = "UTC") -> dict {
+pub fn parts(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarParts {
   return __calendar_parts(timestamp, timezone)
 }
 
@@ -23,7 +129,7 @@ pub fn parts(timestamp, timezone: string = "UTC") -> dict {
  * @api_stability: stable
  * @example: iso_week(timestamp, timezone)
  */
-pub fn iso_week(timestamp, timezone: string = "UTC") -> dict {
+pub fn iso_week(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarIsoWeek {
   let p = parts(timestamp, timezone)
   return {year: p.iso_week_year, week: p.iso_week}
 }
@@ -37,7 +143,7 @@ pub fn iso_week(timestamp, timezone: string = "UTC") -> dict {
  * @api_stability: stable
  * @example: quarter(timestamp, timezone)
  */
-pub fn quarter(timestamp, timezone: string = "UTC") -> int {
+pub fn quarter(timestamp: CalendarInstant, timezone: string = "UTC") -> int {
   return parts(timestamp, timezone).quarter
 }
 
@@ -53,7 +159,11 @@ pub fn quarter(timestamp, timezone: string = "UTC") -> int {
  * @api_stability: stable
  * @example: local_datetime(parts, timezone, disambiguation)
  */
-pub fn local_datetime(parts: dict, timezone: string = "UTC", disambiguation: string = "earlier") {
+pub fn local_datetime(
+  parts: CalendarLocalDateTime,
+  timezone: string = "UTC",
+  disambiguation: CalendarDisambiguation = "earlier",
+) -> CalendarTimestamp {
   return __calendar_from_local(parts, timezone, disambiguation)
 }
 
@@ -67,12 +177,12 @@ pub fn local_datetime(parts: dict, timezone: string = "UTC", disambiguation: str
  * @example: add_calendar_units(timestamp, amount, unit, timezone, disambiguation)
  */
 pub fn add_calendar_units(
-  timestamp,
+  timestamp: CalendarInstant,
   amount: int,
-  unit: string,
+  unit: CalendarUnit,
   timezone: string = "UTC",
-  disambiguation: string = "earlier",
-) {
+  disambiguation: CalendarDisambiguation = "earlier",
+) -> CalendarTimestamp {
   return __calendar_add(timestamp, amount, unit, timezone, disambiguation)
 }
 
@@ -85,7 +195,12 @@ pub fn add_calendar_units(
  * @api_stability: stable
  * @example: boundary(timestamp, unit, edge, timezone)
  */
-pub fn boundary(timestamp, unit: string, edge: string = "start", timezone: string = "UTC") {
+pub fn boundary(
+  timestamp: CalendarInstant,
+  unit: CalendarUnit,
+  edge: CalendarBoundaryEdge = "start",
+  timezone: string = "UTC",
+) -> CalendarTimestamp {
   return __calendar_boundary(timestamp, unit, edge, timezone)
 }
 
@@ -98,7 +213,7 @@ pub fn boundary(timestamp, unit: string, edge: string = "start", timezone: strin
  * @api_stability: stable
  * @example: start_of_day(timestamp, timezone)
  */
-pub fn start_of_day(timestamp, timezone: string = "UTC") {
+pub fn start_of_day(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "day", "start", timezone)
 }
 
@@ -111,7 +226,7 @@ pub fn start_of_day(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: end_of_day(timestamp, timezone)
  */
-pub fn end_of_day(timestamp, timezone: string = "UTC") {
+pub fn end_of_day(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "day", "end", timezone)
 }
 
@@ -124,7 +239,7 @@ pub fn end_of_day(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: start_of_week(timestamp, timezone)
  */
-pub fn start_of_week(timestamp, timezone: string = "UTC") {
+pub fn start_of_week(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "week", "start", timezone)
 }
 
@@ -137,7 +252,7 @@ pub fn start_of_week(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: end_of_week(timestamp, timezone)
  */
-pub fn end_of_week(timestamp, timezone: string = "UTC") {
+pub fn end_of_week(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "week", "end", timezone)
 }
 
@@ -150,7 +265,7 @@ pub fn end_of_week(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: start_of_month(timestamp, timezone)
  */
-pub fn start_of_month(timestamp, timezone: string = "UTC") {
+pub fn start_of_month(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "month", "start", timezone)
 }
 
@@ -163,7 +278,7 @@ pub fn start_of_month(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: end_of_month(timestamp, timezone)
  */
-pub fn end_of_month(timestamp, timezone: string = "UTC") {
+pub fn end_of_month(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "month", "end", timezone)
 }
 
@@ -176,7 +291,7 @@ pub fn end_of_month(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: start_of_quarter(timestamp, timezone)
  */
-pub fn start_of_quarter(timestamp, timezone: string = "UTC") {
+pub fn start_of_quarter(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "quarter", "start", timezone)
 }
 
@@ -189,7 +304,7 @@ pub fn start_of_quarter(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: end_of_quarter(timestamp, timezone)
  */
-pub fn end_of_quarter(timestamp, timezone: string = "UTC") {
+pub fn end_of_quarter(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "quarter", "end", timezone)
 }
 
@@ -202,7 +317,7 @@ pub fn end_of_quarter(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: start_of_year(timestamp, timezone)
  */
-pub fn start_of_year(timestamp, timezone: string = "UTC") {
+pub fn start_of_year(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "year", "start", timezone)
 }
 
@@ -215,7 +330,7 @@ pub fn start_of_year(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: end_of_year(timestamp, timezone)
  */
-pub fn end_of_year(timestamp, timezone: string = "UTC") {
+pub fn end_of_year(timestamp: CalendarInstant, timezone: string = "UTC") -> CalendarTimestamp {
   return boundary(timestamp, "year", "end", timezone)
 }
 
@@ -228,7 +343,13 @@ pub fn end_of_year(timestamp, timezone: string = "UTC") {
  * @api_stability: stable
  * @example: date_range(start, end, unit, timezone, options)
  */
-pub fn date_range(start, end, unit: string = "day", timezone: string = "UTC", options: dict = {}) -> list {
+pub fn date_range(
+  start: CalendarInstant,
+  end: CalendarInstant,
+  unit: CalendarUnit = "day",
+  timezone: string = "UTC",
+  options: CalendarDateRangeOptions = {},
+) -> list<CalendarTimestamp> {
   return __calendar_date_range(start, end, unit, timezone, options)
 }
 
@@ -241,7 +362,12 @@ pub fn date_range(start, end, unit: string = "day", timezone: string = "UTC", op
  * @api_stability: stable
  * @example: next_weekday(timestamp, weekday, timezone, include_today)
  */
-pub fn next_weekday(timestamp, weekday, timezone: string = "UTC", include_today: bool = false) {
+pub fn next_weekday(
+  timestamp: CalendarInstant,
+  weekday: CalendarWeekday,
+  timezone: string = "UTC",
+  include_today: bool = false,
+) -> CalendarTimestamp {
   return __calendar_next_weekday(timestamp, weekday, "next", timezone, include_today)
 }
 
@@ -254,7 +380,12 @@ pub fn next_weekday(timestamp, weekday, timezone: string = "UTC", include_today:
  * @api_stability: stable
  * @example: previous_weekday(timestamp, weekday, timezone, include_today)
  */
-pub fn previous_weekday(timestamp, weekday, timezone: string = "UTC", include_today: bool = false) {
+pub fn previous_weekday(
+  timestamp: CalendarInstant,
+  weekday: CalendarWeekday,
+  timezone: string = "UTC",
+  include_today: bool = false,
+) -> CalendarTimestamp {
   return __calendar_next_weekday(timestamp, weekday, "previous", timezone, include_today)
 }
 
@@ -267,7 +398,7 @@ pub fn previous_weekday(timestamp, weekday, timezone: string = "UTC", include_to
  * @api_stability: stable
  * @example: countries()
  */
-pub fn countries() -> list {
+pub fn countries() -> list<CalendarCountry> {
   return __calendar_countries()
 }
 
@@ -280,7 +411,7 @@ pub fn countries() -> list {
  * @api_stability: stable
  * @example: country_info(code)
  */
-pub fn country_info(code: string) {
+pub fn country_info(code: string) -> CalendarCountry? {
   return __calendar_country_info(code)
 }
 
@@ -293,7 +424,7 @@ pub fn country_info(code: string) {
  * @api_stability: stable
  * @example: country_timezones(code)
  */
-pub fn country_timezones(code: string) {
+pub fn country_timezones(code: string) -> list<string>? {
   let info = country_info(code)
   if info == nil {
     return nil
@@ -311,7 +442,7 @@ pub fn country_timezones(code: string) {
  * @api_stability: stable
  * @example: default_timezone_for_country(code)
  */
-pub fn default_timezone_for_country(code: string) {
+pub fn default_timezone_for_country(code: string) -> string? {
   let info = country_info(code)
   if info == nil || info.default_timezone_ambiguous {
     return nil
@@ -328,7 +459,7 @@ pub fn default_timezone_for_country(code: string) {
  * @api_stability: stable
  * @example: supported_holiday_calendars()
  */
-pub fn supported_holiday_calendars() -> list {
+pub fn supported_holiday_calendars() -> list<CalendarHolidayCalendarInfo> {
   return __calendar_supported_holiday_calendars()
 }
 
@@ -341,7 +472,7 @@ pub fn supported_holiday_calendars() -> list {
  * @api_stability: stable
  * @example: holidays(year, calendar)
  */
-pub fn holidays(year: int, calendar: string = "US-FEDERAL") -> list {
+pub fn holidays(year: int, calendar: string = "US-FEDERAL") -> list<CalendarHoliday> {
   return __calendar_holidays(calendar, year)
 }
 
@@ -354,7 +485,11 @@ pub fn holidays(year: int, calendar: string = "US-FEDERAL") -> list {
  * @api_stability: stable
  * @example: is_holiday(timestamp, calendar, timezone)
  */
-pub fn is_holiday(timestamp, calendar = "US-FEDERAL", timezone = nil) -> bool {
+pub fn is_holiday(
+  timestamp: CalendarInstant,
+  calendar: CalendarBusinessCalendar = "US-FEDERAL",
+  timezone = nil,
+) -> bool {
   return __calendar_is_holiday(timestamp, calendar, timezone)
 }
 
@@ -367,7 +502,7 @@ pub fn is_holiday(timestamp, calendar = "US-FEDERAL", timezone = nil) -> bool {
  * @api_stability: stable
  * @example: is_weekend(timestamp, timezone)
  */
-pub fn is_weekend(timestamp, timezone: string = "UTC") -> bool {
+pub fn is_weekend(timestamp: CalendarInstant, timezone: string = "UTC") -> bool {
   let weekday = parts(timestamp, timezone).iso_weekday
   return weekday == 6 || weekday == 7
 }
@@ -381,7 +516,11 @@ pub fn is_weekend(timestamp, timezone: string = "UTC") -> bool {
  * @api_stability: stable
  * @example: is_business_day(timestamp, calendar, timezone)
  */
-pub fn is_business_day(timestamp, calendar = "US-FEDERAL", timezone = nil) -> bool {
+pub fn is_business_day(
+  timestamp: CalendarInstant,
+  calendar: CalendarBusinessCalendar = "US-FEDERAL",
+  timezone = nil,
+) -> bool {
   return __calendar_is_business_day(timestamp, calendar, timezone)
 }
 
@@ -395,11 +534,11 @@ pub fn is_business_day(timestamp, calendar = "US-FEDERAL", timezone = nil) -> bo
  * @example: next_business_day(timestamp, calendar, timezone, include_today)
  */
 pub fn next_business_day(
-  timestamp,
-  calendar = "US-FEDERAL",
+  timestamp: CalendarInstant,
+  calendar: CalendarBusinessCalendar = "US-FEDERAL",
   timezone = nil,
   include_today: bool = false,
-) {
+) -> CalendarTimestamp {
   return __calendar_next_business_day(timestamp, calendar, timezone, include_today)
 }
 
@@ -412,7 +551,12 @@ pub fn next_business_day(
  * @api_stability: stable
  * @example: add_business_days(timestamp, days, calendar, timezone)
  */
-pub fn add_business_days(timestamp, days: int, calendar = "US-FEDERAL", timezone = nil) {
+pub fn add_business_days(
+  timestamp: CalendarInstant,
+  days: int,
+  calendar: CalendarBusinessCalendar = "US-FEDERAL",
+  timezone = nil,
+) -> CalendarTimestamp {
   return __calendar_add_business_days(timestamp, days, calendar, timezone)
 }
 
@@ -425,7 +569,12 @@ pub fn add_business_days(timestamp, days: int, calendar = "US-FEDERAL", timezone
  * @api_stability: stable
  * @example: business_days_between(start, end, calendar, timezone)
  */
-pub fn business_days_between(start, end, calendar = "US-FEDERAL", timezone = nil) -> int {
+pub fn business_days_between(
+  start: CalendarInstant,
+  end: CalendarInstant,
+  calendar: CalendarBusinessCalendar = "US-FEDERAL",
+  timezone = nil,
+) -> int {
   return __calendar_business_days_between(start, end, calendar, timezone)
 }
 
@@ -438,7 +587,11 @@ pub fn business_days_between(start, end, calendar = "US-FEDERAL", timezone = nil
  * @api_stability: stable
  * @example: business_window(timestamp, calendar, options)
  */
-pub fn business_window(timestamp, calendar = "US-FEDERAL", options: dict = {}) -> dict {
+pub fn business_window(
+  timestamp: CalendarInstant,
+  calendar: CalendarBusinessCalendar = "US-FEDERAL",
+  options: CalendarBusinessWindowOptions = {},
+) -> CalendarBusinessWindow {
   return __calendar_business_window(timestamp, calendar, options)
 }
 
@@ -451,6 +604,10 @@ pub fn business_window(timestamp, calendar = "US-FEDERAL", options: dict = {}) -
  * @api_stability: stable
  * @example: is_business_time(timestamp, calendar, options)
  */
-pub fn is_business_time(timestamp, calendar = "US-FEDERAL", options: dict = {}) -> bool {
+pub fn is_business_time(
+  timestamp: CalendarInstant,
+  calendar: CalendarBusinessCalendar = "US-FEDERAL",
+  options: CalendarBusinessWindowOptions = {},
+) -> bool {
   return business_window(timestamp, calendar, options).inside
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_corrections.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_corrections.harn
@@ -9,11 +9,34 @@ type CorrectionId = string
 
 type CorrectionScope = "this_run" | "this_persona" | "all"
 
+type CorrectionDecision = {
+  actor_id?: string,
+  actor?: string,
+  agent?: string,
+  action?: string,
+  event_kind?: string,
+  outcome?: string,
+  reason?: string,
+  metadata?: dict,
+  raw?: dict,
+}
+
+type CorrectionEvidenceRef = {
+  kind: string,
+  event_id?: string,
+  trace_id?: string,
+  uri?: string,
+  path?: string,
+  line?: int,
+  summary?: string,
+  raw?: dict,
+}
+
 type CorrectionRecord = {
   schema: string,
   correction_id: string,
-  from_decision: any,
-  to_decision: any,
+  from_decision: CorrectionDecision,
+  to_decision: CorrectionDecision,
   reason: string,
   applied_by: string,
   scope: CorrectionScope,
@@ -22,19 +45,35 @@ type CorrectionRecord = {
   action: string?,
   trace_id: string?,
   step: string?,
-  evidence_refs: list<dict>,
+  evidence_refs: list<CorrectionEvidenceRef>,
   metadata: dict,
 }
 
+type CorrectionInput = {
+  from_decision: CorrectionDecision,
+  to_decision: CorrectionDecision,
+  reason: string,
+  applied_by: string,
+  scope?: CorrectionScope,
+  actor_id?: string,
+  actor?: string,
+  agent?: string,
+  action?: string,
+  trace_id?: string,
+  step?: string,
+  evidence_refs?: list<CorrectionEvidenceRef>,
+  metadata?: dict,
+}
+
 type CorrectionQueryFilters = {
-  actor: string?,
-  actor_id: string?,
-  agent: string?,
-  action: string?,
-  scope: CorrectionScope?,
-  since: string?,
-  until: string?,
-  limit: int?,
+  actor?: string,
+  actor_id?: string,
+  agent?: string,
+  action?: string,
+  scope?: CorrectionScope,
+  since?: string,
+  until?: string,
+  limit?: int,
 }
 
 /**
@@ -46,7 +85,7 @@ type CorrectionQueryFilters = {
  * @api_stability: stable
  * @example: record(correction)
  */
-pub fn record(correction) -> CorrectionId {
+pub fn record(correction: CorrectionInput) -> CorrectionId {
   return corrections.record(correction)
 }
 
@@ -59,6 +98,6 @@ pub fn record(correction) -> CorrectionId {
  * @api_stability: stable
  * @example: query(filters)
  */
-pub fn query(filters = {}) -> list<CorrectionRecord> {
+pub fn query(filters: CorrectionQueryFilters = {}) -> list<CorrectionRecord> {
   return corrections.query(filters)
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_run_artifacts.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_run_artifacts.harn
@@ -7,6 +7,25 @@ type RunArtifactsListOptions = {root?: string, namespace?: string, limit?: int}
 
 type RunArtifactWriteOptions = {pretty?: bool, trailing_newline?: bool, ensure_parent?: bool}
 
+type RunArtifactPaths = {
+  facts: string,
+  audit: string,
+  review: string,
+  agent_result: string,
+  agent_trace: string,
+  agent_llm_transcript: string,
+}
+
+type RunArtifactsRun = {
+  kind: string,
+  namespace?: string,
+  run_id: string,
+  root: string,
+  dir: string,
+  modified?: int | float,
+  paths: RunArtifactPaths,
+}
+
 fn __run_artifacts_required_text(value, label) -> string {
   let text = trim(to_string(value ?? ""))
   if text == "" {
@@ -72,15 +91,15 @@ fn __run_artifacts_default_run_id() -> string {
   return to_string(to_int(harness.clock.timestamp())) + "-" + uuid_v7()
 }
 
-fn __run_artifacts_run_dir(run) -> string {
-  let dir = to_string(run?.dir ?? "")
+fn __run_artifacts_run_dir(run: {dir: string}) -> string {
+  let dir = to_string(run.dir ?? "")
   if dir == "" {
     throw "std/run_artifacts: run.dir is required"
   }
   return dir
 }
 
-fn __run_artifacts_path(run, name) -> string {
+fn __run_artifacts_path(run: {dir: string}, name) -> string {
   let rel = __run_artifacts_clean_relative(name, "artifact path")
   let root = path_normalize(__run_artifacts_run_dir(run))
   let joined = path_normalize(path_join(root, rel))
@@ -91,7 +110,7 @@ fn __run_artifacts_path(run, name) -> string {
   return joined
 }
 
-fn __run_artifacts_standard_paths(run) -> dict {
+fn __run_artifacts_standard_paths(run: {dir: string}) -> RunArtifactPaths {
   return {
     facts: __run_artifacts_path(run, "facts.json"),
     audit: __run_artifacts_path(run, "audit.json"),
@@ -102,7 +121,7 @@ fn __run_artifacts_standard_paths(run) -> dict {
   }
 }
 
-fn __run_artifacts_make_run(kind, namespace, root, run_id, dir, modified = nil) -> dict {
+fn __run_artifacts_make_run(kind, namespace, root, run_id, dir, modified = nil) -> RunArtifactsRun {
   let base = {kind: kind, namespace: namespace, run_id: run_id, root: root, dir: dir, modified: modified}
   return base + {paths: __run_artifacts_standard_paths(base)}
 }
@@ -116,7 +135,7 @@ fn __run_artifacts_make_run(kind, namespace, root, run_id, dir, modified = nil) 
  * @api_stability: stable
  * @example: run_artifacts_open("release", {root: root, run_id: "run-1"})
  */
-pub fn run_artifacts_open(kind: string, options: RunArtifactsOpenOptions = {}) -> dict {
+pub fn run_artifacts_open(kind: string, options: RunArtifactsOpenOptions = {}) -> RunArtifactsRun {
   let opts = options ?? {}
   let clean_kind = __run_artifacts_clean_segment(kind, "kind")
   let namespace = __run_artifacts_namespace(opts)
@@ -140,7 +159,7 @@ pub fn run_artifacts_open(kind: string, options: RunArtifactsOpenOptions = {}) -
  * @api_stability: stable
  * @example: run_artifact_path(run, "facts.json")
  */
-pub fn run_artifact_path(run: dict, name: string) -> string {
+pub fn run_artifact_path(run: RunArtifactsRun, name: string) -> string {
   return __run_artifacts_path(run, name)
 }
 
@@ -154,7 +173,7 @@ pub fn run_artifact_path(run: dict, name: string) -> string {
  * @example: run_artifact_write_json(run, "facts.json", facts, {pretty: true})
  */
 pub fn run_artifact_write_json(
-  run: dict,
+  run: RunArtifactsRun,
   name: string,
   value,
   options: RunArtifactWriteOptions = {},
@@ -171,7 +190,7 @@ pub fn run_artifact_write_json(
  * @api_stability: stable
  * @example: run_artifact_read_json(run, "facts.json", {})
  */
-pub fn run_artifact_read_json(run: dict, name: string, fallback = nil) {
+pub fn run_artifact_read_json(run: RunArtifactsRun, name: string, fallback = nil) {
   return read_json(run_artifact_path(run, name), fallback)
 }
 
@@ -185,7 +204,7 @@ pub fn run_artifact_read_json(run: dict, name: string, fallback = nil) {
  * @example: run_artifact_write_text(run, "review.md", body)
  */
 pub fn run_artifact_write_text(
-  run: dict,
+  run: RunArtifactsRun,
   name: string,
   text: string,
   options: RunArtifactWriteOptions = {},
@@ -202,7 +221,7 @@ pub fn run_artifact_write_text(
  * @api_stability: stable
  * @example: run_artifact_read_text(run, "review.md", "")
  */
-pub fn run_artifact_read_text(run: dict, name: string, fallback = nil) {
+pub fn run_artifact_read_text(run: RunArtifactsRun, name: string, fallback = nil) {
   let result = try {
     harness.fs.read_text(run_artifact_path(run, name))
   }
@@ -221,7 +240,7 @@ pub fn run_artifact_read_text(run: dict, name: string, fallback = nil) {
  * @api_stability: stable
  * @example: run_artifact_transcript_dir(run, "agent-llm")
  */
-pub fn run_artifact_transcript_dir(run: dict, name: string = "agent-llm") -> string {
+pub fn run_artifact_transcript_dir(run: RunArtifactsRun, name: string = "agent-llm") -> string {
   let dir_name = if trim(to_string(name ?? "")) == "" {
     "agent-llm"
   } else {
@@ -239,7 +258,7 @@ pub fn run_artifact_transcript_dir(run: dict, name: string = "agent-llm") -> str
  * @api_stability: stable
  * @example: run_artifact_transcript_path(run, "agent-llm")
  */
-pub fn run_artifact_transcript_path(run: dict, name: string = "agent-llm") -> string {
+pub fn run_artifact_transcript_path(run: RunArtifactsRun, name: string = "agent-llm") -> string {
   let dir_name = if trim(to_string(name ?? "")) == "" {
     "agent-llm"
   } else {
@@ -257,7 +276,7 @@ pub fn run_artifact_transcript_path(run: dict, name: string = "agent-llm") -> st
  * @api_stability: stable
  * @example: run_artifacts_list("release", {limit: 5})
  */
-pub fn run_artifacts_list(kind: string, options: RunArtifactsListOptions = {}) -> list<dict> {
+pub fn run_artifacts_list(kind: string, options: RunArtifactsListOptions = {}) -> list<RunArtifactsRun> {
   let opts = options ?? {}
   let clean_kind = __run_artifacts_clean_segment(kind, "kind")
   let namespace = __run_artifacts_namespace(opts)
@@ -307,7 +326,7 @@ pub fn run_artifacts_list(kind: string, options: RunArtifactsListOptions = {}) -
  * @api_stability: stable
  * @example: run_artifacts_from_dir("release", previous_dir)
  */
-pub fn run_artifacts_from_dir(kind: string, dir: string) -> dict {
+pub fn run_artifacts_from_dir(kind: string, dir: string) -> RunArtifactsRun {
   let clean_kind = __run_artifacts_clean_segment(kind, "kind")
   let clean_dir = path_normalize(__run_artifacts_required_text(dir, "dir"))
   let run_id = __run_artifacts_clean_segment(path_basename(clean_dir), "run_id")

--- a/crates/harn-stdlib/src/stdlib/stdlib_tools.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_tools.harn
@@ -1,8 +1,40 @@
-fn __tool_spec_config(spec) {
+type ToolRegistry = {_type: "tool_registry", tools: list<dict>}
+
+type ToolDefinitionConfig = {
+  parameters?: dict,
+  returns?: dict,
+  output_schema?: dict,
+  handler?: any,
+  executor?: string,
+  host_capability?: string,
+  mcp_server?: string,
+  defer_loading?: bool,
+  namespace?: string,
+  annotations?: dict,
+}
+
+type ToolDefinitionSpec = {
+  name: string,
+  description?: string,
+  desc?: string,
+  config?: ToolDefinitionConfig,
+  parameters?: dict,
+  returns?: dict,
+  output_schema?: dict,
+  handler?: any,
+  executor?: string,
+  host_capability?: string,
+  mcp_server?: string,
+  defer_loading?: bool,
+  namespace?: string,
+  annotations?: dict,
+}
+
+fn __tool_spec_config(spec: ToolDefinitionSpec) -> ToolDefinitionConfig {
   if type_of(spec) != "dict" {
     throw "tool_define_many: each spec must be a dict"
   }
-  var config = spec?.config ?? {}
+  var config = spec.config ?? {}
   for key in spec.keys() {
     if !contains(["name", "description", "desc", "config"], key) {
       config = config + {[key]: spec[key]}
@@ -20,7 +52,7 @@ fn __tool_spec_config(spec) {
  * @api_stability: stable
  * @example: tool_define_many(registry, specs)
  */
-pub fn tool_define_many(registry, specs = nil) {
+pub fn tool_define_many(registry, specs: list<ToolDefinitionSpec>? = nil) -> ToolRegistry {
   var target = registry
   var items = specs
   if items == nil {
@@ -32,8 +64,8 @@ pub fn tool_define_many(registry, specs = nil) {
   }
   var tools = target ?? tool_registry()
   for spec in items {
-    let name = spec?.name
-    let description = spec?.description ?? spec?.desc
+    let name = spec.name
+    let description = spec.description ?? spec.desc
     if name == nil || name == "" {
       throw "tool_define_many: each spec needs a non-empty name"
     }
@@ -54,6 +86,6 @@ pub fn tool_define_many(registry, specs = nil) {
  * @api_stability: stable
  * @example: tool_registry_from(specs)
  */
-pub fn tool_registry_from(specs) {
+pub fn tool_registry_from(specs: list<ToolDefinitionSpec>) -> ToolRegistry {
   return tool_define_many(tool_registry(), specs)
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_triggers.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_triggers.harn
@@ -955,13 +955,65 @@ type StreamJoinPlan = {kind: "stream.join", source: any, join: dict}
 
 type StreamWindowPlan = {kind: "stream.window", events: list<any>, window: StreamWindowSpec}
 
+type StreamLlmClassifyConfig = {cache?: string, model?: string, provider?: string}
+
+type StreamLlmClassifyOptions = StreamLlmClassifyConfig?
+
 type StreamLlmClassifyPlan = {
   kind: "stream.llm_classify",
   input: any,
   labels: list<string>,
   cache: string?,
-  options: dict,
+  options: StreamLlmClassifyConfig,
 }
+
+type SpawnToPoolOptions = {
+  pool: string,
+  priority_from?: string,
+  key_from?: string,
+  task_factory: fn(TriggerEvent) -> any,
+}
+
+type SpawnToPoolHandler = {
+  kind: string,
+  pool: string,
+  priority_from: string?,
+  key_from: string?,
+  task_factory: fn(TriggerEvent) -> any,
+}
+
+type ReminderTarget = string | fn(TriggerEvent) -> string?
+
+type ReminderPropagateMode = "none" | "session" | "all" | string
+
+type ReminderInjectOptions = {
+  target?: ReminderTarget,
+  body: string,
+  tags?: list<string>,
+  ttl_turns?: int,
+  dedupe_key?: string,
+  propagate?: ReminderPropagateMode,
+  role_hint?: string,
+  preserve_on_compact?: bool,
+}
+
+type ReminderInjectHandler = {
+  kind: string,
+  target: ReminderTarget?,
+  body: string,
+  tags: list<string>?,
+  ttl_turns: int?,
+  dedupe_key: string?,
+  propagate: ReminderPropagateMode?,
+  role_hint: string?,
+  preserve_on_compact: bool?,
+}
+
+type InterruptTargets = string | list<string> | fn(TriggerEvent) -> list<string>
+
+type InterruptAndSuspendOptions = {target_agents?: InterruptTargets, reason?: string}
+
+type InterruptAndSuspendHandler = {kind: string, target_agents: InterruptTargets?, reason: string?}
 
 /**
  * SpawnToPool builds a handler-variant dict that routes matched events into
@@ -980,12 +1032,12 @@ type StreamLlmClassifyPlan = {
  * @api_stability: experimental
  * @example: trigger_register({handler: SpawnToPool({pool: "pr-review", task_factory: { event -> { -> review(event) } }})})
  */
-pub fn SpawnToPool(options: dict) -> dict {
+pub fn SpawnToPool(options: SpawnToPoolOptions) -> SpawnToPoolHandler {
   return {
     kind: "spawn_to_pool",
     pool: options.pool,
-    priority_from: options?.priority_from,
-    key_from: options?.key_from,
+    priority_from: options.priority_from,
+    key_from: options.key_from,
     task_factory: options.task_factory,
   }
 }
@@ -1018,17 +1070,17 @@ pub fn SpawnToPool(options: dict) -> dict {
  * @api_stability: experimental
  * @example: trigger_register({handler: ReminderInject({target: "current", body: "{{ event.kind }} arrived"})})
  */
-pub fn ReminderInject(options: dict) -> dict {
+pub fn ReminderInject(options: ReminderInjectOptions) -> ReminderInjectHandler {
   return {
     kind: "reminder_inject",
-    target: options?.target,
+    target: options.target,
     body: options.body,
-    tags: options?.tags,
-    ttl_turns: options?.ttl_turns,
-    dedupe_key: options?.dedupe_key,
-    propagate: options?.propagate,
-    role_hint: options?.role_hint,
-    preserve_on_compact: options?.preserve_on_compact,
+    tags: options.tags,
+    ttl_turns: options.ttl_turns,
+    dedupe_key: options.dedupe_key,
+    propagate: options.propagate,
+    role_hint: options.role_hint,
+    preserve_on_compact: options.preserve_on_compact,
   }
 }
 
@@ -1065,8 +1117,8 @@ pub fn ReminderInject(options: dict) -> dict {
  * @api_stability: experimental
  * @example: trigger_register({handler: InterruptAndSuspend({target_agents: "all", reason: "build_storm"})})
  */
-pub fn InterruptAndSuspend(options: dict) -> dict {
-  return {kind: "interrupt_and_suspend", target_agents: options?.target_agents, reason: options?.reason}
+pub fn InterruptAndSuspend(options: InterruptAndSuspendOptions) -> InterruptAndSuspendHandler {
+  return {kind: "interrupt_and_suspend", target_agents: options.target_agents, reason: options.reason}
 }
 
 /**
@@ -1104,8 +1156,22 @@ pub fn stream_fork(source, branches = []) -> StreamForkPlan {
  * @api_stability: stable
  * @example: stream_join(source, join)
  */
-pub fn stream_join(source, join = nil) -> StreamJoinPlan {
+pub fn stream_join(source, join: dict? = nil) -> StreamJoinPlan {
   return {kind: "stream.join", source: source, join: join ?? {}}
+}
+
+fn __stream_llm_classify_options(options: StreamLlmClassifyOptions = nil) -> StreamLlmClassifyConfig {
+  var config = {}
+  if options?.cache != nil {
+    config = config + {cache: options?.cache}
+  }
+  if options?.model != nil {
+    config = config + {model: options?.model}
+  }
+  if options?.provider != nil {
+    config = config + {provider: options?.provider}
+  }
+  return config
 }
 
 /**
@@ -1130,7 +1196,7 @@ pub fn window_by(events, window: StreamWindowSpec) -> StreamWindowPlan {
  * @api_stability: stable
  * @example: llm_classify(input, labels, options)
  */
-pub fn llm_classify(input, labels, options = nil) -> StreamLlmClassifyPlan {
-  let config = options ?? {}
-  return {kind: "stream.llm_classify", input: input, labels: labels, cache: config?.cache, options: config}
+pub fn llm_classify(input, labels: list<string>, options: StreamLlmClassifyOptions = nil) -> StreamLlmClassifyPlan {
+  let config = __stream_llm_classify_options(options)
+  return {kind: "stream.llm_classify", input: input, labels: labels, cache: config.cache, options: config}
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_ui_resource.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_ui_resource.harn
@@ -22,6 +22,8 @@ import { filter_nil } from "std/collections"
 
 type UiResourceVisibility = "app_only" | "model_visible" | "always_visible" | string
 
+type UiResourceContentsEncoding = "utf8" | "base64"
+
 type UiResourceCsp = {
   default_src: list<string>,
   script_src: list<string>,
@@ -57,6 +59,19 @@ type UiResource = {
   meta: dict,
 }
 
+type UiResourceOptions = {
+  description?: string,
+  mime_type?: string,
+  profile?: string,
+  contents_encoding?: UiResourceContentsEncoding,
+  version?: string,
+  permissions?: list<string>,
+  capabilities?: list<string>,
+  csp?: UiResourceCsp,
+  validation?: dict,
+  meta?: dict,
+}?
+
 type UiToolMetaUi = {
   resource_uri: string,
   resource_name: string,
@@ -69,9 +84,15 @@ type UiToolMetaUi = {
 
 type UiToolMeta = {schema: "harn.ui_tool_meta.v1", ui: UiToolMetaUi}
 
+type UiToolMetaOptions = {visibility?: UiResourceVisibility, initial_view?: dict}?
+
 type UiTextFallback = {schema: "harn.ui_fallback.text.v1", content: string}
 
 type UiStructuredFallback = {schema: "harn.ui_fallback.structured.v1", data: dict, text?: string}
+
+type UiStructuredFallbackOptions = {text?: string}?
+
+type UiDefaultTextFallbackOptions = {max_chars?: int}?
 
 type UiHostCapabilities = {
   apps: bool,
@@ -79,6 +100,8 @@ type UiHostCapabilities = {
   permissions: list<string>,
   bridges: list<string>,
 }
+
+type UiHostCapabilityInput = dict?
 
 type UiToolCallEnvelope = {
   schema: "harn.ui_tool_call.v1",
@@ -88,6 +111,8 @@ type UiToolCallEnvelope = {
   params: dict,
 }
 
+type UiToolCallOptions = {id?: string, meta?: dict}?
+
 type UiContextUpdateEnvelope = {
   schema: "harn.ui_context_update.v1",
   jsonrpc: "2.0",
@@ -95,6 +120,8 @@ type UiContextUpdateEnvelope = {
   method: "context/update",
   params: dict,
 }
+
+type UiContextUpdateOptions = {id?: string, model_visible?: bool}?
 
 type UiToolResult = {
   schema: "harn.ui_tool_result.v1",
@@ -105,6 +132,15 @@ type UiToolResult = {
   validation: UiResourceValidationSummary,
   selected: string,
 }
+
+type UiToolResultOptions = {
+  tool_meta?: UiToolMeta,
+  tool_meta_options?: UiToolMetaOptions,
+  text_fallback?: UiTextFallback | string,
+  structured_fallback?: UiStructuredFallback,
+  allow_invalid_resource?: bool,
+  fallback?: UiDefaultTextFallbackOptions,
+}?
 
 let UI_RESOURCE_SCHEMA = "harn.ui_resource.v1"
 
@@ -248,8 +284,7 @@ pub fn ui_resource_sandbox_attr(csp: UiResourceCsp) -> string {
  * @api_stability: stable
  * @example: ui_resource(uri, name, html, options)
  */
-pub fn ui_resource(uri, name, html, options = nil) -> UiResource {
-  let opts = options ?? {}
+pub fn ui_resource(uri: string, name: string, html: string, options: UiResourceOptions = nil) -> UiResource {
   let normalized_uri = __ui_validate_uri(uri)
   let normalized_name = __ui_text(name)
   if normalized_name == "" {
@@ -259,9 +294,9 @@ pub fn ui_resource(uri, name, html, options = nil) -> UiResource {
   // MCP Apps resources communicate with the host through postMessage by
   // contract, so we default to allowing the artifact-web host-bridge surface.
   // Callers can pin a tighter policy via `options.validation`.
-  let validation_options = {allow_host_bridge: true}.merge(opts?.validation ?? {})
+  let validation_options = {allow_host_bridge: true}.merge(options?.validation ?? {})
   let validation = web_artifact_validate(source, validation_options)
-  let encoding = opts?.contents_encoding ?? "utf8"
+  let encoding = options?.contents_encoding ?? "utf8"
   let contents = if encoding == "base64" {
     bytes_to_base64(bytes_from_string(source))
   } else if encoding == "utf8" {
@@ -273,19 +308,19 @@ pub fn ui_resource(uri, name, html, options = nil) -> UiResource {
     schema: UI_RESOURCE_SCHEMA,
     uri: normalized_uri,
     name: normalized_name,
-    description: __ui_first([opts?.description]),
-    mime_type: opts?.mime_type ?? UI_MCP_APP_MIME_TYPE,
-    profile: opts?.profile ?? UI_MCP_APP_PROFILE,
+    description: __ui_first([options?.description]),
+    mime_type: options?.mime_type ?? UI_MCP_APP_MIME_TYPE,
+    profile: options?.profile ?? UI_MCP_APP_PROFILE,
     contents: contents,
     contents_encoding: encoding,
     content_sha256: "sha256:" + sha256(source),
     size_bytes: len(source),
-    version: __ui_first([opts?.version]),
-    permissions: __ui_str_list(opts?.permissions ?? []),
-    capabilities: __ui_str_list(opts?.capabilities ?? []),
-    csp: __ui_csp(opts),
+    version: __ui_first([options?.version]),
+    permissions: __ui_str_list(options?.permissions ?? []),
+    capabilities: __ui_str_list(options?.capabilities ?? []),
+    csp: __ui_csp(options),
     validation: __ui_validation_summary(validation),
-    meta: opts?.meta ?? {},
+    meta: options?.meta ?? {},
   }
   return filter_nil(envelope)
 }
@@ -303,9 +338,8 @@ pub fn ui_resource(uri, name, html, options = nil) -> UiResource {
  * @api_stability: stable
  * @example: ui_tool_meta(resource, options)
  */
-pub fn ui_tool_meta(resource: UiResource, options = nil) -> UiToolMeta {
-  let opts = options ?? {}
-  let visibility = opts?.visibility ?? "app_only"
+pub fn ui_tool_meta(resource: UiResource, options: UiToolMetaOptions = nil) -> UiToolMeta {
+  let visibility = options?.visibility ?? "app_only"
   if !["app_only", "model_visible", "always_visible"].contains(visibility) {
     throw "std/ui_resource: visibility must be app_only, model_visible, or always_visible"
   }
@@ -315,7 +349,7 @@ pub fn ui_tool_meta(resource: UiResource, options = nil) -> UiToolMeta {
       resource_name: resource.name,
       profile: resource.profile ?? UI_MCP_APP_PROFILE,
       visibility: visibility,
-      initial_view: opts?.initial_view,
+      initial_view: options?.initial_view,
       permissions: resource.permissions,
       capabilities: resource.capabilities,
     },
@@ -358,7 +392,7 @@ pub fn ui_tool_meta_to_mcp(meta: UiToolMeta) -> dict {
  * @api_stability: stable
  * @example: ui_text_fallback(content)
  */
-pub fn ui_text_fallback(content) -> UiTextFallback {
+pub fn ui_text_fallback(content: string) -> UiTextFallback {
   let text = __ui_text(content)
   if text == "" {
     throw "std/ui_resource: text fallback content must not be empty"
@@ -375,22 +409,20 @@ pub fn ui_text_fallback(content) -> UiTextFallback {
  * @api_stability: stable
  * @example: ui_structured_fallback(data, options)
  */
-pub fn ui_structured_fallback(data, options = nil) -> UiStructuredFallback {
+pub fn ui_structured_fallback(data: dict, options: UiStructuredFallbackOptions = nil) -> UiStructuredFallback {
   if data == nil {
     throw "std/ui_resource: structured fallback data is required"
   }
-  let opts = options ?? {}
-  return filter_nil({schema: UI_STRUCTURED_FALLBACK_SCHEMA, data: data, text: __ui_first([opts?.text])})
+  return filter_nil({schema: UI_STRUCTURED_FALLBACK_SCHEMA, data: data, text: __ui_first([options?.text])})
 }
 
-fn __ui_default_text_fallback(resource: UiResource, fallback_options) {
+fn __ui_default_text_fallback(resource: UiResource, fallback_options: UiDefaultTextFallbackOptions) {
   let html = if resource.contents_encoding == "base64" {
     bytes_to_string(bytes_from_base64(resource.contents))
   } else {
     resource.contents
   }
-  let opts = fallback_options ?? {}
-  let max_chars = opts?.max_chars ?? 2000
+  let max_chars = fallback_options?.max_chars ?? 2000
   return web_artifact_text_fallback(html, {max_chars: max_chars})
 }
 
@@ -408,28 +440,19 @@ fn __ui_default_text_fallback(resource: UiResource, fallback_options) {
  * @api_stability: stable
  * @example: ui_tool_result(resource, options)
  */
-pub fn ui_tool_result(resource: UiResource, options = nil) -> UiToolResult {
-  let opts = options ?? {}
-  let meta = opts?.tool_meta ?? ui_tool_meta(resource, opts?.tool_meta_options ?? {})
-  let text_fallback = if opts?.text_fallback != nil {
-    if opts.text_fallback?.schema == UI_TEXT_FALLBACK_SCHEMA {
-      opts.text_fallback
+pub fn ui_tool_result(resource: UiResource, options: UiToolResultOptions = nil) -> UiToolResult {
+  let meta = options?.tool_meta ?? ui_tool_meta(resource, options?.tool_meta_options)
+  let text_fallback = if options?.text_fallback != nil {
+    if options?.text_fallback?.schema == UI_TEXT_FALLBACK_SCHEMA {
+      options?.text_fallback
     } else {
-      ui_text_fallback(opts.text_fallback)
+      ui_text_fallback(to_string(options?.text_fallback))
     }
   } else {
-    ui_text_fallback(__ui_default_text_fallback(resource, opts?.fallback ?? {}))
+    ui_text_fallback(__ui_default_text_fallback(resource, options?.fallback))
   }
-  let structured = if opts?.structured_fallback != nil {
-    if opts.structured_fallback?.schema == UI_STRUCTURED_FALLBACK_SCHEMA {
-      opts.structured_fallback
-    } else {
-      ui_structured_fallback(opts.structured_fallback)
-    }
-  } else {
-    nil
-  }
-  let allow_invalid = opts?.allow_invalid_resource ?? false
+  let structured = options?.structured_fallback
+  let allow_invalid = options?.allow_invalid_resource ?? false
   let include_resource = resource.validation.ok || allow_invalid
   let envelope = {
     schema: UI_TOOL_RESULT_SCHEMA,
@@ -457,7 +480,7 @@ pub fn ui_tool_result(resource: UiResource, options = nil) -> UiToolResult {
  * @api_stability: stable
  * @example: ui_host_capabilities(input)
  */
-pub fn ui_host_capabilities(input = nil) -> UiHostCapabilities {
+pub fn ui_host_capabilities(input: UiHostCapabilityInput = nil) -> UiHostCapabilities {
   let value = input ?? {}
   let apps_flag = value?.apps?.enabled ?? value?.ui?.apps ?? value?.apps ?? false
   let apps = type_of(apps_flag) == "bool" ? apps_flag : false
@@ -484,7 +507,7 @@ pub fn ui_host_capabilities(input = nil) -> UiHostCapabilities {
  * @api_stability: stable
  * @example: ui_host_supports_apps(capabilities)
  */
-pub fn ui_host_supports_apps(capabilities = nil) -> bool {
+pub fn ui_host_supports_apps(capabilities: UiHostCapabilityInput = nil) -> bool {
   let caps = ui_host_capabilities(capabilities)
   if !caps.apps {
     return false
@@ -509,7 +532,7 @@ pub fn ui_host_supports_apps(capabilities = nil) -> bool {
  * @api_stability: stable
  * @example: ui_select_for_host(result, capabilities)
  */
-pub fn ui_select_for_host(result: UiToolResult, capabilities = nil) -> UiToolResult {
+pub fn ui_select_for_host(result: UiToolResult, capabilities: UiHostCapabilityInput = nil) -> UiToolResult {
   let supports_apps = ui_host_supports_apps(capabilities)
   let resource = result.ui_resource
   let resource_ok = resource != nil && resource.validation.ok
@@ -533,19 +556,18 @@ pub fn ui_select_for_host(result: UiToolResult, capabilities = nil) -> UiToolRes
  * @api_stability: stable
  * @example: ui_tool_call_envelope(name, params, options)
  */
-pub fn ui_tool_call_envelope(name: string, params = nil, options = nil) -> UiToolCallEnvelope {
-  let opts = options ?? {}
+pub fn ui_tool_call_envelope(name: string, params: dict? = nil, options: UiToolCallOptions = nil) -> UiToolCallEnvelope {
   let tool_name = __ui_text(name)
   if tool_name == "" {
     throw "std/ui_resource: tool name is required"
   }
-  let id = opts?.id ?? "ui_call_" + substring(sha256(tool_name + json_stringify(params ?? {})), 0, 16)
+  let id = options?.id ?? "ui_call_" + substring(sha256(tool_name + json_stringify(params ?? {})), 0, 16)
   return {
     schema: UI_TOOL_CALL_SCHEMA,
     jsonrpc: "2.0",
     id: id,
     method: "tools/call",
-    params: filter_nil({name: tool_name, arguments: params ?? {}, _meta: opts?.meta}),
+    params: filter_nil({name: tool_name, arguments: params ?? {}, _meta: options?.meta}),
   }
 }
 
@@ -558,19 +580,18 @@ pub fn ui_tool_call_envelope(name: string, params = nil, options = nil) -> UiToo
  * @api_stability: stable
  * @example: ui_context_update_envelope(key, value, options)
  */
-pub fn ui_context_update_envelope(key: string, value, options = nil) -> UiContextUpdateEnvelope {
-  let opts = options ?? {}
+pub fn ui_context_update_envelope(key: string, value, options: UiContextUpdateOptions = nil) -> UiContextUpdateEnvelope {
   let context_key = __ui_text(key)
   if context_key == "" {
     throw "std/ui_resource: context update key is required"
   }
-  let id = opts?.id ?? "ui_ctx_" + substring(sha256(context_key + json_stringify(value ?? nil)), 0, 16)
+  let id = options?.id ?? "ui_ctx_" + substring(sha256(context_key + json_stringify(value ?? nil)), 0, 16)
   return {
     schema: UI_CONTEXT_UPDATE_SCHEMA,
     jsonrpc: "2.0",
     id: id,
     method: "context/update",
-    params: filter_nil({key: context_key, value: value, model_visible: opts?.model_visible ?? true}),
+    params: filter_nil({key: context_key, value: value, model_visible: options?.model_visible ?? true}),
   }
 }
 

--- a/crates/harn-stdlib/src/stdlib/stdlib_waitpoint.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_waitpoint.harn
@@ -3,10 +3,12 @@
  *
  * Import with: `import "std/waitpoint"`.
  */
+type WaitpointId = string
+
 type WaitpointStatus = "open" | "completed" | "cancelled"
 
 type Waitpoint = {
-  id: string,
+  id: WaitpointId,
   status: WaitpointStatus,
   created_at: string,
   completed_at: string?,
@@ -15,12 +17,18 @@ type Waitpoint = {
   cancelled_by: string?,
   value: any?,
   reason: string?,
-  metadata: any?,
+  metadata: dict?,
 }
 
-type WaitpointWaitOptions = {timeout?: duration}
+type WaitpointCreateOptions = {id?: WaitpointId, metadata?: dict}
 
-type WaitpointTerminalOptions = {by?: string, reason?: string, metadata?: any}
+type WaitpointCreateInput = WaitpointId | WaitpointCreateOptions | nil
+
+type WaitpointHandle = WaitpointId | dict
+
+type WaitpointWaitOptions = {timeout?: duration}?
+
+type WaitpointTerminalOptions = {by?: string, reason?: string, metadata?: dict}?
 
 type WaitpointTimeoutError = {
   name: "WaitpointTimeoutError",
@@ -34,7 +42,7 @@ type WaitpointCancelledError = {
   category: "cancelled",
   message: string,
   wait_id: string,
-  waitpoint_ids: list<string>,
+  waitpoint_ids: list<WaitpointId>,
   reason: string?,
 }
 
@@ -47,7 +55,7 @@ type WaitpointCancelledError = {
  * @api_stability: stable
  * @example: create(id_or_options)
  */
-pub fn create(id_or_options = nil) {
+pub fn create(id_or_options: WaitpointCreateInput = nil) -> Waitpoint {
   if id_or_options == nil {
     return __waitpoint_create()
   }
@@ -63,7 +71,13 @@ pub fn create(id_or_options = nil) {
  * @api_stability: stable
  * @example: wait(waitpoints, options)
  */
-pub fn wait(waitpoints, options = nil) {
+pub fn wait(waitpoints: string | dict | list, options: WaitpointWaitOptions = nil) -> Waitpoint | list<Waitpoint> {
+  if type_of(waitpoints) == "list" {
+    if options == nil {
+      return __waitpoint_wait(waitpoints)
+    }
+    return __waitpoint_wait(waitpoints, options)
+  }
   if options == nil {
     return __waitpoint_wait(waitpoints)
   }
@@ -79,7 +93,7 @@ pub fn wait(waitpoints, options = nil) {
  * @api_stability: stable
  * @example: complete(waitpoint, value, options)
  */
-pub fn complete(waitpoint, value, options = nil) {
+pub fn complete(waitpoint: WaitpointHandle, value, options: WaitpointTerminalOptions = nil) -> Waitpoint {
   if options == nil {
     return __waitpoint_complete(waitpoint, value)
   }
@@ -95,7 +109,7 @@ pub fn complete(waitpoint, value, options = nil) {
  * @api_stability: stable
  * @example: cancel(waitpoint, options)
  */
-pub fn cancel(waitpoint, options = nil) {
+pub fn cancel(waitpoint: WaitpointHandle, options: WaitpointTerminalOptions = nil) -> Waitpoint {
   if options == nil {
     return __waitpoint_cancel(waitpoint)
   }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2658,23 +2658,27 @@ let result = ui_tool_result(resource, {structured_fallback: ui_structured_fallba
 let rendered = ui_select_for_host(result, host_capabilities)
 ```
 
-- `ui_resource(uri, name, html, options?)` produces `harn.ui_resource.v1`
+- `ui_resource(uri, name, html, options?: UiResourceOptions)` produces
+  `UiResource` (`harn.ui_resource.v1`)
   with `mime_type: "text/html;profile=mcp-app"`, a content hash, CSP/sandbox
   policy, and an embedded `std/artifact/web` validation summary.
   `allow_host_bridge: true` is the default so `parent.postMessage` to the
   host counts as an expected MCP Apps bridge call rather than a finding.
-- `ui_tool_meta(resource, options?)` returns a `_meta.ui` block;
+- `ui_tool_meta(resource, options?: UiToolMetaOptions)` returns a `_meta.ui`
+  block;
   `ui_tool_meta_to_mcp(meta)` serializes it into the MCP `resourceUri` /
   `visibility` / `initialView` shape MCP Apps hosts read from `tools/list`.
-- `ui_tool_result(resource, options?)` wraps the resource with a mandatory
-  text fallback (default: `web_artifact_text_fallback` of the HTML) and an
-  optional structured fallback. Invalid resources are stripped automatically
-  unless the caller passes `allow_invalid_resource: true`.
+- `ui_tool_result(resource, options?: UiToolResultOptions)` wraps the resource
+  with a mandatory text fallback (default: `web_artifact_text_fallback` of the
+  HTML) and an optional `UiStructuredFallback`. Wrap raw fallback data with
+  `ui_structured_fallback(data, options?: UiStructuredFallbackOptions)`.
+  Invalid resources are stripped automatically unless the caller passes
+  `allow_invalid_resource: true`.
 - `ui_select_for_host(result, capabilities?)` picks `ui_resource`,
   `structured_fallback`, or `text_fallback` from the same envelope based on
   host capability advertisements. `ui_host_capabilities` accepts the MCP
   `client_capabilities.apps`, OpenAI Apps SDK `ui.apps`, or bare `{apps:
-  true}` shapes.
+  true}` shapes through `UiHostCapabilityInput`.
 - `ui_tool_call_envelope(name, params?, options?)` and
   `ui_context_update_envelope(key, value, options?)` build the JSON-RPC
   envelopes a sandboxed iframe sends through `window.parent.postMessage`.

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1931,9 +1931,10 @@ registries programmatically. For MCP serving, see the `tool_define` /
 `mcp_tools` API above.
 
 For declarative batches, `import { tool_define_many, tool_registry_from } from
-"std/tools"`. `tool_define_many(registry, specs)` adds a list of `{name,
-description, parameters, handler, ...}` specs to a registry, and
-`tool_registry_from(specs)` creates a fresh registry from the same shape.
+"std/tools"`. `tool_define_many(registry, specs: list<ToolDefinitionSpec>)`
+adds typed `{name, description, parameters, handler, ...}` specs to a
+`ToolRegistry`, and `tool_registry_from(specs)` creates a fresh registry from
+the same shape.
 
 | Function | Parameters | Returns | Description |
 |---|---|---|---|
@@ -2190,8 +2191,8 @@ tool registry dict.
 |---|---|---|---|
 | `tool_registry()` | — | tool registry | Create an empty `{_type: "tool_registry", tools: []}` registry |
 | `tool_define(registry, name, desc, config)` | registry, name, desc: string, config: dict | dict | Add a tool (config: `{parameters, handler, returns?, annotations?, ...}`) |
-| `tool_define_many(registry, specs)` | registry: dict, specs: list | dict | Stdlib helper from `std/tools`; add many declarative tool specs to a registry |
-| `tool_registry_from(specs)` | specs: list | dict | Stdlib helper from `std/tools`; create a registry from declarative tool specs |
+| `tool_define_many(registry, specs)` | registry: `ToolRegistry`, specs: `list<ToolDefinitionSpec>` | `ToolRegistry` | Stdlib helper from `std/tools`; add many declarative tool specs to a registry |
+| `tool_registry_from(specs)` | specs: `list<ToolDefinitionSpec>` | `ToolRegistry` | Stdlib helper from `std/tools`; create a registry from declarative tool specs |
 | `tool_synthesize(config)` | config: dict | closure | Synthesize a deterministic callable tool from a natural-language description |
 | `tool_synthesis_cache()` | — | list | Inspect pinned synthesized tool specs for the current run |
 | `tool_synthesis_clear()` | — | nil | Clear the current run's synthesized tool cache |

--- a/docs/src/interop/ui-resource.md
+++ b/docs/src/interop/ui-resource.md
@@ -33,8 +33,8 @@ let rendered = ui_select_for_host(result, host_capabilities)
 
 ## Resource envelope
 
-`ui_resource(uri, name, html, options?)` returns
-`harn.ui_resource.v1`:
+`ui_resource(uri, name, html, options?: UiResourceOptions)` returns
+`UiResource` (`harn.ui_resource.v1`):
 
 | Field | Purpose |
 |---|---|
@@ -57,8 +57,9 @@ rules used by safe artifact patching. The validator defaults to
 
 ## Tool-declaration metadata
 
-`ui_tool_meta(resource, options?)` returns a `harn.ui_tool_meta.v1`
-envelope and `ui_tool_meta_to_mcp(meta)` serializes it into the
+`ui_tool_meta(resource, options?: UiToolMetaOptions)` returns a
+`UiToolMeta` (`harn.ui_tool_meta.v1`) envelope and
+`ui_tool_meta_to_mcp(meta)` serializes it into the
 camelCase dict shape MCP Apps hosts read from `_meta.ui`:
 
 | MCP key | Harn field |
@@ -77,9 +78,11 @@ places.
 
 ## Fallbacks
 
-`ui_tool_result(resource, options?)` wraps a resource with a mandatory
-text fallback (defaulting to a `web_artifact_text_fallback` projection
-of the resource HTML) and an optional `ui_structured_fallback`.
+`ui_tool_result(resource, options?: UiToolResultOptions)` wraps a resource
+with a mandatory text fallback (defaulting to a `web_artifact_text_fallback`
+projection of the resource HTML) and an optional `UiStructuredFallback`.
+Wrap raw structured data with
+`ui_structured_fallback(data, options?: UiStructuredFallbackOptions)`.
 Hosts without UI support receive both fallbacks instead of the
 resource:
 
@@ -89,10 +92,10 @@ resource:
 | Otherwise, structured fallback present | `structured_fallback` |
 | Otherwise | `text_fallback` |
 
-`ui_host_capabilities` accepts the MCP `client_capabilities.apps`
-shape, the OpenAI Apps SDK `ui.apps` shape, or a bare `{apps: true}`
-record. `ui_host_supports_apps(caps)` returns whether the host can
-render the `mcp-app` profile.
+`ui_host_capabilities(input?: UiHostCapabilityInput)` accepts the MCP
+`client_capabilities.apps` shape, the OpenAI Apps SDK `ui.apps` shape,
+or a bare `{apps: true}` record. `ui_host_supports_apps(caps)` returns
+whether the host can render the `mcp-app` profile.
 
 ## Message envelopes
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -4259,12 +4259,14 @@ previously recorded HITL response events instead of consulting a live host,
 so approval reviewer identities, signed timestamps, and signatures remain
 stable across deterministic replay.
 
-Replay-for-teaching corrections live in `corrections.records`. A
-`CorrectionRecord` captures `{ from_decision, to_decision, reason, applied_by,
-scope }`, with optional actor/action/trace/step metadata. `this_persona` and
-`all` scopes feed `CapabilityPolicy` derivation by tightening the affected
-actor to a read-only side-effect ceiling while matching correction records
-remain applicable.
+Replay-for-teaching corrections live in `corrections.records`. `std/corrections`
+accepts `CorrectionInput`, whose `from_decision` and `to_decision` fields use
+the reusable `CorrectionDecision` shape and whose optional evidence uses
+`list<CorrectionEvidenceRef>`. The stored `CorrectionRecord` captures those
+decisions plus `{ reason, applied_by, scope }`, with optional
+actor/action/trace/step metadata. `this_persona` and `all` scopes feed
+`CapabilityPolicy` derivation by tightening the affected actor to a read-only
+side-effect ceiling while matching correction records remain applicable.
 
 ### Function type annotations
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -288,15 +288,15 @@ MCP Apps-compatible UI resource envelopes with text and structured fallbacks:
 
 | Function | Description |
 |---|---|
-| `ui_resource(uri, name, html, options?)` | Build a `harn.ui_resource.v1` envelope, validate HTML through `std/artifact/web`, and capture a content hash, size, requested permissions, and a CSP/sandbox policy |
-| `ui_tool_meta(resource, options?)` | Build a `_meta.ui` tool-declaration block (`harn.ui_tool_meta.v1`) with visibility, initial view, and permission/capability lists |
+| `ui_resource(uri, name, html, options?: UiResourceOptions)` | Build a `UiResource` (`harn.ui_resource.v1`) envelope, validate HTML through `std/artifact/web`, and capture a content hash, size, requested permissions, and a CSP/sandbox policy |
+| `ui_tool_meta(resource, options?: UiToolMetaOptions)` | Build a `_meta.ui` tool-declaration block (`UiToolMeta`, `harn.ui_tool_meta.v1`) with visibility, initial view, and permission/capability lists |
 | `ui_tool_meta_to_mcp(meta)` | Serialize a tool-meta into the MCP Apps `_meta.ui` dict (`resourceUri`, `visibility`, etc.) for direct inclusion in `tools/list` payloads |
-| `ui_text_fallback(content)` / `ui_structured_fallback(data, options?)` | Build text and structured fallback envelopes for hosts without UI support |
-| `ui_tool_result(resource, options?)` | Wrap a resource with mandatory text and optional structured fallbacks, defaulting the text to a `web_artifact_text_fallback` projection |
-| `ui_select_for_host(result, capabilities?)` | Choose between `ui_resource`, `structured_fallback`, and `text_fallback` for a host based on advertised MCP Apps capability |
-| `ui_host_supports_apps(capabilities?)` / `ui_host_capabilities(input?)` | Detect whether an MCP, MCP Apps, or OpenAI Apps SDK host advertises support for the `mcp-app` profile |
-| `ui_tool_call_envelope(name, params?, options?)` | Build the host→guest JSON-RPC `tools/call` envelope a sandboxed iframe receives over `postMessage` |
-| `ui_context_update_envelope(key, value, options?)` | Build the guest→host JSON-RPC `context/update` envelope used to update model-visible context |
+| `ui_text_fallback(content)` / `ui_structured_fallback(data, options?: UiStructuredFallbackOptions)` | Build `UiTextFallback` and `UiStructuredFallback` envelopes for hosts without UI support |
+| `ui_tool_result(resource, options?: UiToolResultOptions)` | Wrap a resource with mandatory text and optional `UiStructuredFallback`, defaulting the text to a `web_artifact_text_fallback` projection |
+| `ui_select_for_host(result, capabilities?: UiHostCapabilityInput)` | Choose between `ui_resource`, `structured_fallback`, and `text_fallback` for a host based on advertised MCP Apps capability |
+| `ui_host_supports_apps(capabilities?: UiHostCapabilityInput)` / `ui_host_capabilities(input?: UiHostCapabilityInput)` | Detect whether an MCP, MCP Apps, or OpenAI Apps SDK host advertises support for the `mcp-app` profile |
+| `ui_tool_call_envelope(name, params?, options?: UiToolCallOptions)` | Build the host→guest JSON-RPC `tools/call` envelope a sandboxed iframe receives over `postMessage` |
+| `ui_context_update_envelope(key, value, options?: UiContextUpdateOptions)` | Build the guest→host JSON-RPC `context/update` envelope used to update model-visible context |
 | `ui_resource_csp_header(csp)` / `ui_resource_sandbox_attr(csp)` | Project the resource CSP into header value and `<iframe sandbox>` attribute strings |
 | `ui_tool_result_validate(result)` | Reject tool results that are missing required fields or ship a UI resource whose HTML failed validation |
 
@@ -304,7 +304,9 @@ Tool results always carry a non-empty text fallback so plain-text hosts
 still see useful output. UI resources fail closed: `ui_tool_result` omits
 `ui_resource` whenever validation finds errors (network calls, dangerous
 navigation, embedded secrets, etc.) unless the caller opts in with
-`allow_invalid_resource: true` for preview-only use. See
+`allow_invalid_resource: true` for preview-only use. Pass structured fallback
+data through `ui_structured_fallback(...)`; `UiToolResultOptions` expects the
+typed fallback envelope instead of an anonymous raw payload. See
 [examples/ui_resource](https://github.com/burin-labs/harn/tree/main/examples/ui_resource)
 for a dashboard widget and a multi-step review form.
 
@@ -842,10 +844,11 @@ support boundary.
 | `run_artifact_transcript_dir(run, name?)` | Return a transcript sidecar directory such as `agent-llm` or `chat-llm` |
 | `run_artifact_transcript_path(run, name?)` | Return `<transcript-dir>/llm_transcript.jsonl` inside the run directory |
 
-`run_artifacts_open` and `run_artifacts_from_dir` return a dict shaped like
-`{kind, namespace, run_id, root, dir, modified?, paths}`. `paths` contains the
-standard local artifact names: `facts`, `audit`, `review`, `agent_result`,
-`agent_trace`, and `agent_llm_transcript`.
+`run_artifacts_open` and `run_artifacts_from_dir` return `RunArtifactsRun`.
+`run_artifacts_list` returns `list<RunArtifactsRun>`. The nested
+`RunArtifactPaths` shape contains the standard local artifact names: `facts`,
+`audit`, `review`, `agent_result`, `agent_trace`, and
+`agent_llm_transcript`.
 
 ```harn
 import {

--- a/docs/src/stdlib/calendar.md
+++ b/docs/src/stdlib/calendar.md
@@ -9,6 +9,12 @@ and `duration_hours` stay available globally. `std/calendar` adds ISO week
 fields, quarter and boundary helpers, local-time construction with explicit DST
 overlap behavior, supported country metadata, and business-day arithmetic.
 
+Public calendar helpers use reusable shapes instead of anonymous records:
+`CalendarParts`, `CalendarIsoWeek`, `CalendarLocalDateTime`,
+`CalendarDateRangeOptions`, `CalendarCountry`, `CalendarHoliday`,
+`CalendarBusinessCalendar`, `CalendarBusinessWindowOptions`, and
+`CalendarBusinessWindow`.
+
 ## Civil calendar helpers
 
 ```harn

--- a/docs/src/trust-graph.md
+++ b/docs/src/trust-graph.md
@@ -129,12 +129,13 @@ integrations.
 
 Import `std/corrections` for replay-for-teaching records:
 
-- `record(correction)` appends a `CorrectionRecord` with `from_decision`,
-  `to_decision`, `reason`, `applied_by`, and `scope` (`this_run`,
-  `this_persona`, or `all`), plus optional `actor_id`, `action`, `trace_id`,
-  `step`, `evidence_refs`, and `metadata`.
-- `query(filters)` returns corrections by `actor`, `actor_id`, `agent`,
-  `action`, `scope`, `since`, `until`, and `limit`.
+- `record(correction: CorrectionInput)` appends a `CorrectionRecord` with
+  typed `CorrectionDecision` values for `from_decision` and `to_decision`,
+  `reason`, `applied_by`, and `scope` (`this_run`, `this_persona`, or `all`),
+  plus optional `actor_id`, `action`, `trace_id`, `step`,
+  `list<CorrectionEvidenceRef>`, and `metadata`.
+- `query(filters: CorrectionQueryFilters)` returns corrections by `actor`,
+  `actor_id`, `agent`, `action`, `scope`, `since`, `until`, and `limit`.
 
 `this_persona` and `all` corrections are policy inputs. When a human keeps
 correcting an actor's decision path, `policy_for(actor_id)` caps that actor's

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -4257,12 +4257,14 @@ previously recorded HITL response events instead of consulting a live host,
 so approval reviewer identities, signed timestamps, and signatures remain
 stable across deterministic replay.
 
-Replay-for-teaching corrections live in `corrections.records`. A
-`CorrectionRecord` captures `{ from_decision, to_decision, reason, applied_by,
-scope }`, with optional actor/action/trace/step metadata. `this_persona` and
-`all` scopes feed `CapabilityPolicy` derivation by tightening the affected
-actor to a read-only side-effect ceiling while matching correction records
-remain applicable.
+Replay-for-teaching corrections live in `corrections.records`. `std/corrections`
+accepts `CorrectionInput`, whose `from_decision` and `to_decision` fields use
+the reusable `CorrectionDecision` shape and whose optional evidence uses
+`list<CorrectionEvidenceRef>`. The stored `CorrectionRecord` captures those
+decisions plus `{ reason, applied_by, scope }`, with optional
+actor/action/trace/step metadata. `this_persona` and `all` scopes feed
+`CapabilityPolicy` derivation by tightening the affected actor to a read-only
+side-effect ceiling while matching correction records remain applicable.
 
 ### Function type annotations
 


### PR DESCRIPTION
## Summary

- Add reusable typed stdlib shapes for high-value APIs in calendar, corrections, run artifacts, tools, triggers, UI resources, and waitpoints.
- Update conformance coverage to exercise the typed shapes and one compatibility path for nil option envelopes that previously accepted nil.
- Document the new shapes across the stdlib docs, quickref, language spec mirror, and changelog.

Closes #2193

## Validation

- `make conformance` (1400 passed, 0 failed)
- `make fmt-harn && make lint-harn`
- `make lint-test-patterns`
- `make check-language-spec`
- `make check-docs-snippets` (584 checked, 0 failed)
- `make test` (4980 passed, 2 skipped)
