### PR TITLE
Cache runtime type guard metadata

### DIFF
--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -6,6 +6,8 @@ use std::rc::Rc;
 use harn_parser::TypeExpr;
 use serde::{Deserialize, Serialize};
 
+use crate::runtime_guards::RuntimeParamGuard;
+
 /// Bytecode opcodes for the Harn VM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -639,13 +641,34 @@ pub struct CachedCompiledFunction {
     pub(crate) name: String,
     pub(crate) type_params: Vec<String>,
     pub(crate) nominal_type_names: Vec<String>,
-    pub(crate) params: Vec<ParamSlot>,
+    pub(crate) params: Vec<CachedParamSlot>,
     pub(crate) default_start: Option<usize>,
     pub(crate) chunk: CachedChunk,
     pub(crate) is_generator: bool,
     pub(crate) is_stream: bool,
     pub(crate) has_rest_param: bool,
     pub(crate) has_runtime_type_checks: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CachedParamSlot {
+    pub(crate) name: String,
+    pub(crate) type_expr: Option<TypeExpr>,
+    pub(crate) has_default: bool,
+}
+
+impl CachedParamSlot {
+    fn thaw(&self) -> ParamSlot {
+        ParamSlot {
+            name: self.name.clone(),
+            type_expr: self.type_expr.clone(),
+            runtime_guard: self
+                .type_expr
+                .as_ref()
+                .map(RuntimeParamGuard::from_type_expr),
+            has_default: self.has_default,
+        }
+    }
 }
 
 /// One parameter slot of a compiled user-defined function. Carries the
@@ -659,6 +682,10 @@ pub struct ParamSlot {
     /// Declared parameter type. `None` for untyped parameters (gradual
     /// typing); the runtime skips type assertion when absent.
     pub type_expr: Option<TypeExpr>,
+    /// Precomputed runtime validation metadata derived from `type_expr`.
+    /// Bytecode-cache artifacts omit this field and rebuild it at load time.
+    #[serde(skip)]
+    pub(crate) runtime_guard: Option<RuntimeParamGuard>,
     /// True when the parameter has a default-value clause. Diagnostic
     /// only — the canonical authority for arity ranges is
     /// [`CompiledFunction::default_start`].
@@ -672,7 +699,19 @@ impl ParamSlot {
         Self {
             name: param.name.clone(),
             type_expr: param.type_expr.clone(),
+            runtime_guard: param
+                .type_expr
+                .as_ref()
+                .map(RuntimeParamGuard::from_type_expr),
             has_default: param.default_value.is_some(),
+        }
+    }
+
+    fn freeze_for_cache(&self) -> CachedParamSlot {
+        CachedParamSlot {
+            name: self.name.clone(),
+            type_expr: self.type_expr.clone(),
+            has_default: self.has_default,
         }
     }
 
@@ -743,7 +782,11 @@ impl CompiledFunction {
             name: self.name.clone(),
             type_params: self.type_params.clone(),
             nominal_type_names: self.nominal_type_names.clone(),
-            params: self.params.clone(),
+            params: self
+                .params
+                .iter()
+                .map(ParamSlot::freeze_for_cache)
+                .collect(),
             default_start: self.default_start,
             chunk: self.chunk.freeze_for_cache(),
             is_generator: self.is_generator,
@@ -758,7 +801,7 @@ impl CompiledFunction {
             name: cached.name.clone(),
             type_params: cached.type_params.clone(),
             nominal_type_names: cached.nominal_type_names.clone(),
-            params: cached.params.clone(),
+            params: cached.params.iter().map(CachedParamSlot::thaw).collect(),
             default_start: cached.default_start,
             chunk: Rc::new(Chunk::from_cached(&cached.chunk)),
             is_generator: cached.is_generator,

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -352,12 +352,14 @@ impl Compiler {
         Ok(())
     }
 
-    /// Emit runtime type checks for parameters with type annotations.
-    /// Interface types keep their dedicated runtime guard; all other supported
-    /// runtime-checkable types compile to a schema literal and call
-    /// `__assert_schema(value, param_name, schema)`.
+    /// Emit body-local type checks that call-site validation cannot cover.
+    /// Ordinary supplied arguments are validated by precomputed
+    /// [`crate::chunk::ParamSlot`] guards before the frame is entered. The
+    /// bytecode preamble still checks interface parameters, because interface
+    /// satisfaction depends on compiler-collected method metadata, and checks
+    /// defaulted schema parameters only when the caller omitted that argument.
     pub(super) fn emit_type_checks(&mut self, params: &[TypedParam]) {
-        for param in params {
+        for (param_index, param) in params.iter().enumerate() {
             if let Some(type_expr) = &param.type_expr {
                 let check_type = if param.rest {
                     harn_parser::TypeExpr::List(Box::new(type_expr.clone()))
@@ -387,22 +389,49 @@ impl Compiler {
                     }
                 }
 
-                if let Some(schema) = Self::type_expr_to_schema_value(&check_type) {
-                    let fn_idx = self
-                        .chunk
-                        .add_constant(Constant::String("__assert_schema".into()));
-                    self.chunk.emit_u16(Op::Constant, fn_idx, self.line);
-                    self.emit_get_binding(&param.name);
-                    let name_idx = self
-                        .chunk
-                        .add_constant(Constant::String(param.name.clone()));
-                    self.chunk.emit_u16(Op::Constant, name_idx, self.line);
-                    self.emit_vm_value_literal(&schema);
-                    self.chunk.emit_u8(Op::Call, 3, self.line);
-                    self.chunk.emit(Op::Pop, self.line);
+                if param.default_value.is_some() {
+                    if let Some(schema) = Self::type_expr_to_schema_value(&check_type) {
+                        self.emit_default_param_schema_check(param_index, param, &schema);
+                    }
                 }
             }
         }
+    }
+
+    fn emit_default_param_schema_check(
+        &mut self,
+        param_index: usize,
+        param: &TypedParam,
+        schema: &VmValue,
+    ) {
+        self.chunk.emit(Op::GetArgc, self.line);
+        let threshold_idx = self
+            .chunk
+            .add_constant(Constant::Int((param_index + 1) as i64));
+        self.chunk.emit_u16(Op::Constant, threshold_idx, self.line);
+        self.chunk.emit(Op::GreaterEqual, self.line);
+        let supplied_jump = self.chunk.emit_jump(Op::JumpIfTrue, self.line);
+        self.chunk.emit(Op::Pop, self.line);
+        self.emit_schema_assert_call(param, schema);
+        let end_jump = self.chunk.emit_jump(Op::Jump, self.line);
+        self.chunk.patch_jump(supplied_jump);
+        self.chunk.emit(Op::Pop, self.line);
+        self.chunk.patch_jump(end_jump);
+    }
+
+    fn emit_schema_assert_call(&mut self, param: &TypedParam, schema: &VmValue) {
+        let fn_idx = self
+            .chunk
+            .add_constant(Constant::String("__assert_schema".into()));
+        self.chunk.emit_u16(Op::Constant, fn_idx, self.line);
+        self.emit_get_binding(&param.name);
+        let name_idx = self
+            .chunk
+            .add_constant(Constant::String(param.name.clone()));
+        self.chunk.emit_u16(Op::Constant, name_idx, self.line);
+        self.emit_vm_value_literal(schema);
+        self.chunk.emit_u8(Op::Call, 3, self.line);
+        self.chunk.emit(Op::Pop, self.line);
     }
 
     pub(crate) fn type_expr_to_schema_value(type_expr: &harn_parser::TypeExpr) -> Option<VmValue> {

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -58,6 +58,7 @@ pub mod record_filter;
 pub mod redact;
 pub mod run_events;
 pub mod runtime_context;
+pub(crate) mod runtime_guards;
 pub mod runtime_limits;
 pub mod runtime_paths;
 pub mod schema;

--- a/crates/harn-vm/src/runtime_guards.rs
+++ b/crates/harn-vm/src/runtime_guards.rs
@@ -1,0 +1,25 @@
+use std::rc::Rc;
+
+use harn_parser::TypeExpr;
+
+use crate::schema::CanonicalParamSchema;
+
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimeParamGuard {
+    CanonicalSchema(CanonicalParamSchema),
+    InvalidSchema(Rc<str>),
+    TypeExpr(TypeExpr),
+}
+
+impl RuntimeParamGuard {
+    pub(crate) fn from_type_expr(type_expr: &TypeExpr) -> Self {
+        if let Some(schema) = crate::compiler::Compiler::type_expr_to_schema_value(type_expr) {
+            return match crate::schema::canonical_param_schema(&schema) {
+                Ok(schema) => Self::CanonicalSchema(schema),
+                Err(error) => Self::InvalidSchema(Rc::from(error)),
+            };
+        }
+
+        Self::TypeExpr(type_expr.clone())
+    }
+}

--- a/crates/harn-vm/src/runtime_limits.rs
+++ b/crates/harn-vm/src/runtime_limits.rs
@@ -27,6 +27,10 @@ pub struct RuntimeLimits {
     pub max_regex_cache_entries: usize,
     /// Maximum compiled JSON-schema `pattern` regexes kept process-wide.
     pub max_schema_pattern_cache_entries: usize,
+    /// Maximum canonical parameter schemas kept per VM thread.
+    pub max_schema_guard_cache_entries: usize,
+    /// Maximum parsed runtime shape specs kept per VM thread.
+    pub max_shape_spec_cache_entries: usize,
     /// Default queue depth for memory/file/sqlite event-log subscribers.
     pub default_event_log_queue_depth: usize,
     /// Default concurrent agent-session cap per VM thread.
@@ -58,6 +62,8 @@ impl RuntimeLimits {
         max_std_cache_entries: 256,
         max_regex_cache_entries: 128,
         max_schema_pattern_cache_entries: 256,
+        max_schema_guard_cache_entries: 256,
+        max_shape_spec_cache_entries: 256,
         default_event_log_queue_depth: 128,
         max_agent_sessions: 128,
         max_project_fingerprint_depth: 4,
@@ -80,6 +86,8 @@ impl RuntimeLimits {
             "max_std_cache_entries" => self.max_std_cache_entries,
             "max_regex_cache_entries" => self.max_regex_cache_entries,
             "max_schema_pattern_cache_entries" => self.max_schema_pattern_cache_entries,
+            "max_schema_guard_cache_entries" => self.max_schema_guard_cache_entries,
+            "max_shape_spec_cache_entries" => self.max_shape_spec_cache_entries,
             "default_event_log_queue_depth" => self.default_event_log_queue_depth,
             "max_agent_sessions" => self.max_agent_sessions,
             "max_project_fingerprint_depth" => self.max_project_fingerprint_depth,
@@ -193,6 +201,18 @@ pub const RUNTIME_LIMIT_DESCRIPTIONS: &[RuntimeLimitDescription] = &[
         protects: "bounds process-wide memory held by compiled JSON-schema pattern regexes",
     },
     RuntimeLimitDescription {
+        name: "max_schema_guard_cache_entries",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds per-thread memory held by canonical runtime parameter schemas",
+    },
+    RuntimeLimitDescription {
+        name: "max_shape_spec_cache_entries",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds per-thread memory held by parsed runtime shape specs",
+    },
+    RuntimeLimitDescription {
         name: "default_event_log_queue_depth",
         user_visible: true,
         host_configurable: true,
@@ -263,6 +283,8 @@ mod tests {
         assert_eq!(limits.max_std_cache_entries, 256);
         assert_eq!(limits.max_regex_cache_entries, 128);
         assert_eq!(limits.max_schema_pattern_cache_entries, 256);
+        assert_eq!(limits.max_schema_guard_cache_entries, 256);
+        assert_eq!(limits.max_shape_spec_cache_entries, 256);
         assert_eq!(limits.default_event_log_queue_depth, 128);
         assert_eq!(limits.max_agent_sessions, 128);
         assert_eq!(limits.max_project_fingerprint_depth, 4);
@@ -293,6 +315,8 @@ mod tests {
                 "max_std_cache_entries",
                 "max_regex_cache_entries",
                 "max_schema_pattern_cache_entries",
+                "max_schema_guard_cache_entries",
+                "max_shape_spec_cache_entries",
                 "default_event_log_queue_depth",
                 "max_agent_sessions",
                 "max_project_fingerprint_depth",

--- a/crates/harn-vm/src/schema/api.rs
+++ b/crates/harn-vm/src/schema/api.rs
@@ -1,5 +1,9 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
+use crate::runtime_limits::RuntimeLimits;
+use crate::value::value_structural_hash_key;
 use crate::value::{VmError, VmValue};
 
 use super::canonicalize::{canonical_to_json_schema, canonicalize_schema_value};
@@ -9,6 +13,48 @@ use super::transform::{
 };
 use super::type_check::schema_is_object_like;
 use super::validate::{first_param_validation_error, validate_schema_value, ValidationOptions};
+
+const PARAM_SCHEMA_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_schema_guard_cache_entries;
+
+thread_local! {
+    static PARAM_SCHEMA_CACHE: RefCell<HashMap<String, Result<CanonicalParamSchema, Rc<str>>>> =
+        RefCell::new(HashMap::new());
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CanonicalParamSchema {
+    schema: Rc<std::collections::BTreeMap<String, VmValue>>,
+    object_like: bool,
+}
+
+pub(crate) fn canonical_param_schema(schema: &VmValue) -> Result<CanonicalParamSchema, String> {
+    let normalized = canonicalize_schema_value(schema)?;
+    let VmValue::Dict(schema) = normalized else {
+        return Err("schema must be a dict".to_string());
+    };
+    let object_like = schema_is_object_like(&schema);
+    Ok(CanonicalParamSchema {
+        schema,
+        object_like,
+    })
+}
+
+fn cached_canonical_param_schema(schema: &VmValue) -> Result<CanonicalParamSchema, String> {
+    let key = value_structural_hash_key(schema);
+    PARAM_SCHEMA_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(cached) = cache.get(&key) {
+            return cached.clone().map_err(|error| error.as_ref().to_string());
+        }
+
+        let canonical = canonical_param_schema(schema).map_err(Rc::<str>::from);
+        if cache.len() >= PARAM_SCHEMA_CACHE_LIMIT {
+            cache.clear();
+        }
+        cache.insert(key, canonical.clone());
+        canonical.map_err(|error| error.as_ref().to_string())
+    })
+}
 
 pub(crate) fn schema_result_value(
     data: &VmValue,
@@ -78,19 +124,25 @@ pub(crate) fn schema_assert_param(
     param_name: &str,
     schema: &VmValue,
 ) -> Result<(), VmError> {
-    let normalized = canonicalize_schema_value(schema)
+    let normalized = cached_canonical_param_schema(schema)
         .map_err(|error| VmError::TypeError(format!("parameter '{param_name}': {error}")))?;
-    let schema_dict = normalized.as_dict().ok_or_else(|| {
-        VmError::TypeError(format!("parameter '{param_name}': schema must be a dict"))
-    })?;
+    schema_assert_canonical_param(value, param_name, &normalized)
+}
+
+pub(crate) fn schema_assert_canonical_param(
+    value: &VmValue,
+    param_name: &str,
+    schema: &CanonicalParamSchema,
+) -> Result<(), VmError> {
     let options = ValidationOptions {
         apply_defaults: false,
         numeric_compat: true,
     };
+    let schema_dict = schema.schema.as_ref();
     if let Some(error) =
         first_param_validation_error(value, schema_dict, schema_dict, param_name, options)
     {
-        return if schema_is_object_like(schema_dict) {
+        return if schema.object_like {
             Err(VmError::TypeError(error))
         } else {
             Err(VmError::Runtime(format!("TypeError: {error}")))

--- a/crates/harn-vm/src/schema/mod.rs
+++ b/crates/harn-vm/src/schema/mod.rs
@@ -10,10 +10,11 @@ mod type_check;
 mod validate;
 
 pub(crate) use api::{
-    schema_assert_param, schema_expect_value, schema_extend_value, schema_from_json_schema_value,
+    canonical_param_schema, schema_assert_canonical_param, schema_assert_param,
+    schema_expect_value, schema_extend_value, schema_from_json_schema_value,
     schema_from_openapi_schema_value, schema_is_value, schema_omit_value, schema_partial_value,
     schema_pick_value, schema_result_value, schema_to_json_schema_value,
-    schema_to_openapi_schema_value,
+    schema_to_openapi_schema_value, CanonicalParamSchema,
 };
 pub use canonicalize::json_to_vm_value;
 

--- a/crates/harn-vm/src/stdlib/shapes.rs
+++ b/crates/harn-vm/src/stdlib/shapes.rs
@@ -1,8 +1,17 @@
-use std::collections::BTreeMap;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
+use crate::runtime_limits::RuntimeLimits;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
+
+const SHAPE_SPEC_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_shape_spec_cache_entries;
+
+thread_local! {
+    static SHAPE_SPEC_CACHE: RefCell<HashMap<String, Rc<ParsedShapeSpec>>> =
+        RefCell::new(HashMap::new());
+}
 
 pub(crate) fn register_shape_builtins(vm: &mut Vm) {
     vm.register_builtin("keys", |args, _out| {
@@ -213,15 +222,23 @@ fn assert_shape_fields(
     param_name: &str,
     spec: &str,
 ) -> Result<VmValue, VmError> {
-    let parsed = parse_shape_spec(spec);
-    for (field_name, type_spec, optional) in &parsed {
-        match fields.get(field_name.as_str()) {
+    let parsed = cached_shape_spec(spec);
+    assert_parsed_shape_fields(fields, param_name, &parsed)
+}
+
+fn assert_parsed_shape_fields(
+    fields: &BTreeMap<String, VmValue>,
+    param_name: &str,
+    spec: &ParsedShapeSpec,
+) -> Result<VmValue, VmError> {
+    for field in &spec.fields {
+        match fields.get(field.name.as_str()) {
             None => {
-                if !optional {
+                if !field.optional {
                     let actual_keys: Vec<&str> = fields.keys().map(|k| k.as_str()).collect();
-                    let max_dist = if field_name.len() <= 4 { 1 } else { 2 };
+                    let max_dist = if field.name.len() <= 4 { 1 } else { 2 };
                     let suggestion = harn_parser::diagnostic::find_closest_match(
-                        field_name,
+                        &field.name,
                         actual_keys.iter().copied(),
                         max_dist,
                     );
@@ -229,65 +246,77 @@ fn assert_shape_fields(
                     let msg = if let Some(closest) = suggestion {
                         format!(
                             "parameter '{}': missing field '{}' ({}), did you mean '{}'? — {}",
-                            param_name, field_name, type_spec, closest, actual_summary
+                            param_name, field.name, field.type_label, closest, actual_summary
                         )
                     } else {
                         format!(
                             "parameter '{}': missing field '{}' ({}) — {}",
-                            param_name, field_name, type_spec, actual_summary
+                            param_name, field.name, field.type_label, actual_summary
                         )
                     };
                     return Err(VmError::TypeError(msg));
                 }
             }
             Some(val) => {
-                if type_spec.starts_with('{') && type_spec.ends_with('}') {
-                    let inner_spec = &type_spec[1..type_spec.len() - 1];
-                    let nested_struct_fields;
-                    let nested_fields = match val {
-                        VmValue::Dict(map) => map.as_ref(),
-                        VmValue::StructInstance { .. } => {
-                            nested_struct_fields = val.struct_fields_map().unwrap_or_default();
-                            &nested_struct_fields
-                        }
-                        _ => {
-                            return Err(VmError::TypeError(format!(
-                                "parameter '{}': field '{}' expected dict or struct, got {}",
-                                param_name,
-                                field_name,
-                                val.type_name()
-                            )));
-                        }
-                    };
-                    {
-                        let nested_param = format!("{}.{}", param_name, field_name);
-                        assert_shape_fields(nested_fields, &nested_param, inner_spec)?;
-                    }
-                } else if type_spec.contains('|') {
-                    let actual_type = val.type_name();
-                    let is_nil = matches!(val, VmValue::Nil);
-                    let matches = type_spec
-                        .split('|')
-                        .any(|t| t.trim() == actual_type || (t.trim() == "nil" && is_nil));
-                    if !matches {
-                        return Err(VmError::TypeError(format!(
-                            "parameter '{}': field '{}' expected {}, got {}",
-                            param_name, field_name, type_spec, actual_type
-                        )));
-                    }
-                } else {
-                    let actual_type = val.type_name();
-                    if actual_type != type_spec.as_str() {
-                        return Err(VmError::TypeError(format!(
-                            "parameter '{}': field '{}' expected {}, got {}",
-                            param_name, field_name, type_spec, actual_type
-                        )));
-                    }
-                }
+                assert_shape_field_value(val, param_name, field)?;
             }
         }
     }
     Ok(VmValue::Nil)
+}
+
+fn assert_shape_field_value(
+    val: &VmValue,
+    param_name: &str,
+    field: &ParsedShapeField,
+) -> Result<(), VmError> {
+    match &field.kind {
+        ShapeFieldType::Nested(nested) => {
+            let nested_struct_fields;
+            let nested_fields = match val {
+                VmValue::Dict(map) => map.as_ref(),
+                VmValue::StructInstance { .. } => {
+                    nested_struct_fields = val.struct_fields_map().unwrap_or_default();
+                    &nested_struct_fields
+                }
+                _ => {
+                    return Err(VmError::TypeError(format!(
+                        "parameter '{}': field '{}' expected dict or struct, got {}",
+                        param_name,
+                        field.name,
+                        val.type_name()
+                    )));
+                }
+            };
+            let nested_param = format!("{}.{}", param_name, field.name);
+            assert_parsed_shape_fields(nested_fields, &nested_param, nested)?;
+            Ok(())
+        }
+        ShapeFieldType::Union(types) => {
+            let actual_type = val.type_name();
+            let is_nil = matches!(val, VmValue::Nil);
+            let matches = types
+                .iter()
+                .any(|ty| ty == actual_type || (ty == "nil" && is_nil));
+            if !matches {
+                return Err(VmError::TypeError(format!(
+                    "parameter '{}': field '{}' expected {}, got {}",
+                    param_name, field.name, field.type_label, actual_type
+                )));
+            }
+            Ok(())
+        }
+        ShapeFieldType::Scalar(expected) => {
+            let actual_type = val.type_name();
+            if actual_type != expected.as_str() {
+                return Err(VmError::TypeError(format!(
+                    "parameter '{}': field '{}' expected {}, got {}",
+                    param_name, field.name, field.type_label, actual_type
+                )));
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Render the "available fields: …" tail used in missing-field errors.
@@ -302,9 +331,45 @@ pub(crate) fn format_available_fields(keys: &[&str]) -> String {
     }
 }
 
-/// Parse a shape spec string into a list of (field_name, type_spec, optional).
-fn parse_shape_spec(spec: &str) -> Vec<(String, String, bool)> {
-    let mut result = Vec::new();
+#[derive(Debug)]
+struct ParsedShapeSpec {
+    fields: Vec<ParsedShapeField>,
+}
+
+#[derive(Debug)]
+struct ParsedShapeField {
+    name: String,
+    type_label: String,
+    optional: bool,
+    kind: ShapeFieldType,
+}
+
+#[derive(Debug)]
+enum ShapeFieldType {
+    Scalar(String),
+    Union(Vec<String>),
+    Nested(Rc<ParsedShapeSpec>),
+}
+
+fn cached_shape_spec(spec: &str) -> Rc<ParsedShapeSpec> {
+    SHAPE_SPEC_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(parsed) = cache.get(spec) {
+            return Rc::clone(parsed);
+        }
+
+        let parsed = Rc::new(parse_shape_spec(spec));
+        if cache.len() >= SHAPE_SPEC_CACHE_LIMIT {
+            cache.clear();
+        }
+        cache.insert(spec.to_string(), Rc::clone(&parsed));
+        parsed
+    })
+}
+
+/// Parse a shape spec string into reusable runtime validation metadata.
+fn parse_shape_spec(spec: &str) -> ParsedShapeSpec {
+    let mut fields = Vec::new();
     let chars: Vec<char> = spec.chars().collect();
     let len = chars.len();
     let mut i = 0;
@@ -360,14 +425,19 @@ fn parse_shape_spec(spec: &str) -> Vec<(String, String, bool)> {
                 }
             }
         }
-        let type_spec = chars[type_start..i]
+        let type_label = chars[type_start..i]
             .iter()
             .collect::<String>()
             .trim()
             .to_string();
 
-        if !field_name.is_empty() && !type_spec.is_empty() {
-            result.push((field_name, type_spec, optional));
+        if !field_name.is_empty() && !type_label.is_empty() {
+            fields.push(ParsedShapeField {
+                name: field_name,
+                kind: parse_shape_field_type(&type_label),
+                type_label,
+                optional,
+            });
         }
 
         if i < len && chars[i] == ',' {
@@ -375,5 +445,53 @@ fn parse_shape_spec(spec: &str) -> Vec<(String, String, bool)> {
         }
     }
 
-    result
+    ParsedShapeSpec { fields }
+}
+
+fn parse_shape_field_type(type_label: &str) -> ShapeFieldType {
+    if type_label.starts_with('{') && type_label.ends_with('}') {
+        let inner_spec = &type_label[1..type_label.len() - 1];
+        return ShapeFieldType::Nested(Rc::new(parse_shape_spec(inner_spec)));
+    }
+
+    if type_label.contains('|') {
+        return ShapeFieldType::Union(
+            type_label
+                .split('|')
+                .map(str::trim)
+                .filter(|ty| !ty.is_empty())
+                .map(str::to_string)
+                .collect(),
+        );
+    }
+
+    ShapeFieldType::Scalar(type_label.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shape_spec_cache_reuses_parsed_specs() {
+        let first = cached_shape_spec("cache_unique_x: int, cache_unique_y?: string");
+        let second = cached_shape_spec("cache_unique_x: int, cache_unique_y?: string");
+
+        assert!(Rc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn parsed_shape_spec_validates_nested_and_union_fields() {
+        let spec = cached_shape_spec("user: {name: string}, mode: string|nil");
+        let user = VmValue::Dict(Rc::new(BTreeMap::from([(
+            "name".to_string(),
+            VmValue::String(Rc::from("Ada")),
+        )])));
+        let fields = BTreeMap::from([
+            ("user".to_string(), user),
+            ("mode".to_string(), VmValue::Nil),
+        ]);
+
+        assert_parsed_shape_fields(&fields, "payload", &spec).unwrap();
+    }
 }

--- a/crates/harn-vm/src/typecheck.rs
+++ b/crates/harn-vm/src/typecheck.rs
@@ -29,6 +29,7 @@ use harn_parser::typechecker::format_type;
 use harn_parser::TypeExpr;
 
 use crate::chunk::{CompiledFunction, ParamSlot};
+use crate::runtime_guards::RuntimeParamGuard;
 use crate::value::{ArgTypeMismatchError, ArityExpect, ArityMismatchError, VmError, VmValue};
 use crate::vm::CallArgs;
 
@@ -293,25 +294,70 @@ pub(crate) fn validate_user_call_args(
         let Some(expected) = &slot.type_expr else {
             continue;
         };
-        if matches!(expected, TypeExpr::Named(name) if func.declares_type_param(name)) {
+        if let Some(guard) = &slot.runtime_guard {
+            validate_with_runtime_guard(value, guard, func, slot, span)?;
             continue;
         }
-        if let Some(schema) = crate::compiler::Compiler::type_expr_to_schema_value(expected) {
-            crate::schema::schema_assert_param(value, &slot.name, &schema)?;
-            continue;
-        }
-        assert_value_matches_type_with_generics(
-            value,
-            expected,
-            &func.name,
-            &slot.name,
-            span,
-            &func.type_params,
-            &func.nominal_type_names,
-        )?;
+        validate_uncached_type_expr(value, expected, func, slot, span)?;
     }
 
     Ok(())
+}
+
+fn validate_with_runtime_guard(
+    value: &VmValue,
+    guard: &RuntimeParamGuard,
+    func: &CompiledFunction,
+    slot: &ParamSlot,
+    span: Option<Span>,
+) -> Result<(), VmError> {
+    match guard {
+        RuntimeParamGuard::CanonicalSchema(schema) => {
+            crate::schema::schema_assert_canonical_param(value, &slot.name, schema)
+        }
+        RuntimeParamGuard::InvalidSchema(error) => Err(VmError::TypeError(format!(
+            "parameter '{}': {}",
+            slot.name, error
+        ))),
+        RuntimeParamGuard::TypeExpr(expected) => {
+            validate_type_expr_without_schema(value, expected, func, slot, span)
+        }
+    }
+}
+
+fn validate_uncached_type_expr(
+    value: &VmValue,
+    expected: &TypeExpr,
+    func: &CompiledFunction,
+    slot: &ParamSlot,
+    span: Option<Span>,
+) -> Result<(), VmError> {
+    if matches!(expected, TypeExpr::Named(name) if func.declares_type_param(name)) {
+        return Ok(());
+    }
+    if let Some(schema) = crate::compiler::Compiler::type_expr_to_schema_value(expected) {
+        crate::schema::schema_assert_param(value, &slot.name, &schema)?;
+        return Ok(());
+    }
+    validate_type_expr_without_schema(value, expected, func, slot, span)
+}
+
+fn validate_type_expr_without_schema(
+    value: &VmValue,
+    expected: &TypeExpr,
+    func: &CompiledFunction,
+    slot: &ParamSlot,
+    span: Option<Span>,
+) -> Result<(), VmError> {
+    assert_value_matches_type_with_generics(
+        value,
+        expected,
+        &func.name,
+        &slot.name,
+        span,
+        &func.type_params,
+        &func.nominal_type_names,
+    )
 }
 
 /// Validate a builtin call against the parser's signature registry.
@@ -441,6 +487,7 @@ mod tests {
     fn param_slot(name: &str, type_expr: Option<TypeExpr>) -> ParamSlot {
         ParamSlot {
             name: name.to_string(),
+            runtime_guard: type_expr.as_ref().map(RuntimeParamGuard::from_type_expr),
             type_expr,
             has_default: false,
         }
@@ -581,6 +628,29 @@ mod tests {
         validate_user_call(&func, &[vm_int(1)], None).unwrap();
 
         let err = validate_user_call(&func, &[vm_string("bad")], None).unwrap_err();
+        assert!(matches!(err, VmError::Runtime(_) | VmError::TypeError(_)));
+    }
+
+    #[test]
+    fn validate_user_call_uses_cached_runtime_guard_metadata() {
+        let string_schema = VmValue::Dict(Rc::new(std::collections::BTreeMap::from([(
+            "type".to_string(),
+            VmValue::String(Rc::from("string")),
+        )])));
+        let guard = RuntimeParamGuard::CanonicalSchema(
+            crate::schema::canonical_param_schema(&string_schema).unwrap(),
+        );
+        let func = compiled_function(vec![ParamSlot {
+            name: "value".to_string(),
+            type_expr: Some(ty_int()),
+            runtime_guard: Some(guard),
+            has_default: false,
+        }]);
+
+        validate_user_call(&func, &[vm_string("cached")], None).unwrap();
+        validate_user_call(&func, &[vm_string("guard")], None).unwrap();
+
+        let err = validate_user_call(&func, &[vm_int(1)], None).unwrap_err();
         assert!(matches!(err, VmError::Runtime(_) | VmError::TypeError(_)));
     }
 }


### PR DESCRIPTION
## Summary
- precompute runtime parameter guards from typed params and rebuild them when bytecode-cache artifacts thaw
- reuse canonical schema metadata for schema-backed call validation while preserving existing schema validator/error behavior
- cache parsed runtime shape specs and add bounded runtime-limit entries for the new caches

Closes #2207

## Verification
- cargo fmt --check
- cargo test -p harn-vm typecheck
- cargo test -p harn-vm --lib schema::
- cargo test -p harn-vm --lib stdlib::shapes
- cargo test -p harn-vm --lib runtime_limits
- cargo test -p harn-vm --lib bytecode_cache
- cargo test -p harn-vm stdlib::monitors::tests -- --nocapture
- cargo run --quiet --bin harn -- test conformance tests/types/typed_fn.harn
- cargo run --quiet --bin harn -- test conformance tests/types/runtime_schema_param_validation.harn
- cargo run --quiet --bin harn -- test conformance tests/types/shape_runtime_validation.harn
- cargo run --quiet --bin harn -- test conformance tests/stdlib/json_validate.harn
- pre-commit hook
- pre-push hook