### PR TITLE
Add probe primitive for verified observations

### DIFF
--- a/conformance/tests/stdlib/agent_probe.expected
+++ b/conformance/tests/stdlib/agent_probe.expected
@@ -1,0 +1,1 @@
+agent probe ok

--- a/conformance/tests/stdlib/agent_probe.harn
+++ b/conformance/tests/stdlib/agent_probe.harn
@@ -1,0 +1,102 @@
+import { recall_facts } from "std/agent/fact"
+import { probe, probe_eval, probe_typecheck } from "std/agent/probe"
+import "../_common"
+
+pipeline test_agent_probe(_task) {
+  let root = path_join(harness.fs.temp_dir(), "harn-agent-probe-" + uuid())
+  let opts = {root: root, namespace: "agent/facts"}
+  let repo_root = exec("git", "rev-parse", "--show-toplevel").stdout.trim()
+  let harn_bin = harness.env.get_or("HARN_CONFORMANCE_HARN_BIN", resolve_harn_bin(harness, repo_root))
+  // --- eval probe: shell command, no expected → pass derived from exit code
+  let eval_pass = probe_eval("echo probe-eval-ok", opts + {now: "2026-05-23T22:00:00Z"})
+  assert_eq(eval_pass.schema, "harn.probe.v1")
+  assert_eq(eval_pass.kind, "eval")
+  assert_eq(eval_pass.outcome, "pass")
+  assert_eq(trim(eval_pass.evidence.stdout), "probe-eval-ok")
+  assert_eq(eval_pass.evidence.exit_code, 0)
+  assert(starts_with(eval_pass.evidence.trace_id, "probe_"))
+  assert(eval_pass.fact_id != nil && starts_with(eval_pass.fact_id, "fact_"))
+  // --- eval probe with explicit expected (mismatch surfaces as fail)
+  let eval_fail = probe("Eval", "echo not-the-expected", opts + {expected: "expected", now: "2026-05-23T22:00:01Z"})
+  assert_eq(eval_fail.outcome, "fail")
+  assert_eq(eval_fail.expected, "expected")
+  // --- eval probe: non-zero exit derives fail without expected
+  let eval_exit_fail = probe_eval("false", opts + {now: "2026-05-23T22:00:02Z"})
+  assert_eq(eval_exit_fail.outcome, "fail")
+  assert_eq(eval_exit_fail.evidence.exit_code, 1)
+  // --- store_fact: false skips auto-write but still returns a result
+  let no_fact = probe_eval("echo skipped", opts + {store_fact: false})
+  assert_eq(no_fact.outcome, "pass")
+  assert_eq(no_fact.fact_id, nil)
+  // --- typecheck probe: clean fragment → 0 errors → pass
+  let typecheck_pass = probe_typecheck(
+    "pipeline noop() { __io_println(\"hi\") }\n",
+    opts + {harn_binary: harn_bin, now: "2026-05-23T22:00:03Z"},
+  )
+  assert_eq(typecheck_pass.kind, "typecheck")
+  assert_eq(typecheck_pass.outcome, "pass")
+  assert(contains(typecheck_pass.observed, "errors=0"))
+  // --- typecheck probe: type-error fragment → errors > 0 → fail
+  let typecheck_fail = probe_typecheck(
+    "pipeline broken() { let x: int = \"oops\" __io_println(x) }\n",
+    opts + {harn_binary: harn_bin, now: "2026-05-23T22:00:04Z"},
+  )
+  assert_eq(typecheck_fail.outcome, "fail")
+  assert(contains(typecheck_fail.observed, "errors="))
+  // --- typecheck probe with expected error count
+  let typecheck_match = probe_typecheck(
+    "pipeline broken() { let x: int = \"oops\" __io_println(x) }\n",
+    opts + {harn_binary: harn_bin, expected: 1, now: "2026-05-23T22:00:05Z"},
+  )
+  assert_eq(typecheck_match.outcome, "pass")
+  assert_eq(typecheck_match.expected, 1)
+  // --- recall the auto-stored facts (pass+fail+exit_fail+typecheck_pass+typecheck_fail+typecheck_match = 6)
+  let observations = recall_facts("probe", "Observation", 0.0, opts + {limit: 20})
+  assert(len(observations) >= 5)
+  var saw_pass = false
+  var saw_fail = false
+  var saw_typecheck = false
+  for hit in observations {
+    if contains(hit.claim, "probe eval") && contains(hit.claim, "→ pass") {
+      saw_pass = true
+      assert_eq(hit.confidence, 0.9)
+      assert_eq(hit.provenance.source, "probe")
+      assert_eq(hit.provenance.probe_kind, "eval")
+    }
+    if contains(hit.claim, "probe eval") && contains(hit.claim, "→ fail") {
+      saw_fail = true
+      assert_eq(hit.confidence, 0.9)
+    }
+    if contains(hit.claim, "probe typecheck") {
+      saw_typecheck = true
+      assert_eq(hit.provenance.probe_kind, "typecheck")
+    }
+  }
+  assert(saw_pass)
+  assert(saw_fail)
+  assert(saw_typecheck)
+  // --- stub kinds return unknown with confidence 0.4
+  let test_stub = probe("test", "anything", opts + {now: "2026-05-23T22:00:06Z"})
+  assert_eq(test_stub.outcome, "unknown")
+  assert(contains(test_stub.observed, "not yet implemented"))
+  let inspect_stub = probe("Inspect", "anything", opts + {now: "2026-05-23T22:00:07Z"})
+  assert_eq(inspect_stub.outcome, "unknown")
+  // --- validation errors
+  let bad_kind = try {
+    probe("guess", "echo x", opts)
+  }
+  assert(is_err(bad_kind))
+  assert(contains(to_string(unwrap_err(bad_kind)), "HARN-PROBE-002"))
+  let bad_body = try {
+    probe("eval", "", opts)
+  }
+  assert(is_err(bad_body))
+  assert(contains(to_string(unwrap_err(bad_body)), "HARN-PROBE-004"))
+  let bad_lang = try {
+    probe_eval("echo x", opts + {lang: "python"})
+  }
+  assert(is_err(bad_lang))
+  assert(contains(to_string(unwrap_err(bad_lang)), "HARN-PROBE-003"))
+  harness.fs.delete(root)
+  __io_println("agent probe ok")
+}

--- a/crates/harn-skills/src/corpus/harn-probe/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-probe/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: harn-probe
+short: Probe-first verification — run snippets, capture outcomes as typed Facts.
+description: Use to convert a guess about codebase behavior into a recorded observation by running a probe snippet and persisting the outcome as a Fact.
+when_to_use: Use before asserting a claim about behavior, types, or output that you have not yet verified directly. Especially before destructive edits, before describing what a function returns, or before declaring a refactor safe.
+---
+
+# Harn probe
+
+Use this skill when you are about to assert a claim about runtime
+behavior, type-checker output, or command output that you have not
+directly observed in this session. Replace the assertion with a
+`probe(...)` call from `std/agent/probe`, then state the outcome as
+observation, not speculation.
+
+Pair it with [[harn-agent]] for autonomous workflows, [[harn-language]]
+for the typecheck fragments you feed `probe("typecheck", ...)`, and
+[[harn-testing]] for the conformance fixtures that anchor probe-derived
+facts.
+
+## Why probe instead of guess
+
+- Guessing is cheap; verifying is structured tool use that the runtime
+  can record.
+- A `probe` outcome lands in the Fact ledger with
+  `provenance.source = "probe"`, so a follow-up session can recall the
+  verified answer instead of re-guessing.
+- The cost of one probe is bounded shell or typecheck time. The cost of
+  a wrong assertion is a wasted user round-trip plus a potentially
+  destructive edit.
+- Animals learn by *probing* — touching, tasting, testing — not by
+  passive prediction. The same pattern keeps LLM coding assistants
+  honest.
+- Recording the *failure* outcome is just as load-bearing as recording
+  the success. The ledger needs both to invalidate stale claims later.
+
+## When to probe instead of asserting
+
+- You are about to claim a function returns a particular value, type,
+  or shape.
+- You are about to declare a refactor "safe" or a migration
+  "compatible".
+- You are about to assert that a fragment type-checks (or fails to
+  type-check) with a particular diagnostic code.
+- You are about to repeat a fact from training data that may have
+  drifted in this codebase.
+- You are about to recommend a destructive edit (`rm`,
+  `git reset --hard`, schema drop, `--no-verify`) without first
+  observing that the precondition holds.
+- You are about to summarize what a command prints, what a config
+  defaults to, or what an env var does without having run the command
+  in this session.
+
+If you genuinely cannot probe — the surface is non-deterministic, the
+body is too large, the cost is too high — say so out loud rather than
+asserting.
+
+## The probe primitive
+
+`std/agent/probe` exposes `probe(kind, body, options?)` plus
+`probe_eval` and `probe_typecheck` shorthands. Two probe kinds are
+implemented today; `test` and `inspect` are reserved and currently
+return `unknown`.
+
+- `probe_eval(body, options)` runs `body` as a shell command by
+  default. Set `options.lang = "harn"` to run `body` as a Harn snippet
+  via `harn run`. Outcome is `pass` on exit 0 and `fail` otherwise;
+  `options.expected` matches against trimmed stdout for a string and
+  against the integer for a numeric comparison.
+- `probe_typecheck(body, options)` writes the fragment to a temp file
+  and runs `harn check <path> --json`. Outcome is `pass` when there are
+  zero errors; `options.expected` matches the parsed error count.
+
+Every probe returns a `harn.probe.v1` envelope:
+
+- `kind`, `outcome`, `observed` — short summary of what was seen.
+- `evidence` — `trace_id`, `snippet`, `command`, `stdout`, `stderr`,
+  `exit_code`, `duration_ms`, plus `timed_out` when the host enforced a
+  deadline.
+- `fact_id` — id of the auto-stored Observation fact (pass
+  `options.store_fact = false` to suppress the write).
+- `expected`, `asserted_at` — round-tripped from the input.
+
+The Fact body uses `confidence = 0.9` for observed `pass`/`fail` and
+`0.4` for `unknown`, so
+`recall_facts("…", "Observation", 0.8, scope)` returns only
+directly-verified outcomes.
+
+## Probe-first rules
+
+- Probe before asserting. A claim that is not backed by a probe in this
+  session or a recalled probe fact is speculation.
+- Probe small. A probe that takes longer than the work you would save
+  is overhead, not verification. Bound the body and pass
+  `options.timeout_ms` for anything that could hang.
+- Probe deterministic surfaces. Probing a live network endpoint, an
+  LLM call, or wall-clock-sensitive code from inside a probe is rarely
+  useful — those belong in workflows, not facts.
+- Record the failure too. A probe that comes back `fail` is just as
+  load-bearing as one that comes back `pass`.
+- Trust the observed outcome over a recalled fact. If recall says "this
+  type-checks" but a fresh probe says it does not, the fresh probe wins
+  — invalidate the stale fact with `invalidate_facts` from
+  `std/agent/fact` before continuing.
+- Quote the trace_id, not the prose. When you reference a probe outcome
+  in a user message or PR description, cite `fact_id` or
+  `evidence.trace_id` so the reader can find the same observation.
+
+## Composing with Fact recall
+
+Probes write Observations with `provenance.source = "probe"` and
+`provenance.probe_kind = "<kind>"`. Before re-running a probe, recall
+with `recall_facts(query, "Observation", 0.0, scope)` to see if the
+same probe already ran in a recent session. Match by
+`provenance.probe_kind` to scope recall to a particular probe shape
+(eval vs typecheck).
+
+When code drift might have invalidated a recalled fact, use
+`invalidate_facts({kind: "Observation", evidence: {kind: "tool_output",
+ref: trace_id}}, scope)` to tombstone the stale record, then re-probe
+and record the fresh outcome.
+
+## Anti-patterns
+
+- Probing inside a hot loop to "verify each iteration" — bound the
+  loop, probe the boundary condition once.
+- Probing with a body so large that the snippet evidence is meaningless
+  — extract the smallest fragment that exercises the claim.
+- Probing then ignoring the `outcome` field because the prose summary
+  "looks right" — the structured outcome is the contract.
+- Writing prose into `observed` that contradicts the actual outcome —
+  keep `observed` tight and grounded in the captured stdout/stderr.
+- Using `probe("test", ...)` or `probe("inspect", ...)` and expecting a
+  real outcome — they are reserved and return `unknown` today; record
+  the limitation and fall back to `probe_eval` with the appropriate
+  test runner command.
+
+## Probe lifecycle
+
+1. Identify the claim you are about to assert.
+2. Pick the smallest body that exercises it (a single shell command, a
+   3-line Harn fragment, a single typecheck).
+3. Call `probe(kind, body, options)`. Pass `options.expected` when you
+   have a specific value or count in mind so the outcome is a hard
+   match instead of a fuzzy success signal.
+4. Inspect the returned `outcome` and `observed`. Quote
+   `evidence.trace_id` or `fact_id` when summarizing to the user or in
+   a PR description.
+5. If the outcome contradicts a recalled fact, invalidate the stale
+   fact before continuing.
+6. If the outcome unblocks the original task, proceed. If it surfaces
+   an unexpected failure, treat that as new information and decide
+   whether to fix, escalate, or abandon — do not re-assert the original
+   guess.
+
+## Example probes
+
+```harn
+import { probe_eval, probe_typecheck } from "std/agent/probe"
+
+// 1. Verify a shell helper before relying on its exit code.
+let helper = probe_eval(
+  "git diff --quiet HEAD -- crates/harn-stdlib",
+  {expected: 0, timeout_ms: 5000},
+)
+if helper.outcome != "pass" {
+  __io_println("stdlib has uncommitted edits — recall fact: " + helper.fact_id)
+}
+
+// 2. Confirm a fragment type-checks before pasting it into the user's file.
+let tc = probe_typecheck(
+  "pipeline summary() { let x: int = len([1, 2, 3]) __io_println(x) }\n",
+  {expected: 0},
+)
+require tc.outcome == "pass", "fragment fails typecheck: " + tc.observed
+```
+
+## Verify
+
+- Stdlib catalog: `cargo test -p harn-stdlib --test stdlib_modules`
+  round-trips the source.
+- Conformance:
+  `cargo run --quiet --bin harn -- test conformance --filter agent_probe`.
+- Manual smoke: `harn run -e 'import {probe_eval} from "std/agent/probe";
+  __io_println(probe_eval("echo hi").outcome)'`.
+- Skill body: `cargo test -p harn-skills` covers the embedded corpus
+  invariants.
+
+## Kill criterion
+
+If probe-first injection slows tasks by more than 50 percent without
+measurably reducing wrong-assertion incidents over 20 sessions,
+restrict probing to high-risk operations (before destructive edits,
+before declaring a refactor safe) or abandon the always-on nudge.
+Document the kill decision as a Decision fact so future sessions
+inherit the rationale.

--- a/crates/harn-skills/src/lib.rs
+++ b/crates/harn-skills/src/lib.rs
@@ -132,6 +132,7 @@ const SOURCES: &[&str] = &[
     include_str!("corpus/harn-diagnostics/SKILL.md"),
     include_str!("corpus/harn-language/SKILL.md"),
     include_str!("corpus/harn-orchestration/SKILL.md"),
+    include_str!("corpus/harn-probe/SKILL.md"),
     include_str!("corpus/harn-providers/SKILL.md"),
     include_str!("corpus/harn-testing/SKILL.md"),
     include_str!("corpus/harn-tracing/SKILL.md"),
@@ -386,6 +387,7 @@ mod tests {
                 "harn-diagnostics",
                 "harn-language",
                 "harn-orchestration",
+                "harn-probe",
                 "harn-providers",
                 "harn-testing",
                 "harn-tracing",
@@ -481,6 +483,7 @@ mod tests {
             ("harn-diagnostics", ["diagnostic", "repair", "conformance"]),
             ("harn-language", ["quickref", "type", "conformance"]),
             ("harn-orchestration", ["agent_loop", "workflow", "host"]),
+            ("harn-probe", ["probe", "fact", "evidence"]),
             ("harn-providers", ["llm_call", "provider", "schema"]),
             (
                 "harn-testing",

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -422,6 +422,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/fact.harn"),
     },
     StdlibSource {
+        module: "agent/probe",
+        source: include_str!("stdlib/agent/probe.harn"),
+    },
+    StdlibSource {
         module: "agent/presets",
         source: include_str!("stdlib/agent/presets.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/probe.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/probe.harn
@@ -1,0 +1,449 @@
+import { store_fact } from "std/agent/fact"
+import { filter_nil } from "std/collections"
+import { command_run } from "std/command"
+
+type ProbeKind = "eval" | "typecheck" | "test" | "inspect"
+
+type ProbeOutcome = "pass" | "fail" | "unknown"
+
+type ProbeLang = "shell" | "harn"
+
+type ProbeEvidence = {
+  trace_id: string,
+  snippet: string,
+  command?: string,
+  stdout?: string,
+  stderr?: string,
+  exit_code?: int,
+  duration_ms?: int,
+  timed_out?: bool,
+}
+
+type ProbeResult = {
+  schema: "harn.probe.v1",
+  kind: ProbeKind,
+  outcome: ProbeOutcome,
+  observed: string,
+  evidence: ProbeEvidence,
+  fact_id?: string,
+  expected?: any,
+  asserted_at: string,
+}
+
+let PROBE_SCHEMA = "harn.probe.v1"
+
+let PROBE_VALID_KINDS = ["eval", "typecheck", "test", "inspect"]
+
+let PROBE_VALID_LANGS = ["shell", "harn"]
+
+let PROBE_CAPTURE_LIMIT = 4096
+
+fn __probe_error(code, message) {
+  throw code + ": std/agent/probe: " + message
+}
+
+fn __probe_text(value) -> string {
+  if value == nil {
+    return ""
+  }
+  if type_of(value) == "string" {
+    return value
+  }
+  return to_string(value)
+}
+
+fn __probe_kind(value) -> ProbeKind {
+  let raw = __probe_text(value)
+  let normalized = lowercase(replace(trim(raw), "-", "_"))
+  if normalized == "" {
+    __probe_error("HARN-PROBE-002", "kind is required")
+  }
+  if !contains(PROBE_VALID_KINDS, normalized) {
+    __probe_error(
+      "HARN-PROBE-002",
+      "unknown kind `" + raw + "` (expected one of " + join(PROBE_VALID_KINDS, ", ") + ")",
+    )
+  }
+  return normalized
+}
+
+fn __probe_lang(value) -> ProbeLang {
+  if value == nil {
+    return "shell"
+  }
+  let normalized = lowercase(trim(__probe_text(value)))
+  if normalized == "" {
+    return "shell"
+  }
+  if !contains(PROBE_VALID_LANGS, normalized) {
+    __probe_error(
+      "HARN-PROBE-003",
+      "unknown lang `" + __probe_text(value) + "` (expected shell or harn)",
+    )
+  }
+  return normalized
+}
+
+fn __probe_options(options) -> dict {
+  if options == nil {
+    return {}
+  }
+  if type_of(options) != "dict" {
+    __probe_error("HARN-PROBE-001", "options must be a dict")
+  }
+  return options
+}
+
+fn __probe_body(body) -> string {
+  let text = __probe_text(body)
+  if trim(text) == "" {
+    __probe_error("HARN-PROBE-004", "body must be a non-empty string")
+  }
+  return text
+}
+
+fn __probe_truncate(value, limit) -> string {
+  let text = __probe_text(value)
+  if len(text) <= limit {
+    return text
+  }
+  return substring(text, 0, limit) + "\n…[truncated " + to_string(len(text) - limit) + " bytes]"
+}
+
+fn __probe_command_options(opts) -> dict {
+  var out = {}
+  for key in ["cwd", "env", "env_mode", "timeout_ms", "stdin", "max_inline_bytes"] {
+    if opts?[key] != nil {
+      out = out + {[key]: opts[key]}
+    }
+  }
+  return out
+}
+
+fn __probe_temp_path(suffix) -> string {
+  return path_join(harness.fs.temp_dir(), "harn-probe-" + uuid() + suffix)
+}
+
+fn __probe_harn_binary(opts) -> string {
+  let raw = __probe_text(opts?.harn_binary ?? opts?.harn_bin)
+  if raw != "" {
+    return raw
+  }
+  return "harn"
+}
+
+fn __probe_eval(body, opts) -> dict {
+  let lang = __probe_lang(opts?.lang)
+  let cmd_opts = __probe_command_options(opts)
+  let started = harness.clock.monotonic_ms()
+  let result = if lang == "harn" {
+    let path = __probe_temp_path(".harn")
+    harness.fs.write_text(path, body)
+    let argv = [__probe_harn_binary(opts), "run", path]
+    let res = command_run(argv, cmd_opts)
+    harness.fs.delete(path)
+    res
+  } else {
+    command_run({mode: "shell", command: body}, cmd_opts)
+  }
+  let duration_ms = harness.clock.monotonic_ms() - started
+  return {result: result, lang: lang, duration_ms: duration_ms}
+}
+
+fn __probe_typecheck_diagnostics(stdout) -> dict {
+  let parsed = try {
+    json_parse(stdout)
+  }
+  if is_err(parsed) {
+    return {parsed: false, errors: -1, warnings: -1}
+  }
+  let envelope = unwrap(parsed)
+  let summary = envelope?.data?.summary ?? envelope?.summary ?? {}
+  let errors = summary?.errors ?? -1
+  let warnings = summary?.warnings ?? -1
+  return {parsed: true, errors: errors, warnings: warnings, envelope_ok: envelope?.ok ?? nil}
+}
+
+fn __probe_typecheck(body, opts) -> dict {
+  let path = __probe_temp_path(".harn")
+  harness.fs.write_text(path, body)
+  let argv = [__probe_harn_binary(opts), "check", path, "--json"]
+  let started = harness.clock.monotonic_ms()
+  let result = command_run(argv, __probe_command_options(opts))
+  let duration_ms = harness.clock.monotonic_ms() - started
+  harness.fs.delete(path)
+  let diagnostics = __probe_typecheck_diagnostics(result?.stdout ?? "")
+  return {result: result, diagnostics: diagnostics, duration_ms: duration_ms}
+}
+
+fn __probe_compare_expected(observed, expected, kind) -> ProbeOutcome {
+  if expected == nil {
+    return "unknown"
+  }
+  let exp_kind = type_of(expected)
+  if exp_kind == "int" || exp_kind == "float" {
+    if kind == "typecheck" {
+      if type_of(observed) == "dict" && observed?.errors == expected {
+        return "pass"
+      }
+      return "fail"
+    }
+    if type_of(observed) == "int" && observed == expected {
+      return "pass"
+    }
+    return "fail"
+  }
+  let observed_text = if type_of(observed) == "dict" {
+    observed?.stdout ?? ""
+  } else {
+    __probe_text(observed)
+  }
+  if trim(observed_text) == trim(__probe_text(expected)) {
+    return "pass"
+  }
+  return "fail"
+}
+
+fn __probe_eval_outcome(result, expected) -> ProbeOutcome {
+  if result?.timed_out ?? false {
+    return "fail"
+  }
+  if expected != nil {
+    return __probe_compare_expected({stdout: result?.stdout ?? ""}, expected, "eval")
+  }
+  return result?.success ? "pass" : "fail"
+}
+
+fn __probe_typecheck_outcome(result, diagnostics, expected) -> ProbeOutcome {
+  if result?.timed_out ?? false {
+    return "fail"
+  }
+  if !diagnostics.parsed && !result?.success {
+    return "fail"
+  }
+  let errors = diagnostics.errors
+  if expected != nil {
+    return __probe_compare_expected({errors: errors}, expected, "typecheck")
+  }
+  if errors < 0 {
+    return result?.success ? "pass" : "fail"
+  }
+  return errors == 0 ? "pass" : "fail"
+}
+
+fn __probe_observed_eval(result, outcome) -> string {
+  let exit = result?.exit_code
+  let exit_str = exit == nil ? "?" : to_string(exit)
+  let stdout = trim(result?.stdout ?? "")
+  let stderr = trim(result?.stderr ?? "")
+  let summary = "eval exit=" + exit_str + " outcome=" + outcome
+  if stdout != "" {
+    return summary + " stdout=" + __probe_truncate(stdout, 240)
+  }
+  if stderr != "" {
+    return summary + " stderr=" + __probe_truncate(stderr, 240)
+  }
+  return summary
+}
+
+fn __probe_observed_typecheck(diagnostics, outcome) -> string {
+  if !diagnostics.parsed {
+    return "typecheck outcome=" + outcome + " (no JSON envelope)"
+  }
+  return "typecheck outcome=" + outcome
+    + " errors="
+    + to_string(diagnostics.errors)
+    + " warnings="
+    + to_string(diagnostics.warnings)
+}
+
+fn __probe_trace_id(kind, body, observed) -> string {
+  let seed = kind + "\n" + body + "\n" + observed
+  return "probe_" + substring(sha256(seed), 0, 16)
+}
+
+fn __probe_evidence(kind, body, command, observed, result, duration_ms) -> ProbeEvidence {
+  let stdout = result == nil ? nil : __probe_truncate(result?.stdout ?? "", PROBE_CAPTURE_LIMIT)
+  let stderr = result == nil ? nil : __probe_truncate(result?.stderr ?? "", PROBE_CAPTURE_LIMIT)
+  return filter_nil(
+    {
+      trace_id: __probe_trace_id(kind, body, observed),
+      snippet: __probe_truncate(body, PROBE_CAPTURE_LIMIT),
+      command: command,
+      stdout: stdout,
+      stderr: stderr,
+      exit_code: result?.exit_code,
+      duration_ms: duration_ms,
+      timed_out: result?.timed_out ?? false ? true : nil,
+    },
+  )
+}
+
+fn __probe_confidence(outcome) -> float {
+  if outcome == "unknown" {
+    return 0.4
+  }
+  return 0.9
+}
+
+fn __probe_claim(kind, outcome, snippet) -> string {
+  let trimmed = __probe_truncate(trim(snippet), 120)
+  return "probe " + kind + " `" + replace(trimmed, "\n", " ") + "` → " + outcome
+}
+
+fn __probe_provenance(kind, lang, command, opts) -> dict {
+  var prov = {source: "probe", probe_kind: kind}
+  if lang != nil {
+    prov = prov + {lang: lang}
+  }
+  if command != nil && command != "" {
+    prov = prov + {command: command}
+  }
+  let extra = opts?.provenance
+  if extra != nil && type_of(extra) == "dict" {
+    prov = prov + extra
+  }
+  return prov
+}
+
+fn __probe_store_fact(kind, observed, outcome, evidence, opts) {
+  if !(opts?.store_fact ?? true) {
+    return nil
+  }
+  let provenance = __probe_provenance(kind, opts?.lang, evidence?.command, opts)
+  let fact_input = {
+    kind: "observation",
+    claim: __probe_claim(kind, outcome, evidence?.snippet ?? ""),
+    confidence: __probe_confidence(outcome),
+    evidence: [{kind: "tool_output", ref: evidence.trace_id, snippet: __probe_truncate(observed, 1024)}],
+    provenance: provenance,
+  }
+  var fact_opts = {}
+  for key in ["namespace", "scope", "root", "now", "asserted_at", "tags", "embed"] {
+    if opts?[key] != nil {
+      fact_opts = fact_opts + {[key]: opts[key]}
+    }
+  }
+  let stored = try {
+    store_fact(fact_input, fact_opts)
+  }
+  if is_err(stored) {
+    return nil
+  }
+  return unwrap(stored)?.value?.id
+}
+
+fn __probe_envelope(kind, outcome, observed, evidence, opts) -> ProbeResult {
+  let fact_id = __probe_store_fact(kind, observed, outcome, evidence, opts)
+  let asserted_at = __probe_text(opts?.asserted_at ?? opts?.now)
+  return filter_nil(
+    {
+      schema: PROBE_SCHEMA,
+      kind: kind,
+      outcome: outcome,
+      observed: observed,
+      evidence: evidence,
+      fact_id: fact_id,
+      expected: opts?.expected,
+      asserted_at: asserted_at == "" ? date_now_iso() : asserted_at,
+    },
+  )
+}
+
+fn __probe_unsupported(kind, body, opts) -> ProbeResult {
+  let observed = "probe kind `" + kind + "` is not yet implemented (MVP supports eval, typecheck)"
+  let evidence = __probe_evidence(kind, body, nil, observed, nil, nil)
+  return __probe_envelope(kind, "unknown", observed, evidence, opts)
+}
+
+fn __probe_run_eval(body, opts) -> ProbeResult {
+  let kind = "eval"
+  let ran = __probe_eval(body, opts)
+  let result = ran.result
+  let outcome = __probe_eval_outcome(result, opts?.expected)
+  let observed = __probe_observed_eval(result, outcome)
+  let command = if ran.lang == "harn" {
+    join([__probe_harn_binary(opts), "run", "<snippet>"], " ")
+  } else {
+    __probe_truncate(body, 240)
+  }
+  let evidence = __probe_evidence(kind, body, command, observed, result, ran.duration_ms)
+  return __probe_envelope(kind, outcome, observed, evidence, opts + {lang: ran.lang})
+}
+
+fn __probe_run_typecheck(body, opts) -> ProbeResult {
+  let kind = "typecheck"
+  let ran = __probe_typecheck(body, opts)
+  let outcome = __probe_typecheck_outcome(ran.result, ran.diagnostics, opts?.expected)
+  let observed = __probe_observed_typecheck(ran.diagnostics, outcome)
+  let command = join([__probe_harn_binary(opts), "check", "<snippet>", "--json"], " ")
+  let evidence = __probe_evidence(kind, body, command, observed, ran.result, ran.duration_ms)
+  return __probe_envelope(kind, outcome, observed, evidence, opts)
+}
+
+/**
+ * Run a small snippet (shell command, harn fragment, or typecheck fragment)
+ * and persist the verified outcome as a `harn.fact.v1` Observation.
+ *
+ * `kind` selects the probe shape: `"eval"` runs `body` as a shell command
+ * (default) or a harn snippet (`options.lang = "harn"`); `"typecheck"` writes
+ * `body` to a temp file and invokes `harn check --json`. `"test"` and
+ * `"inspect"` are reserved for a follow-up and currently return an
+ * `unknown`-outcome probe so callers can wire them in deterministically.
+ *
+ * `options.expected` opt-in stops the probe from accepting whatever the
+ * subprocess emitted: a string compares against trimmed stdout (eval) and an
+ * int compares against the parsed error count (typecheck). Without an
+ * `expected`, outcome derives from exit code (eval/test) or error count
+ * (typecheck).
+ *
+ * Unless `options.store_fact = false`, the result is auto-recorded with
+ * `store_fact` under the namespace from `options.scope` or
+ * `options.namespace`, with confidence 0.9 for observed pass/fail and 0.4
+ * for `unknown`. Set `options.root` to redirect the fact store at a fixture
+ * directory in tests.
+ *
+ * @effects: [process, store.write]
+ * @allocation: heap
+ * @errors: [HARN-PROBE-001, HARN-PROBE-002, HARN-PROBE-003, HARN-PROBE-004]
+ * @api_stability: experimental
+ * @example: probe("eval", "echo hi", {expected: "hi"})
+ */
+pub fn probe(kind, body, options = nil) -> ProbeResult {
+  let opts = __probe_options(options)
+  let resolved_kind = __probe_kind(kind)
+  let resolved_body = __probe_body(body)
+  if resolved_kind == "eval" {
+    return __probe_run_eval(resolved_body, opts)
+  }
+  if resolved_kind == "typecheck" {
+    return __probe_run_typecheck(resolved_body, opts)
+  }
+  return __probe_unsupported(resolved_kind, resolved_body, opts)
+}
+
+/**
+ * Convenience for `probe("eval", ...)`.
+ *
+ * @effects: [process, store.write]
+ * @allocation: heap
+ * @errors: [HARN-PROBE-001, HARN-PROBE-002, HARN-PROBE-003, HARN-PROBE-004]
+ * @api_stability: experimental
+ * @example: probe_eval("echo hi", {expected: "hi"})
+ */
+pub fn probe_eval(body, options = nil) -> ProbeResult {
+  return probe("eval", body, options)
+}
+
+/**
+ * Convenience for `probe("typecheck", ...)`.
+ *
+ * @effects: [process, store.write]
+ * @allocation: heap
+ * @errors: [HARN-PROBE-001, HARN-PROBE-002, HARN-PROBE-003, HARN-PROBE-004]
+ * @api_stability: experimental
+ * @example: probe_typecheck("let x: int = \"oops\"", {expected: 0})
+ */
+pub fn probe_typecheck(body, options = nil) -> ProbeResult {
+  return probe("typecheck", body, options)
+}

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -414,6 +414,9 @@ Imports starting with `std/` load embedded stdlib modules:
   helpers (agent_progress, agent_progress_tool)
 - `import "std/agent/fact"` — typed fact envelopes over durable memory
   (store_fact, recall_facts, invalidate_facts)
+- `import "std/agent/probe"` — probe-first verification primitive: run a
+  snippet (eval/typecheck) and record the outcome as an Observation fact
+  (probe, probe_eval, probe_typecheck)
 - `import "std/memory"` — append-only durable memory helpers
   (memory_store, memory_recall, memory_summarize, memory_forget)
 - `import "std/trust"` — TrustGraph query and policy helpers
@@ -5330,6 +5333,40 @@ Provides typed `harn.fact.v1` assertions on top of `std/memory`. A fact contains
 | `store_fact(input, options?)` | Store the fact as `MemoryRecord.value`, using the fact id as the memory record id |
 | `recall_facts(query, kind?, min_confidence?, scope?)` | Recall normalized facts and filter by kind/confidence; `scope` may be a scope string or an options dict with normal memory options |
 | `invalidate_facts(predicate, scope?)` | Append memory tombstones; predicates accept exact `fact_...` ids or dicts with `id`, `key`, `kind`, `claim`, `query`, `tag`, `tags`, `evidence_ref`, or `evidence` |
+
+### std/agent/probe module
+
+```harn
+import { probe, probe_eval, probe_typecheck } from "std/agent/probe"
+```
+
+Provides a probe-first verification primitive: instead of asserting a
+claim about runtime behavior, run a small snippet, capture the outcome
+deterministically, and auto-record it as a `harn.fact.v1` Observation
+backed by `std/agent/fact`. Probes return a `harn.probe.v1` envelope
+with `kind`, `outcome` (`pass` / `fail` / `unknown`), `observed` summary,
+`evidence` (trace id, snippet, command, stdout/stderr/exit_code,
+duration_ms), `fact_id` of the auto-stored observation, and the
+round-tripped `expected` and `asserted_at`. MVP supports `eval` and
+`typecheck`; `test` and `inspect` are reserved and currently return an
+`unknown`-outcome envelope so callers can wire them in deterministically.
+
+| Function | Notes |
+|---|---|
+| `probe(kind, body, options?)` | Run a snippet (`eval` or `typecheck` today; `test`/`inspect` reserved) and capture the outcome. `options.expected` enables a hard match (string for stdout, int for typecheck error count); without it, outcome derives from exit code or error count. |
+| `probe_eval(body, options?)` | Convenience for `probe("eval", ...)`. Runs `body` as a shell command by default; `options.lang = "harn"` writes the body to a temp file and runs `harn run <path>`. |
+| `probe_typecheck(body, options?)` | Convenience for `probe("typecheck", ...)`. Writes the fragment to a temp file and runs `harn check <path> --json`, parsing the summary for error and warning counts. |
+
+Unless `options.store_fact = false`, every probe writes an Observation
+with `confidence = 0.9` for observed `pass`/`fail` and `0.4` for
+`unknown`, `provenance.source = "probe"`, and
+`provenance.probe_kind = "<kind>"`. Pass `options.scope`,
+`options.namespace`, or `options.root` to override the fact-store
+location, and `options.harn_binary` to point at a specific Harn CLI
+build for `typecheck` (and `harn`-lang `eval`) probes.
+
+Validation failures throw with `HARN-PROBE-NNN` diagnostic codes:
+`001` (options), `002` (kind), `003` (lang), `004` (body).
 
 ### std/postgres module
 

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -116,6 +116,32 @@ tombstones; predicates accept an exact `fact_...` id string or a dict with
 kind-scoped tags such as `fact:claim:evidence:file_range:README.md:1-3`.
 Validation failures include `HARN-FACT-NNN` codes.
 
+## Probe-first verification
+
+`std/agent/probe` layers a probe primitive on top of `std/agent/fact`:
+run a small snippet, capture the outcome deterministically, and
+auto-record it as an Observation so future sessions recall the verified
+answer instead of re-guessing.
+
+```harn
+import { probe_eval, probe_typecheck } from "std/agent/probe"
+
+let helper = probe_eval("git diff --quiet HEAD -- crates/harn-stdlib", {expected: 0})
+let tc = probe_typecheck(
+  "pipeline summary() { let x: int = len([1, 2, 3]) __io_println(x) }\n",
+  {expected: 0},
+)
+```
+
+Every probe returns a `harn.probe.v1` envelope (`kind`, `outcome`,
+`observed`, `evidence`, `fact_id`) and, unless `options.store_fact =
+false`, writes a `harn.fact.v1` Observation with
+`provenance.source = "probe"` and `provenance.probe_kind = "<kind>"`. Recall
+those observations with `recall_facts(query, "Observation", 0.0, scope)`
+to surface prior probe outcomes before re-running. See
+[`std/agent/probe` in the language spec](language-spec.md#stdagentprobe-module)
+for the full surface area and `HARN-PROBE-NNN` diagnostics.
+
 ## Vector and hybrid backends
 
 `memory_open(namespace, options)` writes an append-only configuration event

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -83,7 +83,7 @@ described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/edit`, `std/artifact/web`, `std/ui_resource`, `std/cache`,
 `std/llm/handlers`, `std/llm/budget`, `std/llm/prompts`, `std/vision`,
 `std/context`, `std/agent_state`, `std/agents`, `std/agent/user`,
-`std/agent/fact`,
+`std/agent/fact`, `std/agent/probe`,
 `std/runtime`, `std/command`, `std/gha`, `std/tui`, `std/git`,
 `std/review`, `std/experiments`,
 `std/project`, `std/memory`, `std/prompt_library`, `std/monitors`,
@@ -1308,6 +1308,20 @@ Typed fact envelopes over `std/memory` for cross-session assertions:
 | `store_fact(input, options?)` | Store a typed fact as `MemoryRecord.value`; `options.namespace` or `options.scope` selects the memory namespace |
 | `recall_facts(query, kind?, min_confidence?, scope?)` | Recall facts by memory query, kind, and minimum confidence |
 | `invalidate_facts(predicate, scope?)` | Append memory tombstones for matching facts by id, key, kind, claim/query, tags, or evidence |
+
+### std/agent/probe
+
+Run a small snippet and persist the verified outcome as a `harn.fact.v1`
+Observation so future sessions recall the answer instead of re-guessing.
+MVP supports `eval` (shell or `harn run`) and `typecheck` (`harn check
+--json`); `test` and `inspect` are reserved and currently return an
+`unknown` outcome.
+
+| Function | Description |
+|---|---|
+| `probe(kind, body, options?)` | Run a snippet of the given kind, capture stdout/stderr/exit code, and auto-record the outcome as an Observation fact |
+| `probe_eval(body, options?)` | Convenience for `probe("eval", ...)` — shell by default, `options.lang = "harn"` runs the body via `harn run` |
+| `probe_typecheck(body, options?)` | Convenience for `probe("typecheck", ...)` — writes the fragment to a temp file and invokes `harn check --json` |
 
 ### std/handoffs
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -412,6 +412,9 @@ Imports starting with `std/` load embedded stdlib modules:
   helpers (agent_progress, agent_progress_tool)
 - `import "std/agent/fact"` — typed fact envelopes over durable memory
   (store_fact, recall_facts, invalidate_facts)
+- `import "std/agent/probe"` — probe-first verification primitive: run a
+  snippet (eval/typecheck) and record the outcome as an Observation fact
+  (probe, probe_eval, probe_typecheck)
 - `import "std/memory"` — append-only durable memory helpers
   (memory_store, memory_recall, memory_summarize, memory_forget)
 - `import "std/trust"` — TrustGraph query and policy helpers
@@ -5328,6 +5331,40 @@ Provides typed `harn.fact.v1` assertions on top of `std/memory`. A fact contains
 | `store_fact(input, options?)` | Store the fact as `MemoryRecord.value`, using the fact id as the memory record id |
 | `recall_facts(query, kind?, min_confidence?, scope?)` | Recall normalized facts and filter by kind/confidence; `scope` may be a scope string or an options dict with normal memory options |
 | `invalidate_facts(predicate, scope?)` | Append memory tombstones; predicates accept exact `fact_...` ids or dicts with `id`, `key`, `kind`, `claim`, `query`, `tag`, `tags`, `evidence_ref`, or `evidence` |
+
+### std/agent/probe module
+
+```harn
+import { probe, probe_eval, probe_typecheck } from "std/agent/probe"
+```
+
+Provides a probe-first verification primitive: instead of asserting a
+claim about runtime behavior, run a small snippet, capture the outcome
+deterministically, and auto-record it as a `harn.fact.v1` Observation
+backed by `std/agent/fact`. Probes return a `harn.probe.v1` envelope
+with `kind`, `outcome` (`pass` / `fail` / `unknown`), `observed` summary,
+`evidence` (trace id, snippet, command, stdout/stderr/exit_code,
+duration_ms), `fact_id` of the auto-stored observation, and the
+round-tripped `expected` and `asserted_at`. MVP supports `eval` and
+`typecheck`; `test` and `inspect` are reserved and currently return an
+`unknown`-outcome envelope so callers can wire them in deterministically.
+
+| Function | Notes |
+|---|---|
+| `probe(kind, body, options?)` | Run a snippet (`eval` or `typecheck` today; `test`/`inspect` reserved) and capture the outcome. `options.expected` enables a hard match (string for stdout, int for typecheck error count); without it, outcome derives from exit code or error count. |
+| `probe_eval(body, options?)` | Convenience for `probe("eval", ...)`. Runs `body` as a shell command by default; `options.lang = "harn"` writes the body to a temp file and runs `harn run <path>`. |
+| `probe_typecheck(body, options?)` | Convenience for `probe("typecheck", ...)`. Writes the fragment to a temp file and runs `harn check <path> --json`, parsing the summary for error and warning counts. |
+
+Unless `options.store_fact = false`, every probe writes an Observation
+with `confidence = 0.9` for observed `pass`/`fail` and `0.4` for
+`unknown`, `provenance.source = "probe"`, and
+`provenance.probe_kind = "<kind>"`. Pass `options.scope`,
+`options.namespace`, or `options.root` to override the fact-store
+location, and `options.harn_binary` to point at a specific Harn CLI
+build for `typecheck` (and `harn`-lang `eval`) probes.
+
+Validation failures throw with `HARN-PROBE-NNN` diagnostic codes:
+`001` (options), `002` (kind), `003` (lang), `004` (body).
 
 ### std/postgres module
 


### PR DESCRIPTION
## Summary

- `std/agent/probe` wraps a small snippet (shell command, harn fragment, or typecheck fragment), captures stdout/stderr/exit-code into a `harn.probe.v1` envelope, and auto-records the outcome as a `harn.fact.v1` Observation so future sessions can recall the verified answer instead of re-guessing.
- MVP supports `eval` (shell or `harn run`) and `typecheck` (`harn check --json`); `test` and `inspect` are reserved and currently return an `unknown` outcome so callers can wire them deterministically.
- Ships a `harn-probe` skill (embedded corpus + `harn skills get harn-probe`) that codifies the probe-first pattern as a persona-mod nudge.
- Pairs with #2251 typed Facts (already shipped) — probes write Observations with `confidence = 0.9` for observed pass/fail, `0.4` for `unknown`, and provenance `{source: "probe", probe_kind: "<kind>"}` so recall can filter by probe shape.

## Test plan

- [x] `cargo test -p harn-stdlib`
- [x] `cargo test -p harn-skills`
- [x] `cargo test -p harn-cli`
- [x] `make lint-harn` + `make fmt-harn`
- [x] `harn test conformance` (1405/1405 pass, including new `agent_probe`)
- [x] Manual smoke: probe_eval pass + fail, probe_typecheck pass + fail
- [ ] (optional follow-up) Cross-model probe-first comparison study per the issue's kill criterion

Closes #2253

🤖 Generated with [Claude Code](https://claude.com/claude-code)