### PR TITLE
Add LOC ratchet for ported handlers (#2314)

### DIFF
--- a/.github/workflows/ported-handler-loc.yml
+++ b/.github/workflows/ported-handler-loc.yml
@@ -1,0 +1,59 @@
+# LOC ratchet for CLI handlers that are mid-port from Rust to the
+# self-hosted .harn cli/* stack. Fails the PR if any handler listed in
+# scripts/ported_handlers.toml has grown past its committed budget.
+# Tracks epic #2293 (subticket #2314 = C1).
+#
+# IMPORTANT: this workflow is NOT yet wired into the required-status
+# set in `ci.yml`'s `CI status` job. Promotion to a required check is
+# tracked as a follow-up to C1; until then a red run reports a result
+# but does not block the merge queue.
+
+name: Ported handler LOC ratchet
+
+on:
+  pull_request:
+    paths:
+      - 'crates/harn-cli/src/commands/**'
+      - 'crates/harn-cli/src/lib.rs'
+      - 'scripts/check_ported_handler_loc.harn'
+      - 'scripts/ported_handlers.toml'
+      - '.github/workflows/ported-handler-loc.yml'
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  SCCACHE_GHA_ENABLED: "true"
+  # Match ci.yml so warnings don't slip in via a path that only this
+  # workflow exercises.
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  ported-handler-loc:
+    name: Ported handler LOC ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        # sccache is a build-cache optimization, not a build requirement.
+        continue-on-error: true
+      - name: Configure Cargo to use sccache
+        if: env.SCCACHE_PATH != ''
+        run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        continue-on-error: true
+        with:
+          shared-key: ported-handler-loc
+          cache-bin: false
+      - name: Run ported-handler LOC ratchet
+        run: make check-ported-handler-loc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration bench-cli-cold-start all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration bench-cli-cold-start all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -444,3 +444,10 @@ lint-no-rust-prompt-prose:
 
 lint-no-xfail-regression:
 	@cargo run --quiet --bin harn -- run scripts/check_xfail_count.harn
+
+# CI ratchet: fail if any Rust CLI handler listed in
+# scripts/ported_handlers.toml grows past its budgeted LOC. Tracks
+# epic #2293 (subticket #2314 = C1). See the script header for how to
+# add new entries / adjust budgets.
+check-ported-handler-loc:
+	@cargo run --quiet --bin harn -- run scripts/check_ported_handler_loc.harn

--- a/scripts/check_ported_handler_loc.harn
+++ b/scripts/check_ported_handler_loc.harn
@@ -1,0 +1,119 @@
+// CI ratchet: fail if any handler listed in scripts/ported_handlers.toml
+// grows beyond its committed LOC budget. The intent is to catch *new*
+// growth in the legacy Rust dispatch path while a CLI subcommand is in
+// the middle of being ported off Rust onto the self-hosted `.harn`
+// cli/* stack — without forcing a clean-up of the existing baseline.
+//
+// Budgets are set to the current LOC + a small slack (~5 lines) so a
+// no-op refactor doesn't trip the gate but a real regression does.
+// When a port advances and shrinks the Rust handler, drop the budget
+// to the new current+5 in the same PR.
+//
+// Line counts match `wc -l` (number of `\n` characters), which is what
+// the budgets in ported_handlers.toml were measured against.
+//
+// Tracks epic #2293 (subticket #2314 = C1).
+let CONFIG_PATH = "scripts/ported_handlers.toml"
+
+/**
+ * Count lines in `text`, matching `wc -l` semantics: the number of
+ * newline characters. Files that end with a trailing newline (the
+ * conventional shape for source files) report the same count as
+ * `wc -l` on disk.
+ */
+pub fn count_lines(text: string) -> int {
+  return text.split("\n").count - 1
+}
+
+/**
+ * Compute the LOC for a single file path. Returns `nil` if the file
+ * is missing — callers decide whether that's a hard error (a budgeted
+ * file should always exist) or a soft skip.
+ */
+pub fn loc_for(path: string) -> int? {
+  if !harness.fs.exists(path) {
+    return nil
+  }
+  return count_lines(harness.fs.read_text(path))
+}
+
+/**
+ * Pure check used by `collect_violations`. Given a handler's configured
+ * `path` / `max_loc` and the `actual` LOC (or `nil` if the file is
+ * missing), return a violation record or `nil` if the entry is within
+ * budget. Split out so tests can exercise the rules without touching
+ * the filesystem.
+ */
+pub fn evaluate_handler(path, max_loc, actual) {
+  if path == nil || path == "" || max_loc == nil {
+    return {path: path, actual: nil, max_loc: max_loc, reason: "invalid entry: path and max_loc are required"}
+  }
+  if actual == nil {
+    return {path: path, actual: nil, max_loc: max_loc, reason: "missing file"}
+  }
+  if actual > max_loc {
+    return {path: path, actual: actual, max_loc: max_loc, reason: "over budget"}
+  }
+  return nil
+}
+
+/**
+ * Walk a parsed `[[handler]]` array and return the subset that exceeds
+ * its budget, as `{path, actual, max_loc, reason}` records. Missing
+ * files are surfaced as violations so a typo in the config fails the
+ * gate instead of silently passing.
+ */
+pub fn collect_violations(handlers) -> list {
+  var violations = []
+  for handler in handlers {
+    let path = handler?.path
+    let max_loc = handler?.max_loc
+    let actual = if path == nil || path == "" {
+      nil
+    } else {
+      loc_for(path)
+    }
+    let v = evaluate_handler(path, max_loc, actual)
+    if v != nil {
+      violations = violations + [v]
+    }
+  }
+  return violations
+}
+
+pipeline main(task) {
+  if !harness.fs.exists(CONFIG_PATH) {
+    __io_eprintln("error: missing ${CONFIG_PATH}")
+    return 1
+  }
+  let parsed = try {
+    toml_parse(harness.fs.read_text(CONFIG_PATH))
+  } catch (err) {
+    __io_eprintln("error: failed to parse ${CONFIG_PATH}: ${err}")
+    return 1
+  }
+  let handlers = parsed?.handler ?? []
+  if handlers.count == 0 {
+    __io_eprintln("error: ${CONFIG_PATH} has no [[handler]] entries")
+    return 1
+  }
+  let violations = collect_violations(handlers)
+  if violations.count == 0 {
+    __io_println("ported-handler LOC ratchet OK (${handlers.count} handler(s) within budget)")
+    return 0
+  }
+  __io_eprintln("::error::ported-handler LOC ratchet failed (${violations.count} violation(s)):")
+  for v in violations {
+    if v.reason == "missing file" {
+      __io_eprintln("  ${v.path}: missing (budget was ${v.max_loc})")
+    } else if v.reason == "invalid entry: path and max_loc are required" {
+      __io_eprintln("  <invalid entry>: ${v.reason}")
+    } else {
+      __io_eprintln("  ${v.path}: ${v.actual} > ${v.max_loc}")
+    }
+  }
+  __io_eprintln(
+    "hint: a ported handler grew. Either shrink it back (preferred — the ratchet exists to keep the Rust dispatch path from regrowing) or, if the growth is intentional, bump the budget in ${CONFIG_PATH} with rationale in the commit message.",
+  )
+  return 1
+}

--- a/scripts/ported_handlers.toml
+++ b/scripts/ported_handlers.toml
@@ -1,0 +1,44 @@
+# LOC ratchet config consumed by scripts/check_ported_handler_loc.harn.
+#
+# Each `[[handler]]` entry caps the maximum line count for a CLI subcommand
+# handler that has been (fully or partially) ported off Rust onto the
+# self-hosted `.harn` cli/* stack. The intent is to catch *new* growth in
+# the legacy Rust path — not to force a cleanup of the existing baseline.
+# Budgets are deliberately set to the current LOC + a small slack (≈5
+# lines) so a no-op refactor doesn't trip the gate but a real regression
+# does.
+#
+# When a port advances and shrinks the Rust handler, drop the budget to
+# the new current+5 in the same PR. When a new handler joins the ratcheted
+# set (a fresh W ticket landing), append a new `[[handler]]` block with
+# its current+5 budget; do not retroactively tighten existing entries.
+#
+# Tracks epic #2293 (subticket #2314 = C1).
+
+[[handler]]
+path = "crates/harn-cli/src/commands/try_cmd.rs"
+max_loc = 112
+
+[[handler]]
+path = "crates/harn-cli/src/commands/trace.rs"
+max_loc = 226
+
+[[handler]]
+path = "crates/harn-cli/src/commands/explain.rs"
+max_loc = 481
+
+[[handler]]
+path = "crates/harn-cli/src/commands/init.rs"
+max_loc = 946
+
+[[handler]]
+path = "crates/harn-cli/src/commands/tool.rs"
+max_loc = 350
+
+[[handler]]
+path = "crates/harn-cli/src/commands/eval_prompt.rs"
+max_loc = 1201
+
+[[handler]]
+path = "crates/harn-cli/src/lib.rs"
+max_loc = 3120

--- a/scripts/tests/check_ported_handler_loc_test.harn
+++ b/scripts/tests/check_ported_handler_loc_test.harn
@@ -1,0 +1,71 @@
+// Tests for scripts/check_ported_handler_loc.harn — exercise the helper
+// functions on synthetic inputs (no filesystem dependency).
+import "../check_ported_handler_loc.harn"
+
+@test
+pipeline test_count_lines_trailing_newline(task) {
+  // Matches `wc -l`: "a\nb\nc\n" has 3 newlines.
+  assert_eq(count_lines("a\nb\nc\n"), 3)
+}
+
+@test
+pipeline test_count_lines_no_trailing_newline(task) {
+  // Also `wc -l` behavior: only newline characters count.
+  assert_eq(count_lines("a\nb\nc"), 2)
+}
+
+@test
+pipeline test_count_lines_empty_string(task) {
+  assert_eq(count_lines(""), 0)
+}
+
+@test
+pipeline test_count_lines_single_newline(task) {
+  assert_eq(count_lines("\n"), 1)
+}
+
+@test
+pipeline test_evaluate_handler_within_budget_returns_nil(task) {
+  assert_eq(evaluate_handler("a.rs", 100, 50), nil)
+}
+
+@test
+pipeline test_evaluate_handler_at_budget_returns_nil(task) {
+  // At-budget is OK; only strict over trips the ratchet.
+  assert_eq(evaluate_handler("a.rs", 100, 100), nil)
+}
+
+@test
+pipeline test_evaluate_handler_over_budget(task) {
+  let v = evaluate_handler("a.rs", 100, 101)
+  assert_eq(v.path, "a.rs")
+  assert_eq(v.actual, 101)
+  assert_eq(v.max_loc, 100)
+  assert_eq(v.reason, "over budget")
+}
+
+@test
+pipeline test_evaluate_handler_missing_file(task) {
+  let v = evaluate_handler("ghost.rs", 100, nil)
+  assert_eq(v.path, "ghost.rs")
+  assert_eq(v.actual, nil)
+  assert_eq(v.reason, "missing file")
+}
+
+@test
+pipeline test_evaluate_handler_invalid_empty_path(task) {
+  let v = evaluate_handler("", 100, 50)
+  assert_eq(v.reason, "invalid entry: path and max_loc are required")
+}
+
+@test
+pipeline test_evaluate_handler_invalid_nil_path(task) {
+  let v = evaluate_handler(nil, 100, 50)
+  assert_eq(v.reason, "invalid entry: path and max_loc are required")
+}
+
+@test
+pipeline test_evaluate_handler_invalid_nil_max_loc(task) {
+  let v = evaluate_handler("a.rs", nil, 50)
+  assert_eq(v.reason, "invalid entry: path and max_loc are required")
+}


### PR DESCRIPTION
## Summary

- New pure-`.harn` CI ratchet (`scripts/check_ported_handler_loc.harn`) — dogfoods the language to enforce per-file LOC budgets on CLI handlers that are mid-port from Rust to the self-hosted `cli/*` stack.
- Initial budgets in `scripts/ported_handlers.toml` are set to each file's current `wc -l` plus a ~5-line slack so a no-op refactor doesn't trip the gate but a real regression does.
- New `make check-ported-handler-loc` target and `.github/workflows/ported-handler-loc.yml` workflow that triggers on touches to `crates/harn-cli/src/commands/**`, `crates/harn-cli/src/lib.rs`, the script, or the config.
- Following the `cli-cold-start-budget` precedent the workflow is intentionally advisory for now (not promoted to a required check on `CI status`); promotion will be filed as a follow-up after the first cycle of regressions has been observed and tuned.

## Initial budgets

Measured against `origin/main`, then padded by ~5 lines:

| Handler | Current LOC | Budget |
| --- | --- | --- |
| `crates/harn-cli/src/commands/try_cmd.rs` | 107 | 112 |
| `crates/harn-cli/src/commands/trace.rs` | 221 | 226 |
| `crates/harn-cli/src/commands/explain.rs` | 476 | 481 |
| `crates/harn-cli/src/commands/init.rs` | 941 | 946 |
| `crates/harn-cli/src/commands/tool.rs` | 345 | 350 |
| `crates/harn-cli/src/commands/eval_prompt.rs` | 1196 | 1201 |
| `crates/harn-cli/src/lib.rs` | 3115 | 3120 |

The intent is to keep the legacy Rust dispatch path from quietly regrowing — not to force a clean-up of the existing baseline. When a port advances and shrinks a handler, the next PR should drop the budget to the new current+5.

Tracks epic #2293, subticket #2314 = C1.

## Test plan

- [x] `cargo run --quiet --bin harn -- run scripts/check_ported_handler_loc.harn` exits 0 on a clean tree
- [x] Synthetically appending 100 lines to `try_cmd.rs` flips it to exit 1 with `::error::` + per-file violation list
- [x] Reverting the change returns it to exit 0
- [x] Multiple simultaneous violations all print (verified with try_cmd + tool)
- [x] `cargo run --quiet --bin harn -- test scripts/tests/check_ported_handler_loc_test.harn` — 11 new unit tests pass (pure-function coverage of `count_lines` and `evaluate_handler`)
- [x] `cargo run --quiet --bin harn -- test scripts/tests/` — full 53-test script suite green
- [x] `harn fmt --check` and `harn lint` clean on both new files
- [x] `actionlint .github/workflows/ported-handler-loc.yml` clean
- [x] Pre-commit + pre-push hooks (clippy, harn fmt/lint, CI ratchet) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)