### PR TITLE
Add CLI dispatch wedge for embedded .harn scripts (#2294)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,6 +2152,7 @@ dependencies = [
  "harn-parser",
  "harn-serve",
  "harn-skills",
+ "harn-stdlib",
  "harn-vm",
  "hmac 0.13.0",
  "include_dir",

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -43,6 +43,7 @@ harn-modules = { path = "../harn-modules", version = "0.8" }
 harn-fmt = { path = "../harn-fmt", version = "0.8" }
 harn-serve = { path = "../harn-serve", version = "0.8" }
 harn-skills = { path = "../harn-skills", version = "0.8" }
+harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }

--- a/crates/harn-cli/src/dispatch.rs
+++ b/crates/harn-cli/src/dispatch.rs
@@ -1,0 +1,184 @@
+//! Subcommand dispatch wedge: routes named subcommands to embedded
+//! `.harn` scripts so CLI surfaces can be implemented in Harn itself
+//! instead of Rust.
+//!
+//! Motivation lives in harn#2293 (epic) and harn#2294 (G1). Scripts are
+//! defined in `crates/harn-stdlib/src/stdlib/cli/<name>.harn` and
+//! registered in [`harn_stdlib::STDLIB_CLI_SCRIPTS`]. Each dispatched
+//! script receives:
+//!
+//!   * `argv: list<string>` — the per-subcommand argv after top-level
+//!     clap parsing. Same global `harn run -- a b c` exposes.
+//!   * `HARN_OUTPUT_JSON=1` (env var) when the caller asked for JSON
+//!     output. Scripts read it via `harness.env.get_or("HARN_OUTPUT_JSON", "0")`
+//!     and switch between human-readable and JSON-envelope rendering
+//!     without re-parsing `--json` themselves.
+//!
+//! Stdout / stderr / exit code propagate through the existing
+//! `execute_run` codepath so the wedge inherits bytecode cache, source
+//! dir handling, harness install, skill loader, and store/metadata/
+//! checkpoint builtins for free.
+//!
+//! A future ticket may replace the temp-file path with an in-memory
+//! entry point if cold-start budgets demand it (harn#2300 / G7 AOT
+//! bytecode embedding is the planned next step).
+//!
+//! ## Example shim
+//!
+//! ```ignore
+//! pub async fn run(args: ExplainArgs) -> i32 {
+//!     let mut argv = Vec::new();
+//!     if let Some(target) = args.target { argv.push(target); }
+//!     if args.catalog { argv.push("--catalog".into()); }
+//!     // ... fold the rest of the parsed flags into argv ...
+//!     crate::dispatch::dispatch_to_embedded_script("explain", argv, args.json).await
+//! }
+//! ```
+
+use std::collections::HashSet;
+use std::io::Write;
+
+use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
+use crate::env_guard::ScopedEnvVar;
+
+/// Env var ports read to decide whether to emit a JSON envelope vs.
+/// human-readable output. Set to `"1"` for the script's lifetime when
+/// the host (clap) saw `--json`; left untouched otherwise so a
+/// user-provided value in the environment still wins.
+pub const JSON_MODE_ENV: &str = "HARN_OUTPUT_JSON";
+
+/// Exit code returned when the named script can't be found in
+/// [`harn_stdlib::STDLIB_CLI_SCRIPTS`]. Matches `EX_SOFTWARE` from
+/// `sysexits.h` — an "internal software error" the user can't fix
+/// without a new release.
+const EX_SOFTWARE: i32 = 70;
+
+/// Dispatch a CLI subcommand to its embedded `.harn` script and forward
+/// stdout/stderr to the real terminal. Returns the exit code the caller
+/// should hand to `process::exit`. Output is written to stderr first,
+/// then stdout, before this returns — matching what `harn run` does.
+pub async fn dispatch_to_embedded_script(
+    script_name: &str,
+    argv: Vec<String>,
+    json_mode: bool,
+) -> i32 {
+    let outcome = run_embedded_script(script_name, argv, json_mode).await;
+    flush_outcome(&outcome);
+    outcome.exit_code
+}
+
+/// Capture-mode variant suitable for tests: returns the full
+/// [`RunOutcome`] instead of writing to real stdio. Production code
+/// should prefer [`dispatch_to_embedded_script`] which flushes for you.
+pub async fn run_embedded_script(
+    script_name: &str,
+    argv: Vec<String>,
+    json_mode: bool,
+) -> RunOutcome {
+    let Some(source) = harn_stdlib::find_cli_script(script_name) else {
+        return RunOutcome {
+            stdout: String::new(),
+            stderr: format!(
+                "internal error: CLI dispatch target '{script_name}' is not embedded.\n\
+                 This is a harn-cli build bug — please file an issue at \
+                 https://github.com/burin-labs/harn/issues.\n"
+            ),
+            exit_code: EX_SOFTWARE,
+        };
+    };
+
+    let temp = match write_script_to_tempfile(script_name, source) {
+        Ok(t) => t,
+        Err(error) => {
+            return RunOutcome {
+                stdout: String::new(),
+                stderr: format!(
+                    "internal error: failed to materialize embedded CLI script \
+                     '{script_name}': {error}\n"
+                ),
+                exit_code: EX_SOFTWARE,
+            };
+        }
+    };
+    let path_str = temp.path().to_string_lossy().into_owned();
+
+    // Set HARN_OUTPUT_JSON only when the host explicitly asked for JSON
+    // mode. If json_mode=false we leave the env alone — a user shell
+    // export still wins, matching the NO_COLOR convention. ScopedEnvVar
+    // restores the prior value on drop so tests stay isolated.
+    let _scope = json_mode.then(|| ScopedEnvVar::set(JSON_MODE_ENV, "1"));
+
+    let outcome = execute_run(
+        &path_str,
+        false,
+        HashSet::new(),
+        argv,
+        Vec::new(),
+        CliLlmMockMode::Off,
+        None,
+        RunProfileOptions::default(),
+    )
+    .await;
+
+    drop(temp);
+    outcome
+}
+
+fn flush_outcome(outcome: &RunOutcome) {
+    if !outcome.stderr.is_empty() {
+        let _ = std::io::stderr().write_all(outcome.stderr.as_bytes());
+    }
+    if !outcome.stdout.is_empty() {
+        let _ = std::io::stdout().write_all(outcome.stdout.as_bytes());
+    }
+}
+
+fn write_script_to_tempfile(name: &str, source: &str) -> std::io::Result<tempfile::NamedTempFile> {
+    // Nested script names like `eval/prompt` collapse to `eval-prompt`
+    // so the temp file stays a single path segment without falling out
+    // of the OS temp dir.
+    let safe_name = name.replace('/', "-");
+    let mut file = tempfile::Builder::new()
+        .prefix(&format!("harn-cli-{safe_name}-"))
+        .suffix(".harn")
+        .tempfile()?;
+    file.write_all(source.as_bytes())?;
+    file.flush()?;
+    Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_script_returns_software_error() {
+        let outcome = run_embedded_script("definitely/not/a/real/script", vec![], false).await;
+        assert_eq!(outcome.exit_code, EX_SOFTWARE);
+        assert!(
+            outcome.stderr.contains("not embedded"),
+            "stderr should explain the dispatch miss; got: {}",
+            outcome.stderr
+        );
+        assert!(outcome.stdout.is_empty());
+    }
+
+    #[tokio::test]
+    async fn echo_round_trips_argv_as_json_array() {
+        let outcome = run_embedded_script("echo", vec!["foo".into(), "bar".into()], false).await;
+        assert_eq!(
+            outcome.exit_code, 0,
+            "echo failed: stderr={}",
+            outcome.stderr
+        );
+        assert_eq!(outcome.stdout, "[\"foo\",\"bar\"]\n");
+        assert!(outcome.stderr.is_empty(), "stderr was: {}", outcome.stderr);
+    }
+
+    #[tokio::test]
+    async fn echo_handles_empty_argv() {
+        let outcome = run_embedded_script("echo", vec![], false).await;
+        assert_eq!(outcome.exit_code, 0, "stderr={}", outcome.stderr);
+        assert_eq!(outcome.stdout, "[]\n");
+    }
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -4,6 +4,8 @@ pub mod acp;
 pub mod cli;
 pub mod commands;
 pub mod config;
+#[doc(hidden)]
+pub mod dispatch;
 pub mod env_guard;
 pub mod format;
 pub mod json_envelope;

--- a/crates/harn-cli/tests/dispatch_echo.rs
+++ b/crates/harn-cli/tests/dispatch_echo.rs
@@ -1,0 +1,32 @@
+#![recursion_limit = "256"]
+
+//! Integration tests for the CLI dispatch wedge (harn#2294 / G1).
+//!
+//! Exercises the public entry point [`harn_cli::dispatch::run_embedded_script`]
+//! to prove that argv → embedded `.harn` script → stdout round-trips
+//! through the same `execute_run` pipeline that production CLI commands
+//! use. Each test runs in a fresh tokio runtime via `#[tokio::test]`.
+
+use harn_cli::dispatch::run_embedded_script;
+
+#[tokio::test]
+async fn echo_dispatch_forwards_two_args_as_json_array() {
+    let outcome = run_embedded_script("echo", vec!["foo".into(), "bar".into()], false).await;
+    assert_eq!(
+        outcome.exit_code, 0,
+        "echo failed: stderr={}",
+        outcome.stderr
+    );
+    assert_eq!(outcome.stdout, "[\"foo\",\"bar\"]\n");
+}
+
+#[tokio::test]
+async fn dispatch_to_unknown_script_returns_software_error() {
+    let outcome = run_embedded_script("this/script/does/not/exist", vec![], false).await;
+    assert_eq!(outcome.exit_code, 70, "expected EX_SOFTWARE on miss");
+    assert!(
+        outcome.stderr.contains("not embedded"),
+        "stderr should explain the dispatch miss; got: {}",
+        outcome.stderr
+    );
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -782,10 +782,38 @@ pub const STDLIB_PROMPT_ASSETS: &[StdlibPromptAsset] = &[
     },
 ];
 
+/// Embedded `.harn` script that backs a CLI subcommand. Looked up by
+/// the `harn-cli` dispatch wedge (see harn#2293 epic and harn#2294 G1)
+/// so subcommands can ship in Harn instead of Rust.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StdlibCliScript {
+    /// Lookup name. For nested scripts this is the path under
+    /// `stdlib/cli/` without the `.harn` extension (e.g. `"eval/prompt"`
+    /// for `stdlib/cli/eval/prompt.harn`).
+    pub name: &'static str,
+    /// Embedded source. Run via the existing `harn run` codepath by the
+    /// dispatch wedge.
+    pub source: &'static str,
+}
+
+pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[StdlibCliScript {
+    name: "echo",
+    source: include_str!("stdlib/cli/echo.harn"),
+}];
+
 pub fn get_stdlib_source(module: &str) -> Option<&'static str> {
     STDLIB_SOURCES
         .iter()
         .find_map(|entry| (entry.module == module).then_some(entry.source))
+}
+
+/// Find an embedded CLI subcommand script by name. Returns the embedded
+/// source string when present, or `None` if no script with that name is
+/// registered in [`STDLIB_CLI_SCRIPTS`].
+pub fn find_cli_script(name: &str) -> Option<&'static str> {
+    STDLIB_CLI_SCRIPTS
+        .iter()
+        .find_map(|entry| (entry.name == name).then_some(entry.source))
 }
 
 pub fn get_stdlib_prompt_asset(path: &str) -> Option<&'static str> {
@@ -996,8 +1024,8 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::{
-        entrypoint_modules, get_stdlib_prompt_asset, get_stdlib_source,
-        public_functions_for_module, STDLIB_PROMPT_ASSETS, STDLIB_SOURCES,
+        entrypoint_modules, find_cli_script, get_stdlib_prompt_asset, get_stdlib_source,
+        public_functions_for_module, STDLIB_CLI_SCRIPTS, STDLIB_PROMPT_ASSETS, STDLIB_SOURCES,
     };
 
     #[test]
@@ -1009,6 +1037,31 @@ mod tests {
                 entry.module
             );
         }
+    }
+
+    #[test]
+    fn cli_scripts_are_non_empty_and_uniquely_named() {
+        let mut seen = BTreeSet::new();
+        for entry in STDLIB_CLI_SCRIPTS {
+            assert!(
+                !entry.source.trim().is_empty(),
+                "cli/{} should have non-empty source",
+                entry.name
+            );
+            assert!(
+                seen.insert(entry.name),
+                "cli/{} is registered more than once in STDLIB_CLI_SCRIPTS",
+                entry.name
+            );
+        }
+    }
+
+    #[test]
+    fn find_cli_script_round_trips() {
+        for entry in STDLIB_CLI_SCRIPTS {
+            assert_eq!(find_cli_script(entry.name), Some(entry.source));
+        }
+        assert!(find_cli_script("not-a-real-script").is_none());
     }
 
     #[test]

--- a/crates/harn-stdlib/src/stdlib/cli/echo.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/echo.harn
@@ -1,0 +1,9 @@
+/**
+ * Demo embedded CLI script for the dispatch wedge (harn#2294).
+ * Prints `argv` as a JSON array so dispatch tests can assert end-to-end
+ * round-trip fidelity for argv → script → stdout. Real ported
+ * subcommands live in sibling files under `stdlib/cli/`.
+ */
+fn main(harness: Harness) {
+  harness.stdio.println(json_stringify(argv))
+}


### PR DESCRIPTION
## Summary

Closes #2294. Foundation for the epic #2293 self-host effort. Introduces a single dispatch entry point — `harn_cli::dispatch::dispatch_to_embedded_script` — that resolves a named script in `harn_stdlib::STDLIB_CLI_SCRIPTS`, runs it through the existing `execute_run` pipeline, and propagates stdout/stderr/exit-code unchanged.

Each dispatched script receives:
- `argv: list<string>` — per-subcommand argv after top-level clap parsing (the same global `harn run -- a b c` exposes).
- `HARN_OUTPUT_JSON=1` env var when the caller asked for JSON output, so scripts can branch human-vs-JSON without re-parsing `--json`. Env scope reuses the existing `env_guard::ScopedEnvVar` RAII guard, so concurrent tests stay isolated.

A demo `cli/echo.harn` round-trips argv as a JSON array, exercised by unit tests in `dispatch.rs` plus an integration test under `tests/dispatch_echo.rs`. Missing-script lookup returns `EX_SOFTWARE` (70).

No user-visible behavior change — no real subcommand uses the wedge yet. That's the job of the W1-W13 port waves in #2293.

## Files

- `crates/harn-stdlib/src/lib.rs` — adds \`StdlibCliScript\` struct, \`STDLIB_CLI_SCRIPTS\` const, \`find_cli_script\` lookup helper, two tests.
- \`crates/harn-stdlib/src/stdlib/cli/echo.harn\` — demo script (8 lines).
- \`crates/harn-cli/Cargo.toml\` — adds \`harn-stdlib\` dep.
- \`crates/harn-cli/src/lib.rs\` — registers the new \`dispatch\` module.
- \`crates/harn-cli/src/dispatch.rs\` — the wedge itself, ~150 lines incl. docs + tests.
- \`crates/harn-cli/tests/dispatch_echo.rs\` — integration test against the public entry.

## Test plan

- [x] \`cargo check -p harn-cli -p harn-stdlib --tests\` (pre-push hook).
- [x] \`cargo test -p harn-stdlib find_cli_script_round_trips\` — covers the lookup helper.
- [x] \`cargo test -p harn-stdlib cli_scripts_are_non_empty_and_uniquely_named\` — catalog invariants.
- [x] \`cargo test -p harn-cli --test dispatch_echo\` — argv round-trip + dispatch miss.
- [x] \`cargo test -p harn-cli dispatch\` — unit tests inside the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)