### PR TITLE
Add adversarial depth regression tests

### DIFF
--- a/conformance/tests/agents/nested_execution_budget_depth.expected
+++ b/conformance/tests/agents/nested_execution_budget_depth.expected
@@ -1,0 +1,8 @@
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/agents/nested_execution_budget_depth.harn
+++ b/conformance/tests/agents/nested_execution_budget_depth.harn
@@ -1,0 +1,68 @@
+fn delegated_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "delegate",
+    "Start a nested child agent.",
+    {
+      handler: { _args ->
+        let child = sub_agent_run(
+          "Nested child should be rejected by the remaining recursion budget.",
+          {provider: "mock", max_iterations: 1},
+        )
+        require !child?.ok, "nested sub-agent must fail closed"
+        require child?.budget_exceeded, "nested sub-agent should report budget exhaustion"
+        require child.error?.category == "budget_exceeded", "nested sub-agent should classify the denial"
+        require contains(child.error?.message ?? "", "sub_agent_run"), "nested sub-agent denial should name the guarded descent"
+        require contains(json_stringify(child?.transcript ?? {}), "nested_execution_budget_denied"), "nested sub-agent transcript should record the denial"
+        return "denied"
+      },
+      parameters: {},
+      returns: {type: "string"},
+    },
+  )
+  return tools
+}
+
+pipeline main() {
+  llm_mock({tool_calls: [{id: "delegate_1", name: "delegate", arguments: {}}]})
+  let parent = agent_loop(
+    "Ask the tool to delegate.",
+    nil,
+    {
+      provider: "mock",
+      tools: delegated_tools(),
+      allowed_tools: ["delegate"],
+      tool_format: "native",
+      max_iterations: 1,
+      policy: {recursion_limit: 0},
+    },
+  )
+  __io_println(contains(parent?.tools?.successful ?? [], "delegate"))
+  __io_println(len(parent?.tools?.rejected ?? []) == 0)
+  let flow = workflow_graph(
+    {
+      name: "budgeted_workflow",
+      entry: "act",
+      capability_policy: {recursion_limit: 0},
+      nodes: {
+        act: {
+          kind: "stage",
+          mode: "agent",
+          model_policy: {provider: "mock"},
+          output_contract: {output_kinds: ["summary"]},
+        },
+      },
+      edges: [],
+    },
+  )
+  let workflow = workflow_execute("Nested workflow stage should be rejected.", flow, [], {max_steps: 1})
+  let stage = workflow?.run?.stages[0]
+  let artifact = stage?.artifacts[0]?.data
+  __io_println(stage?.status == "failed")
+  __io_println(stage?.outcome == "blocked")
+  __io_println(stage?.branch == "failed")
+  __io_println(artifact?.stop_reason == "nested_execution_budget_exhausted")
+  __io_println(artifact?.error?.category == "budget_exceeded")
+  __io_println(contains(artifact?.error?.message ?? "", "workflow_stage: act"))
+}

--- a/crates/harn-vm/src/schema/tests.rs
+++ b/crates/harn-vm/src/schema/tests.rs
@@ -56,6 +56,25 @@ fn deep_items_schema(depth: usize) -> VmValue {
     schema
 }
 
+fn deep_ref_chain_schema(depth: usize) -> VmValue {
+    let mut definitions = BTreeMap::new();
+    for index in 0..depth {
+        let schema = if index + 1 == depth {
+            make_vm_dict(vec![("type", s("string"))])
+        } else {
+            make_vm_dict(vec![(
+                "$ref",
+                s(&format!("#/definitions/Node{}", index + 1)),
+            )])
+        };
+        definitions.insert(format!("Node{index}"), schema);
+    }
+    make_vm_dict(vec![
+        ("$ref", s("#/definitions/Node0")),
+        ("definitions", VmValue::Dict(Rc::new(definitions))),
+    ])
+}
+
 fn deep_node_value(depth: usize) -> VmValue {
     let mut value = s("ok");
     for _ in 0..depth {
@@ -152,6 +171,12 @@ fn many_refs_are_rejected_at_expansion_limit() {
     ]);
 
     assert_schema_error_contains(&schema, "schema $ref expansion limit exceeded (256)");
+}
+
+#[test]
+fn deep_ref_chain_is_rejected_at_depth_limit() {
+    let schema = deep_ref_chain_schema(DEFAULT_SCHEMA_MAX_DEPTH + 2);
+    assert_schema_error_contains(&schema, "schema depth exceeded (128)");
 }
 
 #[test]

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -445,6 +445,25 @@ fn transcript_tokens_used(transcript: &VmValue) -> i64 {
         .unwrap_or(0)
 }
 
+fn nested_budget_denial_error(result: &serde_json::Value) -> Option<VmValue> {
+    if result.get("stop_reason").and_then(|value| value.as_str())
+        != Some("nested_execution_budget_exhausted")
+    {
+        return None;
+    }
+    let error = result
+        .get("error")
+        .filter(|value| !value.is_null())
+        .cloned()
+        .unwrap_or_else(|| {
+            serde_json::json!({
+                "category": "budget_exceeded",
+                "message": "nested execution budget exhausted",
+            })
+        });
+    Some(crate::stdlib::json_to_vm_value(&error))
+}
+
 #[derive(Clone, Debug)]
 struct JsonCandidate {
     text: String,
@@ -759,7 +778,36 @@ pub(super) async fn execute_sub_agent(
         .get("token_budget")
         .and_then(|value| value.as_int())
         .unwrap_or(-1);
-    let budget_exceeded = budget_limit >= 0 && tokens_used >= budget_limit;
+    let nested_budget_error = nested_budget_denial_error(&result);
+    let budget_exceeded =
+        (budget_limit >= 0 && tokens_used >= budget_limit) || nested_budget_error.is_some();
+
+    if let Some(error_value) = nested_budget_error {
+        append_parent_sub_agent_event(
+            spec.parent_session_id.as_deref(),
+            sub_agent_result_event(
+                &spec,
+                false,
+                &summary,
+                evidence_added,
+                true,
+                Some(crate::llm::vm_value_to_json(&error_value)),
+            ),
+        );
+        return Ok(SubAgentExecutionResult {
+            payload: crate::llm::vm_value_to_json(&wrap_sub_agent_error(
+                summary,
+                artifacts,
+                evidence_added,
+                tokens_used,
+                true,
+                &spec.session_id,
+                error_value,
+                Some(transcript.clone()),
+            )),
+            transcript,
+        });
+    }
 
     let mut envelope = sub_agent_base_envelope(
         summary.clone(),
@@ -876,6 +924,23 @@ pub(super) async fn execute_sub_agent(
 mod tests {
     use super::*;
     use crate::llm::mock::{push_llm_mock, reset_llm_mock_state, LlmMock};
+
+    struct ExecutionPolicyGuard;
+
+    impl Drop for ExecutionPolicyGuard {
+        fn drop(&mut self) {
+            crate::orchestration::clear_execution_policy_stacks();
+        }
+    }
+
+    fn push_recursion_policy(limit: usize) -> ExecutionPolicyGuard {
+        crate::orchestration::clear_execution_policy_stacks();
+        crate::orchestration::push_execution_policy(CapabilityPolicy {
+            recursion_limit: Some(limit),
+            ..CapabilityPolicy::default()
+        });
+        ExecutionPolicyGuard
+    }
 
     fn assistant_message(text: &str) -> VmValue {
         VmValue::Dict(Rc::new(BTreeMap::from([
@@ -1062,6 +1127,90 @@ mod tests {
             .collect();
         assert!(event_kinds.iter().any(|kind| kind == "sub_agent_start"));
         assert!(event_kinds.iter().any(|kind| kind == "sub_agent_result"));
+
+        reset_llm_mock_state();
+        crate::agent_sessions::reset_session_store();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_sub_agent_propagates_nested_budget_denial() {
+        crate::agent_sessions::reset_session_store();
+        reset_llm_mock_state();
+        let _policy = push_recursion_policy(0);
+        let parent = crate::agent_sessions::open_or_create(Some("parent-budget".into()));
+        let mut options = BTreeMap::from([
+            ("provider".to_string(), VmValue::String(Rc::from("mock"))),
+            ("model".to_string(), VmValue::String(Rc::from("mock"))),
+            ("max_iterations".to_string(), VmValue::Int(1)),
+        ]);
+        annotate_nested_execution_options(
+            &mut options,
+            NestedExecutionKind::SubAgentRun,
+            "budgeted-worker",
+        );
+
+        let spec = SubAgentRunSpec {
+            name: "budgeted-worker".to_string(),
+            task: "inspect the repo".to_string(),
+            system: None,
+            options,
+            returns_schema: None,
+            session_id: "child-budget".to_string(),
+            parent_session_id: Some(parent.clone()),
+            reminder_propagation: Vec::new(),
+        };
+
+        let mut vm = crate::Vm::new();
+        crate::register_vm_stdlib(&mut vm);
+        let _vm_context = crate::vm::install_async_builtin_child_vm(vm);
+        let result = execute_sub_agent(spec).await.unwrap();
+
+        assert_eq!(result.payload["ok"].as_bool(), Some(false));
+        assert_eq!(result.payload["budget_exceeded"].as_bool(), Some(true));
+        assert_eq!(
+            result.payload["error"]["category"].as_str(),
+            Some("budget_exceeded")
+        );
+        assert!(
+            result.payload["error"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("sub_agent_run")),
+            "{:?}",
+            result.payload
+        );
+        assert!(result
+            .payload
+            .get("transcript")
+            .and_then(|transcript| transcript.get("events"))
+            .and_then(|events| events.as_array())
+            .is_some_and(|events| events
+                .iter()
+                .any(|event| event["kind"] == "nested_execution_budget_denied")));
+
+        let parent_events = crate::agent_sessions::snapshot(&parent)
+            .and_then(|value| value.as_dict().cloned())
+            .and_then(|dict| dict.get("events").cloned())
+            .and_then(|value| match value {
+                VmValue::List(list) => Some((*list).clone()),
+                _ => None,
+            })
+            .expect("parent events");
+        let result_event = parent_events
+            .iter()
+            .filter_map(|event| event.as_dict())
+            .find(|dict| {
+                dict.get("kind").map(VmValue::display).as_deref() == Some("sub_agent_result")
+            })
+            .expect("sub_agent_result event");
+        let metadata = result_event
+            .get("metadata")
+            .and_then(|value| value.as_dict())
+            .expect("event metadata");
+        assert!(matches!(metadata.get("ok"), Some(VmValue::Bool(false))));
+        assert!(matches!(
+            metadata.get("budget_exceeded"),
+            Some(VmValue::Bool(true))
+        ));
 
         reset_llm_mock_state();
         crate::agent_sessions::reset_session_store();

--- a/crates/harn-vm/src/stdlib/template/tests.rs
+++ b/crates/harn-vm/src/stdlib/template/tests.rs
@@ -609,7 +609,40 @@ fn include_cycle_detected() {
     let src = fs::read_to_string(&a).unwrap();
     let r = render_template_result(&src, None, Some(dir.path()), Some(&a));
     assert!(r.is_err());
-    assert!(r.unwrap_err().kind.contains("circular include"));
+    let kind = r.unwrap_err().kind;
+    assert!(kind.contains("circular include"));
+    assert!(kind.contains("a.prompt"), "{kind}");
+    assert!(kind.contains("b.prompt"), "{kind}");
+    assert!(kind.contains('→'), "{kind}");
+}
+
+#[test]
+fn include_depth_limit_reports_runtime_ceiling() {
+    use crate::runtime_limits::RuntimeLimits;
+    use std::fs;
+
+    let dir = tempdir();
+    let limit = RuntimeLimits::DEFAULT.max_template_include_depth;
+    for index in 0..=limit + 1 {
+        let path = dir.path().join(format!("{index}.prompt"));
+        let body = if index == limit + 1 {
+            "leaf".to_string()
+        } else {
+            format!(r#"{{{{ include "{}.prompt" }}}}"#, index + 1)
+        };
+        fs::write(path, body).unwrap();
+    }
+
+    let parent = dir.path().join("0.prompt");
+    let src = fs::read_to_string(&parent).unwrap();
+    let err = render_template_result(&src, None, Some(dir.path()), Some(&parent))
+        .expect_err("include chain should exceed the template include ceiling");
+    assert!(
+        err.kind
+            .contains(&format!("include depth exceeded ({limit} levels)")),
+        "{}",
+        err.kind
+    );
 }
 
 #[test]

--- a/crates/harn-vm/src/vm/depth_regression_tests.rs
+++ b/crates/harn-vm/src/vm/depth_regression_tests.rs
@@ -1,0 +1,178 @@
+use crate::runtime_limits::RuntimeLimits;
+use crate::stdlib::register_vm_stdlib;
+use crate::{VmError, VmValue};
+
+use super::Vm;
+
+fn execute_with_limits(source: &str, limits: RuntimeLimits) -> (Vm, Result<VmValue, VmError>) {
+    let chunk = crate::compile_source(source).expect("source compiles");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime builds");
+
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                vm.runtime_limits = limits;
+                let result = vm.execute(&chunk).await;
+                (vm, result)
+            })
+            .await
+    })
+}
+
+fn limits_with_max_frames(max_vm_frames: usize) -> RuntimeLimits {
+    RuntimeLimits {
+        max_vm_frames,
+        ..RuntimeLimits::default()
+    }
+}
+
+fn assert_stack_overflow(error: &VmError) {
+    let message = error.to_string();
+    assert!(
+        message.contains("Stack overflow: too many nested calls"),
+        "expected stack overflow, got {message}"
+    );
+}
+
+#[test]
+fn non_tail_recursion_fails_with_bounded_vm_stack_trace() {
+    let limits = limits_with_max_frames(16);
+    let (vm, result) = execute_with_limits(
+        r#"
+pipeline main() {
+  fn dive(n: int) -> int {
+    if n <= 0 {
+      return 0
+    }
+    return 1 + dive(n - 1)
+  }
+  dive(128)
+}
+"#,
+        limits,
+    );
+
+    let error = result.expect_err("non-tail recursion must hit VM frame limit");
+    assert_stack_overflow(&error);
+    assert!(
+        vm.error_stack_trace.len() <= limits.max_vm_frames,
+        "stack trace grew past VM frame limit: {:?}",
+        vm.error_stack_trace
+    );
+    assert!(
+        vm.error_stack_trace
+            .iter()
+            .any(|(name, _, _, _)| name == "dive"),
+        "stack trace should identify the recursive function: {:?}",
+        vm.error_stack_trace
+    );
+}
+
+#[test]
+fn tail_recursive_countdown_runs_beyond_frame_limit() {
+    let (vm, result) = execute_with_limits(
+        r#"
+pipeline main() {
+  fn countdown(n: int, acc: int) -> int {
+    if n <= 0 {
+      return acc
+    }
+    return countdown(n - 1, acc + 1)
+  }
+  log(countdown(200, 0))
+}
+"#,
+        limits_with_max_frames(8),
+    );
+
+    result.expect("tail recursion should reuse the current frame");
+    assert_eq!(vm.output().trim(), "[harn] 200");
+}
+
+#[test]
+fn tracked_step_tail_recursion_uses_explicit_frames() {
+    let (vm, result) = execute_with_limits(
+        r#"
+@step(name: "tracked_countdown")
+fn tracked_countdown(n: int) -> int {
+  if n <= 0 {
+    return 0
+  }
+  return tracked_countdown(n - 1)
+}
+
+pipeline main() {
+  tracked_countdown(64)
+}
+"#,
+        limits_with_max_frames(12),
+    );
+
+    let error = result.expect_err("tracked functions must preserve lifecycle frame boundaries");
+    assert_stack_overflow(&error);
+    assert!(
+        vm.error_stack_trace
+            .iter()
+            .any(|(name, _, _, _)| name == "tracked_countdown"),
+        "stack trace should identify the tracked recursive function: {:?}",
+        vm.error_stack_trace
+    );
+}
+
+#[test]
+fn callback_methods_do_not_accumulate_frames_per_item() {
+    let (vm, result) = execute_with_limits(
+        r#"
+pipeline main() {
+  let xs = range(0, 256).to_list()
+  let mapped = xs.map({ x -> x + 1 })
+  let filtered = mapped.filter({ x -> x % 64 == 0 })
+  let dict = {a: 1, b: 2, c: 3, d: 4}
+    .map_values({ v -> v + 10 })
+    .filter({ v -> v > 12 })
+  let set_out = set(xs)
+    .map({ x -> x % 11 })
+    .filter({ x -> x < 3 })
+
+  log(len(mapped))
+  log(filtered[0])
+  log(dict.count())
+  log(set_out.count())
+}
+"#,
+        limits_with_max_frames(8),
+    );
+
+    result.expect("callback-heavy collection dispatch should stay within the frame budget");
+    assert_eq!(
+        vm.output().trim(),
+        "[harn] 256\n[harn] 64\n[harn] 2\n[harn] 3"
+    );
+}
+
+#[test]
+fn recursive_callback_body_uses_same_frame_budget() {
+    let (_vm, result) = execute_with_limits(
+        r#"
+pipeline main() {
+  fn recurse(n: int) -> int {
+    if n <= 0 {
+      return 0
+    }
+    return 1 + recurse(n - 1)
+  }
+  range(0, 3).to_list().map({ x -> recurse(64) })
+}
+"#,
+        limits_with_max_frames(12),
+    );
+
+    let error = result.expect_err("recursive callback bodies should hit the VM frame budget");
+    assert_stack_overflow(&error);
+}

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -14,6 +14,8 @@ mod scope;
 mod state;
 
 #[cfg(test)]
+mod depth_regression_tests;
+#[cfg(test)]
 mod tests_debug;
 #[cfg(test)]
 mod tests_runtime;


### PR DESCRIPTION
Closes #2206

## Summary
- add VM depth regression coverage for bounded stack traces, tail recursion, tracked-step recursion, and callback frame behavior
- propagate nested execution budget denials through sub_agent_run as failed budget-exceeded results
- add schema deep-ref, template include depth/cycle, and nested agent/workflow budget conformance coverage

## Verification
- cargo test -p harn-vm depth_regression_tests -- --nocapture
- cargo test -p harn-vm schema::tests -- --nocapture
- cargo test -p harn-vm include_ -- --nocapture
- cargo test -p harn-vm execute_sub_agent_propagates_nested_budget_denial -- --nocapture
- cargo run --quiet --bin harn -- test conformance --filter nested_execution_budget_depth
- cargo run --quiet --bin harn -- fmt --check conformance/tests/agents/nested_execution_budget_depth.harn
- cargo run --quiet --bin harn -- lint conformance/tests/agents/nested_execution_budget_depth.harn
- cargo fmt --check
- git diff --check
- make lint-test-patterns
- make test
- pre-commit hooks
- pre-push hooks