### PR TITLE
Bound recursive runtime walkers

### DIFF
--- a/crates/harn-parser/src/parser/decls.rs
+++ b/crates/harn-parser/src/parser/decls.rs
@@ -327,7 +327,9 @@ impl Parser {
                     self.skip_newlines();
                     let mut args = Vec::new();
                     while !self.check(&TokenKind::RParen) {
-                        args.push(self.parse_attribute_value()?);
+                        args.push(self.with_nesting("attribute argument", |parser| {
+                            parser.parse_attribute_value()
+                        })?);
                         self.skip_newlines();
                         if self.check(&TokenKind::Comma) {
                             self.advance();
@@ -356,7 +358,9 @@ impl Parser {
                 self.skip_newlines();
                 let mut items = Vec::new();
                 while !self.check(&TokenKind::RBracket) {
-                    items.push(self.parse_attribute_value()?);
+                    items.push(self.with_nesting("attribute list item", |parser| {
+                        parser.parse_attribute_value()
+                    })?);
                     self.skip_newlines();
                     if self.check(&TokenKind::Comma) {
                         self.advance();
@@ -398,7 +402,9 @@ impl Parser {
                     };
                     self.consume(&TokenKind::Colon, ":")?;
                     self.skip_newlines();
-                    let value = self.parse_attribute_value()?;
+                    let value = self.with_nesting("attribute dict value", |parser| {
+                        parser.parse_attribute_value()
+                    })?;
                     entries.push(DictEntry { key, value });
                     self.skip_newlines();
                     if self.check(&TokenKind::Comma) {

--- a/crates/harn-parser/src/parser/expressions.rs
+++ b/crates/harn-parser/src/parser/expressions.rs
@@ -7,8 +7,16 @@ use super::state::Parser;
 impl Parser {
     /// Parse a single expression (for string interpolation).
     pub fn parse_single_expression(&mut self) -> Result<SNode, ParserError> {
+        self.check_token_nesting_limit()?;
         self.skip_newlines();
         self.parse_expression()
+    }
+
+    pub(super) fn parse_nested_expression(
+        &mut self,
+        context: &'static str,
+    ) -> Result<SNode, ParserError> {
+        self.with_nesting(context, |parser| parser.parse_expression())
     }
 
     pub(super) fn parse_expression(&mut self) -> Result<SNode, ParserError> {
@@ -71,11 +79,11 @@ impl Parser {
         let start = condition.span;
         self.advance(); // skip ?
         self.skip_newlines();
-        let true_val = self.parse_ternary()?;
+        let true_val = self.with_nesting("ternary expression", |parser| parser.parse_ternary())?;
         // `consume` already skips leading newlines for `:`.
         self.consume(&TokenKind::Colon, ":")?;
         self.skip_newlines();
-        let false_val = self.parse_ternary()?;
+        let false_val = self.with_nesting("ternary expression", |parser| parser.parse_ternary())?;
         Ok(spanned(
             Node::Ternary {
                 condition: Box::new(condition),
@@ -299,7 +307,7 @@ impl Parser {
         let start = left.span;
         self.advance();
         self.skip_newlines();
-        let right = self.parse_exponent()?;
+        let right = self.with_nesting("exponent expression", |parser| parser.parse_exponent())?;
         Ok(spanned(
             Node::BinaryOp {
                 op: "**".into(),
@@ -314,7 +322,7 @@ impl Parser {
         if self.check(&TokenKind::Not) {
             let start = self.current_span();
             self.advance();
-            let operand = self.parse_unary()?;
+            let operand = self.with_nesting("unary expression", |parser| parser.parse_unary())?;
             return Ok(spanned(
                 Node::UnaryOp {
                     op: "!".into(),
@@ -326,7 +334,7 @@ impl Parser {
         if self.check(&TokenKind::Minus) {
             let start = self.current_span();
             self.advance();
-            let operand = self.parse_unary()?;
+            let operand = self.with_nesting("unary expression", |parser| parser.parse_unary())?;
             return Ok(spanned(
                 Node::UnaryOp {
                     op: "-".into(),
@@ -400,7 +408,7 @@ impl Parser {
                     let end_expr = if self.check(&TokenKind::RBracket) {
                         None
                     } else {
-                        Some(Box::new(self.parse_expression()?))
+                        Some(Box::new(self.parse_nested_expression("slice bound")?))
                     };
                     self.consume(&TokenKind::RBracket, "]")?;
                     expr = spanned(
@@ -412,13 +420,13 @@ impl Parser {
                         Span::merge(start, self.prev_span()),
                     );
                 } else {
-                    let index = self.parse_expression()?;
+                    let index = self.parse_nested_expression("subscript index")?;
                     if self.check(&TokenKind::Colon) {
                         self.advance();
                         let end_expr = if self.check(&TokenKind::RBracket) {
                             None
                         } else {
-                            Some(Box::new(self.parse_expression()?))
+                            Some(Box::new(self.parse_nested_expression("slice bound")?))
                         };
                         self.consume(&TokenKind::RBracket, "]")?;
                         expr = spanned(
@@ -517,7 +525,7 @@ impl Parser {
                     let start = expr.span;
                     self.advance(); // consume ?
                     self.advance(); // consume [
-                    let index = self.parse_expression()?;
+                    let index = self.parse_nested_expression("optional subscript index")?;
                     self.consume(&TokenKind::RBracket, "]")?;
                     expr = spanned(
                         Node::OptionalSubscriptAccess {
@@ -756,8 +764,11 @@ impl Parser {
             }
             TokenKind::LParen => {
                 self.advance();
-                let expr = self.parse_expression()?;
-                self.consume(&TokenKind::RParen, ")")?;
+                let expr = self.with_nesting("parenthesized expression", |parser| {
+                    let expr = parser.parse_expression()?;
+                    parser.consume(&TokenKind::RParen, ")")?;
+                    Ok(expr)
+                })?;
                 Ok(expr)
             }
             TokenKind::LBracket => self.parse_list_literal(),
@@ -878,10 +889,10 @@ impl Parser {
                 self.advance();
                 self.consume(&TokenKind::Colon, ":")?;
                 self.skip_newlines();
-                let value = self.parse_expression()?;
+                let value = self.parse_nested_expression("HITL argument")?;
                 (Some(raw), value)
             } else {
-                (None, self.parse_expression()?)
+                (None, self.parse_nested_expression("HITL argument")?)
             };
             let arg_span = Span::merge(arg_start, self.prev_span());
             args.push(HitlArg {
@@ -920,17 +931,17 @@ impl Parser {
                     self.advance();
                     self.consume(&TokenKind::Dot, ".")?;
                     let spread_start = self.tokens[saved_pos].span;
-                    let expr = self.parse_expression()?;
+                    let expr = self.parse_nested_expression("list spread")?;
                     elements.push(spanned(
                         Node::Spread(Box::new(expr)),
                         Span::merge(spread_start, self.prev_span()),
                     ));
                 } else {
                     self.pos = saved_pos;
-                    elements.push(self.parse_expression()?);
+                    elements.push(self.parse_nested_expression("list element")?);
                 }
             } else {
-                elements.push(self.parse_expression()?);
+                elements.push(self.parse_nested_expression("list element")?);
             }
             self.skip_newlines();
             if self.check(&TokenKind::Comma) {
@@ -1064,7 +1075,7 @@ impl Parser {
                     if self.check(&TokenKind::Dot) {
                         self.advance();
                         let spread_start = self.tokens[saved_pos].span;
-                        let expr = self.parse_expression()?;
+                        let expr = self.parse_nested_expression("dict spread")?;
                         entries.push(DictEntry {
                             key: spanned(Node::NilLiteral, spread_start),
                             value: spanned(
@@ -1086,7 +1097,7 @@ impl Parser {
             }
             let key = if self.check(&TokenKind::LBracket) {
                 self.advance();
-                let k = self.parse_expression()?;
+                let k = self.parse_nested_expression("computed dict key")?;
                 self.consume(&TokenKind::RBracket, "]")?;
                 k
             } else if matches!(
@@ -1108,7 +1119,7 @@ impl Parser {
                 spanned(Node::StringLiteral(name), key_span)
             };
             self.consume(&TokenKind::Colon, ":")?;
-            let value = self.parse_expression()?;
+            let value = self.parse_nested_expression("dict value")?;
             entries.push(DictEntry { key, value });
             self.skip_newlines();
             if self.check(&TokenKind::Comma) {
@@ -1182,7 +1193,7 @@ impl Parser {
             let default_value = if self.check(&TokenKind::Assign) {
                 self.advance();
                 seen_default = true;
-                Some(Box::new(self.parse_expression()?))
+                Some(Box::new(self.parse_nested_expression("parameter default")?))
             } else {
                 if seen_default && !is_rest {
                     return Err(self.error(
@@ -1227,17 +1238,17 @@ impl Parser {
                     self.advance();
                     self.consume(&TokenKind::Dot, ".")?;
                     let spread_start = self.tokens[saved_pos].span;
-                    let expr = self.parse_expression()?;
+                    let expr = self.parse_nested_expression("spread argument")?;
                     args.push(spanned(
                         Node::Spread(Box::new(expr)),
                         Span::merge(spread_start, self.prev_span()),
                     ));
                 } else {
                     self.pos = saved_pos;
-                    args.push(self.parse_expression()?);
+                    args.push(self.parse_nested_expression("argument")?);
                 }
             } else {
-                args.push(self.parse_expression()?);
+                args.push(self.parse_nested_expression("argument")?);
             }
             self.skip_newlines();
             if self.check(&TokenKind::Comma) {

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -23,6 +23,83 @@ mod tests {
     }
 
     #[test]
+    fn parser_reports_expression_nesting_depth_limit() {
+        let depth = state::MAX_NESTING_DEPTH + 1;
+        let source = format!("let x = {}0{}", "(".repeat(depth), ")".repeat(depth));
+
+        let Err(err) = parse_source(&source) else {
+            panic!("expected parser depth limit");
+        };
+        let message = err.to_string();
+
+        assert!(message.contains("parser nesting depth within"));
+        assert!(message.contains(&format!("{} levels", state::MAX_NESTING_DEPTH)));
+    }
+
+    #[test]
+    fn parser_reports_unary_nesting_depth_limit() {
+        let depth = state::MAX_NESTING_DEPTH + 1;
+        let source = format!("let x = {}true", "!".repeat(depth));
+
+        let Err(err) = parse_source(&source) else {
+            panic!("expected parser depth limit");
+        };
+        let message = err.to_string();
+
+        assert!(message.contains("parser nesting depth within"));
+        assert!(message.contains(&format!("{} levels", state::MAX_NESTING_DEPTH)));
+    }
+
+    #[test]
+    fn parser_reports_block_nesting_depth_limit() {
+        let depth = state::MAX_NESTING_DEPTH + 1;
+        let mut source = String::new();
+        for _ in 0..depth {
+            source.push_str("if true {\n");
+        }
+        source.push_str("let x = 1\n");
+        for _ in 0..depth {
+            source.push_str("}\n");
+        }
+
+        let Err(err) = parse_source(&source) else {
+            panic!("expected parser depth limit");
+        };
+        let message = err.to_string();
+
+        assert!(message.contains("parser nesting depth within"));
+        assert!(message.contains(&format!("{} levels", state::MAX_NESTING_DEPTH)));
+    }
+
+    #[test]
+    fn parser_reports_list_literal_nesting_depth_limit() {
+        let depth = state::MAX_NESTING_DEPTH + 1;
+        let source = format!("let x = {}0{}", "[".repeat(depth), "]".repeat(depth));
+
+        let Err(err) = parse_source(&source) else {
+            panic!("expected parser depth limit");
+        };
+        let message = err.to_string();
+
+        assert!(message.contains("parser nesting depth within"));
+        assert!(message.contains(&format!("{} levels", state::MAX_NESTING_DEPTH)));
+    }
+
+    #[test]
+    fn parser_reports_type_nesting_depth_limit() {
+        let depth = state::MAX_NESTING_DEPTH + 1;
+        let source = format!("let x: {}int{} = []", "[".repeat(depth), "]".repeat(depth));
+
+        let Err(err) = parse_source(&source) else {
+            panic!("expected parser depth limit");
+        };
+        let message = err.to_string();
+
+        assert!(message.contains("parser nesting depth within"));
+        assert!(message.contains(&format!("{} levels", state::MAX_NESTING_DEPTH)));
+    }
+
+    #[test]
     fn parses_scoped_selective_import_as_slash_path() {
         let nodes =
             parse_source("pub import std::personas::prelude::{verify_then_act, bounded_loop}")

--- a/crates/harn-parser/src/parser/patterns.rs
+++ b/crates/harn-parser/src/parser/patterns.rs
@@ -36,7 +36,9 @@ impl Parser {
                 };
                 let default_value = if self.check(&TokenKind::Assign) {
                     self.advance();
-                    Some(Box::new(self.parse_expression()?))
+                    Some(Box::new(
+                        self.parse_nested_expression("binding pattern default")?,
+                    ))
                 } else {
                     None
                 };
@@ -71,7 +73,9 @@ impl Parser {
                 let name = self.consume_identifier("element name")?;
                 let default_value = if self.check(&TokenKind::Assign) {
                     self.advance();
-                    Some(Box::new(self.parse_expression()?))
+                    Some(Box::new(
+                        self.parse_nested_expression("binding pattern default")?,
+                    ))
                 } else {
                     None
                 };

--- a/crates/harn-parser/src/parser/state.rs
+++ b/crates/harn-parser/src/parser/state.rs
@@ -3,11 +3,14 @@ use harn_lexer::{Span, Token, TokenKind};
 
 use super::error::ParserError;
 
+pub(crate) const MAX_NESTING_DEPTH: usize = 64;
+
 /// Recursive descent parser for Harn.
 pub struct Parser {
     pub(super) tokens: Vec<Token>,
     pub(super) pos: usize,
     pub(super) errors: Vec<ParserError>,
+    nesting_depth: usize,
 }
 
 impl Parser {
@@ -16,7 +19,33 @@ impl Parser {
             tokens,
             pos: 0,
             errors: Vec::new(),
+            nesting_depth: 0,
         }
+    }
+
+    pub(super) fn check_token_nesting_limit(&self) -> Result<(), ParserError> {
+        let mut depth = 0usize;
+        for token in &self.tokens {
+            match token.kind {
+                TokenKind::LBrace | TokenKind::LBracket | TokenKind::LParen => {
+                    depth += 1;
+                    if depth > MAX_NESTING_DEPTH {
+                        return Err(ParserError::Unexpected {
+                            got: "source nesting depth exceeded".to_string(),
+                            expected: format!(
+                                "parser nesting depth within {MAX_NESTING_DEPTH} levels"
+                            ),
+                            span: token.span,
+                        });
+                    }
+                }
+                TokenKind::RBrace | TokenKind::RBracket | TokenKind::RParen => {
+                    depth = depth.saturating_sub(1);
+                }
+                _ => {}
+            }
+        }
+        Ok(())
     }
 
     pub(super) fn current_span(&self) -> Span {
@@ -58,6 +87,8 @@ impl Parser {
 
     /// Parse a complete .harn file. Reports multiple errors via recovery.
     pub fn parse(&mut self) -> Result<Vec<SNode>, ParserError> {
+        self.check_token_nesting_limit()?;
+
         let mut nodes = Vec::new();
         self.skip_newlines();
 
@@ -424,5 +455,23 @@ impl Parser {
 
     pub(super) fn error(&self, expected: &str) -> ParserError {
         self.make_error(expected)
+    }
+
+    pub(super) fn with_nesting<T>(
+        &mut self,
+        context: &'static str,
+        f: impl FnOnce(&mut Self) -> Result<T, ParserError>,
+    ) -> Result<T, ParserError> {
+        if self.nesting_depth >= MAX_NESTING_DEPTH {
+            return Err(ParserError::Unexpected {
+                got: format!("{context} nesting depth exceeded"),
+                expected: format!("parser nesting depth within {MAX_NESTING_DEPTH} levels"),
+                span: self.current_span(),
+            });
+        }
+        self.nesting_depth += 1;
+        let result = f(self);
+        self.nesting_depth = self.nesting_depth.saturating_sub(1);
+        result
     }
 }

--- a/crates/harn-parser/src/parser/statements.rs
+++ b/crates/harn-parser/src/parser/statements.rs
@@ -6,6 +6,10 @@ use super::state::Parser;
 
 impl Parser {
     pub(super) fn parse_block(&mut self) -> Result<Vec<SNode>, ParserError> {
+        self.with_nesting("block", |parser| parser.parse_block_inner())
+    }
+
+    fn parse_block_inner(&mut self) -> Result<Vec<SNode>, ParserError> {
         let mut stmts = Vec::new();
         self.skip_newlines();
 
@@ -195,7 +199,9 @@ impl Parser {
         let else_body = if self.check(&TokenKind::Else) {
             self.advance();
             if self.check(&TokenKind::If) {
-                Some(vec![self.parse_if_else()?])
+                Some(vec![
+                    self.with_nesting("if/else", |parser| parser.parse_if_else())?
+                ])
             } else {
                 self.consume(&TokenKind::LBrace, "{")?;
                 let body = self.parse_block()?;

--- a/crates/harn-parser/src/parser/types.rs
+++ b/crates/harn-parser/src/parser/types.rs
@@ -5,6 +5,13 @@ use super::error::ParserError;
 use super::state::Parser;
 
 impl Parser {
+    pub(super) fn parse_nested_type_expr(
+        &mut self,
+        context: &'static str,
+    ) -> Result<TypeExpr, ParserError> {
+        self.with_nesting(context, |parser| parser.parse_type_expr())
+    }
+
     /// Parse a comma-separated list of type parameters until `>`.
     ///
     /// Each parameter may be prefixed with a variance marker:
@@ -34,7 +41,7 @@ impl Parser {
             return Err(self.error("type argument"));
         }
         while !self.is_at_end() && !self.check(&TokenKind::Gt) {
-            args.push(self.parse_type_expr()?);
+            args.push(self.parse_nested_type_expr("type argument")?);
             self.skip_newlines();
             if self.check(&TokenKind::Comma) {
                 self.advance();
@@ -176,7 +183,7 @@ impl Parser {
         }
         if self.check(&TokenKind::LBracket) {
             self.advance();
-            let inner = self.parse_type_expr()?;
+            let inner = self.parse_nested_type_expr("list type")?;
             self.consume(&TokenKind::RBracket, "]")?;
             return Ok(TypeExpr::List(Box::new(inner)));
         }
@@ -218,7 +225,7 @@ impl Parser {
             let mut params = Vec::new();
             self.skip_newlines();
             while !self.is_at_end() && !self.check(&TokenKind::RParen) {
-                params.push(self.parse_type_expr()?);
+                params.push(self.parse_nested_type_expr("function parameter type")?);
                 self.skip_newlines();
                 if self.check(&TokenKind::Comma) {
                     self.advance();
@@ -227,7 +234,7 @@ impl Parser {
             }
             self.consume(&TokenKind::RParen, ")")?;
             self.consume(&TokenKind::Arrow, "->")?;
-            let return_type = self.parse_type_expr()?;
+            let return_type = self.parse_nested_type_expr("function return type")?;
             return Ok(TypeExpr::FnType {
                 params,
                 return_type: Box::new(return_type),
@@ -282,7 +289,7 @@ impl Parser {
                 false
             };
             self.consume(&TokenKind::Colon, ":")?;
-            let type_expr = self.parse_type_expr()?;
+            let type_expr = self.parse_nested_type_expr("shape field type")?;
             fields.push(ShapeField {
                 name,
                 type_expr,

--- a/crates/harn-parser/src/visit.rs
+++ b/crates/harn-parser/src/visit.rs
@@ -3,7 +3,7 @@
 //!
 //! Centralizing this here keeps a single source of truth for which
 //! children each `Node` variant has — adding a new variant requires
-//! one edit (in [`walk_children`]) and every consumer benefits.
+//! one edit (in `collect_children`) and every consumer benefits.
 //!
 //! # Usage
 //!
@@ -26,39 +26,62 @@ use crate::ast::{BindingPattern, DictEntry, MatchArm, Node, SNode, SelectCase};
 /// Walk every node in `program` in pre-order, invoking `visitor` on
 /// each.
 pub fn walk_program(program: &[SNode], visitor: &mut impl FnMut(&SNode)) {
-    for node in program {
-        walk_node(node, visitor);
-    }
+    let mut stack = Vec::with_capacity(program.len());
+    push_nodes_reversed(program, &mut stack);
+    walk_stack(&mut stack, visitor);
 }
 
 /// Visit `node`, then recurse into its children.
 pub fn walk_node(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
-    visitor(node);
-    walk_children(node, visitor);
+    let mut stack = vec![node];
+    walk_stack(&mut stack, visitor);
 }
 
 /// Recurse into `node`'s children without re-visiting `node` itself.
 /// Useful when a caller wants to handle the parent specially and then
 /// continue the default traversal.
 pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
+    let mut stack = Vec::new();
+    push_children_reversed(node, &mut stack);
+    walk_stack(&mut stack, visitor);
+}
+
+fn walk_stack(stack: &mut Vec<&SNode>, visitor: &mut impl FnMut(&SNode)) {
+    while let Some(node) = stack.pop() {
+        visitor(node);
+        push_children_reversed(node, stack);
+    }
+}
+
+fn push_children_reversed<'a>(node: &'a SNode, stack: &mut Vec<&'a SNode>) {
+    let mut children = Vec::new();
+    collect_children(node, &mut children);
+    stack.extend(children.into_iter().rev());
+}
+
+fn push_nodes_reversed<'a>(nodes: &'a [SNode], stack: &mut Vec<&'a SNode>) {
+    stack.extend(nodes.iter().rev());
+}
+
+fn collect_children<'a>(node: &'a SNode, children: &mut Vec<&'a SNode>) {
     match &node.node {
         Node::AttributedDecl { attributes, inner } => {
             for attr in attributes {
                 for arg in &attr.args {
-                    walk_node(&arg.value, visitor);
+                    children.push(&arg.value);
                 }
             }
-            walk_node(inner, visitor);
+            children.push(inner);
         }
         Node::Pipeline { body, .. } | Node::OverrideDecl { body, .. } => {
-            walk_nodes(body, visitor);
+            collect_nodes(body, children);
         }
         Node::LetBinding { pattern, value, .. } | Node::VarBinding { pattern, value, .. } => {
-            walk_binding_pattern(pattern, visitor);
-            walk_node(value, visitor);
+            collect_binding_pattern(pattern, children);
+            children.push(value);
         }
         Node::ConstBinding { value, .. } => {
-            walk_node(value, visitor);
+            children.push(value);
         }
         Node::EnumDecl { .. }
         | Node::StructDecl { .. }
@@ -68,16 +91,16 @@ pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
         | Node::TypeDecl { .. }
         | Node::BreakStmt
         | Node::ContinueStmt => {}
-        Node::ImplBlock { methods, .. } => walk_nodes(methods, visitor),
+        Node::ImplBlock { methods, .. } => collect_nodes(methods, children),
         Node::IfElse {
             condition,
             then_body,
             else_body,
         } => {
-            walk_node(condition, visitor);
-            walk_nodes(then_body, visitor);
+            children.push(condition);
+            collect_nodes(then_body, children);
             if let Some(body) = else_body {
-                walk_nodes(body, visitor);
+                collect_nodes(body, children);
             }
         }
         Node::ForIn {
@@ -85,31 +108,31 @@ pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
             iterable,
             body,
         } => {
-            walk_binding_pattern(pattern, visitor);
-            walk_node(iterable, visitor);
-            walk_nodes(body, visitor);
+            collect_binding_pattern(pattern, children);
+            children.push(iterable);
+            collect_nodes(body, children);
         }
         Node::MatchExpr { value, arms } => {
-            walk_node(value, visitor);
+            children.push(value);
             for arm in arms {
-                walk_match_arm(arm, visitor);
+                collect_match_arm(arm, children);
             }
         }
         Node::WhileLoop { condition, body } => {
-            walk_node(condition, visitor);
-            walk_nodes(body, visitor);
+            children.push(condition);
+            collect_nodes(body, children);
         }
         Node::Retry { count, body } => {
-            walk_node(count, visitor);
-            walk_nodes(body, visitor);
+            children.push(count);
+            collect_nodes(body, children);
         }
         Node::CostRoute { options, body } => {
-            walk_option_values(options, visitor);
-            walk_nodes(body, visitor);
+            collect_option_values(options, children);
+            collect_nodes(body, children);
         }
         Node::ReturnStmt { value } | Node::YieldExpr { value } => {
             if let Some(value) = value {
-                walk_node(value, visitor);
+                children.push(value);
             }
         }
         Node::TryCatch {
@@ -119,10 +142,10 @@ pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
             finally_body,
             ..
         } => {
-            walk_nodes(body, visitor);
-            walk_nodes(catch_body, visitor);
+            collect_nodes(body, children);
+            collect_nodes(catch_body, children);
             if let Some(body) = finally_body {
-                walk_nodes(body, visitor);
+                collect_nodes(body, children);
             }
         }
         Node::TryExpr { body }
@@ -130,53 +153,53 @@ pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
         | Node::DeferStmt { body }
         | Node::MutexBlock { body }
         | Node::Block(body)
-        | Node::Closure { body, .. } => walk_nodes(body, visitor),
+        | Node::Closure { body, .. } => collect_nodes(body, children),
         Node::FnDecl { body, .. } | Node::ToolDecl { body, .. } => {
-            walk_nodes(body, visitor);
+            collect_nodes(body, children);
         }
-        Node::SkillDecl { fields, .. } => walk_field_values(fields, visitor),
+        Node::SkillDecl { fields, .. } => collect_field_values(fields, children),
         Node::EvalPackDecl {
             fields,
             body,
             summarize,
             ..
         } => {
-            walk_field_values(fields, visitor);
-            walk_nodes(body, visitor);
+            collect_field_values(fields, children);
+            collect_nodes(body, children);
             if let Some(body) = summarize {
-                walk_nodes(body, visitor);
+                collect_nodes(body, children);
             }
         }
         Node::RangeExpr { start, end, .. } => {
-            walk_node(start, visitor);
-            walk_node(end, visitor);
+            children.push(start);
+            children.push(end);
         }
         Node::GuardStmt {
             condition,
             else_body,
         } => {
-            walk_node(condition, visitor);
-            walk_nodes(else_body, visitor);
+            children.push(condition);
+            collect_nodes(else_body, children);
         }
         Node::RequireStmt { condition, message } => {
-            walk_node(condition, visitor);
+            children.push(condition);
             if let Some(message) = message {
-                walk_node(message, visitor);
+                children.push(message);
             }
         }
         Node::DeadlineBlock { duration, body } => {
-            walk_node(duration, visitor);
-            walk_nodes(body, visitor);
+            children.push(duration);
+            collect_nodes(body, children);
         }
         Node::EmitExpr { value }
         | Node::ThrowStmt { value }
         | Node::Spread(value)
         | Node::TryOperator { operand: value }
         | Node::TryStar { operand: value }
-        | Node::UnaryOp { operand: value, .. } => walk_node(value, visitor),
+        | Node::UnaryOp { operand: value, .. } => children.push(value),
         Node::HitlExpr { args, .. } => {
             for arg in args {
-                walk_node(&arg.value, visitor);
+                children.push(&arg.value);
             }
         }
         Node::Parallel {
@@ -185,9 +208,9 @@ pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
             options,
             ..
         } => {
-            walk_node(expr, visitor);
-            walk_option_values(options, visitor);
-            walk_nodes(body, visitor);
+            children.push(expr);
+            collect_option_values(options, children);
+            collect_nodes(body, children);
         }
         Node::SelectExpr {
             cases,
@@ -195,61 +218,61 @@ pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
             default_body,
         } => {
             for case in cases {
-                walk_select_case(case, visitor);
+                collect_select_case(case, children);
             }
             if let Some((duration, body)) = timeout {
-                walk_node(duration, visitor);
-                walk_nodes(body, visitor);
+                children.push(duration);
+                collect_nodes(body, children);
             }
             if let Some(body) = default_body {
-                walk_nodes(body, visitor);
+                collect_nodes(body, children);
             }
         }
         Node::FunctionCall { args, .. } | Node::EnumConstruct { args, .. } => {
-            walk_nodes(args, visitor);
+            collect_nodes(args, children);
         }
         Node::MethodCall { object, args, .. } | Node::OptionalMethodCall { object, args, .. } => {
-            walk_node(object, visitor);
-            walk_nodes(args, visitor);
+            children.push(object);
+            collect_nodes(args, children);
         }
         Node::PropertyAccess { object, .. } | Node::OptionalPropertyAccess { object, .. } => {
-            walk_node(object, visitor);
+            children.push(object);
         }
         Node::SubscriptAccess { object, index }
         | Node::OptionalSubscriptAccess { object, index } => {
-            walk_node(object, visitor);
-            walk_node(index, visitor);
+            children.push(object);
+            children.push(index);
         }
         Node::SliceAccess { object, start, end } => {
-            walk_node(object, visitor);
+            children.push(object);
             if let Some(start) = start {
-                walk_node(start, visitor);
+                children.push(start);
             }
             if let Some(end) = end {
-                walk_node(end, visitor);
+                children.push(end);
             }
         }
         Node::BinaryOp { left, right, .. } => {
-            walk_node(left, visitor);
-            walk_node(right, visitor);
+            children.push(left);
+            children.push(right);
         }
         Node::Ternary {
             condition,
             true_expr,
             false_expr,
         } => {
-            walk_node(condition, visitor);
-            walk_node(true_expr, visitor);
-            walk_node(false_expr, visitor);
+            children.push(condition);
+            children.push(true_expr);
+            children.push(false_expr);
         }
         Node::Assignment { target, value, .. } => {
-            walk_node(target, visitor);
-            walk_node(value, visitor);
+            children.push(target);
+            children.push(value);
         }
         Node::StructConstruct { fields, .. } | Node::DictLiteral(fields) => {
-            walk_dict_entries(fields, visitor);
+            collect_dict_entries(fields, children);
         }
-        Node::ListLiteral(items) | Node::OrPattern(items) => walk_nodes(items, visitor),
+        Node::ListLiteral(items) | Node::OrPattern(items) => collect_nodes(items, children),
         Node::InterpolatedString(_)
         | Node::StringLiteral(_)
         | Node::RawStringLiteral(_)
@@ -262,60 +285,111 @@ pub fn walk_children(node: &SNode, visitor: &mut impl FnMut(&SNode)) {
     }
 }
 
-fn walk_nodes(nodes: &[SNode], visitor: &mut impl FnMut(&SNode)) {
-    for node in nodes {
-        walk_node(node, visitor);
-    }
+fn collect_nodes<'a>(nodes: &'a [SNode], children: &mut Vec<&'a SNode>) {
+    children.extend(nodes.iter());
 }
 
-fn walk_dict_entries(entries: &[DictEntry], visitor: &mut impl FnMut(&SNode)) {
+fn collect_dict_entries<'a>(entries: &'a [DictEntry], children: &mut Vec<&'a SNode>) {
     for entry in entries {
-        walk_node(&entry.key, visitor);
-        walk_node(&entry.value, visitor);
+        children.push(&entry.key);
+        children.push(&entry.value);
     }
 }
 
-fn walk_field_values(fields: &[(String, SNode)], visitor: &mut impl FnMut(&SNode)) {
+fn collect_field_values<'a>(fields: &'a [(String, SNode)], children: &mut Vec<&'a SNode>) {
     for (_, value) in fields {
-        walk_node(value, visitor);
+        children.push(value);
     }
 }
 
-fn walk_option_values(options: &[(String, SNode)], visitor: &mut impl FnMut(&SNode)) {
+fn collect_option_values<'a>(options: &'a [(String, SNode)], children: &mut Vec<&'a SNode>) {
     for (_, value) in options {
-        walk_node(value, visitor);
+        children.push(value);
     }
 }
 
-fn walk_match_arm(arm: &MatchArm, visitor: &mut impl FnMut(&SNode)) {
-    walk_node(&arm.pattern, visitor);
+fn collect_match_arm<'a>(arm: &'a MatchArm, children: &mut Vec<&'a SNode>) {
+    children.push(&arm.pattern);
     if let Some(guard) = &arm.guard {
-        walk_node(guard, visitor);
+        children.push(guard);
     }
-    walk_nodes(&arm.body, visitor);
+    collect_nodes(&arm.body, children);
 }
 
-fn walk_select_case(case: &SelectCase, visitor: &mut impl FnMut(&SNode)) {
-    walk_node(&case.channel, visitor);
-    walk_nodes(&case.body, visitor);
+fn collect_select_case<'a>(case: &'a SelectCase, children: &mut Vec<&'a SNode>) {
+    children.push(&case.channel);
+    collect_nodes(&case.body, children);
 }
 
-fn walk_binding_pattern(pattern: &BindingPattern, visitor: &mut impl FnMut(&SNode)) {
+fn collect_binding_pattern<'a>(pattern: &'a BindingPattern, children: &mut Vec<&'a SNode>) {
     match pattern {
         BindingPattern::Identifier(_) | BindingPattern::Pair(_, _) => {}
         BindingPattern::Dict(fields) => {
             for field in fields {
                 if let Some(default) = &field.default_value {
-                    walk_node(default, visitor);
+                    children.push(default);
                 }
             }
         }
         BindingPattern::List(items) => {
             for item in items {
                 if let Some(default) = &item.default_value {
-                    walk_node(default, visitor);
+                    children.push(default);
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{spanned, Node};
+    use harn_lexer::Span;
+
+    fn dummy(node: Node) -> SNode {
+        spanned(node, Span::dummy())
+    }
+
+    #[test]
+    fn walk_program_preserves_preorder() {
+        let program = vec![dummy(Node::LetBinding {
+            pattern: BindingPattern::Identifier("x".to_string()),
+            type_ann: None,
+            value: Box::new(dummy(Node::BinaryOp {
+                op: "+".to_string(),
+                left: Box::new(dummy(Node::IntLiteral(1))),
+                right: Box::new(dummy(Node::IntLiteral(2))),
+            })),
+        })];
+        let mut seen = Vec::new();
+
+        walk_program(&program, &mut |node| {
+            seen.push(match &node.node {
+                Node::LetBinding { .. } => "let",
+                Node::BinaryOp { .. } => "binary",
+                Node::IntLiteral(1) => "one",
+                Node::IntLiteral(2) => "two",
+                other => panic!("unexpected node {other:?}"),
+            });
+        });
+
+        assert_eq!(seen, vec!["let", "binary", "one", "two"]);
+    }
+
+    #[test]
+    fn walk_node_handles_deep_unary_chain_iteratively() {
+        let mut node = dummy(Node::IntLiteral(0));
+        for _ in 0..10_000 {
+            node = dummy(Node::UnaryOp {
+                op: "!".to_string(),
+                operand: Box::new(node),
+            });
+        }
+
+        let mut count = 0usize;
+        walk_node(&node, &mut |_| count += 1);
+
+        assert_eq!(count, 10_001);
     }
 }

--- a/crates/harn-vm/src/runtime_limits.rs
+++ b/crates/harn-vm/src/runtime_limits.rs
@@ -37,6 +37,12 @@ pub struct RuntimeLimits {
     pub max_agent_sessions: usize,
     /// Maximum directory descent for project fingerprint discovery.
     pub max_project_fingerprint_depth: usize,
+    /// Maximum nested runtime shape-spec validation depth.
+    pub max_shape_validation_depth: usize,
+    /// Maximum nested YAML depth walked while extracting project enrichment hints.
+    pub max_project_enrich_yaml_depth: usize,
+    /// Maximum nested prompt-template AST/expression depth.
+    pub max_template_ast_depth: usize,
     /// Maximum collection items the compiler may materialize while folding constants.
     pub max_constant_folded_collection_items: usize,
     /// Maximum string bytes the compiler may materialize while folding constants.
@@ -67,6 +73,9 @@ impl RuntimeLimits {
         default_event_log_queue_depth: 128,
         max_agent_sessions: 128,
         max_project_fingerprint_depth: 4,
+        max_shape_validation_depth: 64,
+        max_project_enrich_yaml_depth: 128,
+        max_template_ast_depth: 128,
         max_constant_folded_collection_items: 4_096,
         max_constant_folded_string_bytes: 64 * 1024,
         max_nested_execution_depth: 8,
@@ -91,6 +100,9 @@ impl RuntimeLimits {
             "default_event_log_queue_depth" => self.default_event_log_queue_depth,
             "max_agent_sessions" => self.max_agent_sessions,
             "max_project_fingerprint_depth" => self.max_project_fingerprint_depth,
+            "max_shape_validation_depth" => self.max_shape_validation_depth,
+            "max_project_enrich_yaml_depth" => self.max_project_enrich_yaml_depth,
+            "max_template_ast_depth" => self.max_template_ast_depth,
             "max_constant_folded_collection_items" => self.max_constant_folded_collection_items,
             "max_constant_folded_string_bytes" => self.max_constant_folded_string_bytes,
             "max_nested_execution_depth" => self.max_nested_execution_depth,
@@ -231,6 +243,24 @@ pub const RUNTIME_LIMIT_DESCRIPTIONS: &[RuntimeLimitDescription] = &[
         protects: "bounds project fingerprint discovery in large or adversarial directory trees",
     },
     RuntimeLimitDescription {
+        name: "max_shape_validation_depth",
+        user_visible: true,
+        host_configurable: false,
+        protects: "bounds runtime shape validation for nested dicts and structs",
+    },
+    RuntimeLimitDescription {
+        name: "max_project_enrich_yaml_depth",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds project enrichment traversal of nested hook YAML",
+    },
+    RuntimeLimitDescription {
+        name: "max_template_ast_depth",
+        user_visible: true,
+        host_configurable: false,
+        protects: "bounds nested prompt-template control structures and expressions",
+    },
+    RuntimeLimitDescription {
         name: "max_constant_folded_collection_items",
         user_visible: false,
         host_configurable: false,
@@ -288,6 +318,9 @@ mod tests {
         assert_eq!(limits.default_event_log_queue_depth, 128);
         assert_eq!(limits.max_agent_sessions, 128);
         assert_eq!(limits.max_project_fingerprint_depth, 4);
+        assert_eq!(limits.max_shape_validation_depth, 64);
+        assert_eq!(limits.max_project_enrich_yaml_depth, 128);
+        assert_eq!(limits.max_template_ast_depth, 128);
         assert_eq!(limits.max_constant_folded_collection_items, 4_096);
         assert_eq!(limits.max_constant_folded_string_bytes, 64 * 1024);
         assert_eq!(limits.max_nested_execution_depth, 8);
@@ -320,6 +353,9 @@ mod tests {
                 "default_event_log_queue_depth",
                 "max_agent_sessions",
                 "max_project_fingerprint_depth",
+                "max_shape_validation_depth",
+                "max_project_enrich_yaml_depth",
+                "max_template_ast_depth",
                 "max_constant_folded_collection_items",
                 "max_constant_folded_string_bytes",
                 "max_nested_execution_depth",

--- a/crates/harn-vm/src/stdlib/project_enrich.rs
+++ b/crates/harn-vm/src/stdlib/project_enrich.rs
@@ -8,6 +8,7 @@ use serde_yaml::Value as YamlValue;
 use sha2::{Digest, Sha256};
 
 use crate::llm::{execute_llm_call, extract_llm_options, vm_value_to_json};
+use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::json_to_vm_value;
 use crate::value::{ErrorCategory, VmError, VmValue};
 use crate::vm::Vm;
@@ -33,6 +34,7 @@ const MAX_SOURCE_FILES: usize = 8;
 const MAX_FILE_CHARS: usize = 4_000;
 const MAX_TOTAL_CONTEXT_CHARS: usize = 24_000;
 const DEFAULT_BUDGET_TOKENS: i64 = 4_000;
+const PROJECT_ENRICH_YAML_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_project_enrich_yaml_depth;
 
 #[derive(Debug, Clone)]
 struct ProjectEnrichOptions {
@@ -381,6 +383,8 @@ struct HookEvidence {
     providers: Vec<String>,
     files: Vec<String>,
     stages: BTreeMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -686,6 +690,7 @@ fn collect_hook_evidence(root: &Path) -> HookEvidence {
     let mut providers = Vec::new();
     let mut files = Vec::new();
     let mut stages = BTreeMap::new();
+    let mut warnings = Vec::new();
 
     let githooks_dir = root.join(".githooks");
     if let Ok(entries) = std::fs::read_dir(&githooks_dir) {
@@ -734,7 +739,9 @@ fn collect_hook_evidence(root: &Path) -> HookEvidence {
         push_unique_string(&mut providers, "lefthook".to_string());
         push_unique_string(&mut files, relative_posix(root, &lefthook_path));
         if let Ok(content) = std::fs::read_to_string(&lefthook_path) {
-            collect_lefthook_hooks(&content, &mut stages);
+            if let Err(error) = collect_lefthook_hooks(&content, &mut stages) {
+                warnings.push(format!("lefthook.yml: {error}"));
+            }
         }
     }
 
@@ -780,6 +787,7 @@ fn collect_hook_evidence(root: &Path) -> HookEvidence {
         providers,
         files,
         stages,
+        warnings,
     }
 }
 
@@ -848,12 +856,15 @@ fn collect_pre_commit_hooks(content: &str, stages: &mut BTreeMap<String, Vec<Str
     }
 }
 
-fn collect_lefthook_hooks(content: &str, stages: &mut BTreeMap<String, Vec<String>>) {
+fn collect_lefthook_hooks(
+    content: &str,
+    stages: &mut BTreeMap<String, Vec<String>>,
+) -> Result<(), String> {
     let Ok(parsed) = serde_yaml::from_str::<YamlValue>(content) else {
-        return;
+        return Ok(());
     };
     let Some(root) = parsed.as_mapping() else {
-        return;
+        return Ok(());
     };
     for (stage, value) in root {
         let Some(stage_name) = stage.as_str() else {
@@ -864,40 +875,59 @@ fn collect_lefthook_hooks(content: &str, stages: &mut BTreeMap<String, Vec<Strin
         }
         collect_nested_run_commands(value, &mut |command| {
             push_stage_command(stages, stage_name, command);
-        });
+        })?;
     }
+    Ok(())
 }
 
-fn collect_nested_run_commands(value: &YamlValue, sink: &mut dyn FnMut(String)) {
-    match value {
-        YamlValue::Mapping(mapping) => {
-            if let Some(run) = mapping
-                .get(YamlValue::String("run".to_string()))
-                .and_then(YamlValue::as_str)
-            {
-                for command in shell_commands(run) {
-                    sink(command);
+fn collect_nested_run_commands(
+    value: &YamlValue,
+    sink: &mut dyn FnMut(String),
+) -> Result<(), String> {
+    let mut stack = vec![(value, 0usize)];
+    while let Some((value, depth)) = stack.pop() {
+        if depth > PROJECT_ENRICH_YAML_MAX_DEPTH {
+            return Err(format!(
+                "YAML traversal depth exceeded ({} levels)",
+                PROJECT_ENRICH_YAML_MAX_DEPTH
+            ));
+        }
+
+        match value {
+            YamlValue::Mapping(mapping) => {
+                if let Some(run) = mapping
+                    .get(YamlValue::String("run".to_string()))
+                    .and_then(YamlValue::as_str)
+                {
+                    for command in shell_commands(run) {
+                        sink(command);
+                    }
+                }
+                let mut entries = mapping.iter().collect::<Vec<_>>();
+                entries.sort_by(|(left, _), (right, _)| {
+                    left.as_str()
+                        .unwrap_or_default()
+                        .cmp(right.as_str().unwrap_or_default())
+                });
+                for (key, child) in entries.into_iter().rev() {
+                    let Some(key) = key.as_str() else {
+                        continue;
+                    };
+                    if key == "run" {
+                        continue;
+                    }
+                    stack.push((child, depth + 1));
                 }
             }
-            let mut entries = mapping.iter().collect::<Vec<_>>();
-            entries.sort_by_key(|(key, _)| key.as_str().unwrap_or_default().to_string());
-            for (key, child) in entries {
-                let Some(key) = key.as_str() else {
-                    continue;
-                };
-                if key == "run" {
-                    continue;
+            YamlValue::Sequence(items) => {
+                for item in items.iter().rev() {
+                    stack.push((item, depth + 1));
                 }
-                collect_nested_run_commands(child, sink);
             }
+            _ => {}
         }
-        YamlValue::Sequence(items) => {
-            for item in items {
-                collect_nested_run_commands(item, sink);
-            }
-        }
-        _ => {}
     }
+    Ok(())
 }
 
 fn collect_package_manifest_evidence(
@@ -1833,6 +1863,49 @@ exit 1
         assert_eq!(estimate_tokens(""), 0);
         assert_eq!(estimate_tokens("abcd"), 1);
         assert_eq!(estimate_tokens("abcde"), 2);
+    }
+
+    #[test]
+    fn lefthook_run_collection_preserves_sorted_depth_first_order() {
+        let value: YamlValue = serde_yaml::from_str(
+            r#"
+commands:
+  z:
+    run: echo z
+  a:
+    run: echo a
+  list:
+    - run: echo list
+"#,
+        )
+        .expect("yaml");
+        let mut commands = Vec::new();
+
+        collect_nested_run_commands(&value, &mut |command| commands.push(command))
+            .expect("collect commands");
+
+        assert_eq!(commands, vec!["echo a", "echo list", "echo z"]);
+    }
+
+    #[test]
+    fn lefthook_run_collection_reports_yaml_depth_limit() {
+        let mut run = serde_yaml::Mapping::new();
+        run.insert(
+            YamlValue::String("run".to_string()),
+            YamlValue::String("echo too-deep".to_string()),
+        );
+        let mut value = YamlValue::Mapping(run);
+        for _ in 0..=PROJECT_ENRICH_YAML_MAX_DEPTH {
+            value = YamlValue::Sequence(vec![value]);
+        }
+
+        let mut commands = Vec::new();
+        let err = collect_nested_run_commands(&value, &mut |command| commands.push(command))
+            .expect_err("depth limit");
+
+        assert!(commands.is_empty());
+        assert!(err.contains("YAML traversal depth exceeded"));
+        assert!(err.contains(&format!("({PROJECT_ENRICH_YAML_MAX_DEPTH} levels)")));
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/shapes.rs
+++ b/crates/harn-vm/src/stdlib/shapes.rs
@@ -7,6 +7,7 @@ use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
 const SHAPE_SPEC_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_shape_spec_cache_entries;
+const SHAPE_VALIDATION_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_shape_validation_depth;
 
 thread_local! {
     static SHAPE_SPEC_CACHE: RefCell<HashMap<String, Rc<ParsedShapeSpec>>> =
@@ -231,6 +232,15 @@ fn assert_parsed_shape_fields(
     param_name: &str,
     spec: &ParsedShapeSpec,
 ) -> Result<VmValue, VmError> {
+    assert_parsed_shape_fields_at_depth(fields, param_name, spec, 0)
+}
+
+fn assert_parsed_shape_fields_at_depth(
+    fields: &BTreeMap<String, VmValue>,
+    param_name: &str,
+    spec: &ParsedShapeSpec,
+    depth: usize,
+) -> Result<VmValue, VmError> {
     for field in &spec.fields {
         match fields.get(field.name.as_str()) {
             None => {
@@ -258,7 +268,7 @@ fn assert_parsed_shape_fields(
                 }
             }
             Some(val) => {
-                assert_shape_field_value(val, param_name, field)?;
+                assert_shape_field_value(val, param_name, field, depth)?;
             }
         }
     }
@@ -269,6 +279,7 @@ fn assert_shape_field_value(
     val: &VmValue,
     param_name: &str,
     field: &ParsedShapeField,
+    depth: usize,
 ) -> Result<(), VmError> {
     match &field.kind {
         ShapeFieldType::Nested(nested) => {
@@ -289,8 +300,15 @@ fn assert_shape_field_value(
                 }
             };
             let nested_param = format!("{}.{}", param_name, field.name);
-            assert_parsed_shape_fields(nested_fields, &nested_param, nested)?;
+            if depth >= SHAPE_VALIDATION_MAX_DEPTH {
+                return Err(shape_depth_error(&nested_param));
+            }
+            assert_parsed_shape_fields_at_depth(nested_fields, &nested_param, nested, depth + 1)?;
             Ok(())
+        }
+        ShapeFieldType::DepthExceeded => {
+            let nested_param = format!("{}.{}", param_name, field.name);
+            Err(shape_depth_error(&nested_param))
         }
         ShapeFieldType::Union(types) => {
             let actual_type = val.type_name();
@@ -317,6 +335,13 @@ fn assert_shape_field_value(
             Ok(())
         }
     }
+}
+
+fn shape_depth_error(param_name: &str) -> VmError {
+    VmError::TypeError(format!(
+        "parameter '{}': shape validation depth exceeded ({} levels)",
+        param_name, SHAPE_VALIDATION_MAX_DEPTH
+    ))
 }
 
 /// Render the "available fields: …" tail used in missing-field errors.
@@ -349,6 +374,7 @@ enum ShapeFieldType {
     Scalar(String),
     Union(Vec<String>),
     Nested(Rc<ParsedShapeSpec>),
+    DepthExceeded,
 }
 
 fn cached_shape_spec(spec: &str) -> Rc<ParsedShapeSpec> {
@@ -369,6 +395,10 @@ fn cached_shape_spec(spec: &str) -> Rc<ParsedShapeSpec> {
 
 /// Parse a shape spec string into reusable runtime validation metadata.
 fn parse_shape_spec(spec: &str) -> ParsedShapeSpec {
+    parse_shape_spec_at_depth(spec, 0)
+}
+
+fn parse_shape_spec_at_depth(spec: &str, depth: usize) -> ParsedShapeSpec {
     let mut fields = Vec::new();
     let chars: Vec<char> = spec.chars().collect();
     let len = chars.len();
@@ -415,10 +445,11 @@ fn parse_shape_spec(spec: &str) -> ParsedShapeSpec {
                     brace_depth += 1;
                     i += 1;
                 }
-                '}' => {
+                '}' if brace_depth > 0 => {
                     brace_depth -= 1;
                     i += 1;
                 }
+                '}' => break,
                 ',' if brace_depth == 0 => break,
                 _ => {
                     i += 1;
@@ -434,7 +465,7 @@ fn parse_shape_spec(spec: &str) -> ParsedShapeSpec {
         if !field_name.is_empty() && !type_label.is_empty() {
             fields.push(ParsedShapeField {
                 name: field_name,
-                kind: parse_shape_field_type(&type_label),
+                kind: parse_shape_field_type(&type_label, depth),
                 type_label,
                 optional,
             });
@@ -448,10 +479,13 @@ fn parse_shape_spec(spec: &str) -> ParsedShapeSpec {
     ParsedShapeSpec { fields }
 }
 
-fn parse_shape_field_type(type_label: &str) -> ShapeFieldType {
+fn parse_shape_field_type(type_label: &str, depth: usize) -> ShapeFieldType {
     if type_label.starts_with('{') && type_label.ends_with('}') {
+        if depth >= SHAPE_VALIDATION_MAX_DEPTH {
+            return ShapeFieldType::DepthExceeded;
+        }
         let inner_spec = &type_label[1..type_label.len() - 1];
-        return ShapeFieldType::Nested(Rc::new(parse_shape_spec(inner_spec)));
+        return ShapeFieldType::Nested(Rc::new(parse_shape_spec_at_depth(inner_spec, depth + 1)));
     }
 
     if type_label.contains('|') {
@@ -493,5 +527,42 @@ mod tests {
         ]);
 
         assert_parsed_shape_fields(&fields, "payload", &spec).unwrap();
+    }
+
+    fn nested_shape_spec(depth: usize) -> String {
+        let mut spec = "leaf: int".to_string();
+        for _ in 0..depth {
+            spec = format!("child: {{{spec}}}");
+        }
+        spec
+    }
+
+    fn nested_fields(depth: usize) -> BTreeMap<String, VmValue> {
+        let mut fields = BTreeMap::from([("leaf".to_string(), VmValue::Int(1))]);
+        for _ in 0..depth {
+            fields = BTreeMap::from([("child".to_string(), VmValue::Dict(Rc::new(fields)))]);
+        }
+        fields
+    }
+
+    #[test]
+    fn shape_validation_allows_normal_nested_specs() {
+        let fields = nested_fields(3);
+        let spec = nested_shape_spec(3);
+
+        assert!(assert_shape_fields(&fields, "payload", &spec).is_ok());
+    }
+
+    #[test]
+    fn shape_validation_reports_depth_limit_with_field_path() {
+        let depth = SHAPE_VALIDATION_MAX_DEPTH + 1;
+        let fields = nested_fields(depth);
+        let spec = nested_shape_spec(depth);
+
+        let err = assert_shape_fields(&fields, "payload", &spec).expect_err("depth limit");
+        let message = err.to_string();
+        assert!(message.contains("shape validation depth exceeded"));
+        assert!(message.contains(&format!("({SHAPE_VALIDATION_MAX_DEPTH} levels)")));
+        assert!(message.contains("payload.child"));
     }
 }

--- a/crates/harn-vm/src/stdlib/template/expr_parser.rs
+++ b/crates/harn-vm/src/stdlib/template/expr_parser.rs
@@ -1,5 +1,8 @@
 use super::ast::{BinOp, Expr, PathSeg, UnOp};
 use super::error::TemplateError;
+use crate::runtime_limits::RuntimeLimits;
+
+const TEMPLATE_EXPR_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_template_ast_depth;
 
 pub(super) fn parse_expr(src: &str, line: usize, col: usize) -> Result<Expr, TemplateError> {
     let tokens = tokenize_expr(src, line, col)?;
@@ -9,7 +12,7 @@ pub(super) fn parse_expr(src: &str, line: usize, col: usize) -> Result<Expr, Tem
         line,
         col,
     };
-    let e = p.parse_filter()?;
+    let e = p.parse_filter(0)?;
     if p.pos < tokens.len() {
         return Err(TemplateError::new(
             line,
@@ -254,8 +257,19 @@ impl<'a> ExprParser<'a> {
         TemplateError::new(self.line, self.col, m)
     }
 
-    fn parse_filter(&mut self) -> Result<Expr, TemplateError> {
-        let mut left = self.parse_or()?;
+    fn check_depth(&self, depth: usize) -> Result<(), TemplateError> {
+        if depth > TEMPLATE_EXPR_MAX_DEPTH {
+            Err(self.err(format!(
+                "template expression depth exceeded ({TEMPLATE_EXPR_MAX_DEPTH} levels)"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn parse_filter(&mut self, depth: usize) -> Result<Expr, TemplateError> {
+        self.check_depth(depth)?;
+        let mut left = self.parse_or(depth)?;
         while self.eat(&EToken::Pipe) {
             let name = match self.peek() {
                 Some(EToken::Ident(n)) => n.clone(),
@@ -265,7 +279,7 @@ impl<'a> ExprParser<'a> {
             let mut args = Vec::new();
             if self.eat(&EToken::Colon) {
                 loop {
-                    let a = self.parse_or()?;
+                    let a = self.parse_or(depth + 1)?;
                     args.push(a);
                     if !self.eat(&EToken::Comma) {
                         break;
@@ -277,34 +291,38 @@ impl<'a> ExprParser<'a> {
         Ok(left)
     }
 
-    fn parse_or(&mut self) -> Result<Expr, TemplateError> {
-        let mut left = self.parse_and()?;
+    fn parse_or(&mut self, depth: usize) -> Result<Expr, TemplateError> {
+        self.check_depth(depth)?;
+        let mut left = self.parse_and(depth)?;
         while self.eat(&EToken::OrKw) {
-            let right = self.parse_and()?;
+            let right = self.parse_and(depth)?;
             left = Expr::Binary(BinOp::Or, Box::new(left), Box::new(right));
         }
         Ok(left)
     }
 
-    fn parse_and(&mut self) -> Result<Expr, TemplateError> {
-        let mut left = self.parse_not()?;
+    fn parse_and(&mut self, depth: usize) -> Result<Expr, TemplateError> {
+        self.check_depth(depth)?;
+        let mut left = self.parse_not(depth)?;
         while self.eat(&EToken::AndKw) {
-            let right = self.parse_not()?;
+            let right = self.parse_not(depth)?;
             left = Expr::Binary(BinOp::And, Box::new(left), Box::new(right));
         }
         Ok(left)
     }
 
-    fn parse_not(&mut self) -> Result<Expr, TemplateError> {
+    fn parse_not(&mut self, depth: usize) -> Result<Expr, TemplateError> {
+        self.check_depth(depth)?;
         if self.eat(&EToken::Bang) || self.eat(&EToken::NotKw) {
-            let inner = self.parse_not()?;
+            let inner = self.parse_not(depth + 1)?;
             return Ok(Expr::Unary(UnOp::Not, Box::new(inner)));
         }
-        self.parse_cmp()
+        self.parse_cmp(depth)
     }
 
-    fn parse_cmp(&mut self) -> Result<Expr, TemplateError> {
-        let left = self.parse_unary()?;
+    fn parse_cmp(&mut self, depth: usize) -> Result<Expr, TemplateError> {
+        self.check_depth(depth)?;
+        let left = self.parse_unary(depth)?;
         let op = match self.peek() {
             Some(EToken::EqEq) => Some(BinOp::Eq),
             Some(EToken::BangEq) => Some(BinOp::Neq),
@@ -316,17 +334,19 @@ impl<'a> ExprParser<'a> {
         };
         if let Some(op) = op {
             self.pos += 1;
-            let right = self.parse_unary()?;
+            let right = self.parse_unary(depth)?;
             return Ok(Expr::Binary(op, Box::new(left), Box::new(right)));
         }
         Ok(left)
     }
 
-    fn parse_unary(&mut self) -> Result<Expr, TemplateError> {
-        self.parse_primary()
+    fn parse_unary(&mut self, depth: usize) -> Result<Expr, TemplateError> {
+        self.check_depth(depth)?;
+        self.parse_primary(depth)
     }
 
-    fn parse_primary(&mut self) -> Result<Expr, TemplateError> {
+    fn parse_primary(&mut self, depth: usize) -> Result<Expr, TemplateError> {
+        self.check_depth(depth)?;
         let tok = self
             .peek()
             .cloned()
@@ -340,7 +360,7 @@ impl<'a> ExprParser<'a> {
             EToken::Float(f) => Expr::Float(f),
             EToken::Str(s) => Expr::Str(s),
             EToken::LParen => {
-                let e = self.parse_or()?;
+                let e = self.parse_or(depth + 1)?;
                 if !self.eat(&EToken::RParen) {
                     return Err(self.err("expected `)`"));
                 }
@@ -348,7 +368,7 @@ impl<'a> ExprParser<'a> {
             }
             EToken::Ident(name) => self.parse_path(name)?,
             EToken::Bang | EToken::NotKw => {
-                let inner = self.parse_primary()?;
+                let inner = self.parse_primary(depth + 1)?;
                 Expr::Unary(UnOp::Not, Box::new(inner))
             }
             other => return Err(self.err(format!("unexpected token `{:?}`", other))),

--- a/crates/harn-vm/src/stdlib/template/lint.rs
+++ b/crates/harn-vm/src/stdlib/template/lint.rs
@@ -8,6 +8,9 @@
 
 use super::ast::{BinOp, Expr, Node, PathSeg};
 use super::parser::parse as parse_template;
+use crate::runtime_limits::RuntimeLimits;
+
+const TEMPLATE_LINT_AST_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_template_ast_depth;
 
 /// Parse a template source string into a flat list of lintable
 /// constructs (conditionals + sections). Returns `Err` when the
@@ -16,7 +19,7 @@ use super::parser::parse as parse_template;
 pub fn parse(src: &str) -> Result<Vec<LintConstruct>, String> {
     let nodes = parse_template(src).map_err(|error| error.message())?;
     let mut out = Vec::new();
-    walk_nodes(&nodes, &mut out);
+    walk_nodes(&nodes, &mut out, 0)?;
     Ok(out)
 }
 
@@ -90,13 +93,18 @@ impl IdentityField {
     }
 }
 
-fn walk_nodes(nodes: &[Node], out: &mut Vec<LintConstruct>) {
+fn walk_nodes(nodes: &[Node], out: &mut Vec<LintConstruct>, depth: usize) -> Result<(), String> {
     for node in nodes {
-        walk_node(node, out);
+        walk_node(node, out, depth)?;
     }
+    Ok(())
 }
 
-fn walk_node(node: &Node, out: &mut Vec<LintConstruct>) {
+fn walk_node(node: &Node, out: &mut Vec<LintConstruct>, depth: usize) -> Result<(), String> {
+    if depth > TEMPLATE_LINT_AST_MAX_DEPTH {
+        return Err(lint_depth_error(node));
+    }
+
     match node {
         Node::Text(_) | Node::Expr { .. } | Node::LegacyBareInterp { .. } => {}
         Node::If {
@@ -112,17 +120,17 @@ fn walk_node(node: &Node, out: &mut Vec<LintConstruct>) {
                     col: branch.col,
                     condition: classify_condition(&branch.cond),
                 });
-                walk_nodes(&branch.body, out);
+                walk_nodes(&branch.body, out, depth + 1)?;
             }
             out.push(LintConstruct::IfChain { branches: summary });
             if let Some(else_body) = else_branch {
-                walk_nodes(else_body, out);
+                walk_nodes(else_body, out, depth + 1)?;
             }
         }
         Node::For { body, empty, .. } => {
-            walk_nodes(body, out);
+            walk_nodes(body, out, depth + 1)?;
             if let Some(empty) = empty {
-                walk_nodes(empty, out);
+                walk_nodes(empty, out, depth + 1)?;
             }
         }
         Node::Include { .. } => {
@@ -142,8 +150,28 @@ fn walk_node(node: &Node, out: &mut Vec<LintConstruct>) {
                 line: *line,
                 col: *col,
             });
-            walk_nodes(body, out);
+            walk_nodes(body, out, depth + 1)?;
         }
+    }
+    Ok(())
+}
+
+fn lint_depth_error(node: &Node) -> String {
+    let prefix = format!("template lint AST depth exceeded ({TEMPLATE_LINT_AST_MAX_DEPTH} levels)");
+    match node_location(node) {
+        Some((line, col)) => format!("{prefix} at {line}:{col}"),
+        None => prefix,
+    }
+}
+
+fn node_location(node: &Node) -> Option<(usize, usize)> {
+    match node {
+        Node::Expr { line, col, .. }
+        | Node::If { line, col, .. }
+        | Node::For { line, col, .. }
+        | Node::Include { line, col, .. }
+        | Node::Section { line, col, .. } => Some((*line, *col)),
+        Node::Text(_) | Node::LegacyBareInterp { .. } => None,
     }
 }
 
@@ -192,15 +220,24 @@ fn match_identity_compare(expr: &Expr) -> Option<IdentityField> {
 /// `llm.capabilities.<flag> == <literal>`, returning the flag name.
 fn match_capability_path(expr: &Expr) -> Option<ConditionShape> {
     fn find_capability_path(expr: &Expr) -> Option<String> {
-        match expr {
-            Expr::Path(path) => capability_flag_from_path(path),
-            Expr::Unary(_, inner) => find_capability_path(inner),
-            Expr::Binary(_, lhs, rhs) => {
-                find_capability_path(lhs).or_else(|| find_capability_path(rhs))
+        let mut stack = vec![expr];
+        while let Some(expr) = stack.pop() {
+            match expr {
+                Expr::Path(path) => {
+                    if let Some(flag) = capability_flag_from_path(path) {
+                        return Some(flag);
+                    }
+                }
+                Expr::Unary(_, inner) => stack.push(inner),
+                Expr::Binary(_, lhs, rhs) => {
+                    stack.push(rhs);
+                    stack.push(lhs);
+                }
+                Expr::Filter(inner, _, _) => stack.push(inner),
+                _ => {}
             }
-            Expr::Filter(inner, _, _) => find_capability_path(inner),
-            _ => None,
         }
+        None
     }
     let flag = find_capability_path(expr)?;
     Some(ConditionShape::CapabilityFlag { flag })
@@ -291,6 +328,57 @@ mod tests {
             if_chains[1][0].condition,
             ConditionShape::CapabilityFlag { ref flag, .. } if flag == "prefers_xml_scaffolding"
         ));
+    }
+
+    #[test]
+    fn capability_flag_detection_handles_wide_binary_expression() {
+        let mut terms = (0..300).map(|idx| format!("flag{idx}")).collect::<Vec<_>>();
+        terms.push("llm.capabilities.native_tools".to_string());
+        let src = format!("{{{{ if {} }}}}x{{{{ end }}}}", terms.join(" or "));
+
+        let constructs = parse_ok(&src);
+        let branches = first_if(&constructs);
+
+        assert!(matches!(
+            branches[0].condition,
+            ConditionShape::CapabilityFlag { ref flag, .. } if flag == "native_tools"
+        ));
+    }
+
+    #[test]
+    fn parse_reports_template_control_depth_limit() {
+        let depth = RuntimeLimits::DEFAULT.max_template_ast_depth + 1;
+        let mut src = String::new();
+        for _ in 0..depth {
+            src.push_str("{{ if true }}");
+        }
+        src.push('x');
+        for _ in 0..depth {
+            src.push_str("{{ end }}");
+        }
+
+        let err = parse(&src).expect_err("depth limit");
+
+        assert!(err.contains("template nesting depth exceeded"));
+        assert!(err.contains(&format!(
+            "({} levels)",
+            RuntimeLimits::DEFAULT.max_template_ast_depth
+        )));
+    }
+
+    #[test]
+    fn parse_reports_template_expression_depth_limit() {
+        let depth = RuntimeLimits::DEFAULT.max_template_ast_depth + 1;
+        let condition = format!("{}llm.capabilities.native_tools", "!".repeat(depth));
+        let src = format!("{{{{ if {condition} }}}}x{{{{ end }}}}");
+
+        let err = parse(&src).expect_err("depth limit");
+
+        assert!(err.contains("template expression depth exceeded"));
+        assert!(err.contains(&format!(
+            "({} levels)",
+            RuntimeLimits::DEFAULT.max_template_ast_depth
+        )));
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/template/parser.rs
+++ b/crates/harn-vm/src/stdlib/template/parser.rs
@@ -3,12 +3,16 @@ use super::error::TemplateError;
 use super::expr_parser::parse_expr;
 use super::lexer::{tokenize, Token};
 use super::sections;
+use crate::runtime_limits::RuntimeLimits;
+
+const TEMPLATE_AST_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_template_ast_depth;
 
 pub(super) fn parse(src: &str) -> Result<Vec<Node>, TemplateError> {
     let tokens = tokenize(src)?;
     let mut p = Parser {
         tokens: &tokens,
         pos: 0,
+        depth: 0,
     };
     let nodes = p.parse_block(&[])?;
     if p.pos < tokens.len() {
@@ -20,6 +24,7 @@ pub(super) fn parse(src: &str) -> Result<Vec<Node>, TemplateError> {
 struct Parser<'a> {
     tokens: &'a [Token],
     pos: usize,
+    depth: usize,
 }
 
 impl<'a> Parser<'a> {
@@ -28,6 +33,21 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_block(&mut self, stops: &[&str]) -> Result<Vec<Node>, TemplateError> {
+        let (line, col) = self.peek_location();
+        if self.depth >= TEMPLATE_AST_MAX_DEPTH {
+            return Err(TemplateError::new(
+                line,
+                col,
+                format!("template nesting depth exceeded ({TEMPLATE_AST_MAX_DEPTH} levels)"),
+            ));
+        }
+        self.depth += 1;
+        let result = self.parse_block_inner(stops);
+        self.depth = self.depth.saturating_sub(1);
+        result
+    }
+
+    fn parse_block_inner(&mut self, stops: &[&str]) -> Result<Vec<Node>, TemplateError> {
         let mut out = Vec::new();
         while let Some(tok) = self.peek() {
             match tok {
@@ -104,6 +124,13 @@ impl<'a> Parser<'a> {
             }
         }
         Ok(out)
+    }
+
+    fn peek_location(&self) -> (usize, usize) {
+        match self.peek() {
+            Some(Token::Directive { line, col, .. }) => (*line, *col),
+            _ => (1, 1),
+        }
     }
 
     fn parse_if(


### PR DESCRIPTION
## Summary
- Add runtime limit entries and depth errors for runtime shape validation, project enrichment YAML traversal, and prompt-template AST/expression parsing.
- Convert VM-adjacent recursive walkers to bounded or iterative traversal, including project enrichment hook command collection, template lint capability matching, and parser AST visiting.
- Add parser/template/shape/project-enrichment regression coverage for adversarial depth while preserving normal nesting behavior.

## Verification
- `cargo test -p harn-parser --lib`
- `cargo test -p harn-vm --lib`
- `cargo test -p harn-lint --lib`
- `cargo test -p harn-fmt --lib`
- `cargo run --quiet --bin harn -- test conformance`
- `make lint-test-patterns`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- pre-commit hooks: rustfmt, prompt-prose lint, changed-package clippy, generated highlight check
- pre-push hooks: targeted local checks, generated highlight check

Closes #2203