### PR TITLE
Add typed fact memory helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ condensed series summaries instead of full per-patch history.
   compaction, and tool-disclosure experiments. The smoke manifest exercises
   three tasks across three context modes and writes stable JSON/JSONL/Markdown
   artifacts that hosted eval tooling and downstream products can ingest.
+- **Typed facts over memory (#2251).** Added `std/agent/fact` with
+  `harn.fact.v1` normalization, stable `fact_...` ids,
+  `store_fact(...)`, `recall_facts(...)`, and `invalidate_facts(...)`
+  wrappers over `std/memory`. Facts store as `MemoryRecord.value` under
+  reserved `fact:<kind>:<id>` keys, carry evidence/confidence/provenance,
+  add canonical evidence tags for invalidation, and surface `HARN-FACT-NNN`
+  validation codes.
 - **First-class compaction instructions (#2190).** Manual session compaction,
   transcript auto-compaction, host-triggered compaction, and `agent_loop`
   auto-compaction now accept a typed `CompactionPolicy` with optional

--- a/conformance/tests/stdlib/agent_fact_store.expected
+++ b/conformance/tests/stdlib/agent_fact_store.expected
@@ -1,0 +1,1 @@
+agent fact store ok

--- a/conformance/tests/stdlib/agent_fact_store.harn
+++ b/conformance/tests/stdlib/agent_fact_store.harn
@@ -1,0 +1,54 @@
+import { invalidate_facts, recall_facts, store_fact } from "std/agent/fact"
+
+pipeline test_agent_fact_store(_task) {
+  let root = path_join(harness.fs.temp_dir(), "harn-agent-facts-" + uuid())
+  let opts = {root: root, namespace: "agent/facts"}
+  let first = store_fact(
+    {
+      kind: "Claim",
+      claim: "Alice prefers Rust examples",
+      confidence: 0.82,
+      evidence: [{kind: "FileRange", ref: "README.md:1-3", snippet: "Rust examples"}],
+      provenance: {agent: "codex", run_id: "run-1"},
+      valid_until: {event: "README preference guidance changes", asserted_at: "2026-05-23T22:00:00Z"},
+    },
+    opts + {now: "2026-05-23T22:00:00Z"},
+  )
+  store_fact(
+    {
+      kind: "Hypothesis",
+      claim: "Bob prefers TypeScript examples",
+      confidence: 0.4,
+      evidence: [{kind: "ToolOutput", ref: "tool:interview", snippet: "TypeScript"}],
+      provenance: {agent: "codex"},
+    },
+    opts + {now: "2026-05-23T22:00:01Z"},
+  )
+  assert_eq(first._type, "memory_record")
+  assert_eq(first.value.schema, "harn.fact.v1")
+  assert_eq(first.value.kind, "claim")
+  assert_eq(first.key, "fact:claim:" + first.value.id)
+  assert(contains(first.tags, "fact:evidence:file_range:README.md:1-3"))
+  assert(contains(first.tags, "fact:claim:evidence:file_range:README.md:1-3"))
+  assert_eq(first.value.evidence[0].kind, "file_range")
+  let confident = recall_facts("examples", nil, 0.8, opts + {limit: 5})
+  assert_eq(len(confident), 1)
+  assert_eq(confident[0].claim, "Alice prefers Rust examples")
+  assert_eq(confident[0].memory_key, first.key)
+  let claims = recall_facts("examples", "Claim", 0.0, opts + {limit: 5})
+  assert_eq(len(claims), 1)
+  assert_eq(claims[0].kind, "claim")
+  let invalidated = invalidate_facts(
+    {kind: "Claim", evidence: {kind: "FileRange", ref: "README.md:1-3"}},
+    opts + {now: "2026-05-23T22:00:02Z"},
+  )
+  assert_eq(invalidated.forgotten, 1)
+  assert_eq(len(recall_facts("Alice", nil, 0.0, opts + {limit: 5})), 0)
+  let bad_kind = try {
+    store_fact({kind: "Guess", claim: "unsupported", confidence: 0.5}, opts)
+  }
+  assert(is_err(bad_kind))
+  assert(contains(to_string(unwrap_err(bad_kind)), "HARN-FACT-002"))
+  harness.fs.delete(root)
+  __io_println("agent fact store ok")
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -418,6 +418,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/judge.harn"),
     },
     StdlibSource {
+        module: "agent/fact",
+        source: include_str!("stdlib/agent/fact.harn"),
+    },
+    StdlibSource {
         module: "agent/presets",
         source: include_str!("stdlib/agent/presets.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/fact.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/fact.harn
@@ -1,0 +1,585 @@
+import { filter_nil } from "std/collections"
+import { memory_forget, memory_recall, memory_store } from "std/memory"
+
+type FactKind = "observation" | "claim" | "hypothesis" | "decision" | "constraint"
+
+type FactEvidenceKind = "trace_ref" | "file_range" | "tool_output" | "user_input"
+
+type FactEvidence = {kind: FactEvidenceKind, ref: string, snippet?: string}
+
+type FactValidUntil = {event: any, asserted_at: string}
+
+type Fact = {
+  schema: "harn.fact.v1",
+  id: string,
+  kind: FactKind,
+  claim: string,
+  evidence: list<FactEvidence>,
+  confidence: float,
+  provenance: dict,
+  valid_until?: FactValidUntil,
+  asserted_at: string,
+}
+
+let FACT_SCHEMA = "harn.fact.v1"
+
+let FACT_VALID_KINDS = ["observation", "claim", "hypothesis", "decision", "constraint"]
+
+let FACT_VALID_EVIDENCE_KINDS = ["trace_ref", "file_range", "tool_output", "user_input"]
+
+fn __fact_error(code, message) {
+  throw code + ": std/agent/fact: " + message
+}
+
+fn __fact_text(value) -> string {
+  if value == nil {
+    return ""
+  }
+  if type_of(value) == "string" {
+    return trim(value)
+  }
+  return trim(to_string(value))
+}
+
+fn __fact_in(needle, allowed) -> bool {
+  for candidate in allowed {
+    if candidate == needle {
+      return true
+    }
+  }
+  return false
+}
+
+fn __fact_kind(value) -> FactKind {
+  let raw = __fact_text(value)
+  let normalized = lowercase(replace(raw, "-", "_"))
+  if normalized == "" {
+    __fact_error("HARN-FACT-002", "kind is required")
+  }
+  if !__fact_in(normalized, FACT_VALID_KINDS) {
+    __fact_error("HARN-FACT-002", "unknown kind `" + raw + "`")
+  }
+  return normalized
+}
+
+fn __fact_evidence_kind(value) -> FactEvidenceKind {
+  let raw = __fact_text(value)
+  let normalized = lowercase(replace(raw, "-", "_"))
+  if normalized == "traceref" {
+    return "trace_ref"
+  }
+  if normalized == "filerange" {
+    return "file_range"
+  }
+  if normalized == "tooloutput" {
+    return "tool_output"
+  }
+  if normalized == "userinput" {
+    return "user_input"
+  }
+  if !__fact_in(normalized, FACT_VALID_EVIDENCE_KINDS) {
+    __fact_error("HARN-FACT-005", "unknown evidence.kind `" + raw + "`")
+  }
+  return normalized
+}
+
+fn __fact_confidence(value) -> float {
+  if value == nil {
+    __fact_error("HARN-FACT-004", "confidence is required")
+  }
+  let kind = type_of(value)
+  if kind != "int" && kind != "float" {
+    __fact_error("HARN-FACT-004", "confidence must be a number in [0, 1]")
+  }
+  let confidence = value + 0.0
+  if confidence < 0.0 || confidence > 1.0 {
+    __fact_error("HARN-FACT-004", "confidence must be in [0, 1]")
+  }
+  return confidence
+}
+
+fn __fact_string_list(value) -> list<string> {
+  if value == nil {
+    return []
+  }
+  let raw = if type_of(value) == "list" {
+    value
+  } else {
+    [value]
+  }
+  var out = []
+  for entry in raw {
+    let text = __fact_text(entry)
+    if text != "" && !contains(out, text) {
+      out = out.push(text)
+    }
+  }
+  return out
+}
+
+fn __fact_push_tag(tags, tag) -> list<string> {
+  let text = __fact_text(tag)
+  if text == "" || contains(tags, text) {
+    return tags
+  }
+  return tags.push(text)
+}
+
+fn __fact_evidence_entry(entry) -> FactEvidence {
+  if type_of(entry) != "dict" {
+    __fact_error("HARN-FACT-005", "evidence entries must be dicts")
+  }
+  let kind = __fact_evidence_kind(entry?.kind)
+  let ref = __fact_text(entry?.ref)
+  if ref == "" {
+    __fact_error("HARN-FACT-005", "evidence.ref is required")
+  }
+  let snippet = __fact_text(entry?.snippet)
+  return filter_nil({kind: kind, ref: ref, snippet: snippet})
+}
+
+fn __fact_evidence(value) -> list<FactEvidence> {
+  if value == nil {
+    return []
+  }
+  if type_of(value) != "list" {
+    __fact_error("HARN-FACT-005", "evidence must be a list")
+  }
+  var out = []
+  for entry in value {
+    out = out.push(__fact_evidence_entry(entry))
+  }
+  return out
+}
+
+fn __fact_evidence_tags(fact_kind, evidence) -> list<string> {
+  var out = []
+  for item in evidence {
+    out = __fact_push_tag(out, "fact:evidence:" + item.kind)
+    out = __fact_push_tag(out, "fact:evidence_ref:" + item.ref)
+    out = __fact_push_tag(out, "fact:evidence:" + item.kind + ":" + item.ref)
+    out = __fact_push_tag(out, "fact:" + fact_kind + ":evidence:" + item.kind)
+    out = __fact_push_tag(out, "fact:" + fact_kind + ":evidence_ref:" + item.ref)
+    out = __fact_push_tag(out, "fact:" + fact_kind + ":evidence:" + item.kind + ":" + item.ref)
+  }
+  return out
+}
+
+fn __fact_provenance(value) -> dict {
+  if value == nil {
+    return {}
+  }
+  if type_of(value) != "dict" {
+    __fact_error("HARN-FACT-006", "provenance must be a dict")
+  }
+  return value
+}
+
+fn __fact_valid_until(value) -> FactValidUntil? {
+  if value == nil {
+    return nil
+  }
+  if type_of(value) != "dict" {
+    __fact_error("HARN-FACT-007", "valid_until must be a dict")
+  }
+  if value?.event == nil {
+    __fact_error("HARN-FACT-007", "valid_until.event is required")
+  }
+  let asserted_at = __fact_text(value?.asserted_at)
+  if asserted_at == "" {
+    __fact_error("HARN-FACT-007", "valid_until.asserted_at is required")
+  }
+  return {event: value.event, asserted_at: asserted_at}
+}
+
+fn __fact_options(options, caller) -> dict {
+  if options == nil {
+    return {}
+  }
+  if type_of(options) != "dict" {
+    __fact_error("HARN-FACT-001", caller + " options must be a dict")
+  }
+  return options
+}
+
+/**
+ * Return the canonical memory namespace for a fact scope.
+ *
+ * The default namespace is project-scoped because the VM-native memory root is
+ * already project-local unless a caller provides `options.root`.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: fact_namespace(scope)
+ */
+pub fn fact_namespace(scope = nil) -> string {
+  let raw = lowercase(__fact_text(scope))
+  if raw == "" || raw == "project" {
+    return "project/facts"
+  }
+  if raw == "workspace" {
+    return "workspace/facts"
+  }
+  if raw == "user" {
+    return "user/facts"
+  }
+  return __fact_text(scope)
+}
+
+/**
+ * Build a stable fact id from the normalized schema-bearing fields.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: fact_id(kind, claim, evidence, provenance)
+ */
+pub fn fact_id(kind, claim, evidence = nil, provenance = nil) -> string {
+  let seed = to_string(__fact_kind(kind))
+    + "\n"
+    + __fact_text(claim)
+    + "\n"
+    + json_stringify(__fact_evidence(evidence))
+    + "\n"
+    + json_stringify(__fact_provenance(provenance))
+  return "fact_" + substring(sha256(seed), 0, 32)
+}
+
+/**
+ * Return the reserved memory key for a fact.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: fact_key(fact)
+ */
+pub fn fact_key(fact_value) -> string {
+  let fact = fact_validate(fact_value)
+  return "fact:" + fact.kind + ":" + fact.id
+}
+
+/**
+ * Return the canonical memory tags for a fact.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: fact_tags(fact, tags)
+ */
+pub fn fact_tags(fact_value, tags = nil) -> list<string> {
+  let fact = fact_validate(fact_value)
+  var out = ["fact", "fact:" + fact.kind, "schema:" + FACT_SCHEMA]
+  for tag in __fact_evidence_tags(fact.kind, fact.evidence) {
+    out = __fact_push_tag(out, tag)
+  }
+  for tag in __fact_string_list(tags) {
+    out = __fact_push_tag(out, tag)
+  }
+  return out
+}
+
+/**
+ * Normalize and validate a `harn.fact.v1` envelope.
+ *
+ * `kind` accepts the issue shorthand (`Claim`, `FileRange`, etc.) but stores
+ * lower snake-case strings so facts compose with the rest of the stdlib.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [HARN-FACT-001, HARN-FACT-002, HARN-FACT-003, HARN-FACT-004, HARN-FACT-005, HARN-FACT-006, HARN-FACT-007]
+ * @api_stability: experimental
+ * @example: fact(input, options)
+ */
+pub fn fact(input, options = nil) -> Fact {
+  if input == nil || type_of(input) != "dict" {
+    __fact_error("HARN-FACT-001", "fact input must be a dict")
+  }
+  if input?.schema != nil && input.schema != FACT_SCHEMA {
+    __fact_error("HARN-FACT-001", "unsupported schema `" + __fact_text(input.schema) + "`")
+  }
+  let opts = __fact_options(options, "fact")
+  let kind = __fact_kind(opts?.kind ?? input?.kind)
+  let claim = __fact_text(opts?.claim ?? input?.claim)
+  if claim == "" {
+    __fact_error("HARN-FACT-003", "claim is required")
+  }
+  let confidence = __fact_confidence(opts?.confidence ?? input?.confidence)
+  let evidence = __fact_evidence(opts?.evidence ?? input?.evidence)
+  let provenance = __fact_provenance(opts?.provenance ?? input?.provenance)
+  let valid_until = __fact_valid_until(opts?.valid_until ?? input?.valid_until)
+  let asserted_at = __fact_text(opts?.asserted_at ?? input?.asserted_at ?? opts?.now)
+  if opts?.require_asserted_at ?? false && asserted_at == "" {
+    __fact_error("HARN-FACT-009", "asserted_at is required")
+  }
+  let raw_id = __fact_text(opts?.id ?? input?.id)
+  let id = raw_id == "" ? fact_id(kind, claim, evidence, provenance) : raw_id
+  return filter_nil(
+    {
+      schema: FACT_SCHEMA,
+      id: id,
+      kind: kind,
+      claim: claim,
+      evidence: evidence,
+      confidence: confidence,
+      provenance: provenance,
+      valid_until: valid_until,
+      asserted_at: asserted_at == "" ? date_now_iso() : asserted_at,
+    },
+  )
+}
+
+/**
+ * Validate and return a normalized `harn.fact.v1` envelope.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: [HARN-FACT-001, HARN-FACT-002, HARN-FACT-003, HARN-FACT-004, HARN-FACT-005, HARN-FACT-006, HARN-FACT-007, HARN-FACT-009]
+ * @api_stability: experimental
+ * @example: fact_validate(input)
+ */
+pub fn fact_validate(input) -> Fact {
+  return fact(input, {require_asserted_at: true})
+}
+
+/**
+ * Store a typed fact as `MemoryRecord.value` under a reserved `fact:<kind>:<id>` key.
+ *
+ * Options are forwarded to `memory_store`; `options.namespace` overrides the
+ * fact namespace, and `options.scope` maps through `fact_namespace`.
+ *
+ * @effects: [store.write]
+ * @allocation: heap
+ * @errors: [HARN-FACT-001, HARN-FACT-002, HARN-FACT-003, HARN-FACT-004, HARN-FACT-005, HARN-FACT-006, HARN-FACT-007]
+ * @api_stability: experimental
+ * @example: store_fact(input, options)
+ */
+pub fn store_fact(input, options = nil) {
+  let opts = __fact_options(options, "store_fact")
+  let fact_value = fact(input, opts)
+  let namespace = opts?.namespace ?? fact_namespace(opts?.scope)
+  let key = opts?.key ?? fact_key(fact_value)
+  let tags = fact_tags(fact_value, opts?.tags)
+  return memory_store(
+    namespace,
+    key,
+    fact_value,
+    tags,
+    opts + {id: fact_value.id, provenance: fact_value.provenance},
+  )
+}
+
+fn __fact_scope_options(scope) -> dict {
+  if scope == nil {
+    return {}
+  }
+  if type_of(scope) == "dict" {
+    return scope
+  }
+  return {scope: scope}
+}
+
+fn __fact_positive_int(value, fallback) {
+  if type_of(value) == "int" && value > 0 {
+    return value
+  }
+  return fallback
+}
+
+fn __fact_recall_hit(record) {
+  let fact_value = fact_validate(record.value)
+  return filter_nil(
+    fact_value
+      + {
+      score: record?.score,
+      memory_record_id: record?.id,
+      memory_key: record?.key,
+      memory_namespace: record?.namespace,
+      stored_at: record?.stored_at,
+    },
+  )
+}
+
+/**
+ * Recall typed facts from memory, filtering by kind and minimum confidence.
+ *
+ * `scope` may be a scope string (`"project"`, `"workspace"`, `"user"`) or an
+ * options dict containing `namespace`, `root`, `limit`, `recall_limit`, and
+ * normal `memory_recall` options.
+ *
+ * @effects: [store.read]
+ * @allocation: heap
+ * @errors: [HARN-FACT-001, HARN-FACT-002, HARN-FACT-004]
+ * @api_stability: experimental
+ * @example: recall_facts(query, kind, min_confidence, scope)
+ */
+pub fn recall_facts(query, kind = nil, min_confidence = nil, scope = nil) -> list {
+  let opts = __fact_scope_options(scope)
+  let namespace = opts?.namespace ?? fact_namespace(opts?.scope)
+  let resolved_kind = kind == nil ? nil : __fact_kind(kind)
+  let min = min_confidence == nil ? 0.0 : __fact_confidence(min_confidence)
+  let limit = __fact_positive_int(opts?.limit ?? opts?.k, 5)
+  let recall_limit = __fact_positive_int(opts?.recall_limit, limit * 4)
+  let records = memory_recall(namespace, query, recall_limit < limit ? limit : recall_limit, opts)
+  var out = []
+  for record in records {
+    if record?.value?.schema != FACT_SCHEMA {
+      continue
+    }
+    let hit_result = try {
+      __fact_recall_hit(record)
+    }
+    if is_err(hit_result) {
+      continue
+    }
+    let hit = unwrap(hit_result)
+    if resolved_kind != nil && hit.kind != resolved_kind {
+      continue
+    }
+    if hit.confidence < min {
+      continue
+    }
+    out = out.push(hit)
+    if len(out) >= limit {
+      break
+    }
+  }
+  return out
+}
+
+fn __fact_forget_predicate(predicate) -> dict {
+  if predicate == nil {
+    __fact_error("HARN-FACT-008", "invalidate_facts predicate is required")
+  }
+  if type_of(predicate) == "string" {
+    let text = __fact_text(predicate)
+    if text == "" {
+      __fact_error("HARN-FACT-008", "invalidate_facts predicate must be non-empty")
+    }
+    if starts_with(text, "fact_") {
+      return {id: text}
+    }
+    return {query: text}
+  }
+  if type_of(predicate) != "dict" {
+    __fact_error("HARN-FACT-008", "invalidate_facts predicate must be a string or dict")
+  }
+  var out = {}
+  if predicate?.id != nil {
+    out.id = predicate.id
+  }
+  if predicate?.key != nil {
+    out.key = predicate.key
+  }
+  let fact_kind = predicate?.kind == nil ? nil : __fact_kind(predicate.kind)
+  let evidence_tags = __fact_forget_evidence_tags(predicate, fact_kind)
+  if len(evidence_tags) > 0 {
+    out.tags = evidence_tags
+  } else if fact_kind != nil {
+    out.tags = ["fact:" + to_string(fact_kind)]
+  } else if predicate?.tag != nil || predicate?.tags != nil {
+    out.tags = __fact_string_list(predicate?.tag ?? predicate?.tags)
+  }
+  if predicate?.claim != nil {
+    out.query = predicate.claim
+  } else if predicate?.query != nil {
+    out.query = predicate.query
+  }
+  if len(out.keys()) == 0 {
+    __fact_error("HARN-FACT-008", "invalidate_facts predicate matched no supported fields")
+  }
+  return out
+}
+
+fn __fact_forget_evidence_tags(predicate, fact_kind = nil) -> list<string> {
+  var out = []
+  if predicate?.evidence_ref != nil {
+    out = __fact_push_tag(out, __fact_evidence_ref_tag(fact_kind, predicate.evidence_ref))
+  }
+  if predicate?.evidence == nil {
+    return out
+  }
+  let evidence = predicate.evidence
+  if type_of(evidence) == "string" {
+    return __fact_push_tag(out, __fact_evidence_ref_tag(fact_kind, evidence))
+  }
+  if type_of(evidence) == "dict" {
+    return __fact_forget_evidence_entry(out, fact_kind, evidence)
+  }
+  if type_of(evidence) != "list" {
+    __fact_error("HARN-FACT-008", "invalidate_facts evidence must be a string, dict, or list")
+  }
+  for entry in evidence {
+    if type_of(entry) == "string" {
+      out = __fact_push_tag(out, __fact_evidence_ref_tag(fact_kind, entry))
+    } else if type_of(entry) == "dict" {
+      out = __fact_forget_evidence_entry(out, fact_kind, entry)
+    } else {
+      __fact_error("HARN-FACT-008", "invalidate_facts evidence entries must be strings or dicts")
+    }
+  }
+  return out
+}
+
+fn __fact_evidence_ref_tag(fact_kind, ref) -> string {
+  let text = __fact_text(ref)
+  if fact_kind == nil {
+    return "fact:evidence_ref:" + text
+  }
+  return "fact:" + to_string(fact_kind) + ":evidence_ref:" + text
+}
+
+fn __fact_evidence_kind_tag(fact_kind, kind) -> string {
+  let text = to_string(kind)
+  if fact_kind == nil {
+    return "fact:evidence:" + text
+  }
+  return "fact:" + to_string(fact_kind) + ":evidence:" + text
+}
+
+fn __fact_evidence_exact_tag(fact_kind, kind, ref) -> string {
+  let text = to_string(kind) + ":" + __fact_text(ref)
+  if fact_kind == nil {
+    return "fact:evidence:" + text
+  }
+  return "fact:" + to_string(fact_kind) + ":evidence:" + text
+}
+
+fn __fact_forget_evidence_entry(out, fact_kind, entry) -> list<string> {
+  let kind = entry?.kind == nil ? nil : __fact_evidence_kind(entry.kind)
+  let ref = __fact_text(entry?.ref)
+  if kind != nil && ref != "" {
+    return __fact_push_tag(out, __fact_evidence_exact_tag(fact_kind, kind, ref))
+  }
+  if ref != "" {
+    return __fact_push_tag(out, __fact_evidence_ref_tag(fact_kind, ref))
+  }
+  if kind != nil {
+    return __fact_push_tag(out, __fact_evidence_kind_tag(fact_kind, kind))
+  }
+  __fact_error("HARN-FACT-008", "invalidate_facts evidence requires kind or ref")
+}
+
+/**
+ * Invalidate matching facts by appending a memory tombstone.
+ *
+ * A string predicate invalidates an exact fact id when it starts with
+ * `fact_`; otherwise it is treated as a query. Dict predicates accept `id`,
+ * `key`, `kind`, `claim`, `query`, `tag`, `tags`, `evidence_ref`, and
+ * `evidence`.
+ *
+ * @effects: [store.write]
+ * @allocation: heap
+ * @errors: [HARN-FACT-002, HARN-FACT-008]
+ * @api_stability: experimental
+ * @example: invalidate_facts(predicate, scope)
+ */
+pub fn invalidate_facts(predicate, scope = nil) {
+  let opts = __fact_scope_options(scope)
+  let namespace = opts?.namespace ?? fact_namespace(opts?.scope)
+  return memory_forget(namespace, __fact_forget_predicate(predicate), opts)
+}

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -412,6 +412,8 @@ Imports starting with `std/` load embedded stdlib modules:
   agent_state_handoff)
 - `import "std/agent/progress"` — agent progress narration and task-list
   helpers (agent_progress, agent_progress_tool)
+- `import "std/agent/fact"` — typed fact envelopes over durable memory
+  (store_fact, recall_facts, invalidate_facts)
 - `import "std/memory"` — append-only durable memory helpers
   (memory_store, memory_recall, memory_summarize, memory_forget)
 - `import "std/trust"` — TrustGraph query and policy helpers
@@ -5305,6 +5307,29 @@ LLM prose can pass `summary.records` to `llm_call`.
 tombstone event. Predicates may be a string (substring match against searchable
 record text) or a dict using any combination of `id`, `key`, `tag` / `tags`,
 and `query`; all provided dict predicates must match.
+
+### std/agent/fact module
+
+```harn
+import { store_fact, recall_facts, invalidate_facts } from "std/agent/fact"
+```
+
+Provides typed `harn.fact.v1` assertions on top of `std/memory`. A fact contains
+`kind`, `claim`, `evidence`, `confidence`, `provenance`, optional
+`valid_until`, and `asserted_at`. Kinds normalize to `observation`, `claim`,
+`hypothesis`, `decision`, or `constraint`; evidence kinds normalize to
+`trace_ref`, `file_range`, `tool_output`, or `user_input`.
+
+| Function | Notes |
+|---|---|
+| `fact(input, options?)` / `fact_validate(input)` | Normalize and validate a `harn.fact.v1` envelope; validation failures include `HARN-FACT-NNN` codes |
+| `fact_namespace(scope?)` | Map `project`, `workspace`, or `user` to the default fact namespace, defaulting to `project/facts` |
+| `fact_id(kind, claim, evidence?, provenance?)` | Build a stable `fact_...` id from normalized assertion fields |
+| `fact_key(fact)` | Return the reserved `fact:<kind>:<id>` memory key |
+| `fact_tags(fact, tags?)` | Return `fact`, `fact:<kind>`, `schema:harn.fact.v1`, generic and kind-scoped evidence tags, and caller tags |
+| `store_fact(input, options?)` | Store the fact as `MemoryRecord.value`, using the fact id as the memory record id |
+| `recall_facts(query, kind?, min_confidence?, scope?)` | Recall normalized facts and filter by kind/confidence; `scope` may be a scope string or an options dict with normal memory options |
+| `invalidate_facts(predicate, scope?)` | Append memory tombstones; predicates accept exact `fact_...` ids or dicts with `id`, `key`, `kind`, `claim`, `query`, `tag`, `tags`, `evidence_ref`, or `evidence` |
 
 ### std/postgres module
 

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -24,6 +24,9 @@ let summary = memory_summarize("workspace/acme", {limit: 10})
 | `memory_summarize(namespace, window?, options?)` | `memory_summary` | Build an extractive summary over recent or query-filtered records |
 | `memory_forget(namespace, predicate, options?)` | `dict` | Append a tombstone for matching records |
 
+Typed fact helpers live in `std/agent/fact` and store `harn.fact.v1`
+envelopes on top of this same memory log.
+
 ## Storage
 
 The VM-native backend stores append-only JSONL events at
@@ -75,6 +78,43 @@ observations in the log for auditability.
 Predicates may be a string substring match, or a dict with any combination of
 `id`, `key`, `tag` / `tags`, and `query`. Dict predicates are conjunctive: all
 provided fields must match.
+
+## Typed facts
+
+`std/agent/fact` provides typed assertions over `std/memory` for agents that
+need durable, queryable claims rather than freeform observations:
+
+```harn
+import { recall_facts, store_fact } from "std/agent/fact"
+
+store_fact({
+  kind: "claim",
+  claim: "Alice prefers Rust examples",
+  confidence: 0.82,
+  evidence: [{kind: "file_range", ref: "README.md:1-3"}],
+  provenance: {agent: "codex", run_id: "run-1"},
+})
+
+let facts = recall_facts("Rust examples", "claim", 0.8)
+```
+
+Facts normalize to `harn.fact.v1` with `kind`, `claim`, `evidence`,
+`confidence`, `provenance`, optional `valid_until`, and `asserted_at`.
+`store_fact` writes the fact as `MemoryRecord.value`, sets the memory record id
+to the fact id, and uses the reserved key shape `fact:<kind>:<id>` with
+`fact`, `fact:<kind>`, `schema:harn.fact.v1`, and evidence tags. The default
+namespace is `project/facts`; pass `options.namespace`, `options.scope`, or
+normal memory options such as `root` to control placement.
+
+`recall_facts(query, kind?, min_confidence?, scope?)` returns normalized facts
+augmented with `score`, `memory_record_id`, `memory_key`, `memory_namespace`,
+and `stored_at`. `invalidate_facts(predicate, scope?)` appends memory
+tombstones; predicates accept an exact `fact_...` id string or a dict with
+`id`, `key`, `kind`, `claim`, `query`, `tag`, `tags`, `evidence_ref`, or
+`evidence`. Evidence predicates match canonical evidence tags such as
+`fact:evidence:file_range:README.md:1-3`; when `kind` is supplied, they match
+kind-scoped tags such as `fact:claim:evidence:file_range:README.md:1-3`.
+Validation failures include `HARN-FACT-NNN` codes.
 
 ## Vector and hybrid backends
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -83,6 +83,7 @@ described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/edit`, `std/artifact/web`, `std/ui_resource`, `std/cache`,
 `std/llm/handlers`, `std/llm/budget`, `std/llm/prompts`, `std/vision`,
 `std/context`, `std/agent_state`, `std/agents`, `std/agent/user`,
+`std/agent/fact`,
 `std/runtime`, `std/command`, `std/gha`, `std/tui`, `std/git`,
 `std/review`, `std/experiments`,
 `std/project`, `std/memory`, `std/prompt_library`, `std/monitors`,
@@ -1293,6 +1294,20 @@ Simulated-user helpers for eval harnesses:
 | `simulated_user_post_turn(answerer, options?)` | Build a `post_turn_callback` that answers plain-text clarification questions |
 | `simulated_user_status(answerer)` | Return public state such as reply and LLM-call counts |
 | `simulated_user_read_tools(registry?, options?)` | Alias for read-only host research tools appropriate for an agentic simulated user |
+
+### std/agent/fact
+
+Typed fact envelopes over `std/memory` for cross-session assertions:
+
+| Function | Description |
+|---|---|
+| `fact(input, options?)` | Normalize and validate a `harn.fact.v1` envelope with kind, claim, evidence, confidence, provenance, optional `valid_until`, and `asserted_at` |
+| `fact_id(kind, claim, evidence?, provenance?)` | Build a stable fact id from the normalized assertion fields |
+| `fact_key(fact)` | Return the reserved `fact:<kind>:<id>` memory key |
+| `fact_tags(fact, tags?)` | Return canonical fact memory tags, generic and kind-scoped evidence tags, and caller tags |
+| `store_fact(input, options?)` | Store a typed fact as `MemoryRecord.value`; `options.namespace` or `options.scope` selects the memory namespace |
+| `recall_facts(query, kind?, min_confidence?, scope?)` | Recall facts by memory query, kind, and minimum confidence |
+| `invalidate_facts(predicate, scope?)` | Append memory tombstones for matching facts by id, key, kind, claim/query, tags, or evidence |
 
 ### std/handoffs
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -410,6 +410,8 @@ Imports starting with `std/` load embedded stdlib modules:
   agent_state_handoff)
 - `import "std/agent/progress"` — agent progress narration and task-list
   helpers (agent_progress, agent_progress_tool)
+- `import "std/agent/fact"` — typed fact envelopes over durable memory
+  (store_fact, recall_facts, invalidate_facts)
 - `import "std/memory"` — append-only durable memory helpers
   (memory_store, memory_recall, memory_summarize, memory_forget)
 - `import "std/trust"` — TrustGraph query and policy helpers
@@ -5303,6 +5305,29 @@ LLM prose can pass `summary.records` to `llm_call`.
 tombstone event. Predicates may be a string (substring match against searchable
 record text) or a dict using any combination of `id`, `key`, `tag` / `tags`,
 and `query`; all provided dict predicates must match.
+
+### std/agent/fact module
+
+```harn
+import { store_fact, recall_facts, invalidate_facts } from "std/agent/fact"
+```
+
+Provides typed `harn.fact.v1` assertions on top of `std/memory`. A fact contains
+`kind`, `claim`, `evidence`, `confidence`, `provenance`, optional
+`valid_until`, and `asserted_at`. Kinds normalize to `observation`, `claim`,
+`hypothesis`, `decision`, or `constraint`; evidence kinds normalize to
+`trace_ref`, `file_range`, `tool_output`, or `user_input`.
+
+| Function | Notes |
+|---|---|
+| `fact(input, options?)` / `fact_validate(input)` | Normalize and validate a `harn.fact.v1` envelope; validation failures include `HARN-FACT-NNN` codes |
+| `fact_namespace(scope?)` | Map `project`, `workspace`, or `user` to the default fact namespace, defaulting to `project/facts` |
+| `fact_id(kind, claim, evidence?, provenance?)` | Build a stable `fact_...` id from normalized assertion fields |
+| `fact_key(fact)` | Return the reserved `fact:<kind>:<id>` memory key |
+| `fact_tags(fact, tags?)` | Return `fact`, `fact:<kind>`, `schema:harn.fact.v1`, generic and kind-scoped evidence tags, and caller tags |
+| `store_fact(input, options?)` | Store the fact as `MemoryRecord.value`, using the fact id as the memory record id |
+| `recall_facts(query, kind?, min_confidence?, scope?)` | Recall normalized facts and filter by kind/confidence; `scope` may be a scope string or an options dict with normal memory options |
+| `invalidate_facts(predicate, scope?)` | Append memory tombstones; predicates accept exact `fact_...` ids or dicts with `id`, `key`, `kind`, `claim`, `query`, `tag`, `tags`, `evidence_ref`, or `evidence` |
 
 ### std/postgres module
 


### PR DESCRIPTION
## Summary

- Add `std/agent/fact` with `harn.fact.v1` normalization, validation, stable fact ids, project-scoped default namespace, and memory-backed `store_fact`, `recall_facts`, and `invalidate_facts` helpers.
- Store facts as `MemoryRecord.value` under reserved `fact:<kind>:<id>` keys with canonical fact/evidence tags, including kind-scoped evidence tags for precise invalidation.
- Add conformance coverage for round-trip storage, confidence filtering, kind normalization, evidence-based invalidation, and `HARN-FACT-NNN` diagnostics.
- Document the new module in the spec, memory docs, modules reference, generated language spec, and changelog.

Closes #2251

## Verification

- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/agent/fact.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/stdlib/agent_fact_store.harn`
- `cargo run --quiet --bin harn -- test conformance --filter agent_fact_store`
- `make lint-harn`
- `make fmt-harn`
- `make check-docs-snippets`
- `make lint-test-patterns`
- `cargo test -p harn-stdlib key_stdlib_modules_resolve`
- `cargo test -p harn-vm memory`
