### PR TITLE
[codex] Cap Content-Length in test HTTP readers

### DIFF
--- a/crates/harn-cli/src/commands/connect/tests.rs
+++ b/crates/harn-cli/src/commands/connect/tests.rs
@@ -9,6 +9,9 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
+use harn_vm::connectors::testkit::{
+    http_content_length_from_header_lines, TEST_HTTP_MAX_BODY_BYTES,
+};
 use harn_vm::secrets::SecretId;
 use url::Url;
 
@@ -556,15 +559,13 @@ fn read_http_request(stream: &mut TcpStream) -> String {
         buffer.extend_from_slice(&chunk[..read]);
         let text = String::from_utf8_lossy(&buffer);
         if let Some((headers, body)) = text.split_once("\r\n\r\n") {
-            let content_length = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse::<usize>().ok())
-                        .flatten()
-                })
-                .unwrap_or(0);
+            let content_length = match http_content_length_from_header_lines(
+                headers.lines(),
+                TEST_HTTP_MAX_BODY_BYTES,
+            ) {
+                Ok(content_length) => content_length,
+                Err(_) => break,
+            };
             if body.len() >= content_length {
                 break;
             }

--- a/crates/harn-dap/src/main.rs
+++ b/crates/harn-dap/src/main.rs
@@ -14,6 +14,8 @@ use debugger::Debugger;
 use host_bridge::{deliver_reply, pending_map_new, DapHostBridge, DapHostCallReply, PendingMap};
 use protocol::{DapMessage, DapResponse};
 
+const MAX_DAP_FRAME_BYTES: usize = 16 * 1024 * 1024;
+
 fn main() {
     // Shared seq counter spans both forward responses (debugger.next_seq)
     // and reverse requests (DapHostBridge.next_seq) so every adapter-
@@ -97,7 +99,15 @@ fn stdin_reader(request_tx: Sender<DapMessage>, pending: PendingMap) {
     let stdin = io::stdin();
     let mut reader = io::BufReader::new(stdin.lock());
 
-    while let Some(content_length) = read_content_length(&mut reader) {
+    loop {
+        let content_length = match read_content_length(&mut reader) {
+            Ok(Some(content_length)) => content_length,
+            Ok(None) => break,
+            Err(error) => {
+                eprintln!("Failed to read DAP frame header: {error}");
+                break;
+            }
+        };
         if content_length == 0 {
             continue;
         }
@@ -135,28 +145,44 @@ fn stdin_reader(request_tx: Sender<DapMessage>, pending: PendingMap) {
     }
 }
 
-fn read_content_length(reader: &mut io::BufReader<io::StdinLock>) -> Option<usize> {
+fn read_content_length<R: BufRead>(reader: &mut R) -> io::Result<Option<usize>> {
     let mut content_length = 0usize;
     loop {
         let mut line = String::new();
         match reader.read_line(&mut line) {
-            Ok(0) => return None,
+            Ok(0) => return Ok(None),
             Ok(_) => {
                 let trimmed = line.trim();
                 if trimmed.is_empty() {
                     if content_length > 0 {
-                        return Some(content_length);
+                        return Ok(Some(content_length));
                     }
                     continue;
                 }
-                if let Some(val) = trimmed.strip_prefix("Content-Length:") {
+                if let Some((name, val)) = trimmed.split_once(':') {
+                    if !name.eq_ignore_ascii_case("Content-Length") {
+                        continue;
+                    }
                     if let Ok(len) = val.trim().parse::<usize>() {
-                        content_length = len;
+                        content_length = bounded_dap_content_length(len)?;
                     }
                 }
             }
-            Err(_) => return None,
+            Err(error) => return Err(error),
         }
+    }
+}
+
+fn bounded_dap_content_length(content_length: usize) -> io::Result<usize> {
+    if content_length > MAX_DAP_FRAME_BYTES {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "DAP Content-Length {content_length} exceeds limit {MAX_DAP_FRAME_BYTES} bytes"
+            ),
+        ))
+    } else {
+        Ok(content_length)
     }
 }
 
@@ -173,4 +199,26 @@ fn send_response(stdout: &Arc<Mutex<Box<dyn Write + Send>>>, response: &DapRespo
     let _ = guard.write_all(header.as_bytes());
     let _ = guard.write_all(body.as_bytes());
     let _ = guard.flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_content_length_accepts_case_insensitive_header() {
+        let mut reader = io::BufReader::new(b"content-length: 12\r\n\r\n".as_slice());
+        assert_eq!(
+            read_content_length(&mut reader).expect("content length"),
+            Some(12)
+        );
+    }
+
+    #[test]
+    fn read_content_length_rejects_oversized_frame() {
+        let header = format!("Content-Length: {}\r\n\r\n", MAX_DAP_FRAME_BYTES + 1);
+        let mut reader = io::BufReader::new(header.as_bytes());
+        let error = read_content_length(&mut reader).expect_err("oversized frame");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
 }

--- a/crates/harn-vm/src/connectors/test_util.rs
+++ b/crates/harn-vm/src/connectors/test_util.rs
@@ -22,6 +22,8 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 
+use crate::http::framing::{http_content_length_from_headers, TEST_HTTP_MAX_BODY_BYTES};
+
 #[allow(unused_imports)]
 pub(crate) use crate::triggers::test_util::clock::MockClock;
 
@@ -290,11 +292,13 @@ async fn read_request(stream: &mut TcpStream) -> Option<FakeHttpRequest> {
         }
     }
 
-    let content_length = headers
-        .get("content-length")
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(0);
-    while buffer.len() < header_end + content_length {
+    let content_length = match http_content_length_from_headers(&headers, TEST_HTTP_MAX_BODY_BYTES)
+    {
+        Ok(content_length) => content_length,
+        Err(_) => return None,
+    };
+    let body_end = header_end.checked_add(content_length)?;
+    while buffer.len() < body_end {
         let n = match stream.read(&mut temp).await {
             Ok(n) => n,
             Err(_) => return None,
@@ -304,8 +308,7 @@ async fn read_request(stream: &mut TcpStream) -> Option<FakeHttpRequest> {
         }
         buffer.extend_from_slice(&temp[..n]);
     }
-    let body =
-        String::from_utf8_lossy(&buffer[header_end..header_end + content_length]).to_string();
+    let body = String::from_utf8_lossy(&buffer[header_end..body_end]).to_string();
 
     Some(FakeHttpRequest {
         method,
@@ -412,6 +415,26 @@ mod tests {
         assert!(body_a.contains("\"index\":0"));
         assert_eq!(status_b, 429);
         assert!(body_b.contains("\"index\":1"));
+    }
+
+    #[tokio::test]
+    async fn oversized_content_length_is_dropped_without_capture() {
+        let server =
+            FakeHttpServer::start_with_capacity("oversized-body", 1, |_index, _addr, _request| {
+                FakeHttpResponse::text(200, "unexpected")
+            })
+            .await;
+        let mut stream = TcpStream::connect(server.addr()).await.expect("connect");
+        let request = format!(
+            "POST /oversized HTTP/1.1\r\ncontent-length: {}\r\n\r\n",
+            TEST_HTTP_MAX_BODY_BYTES + 1
+        );
+        stream.write_all(request.as_bytes()).await.expect("write");
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.expect("read eof");
+
+        assert!(response.is_empty());
+        assert!(server.requests().is_empty());
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/connectors/testkit.rs
+++ b/crates/harn-vm/src/connectors/testkit.rs
@@ -13,6 +13,9 @@ use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+pub use crate::http::framing::{
+    http_content_length_from_header_lines, HttpContentLengthLimitError, TEST_HTTP_MAX_BODY_BYTES,
+};
 pub use crate::http::{HttpMockCallSnapshot, HttpMockResponse};
 pub use crate::triggers::test_util::clock::{
     active_mock_clock, install_override as install_clock_override, instant_now, now_ms, now_utc,

--- a/crates/harn-vm/src/http/framing.rs
+++ b/crates/harn-vm/src/http/framing.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+/// Shared cap for lightweight HTTP readers used by in-process test servers.
+pub const TEST_HTTP_MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HttpContentLengthLimitError {
+    pub content_length: usize,
+    pub max_bytes: usize,
+}
+
+impl fmt::Display for HttpContentLengthLimitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "HTTP Content-Length {} exceeds limit {} bytes",
+            self.content_length, self.max_bytes
+        )
+    }
+}
+
+impl Error for HttpContentLengthLimitError {}
+
+pub fn enforce_http_content_length_limit(
+    content_length: usize,
+    max_bytes: usize,
+) -> Result<usize, HttpContentLengthLimitError> {
+    if content_length > max_bytes {
+        Err(HttpContentLengthLimitError {
+            content_length,
+            max_bytes,
+        })
+    } else {
+        Ok(content_length)
+    }
+}
+
+pub fn parse_http_content_length(
+    value: Option<&str>,
+    max_bytes: usize,
+) -> Result<usize, HttpContentLengthLimitError> {
+    let Some(value) = value else {
+        return Ok(0);
+    };
+    let Ok(content_length) = value.trim().parse::<usize>() else {
+        return Ok(0);
+    };
+    enforce_http_content_length_limit(content_length, max_bytes)
+}
+
+#[cfg(test)]
+pub fn http_content_length_from_headers(
+    headers: &BTreeMap<String, String>,
+    max_bytes: usize,
+) -> Result<usize, HttpContentLengthLimitError> {
+    parse_http_content_length(headers.get("content-length").map(String::as_str), max_bytes)
+}
+
+pub fn http_content_length_from_header_lines<'a>(
+    lines: impl IntoIterator<Item = &'a str>,
+    max_bytes: usize,
+) -> Result<usize, HttpContentLengthLimitError> {
+    let value = lines.into_iter().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("content-length")
+            .then_some(value.trim())
+    });
+    parse_http_content_length(value, max_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_or_invalid_content_length_defaults_to_zero() {
+        assert_eq!(
+            parse_http_content_length(None, TEST_HTTP_MAX_BODY_BYTES).expect("missing length"),
+            0
+        );
+        assert_eq!(
+            parse_http_content_length(Some("not-a-number"), TEST_HTTP_MAX_BODY_BYTES)
+                .expect("invalid length"),
+            0
+        );
+    }
+
+    #[test]
+    fn header_line_lookup_is_case_insensitive() {
+        let headers = ["Host: example.test", "Content-Length: 12"];
+        assert_eq!(
+            http_content_length_from_header_lines(headers, TEST_HTTP_MAX_BODY_BYTES)
+                .expect("content length"),
+            12
+        );
+    }
+
+    #[test]
+    fn oversized_content_length_is_rejected() {
+        let error = parse_http_content_length(
+            Some(&(TEST_HTTP_MAX_BODY_BYTES + 1).to_string()),
+            TEST_HTTP_MAX_BODY_BYTES,
+        )
+        .expect_err("oversized content length");
+        assert_eq!(error.content_length, TEST_HTTP_MAX_BODY_BYTES + 1);
+        assert_eq!(error.max_bytes, TEST_HTTP_MAX_BODY_BYTES);
+    }
+}

--- a/crates/harn-vm/src/http/mod.rs
+++ b/crates/harn-vm/src/http/mod.rs
@@ -6,6 +6,7 @@ use crate::value::{VmClosure, VmError, VmValue};
 use crate::vm::Vm;
 
 mod client;
+pub(crate) mod framing;
 mod mock;
 mod streaming;
 #[cfg(test)]

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -751,6 +751,7 @@ async fn ollama_warmup(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::framing::{http_content_length_from_header_lines, TEST_HTTP_MAX_BODY_BYTES};
     use crate::llm::env_lock;
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -1290,16 +1291,20 @@ mod tests {
             let text = String::from_utf8_lossy(&data);
             if let Some(header_end) = text.find("\r\n\r\n") {
                 let headers = &text[..header_end];
-                let content_length = headers
-                    .lines()
-                    .find_map(|line| {
-                        let (name, value) = line.split_once(':')?;
-                        name.eq_ignore_ascii_case("content-length")
-                            .then(|| value.trim().parse::<usize>().ok())
-                            .flatten()
-                    })
-                    .unwrap_or(0);
-                if data.len() >= header_end + 4 + content_length {
+                let content_length = match http_content_length_from_header_lines(
+                    headers.lines(),
+                    TEST_HTTP_MAX_BODY_BYTES,
+                ) {
+                    Ok(content_length) => content_length,
+                    Err(_) => break,
+                };
+                let Some(body_end) = header_end
+                    .checked_add(4)
+                    .and_then(|body_start| body_start.checked_add(content_length))
+                else {
+                    break;
+                };
+                if data.len() >= body_end {
                     break;
                 }
             }

--- a/crates/harn-vm/src/llm/healthcheck.rs
+++ b/crates/harn-vm/src/llm/healthcheck.rs
@@ -263,6 +263,7 @@ fn body_snippet(body: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::http::framing::{http_content_length_from_header_lines, TEST_HTTP_MAX_BODY_BYTES};
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
@@ -349,17 +350,23 @@ mod tests {
         let Some((headers, body)) = request.split_once("\r\n\r\n") else {
             return false;
         };
-        let content_length = headers
-            .lines()
-            .find_map(|line| line.strip_prefix("content-length: "))
-            .or_else(|| {
-                headers
-                    .lines()
-                    .find_map(|line| line.strip_prefix("Content-Length: "))
-            })
-            .and_then(|value| value.trim().parse::<usize>().ok())
-            .unwrap_or(0);
+        let content_length = match http_content_length_from_header_lines(
+            headers.lines(),
+            TEST_HTTP_MAX_BODY_BYTES,
+        ) {
+            Ok(content_length) => content_length,
+            Err(_) => return true,
+        };
         body.len() >= content_length
+    }
+
+    #[test]
+    fn request_complete_stops_on_oversized_content_length() {
+        let request = format!(
+            "POST /probe HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+            TEST_HTTP_MAX_BODY_BYTES + 1
+        );
+        assert!(request_complete(&request));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -2546,6 +2546,7 @@ fn register_harn_mcp_namespace(vm: &mut Vm) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::framing::{http_content_length_from_headers, TEST_HTTP_MAX_BODY_BYTES};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::mpsc;
@@ -3341,14 +3342,13 @@ llm_mock_clear()
                 headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
             }
         }
-        let content_length = headers
-            .get("content-length")
-            .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(0);
+        let content_length = http_content_length_from_headers(&headers, TEST_HTTP_MAX_BODY_BYTES)?;
         let mut body = buffer[header_end + 4..].to_vec();
+        let mut chunk = [0_u8; 8192];
         while body.len() < content_length {
-            let mut chunk = vec![0; content_length - body.len()];
-            let bytes = stream.read(&mut chunk).await?;
+            let remaining = content_length - body.len();
+            let read_len = remaining.min(chunk.len());
+            let bytes = stream.read(&mut chunk[..read_len]).await?;
             if bytes == 0 {
                 break;
             }
@@ -3356,6 +3356,29 @@ llm_mock_clear()
         }
         body.truncate(content_length);
         Ok((request_line, headers, body))
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn read_http_request_rejects_oversized_content_length() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let client = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.expect("connect");
+            let request = format!(
+                "POST /mcp HTTP/1.1\r\ncontent-length: {}\r\n\r\n",
+                TEST_HTTP_MAX_BODY_BYTES + 1
+            );
+            stream.write_all(request.as_bytes()).await.expect("write");
+        });
+
+        let (mut stream, _) = listener.accept().await.expect("accept");
+        let error = read_http_request(&mut stream)
+            .await
+            .expect_err("oversized content length should be rejected");
+        assert!(error.to_string().contains("exceeds limit"));
+        client.await.expect("client task");
     }
 
     async fn write_http_json(


### PR DESCRIPTION
## Summary

Fixes #2263.

- Add a shared bounded HTTP Content-Length parser for lightweight in-process test servers.
- Apply a 16 MiB cap to MCP, connector fake server, healthcheck, Ollama, and CLI OAuth test request readers before they wait for or allocate request bodies.
- Harden the DAP stdin frame reader against the same unbounded Content-Length allocation shape.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-2263 cargo test -p harn-vm --lib content_length`
- `CARGO_TARGET_DIR=/tmp/harn-target-2263 cargo test -p harn-vm --lib header_line_lookup_is_case_insensitive`
- `CARGO_TARGET_DIR=/tmp/harn-target-2263 cargo test -p harn-vm --lib ollama_readiness_verifies_model_and_warms_matched_tag`
- `CARGO_TARGET_DIR=/tmp/harn-target-2263 cargo test -p harn-vm --lib sends_configured_probe_request_with_candidate_key`
- `CARGO_TARGET_DIR=/tmp/harn-target-2263 cargo test -p harn-cli --lib generic_mcp_oauth_discovers_metadata_and_registers_client`
- `CARGO_TARGET_DIR=/tmp/harn-target-2263 cargo test -p harn-dap read_content_length`
- `cargo fmt --all -- --check`
- `make lint-test-patterns`
- pre-commit hook: Rust fmt, prompt-prose ratchet, clippy on changed packages, xfail ratchet
- pre-push hook: targeted local checks