### PR TITLE
Harden MCP OAuth discovery and issuer binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ condensed series summaries instead of full per-patch history.
   `agent_session_open(..., {workspace_anchor: ...})` or
   `agent_session_set_workspace_anchor(...)`. Foundation for the
   cross-project handoff epic (#2208).
+- **MCP RC authorization hardening (#2186).** Centralized MCP OAuth/OIDC
+  discovery helpers for protected-resource metadata, `WWW-Authenticate`
+  parsing, OAuth/OIDC authorization-server discovery, issuer binding, scope
+  selection, registration-mode selection, and native-app dynamic registration.
+  `harn mcp login` and `harn connect` now share the helper surface, validate
+  authorization-response issuers, and keep HTTP OAuth guidance separate from
+  local stdio credential handling.
 - **Reusable context-engineering eval primitives (#2195).** Added
   `harn eval context` plus portable `harn.context_eval.manifest.v1` and
   `harn.context_eval.report.v1` shapes for deterministic pack, projection,

--- a/crates/harn-cli/src/commands/connect.rs
+++ b/crates/harn-cli/src/commands/connect.rs
@@ -71,6 +71,8 @@ struct StoredConnectorToken {
     #[serde(default)]
     client_secret: Option<String>,
     token_endpoint_auth_method: String,
+    #[serde(default)]
+    issuer: Option<String>,
     resource: String,
     #[serde(default)]
     scopes: Option<String>,
@@ -99,32 +101,8 @@ struct ConnectIndexEntry {
     last_used_at_unix: Option<i64>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-struct OAuthProtectedResource {
-    #[serde(default)]
-    authorization_servers: Vec<String>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct OAuthServerMetadata {
-    authorization_endpoint: String,
-    token_endpoint: String,
-    #[serde(default)]
-    registration_endpoint: Option<String>,
-    #[serde(default)]
-    token_endpoint_auth_methods_supported: Vec<String>,
-    #[serde(default)]
-    code_challenge_methods_supported: Vec<String>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct DynamicClientRegistrationResponse {
-    client_id: String,
-    #[serde(default)]
-    client_secret: Option<String>,
-    #[serde(default)]
-    token_endpoint_auth_method: Option<String>,
-}
+type OAuthServerMetadata = harn_vm::mcp_auth::OAuthAuthorizationServerMetadata;
+type DynamicClientRegistrationResponse = harn_vm::mcp_auth::OAuthDynamicClientRegistrationResponse;
 
 #[derive(Clone, Debug, Deserialize)]
 struct TokenResponse {

--- a/crates/harn-cli/src/commands/connect/callback.rs
+++ b/crates/harn-cli/src/commands/connect/callback.rs
@@ -8,6 +8,11 @@ use super::OAUTH_CALLBACK_TIMEOUT;
 
 const CALLBACK_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+pub(super) struct OAuthCallbackResponse {
+    pub(super) code: String,
+    pub(super) issuer: Option<String>,
+}
+
 pub(super) fn bind_loopback_listener(redirect_uri: &str) -> Result<(TcpListener, String), String> {
     let mut parsed =
         Url::parse(redirect_uri).map_err(|error| format!("Invalid redirect URI: {error}"))?;
@@ -38,17 +43,22 @@ pub(super) fn bind_loopback_listener(redirect_uri: &str) -> Result<(TcpListener,
     Ok((listener, parsed.to_string()))
 }
 
-pub(super) fn wait_for_oauth_code(
+pub(super) fn wait_for_oauth_response(
     listener: TcpListener,
     redirect_uri: &str,
     expected_state: &str,
-) -> Result<String, String> {
+) -> Result<OAuthCallbackResponse, String> {
     let query = wait_for_callback_query(listener, redirect_uri, Some(expected_state))?;
-    query
-        .into_iter()
+    let code = query
+        .iter()
         .find(|(key, _)| key == "code")
-        .map(|(_, value)| value)
-        .ok_or_else(|| "OAuth callback did not include an authorization code".to_string())
+        .map(|(_, value)| value.clone())
+        .ok_or_else(|| "OAuth callback did not include an authorization code".to_string())?;
+    let issuer = query
+        .into_iter()
+        .find(|(key, _)| key == "iss")
+        .map(|(_, value)| value);
+    Ok(OAuthCallbackResponse { code, issuer })
 }
 
 pub(super) fn wait_for_github_installation(

--- a/crates/harn-cli/src/commands/connect/oauth.rs
+++ b/crates/harn-cli/src/commands/connect/oauth.rs
@@ -1,5 +1,11 @@
 use base64::Engine;
-use serde::Deserialize;
+use harn_vm::mcp_auth::{
+    determine_token_endpoint_auth_method, discover_mcp_oauth, dynamic_client_registration_body,
+    ensure_pkce_s256_supported, select_client_registration_mode,
+    validate_authorization_response_issuer, validate_issuer_binding,
+    validate_token_endpoint_auth_method, OAuthClientRegistrationMode,
+    OAuthClientRegistrationOptions,
+};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use url::Url;
@@ -7,14 +13,14 @@ use url::Url;
 use crate::cli::{ConnectGenericArgs, ConnectLinearArgs, ConnectOAuthArgs};
 use crate::package::{self, ProviderOAuthManifest};
 
-use super::callback::{bind_loopback_listener, wait_for_oauth_code};
+use super::callback::{bind_loopback_listener, wait_for_oauth_response};
 use super::store::{
     connector_token_summary, current_unix_timestamp, format_expiry, load_connector_token,
     save_connector_token,
 };
 use super::{
-    DynamicClientRegistrationResponse, OAuthConnectRequest, OAuthProtectedResource,
-    OAuthProviderDefaults, OAuthServerMetadata, StoredConnectorToken, TokenResponse,
+    DynamicClientRegistrationResponse, OAuthConnectRequest, OAuthProviderDefaults,
+    OAuthServerMetadata, StoredConnectorToken, TokenResponse,
 };
 
 pub(super) async fn run_connect_named_oauth(
@@ -209,6 +215,9 @@ pub(super) async fn run_oauth_connect(mut request: OAuthConnectRequest) -> Resul
     };
     if let Some(discovery) = discovery.as_ref() {
         ensure_pkce_support(&discovery.metadata)?;
+        if request.scopes.is_none() && !discovery.scopes.is_empty() {
+            request.scopes = Some(discovery.scopes.join(" "));
+        }
     }
 
     let authorization_endpoint = request
@@ -262,7 +271,10 @@ pub(super) async fn run_oauth_connect(mut request: OAuthConnectRequest) -> Resul
         println!("Open this URL manually:\n{auth_url}");
     }
 
-    let code = wait_for_oauth_code(listener, &redirect_uri, &state)?;
+    let callback = wait_for_oauth_response(listener, &redirect_uri, &state)?;
+    if let Some(discovery) = discovery.as_ref() {
+        validate_authorization_response_issuer(&discovery.metadata, callback.issuer.as_deref())?;
+    }
     let token = exchange_authorization_code(
         &token_endpoint,
         AuthorizationCodeExchange {
@@ -272,7 +284,7 @@ pub(super) async fn run_oauth_connect(mut request: OAuthConnectRequest) -> Resul
             redirect_uri: &redirect_uri,
             resource: &request.resource,
             scopes: request.scopes.as_deref(),
-            code: &code,
+            code: &callback.code,
             code_verifier: &code_verifier,
         },
     )
@@ -289,6 +301,7 @@ pub(super) async fn run_oauth_connect(mut request: OAuthConnectRequest) -> Resul
         client_id,
         client_secret,
         token_endpoint_auth_method: token_auth_method,
+        issuer: discovery.as_ref().map(|discovery| discovery.issuer.clone()),
         resource: request.resource.clone(),
         scopes: request.scopes.clone(),
         connected_at_unix: current_unix_timestamp(),
@@ -324,6 +337,26 @@ pub(super) async fn resolve_oauth_client(
     discovery: Option<&OAuthDiscoveryResult>,
     registration_endpoint: Option<&str>,
 ) -> Result<(String, Option<String>, String), String> {
+    let registration_mode = discovery
+        .map(|discovery| {
+            select_client_registration_mode(
+                &discovery.metadata,
+                OAuthClientRegistrationOptions {
+                    client_id: request.client_id.as_deref(),
+                    client_secret: request.client_secret.as_deref(),
+                    client_id_metadata_document_url: request.client_id.as_deref(),
+                },
+            )
+        })
+        .unwrap_or_else(|| {
+            if request.client_id.is_some() {
+                OAuthClientRegistrationMode::PreRegistered
+            } else if registration_endpoint.is_some() {
+                OAuthClientRegistrationMode::DynamicClientRegistration
+            } else {
+                OAuthClientRegistrationMode::Manual
+            }
+        });
     if let Some(client_id) = request.client_id.clone() {
         let token_auth_method = request
             .token_auth_method
@@ -345,6 +378,11 @@ pub(super) async fn resolve_oauth_client(
         return Ok((client_id, request.client_secret.clone(), token_auth_method));
     }
 
+    if registration_mode != OAuthClientRegistrationMode::DynamicClientRegistration {
+        return Err(
+            "No client_id available. Supply --client-id, use a Client ID Metadata Document URL as --client-id when supported, or use a server that supports dynamic client registration.".to_string()
+        );
+    }
     let registration_endpoint = registration_endpoint.ok_or_else(|| {
         "No client_id available. Supply --client-id or use a server that supports dynamic client registration.".to_string()
     })?;
@@ -375,9 +413,15 @@ pub(super) async fn run_connect_refresh(
     let refresh_token = stored.refresh_token.clone().ok_or_else(|| {
         format!("stored connector token for {provider_name} does not include a refresh token")
     })?;
+    let mut token_endpoint = stored.token_endpoint.clone();
+    if let Some(stored_issuer) = stored.issuer.as_deref() {
+        let discovery = discover_oauth_server(&stored.resource).await?;
+        validate_issuer_binding(stored_issuer, &discovery.issuer)?;
+        token_endpoint = discovery.metadata.token_endpoint;
+    }
     let refreshed = request_token(
         &reqwest::Client::new(),
-        &stored.token_endpoint,
+        &token_endpoint,
         &stored.token_endpoint_auth_method,
         &stored.client_id,
         stored.client_secret.as_deref(),
@@ -394,6 +438,7 @@ pub(super) async fn run_connect_refresh(
     stored.expires_at_unix = refreshed
         .expires_in
         .map(|seconds| current_unix_timestamp().saturating_add(seconds));
+    stored.token_endpoint = token_endpoint;
     stored.last_used_at_unix = Some(current_unix_timestamp());
     save_connector_token(&stored).await?;
 
@@ -410,112 +455,19 @@ pub(super) async fn run_connect_refresh(
 }
 
 pub(super) async fn discover_oauth_server(resource: &str) -> Result<OAuthDiscoveryResult, String> {
-    let resource_url =
-        Url::parse(resource).map_err(|error| format!("Invalid resource URL: {error}"))?;
-    let resource_metadata =
-        fetch_first_json::<OAuthProtectedResource>(&protected_resource_candidates(&resource_url))
-            .await?
-            .ok_or_else(|| "OAuth protected resource metadata not found".to_string())?;
-    let auth_server_url = resource_metadata
-        .authorization_servers
-        .first()
-        .cloned()
-        .ok_or_else(|| {
-            "OAuth protected resource metadata did not advertise an authorization server"
-                .to_string()
-        })?;
-    let auth_server = Url::parse(&auth_server_url).map_err(|error| {
-        format!("Invalid authorization server URL '{auth_server_url}': {error}")
-    })?;
-    let metadata =
-        fetch_first_json::<OAuthServerMetadata>(&authorization_server_candidates(&auth_server))
-            .await?
-            .ok_or_else(|| "Authorization server metadata not found".to_string())?;
-    Ok(OAuthDiscoveryResult { metadata })
-}
-
-pub(super) fn protected_resource_candidates(resource_url: &Url) -> Vec<Url> {
-    let mut urls = Vec::new();
-    let path = resource_url
-        .path()
-        .trim_start_matches('/')
-        .trim_end_matches('/');
-    if !path.is_empty() {
-        let mut url = resource_url.clone();
-        url.set_path(&format!("/.well-known/oauth-protected-resource/{path}"));
-        url.set_query(None);
-        url.set_fragment(None);
-        urls.push(url);
-    }
-    let mut root = resource_url.clone();
-    root.set_path("/.well-known/oauth-protected-resource");
-    root.set_query(None);
-    root.set_fragment(None);
-    urls.push(root);
-    urls
-}
-
-pub(super) fn authorization_server_candidates(auth_server_url: &Url) -> Vec<Url> {
-    let mut urls = Vec::new();
-    let path = auth_server_url.path().trim_end_matches('/');
-    if !path.is_empty() && path != "/" {
-        let trimmed = path.trim_start_matches('/');
-        let mut oauth = auth_server_url.clone();
-        oauth.set_path(&format!(
-            "/.well-known/oauth-authorization-server/{trimmed}"
-        ));
-        oauth.set_query(None);
-        oauth.set_fragment(None);
-        urls.push(oauth);
-
-        let mut oidc = auth_server_url.clone();
-        oidc.set_path(&format!("/.well-known/openid-configuration/{trimmed}"));
-        oidc.set_query(None);
-        oidc.set_fragment(None);
-        urls.push(oidc);
-    }
-
-    let mut oauth = auth_server_url.clone();
-    oauth.set_path("/.well-known/oauth-authorization-server");
-    oauth.set_query(None);
-    oauth.set_fragment(None);
-    urls.push(oauth);
-
-    let mut oidc = auth_server_url.clone();
-    oidc.set_path("/.well-known/openid-configuration");
-    oidc.set_query(None);
-    oidc.set_fragment(None);
-    urls.push(oidc);
-    urls
-}
-
-pub(super) async fn fetch_first_json<T: for<'de> Deserialize<'de>>(
-    candidates: &[Url],
-) -> Result<Option<T>, String> {
     let client = reqwest::Client::new();
-    for candidate in candidates {
-        let response = match client.get(candidate.clone()).send().await {
-            Ok(response) => response,
-            Err(_) => continue,
-        };
-        if !response.status().is_success() {
-            continue;
-        }
-        let parsed = response
-            .json::<T>()
-            .await
-            .map_err(|error| format!("Failed to parse {}: {error}", candidate))?;
-        return Ok(Some(parsed));
-    }
-    Ok(None)
+    let discovery = discover_mcp_oauth(&client, resource)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(OAuthDiscoveryResult {
+        metadata: discovery.authorization_server_metadata,
+        issuer: discovery.authorization_server_issuer,
+        scopes: discovery.scopes,
+    })
 }
 
 pub(super) fn ensure_pkce_support(metadata: &OAuthServerMetadata) -> Result<(), String> {
-    let methods = &metadata.code_challenge_methods_supported;
-    if methods.is_empty() || methods.iter().any(|method| method == "S256") {
-        return Ok(());
-    }
-    Err("Authorization server does not advertise PKCE S256 support".to_string())
+    ensure_pkce_s256_supported(metadata)
 }
 
 pub(super) async fn dynamic_client_registration(
@@ -524,16 +476,7 @@ pub(super) async fn dynamic_client_registration(
     scopes: Option<&str>,
 ) -> Result<DynamicClientRegistrationResponse, String> {
     let client = reqwest::Client::new();
-    let mut body = serde_json::json!({
-        "client_name": "Harn CLI",
-        "redirect_uris": [redirect_uri],
-        "grant_types": ["authorization_code", "refresh_token"],
-        "response_types": ["code"],
-        "token_endpoint_auth_method": "none",
-    });
-    if let Some(scopes) = scopes {
-        body["scope"] = serde_json::json!(scopes);
-    }
+    let body = dynamic_client_registration_body("Harn CLI", [redirect_uri], scopes);
     let response = client
         .post(registration_endpoint)
         .json(&body)
@@ -557,33 +500,11 @@ pub(super) fn determine_token_auth_method(
     metadata: &OAuthServerMetadata,
     client_secret: Option<&String>,
 ) -> Result<String, String> {
-    let methods = &metadata.token_endpoint_auth_methods_supported;
-    if client_secret.is_some() {
-        if methods.is_empty() || methods.iter().any(|method| method == "client_secret_post") {
-            return Ok("client_secret_post".to_string());
-        }
-        if methods.iter().any(|method| method == "client_secret_basic") {
-            return Ok("client_secret_basic".to_string());
-        }
-        return Err(
-            "Authorization server does not support client_secret_post or client_secret_basic"
-                .to_string(),
-        );
-    }
-
-    if methods.is_empty() || methods.iter().any(|method| method == "none") {
-        return Ok("none".to_string());
-    }
-    Err("Authorization server requires client authentication. Supply --client-secret or configure a registered client.".to_string())
+    determine_token_endpoint_auth_method(metadata, client_secret.map(String::as_str))
 }
 
 pub(super) fn validate_token_auth_method(method: &str) -> Result<(), String> {
-    match method {
-        "none" | "client_secret_post" | "client_secret_basic" => Ok(()),
-        other => Err(format!(
-            "unsupported token auth method '{other}'; expected none, client_secret_post, or client_secret_basic"
-        )),
-    }
+    validate_token_endpoint_auth_method(method)
 }
 
 pub(super) fn build_authorization_url(
@@ -714,4 +635,6 @@ pub(super) fn random_hex(bytes: usize) -> String {
 
 pub(super) struct OAuthDiscoveryResult {
     pub(super) metadata: OAuthServerMetadata,
+    pub(super) issuer: String,
+    pub(super) scopes: Vec<String>,
 }

--- a/crates/harn-cli/src/commands/connect/store.rs
+++ b/crates/harn-cli/src/commands/connect/store.rs
@@ -300,6 +300,7 @@ pub(super) fn connector_token_summary(token: &StoredConnectorToken) -> JsonValue
         "connected_at_unix": token.connected_at_unix,
         "last_used_at_unix": token.last_used_at_unix,
         "resource": token.resource,
+        "issuer": token.issuer,
     })
 }
 

--- a/crates/harn-cli/src/commands/connect/tests.rs
+++ b/crates/harn-cli/src/commands/connect/tests.rs
@@ -507,7 +507,7 @@ fn spawn_generic_mcp_oauth_server() -> (String, thread::JoinHandle<()>) {
     let base_url = format!("http://127.0.0.1:{port}");
     let server_base_url = base_url.clone();
     let handle = thread::spawn(move || {
-        for _ in 0..3 {
+        for _ in 0..4 {
             let (mut stream, _) = listener.accept().expect("oauth request");
             let request = read_http_request(&mut stream);
             let path = request
@@ -515,21 +515,31 @@ fn spawn_generic_mcp_oauth_server() -> (String, thread::JoinHandle<()>) {
                 .next()
                 .and_then(|line| line.split_whitespace().nth(1))
                 .unwrap_or("/");
-            if path.starts_with("/.well-known/oauth-protected-resource/mcp/notion") {
+            if path.starts_with("/mcp/notion") {
+                write_response(
+                    &mut stream,
+                    &format!(
+                        "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Bearer resource_metadata=\"{server_base_url}/.well-known/oauth-protected-resource/mcp/notion\", scope=\"mcp.read\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    ),
+                );
+            } else if path.starts_with("/.well-known/oauth-protected-resource/mcp/notion") {
                 write_json_response(
                     &mut stream,
-                    &format!(r#"{{"authorization_servers":["{server_base_url}/oauth"]}}"#),
+                    &format!(
+                        r#"{{"authorization_servers":["{server_base_url}/oauth"],"scopes_supported":["mcp.read"]}}"#
+                    ),
                 );
             } else if path.starts_with("/.well-known/oauth-authorization-server/oauth") {
                 write_json_response(
                     &mut stream,
                     &format!(
-                        r#"{{"authorization_endpoint":"{server_base_url}/oauth/authorize","token_endpoint":"{server_base_url}/oauth/token","registration_endpoint":"{server_base_url}/oauth/register","code_challenge_methods_supported":["S256"],"token_endpoint_auth_methods_supported":["none","client_secret_post"]}}"#
+                        r#"{{"issuer":"{server_base_url}/oauth","authorization_endpoint":"{server_base_url}/oauth/authorize","token_endpoint":"{server_base_url}/oauth/token","registration_endpoint":"{server_base_url}/oauth/register","code_challenge_methods_supported":["S256"],"token_endpoint_auth_methods_supported":["none","client_secret_post"]}}"#
                     ),
                 );
             } else if path.starts_with("/oauth/register") {
                 assert!(request.contains("http://127.0.0.1:49152/oauth/callback"));
                 assert!(request.contains("mcp.read"));
+                assert!(request.contains("\"application_type\":\"native\""));
                 write_json_response(
                     &mut stream,
                     r#"{"client_id":"dynamic-client","token_endpoint_auth_method":"none"}"#,

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -124,6 +124,13 @@ const MCP_RESULT_TYPES: &[&str] = &["complete", "input_required"];
 const MCP_INPUT_REQUIRED_RESULT_TYPE: &str = "input_required";
 const MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE: i32 = -32004;
 const MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE: &str = "Unsupported protocol version";
+const MCP_OAUTH_CLIENT_REGISTRATION_MODES: &[&str] = &[
+    "pre_registered",
+    "client_id_metadata_document",
+    "dynamic_client_registration",
+    "manual",
+];
+const MCP_OAUTH_APPLICATION_TYPES: &[&str] = &["native", "web"];
 const MCP_LOGGING_LEVELS: &[&str] = &[
     "debug",
     "info",
@@ -366,6 +373,8 @@ fn generate_manifest() -> Result<String, String> {
                 "code": MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_CODE,
                 "message": MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE,
             },
+            "oauthClientRegistrationModes": MCP_OAUTH_CLIENT_REGISTRATION_MODES,
+            "oauthApplicationTypes": MCP_OAUTH_APPLICATION_TYPES,
             "loggingLevels": MCP_LOGGING_LEVELS,
         },
         "receipts": {
@@ -598,6 +607,16 @@ fn generate_typescript() -> String {
         "MCP_LOGGING_LEVELS",
         MCP_LOGGING_LEVELS,
         "MCPLoggingLevel",
+    ));
+    out.push_str(&ts_array(
+        "MCP_OAUTH_CLIENT_REGISTRATION_MODES",
+        MCP_OAUTH_CLIENT_REGISTRATION_MODES,
+        "MCPOAuthClientRegistrationMode",
+    ));
+    out.push_str(&ts_array(
+        "MCP_OAUTH_APPLICATION_TYPES",
+        MCP_OAUTH_APPLICATION_TYPES,
+        "MCPOAuthApplicationType",
     ));
 
     out.push_str(
@@ -951,6 +970,53 @@ export interface MCPPrompt {
   arguments?: ACPObject[]
 }
 
+export interface MCPOAuthProtectedResourceMetadata {
+  resource?: string
+  authorization_servers: string[]
+  scopes_supported?: string[]
+  bearer_methods_supported?: string[]
+  [key: string]: ACPValue | undefined
+}
+
+export interface MCPOAuthAuthorizationServerMetadata {
+  issuer: string
+  authorization_endpoint: string
+  token_endpoint: string
+  registration_endpoint?: string
+  token_endpoint_auth_methods_supported?: string[]
+  code_challenge_methods_supported?: string[]
+  scopes_supported?: string[]
+  client_id_metadata_document_supported?: boolean
+  authorization_response_iss_parameter_supported?: boolean
+  [key: string]: ACPValue | undefined
+}
+
+export interface MCPOAuthWwwAuthenticateChallenge {
+  scheme: string
+  params: Record<string, string>
+}
+
+export interface MCPOAuthDiscoveryResult {
+  protectedResourceMetadataUrl: string
+  protectedResourceMetadata: MCPOAuthProtectedResourceMetadata
+  authorizationServerIssuer: string
+  authorizationServerMetadataUrl: string
+  authorizationServerMetadataKind: "oauth_authorization_server" | "openid_configuration"
+  authorizationServerMetadata: MCPOAuthAuthorizationServerMetadata
+  challenge?: MCPOAuthWwwAuthenticateChallenge
+  scopes: string[]
+}
+
+export interface MCPOAuthDynamicClientRegistrationRequest {
+  client_name: string
+  redirect_uris: string[]
+  grant_types: string[]
+  response_types: string[]
+  token_endpoint_auth_method: string
+  application_type: MCPOAuthApplicationType
+  scope?: string
+}
+
 export function isRequest(msg: ACPMessage): msg is ACPRequest {
   return "id" in msg && "method" in msg
 }
@@ -1025,6 +1091,14 @@ fn generate_swift() -> String {
     out.push_str(&swift_string_array(
         "mcpCacheResultFields",
         MCP_CACHE_RESULT_FIELDS,
+    ));
+    out.push_str(&swift_string_array(
+        "mcpOAuthClientRegistrationModes",
+        MCP_OAUTH_CLIENT_REGISTRATION_MODES,
+    ));
+    out.push_str(&swift_string_array(
+        "mcpOAuthApplicationTypes",
+        MCP_OAUTH_APPLICATION_TYPES,
     ));
     out.push_str(&swift_string_array(
         "acpSessionUpdateExtensions",
@@ -1115,6 +1189,14 @@ fn generate_swift() -> String {
     out.push_str(&swift_enum(
         "HarnMCPLoggingLevel",
         &strs_to_strings(MCP_LOGGING_LEVELS),
+    ));
+    out.push_str(&swift_enum(
+        "HarnMCPOAuthClientRegistrationMode",
+        &strs_to_strings(MCP_OAUTH_CLIENT_REGISTRATION_MODES),
+    ));
+    out.push_str(&swift_enum(
+        "HarnMCPOAuthApplicationType",
+        &strs_to_strings(MCP_OAUTH_APPLICATION_TYPES),
     ));
 
     out.push_str(
@@ -1861,6 +1943,80 @@ public struct HarnMCPPrompt: Codable, Sendable, Equatable {
     public var title: String?
     public var description: String?
     public var arguments: [HarnACPObject]?
+}
+
+public struct HarnMCPOAuthProtectedResourceMetadata: Codable, Sendable, Equatable {
+    public var resource: String?
+    public var authorizationServers: [String]
+    public var scopesSupported: [String]?
+    public var bearerMethodsSupported: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case resource
+        case authorizationServers = "authorization_servers"
+        case scopesSupported = "scopes_supported"
+        case bearerMethodsSupported = "bearer_methods_supported"
+    }
+}
+
+public struct HarnMCPOAuthAuthorizationServerMetadata: Codable, Sendable, Equatable {
+    public var issuer: String
+    public var authorizationEndpoint: String
+    public var tokenEndpoint: String
+    public var registrationEndpoint: String?
+    public var tokenEndpointAuthMethodsSupported: [String]?
+    public var codeChallengeMethodsSupported: [String]?
+    public var scopesSupported: [String]?
+    public var clientIdMetadataDocumentSupported: Bool?
+    public var authorizationResponseIssParameterSupported: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case issuer
+        case authorizationEndpoint = "authorization_endpoint"
+        case tokenEndpoint = "token_endpoint"
+        case registrationEndpoint = "registration_endpoint"
+        case tokenEndpointAuthMethodsSupported = "token_endpoint_auth_methods_supported"
+        case codeChallengeMethodsSupported = "code_challenge_methods_supported"
+        case scopesSupported = "scopes_supported"
+        case clientIdMetadataDocumentSupported = "client_id_metadata_document_supported"
+        case authorizationResponseIssParameterSupported = "authorization_response_iss_parameter_supported"
+    }
+}
+
+public struct HarnMCPOAuthWwwAuthenticateChallenge: Codable, Sendable, Equatable {
+    public var scheme: String
+    public var params: [String: String]
+}
+
+public struct HarnMCPOAuthDiscoveryResult: Codable, Sendable, Equatable {
+    public var protectedResourceMetadataUrl: String
+    public var protectedResourceMetadata: HarnMCPOAuthProtectedResourceMetadata
+    public var authorizationServerIssuer: String
+    public var authorizationServerMetadataUrl: String
+    public var authorizationServerMetadataKind: String
+    public var authorizationServerMetadata: HarnMCPOAuthAuthorizationServerMetadata
+    public var challenge: HarnMCPOAuthWwwAuthenticateChallenge?
+    public var scopes: [String]
+}
+
+public struct HarnMCPOAuthDynamicClientRegistrationRequest: Codable, Sendable, Equatable {
+    public var clientName: String
+    public var redirectUris: [String]
+    public var grantTypes: [String]
+    public var responseTypes: [String]
+    public var tokenEndpointAuthMethod: String
+    public var applicationType: HarnMCPOAuthApplicationType
+    public var scope: String?
+
+    enum CodingKeys: String, CodingKey {
+        case clientName = "client_name"
+        case redirectUris = "redirect_uris"
+        case grantTypes = "grant_types"
+        case responseTypes = "response_types"
+        case tokenEndpointAuthMethod = "token_endpoint_auth_method"
+        case applicationType = "application_type"
+        case scope
+    }
 }
 "#,
     );
@@ -3619,6 +3775,9 @@ mod tests {
         assert!(ts.contains("export interface MCPRequestMeta"));
         assert!(ts.contains("export interface MCPDiscoverResult"));
         assert!(ts.contains("export interface MCPInputRequiredResult"));
+        assert!(ts.contains("export interface MCPOAuthDiscoveryResult"));
+        assert!(ts.contains("MCP_OAUTH_CLIENT_REGISTRATION_MODES"));
+        assert!(ts.contains("application_type: MCPOAuthApplicationType"));
         assert!(ts.contains("MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR"));
         assert!(ts.contains("server/discover"));
         assert!(ts.contains("io.modelcontextprotocol/protocolVersion"));
@@ -3640,6 +3799,9 @@ mod tests {
         assert!(swift.contains("public struct HarnMCPRequestMeta"));
         assert!(swift.contains("public struct HarnMCPDiscoverResult"));
         assert!(swift.contains("public struct HarnMCPInputRequiredResult"));
+        assert!(swift.contains("public struct HarnMCPOAuthDiscoveryResult"));
+        assert!(swift.contains("public enum HarnMCPOAuthClientRegistrationMode"));
+        assert!(swift.contains("case applicationType = \"application_type\""));
         assert!(swift.contains("HarnMCPUnsupportedProtocolVersionError"));
         assert!(
             swift.contains("case protocolVersion = \"io.modelcontextprotocol/protocolVersion\"")

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -4,6 +4,13 @@ use std::path::PathBuf;
 use std::{env, fs, process};
 
 use base64::Engine;
+use harn_vm::mcp_auth::{
+    determine_token_endpoint_auth_method, discover_mcp_oauth, dynamic_client_registration_body,
+    ensure_pkce_s256_supported, select_client_registration_mode,
+    validate_authorization_response_issuer, validate_issuer_binding,
+    validate_token_endpoint_auth_method, OAuthClientRegistrationMode,
+    OAuthClientRegistrationOptions,
+};
 use harn_vm::secrets::{KeyringSecretProvider, SecretBytes, SecretId, SecretProvider};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -38,36 +45,13 @@ pub(crate) struct StoredOAuthToken {
     pub client_id: String,
     pub client_secret: Option<String>,
     pub token_endpoint_auth_method: String,
+    pub issuer: String,
     pub resource: String,
     pub scopes: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-struct OAuthProtectedResource {
-    #[serde(default)]
-    authorization_servers: Vec<String>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct OAuthServerMetadata {
-    authorization_endpoint: String,
-    token_endpoint: String,
-    #[serde(default)]
-    registration_endpoint: Option<String>,
-    #[serde(default)]
-    token_endpoint_auth_methods_supported: Vec<String>,
-    #[serde(default)]
-    code_challenge_methods_supported: Vec<String>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct DynamicClientRegistrationResponse {
-    client_id: String,
-    #[serde(default)]
-    client_secret: Option<String>,
-    #[serde(default)]
-    token_endpoint_auth_method: Option<String>,
-}
+type OAuthServerMetadata = harn_vm::mcp_auth::OAuthAuthorizationServerMetadata;
+type DynamicClientRegistrationResponse = harn_vm::mcp_auth::OAuthDynamicClientRegistrationResponse;
 
 #[derive(Clone, Debug, Deserialize)]
 struct TokenResponse {
@@ -102,7 +86,13 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            delete_stored_token(&server.url)
+            let discovery = discover_oauth_server(&server.url)
+                .await
+                .unwrap_or_else(|error| {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                });
+            delete_stored_token(&server.url, &discovery.issuer)
                 .await
                 .unwrap_or_else(|error| {
                     eprintln!("error: {error}");
@@ -118,7 +108,13 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            match load_stored_token(&server.url).await {
+            let discovery = discover_oauth_server(&server.url)
+                .await
+                .unwrap_or_else(|error| {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                });
+            match load_stored_token(&server.url, &discovery.issuer).await {
                 Ok(Some(token)) => {
                     println!("Server: {}", server.name);
                     println!("URL: {}", server.url);
@@ -133,6 +129,7 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                     );
                     println!("Client ID: {}", token.client_id);
                     println!("Token auth method: {}", token.token_endpoint_auth_method);
+                    println!("Issuer: {}", token.issuer);
                 }
                 Ok(None) => {
                     println!("Server: {}", server.name);
@@ -165,12 +162,14 @@ pub(crate) async fn resolve_auth_for_server(
         return Ok(AuthResolution::None);
     }
 
-    let Some(mut stored) = load_stored_token(&server.url).await? else {
+    let discovery = discover_oauth_server(&server.url).await?;
+    let Some(mut stored) = load_stored_token(&server.url, &discovery.issuer).await? else {
         return Ok(AuthResolution::None);
     };
+    validate_issuer_binding(&stored.issuer, &discovery.issuer)?;
 
     if token_needs_refresh(&stored) {
-        stored = refresh_token_if_needed(&stored).await?;
+        stored = refresh_token_if_needed(&stored, &discovery).await?;
         save_stored_token(&stored).await?;
     }
 
@@ -184,31 +183,41 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
     })?;
     let discovery = discover_oauth_server(&server.url).await?;
     ensure_pkce_support(&discovery.metadata)?;
+    let requested_scopes = options
+        .scope
+        .clone()
+        .or(server.scopes.clone())
+        .or_else(|| (!discovery.scopes.is_empty()).then(|| discovery.scopes.join(" ")));
 
+    let configured_client_id = options.client_id.clone().or(server.client_id.clone());
+    let configured_client_secret = options
+        .client_secret
+        .clone()
+        .or(server.client_secret.clone());
+    let registration_mode = select_client_registration_mode(
+        &discovery.metadata,
+        OAuthClientRegistrationOptions {
+            client_id: configured_client_id.as_deref(),
+            client_secret: configured_client_secret.as_deref(),
+            client_id_metadata_document_url: configured_client_id.as_deref(),
+        },
+    );
     let (client_id, client_secret, token_auth_method) = if let Some(client_id) =
-        options.client_id.clone().or(server.client_id.clone())
+        configured_client_id.clone()
     {
-        let token_auth_method = determine_token_auth_method(
-            &discovery.metadata,
-            options
-                .client_secret
-                .clone()
-                .or(server.client_secret.clone())
-                .as_ref(),
-        )?;
-        (
-            client_id,
-            options
-                .client_secret
-                .clone()
-                .or(server.client_secret.clone()),
-            token_auth_method,
-        )
-    } else if let Some(registration_endpoint) = &discovery.metadata.registration_endpoint {
+        let token_auth_method =
+            determine_token_auth_method(&discovery.metadata, configured_client_secret.as_ref())?;
+        (client_id, configured_client_secret, token_auth_method)
+    } else if registration_mode == OAuthClientRegistrationMode::DynamicClientRegistration {
+        let registration_endpoint = discovery
+            .metadata
+            .registration_endpoint
+            .as_deref()
+            .ok_or_else(|| "dynamic client registration endpoint missing".to_string())?;
         let registration = dynamic_client_registration(
             registration_endpoint,
             &options.redirect_uri,
-            options.scope.as_deref().or(server.scopes.as_deref()),
+            requested_scopes.as_deref(),
         )
         .await?;
         let auth_method = registration
@@ -222,7 +231,7 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         )
     } else {
         return Err(
-            "No client_id available. Supply --client-id (optionally --client-secret) or use a server that supports dynamic client registration.".to_string()
+            "No client_id available. Supply --client-id, use a Client ID Metadata Document URL as --client-id when supported, or use a server that supports dynamic client registration.".to_string()
         );
     };
 
@@ -237,7 +246,7 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         &state,
         &code_challenge,
         &server.url,
-        options.scope.as_deref().or(server.scopes.as_deref()),
+        requested_scopes.as_deref(),
     )?;
 
     println!("Server: {} ({})", server.name, server.url);
@@ -249,7 +258,8 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         println!("Open this URL manually:\n{}", auth_url);
     }
 
-    let code = wait_for_oauth_code(callback_listener, &options.redirect_uri, &state)?;
+    let callback = wait_for_oauth_response(callback_listener, &options.redirect_uri, &state)?;
+    validate_authorization_response_issuer(&discovery.metadata, callback.issuer.as_deref())?;
     let token = exchange_authorization_code(
         &discovery.metadata,
         AuthorizationCodeExchange {
@@ -258,8 +268,8 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
             token_auth_method: &token_auth_method,
             redirect_uri: &options.redirect_uri,
             resource: &server.url,
-            scopes: options.scope.as_deref().or(server.scopes.as_deref()),
-            code: &code,
+            scopes: requested_scopes.as_deref(),
+            code: &callback.code,
             code_verifier: &code_verifier,
         },
     )
@@ -275,8 +285,9 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         client_id,
         client_secret,
         token_endpoint_auth_method: token_auth_method,
+        issuer: discovery.issuer,
         resource: server.url.clone(),
-        scopes: options.scope.clone().or(server.scopes),
+        scopes: requested_scopes,
     };
     save_stored_token(&stored).await?;
     println!("OAuth token stored for {}.", server.name);
@@ -352,112 +363,19 @@ fn find_manifest() -> Result<(PathBuf, package::Manifest), String> {
 }
 
 async fn discover_oauth_server(server_url: &str) -> Result<OAuthDiscoveryResult, String> {
-    let resource_url =
-        Url::parse(server_url).map_err(|error| format!("Invalid server URL: {error}"))?;
-    let resource_metadata =
-        fetch_first_json::<OAuthProtectedResource>(&protected_resource_candidates(&resource_url))
-            .await?
-            .ok_or_else(|| "OAuth protected resource metadata not found".to_string())?;
-    let auth_server_url = resource_metadata
-        .authorization_servers
-        .first()
-        .cloned()
-        .ok_or_else(|| {
-            "OAuth protected resource metadata did not advertise an authorization server"
-                .to_string()
-        })?;
-    let auth_server = Url::parse(&auth_server_url).map_err(|error| {
-        format!("Invalid authorization server URL '{auth_server_url}': {error}")
-    })?;
-    let metadata =
-        fetch_first_json::<OAuthServerMetadata>(&authorization_server_candidates(&auth_server))
-            .await?
-            .ok_or_else(|| "Authorization server metadata not found".to_string())?;
-    Ok(OAuthDiscoveryResult { metadata })
-}
-
-fn protected_resource_candidates(resource_url: &Url) -> Vec<Url> {
-    let mut urls = Vec::new();
-    let path = resource_url
-        .path()
-        .trim_start_matches('/')
-        .trim_end_matches('/');
-    if !path.is_empty() {
-        let mut url = resource_url.clone();
-        url.set_path(&format!("/.well-known/oauth-protected-resource/{path}"));
-        url.set_query(None);
-        url.set_fragment(None);
-        urls.push(url);
-    }
-    let mut root = resource_url.clone();
-    root.set_path("/.well-known/oauth-protected-resource");
-    root.set_query(None);
-    root.set_fragment(None);
-    urls.push(root);
-    urls
-}
-
-fn authorization_server_candidates(auth_server_url: &Url) -> Vec<Url> {
-    let mut urls = Vec::new();
-    let path = auth_server_url.path().trim_end_matches('/');
-    if !path.is_empty() && path != "/" {
-        let trimmed = path.trim_start_matches('/');
-        let mut oauth = auth_server_url.clone();
-        oauth.set_path(&format!(
-            "/.well-known/oauth-authorization-server/{trimmed}"
-        ));
-        oauth.set_query(None);
-        oauth.set_fragment(None);
-        urls.push(oauth);
-
-        let mut oidc = auth_server_url.clone();
-        oidc.set_path(&format!("/.well-known/openid-configuration/{trimmed}"));
-        oidc.set_query(None);
-        oidc.set_fragment(None);
-        urls.push(oidc);
-    }
-
-    let mut oauth = auth_server_url.clone();
-    oauth.set_path("/.well-known/oauth-authorization-server");
-    oauth.set_query(None);
-    oauth.set_fragment(None);
-    urls.push(oauth);
-
-    let mut oidc = auth_server_url.clone();
-    oidc.set_path("/.well-known/openid-configuration");
-    oidc.set_query(None);
-    oidc.set_fragment(None);
-    urls.push(oidc);
-    urls
-}
-
-async fn fetch_first_json<T: for<'de> Deserialize<'de>>(
-    candidates: &[Url],
-) -> Result<Option<T>, String> {
     let client = reqwest::Client::new();
-    for candidate in candidates {
-        let response = match client.get(candidate.clone()).send().await {
-            Ok(response) => response,
-            Err(_) => continue,
-        };
-        if !response.status().is_success() {
-            continue;
-        }
-        let parsed = response
-            .json::<T>()
-            .await
-            .map_err(|error| format!("Failed to parse {}: {error}", candidate))?;
-        return Ok(Some(parsed));
-    }
-    Ok(None)
+    let discovery = discover_mcp_oauth(&client, server_url)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(OAuthDiscoveryResult {
+        metadata: discovery.authorization_server_metadata,
+        issuer: discovery.authorization_server_issuer,
+        scopes: discovery.scopes,
+    })
 }
 
 fn ensure_pkce_support(metadata: &OAuthServerMetadata) -> Result<(), String> {
-    let methods = &metadata.code_challenge_methods_supported;
-    if methods.is_empty() || methods.iter().any(|method| method == "S256") {
-        return Ok(());
-    }
-    Err("Authorization server does not advertise PKCE S256 support".to_string())
+    ensure_pkce_s256_supported(metadata)
 }
 
 async fn dynamic_client_registration(
@@ -466,16 +384,7 @@ async fn dynamic_client_registration(
     scopes: Option<&str>,
 ) -> Result<DynamicClientRegistrationResponse, String> {
     let client = reqwest::Client::new();
-    let mut body = serde_json::json!({
-        "client_name": "Harn CLI",
-        "redirect_uris": [redirect_uri],
-        "grant_types": ["authorization_code", "refresh_token"],
-        "response_types": ["code"],
-        "token_endpoint_auth_method": "none",
-    });
-    if let Some(scopes) = scopes {
-        body["scope"] = serde_json::json!(scopes);
-    }
+    let body = dynamic_client_registration_body("Harn CLI", [redirect_uri], scopes);
     let response = client
         .post(registration_endpoint)
         .json(&body)
@@ -499,24 +408,7 @@ fn determine_token_auth_method(
     metadata: &OAuthServerMetadata,
     client_secret: Option<&String>,
 ) -> Result<String, String> {
-    let methods = &metadata.token_endpoint_auth_methods_supported;
-    if client_secret.is_some() {
-        if methods.is_empty() || methods.iter().any(|method| method == "client_secret_post") {
-            return Ok("client_secret_post".to_string());
-        }
-        if methods.iter().any(|method| method == "client_secret_basic") {
-            return Ok("client_secret_basic".to_string());
-        }
-        return Err(
-            "Authorization server does not support client_secret_post or client_secret_basic"
-                .to_string(),
-        );
-    }
-
-    if methods.is_empty() || methods.iter().any(|method| method == "none") {
-        return Ok("none".to_string());
-    }
-    Err("Authorization server requires client authentication. Supply --client-secret or configure a registered client.".to_string())
+    determine_token_endpoint_auth_method(metadata, client_secret.map(String::as_str))
 }
 
 fn build_authorization_url(
@@ -563,11 +455,16 @@ fn bind_callback_listener(redirect_uri: &str) -> Result<TcpListener, String> {
     Ok(listener)
 }
 
-fn wait_for_oauth_code(
+struct OAuthCallbackResponse {
+    code: String,
+    issuer: Option<String>,
+}
+
+fn wait_for_oauth_response(
     listener: TcpListener,
     redirect_uri: &str,
     expected_state: &str,
-) -> Result<String, String> {
+) -> Result<OAuthCallbackResponse, String> {
     let expected_path = Url::parse(redirect_uri)
         .map_err(|error| format!("Invalid redirect URI: {error}"))?
         .path()
@@ -615,11 +512,16 @@ fn wait_for_oauth_code(
     };
     let _ = stream.write_all(response.as_bytes());
 
-    callback_url
+    let code = callback_url
         .query_pairs()
         .find(|(key, _)| key == "code")
         .map(|(_, value)| value.into_owned())
-        .ok_or_else(|| "OAuth callback did not include an authorization code".to_string())
+        .ok_or_else(|| "OAuth callback did not include an authorization code".to_string())?;
+    let issuer = callback_url
+        .query_pairs()
+        .find(|(key, _)| key == "iss")
+        .map(|(_, value)| value.into_owned());
+    Ok(OAuthCallbackResponse { code, issuer })
 }
 
 async fn exchange_authorization_code(
@@ -660,10 +562,14 @@ struct AuthorizationCodeExchange<'a> {
     code_verifier: &'a str,
 }
 
-async fn refresh_token_if_needed(token: &StoredOAuthToken) -> Result<StoredOAuthToken, String> {
+async fn refresh_token_if_needed(
+    token: &StoredOAuthToken,
+    discovery: &OAuthDiscoveryResult,
+) -> Result<StoredOAuthToken, String> {
     if !token_needs_refresh(token) {
         return Ok(token.clone());
     }
+    validate_issuer_binding(&token.issuer, &discovery.issuer)?;
 
     let refresh_token = token.refresh_token.clone().ok_or_else(|| {
         "Stored OAuth token has expired and does not include a refresh token".to_string()
@@ -677,7 +583,7 @@ async fn refresh_token_if_needed(token: &StoredOAuthToken) -> Result<StoredOAuth
     ];
     let refreshed = request_token(
         &client,
-        &token.token_endpoint,
+        &discovery.metadata.token_endpoint,
         &token.token_endpoint_auth_method,
         &token.client_id,
         token.client_secret.as_deref(),
@@ -692,10 +598,11 @@ async fn refresh_token_if_needed(token: &StoredOAuthToken) -> Result<StoredOAuth
         expires_at_unix: refreshed
             .expires_in
             .map(|seconds| current_unix_timestamp().saturating_add(seconds)),
-        token_endpoint: token.token_endpoint.clone(),
+        token_endpoint: discovery.metadata.token_endpoint.clone(),
         client_id: token.client_id.clone(),
         client_secret: token.client_secret.clone(),
         token_endpoint_auth_method: token.token_endpoint_auth_method.clone(),
+        issuer: token.issuer.clone(),
         resource: token.resource.clone(),
         scopes: token.scopes.clone(),
     })
@@ -709,6 +616,7 @@ async fn request_token(
     client_secret: Option<&str>,
     form: &[(&str, String)],
 ) -> Result<TokenResponse, String> {
+    validate_token_endpoint_auth_method(token_auth_method)?;
     let mut request = client.post(token_endpoint).form(form);
     match token_auth_method {
         "client_secret_basic" => {
@@ -773,15 +681,21 @@ async fn save_stored_token(token: &StoredOAuthToken) -> Result<(), String> {
         .map_err(|error| format!("Failed to serialize OAuth token: {error}"))?;
     oauth_token_provider()
         .put(
-            &token_secret_id(&token.resource),
+            &token_secret_id(&token.resource, &token.issuer),
             SecretBytes::from(payload.into_bytes()),
         )
         .await
         .map_err(|error| format!("Failed to store OAuth token in keyring: {error}"))
 }
 
-async fn load_stored_token(resource: &str) -> Result<Option<StoredOAuthToken>, String> {
-    let payload = match oauth_token_provider().get(&token_secret_id(resource)).await {
+async fn load_stored_token(
+    resource: &str,
+    issuer: &str,
+) -> Result<Option<StoredOAuthToken>, String> {
+    let payload = match oauth_token_provider()
+        .get(&token_secret_id(resource, issuer))
+        .await
+    {
         Ok(secret) => secret,
         Err(harn_vm::secrets::SecretError::NotFound { .. }) => return Ok(None),
         Err(error) => return Err(format!("Failed to read OAuth token from keyring: {error}")),
@@ -792,15 +706,19 @@ async fn load_stored_token(resource: &str) -> Result<Option<StoredOAuthToken>, S
     Ok(Some(token))
 }
 
-async fn delete_stored_token(resource: &str) -> Result<(), String> {
+async fn delete_stored_token(resource: &str, issuer: &str) -> Result<(), String> {
     oauth_token_provider()
-        .delete(&token_secret_id(resource))
+        .delete(&token_secret_id(resource, issuer))
         .await
         .map_err(|error| format!("Failed to delete OAuth token from keyring: {error}"))
 }
 
-fn token_store_account(resource: &str) -> String {
-    let digest = Sha256::digest(resource.as_bytes());
+fn token_store_account(resource: &str, issuer: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(resource.as_bytes());
+    hasher.update([0]);
+    hasher.update(issuer.as_bytes());
+    let digest = hasher.finalize();
     format!(
         "mcp-{}",
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
@@ -811,8 +729,8 @@ fn oauth_token_provider() -> KeyringSecretProvider {
     KeyringSecretProvider::new(KEYRING_SERVICE)
 }
 
-fn token_secret_id(resource: &str) -> SecretId {
-    SecretId::new("", token_store_account(resource))
+fn token_secret_id(resource: &str, issuer: &str) -> SecretId {
+    SecretId::new("", token_store_account(resource, issuer))
 }
 
 fn format_expiry(unix: i64) -> String {
@@ -837,6 +755,7 @@ fn html_response(status: u16, message: &str) -> String {
         400 => ("Authorization Failed", "#c76b19", "Retry Needed"),
         _ => ("Callback Error", "#b42318", "Invalid Request"),
     };
+    let message = html_escape(message);
     format!(
         r#"{status_line}
 Content-Type: text/html; charset=utf-8
@@ -877,18 +796,38 @@ p {{ margin: 0; color: #c6cfdb; font-size: 15px; line-height: 1.55; }}
     )
 }
 
+fn html_escape(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
 struct OAuthDiscoveryResult {
     metadata: OAuthServerMetadata,
+    issuer: String,
+    scopes: Vec<String>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harn_vm::mcp_auth::{
+        authorization_server_metadata_candidates, protected_resource_metadata_candidates,
+    };
 
     #[test]
     fn protected_resource_candidate_prefers_path_specific_url() {
         let url = Url::parse("https://example.com/mcp/notion").unwrap();
-        let candidates = protected_resource_candidates(&url);
+        let candidates = protected_resource_metadata_candidates(&url);
         assert_eq!(
             candidates[0].as_str(),
             "https://example.com/.well-known/oauth-protected-resource/mcp/notion"
@@ -902,21 +841,34 @@ mod tests {
     #[test]
     fn authorization_server_candidate_prefers_path_specific_metadata() {
         let url = Url::parse("https://auth.example.com/oauth").unwrap();
-        let candidates = authorization_server_candidates(&url);
+        let candidates = authorization_server_metadata_candidates(&url);
         assert_eq!(
-            candidates[0].as_str(),
+            candidates[0].url.as_str(),
             "https://auth.example.com/.well-known/oauth-authorization-server/oauth"
         );
         assert_eq!(
-            candidates[1].as_str(),
+            candidates[1].url.as_str(),
             "https://auth.example.com/.well-known/openid-configuration/oauth"
+        );
+        assert_eq!(
+            candidates[2].url.as_str(),
+            "https://auth.example.com/oauth/.well-known/openid-configuration"
         );
     }
 
     #[test]
     fn token_store_account_is_stable() {
-        let first = token_store_account("https://mcp.notion.com");
-        let second = token_store_account("https://mcp.notion.com");
+        let first = token_store_account("https://mcp.notion.com", "https://auth.example");
+        let second = token_store_account("https://mcp.notion.com", "https://auth.example");
+        let other = token_store_account("https://mcp.notion.com", "https://other.example");
         assert_eq!(first, second);
+        assert_ne!(first, other);
+    }
+
+    #[test]
+    fn callback_html_response_escapes_message() {
+        let response = html_response(400, "<script>alert('x')</script>&");
+        assert!(response.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;&amp;"));
+        assert!(!response.contains("<script>"));
     }
 }

--- a/crates/harn-cli/src/commands/mcp/oauth_resource.rs
+++ b/crates/harn-cli/src/commands/mcp/oauth_resource.rs
@@ -3,6 +3,10 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use axum::http::{HeaderMap, HeaderValue};
+use harn_vm::mcp_auth::{
+    bearer_challenge_value, protected_resource_metadata_path, split_scope_value,
+    BearerChallengeError,
+};
 use jsonwebtoken::jwk::JwkSet;
 use jsonwebtoken::{decode, decode_header, DecodingKey, Validation};
 use serde::Deserialize;
@@ -177,32 +181,22 @@ impl OAuthResourceServer {
         mcp_path: &str,
         error: Option<OAuthChallengeError>,
     ) -> HeaderValue {
-        let mut parts = vec![format!(
-            "resource_metadata=\"{}\"",
-            quote_value(&self.resource_metadata_url(headers, mcp_path))
-        )];
-        if !self.config.scopes.is_empty() {
-            parts.push(format!(
-                "scope=\"{}\"",
-                quote_value(&self.config.scopes.join(" "))
-            ));
-        }
-        if let Some(error) = error {
-            let (code, description) = match error {
-                OAuthChallengeError::InvalidToken(description) => ("invalid_token", description),
-                OAuthChallengeError::InsufficientScope => (
-                    "insufficient_scope",
-                    "Token does not include the required MCP scope".to_string(),
-                ),
-            };
-            parts.insert(0, format!("error=\"{}\"", quote_value(code)));
-            parts.push(format!(
-                "error_description=\"{}\"",
-                quote_value(&description)
-            ));
-        }
-        HeaderValue::from_str(&format!("Bearer {}", parts.join(", ")))
-            .unwrap_or_else(|_| HeaderValue::from_static("Bearer"))
+        let error = error.as_ref().map(|error| match error {
+            OAuthChallengeError::InvalidToken(description) => BearerChallengeError {
+                code: "invalid_token",
+                description: Some(description.as_str()),
+            },
+            OAuthChallengeError::InsufficientScope => BearerChallengeError {
+                code: "insufficient_scope",
+                description: Some("Token does not include the required MCP scope"),
+            },
+        });
+        HeaderValue::from_str(&bearer_challenge_value(
+            &self.resource_metadata_url(headers, mcp_path),
+            &self.config.scopes,
+            error,
+        ))
+        .unwrap_or_else(|_| HeaderValue::from_static("Bearer"))
     }
 
     pub(crate) async fn validate_bearer(
@@ -277,7 +271,7 @@ impl OAuthResourceServer {
         if let Some(resource) = response.resource {
             audiences.extend(resource.into_vec());
         }
-        let mut scopes = parse_scope_string(response.scope.as_deref());
+        let mut scopes = split_scope_value(response.scope.as_deref());
         if let Some(scp) = response.scp {
             scopes.extend(scp.into_vec());
         }
@@ -402,15 +396,6 @@ pub(crate) enum OAuthChallengeError {
     InsufficientScope,
 }
 
-pub(crate) fn protected_resource_metadata_path(mcp_path: &str) -> String {
-    let mcp_path = normalize_path(mcp_path);
-    if mcp_path == "/" {
-        "/.well-known/oauth-protected-resource".to_string()
-    } else {
-        format!("/.well-known/oauth-protected-resource{mcp_path}")
-    }
-}
-
 fn token_claims_from_json(value: JsonValue) -> TokenClaims {
     let issuer = value
         .get("iss")
@@ -418,7 +403,7 @@ fn token_claims_from_json(value: JsonValue) -> TokenClaims {
         .map(ToString::to_string);
     let mut audiences = json_strings(value.get("aud"));
     audiences.extend(json_strings(value.get("resource")));
-    let mut scopes = parse_scope_string(value.get("scope").and_then(JsonValue::as_str));
+    let mut scopes = split_scope_value(value.get("scope").and_then(JsonValue::as_str));
     scopes.extend(json_strings(value.get("scp")));
     TokenClaims {
         issuer,
@@ -506,23 +491,9 @@ fn split_scope_env(name: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn parse_scope_string(value: Option<&str>) -> Vec<String> {
-    value
-        .unwrap_or_default()
-        .split_whitespace()
-        .map(str::trim)
-        .filter(|segment| !segment.is_empty())
-        .map(ToString::to_string)
-        .collect()
-}
-
 fn env_nonempty(name: &str) -> Option<String> {
     std::env::var(name)
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-}
-
-fn quote_value(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -36,6 +36,7 @@ pub mod jsonrpc;
 pub mod llm;
 pub mod llm_config;
 pub mod mcp;
+pub mod mcp_auth;
 pub mod mcp_card;
 pub mod mcp_elicit;
 pub mod mcp_file_upload;

--- a/crates/harn-vm/src/mcp_auth.rs
+++ b/crates/harn-vm/src/mcp_auth.rs
@@ -1,0 +1,1009 @@
+//! MCP OAuth/OIDC authorization helpers.
+//!
+//! The MCP authorization profile is an HTTP transport profile. This module
+//! keeps discovery, challenge parsing, issuer binding, and registration-mode
+//! decisions in one place so Harn clients and servers do not each carry partial
+//! copies of the OAuth/OIDC rules.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use reqwest::header::{ACCEPT, WWW_AUTHENTICATE};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use url::Url;
+
+pub const OAUTH_PROTECTED_RESOURCE_WELL_KNOWN_PATH: &str = "/.well-known/oauth-protected-resource";
+pub const OAUTH_AUTHORIZATION_SERVER_WELL_KNOWN_PATH: &str =
+    "/.well-known/oauth-authorization-server";
+pub const OIDC_CONFIGURATION_WELL_KNOWN_PATH: &str = "/.well-known/openid-configuration";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WwwAuthenticateChallenge {
+    pub scheme: String,
+    pub params: BTreeMap<String, String>,
+}
+
+impl WwwAuthenticateChallenge {
+    pub fn bearer_resource_metadata(&self) -> Option<&str> {
+        self.scheme
+            .eq_ignore_ascii_case("bearer")
+            .then(|| self.params.get("resource_metadata").map(String::as_str))
+            .flatten()
+    }
+
+    pub fn bearer_scope(&self) -> Option<&str> {
+        self.scheme
+            .eq_ignore_ascii_case("bearer")
+            .then(|| self.params.get("scope").map(String::as_str))
+            .flatten()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct OAuthProtectedResourceMetadata {
+    #[serde(default)]
+    pub resource: Option<String>,
+    #[serde(default)]
+    pub authorization_servers: Vec<String>,
+    #[serde(default)]
+    pub scopes_supported: Vec<String>,
+    #[serde(default)]
+    pub bearer_methods_supported: Vec<String>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OAuthAuthorizationServerMetadata {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    #[serde(default)]
+    pub registration_endpoint: Option<String>,
+    #[serde(default)]
+    pub token_endpoint_auth_methods_supported: Vec<String>,
+    #[serde(default)]
+    pub code_challenge_methods_supported: Vec<String>,
+    #[serde(default)]
+    pub scopes_supported: Vec<String>,
+    #[serde(default)]
+    pub client_id_metadata_document_supported: bool,
+    #[serde(default)]
+    pub authorization_response_iss_parameter_supported: bool,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, JsonValue>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct OAuthDynamicClientRegistrationResponse {
+    pub client_id: String,
+    #[serde(default)]
+    pub client_secret: Option<String>,
+    #[serde(default)]
+    pub token_endpoint_auth_method: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthAuthorizationServerMetadataKind {
+    OAuthAuthorizationServer,
+    OpenIdConfiguration,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OAuthAuthorizationServerMetadataCandidate {
+    pub url: Url,
+    pub kind: OAuthAuthorizationServerMetadataKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthClientRegistrationMode {
+    PreRegistered,
+    ClientIdMetadataDocument,
+    DynamicClientRegistration,
+    Manual,
+}
+
+impl OAuthClientRegistrationMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PreRegistered => "pre_registered",
+            Self::ClientIdMetadataDocument => "client_id_metadata_document",
+            Self::DynamicClientRegistration => "dynamic_client_registration",
+            Self::Manual => "manual",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OAuthApplicationType {
+    Native,
+    Web,
+}
+
+impl OAuthApplicationType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Web => "web",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OAuthClientRegistrationOptions<'a> {
+    pub client_id: Option<&'a str>,
+    pub client_secret: Option<&'a str>,
+    pub client_id_metadata_document_url: Option<&'a str>,
+}
+
+#[derive(Clone, Debug)]
+pub struct McpOAuthDiscovery {
+    pub protected_resource_metadata_url: Url,
+    pub protected_resource_metadata: OAuthProtectedResourceMetadata,
+    pub authorization_server_issuer: String,
+    pub authorization_server_metadata_url: Url,
+    pub authorization_server_metadata_kind: OAuthAuthorizationServerMetadataKind,
+    pub authorization_server_metadata: OAuthAuthorizationServerMetadata,
+    pub challenge: Option<WwwAuthenticateChallenge>,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum McpOAuthDiscoveryError {
+    InvalidResourceUrl(String),
+    InvalidResourceMetadataUrl(String),
+    InvalidAuthorizationServerUrl { issuer: String, error: String },
+    ProtectedResourceMetadataNotFound,
+    MissingAuthorizationServer,
+    AuthorizationServerMetadataNotFound { issuer: String },
+    AuthorizationServerIssuerMismatch { expected: String, actual: String },
+    AuthorizationServerIssuerMissing { expected: String },
+    Json { url: String, error: String },
+}
+
+impl fmt::Display for McpOAuthDiscoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidResourceUrl(error) => write!(f, "invalid MCP resource URL: {error}"),
+            Self::InvalidResourceMetadataUrl(error) => {
+                write!(f, "invalid resource_metadata URL in WWW-Authenticate: {error}")
+            }
+            Self::InvalidAuthorizationServerUrl { issuer, error } => {
+                write!(f, "invalid authorization server URL '{issuer}': {error}")
+            }
+            Self::ProtectedResourceMetadataNotFound => {
+                write!(f, "OAuth protected resource metadata not found")
+            }
+            Self::MissingAuthorizationServer => write!(
+                f,
+                "OAuth protected resource metadata did not advertise an authorization server"
+            ),
+            Self::AuthorizationServerMetadataNotFound { issuer } => {
+                write!(f, "authorization server metadata not found for issuer '{issuer}'")
+            }
+            Self::AuthorizationServerIssuerMismatch { expected, actual } => write!(
+                f,
+                "authorization server metadata issuer mismatch: expected '{expected}', got '{actual}'"
+            ),
+            Self::AuthorizationServerIssuerMissing { expected } => write!(
+                f,
+                "authorization server metadata for '{expected}' did not include an issuer"
+            ),
+            Self::Json { url, error } => write!(f, "failed to parse {url}: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for McpOAuthDiscoveryError {}
+
+pub fn parse_www_authenticate(header: &str) -> Vec<WwwAuthenticateChallenge> {
+    let mut challenges = Vec::<WwwAuthenticateChallenge>::new();
+    let mut current: Option<WwwAuthenticateChallenge> = None;
+
+    for segment in split_challenge_segments(header) {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            continue;
+        }
+        let (first, rest) = split_first_token(segment);
+        let starts_challenge = !first.contains('=');
+        if starts_challenge {
+            if let Some(challenge) = current.take() {
+                challenges.push(challenge);
+            }
+            let mut challenge = WwwAuthenticateChallenge {
+                scheme: first.to_string(),
+                params: BTreeMap::new(),
+            };
+            if !rest.trim().is_empty() {
+                parse_auth_param(rest.trim(), &mut challenge.params);
+            }
+            current = Some(challenge);
+        } else if let Some(challenge) = current.as_mut() {
+            parse_auth_param(segment, &mut challenge.params);
+        }
+    }
+
+    if let Some(challenge) = current {
+        challenges.push(challenge);
+    }
+    challenges
+}
+
+pub fn parse_www_authenticate_headers<'a>(
+    headers: impl IntoIterator<Item = &'a str>,
+) -> Vec<WwwAuthenticateChallenge> {
+    headers
+        .into_iter()
+        .flat_map(parse_www_authenticate)
+        .collect()
+}
+
+pub fn bearer_challenge_from_headers<'a>(
+    headers: impl IntoIterator<Item = &'a str>,
+) -> Option<WwwAuthenticateChallenge> {
+    let mut first_bearer = None;
+    for challenge in parse_www_authenticate_headers(headers) {
+        if !challenge.scheme.eq_ignore_ascii_case("bearer") {
+            continue;
+        }
+        if challenge.bearer_resource_metadata().is_some() {
+            return Some(challenge);
+        }
+        first_bearer.get_or_insert(challenge);
+    }
+    first_bearer
+}
+
+pub fn protected_resource_metadata_candidates(resource_url: &Url) -> Vec<Url> {
+    let mut urls = Vec::new();
+    let path = resource_url
+        .path()
+        .trim_start_matches('/')
+        .trim_end_matches('/');
+    if !path.is_empty() {
+        let mut url = resource_url.clone();
+        url.set_path(&format!(
+            "{OAUTH_PROTECTED_RESOURCE_WELL_KNOWN_PATH}/{path}"
+        ));
+        url.set_query(None);
+        url.set_fragment(None);
+        urls.push(url);
+    }
+    let mut root = resource_url.clone();
+    root.set_path(OAUTH_PROTECTED_RESOURCE_WELL_KNOWN_PATH);
+    root.set_query(None);
+    root.set_fragment(None);
+    urls.push(root);
+    urls
+}
+
+pub fn protected_resource_metadata_path(mcp_path: &str) -> String {
+    let mcp_path = normalize_path(mcp_path);
+    if mcp_path == "/" {
+        OAUTH_PROTECTED_RESOURCE_WELL_KNOWN_PATH.to_string()
+    } else {
+        format!("{OAUTH_PROTECTED_RESOURCE_WELL_KNOWN_PATH}{mcp_path}")
+    }
+}
+
+pub fn authorization_server_metadata_candidates(
+    auth_server_url: &Url,
+) -> Vec<OAuthAuthorizationServerMetadataCandidate> {
+    let mut urls = Vec::new();
+    let path = auth_server_url.path();
+    let has_path = !path.is_empty() && path != "/";
+    if has_path {
+        let trimmed = path.trim_start_matches('/');
+
+        let mut oauth = auth_server_url.clone();
+        oauth.set_path(&format!(
+            "{OAUTH_AUTHORIZATION_SERVER_WELL_KNOWN_PATH}/{trimmed}"
+        ));
+        oauth.set_query(None);
+        oauth.set_fragment(None);
+        urls.push(OAuthAuthorizationServerMetadataCandidate {
+            url: oauth,
+            kind: OAuthAuthorizationServerMetadataKind::OAuthAuthorizationServer,
+        });
+
+        let mut oidc_inserted = auth_server_url.clone();
+        oidc_inserted.set_path(&format!("{OIDC_CONFIGURATION_WELL_KNOWN_PATH}/{trimmed}"));
+        oidc_inserted.set_query(None);
+        oidc_inserted.set_fragment(None);
+        urls.push(OAuthAuthorizationServerMetadataCandidate {
+            url: oidc_inserted,
+            kind: OAuthAuthorizationServerMetadataKind::OpenIdConfiguration,
+        });
+
+        let mut oidc_appended = auth_server_url.clone();
+        let base = path.trim_end_matches('/');
+        oidc_appended.set_path(&format!("{base}{OIDC_CONFIGURATION_WELL_KNOWN_PATH}"));
+        oidc_appended.set_query(None);
+        oidc_appended.set_fragment(None);
+        urls.push(OAuthAuthorizationServerMetadataCandidate {
+            url: oidc_appended,
+            kind: OAuthAuthorizationServerMetadataKind::OpenIdConfiguration,
+        });
+        return urls;
+    }
+
+    let mut oauth = auth_server_url.clone();
+    oauth.set_path(OAUTH_AUTHORIZATION_SERVER_WELL_KNOWN_PATH);
+    oauth.set_query(None);
+    oauth.set_fragment(None);
+    urls.push(OAuthAuthorizationServerMetadataCandidate {
+        url: oauth,
+        kind: OAuthAuthorizationServerMetadataKind::OAuthAuthorizationServer,
+    });
+
+    let mut oidc = auth_server_url.clone();
+    oidc.set_path(OIDC_CONFIGURATION_WELL_KNOWN_PATH);
+    oidc.set_query(None);
+    oidc.set_fragment(None);
+    urls.push(OAuthAuthorizationServerMetadataCandidate {
+        url: oidc,
+        kind: OAuthAuthorizationServerMetadataKind::OpenIdConfiguration,
+    });
+    urls
+}
+
+pub async fn discover_mcp_oauth(
+    client: &reqwest::Client,
+    resource: &str,
+) -> Result<McpOAuthDiscovery, McpOAuthDiscoveryError> {
+    let resource_url = Url::parse(resource)
+        .map_err(|error| McpOAuthDiscoveryError::InvalidResourceUrl(error.to_string()))?;
+    discover_mcp_oauth_from_url(client, &resource_url).await
+}
+
+pub async fn discover_mcp_oauth_from_url(
+    client: &reqwest::Client,
+    resource_url: &Url,
+) -> Result<McpOAuthDiscovery, McpOAuthDiscoveryError> {
+    let challenge = fetch_resource_challenge(client, resource_url).await;
+    let challenged_metadata_url = challenge
+        .as_ref()
+        .and_then(WwwAuthenticateChallenge::bearer_resource_metadata)
+        .map(|url| {
+            Url::parse(url).map_err(|error| {
+                McpOAuthDiscoveryError::InvalidResourceMetadataUrl(error.to_string())
+            })
+        })
+        .transpose()?;
+
+    let metadata_candidates = challenged_metadata_url
+        .into_iter()
+        .chain(protected_resource_metadata_candidates(resource_url))
+        .collect::<Vec<_>>();
+    let (protected_resource_metadata_url, protected_resource_metadata) =
+        fetch_first_json::<OAuthProtectedResourceMetadata>(client, &metadata_candidates)
+            .await?
+            .ok_or(McpOAuthDiscoveryError::ProtectedResourceMetadataNotFound)?;
+    let authorization_server_issuer = protected_resource_metadata
+        .authorization_servers
+        .first()
+        .cloned()
+        .ok_or(McpOAuthDiscoveryError::MissingAuthorizationServer)?;
+    let auth_server_url = Url::parse(&authorization_server_issuer).map_err(|error| {
+        McpOAuthDiscoveryError::InvalidAuthorizationServerUrl {
+            issuer: authorization_server_issuer.clone(),
+            error: error.to_string(),
+        }
+    })?;
+    let (authorization_server_metadata_url, authorization_server_metadata_kind, metadata) =
+        fetch_authorization_server_metadata(client, &authorization_server_issuer, &auth_server_url)
+            .await?;
+    let scopes = select_oauth_scopes(
+        challenge
+            .as_ref()
+            .and_then(WwwAuthenticateChallenge::bearer_scope),
+        &protected_resource_metadata.scopes_supported,
+    );
+    Ok(McpOAuthDiscovery {
+        protected_resource_metadata_url,
+        protected_resource_metadata,
+        authorization_server_issuer,
+        authorization_server_metadata_url,
+        authorization_server_metadata_kind,
+        authorization_server_metadata: metadata,
+        challenge,
+        scopes,
+    })
+}
+
+pub async fn fetch_authorization_server_metadata(
+    client: &reqwest::Client,
+    expected_issuer: &str,
+    auth_server_url: &Url,
+) -> Result<
+    (
+        Url,
+        OAuthAuthorizationServerMetadataKind,
+        OAuthAuthorizationServerMetadata,
+    ),
+    McpOAuthDiscoveryError,
+> {
+    let candidates = authorization_server_metadata_candidates(auth_server_url);
+    for candidate in candidates {
+        let Some(metadata) =
+            fetch_json::<OAuthAuthorizationServerMetadata>(client, &candidate.url).await?
+        else {
+            continue;
+        };
+        validate_authorization_server_issuer(expected_issuer, &metadata)?;
+        return Ok((candidate.url, candidate.kind, metadata));
+    }
+    Err(
+        McpOAuthDiscoveryError::AuthorizationServerMetadataNotFound {
+            issuer: expected_issuer.to_string(),
+        },
+    )
+}
+
+pub fn validate_authorization_server_issuer(
+    expected_issuer: &str,
+    metadata: &OAuthAuthorizationServerMetadata,
+) -> Result<(), McpOAuthDiscoveryError> {
+    if metadata.issuer.is_empty() {
+        return Err(McpOAuthDiscoveryError::AuthorizationServerIssuerMissing {
+            expected: expected_issuer.to_string(),
+        });
+    }
+    if metadata.issuer != expected_issuer {
+        return Err(McpOAuthDiscoveryError::AuthorizationServerIssuerMismatch {
+            expected: expected_issuer.to_string(),
+            actual: metadata.issuer.clone(),
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_authorization_response_issuer(
+    metadata: &OAuthAuthorizationServerMetadata,
+    response_issuer: Option<&str>,
+) -> Result<(), String> {
+    match (
+        metadata.authorization_response_iss_parameter_supported,
+        response_issuer,
+    ) {
+        (true, Some(actual)) if actual == metadata.issuer => Ok(()),
+        (true, Some(actual)) => Err(format!(
+            "authorization response issuer mismatch: expected '{}', got '{}'",
+            metadata.issuer, actual
+        )),
+        (true, None) => Err(
+            "authorization response did not include required RFC 9207 iss parameter".to_string(),
+        ),
+        (false, Some(actual)) if actual == metadata.issuer => Ok(()),
+        (false, Some(actual)) => Err(format!(
+            "authorization response issuer mismatch: expected '{}', got '{}'",
+            metadata.issuer, actual
+        )),
+        (false, None) => Ok(()),
+    }
+}
+
+pub fn validate_issuer_binding(stored_issuer: &str, current_issuer: &str) -> Result<(), String> {
+    if stored_issuer == current_issuer {
+        Ok(())
+    } else {
+        Err(format!(
+            "stored OAuth credentials are bound to issuer '{stored_issuer}', but the MCP resource now advertises '{current_issuer}'"
+        ))
+    }
+}
+
+pub fn select_oauth_scopes(
+    challenge_scope: Option<&str>,
+    scopes_supported: &[String],
+) -> Vec<String> {
+    let challenged = split_scope_value(challenge_scope);
+    if challenged.is_empty() {
+        dedupe_scopes(scopes_supported.iter().map(String::as_str))
+    } else {
+        challenged
+    }
+}
+
+pub fn accumulate_oauth_scopes<'a>(
+    existing: impl IntoIterator<Item = &'a str>,
+    challenged: impl IntoIterator<Item = &'a str>,
+) -> Vec<String> {
+    dedupe_scopes(existing.into_iter().chain(challenged))
+}
+
+pub fn split_scope_value(value: Option<&str>) -> Vec<String> {
+    dedupe_scopes(
+        value
+            .unwrap_or_default()
+            .split_whitespace()
+            .map(str::trim)
+            .filter(|scope| !scope.is_empty()),
+    )
+}
+
+pub fn select_client_registration_mode(
+    metadata: &OAuthAuthorizationServerMetadata,
+    options: OAuthClientRegistrationOptions<'_>,
+) -> OAuthClientRegistrationMode {
+    if let Some(client_id) = options.client_id {
+        if options.client_secret.is_none() && is_client_id_metadata_document_url(client_id) {
+            return OAuthClientRegistrationMode::ClientIdMetadataDocument;
+        }
+        return OAuthClientRegistrationMode::PreRegistered;
+    }
+    if options
+        .client_id_metadata_document_url
+        .is_some_and(is_client_id_metadata_document_url)
+        && metadata.client_id_metadata_document_supported
+    {
+        return OAuthClientRegistrationMode::ClientIdMetadataDocument;
+    }
+    if metadata.registration_endpoint.is_some() {
+        return OAuthClientRegistrationMode::DynamicClientRegistration;
+    }
+    OAuthClientRegistrationMode::Manual
+}
+
+pub fn is_client_id_metadata_document_url(client_id: &str) -> bool {
+    Url::parse(client_id)
+        .ok()
+        .filter(|url| url.scheme() == "https")
+        .and_then(|url| {
+            let path = url.path().trim_matches('/');
+            (!path.is_empty()).then_some(())
+        })
+        .is_some()
+}
+
+pub fn ensure_pkce_s256_supported(
+    metadata: &OAuthAuthorizationServerMetadata,
+) -> Result<(), String> {
+    let methods = &metadata.code_challenge_methods_supported;
+    if methods.is_empty() || methods.iter().any(|method| method == "S256") {
+        return Ok(());
+    }
+    Err("Authorization server does not advertise PKCE S256 support".to_string())
+}
+
+pub fn determine_token_endpoint_auth_method(
+    metadata: &OAuthAuthorizationServerMetadata,
+    client_secret: Option<&str>,
+) -> Result<String, String> {
+    let methods = &metadata.token_endpoint_auth_methods_supported;
+    if client_secret.is_some() {
+        if methods.is_empty() || methods.iter().any(|method| method == "client_secret_post") {
+            return Ok("client_secret_post".to_string());
+        }
+        if methods.iter().any(|method| method == "client_secret_basic") {
+            return Ok("client_secret_basic".to_string());
+        }
+        return Err(
+            "Authorization server does not support client_secret_post or client_secret_basic"
+                .to_string(),
+        );
+    }
+
+    if methods.is_empty() || methods.iter().any(|method| method == "none") {
+        return Ok("none".to_string());
+    }
+    Err("Authorization server requires client authentication. Supply --client-secret or configure a registered client.".to_string())
+}
+
+pub fn validate_token_endpoint_auth_method(method: &str) -> Result<(), String> {
+    match method {
+        "none" | "client_secret_post" | "client_secret_basic" => Ok(()),
+        other => Err(format!(
+            "unsupported token auth method '{other}'; expected none, client_secret_post, or client_secret_basic"
+        )),
+    }
+}
+
+pub fn application_type_for_redirect_uris<'a>(
+    redirect_uris: impl IntoIterator<Item = &'a str>,
+) -> OAuthApplicationType {
+    if redirect_uris.into_iter().all(redirect_uri_is_native) {
+        OAuthApplicationType::Native
+    } else {
+        OAuthApplicationType::Web
+    }
+}
+
+pub fn dynamic_client_registration_body<'a>(
+    client_name: &str,
+    redirect_uris: impl IntoIterator<Item = &'a str>,
+    scopes: Option<&str>,
+) -> JsonValue {
+    let redirect_uris = redirect_uris
+        .into_iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let application_type =
+        application_type_for_redirect_uris(redirect_uris.iter().map(String::as_str));
+    let mut body = json!({
+        "client_name": client_name,
+        "redirect_uris": redirect_uris,
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "application_type": application_type.as_str(),
+    });
+    if let Some(scopes) = scopes.filter(|scopes| !scopes.trim().is_empty()) {
+        body["scope"] = json!(scopes);
+    }
+    body
+}
+
+pub fn bearer_challenge_value(
+    resource_metadata_url: &str,
+    scopes: &[String],
+    error: Option<BearerChallengeError<'_>>,
+) -> String {
+    let mut parts = vec![format!(
+        "resource_metadata=\"{}\"",
+        quote_auth_value(resource_metadata_url)
+    )];
+    if !scopes.is_empty() {
+        parts.push(format!("scope=\"{}\"", quote_auth_value(&scopes.join(" "))));
+    }
+    if let Some(error) = error {
+        parts.insert(0, format!("error=\"{}\"", quote_auth_value(error.code)));
+        if let Some(description) = error.description {
+            parts.push(format!(
+                "error_description=\"{}\"",
+                quote_auth_value(description)
+            ));
+        }
+    }
+    format!("Bearer {}", parts.join(", "))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BearerChallengeError<'a> {
+    pub code: &'a str,
+    pub description: Option<&'a str>,
+}
+
+fn split_challenge_segments(header: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    let mut in_quote = false;
+    let mut escaped = false;
+    for (index, character) in header.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match character {
+            '\\' if in_quote => escaped = true,
+            '"' => in_quote = !in_quote,
+            ',' if !in_quote => {
+                segments.push(&header[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    segments.push(&header[start..]);
+    segments
+}
+
+fn split_first_token(segment: &str) -> (&str, &str) {
+    let trimmed = segment.trim_start();
+    match trimmed.find(char::is_whitespace) {
+        Some(index) => (&trimmed[..index], &trimmed[index..]),
+        None => (trimmed, ""),
+    }
+}
+
+fn parse_auth_param(segment: &str, params: &mut BTreeMap<String, String>) {
+    let Some((key, raw_value)) = segment.split_once('=') else {
+        return;
+    };
+    let key = key.trim().to_ascii_lowercase();
+    if key.is_empty() {
+        return;
+    }
+    params.insert(key, parse_auth_value(raw_value.trim()));
+}
+
+fn parse_auth_value(raw_value: &str) -> String {
+    let Some(stripped) = raw_value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+    else {
+        return raw_value.trim().to_string();
+    };
+    let mut value = String::new();
+    let mut chars = stripped.chars();
+    while let Some(character) = chars.next() {
+        if character == '\\' {
+            if let Some(escaped) = chars.next() {
+                value.push(escaped);
+            }
+        } else {
+            value.push(character);
+        }
+    }
+    value
+}
+
+async fn fetch_resource_challenge(
+    client: &reqwest::Client,
+    resource_url: &Url,
+) -> Option<WwwAuthenticateChallenge> {
+    let response = client
+        .get(resource_url.clone())
+        .header(ACCEPT, "application/json")
+        .send()
+        .await
+        .ok()?;
+    let header_values = response
+        .headers()
+        .get_all(WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .collect::<Vec<_>>();
+    bearer_challenge_from_headers(header_values)
+}
+
+async fn fetch_first_json<T: for<'de> Deserialize<'de>>(
+    client: &reqwest::Client,
+    candidates: &[Url],
+) -> Result<Option<(Url, T)>, McpOAuthDiscoveryError> {
+    for candidate in candidates {
+        if let Some(parsed) = fetch_json::<T>(client, candidate).await? {
+            return Ok(Some((candidate.clone(), parsed)));
+        }
+    }
+    Ok(None)
+}
+
+async fn fetch_json<T: for<'de> Deserialize<'de>>(
+    client: &reqwest::Client,
+    url: &Url,
+) -> Result<Option<T>, McpOAuthDiscoveryError> {
+    let response = match client.get(url.clone()).send().await {
+        Ok(response) => response,
+        Err(_) => return Ok(None),
+    };
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    response
+        .json::<T>()
+        .await
+        .map(Some)
+        .map_err(|error| McpOAuthDiscoveryError::Json {
+            url: url.to_string(),
+            error: error.to_string(),
+        })
+}
+
+fn dedupe_scopes<'a>(scopes: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut ordered = Vec::new();
+    for scope in scopes {
+        let scope = scope.trim();
+        if !scope.is_empty() && seen.insert(scope.to_string()) {
+            ordered.push(scope.to_string());
+        }
+    }
+    ordered
+}
+
+fn redirect_uri_is_native(redirect_uri: &str) -> bool {
+    let Ok(url) = Url::parse(redirect_uri) else {
+        return false;
+    };
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return true;
+    }
+    matches!(
+        url.host_str(),
+        Some("127.0.0.1") | Some("localhost") | Some("::1") | Some("[::1]")
+    )
+}
+
+fn normalize_path(path: &str) -> String {
+    let trimmed = path.trim();
+    if trimmed.is_empty() || trimmed == "/" {
+        "/".to_string()
+    } else if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+fn quote_auth_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata(
+        issuer: &str,
+        registration_endpoint: Option<&str>,
+    ) -> OAuthAuthorizationServerMetadata {
+        OAuthAuthorizationServerMetadata {
+            issuer: issuer.to_string(),
+            authorization_endpoint: format!("{issuer}/authorize"),
+            token_endpoint: format!("{issuer}/token"),
+            registration_endpoint: registration_endpoint.map(ToString::to_string),
+            token_endpoint_auth_methods_supported: vec!["none".to_string()],
+            code_challenge_methods_supported: vec!["S256".to_string()],
+            scopes_supported: Vec::new(),
+            client_id_metadata_document_supported: false,
+            authorization_response_iss_parameter_supported: false,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn parses_bearer_challenge_resource_metadata_and_scope() {
+        let challenges = parse_www_authenticate(
+            r#"Bearer realm="mcp", resource_metadata="https://mcp.example/.well-known/oauth-protected-resource", scope="files:read files:write""#,
+        );
+        assert_eq!(challenges.len(), 1);
+        let challenge = &challenges[0];
+        assert_eq!(
+            challenge.bearer_resource_metadata(),
+            Some("https://mcp.example/.well-known/oauth-protected-resource")
+        );
+        assert_eq!(
+            split_scope_value(challenge.bearer_scope()),
+            vec!["files:read", "files:write"]
+        );
+    }
+
+    #[test]
+    fn parses_multiple_www_authenticate_challenges() {
+        let challenge = bearer_challenge_from_headers([
+            r#"Basic realm="old""#,
+            r#"Bearer error="insufficient_scope", scope="admin", resource_metadata="https://mcp.example/meta""#,
+        ])
+        .expect("bearer challenge");
+        assert_eq!(
+            challenge.params.get("error").map(String::as_str),
+            Some("insufficient_scope")
+        );
+        assert_eq!(
+            challenge.bearer_resource_metadata(),
+            Some("https://mcp.example/meta")
+        );
+    }
+
+    #[test]
+    fn bearer_challenge_selection_prefers_resource_metadata() {
+        let challenge = bearer_challenge_from_headers([
+            r#"Bearer realm="old", Bearer resource_metadata="https://mcp.example/meta""#,
+        ])
+        .expect("bearer challenge");
+        assert_eq!(
+            challenge.bearer_resource_metadata(),
+            Some("https://mcp.example/meta")
+        );
+    }
+
+    #[test]
+    fn authorization_server_candidates_include_oidc_path_appending() {
+        let issuer = Url::parse("https://auth.example.com/tenant1").unwrap();
+        let candidates = authorization_server_metadata_candidates(&issuer);
+        let urls = candidates
+            .iter()
+            .map(|candidate| candidate.url.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            urls,
+            vec![
+                "https://auth.example.com/.well-known/oauth-authorization-server/tenant1",
+                "https://auth.example.com/.well-known/openid-configuration/tenant1",
+                "https://auth.example.com/tenant1/.well-known/openid-configuration",
+            ]
+        );
+    }
+
+    #[test]
+    fn validates_authorization_server_issuer_without_normalization() {
+        let mut metadata = metadata("https://auth.example.com", None);
+        validate_authorization_server_issuer("https://auth.example.com", &metadata).unwrap();
+        metadata.issuer = "https://auth.example.com/".to_string();
+        let err = validate_authorization_server_issuer("https://auth.example.com", &metadata)
+            .expect_err("issuer mismatch");
+        assert!(err.to_string().contains("issuer mismatch"));
+    }
+
+    #[test]
+    fn authorization_response_issuer_validation_follows_rfc9207_advertisement() {
+        let mut metadata = metadata("https://auth.example.com", None);
+        assert!(validate_authorization_response_issuer(&metadata, None).is_ok());
+        assert!(
+            validate_authorization_response_issuer(&metadata, Some("https://other.example"))
+                .is_err()
+        );
+        metadata.authorization_response_iss_parameter_supported = true;
+        assert!(validate_authorization_response_issuer(&metadata, None).is_err());
+        assert!(validate_authorization_response_issuer(
+            &metadata,
+            Some("https://auth.example.com")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn scope_selection_prefers_challenge_scope_then_metadata_scope() {
+        assert_eq!(
+            select_oauth_scopes(Some("files:read files:write files:read"), &[]),
+            vec!["files:read", "files:write"]
+        );
+        assert_eq!(
+            select_oauth_scopes(None, &["basic".to_string(), "profile".to_string()]),
+            vec!["basic", "profile"]
+        );
+    }
+
+    #[test]
+    fn client_registration_mode_selection_is_explicit() {
+        let mut meta = metadata(
+            "https://auth.example.com",
+            Some("https://auth.example.com/reg"),
+        );
+        assert_eq!(
+            select_client_registration_mode(&meta, OAuthClientRegistrationOptions::default()),
+            OAuthClientRegistrationMode::DynamicClientRegistration
+        );
+        assert_eq!(
+            select_client_registration_mode(
+                &meta,
+                OAuthClientRegistrationOptions {
+                    client_id: Some("static-client"),
+                    ..OAuthClientRegistrationOptions::default()
+                },
+            ),
+            OAuthClientRegistrationMode::PreRegistered
+        );
+        meta.client_id_metadata_document_supported = true;
+        assert_eq!(
+            select_client_registration_mode(
+                &meta,
+                OAuthClientRegistrationOptions {
+                    client_id: Some("https://client.example/oauth/client.json"),
+                    ..OAuthClientRegistrationOptions::default()
+                },
+            ),
+            OAuthClientRegistrationMode::ClientIdMetadataDocument
+        );
+    }
+
+    #[test]
+    fn dynamic_registration_body_marks_loopback_clients_native() {
+        let body = dynamic_client_registration_body(
+            "Harn CLI",
+            ["http://127.0.0.1:49152/oauth/callback"],
+            Some("mcp.read"),
+        );
+        assert_eq!(body["application_type"], "native");
+        assert_eq!(body["token_endpoint_auth_method"], "none");
+        assert_eq!(body["grant_types"][1], "refresh_token");
+        assert_eq!(body["scope"], "mcp.read");
+    }
+
+    #[test]
+    fn token_refresh_binding_rejects_cross_issuer_reuse() {
+        assert!(
+            validate_issuer_binding("https://issuer-a.example", "https://issuer-a.example").is_ok()
+        );
+        assert!(
+            validate_issuer_binding("https://issuer-a.example", "https://issuer-b.example")
+                .is_err()
+        );
+    }
+}

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -1007,6 +1007,11 @@ standalone CLI reuse. Treat that as durable delegated access:
 
 - prefer the narrowest scopes the server supports
 - treat configured `client_secret` values as secrets
+- expect HTTP MCP servers to publish RFC 9728 protected-resource metadata and
+  OAuth/OIDC authorization-server metadata; Harn validates issuer binding before
+  storing or refreshing tokens
+- use local environment variables or client-managed secrets for stdio MCP
+  servers; the HTTP OAuth discovery flow does not apply to local stdio launches
 - review remote MCP capabilities before wiring them into autonomous workflows
 
 ### Safer write defaults

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -85,6 +85,11 @@ harn mcp serve \
 
 ## Auth
 
+MCP OAuth applies only to HTTP transports. Local stdio servers are launched by
+the client process and should receive credentials through the launch
+environment or client-specific secret configuration, not through HTTP
+`WWW-Authenticate`, protected-resource metadata, or bearer-token refresh.
+
 For HTTP transports, prefer OAuth resource-server mode. Set
 `HARN_MCP_OAUTH_AUTHORIZATION_SERVERS` to a comma-separated list of issuer URLs
 and configure exactly how the MCP server validates bearer tokens:
@@ -106,8 +111,9 @@ Recommended production settings:
   for the MCP control plane
 
 When OAuth mode is configured, unauthenticated HTTP requests return `401` with
-`WWW-Authenticate: Bearer resource_metadata="..."`, and the server publishes
-RFC 9728 protected resource metadata at both:
+`WWW-Authenticate: Bearer resource_metadata="..."`. The challenge includes
+`scope="..."` when `HARN_MCP_OAUTH_SCOPES` is set. The server publishes RFC
+9728 protected resource metadata at both:
 
 - `/.well-known/oauth-protected-resource`
 - `/.well-known/oauth-protected-resource/<mcp-path>`
@@ -115,8 +121,8 @@ RFC 9728 protected resource metadata at both:
 The metadata includes `authorization_servers`, the canonical `resource`, and
 `scopes_supported` when scopes are configured. Access tokens must be sent on
 every HTTP request as `Authorization: Bearer <token>`. Tokens are rejected when
-they are inactive, expired, issued for a different audience/resource, or missing
-required scopes.
+they are inactive, expired, issued for a different audience/resource or issuer,
+or missing required scopes.
 
 `HARN_ORCHESTRATOR_API_KEYS` remains available as a legacy compatibility mode.
 Set it to a comma-separated key list to require API keys.
@@ -126,9 +132,8 @@ HTTP clients can authenticate with either:
 - `Authorization: Bearer <key>`
 - `x-api-key: <key>`
 
-Stdio clients, and legacy HTTP clients that do not yet send an Authorization
-header, can authenticate during `initialize` using a deprecated Harn extension
-field:
+Legacy clients that do not yet send an Authorization header can authenticate
+during `initialize` using a deprecated Harn extension field:
 
 ```json
 {

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -42,6 +42,16 @@ public enum HarnProtocolConstants {
         "ttlMs",
         "cacheScope",
     ]
+    public static let mcpOAuthClientRegistrationModes: [String] = [
+        "pre_registered",
+        "client_id_metadata_document",
+        "dynamic_client_registration",
+        "manual",
+    ]
+    public static let mcpOAuthApplicationTypes: [String] = [
+        "native",
+        "web",
+    ]
     public static let acpSessionUpdateExtensions: [String] = [
         "available_commands_update",
         "fs_watch",
@@ -488,6 +498,30 @@ public enum HarnMCPLoggingLevel: String, Codable, Sendable, CaseIterable {
         "critical",
         "alert",
         "emergency",
+    ].map { Self(rawValue: $0)! }
+}
+
+public enum HarnMCPOAuthClientRegistrationMode: String, Codable, Sendable, CaseIterable {
+    case preRegistered = "pre_registered"
+    case clientIdMetadataDocument = "client_id_metadata_document"
+    case dynamicClientRegistration = "dynamic_client_registration"
+    case manual = "manual"
+
+    public static let allCases: [Self] = [
+        "pre_registered",
+        "client_id_metadata_document",
+        "dynamic_client_registration",
+        "manual",
+    ].map { Self(rawValue: $0)! }
+}
+
+public enum HarnMCPOAuthApplicationType: String, Codable, Sendable, CaseIterable {
+    case native = "native"
+    case web = "web"
+
+    public static let allCases: [Self] = [
+        "native",
+        "web",
     ].map { Self(rawValue: $0)! }
 }
 
@@ -1234,4 +1268,78 @@ public struct HarnMCPPrompt: Codable, Sendable, Equatable {
     public var title: String?
     public var description: String?
     public var arguments: [HarnACPObject]?
+}
+
+public struct HarnMCPOAuthProtectedResourceMetadata: Codable, Sendable, Equatable {
+    public var resource: String?
+    public var authorizationServers: [String]
+    public var scopesSupported: [String]?
+    public var bearerMethodsSupported: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case resource
+        case authorizationServers = "authorization_servers"
+        case scopesSupported = "scopes_supported"
+        case bearerMethodsSupported = "bearer_methods_supported"
+    }
+}
+
+public struct HarnMCPOAuthAuthorizationServerMetadata: Codable, Sendable, Equatable {
+    public var issuer: String
+    public var authorizationEndpoint: String
+    public var tokenEndpoint: String
+    public var registrationEndpoint: String?
+    public var tokenEndpointAuthMethodsSupported: [String]?
+    public var codeChallengeMethodsSupported: [String]?
+    public var scopesSupported: [String]?
+    public var clientIdMetadataDocumentSupported: Bool?
+    public var authorizationResponseIssParameterSupported: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case issuer
+        case authorizationEndpoint = "authorization_endpoint"
+        case tokenEndpoint = "token_endpoint"
+        case registrationEndpoint = "registration_endpoint"
+        case tokenEndpointAuthMethodsSupported = "token_endpoint_auth_methods_supported"
+        case codeChallengeMethodsSupported = "code_challenge_methods_supported"
+        case scopesSupported = "scopes_supported"
+        case clientIdMetadataDocumentSupported = "client_id_metadata_document_supported"
+        case authorizationResponseIssParameterSupported = "authorization_response_iss_parameter_supported"
+    }
+}
+
+public struct HarnMCPOAuthWwwAuthenticateChallenge: Codable, Sendable, Equatable {
+    public var scheme: String
+    public var params: [String: String]
+}
+
+public struct HarnMCPOAuthDiscoveryResult: Codable, Sendable, Equatable {
+    public var protectedResourceMetadataUrl: String
+    public var protectedResourceMetadata: HarnMCPOAuthProtectedResourceMetadata
+    public var authorizationServerIssuer: String
+    public var authorizationServerMetadataUrl: String
+    public var authorizationServerMetadataKind: String
+    public var authorizationServerMetadata: HarnMCPOAuthAuthorizationServerMetadata
+    public var challenge: HarnMCPOAuthWwwAuthenticateChallenge?
+    public var scopes: [String]
+}
+
+public struct HarnMCPOAuthDynamicClientRegistrationRequest: Codable, Sendable, Equatable {
+    public var clientName: String
+    public var redirectUris: [String]
+    public var grantTypes: [String]
+    public var responseTypes: [String]
+    public var tokenEndpointAuthMethod: String
+    public var applicationType: HarnMCPOAuthApplicationType
+    public var scope: String?
+
+    enum CodingKeys: String, CodingKey {
+        case clientName = "client_name"
+        case redirectUris = "redirect_uris"
+        case grantTypes = "grant_types"
+        case responseTypes = "response_types"
+        case tokenEndpointAuthMethod = "token_endpoint_auth_method"
+        case applicationType = "application_type"
+        case scope
+    }
 }

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -316,6 +316,20 @@ export const MCP_LOGGING_LEVELS = [
 ] as const
 export type MCPLoggingLevel = (typeof MCP_LOGGING_LEVELS)[number]
 
+export const MCP_OAUTH_CLIENT_REGISTRATION_MODES = [
+  "pre_registered",
+  "client_id_metadata_document",
+  "dynamic_client_registration",
+  "manual",
+] as const
+export type MCPOAuthClientRegistrationMode = (typeof MCP_OAUTH_CLIENT_REGISTRATION_MODES)[number]
+
+export const MCP_OAUTH_APPLICATION_TYPES = [
+  "native",
+  "web",
+] as const
+export type MCPOAuthApplicationType = (typeof MCP_OAUTH_APPLICATION_TYPES)[number]
+
 
 export type ACPObject = { [key: string]: ACPValue }
 export type ACPValue = null | boolean | number | string | ACPValue[] | ACPObject
@@ -664,6 +678,53 @@ export interface MCPPrompt {
   title?: string
   description?: string
   arguments?: ACPObject[]
+}
+
+export interface MCPOAuthProtectedResourceMetadata {
+  resource?: string
+  authorization_servers: string[]
+  scopes_supported?: string[]
+  bearer_methods_supported?: string[]
+  [key: string]: ACPValue | undefined
+}
+
+export interface MCPOAuthAuthorizationServerMetadata {
+  issuer: string
+  authorization_endpoint: string
+  token_endpoint: string
+  registration_endpoint?: string
+  token_endpoint_auth_methods_supported?: string[]
+  code_challenge_methods_supported?: string[]
+  scopes_supported?: string[]
+  client_id_metadata_document_supported?: boolean
+  authorization_response_iss_parameter_supported?: boolean
+  [key: string]: ACPValue | undefined
+}
+
+export interface MCPOAuthWwwAuthenticateChallenge {
+  scheme: string
+  params: Record<string, string>
+}
+
+export interface MCPOAuthDiscoveryResult {
+  protectedResourceMetadataUrl: string
+  protectedResourceMetadata: MCPOAuthProtectedResourceMetadata
+  authorizationServerIssuer: string
+  authorizationServerMetadataUrl: string
+  authorizationServerMetadataKind: "oauth_authorization_server" | "openid_configuration"
+  authorizationServerMetadata: MCPOAuthAuthorizationServerMetadata
+  challenge?: MCPOAuthWwwAuthenticateChallenge
+  scopes: string[]
+}
+
+export interface MCPOAuthDynamicClientRegistrationRequest {
+  client_name: string
+  redirect_uris: string[]
+  grant_types: string[]
+  response_types: string[]
+  token_endpoint_auth_method: string
+  application_type: MCPOAuthApplicationType
+  scope?: string
 }
 
 export function isRequest(msg: ACPMessage): msg is ACPRequest {

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -271,6 +271,16 @@
       "notifications/initialized",
       "notifications/message"
     ],
+    "oauthApplicationTypes": [
+      "native",
+      "web"
+    ],
+    "oauthClientRegistrationModes": [
+      "pre_registered",
+      "client_id_metadata_document",
+      "dynamic_client_registration",
+      "manual"
+    ],
     "protocolVersion": "2025-11-25",
     "protocolVersions": [
       "DRAFT-2026-v1",


### PR DESCRIPTION
## Summary
- add shared MCP OAuth/OIDC helpers for protected-resource discovery, WWW-Authenticate parsing, authorization-server/OIDC metadata fallback, issuer binding, scope selection, and client registration mode decisions
- apply the helpers across `harn mcp`, `harn connect`, MCP resource-server challenges, and generated TypeScript/Swift protocol shapes
- bind stored HTTP MCP credentials to issuer, validate authorization-response `iss`, harden refresh paths, and clarify that MCP OAuth guidance is HTTP-only while stdio uses launch-time credentials

Fixes #2186

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-2186 cargo check -p harn-vm -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-2186 cargo test -p harn-vm mcp_auth --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2186 cargo test -p harn-cli commands::mcp::tests --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2186 make check-protocol-artifacts`
- `CARGO_TARGET_DIR=/tmp/harn-target-2186 make check-bindings`
- `CARGO_TARGET_DIR=/tmp/harn-target-2186 make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-2186 make test`