### PR TITLE
Port `harn eval prompt` (rendering layer) to .harn (#2305)

### DIFF
--- a/crates/harn-cli/src/commands/eval_prompt.rs
+++ b/crates/harn-cli/src/commands/eval_prompt.rs
@@ -8,6 +8,25 @@
 //! tiny Harn driver and route through the existing `execute_run`
 //! pipeline so credentialed LLM calls, mock fixtures, and the
 //! `LlmRenderContext` injection all stay on the canonical path.
+//!
+//! ## .harn dispatch (W5 partial port — see harn#2305)
+//!
+//! The **aggregation layer** (fleet resolution, per-model rendering via
+//! `LlmRenderContext`, run/judge fanout, context-fixture evaluation)
+//! stays in Rust — it reaches into `harn_vm::stdlib::template`,
+//! `harn_vm::llm_config`, and `harn_vm::orchestration` internals that
+//! aren't exposed to script-land today.
+//!
+//! The **rendering layer** (terminal / JSON / HTML) is delegated to
+//! `crates/harn-stdlib/src/stdlib/cli/eval/prompt.harn`. The Rust shim
+//! serialises the assembled `PromptReport` to JSON and forwards it via
+//! [`PROMPT_REPORT_ENV`] plus a couple of mode env vars, then routes
+//! through the standard dispatch wedge. The script just reads the
+//! report, picks a formatter, and emits the payload (or writes it to
+//! `--out-file`).
+//!
+//! `HARN_CLI_IMPL=rust` keeps the legacy direct-render path for the
+//! parity-snapshot harness (#2299) until the C1 ratchet (#2314) lands.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -24,8 +43,35 @@ use serde_json::Value as JsonValue;
 
 use crate::cli::{EvalPromptArgs, EvalPromptMode, EvalPromptOutput};
 use crate::config;
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
 
 use super::eval_prompt_context::{evaluate_context_fixtures, PromptContextEvalReport};
+
+/// Env var the embedded `cli/eval/prompt` script reads to pick up the
+/// pre-serialised [`PromptReport`]. The Rust shim does all of the
+/// aggregation (fleet rendering, run/judge fanout, context-fixture
+/// evaluation) and hands the script the assembled report so it only
+/// has to format it.
+const PROMPT_REPORT_ENV: &str = "HARN_EVAL_PROMPT_REPORT_JSON";
+
+/// Env var the script reads to select the output format ("terminal",
+/// "json", or "html"). Defaulted to "terminal" if unset so the script
+/// stays robust against future Rust-side bugs.
+const PROMPT_OUTPUT_ENV: &str = "HARN_EVAL_PROMPT_OUTPUT";
+
+/// Serializes the dispatch-render path so concurrent in-process callers
+/// (the existing `eval_prompt_cli` integration tests run multiple
+/// `run` invocations in parallel) don't race on the global env vars
+/// the Rust shim sets to hand the report off to the .harn script. The
+/// CLI binary itself is single-call, so this mutex is uncontended in
+/// production; in tests it serialises the dispatch window only —
+/// aggregation still parallelises freely.
+///
+/// A future iteration could pass the report through a script-local
+/// channel that doesn't go through process-global env vars, but adding
+/// that to G1's dispatch wedge is out of scope for W5.
+static DISPATCH_RENDER_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Resolved per-model envelope produced by `--mode render`.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -103,6 +149,41 @@ impl From<&BranchDecision> for TemplateBranch {
 }
 
 pub async fn run(args: EvalPromptArgs) -> i32 {
+    let report = match aggregate_report(&args).await {
+        Ok(report) => report,
+        Err(code) => return code,
+    };
+
+    // Compute the post-render exit code from the aggregated report —
+    // both the legacy direct-render path and the .harn dispatch path
+    // must return the same code for the same report.
+    let exit_code = post_render_exit_code(&report);
+
+    // `HARN_CLI_IMPL=rust` keeps the legacy direct-render path so the
+    // parity-snapshot harness (#2299) can compare both impls byte-for-byte
+    // (terminal/html) and structurally (json) until C1 (#2314) deletes it.
+    let use_legacy = std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust");
+
+    if use_legacy {
+        if let Err(code) = legacy_render(&report, args.output, args.out_file.as_deref()) {
+            return code;
+        }
+        return exit_code;
+    }
+
+    match dispatch_render(&report, args.output, args.out_file.as_deref()).await {
+        Ok(()) => exit_code,
+        Err(code) => code,
+    }
+}
+
+/// Build the aggregated [`PromptReport`] without rendering it.
+///
+/// Pulled out of [`run`] so both the legacy direct-render path and the
+/// new `.harn` dispatch path see the *same* report. Returns an exit
+/// code on any aggregation failure (template read, fleet resolution,
+/// context fixture parse / evaluate, run/judge dispatch).
+async fn aggregate_report(args: &EvalPromptArgs) -> Result<PromptReport, i32> {
     let template_path = match fs::canonicalize(&args.file) {
         Ok(p) => p,
         Err(error) => {
@@ -110,34 +191,34 @@ pub async fn run(args: EvalPromptArgs) -> i32 {
                 "error: cannot resolve template path {}: {error}",
                 args.file.display()
             );
-            return 1;
+            return Err(1);
         }
     };
     let template_source = match fs::read_to_string(&template_path) {
         Ok(s) => s,
         Err(error) => {
             eprintln!("error: failed to read {}: {error}", template_path.display());
-            return 1;
+            return Err(1);
         }
     };
 
-    let fleet = match resolve_fleet(&args, &template_path) {
+    let fleet = match resolve_fleet(args, &template_path) {
         Ok(f) => f,
         Err(error) => {
             eprintln!("error: {error}");
-            return 2;
+            return Err(2);
         }
     };
     if fleet.is_empty() {
         eprintln!("error: fleet is empty — supply `--fleet <models>` or `--fleet-name <name>`");
-        return 2;
+        return Err(2);
     }
 
     let bindings = match load_bindings(args.bindings.as_deref()) {
         Ok(b) => b,
         Err(error) => {
             eprintln!("error: {error}");
-            return 1;
+            return Err(1);
         }
     };
 
@@ -164,7 +245,7 @@ pub async fn run(args: EvalPromptArgs) -> i32 {
             Ok(context_eval) => report.context_eval = Some(context_eval),
             Err(error) => {
                 eprintln!("error: {error}");
-                return 1;
+                return Err(1);
             }
         }
     }
@@ -185,7 +266,7 @@ pub async fn run(args: EvalPromptArgs) -> i32 {
         .await;
         match outputs {
             Ok(map) => report.runs = map,
-            Err(code) => return code,
+            Err(code) => return Err(code),
         }
     }
 
@@ -199,21 +280,29 @@ pub async fn run(args: EvalPromptArgs) -> i32 {
         .await
         {
             Ok(judge) => report.judge = Some(judge),
-            Err(code) => return code,
+            Err(code) => return Err(code),
         }
     }
 
-    let payload = match args.output {
-        EvalPromptOutput::Terminal => render_terminal(&report),
-        EvalPromptOutput::Json => render_json(&report),
-        EvalPromptOutput::Html => render_html(&report),
+    Ok(report)
+}
+
+fn legacy_render(
+    report: &PromptReport,
+    output: EvalPromptOutput,
+    out_file: Option<&Path>,
+) -> Result<(), i32> {
+    let payload = match output {
+        EvalPromptOutput::Terminal => render_terminal(report),
+        EvalPromptOutput::Json => render_json(report),
+        EvalPromptOutput::Html => render_html(report),
     };
 
-    match args.out_file {
+    match out_file {
         Some(path) => {
-            if let Err(error) = fs::write(&path, payload) {
+            if let Err(error) = fs::write(path, &payload) {
                 eprintln!("error: failed to write {}: {error}", path.display());
-                return 1;
+                return Err(1);
             }
             eprintln!("wrote {}", path.display());
         }
@@ -222,7 +311,92 @@ pub async fn run(args: EvalPromptArgs) -> i32 {
             let _ = stdout.write_all(payload.as_bytes());
         }
     }
+    Ok(())
+}
 
+/// Dispatch to the embedded `cli/eval/prompt` script for the rendering
+/// pass. The script reads the pre-serialised report from
+/// [`PROMPT_REPORT_ENV`] and picks a formatter based on
+/// [`PROMPT_OUTPUT_ENV`], always emitting the payload to stdout.
+///
+/// `--out-file` is honored on the Rust side (capture-mode dispatch)
+/// rather than in the script: the script runs inside the standard
+/// `harn run` sandbox, where `harness.fs.write_text` is constrained to
+/// `workspace_roots`. The legacy direct-render path used `std::fs::write`
+/// which has no such restriction, so writing the captured stdout out
+/// here preserves parity with the prior `--out-file /tmp/...` flow.
+///
+/// **Concurrency.** Held under [`DISPATCH_RENDER_LOCK`] so concurrent
+/// in-process callers don't race on the global env vars that hand the
+/// report to the script. See the lock's docstring for the trade-off
+/// rationale.
+async fn dispatch_render(
+    report: &PromptReport,
+    output: EvalPromptOutput,
+    out_file: Option<&Path>,
+) -> Result<(), i32> {
+    let report_json = match serde_json::to_string(report) {
+        Ok(json) => json,
+        Err(error) => {
+            eprintln!("error: failed to serialise PromptReport for dispatch: {error}");
+            return Err(1);
+        }
+    };
+    let output_label = match output {
+        EvalPromptOutput::Terminal => "terminal",
+        EvalPromptOutput::Json => "json",
+        EvalPromptOutput::Html => "html",
+    };
+
+    let _dispatch_guard = DISPATCH_RENDER_LOCK.lock().await;
+    let _report_guard = ScopedEnvVar::set(PROMPT_REPORT_ENV, &report_json);
+    let _output_guard = ScopedEnvVar::set(PROMPT_OUTPUT_ENV, output_label);
+
+    // We intentionally don't forward `--json` to the wedge: the script
+    // already knows the output format via PROMPT_OUTPUT_ENV. The wedge's
+    // `--json` env (`HARN_OUTPUT_JSON`) is a separate convention for
+    // commands that have only two modes (human / json envelope); this
+    // script has three (terminal / json-report / html).
+    let outcome = dispatch::run_embedded_script("eval/prompt", Vec::new(), false).await;
+
+    // Always flush the script's stderr to the real terminal, regardless
+    // of out_file handling, so error/warning lines surface.
+    if !outcome.stderr.is_empty() {
+        use std::io::Write as _;
+        let _ = std::io::stderr().write_all(outcome.stderr.as_bytes());
+    }
+
+    if outcome.exit_code != 0 {
+        // Surface the script's stdout too on failure — the script's
+        // diagnostic posture is to use stderr for messages but a future
+        // contributor might trip and emit a partial payload to stdout
+        // before exiting. Better to surface that than silently drop it.
+        if !outcome.stdout.is_empty() {
+            use std::io::Write as _;
+            let _ = std::io::stdout().write_all(outcome.stdout.as_bytes());
+        }
+        return Err(outcome.exit_code);
+    }
+
+    match out_file {
+        Some(path) => {
+            if let Err(error) = fs::write(path, &outcome.stdout) {
+                eprintln!("error: failed to write {}: {error}", path.display());
+                return Err(1);
+            }
+            eprintln!("wrote {}", path.display());
+        }
+        None => {
+            use std::io::Write as _;
+            let _ = std::io::stdout().write_all(outcome.stdout.as_bytes());
+        }
+    }
+    Ok(())
+}
+
+/// Compute the post-render exit code. Extracted so both the legacy
+/// path and the dispatch path agree on what counts as a non-zero exit.
+fn post_render_exit_code(report: &PromptReport) -> i32 {
     let context_eval_active = report.context_eval.is_some();
     if !context_eval_active && report.renders.iter().any(|r| r.error.is_some()) {
         return 1;

--- a/crates/harn-cli/tests/eval_prompt_dispatch.rs
+++ b/crates/harn-cli/tests/eval_prompt_dispatch.rs
@@ -1,0 +1,219 @@
+#![recursion_limit = "256"]
+
+//! `harn eval prompt` partial-port verification (harn#2305 / W5).
+//!
+//! Asserts that the rendering layer ported to
+//! `crates/harn-stdlib/src/stdlib/cli/eval/prompt.harn` produces the
+//! same output as the legacy Rust path. Aggregation (fleet rendering,
+//! run/judge fanout, context-fixture evaluation) stays in Rust on both
+//! impls — only the formatting differs — so byte-for-byte parity is
+//! the bar for terminal/HTML, and structural-JSON parity is the bar
+//! for `--output json`.
+//!
+//! The `HARN_CLI_IMPL=rust` escape hatch keeps the legacy direct-render
+//! path so this test can compare both sides at runtime until the C1
+//! ratchet (#2314) deletes it.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// A four-profile mock-free render fixture: each fleet member maps to a
+/// distinct capability family (claude / gpt / gemini / qwen) so the
+/// rendered envelopes differ across the report, and the terminal
+/// renderer's "diff vs #0" summary actually fires.
+const RENDER_TEMPLATE: &str = "{{ if llm.capabilities.native_tools }}\
+native_tools: call finish_task() when done.\n\
+{{ else }}\
+text_tools: emit `<<DONE>>` when done.\n\
+{{ end }}\
+provider={{ llm.provider }} family={{ llm.family }}\n";
+
+const FLEET: &[&str] = &[
+    "claude-3-5-sonnet",
+    "gpt-4o",
+    "gemini-1.5-pro",
+    "ollama:qwen3.5",
+];
+
+#[test]
+fn terminal_output_is_byte_identical_between_impls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let template = dir.path().join("system.harn.prompt");
+    fs::write(&template, RENDER_TEMPLATE).expect("write template");
+
+    let harn = run_eval_prompt(&template, "terminal", &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+
+    let rust = run_eval_prompt(&template, "terminal", &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "terminal stdout diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust.stdout, harn.stdout
+    );
+}
+
+#[test]
+fn html_output_is_byte_identical_between_impls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let template = dir.path().join("system.harn.prompt");
+    fs::write(&template, RENDER_TEMPLATE).expect("write template");
+
+    let harn = run_eval_prompt(&template, "html", &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+
+    let rust = run_eval_prompt(&template, "html", &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "html stdout diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust.stdout, harn.stdout
+    );
+}
+
+#[test]
+fn json_output_is_structurally_identical_between_impls() {
+    // Harn's `json_stringify_pretty` sorts dict keys alphabetically;
+    // serde's `to_string_pretty` emits struct fields in declaration
+    // order. The wire byte order can therefore differ even though the
+    // parsed shapes match — assert structural equality, not byte
+    // identity, for the JSON path.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let template = dir.path().join("system.harn.prompt");
+    fs::write(&template, RENDER_TEMPLATE).expect("write template");
+
+    let harn = run_eval_prompt(&template, "json", &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+
+    let rust = run_eval_prompt(&template, "json", &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+
+    let harn_value: serde_json::Value =
+        serde_json::from_str(&harn.stdout).expect("harn JSON parses");
+    let rust_value: serde_json::Value =
+        serde_json::from_str(&rust.stdout).expect("rust JSON parses");
+    assert_eq!(
+        rust_value, harn_value,
+        "json shape diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust.stdout, harn.stdout
+    );
+}
+
+#[test]
+fn out_file_writes_match_between_impls() {
+    // Exercises the script's `--out-file` (HARN_EVAL_PROMPT_OUT_FILE)
+    // branch: the rendered payload goes to disk, and a "wrote <path>"
+    // line goes to stderr. Both stdout and on-disk bytes must match.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let template = dir.path().join("system.harn.prompt");
+    fs::write(&template, RENDER_TEMPLATE).expect("write template");
+
+    let harn_out = dir.path().join("harn.txt");
+    let rust_out = dir.path().join("rust.txt");
+
+    let harn = run_eval_prompt_with(
+        &[
+            template.to_str().unwrap(),
+            "--fleet",
+            &FLEET.join(","),
+            "--output",
+            "terminal",
+            "--out-file",
+            harn_out.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    assert!(harn.stdout.is_empty(), "out_file should suppress stdout");
+
+    let rust = run_eval_prompt_with(
+        &[
+            template.to_str().unwrap(),
+            "--fleet",
+            &FLEET.join(","),
+            "--output",
+            "terminal",
+            "--out-file",
+            rust_out.to_str().unwrap(),
+        ],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    assert!(rust.stdout.is_empty(), "out_file should suppress stdout");
+
+    let harn_bytes = fs::read_to_string(&harn_out).expect("harn out_file");
+    let rust_bytes = fs::read_to_string(&rust_out).expect("rust out_file");
+    assert_eq!(
+        harn_bytes, rust_bytes,
+        "out_file contents diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust_bytes, harn_bytes
+    );
+}
+
+#[test]
+fn help_is_byte_identical_between_impls() {
+    // Clap intercepts `--help` before either impl ever runs, so the
+    // env var has no effect — pin the equality anyway so we catch a
+    // future regression where someone routes --help through the wedge.
+    let harn = run_eval_prompt_with(&["--help"], &[]);
+    let rust = run_eval_prompt_with(&["--help"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(harn.exit_code, 0);
+    assert_eq!(rust.exit_code, 0);
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "--help stdout diverged across impls"
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────
+
+struct ProcessOutcome {
+    stdout: String,
+    stderr: String,
+    exit_code: i32,
+}
+
+fn run_eval_prompt(template: &Path, output: &str, extra_env: &[(&str, &str)]) -> ProcessOutcome {
+    run_eval_prompt_with(
+        &[
+            template.to_str().expect("template path utf-8"),
+            "--fleet",
+            &FLEET.join(","),
+            "--output",
+            output,
+        ],
+        extra_env,
+    )
+}
+
+fn run_eval_prompt_with(argv: &[&str], extra_env: &[(&str, &str)]) -> ProcessOutcome {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harn"));
+    cmd.arg("eval").arg("prompt");
+    for arg in argv {
+        cmd.arg(arg);
+    }
+    // Drop ambient env that could perturb the renders across the two
+    // subprocess invocations: terminal-detection env vars (`NO_COLOR`,
+    // `HARN_COLOR`) and any inherited provider keys aren't needed for
+    // mock-free render mode and would only add noise to the diff.
+    for key in ["NO_COLOR", "HARN_COLOR", "HARN_CLI_IMPL"] {
+        cmd.env_remove(key);
+    }
+    let mut env_map: BTreeMap<&str, &str> = BTreeMap::new();
+    for (k, v) in extra_env {
+        env_map.insert(*k, *v);
+    }
+    for (k, v) in &env_map {
+        cmd.env(*k, *v);
+    }
+    let output = cmd.output().expect("spawn harn eval prompt");
+    ProcessOutcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code().unwrap_or(-1),
+    }
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -810,6 +810,10 @@ pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
         source: include_str!("stdlib/cli/echo.harn"),
     },
     StdlibCliScript {
+        name: "eval/prompt",
+        source: include_str!("stdlib/cli/eval/prompt.harn"),
+    },
+    StdlibCliScript {
         name: "explain",
         source: include_str!("stdlib/cli/explain.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/eval/prompt.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/eval/prompt.harn
@@ -1,0 +1,484 @@
+/**
+ * `harn eval prompt` reporting layer ported to .harn — see harn#2305
+ * (W5).
+ *
+ * **Pragmatic partial port.** The full `eval prompt` Rust handler is
+ * ~1000 LOC and is tightly entangled with VM internals (it pushes
+ * `LlmRenderContext` guards around `render_template_to_string`, builds
+ * tempfile harn pipelines to drive `llm_call`/judge fanout, reads the
+ * provider catalog through `llm_config`, and routes context-fixture
+ * evaluation through `harn_vm::orchestration::assemble_context`). None
+ * of that is reachable from script-land today without exposing a wider
+ * VM surface than W5 should land.
+ *
+ * What this script owns: the **rendering / reporting layer** — the
+ * three output formats (terminal, JSON, HTML) and writing them to
+ * stdout or `--out-file`. The Rust shim does the fleet resolution,
+ * fleet rendering, run/judge fanout, and context-fixture evaluation,
+ * collects the result into a `PromptReport`, serialises it to JSON,
+ * and hands it off here.
+ *
+ * The wider port (replacing `eval_prompt.rs` with a thin shim) is
+ * deferred until G4 (#2297) exposes the missing host capabilities
+ * (template render with `LlmRenderContext`, provider-catalog
+ * resolution, `llm_call` parameterised by provider/model). That work
+ * is intentionally scoped out of W5 to keep this PR reviewable.
+ *
+ * Inputs (from the dispatch shim in crates/harn-cli/src/commands/eval_prompt.rs):
+ *   HARN_EVAL_PROMPT_REPORT_JSON — serialised `PromptReport` (see the
+ *     struct in eval_prompt.rs for the canonical shape). Top-level
+ *     keys: `template_path`, `mode`, `renders`, `runs` (optional),
+ *     `judge` (optional), `context_eval` (optional).
+ *   HARN_EVAL_PROMPT_OUTPUT      — "terminal" | "json" | "html".
+ *
+ * The Rust shim serialises both env vars under a tokio Mutex so
+ * concurrent in-process callers (the existing eval_prompt_cli tests)
+ * don't clobber each other mid-dispatch.
+ *
+ * The script always emits its rendered payload to stdout. `--out-file`
+ * is handled on the Rust side after dispatch returns: the script runs
+ * under the standard `harn run` sandbox where `harness.fs.write_text`
+ * is restricted to `workspace_roots`, but users invoke `--out-file
+ * /tmp/...` all the time. Capturing the script's stdout and writing it
+ * from the unsandboxed shim preserves that behavior.
+ */
+fn __safe_string(value, fallback: string) -> string {
+  if type_of(value) == "string" {
+    return value
+  }
+  return fallback
+}
+
+fn __safe_list(value) -> list {
+  if type_of(value) == "list" {
+    return value
+  }
+  return []
+}
+
+fn __safe_dict(value) -> dict {
+  if type_of(value) == "dict" {
+    return value
+  }
+  return {}
+}
+
+fn __ends_with_newline(s: string) -> bool {
+  if len(s) == 0 {
+    return false
+  }
+  return s[len(s) - 1] == "\n"
+}
+
+/**
+ * Format a float as `"X.YYY"` (3 decimal places, always padded with
+ * trailing zeros). Mirrors Rust's `format!("{:.3}", x)` rounding /
+ * padding behavior — needed because Harn's `to_string` for `Float`
+ * uses `{n}` / `{n:.1}` which doesn't pad.
+ */
+fn __format_float_3(value) -> string {
+  let f = to_float(value) ?? 0.0
+  let negative = f < 0.0
+  let abs_f = if negative {
+    -f
+  } else {
+    f
+  }
+  // Round half-up to 3 decimals via int math.
+  let scaled = to_int(round(abs_f * 1000.0)) ?? 0
+  let whole = scaled / 1000
+  let frac = scaled - whole * 1000
+  var frac_str = to_string(frac)
+  while len(frac_str) < 3 {
+    frac_str = "0" + frac_str
+  }
+  let sign = if negative && (whole != 0 || frac != 0) {
+    "-"
+  } else {
+    ""
+  }
+  return sign + to_string(whole) + "." + frac_str
+}
+
+/**
+ * ─── Terminal rendering ───────────────────────────────────────────────────
+ */
+fn __line_diff_summary(baseline, candidate) -> string {
+  // Match the Rust impl's BTreeSet semantics: count *unique* lines on
+  // either side, not raw line counts.
+  var baseline_set = {}
+  for line in baseline {
+    baseline_set = baseline_set + {[line]: true}
+  }
+  var candidate_set = {}
+  for line in candidate {
+    candidate_set = candidate_set + {[line]: true}
+  }
+  var only_in_baseline = 0
+  for k in keys(baseline_set) {
+    if candidate_set[k] == nil {
+      only_in_baseline = only_in_baseline + 1
+    }
+  }
+  var only_in_candidate = 0
+  for k in keys(candidate_set) {
+    if baseline_set[k] == nil {
+      only_in_candidate = only_in_candidate + 1
+    }
+  }
+  if only_in_baseline == 0 && only_in_candidate == 0 {
+    let total_baseline = len(baseline)
+    let total_candidate = len(candidate)
+    if total_baseline == total_candidate {
+      return ""
+    }
+    return to_string(total_baseline) + " vs " + to_string(total_candidate)
+      + " lines (same content set, different ordering or repeats)"
+  }
+  return to_string(only_in_baseline) + " line(s) only in baseline, "
+    + to_string(only_in_candidate)
+    + " line(s) only here"
+}
+
+fn __first_rendered(renders) -> string {
+  for r in renders {
+    let rd = __safe_dict(r)
+    if type_of(rd["rendered"]) == "string" {
+      return rd["rendered"]
+    }
+  }
+  return ""
+}
+
+fn __terminal_render_section(render, idx, baseline_lines) -> string {
+  var out = "## [" + to_string(idx) + "] "
+    + __safe_string(render["selector"], "")
+    + " ("
+    + __safe_string(render["provider"], "")
+    + "/"
+    + __safe_string(render["model"], "")
+    + ")  family="
+    + __safe_string(render["family"], "")
+    + "\n"
+  let auth_available = render["auth_available"] ?? true
+  if !auth_available {
+    out = out + "    auth: not configured\n"
+  }
+  let error = render["error"]
+  if type_of(error) == "string" {
+    out = out + "    render error: " + error + "\n\n"
+    return out
+  }
+  let rendered = render["rendered"]
+  if type_of(rendered) != "string" {
+    return out
+  }
+  out = out + "---\n"
+  out = out + rendered
+  if !__ends_with_newline(rendered) {
+    out = out + "\n"
+  }
+  out = out + "---\n"
+  if idx > 0 && len(baseline_lines) > 0 {
+    let candidate_lines = split(rendered, "\n")
+    // Rust uses `lines()` which drops a trailing empty entry from a
+    // terminal "\n"; mirror that here so the diff summary matches.
+    var candidate_trim = candidate_lines
+    if len(candidate_trim) > 0 && candidate_trim[len(candidate_trim) - 1] == "" {
+      candidate_trim = candidate_trim[0:len(candidate_trim) - 1]
+    }
+    let summary = __line_diff_summary(baseline_lines, candidate_trim)
+    if summary != "" {
+      out = out + "    diff vs #0: " + summary + "\n"
+    }
+  }
+  out = out + "\n"
+  return out
+}
+
+fn __terminal_render_context_eval(context_eval) -> string {
+  var out = "\n# Context fixture gates: "
+    + to_string(context_eval["passed"] ?? 0)
+    + " passed / "
+    + to_string(context_eval["total"] ?? 0)
+    + " total\n"
+  for fixture in __safe_list(context_eval["fixtures"]) {
+    let fx = __safe_dict(fixture)
+    out = out + "\n## " + __safe_string(fx["path"], "")
+      + " ("
+      + to_string(fx["passed"] ?? 0)
+      + " passed / "
+      + to_string(fx["total"] ?? 0)
+      + " total)\n"
+    for case in __safe_list(fx["cases"]) {
+      let cs = __safe_dict(case)
+      let score = __safe_dict(cs["score"])
+      let budget = __safe_dict(cs["budget"])
+      let selected = __safe_list(cs["selected_artifact_ids"])
+      let pass_label = if cs["pass"] ?? false {
+        "pass"
+      } else {
+        "fail"
+      }
+      let overall = score["overall"] ?? 0.0
+      out = out + "- " + __safe_string(cs["id"], "")
+        + ": "
+        + pass_label
+        + " score="
+        + __format_float_3(overall)
+        + " selected=["
+        + join(selected, ", ")
+        + "] tokens="
+        + to_string(budget["total_tokens"] ?? 0)
+        + "/"
+        + to_string(budget["budget_tokens"] ?? 0)
+        + "\n"
+      for failure in __safe_list(cs["failures"]) {
+        out = out + "    failure: " + to_string(failure) + "\n"
+      }
+    }
+  }
+  return out
+}
+
+fn __terminal_render_runs(report) -> string {
+  let runs = __safe_dict(report["runs"])
+  if len(keys(runs)) == 0 {
+    return ""
+  }
+  var out = "\n# Model responses\n"
+  for render in __safe_list(report["renders"]) {
+    let rd = __safe_dict(render)
+    let selector = __safe_string(rd["selector"], "")
+    let run = runs[selector]
+    if run == nil {
+      continue
+    }
+    let run_d = __safe_dict(run)
+    out = out + "\n## " + selector
+      + " ("
+      + __safe_string(rd["model"], "")
+      + ")\n"
+    if run_d["skipped"] ?? false {
+      out = out + "    skipped: unauthenticated provider\n"
+      continue
+    }
+    let error = run_d["error"]
+    if type_of(error) == "string" {
+      out = out + "    error: " + error + "\n"
+      continue
+    }
+    let response = run_d["response"]
+    if type_of(response) == "string" {
+      out = out + "---\n" + response
+      if !__ends_with_newline(response) {
+        out = out + "\n"
+      }
+      out = out + "---\n"
+    }
+  }
+  return out
+}
+
+fn __render_terminal(report) -> string {
+  var out = "# harn eval prompt — "
+    + __safe_string(report["template_path"], "")
+    + " (mode: "
+    + __safe_string(report["mode"], "")
+    + ")\n\n"
+  let renders = __safe_list(report["renders"])
+  let baseline_text = __first_rendered(renders)
+  var baseline_lines = []
+  if baseline_text != "" {
+    baseline_lines = split(baseline_text, "\n")
+    if len(baseline_lines) > 0 && baseline_lines[len(baseline_lines) - 1] == "" {
+      baseline_lines = baseline_lines[0:len(baseline_lines) - 1]
+    }
+  }
+  var idx = 0
+  for render in renders {
+    out = out + __terminal_render_section(__safe_dict(render), idx, baseline_lines)
+    idx = idx + 1
+  }
+  let context_eval = report["context_eval"]
+  if type_of(context_eval) == "dict" {
+    out = out + __terminal_render_context_eval(context_eval)
+  }
+  out = out + __terminal_render_runs(report)
+  let judge = report["judge"]
+  if type_of(judge) == "dict" {
+    out = out + "\n# Judge verdict ("
+      + __safe_string(judge["judge_model"], "")
+      + "): \n"
+      + __safe_string(judge["verdict"], "")
+      + "\n"
+  }
+  return out
+}
+
+/**
+ * ─── JSON rendering ───────────────────────────────────────────────────────
+ */
+fn __render_json(report) -> string {
+  // The Rust impl emits serde_json's pretty form of the PromptReport
+  // verbatim. Harn's `json_stringify_pretty` sorts keys alphabetically,
+  // so the wire byte order differs from serde's struct-field order —
+  // but parsing both sides into a serde_json::Value compares equal.
+  // The dispatch parity tests assert structural equality, not byte
+  // identity, for the JSON path. The trailing newline matches Rust's
+  // `format!("{s}\n")`.
+  return json_stringify_pretty(report) + "\n"
+}
+
+/**
+ * ─── HTML rendering ───────────────────────────────────────────────────────
+ */
+fn __html_escape(s: string) -> string {
+  // The ampersand replace must run first to avoid double-encoding the
+  // ampersands that the other replacements introduce.
+  return s
+    .replace("&", "&amp;")
+    .replace("<", "&lt;")
+    .replace(">", "&gt;")
+    .replace("\"", "&quot;")
+    .replace("'", "&#39;")
+}
+
+fn __html_render_card(render, runs) -> string {
+  var out = "<div class=\"card\"><h2>"
+    + __html_escape(__safe_string(render["selector"], ""))
+    + " <span class=\"meta\">("
+    + __html_escape(__safe_string(render["provider"], ""))
+    + " / "
+    + __html_escape(__safe_string(render["model"], ""))
+    + " · "
+    + __html_escape(__safe_string(render["family"], ""))
+    + ")</span></h2>"
+  if !(render["auth_available"] ?? true) {
+    out = out + "<p class=\"skip\">auth: not configured</p>"
+  }
+  let error = render["error"]
+  let rendered = render["rendered"]
+  if type_of(error) == "string" {
+    out = out + "<p class=\"err\">render error: " + __html_escape(error) + "</p>"
+  } else if type_of(rendered) == "string" {
+    out = out + "<pre>" + __html_escape(rendered) + "</pre>"
+  }
+  let selector = __safe_string(render["selector"], "")
+  let run = runs[selector]
+  if type_of(run) == "dict" {
+    if run["skipped"] ?? false {
+      out = out + "<p class=\"skip\">run: skipped (no credentials)</p>"
+    } else {
+      let run_error = run["error"]
+      let response = run["response"]
+      if type_of(run_error) == "string" {
+        out = out + "<p class=\"err\">run error: " + __html_escape(run_error) + "</p>"
+      } else if type_of(response) == "string" {
+        out = out + "<h3>response</h3><pre>" + __html_escape(response) + "</pre>"
+      }
+    }
+  }
+  out = out + "</div>"
+  return out
+}
+
+fn __render_html(report) -> string {
+  var out = "<!doctype html><html><head><meta charset=\"utf-8\"><title>"
+    + "harn eval prompt report</title>"
+  out = out + "<style>body{font-family:system-ui,sans-serif;margin:2rem;color:#222}h1{margin-bottom:0}"
+  out = out + ".meta{color:#666;font-size:0.9rem;margin-bottom:1.5rem}"
+  out = out + ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(28rem,1fr));gap:1rem}"
+  out = out + ".card{border:1px solid #ddd;border-radius:6px;padding:1rem;background:#fafafa}"
+  out = out + ".card h2{margin-top:0;font-size:1rem}"
+  out = out
+    + "pre{background:#fff;border:1px solid #eee;padding:0.75rem;overflow:auto;white-space:pre-wrap;font-size:0.85rem}"
+  out = out + ".err{color:#b00}.skip{color:#888;font-style:italic}"
+  out = out + "</style></head><body>"
+  out = out + "<h1>harn eval prompt</h1><div class=\"meta\">"
+    + __html_escape(__safe_string(report["template_path"], ""))
+    + " · mode: "
+    + __safe_string(report["mode"], "")
+    + "</div>"
+  out = out + "<div class=\"grid\">"
+  let runs = __safe_dict(report["runs"])
+  for render in __safe_list(report["renders"]) {
+    out = out + __html_render_card(__safe_dict(render), runs)
+  }
+  out = out + "</div>"
+  let context_eval = report["context_eval"]
+  if type_of(context_eval) == "dict" {
+    out = out + "<h2>Context fixture gates</h2><p>"
+      + to_string(context_eval["passed"] ?? 0)
+      + " passed / "
+      + to_string(context_eval["total"] ?? 0)
+      + " total</p>"
+    for fixture in __safe_list(context_eval["fixtures"]) {
+      let fx = __safe_dict(fixture)
+      out = out + "<h3>" + __html_escape(__safe_string(fx["path"], "")) + "</h3><ul>"
+      for case in __safe_list(fx["cases"]) {
+        let cs = __safe_dict(case)
+        let score = __safe_dict(cs["score"])
+        let budget = __safe_dict(cs["budget"])
+        let pass_label = if cs["pass"] ?? false {
+          "pass"
+        } else {
+          "fail"
+        }
+        let selected = __safe_list(cs["selected_artifact_ids"])
+        out = out + "<li><strong>" + __html_escape(__safe_string(cs["id"], ""))
+          + "</strong>: "
+          + pass_label
+          + " · score "
+          + __format_float_3(score["overall"] ?? 0.0)
+          + " · selected ["
+          + __html_escape(join(selected, ", "))
+          + "] · tokens "
+          + to_string(budget["total_tokens"] ?? 0)
+          + "/"
+          + to_string(budget["budget_tokens"] ?? 0)
+          + "</li>"
+      }
+      out = out + "</ul>"
+    }
+  }
+  let judge = report["judge"]
+  if type_of(judge) == "dict" {
+    out = out + "<h2>Judge (" + __html_escape(__safe_string(judge["judge_model"], "")) + ")</h2>"
+      + "<pre>"
+      + __html_escape(__safe_string(judge["verdict"], ""))
+      + "</pre>"
+  }
+  out = out + "</body></html>\n"
+  return out
+}
+
+/**
+ * ─── Entrypoint ───────────────────────────────────────────────────────────
+ */
+fn main(harness: Harness) {
+  let raw = harness.env.get_or("HARN_EVAL_PROMPT_REPORT_JSON", "")
+  if raw == "" {
+    harness.stdio
+      .eprintln("internal error: HARN_EVAL_PROMPT_REPORT_JSON not set by dispatch shim")
+    exit(70)
+  }
+  let report = try {
+    json_parse(raw)
+  } catch (e) {
+    harness.stdio.eprintln("internal error: failed to parse PromptReport: " + to_string(e))
+    exit(70)
+  }
+  let output = harness.env.get_or("HARN_EVAL_PROMPT_OUTPUT", "terminal")
+  let payload = if output == "json" {
+    __render_json(report)
+  } else if output == "html" {
+    __render_html(report)
+  } else {
+    __render_terminal(report)
+  }
+  // Always print to stdout (no trailing newline — the rendered payloads
+  // already include their own terminating newline). The Rust shim
+  // intercepts captured stdout and writes it to `--out-file` if set.
+  __io_print(payload)
+}


### PR DESCRIPTION
## Summary

Closes #2305. Part of the #2293 self-host epic — W5 of the port waves.

**Partial port — pragmatic scope split.** The marquee `harn eval prompt` is ~1000 LOC and tightly entangled with VM internals (`LlmRenderContext` push/pop around template rendering, synthesised harn pipelines that drive `llm_call` fanout via `execute_run`, `llm_config::resolve_model_info` for fleet alias expansion, `harn_vm::orchestration::assemble_context` for context-fixture evaluation). None of that is reachable from script-land until G4 (#2297) exposes the missing host capabilities.

Boundary lands at the **rendering layer**: the Rust handler aggregates a `PromptReport` exactly as it always did, serialises it to JSON, and hands it to the embedded `cli/eval/prompt.harn` script which owns the three output formats (terminal / JSON / HTML) and the `--out-file` plumbing. The wider port (replacing the Rust shim entirely) is tracked alongside G4.

## What landed

- `crates/harn-stdlib/src/stdlib/cli/eval/prompt.harn` (~450 LOC) — terminal / JSON / HTML renderers. Reads `HARN_EVAL_PROMPT_REPORT_JSON` + `HARN_EVAL_PROMPT_OUTPUT`, emits to stdout.
- `crates/harn-cli/src/commands/eval_prompt.rs` — `run` refactored: `aggregate_report` → `legacy_render` (under `HARN_CLI_IMPL=rust`) or `dispatch_render`. Both paths see the same report; `post_render_exit_code` is shared. Dispatch serialises via `tokio::sync::Mutex` so concurrent in-process callers (`eval_prompt_cli.rs` runs four `run` invocations in parallel) don't clobber each other's env vars.
- `crates/harn-stdlib/src/lib.rs` — registers `eval/prompt` in `STDLIB_CLI_SCRIPTS`.
- `crates/harn-cli/tests/eval_prompt_dispatch.rs` — 5 subprocess parity tests:
  - terminal byte-identity
  - HTML byte-identity
  - JSON structural-identity (Harn sorts keys alphabetically; serde emits struct-field order)
  - `--out-file` round-trip
  - `--help` byte-identity

`--out-file` is honored on the Rust side after capturing the script's stdout because the `harn run` sandbox restricts `harness.fs.write_text` to `workspace_roots`, but users invoke `--out-file /tmp/...` all the time.

## Test plan

- [x] `cargo test -p harn-cli --test eval_prompt_dispatch` — 5/5 pass
- [x] `cargo test -p harn-cli --test eval_prompt_cli` — 5/5 pass (no regression on the pre-existing render-mode coverage)
- [x] `cargo test -p harn-cli --test dispatch_echo --test parity_dispatch` — 4/4 pass (G1 wedge unaffected)
- [x] `cargo test -p harn-cli --lib commands::eval_prompt` — 4/4 pass
- [x] `cargo clippy -p harn-cli -p harn-stdlib --no-deps` — clean
- [x] `harn lint` / `harn fmt --check` on the new script — clean
- [x] Manual: terminal/json/html parity vs `HARN_CLI_IMPL=rust` on a two-model fleet — byte-identical (terminal/html) and structurally-equal (json)

## Out of scope

- Replacing the Rust aggregation with a pure-.harn pipeline — gated on G4 (#2297).
- C1 ratchet (#2314) will delete the `HARN_CLI_IMPL=rust` escape hatch once parity holds across the wave.
- `eval context`, `eval tool-calls`, `eval model-selector`, `eval coding-agent` — W6 (#2306) and W7 (#2307).

🤖 Generated with [Claude Code](https://claude.com/claude-code)