### PR TITLE
Port scaffolding cluster (init/new/tool new) to .harn (#2308)

### DIFF
--- a/crates/harn-cli/src/commands/init.rs
+++ b/crates/harn-cli/src/commands/init.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use crate::cli::{NewArgs, ProjectTemplate};
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
 use crate::package::current_harn_range_example;
 
 pub(crate) fn resolve_new_args(
@@ -25,7 +27,13 @@ pub(crate) fn resolve_new_args(
     }
 }
 
-pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
+/// `harn init` and `harn new` dispatch shim. Resolves the destination
+/// directory in Rust (matches the legacy behavior that errors if a
+/// non-`init` name already exists), then delegates the template render +
+/// file-write loop to `cli/scaffold/init.harn` (harn#2308 / W8 of the
+/// harn-cli self-host epic). The legacy Rust implementation stays
+/// behind `HARN_CLI_IMPL=rust` until the C1 ratchet (#2314) removes it.
+pub(crate) async fn init_project(name: Option<&str>, template: ProjectTemplate) {
     let dir = match name {
         Some(n) => {
             let dir = PathBuf::from(n);
@@ -37,18 +45,76 @@ pub(crate) fn init_project(name: Option<&str>, template: ProjectTemplate) {
                 eprintln!("Failed to create directory: {e}");
                 process::exit(1);
             });
-            println!("Creating project '{}'...", n);
             dir
         }
-        None => {
-            println!("Initializing harn project in current directory...");
-            PathBuf::from(".")
-        }
+        None => PathBuf::from("."),
     };
 
     let project_name = name
         .and_then(|value| Path::new(value).file_name().and_then(|name| name.to_str()))
-        .unwrap_or("my-project");
+        .unwrap_or("my-project")
+        .to_string();
+
+    if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
+        init_project_rust(name, &dir, &project_name, template);
+        return;
+    }
+
+    let exit = dispatch_to_script(name, &dir, &project_name, template).await;
+    if exit != 0 {
+        process::exit(exit);
+    }
+}
+
+async fn dispatch_to_script(
+    name: Option<&str>,
+    dir: &Path,
+    project_name: &str,
+    template: ProjectTemplate,
+) -> i32 {
+    let dir_str = dir.display().to_string();
+    let template_id = template_id(template);
+    let harn_range = current_harn_range_example();
+    let name_str = name.unwrap_or("");
+    let _name_env = ScopedEnvVar::set("HARN_INIT_NAME", name_str);
+    let _project_env = ScopedEnvVar::set("HARN_INIT_PROJECT_NAME", project_name);
+    let _dir_env = ScopedEnvVar::set("HARN_INIT_DIR", &dir_str);
+    let _template_env = ScopedEnvVar::set("HARN_INIT_TEMPLATE", template_id);
+    let _range_env = ScopedEnvVar::set("HARN_INIT_HARN_RANGE", &harn_range);
+    let _mode_env = ScopedEnvVar::set(
+        "HARN_INIT_MODE",
+        if name.is_some() { "new" } else { "init" },
+    );
+    dispatch::dispatch_to_embedded_script("scaffold/init", Vec::new(), /* json_mode */ false).await
+}
+
+fn template_id(template: ProjectTemplate) -> &'static str {
+    match template {
+        ProjectTemplate::Basic => "basic",
+        ProjectTemplate::Agent => "agent",
+        ProjectTemplate::Chat => "chat",
+        ProjectTemplate::McpServer => "mcp-server",
+        ProjectTemplate::Eval => "eval",
+        ProjectTemplate::PipelineLab => "pipeline-lab",
+        ProjectTemplate::Package => "package",
+        ProjectTemplate::Connector => "connector",
+    }
+}
+
+/// Legacy Rust implementation. Kept behind `HARN_CLI_IMPL=rust` for the
+/// parity harness (#2299). The C1 ratchet (#2314) removes this path
+/// once the `.harn` impl is the production default everywhere.
+fn init_project_rust(
+    name: Option<&str>,
+    dir: &Path,
+    project_name: &str,
+    template: ProjectTemplate,
+) {
+    if let Some(n) = name {
+        println!("Creating project '{}'...", n);
+    } else {
+        println!("Initializing harn project in current directory...");
+    }
     for (relative_path, content) in template_files(project_name, template) {
         write_if_new(&dir.join(relative_path), &content);
     }

--- a/crates/harn-cli/src/commands/tool.rs
+++ b/crates/harn-cli/src/commands/tool.rs
@@ -5,12 +5,20 @@ use crate::cli::ToolNewArgs;
 use crate::commands::scaffold_common::{
     harn_identifier_with_prefix, harn_string_literal, write_file,
 };
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
 use crate::package::{
     current_harn_range_example, generate_package_docs_impl, toml_string_literal,
     validate_package_alias, PackageError,
 };
 
-pub(crate) fn run_new(args: &ToolNewArgs) -> Result<(), PackageError> {
+/// `harn tool new` dispatch shim. Validates the requested package alias
+/// in Rust, resolves the destination directory, then delegates the
+/// template render + file-write loop to `cli/scaffold/tool_new.harn`
+/// (harn#2308 / W8 of the harn-cli self-host epic). The legacy Rust
+/// implementation stays behind `HARN_CLI_IMPL=rust` until the C1 ratchet
+/// (#2314) removes it.
+pub(crate) async fn run_new(args: &ToolNewArgs) -> Result<(), PackageError> {
     validate_package_alias(&args.name)?;
     let dest = args
         .dir
@@ -37,13 +45,18 @@ pub(crate) fn run_new(args: &ToolNewArgs) -> Result<(), PackageError> {
         .description
         .clone()
         .unwrap_or_else(|| format!("Custom Harn tool package for {}.", args.name));
+    if description.contains('\n') || description.contains('\r') {
+        return Err("tool description must be a single line".to_string().into());
+    }
     let ident = harn_identifier(&args.name)?;
     let handler = format!("handle_{ident}");
 
-    for (relative_path, content) in tool_template_files(&args.name, &ident, &handler, &description)?
-    {
-        write_file(&dest, relative_path, &content)?;
+    if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
+        run_new_rust(&args.name, &dest, &ident, &handler, &description)?;
+    } else {
+        dispatch_to_script(&args.name, &dest, &ident, &handler, &description).await?;
     }
+
     generate_package_docs_impl(Some(&dest), None, false)?;
 
     println!(
@@ -55,6 +68,49 @@ pub(crate) fn run_new(args: &ToolNewArgs) -> Result<(), PackageError> {
     println!("  harn package check");
     println!("  harn package docs --check");
     println!("  harn package pack --dry-run");
+    Ok(())
+}
+
+async fn dispatch_to_script(
+    name: &str,
+    dest: &std::path::Path,
+    ident: &str,
+    handler: &str,
+    description: &str,
+) -> Result<(), PackageError> {
+    let dest_str = dest.display().to_string();
+    let harn_range = current_harn_range_example();
+    let _name_env = ScopedEnvVar::set("HARN_TOOL_NAME", name);
+    let _dest_env = ScopedEnvVar::set("HARN_TOOL_DEST", &dest_str);
+    let _ident_env = ScopedEnvVar::set("HARN_TOOL_IDENT", ident);
+    let _handler_env = ScopedEnvVar::set("HARN_TOOL_HANDLER", handler);
+    let _desc_env = ScopedEnvVar::set("HARN_TOOL_DESCRIPTION", description);
+    let _range_env = ScopedEnvVar::set("HARN_TOOL_HARN_RANGE", &harn_range);
+    let exit = dispatch::dispatch_to_embedded_script(
+        "scaffold/tool_new",
+        Vec::new(),
+        /* json_mode */ false,
+    )
+    .await;
+    if exit != 0 {
+        return Err(format!("tool new scaffolder exited with code {exit}").into());
+    }
+    Ok(())
+}
+
+/// Legacy Rust implementation. Kept behind `HARN_CLI_IMPL=rust` for the
+/// parity harness (#2299). The C1 ratchet (#2314) removes this path
+/// once the `.harn` impl is the production default everywhere.
+fn run_new_rust(
+    name: &str,
+    dest: &std::path::Path,
+    ident: &str,
+    handler: &str,
+    description: &str,
+) -> Result<(), PackageError> {
+    for (relative_path, content) in tool_template_files(name, ident, handler, description)? {
+        write_file(dest, relative_path, &content)?;
+    }
     Ok(())
 }
 
@@ -281,22 +337,9 @@ mod tests {
         assert_eq!(harn_identifier("123-tool").unwrap(), "tool_123_tool");
     }
 
-    #[test]
-    fn force_overwrites_templates_without_deleting_extra_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        let dest = tmp.path().join("acme-tool");
-        fs::create_dir_all(&dest).unwrap();
-        fs::write(dest.join("keep.txt"), "keep").unwrap();
-
-        run_new(&ToolNewArgs {
-            name: "acme-tool".to_string(),
-            description: None,
-            dir: Some(dest.display().to_string()),
-            force: true,
-        })
-        .unwrap();
-
-        assert_eq!(fs::read_to_string(dest.join("keep.txt")).unwrap(), "keep");
-        assert!(dest.join("harn.toml").exists());
-    }
+    // The force-overwrite behavior moved to a subprocess parity test in
+    // `tests/scaffold_dispatch.rs`: the dispatched `.harn` impl runs the
+    // full VM and would overflow the default `#[tokio::test]` thread
+    // stack here. The subprocess inherits the workspace-level 16 MiB
+    // runtime stack via `harn_cli::install_signal_shutdown_handler`.
 }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -899,9 +899,11 @@ async fn async_main() {
                 }
             }
         }
-        Command::Init(args) => commands::init::init_project(args.name.as_deref(), args.template),
+        Command::Init(args) => {
+            commands::init::init_project(args.name.as_deref(), args.template).await
+        }
         Command::New(args) => match commands::init::resolve_new_args(&args) {
-            Ok((name, template)) => commands::init::init_project(name.as_deref(), template),
+            Ok((name, template)) => commands::init::init_project(name.as_deref(), template).await,
             Err(error) => {
                 eprintln!("error: {error}");
                 process::exit(1);
@@ -1468,7 +1470,7 @@ async fn async_main() {
         },
         Command::Tool(args) => match args.command {
             ToolCommand::New(new_args) => {
-                if let Err(error) = commands::tool::run_new(&new_args) {
+                if let Err(error) = commands::tool::run_new(&new_args).await {
                     eprintln!("error: {error}");
                     process::exit(1);
                 }

--- a/crates/harn-cli/tests/scaffold_dispatch.rs
+++ b/crates/harn-cli/tests/scaffold_dispatch.rs
@@ -1,0 +1,279 @@
+#![recursion_limit = "256"]
+
+//! Parity tests for the scaffolding cluster (harn#2308 / W8).
+//!
+//! Each test runs the same `harn` subcommand twice — once with the
+//! default `.harn` dispatch impl, and once with `HARN_CLI_IMPL=rust`
+//! forcing the legacy handler — and asserts that the generated file
+//! tree is byte-identical between the two. Subprocesses are used
+//! because the dispatched `.harn` script spawns a full VM and would
+//! overflow the default `#[tokio::test]` thread stack if run in-process.
+//!
+//! The C1 ratchet (harn#2314) removes the legacy Rust paths once these
+//! parity tests have ridden in production for a release.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Snapshot of every file in a directory tree, keyed by path relative
+/// to the snapshot root. Used to compare two scaffolded layouts.
+type Snapshot = BTreeMap<String, Vec<u8>>;
+
+fn harn_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_harn")
+}
+
+fn run_scaffold(args: &[&str], cwd: &Path, rust_impl: bool) -> Output {
+    let mut cmd = Command::new(harn_bin());
+    cmd.args(args).current_dir(cwd);
+    if rust_impl {
+        cmd.env("HARN_CLI_IMPL", "rust");
+    } else {
+        // Inherit env, but make sure no stale parity selector from the
+        // user's shell leaks in and pins the run to the legacy impl.
+        cmd.env_remove("HARN_CLI_IMPL");
+    }
+    cmd.output().expect("spawn harn subcommand")
+}
+
+fn snapshot_tree(root: &Path) -> Snapshot {
+    let mut out = BTreeMap::new();
+    fn walk(root: &Path, dir: &Path, out: &mut Snapshot) {
+        let entries = match fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                walk(root, &path, out);
+            } else if file_type.is_file() {
+                let rel = path
+                    .strip_prefix(root)
+                    .expect("file under root")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                let bytes = fs::read(&path).expect("read file");
+                out.insert(rel, bytes);
+            }
+        }
+    }
+    walk(root, root, &mut out);
+    out
+}
+
+fn assert_snapshots_match(label: &str, harn_snapshot: &Snapshot, rust_snapshot: &Snapshot) {
+    let harn_keys: Vec<&String> = harn_snapshot.keys().collect();
+    let rust_keys: Vec<&String> = rust_snapshot.keys().collect();
+    assert_eq!(
+        harn_keys, rust_keys,
+        "{label}: file list diverges between .harn and rust impls"
+    );
+    for (path, harn_bytes) in harn_snapshot {
+        let rust_bytes = rust_snapshot
+            .get(path)
+            .unwrap_or_else(|| panic!("{label}: missing {path} in rust snapshot"));
+        if harn_bytes != rust_bytes {
+            let harn_text = String::from_utf8_lossy(harn_bytes);
+            let rust_text = String::from_utf8_lossy(rust_bytes);
+            panic!(
+                "{label}: byte mismatch in {path}\n--- harn impl ---\n{harn_text}\n--- rust impl ---\n{rust_text}\n",
+            );
+        }
+    }
+}
+
+fn pair_run(
+    label: &str,
+    args_with: impl Fn(&Path) -> Vec<String>,
+    project_subdir: Option<&str>,
+) -> (Snapshot, Snapshot) {
+    let harn_tmp = tempfile::tempdir().expect("tempdir harn");
+    let rust_tmp = tempfile::tempdir().expect("tempdir rust");
+
+    let harn_args = args_with(harn_tmp.path());
+    let rust_args = args_with(rust_tmp.path());
+    let harn_argv: Vec<&str> = harn_args.iter().map(String::as_str).collect();
+    let rust_argv: Vec<&str> = rust_args.iter().map(String::as_str).collect();
+
+    let harn_out = run_scaffold(&harn_argv, harn_tmp.path(), false);
+    assert!(
+        harn_out.status.success(),
+        "{label}: .harn dispatch failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&harn_out.stdout),
+        String::from_utf8_lossy(&harn_out.stderr),
+    );
+    let rust_out = run_scaffold(&rust_argv, rust_tmp.path(), true);
+    assert!(
+        rust_out.status.success(),
+        "{label}: rust impl failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&rust_out.stdout),
+        String::from_utf8_lossy(&rust_out.stderr),
+    );
+
+    let harn_root: PathBuf = project_subdir
+        .map(|s| harn_tmp.path().join(s))
+        .unwrap_or_else(|| harn_tmp.path().to_path_buf());
+    let rust_root: PathBuf = project_subdir
+        .map(|s| rust_tmp.path().join(s))
+        .unwrap_or_else(|| rust_tmp.path().to_path_buf());
+    let harn_snap = snapshot_tree(&harn_root);
+    let rust_snap = snapshot_tree(&rust_root);
+    assert!(
+        !harn_snap.is_empty(),
+        "{label}: .harn impl produced no files under {}",
+        harn_root.display()
+    );
+    (harn_snap, rust_snap)
+}
+
+#[test]
+fn tool_new_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "tool new",
+        |tmp| {
+            vec![
+                "tool".into(),
+                "new".into(),
+                "acme-tool".into(),
+                "--dir".into(),
+                tmp.join("acme-tool").display().to_string(),
+                "--description".into(),
+                "Acme tool for testing parity.".into(),
+            ]
+        },
+        Some("acme-tool"),
+    );
+    assert_snapshots_match("tool new", &harn_snap, &rust_snap);
+    // Spot-check key files so a structural drift fails loudly even if
+    // the byte comparison happens to coincide.
+    assert!(harn_snap.contains_key("harn.toml"), "harn.toml present");
+    assert!(
+        harn_snap.contains_key("lib/tools.harn"),
+        "lib/tools.harn present"
+    );
+    assert!(
+        harn_snap.contains_key(".github/workflows/harn-package.yml"),
+        "workflow yaml present"
+    );
+}
+
+#[test]
+fn tool_new_force_preserves_pre_existing_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path().join("acme-tool");
+    fs::create_dir_all(&dest).unwrap();
+    fs::write(dest.join("keep.txt"), "keep").unwrap();
+    let out = run_scaffold(
+        &[
+            "tool",
+            "new",
+            "acme-tool",
+            "--dir",
+            &dest.display().to_string(),
+            "--force",
+        ],
+        tmp.path(),
+        false,
+    );
+    assert!(
+        out.status.success(),
+        "tool new --force failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(fs::read_to_string(dest.join("keep.txt")).unwrap(), "keep");
+    assert!(dest.join("harn.toml").exists());
+}
+
+#[test]
+fn init_basic_dispatch_matches_rust_impl() {
+    // `harn init` writes into the current working directory, so each
+    // impl runs inside its own tempdir.
+    let (harn_snap, rust_snap) = pair_run("init basic", |_tmp| vec!["init".into()], None);
+    assert_snapshots_match("init basic", &harn_snap, &rust_snap);
+    assert!(harn_snap.contains_key("harn.toml"));
+    assert!(harn_snap.contains_key("main.harn"));
+    assert!(harn_snap.contains_key("lib/helpers.harn"));
+    assert!(harn_snap.contains_key("tests/test_main.harn"));
+}
+
+#[test]
+fn new_package_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "new package",
+        |_tmp| vec!["new".into(), "package".into(), "sample-pkg".into()],
+        Some("sample-pkg"),
+    );
+    assert_snapshots_match("new package", &harn_snap, &rust_snap);
+    assert!(harn_snap.contains_key("harn.toml"));
+    assert!(harn_snap.contains_key("lib/main.harn"));
+    assert!(harn_snap.contains_key("docs/api.md"));
+}
+
+#[test]
+fn new_connector_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "new connector",
+        |_tmp| vec!["new".into(), "connector".into(), "sample-conn".into()],
+        Some("sample-conn"),
+    );
+    assert_snapshots_match("new connector", &harn_snap, &rust_snap);
+    assert!(harn_snap.contains_key("connectors/echo.harn"));
+}
+
+#[test]
+fn init_agent_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "init agent",
+        |_tmp| vec!["init".into(), "--template".into(), "agent".into()],
+        None,
+    );
+    assert_snapshots_match("init agent", &harn_snap, &rust_snap);
+    assert!(harn_snap.contains_key("tests/test_agent.harn"));
+}
+
+#[test]
+fn init_chat_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "init chat",
+        |_tmp| vec!["init".into(), "--template".into(), "chat".into()],
+        None,
+    );
+    assert_snapshots_match("init chat", &harn_snap, &rust_snap);
+}
+
+#[test]
+fn init_mcp_server_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "init mcp-server",
+        |_tmp| vec!["init".into(), "--template".into(), "mcp-server".into()],
+        None,
+    );
+    assert_snapshots_match("init mcp-server", &harn_snap, &rust_snap);
+}
+
+#[test]
+fn init_eval_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "init eval",
+        |_tmp| vec!["init".into(), "--template".into(), "eval".into()],
+        None,
+    );
+    assert_snapshots_match("init eval", &harn_snap, &rust_snap);
+}
+
+#[test]
+fn init_pipeline_lab_dispatch_matches_rust_impl() {
+    let (harn_snap, rust_snap) = pair_run(
+        "init pipeline-lab",
+        |_tmp| vec!["init".into(), "--template".into(), "pipeline-lab".into()],
+        None,
+    );
+    assert_snapshots_match("init pipeline-lab", &harn_snap, &rust_snap);
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -814,6 +814,14 @@ pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
         source: include_str!("stdlib/cli/explain.harn"),
     },
     StdlibCliScript {
+        name: "scaffold/init",
+        source: include_str!("stdlib/cli/scaffold/init.harn"),
+    },
+    StdlibCliScript {
+        name: "scaffold/tool_new",
+        source: include_str!("stdlib/cli/scaffold/tool_new.harn"),
+    },
+    StdlibCliScript {
         name: "trace_import",
         source: include_str!("stdlib/cli/trace_import.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/scaffold/init.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/scaffold/init.harn
@@ -1,0 +1,722 @@
+/**
+ * `harn init` and `harn new` ported to .harn — see harn#2308 (W8).
+ *
+ * Renders the eight project starter templates (basic, agent, chat,
+ * mcp-server, eval, pipeline-lab, package, connector) and writes each
+ * template file to disk, skipping files that already exist (mirrors the
+ * Rust `write_if_new` semantics). The dispatch shim in
+ * crates/harn-cli/src/commands/init.rs resolves args, creates the
+ * destination dir, and hands the rendered project name + template
+ * identifier to this script via env vars.
+ *
+ * Inputs (set by the shim before dispatch):
+ *   HARN_INIT_NAME           — optional human project name shown by "cd"
+ *   HARN_INIT_PROJECT_NAME   — sanitized project name embedded in
+ *                              manifests and README headers
+ *   HARN_INIT_DIR            — destination directory (already created)
+ *   HARN_INIT_TEMPLATE       — one of: basic, agent, chat, mcp-server,
+ *                              eval, pipeline-lab, package, connector
+ *   HARN_INIT_HARN_RANGE     — current harn version range (e.g. ">=0.7,<0.8")
+ *   HARN_INIT_MODE           — "init" or "new" (informational, not currently
+ *                              branched on but kept for future divergence)
+ */
+fn __basic_manifest(project_name: string) -> string {
+  return "[package]\n"
+    + "name = \""
+    + project_name
+    + "\"\n"
+    + "version = \"0.1.0\"\n"
+    + "\n"
+    + "[dependencies]\n"
+}
+
+fn __chat_manifest(project_name: string) -> string {
+  return "[package]\n"
+    + "name = \""
+    + project_name
+    + "\"\n"
+    + "version = \"0.1.0\"\n"
+    + "\n"
+    + "[dependencies]\n"
+    + "\n"
+    + "[llm.aliases]\n"
+    + "chat = { id = \"llama3.2\", provider = \"ollama\" }\n"
+}
+
+fn __package_manifest(project_name: string, harn_range: string) -> string {
+  return "[package]\n"
+    + "name = \""
+    + project_name
+    + "\"\n"
+    + "version = \"0.1.0\"\n"
+    + "description = \"Reusable Harn package.\"\n"
+    + "license = \"MIT OR Apache-2.0\"\n"
+    + "repository = \"https://github.com/OWNER/"
+    + project_name
+    + "\"\n"
+    + "harn = \""
+    + harn_range
+    + "\"\n"
+    + "docs_url = \"docs/api.md\"\n"
+    + "\n"
+    + "[exports]\n"
+    + "lib = \"lib/main.harn\"\n"
+    + "\n"
+    + "[dependencies]\n"
+}
+
+fn __connector_manifest(project_name: string, harn_range: string) -> string {
+  return "[package]\n"
+    + "name = \""
+    + project_name
+    + "\"\n"
+    + "version = \"0.1.0\"\n"
+    + "description = \"Pure-Harn connector package.\"\n"
+    + "license = \"MIT OR Apache-2.0\"\n"
+    + "repository = \"https://github.com/OWNER/"
+    + project_name
+    + "\"\n"
+    + "harn = \""
+    + harn_range
+    + "\"\n"
+    + "docs_url = \"docs/api.md\"\n"
+    + "\n"
+    + "[exports]\n"
+    + "connector = \"connectors/echo.harn\"\n"
+    + "\n"
+    + "[[providers]]\n"
+    + "id = \"echo\"\n"
+    + "connector = { harn = \"connectors/echo\" }\n"
+    + "\n"
+    + "[connector_contract]\n"
+    + "version = 1\n"
+    + "\n"
+    + "[[connector_contract.fixtures]]\n"
+    + "provider = \"echo\"\n"
+    + "name = \"message\"\n"
+    + "kind = \"webhook\"\n"
+    + "body_json = { message = \"hello\" }\n"
+    + "expect_type = \"event\"\n"
+    + "expect_kind = \"webhook\"\n"
+    + "expect_event_count = 1\n"
+    + "\n"
+    + "[dependencies]\n"
+}
+
+fn __basic_files(project_name: string, harn_range: string) -> list {
+  return [
+    ["harn.toml", __basic_manifest(project_name)],
+    [
+      "main.harn",
+      "import \"lib/helpers\"\n"
+        + "\n"
+        + "pipeline default(task) {\n"
+        + "  let greeting = greet(\"world\")\n"
+        + "  log(greeting)\n"
+        + "}\n",
+    ],
+    [
+      "lib/helpers.harn",
+      "fn greet(name) {\n"
+        + "  return \"Hello, \" + name + \"!\"\n"
+        + "}\n"
+        + "\n"
+        + "fn add(a, b) {\n"
+        + "  return a + b\n"
+        + "}\n",
+    ],
+    [
+      "tests/test_main.harn",
+      "import \"../lib/helpers\"\n"
+        + "\n"
+        + "pipeline test_greet(task) {\n"
+        + "  assert_eq(greet(\"world\"), \"Hello, world!\")\n"
+        + "  assert_eq(greet(\"Harn\"), \"Hello, Harn!\")\n"
+        + "}\n"
+        + "\n"
+        + "pipeline test_add(task) {\n"
+        + "  assert_eq(add(2, 3), 5)\n"
+        + "  assert_eq(add(-1, 1), 0)\n"
+        + "  assert_eq(add(0, 0), 0)\n"
+        + "}\n",
+    ],
+  ]
+}
+
+fn __agent_files(project_name: string, harn_range: string) -> list {
+  let main_harn = "import { agent_host_tools } from \"std/agent/host_tools\"\n"
+    + "import { audit_agent } from \"std/agent/presets\"\n"
+    + "\n"
+    + "fn main(harness: Harness) {\n"
+    + "  let task = harness.env.get_or(\"HARN_TASK\", \"Review the repository\")\n"
+    + "  let root = cwd()\n"
+    + "  let tools = agent_host_tools(\n"
+    + "    nil,\n"
+    + "    {\n"
+    + "      root: root,\n"
+    + "      cwd: root,\n"
+    + "      enabled_tools: [\"list_directory\", \"read_file\", \"search_files\"],\n"
+    + "      max_inline_bytes: 6000,\n"
+    + "      search_exclude_globs: [\".git/**\", \".harn/**\", \"target/**\", \"node_modules/**\"],\n"
+    + "    },\n"
+    + "  )\n"
+    + "  let result = audit_agent(\n"
+    + "    task,\n"
+    + "    {\n"
+    + "      system: \"You are a careful repository auditor. Use the read-only tools to inspect before answering. Do not guess file contents, and do not discuss provider, model, harness, or system-prompt details.\",\n"
+    + "      tools: tools,\n"
+    + "      max_iterations: 6,\n"
+    + "      llm_options: {temperature: 0},\n"
+    + "    },\n"
+    + "  )\n"
+    + "  harness.stdio.println(result.visible_text ?? result.text ?? \"\")\n"
+    + "}\n"
+  // Triple-quoted in the Rust source — embed the literal Harn snippet
+  // inside the mock-driven test exactly as the original handler did.
+  let test_harn = "import { audit_agent } from \"std/agent/presets\"\n"
+    + "\n"
+    + "pipeline test_agent_smoke(task) {\n"
+    + "  llm_mock_clear()\n"
+    + "  llm_mock({text: \"<user_response>Repository looks healthy.</user_response>\\n<done>##DONE##</done>\"})\n"
+    + "  let result = audit_agent(\n"
+    + "    \"Review the repository\",\n"
+    + "    {provider: \"mock\", model: \"mock\", loop_until_done: false, max_iterations: 1},\n"
+    + "  )\n"
+    + "  assert_eq(result.status, \"done\")\n"
+    + "}\n"
+  let readme = "# " + project_name + "\n"
+    + "\n"
+    + "Read-only agent starter for Harn.\n"
+    + "\n"
+    + "## Run\n"
+    + "\n"
+    + "```bash\n"
+    + "HARN_TASK=\"Summarize this repository\" harn run main.harn\n"
+    + "```\n"
+    + "\n"
+    + "Run `harn quickstart` first if this project does not already have an LLM\n"
+    + "provider configured. The starter uses scoped read-only tools by default; add\n"
+    + "write or command tools only when the task needs them.\n"
+  return [
+    ["harn.toml", __basic_manifest(project_name)],
+    ["main.harn", main_harn],
+    ["tests/test_agent.harn", test_harn],
+    ["README.md", readme],
+  ]
+}
+
+fn __chat_files(project_name: string, harn_range: string) -> list {
+  let main_harn = "fn build_chat_prompt(history, message) {\n"
+    + "  if history == \"\" {\n"
+    + "    return \"User: \" + message\n"
+    + "  }\n"
+    + "  return history + \"\\nUser: \" + message\n"
+    + "}\n"
+    + "\n"
+    + "fn stream_reply(harness: Harness, prompt, system, options) {\n"
+    + "  var answer = \"\"\n"
+    + "  let chunks = llm_stream_call(prompt, system, options)\n"
+    + "  for chunk in chunks {\n"
+    + "    harness.stdio.print(chunk.visible_delta)\n"
+    + "    answer = chunk.partial\n"
+    + "  }\n"
+    + "  harness.stdio.println(\"\")\n"
+    + "  return answer\n"
+    + "}\n"
+    + "\n"
+    + "fn main(harness: Harness) {\n"
+    + "  let system = env_or(\"HARN_CHAT_SYSTEM\", \"You are a concise, helpful assistant.\")\n"
+    + "  let model = env_or(\"HARN_CHAT_MODEL\", \"chat\")\n"
+    + "  let options = {model: model, max_tokens: 2048, temperature: 0.7}\n"
+    + "  var history = \"\"\n"
+    + "  harness.stdio.println(\"Harn chat. Type /clear to reset history or /exit to quit.\")\n"
+    + "  while true {\n"
+    + "    harness.stdio.print(\"you> \")\n"
+    + "    let raw = harness.stdio.read_line()\n"
+    + "    if !raw.ok {\n"
+    + "      break\n"
+    + "    }\n"
+    + "    let message = trim(raw.value)\n"
+    + "    if message == \"\" {\n"
+    + "      continue\n"
+    + "    }\n"
+    + "    if message == \"/exit\" || message == \"/quit\" {\n"
+    + "      break\n"
+    + "    }\n"
+    + "    if message == \"/clear\" {\n"
+    + "      history = \"\"\n"
+    + "      harness.stdio.println(\"history cleared\")\n"
+    + "      continue\n"
+    + "    }\n"
+    + "    let prompt = build_chat_prompt(history, message)\n"
+    + "    harness.stdio.print(\"assistant> \")\n"
+    + "    let answer = stream_reply(harness, prompt, system, options)\n"
+    + "    history = prompt + \"\\nAssistant: \" + answer + \"\\n\"\n"
+    + "  }\n"
+    + "}\n"
+  let readme = "# " + project_name + "\n"
+    + "\n"
+    + "Streaming chat starter for Harn.\n"
+    + "\n"
+    + "## Provider\n"
+    + "\n"
+    + "`harn.toml` defines a `chat` model alias backed by Ollama's `llama3.2` model:\n"
+    + "\n"
+    + "```toml\n"
+    + "[llm.aliases]\n"
+    + "chat = { id = \"llama3.2\", provider = \"ollama\" }\n"
+    + "```\n"
+    + "\n"
+    + "Edit that alias to use any configured provider, or set `HARN_CHAT_MODEL` when\n"
+    + "running the project.\n"
+    + "\n"
+    + "## Run\n"
+    + "\n"
+    + "```bash\n"
+    + "harn run main.harn\n"
+    + "```\n"
+    + "\n"
+    + "Inside the chat loop, type `/clear` to reset local history and `/exit` to quit.\n"
+  return [["harn.toml", __chat_manifest(project_name)], ["main.harn", main_harn], ["README.md", readme]]
+}
+
+fn __mcp_files(project_name: string, harn_range: string) -> list {
+  let main_harn = "pipeline default(task) {\n"
+    + "  var tools = tool_registry()\n"
+    + "  tools = tool_define(tools, \"ping\", \"Return a pong response\", {\n"
+    + "    parameters: {\n"
+    + "      type: \"object\",\n"
+    + "      properties: {\n"
+    + "        message: {type: \"string\"}\n"
+    + "      },\n"
+    + "      required: [\"message\"]\n"
+    + "    },\n"
+    + "    returns: {\n"
+    + "      type: \"object\",\n"
+    + "      properties: {\n"
+    + "        message: {type: \"string\"},\n"
+    + "        echoed: {type: \"string\"}\n"
+    + "      }\n"
+    + "    },\n"
+    + "    handler: fn(args) {\n"
+    + "      return {\n"
+    + "        message: \"pong\",\n"
+    + "        echoed: args.message\n"
+    + "      }\n"
+    + "    }\n"
+    + "  })\n"
+    + "\n"
+    + "  mcp_tools(tools)\n"
+    + "  mcp_resource({\n"
+    + "    uri: \"info://server\",\n"
+    + "    name: \"server-info\",\n"
+    + "    text: \"Harn MCP starter server\"\n"
+    + "  })\n"
+    + "}\n"
+  return [["harn.toml", __basic_manifest(project_name)], ["main.harn", main_harn]]
+}
+
+fn __eval_files(project_name: string, harn_range: string) -> list {
+  let main_harn = "pipeline default(task) {\n"
+    + "  let input = \"hello world\"\n"
+    + "  let output = input.upper()\n"
+    + "  let passed = output == \"HELLO WORLD\"\n"
+    + "\n"
+    + "  eval_metric(\"passed\", passed)\n"
+    + "  eval_metric(\"output_length\", len(output))\n"
+    + "\n"
+    + "  log(json_stringify({\n"
+    + "    input: input,\n"
+    + "    output: output,\n"
+    + "    passed: passed\n"
+    + "  }))\n"
+    + "}\n"
+  let test_harn = "pipeline test_eval_metrics(task) {\n"
+    + "  eval_metric(\"accuracy\", 1.0, {suite: \"smoke\"})\n"
+    + "  let metrics = eval_metrics()\n"
+    + "\n"
+    + "  assert_eq(len(metrics), 1)\n"
+    + "  assert_eq(metrics[0].name, \"accuracy\")\n"
+    + "}\n"
+  let suite = "{\n"
+    + "  \"_type\": \"eval_suite_manifest\",\n"
+    + "  \"id\": \"sample-suite\",\n"
+    + "  \"name\": \"Sample Eval Suite\",\n"
+    + "  \"base_dir\": \".\",\n"
+    + "  \"cases\": [\n"
+    + "    {\n"
+    + "      \"label\": \"replace-with-a-run-record\",\n"
+    + "      \"run_path\": \".harn-runs/sample-run.json\"\n"
+    + "    }\n"
+    + "  ]\n"
+    + "}\n"
+  return [
+    ["harn.toml", __basic_manifest(project_name)],
+    ["main.harn", main_harn],
+    ["tests/test_eval.harn", test_harn],
+    ["eval-suite.json", suite],
+  ]
+}
+
+fn __pipeline_lab_files(project_name: string, harn_range: string) -> list {
+  let host_harn = "pub fn build_context(task) {\n"
+    + "  return {\n"
+    + "    task: task,\n"
+    + "    cwd: cwd(),\n"
+    + "  }\n"
+    + "}\n"
+    + "\n"
+    + "pub fn request_permission(tool_name, request_args) -> bool {\n"
+    + "  return true\n"
+    + "}\n"
+  let pipeline_harn = "pipeline default(task) {\n"
+    + "  let context = build_context(env_or(\"HARN_TASK\", \"\"))\n"
+    + "  let result = llm_call(\n"
+    + "    \"Task: \" + context.task + \"\\nWorkspace: \" + context.cwd,\n"
+    + "    \"You are a concise coding assistant. Reply in 3 bullets max.\",\n"
+    + "  )\n"
+    + "  log(result.text)\n"
+    + "}\n"
+  let readme = "# Pipeline Lab\n"
+    + "\n"
+    + "Use this project to iterate on a Harn workflow against a local Harn-native host module.\n"
+    + "\n"
+    + "## Run\n"
+    + "\n"
+    + "```bash\n"
+    + "harn playground --task \"Explain this repository\"\n"
+    + "```\n"
+    + "\n"
+    + "## Watch mode\n"
+    + "\n"
+    + "```bash\n"
+    + "harn playground --watch --task \"Tighten the workflow prompt\"\n"
+    + "```\n"
+    + "\n"
+    + "Edit `host.harn` or `pipeline.harn` and the playground will re-run automatically.\n"
+  return [
+    ["harn.toml", __basic_manifest(project_name)],
+    ["host.harn", host_harn],
+    ["pipeline.harn", pipeline_harn],
+    ["README.md", readme],
+  ]
+}
+
+fn __package_files(project_name: string, harn_range: string) -> list {
+  let lib_main = "/// Return a greeting for `name`.\n"
+    + "pub fn greet(name: string) -> string {\n"
+    + "  return \"Hello, \" + name + \"!\"\n"
+    + "}\n"
+  let main_harn = "import \"lib/main\"\n"
+    + "\n"
+    + "pipeline default(task) {\n"
+    + "  log(greet(\"world\"))\n"
+    + "}\n"
+  let test_harn = "import \"../lib/main\"\n"
+    + "\n"
+    + "pipeline test_greet(task) {\n"
+    + "  assert_eq(greet(\"Harn\"), \"Hello, Harn!\")\n"
+    + "}\n"
+  let workflow = "name: Harn package\n"
+    + "\n"
+    + "on:\n"
+    + "  pull_request:\n"
+    + "  push:\n"
+    + "    branches: [main]\n"
+    + "\n"
+    + "jobs:\n"
+    + "  package:\n"
+    + "    runs-on: ubuntu-latest\n"
+    + "    steps:\n"
+    + "      - uses: actions/checkout@v4\n"
+    + "      - uses: taiki-e/install-action@cargo-binstall\n"
+    + "      - run: cargo binstall harn-cli --no-confirm\n"
+    + "      - run: harn install --locked --offline || harn install\n"
+    + "      - run: harn test tests/\n"
+    + "      - run: harn package check\n"
+    + "      - run: harn package docs --check\n"
+    + "      - run: harn package pack --dry-run\n"
+  let readme = "# " + project_name + "\n"
+    + "\n"
+    + "Reusable Harn package.\n"
+    + "\n"
+    + "## Quickstart\n"
+    + "\n"
+    + "```bash\n"
+    + "harn add ../"
+    + project_name
+    + "\n"
+    + "harn test tests/\n"
+    + "harn package check\n"
+    + "harn package docs\n"
+    + "harn package pack\n"
+    + "```\n"
+    + "\n"
+    + "Consumers import stable modules through the `[exports]` entries in `harn.toml`.\n"
+  let docs = "# API Reference: " + project_name + "\n"
+    + "\n"
+    + "Generated by `harn package docs`.\n"
+    + "\n"
+    + "Version: `0.1.0`\n"
+    + "\n"
+    + "## Export `lib`\n"
+    + "\n"
+    + "`lib/main.harn`\n"
+    + "\n"
+    + "### fn `greet`\n"
+    + "\n"
+    + "Return a greeting for `name`.\n"
+    + "\n"
+    + "```harn\n"
+    + "pub fn greet(name: string) -> string\n"
+    + "```\n"
+  return [
+    ["harn.toml", __package_manifest(project_name, harn_range)],
+    ["lib/main.harn", lib_main],
+    ["main.harn", main_harn],
+    ["tests/test_main.harn", test_harn],
+    [".github/workflows/harn-package.yml", workflow],
+    ["README.md", readme],
+    ["LICENSE", "MIT OR Apache-2.0\n"],
+    ["docs/api.md", docs],
+  ]
+}
+
+fn __connector_files(project_name: string, harn_range: string) -> list {
+  let echo_harn = "/// Connector provider id.\n"
+    + "pub fn provider_id() {\n"
+    + "  return \"echo\"\n"
+    + "}\n"
+    + "\n"
+    + "/// Trigger kinds emitted by this connector.\n"
+    + "pub fn kinds() {\n"
+    + "  return [\"webhook\"]\n"
+    + "}\n"
+    + "\n"
+    + "/// JSON payload schema for normalized inbound events.\n"
+    + "pub fn payload_schema() {\n"
+    + "  return {\n"
+    + "    harn_schema_name: \"EchoEventPayload\",\n"
+    + "    json_schema: {\n"
+    + "      type: \"object\",\n"
+    + "      additionalProperties: true,\n"
+    + "    },\n"
+    + "  }\n"
+    + "}\n"
+    + "\n"
+    + "/// Convert one inbound request into Harn trigger events.\n"
+    + "pub fn normalize_inbound(raw) {\n"
+    + "  let body = raw.body_json ?? json_parse(raw.body_text)\n"
+    + "  return {\n"
+    + "    type: \"event\",\n"
+    + "    event: {\n"
+    + "      kind: \"webhook\",\n"
+    + "      dedupe_key: \"echo:\" + (body.message ?? \"message\"),\n"
+    + "      payload: body,\n"
+    + "    },\n"
+    + "  }\n"
+    + "}\n"
+  let main_harn = "import \"connectors/echo\"\n"
+    + "\n"
+    + "pipeline default(task) {\n"
+    + "  log(provider_id())\n"
+    + "}\n"
+  let test_harn = "import \"../connectors/echo\"\n"
+    + "\n"
+    + "pipeline test_provider_id(task) {\n"
+    + "  assert_eq(provider_id(), \"echo\")\n"
+    + "  assert_eq(kinds(), [\"webhook\"])\n"
+    + "}\n"
+  let workflow = "name: Harn connector package\n"
+    + "\n"
+    + "on:\n"
+    + "  pull_request:\n"
+    + "  push:\n"
+    + "    branches: [main]\n"
+    + "\n"
+    + "jobs:\n"
+    + "  package:\n"
+    + "    runs-on: ubuntu-latest\n"
+    + "    steps:\n"
+    + "      - uses: actions/checkout@v4\n"
+    + "      - uses: taiki-e/install-action@cargo-binstall\n"
+    + "      - run: cargo binstall harn-cli --no-confirm\n"
+    + "      - run: harn install --locked --offline || harn install\n"
+    + "      - run: harn connector test .\n"
+    + "      - run: harn package check\n"
+    + "      - run: harn package docs --check\n"
+    + "      - run: harn package pack --dry-run\n"
+  let readme = "# " + project_name + "\n"
+    + "\n"
+    + "Pure-Harn connector package.\n"
+    + "\n"
+    + "## Quickstart\n"
+    + "\n"
+    + "```bash\n"
+    + "harn connector test .\n"
+    + "harn package check\n"
+    + "harn package docs\n"
+    + "harn package pack\n"
+    + "```\n"
+    + "\n"
+    + "Consumers import the connector through the stable `[exports]` entry in `harn.toml`.\n"
+  let docs = "# API Reference: " + project_name + "\n"
+    + "\n"
+    + "Generated by `harn package docs`.\n"
+    + "\n"
+    + "Version: `0.1.0`\n"
+    + "\n"
+    + "## Export `connector`\n"
+    + "\n"
+    + "`connectors/echo.harn`\n"
+    + "\n"
+    + "### fn `provider_id`\n"
+    + "\n"
+    + "Connector provider id.\n"
+    + "\n"
+    + "```harn\n"
+    + "pub fn provider_id()\n"
+    + "```\n"
+    + "\n"
+    + "### fn `kinds`\n"
+    + "\n"
+    + "Trigger kinds emitted by this connector.\n"
+    + "\n"
+    + "```harn\n"
+    + "pub fn kinds()\n"
+    + "```\n"
+    + "\n"
+    + "### fn `payload_schema`\n"
+    + "\n"
+    + "JSON payload schema for normalized inbound events.\n"
+    + "\n"
+    + "```harn\n"
+    + "pub fn payload_schema()\n"
+    + "```\n"
+    + "\n"
+    + "### fn `normalize_inbound`\n"
+    + "\n"
+    + "Convert one inbound request into Harn trigger events.\n"
+    + "\n"
+    + "```harn\n"
+    + "pub fn normalize_inbound(raw)\n"
+    + "```\n"
+  return [
+    ["harn.toml", __connector_manifest(project_name, harn_range)],
+    ["connectors/echo.harn", echo_harn],
+    ["main.harn", main_harn],
+    ["tests/test_connector.harn", test_harn],
+    [".github/workflows/harn-package.yml", workflow],
+    ["README.md", readme],
+    ["LICENSE", "MIT OR Apache-2.0\n"],
+    ["docs/api.md", docs],
+  ]
+}
+
+fn __template_files(template: string, project_name: string, harn_range: string) -> list {
+  if template == "basic" {
+    return __basic_files(project_name, harn_range)
+  }
+  if template == "agent" {
+    return __agent_files(project_name, harn_range)
+  }
+  if template == "chat" {
+    return __chat_files(project_name, harn_range)
+  }
+  if template == "mcp-server" {
+    return __mcp_files(project_name, harn_range)
+  }
+  if template == "eval" {
+    return __eval_files(project_name, harn_range)
+  }
+  if template == "pipeline-lab" {
+    return __pipeline_lab_files(project_name, harn_range)
+  }
+  if template == "package" {
+    return __package_files(project_name, harn_range)
+  }
+  if template == "connector" {
+    return __connector_files(project_name, harn_range)
+  }
+  throw "unknown template: " + template
+}
+
+fn __write_if_new(harness: Harness, dir: string, rel: string, content: string) {
+  let path = path_join(dir, rel)
+  let parent = dirname(path)
+  if parent != "" && !harness.fs.exists(parent) {
+    try {
+      harness.fs.mkdir(parent)
+    } catch (e) {
+      harness.stdio.eprintln("Failed to create " + parent + ": " + to_string(e))
+      return
+    }
+  }
+  if harness.fs.exists(path) {
+    harness.stdio.println("  skip  " + path + " (already exists)")
+    return
+  }
+  try {
+    harness.fs.write_text(path, content)
+  } catch (e) {
+    harness.stdio.eprintln("Failed to write " + path + ": " + to_string(e))
+    return
+  }
+  harness.stdio.println("  create  " + path)
+}
+
+fn __print_next_steps(harness: Harness, name: string, template: string) {
+  harness.stdio.println("")
+  if name != "" {
+    harness.stdio.println("  cd " + name)
+  }
+  if template == "chat" {
+    harness.stdio.println("  harn run main.harn       # run the program")
+  } else if template == "mcp-server" {
+    harness.stdio.println("  harn serve mcp main.harn # expose the starter MCP server")
+  } else if template == "pipeline-lab" {
+    harness.stdio.println("  harn playground --task \"Explain this repo\"    # run the lab")
+    harness.stdio
+      .println("  harn playground --watch --task \"Refine the prompt\"  # live iteration")
+  } else {
+    // basic | agent | eval | package | connector
+    harness.stdio.println("  harn run main.harn       # run the program")
+    harness.stdio.println("  harn test tests/         # run the tests")
+  }
+  harness.stdio.println("  harn fmt main.harn       # format code")
+  harness.stdio.println("  harn lint main.harn      # lint code")
+  if template == "package" || template == "connector" {
+    harness.stdio.println("  harn package check       # validate publish readiness")
+    harness.stdio.println("  harn package docs        # generate API docs")
+    harness.stdio.println("  harn package pack        # build an inspectable artifact")
+  }
+  harness.stdio.println("  harn doctor              # verify the local environment")
+}
+
+fn main(harness: Harness) {
+  let name = harness.env.get_or("HARN_INIT_NAME", "")
+  let project_name = harness.env.get_or("HARN_INIT_PROJECT_NAME", "my-project")
+  let dir = harness.env.get_or("HARN_INIT_DIR", "")
+  let template = harness.env.get_or("HARN_INIT_TEMPLATE", "basic")
+  let harn_range = harness.env.get_or("HARN_INIT_HARN_RANGE", "")
+  if dir == "" || harn_range == "" {
+    harness.stdio
+      .eprintln("init: HARN_INIT_DIR and HARN_INIT_HARN_RANGE must be set")
+    exit(2)
+  }
+  if name != "" {
+    harness.stdio.println("Creating project '" + name + "'...")
+  } else {
+    harness.stdio.println("Initializing harn project in current directory...")
+  }
+  let files = try {
+    __template_files(template, project_name, harn_range)
+  } catch (e) {
+    harness.stdio.eprintln(to_string(e))
+    exit(2)
+  }
+  for entry in files {
+    __write_if_new(harness, dir, entry[0], entry[1])
+  }
+  __print_next_steps(harness, name, template)
+}

--- a/crates/harn-stdlib/src/stdlib/cli/scaffold/tool_new.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/scaffold/tool_new.harn
@@ -1,0 +1,312 @@
+/**
+ * `harn tool new` ported to .harn — see harn#2308 (W8).
+ *
+ * Scaffolds a Harn package that exports one custom tool. The dispatch
+ * shim in crates/harn-cli/src/commands/tool.rs resolves the destination
+ * directory and validates the package alias in Rust, then hands the
+ * pre-computed identifiers to this script via env vars. The script does
+ * the template render + file write loop, and the shim finishes by
+ * generating docs/api.md through `generate_package_docs_impl` (kept in
+ * Rust because it depends on the full package manifest pipeline).
+ *
+ * Inputs (set by the shim before dispatch):
+ *   HARN_TOOL_NAME         — package alias (validated upstream)
+ *   HARN_TOOL_DEST         — absolute path to destination directory
+ *   HARN_TOOL_IDENT        — sanitized Harn identifier derived from name
+ *   HARN_TOOL_HANDLER      — handler function name (handle_<ident>)
+ *   HARN_TOOL_DESCRIPTION  — description string (raw, unescaped)
+ *   HARN_TOOL_HARN_RANGE   — current Harn version range (e.g. ">=0.7,<0.8")
+ */
+fn __escape_basic_string(value: string) -> string {
+  // Order matters: replace the backslash first so subsequent inserted
+  // backslashes are not re-escaped. The remaining characters mirror the
+  // Rust scaffolder's basic-string escaping for the (deliberately
+  // restricted) inputs we accept — names are ASCII identifiers and the
+  // description is a single user-supplied line. Control characters are
+  // accepted as-is; the Rust dispatch shim rejects multi-line input
+  // before reaching this point.
+  var out = replace(value, "\\", "\\\\")
+  out = replace(out, "\"", "\\\"")
+  out = replace(out, "\n", "\\n")
+  out = replace(out, "\r", "\\r")
+  out = replace(out, "\t", "\\t")
+  return out
+}
+
+fn __harn_string_literal(value: string) -> string {
+  return "\"" + __escape_basic_string(value) + "\""
+}
+
+fn __toml_string_literal(value: string) -> string {
+  // TOML basic-string escaping uses the same escapes for the subset
+  // accepted here. Mirrors crates/harn-cli/src/package/manifest.rs.
+  return __harn_string_literal(value)
+}
+
+fn __strip_trailing_periods(value: string) -> string {
+  // substring(s, start, length) — second arg is length, not end index.
+  var out = value
+  while len(out) > 0 && ends_with(out, ".") {
+    out = substring(out, 0, len(out) - 1)
+  }
+  return out
+}
+
+fn __render_harn_toml(package_name: string, description: string, harn_range: string) -> string {
+  let pkg = __toml_string_literal(package_name)
+  let desc = __toml_string_literal(description)
+  let repo = __toml_string_literal("https://github.com/OWNER/" + package_name)
+  let prov = __toml_string_literal("https://github.com/OWNER/" + package_name + "/releases/tag/v0.1.0")
+  return "[package]\n"
+    + "name = "
+    + pkg
+    + "\n"
+    + "version = \"0.1.0\"\n"
+    + "description = "
+    + desc
+    + "\n"
+    + "license = \"MIT OR Apache-2.0\"\n"
+    + "repository = "
+    + repo
+    + "\n"
+    + "provenance = "
+    + prov
+    + "\n"
+    + "harn = \""
+    + harn_range
+    + "\"\n"
+    + "docs_url = \"docs/api.md\"\n"
+    + "permissions = [\"tool:read_only\"]\n"
+    + "\n"
+    + "[exports]\n"
+    + "tools = \"lib/tools.harn\"\n"
+    + "\n"
+    + "[[package.tools]]\n"
+    + "name = "
+    + pkg
+    + "\n"
+    + "module = \"lib/tools.harn\"\n"
+    + "symbol = \"tools\"\n"
+    + "description = "
+    + desc
+    + "\n"
+    + "permissions = [\"tool:read_only\"]\n"
+    + "\n"
+    + "[package.tools.input_schema]\n"
+    + "type = \"object\"\n"
+    + "required = [\"text\"]\n"
+    + "\n"
+    + "[package.tools.input_schema.properties.text]\n"
+    + "type = \"string\"\n"
+    + "description = \"Text to echo.\"\n"
+    + "\n"
+    + "[package.tools.output_schema]\n"
+    + "type = \"string\"\n"
+    + "\n"
+    + "[package.tools.annotations]\n"
+    + "kind = \"read\"\n"
+    + "side_effect_level = \"read_only\"\n"
+    + "\n"
+    + "[package.tools.annotations.arg_schema]\n"
+    + "required = [\"text\"]\n"
+    + "\n"
+    + "[dependencies]\n"
+}
+
+fn __render_tools_harn(package_name: string, handler: string, description: string) -> string {
+  let tool_name = __harn_string_literal(package_name)
+  let desc_lit = __harn_string_literal(description)
+  // Mirrors the Rust handler's `description.trim_end_matches('.')` so
+  // the docstring summary reads naturally with the trailing period we
+  // add back in the rendered text.
+  let handler_doc = __strip_trailing_periods(description)
+  return "/** " + handler_doc + ". */\n"
+    + "pub fn "
+    + handler
+    + "(args) {\n"
+    + "  let input = schema_expect(args, {\n"
+    + "    type: \"object\",\n"
+    + "    properties: {\n"
+    + "      text: {type: \"string\"}\n"
+    + "    },\n"
+    + "    required: [\"text\"]\n"
+    + "  })\n"
+    + "  return input.text\n"
+    + "}\n"
+    + "\n"
+    + "/** Return a tool registry containing `"
+    + package_name
+    + "`. */\n"
+    + "pub fn tools(registry = nil) {\n"
+    + "  var reg = registry ?? tool_registry()\n"
+    + "  reg = tool_define(reg, "
+    + tool_name
+    + ", "
+    + desc_lit
+    + ", {\n"
+    + "    parameters: {\n"
+    + "      text: {\n"
+    + "        type: \"string\",\n"
+    + "        description: \"Text to echo.\"\n"
+    + "      }\n"
+    + "    },\n"
+    + "    returns: {type: \"string\"},\n"
+    + "    annotations: {\n"
+    + "      kind: \"read\",\n"
+    + "      side_effect_level: \"read_only\",\n"
+    + "      arg_schema: {required: [\"text\"]}\n"
+    + "    },\n"
+    + "    handler: "
+    + handler
+    + "\n"
+    + "  })\n"
+    + "  return reg\n"
+    + "}\n"
+}
+
+fn __render_main_harn(package_name: string) -> string {
+  let tool_name = __harn_string_literal(package_name)
+  return "import { agent_dispatch_tool_call } from \"std/agent/primitives\"\n"
+    + "import { tools } from \"lib/tools\"\n"
+    + "\n"
+    + "pipeline default() {\n"
+    + "  let registry = tools()\n"
+    + "  var text = \"hello\"\n"
+    + "  if len(argv) > 0 {\n"
+    + "    text = argv[0]\n"
+    + "  }\n"
+    + "  let result = agent_dispatch_tool_call({\n"
+    + "    name: "
+    + tool_name
+    + ",\n"
+    + "    arguments: {text: text}\n"
+    + "  }, registry)\n"
+    + "  if !result.ok {\n"
+    + "    throw (result.error?.message ?? \"tool call failed\")\n"
+    + "  }\n"
+    + "  log(result.rendered_result)\n"
+    + "}\n"
+}
+
+fn __render_test_harn(package_name: string, ident: string) -> string {
+  let tool_name = __harn_string_literal(package_name)
+  return "import { agent_dispatch_tool_call } from \"std/agent/primitives\"\n"
+    + "import { tools } from \"../lib/tools\"\n"
+    + "\n"
+    + "pipeline test_"
+    + ident
+    + "_tool(task) {\n"
+    + "  let registry = tools()\n"
+    + "  let ok = agent_dispatch_tool_call({\n"
+    + "    name: "
+    + tool_name
+    + ",\n"
+    + "    arguments: {text: \"hello\"}\n"
+    + "  }, registry)\n"
+    + "  assert(ok.ok, ok.error?.message ?? \"tool call should pass\")\n"
+    + "  assert_eq(ok.rendered_result, \"hello\")\n"
+    + "\n"
+    + "  let bad = agent_dispatch_tool_call({\n"
+    + "    name: "
+    + tool_name
+    + ",\n"
+    + "    arguments: {}\n"
+    + "  }, registry)\n"
+    + "  assert(!bad.ok, \"schema validation should reject missing text\")\n"
+    + "}\n"
+}
+
+fn __render_readme(package_name: string, description: string) -> string {
+  return "# " + package_name + "\n"
+    + "\n"
+    + description
+    + "\n"
+    + "\n"
+    + "## Develop\n"
+    + "\n"
+    + "```bash\n"
+    + "harn test tests/\n"
+    + "harn package check\n"
+    + "harn package docs --check\n"
+    + "harn package pack --dry-run\n"
+    + "```\n"
+    + "\n"
+    + "## Install into another project\n"
+    + "\n"
+    + "```bash\n"
+    + "harn add ../"
+    + package_name
+    + "\n"
+    + "harn install\n"
+    + "```\n"
+    + "\n"
+    + "Consumers import the stable registry builder with:\n"
+    + "\n"
+    + "```harn\n"
+    + "import { tools } from \""
+    + package_name
+    + "/tools\"\n"
+    + "```\n"
+}
+
+fn __render_workflow_yaml() -> string {
+  return "name: Harn tool package\n"
+    + "\n"
+    + "on:\n"
+    + "  pull_request:\n"
+    + "  push:\n"
+    + "    branches: [main]\n"
+    + "\n"
+    + "jobs:\n"
+    + "  package:\n"
+    + "    runs-on: ubuntu-latest\n"
+    + "    steps:\n"
+    + "      - uses: actions/checkout@v4\n"
+    + "      - uses: taiki-e/install-action@cargo-binstall\n"
+    + "      - run: cargo binstall harn-cli --no-confirm\n"
+    + "      - run: harn install --locked --offline || harn install\n"
+    + "      - run: harn test tests/\n"
+    + "      - run: harn package check\n"
+    + "      - run: harn package docs --check\n"
+    + "      - run: harn package pack --dry-run\n"
+}
+
+fn __write(harness: Harness, dest: string, rel: string, content: string) {
+  let path = path_join(dest, rel)
+  let parent = dirname(path)
+  if parent != "" && !harness.fs.exists(parent) {
+    try {
+      harness.fs.mkdir(parent)
+    } catch (e) {
+      harness.stdio.eprintln("failed to create " + parent + ": " + to_string(e))
+      exit(1)
+    }
+  }
+  try {
+    harness.fs.write_text(path, content)
+  } catch (e) {
+    harness.stdio.eprintln("failed to write " + path + ": " + to_string(e))
+    exit(1)
+  }
+}
+
+fn main(harness: Harness) {
+  let name = harness.env.get_or("HARN_TOOL_NAME", "")
+  let dest = harness.env.get_or("HARN_TOOL_DEST", "")
+  let ident = harness.env.get_or("HARN_TOOL_IDENT", "")
+  let handler = harness.env.get_or("HARN_TOOL_HANDLER", "")
+  let description = harness.env.get_or("HARN_TOOL_DESCRIPTION", "")
+  let harn_range = harness.env.get_or("HARN_TOOL_HARN_RANGE", "")
+  if name == "" || dest == "" || ident == "" || handler == "" || harn_range == "" {
+    harness.stdio
+      .eprintln("tool new: HARN_TOOL_{NAME,DEST,IDENT,HANDLER,HARN_RANGE} must be set")
+    exit(2)
+  }
+  __write(harness, dest, "harn.toml", __render_harn_toml(name, description, harn_range))
+  __write(harness, dest, "lib/tools.harn", __render_tools_harn(name, handler, description))
+  __write(harness, dest, "main.harn", __render_main_harn(name))
+  __write(harness, dest, "tests/test_tool.harn", __render_test_harn(name, ident))
+  __write(harness, dest, "README.md", __render_readme(name, description))
+  __write(harness, dest, "LICENSE", "MIT OR Apache-2.0\n")
+  __write(harness, dest, ".github/workflows/harn-package.yml", __render_workflow_yaml())
+}


### PR DESCRIPTION
## Summary

W8 of the harn-cli self-host epic (harn#2293). Closes #2308.

Moves the template render + file-write loop for three of the four scaffolding commands into embedded `.harn` scripts dispatched through the G1 wedge:

- `harn init`, `harn new <NAME> [--template KIND]`, `harn new package NAME`, `harn new connector NAME` → all dispatch to `cli/scaffold/init.harn` with template kind passed via env.
- `harn tool new <NAME>` → dispatches to `cli/scaffold/tool_new.harn`; the post-write `generate_package_docs_impl` call stays in Rust because it depends on the full package manifest pipeline (G3 / G5 surface area, not part of the scaffolder).

Each Rust shim resolves the destination directory and pre-computes any identifiers/escapes the `.harn` script needs (sanitised Harn identifier, handler function name, current `harn` range), then sets env vars and dispatches. The legacy Rust handlers stay behind `HARN_CLI_IMPL=rust` for the parity harness (#2299) until the C1 ratchet (#2314) removes them.

## Deferred — `harn quickstart`

Splitting quickstart cleanly requires more than a scaffolder split: its provider-selection loop reaches into

- `harn_vm::llm::ollama_readiness` (HTTP probe of the local Ollama daemon),
- `harn_vm::llm_config::{resolve_model_info, default_tool_format}` (model alias resolution + tool format),
- `Command::new("df")` / `sysctl -n hw.optional.arm64` / `nvidia-smi -L` for the readiness report,
- `reedline` for the provider/model picker and `rpassword` for the API-key prompt.

None of those have a `.harn` surface today (G4 host caps are explicitly out of scope per the W8 brief), and per the brief's "ship 1 done than 4 broken" guidance quickstart will follow up as its own port wave once the disk/GPU probe and Ollama readiness surfaces exist in Harn. Filing as a tracking issue and including the rationale in the commit body.

## Files

- `crates/harn-stdlib/src/stdlib/cli/scaffold/init.harn` — renders all 8 project templates (basic, agent, chat, mcp-server, eval, pipeline-lab, package, connector), writes files with `write_if_new` skip semantics, prints template-specific next-steps.
- `crates/harn-stdlib/src/stdlib/cli/scaffold/tool_new.harn` — renders the 7-file tool-package template (harn.toml, lib/tools.harn, main.harn, tests/test_tool.harn, README.md, LICENSE, .github/workflows/harn-package.yml).
- `crates/harn-stdlib/src/lib.rs` — registers both scripts in `STDLIB_CLI_SCRIPTS`.
- `crates/harn-cli/src/commands/init.rs` — dispatch shim + legacy Rust path behind `HARN_CLI_IMPL=rust`.
- `crates/harn-cli/src/commands/tool.rs` — dispatch shim + legacy Rust path; post-dispatch `generate_package_docs_impl` call kept in Rust.
- `crates/harn-cli/src/lib.rs` — awaits the new async `init_project` / `tool::run_new`.
- `crates/harn-cli/tests/scaffold_dispatch.rs` — 10 subprocess parity tests covering every template + force-overwrite.

## Test plan

- [x] `cargo test -p harn-cli --test scaffold_dispatch` — 10/10 pass (subprocess byte-diff against `HARN_CLI_IMPL=rust` for each template).
- [x] `cargo test -p harn-cli --lib commands::tool commands::init` — all pass.
- [x] `cargo test -p harn-stdlib` — passes; new scripts in `STDLIB_CLI_SCRIPTS` are non-empty + uniquely named.
- [x] `cargo clippy -p harn-cli -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `harn lint crates/harn-stdlib/src/stdlib/cli/scaffold/*.harn` — no issues.
- [x] Pre-commit + pre-push hooks pass (cargo fmt, clippy, harn fmt, harn lint, highlight keyword sync).