### PR TITLE
docs: How-to recipes restructure (Phase 2 of #2214)

### DIFF
--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -1,12 +1,25 @@
 # Cookbook
 
-Practical patterns for building agents and pipelines in Harn. Each
-recipe is self-contained with a short explanation and working code.
+Task-oriented recipes for building agents and pipelines in Harn. Each
+recipe is self-contained — copy a block into a `.harn` file, set the
+provider credentials it expects, and run.
 
-## 1. Basic LLM call
+For deeper topics that need their own pages, see:
 
-Single-shot prompt with a system message. Set `ANTHROPIC_API_KEY` (or the
-appropriate key for your provider) before running.
+- [Channel cookbook](./cookbooks/channels.md) — agent channel patterns
+- [Pool cookbook](./cookbooks/pools.md) — agent pool patterns
+- [Pipeline lifecycle cookbook](./cookbooks/lifecycle.md) — `on_finish`,
+  handoffs, suspend/resume
+- [Tool hooks cookbook](./cookbooks/tool-hooks.md) — `preset_run_command`
+  recipes per stack
+- [OAuth client + provider cookbook](./oauth.md) — connector OAuth
+
+## LLM calls
+
+### How to make a basic LLM call
+
+Single-shot prompt with a system message. Set `ANTHROPIC_API_KEY` (or
+the appropriate key for your provider) before running.
 
 ```harn
 pipeline default(task) {
@@ -18,7 +31,7 @@ pipeline default(task) {
 }
 ```
 
-To use a different provider or model, pass an options dict:
+To switch provider or model, pass an options dict:
 
 ```harn
 pipeline default(task) {
@@ -31,10 +44,78 @@ pipeline default(task) {
 }
 ```
 
-## 2. Agent loop with tools
+### How to ask for structured JSON output
 
-Register tools with JSON Schema-compatible definitions, generate a
-system prompt that describes them, then let the LLM call tools in a loop.
+Ask the model for JSON, parse it with `json_parse`, and validate the
+shape before using it. Wrap the parse in `retry` so a malformed first
+attempt does not end the run.
+
+```harn
+pipeline default(task) {
+  let system = """
+You are a task planner. Given a task description, break it into steps.
+Respond with ONLY a JSON array of objects, each with "step" (string) and
+"priority" (int 1-5). No other text.
+"""
+
+  fn get_plan(task_desc) {
+    retry 3 {
+      let raw = llm_call(task_desc, system)
+      let parsed = json_parse(raw.text)
+
+      guard type_of(parsed) == "list" else {
+        throw "Expected a JSON array, got: ${type_of(parsed)}"
+      }
+
+      for item in parsed {
+        guard item.has("step") && item.has("priority") else {
+          throw "Missing required fields in: ${json_stringify(item)}"
+        }
+      }
+
+      return parsed
+    }
+  }
+
+  let plan = get_plan("Build a REST API for a todo app")
+  let sorted = plan.filter({ s -> s.priority <= 3 })
+  for step in sorted {
+    log("[P${step.priority}] ${step.step}")
+  }
+}
+```
+
+For schema-validated JSON without the manual guards, use
+[`llm_call_structured`](./llm/llm_call.md#llm_call_structured).
+
+### How to evaluate prompts in parallel
+
+`parallel each` fans out a list of prompts. Results preserve the input
+order.
+
+```harn
+let prompts = [
+  "Explain quicksort in two sentences.",
+  "Explain mergesort in two sentences.",
+  "Explain heapsort in two sentences."
+]
+
+let responses = parallel each prompts { p ->
+  llm_call(p, "Be concise.")
+}
+
+for r in responses {
+  log(r.text)
+}
+```
+
+## Tools and agent loops
+
+### How to give an agent tools
+
+Register tools with JSON Schema-compatible parameters, generate a system
+prompt that describes them, then let the LLM call tools in a loop. For
+typed tools and Tool Vault, see [LLM tools](./llm/tools.md).
 
 ```harn
 pipeline default(task) {
@@ -83,43 +164,30 @@ pipeline default(task) {
 }
 ```
 
-## 3. Parallel tool execution
+For loop-until-done agents that own completion detection and budget
+enforcement, reach for [`agent_loop`](./llm/agent_loop.md) instead of
+writing the loop yourself.
 
-Run multiple independent operations concurrently with `parallel each`.
-Results preserve the original list order.
+### How to delegate to multiple worker agents
 
-```harn
-pipeline default(task) {
-  let files = ["src/main.rs", "src/lib.rs", "src/utils.rs"]
-
-  let reviews = parallel each files { file ->
-    let content = read_file(file)
-    llm_call(
-      "Review this code for bugs and suggest fixes:\n\n${content}",
-      "You are a senior code reviewer. Be specific."
-    )
-  }
-
-  for i in 0 to files.count exclusive {
-    log("=== ${files[i]} ===")
-    log(reviews[i])
-  }
-}
-```
-
-Use `parallel` when you need to run N indexed tasks rather than mapping
-over a list:
+Spawn workers for different roles and collect their results.
 
 ```harn
 pipeline default(task) {
-  let prompts = [
-    "Write a haiku about Rust",
-    "Write a haiku about concurrency",
-    "Write a haiku about debugging"
-  ]
+  let roles = ["research", "analyze", "summarize"]
 
-  let results = parallel(prompts.count) { i ->
-    llm_call(prompts[i], "You are a poet.")
+  let results = parallel each roles { role ->
+    let agent = spawn_agent({
+      name: role,
+      task: "Handle ${role}: ${task}",
+      node: {
+        kind: "subagent",
+        mode: "llm",
+        model_policy: {provider: "mock"},
+        output_contract: {output_kinds: ["summary"]},
+      },
+    })
+    wait_agent(agent)
   }
 
   for r in results {
@@ -128,7 +196,9 @@ pipeline default(task) {
 }
 ```
 
-## 4. MCP client integration
+## MCP servers
+
+### How to call an MCP server
 
 Connect to an MCP-compatible tool server, list available tools, and call
 them. This example uses the filesystem MCP server.
@@ -137,22 +207,18 @@ them. This example uses the filesystem MCP server.
 pipeline default(task) {
   let client = mcp_connect("npx", ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"])
 
-  // Check connection
   let info = mcp_server_info(client)
   log("Connected to: ${info.name}")
 
-  // List available tools
   let tools = mcp_list_tools(client)
   for t in tools {
     log("Tool: ${t.name} - ${t.description}")
   }
 
-  // Write a file, then read it back
   mcp_call(client, "write_file", {path: "/tmp/hello.txt", content: "Hello from Harn!"})
   let content = mcp_call(client, "read_file", {path: "/tmp/hello.txt"})
   log("File content: ${content}")
 
-  // List directory
   let entries = mcp_call(client, "list_directory", {path: "/tmp"})
   log(entries)
 
@@ -160,374 +226,28 @@ pipeline default(task) {
 }
 ```
 
-You can also declare MCP servers in `harn.toml` for automatic connection.
-See [MCP and ACP Integration](./mcp-and-acp.md) for details.
+You can also declare MCP servers in `harn.toml` for automatic
+connection. See [MCP, ACP, and A2A integration](./mcp-and-acp.md) for the
+config surface.
 
-For remote HTTP MCP servers, authorize once with the CLI and then reuse the
-stored token automatically from `harn.toml`:
+For remote HTTP MCP servers, authorize once with the CLI and reuse the
+stored token:
 
 ```bash
 harn mcp redirect-uri
 harn mcp login https://mcp.notion.com/mcp --scope "read write"
 ```
 
-## 5. Filtering with `in` and `not in`
+### How to give an agent MCP tools
 
-Use the `in` and `not in` operators to filter collections by membership.
-
-```harn
-pipeline default(task) {
-  let allowed_extensions = [".rs", ".harn", ".toml"]
-  let files = list_dir("src")
-
-  // Filter files to only allowed extensions
-  let relevant = files.filter({ f ->
-    let ext = extname(f)
-    ext in allowed_extensions
-  })
-
-  log("Relevant files: ${relevant}")
-
-  // Exclude specific keys from a config dict
-  let config = {host: "localhost", port: 8080, debug: true, secret: "abc"}
-  let sensitive = ["secret", "password"]
-
-  let safe = {}
-  for entry in config {
-    if entry.key not in sensitive {
-      log("${entry.key}: ${entry.value}")
-    }
-  }
-}
-```
-
-The `in` operator works with lists, strings (substring test), dicts
-(key membership), and sets.
-
-## 6. Pipeline composition
-
-Split agent logic across files and compose pipelines using imports
-and inheritance.
-
-**lib/context.harn** -- shared context-gathering logic:
-
-```harn
-fn gather_context(task) {
-  let readme = read_file("README.md")
-  return {
-    task: task,
-    readme: readme,
-    timestamp: timestamp()
-  }
-}
-```
-
-**lib/review.harn** -- a reusable review pipeline:
-
-```harn,ignore
-import "lib/context"
-
-pipeline review(task) {
-  let ctx = gather_context(task)
-  let prompt = "Review this project.\n\nREADME:\n${ctx.readme}\n\nTask: ${ctx.task}"
-  let result = llm_call(prompt, "You are a code reviewer.")
-  log(result)
-}
-```
-
-**main.harn** -- extend and customize:
-
-```harn,ignore
-import "lib/review"
-
-pipeline default(task) extends review {
-  override setup() {
-    log("Starting custom review pipeline")
-  }
-}
-```
-
-## 7. Error handling in agent loops
-
-Wrap LLM calls in `try`/`catch` with `retry` to handle transient failures.
-Use typed catch for structured error handling.
-
-```harn
-pipeline default(task) {
-  enum AgentError {
-    LlmFailure(message)
-    ParseFailure(raw)
-    Timeout(seconds)
-  }
-
-  fn safe_llm_call(prompt, system) {
-    retry 3 {
-      try {
-        let raw = llm_call(prompt, system)
-        return json_parse(raw.text)
-      } catch (e) {
-        log("LLM call failed: ${e}")
-        throw AgentError.LlmFailure(to_string(e))
-      }
-    }
-  }
-
-  try {
-    let result = safe_llm_call(
-      "Return a JSON object with keys 'summary' and 'score'.",
-      "You are an evaluator. Always respond with valid JSON only."
-    )
-    log("Summary: ${result.summary}")
-    log("Score: ${result.score}")
-  } catch (e) {
-    // Harn supports a single catch per try; branch on the error type here.
-    if type_of(e) == "enum" {
-      match e.variant {
-        "LlmFailure" -> { log("LLM failed after retries: ${e.fields[0]}") }
-        "ParseFailure" -> { log("Could not parse LLM output: ${e.fields[0]}") }
-        "Timeout" -> { log("Timed out after ${e.fields[0]}s") }
-      }
-    } else {
-      log("Unexpected error: ${e}")
-    }
-  }
-}
-```
-
-## 8. Channel-based coordination
-
-Use channels to coordinate between spawned tasks. One task produces work,
-another consumes it.
-
-```harn
-pipeline default(task) {
-  let ch = channel("work", 10)
-  let results_ch = channel("results", 10)
-
-  // Producer: send work items
-  let producer = spawn {
-    let items = ["item_a", "item_b", "item_c"]
-    for item in items {
-      send(ch, item)
-    }
-    send(ch, "DONE")
-  }
-
-  // Consumer: process work items
-  let consumer = spawn {
-    var processed = 0
-    var running = true
-    while running {
-      let item = receive(ch)
-      if item == "DONE" {
-        running = false
-      } else {
-        let result = "processed: ${item}"
-        send(results_ch, result)
-        processed = processed + 1
-      }
-    }
-    send(results_ch, "COMPLETE:${processed}")
-  }
-
-  await(producer)
-  await(consumer)
-
-  // Collect results
-  var collecting = true
-  while collecting {
-    let msg = receive(results_ch)
-    if msg.starts_with("COMPLETE:") {
-      log(msg)
-      collecting = false
-    } else {
-      log(msg)
-    }
-  }
-}
-```
-
-## 9. Context building pattern
-
-Gather context from multiple sources, merge it into a single dict, and
-pass it to an LLM.
-
-```harn
-pipeline default(task) {
-  fn read_or_empty(path) {
-    try {
-      return read_file(path)
-    } catch (e) {
-      return ""
-    }
-  }
-
-  // Gather context from multiple sources in parallel
-  let sources = ["README.md", "CHANGELOG.md", "docs/architecture.md"]
-
-  let contents = parallel each sources { path ->
-    {path: path, content: read_or_empty(path)}
-  }
-
-  // Build a merged context dict
-  var context = {task: task, files: {}}
-  for item in contents {
-    if item.content != "" {
-      context = context.merge({files: context.files.merge({[item.path]: item.content})})
-    }
-  }
-
-  // Format context for the LLM
-  var prompt = "Task: ${task}\n\n"
-  for entry in context.files {
-    prompt += "=== ${entry.key} ===\n${entry.value}\n\n"
-  }
-
-  let result = llm_call(prompt, "You are a helpful assistant. Use the provided files as context.")
-  log(result)
-}
-```
-
-## 10. Structured output parsing
-
-Ask the LLM for JSON output, parse it with `json_parse`, and validate
-the structure before using it.
-
-```harn
-pipeline default(task) {
-  let system = """
-You are a task planner. Given a task description, break it into steps.
-Respond with ONLY a JSON array of objects, each with "step" (string) and
-"priority" (int 1-5). No other text.
-"""
-
-  fn get_plan(task_desc) {
-    retry 3 {
-      let raw = llm_call(task_desc, system)
-      let parsed = json_parse(raw.text)
-
-      // Validate structure
-      guard type_of(parsed) == "list" else {
-        throw "Expected a JSON array, got: ${type_of(parsed)}"
-      }
-
-      for item in parsed {
-        guard item.has("step") && item.has("priority") else {
-          throw "Missing required fields in: ${json_stringify(item)}"
-        }
-      }
-
-      return parsed
-    }
-  }
-
-  let plan = get_plan("Build a REST API for a todo app")
-
-  if plan != nil {
-    let sorted = plan.filter({ s -> s.priority <= 3 })
-    for step in sorted {
-      log("[P${step.priority}] ${step.step}")
-    }
-  } else {
-    log("Failed to get a valid plan after retries")
-  }
-}
-```
-
-## 11. Sets for deduplication and membership testing
-
-Use sets to track processed items and avoid duplicates. Sets provide
-O(1)-style membership testing via `set_contains` and are immutable --
-operations like `set_add` return a new set.
-
-```harn
-pipeline default(task) {
-  let urls = [
-    "https://example.com/a",
-    "https://example.com/b",
-    "https://example.com/a",
-    "https://example.com/c",
-    "https://example.com/b"
-  ]
-
-  // Deduplicate with set(), then convert back to a list
-  let unique_urls = to_list(set(urls))
-  log("${len(unique_urls)} unique URLs out of ${len(urls)} total")
-
-  // Track which URLs have been processed
-  var visited = set()
-
-  for url in unique_urls {
-    if !set_contains(visited, url) {
-      log("Processing: ${url}")
-      visited = set_add(visited, url)
-    }
-  }
-
-  // Set operations: find overlap between two batches
-  let batch_a = set("task-1", "task-2", "task-3")
-  let batch_b = set("task-2", "task-3", "task-4")
-
-  let already_done = set_intersect(batch_a, batch_b)
-  let new_work = set_difference(batch_b, batch_a)
-
-  log("Overlap: ${len(already_done)}, New: ${len(new_work)}")
-}
-```
-
-## 12. Typed functions with runtime enforcement
-
-Add type annotations to function parameters for automatic runtime
-validation. When a caller passes a value of the wrong type, the VM
-throws a `TypeError` before the function body executes.
-
-```harn,ignore
-pipeline default(task) {
-  fn summarize(text: string, max_words: int) -> string {
-    let words = text.split(" ")
-    if words.count <= max_words {
-      return text
-    }
-    let truncated = words.slice(0, max_words)
-    return "${join(truncated, " ")}..."
-  }
-
-  log(summarize("The quick brown fox jumps over the lazy dog", 5))
-
-  // Catch type errors gracefully. `harn check` rejects this call statically
-  // before the catch can run — the example is shown for illustration only.
-  try {
-    summarize(42, "not a number")
-  } catch (e) {
-    log("Caught: ${e}")
-    // -> TypeError: parameter 'text' expected string, got int (42)
-  }
-
-  // Works with all primitive types: string, int, float, bool, list, dict, set
-  fn process_batch(items: list, verbose: bool) {
-    for item in items {
-      if verbose {
-        log("Processing: ${item}")
-      }
-    }
-    log("Done: ${len(items)} items")
-  }
-
-  process_batch(["a", "b", "c"], true)
-}
-```
-
-## 13. MCP client with agent loop
-
-Connect to an MCP server and pass its tools to an `agent_loop`, letting
-the LLM decide which tools to call.
+Connect to an MCP server and feed its tools to `agent_loop`. The LLM
+chooses which to call.
 
 ```harn
 pipeline default(task) {
   let client = mcp_connect("npx", ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"])
   let mcp_tool_list = mcp_list_tools(client)
 
-  // Build a tool registry from MCP tools
   var tools = tool_registry()
   for t in mcp_tool_list {
     tools = tool_define(tools, t.name, t.description, {
@@ -552,11 +272,92 @@ pipeline default(task) {
 }
 ```
 
-## 14. Recursive agent with tail call optimization
+## Concurrency
 
-Tail-recursive functions are optimized by the VM, so they do not overflow
-the stack even across thousands of iterations. This is an advanced pattern
-useful for processing a queue of work items one at a time.
+### How to run N indexed tasks in parallel
+
+Use `parallel` when the unit of work is "N independent operations" and
+you want them indexed by position.
+
+```harn
+pipeline default(task) {
+  let prompts = [
+    "Write a haiku about Rust",
+    "Write a haiku about concurrency",
+    "Write a haiku about debugging"
+  ]
+
+  let results = parallel(prompts.count) { i ->
+    llm_call(prompts[i], "You are a poet.")
+  }
+
+  for r in results {
+    log(r)
+  }
+}
+```
+
+Use `parallel each` when you're mapping over a collection. See
+[Concurrency](./concurrency.md) for the full surface, including
+backpressure and streamed results.
+
+### How to coordinate spawned tasks with channels
+
+Channels coordinate producers and consumers. Use them when one spawned
+task needs to hand work to another and you want backpressure rather
+than an unbounded queue.
+
+```harn
+pipeline default(task) {
+  let ch = channel("work", 10)
+  let results_ch = channel("results", 10)
+
+  let producer = spawn {
+    let items = ["item_a", "item_b", "item_c"]
+    for item in items {
+      send(ch, item)
+    }
+    send(ch, "DONE")
+  }
+
+  let consumer = spawn {
+    var processed = 0
+    var running = true
+    while running {
+      let item = receive(ch)
+      if item == "DONE" {
+        running = false
+      } else {
+        send(results_ch, "processed: ${item}")
+        processed = processed + 1
+      }
+    }
+    send(results_ch, "COMPLETE:${processed}")
+  }
+
+  await(producer)
+  await(consumer)
+
+  var collecting = true
+  while collecting {
+    let msg = receive(results_ch)
+    if msg.starts_with("COMPLETE:") {
+      log(msg)
+      collecting = false
+    } else {
+      log(msg)
+    }
+  }
+}
+```
+
+For durable cross-agent channels (publish from one pipeline, subscribe
+from another), see the [Channel cookbook](./cookbooks/channels.md).
+
+### How to recurse without blowing the stack
+
+Tail-recursive functions are optimized by the VM, so deep recursion does
+not overflow even across thousands of iterations.
 
 ```harn
 pipeline default(task) {
@@ -588,7 +389,8 @@ pipeline default(task) {
 }
 ```
 
-For non-LLM workloads, TCO handles deep recursion without issues:
+For non-LLM workloads, tail-call optimization handles deep recursion
+without issue:
 
 ```harn
 pipeline default(task) {
@@ -603,63 +405,263 @@ pipeline default(task) {
 }
 ```
 
-## 15. Multi-agent delegation
+## Error handling
 
-Spawn worker agents for different roles and collect their results in
-parallel.
+### How to retry and structure errors
+
+Wrap LLM calls in `try`/`catch` with `retry` to handle transient
+failures. Use a typed catch when you want different handling per error
+kind.
 
 ```harn
-// Spawn workers and collect results
 pipeline default(task) {
-  let roles = ["research", "analyze", "summarize"]
-  let _results = parallel each roles { role ->
-    let agent = spawn_agent({
-      name: role,
-      task: "Handle ${role}: ${task}",
-      node: {
-        kind: "subagent",
-        mode: "llm",
-        model_policy: {provider: "mock"},
-        output_contract: {output_kinds: ["summary"]},
-      },
-    })
-    wait_agent(agent)
+  enum AgentError {
+    LlmFailure(message)
+    ParseFailure(raw)
+    Timeout(seconds)
+  }
+
+  fn safe_llm_call(prompt, system) {
+    retry 3 {
+      try {
+        let raw = llm_call(prompt, system)
+        return json_parse(raw.text)
+      } catch (e) {
+        log("LLM call failed: ${e}")
+        throw AgentError.LlmFailure(to_string(e))
+      }
+    }
+  }
+
+  try {
+    let result = safe_llm_call(
+      "Return a JSON object with keys 'summary' and 'score'.",
+      "You are an evaluator. Always respond with valid JSON only."
+    )
+    log("Summary: ${result.summary}")
+    log("Score: ${result.score}")
+  } catch (e) {
+    if type_of(e) == "enum" {
+      match e.variant {
+        "LlmFailure" -> { log("LLM failed after retries: ${e.fields[0]}") }
+        "ParseFailure" -> { log("Could not parse LLM output: ${e.fields[0]}") }
+        "Timeout" -> { log("Timed out after ${e.fields[0]}s") }
+      }
+    } else {
+      log("Unexpected error: ${e}")
+    }
   }
 }
 ```
 
-## 16. Parallel LLM evaluation
+For deeper coverage of the error model, see
+[Error handling](./error-handling.md).
 
-Evaluate multiple prompts concurrently using `parallel each`.
+## Patterns
+
+### How to build context from multiple sources
+
+Gather context in parallel, merge it into a single dict, and feed it to
+the model.
 
 ```harn
-// Evaluate multiple prompts in parallel
-let prompts = ["Explain X", "Explain Y", "Explain Z"]
-let responses = parallel each prompts { p ->
-  llm_call(p)
+pipeline default(task) {
+  fn read_or_empty(path) {
+    try {
+      return read_file(path)
+    } catch (e) {
+      return ""
+    }
+  }
+
+  let sources = ["README.md", "CHANGELOG.md", "docs/architecture.md"]
+
+  let contents = parallel each sources { path ->
+    {path: path, content: read_or_empty(path)}
+  }
+
+  var context = {task: task, files: {}}
+  for item in contents {
+    if item.content != "" {
+      context = context.merge({files: context.files.merge({[item.path]: item.content})})
+    }
+  }
+
+  var prompt = "Task: ${task}\n\n"
+  for entry in context.files {
+    prompt += "=== ${entry.key} ===\n${entry.value}\n\n"
+  }
+
+  let result = llm_call(prompt, "You are a helpful assistant. Use the provided files as context.")
+  log(result)
 }
 ```
 
-## 17. MCP client usage
+### How to compose pipelines across files
 
-Connect to an MCP server, list tools, call one, and disconnect.
+Split logic into reusable pipelines using `import` and `extends`. See
+[Modules and imports](./modules.md) for the resolution rules.
 
-```harn
-// Connect to an MCP server and call tools
-let client = mcp_connect("npx", ["-y", "some-mcp-server"])
-let tools = mcp_list_tools(client)
-log("Available: ${len(tools)} tools")
-let result = mcp_call(client, "tool_name", {arg: "value"})
-mcp_disconnect(client)
-```
-
-## 18. Eval metrics tracking
-
-Track quality metrics during agent execution for later analysis.
+**lib/context.harn** — shared context gathering:
 
 ```harn
-// Track quality metrics during agent execution
-eval_metric("accuracy", score, {model: model_name})
-let usage = llm_usage()
-eval_metric("cost_tokens", usage.input_tokens + usage.output_tokens)
+fn gather_context(task) {
+  let readme = read_file("README.md")
+  return {
+    task: task,
+    readme: readme,
+    timestamp: timestamp()
+  }
+}
 ```
+
+**lib/review.harn** — a reusable review pipeline:
+
+```harn,ignore
+import "lib/context"
+
+pipeline review(task) {
+  let ctx = gather_context(task)
+  let prompt = "Review this project.\n\nREADME:\n${ctx.readme}\n\nTask: ${ctx.task}"
+  let result = llm_call(prompt, "You are a code reviewer.")
+  log(result)
+}
+```
+
+**main.harn** — extend and customize:
+
+```harn,ignore
+import "lib/review"
+
+pipeline default(task) extends review {
+  override setup() {
+    log("Starting custom review pipeline")
+  }
+}
+```
+
+### How to filter with `in` and `not in`
+
+`in` works on lists, strings (substring test), dicts (key membership),
+and sets.
+
+```harn
+pipeline default(task) {
+  let allowed_extensions = [".rs", ".harn", ".toml"]
+  let files = list_dir("src")
+
+  let relevant = files.filter({ f ->
+    let ext = extname(f)
+    ext in allowed_extensions
+  })
+
+  log("Relevant files: ${relevant}")
+
+  let config = {host: "localhost", port: 8080, debug: true, secret: "abc"}
+  let sensitive = ["secret", "password"]
+
+  for entry in config {
+    if entry.key not in sensitive {
+      log("${entry.key}: ${entry.value}")
+    }
+  }
+}
+```
+
+### How to deduplicate with sets
+
+Sets give O(1)-style membership testing and are immutable —
+`set_add` returns a new set rather than mutating in place.
+
+```harn
+pipeline default(task) {
+  let urls = [
+    "https://example.com/a",
+    "https://example.com/b",
+    "https://example.com/a",
+    "https://example.com/c",
+    "https://example.com/b"
+  ]
+
+  let unique_urls = to_list(set(urls))
+  log("${len(unique_urls)} unique URLs out of ${len(urls)} total")
+
+  var visited = set()
+  for url in unique_urls {
+    if !set_contains(visited, url) {
+      log("Processing: ${url}")
+      visited = set_add(visited, url)
+    }
+  }
+
+  let batch_a = set("task-1", "task-2", "task-3")
+  let batch_b = set("task-2", "task-3", "task-4")
+
+  let already_done = set_intersect(batch_a, batch_b)
+  let new_work = set_difference(batch_b, batch_a)
+
+  log("Overlap: ${len(already_done)}, New: ${len(new_work)}")
+}
+```
+
+### How to enforce types at call boundaries
+
+Annotate function parameters. The VM throws a `TypeError` before the
+body runs if a caller passes the wrong type; `harn check` rejects most
+of these statically.
+
+```harn,ignore
+pipeline default(task) {
+  fn summarize(text: string, max_words: int) -> string {
+    let words = text.split(" ")
+    if words.count <= max_words {
+      return text
+    }
+    let truncated = words.slice(0, max_words)
+    return "${join(truncated, " ")}..."
+  }
+
+  log(summarize("The quick brown fox jumps over the lazy dog", 5))
+
+  try {
+    summarize(42, "not a number")
+  } catch (e) {
+    log("Caught: ${e}")
+    // -> TypeError: parameter 'text' expected string, got int (42)
+  }
+
+  fn process_batch(items: list, verbose: bool) {
+    for item in items {
+      if verbose {
+        log("Processing: ${item}")
+      }
+    }
+    log("Done: ${len(items)} items")
+  }
+
+  process_batch(["a", "b", "c"], true)
+}
+```
+
+Annotations cover `string`, `int`, `float`, `bool`, `list`, `dict`, and
+`set`. For structural shape types, see [Language basics](./language-basics.md#types-and-values).
+
+### How to track quality metrics
+
+`eval_metric` records named values to the run record for later
+analysis. Track accuracy, latency, token usage, and failure counts
+during agent execution.
+
+```harn
+pipeline default(task) {
+  let result = llm_call(task, "Be concise.")
+  let usage = llm_usage()
+
+  eval_metric("cost_tokens", usage.input_tokens + usage.output_tokens)
+  eval_metric("output_length", result.text.length, {model: result.model})
+  log(result.text)
+}
+```
+
+See [Debugging agent runs](./debugging.md#evaluation) for the eval
+harness around these calls.

--- a/docs/src/cookbooks/channels.md
+++ b/docs/src/cookbooks/channels.md
@@ -1,16 +1,16 @@
 # Channel cookbook
 
-Five end-to-end patterns for agent channels (#1870). Each recipe is a
-complete, copy-paste starting point. For the surface reference see
+End-to-end patterns for agent channels. Each recipe is a self-contained,
+copy-paste starting point. For the surface reference see
 [Agent channels](../agent-channels.md); for the LLM-friendly quickref
 see the "Durable agent channels" section in `docs/llm/harn-quickref.md`.
 
-The recipes use `harn,ignore` fences because they show full
-multi-agent topologies (publisher pipeline + subscriber pipeline). Each
-fragment type-checks; the orchestration loop assumes a host that runs
-both pipelines (such as `harn orchestrator`).
+The recipes use `harn,ignore` fences because they wire up full
+multi-pipeline topologies (publisher + subscriber). Each fragment
+type-checks; the orchestration loop assumes a host that runs both
+pipelines, such as `harn orchestrator`.
 
-## 1. Release handshake
+## Release handshake
 
 One agent waits for another's emit before proceeding. The PR agent
 emits `pr.merged` on each merge; a release agent batches three of them
@@ -83,7 +83,7 @@ Why a signed receipt: the replay oracle verifies the same three SHAs
 fire the same release across two runs of the same pipeline. See
 [CH-07 replay receipts](../agent-channels.md#observability).
 
-## 2. Periodic check-in via tool-call counting
+## Periodic check-in via tool-call counting
 
 Inject a reflection prompt into a running agent loop every 30 tool
 calls. The agent emits `tool_call.completed` on each tool use (via a
@@ -140,7 +140,7 @@ Why `dedupe_key`: if the agent stalls mid-reflection and 30 more tools
 are dispatched, the next reminder replaces (rather than stacks on) the
 pending one.
 
-## 3. Multi-agent feedback loop
+## Multi-agent feedback loop
 
 A planner agent drafts a plan; reviewer agents critique it; the
 planner subscribes to the critiques and revises. Channels make this a
@@ -211,7 +211,7 @@ running* in `agent_loop`. Spawning a new task would lose its
 transcript; injecting a reminder lets it incorporate the critique on
 the next turn.
 
-## 4. Pipeline progress dashboard
+## Pipeline progress dashboard
 
 Every step in every pipeline emits `pipeline.step.completed`; a
 monitoring agent tenant-wide subscribes and maintains a live
@@ -271,7 +271,7 @@ dispatcher's retry policy, DLQ routing, and replay receipts. If the
 dashboard handler throws, the channel emit still lands cleanly on
 `lifecycle.channel.audit`; the failed match goes to `trigger.dlq`.
 
-## 5. Cross-pipeline coordination via drain handoff
+## Cross-pipeline coordination via drain handoff
 
 Pipeline A processes work synchronously up to a watermark, then drains
 deferred items by emitting a channel event. A nightly settlement

--- a/docs/src/cookbooks/lifecycle.md
+++ b/docs/src/cookbooks/lifecycle.md
@@ -1,20 +1,19 @@
 # Pipeline lifecycle cookbook
 
-Five end-to-end patterns for the callback-first pipeline lifecycle
-(epic #1853). Each recipe is a complete, copy-paste starting point.
-For the surface reference see [Pipeline lifecycle](../pipeline-lifecycle.md);
-for the per-preset stdlib reference see
+End-to-end patterns for the callback-first pipeline lifecycle. Each
+recipe is a self-contained, copy-paste starting point. For the surface
+reference see [Pipeline lifecycle](../pipeline-lifecycle.md); for the
+per-preset stdlib reference see
 [Pipeline lifecycle presets](../stdlib/lifecycle.md); for the
 LLM-friendly quickref see the "Pipeline lifecycle" section in
 `docs/llm/harn-quickref.md`.
 
 The recipes use `harn,ignore` fences because they wire up full
-multi-pipeline topologies (producer pipeline, drain pipeline, trigger
-handlers, host integration glue). Each fragment type-checks; the
-orchestration loop assumes a host that runs the constituent pipelines
-(such as `harn orchestrator`).
+multi-pipeline topologies (producer, drain, trigger handlers, host glue).
+Each fragment type-checks; the orchestration loop assumes a host that
+runs the constituent pipelines, such as `harn orchestrator`.
 
-## 1. Nightly settlement handoff
+## Nightly settlement handoff
 
 A live ingest pipeline triages events synchronously up to a watermark,
 then hands deferred work off to a separate nightly settlement
@@ -73,7 +72,7 @@ chain, and on_finish policy. A failure mid-settle does not unwind the
 live ingest run, and a `pre_finish` block on the nightly pipeline
 holds finish open until the per-item drain completes.
 
-## 2. Audit every drain decision to a custom store
+## Audit every drain decision to a custom store
 
 A regulated team needs every disposition the settlement-agent loop
 makes to land in an external audit store (Splunk, BigQuery, S3), not
@@ -127,7 +126,7 @@ Why `with_telemetry` outside the drain: the wrapper emits
 a stable span name, so the external store sees a paired pair of
 records bracketing the per-item entries.
 
-## 3. Long-paused agent with resume-continuity reminder
+## Long-paused agent with resume-continuity reminder
 
 A research agent self-parks via `agent_await_resumption` and may
 sleep for hours. When it resumes, two things must happen exactly
@@ -179,7 +178,7 @@ suspend snapshot, so a cold-restore (`harn run --resume <path>`)
 reconstitutes the same wake conditions instead of re-evaluating the
 shape at resume time.
 
-## 4. Hook-based supervision — deny suspend during business hours
+## Hook-based supervision: deny suspend during business hours
 
 A SaaS team wants to prevent any agent from self-parking between 9 AM
 and 5 PM local time (so the on-call rotation can intervene with full
@@ -228,7 +227,7 @@ Why the dedupe key: if the agent retries the suspend three times in
 one turn, the dedupe collapses the reminder to one entry rather than
 stacking three identical bodies.
 
-## 5. Replay-deterministic test harness for a multi-suspend pipeline
+## Replay-deterministic test harness for a multi-suspend pipeline
 
 A pipeline suspends a worker, waits for an external event, resumes,
 suspends again, and finally drains. The conformance fixture needs to

--- a/docs/src/cookbooks/pools.md
+++ b/docs/src/cookbooks/pools.md
@@ -1,17 +1,16 @@
 # Pool cookbook
 
-Four end-to-end patterns for agent pools (#1883). Each recipe is a
-complete, copy-paste starting point. For the surface reference see
-[Agent pools](../agent-pools.md); for the LLM-friendly quickref see
-the "Agent pools" section in `docs/llm/harn-quickref.md`.
+End-to-end patterns for agent pools. Each recipe is a self-contained,
+copy-paste starting point. For the surface reference see
+[Agent pools](../agent-pools.md); for the LLM-friendly quickref see the
+"Agent pools" section in `docs/llm/harn-quickref.md`.
 
 The recipes use `harn,ignore` fences because they wire up full
-multi-pipeline topologies (producer pipeline, pool-draining pipeline,
-and trigger handlers). Each fragment type-checks; the orchestration
-loop assumes a host that runs the constituent pipelines (such as
-`harn orchestrator`).
+multi-pipeline topologies (producer, pool-draining pipeline, trigger
+handlers). Each fragment type-checks; the orchestration loop assumes a
+host that runs the constituent pipelines, such as `harn orchestrator`.
 
-## 1. Rate-limited webhook processor
+## Rate-limited webhook processor
 
 Every webhook source posts to a single `channel:webhook.received`
 channel. A pool with `max_concurrent: 10`, a per-source fair queue,
@@ -56,7 +55,8 @@ pipeline webhook_intake_setup() {
 }
 
 fn process_webhook(payload) {
-  // Idempotent handler — see recipe 4 for the durable-key pattern.
+  // Idempotent handler — see "Burst absorber for nightly batch jobs"
+  // below for the durable-key pattern.
   return upsert_event(payload.source, payload.body)
 }
 ```
@@ -77,7 +77,7 @@ deploy. Pipeline scope reloads queued tasks from
 `.harn/pools/<pipeline_id>__webhook-work.jsonl` so an in-flight burst
 does not vanish on restart.
 
-## 2. GPU-routed inference pool
+## GPU-routed inference pool
 
 A multi-tenant inference service has four GPUs. Each inference call
 must run on exactly one GPU; the pool's `max_concurrent` is sized to
@@ -148,7 +148,7 @@ worker tier (#306). Today this fails with a `host-routed (harn-cloud)
 `scope: "session"` for local development and flip the scope at deploy
 time.
 
-## 3. Cross-customer fairness
+## Cross-customer fairness
 
 A SaaS backend runs per-customer agent tasks (PR review, doc gen,
 test triage). Without fairness, a single noisy customer's batch of
@@ -207,10 +207,10 @@ without losing any work.
 
 Why `scope: "pipeline"`: the queue depth at restart can be tens of
 thousands of tasks. Pipeline scope reloads them and resumes
-draining; the per-task idempotency key (see recipe 4) catches the
+draining; the per-task idempotency key from "Burst absorber" catches the
 brief window where in-flight tasks are re-enqueued.
 
-## 4. Burst absorber for nightly batch jobs
+## Burst absorber for nightly batch jobs
 
 A nightly cron triggers thousands of report-generation tasks. They
 need to all *eventually* run, but only a few at a time to avoid

--- a/docs/src/cookbooks/tool-hooks.md
+++ b/docs/src/cookbooks/tool-hooks.md
@@ -1,23 +1,20 @@
 # Tool hooks cookbook
 
-Copy-paste recipes for the
-[`preset_run_command`](../tool-hooks.md) wrapper. Each recipe is
-self-contained — drop it into a `pipeline default(task) { ... }` body,
-wire the returned closure into your `agent_loop`'s `run_command`
-handler, and you have working catalogue-driven command guards.
+Copy-paste recipes for the [`preset_run_command`](../tool-hooks.md)
+wrapper. Drop one into a `pipeline default(task) { ... }` body, wire
+the returned closure into your `agent_loop`'s `run_command` handler,
+and you have working catalogue-driven command guards.
 
 For the full surface reference see [Preset tool hooks](../tool-hooks.md).
-To extend the shipped catalogues see [Contributing preset
-hooks](../contributing/preset-hooks.md).
+To extend the shipped catalogues see
+[Contributing preset hooks](../contributing/preset-hooks.md).
 
-The recipes use `harn,ignore` fences because they show full
-agent-loop topologies (handler + dispatch + transcript wiring) that
-need an active session to type-check end-to-end. Each fragment is the
-same shape as the conformance fixtures under
-`conformance/tests/stdlib/tool_hooks_*.harn`, so you can copy and
-adapt them with confidence.
+The recipes use `harn,ignore` fences because they show full agent-loop
+topologies (handler + dispatch + transcript wiring) that need an active
+session to type-check end-to-end. Each fragment matches a conformance
+fixture under `conformance/tests/stdlib/tool_hooks_*.harn`.
 
-## 1. Rust agent: safe `cargo`
+## Rust agent: safe `cargo`
 
 A Rust coding agent should never thrash the workspace lockfile, should
 keep `println!` output visible from `cargo test`, and should never
@@ -52,7 +49,7 @@ What fires here:
 - The universal catalogue's `git push --force main` and `rm -rf /`
   denies fire regardless of `stacks`.
 
-## 2. Python agent: virtualenv-friendly defaults
+## Python agent: virtualenv-friendly defaults
 
 Same shape, different opt-in. The Python catalogue rewrites `find` to
 `rg --files`, warns on system-wide `pip install`, and keeps `pytest`
@@ -70,7 +67,7 @@ pipeline default(task) {
 }
 ```
 
-## 3. TypeScript agent: refuse `--legacy-peer-deps`
+## TypeScript agent: refuse `--legacy-peer-deps`
 
 The TypeScript catalogue's `ts.npm_install_force_resolution` rule is
 informational by default (warning severity, no rewrite). For a
@@ -92,9 +89,9 @@ pipeline default(task) {
 With `tool_hooks_mode_deny_with_explanation` as the wrapper-wide mode,
 **every** match denies — not just the npm one. For per-rule
 gradations, use the default rewrite-with-audit mode and write
-deny-only `custom_rules` (recipe 5).
+deny-only `custom_rules` (see the SQL recipe below).
 
-## 4. Swift agent: protect `.build/` from accidental cleans
+## Swift agent: protect `.build/` from accidental cleans
 
 The Swift catalogue ships one rule by default. Compose it with custom
 rules for project-specific extensions:
@@ -124,7 +121,7 @@ pipeline default(task) {
 }
 ```
 
-## 5. SQL agent: deny `SELECT *` without a `LIMIT`
+## SQL agent: deny `SELECT *` without a `LIMIT`
 
 The shipped `sql.select_star_warning` rule is `severity: "warning"`
 without a rewrite — it surfaces the pattern but doesn't block. To
@@ -161,7 +158,7 @@ Custom rules are matched before the registry, so the deny fires
 ahead of the catalogue's softer warning. The default mode would
 otherwise let unbounded `SELECT *` through with a warning audit.
 
-## 6. Harn dogfood agent: silence `cargo run --bin harn`
+## Harn dogfood agent: silence `cargo run --bin harn`
 
 The Harn catalogue patches CLAUDE.md's "always pass `--quiet`"
 guidance into the dispatcher itself. Opt-in is one line:
@@ -182,7 +179,7 @@ A bare `cargo run --bin harn -- run examples/hello.harn` rewrites to
 `cargo --quiet run --bin harn -- run examples/hello.harn`, and the
 audit envelope explains why.
 
-## 7. Multi-stack agent with classifier fallback
+## Multi-stack agent with classifier fallback
 
 A polyglot agent needs every shipped catalogue plus a model-driven
 fallback for ad-hoc commands. The classifier is opt-in — leaving
@@ -222,7 +219,7 @@ What the classifier adds:
   `tool_hook_classifier_verdict` audit entry so you can see exactly
   which decisions were model-driven.
 
-## 8. Audit-only rollout (preview, then enforce)
+## Audit-only rollout: preview, then enforce
 
 Roll a new catalogue out by running it in `passthrough_only_audit`
 mode first; collect the `tool_rule_warning` audit entries; once the
@@ -248,7 +245,7 @@ pipeline default(task) {
 with your transcript persistence to retain the rule-firings beyond
 the pipeline run.
 
-## 9. Preview without executing
+## Preview without executing
 
 Omit `inner` to get decision envelopes back without running anything.
 Useful for unit tests, dry-runs, and replaying a transcript with
@@ -271,7 +268,7 @@ Audit + reminder side effects still fire in preview mode, so a
 test asserting on `lifecycle_audit_log_take()` sees the rule
 firings even though no command actually executed.
 
-## 10. Composing with `register_tool_hook`
+## Composing with `register_tool_hook`
 
 `preset_run_command` is the in-tool wrapper for `run_command`-shaped
 tools. The general


### PR DESCRIPTION
Phase 2 of the docs reorganization tracked at #2214. Phase 1 ([#2231](https://github.com/burin-labs/harn/pull/2231)) added the orientation layer (Concepts chapter, Diataxis SUMMARY, branded theme, landing). This PR cleans up the how-to layer.

## Why

The recipes in `cookbook.md` and `cookbooks/*.md` were structured as ordered lists (`1. ...`, `2. ...`, `3. ...`). That formatting implies a sequence — but [Diataxis](https://diataxis.fr/how-to-guides/) is explicit that how-to guides should be **goal-oriented**, **independent**, and **named by the task they accomplish**. A reader landing on "3. Parallel tool execution" can't tell whether they need to read 1 and 2 first.

## What changed

### `cookbook.md` (665 → 668 lines)

- Replaced numbered section headings with descriptive titles that name the task: `## 1. Basic LLM call` → `### How to make a basic LLM call`, `## 8. Channel-based coordination` → `### How to coordinate spawned tasks with channels`, etc.
- Grouped recipes by theme so the H2 surface is **LLM calls**, **Tools and agent loops**, **MCP servers**, **Concurrency**, **Error handling**, **Patterns** — making the page work as a TOC instead of a single linear list.
- Added a short pointer index at the top to the four sub-cookbooks plus `oauth.md` for readers who arrive looking for a deeper topic.
- Consolidated three near-identical MCP recipes (was #4 + #13 + #17) into two non-overlapping entries: "How to call an MCP server" and "How to give an agent MCP tools".
- Folded the two five-line stub recipes (was #16 parallel-each LLM eval and #17 MCP client usage) into the surrounding entries rather than leaving them as filler.

### `cookbooks/{channels,lifecycle,pools,tool-hooks}.md`

- Dropped the numeric prefixes from every recipe heading. "1. Release handshake" → "Release handshake", etc.
- Rewrote the boilerplate intro sentence on each page: dropped the recipe count (e.g. "Five end-to-end patterns for X (#issue)") so the intro doesn't lie when a recipe gets added or removed later.
- Updated two stale "see recipe N" cross-references in `pools.md` and one in `tool-hooks.md` to name the recipes they point at.

### Out of scope (filed as follow-ups)

- **Tutorial for suspend/resume daemons** ([#2274](https://github.com/burin-labs/harn/issues/2274)) — the landing page promises "Suspend and resume" as a Harn feature; reference exists at `agent-lifecycle.md` but no walkthrough.
- **Slopwash sweep on long-tail reference pages** ([#2275](https://github.com/burin-labs/harn/issues/2275)) — the highest-traffic pages were polished in Phase 1; the 500+ LOC pages (`language-spec.md`, `diagnostics.md`, `builtins.md`, `cli-reference.md`, `mcp-and-acp.md`, etc.) still want a pass. Sampled the next-tier reference pages (`language-basics.md`, `modules.md`, `concurrency.md`, `streams.md`, `error-handling.md`, `runtime-context.md`, `best-practices.md`, `debugging.md`, `scripting-cheatsheet.md`, `common-tasks.md`, `testing.md`) and found them already slopwash-clean.

## Files unchanged

- `SUMMARY.md` — section layout is correct as-is; only headings and content inside the cookbook pages moved.
- `introduction.md` — landing CTAs still point to `./cookbook.html` and `./getting-started.html`; both names are stable.

## Test plan

- [x] `mdbook build` completes (one pre-existing search-index size warning).
- [x] `npx markdownlint-cli2 'docs/src/cookbook.md' 'docs/src/cookbooks/**/*.md'` passes with 0 errors.
- [x] Pre-commit + pre-push hooks pass.
- [x] All outgoing internal links from `cookbook.md` resolve to existing files.
- [x] No "recipe N" or "section N" backreferences remain in the cookbooks/ pages.
- [ ] Visual check of the rendered cookbook page on the hosted site after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)