### PR TITLE
Sandbox harn run by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,10 @@ condensed series summaries instead of full per-patch history.
   catalog metadata and lazy-loadable body by default, but Harn strips
   command-bearing frontmatter (`hooks`, `command`, `run`) from both the
   startup registry and lazy hydration path unless provenance verifies.
+- **`harn run` is sandboxed by default (#2258).** Direct runs now push a
+  `worktree` capability policy before user code executes. The policy roots
+  filesystem and subprocess cwd access at the project/cwd root and denies
+  network side effects unless the operator explicitly passes `--no-sandbox`.
 - **Schema traversal hardening (#2202).** Runtime schema canonicalization,
   JSON Schema/OpenAPI export, validation, runtime parameter assertions,
   sub-agent return-schema validation, and JSON-stream schema setup now share

--- a/conformance/tests/sandbox_hardened/sandbox_hardened_backend_identity.harn
+++ b/conformance/tests/sandbox_hardened/sandbox_hardened_backend_identity.harn
@@ -24,8 +24,8 @@ pipeline default() {
     "noop"
   }
   __io_println(backend == expected)
-  // Without an active orchestration policy the script runs at the
-  // unrestricted profile — that is the documented `harn run` default.
+  // The conformance runner exercises the direct VM path; `harn run`
+  // installs its default worktree policy in CLI-specific coverage.
   __io_println(sandbox_active_profile())
   // Each shipped backend reports availability as `true` on its host.
   // (Linux Landlock/seccomp are runtime-detected by the per-mechanism

--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -23,6 +23,10 @@ pub(crate) struct RunArgs {
     /// Allow only the listed builtins as a comma-separated list.
     #[arg(long, conflicts_with = "deny")]
     pub allow: Option<String>,
+    /// Disable the default worktree filesystem/process sandbox and
+    /// network egress fail-closed guard for this run.
+    #[arg(long = "no-sandbox", action = clap::ArgAction::SetTrue)]
+    pub no_sandbox: bool,
     /// Evaluate inline Harn code instead of a file.
     #[arg(short = 'e')]
     pub eval: Option<String>,

--- a/crates/harn-cli/src/cli/time.rs
+++ b/crates/harn-cli/src/cli/time.rs
@@ -31,6 +31,10 @@ pub(crate) struct TimeRunArgs {
     /// invocation only.
     #[arg(long = "no-cache")]
     pub no_cache: bool,
+    /// Disable the default worktree filesystem/process sandbox and
+    /// network egress fail-closed guard for this run.
+    #[arg(long = "no-sandbox", action = clap::ArgAction::SetTrue)]
+    pub no_sandbox: bool,
     /// Positional arguments passed to the pipeline as the global `argv`
     /// list. Place them after a `--` separator: `harn time run script.harn -- a b c`.
     #[arg(last = true)]

--- a/crates/harn-cli/src/commands/package_scaffold.rs
+++ b/crates/harn-cli/src/commands/package_scaffold.rs
@@ -9,7 +9,9 @@ use tempfile::TempDir;
 use url::Url;
 
 use crate::cli::PackageScaffoldOpenapiArgs;
-use crate::commands::run::{execute_run, CliLlmMockMode, RunProfileOptions};
+use crate::commands::run::{
+    execute_run_with_sandbox_options, CliLlmMockMode, RunProfileOptions, RunSandboxOptions,
+};
 use crate::commands::scaffold_common::{
     harn_identifier, harn_string_literal, pascal_identifier_from_snake, validate_harn_identifier,
     write_bytes, write_file,
@@ -395,12 +397,17 @@ async fn generate_sdk_source(
     client_name: &str,
     default_base_url: &str,
 ) -> Result<(), PackageError> {
-    let tmp = tempfile::tempdir()
-        .map_err(|error| format!("failed to create OpenAPI generation temp dir: {error}"))?;
     if let Some(parent) = out_path.parent() {
         fs::create_dir_all(parent)
             .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
     }
+    let package_root = out_path
+        .parent()
+        .and_then(Path::parent)
+        .or_else(|| out_path.parent())
+        .unwrap_or_else(|| Path::new("."));
+    let tmp = tempfile::tempdir()
+        .map_err(|error| format!("failed to create OpenAPI generation temp dir: {error}"))?;
     let script_path = tmp.path().join("generate_openapi_sdk.harn");
     let script = format!(
         r#"import {{ codegen_module, parse }} from {import_path}
@@ -431,7 +438,7 @@ pipeline default() {{
     );
     fs::write(&script_path, script)
         .map_err(|error| format!("failed to write {}: {error}", script_path.display()))?;
-    let outcome = execute_run(
+    let outcome = execute_run_with_sandbox_options(
         &script_path.display().to_string(),
         false,
         HashSet::new(),
@@ -446,6 +453,7 @@ pipeline default() {{
         CliLlmMockMode::Off,
         None,
         RunProfileOptions::default(),
+        RunSandboxOptions::default().with_workspace_root(package_root),
     )
     .await;
     if outcome.exit_code != 0 {
@@ -1042,7 +1050,7 @@ paths: {}
             false,
         )
         .unwrap();
-        let outcome = execute_run(
+        let outcome = execute_run_with_sandbox_options(
             &out.join("tests/smoke.harn").display().to_string(),
             false,
             HashSet::new(),
@@ -1051,6 +1059,7 @@ paths: {}
             CliLlmMockMode::Off,
             None,
             RunProfileOptions::default(),
+            RunSandboxOptions::disabled(),
         )
         .await;
         assert_eq!(outcome.exit_code, 0, "{}{}", outcome.stderr, outcome.stdout);

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -373,6 +373,41 @@ impl RunProfileOptions {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RunSandboxOptions {
+    /// Install the default `harn run` sandbox for this invocation.
+    pub enabled: bool,
+    /// Override the workspace root used by the default sandbox. This is
+    /// intended for host-generated scripts whose source file lives outside
+    /// the workspace they operate on.
+    pub workspace_root: Option<PathBuf>,
+}
+
+impl Default for RunSandboxOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            workspace_root: None,
+        }
+    }
+}
+
+impl RunSandboxOptions {
+    /// Disable the default direct-run sandbox and egress guard.
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            workspace_root: None,
+        }
+    }
+
+    /// Constrain the default sandbox to an explicit workspace root.
+    pub fn with_workspace_root(mut self, workspace_root: impl Into<PathBuf>) -> Self {
+        self.workspace_root = Some(workspace_root.into());
+        self
+    }
+}
+
 #[derive(Clone)]
 pub struct RunInterruptTokens {
     pub cancel_token: Arc<AtomicBool>,
@@ -388,6 +423,7 @@ struct ExecuteRunInputs<'a> {
     llm_mock_mode: CliLlmMockMode,
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
+    sandbox: RunSandboxOptions,
     interrupt_tokens: Option<RunInterruptTokens>,
     json: Option<(RunJsonOptions, Box<dyn io::Write + Send>)>,
     timing: Option<&'a mut RunTiming>,
@@ -466,6 +502,7 @@ pub(crate) async fn run_file(
         llm_mock_mode,
         attestation,
         profile,
+        RunSandboxOptions::default(),
         None,
         HarnpackRunOptions::default(),
     )
@@ -495,6 +532,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     llm_mock_mode: CliLlmMockMode,
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
+    sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
     harnpack: HarnpackRunOptions,
 ) {
@@ -513,6 +551,7 @@ pub(crate) async fn run_file_with_skill_dirs(
         llm_mock_mode,
         attestation,
         profile,
+        sandbox,
         interrupt_tokens: Some(interrupt_tokens.clone()),
         json: json_with_stdout,
         timing: None,
@@ -548,6 +587,7 @@ pub(crate) async fn run_resume_with_skill_dirs(
     llm_mock_mode: CliLlmMockMode,
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
+    sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
 ) {
     let source = r#"import { resume_agent, wait_agent } from "std/agent/workers"
@@ -584,6 +624,7 @@ pipeline main(task) {
         llm_mock_mode,
         attestation,
         profile,
+        sandbox,
         json,
         HarnpackRunOptions::default(),
     )
@@ -638,6 +679,113 @@ impl Drop for StdoutPassthroughGuard {
     fn drop(&mut self) {
         harn_vm::set_stdout_passthrough(self.previous);
     }
+}
+
+struct ExecutionPolicyGuard;
+
+impl Drop for ExecutionPolicyGuard {
+    fn drop(&mut self) {
+        harn_vm::orchestration::pop_execution_policy();
+    }
+}
+
+struct RunSandboxScope {
+    _execution_policy: Option<ExecutionPolicyGuard>,
+    _egress_policy: Option<harn_vm::egress::ExplicitEgressPolicyGuard>,
+}
+
+impl RunSandboxScope {
+    fn disabled() -> Self {
+        Self {
+            _execution_policy: None,
+            _egress_policy: None,
+        }
+    }
+}
+
+fn install_run_sandbox_scope(
+    options: &RunSandboxOptions,
+    workspace_root: &Path,
+    stderr: &mut String,
+) -> RunSandboxScope {
+    if !options.enabled {
+        stderr.push_str(
+            "warning: harn run --no-sandbox disables filesystem, process, and egress sandbox defaults\n",
+        );
+        return RunSandboxScope::disabled();
+    }
+
+    let execution_policy = if harn_vm::orchestration::current_execution_policy().is_none() {
+        harn_vm::orchestration::push_execution_policy(default_run_capability_policy(
+            workspace_root,
+        ));
+        Some(ExecutionPolicyGuard)
+    } else {
+        None
+    };
+    let egress_policy = Some(harn_vm::egress::require_explicit_egress_policy_for_host());
+
+    RunSandboxScope {
+        _execution_policy: execution_policy,
+        _egress_policy: egress_policy,
+    }
+}
+
+fn default_run_capability_policy(
+    workspace_root: &Path,
+) -> harn_vm::orchestration::CapabilityPolicy {
+    harn_vm::orchestration::CapabilityPolicy {
+        workspace_roots: vec![normalize_run_workspace_root(workspace_root)
+            .display()
+            .to_string()],
+        side_effect_level: Some("process_exec".to_string()),
+        sandbox_profile: harn_vm::orchestration::SandboxProfile::Worktree,
+        ..harn_vm::orchestration::CapabilityPolicy::default()
+    }
+}
+
+fn normalize_run_workspace_root(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn default_run_workspace_root(project_root: Option<&Path>, source_parent: &Path) -> PathBuf {
+    project_root
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| source_parent.to_path_buf())
+}
+
+fn run_sandbox_attestation(sandbox: &RunSandboxOptions) -> serde_json::Value {
+    let active_policy = harn_vm::orchestration::current_execution_policy();
+    let active = active_policy.is_some();
+    let workspace_roots = active_policy
+        .as_ref()
+        .map(|policy| policy.workspace_roots.clone())
+        .unwrap_or_default();
+    let profile = active_policy
+        .as_ref()
+        .map(|policy| policy.sandbox_profile.as_str())
+        .unwrap_or("unrestricted");
+    let egress = if sandbox.enabled {
+        "explicit_policy_required"
+    } else if active {
+        "host_policy"
+    } else {
+        "unrestricted"
+    };
+
+    serde_json::json!({
+        "run_default_enabled": sandbox.enabled,
+        "active": active,
+        "workspace_roots": workspace_roots,
+        "profile": profile,
+        "egress": egress,
+    })
 }
 
 // User-facing copy on Ctrl-C. We want the operator to know that a brief
@@ -720,7 +868,7 @@ pub async fn execute_run(
     attestation: Option<RunAttestationOptions>,
     profile: RunProfileOptions,
 ) -> RunOutcome {
-    execute_run_with_harnpack_options(
+    execute_run_with_harnpack_and_sandbox_options(
         path,
         trace,
         denied_builtins,
@@ -729,6 +877,37 @@ pub async fn execute_run(
         llm_mock_mode,
         attestation,
         profile,
+        RunSandboxOptions::default(),
+        HarnpackRunOptions::default(),
+    )
+    .await
+}
+
+/// [`execute_run`] with an explicit sandbox policy override for in-process
+/// callers whose source path is intentionally outside the workspace they
+/// operate on.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_run_with_sandbox_options(
+    path: &str,
+    trace: bool,
+    denied_builtins: HashSet<String>,
+    script_argv: Vec<String>,
+    skill_dirs_raw: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
+    attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
+    sandbox: RunSandboxOptions,
+) -> RunOutcome {
+    execute_run_with_harnpack_and_sandbox_options(
+        path,
+        trace,
+        denied_builtins,
+        script_argv,
+        skill_dirs_raw,
+        llm_mock_mode,
+        attestation,
+        profile,
+        sandbox,
         HarnpackRunOptions::default(),
     )
     .await
@@ -750,6 +929,34 @@ pub async fn execute_run_with_harnpack_options(
     profile: RunProfileOptions,
     harnpack: HarnpackRunOptions,
 ) -> RunOutcome {
+    execute_run_with_harnpack_and_sandbox_options(
+        path,
+        trace,
+        denied_builtins,
+        script_argv,
+        skill_dirs_raw,
+        llm_mock_mode,
+        attestation,
+        profile,
+        RunSandboxOptions::default(),
+        harnpack,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_run_with_harnpack_and_sandbox_options(
+    path: &str,
+    trace: bool,
+    denied_builtins: HashSet<String>,
+    script_argv: Vec<String>,
+    skill_dirs_raw: Vec<String>,
+    llm_mock_mode: CliLlmMockMode,
+    attestation: Option<RunAttestationOptions>,
+    profile: RunProfileOptions,
+    sandbox: RunSandboxOptions,
+    harnpack: HarnpackRunOptions,
+) -> RunOutcome {
     execute_run_inner(ExecuteRunInputs {
         path,
         trace,
@@ -759,6 +966,7 @@ pub async fn execute_run_with_harnpack_options(
         llm_mock_mode,
         attestation,
         profile,
+        sandbox,
         interrupt_tokens: None,
         json: None,
         timing: None,
@@ -794,6 +1002,7 @@ pub async fn execute_run_json(
         llm_mock_mode,
         attestation,
         profile,
+        sandbox: RunSandboxOptions::default(),
         interrupt_tokens: None,
         json: Some((options, out)),
         timing: None,
@@ -809,6 +1018,7 @@ pub(crate) async fn execute_run_with_timing(
     path: &str,
     script_argv: Vec<String>,
     timing: Option<&mut RunTiming>,
+    sandbox: RunSandboxOptions,
 ) -> RunOutcome {
     execute_run_inner(ExecuteRunInputs {
         path,
@@ -819,6 +1029,7 @@ pub(crate) async fn execute_run_with_timing(
         llm_mock_mode: CliLlmMockMode::Off,
         attestation: None,
         profile: RunProfileOptions::default(),
+        sandbox,
         interrupt_tokens: None,
         json: None,
         timing,
@@ -840,6 +1051,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         llm_mock_mode,
         attestation,
         profile,
+        sandbox,
         interrupt_tokens,
         json,
         mut timing,
@@ -932,6 +1144,11 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     // Metadata/store rooted at harn.toml when present; source dir otherwise.
     let project_root = harn_vm::stdlib::process::find_project_root(source_parent);
     let store_base = project_root.as_deref().unwrap_or(source_parent);
+    let sandbox_root = sandbox
+        .workspace_root
+        .clone()
+        .unwrap_or_else(|| default_run_workspace_root(project_root.as_deref(), source_parent));
+    let _sandbox_scope = install_run_sandbox_scope(&sandbox, &sandbox_root, &mut stderr);
     let attestation_started_at_ms = now_ms();
     let attestation_log = if attestation.is_some() {
         Some(harn_vm::event_log::install_memory_for_current_thread(256))
@@ -946,6 +1163,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
                 "pipeline": path,
                 "argv": &script_argv,
                 "project_root": store_base.display().to_string(),
+                "sandbox": run_sandbox_attestation(&sandbox),
             }),
         )
         .await;
@@ -1815,11 +2033,14 @@ pub(crate) async fn run_watch(path: &str, denied_builtins: HashSet<String>) {
 
 #[cfg(test)]
 mod tests {
+    use super::harnpack::HarnpackRunOptions;
     use super::{
-        execute_explain_cost, execute_run, split_eval_header, CliLlmMockMode, RunProfileOptions,
-        StdoutPassthroughGuard,
+        default_run_workspace_root, execute_explain_cost, execute_run,
+        execute_run_with_harnpack_and_sandbox_options, run_sandbox_attestation, split_eval_header,
+        CliLlmMockMode, RunProfileOptions, RunSandboxOptions, StdoutPassthroughGuard,
     };
     use std::collections::HashSet;
+    use std::path::Path;
 
     #[test]
     fn split_eval_header_no_imports_returns_full_body() {
@@ -1908,6 +2129,197 @@ pipeline main() {
         );
     }
 
+    #[test]
+    fn default_run_workspace_root_prefers_manifest_root_then_cwd() {
+        let project = tempfile::TempDir::new().expect("project");
+        let source_parent = project.path().join("scripts");
+        let cwd = std::env::current_dir().expect("cwd");
+
+        assert_eq!(
+            default_run_workspace_root(Some(project.path()), &source_parent),
+            project.path()
+        );
+        assert_eq!(default_run_workspace_root(None, Path::new("scripts")), cwd);
+    }
+
+    #[test]
+    fn run_sandbox_attestation_reports_effective_policy() {
+        harn_vm::reset_thread_local_state();
+        let policy = harn_vm::orchestration::CapabilityPolicy {
+            workspace_roots: vec!["/tmp/workspace".to_string()],
+            sandbox_profile: harn_vm::orchestration::SandboxProfile::OsHardened,
+            ..harn_vm::orchestration::CapabilityPolicy::default()
+        };
+        harn_vm::orchestration::push_execution_policy(policy);
+
+        let metadata = run_sandbox_attestation(&RunSandboxOptions::disabled());
+
+        assert_eq!(metadata["run_default_enabled"], false);
+        assert_eq!(metadata["active"], true);
+        assert_eq!(metadata["workspace_roots"][0], "/tmp/workspace");
+        assert_eq!(metadata["profile"], "os_hardened");
+        assert_eq!(metadata["egress"], "host_policy");
+        harn_vm::reset_thread_local_state();
+    }
+
+    #[tokio::test]
+    async fn execute_run_default_sandbox_reports_worktree_profile() {
+        harn_vm::reset_thread_local_state();
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let script = temp.path().join("main.harn");
+        std::fs::write(
+            &script,
+            r#"
+pipeline main() {
+  __io_println(sandbox_active_profile())
+}
+"#,
+        )
+        .expect("write script");
+
+        let outcome = execute_run(
+            &script.to_string_lossy(),
+            false,
+            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code, 0, "stderr:\n{}", outcome.stderr);
+        assert_eq!(outcome.stdout.trim(), "worktree");
+        harn_vm::reset_thread_local_state();
+    }
+
+    #[tokio::test]
+    async fn execute_run_default_sandbox_blocks_outside_workspace_read() {
+        harn_vm::reset_thread_local_state();
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let project = temp.path().join("project");
+        let outside = temp.path().join("outside.txt");
+        std::fs::create_dir(&project).expect("create project");
+        std::fs::write(project.join("harn.toml"), "").expect("write manifest");
+        std::fs::write(&outside, "secret").expect("write outside");
+        let script = project.join("main.harn");
+        let outside_literal = outside.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            &script,
+            format!(
+                r#"
+pipeline main() {{
+  __io_println(sandbox_active_profile())
+  let _ = read_file("{}")
+}}
+"#,
+                outside_literal
+            ),
+        )
+        .expect("write script");
+
+        let outcome = execute_run(
+            &script.to_string_lossy(),
+            false,
+            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code, 1, "stdout:\n{}", outcome.stdout);
+        assert!(
+            outcome.stderr.contains("sandbox violation"),
+            "stderr:\n{}",
+            outcome.stderr
+        );
+        harn_vm::reset_thread_local_state();
+    }
+
+    #[tokio::test]
+    async fn execute_run_no_sandbox_allows_outside_workspace_read() {
+        harn_vm::reset_thread_local_state();
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let project = temp.path().join("project");
+        let outside = temp.path().join("outside.txt");
+        std::fs::create_dir(&project).expect("create project");
+        std::fs::write(&outside, "secret").expect("write outside");
+        let script = project.join("main.harn");
+        let outside_literal = outside.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            &script,
+            format!(
+                r#"
+pipeline main() {{
+  __io_println(sandbox_active_profile())
+  __io_println(read_file("{}"))
+}}
+"#,
+                outside_literal
+            ),
+        )
+        .expect("write script");
+
+        let outcome = execute_run_with_harnpack_and_sandbox_options(
+            &script.to_string_lossy(),
+            false,
+            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+            RunSandboxOptions::disabled(),
+            HarnpackRunOptions::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code, 0, "stderr:\n{}", outcome.stderr);
+        assert_eq!(outcome.stdout.trim(), "unrestricted\nsecret");
+        assert!(outcome.stderr.contains("--no-sandbox"));
+        harn_vm::reset_thread_local_state();
+    }
+
+    #[tokio::test]
+    async fn execute_run_denies_network_by_default() {
+        harn_vm::reset_thread_local_state();
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let script = temp.path().join("main.harn");
+        std::fs::write(
+            &script,
+            r#"
+pipeline main() {
+  let _ = http_get("https://example.com/")
+}
+"#,
+        )
+        .expect("write script");
+
+        let outcome = execute_run(
+            &script.to_string_lossy(),
+            false,
+            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code, 1, "stdout:\n{}", outcome.stdout);
+        assert!(
+            outcome.stderr.contains("exceeds network ceiling"),
+            "stderr:\n{}",
+            outcome.stderr
+        );
+        harn_vm::reset_thread_local_state();
+    }
+
     #[cfg(feature = "hostlib")]
     #[tokio::test]
     async fn execute_run_installs_hostlib_gate() {
@@ -1968,7 +2380,7 @@ pipeline main() {
         )
         .expect("write script");
 
-        let outcome = execute_run(
+        let outcome = execute_run_with_harnpack_and_sandbox_options(
             &temp.path().to_string_lossy(),
             false,
             HashSet::new(),
@@ -1977,6 +2389,8 @@ pipeline main() {
             CliLlmMockMode::Off,
             None,
             RunProfileOptions::default(),
+            RunSandboxOptions::disabled(),
+            HarnpackRunOptions::default(),
         )
         .await;
 

--- a/crates/harn-cli/src/commands/time.rs
+++ b/crates/harn-cli/src/commands/time.rs
@@ -122,6 +122,11 @@ pub(crate) async fn run(args: TimeRunArgs) {
     let mut timing = RunTiming::default();
     let cpu_start = cpu_ms();
     let wall_start = std::time::Instant::now();
+    let sandbox = if args.no_sandbox {
+        crate::commands::run::RunSandboxOptions::disabled()
+    } else {
+        crate::commands::run::RunSandboxOptions::default()
+    };
 
     // In `--json` mode stdout is owned by the envelope, so we keep
     // script output buffered (passthrough disabled) and write it to
@@ -141,13 +146,19 @@ pub(crate) async fn run(args: TimeRunArgs) {
                 process::exit(1);
             }
             let path_str = tmp_path.to_string_lossy().into_owned();
-            let outcome =
-                execute_run_with_timing(&path_str, args.argv.clone(), Some(&mut timing)).await;
+            let outcome = execute_run_with_timing(
+                &path_str,
+                args.argv.clone(),
+                Some(&mut timing),
+                sandbox.clone(),
+            )
+            .await;
             drop(tmp);
             (None, outcome)
         }
         (None, Some(file)) => {
-            let outcome = execute_run_with_timing(file, args.argv.clone(), Some(&mut timing)).await;
+            let outcome =
+                execute_run_with_timing(file, args.argv.clone(), Some(&mut timing), sandbox).await;
             (Some(file.to_string()), outcome)
         }
         (Some(_), Some(_)) => {

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -219,6 +219,11 @@ async fn async_main() {
                 agent_id: args.attest_agent.clone(),
             });
             let profile_options = run_profile_options(&args.profile);
+            let sandbox_options = if args.no_sandbox {
+                commands::run::RunSandboxOptions::disabled()
+            } else {
+                commands::run::RunSandboxOptions::default()
+            };
             let json_options = args
                 .json
                 .then_some(commands::run::RunJsonOptions { quiet: args.quiet });
@@ -237,6 +242,7 @@ async fn async_main() {
                     llm_mock_mode,
                     attestation,
                     profile_options,
+                    sandbox_options.clone(),
                     json_options,
                 )
                 .await;
@@ -270,6 +276,7 @@ async fn async_main() {
                             llm_mock_mode.clone(),
                             attestation.clone(),
                             profile_options.clone(),
+                            sandbox_options.clone(),
                             json_options.clone(),
                             harnpack_options.clone(),
                         )
@@ -290,6 +297,7 @@ async fn async_main() {
                             llm_mock_mode,
                             attestation,
                             profile_options,
+                            sandbox_options,
                             json_options,
                             harnpack_options,
                         )

--- a/crates/harn-cli/tests/burin_mini_playground.rs
+++ b/crates/harn-cli/tests/burin_mini_playground.rs
@@ -19,7 +19,10 @@ use std::path::{Path, PathBuf};
 use std::thread;
 
 use harn_cli::commands::playground::{execute_playground_inputs, PlaygroundInputs};
-use harn_cli::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
+use harn_cli::commands::run::{
+    execute_run_with_sandbox_options, CliLlmMockMode, RunOutcome, RunProfileOptions,
+    RunSandboxOptions,
+};
 use harn_cli::tests::common::{cwd_lock, env_lock};
 use tempfile::TempDir;
 
@@ -472,13 +475,14 @@ fn burin_mini_semantic_evaluator_heuristic_passes_for_rate_limit_fixture() {
     let report = experiment_root.join("evals/fixtures/rate_limit_auth-report.json");
     let semantic = temp.path().join("rate_limit_auth.semantic.json");
     let semantic_clone = semantic.clone();
+    let sandbox_root = temp.path().to_path_buf();
 
     let outcome: RunOutcome = run_in_harn_runtime(move || async move {
         let _env_guard = env_lock::lock_env().lock().await;
         let _cwd_guard = cwd_lock::lock_cwd_async().await;
         harn_vm::reset_thread_local_state();
         std::env::set_var("BURIN_MINI_SEMANTIC_EVAL_MODE", "heuristic");
-        let result = execute_run(
+        let result = execute_run_with_sandbox_options(
             &evaluator.to_string_lossy(),
             false,
             HashSet::new(),
@@ -491,6 +495,7 @@ fn burin_mini_semantic_evaluator_heuristic_passes_for_rate_limit_fixture() {
             CliLlmMockMode::Off,
             None,
             RunProfileOptions::default(),
+            RunSandboxOptions::default().with_workspace_root(sandbox_root),
         )
         .await;
         std::env::remove_var("BURIN_MINI_SEMANTIC_EVAL_MODE");

--- a/crates/harn-vm/src/egress.rs
+++ b/crates/harn-vm/src/egress.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 #[cfg(test)]
 use std::collections::{HashMap, HashSet};
@@ -18,6 +19,10 @@ pub const HARN_EGRESS_ALLOW_ENV: &str = "HARN_EGRESS_ALLOW";
 pub const HARN_EGRESS_DENY_ENV: &str = "HARN_EGRESS_DENY";
 pub const HARN_EGRESS_DEFAULT_ENV: &str = "HARN_EGRESS_DEFAULT";
 pub const EGRESS_AUDIT_TOPIC: &str = "connectors.egress.audit";
+
+thread_local! {
+    static REQUIRE_EXPLICIT_EGRESS_POLICY_DEPTH: RefCell<usize> = const { RefCell::new(0) };
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DefaultAction {
@@ -165,11 +170,38 @@ pub fn reset_egress_policy_for_host() {
         guard.env_checked = false;
         guard.policy = None;
     }
+    clear_explicit_egress_policy_requirement_for_host();
+}
+
+pub(crate) fn clear_explicit_egress_policy_requirement_for_host() {
+    REQUIRE_EXPLICIT_EGRESS_POLICY_DEPTH.with(|depth| *depth.borrow_mut() = 0);
 }
 
 #[cfg(test)]
 pub fn reset_egress_policy_for_tests() {
     reset_egress_policy_for_host();
+}
+
+/// Scope outbound network to explicit `egress_policy(...)` /
+/// `HARN_EGRESS_*` configuration. Without a configured policy, URL
+/// checks return [`EgressBlocked`] before opening a socket.
+pub fn require_explicit_egress_policy_for_host() -> ExplicitEgressPolicyGuard {
+    REQUIRE_EXPLICIT_EGRESS_POLICY_DEPTH.with(|depth| {
+        *depth.borrow_mut() += 1;
+    });
+    ExplicitEgressPolicyGuard
+}
+
+#[derive(Debug)]
+pub struct ExplicitEgressPolicyGuard;
+
+impl Drop for ExplicitEgressPolicyGuard {
+    fn drop(&mut self) {
+        REQUIRE_EXPLICIT_EGRESS_POLICY_DEPTH.with(|depth| {
+            let mut depth = depth.borrow_mut();
+            *depth = depth.saturating_sub(1);
+        });
+    }
 }
 
 fn check_url(surface: &str, raw_url: &str) -> Result<Option<EgressBlocked>, VmError> {
@@ -178,17 +210,26 @@ fn check_url(surface: &str, raw_url: &str) -> Result<Option<EgressBlocked>, VmEr
         let guard = state().read().expect("egress policy state poisoned");
         #[cfg(test)]
         {
-            guard
-                .test_policies
-                .get(&std::thread::current().id())
-                .cloned()
+            let thread_id = std::thread::current().id();
+            guard.test_policies.get(&thread_id).cloned()
         }
         #[cfg(not(test))]
         {
             guard.policy.clone()
         }
     };
+    let require_explicit_policy =
+        REQUIRE_EXPLICIT_EGRESS_POLICY_DEPTH.with(|depth| *depth.borrow() > 0);
     let Some(configured) = configured else {
+        if require_explicit_policy {
+            let target = EgressTarget::parse(raw_url)?;
+            return Ok(Some(blocked(
+                surface,
+                raw_url,
+                &target,
+                "no egress policy configured".to_string(),
+            )));
+        }
         return Ok(None);
     };
     let target = EgressTarget::parse(raw_url)?;
@@ -780,6 +821,58 @@ mod tests {
             "https://api.example.com/resource?access_token=%5Bredacted%5D&ok=1"
         );
         assert!(!blocked.to_string().contains("secret-token"));
+    }
+
+    #[test]
+    fn require_explicit_policy_blocks_unconfigured_egress() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_egress_policy_for_tests();
+        {
+            let _scope = require_explicit_egress_policy_for_host();
+            let blocked = check_url("http_get", "https://api.example.com/status")
+                .unwrap()
+                .expect("missing policy blocks");
+            assert_eq!(blocked.reason, "no egress policy configured");
+            assert_eq!(blocked.host, "api.example.com");
+        }
+        assert!(check_url("http_get", "https://api.example.com/status")
+            .unwrap()
+            .is_none());
+        reset_egress_policy_for_tests();
+    }
+
+    #[test]
+    fn reset_thread_local_state_clears_required_policy_scope() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_egress_policy_for_tests();
+        let _scope = require_explicit_egress_policy_for_host();
+
+        crate::reset_thread_local_state();
+
+        assert!(check_url("http_get", "https://api.example.com/status")
+            .unwrap()
+            .is_none());
+        reset_egress_policy_for_tests();
+    }
+
+    #[test]
+    fn explicit_environment_policy_satisfies_required_policy_scope() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_egress_policy_for_tests();
+        std::env::set_var(HARN_EGRESS_ALLOW_ENV, "api.example.com");
+        std::env::set_var(HARN_EGRESS_DEFAULT_ENV, "deny");
+        let _scope = require_explicit_egress_policy_for_host();
+
+        assert!(check_url("http_get", "https://api.example.com/status")
+            .unwrap()
+            .is_none());
+        assert!(check_url("http_get", "https://other.example.com/status")
+            .unwrap()
+            .is_some());
+
+        std::env::remove_var(HARN_EGRESS_ALLOW_ENV);
+        std::env::remove_var(HARN_EGRESS_DEFAULT_ENV);
+        reset_egress_policy_for_tests();
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -386,6 +386,7 @@ pub fn reset_thread_local_state() {
     http::reset_http_state();
     channels::reset_channel_state();
     event_log::reset_active_event_log();
+    egress::clear_explicit_egress_policy_requirement_for_host();
     stdlib::reset_stdlib_state();
     connectors::clear_active_connector_clients();
     orchestration::clear_runtime_hooks();

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -122,13 +122,14 @@ pub fn enforce_tool_arg_constraints(
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxProfile {
-    /// No path enforcement, no OS confinement. Used by `harn run` when
-    /// no orchestration policy is active and by escape hatches that
-    /// explicitly disable isolation.
+    /// No path enforcement, no OS confinement. Used by direct VM
+    /// embeddings with no orchestration policy and by escape hatches
+    /// that explicitly disable isolation.
     Unrestricted,
     /// Workspace-root path enforcement plus best-effort OS confinement.
     /// Honors `HARN_HANDLER_SANDBOX={off,warn,enforce}` for the OS
-    /// portion. Default for orchestrator-launched workflows.
+    /// portion. Default for `harn run` and orchestrator-launched
+    /// workflows.
     #[default]
     Worktree,
     /// Workspace-root path enforcement plus required OS confinement.

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1034,7 +1034,10 @@ CIDR ranges (`127.0.0.0/8`), and optional port restrictions
 (`api.example.com:443`). Deny rules override allow rules; `default: "deny"`
 turns the policy into an allowlist. Operators can seed the same policy without
 editing scripts via comma-separated `HARN_EGRESS_ALLOW`, `HARN_EGRESS_DENY`,
-and `HARN_EGRESS_DEFAULT=deny`.
+and `HARN_EGRESS_DEFAULT=deny`. Under default `harn run`, the worktree
+sandbox denies network side effects before destination policy is consulted;
+use `egress_policy(...)` for network-enabled host policies or explicit
+`--no-sandbox` runs.
 
 ```harn
 pipeline main(task) {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -13,6 +13,7 @@ harn run --profile --profile-json profile.json <file.harn>
 harn run -e 'log("hello")'
 harn run --deny shell,exec <file.harn>
 harn run --allow read_file,write_file <file.harn>
+harn run --no-sandbox <file.harn>
 harn run --yes <file.harn>
 harn run --explain-cost <file.harn>
 harn run --attest <file.harn>
@@ -33,6 +34,7 @@ harn run --resume .harn/workers/worker_...json
 | `--resume <handle-or-snapshot>` | Cold-restore a suspended top-level agent from its persisted worker snapshot |
 | `--deny <builtins>` | Deny specific builtins (comma-separated) |
 | `--allow <builtins>` | Allow only specific builtins (comma-separated) |
+| `--no-sandbox` | Disable the default worktree filesystem/process sandbox and network side-effect ceiling |
 | `--yes` | Accept first-run provider setup prompts, including local Ollama config seeding |
 | `--attest` | Emit a signed provenance receipt after execution |
 | `--receipt-out <path>` | Write the receipt to a specific JSON path |
@@ -78,6 +80,14 @@ You can also run a file directly without the `run` subcommand:
 ```bash
 harn main.harn
 ```
+
+By default, `harn run` installs a worktree sandbox before executing
+the VM. Filesystem and subprocess cwd access are rooted at the nearest
+`harn.toml` project root, or at the invocation working directory when
+no project manifest is present. Network side effects are denied by the
+same default policy. Use `--no-sandbox` only for scripts that need the
+old unrestricted process behavior; the CLI emits a warning when this
+escape hatch is used.
 
 Before starting the VM, `harn run <file>` builds the cross-module
 graph for the entry file. When all imports resolve, unknown call
@@ -368,6 +378,7 @@ and per-tool-call latency. Today only `harn time run` is supported.
 harn time run main.harn
 harn time run main.harn --json
 harn time run main.harn --json --no-cache
+harn time run main.harn --no-sandbox
 harn time run -e 'log("hi")' --json
 harn time run script.harn -- arg1 arg2
 ```
@@ -415,7 +426,8 @@ output is redirected to stderr so `harn time run … --json | jq …` works
 without filtering. Diagnostics and non-zero exit codes from the wrapped
 run still propagate through `harn time`. `--no-cache` sets
 `HARN_BYTECODE_CACHE=0` for the duration of the invocation only,
-forcing a cold parse/typecheck/compile.
+forcing a cold parse/typecheck/compile. `--no-sandbox` is forwarded to
+the wrapped `harn run` path.
 
 ## harn viz
 

--- a/docs/src/host-boundary.md
+++ b/docs/src/host-boundary.md
@@ -84,14 +84,16 @@ embedders ship richer behavior via the `HostCallBridge` trait described in
 
 ## Process sandbox
 
-The runtime confines every subprocess it spawns under an active
-capability ceiling. The default profile is `worktree` —
-workspace-root path enforcement plus best-effort OS-level
-confinement (Linux Landlock + seccomp, macOS sandbox-exec, Windows
-AppContainer + Job Object). Pipelines that spawn untrusted code opt
-into `os_hardened`, which makes the OS confinement *required* and
-turns every spawn into a `tool_rejected` if the platform mechanism
-is missing.
+`harn run` installs a default `worktree` capability ceiling before
+executing user code. The runtime confines every subprocess it spawns
+under that ceiling unless the operator passes `--no-sandbox`. The
+default profile is workspace-root path enforcement plus best-effort
+OS-level confinement (Linux Landlock + seccomp, macOS sandbox-exec,
+Windows AppContainer + Job Object), with network side effects denied
+by the default ceiling. Pipelines that spawn untrusted code opt into
+`os_hardened`, which makes the OS confinement *required* and turns
+every spawn into a `tool_rejected` if the platform mechanism is
+missing.
 
 See [Process sandboxing](./sandboxing.md) for the full per-platform
 capability → kernel-knob mapping table, profile selection examples,

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -6338,8 +6338,28 @@ persona_step_allowlist = ["legacy_helper"]
 
 ## Sandbox mode
 
-The `harn run` command supports sandbox flags that restrict which builtins
-a program may call.
+The `harn run` command installs a default worktree sandbox before the
+VM starts. The default policy uses `sandbox_profile: "worktree"`,
+roots filesystem/process access at the nearest `harn.toml` project
+root (or the invocation working directory when no project manifest is
+present), allows local process execution, and denies network side
+effects. This makes direct runs fail closed for filesystem escapes,
+subprocess working directories, and outbound HTTP/connectors unless
+the operator explicitly opts out.
+
+`harn run` also supports builtin allow/deny flags that restrict which
+builtins a program may call.
+
+### --no-sandbox
+
+```bash
+harn run --no-sandbox script.harn
+```
+
+Disables the default worktree filesystem/process sandbox and the
+network side-effect ceiling for this invocation. The CLI emits a
+warning when this escape hatch is used. `--deny` / `--allow` still
+apply when present.
 
 ### --deny
 
@@ -6428,11 +6448,12 @@ per-platform mechanisms are:
   derived from the same policy.
 
 `SandboxProfile::Unrestricted` skips both path enforcement and OS
-confinement (used by `harn run` when no orchestration policy is
-active). `SandboxProfile::Wasi` is testbench-only — subprocesses are
-intercepted by the process tape and resolved against recorded WASI
-modules. See the [sandboxing guide](https://harnlang.com/sandboxing.html) for
-the full per-platform capability → kernel-knob mapping table.
+confinement; `harn run --no-sandbox` is the CLI escape hatch that
+leaves direct runs in that state. `SandboxProfile::Wasi` is
+testbench-only — subprocesses are intercepted by the process tape and
+resolved against recorded WASI modules. See the
+[sandboxing guide](https://harnlang.com/sandboxing.html) for the full
+per-platform capability → kernel-knob mapping table.
 
 ## Test framework
 

--- a/docs/src/sandboxing.md
+++ b/docs/src/sandboxing.md
@@ -1,9 +1,18 @@
 # Process sandboxing
 
-Harn ships an OS-level process sandbox that engages whenever a
-subprocess is spawned under an active capability policy. The sandbox
-runs in addition to the workspace-root path enforcement and the
-approval-policy DSL — defense in depth, not a replacement.
+Harn ships a default `harn run` worktree sandbox plus an OS-level
+process sandbox that engages whenever a subprocess is spawned under an
+active capability policy. The OS sandbox runs in addition to the
+workspace-root path enforcement and the approval-policy DSL — defense
+in depth, not a replacement.
+
+Direct `harn run` invocations install a `worktree` capability policy
+before the VM starts. The policy roots filesystem and process-cwd
+access at the nearest `harn.toml` project root, or at the invocation
+working directory when no manifest is present, and sets the
+side-effect ceiling below `network`. Pass `--no-sandbox` to opt out
+for a single run; the CLI prints a warning when that escape hatch is
+used.
 
 ## Sandbox profiles
 
@@ -178,7 +187,7 @@ scripts and conformance fixtures:
 |---|---|---|
 | `sandbox_active_backend()` | `string` | name of the compiled-in backend (`linux`, `macos`, `windows`, `openbsd`, `noop`) |
 | `sandbox_backend_available()` | `bool` | whether the platform mechanism behind the backend is reachable on the running host |
-| `sandbox_active_profile()` | `string` | profile carried by the current execution policy (`unrestricted` if no policy is active) |
+| `sandbox_active_profile()` | `string` | profile carried by the current execution policy (`worktree` under default `harn run`, `unrestricted` if no policy is active) |
 
 ## Replay fidelity
 
@@ -197,8 +206,8 @@ mechanism.
 
 - gVisor / Firecracker / Kata containers — those belong to
   `harn-cloud`'s `SandboxBackend` impl, not the local runtime.
-- Network egress allow/deny by domain — leave to `with_consent` /
-  `approval_policy.rules`.
+- Destination-level network egress allow/deny — use `egress_policy(...)`
+  or `HARN_EGRESS_*` once a host policy allows network side effects.
 - Sandboxing for in-process work (LLM calls, deterministic Harn
   evaluation). Capability ceilings and the approval policy are the
   enforcement layers there; the OS sandbox only kicks in when Harn

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -6336,8 +6336,28 @@ persona_step_allowlist = ["legacy_helper"]
 
 ## Sandbox mode
 
-The `harn run` command supports sandbox flags that restrict which builtins
-a program may call.
+The `harn run` command installs a default worktree sandbox before the
+VM starts. The default policy uses `sandbox_profile: "worktree"`,
+roots filesystem/process access at the nearest `harn.toml` project
+root (or the invocation working directory when no project manifest is
+present), allows local process execution, and denies network side
+effects. This makes direct runs fail closed for filesystem escapes,
+subprocess working directories, and outbound HTTP/connectors unless
+the operator explicitly opts out.
+
+`harn run` also supports builtin allow/deny flags that restrict which
+builtins a program may call.
+
+### --no-sandbox
+
+```bash
+harn run --no-sandbox script.harn
+```
+
+Disables the default worktree filesystem/process sandbox and the
+network side-effect ceiling for this invocation. The CLI emits a
+warning when this escape hatch is used. `--deny` / `--allow` still
+apply when present.
 
 ### --deny
 
@@ -6426,11 +6446,12 @@ per-platform mechanisms are:
   derived from the same policy.
 
 `SandboxProfile::Unrestricted` skips both path enforcement and OS
-confinement (used by `harn run` when no orchestration policy is
-active). `SandboxProfile::Wasi` is testbench-only — subprocesses are
-intercepted by the process tape and resolved against recorded WASI
-modules. See the [sandboxing guide](https://harnlang.com/sandboxing.html) for
-the full per-platform capability → kernel-knob mapping table.
+confinement; `harn run --no-sandbox` is the CLI escape hatch that
+leaves direct runs in that state. `SandboxProfile::Wasi` is
+testbench-only — subprocesses are intercepted by the process tape and
+resolved against recorded WASI modules. See the
+[sandboxing guide](https://harnlang.com/sandboxing.html) for the full
+per-platform capability → kernel-knob mapping table.
 
 ## Test framework
 


### PR DESCRIPTION
## Summary
- Install a default worktree sandbox for `harn run`, rooted at the nearest project manifest or invocation cwd, with local process execution allowed and network side effects denied.
- Add `--no-sandbox` for `harn run` and `harn time run`, an explicit egress fail-closed guard, and effective sandbox attestation metadata.
- Update generated-script/test callers that need explicit sandbox roots, and refresh docs, spec, and changelog coverage.

Closes #2258

## Verification
- `cargo test -p harn-vm egress::tests --lib`
- `cargo test -p harn-cli commands::run::tests --lib`
- `cargo test -p harn-cli --test time_cli`
- `cargo test -p harn-cli commands::package_scaffold::tests::scaffold_openapi_package_passes_local_package_gates --lib -- --nocapture`
- `cargo test -p harn-cli commands::package_scaffold::tests::force_preserves_extra_files --lib -- --nocapture`
- `cargo test -p harn-cli --test burin_mini_playground burin_mini_semantic_evaluator_heuristic_passes_for_rate_limit_fixture -- --nocapture`
- `cargo run --quiet --bin harn -- run -e '__io_println(sandbox_active_profile())'`
- `cargo run --quiet --bin harn -- run --no-sandbox -e '__io_println(sandbox_active_profile())'`
- `cargo run --quiet --bin harn -- run -e 'let _ = http_get("https://example.com/")'` (expected failure: network ceiling)
- `make sync-language-spec`
- `make check-language-spec`
- `cargo fmt --all --check`
- `git diff --check`
- `make lint-test-patterns`
- `cargo clippy -p harn-vm -p harn-cli --lib -- -D warnings`
- `make test`
- pre-commit and pre-push hooks
