### PR TITLE
Migrate YAML parsing to serde_yml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,7 +2171,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "sha2 0.11.0",
  "subtle",
  "tar",
@@ -2382,7 +2382,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "sha2 0.11.0",
  "subtle",
  "tempfile",
@@ -2457,7 +2457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "serde_yaml",
+ "serde_yml",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "sha3",
@@ -3233,6 +3233,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -4895,16 +4905,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -6204,12 +6216,6 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -48,7 +48,7 @@ axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time", "process"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yml = "0.0.12"
 semver = "1"
 reedline = "0.47"
 nu-ansi-term = "0.50"

--- a/crates/harn-cli/src/commands/package_scaffold.rs
+++ b/crates/harn-cli/src/commands/package_scaffold.rs
@@ -232,7 +232,7 @@ fn read_spec_path(path: &Path) -> Result<(String, Vec<u8>), PackageError> {
 fn parse_spec_value(text: &str, source_label: &str) -> Result<(Value, bool), PackageError> {
     match serde_json::from_str::<Value>(text) {
         Ok(value) => Ok((value, true)),
-        Err(json_error) => match serde_yaml::from_str::<Value>(text) {
+        Err(json_error) => match serde_yml::from_str::<Value>(text) {
             Ok(value) => Ok((value, false)),
             Err(yaml_error) => Err(format!(
                 "failed to parse OpenAPI spec {source_label} as JSON ({json_error}) or YAML ({yaml_error})"

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yml = "0.0.12"
 sha2 = "0.11"
 subtle = "2"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] }

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -651,7 +651,7 @@ async fn version() -> Response {
 }
 
 async fn openapi_json() -> Response {
-    match serde_yaml::from_str::<Value>(OPENAPI_YAML) {
+    match serde_yml::from_str::<Value>(OPENAPI_YAML) {
         Ok(value) => Json(value).into_response(),
         Err(error) => api_error(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -64,7 +64,7 @@ url = "2"
 globset = "0.4"
 walkdir = "2"
 toml = "1.1"
-serde_yaml = "0.9"
+serde_yml = "0.0.12"
 serde = { version = "1", features = ["derive"] }
 serde_path_to_error = "0.1"
 tiktoken-rs = "0.11.0"

--- a/crates/harn-vm/src/orchestration/playground/manifest.rs
+++ b/crates/harn-vm/src/orchestration/playground/manifest.rs
@@ -236,7 +236,7 @@ impl ScenarioManifest {
             .map(|ext| ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml"))
             .unwrap_or(false);
         let manifest: ScenarioManifest = if is_yaml {
-            serde_yaml::from_slice(bytes).map_err(|error| {
+            serde_yml::from_slice(bytes).map_err(|error| {
                 VmError::Runtime(format!(
                     "failed to parse YAML scenario manifest {}: {error}",
                     path.display()
@@ -445,6 +445,10 @@ mod tests {
         ScenarioManifest::parse(s.as_bytes(), &PathBuf::from("test.json")).unwrap()
     }
 
+    fn yaml(s: &str) -> ScenarioManifest {
+        ScenarioManifest::parse(s.as_bytes(), &PathBuf::from("test.yaml")).unwrap()
+    }
+
     #[test]
     fn parses_minimal_manifest() {
         let m = json(
@@ -457,6 +461,21 @@ mod tests {
         );
         assert_eq!(m.scenario, "x");
         assert_eq!(m.repos.len(), 1);
+    }
+
+    #[test]
+    fn parses_yaml_manifest() {
+        let m = yaml(
+            r#"_type: merge_captain_playground_scenario
+scenario: x
+owner: burin-labs
+repos:
+  - name: alpha
+    default_branch: main
+"#,
+        );
+        assert_eq!(m.scenario, "x");
+        assert_eq!(m.repos[0].name, "alpha");
     }
 
     #[test]

--- a/crates/harn-vm/src/skills/frontmatter.rs
+++ b/crates/harn-vm/src/skills/frontmatter.rs
@@ -12,7 +12,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use serde_yaml::Value as YamlValue;
+use serde_yml::Value as YamlValue;
 
 /// Recognized SKILL.md frontmatter fields.
 ///
@@ -168,7 +168,7 @@ pub fn parse_frontmatter(yaml: &str) -> Result<ParsedFrontmatter, String> {
         });
     }
     let raw: YamlValue =
-        serde_yaml::from_str(yaml).map_err(|e| format!("invalid SKILL.md YAML: {e}"))?;
+        serde_yml::from_str(yaml).map_err(|e| format!("invalid SKILL.md YAML: {e}"))?;
     let map = match raw {
         YamlValue::Mapping(m) => m,
         YamlValue::Null => {
@@ -186,7 +186,7 @@ pub fn parse_frontmatter(yaml: &str) -> Result<ParsedFrontmatter, String> {
     };
 
     // Normalize keys: hyphens -> underscores, strip surrounding whitespace.
-    let mut normalized = serde_yaml::Mapping::new();
+    let mut normalized = serde_yml::Mapping::new();
     let mut unknown_fields = Vec::new();
     for (k, v) in map {
         let key_str = match k {
@@ -209,7 +209,7 @@ pub fn parse_frontmatter(yaml: &str) -> Result<ParsedFrontmatter, String> {
     // Hooks sometimes arrive as a list of `{event: "...", command: "..."}`
     // entries rather than a map. Normalize both into a BTreeMap.
     if let Some(YamlValue::Sequence(seq)) = normalized.get("hooks").cloned() {
-        let mut flat = serde_yaml::Mapping::new();
+        let mut flat = serde_yml::Mapping::new();
         for item in seq {
             if let YamlValue::Mapping(entry) = item {
                 let event = entry
@@ -231,7 +231,7 @@ pub fn parse_frontmatter(yaml: &str) -> Result<ParsedFrontmatter, String> {
     }
 
     let manifest: SkillManifest =
-        serde_yaml::from_value(YamlValue::Mapping(normalized)).map_err(|e| {
+        serde_yml::from_value(YamlValue::Mapping(normalized)).map_err(|e| {
             format!(
                 "SKILL.md frontmatter is well-formed YAML but doesn't match the expected field \
                  shapes: {e}"

--- a/crates/harn-vm/src/stdlib/json.rs
+++ b/crates/harn-vm/src/stdlib/json.rs
@@ -84,7 +84,7 @@ pub(crate) fn register_json_builtins(vm: &mut Vm) {
 
     vm.register_builtin("yaml_parse", |args, _out| {
         let text = args.first().map(|a| a.display()).unwrap_or_default();
-        match serde_yaml::from_str::<serde_yaml::Value>(&text) {
+        match serde_yml::from_str::<serde_yml::Value>(&text) {
             Ok(value) => match serde_json::to_value(value) {
                 Ok(json_value) => Ok(schema::json_to_vm_value(&json_value)),
                 Err(error) => Err(VmError::Thrown(VmValue::String(Rc::from(format!(
@@ -100,7 +100,7 @@ pub(crate) fn register_json_builtins(vm: &mut Vm) {
     vm.register_builtin("yaml_stringify", |args, _out| {
         let value = args.first().unwrap_or(&VmValue::Nil);
         let data_value = vm_value_to_data_value(value);
-        serde_yaml::to_string(&data_value)
+        serde_yml::to_string(&data_value)
             .map(|text| VmValue::String(Rc::from(text)))
             .map_err(|error| {
                 VmError::Thrown(VmValue::String(Rc::from(format!(

--- a/crates/harn-vm/src/stdlib/project_enrich.rs
+++ b/crates/harn-vm/src/stdlib/project_enrich.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 use std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
-use serde_yaml::Value as YamlValue;
+use serde_yml::Value as YamlValue;
 use sha2::{Digest, Sha256};
 
 use crate::llm::{execute_llm_call, extract_llm_options, vm_value_to_json};
@@ -514,7 +514,7 @@ fn collect_workflow_evidence(
         scan.combined_text.push_str(&content);
 
         let rel_path = relative_posix(root, &path);
-        let parsed = match serde_yaml::from_str::<YamlValue>(&content) {
+        let parsed = match serde_yml::from_str::<YamlValue>(&content) {
             Ok(value) => value,
             Err(_) => continue,
         };
@@ -545,7 +545,7 @@ fn collect_workflow_evidence(
 }
 
 fn collect_workflow_jobs(
-    jobs: &serde_yaml::Mapping,
+    jobs: &serde_yml::Mapping,
     workflow_name: &str,
     required_checks: Option<&BTreeSet<String>>,
 ) -> Vec<WorkflowJobEvidence> {
@@ -792,7 +792,7 @@ fn collect_hook_evidence(root: &Path) -> HookEvidence {
 }
 
 fn collect_pre_commit_hooks(content: &str, stages: &mut BTreeMap<String, Vec<String>>) {
-    let Ok(parsed) = serde_yaml::from_str::<YamlValue>(content) else {
+    let Ok(parsed) = serde_yml::from_str::<YamlValue>(content) else {
         return;
     };
     let default_stages = parsed
@@ -860,7 +860,7 @@ fn collect_lefthook_hooks(
     content: &str,
     stages: &mut BTreeMap<String, Vec<String>>,
 ) -> Result<(), String> {
-    let Ok(parsed) = serde_yaml::from_str::<YamlValue>(content) else {
+    let Ok(parsed) = serde_yml::from_str::<YamlValue>(content) else {
         return Ok(());
     };
     let Some(root) = parsed.as_mapping() else {
@@ -1867,7 +1867,7 @@ exit 1
 
     #[test]
     fn lefthook_run_collection_preserves_sorted_depth_first_order() {
-        let value: YamlValue = serde_yaml::from_str(
+        let value: YamlValue = serde_yml::from_str(
             r#"
 commands:
   z:
@@ -1889,7 +1889,7 @@ commands:
 
     #[test]
     fn lefthook_run_collection_reports_yaml_depth_limit() {
-        let mut run = serde_yaml::Mapping::new();
+        let mut run = serde_yml::Mapping::new();
         run.insert(
             YamlValue::String("run".to_string()),
             YamlValue::String("echo too-deep".to_string()),


### PR DESCRIPTION
## Summary

- migrate all direct Rust YAML parsing/serialization users from deprecated `serde_yaml` to maintained `serde_yml`
- remove `serde_yaml` and `unsafe-libyaml` from `Cargo.lock`
- add YAML scenario manifest coverage alongside existing JSON manifest tests

Closes #2262.

## Verification

- `cargo check -p harn-vm -p harn-cli -p harn-serve`
- `cargo test -p harn-vm --lib frontmatter`
- `cargo test -p harn-vm --lib parses_yaml_manifest`
- `cargo test -p harn-vm --lib operator_meta_collects_workflows_hooks_manifests_and_merge_policy`
- `cargo test -p harn-cli --lib load_spec_accepts_file_url`
- `cargo test -p harn-serve --lib openapi_json_is_served_from_canonical_spec`
- `cargo run --bin harn -- test conformance --filter yaml_toml_builtins`
- `cargo fmt --all -- --check`
- `cargo clippy -p harn-vm -p harn-cli -p harn-serve --all-targets -- -D warnings`
- `git diff --check`
- `rg -n "serde_yaml|unsafe-libyaml" Cargo.toml Cargo.lock crates` (no matches)
- `cargo tree -i serde_yaml --workspace` (confirmed absent)

