### PR TITLE
Gate legacy SHA-1 webhook HMACs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,10 @@ condensed series summaries instead of full per-patch history.
 
 ### Fixed
 
+- **Legacy SHA-1 webhook HMACs now require explicit opt-in (#2260).**
+  `webhook_intake_register(..., algorithm: "sha1")` and
+  `std/connectors/shared::verify_hmac_signature(..., "sha1")` now require
+  `allow_legacy_sha1: true`; SHA-256 remains the default for new connectors.
 - **Secret redaction and scanning now share one token catalog.**
   `secret_scan`, token redaction, and provider-error sanitization now use the
   same high-confidence secret patterns. JWTs, Bearer tokens, and full private

--- a/conformance/tests/stdlib/connectors_shared.expected
+++ b/conformance/tests/stdlib/connectors_shared.expected
@@ -1,5 +1,7 @@
 true
 false
+false
+true
 true
 issuer
 true

--- a/conformance/tests/stdlib/connectors_shared.harn
+++ b/conformance/tests/stdlib/connectors_shared.harn
@@ -10,6 +10,11 @@ pipeline test(task) {
   let signature = "sha256=" + hmac_sha256("secret", "payload")
   __io_println(verify_hmac_signature("payload", signature, "secret", "sha256"))
   __io_println(verify_hmac_signature("payload", signature, "wrong", "sha256"))
+  let legacy_signature = "sha1=" + hmac_sha1("secret", "payload")
+  __io_println(verify_hmac_signature("payload", legacy_signature, "secret", "sha1"))
+  __io_println(
+    verify_hmac_signature("payload", legacy_signature, "secret", "sha1", {allow_legacy_sha1: true}),
+  )
   let root = project_root() ?? cwd()
   let private_key = harness.fs.read_text(path_join(root, "conformance/helpers/github_app_test_key.pem"))
   let token = jwt_sign("RS256", {iss: "issuer", aud: "audience", exp: 4102444800}, private_key)

--- a/conformance/tests/triggers/webhook_intake_sha1_legacy.harn
+++ b/conformance/tests/triggers/webhook_intake_sha1_legacy.harn
@@ -6,6 +6,7 @@ pipeline test(task) {
       id: "legacy-sha1",
       secret: "legacy-secret",
       algorithm: "sha1",
+      allow_legacy_sha1: true,
       signature_header: "x-hub-signature",
       signature_prefix: "sha1=",
       delivery_id_header: "x-legacy-delivery",

--- a/conformance/tests/triggers/webhook_intake_sha1_requires_opt_in.error
+++ b/conformance/tests/triggers/webhook_intake_sha1_requires_opt_in.error
@@ -1,0 +1,1 @@
+set `allow_legacy_sha1: true` to verify HMAC-SHA1 signatures

--- a/conformance/tests/triggers/webhook_intake_sha1_requires_opt_in.harn
+++ b/conformance/tests/triggers/webhook_intake_sha1_requires_opt_in.harn
@@ -1,0 +1,13 @@
+pipeline test(task) {
+  webhook_intake_register(
+    {
+      id: "sha1-without-opt-in",
+      secret: "legacy-secret",
+      algorithm: "sha1",
+      signature_header: "x-hub-signature",
+      signature_prefix: "sha1=",
+      delivery_id_header: "x-legacy-delivery",
+      topic: "tests.intake.legacy",
+    },
+  )
+}

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -243,14 +243,15 @@ the connector that consumes the topic.\n\n",
     out.push_str("Builtins:\n\n");
     out.push_str(
         "- `webhook_intake_register(config) -> dict` — register an intake. Returns\n  \
-`{ id, path, topic, signature_header, signature_prefix,\n  signature_encoding, algorithm, delivery_id_header,\n  dedupe_ttl_seconds }`. Config keys:\n  \
+`{ id, path, topic, signature_header, signature_prefix,\n  signature_encoding, algorithm, allow_legacy_sha1, delivery_id_header,\n  dedupe_ttl_seconds }`. Config keys:\n  \
 - `id` (optional) — pin the intake id; one is generated if omitted.\n  \
 - `path` (optional) — HTTP path scope. When set, `webhook_intake_feed`\n    rejects deliveries on a different path.\n  \
 - `secret` (string or bytes, required) — HMAC key.\n  \
 - `signature_header` (required) — e.g. `\"x-hub-signature-256\"`.\n  \
 - `signature_prefix` — defaults to `\"<algorithm>=\"`. Pass `\"\"` to opt out.\n  \
 - `signature_encoding` — `\"hex\"` (default) or `\"base64\"`.\n  \
-- `algorithm` — `\"sha256\"` (default) or `\"sha1\"` (legacy).\n  \
+- `algorithm` — `\"sha256\"` (default) or legacy `\"sha1\"` when `allow_legacy_sha1` is true.\n  \
+- `allow_legacy_sha1` — explicit opt-in for existing providers that still sign with HMAC-SHA1.\n  \
 - `delivery_id_header` (required) — e.g. `\"x-github-delivery\"`.\n  \
 - `topic` (required) — event-log topic accepted deliveries are appended to.\n  \
 - `dedupe_ttl_seconds` — defaults to 24h.\n\

--- a/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
@@ -13,18 +13,23 @@ fn __strip_signature_prefix(signature) {
 }
 
 /**
- * verify_hmac_signature.
+ * Constant-time HMAC signature check.
+ * Legacy HMAC-SHA1 requires options.allow_legacy_sha1.
  *
  * @effects: []
  * @allocation: heap
  * @errors: []
  * @api_stability: stable
- * @example: verify_hmac_signature(body, signature, secret, algorithm)
+ * @example: verify_hmac_signature(body, signature, secret, algorithm, options)
  */
-pub fn verify_hmac_signature(body, signature, secret, algorithm = "sha256") {
+pub fn verify_hmac_signature(body, signature, secret, algorithm = "sha256", options = nil) {
   let alg = lowercase(trim(algorithm ?? "sha256"))
   let provided = __strip_signature_prefix(signature)
+  let opts = options ?? {}
   if alg == "sha1" || alg == "hmac-sha1" {
+    if !(opts.allow_legacy_sha1 ?? false) {
+      return false
+    }
     return constant_time_eq(hmac_sha1(secret, body), provided)
   }
   if alg != "sha256" && alg != "hmac-sha256" {

--- a/crates/harn-vm/src/connectors/shared.rs
+++ b/crates/harn-vm/src/connectors/shared.rs
@@ -25,14 +25,25 @@ impl<T: Connector + ?Sized> ConnectorBase for T {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HmacSignatureAlgorithm {
-    Sha1,
+    LegacySha1,
     Sha256,
 }
 
 impl HmacSignatureAlgorithm {
     pub fn parse(raw: &str) -> Result<Self, ConnectorError> {
+        Self::parse_with_legacy_sha1(raw, false)
+    }
+
+    pub fn parse_with_legacy_sha1(
+        raw: &str,
+        allow_legacy_sha1: bool,
+    ) -> Result<Self, ConnectorError> {
         match raw.trim().to_ascii_lowercase().as_str() {
-            "sha1" | "hmac-sha1" => Ok(Self::Sha1),
+            "sha1" | "hmac-sha1" if allow_legacy_sha1 => Ok(Self::LegacySha1),
+            "sha1" | "hmac-sha1" => Err(ConnectorError::Unsupported(
+                "HMAC-SHA1 is legacy; set `allow_legacy_sha1: true` for an existing provider"
+                    .to_string(),
+            )),
             "sha256" | "hmac-sha256" | "" => Ok(Self::Sha256),
             other => Err(ConnectorError::Unsupported(format!(
                 "unsupported HMAC signature algorithm `{other}`"
@@ -62,7 +73,7 @@ pub fn verify_hmac_signature(
         detail: error.to_string(),
     })?;
     let expected = match algorithm {
-        HmacSignatureAlgorithm::Sha1 => hmac::hmac_sha1(secret.as_bytes(), body),
+        HmacSignatureAlgorithm::LegacySha1 => hmac::hmac_sha1(secret.as_bytes(), body),
         HmacSignatureAlgorithm::Sha256 => hmac::hmac_sha256(secret.as_bytes(), body),
     };
     Ok(hmac::secure_eq(&expected, &provided))
@@ -387,6 +398,27 @@ mod tests {
             signature,
             "It's a Secret to Everybody",
             HmacSignatureAlgorithm::Sha256,
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn hmac_signature_sha1_requires_explicit_legacy_algorithm() {
+        let parse_error = HmacSignatureAlgorithm::parse("sha1").expect_err("sha1 is gated");
+        assert!(parse_error.to_string().contains("allow_legacy_sha1"));
+        assert_eq!(
+            HmacSignatureAlgorithm::parse_with_legacy_sha1("sha1", true).unwrap(),
+            HmacSignatureAlgorithm::LegacySha1
+        );
+
+        let body = b"legacy";
+        let digest = hmac::hmac_sha1(b"legacy-secret", body);
+        let signature = format!("sha1={}", hex::encode(digest));
+        assert!(verify_hmac_signature(
+            body,
+            &signature,
+            "legacy-secret",
+            HmacSignatureAlgorithm::LegacySha1,
         )
         .unwrap());
     }

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -2399,13 +2399,22 @@ fn parse_webhook_intake_config(
     let delivery_id_header =
         required_string(config, "delivery_id_header", "webhook_intake_register")?;
     let topic = required_string(config, "topic", "webhook_intake_register")?;
+    let allow_legacy_sha1 =
+        optional_bool(config, "allow_legacy_sha1", "webhook_intake_register")?.unwrap_or(false);
 
     let algorithm = match optional_string(config, "algorithm").as_deref() {
-        Some(raw) => HmacAlgorithm::parse(raw).ok_or_else(|| {
-            VmError::Runtime(format!(
-                "webhook_intake_register: unsupported algorithm `{raw}`, expected sha256 or sha1"
-            ))
-        })?,
+        Some(raw) if HmacAlgorithm::is_legacy_sha1_alias(raw) && !allow_legacy_sha1 => {
+            return Err(VmError::Runtime(
+                "webhook_intake_register: algorithm `sha1` is legacy; set `allow_legacy_sha1: true` to verify HMAC-SHA1 signatures".to_string(),
+            ));
+        }
+        Some(raw) => {
+            HmacAlgorithm::parse_with_legacy_sha1(raw, allow_legacy_sha1).ok_or_else(|| {
+                VmError::Runtime(format!(
+                    "webhook_intake_register: unsupported algorithm `{raw}`, expected sha256"
+                ))
+            })?
+        }
         None => HmacAlgorithm::default(),
     };
     let signature_encoding = match optional_string(config, "signature_encoding").as_deref() {
@@ -2449,6 +2458,7 @@ fn parse_webhook_intake_config(
         signature_prefix,
         signature_encoding,
         algorithm,
+        allow_legacy_sha1,
         secret,
         delivery_id_header,
         topic,

--- a/crates/harn-vm/src/triggers/webhook_intake.rs
+++ b/crates/harn-vm/src/triggers/webhook_intake.rs
@@ -86,11 +86,22 @@ pub enum HmacAlgorithm {
 
 impl HmacAlgorithm {
     pub fn parse(raw: &str) -> Option<Self> {
+        Self::parse_with_legacy_sha1(raw, false)
+    }
+
+    pub fn parse_with_legacy_sha1(raw: &str, allow_legacy_sha1: bool) -> Option<Self> {
         match raw.trim().to_ascii_lowercase().as_str() {
             "" | "sha256" | "hmac-sha256" => Some(Self::Sha256),
-            "sha1" | "hmac-sha1" => Some(Self::Sha1),
+            "sha1" | "hmac-sha1" if allow_legacy_sha1 => Some(Self::Sha1),
             _ => None,
         }
+    }
+
+    pub fn is_legacy_sha1_alias(raw: &str) -> bool {
+        matches!(
+            raw.trim().to_ascii_lowercase().as_str(),
+            "sha1" | "hmac-sha1"
+        )
     }
 
     pub fn as_str(&self) -> &'static str {
@@ -136,6 +147,7 @@ pub struct WebhookIntakeConfig {
     pub signature_prefix: Option<String>,
     pub signature_encoding: SignatureEncoding,
     pub algorithm: HmacAlgorithm,
+    pub allow_legacy_sha1: bool,
     pub secret: Vec<u8>,
     pub delivery_id_header: String,
     pub topic: String,
@@ -191,6 +203,7 @@ pub struct WebhookIntakeSnapshot {
     pub signature_prefix: Option<String>,
     pub signature_encoding: String,
     pub algorithm: String,
+    pub allow_legacy_sha1: bool,
     pub delivery_id_header: String,
     pub dedupe_ttl_seconds: u64,
 }
@@ -299,6 +312,11 @@ pub fn register_webhook_intake(
             "secret cannot be empty".to_string(),
         ));
     }
+    if config.algorithm == HmacAlgorithm::Sha1 && !config.allow_legacy_sha1 {
+        return Err(WebhookIntakeError::Config(
+            "algorithm `sha1` is legacy; set `allow_legacy_sha1: true` to verify SHA-1 HMAC signatures for an existing provider".to_string(),
+        ));
+    }
     Topic::new(config.topic.clone())
         .map_err(|error| WebhookIntakeError::Config(format!("invalid topic: {error}")))?;
 
@@ -331,6 +349,7 @@ pub fn register_webhook_intake(
             signature_prefix: config.signature_prefix.clone(),
             signature_encoding: config.signature_encoding.as_str().to_string(),
             algorithm: config.algorithm.as_str().to_string(),
+            allow_legacy_sha1: config.allow_legacy_sha1,
             delivery_id_header: normalize_header(&config.delivery_id_header),
             dedupe_ttl_seconds: config.dedupe_ttl.as_secs(),
         };
@@ -705,6 +724,7 @@ mod tests {
             signature_prefix: Some("sha256=".to_string()),
             signature_encoding: SignatureEncoding::Hex,
             algorithm: HmacAlgorithm::Sha256,
+            allow_legacy_sha1: false,
             secret: secret.to_vec(),
             delivery_id_header: "x-test-delivery".to_string(),
             topic: "tests.webhook_intake".to_string(),
@@ -845,6 +865,7 @@ mod tests {
         let body = b"legacy".to_vec();
         let mut config = make_config(b"legacy-secret");
         config.algorithm = HmacAlgorithm::Sha1;
+        config.allow_legacy_sha1 = true;
         config.signature_prefix = Some("sha1=".to_string());
         let snapshot = register_webhook_intake(config.clone()).expect("register");
 
@@ -856,6 +877,27 @@ mod tests {
         .await
         .expect("feed");
         assert_eq!(outcome.status, "accepted");
+    }
+
+    #[test]
+    fn hmac_algorithm_parser_gates_sha1() {
+        assert_eq!(HmacAlgorithm::parse("sha256"), Some(HmacAlgorithm::Sha256));
+        assert_eq!(HmacAlgorithm::parse("sha1"), None);
+        assert_eq!(
+            HmacAlgorithm::parse_with_legacy_sha1("sha1", true),
+            Some(HmacAlgorithm::Sha1)
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_sha1_without_legacy_opt_in() {
+        reset().await;
+        let mut config = make_config(b"legacy-secret");
+        config.algorithm = HmacAlgorithm::Sha1;
+        config.signature_prefix = Some("sha1=".to_string());
+
+        let error = register_webhook_intake(config).expect_err("sha1 requires opt-in");
+        assert!(error.to_string().contains("set `allow_legacy_sha1: true`"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -188,7 +188,7 @@ Builtins:
 
 - `webhook_intake_register(config) -> dict` — register an intake. Returns
   `{ id, path, topic, signature_header, signature_prefix,
-  signature_encoding, algorithm, delivery_id_header,
+  signature_encoding, algorithm, allow_legacy_sha1, delivery_id_header,
   dedupe_ttl_seconds }`. Config keys:
   - `id` (optional) — pin the intake id; one is generated if omitted.
   - `path` (optional) — HTTP path scope. When set, `webhook_intake_feed`
@@ -197,7 +197,8 @@ Builtins:
   - `signature_header` (required) — e.g. `"x-hub-signature-256"`.
   - `signature_prefix` — defaults to `"<algorithm>="`. Pass `""` to opt out.
   - `signature_encoding` — `"hex"` (default) or `"base64"`.
-  - `algorithm` — `"sha256"` (default) or `"sha1"` (legacy).
+  - `algorithm` — `"sha256"` (default) or legacy `"sha1"` when `allow_legacy_sha1` is true.
+  - `allow_legacy_sha1` — explicit opt-in for existing providers that still sign with HMAC-SHA1.
   - `delivery_id_header` (required) — e.g. `"x-github-delivery"`.
   - `topic` (required) — event-log topic accepted deliveries are appended to.
   - `dedupe_ttl_seconds` — defaults to 24h.

--- a/docs/src/connectors/authoring.md
+++ b/docs/src/connectors/authoring.md
@@ -587,6 +587,9 @@ need timestamp-window checks, audit events, or a provider-specific signed
 message format. Use `std/connectors/shared` inside Harn package exports for
 local HMAC checks, JWT/JWKS verification, outbound HTTP policy, OAuth2 token
 refresh, package-local token buckets, and cursor pagination.
+Existing providers that still sign with HMAC-SHA1 must call
+`verify_hmac_signature(..., "sha1", {allow_legacy_sha1: true})`; new
+connectors should use SHA-256 or a provider-specific verifier.
 
 ## Outbound HTTP policy
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -159,7 +159,7 @@ Connector package helpers for common provider plumbing:
 | `connector_http_json(method, url, options?)` | `connector_http_request` plus response JSON parsing; invalid JSON returns `error.category == "invalid_json"` |
 | `connector_http_header(headers_or_response, name)` | Case-insensitive header lookup for response envelopes or raw header dicts |
 | `connector_http_rate_limit(headers_or_response)` | Extract `Retry-After`, `RateLimit-*`, and `X-RateLimit-*` metadata, including `retry_after_ms` when parseable |
-| `verify_hmac_signature(body, signature, secret, algorithm?)` | Constant-time check for bare or `sha256=`/`sha1=` HMAC signatures |
+| `verify_hmac_signature(body, signature, secret, algorithm?, options?)` | Constant-time check for bare or `sha256=` signatures; legacy `sha1=` requires `options.allow_legacy_sha1` |
 | `verify_jwt(token, jwks_url, options?)` | Verify a compact JWT against a JWKS URL, or `options.inline_jwks`, returning `{ok, claims, error}` |
 | `oauth2_token_refresh(client_id, client_secret, refresh_token, token_url, options?)` | Refresh an OAuth2 access token with form-encoded `grant_type=refresh_token` |
 | `rate_limit_token_bucket(state?, config?, now_ms?)` | Pure token-bucket transition for package-local quota decisions |

--- a/docs/src/triggers/webhook-intake.md
+++ b/docs/src/triggers/webhook-intake.md
@@ -30,7 +30,7 @@ The substrate is exposed as five Harn builtins.
 
 Register an intake. Returns a snapshot dict
 (`{ id, path, topic, signature_header, signature_prefix,
-signature_encoding, algorithm, delivery_id_header,
+signature_encoding, algorithm, allow_legacy_sha1, delivery_id_header,
 dedupe_ttl_seconds }`). Config keys:
 
 | Key | Required | Default | Description |
@@ -41,7 +41,8 @@ dedupe_ttl_seconds }`). Config keys:
 | `signature_header` | yes | — | Header name carrying the signature, e.g. `"x-hub-signature-256"`. |
 | `signature_prefix` | no | `"<algorithm>="` (e.g. `"sha256="`) | Prefix to strip before decoding. Pass `""` to opt out. |
 | `signature_encoding` | no | `"hex"` | `"hex"` or `"base64"`. |
-| `algorithm` | no | `"sha256"` | `"sha256"` or `"sha1"` (legacy). |
+| `algorithm` | no | `"sha256"` | `"sha256"` or legacy `"sha1"` when `allow_legacy_sha1` is true. |
+| `allow_legacy_sha1` | no | `false` | Explicit opt-in for existing providers that still sign with HMAC-SHA1. |
 | `delivery_id_header` | yes | — | Header name carrying the delivery id, e.g. `"x-github-delivery"`. |
 | `topic` | yes | — | Event-log topic to append accepted deliveries onto. |
 | `dedupe_ttl_seconds` | no | 86400 (24h) | How long delivery ids stay claimed in the inbox. |


### PR DESCRIPTION
## Summary

- Require `allow_legacy_sha1: true` before webhook intake accepts `algorithm: "sha1"`, including direct Rust `WebhookIntakeConfig` registration.
- Make connector shared HMAC SHA-1 usage explicit via `LegacySha1` / `parse_with_legacy_sha1`, and require the same opt-in in the Harn `std/connectors/shared` helper.
- Add conformance coverage, update docs, regenerate the trigger quickref, and record the change in the changelog.

Closes #2260.

## Verification

- `cargo test -p harn-vm sha1 --lib`
- `cargo run --quiet --bin harn -- test conformance --filter webhook_intake_sha1`
- `cargo run --quiet --bin harn -- test conformance --filter connectors_shared`
- `cargo fmt --all --check`
- `make check-trigger-quickref`
- `make lint-test-patterns`
- `make lint-harn`
- Pre-commit hook: Rust fmt, staged Harn fmt/lint, changed-package clippy, markdownlint, generated highlight check
- Pre-push hook: targeted local checks, affected Harn fmt/lint, markdownlint, generated highlight check