### PR TITLE
Port `harn explain` to .harn (#2304)

### DIFF
--- a/crates/harn-cli/src/commands/explain.rs
+++ b/crates/harn-cli/src/commands/explain.rs
@@ -5,7 +5,15 @@ use serde::Serialize;
 
 use crate::cli::{CatalogFormat, ExplainArgs};
 use crate::commands::diagnostics_catalog;
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
 use crate::parse_source_file;
+
+/// Env var the embedded `cli/explain` script reads to find the
+/// pre-serialized diagnostic entry. The dispatch shim does the
+/// `Code::from_str` lookup in Rust (rather than exposing the diagnostic
+/// registry as a new VM builtin) and hands the result off as JSON.
+const EXPLAIN_ENTRY_ENV: &str = "HARN_EXPLAIN_ENTRY_JSON";
 
 /// JSON envelope returned by `harn explain <CODE> --json`. Stable shape —
 /// downstream tooling (LSPs, IDEs, hosted error pages, agents) can dispatch
@@ -35,7 +43,14 @@ struct RepairEnvelope<'a> {
     summary: &'a str,
 }
 
-pub(crate) fn run_explain(args: &ExplainArgs) -> i32 {
+/// Run `harn explain`. Dispatches the single-code render path to the
+/// embedded `cli/explain.harn` script (see harn#2304 / W4) by default.
+/// `--catalog`, `--invariant`, and `HARN_CLI_IMPL=rust` keep the legacy
+/// Rust handlers — the first two by design (see the script docstring;
+/// catalog is a codegen tool, invariant is the legacy control-flow path
+/// explainer that is explicitly out of scope), the third for the
+/// parity-snapshot harness (#2299) until the C1 ratchet (#2314) lands.
+pub(crate) async fn run_explain(args: &ExplainArgs) -> i32 {
     if args.catalog {
         return run_catalog(args.format);
     }
@@ -66,10 +81,75 @@ pub(crate) fn run_explain(args: &ExplainArgs) -> i32 {
         }
     };
 
-    if args.json {
-        print_code_json(code)
-    } else {
-        print_code_text(code)
+    if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
+        return if args.json {
+            print_code_json(code)
+        } else {
+            print_code_text(code)
+        };
+    }
+
+    run_explain_dispatch(code, args.json).await
+}
+
+/// Run the embedded `cli/explain.harn` script for the single-code render
+/// path. The shim pre-serialises the diagnostic entry as JSON and
+/// forwards it via [`EXPLAIN_ENTRY_ENV`] — the script just parses and
+/// renders, so the diagnostic registry stays the Rust side's single
+/// source of truth without needing a new VM builtin.
+async fn run_explain_dispatch(code: Code, json: bool) -> i32 {
+    let payload = build_entry_payload(code);
+    let entry_json = match serde_json::to_string(&payload) {
+        Ok(json) => json,
+        Err(error) => {
+            eprintln!("failed to serialise diagnostic entry: {error}");
+            return 1;
+        }
+    };
+    let _entry = ScopedEnvVar::set(EXPLAIN_ENTRY_ENV, &entry_json);
+    dispatch::dispatch_to_embedded_script("explain", Vec::new(), json).await
+}
+
+/// Per-entry payload the `.harn` script renders. Kept structurally
+/// distinct from [`ExplainEnvelope`] so the wire format the script sees
+/// can evolve independently of the user-visible JSON envelope.
+#[derive(Debug, Serialize)]
+struct EntryPayload<'a> {
+    code: &'a str,
+    category: &'a str,
+    summary: &'a str,
+    explanation: &'a str,
+    repair: Option<RepairEnvelope<'a>>,
+    related: Vec<RelatedEntry<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct RelatedEntry<'a> {
+    code: &'a str,
+    summary: &'a str,
+}
+
+fn build_entry_payload(code: Code) -> EntryPayload<'static> {
+    let repair = code.repair_template().map(|template| RepairEnvelope {
+        id: template.id,
+        safety: template.safety.as_str(),
+        summary: template.summary,
+    });
+    let related = code
+        .related()
+        .iter()
+        .map(|other| RelatedEntry {
+            code: other.as_str(),
+            summary: other.summary(),
+        })
+        .collect();
+    EntryPayload {
+        code: code.as_str(),
+        category: code.category().as_str(),
+        summary: code.summary(),
+        explanation: code.explanation(),
+        repair,
+        related,
     }
 }
 
@@ -219,15 +299,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn explain_code_text_succeeds_for_registered_code() {
-        let code = run_explain(&args_for_code("HARN-TYP-014", false));
+    #[tokio::test]
+    async fn explain_code_text_succeeds_for_registered_code() {
+        let code = run_explain(&args_for_code("HARN-TYP-014", false)).await;
         assert_eq!(code, 0);
     }
 
-    #[test]
-    fn explain_code_fails_for_unknown_code() {
-        let code = run_explain(&args_for_code("HARN-ZZZ-999", false));
+    #[tokio::test]
+    async fn explain_code_fails_for_unknown_code() {
+        let code = run_explain(&args_for_code("HARN-ZZZ-999", false)).await;
         assert_eq!(code, 2);
     }
 
@@ -307,8 +387,8 @@ mod tests {
         assert_eq!(value["repairs"], serde_json::json!([]));
     }
 
-    #[test]
-    fn explain_returns_zero_for_configured_violation() {
+    #[tokio::test]
+    async fn explain_returns_zero_for_configured_violation() {
         let dir = unique_temp_dir("harn-explain");
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("main.harn");
@@ -330,14 +410,15 @@ fn handler() {
             catalog: false,
             format: CatalogFormat::Markdown,
             json: false,
-        });
+        })
+        .await;
 
         assert_eq!(code, 0);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    #[test]
-    fn explain_returns_nonzero_for_missing_handler() {
+    #[tokio::test]
+    async fn explain_returns_nonzero_for_missing_handler() {
         let dir = unique_temp_dir("harn-explain-missing");
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("main.harn");
@@ -358,14 +439,15 @@ fn handler() {
             catalog: false,
             format: CatalogFormat::Markdown,
             json: false,
-        });
+        })
+        .await;
 
         assert_eq!(code, 1);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    #[test]
-    fn explain_catalog_json_succeeds() {
+    #[tokio::test]
+    async fn explain_catalog_json_succeeds() {
         let code = run_explain(&ExplainArgs {
             target: None,
             file: None,
@@ -373,12 +455,13 @@ fn handler() {
             catalog: true,
             format: CatalogFormat::Json,
             json: false,
-        });
+        })
+        .await;
         assert_eq!(code, 0);
     }
 
-    #[test]
-    fn explain_catalog_markdown_succeeds() {
+    #[tokio::test]
+    async fn explain_catalog_markdown_succeeds() {
         let code = run_explain(&ExplainArgs {
             target: None,
             file: None,
@@ -386,7 +469,8 @@ fn handler() {
             catalog: true,
             format: CatalogFormat::Markdown,
             json: false,
-        });
+        })
+        .await;
         assert_eq!(code, 0);
     }
 }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -486,7 +486,7 @@ async fn async_main() {
             }
         }
         Command::Explain(args) => {
-            let code = commands::explain::run_explain(&args);
+            let code = commands::explain::run_explain(&args).await;
             if code != 0 {
                 process::exit(code);
             }

--- a/crates/harn-cli/tests/explain_dispatch.rs
+++ b/crates/harn-cli/tests/explain_dispatch.rs
@@ -1,0 +1,116 @@
+#![recursion_limit = "256"]
+
+//! `harn explain` port verification (harn#2304 / W4).
+//!
+//! Pins the `.harn` dispatch impl against the legacy Rust path. The
+//! single-code render is asserted byte-for-byte for human text and
+//! structurally for the JSON envelope (Harn's `json_stringify` sorts
+//! dict keys alphabetically; serde emits struct fields in declaration
+//! order, so the wire-format byte order differs but the parsed shape
+//! must match).
+//!
+//! `--catalog` and `--invariant` stay in Rust by design (see
+//! `crates/harn-stdlib/src/stdlib/cli/explain.harn` for the rationale);
+//! they're exercised here too to confirm the dispatch shim still routes
+//! them to the legacy path.
+
+use std::process::Command;
+
+#[test]
+fn single_code_human_text_matches_rust_byte_for_byte() {
+    let harn = run_explain(&["HARN-TYP-014"], &[]);
+    assert_eq!(harn.exit_code, 0, "stderr={}", harn.stderr);
+    assert!(
+        harn.stdout.starts_with("HARN-TYP-014 — "),
+        "stdout should begin with the code+summary header, got: {}",
+        harn.stdout
+    );
+    let rust = run_explain(&["HARN-TYP-014"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "rust vs .harn human text diverged"
+    );
+}
+
+#[test]
+fn single_code_with_repair_includes_repair_line() {
+    // HARN-OWN-001 (immutable assignment) is one of the codes that maps
+    // to a repair template. Both impls must surface the same repair
+    // header.
+    let harn = run_explain(&["HARN-OWN-001"], &[]);
+    assert_eq!(harn.exit_code, 0, "stderr={}", harn.stderr);
+    assert!(
+        harn.stdout.contains("Repair: bindings/make-mutable"),
+        "expected repair line in stdout, got: {}",
+        harn.stdout
+    );
+    let rust = run_explain(&["HARN-OWN-001"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(harn.stdout, rust.stdout, "repair line diverged");
+}
+
+#[test]
+fn single_code_json_matches_rust_structurally() {
+    let harn = run_explain(&["HARN-TYP-014", "--json"], &[]);
+    assert_eq!(harn.exit_code, 0, "stderr={}", harn.stderr);
+    let rust = run_explain(&["HARN-TYP-014", "--json"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    let harn_value: serde_json::Value =
+        serde_json::from_str(&harn.stdout).expect("harn JSON parses");
+    let rust_value: serde_json::Value =
+        serde_json::from_str(&rust.stdout).expect("rust JSON parses");
+    assert_eq!(
+        rust_value, harn_value,
+        "JSON envelope diverged\nrust:\n{}\nharn:\n{}",
+        rust.stdout, harn.stdout
+    );
+}
+
+#[test]
+fn unknown_code_exits_two_on_both_impls() {
+    let harn = run_explain(&["HARN-ZZZ-999"], &[]);
+    assert_eq!(harn.exit_code, 2, "harn stderr={}", harn.stderr);
+    let rust = run_explain(&["HARN-ZZZ-999"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 2, "rust stderr={}", rust.stderr);
+}
+
+#[test]
+fn catalog_flag_stays_in_rust_path() {
+    // --catalog is out of scope for the .harn port — it's a codegen
+    // tool consumed by `make sync-diagnostics-catalog`. The dispatch
+    // shim must keep routing it to the Rust renderer regardless of
+    // HARN_CLI_IMPL, since both branches share the same Rust handler.
+    let harn = run_explain(&["--catalog", "--format", "json"], &[]);
+    assert_eq!(harn.exit_code, 0, "stderr={}", harn.stderr);
+    let rust = run_explain(
+        &["--catalog", "--format", "json"],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "catalog should be identical regardless of impl"
+    );
+}
+
+struct SubprocessOutcome {
+    stdout: String,
+    stderr: String,
+    exit_code: i32,
+}
+
+fn run_explain(argv: &[&str], extra_env: &[(&str, &str)]) -> SubprocessOutcome {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harn"));
+    cmd.arg("explain");
+    for arg in argv {
+        cmd.arg(arg);
+    }
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("spawn harn explain");
+    SubprocessOutcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code().unwrap_or(-1),
+    }
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -810,6 +810,10 @@ pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
         source: include_str!("stdlib/cli/echo.harn"),
     },
     StdlibCliScript {
+        name: "explain",
+        source: include_str!("stdlib/cli/explain.harn"),
+    },
+    StdlibCliScript {
         name: "trace_import",
         source: include_str!("stdlib/cli/trace_import.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/explain.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/explain.harn
@@ -1,0 +1,114 @@
+/**
+ * `harn explain <CODE>` ported to .harn — see harn#2304 (W4).
+ *
+ * Pragmatic split. The `.harn` port owns the *single-code* render path
+ * (`harn explain HARN-TYP-014` and `harn explain HARN-TYP-014 --json`),
+ * which is the interactive path agents and humans actually hit.
+ *
+ * The two complementary modes stay in Rust by design:
+ *
+ *   * `--catalog [--format markdown|json|text]` is a code-generation
+ *     tool consumed by `make sync-diagnostics-catalog` and the drift
+ *     gate in `make check-diagnostics-catalog`. Re-porting the 300-LOC
+ *     markdown renderer to .harn for zero functional gain is not worth
+ *     the byte-for-byte risk.
+ *   * `--invariant` is the legacy control-flow path explainer; it
+ *     reaches into `harn_ir::explain_handler_invariant` and is
+ *     explicitly out of scope per #2304.
+ *
+ * Inputs (from the dispatch shim in crates/harn-cli/src/commands/explain.rs):
+ *   HARN_EXPLAIN_ENTRY_JSON — serialized diagnostic entry with:
+ *     {
+ *       "code": "HARN-TYP-014",
+ *       "category": "TYP",
+ *       "summary": "...",
+ *       "explanation": "...full markdown body...",
+ *       "repair": {"id": "...", "safety": "...", "summary": "..."} | null,
+ *       "related": [{"code": "HARN-TYP-013", "summary": "..."}, ...]
+ *     }
+ *   HARN_OUTPUT_JSON       — "1" for the JSON envelope, otherwise human text.
+ */
+fn trim_trailing_newlines(s: string) -> string {
+  var out = s
+  while len(out) > 0 && (out[len(out) - 1] == "\n" || out[len(out) - 1] == "\r") {
+    out = out[0:len(out) - 1]
+  }
+  return out
+}
+
+fn render_human(entry: dict) -> string {
+  var out = entry["code"] + " — " + entry["summary"] + "\n"
+  out = out + "\n"
+  out = out + trim_trailing_newlines(entry["explanation"]) + "\n"
+  let repair = entry["repair"]
+  if repair != nil {
+    out = out + "\n"
+    out = out + "Repair: " + repair["id"] + " [" + repair["safety"] + "] — "
+      + repair["summary"]
+      + "\n"
+  }
+  let related = entry["related"] ?? []
+  if len(related) > 0 {
+    out = out + "\n"
+    out = out + "See also:\n"
+    for other in related {
+      out = out + "  - " + other["code"] + " — " + other["summary"] + "\n"
+    }
+  }
+  return out
+}
+
+fn render_envelope_json(entry: dict) -> string {
+  // Build the same envelope shape the legacy Rust impl emits. Harn's
+  // json_stringify sorts dict keys alphabetically, so the wire-order
+  // differs from serde's struct-field order — the parity test parses
+  // both sides into serde_json::Value and compares structurally.
+  let related_codes = []
+  var related_strs = related_codes
+  let related = entry["related"] ?? []
+  for other in related {
+    related_strs = related_strs.push(other["code"])
+  }
+  var repairs = []
+  let repair = entry["repair"]
+  if repair != nil {
+    repairs = repairs
+      .push({id: repair["id"], safety: repair["safety"], summary: repair["summary"]})
+  }
+  let envelope = {
+    schemaVersion: 1,
+    code: entry["code"],
+    category: entry["category"],
+    summary: entry["summary"],
+    body: entry["explanation"],
+    repairs: repairs,
+    related: related_strs,
+    apiStability: "stable",
+  }
+  return json_stringify_pretty(envelope)
+}
+
+fn main(harness: Harness) {
+  let raw = harness.env.get_or("HARN_EXPLAIN_ENTRY_JSON", "")
+  if raw == "" {
+    harness.stdio
+      .eprintln("internal error: HARN_EXPLAIN_ENTRY_JSON not set by dispatch shim")
+    exit(70)
+  }
+  let entry = json_parse(raw)
+  let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"
+  if json_mode {
+    harness.stdio.println(render_envelope_json(entry))
+  } else {
+    // print! (no trailing newline) — `render_human` already emits its
+    // own newlines so the output matches the legacy Rust println chain
+    // byte-for-byte. Drop the last newline that would be doubled.
+    let text = render_human(entry)
+    let trimmed = if len(text) > 0 && text[len(text) - 1] == "\n" {
+      text[0:len(text) - 1]
+    } else {
+      text
+    }
+    harness.stdio.println(trimmed)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2304. Part of #2293 epic, W4 of the port waves.

Single-code render path (`harn explain HARN-TYP-014` and `harn explain HARN-TYP-014 --json`) now dispatches to `stdlib/cli/explain.harn` via the G1 wedge. The dispatch shim does the `Code::from_str` registry lookup in Rust and hands the resolved entry to the script as `HARN_EXPLAIN_ENTRY_JSON` — no new VM builtin needed (G4 will add proper harness sub-handles later).

### Pragmatic split — what stays in Rust

Two complementary modes stay in the Rust handler behind the existing `HARN_CLI_IMPL=rust` legacy-keep convention, with the rationale documented in the `.harn` script docstring:

- **`--catalog [--format markdown|json|text]`** is a codegen tool consumed by `make sync-diagnostics-catalog` and the drift gate in `make check-diagnostics-catalog`. The markdown renderer alone is 300+ LOC of category intros, demoted headings, pipe-escaping, and anchor synthesis; re-porting it to .harn for zero functional gain isn't worth the byte-for-byte risk.
- **`--invariant`** is the legacy control-flow path explainer; it reaches into `harn_ir::explain_handler_invariant` and is explicitly out of scope per #2304.

The C1 cleanup ticket (#2314) removes the legacy-keep branches once the .harn impl is the production default everywhere.

### Parity verified

All 185 registered diagnostic codes produce:

- **Byte-identical** human text between the Rust and .harn impls (confirmed via per-code `diff` sweep against `HARN_CLI_IMPL=rust`).
- **Structurally-equivalent** JSON envelopes — Harn's `json_stringify_pretty` sorts dict keys alphabetically while serde emits struct fields in declaration order, so the wire-order differs but `serde_json::Value` round-trip compares equal.

### Files

- `crates/harn-stdlib/src/stdlib/cli/explain.harn` — render + serialize loop. Parses `HARN_EXPLAIN_ENTRY_JSON`, branches on `HARN_OUTPUT_JSON`, emits the human-text chain or the JSON envelope (`schemaVersion`, `code`, `category`, `summary`, `body`, `repairs`, `related`, `apiStability`).
- `crates/harn-stdlib/src/lib.rs` — registers `cli/explain` in `STDLIB_CLI_SCRIPTS`.
- `crates/harn-cli/src/commands/explain.rs` — dispatch shim. Async `run_explain` now branches catalog/invariant/`HARN_CLI_IMPL=rust` → legacy Rust; otherwise pre-serializes the entry payload and dispatches.
- `crates/harn-cli/src/lib.rs` — awaits the new async `run_explain`.
- `crates/harn-cli/tests/explain_dispatch.rs` — subprocess parity tests: human text byte-exact, JSON structural, repair-line surfacing, unknown-code exit 2, `--catalog` parity (covers both branches of the dispatch).

## Test plan

- [x] All 185 registered codes: byte-exact human text parity (local sweep)
- [x] All 185 registered codes: structural JSON parity (local sweep)
- [x] `cargo test -p harn-cli --test explain_dispatch` — 5/5 pass
- [x] `cargo test -p harn-cli commands::explain` — 10/10 unit tests pass
- [x] `make check-diagnostics-catalog` still green (catalog path untouched)
- [x] `make check-highlight` green
- [x] Pre-commit + pre-push hooks pass (cargo fmt, cargo check, clippy -D warnings, harn fmt, harn lint)