### PR TITLE
Use RustCrypto HMAC implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,7 @@ dependencies = [
  "harn-stdlib",
  "hex",
  "hkdf 0.13.0",
+ "hmac 0.13.0",
  "httpdate",
  "ignore",
  "ipnet",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -59,6 +59,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 futures = "0.3"
 blake3 = "1"
 sha2 = "0.11"
+hmac = "0.13"
 tar = { version = "0.4", default-features = false }
 flate2 = "1"
 subtle = "2.6"
@@ -99,7 +100,6 @@ default = ["hostlib"]
 hostlib = ["dep:harn-hostlib", "harn-serve/hostlib"]
 
 [dev-dependencies]
-hmac = "0.13"
 rcgen = "0.14"
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 wat = "1"

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use axum::http::{header, StatusCode};
 use futures::{SinkExt, StreamExt};
+use hmac::{Hmac, KeyInit, Mac};
 use serde_json::{json, Value as JsonValue};
 
 use super::acp_hub::ACP_PATH;
@@ -19,7 +20,7 @@ use harn_vm::secrets::{
 use harn_vm::{
     ProviderId, TriggerBindingSource, TriggerBindingSpec, TriggerHandlerSpec, TriggerRetryConfig,
 };
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use tempfile::{tempdir, TempDir};
 
 use crate::commands::orchestrator::origin_guard::OriginAllowList;
@@ -135,28 +136,12 @@ fn webhook_route(path: &str) -> RouteConfig {
 }
 
 fn github_signature(secret: &str, body: &[u8]) -> String {
-    const BLOCK: usize = 64;
-    let mut key = secret.as_bytes().to_vec();
-    if key.len() > BLOCK {
-        key = Sha256::digest(&key).to_vec();
-    }
-    key.resize(BLOCK, 0);
-    let mut inner_pad = vec![0x36; BLOCK];
-    let mut outer_pad = vec![0x5c; BLOCK];
-    for i in 0..BLOCK {
-        inner_pad[i] ^= key[i];
-        outer_pad[i] ^= key[i];
-    }
-    let mut inner = Sha256::new();
-    inner.update(&inner_pad);
-    inner.update(body);
-    let inner_digest = inner.finalize();
-
-    let mut outer = Sha256::new();
-    outer.update(&outer_pad);
-    outer.update(inner_digest);
-    let digest = outer.finalize();
-    let encoded = digest
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(body);
+    let encoded = mac
+        .finalize()
+        .into_bytes()
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect::<String>();

--- a/crates/harn-cli/src/commands/orchestrator/reload.rs
+++ b/crates/harn-cli/src/commands/orchestrator/reload.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::time::Duration;
 
 use base64::Engine;
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use serde::Deserialize;
 use serde_json::json;
@@ -155,7 +156,10 @@ fn canonical_authorization(
     body: &[u8],
 ) -> String {
     let signed = canonical_request_message(method, path, &timestamp.to_string(), body);
-    let signature = hmac_sha256(secret.as_bytes(), signed.as_bytes());
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(signed.as_bytes());
+    let signature = mac.finalize().into_bytes();
     format!(
         "{} timestamp={},signature={}",
         harn_vm::connectors::DEFAULT_CANONICAL_HMAC_SCHEME,
@@ -179,32 +183,23 @@ fn canonical_request_message(method: &str, path: &str, timestamp: &str, body: &[
     )
 }
 
-fn hmac_sha256(secret: &[u8], data: &[u8]) -> Vec<u8> {
-    const BLOCK_SIZE: usize = 64;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let mut key = if secret.len() > BLOCK_SIZE {
-        Sha256::digest(secret).to_vec()
-    } else {
-        secret.to_vec()
-    };
-    key.resize(BLOCK_SIZE, 0);
+    #[test]
+    fn canonical_authorization_matches_hmac_sha256_vector() {
+        let authorization = canonical_authorization(
+            "shared-secret",
+            "POST",
+            "/admin/reload",
+            1_700_000_000,
+            br#"{"source":"cli"}"#,
+        );
 
-    let mut inner_pad = vec![0x36; BLOCK_SIZE];
-    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
-    for (pad, key_byte) in inner_pad.iter_mut().zip(key.iter()) {
-        *pad ^= *key_byte;
+        assert_eq!(
+            authorization,
+            "HMAC-SHA256 timestamp=1700000000,signature=T+24RdJUvyIi81K07TCWx+E8hGNnTnBozRW+jzUacPg="
+        );
     }
-    for (pad, key_byte) in outer_pad.iter_mut().zip(key.iter()) {
-        *pad ^= *key_byte;
-    }
-
-    let mut inner = Sha256::new();
-    inner.update(&inner_pad);
-    inner.update(data);
-    let inner_digest = inner.finalize();
-
-    let mut outer = Sha256::new();
-    outer.update(&outer_pad);
-    outer.update(inner_digest);
-    outer.finalize().to_vec()
 }

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -52,6 +52,7 @@ data-encoding = "2"
 ed25519-dalek = { version = "2", features = ["pem", "pkcs8", "rand_core"] }
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 hex = "0.4"
+hmac = "0.13"
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"

--- a/crates/harn-vm/src/connectors/hmac.rs
+++ b/crates/harn-vm/src/connectors/hmac.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
+use hmac::{Hmac, KeyInit, Mac};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
@@ -1156,64 +1157,15 @@ fn sha256_hex(data: &[u8]) -> String {
 }
 
 pub(crate) fn hmac_sha256(secret: &[u8], data: &[u8]) -> Vec<u8> {
-    const BLOCK_SIZE: usize = 64;
-
-    let mut key = if secret.len() > BLOCK_SIZE {
-        Sha256::digest(secret).to_vec()
-    } else {
-        secret.to_vec()
-    };
-    key.resize(BLOCK_SIZE, 0);
-
-    let mut inner_pad = vec![0x36; BLOCK_SIZE];
-    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
-    for (slot, key_byte) in inner_pad.iter_mut().zip(&key) {
-        *slot ^= key_byte;
-    }
-    for (slot, key_byte) in outer_pad.iter_mut().zip(&key) {
-        *slot ^= key_byte;
-    }
-
-    let mut inner = Sha256::new();
-    inner.update(&inner_pad);
-    inner.update(data);
-    let inner_digest = inner.finalize();
-
-    let mut outer = Sha256::new();
-    outer.update(&outer_pad);
-    outer.update(inner_digest);
-    outer.finalize().to_vec()
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
 }
 
 pub(crate) fn hmac_sha1(secret: &[u8], data: &[u8]) -> Vec<u8> {
-    use sha1::{Digest, Sha1};
-    const BLOCK_SIZE: usize = 64;
-
-    let mut key = if secret.len() > BLOCK_SIZE {
-        Sha1::digest(secret).to_vec()
-    } else {
-        secret.to_vec()
-    };
-    key.resize(BLOCK_SIZE, 0);
-
-    let mut inner_pad = vec![0x36; BLOCK_SIZE];
-    let mut outer_pad = vec![0x5c; BLOCK_SIZE];
-    for (slot, key_byte) in inner_pad.iter_mut().zip(&key) {
-        *slot ^= key_byte;
-    }
-    for (slot, key_byte) in outer_pad.iter_mut().zip(&key) {
-        *slot ^= key_byte;
-    }
-
-    let mut inner = Sha1::new();
-    inner.update(&inner_pad);
-    inner.update(data);
-    let inner_digest = inner.finalize();
-
-    let mut outer = Sha1::new();
-    outer.update(&outer_pad);
-    outer.update(inner_digest);
-    outer.finalize().to_vec()
+    let mut mac = Hmac::<sha1::Sha1>::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
 }
 
 pub(crate) fn secure_eq(expected: &[u8], provided: &[u8]) -> bool {
@@ -1307,6 +1259,36 @@ mod tests {
     ) -> Vec<(u64, crate::event_log::LogEvent)> {
         let topic = Topic::new(SIGNATURE_VERIFY_AUDIT_TOPIC).unwrap();
         log.read_range(&topic, None, 32).await.unwrap()
+    }
+
+    #[test]
+    fn hmac_sha256_matches_rfc4231_vectors() {
+        assert_eq!(
+            hex::encode(hmac_sha256(&[0x0b; 20], b"Hi There")),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+        assert_eq!(
+            hex::encode(hmac_sha256(
+                &[0xaa; 131],
+                b"Test Using Larger Than Block-Size Key - Hash Key First",
+            )),
+            "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54"
+        );
+    }
+
+    #[test]
+    fn hmac_sha1_matches_rfc2202_vectors() {
+        assert_eq!(
+            hex::encode(hmac_sha1(&[0x0b; 20], b"Hi There")),
+            "b617318655057264e28bc0b6fb378c8ef146be00"
+        );
+        assert_eq!(
+            hex::encode(hmac_sha1(
+                &[0xaa; 80],
+                b"Test Using Larger Than Block-Size Key - Hash Key First",
+            )),
+            "aa4ae5e15272d00e95705637ce8a3b55ed402112"
+        );
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/connectors/testkit.rs
+++ b/crates/harn-vm/src/connectors/testkit.rs
@@ -8,7 +8,6 @@ use std::time::Duration as StdDuration;
 
 use async_trait::async_trait;
 use serde_json::{json, Value as JsonValue};
-use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -561,27 +560,7 @@ pub fn webhook_binding(
 }
 
 fn hmac_sha256_hex(secret: &[u8], data: &[u8]) -> String {
-    const BLOCK_SIZE: usize = 64;
-    let mut key = if secret.len() > BLOCK_SIZE {
-        Sha256::digest(secret).to_vec()
-    } else {
-        secret.to_vec()
-    };
-    key.resize(BLOCK_SIZE, 0);
-    let mut outer = vec![0x5c; BLOCK_SIZE];
-    let mut inner = vec![0x36; BLOCK_SIZE];
-    for i in 0..BLOCK_SIZE {
-        outer[i] ^= key[i];
-        inner[i] ^= key[i];
-    }
-    let mut inner_hash = Sha256::new();
-    inner_hash.update(&inner);
-    inner_hash.update(data);
-    let inner_result = inner_hash.finalize();
-    let mut outer_hash = Sha256::new();
-    outer_hash.update(&outer);
-    outer_hash.update(inner_result);
-    hex::encode(outer_hash.finalize())
+    hex::encode(crate::connectors::hmac::hmac_sha256(secret, data))
 }
 
 pub async fn advance_until<F>(


### PR DESCRIPTION
## Summary

- replace hand-rolled HMAC-SHA256/SHA1 helpers in `harn-vm` with RustCrypto `hmac::Hmac`
- remove the duplicate manual HMAC fixture helper in the connector testkit
- remove related hand-rolled HMAC-SHA256 copies from the orchestrator reload path and listener tests
- add direct RFC/Python-vector coverage for SHA-256, SHA-1, and reload canonical authorization

Closes #2261

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo test -p harn-vm hmac_sha -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo test -p harn-vm connectors::hmac::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo test -p harn-vm connectors::shared::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo test -p harn-vm --test connector_testkit_public_api -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo run --quiet --bin harn -- test conformance --filter hmac`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo run --quiet --bin harn -- test conformance --filter connectors_shared`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo run --quiet --bin harn -- test conformance --filter webhook_intake_sha1_legacy`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo run --quiet --bin harn -- test conformance --filter webhook_intake_round_trip`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo test -p harn-cli canonical_authorization_matches_hmac_sha256_vector -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo test -p harn-cli webhook_first_delivery_is_appended -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2261 cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `make lint-test-patterns`
- pre-commit hook: full workspace clippy passed
- pre-push hook: targeted checks passed