### PR TITLE
Fix Anthropic provider HTTP-400 cascades exposed by step-judge audit

### DIFF
--- a/crates/harn-cli/assets/evals/coding_agent_suite.harn
+++ b/crates/harn-cli/assets/evals/coding_agent_suite.harn
@@ -769,7 +769,7 @@ fn __run_fixture_agent(
     max_iterations: max_iterations,
     iteration_budget: {mode: "fixed", initial: max_iterations, max: max_iterations, extend_by: 0},
     turn_policy: {allow_done_sentinel: tool_format == "text", max_prose_chars: 30000},
-    llm_options: {temperature: 0, max_tokens: 1024},
+    llm_options: {temperature: 0, max_tokens: 2048},
   }
   if step_judge_config != nil {
     options = options + {step_judge: step_judge_config}

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -241,7 +241,15 @@ impl AnthropicProvider {
         // Claude Opus 4.7+ rejects non-default sampling parameters with
         // HTTP 400. We strip them transparently and warn once per model
         // so pipeline authors don't have to special-case each release.
-        let strip_sampling = model_rejects_sampling_params(&opts.model);
+        //
+        // Anthropic also rejects `temperature != 1` when thinking is
+        // active (adaptive, effort, or enabled): "temperature may only
+        // be set to 1 when thinking is enabled". Strip sampling params
+        // in that case too so callers can default to temperature=0 for
+        // determinism without having to know which models silently
+        // auto-enable thinking.
+        let thinking_active = !matches!(opts.thinking, ThinkingConfig::Disabled);
+        let strip_sampling = model_rejects_sampling_params(&opts.model) || thinking_active;
         let any_sampling_supplied =
             opts.temperature.is_some() || opts.top_p.is_some() || opts.top_k.is_some();
         if strip_sampling && any_sampling_supplied {
@@ -263,7 +271,11 @@ impl AnthropicProvider {
         }
         if let Some(ref tools) = opts.native_tools {
             if !tools.is_empty() {
-                body["tools"] = serde_json::json!(tools);
+                let sanitized: Vec<serde_json::Value> = tools
+                    .iter()
+                    .map(sanitize_anthropic_tool_for_request)
+                    .collect();
+                body["tools"] = serde_json::json!(sanitized);
             }
         }
         if let Some(ref tc) = opts.tool_choice {
@@ -327,6 +339,22 @@ impl AnthropicProvider {
         )
         .await
     }
+}
+
+/// Strip Harn-internal extensions that Anthropic's strict request validator
+/// rejects with HTTP 400 (`Extra inputs are not permitted`). Mirrors the
+/// equivalent helper in `openai_compat.rs`. Anthropic's native-tools shape
+/// keeps tool fields at the root (no `function` wrapper), so we strip
+/// only at that level.
+fn sanitize_anthropic_tool_for_request(tool: &serde_json::Value) -> serde_json::Value {
+    let mut tool = tool.clone();
+    if let Some(object) = tool.as_object_mut() {
+        object.remove("x-harn-output-schema");
+        object.remove("defer_loading");
+        object.remove("namespace");
+        object.remove("namespaces");
+    }
+    tool
 }
 
 fn force_json_via_tool_use(body: &mut serde_json::Value, schema: &serde_json::Value) {
@@ -459,6 +487,51 @@ mod tests {
         let provider = AnthropicProvider;
         assert!(provider.supports_defer_loading("claude-opus-4-7"));
         assert!(!provider.supports_defer_loading("claude-opus-3-5"));
+    }
+
+    #[test]
+    fn temperature_stripped_when_thinking_active() {
+        // Anthropic rejects HTTP 400 if `temperature != 1` when thinking is
+        // active. Strip the temperature transparently so callers can default
+        // to temperature=0 for determinism without having to know which
+        // models silently auto-enable thinking.
+        let mut payload = base_payload();
+        payload.temperature = Some(0.0);
+        payload.thinking = ThinkingConfig::Adaptive;
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert!(
+            body.get("temperature").is_none(),
+            "temperature must be stripped when thinking is active to avoid HTTP 400"
+        );
+        // Sanity: temperature is preserved when thinking is disabled.
+        let mut payload2 = base_payload();
+        payload2.temperature = Some(0.0);
+        payload2.thinking = ThinkingConfig::Disabled;
+        let body2 = AnthropicProvider::build_request_body(&payload2);
+        assert_eq!(body2["temperature"], serde_json::json!(0.0));
+    }
+
+    #[test]
+    fn native_tools_strip_harn_internal_extensions() {
+        let mut payload = base_payload();
+        payload.native_tools = Some(vec![serde_json::json!({
+            "name": "read_file",
+            "description": "Read a file",
+            "input_schema": {"type": "object"},
+            "x-harn-output-schema": {"type": "object"},
+            "defer_loading": true,
+            "namespace": "fs",
+        })]);
+        let body = AnthropicProvider::build_request_body(&payload);
+        let sent = body["tools"][0].as_object().expect("tool object");
+        assert!(
+            !sent.contains_key("x-harn-output-schema"),
+            "Anthropic rejects unknown tool fields with HTTP 400; the x-harn-output-schema \
+             extension must be stripped before sending"
+        );
+        assert!(!sent.contains_key("defer_loading"));
+        assert!(!sent.contains_key("namespace"));
+        assert!(sent.contains_key("input_schema"));
     }
 
     #[test]

--- a/experiments/step-judge/REPORT.md
+++ b/experiments/step-judge/REPORT.md
@@ -1,203 +1,77 @@
 # Step-Judge Experiment — Report (2026-05-23)
 
-**Decision: GO.** Ship `step_judge` as an opt-in recommended preset using the
-asymmetric pairing (cheap generator + strong judge). Default `on_veto: "replace"`
-and default neutral rubric, both empirically validated against alternatives.
+**Decision: GO** as opt-in. Ship `step_judge` with `on_veto: "replace"` and
+the neutral rubric as defaults (both empirically validated). Document the
+asymmetric pairing (cheap generator + strong judge) as the recommended
+preset; do not recommend symmetric pairings.
 
-## Headline numbers
+## Headline
 
 | Cell | Pass rate | Cost (USD) | Lift vs baseline |
 |---|---:|---:|---:|
-| `baseline-cheap` (Haiku 4.5, no judge) | 3/6 = **50%** | $0.31 | — |
-| `symmetric-cheap` (Haiku 4.5 gen + Haiku 4.5 judge) | 3/6 = **50%** | $0.29 | **0pp** |
-| `asymmetric` (Haiku 4.5 gen + Sonnet 4.6 judge) | 5/6 = **83%** | **$0.14** | **+33pp** |
-| `symmetric-strong` (Sonnet 4.6 gen + Sonnet 4.6 judge) | 5/6 = **83%** | $0.33 | +33pp |
+| `baseline-cheap` (Haiku 4.5 alone) | 50% | $0.31 | — |
+| `symmetric-cheap` (Haiku + Haiku judge) | 50% | $0.29 | 0pp |
+| `asymmetric` (Haiku + Sonnet judge) | **83%** | **$0.14** | **+33pp** |
+| `symmetric-strong` (Sonnet + Sonnet) | 83% | $0.33 | +33pp |
 
-All cells via OpenRouter, text tool format (OpenRouter Anthropic doesn't have
-native tools catalogued in Harn — see follow-up), 6 fixtures from the existing
-`harn eval coding-agent` suite, 1 replicate.
+Directional probes vs `asymmetric` default: `adversarial rubric` −33pp,
+`retain on_veto` −33pp. Both shipped defaults validated.
+
+6 fixtures × 1 replicate per cell, OpenRouter, `--tool-format text`,
+total spend $1.45.
 
 ## Per-fixture truth table
 
-Headline pass rate hides where the cells actually diverge. Truth table
-(✓ = passed, ✗ = failed) reconstructed from each cell's `summary.json`:
+(✓ = passed, ✗ = failed)
 
-| Fixture | baseline-cheap | symmetric-cheap | asymmetric | symmetric-strong | probe-adversarial | probe-retain |
+| Fixture | baseline | sym-cheap | asym | sym-strong | adv | retain |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
-| `python-add` | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ |
-| `cli-help-flag` | ✓ | ✓ | **✗** | ✓ | ✓ | ✗ |
-| `test-output-first` | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
-| `docs-symbol-rename` | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ |
-| `read-only-audit` | ✓ | ✓ | ✓ | **✗** | ✗ | ✗ |
-| `no-tool-diagnosis` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| python-add | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ |
+| cli-help-flag | ✓ | ✓ | **✗** | ✓ | ✓ | ✗ |
+| test-output-first | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ |
+| docs-symbol-rename | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ |
+| read-only-audit | ✓ | ✓ | ✓ | **✗** | ✗ | ✗ |
+| no-tool-diagnosis | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
-Key observations the truth table forces (which the headline numbers hide):
+The truth table is what justifies the GO. The `asymmetric` cell is a
++50pp recovery on 3 multi-tool fixtures (`python-add`,
+`test-output-first`, `docs-symbol-rename`), netted against one regression
+on `cli-help-flag` where the judge's veto-and-regen cycle consumed the
+iteration budget. `symmetric-strong` shows a different regression
+(`read-only-audit`) where the strong judge drives over-engineering on a
+trivial fixture.
 
-- **`asymmetric` regressed `cli-help-flag`** — a fixture that the baseline
-  Haiku alone solved. The judge intervention cut the run short
-  (5 iterations vs baseline's 6, 8 tool calls vs baseline's 23). So the
-  "+33pp" win is actually a +50pp recovery on 3 multi-tool fixtures (python-add,
-  test-output-first, docs-symbol-rename) netted against a regression on 1.
-  **Regression rate matters and was not in the pre-registered metrics.**
-- **`symmetric-strong` regressed `read-only-audit`** — the trivial
-  "read one file, say no edits" task. Sonnet+Sonnet emitted 8 tool calls and
-  only 30 output tokens before timing out. Strong-model overthinking + strong
-  judge demanding more rigor is its own pathology, separate from the
-  cheap-judge-cheap pathology.
-- **Both probes regressed `read-only-audit` too**, plus `python-add` and
-  `test-output-first`. The adversarial rubric drove false-positive vetoes;
-  the retain shape polluted context with bad turns. Both effects compound on
-  trivial tasks where the right move is "do nothing more."
-- **`no-tool-diagnosis` passes in every cell**, including baseline. Pure prose
-  responses never trigger the judge's failure modes — confirms the judge
-  primitive is benign-safe for non-tool workflows.
+## Mechanism
 
-## Directional probes (asymmetric base)
+Three distinct effects compose the +33pp lift:
 
-| Probe | Pass rate | Cost | Lift vs asymmetric default |
-|---|---:|---:|---:|
-| `asymmetric` (default — neutral rubric, pop-and-regen) | 5/6 = 83% | $0.14 | (reference) |
-| `probe-rubric-adversarial` (adversarial rubric, pop-and-regen) | 3/6 = **50%** | $0.19 | **−33pp** |
-| `probe-transcript-shape-retain` (neutral rubric, retain) | 3/6 = **50%** | $0.19 | **−33pp** |
-
-Both probes hurt. Adversarial rubric drove false-positive vetoes that pushed
-the agent off task; retain mode polluted the context with bad turns + critiques
-and reduced regeneration quality. The defaults shipped in `step_judge.harn` are
-the empirically right defaults.
-
-## Mechanism analysis — what the transcripts actually show
-
-The headline "asymmetric judge lifts pass rate" wraps three distinct sub-effects
-that the per-run telemetry exposes:
-
-### Effect 1 — recovery from Haiku text-format tool-call collapse
-
-This is the **dominant** effect and was not anticipated in the pre-registered
-design. Across baseline-cheap and symmetric-cheap, the 3 failing fixtures
-(`python-add`, `test-output-first`, `docs-symbol-rename`) all show an identical
-telemetry signature:
-
-| Cell | Fixture | iters | tool_calls | rejected | input_tokens | output_tokens |
-|---|---|---:|---:|---:|---:|---:|
-| baseline-cheap | python-add | 3 | **0** | 0 | 8496 | **3072** |
-| baseline-cheap | test-output-first | 3 | **0** | 0 | 6404 | **3072** |
-| baseline-cheap | docs-symbol-rename | 2 | 16 | **7** | 4796 | 1741 |
-| symmetric-cheap | python-add | 3 | **0** | 0 | 8496 | **3072** |
-| symmetric-cheap | test-output-first | 3 | **0** | 0 | 6404 | **3072** |
-| symmetric-cheap | docs-symbol-rename | 2 | 16 | **7** | 4796 | 1741 |
-
-The `tool_calls = 0` + `output_tokens = 3072` (hitting the max-tokens cap)
-fingerprint is unmistakable: **Haiku 4.5 in text-format tool mode emits a flood
-of malformed/empty `<function_calls>` tags instead of structured calls,
-exhausts the output budget, and silently terminates the loop without
-dispatching any tool.** Symmetric-cheap inherits the same failure — Haiku-judge
-either passes the malformed response (sycophancy) or vetoes it but the
-regeneration hits the same pathology, since the same model has the same bug.
-
-Direct evidence from an earlier sanity run's transcript
-(`/private/tmp/step-judge-sanity`) where Sonnet judged Haiku:
-
-> Judge feedback (verdict: revise):
-> *"The response is entirely broken: it emits only a flood of empty
-> `<function_calls>` tags without any actual tool call content (no function
-> name, no arguments). Regenerate with a single, properly formed tool call …"*
-
-The Sonnet judge in asymmetric correctly diagnoses this structural failure
-and the pop-and-regen pushes Haiku into a working state. The
-`docs-symbol-rename` case is similar but a different sub-mode: 16 tool calls
-but 7 rejected (43%) — the model attempts tool calls but malforms them
-badly, terminating after 2 iterations.
-
-This finding is independent of step_judge and worth a standalone follow-up
-(filed below).
-
-### Effect 2 — strong judge causes strong-model regressions
-
-`symmetric-strong` solves all four multi-tool fixtures (per-fixture telemetry
-confirms Sonnet handles tool-format cleanly: 50–80 tool calls, ~12–15% rejected
-rate, no max-token cap hits). But it regressed `read-only-audit`: 8 tool calls,
-4 iterations, only 30 output tokens before failing. The likely chain — Sonnet
-generator does the trivial audit correctly in 1–2 calls; Sonnet judge
-demands more rigorous evidence; pop-and-regen drives the model into
-over-exploration until iteration cap. Cheap models pass this fixture because
-they don't over-engineer in the first place.
-
-### Effect 3 — judge can destructively short-circuit runs
-
-`cli-help-flag` is the cleanest case. Baseline-cheap solved it in 6
-iterations / 23 tool calls / 6 rejected. Asymmetric attempted it in 5
-iterations / 8 tool calls / 3 rejected and **failed**. The judge's
-veto-and-regen cycle cut the run short — each veto consumes 2 iterations
-(the popped turn + the regenerated turn), and with `max_iterations=8` the
-agent had no headroom. This is the **failure mode the GO recommendation
-needs to be honest about**: the +33pp net lift includes a regression
-that breaks one previously-passing fixture.
-
-Adversarial rubric (probe) makes this worse — `python-add` and
-`test-output-first` both regressed because the adversarial rubric drives more
-vetoes, eating more iteration budget.
+1. **Recovery from cheap-model tool-emission failure (dominant).** The
+   three baseline failures all show `tool_calls=0` and `output_tokens`
+   pinned at the max-tokens cap. The Sonnet judge catches these
+   structural failures and forces regeneration; the Haiku judge
+   (symmetric) often passes them sycophantically.
+2. **Cheap-judges-cheap is flat** (0pp lift) — matches Snorkel's
+   self-critique paradox prediction.
+3. **Judge can destructively short-circuit runs.** Each veto consumes
+   2 iterations (popped turn + regenerated turn). At
+   `max_iterations: 8`, judge-heavy runs can leave 2 iterations for
+   actual progress, which is what regressed `cli-help-flag`. Adversarial
+   rubric and `retain` make this worse.
 
 ## Cost mechanism (the surprise)
 
-Naïve expectation: judge calls are pure cost overhead. Observed: asymmetric
-costs *less* than baseline. Why this works:
+Asymmetric costs *less* than baseline (−56%) because:
 
-1. **Failed turns aren't free.** Baseline-cheap's 3 failed runs each burned
-   3072 output tokens of malformed text trying-and-failing to emit tool
-   calls. That's the bulk of the $0.31 baseline cost.
-2. **Judge calls are cheap.** From the sanity-run typed_checkpoint telemetry:
-   judge input averaged ~1400 tokens, output averaged ~44 tokens
-   (verdict + reasoning + critique JSON), wall-clock ~1.5–3s per call.
-   At Sonnet 4.6 prices that's ~$0.005/call. With ~5–10 judge calls per
-   fixture, judge overhead is ~$0.03–0.05/run.
-3. **Vetoes prevent wasted generations.** Each pop saves a future generator
-   call that would have been spent recovering from the bad turn or, worse,
-   was already trapped in the max-output-tokens death spiral.
-4. **Asymmetric ≠ a free win.** The cost saving is specific to the
-   bad-baseline case. If your generator already works, the judge is pure
-   overhead (`symmetric-strong` is +$0.02 vs baseline-cheap and would be
-   worse if Sonnet didn't recover the 3 failing fixtures).
+1. Failed baseline turns aren't free — they burn the full output cap
+   producing malformed text the model can't recover from.
+2. Judge calls are cheap (~$0.005 each: ~1400 input + ~44 output tokens
+   at Sonnet 4.6 pricing).
+3. Vetoes prevent the cascade. One judge call buys you ~2 wasted
+   generator turns.
 
-## Caveats
-
-- **n=6 fixtures × 1 replicate = 6 observations per cell.** A single fixture
-  flipping pass/fail moves a cell by 17pp. Headline lifts of +33pp could
-  shrink to +17pp or balloon to +50pp at this sample size. Replicates 2–3 +
-  6 more fixtures (~$5 of API spend) would tighten estimates.
-- **Text tool format only.** OpenRouter Anthropic models don't have native
-  tools catalogued in Harn. The text-format collapse pathology (Effect 1)
-  might disappear or shrink under native tools. Filed as follow-up.
-- **Prefix-cache utilization not measured.** `cache_read_tokens` came back 0
-  across all judge calls (verified in raw transcripts), suggesting OpenRouter's
-  Anthropic passthrough doesn't surface cache hit metadata. Could be additional
-  cost savings on the table — the judge would benefit from prefix cache because
-  every call to the same session shares a long stable prefix.
-- **Regression rate not in pre-registered metrics.** asymmetric broke
-  `cli-help-flag`; symmetric-strong broke `read-only-audit`. Future
-  experiments should track baseline-pass-cell-fail explicitly, not just
-  net lift. Filed as follow-up.
-- **Iteration-budget × judge interaction is structural.** Each veto consumes
-  2 iterations. Default `max_attempts: 3` × 2 iterations = up to 6 vetoes
-  per fixture could fit inside `max_iterations: 8` — leaving as little as
-  2 iterations for actual progress. Documented as a config tradeoff in
-  `step_judge.harn`.
-
-## Go / no-go applied
-
-Per the pre-registered criteria in `experiments/step-judge/README.md`:
-
-| Criterion | Threshold | Measured | Verdict |
-|---|---|---|---|
-| asymmetric pass-rate lift | ≥ 15pp at ≤ 3× baseline cost | **+33pp at 0.45× baseline cost** | **GO** |
-| symmetric-cheap pass-rate lift | ≥ 10pp at ≤ 2× baseline cost | 0pp at 0.91× baseline cost | NOT MET |
-
-**Decision: ship the primitive as an opt-in with the asymmetric preset as the
-documented recommendation.** Honest framing of the win: asymmetric recovers
-3 multi-tool fixtures that fail because of an underlying Haiku text-format
-tool-emission bug. Net of one regression (`cli-help-flag`), pass rate goes
-3→5 and cost drops from $0.31 to $0.14. The primitive is a force-multiplier
-for cheap models on tool-heavy tasks; it is *not* a free quality booster
-for already-working setups.
+This is specific to the bad-baseline case. If the generator already
+works, the judge is pure overhead (`symmetric-strong` is +$0.02 vs
+baseline because Sonnet doesn't need the help).
 
 ## Recommended shipping config
 
@@ -213,45 +87,69 @@ agent_loop(message, system, {
 })
 ```
 
-Do **not** recommend `symmetric` pairings (cheap-cheap is flat by data,
-strong-strong adds cost without gain when the generator already works).
+Do **not** recommend `symmetric` pairings (cheap-cheap is flat,
+strong-strong adds cost without gain).
+
+## Caveats
+
+- n=6 fixtures × 1 replicate per cell. One fixture flipping moves a
+  cell by 17pp. Headline lifts have wide CIs.
+- Text tool format only (OpenRouter Anthropic native tools not
+  catalogued; see follow-up #2319). Native-format numbers may differ.
+- `cache_read_tokens` was 0 across all calls — cache attribution
+  through OpenRouter is broken or genuinely not engaging (#2320).
+- Regression rate isn't in pre-registered metrics; the truth table
+  surfaces it but the runner should track it natively (#2318).
+
+## Go / no-go
+
+| Criterion | Threshold | Measured | Verdict |
+|---|---|---|---|
+| asymmetric pass-rate lift | ≥ 15pp at ≤ 3× baseline cost | +33pp at 0.45× | **GO** |
+| symmetric-cheap pass-rate lift | ≥ 10pp at ≤ 2× baseline cost | 0pp at 0.91× | not met |
 
 ## Follow-up issues
 
-To be filed against `harn` after this PR merges:
+- #2317 — Haiku 4.5 text-format tool-emission collapse (root cause of
+  3/6 baseline failures, independent of step_judge)
+- #2318 — Eval runner: track per-cell regression rate
+- #2319 — Provider catalog: openrouter:anthropic/claude-* native-tools
+- #2320 — Cache attribution via OpenRouter
+- burin-labs/burin-code#1155 — burin-code TUI adoption
 
-1. **Haiku 4.5 text-format tool-emission collapse** (NEW, root-cause). Three
-   of six fixtures fail baseline because Haiku in text-tool mode emits
-   malformed `<function_calls>` tags + hits the 3072 output cap. Reproducible
-   and independent of `step_judge`. Should be fixed in the text-tool prompt
-   layer or by raising `max_output_tokens` for text-format runs.
-2. **Eval runner: track per-cell regression rate** (NEW). Add a
-   `regressions_vs_baseline` field to `summary.json` (count of fixtures
-   that passed in `--baseline-comparison-against <run>` but failed in this
-   run). Current "lift" metric hides destructive judge interactions.
-3. **Extend provider catalog** with `openrouter:anthropic/claude-*`
-   native-tools entries so OpenRouter users don't have to fall back to text
-   format and trigger Effect 1.
-4. **Investigate prefix-cache attribution** through OpenRouter —
-   `cache_read_tokens` is silently 0 in both generator and judge telemetry.
-5. **Run main grid replicates 2 and 3** + add 6 burin-examples-targeted
-   fixtures (~$5 spend) to tighten the lift estimate.
-6. **Judge-architecture sweep** — swap the Sonnet judge for GPT-4.1-mini and
-   DeepSeek V3.2 to see if asymmetry is provider-agnostic.
-7. **`read-only-audit` fixture brittleness** — the only fixture where
-   strong-judge causes regression. Investigate whether the verifier is too
-   strict on output format, or whether the fixture description invites
-   over-engineering.
-8. **Document iteration-budget × max_attempts interaction** — at the current
-   defaults, judge vetoes can consume up to 6/8 iterations leaving no
-   headroom for actual progress. Either raise default `max_iterations` when
-   `step_judge` is enabled, or surface a warning in the runner.
+Remaining (no separate issue, handled in next experiment round):
 
-And the cross-repo burin-code re-platform issue (filed separately, see the
-harn PR description).
+- Replicates 2-3 + 6 more burin-examples-targeted fixtures (~$5)
+- Judge-architecture sweep (GPT-4.1-mini, DeepSeek V3.2)
+- `read-only-audit` fixture brittleness investigation
+- Iteration budget × `max_attempts` interaction documentation
+
+## v2 audit fixes (this PR)
+
+Three Anthropic-provider bugs surfaced while validating against
+`--tool-format native` (which sidesteps Effect 1 entirely). All three
+were silently HTTP-400-ing every native call to Anthropic and are
+independent of `step_judge`:
+
+1. **`x-harn-output-schema` extension stripped.** Anthropic's strict
+   validator rejected the Harn-internal tool field. Mirror the
+   `openai_compat.rs` sanitizer.
+2. **`temperature` stripped when thinking is active.** Anthropic
+   rejects `temperature != 1` when thinking is enabled; Haiku 4.5+
+   auto-enables adaptive thinking. Callers no longer have to set
+   `thinking: {mode: "disabled"}` defensively.
+3. **Eval suite `max_tokens` bumped 1024 → 2048.** Anthropic requires
+   `max_tokens > thinking.budget_tokens`; the previous cap conflicted
+   with Haiku 4.5's auto-applied budget.
+
+Both provider fixes ship with regression tests. The headline experiment
+numbers above don't change (original run used text format via
+OpenRouter, which doesn't hit any of these constraints), but the fixes
+unblock a future v2.1 experiment that re-runs the GO cell against
+direct Anthropic native tools to measure Effect 1's contribution.
 
 ## Raw data
 
-All `summary.json` files in `experiments/step-judge/results/main-grid-2026-05-23/`,
-one subdir per cell + probe. Full per-run JSONL + transcript_events are
-gitignored under the timestamped run dir.
+`summary.json` per cell in `results/main-grid-2026-05-23/`.
+Per-run JSONL + transcript_events are gitignored under the
+timestamped run dir.


### PR DESCRIPTION
## Summary

Three independent Anthropic-provider bugs surfaced when re-running step-judge fixtures against `--tool-format native` (instead of openrouter+text from #2291). All three silently HTTP-400'd every native Anthropic call and were independent of `step_judge` itself.

1. **`x-harn-output-schema` extension sanitization.** The native-tool builder attaches a Harn-internal `x-harn-output-schema` field on every tool. The OpenAI-compat adapter strips it; the Anthropic adapter passed it through and triggered `HTTP 400: tools.0.custom.x-harn-output-schema: Extra inputs are not permitted`. Mirror the `openai_compat.rs` sanitizer.
2. **`temperature` stripped when thinking is active.** Anthropic rejects `temperature != 1` when thinking is enabled. Claude Haiku 4.5+ silently auto-enables adaptive thinking, so any caller defaulting to `temperature: 0` for determinism hits this. Extend the existing `strip_sampling` gate to also fire when thinking is active. Callers no longer need to set `thinking: {mode: "disabled"}` defensively.
3. **Eval suite `max_tokens` bumped 1024 → 2048.** Anthropic requires `max_tokens > thinking.budget_tokens` (default 10000). The previous cap conflicted with Haiku's auto-applied budget. Minimum workaround; a more general auto-rewrite is filed as a follow-up.

Both provider fixes ship with regression tests.

## REPORT.md condensed

Trimmed `experiments/step-judge/REPORT.md` from 257 → 155 lines (~40% reduction). The condensed version leads with **decision + headline numbers + per-fixture truth table + recommended config**. Discovery timeline, mechanism narration, and post-merge findings collapsed to one short "v2 audit fixes" section. The substantive content (decision, truth table, recommended config, follow-ups) is unchanged.

## Why the experiment numbers don't change

The original run used `--tool-format text` via OpenRouter, which doesn't hit any of these three constraints. These fixes unblock a future v2.1 experiment that re-runs the GO cell against direct Anthropic native tools to measure Effect 1's contribution to the +33pp lift.

## Test plan

- [x] `cargo test -p harn-vm --lib providers::anthropic` — 17 passed (2 new regression tests added)
- [x] Live API sanity: `anthropic:claude-haiku-4-5-20251001` with `--tool-format native` now reaches the agent loop and dispatches tools end-to-end (previously HTTP 400 on first call)
- [x] Markdown lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)