### PR TITLE
Add MCP RC server support for generic and orchestrator servers

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve/http.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/http.rs
@@ -15,6 +15,8 @@ use futures::{stream, StreamExt};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
+use harn_vm::mcp_protocol;
+
 use crate::cli::McpServeArgs;
 #[cfg(test)]
 use crate::cli::OrchestratorLocalArgs;
@@ -165,12 +167,34 @@ async fn http_post_request(
         }
     };
 
+    // Validate the RC HTTP-level headers (`Mcp-Method`, `Mcp-Name`,
+    // explicit `MCP-Protocol-Version`) against the JSON-RPC body. The
+    // helper returns a JSON-RPC error body when the headers contradict
+    // the body so we can return the standard `-32004` /  `-32600` shapes
+    // rather than an opaque HTTP 400.
+    let body_method = request.get("method").and_then(JsonValue::as_str);
+    let body_params = request.get("params");
+    let body_name = body_method.and_then(|method| {
+        mcp_protocol::rc_name_header_value(method, body_params.unwrap_or(&JsonValue::Null))
+    });
+    let body_id = request.get("id").cloned().unwrap_or(JsonValue::Null);
+    let rc_outcome = match mcp_protocol::negotiate_rc_http_request(
+        |key| headers.get(key).and_then(|value| value.to_str().ok()),
+        body_method,
+        body_name.as_deref(),
+        &body_id,
+    ) {
+        Ok(outcome) => outcome,
+        Err(error_response) => return Json(error_response).into_response(),
+    };
+    let rc_session_optional = rc_outcome.mode.is_modern();
+
     let header_session = headers
         .get(MCP_SESSION_HEADER)
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
     let (session_id, session, created) =
-        match lookup_or_create_session(&state, &request, header_session) {
+        match lookup_or_create_session(&state, &request, header_session, rc_session_optional) {
             Ok(value) => value,
             Err(response) => return response,
         };
@@ -178,6 +202,17 @@ async fn http_post_request(
     let mut current = session.state.lock().expect("HTTP session poisoned").clone();
     if authenticated {
         current.authenticated = true;
+    }
+    if rc_outcome.mode.is_modern() {
+        // The RC HTTP path is stateless: the orchestrator must not lean
+        // on a sticky `MCP-Session-Id` for either initialization or
+        // capability negotiation. Stamping the session up-front keeps
+        // the per-request dispatcher's invariants intact while letting
+        // the handler return without ever advertising a session id.
+        current.protocol_mode = mcp_protocol::McpProtocolMode::Modern;
+        current.initialized = true;
+        current.authenticated = true;
+        current.protocol_version = mcp_protocol::DRAFT_PROTOCOL_VERSION.to_string();
     }
     // If the client opened a session-wide SSE (GET /mcp), wire the
     // active progress bus to it so per-request progress notifications
@@ -198,13 +233,22 @@ async fn http_post_request(
         Err(error) => return (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
     };
     *session.state.lock().expect("HTTP session poisoned") = updated;
+    // Do not surface a session id to RC clients: the modern profile
+    // promises stateless POSTs, and the only reason we keep an internal
+    // session record is so list-change broadcasts have somewhere to
+    // attach when the client also opens a GET stream.
+    let session_id_to_emit = if rc_outcome.mode.is_modern() {
+        None
+    } else {
+        created.then_some(session_id.as_str())
+    };
+    let negotiated_version = rc_outcome
+        .protocol_version
+        .as_deref()
+        .unwrap_or(MCP_PROTOCOL_VERSION);
     if response_json.is_null() {
         let mut response = StatusCode::ACCEPTED.into_response();
-        attach_streamable_headers(
-            &mut response,
-            created.then_some(session_id.as_str()),
-            MCP_PROTOCOL_VERSION,
-        );
+        attach_streamable_headers(&mut response, session_id_to_emit, negotiated_version);
         return response;
     }
 
@@ -213,11 +257,7 @@ async fn http_post_request(
     } else {
         Json(response_json).into_response()
     };
-    attach_streamable_headers(
-        &mut response,
-        created.then_some(session_id.as_str()),
-        MCP_PROTOCOL_VERSION,
-    );
+    attach_streamable_headers(&mut response, session_id_to_emit, negotiated_version);
     response
 }
 
@@ -236,61 +276,63 @@ async fn http_get_stream(State(state): State<HttpState>, headers: HeaderMap) -> 
     if !accepts_media(&headers, "text/event-stream") {
         return StatusCode::NOT_ACCEPTABLE.into_response();
     }
-    let Some(session_id) = headers
-        .get(MCP_SESSION_HEADER)
+
+    // RC clients open a GET stream without an `MCP-Session-Id`: we mint
+    // a transient session record so the broadcast forwarders have a
+    // place to attach. Legacy clients still must look up their session
+    // by id, which preserves the existing error semantics.
+    let rc_mode = headers
+        .get(MCP_PROTOCOL_HEADER)
         .and_then(|value| value.to_str().ok())
-    else {
-        return StatusCode::BAD_REQUEST.into_response();
+        == Some(mcp_protocol::DRAFT_PROTOCOL_VERSION);
+    let header_session = headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|value| value.to_str().ok());
+    let (session, negotiated_version) = match header_session {
+        Some(session_id) => {
+            let Some(session) = state
+                .sessions
+                .lock()
+                .expect("MCP sessions poisoned")
+                .get(session_id)
+                .cloned()
+            else {
+                return StatusCode::NOT_FOUND.into_response();
+            };
+            (session, MCP_PROTOCOL_VERSION)
+        }
+        None if rc_mode => {
+            let session = Arc::new(HttpSession::default());
+            {
+                let mut guard = session.state.lock().expect("HTTP session poisoned");
+                guard.initialized = true;
+                guard.authenticated = true;
+                guard.protocol_mode = mcp_protocol::McpProtocolMode::Modern;
+                guard.protocol_version = mcp_protocol::DRAFT_PROTOCOL_VERSION.to_string();
+            }
+            // Keep the transient session reachable from the registry so
+            // resource-subscription bookkeeping in the forwarders has a
+            // stable record to mutate. The RC client never learns of an
+            // id; the registry entry exists purely for the broadcasters.
+            let session_id = Uuid::now_v7().to_string();
+            state
+                .sessions
+                .lock()
+                .expect("MCP sessions poisoned")
+                .insert(session_id, session.clone());
+            (session, mcp_protocol::DRAFT_PROTOCOL_VERSION)
+        }
+        None => return StatusCode::BAD_REQUEST.into_response(),
     };
-    let Some(session) = state
-        .sessions
-        .lock()
-        .expect("MCP sessions poisoned")
-        .get(session_id)
-        .cloned()
-    else {
-        return StatusCode::NOT_FOUND.into_response();
-    };
+
     let (tx, rx) = unbounded::<JsonValue>();
-    *session.sse_tx.lock().expect("SSE sender poisoned") = Some(tx);
-    if let Some(sender) = session
-        .sse_tx
-        .lock()
-        .expect("SSE sender poisoned")
-        .as_ref()
-        .cloned()
-    {
-        spawn_list_notification_forwarder(state.service.clone(), sender);
-    }
-    if let Some(sender) = session
-        .sse_tx
-        .lock()
-        .expect("SSE sender poisoned")
-        .as_ref()
-        .cloned()
-    {
-        spawn_resource_notification_forwarder(state.service.clone(), sender, session.clone());
-    }
-    if let Some(sender) = session
-        .sse_tx
-        .lock()
-        .expect("SSE sender poisoned")
-        .as_ref()
-        .cloned()
-    {
-        spawn_task_notification_forwarder(state.service.clone(), sender, session.clone());
-    }
-    if let Some(sender) = session
-        .sse_tx
-        .lock()
-        .expect("SSE sender poisoned")
-        .as_ref()
-        .cloned()
-    {
-        spawn_log_notification_forwarder(state.service.clone(), sender, session.clone());
-    }
+    *session.sse_tx.lock().expect("SSE sender poisoned") = Some(tx.clone());
+    spawn_list_notification_forwarder(state.service.clone(), tx.clone());
+    spawn_resource_notification_forwarder(state.service.clone(), tx.clone(), session.clone());
+    spawn_task_notification_forwarder(state.service.clone(), tx.clone(), session.clone());
+    spawn_log_notification_forwarder(state.service.clone(), tx, session.clone());
     let mut response = sse_response(rx).into_response();
-    attach_streamable_headers(&mut response, None, MCP_PROTOCOL_VERSION);
+    attach_streamable_headers(&mut response, None, negotiated_version);
     response
 }
 
@@ -515,6 +557,7 @@ fn lookup_or_create_session(
     state: &HttpState,
     request: &JsonValue,
     header_session: Option<String>,
+    session_optional: bool,
 ) -> Result<(String, Arc<HttpSession>, bool), Response> {
     let method = request
         .get("method")
@@ -525,9 +568,18 @@ fn lookup_or_create_session(
         if let Some(session) = sessions.get(&session_id).cloned() {
             return Ok((session_id, session, false));
         }
-        return Err((StatusCode::NOT_FOUND, "unknown MCP session").into_response());
+        // Modern clients are not required to mint or reuse a session;
+        // an unknown `MCP-Session-Id` quietly falls back to a fresh
+        // transient session so the same client can mix legacy and RC
+        // calls during the transition window.
+        if !session_optional {
+            return Err((StatusCode::NOT_FOUND, "unknown MCP session").into_response());
+        }
     }
-    if method != "initialize" {
+    if !session_optional
+        && method != "initialize"
+        && method != harn_vm::mcp_protocol::METHOD_SERVER_DISCOVER
+    {
         return Err((StatusCode::BAD_REQUEST, "missing MCP session").into_response());
     }
     let session_id = Uuid::now_v7().to_string();
@@ -617,7 +669,13 @@ fn validate_protocol_header(headers: &HeaderMap) -> Result<(), Box<Response>> {
     else {
         return Ok(());
     };
-    if value == MCP_PROTOCOL_VERSION || value == "2025-03-26" {
+    // Accept the stable production version, the prior `2025-03-26`
+    // shipping version (still in the wild), and the RC profile both
+    // sides opt into per request.
+    if value == MCP_PROTOCOL_VERSION
+        || value == "2025-03-26"
+        || value == mcp_protocol::DRAFT_PROTOCOL_VERSION
+    {
         Ok(())
     } else {
         Err(Box::new(StatusCode::BAD_REQUEST.into_response()))

--- a/crates/harn-cli/src/commands/mcp/serve/protocol.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/protocol.rs
@@ -1,6 +1,9 @@
 use serde_json::{json, Value as JsonValue};
 
-use harn_vm::mcp_protocol;
+use harn_vm::mcp_protocol::{
+    self, apply_rc_result_envelope, enforce_request_protocol_version, parse_request_metadata,
+    server_discover_result, McpCacheHint, McpProtocolMode,
+};
 
 use super::types::{ConnectionState, McpOrchestratorService};
 use super::MCP_PROTOCOL_VERSION;
@@ -18,6 +21,32 @@ impl McpOrchestratorService {
             .unwrap_or_default();
         let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
 
+        // Per-request RC negotiation: a Modern client tags every payload
+        // with `_meta.io.modelcontextprotocol/protocolVersion`. We never
+        // promote a connection to Modern based on initialize alone — the
+        // RC explicitly forbids that — but a session may still receive
+        // a mix of Legacy and Modern requests over its lifetime.
+        let metadata = parse_request_metadata(&params);
+        let request_mode = match enforce_request_protocol_version(&id, &metadata) {
+            Ok(Some(mode)) => mode,
+            Ok(None) => McpProtocolMode::Legacy,
+            Err(response) => return response,
+        };
+
+        // server/discover and initialize are the two compatibility
+        // probes: server/discover is the modern entry point, initialize
+        // is the legacy one. Both must work without prior session state.
+        if method == mcp_protocol::METHOD_SERVER_DISCOVER {
+            session.protocol_mode = McpProtocolMode::Modern;
+            // The orchestrator advertises itself as authenticated once
+            // it has accepted a discover from a peer that survived the
+            // HTTP-layer auth check; legacy clients still get the same
+            // capability negotiation through `initialize`.
+            session.authenticated = true;
+            session.initialized = true;
+            return self.handle_server_discover(id);
+        }
+
         if method == "initialize" {
             return self.handle_initialize(id, session, &params);
         }
@@ -26,9 +55,22 @@ impl McpOrchestratorService {
             return JsonValue::Null;
         }
 
+        // RC clients can skip `initialize` entirely: any RC-tagged
+        // request implicitly bootstraps the session and pins the
+        // connection mode forward. Legacy clients still get the
+        // original "server not initialized" guard.
+        if request_mode.is_modern() {
+            session.initialized = true;
+            session.authenticated = true;
+            session.protocol_mode = McpProtocolMode::Modern;
+            session.protocol_version = mcp_protocol::DRAFT_PROTOCOL_VERSION.to_string();
+        }
+
         if !session.initialized && method != "ping" {
             return harn_vm::jsonrpc::error_response(id, -32002, "server not initialized");
         }
+        let mode = session.protocol_mode;
+
         if let Some(response) =
             mcp_protocol::unsupported_client_bound_method_response(id.clone(), method)
         {
@@ -41,21 +83,39 @@ impl McpOrchestratorService {
             mcp_protocol::METHOD_LOGGING_SET_LEVEL => {
                 self.handle_logging_set_level(id, session, &params)
             }
-            "tools/list" => self.handle_tools_list(id, &params),
-            "tools/call" => self.handle_tools_call(id, session, &params).await,
+            "tools/list" => apply_envelope(self.handle_tools_list(id, &params), mode, list_hint()),
+            "tools/call" => apply_envelope(
+                self.handle_tools_call(id, session, &params).await,
+                mode,
+                None,
+            ),
             mcp_protocol::METHOD_TASKS_GET => self.handle_tasks_get(id, session, &params),
             mcp_protocol::METHOD_TASKS_RESULT => {
                 self.handle_tasks_result(id, session, &params).await
             }
             mcp_protocol::METHOD_TASKS_LIST => self.handle_tasks_list(id, session, &params),
             mcp_protocol::METHOD_TASKS_CANCEL => self.handle_tasks_cancel(id, session, &params),
-            "resources/list" => self.handle_resources_list(id, &params).await,
-            "resources/read" => self.handle_resources_read(id, &params).await,
+            "resources/list" => apply_envelope(
+                self.handle_resources_list(id, &params).await,
+                mode,
+                list_hint(),
+            ),
+            "resources/read" => apply_envelope(
+                self.handle_resources_read(id, &params).await,
+                mode,
+                read_hint(),
+            ),
             "resources/subscribe" => self.handle_resources_subscribe(id, session, &params).await,
             "resources/unsubscribe" => self.handle_resources_unsubscribe(id, session, &params),
-            "resources/templates/list" => self.handle_resource_templates_list(id, &params),
-            "prompts/list" => self.handle_prompts_list(id, &params),
-            "prompts/get" => self.handle_prompts_get(id, &params),
+            "resources/templates/list" => apply_envelope(
+                self.handle_resource_templates_list(id, &params),
+                mode,
+                list_hint(),
+            ),
+            "prompts/list" => {
+                apply_envelope(self.handle_prompts_list(id, &params), mode, list_hint())
+            }
+            "prompts/get" => apply_envelope(self.handle_prompts_get(id, &params), mode, None),
             mcp_protocol::METHOD_COMPLETION_COMPLETE => {
                 self.handle_completion_complete(id, &params).await
             }
@@ -67,6 +127,17 @@ impl McpOrchestratorService {
                 harn_vm::jsonrpc::error_response(id, -32601, &format!("Method not found: {method}"))
             }
         }
+    }
+
+    pub(super) fn handle_server_discover(&self, id: JsonValue) -> JsonValue {
+        harn_vm::jsonrpc::response(
+            id,
+            server_discover_result(
+                orchestrator_capabilities(),
+                orchestrator_server_info(),
+                Some("Expose Harn trigger and orchestrator controls over MCP."),
+            ),
+        )
     }
 
     pub(super) fn handle_initialize(
@@ -106,27 +177,20 @@ impl McpOrchestratorService {
             session.authenticated = true;
         }
         session.initialized = true;
+        session.protocol_mode = McpProtocolMode::Legacy;
 
-        harn_vm::jsonrpc::response(
-            id,
-            json!({
-                "protocolVersion": MCP_PROTOCOL_VERSION,
-                "capabilities": {
-                    "tools": { "listChanged": true },
-                    "resources": { "listChanged": true, "subscribe": true },
-                    "prompts": { "listChanged": true },
-                    "logging": mcp_protocol::logging_capability(),
-                    "tasks": mcp_protocol::tasks_capability(),
-                    "completions": mcp_protocol::completions_capability(),
-                },
-                "serverInfo": {
-                    "name": "harn-orchestrator",
-                    "title": "Harn Orchestrator MCP",
-                    "version": env!("CARGO_PKG_VERSION"),
-                },
-                "instructions": "Expose Harn trigger and orchestrator controls over MCP."
-            }),
-        )
+        let mut result = json!({
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": orchestrator_capabilities(),
+            "serverInfo": orchestrator_server_info(),
+            "instructions": "Expose Harn trigger and orchestrator controls over MCP."
+        });
+        // Legacy initialize never carries `resultType`, so this leaves
+        // the existing wire bytes unchanged. The branch keeps the path
+        // symmetric in case a Modern client routes through here for
+        // backwards-compat probing.
+        apply_rc_result_envelope(&mut result, session.protocol_mode, None);
+        harn_vm::jsonrpc::response(id, result)
     }
 
     pub(super) fn handle_prompts_list(&self, id: JsonValue, params: &JsonValue) -> JsonValue {
@@ -342,6 +406,51 @@ impl McpOrchestratorService {
             ],
         )
     }
+}
+
+/// Capabilities advertised by both `initialize` and `server/discover`.
+/// Kept in a single place so the two paths cannot drift apart silently.
+pub(super) fn orchestrator_capabilities() -> JsonValue {
+    json!({
+        "tools": { "listChanged": true },
+        "resources": { "listChanged": true, "subscribe": true },
+        "prompts": { "listChanged": true },
+        "logging": mcp_protocol::logging_capability(),
+        "tasks": mcp_protocol::tasks_capability(),
+        "completions": mcp_protocol::completions_capability(),
+    })
+}
+
+pub(super) fn orchestrator_server_info() -> JsonValue {
+    json!({
+        "name": "harn-orchestrator",
+        "title": "Harn Orchestrator MCP",
+        "version": env!("CARGO_PKG_VERSION"),
+    })
+}
+
+fn list_hint() -> Option<&'static McpCacheHint> {
+    const LIST: McpCacheHint = McpCacheHint::list_default();
+    Some(&LIST)
+}
+
+fn read_hint() -> Option<&'static McpCacheHint> {
+    const READ: McpCacheHint = McpCacheHint::read_default();
+    Some(&READ)
+}
+
+/// Stamp the RC `resultType`/cache-hint envelope onto a handler's
+/// response in one place. Error responses pass through untouched —
+/// the RC envelope only applies to `result` bodies.
+fn apply_envelope(
+    mut response: JsonValue,
+    mode: McpProtocolMode,
+    hint: Option<&'static McpCacheHint>,
+) -> JsonValue {
+    if let Some(result) = response.get_mut("result") {
+        apply_rc_result_envelope(result, mode, hint);
+    }
+    response
 }
 
 pub(super) fn paginated_list_response(

--- a/crates/harn-cli/src/commands/mcp/serve/types.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/types.rs
@@ -157,6 +157,12 @@ pub(super) struct ConnectionState {
     pub(super) protocol_version: String,
     pub(super) subscribed_resources: BTreeSet<String>,
     pub(super) log_level: mcp_protocol::McpLogLevel,
+    /// RC clients negotiate per request; the orchestrator records the
+    /// last observed mode on the connection so list-change notifications
+    /// or progress streams know which envelope shape to send. Defaults
+    /// to [`McpProtocolMode::Legacy`] until the first RC-tagged request
+    /// arrives.
+    pub(super) protocol_mode: mcp_protocol::McpProtocolMode,
 }
 
 impl Default for ConnectionState {
@@ -168,6 +174,7 @@ impl Default for ConnectionState {
             protocol_version: MCP_PROTOCOL_VERSION.to_string(),
             subscribed_resources: BTreeSet::new(),
             log_level: mcp_protocol::McpLogLevel::Info,
+            protocol_mode: mcp_protocol::McpProtocolMode::Legacy,
         }
     }
 }

--- a/crates/harn-cli/src/commands/mcp/serve_tests.rs
+++ b/crates/harn-cli/src/commands/mcp/serve_tests.rs
@@ -1694,3 +1694,382 @@ async fn legacy_sse_routes_are_marked_deprecated() {
         Some("true")
     );
 }
+
+fn rc_meta() -> JsonValue {
+    json!({
+        mcp_protocol::RC_META_KEY_PROTOCOL_VERSION: mcp_protocol::DRAFT_PROTOCOL_VERSION,
+        mcp_protocol::RC_META_KEY_CLIENT_INFO: {"name": "rc-client", "version": "1.0"},
+        mcp_protocol::RC_META_KEY_CLIENT_CAPABILITIES: {},
+    })
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn server_discover_returns_capabilities_and_skips_initialize() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = McpOrchestratorService::new_local(args.local.clone()).unwrap();
+    let mut session = ConnectionState::default();
+    let response = service
+        .handle_request(
+            &mut session,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": mcp_protocol::METHOD_SERVER_DISCOVER,
+                "params": {}
+            }),
+        )
+        .await;
+    assert_eq!(
+        response["result"]["resultType"],
+        json!(mcp_protocol::RESULT_TYPE_COMPLETE)
+    );
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        json!(mcp_protocol::DRAFT_PROTOCOL_VERSION)
+    );
+    let supported = response["result"]["supportedVersions"]
+        .as_array()
+        .expect("supportedVersions array");
+    assert!(supported
+        .iter()
+        .any(|v| v == &json!(mcp_protocol::DRAFT_PROTOCOL_VERSION)));
+    assert!(supported.iter().any(|v| v == &json!(MCP_PROTOCOL_VERSION)));
+    assert_eq!(
+        response["result"]["capabilities"]["tools"]["listChanged"],
+        json!(true)
+    );
+    assert!(session.initialized);
+    assert!(session.authenticated);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rc_tools_list_returns_result_type_and_cache_hint_without_initialize() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = McpOrchestratorService::new_local(args.local.clone()).unwrap();
+    // No prior initialize: a Modern client should still be able to call
+    // tools/list with `_meta` metadata.
+    let mut session = ConnectionState::default();
+    let response = service
+        .handle_request(
+            &mut session,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": { "_meta": rc_meta() }
+            }),
+        )
+        .await;
+    assert_eq!(
+        response["result"]["resultType"],
+        json!(mcp_protocol::RESULT_TYPE_COMPLETE)
+    );
+    assert_eq!(
+        response["result"]["ttlMs"],
+        json!(mcp_protocol::DEFAULT_LIST_CACHE_TTL_MS)
+    );
+    assert_eq!(
+        response["result"]["cacheScope"],
+        json!(mcp_protocol::DEFAULT_LIST_CACHE_SCOPE)
+    );
+    assert!(response["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .any(|tool| tool["name"] == json!("harn.trigger.list")));
+    assert!(session.initialized);
+    assert_eq!(session.protocol_mode, mcp_protocol::McpProtocolMode::Modern);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rc_request_with_unsupported_protocol_version_returns_minus_32004() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = McpOrchestratorService::new_local(args.local.clone()).unwrap();
+    let mut session = ConnectionState::default();
+    let response = service
+        .handle_request(
+            &mut session,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/list",
+                "params": {
+                    "_meta": {
+                        mcp_protocol::RC_META_KEY_PROTOCOL_VERSION: "2099-01-01"
+                    }
+                }
+            }),
+        )
+        .await;
+    assert_eq!(
+        response["error"]["code"],
+        json!(mcp_protocol::UNSUPPORTED_PROTOCOL_VERSION_CODE)
+    );
+    let supported = response["error"]["data"]["supported"]
+        .as_array()
+        .expect("supported array");
+    assert!(supported
+        .iter()
+        .any(|v| v == &json!(mcp_protocol::DRAFT_PROTOCOL_VERSION)));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn legacy_initialize_still_negotiates_stable_protocol_version() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = McpOrchestratorService::new_local(args.local.clone()).unwrap();
+    let mut session = ConnectionState::default();
+    let response = service
+        .handle_request(
+            &mut session,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": { "name": "legacy", "version": "1.0" }
+                }
+            }),
+        )
+        .await;
+    assert_eq!(response["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+    // Legacy responses must remain free of RC envelope fields so the
+    // existing 2025-11-25 wire shape stays byte-stable.
+    assert!(response["result"].get("resultType").is_none());
+    assert!(response["result"].get("ttlMs").is_none());
+    assert_eq!(session.protocol_mode, mcp_protocol::McpProtocolMode::Legacy);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http_rc_request_returns_no_session_id_and_negotiates_draft_version() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = Arc::new(McpOrchestratorService::new_local(args.local.clone()).unwrap());
+    let router = http_router_for_service(
+        service.clone(),
+        "/mcp".to_string(),
+        "/sse".to_string(),
+        "/messages".to_string(),
+    );
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("accept", "application/json")
+                .header("content-type", "application/json")
+                .header(MCP_PROTOCOL_HEADER, mcp_protocol::DRAFT_PROTOCOL_VERSION)
+                .header(mcp_protocol::RC_HEADER_METHOD, "tools/list")
+                .body(Body::from(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "tools/list",
+                        "params": { "_meta": rc_meta() }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(MCP_PROTOCOL_HEADER)
+            .and_then(|value| value.to_str().ok()),
+        Some(mcp_protocol::DRAFT_PROTOCOL_VERSION),
+        "RC responses must echo the negotiated draft version"
+    );
+    assert!(
+        response.headers().get(MCP_SESSION_HEADER).is_none(),
+        "RC responses must not emit MCP-Session-Id"
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: JsonValue = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        body["result"]["resultType"],
+        json!(mcp_protocol::RESULT_TYPE_COMPLETE)
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http_rc_request_rejects_method_header_mismatch() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = Arc::new(McpOrchestratorService::new_local(args.local.clone()).unwrap());
+    let router = http_router_for_service(
+        service.clone(),
+        "/mcp".to_string(),
+        "/sse".to_string(),
+        "/messages".to_string(),
+    );
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("accept", "application/json")
+                .header("content-type", "application/json")
+                .header(MCP_PROTOCOL_HEADER, mcp_protocol::DRAFT_PROTOCOL_VERSION)
+                .header(mcp_protocol::RC_HEADER_METHOD, "tools/list")
+                .body(Body::from(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": { "name": "harn.trigger.list", "_meta": rc_meta() }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: JsonValue = serde_json::from_slice(&body).unwrap();
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["error"]["code"], json!(-32600));
+    assert_eq!(body["error"]["data"]["headerValue"], "tools/list");
+    assert_eq!(body["error"]["data"]["bodyMethod"], "tools/call");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rc_http_get_stream_works_without_session_id() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = Arc::new(McpOrchestratorService::new_local(args.local.clone()).unwrap());
+    let router = http_router_for_service(
+        service.clone(),
+        "/mcp".to_string(),
+        "/sse".to_string(),
+        "/messages".to_string(),
+    );
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/mcp")
+                .header("accept", "text/event-stream")
+                .header(MCP_PROTOCOL_HEADER, mcp_protocol::DRAFT_PROTOCOL_VERSION)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(MCP_PROTOCOL_HEADER)
+            .and_then(|value| value.to_str().ok()),
+        Some(mcp_protocol::DRAFT_PROTOCOL_VERSION)
+    );
+    assert!(response
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("text/event-stream")));
+
+    let mut stream = response.into_body().into_data_stream();
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+        .await
+        .expect("timed out waiting for SSE prime event")
+        .expect("SSE stream ended")
+        .expect("SSE body error");
+    service.notify_manifest_reloaded();
+    let mut buffer = String::new();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !buffer.contains("notifications/tools/list_changed") {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "RC GET stream did not receive list_changed notification; body={buffer}"
+        );
+        let chunk = tokio::time::timeout(remaining, stream.next())
+            .await
+            .expect("timed out waiting for SSE notification")
+            .expect("SSE stream ended")
+            .expect("SSE body error");
+        buffer.push_str(std::str::from_utf8(&chunk).unwrap());
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn legacy_initialize_http_path_still_returns_session_id() {
+    let _guard = lock_harn_state();
+    let temp = TempDir::new().unwrap();
+    write_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = Arc::new(McpOrchestratorService::new_local(args.local.clone()).unwrap());
+    let router = http_router_for_service(
+        service.clone(),
+        "/mcp".to_string(),
+        "/sse".to_string(),
+        "/messages".to_string(),
+    );
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("accept", "application/json")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": MCP_PROTOCOL_VERSION,
+                            "capabilities": {},
+                            "clientInfo": { "name": "legacy-http", "version": "1.0" }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(MCP_PROTOCOL_HEADER)
+            .and_then(|value| value.to_str().ok()),
+        Some(MCP_PROTOCOL_VERSION)
+    );
+    assert!(
+        response.headers().get(MCP_SESSION_HEADER).is_some(),
+        "legacy initialize must mint a session id"
+    );
+}

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -19,15 +19,13 @@ use crate::stdlib::json_to_vm_value;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
-/// MCP protocol version we negotiate by default.
-const PROTOCOL_VERSION: &str = "2025-11-25";
-const DRAFT_PROTOCOL_VERSION: &str = "DRAFT-2026-v1";
-const UNSUPPORTED_PROTOCOL_VERSION_CODE: i64 = -32004;
-const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
-const CLIENT_INFO_META_KEY: &str = "io.modelcontextprotocol/clientInfo";
-const CLIENT_CAPABILITIES_META_KEY: &str = "io.modelcontextprotocol/clientCapabilities";
+use crate::mcp_protocol::{
+    DRAFT_PROTOCOL_VERSION, PROTOCOL_VERSION, RC_META_KEY_CLIENT_CAPABILITIES,
+    RC_META_KEY_CLIENT_INFO, RC_META_KEY_PROTOCOL_VERSION, RESULT_TYPE_INPUT_REQUIRED,
+    UNSUPPORTED_PROTOCOL_VERSION_CODE,
+};
+
 const X_MCP_HEADER: &str = "x-mcp-header";
-const INPUT_REQUIRED_RESULT_TYPE: &str = "input_required";
 const MCP_INPUT_REQUIRED_MAX_ROUNDS: usize = 8;
 
 /// Default timeout for MCP requests (60 seconds).
@@ -1518,12 +1516,12 @@ fn request_params_for_protocol(
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
     meta.insert(
-        PROTOCOL_VERSION_META_KEY.to_string(),
+        RC_META_KEY_PROTOCOL_VERSION.to_string(),
         serde_json::Value::String(protocol_version.to_string()),
     );
-    meta.insert(CLIENT_INFO_META_KEY.to_string(), client_info());
+    meta.insert(RC_META_KEY_CLIENT_INFO.to_string(), client_info());
     meta.insert(
-        CLIENT_CAPABILITIES_META_KEY.to_string(),
+        RC_META_KEY_CLIENT_CAPABILITIES.to_string(),
         modern_client_capabilities(),
     );
     object.insert("_meta".to_string(), serde_json::Value::Object(meta));
@@ -1869,7 +1867,7 @@ pub(crate) async fn call_mcp_tool(
         .await?;
     for _ in 0..MCP_INPUT_REQUIRED_MAX_ROUNDS {
         if result.get("resultType").and_then(|value| value.as_str())
-            != Some(INPUT_REQUIRED_RESULT_TYPE)
+            != Some(RESULT_TYPE_INPUT_REQUIRED)
         {
             break;
         }
@@ -1888,7 +1886,7 @@ pub(crate) async fn call_mcp_tool(
             )
             .await?;
     }
-    if result.get("resultType").and_then(|value| value.as_str()) == Some(INPUT_REQUIRED_RESULT_TYPE)
+    if result.get("resultType").and_then(|value| value.as_str()) == Some(RESULT_TYPE_INPUT_REQUIRED)
     {
         return Err(VmError::Runtime(format!(
             "MCP tool '{tool_name}' still required input after {MCP_INPUT_REQUIRED_MAX_ROUNDS} rounds"
@@ -2959,15 +2957,15 @@ llm_mock_clear()
         assert!(!request.headers.contains_key("mcp-session-id"));
         let meta = &request.body["params"]["_meta"];
         assert_eq!(
-            meta[PROTOCOL_VERSION_META_KEY],
+            meta[RC_META_KEY_PROTOCOL_VERSION],
             serde_json::json!(DRAFT_PROTOCOL_VERSION)
         );
         assert_eq!(
-            meta[CLIENT_INFO_META_KEY]["name"],
+            meta[RC_META_KEY_CLIENT_INFO]["name"],
             serde_json::json!("harn")
         );
         assert_eq!(
-            meta[CLIENT_CAPABILITIES_META_KEY]["roots"],
+            meta[RC_META_KEY_CLIENT_CAPABILITIES]["roots"],
             serde_json::json!({})
         );
     }

--- a/crates/harn-vm/src/mcp_protocol.rs
+++ b/crates/harn-vm/src/mcp_protocol.rs
@@ -2,7 +2,15 @@
 
 use serde_json::{json, Value as JsonValue};
 
+/// Stable, production MCP protocol version that Harn defaults to.
 pub const PROTOCOL_VERSION: &str = "2025-11-25";
+/// RC profile published alongside the stable version. Both clients and
+/// servers opt into this profile per request; the runtime never assumes
+/// a connection is RC-only unless the client signals it via metadata or
+/// HTTP headers.
+pub const DRAFT_PROTOCOL_VERSION: &str = "DRAFT-2026-v1";
+
+pub const METHOD_SERVER_DISCOVER: &str = "server/discover";
 pub const METHOD_TASKS_GET: &str = "tasks/get";
 pub const METHOD_TASKS_RESULT: &str = "tasks/result";
 pub const METHOD_TASKS_LIST: &str = "tasks/list";
@@ -16,9 +24,41 @@ pub const METHOD_ROOTS_LIST_CHANGED_NOTIFICATION: &str = "notifications/roots/li
 pub const METHOD_LOGGING_SET_LEVEL: &str = "logging/setLevel";
 pub const METHOD_LOGGING_MESSAGE_NOTIFICATION: &str = "notifications/message";
 pub const RELATED_TASK_META_KEY: &str = "io.modelcontextprotocol/related-task";
+
+/// RC request metadata keys carried inside `params._meta` so the server
+/// can identify the client's protocol target without a sticky session.
+pub const RC_META_KEY_PROTOCOL_VERSION: &str = "io.modelcontextprotocol/protocolVersion";
+pub const RC_META_KEY_CLIENT_INFO: &str = "io.modelcontextprotocol/clientInfo";
+pub const RC_META_KEY_CLIENT_CAPABILITIES: &str = "io.modelcontextprotocol/clientCapabilities";
+
+/// RC HTTP headers expected on streamable POSTs.
+pub const RC_HEADER_PROTOCOL_VERSION: &str = "mcp-protocol-version";
+pub const RC_HEADER_METHOD: &str = "mcp-method";
+pub const RC_HEADER_NAME: &str = "mcp-name";
+
+/// `resultType` discriminants exposed to RC clients on every response
+/// result body. Legacy clients never see this field, which preserves the
+/// pre-RC wire format byte-for-byte.
+pub const RESULT_TYPE_COMPLETE: &str = "complete";
+pub const RESULT_TYPE_INPUT_REQUIRED: &str = "input_required";
+
+/// JSON-RPC error code reserved by the RC for unsupported protocol
+/// version negotiation. Returned with `data.supported` listing the
+/// versions the peer accepts.
+pub const UNSUPPORTED_PROTOCOL_VERSION_CODE: i64 = -32004;
+
 pub const DEFAULT_TASK_POLL_INTERVAL_MS: u64 = 250;
 pub const DEFAULT_MCP_LIST_PAGE_SIZE: usize = 100;
 pub const MCP_LIST_PAGE_SIZE_ENV: &str = "HARN_MCP_LIST_PAGE_SIZE";
+
+/// Conservative cache hints emitted with list/read results when an RC
+/// client asked for them. Both surfaces fall back to these defaults so
+/// implementations can opt out per handler if a tighter or looser bound
+/// is appropriate.
+pub const DEFAULT_LIST_CACHE_TTL_MS: u64 = 5_000;
+pub const DEFAULT_LIST_CACHE_SCOPE: &str = "private";
+pub const DEFAULT_READ_CACHE_TTL_MS: u64 = 1_000;
+pub const DEFAULT_READ_CACHE_SCOPE: &str = "private";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct McpListPage {
@@ -94,6 +134,292 @@ impl McpToolTaskSupport {
             Self::Forbidden => "forbidden",
         }
     }
+}
+
+/// Identifies which MCP profile a single request targets. The mode is
+/// negotiated per request from `_meta` or HTTP headers, never sticky.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum McpProtocolMode {
+    /// `2025-11-25` initialize/notify flow with session-id stickiness.
+    #[default]
+    Legacy,
+    /// RC profile: per-request metadata, optional cache hints, explicit
+    /// `resultType` discriminants, no session stickiness.
+    Modern,
+}
+
+impl McpProtocolMode {
+    pub fn is_modern(self) -> bool {
+        matches!(self, Self::Modern)
+    }
+
+    pub fn default_protocol_version(self) -> &'static str {
+        match self {
+            Self::Legacy => PROTOCOL_VERSION,
+            Self::Modern => DRAFT_PROTOCOL_VERSION,
+        }
+    }
+}
+
+/// Returns the protocol versions this Harn build understands when
+/// peers ask via `server/discover` or fail with `-32004`.
+pub fn supported_protocol_versions() -> &'static [&'static str] {
+    &[DRAFT_PROTOCOL_VERSION, PROTOCOL_VERSION]
+}
+
+pub fn is_supported_protocol_version(version: &str) -> bool {
+    supported_protocol_versions().contains(&version)
+}
+
+/// Parsed per-request RC metadata. All fields are optional; legacy
+/// requests yield an empty struct.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct McpRequestMetadata {
+    pub protocol_version: Option<String>,
+    pub client_info: Option<JsonValue>,
+    pub client_capabilities: Option<JsonValue>,
+}
+
+impl McpRequestMetadata {
+    pub fn mode(&self) -> McpProtocolMode {
+        match self.protocol_version.as_deref() {
+            Some(DRAFT_PROTOCOL_VERSION) => McpProtocolMode::Modern,
+            _ => McpProtocolMode::Legacy,
+        }
+    }
+}
+
+/// Extract RC metadata from a request's `params._meta` block. Unknown
+/// keys are ignored so this stays forward-compatible with future RC
+/// drafts.
+pub fn parse_request_metadata(params: &JsonValue) -> McpRequestMetadata {
+    let Some(meta) = params.get("_meta").and_then(JsonValue::as_object) else {
+        return McpRequestMetadata::default();
+    };
+    let protocol_version = meta
+        .get(RC_META_KEY_PROTOCOL_VERSION)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    let client_info = meta.get(RC_META_KEY_CLIENT_INFO).cloned();
+    let client_capabilities = meta.get(RC_META_KEY_CLIENT_CAPABILITIES).cloned();
+    McpRequestMetadata {
+        protocol_version,
+        client_info,
+        client_capabilities,
+    }
+}
+
+/// Validate that a request's metadata targets a supported version.
+/// Returns an `Err(error_response)` payload ready to ship back to the
+/// client when the version is recognized but unsupported, leaving the
+/// caller to send the response. `Ok(None)` means legacy; `Ok(Some(meta))`
+/// means RC.
+pub fn enforce_request_protocol_version(
+    id: &JsonValue,
+    metadata: &McpRequestMetadata,
+) -> Result<Option<McpProtocolMode>, JsonValue> {
+    let Some(version) = metadata.protocol_version.as_deref() else {
+        return Ok(None);
+    };
+    if !is_supported_protocol_version(version) {
+        return Err(unsupported_protocol_version_response(id.clone(), version));
+    }
+    Ok(Some(metadata.mode()))
+}
+
+/// Build the `-32004 Unsupported protocol version` JSON-RPC error the
+/// RC expects so a client can retry with a mutually-supported version.
+pub fn unsupported_protocol_version_response(
+    id: impl Into<JsonValue>,
+    requested: &str,
+) -> JsonValue {
+    crate::jsonrpc::error_response_with_data(
+        id,
+        UNSUPPORTED_PROTOCOL_VERSION_CODE,
+        "Unsupported protocol version",
+        json!({
+            "supported": supported_protocol_versions(),
+            "requested": requested,
+        }),
+    )
+}
+
+/// HTTP-header validation outcome. Errors carry a JSON-RPC body so the
+/// HTTP layer can ship either an HTTP 400 with the body or a 200 with
+/// the JSON-RPC error — both paths exist in the RC spec.
+#[derive(Clone, Debug)]
+pub struct RcHttpHeaderOutcome {
+    pub mode: McpProtocolMode,
+    pub protocol_version: Option<String>,
+}
+
+/// Inspect the streamable HTTP request headers for the RC signals the
+/// server has to validate. The function is pure: it returns the
+/// negotiated mode and the version pinned by the client, or a JSON-RPC
+/// error body when the headers contradict the request body or name a
+/// version the server does not support.
+///
+/// `body_method` and `body_name` are the values pulled from the JSON-RPC
+/// body so the helper can detect a header/body mismatch.
+pub fn negotiate_rc_http_request<'a, F>(
+    headers: F,
+    body_method: Option<&str>,
+    body_name: Option<&str>,
+    request_id: &JsonValue,
+) -> Result<RcHttpHeaderOutcome, JsonValue>
+where
+    F: Fn(&str) -> Option<&'a str>,
+{
+    let mut outcome = RcHttpHeaderOutcome {
+        mode: McpProtocolMode::Legacy,
+        protocol_version: None,
+    };
+
+    if let Some(value) = headers(RC_HEADER_PROTOCOL_VERSION) {
+        if !is_supported_protocol_version(value) {
+            return Err(unsupported_protocol_version_response(
+                request_id.clone(),
+                value,
+            ));
+        }
+        outcome.protocol_version = Some(value.to_string());
+        if value == DRAFT_PROTOCOL_VERSION {
+            outcome.mode = McpProtocolMode::Modern;
+        }
+    }
+
+    if let Some(method_header) = headers(RC_HEADER_METHOD) {
+        outcome.mode = McpProtocolMode::Modern;
+        if let Some(body_method) = body_method {
+            if method_header != body_method {
+                return Err(crate::jsonrpc::error_response_with_data(
+                    request_id.clone(),
+                    -32600,
+                    "Mcp-Method header does not match request body",
+                    json!({
+                        "headerValue": method_header,
+                        "bodyMethod": body_method,
+                    }),
+                ));
+            }
+        }
+    }
+
+    if let Some(name_header) = headers(RC_HEADER_NAME) {
+        outcome.mode = McpProtocolMode::Modern;
+        let expected = body_name.unwrap_or_default();
+        if !expected.is_empty() && name_header != expected {
+            return Err(crate::jsonrpc::error_response_with_data(
+                request_id.clone(),
+                -32600,
+                "Mcp-Name header does not match request body",
+                json!({
+                    "headerValue": name_header,
+                    "bodyName": expected,
+                }),
+            ));
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Pulls the standard `Mcp-Name` header value for a request body. RC
+/// servers cross-check this against the header sent on the wire; RC
+/// clients use the same helper when authoring outbound requests.
+pub fn rc_name_header_value(method: &str, params: &JsonValue) -> Option<String> {
+    match method {
+        "tools/call" | "prompts/get" => params
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+        "resources/read" => params
+            .get("uri")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+/// Modify a JSON-RPC result body in place to include the RC's
+/// per-result discriminants when the response targets a Modern client.
+/// Legacy clients see no change.
+pub fn apply_rc_result_envelope(
+    result: &mut JsonValue,
+    mode: McpProtocolMode,
+    cache: Option<&McpCacheHint>,
+) {
+    if !mode.is_modern() {
+        return;
+    }
+    let Some(object) = result.as_object_mut() else {
+        return;
+    };
+    object
+        .entry("resultType")
+        .or_insert_with(|| JsonValue::String(RESULT_TYPE_COMPLETE.to_string()));
+    if let Some(hint) = cache {
+        if let Some(ttl) = hint.ttl_ms {
+            object.insert("ttlMs".to_string(), json!(ttl));
+        }
+        if let Some(scope) = hint.scope {
+            object.insert("cacheScope".to_string(), JsonValue::String(scope.into()));
+        }
+    }
+}
+
+/// Conservative cache hint surfaced on RC results. Servers can override
+/// the defaults per handler when they have a better answer; clients fall
+/// back to the constants in [`DEFAULT_LIST_CACHE_TTL_MS`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct McpCacheHint {
+    pub ttl_ms: Option<u64>,
+    pub scope: Option<&'static str>,
+}
+
+impl McpCacheHint {
+    pub const fn list_default() -> Self {
+        Self {
+            ttl_ms: Some(DEFAULT_LIST_CACHE_TTL_MS),
+            scope: Some(DEFAULT_LIST_CACHE_SCOPE),
+        }
+    }
+
+    pub const fn read_default() -> Self {
+        Self {
+            ttl_ms: Some(DEFAULT_READ_CACHE_TTL_MS),
+            scope: Some(DEFAULT_READ_CACHE_SCOPE),
+        }
+    }
+
+    pub const fn none() -> Self {
+        Self {
+            ttl_ms: None,
+            scope: None,
+        }
+    }
+}
+
+/// Build the canonical `server/discover` result both server surfaces
+/// share. Callers supply their advertised capabilities and serverInfo;
+/// the helper handles `resultType`, `supportedVersions`, instructions,
+/// and any RC-required envelope fields.
+pub fn server_discover_result(
+    capabilities: JsonValue,
+    server_info: JsonValue,
+    instructions: Option<&str>,
+) -> JsonValue {
+    let mut result = json!({
+        "resultType": RESULT_TYPE_COMPLETE,
+        "protocolVersion": DRAFT_PROTOCOL_VERSION,
+        "supportedVersions": supported_protocol_versions(),
+        "capabilities": capabilities,
+        "serverInfo": server_info,
+    });
+    if let Some(instructions) = instructions {
+        result["instructions"] = JsonValue::String(instructions.to_string());
+    }
+    result
 }
 
 pub fn unsupported_latest_spec_method(method: &str) -> Option<&'static UnsupportedMcpMethod> {
@@ -576,5 +902,181 @@ mod tests {
         let err = mcp_list_page(&json!({"cursor": "not-base64"}), 5, "resources/list")
             .expect_err("malformed cursor should fail");
         assert_eq!(err, "invalid resources/list cursor");
+    }
+
+    #[test]
+    fn rc_metadata_round_trips_through_meta_block() {
+        let params = json!({
+            "_meta": {
+                RC_META_KEY_PROTOCOL_VERSION: DRAFT_PROTOCOL_VERSION,
+                RC_META_KEY_CLIENT_INFO: {"name": "harn", "version": "x"},
+                RC_META_KEY_CLIENT_CAPABILITIES: {"roots": {}},
+            }
+        });
+        let meta = parse_request_metadata(&params);
+        assert_eq!(
+            meta.protocol_version.as_deref(),
+            Some(DRAFT_PROTOCOL_VERSION)
+        );
+        assert_eq!(
+            meta.client_info,
+            Some(json!({"name": "harn", "version": "x"}))
+        );
+        assert_eq!(meta.client_capabilities, Some(json!({"roots": {}})));
+        assert_eq!(meta.mode(), McpProtocolMode::Modern);
+    }
+
+    #[test]
+    fn rc_metadata_defaults_to_legacy_when_absent() {
+        let meta = parse_request_metadata(&json!({}));
+        assert_eq!(meta, McpRequestMetadata::default());
+        assert_eq!(meta.mode(), McpProtocolMode::Legacy);
+    }
+
+    #[test]
+    fn enforce_request_protocol_version_rejects_unknown_version() {
+        let meta = McpRequestMetadata {
+            protocol_version: Some("2099-01-01".to_string()),
+            ..Default::default()
+        };
+        let id = json!(7);
+        let err =
+            enforce_request_protocol_version(&id, &meta).expect_err("unknown version should error");
+        assert_eq!(err["id"], id);
+        assert_eq!(
+            err["error"]["code"],
+            json!(UNSUPPORTED_PROTOCOL_VERSION_CODE)
+        );
+        assert_eq!(err["error"]["data"]["requested"], json!("2099-01-01"));
+        let supported = err["error"]["data"]["supported"].as_array().unwrap();
+        assert!(supported.iter().any(|v| v == DRAFT_PROTOCOL_VERSION));
+        assert!(supported.iter().any(|v| v == PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn enforce_request_protocol_version_returns_modern_mode_for_draft() {
+        let meta = McpRequestMetadata {
+            protocol_version: Some(DRAFT_PROTOCOL_VERSION.to_string()),
+            ..Default::default()
+        };
+        let mode = enforce_request_protocol_version(&json!(1), &meta).unwrap();
+        assert_eq!(mode, Some(McpProtocolMode::Modern));
+    }
+
+    #[test]
+    fn negotiate_rc_http_headers_detects_draft_protocol_header() {
+        let headers = std::collections::HashMap::from([(
+            RC_HEADER_PROTOCOL_VERSION.to_string(),
+            DRAFT_PROTOCOL_VERSION.to_string(),
+        )]);
+        let outcome = negotiate_rc_http_request(
+            |key| headers.get(key).map(String::as_str),
+            Some("tools/list"),
+            None,
+            &json!(1),
+        )
+        .unwrap();
+        assert_eq!(outcome.mode, McpProtocolMode::Modern);
+        assert_eq!(
+            outcome.protocol_version.as_deref(),
+            Some(DRAFT_PROTOCOL_VERSION)
+        );
+    }
+
+    #[test]
+    fn negotiate_rc_http_headers_rejects_method_body_mismatch() {
+        let headers = std::collections::HashMap::from([(
+            RC_HEADER_METHOD.to_string(),
+            "tools/list".to_string(),
+        )]);
+        let err = negotiate_rc_http_request(
+            |key| headers.get(key).map(String::as_str),
+            Some("tools/call"),
+            None,
+            &json!(2),
+        )
+        .expect_err("header/body mismatch must error");
+        assert_eq!(err["error"]["code"], json!(-32600));
+        assert_eq!(err["error"]["data"]["headerValue"], json!("tools/list"));
+        assert_eq!(err["error"]["data"]["bodyMethod"], json!("tools/call"));
+    }
+
+    #[test]
+    fn negotiate_rc_http_headers_rejects_name_body_mismatch() {
+        let headers = std::collections::HashMap::from([
+            (RC_HEADER_METHOD.to_string(), "tools/call".to_string()),
+            (RC_HEADER_NAME.to_string(), "wrong".to_string()),
+        ]);
+        let err = negotiate_rc_http_request(
+            |key| headers.get(key).map(String::as_str),
+            Some("tools/call"),
+            Some("right"),
+            &json!(3),
+        )
+        .expect_err("name mismatch must error");
+        assert_eq!(err["error"]["code"], json!(-32600));
+        assert_eq!(err["error"]["data"]["bodyName"], json!("right"));
+    }
+
+    #[test]
+    fn rc_name_header_value_extracts_method_subject() {
+        assert_eq!(
+            rc_name_header_value("tools/call", &json!({"name": "demo"})),
+            Some("demo".to_string())
+        );
+        assert_eq!(
+            rc_name_header_value("prompts/get", &json!({"name": "p"})),
+            Some("p".to_string())
+        );
+        assert_eq!(
+            rc_name_header_value("resources/read", &json!({"uri": "harn://x"})),
+            Some("harn://x".to_string())
+        );
+        assert_eq!(rc_name_header_value("tools/list", &json!({})), None);
+    }
+
+    #[test]
+    fn apply_rc_result_envelope_adds_result_type_and_cache_only_for_modern() {
+        let mut modern = json!({"tools": []});
+        apply_rc_result_envelope(
+            &mut modern,
+            McpProtocolMode::Modern,
+            Some(&McpCacheHint::list_default()),
+        );
+        assert_eq!(modern["resultType"], json!(RESULT_TYPE_COMPLETE));
+        assert_eq!(modern["ttlMs"], json!(DEFAULT_LIST_CACHE_TTL_MS));
+        assert_eq!(modern["cacheScope"], json!(DEFAULT_LIST_CACHE_SCOPE));
+
+        let mut legacy = json!({"tools": []});
+        apply_rc_result_envelope(
+            &mut legacy,
+            McpProtocolMode::Legacy,
+            Some(&McpCacheHint::list_default()),
+        );
+        assert!(legacy.get("resultType").is_none());
+        assert!(legacy.get("ttlMs").is_none());
+        assert!(legacy.get("cacheScope").is_none());
+    }
+
+    #[test]
+    fn apply_rc_result_envelope_preserves_caller_provided_result_type() {
+        let mut result = json!({"resultType": RESULT_TYPE_INPUT_REQUIRED});
+        apply_rc_result_envelope(&mut result, McpProtocolMode::Modern, None);
+        assert_eq!(result["resultType"], json!(RESULT_TYPE_INPUT_REQUIRED));
+    }
+
+    #[test]
+    fn server_discover_result_advertises_both_versions() {
+        let discover = server_discover_result(
+            json!({"tools": {}}),
+            json!({"name": "harn", "version": "x"}),
+            Some("hello"),
+        );
+        assert_eq!(discover["resultType"], json!(RESULT_TYPE_COMPLETE));
+        assert_eq!(discover["protocolVersion"], json!(DRAFT_PROTOCOL_VERSION));
+        let supported = discover["supportedVersions"].as_array().unwrap();
+        assert!(supported.iter().any(|v| v == DRAFT_PROTOCOL_VERSION));
+        assert!(supported.iter().any(|v| v == PROTOCOL_VERSION));
+        assert_eq!(discover["instructions"], json!("hello"));
     }
 }

--- a/crates/harn-vm/src/mcp_server/mod.rs
+++ b/crates/harn-vm/src/mcp_server/mod.rs
@@ -17,7 +17,7 @@ mod uri;
 #[cfg(test)]
 mod tests;
 
-const PROTOCOL_VERSION: &str = "2025-11-25";
+use crate::mcp_protocol::PROTOCOL_VERSION;
 pub use defs::{
     McpCompletionSource, McpPromptArgDef, McpPromptDef, McpResourceDef, McpResourceTemplateDef,
     McpToolDef,

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -8,6 +8,10 @@ use crate::mcp_progress::{
     active_bus as active_progress_bus, install_active_bus as install_active_progress_bus,
     is_valid_progress_token, scope_context, ProgressBus, ProgressContext,
 };
+use crate::mcp_protocol::{
+    self, apply_rc_result_envelope, enforce_request_protocol_version, parse_request_metadata,
+    server_discover_result, McpCacheHint, McpProtocolMode,
+};
 use crate::stdlib::json_to_vm_value;
 use crate::value::VmError;
 use crate::vm::Vm;
@@ -164,35 +168,43 @@ impl McpServer {
         let id = msg.get("id").cloned()?;
         let params = msg.get("params").cloned().unwrap_or(serde_json::json!({}));
 
+        let metadata = parse_request_metadata(&params);
+        let mode = match enforce_request_protocol_version(&id, &metadata) {
+            Ok(Some(mode)) => mode,
+            Ok(None) => McpProtocolMode::Legacy,
+            Err(response) => return Some(response),
+        };
+
         if let Some(response) =
-            crate::mcp_protocol::unsupported_client_bound_method_response(id.clone(), method)
+            mcp_protocol::unsupported_client_bound_method_response(id.clone(), method)
         {
             return Some(response);
         }
 
         Some(match method {
+            mcp_protocol::METHOD_SERVER_DISCOVER => self.handle_server_discover(&id),
             "initialize" => self.handle_initialize(&id),
             "ping" => crate::jsonrpc::response(id.clone(), serde_json::json!({})),
             "logging/setLevel" => self.handle_logging_set_level(&id, &params),
             "harn.hitl.respond" => self.handle_hitl_respond(&id, &params).await,
-            "tools/list" => self.handle_tools_list(&id, &params),
-            "tools/call" => self.handle_tools_call(&id, &params, vm).await,
-            crate::mcp_protocol::METHOD_TASKS_GET => self.handle_task_lookup(&id, &params),
-            crate::mcp_protocol::METHOD_TASKS_RESULT => self.handle_task_lookup(&id, &params),
-            crate::mcp_protocol::METHOD_TASKS_LIST => self.handle_tasks_list(&id, &params),
-            crate::mcp_protocol::METHOD_TASKS_CANCEL => self.handle_task_lookup(&id, &params),
-            "resources/list" => self.handle_resources_list(&id, &params),
-            "resources/read" => self.handle_resources_read(&id, &params, vm).await,
+            "tools/list" => self.handle_tools_list(&id, &params, mode),
+            "tools/call" => self.handle_tools_call(&id, &params, vm, mode).await,
+            mcp_protocol::METHOD_TASKS_GET => self.handle_task_lookup(&id, &params),
+            mcp_protocol::METHOD_TASKS_RESULT => self.handle_task_lookup(&id, &params),
+            mcp_protocol::METHOD_TASKS_LIST => self.handle_tasks_list(&id, &params),
+            mcp_protocol::METHOD_TASKS_CANCEL => self.handle_task_lookup(&id, &params),
+            "resources/list" => self.handle_resources_list(&id, &params, mode),
+            "resources/read" => self.handle_resources_read(&id, &params, vm, mode).await,
             "resources/subscribe" => self.handle_resources_subscribe(&id, &params),
             "resources/unsubscribe" => self.handle_resources_unsubscribe(&id, &params),
-            "resources/templates/list" => self.handle_resource_templates_list(&id, &params),
-            "prompts/list" => self.handle_prompts_list(&id, &params),
-            "prompts/get" => self.handle_prompts_get(&id, &params, vm).await,
-            crate::mcp_protocol::METHOD_COMPLETION_COMPLETE => {
+            "resources/templates/list" => self.handle_resource_templates_list(&id, &params, mode),
+            "prompts/list" => self.handle_prompts_list(&id, &params, mode),
+            "prompts/get" => self.handle_prompts_get(&id, &params, vm, mode).await,
+            mcp_protocol::METHOD_COMPLETION_COMPLETE => {
                 self.handle_completion_complete(&id, &params, vm).await
             }
-            _ if crate::mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
-                crate::mcp_protocol::unsupported_latest_spec_method_response(id.clone(), method)
+            _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
+                mcp_protocol::unsupported_latest_spec_method_response(id.clone(), method)
                     .expect("checked unsupported MCP method")
             }
             _ => serde_json::json!({
@@ -206,7 +218,7 @@ impl McpServer {
         })
     }
 
-    fn handle_initialize(&self, id: &serde_json::Value) -> serde_json::Value {
+    fn server_capabilities(&self) -> serde_json::Map<String, serde_json::Value> {
         let mut capabilities = serde_json::Map::new();
         if !self.tools.is_empty() {
             capabilities.insert("tools".into(), serde_json::json!({ "listChanged": true }));
@@ -224,16 +236,16 @@ impl McpServer {
             capabilities.insert("prompts".into(), serde_json::json!({ "listChanged": true }));
         }
         capabilities.insert("logging".into(), serde_json::json!({}));
-        capabilities.insert("tasks".into(), crate::mcp_protocol::tasks_capability());
-        capabilities.insert(
-            "completions".into(),
-            crate::mcp_protocol::completions_capability(),
-        );
+        capabilities.insert("tasks".into(), mcp_protocol::tasks_capability());
+        capabilities.insert("completions".into(), mcp_protocol::completions_capability());
         // Always advertise elicitation: any registered tool may decide
         // at runtime whether to call `mcp_elicit(...)`, so capability
         // negotiation can't be tied to a static check.
         capabilities.insert("elicitation".into(), serde_json::json!({}));
+        capabilities
+    }
 
+    fn server_info_value(&self) -> serde_json::Value {
         let mut server_info = serde_json::json!({
             "name": self.server_name,
             "version": self.server_version
@@ -241,14 +253,24 @@ impl McpServer {
         if let Some(ref card) = self.server_card {
             server_info["card"] = card.clone();
         }
+        server_info
+    }
 
+    fn handle_server_discover(&self, id: &serde_json::Value) -> serde_json::Value {
+        let capabilities = serde_json::Value::Object(self.server_capabilities());
+        let result = server_discover_result(capabilities, self.server_info_value(), None);
+        crate::jsonrpc::response(id.clone(), result)
+    }
+
+    fn handle_initialize(&self, id: &serde_json::Value) -> serde_json::Value {
+        let capabilities = self.server_capabilities();
         serde_json::json!({
             "jsonrpc": "2.0",
             "id": id,
             "result": {
                 "protocolVersion": PROTOCOL_VERSION,
                 "capabilities": capabilities,
-                "serverInfo": server_info
+                "serverInfo": self.server_info_value(),
             }
         })
     }
@@ -257,9 +279,9 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
+        mode: McpProtocolMode,
     ) -> serde_json::Value {
-        let page = match crate::mcp_protocol::mcp_list_page(params, self.tools.len(), "tools/list")
-        {
+        let page = match mcp_protocol::mcp_list_page(params, self.tools.len(), "tools/list") {
             Ok(page) => page,
             Err(error) => return crate::jsonrpc::error_response(id.clone(), -32602, &error),
         };
@@ -283,9 +305,8 @@ impl McpServer {
                 if let Some(ref icons) = t.icons {
                     entry["icons"] = icons.clone();
                 }
-                entry["execution"] = crate::mcp_protocol::tool_execution(
-                    crate::mcp_protocol::McpToolTaskSupport::Forbidden,
-                );
+                entry["execution"] =
+                    mcp_protocol::tool_execution(mcp_protocol::McpToolTaskSupport::Forbidden);
                 entry
             })
             .collect();
@@ -294,6 +315,7 @@ impl McpServer {
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
+        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -307,10 +329,11 @@ impl McpServer {
         id: &serde_json::Value,
         params: &serde_json::Value,
         vm: &mut Vm,
+        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
-        if crate::mcp_protocol::requests_task_augmentation(params) {
-            return crate::mcp_protocol::task_augmentation_error_response(
+        if mcp_protocol::requests_task_augmentation(params) {
+            return mcp_protocol::task_augmentation_error_response(
                 id.clone(),
                 "tools/call",
                 -32602,
@@ -339,13 +362,15 @@ impl McpServer {
         if let Err(message) =
             crate::mcp_file_upload::validate_file_inputs_for_call(&arguments, &tool.input_schema)
         {
+            let mut call_result = serde_json::json!({
+                "content": [{ "type": "text", "text": message }],
+                "isError": true
+            });
+            apply_rc_result_envelope(&mut call_result, mode, None);
             return serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": id,
-                "result": {
-                    "content": [{ "type": "text", "text": message }],
-                    "isError": true
-                }
+                "result": call_result,
             });
         }
         let args_vm = json_to_vm_value(&arguments);
@@ -383,20 +408,25 @@ impl McpServer {
                     };
                     call_result["structuredContent"] = structured;
                 }
+                apply_rc_result_envelope(&mut call_result, mode, None);
                 serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": id,
                     "result": call_result
                 })
             }
-            Err(e) => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {
+            Err(e) => {
+                let mut call_result = serde_json::json!({
                     "content": [{ "type": "text", "text": format!("{e}") }],
                     "isError": true
-                }
-            }),
+                });
+                apply_rc_result_envelope(&mut call_result, mode, None);
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": call_result,
+                })
+            }
         }
     }
 
@@ -472,6 +502,7 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
+        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let mut all_resources = Vec::with_capacity(self.resources.len() + 1);
         if self.server_card.is_some() {
@@ -496,18 +527,18 @@ impl McpServer {
             entry
         }));
 
-        let page =
-            match crate::mcp_protocol::mcp_list_page(params, all_resources.len(), "resources/list")
-            {
-                Ok(page) => page,
-                Err(error) => return crate::jsonrpc::error_response(id.clone(), -32602, &error),
-            };
+        let page = match mcp_protocol::mcp_list_page(params, all_resources.len(), "resources/list")
+        {
+            Ok(page) => page,
+            Err(error) => return crate::jsonrpc::error_response(id.clone(), -32602, &error),
+        };
         let resources = all_resources[page.start..page.end].to_vec();
 
         let mut result = serde_json::json!({ "resources": resources });
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
+        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -521,6 +552,7 @@ impl McpServer {
         id: &serde_json::Value,
         params: &serde_json::Value,
         vm: &mut Vm,
+        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let uri = params.get("uri").and_then(|u| u.as_str()).unwrap_or("");
 
@@ -534,10 +566,12 @@ impl McpServer {
                     "text": serde_json::to_string(card).unwrap_or_else(|_| "{}".to_string()),
                     "mimeType": "application/json",
                 });
+                let mut result = serde_json::json!({ "contents": [content] });
+                apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::read_default()));
                 return serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "contents": [content] }
+                    "result": result
                 });
             }
         }
@@ -548,10 +582,12 @@ impl McpServer {
             if let Some(ref mime) = resource.mime_type {
                 content["mimeType"] = serde_json::json!(mime);
             }
+            let mut result = serde_json::json!({ "contents": [content] });
+            apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::read_default()));
             return serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": id,
-                "result": { "contents": [content] }
+                "result": result
             });
         }
 
@@ -568,10 +604,16 @@ impl McpServer {
                         if let Some(ref mime) = tmpl.mime_type {
                             content["mimeType"] = serde_json::json!(mime);
                         }
+                        let mut result = serde_json::json!({ "contents": [content] });
+                        apply_rc_result_envelope(
+                            &mut result,
+                            mode,
+                            Some(&McpCacheHint::read_default()),
+                        );
                         serde_json::json!({
                             "jsonrpc": "2.0",
                             "id": id,
-                            "result": { "contents": [content] }
+                            "result": result
                         })
                     }
                     Err(e) => serde_json::json!({
@@ -629,8 +671,9 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
+        mode: McpProtocolMode,
     ) -> serde_json::Value {
-        let page = match crate::mcp_protocol::mcp_list_page(
+        let page = match mcp_protocol::mcp_list_page(
             params,
             self.resource_templates.len(),
             "resources/templates/list",
@@ -660,6 +703,7 @@ impl McpServer {
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
+        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -672,12 +716,12 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
+        mode: McpProtocolMode,
     ) -> serde_json::Value {
-        let page =
-            match crate::mcp_protocol::mcp_list_page(params, self.prompts.len(), "prompts/list") {
-                Ok(page) => page,
-                Err(error) => return crate::jsonrpc::error_response(id.clone(), -32602, &error),
-            };
+        let page = match mcp_protocol::mcp_list_page(params, self.prompts.len(), "prompts/list") {
+            Ok(page) => page,
+            Err(error) => return crate::jsonrpc::error_response(id.clone(), -32602, &error),
+        };
         let prompts: Vec<serde_json::Value> = self.prompts[page.start..page.end]
             .iter()
             .map(|p| {
@@ -710,6 +754,7 @@ impl McpServer {
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
+        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -736,6 +781,7 @@ impl McpServer {
         id: &serde_json::Value,
         params: &serde_json::Value,
         vm: &mut Vm,
+        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
 
@@ -761,10 +807,12 @@ impl McpServer {
         match result {
             Ok(value) => {
                 let messages = prompt_value_to_messages(&value);
+                let mut result = serde_json::json!({ "messages": messages });
+                apply_rc_result_envelope(&mut result, mode, None);
                 serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "messages": messages }
+                    "result": result
                 })
             }
             Err(e) => serde_json::json!({

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -583,6 +583,208 @@ async fn server_tool_call_rejects_task_augmentation() {
     );
 }
 
+fn rc_metadata_params(rest: serde_json::Value) -> serde_json::Value {
+    let mut object = match rest {
+        serde_json::Value::Object(map) => map,
+        serde_json::Value::Null => serde_json::Map::new(),
+        other => serde_json::Map::from_iter([("value".to_string(), other)]),
+    };
+    object.insert(
+        "_meta".to_string(),
+        serde_json::json!({
+            crate::mcp_protocol::RC_META_KEY_PROTOCOL_VERSION:
+                crate::mcp_protocol::DRAFT_PROTOCOL_VERSION,
+            crate::mcp_protocol::RC_META_KEY_CLIENT_INFO: {"name": "rc-client", "version": "1.0"},
+            crate::mcp_protocol::RC_META_KEY_CLIENT_CAPABILITIES: {},
+        }),
+    );
+    serde_json::Value::Object(object)
+}
+
+#[tokio::test]
+async fn server_discover_returns_capabilities_and_supported_versions() {
+    let server = McpServer::new(
+        "rc-test".to_string(),
+        Vec::new(),
+        vec![McpResourceDef {
+            uri: "docs://readme".to_string(),
+            name: "README".to_string(),
+            title: None,
+            description: None,
+            mime_type: Some("text/plain".to_string()),
+            text: "hello".to_string(),
+        }],
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+    let response = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                1,
+                crate::mcp_protocol::METHOD_SERVER_DISCOVER,
+                serde_json::json!({}),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert_eq!(
+        response["result"]["resultType"],
+        serde_json::json!(crate::mcp_protocol::RESULT_TYPE_COMPLETE)
+    );
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        serde_json::json!(crate::mcp_protocol::DRAFT_PROTOCOL_VERSION)
+    );
+    let supported = response["result"]["supportedVersions"]
+        .as_array()
+        .expect("supportedVersions");
+    assert!(supported
+        .iter()
+        .any(|v| v == &serde_json::json!(crate::mcp_protocol::DRAFT_PROTOCOL_VERSION)));
+    assert!(supported
+        .iter()
+        .any(|v| v == &serde_json::json!(crate::mcp_protocol::PROTOCOL_VERSION)));
+    assert_eq!(
+        response["result"]["capabilities"]["resources"]["subscribe"],
+        serde_json::json!(true)
+    );
+    assert_eq!(response["result"]["serverInfo"]["name"], "rc-test");
+}
+
+#[tokio::test]
+async fn server_rejects_request_with_unsupported_protocol_version_metadata() {
+    let server = McpServer::new(
+        "rc-test".to_string(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+    let response = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                7,
+                "tools/list",
+                serde_json::json!({
+                    "_meta": {
+                        crate::mcp_protocol::RC_META_KEY_PROTOCOL_VERSION: "2099-01-01"
+                    }
+                }),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert_eq!(
+        response["error"]["code"],
+        serde_json::json!(crate::mcp_protocol::UNSUPPORTED_PROTOCOL_VERSION_CODE)
+    );
+    let supported = response["error"]["data"]["supported"]
+        .as_array()
+        .expect("supported array");
+    assert!(supported
+        .iter()
+        .any(|v| v == &serde_json::json!(crate::mcp_protocol::DRAFT_PROTOCOL_VERSION)));
+}
+
+#[tokio::test]
+async fn server_modern_tools_list_emits_result_type_and_cache_hint() {
+    let server = McpServer::new(
+        "rc-test".to_string(),
+        Vec::new(),
+        vec![McpResourceDef {
+            uri: "docs://readme".to_string(),
+            name: "README".to_string(),
+            title: None,
+            description: None,
+            mime_type: Some("text/plain".to_string()),
+            text: "hello".to_string(),
+        }],
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+
+    let modern = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                1,
+                "resources/list",
+                rc_metadata_params(serde_json::json!({})),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("modern response");
+    assert_eq!(
+        modern["result"]["resultType"],
+        serde_json::json!(crate::mcp_protocol::RESULT_TYPE_COMPLETE)
+    );
+    assert_eq!(
+        modern["result"]["cacheScope"],
+        serde_json::json!(crate::mcp_protocol::DEFAULT_LIST_CACHE_SCOPE)
+    );
+    assert_eq!(
+        modern["result"]["ttlMs"],
+        serde_json::json!(crate::mcp_protocol::DEFAULT_LIST_CACHE_TTL_MS)
+    );
+
+    let legacy = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(2, "resources/list", serde_json::json!({})),
+            &mut vm,
+        )
+        .await
+        .expect("legacy response");
+    assert!(
+        legacy["result"].get("resultType").is_none(),
+        "legacy clients must not see resultType: {legacy}"
+    );
+    assert!(legacy["result"].get("ttlMs").is_none());
+    assert!(legacy["result"].get("cacheScope").is_none());
+}
+
+#[tokio::test]
+async fn server_modern_resources_read_emits_cache_hint() {
+    let server = McpServer::new(
+        "rc-test".to_string(),
+        Vec::new(),
+        vec![McpResourceDef {
+            uri: "docs://readme".to_string(),
+            name: "README".to_string(),
+            title: None,
+            description: None,
+            mime_type: Some("text/plain".to_string()),
+            text: "hello".to_string(),
+        }],
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+    let response = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                1,
+                "resources/read",
+                rc_metadata_params(serde_json::json!({"uri": "docs://readme"})),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert_eq!(
+        response["result"]["resultType"],
+        serde_json::json!(crate::mcp_protocol::RESULT_TYPE_COMPLETE)
+    );
+    assert_eq!(
+        response["result"]["ttlMs"],
+        serde_json::json!(crate::mcp_protocol::DEFAULT_READ_CACHE_TTL_MS)
+    );
+}
+
 #[tokio::test]
 async fn server_task_endpoints_are_protocol_shaped_without_inline_tasks() {
     let server = McpServer::new(


### PR DESCRIPTION
## Summary
- Lifts the RC protocol constants/metadata helpers PR #2184 already needed for the client into `crates/harn-vm/src/mcp_protocol.rs` so both server surfaces negotiate the RC the same way (no duplicate header/version/cache code).
- Generic VM server (`crates/harn-vm/src/mcp_server`) and the orchestrator/CLI server (`crates/harn-cli/src/commands/mcp/serve/*`) now answer `server/discover`, accept per-request `_meta` metadata, validate the `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers against the body, and emit `resultType: "complete"` plus conservative `ttlMs`/`cacheScope` hints on list/read results. Legacy clients see byte-stable responses.
- Orchestrator HTTP path drops the `MCP-Session-Id` requirement in the RC profile: POSTs run statelessly and the GET stream lets a Modern client subscribe to list-change notifications without a sticky session. Mismatched RC headers return modern JSON-RPC errors (`-32600` for header/body mismatch, `-32004` for unsupported versions) instead of opaque 400s.

Closes #2185.

## Test plan
- [x] `cargo test -p harn-vm --lib mcp` — 130/130 pass
- [x] `cargo test -p harn-cli --lib commands::mcp::serve` — 33/33 pass (includes 8 new RC tests: `server_discover_returns_capabilities_and_skips_initialize`, `rc_tools_list_returns_result_type_and_cache_hint_without_initialize`, `rc_request_with_unsupported_protocol_version_returns_minus_32004`, `legacy_initialize_still_negotiates_stable_protocol_version`, `http_rc_request_returns_no_session_id_and_negotiates_draft_version`, `http_rc_request_rejects_method_header_mismatch`, `rc_http_get_stream_works_without_session_id`, `legacy_initialize_http_path_still_returns_session_id`)
- [x] `make check-protocol-artifacts` — Harn protocol artifacts OK
- [x] `cargo clippy -p harn-vm -p harn-cli --tests` — clean
- [x] `cargo fmt --check` — clean