### PR TITLE
Port `harn try` to .harn (#2302)

### DIFF
--- a/crates/harn-cli/src/commands/try_cmd.rs
+++ b/crates/harn-cli/src/commands/try_cmd.rs
@@ -1,34 +1,56 @@
-//! `harn try "<prompt>"` — minimal agent_loop convenience wrapper.
+//! `harn try "<prompt>"` — dispatches to the embedded
+//! `cli/try.harn` script (see harn#2302 / W2). The shim is
+//! intentionally tiny because all the agent_loop wiring lives in
+//! the .harn impl now.
 //!
-//! Internally synthesizes a one-line Harn script and routes through the
-//! existing run pipeline. Uses the `llm_retries` agent_loop option
-//! directly because the synthesized script is meant to stay readable as
-//! a single line; users who want composable middleware should write a
-//! script with `with_retry(default_llm_caller(), {...})` from
-//! `std/llm/handlers` instead.
-
-use std::collections::HashSet;
-use std::fs;
+//! `HARN_CLI_IMPL=rust` is reserved for the parity-snapshot harness
+//! to keep both impls comparable until the harn impl is the default
+//! everywhere (see C1 ratchet, #2314).
 
 use harn_vm::llm_config;
 
 use crate::cli::TryArgs;
-use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
 
 pub(crate) async fn run(args: TryArgs) {
-    let mock_active = std::env::var("HARN_LLM_PROVIDER")
-        .map(|v| v == "mock")
-        .unwrap_or(false);
-    if !mock_active && llm_config::available_provider_names().is_empty() {
+    if !mock_provider_active() && llm_config::available_provider_names().is_empty() {
         eprintln!("{}", crate::commands::doctor::no_credentials_hint());
         std::process::exit(1);
     }
 
+    if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
+        run_via_legacy_synth(args).await;
+        return;
+    }
+
+    let _max = ScopedEnvVar::set("HARN_TRY_MAX_ITERS", &args.max_iterations.to_string());
+    let exit =
+        dispatch::dispatch_to_embedded_script("try", vec![args.prompt], /* json_mode */ false)
+            .await;
+    if exit != 0 {
+        std::process::exit(exit);
+    }
+}
+
+fn mock_provider_active() -> bool {
+    std::env::var("HARN_LLM_PROVIDER")
+        .map(|v| v == "mock")
+        .unwrap_or(false)
+}
+
+/// Legacy synth-into-tempfile-then-`execute_run` path, retained so the
+/// parity-snapshot harness can pin the new dispatch against it. The
+/// C1 ratchet (#2314) removes this once the .harn impl is the
+/// production default everywhere.
+async fn run_via_legacy_synth(args: TryArgs) {
+    use std::collections::HashSet;
+    use std::fs;
+
+    use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
+
     let escaped = escape_for_harn_string(&args.prompt);
     let max_iters = args.max_iterations;
-    // No `tools` option: the registered-tool contract requires schemas,
-    // not bare identifiers, and `harn try` is meant to be a zero-config
-    // smoke test. Users can drop into `harn run` for tool-augmented loops.
     let script = format!(
         "let result = agent_loop(\"{escaped}\", nil, {{\n    max_iterations: {max_iters},\n    llm_retries: 2\n}})\n__io_println(result.text)\n"
     );

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -802,6 +802,10 @@ pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
         source: include_str!("stdlib/cli/echo.harn"),
     },
     StdlibCliScript {
+        name: "try",
+        source: include_str!("stdlib/cli/try.harn"),
+    },
+    StdlibCliScript {
         name: "version",
         source: include_str!("stdlib/cli/version.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/try.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/try.harn
@@ -1,0 +1,26 @@
+/**
+ * `harn try "<prompt>"` ported to .harn — see harn#2302 (W2).
+ *
+ * Zero-config agent_loop convenience wrapper. The legacy Rust handler
+ * synthesized this exact script into a temp file and shelled out
+ * through `execute_run`; this port collapses that round-trip by
+ * embedding the script directly.
+ *
+ * Inputs (from the dispatch shim in crates/harn-cli/src/commands/try_cmd.rs):
+ *   argv[0]            — prompt text
+ *   HARN_TRY_MAX_ITERS — max agent_loop iterations (default 5)
+ */
+fn main(harness: Harness) {
+  if len(argv) < 1 {
+    harness.stdio.eprintln("try: prompt is required")
+    exit(2)
+  }
+  let prompt = argv[0]
+  let max_iters = to_int(harness.env.get_or("HARN_TRY_MAX_ITERS", "5")) ?? 5
+  // No `tools` option: the registered-tool contract requires schemas,
+  // not bare identifiers, and `harn try` is meant to be a zero-config
+  // smoke test. Users wanting tool-augmented loops should use `harn
+  // run` with a script that builds the options explicitly.
+  let result = agent_loop(prompt, nil, {max_iterations: max_iters, llm_retries: 2})
+  harness.stdio.println(result.text)
+}


### PR DESCRIPTION
## Summary

Closes #2302. Part of #2293 epic, W2 of the port waves.

Closes the loop the legacy `try_cmd.rs` started: it was already half-self-hosted by synthesizing a one-liner Harn script into a tempfile; W2 just embeds that one-liner properly.

Stacked on #2327 (G6 — parity harness) which contains W1 (#2328).

### Changes

- `crates/harn-stdlib/src/stdlib/cli/try.harn` — the `agent_loop` call itself. Reads the prompt from `argv[0]`, `max_iterations` from the `HARN_TRY_MAX_ITERS` env var.
- `crates/harn-stdlib/src/lib.rs` — registers `cli/try` in `STDLIB_CLI_SCRIPTS`.
- `crates/harn-cli/src/commands/try_cmd.rs` — dispatch shim that forwards to the embedded script and keeps the legacy synth path behind `HARN_CLI_IMPL=rust` for the parity harness.

### Why the no-provider preflight stays in Rust

`llm_config::available_provider_names()` runs before we even know whether to dispatch — moving that lookup into the script would mean booting the VM just to print a "no provider configured" hint. Keeping it as a Rust early-exit keeps the user-facing latency on misconfigurations low.

## Test plan

- [ ] CI: `harn try "say hi"` with `HARN_LLM_PROVIDER=mock` produces the same output as before
- [ ] `cargo test -p harn-cli --test version_dispatch` (W1) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)