### PR TITLE
Port `harn models` (list/recommend/test) to .harn (#2309)

### DIFF
--- a/crates/harn-cli/src/commands/models/list.rs
+++ b/crates/harn-cli/src/commands/models/list.rs
@@ -1,11 +1,90 @@
+//! `harn models list` — list configured models grouped by provider.
+//!
+//! ## .harn dispatch (W9 — see harn#2309)
+//!
+//! The filter + render pipeline lives in
+//! `crates/harn-stdlib/src/stdlib/cli/models/list.harn`. The catalog
+//! itself comes from the `llm_catalog()` free builtin landed in G4
+//! (#2297 / #2343), so the script owns the entire data-shape
+//! transformation end-to-end. The Rust shim's only contribution is
+//! detecting installed Ollama models out-of-process (sandboxed scripts
+//! can't run `ollama list`) and threading the parsed `--provider` /
+//! `--installed-only` flags through env vars.
+//!
+//! `HARN_CLI_IMPL=rust` keeps the legacy direct path for the
+//! parity-snapshot harness (#2299) until the C1 ratchet (#2314) lands.
+
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write as _;
 
 use harn_vm::llm_config;
 use serde_json::json;
 
 use crate::cli::ModelsListArgs;
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
+
+/// Env var the embedded `cli/models/list` script reads to pick up the
+/// `--provider` filter. Empty when no filter was passed.
+const LIST_PROVIDER_ENV: &str = "HARN_MODELS_LIST_PROVIDER";
+
+/// Env var for `--installed-only`. `"1"` iff the flag was set.
+const LIST_INSTALLED_ONLY_ENV: &str = "HARN_MODELS_LIST_INSTALLED_ONLY";
+
+/// Env var carrying the JSON list of installed Ollama model ids. The
+/// Rust shim resolves these via `ollama list` (which scripts can't run
+/// because the sandbox would block the subprocess) and hands them
+/// across as a single payload so the script doesn't have to.
+const LIST_INSTALLED_OLLAMA_ENV: &str = "HARN_MODELS_INSTALLED_OLLAMA";
+
+/// Serialises the dispatch path so concurrent in-process callers don't
+/// race on the global env vars the shim sets. Same pattern as the
+/// other partial-port commands (see harn#2305 / #2306).
+static DISPATCH_LIST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 pub(crate) async fn run(args: ModelsListArgs) {
+    if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
+        run_legacy(args).await;
+        return;
+    }
+    let exit_code = run_dispatch(args).await;
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+}
+
+async fn run_dispatch(args: ModelsListArgs) -> i32 {
+    let installed = detect_installed_ollama_models().await;
+    let installed_vec: Vec<String> = installed.iter().cloned().collect();
+    let installed_json = match serde_json::to_string(&installed_vec) {
+        Ok(json) => json,
+        Err(error) => {
+            eprintln!("error: failed to serialise installed ollama set: {error}");
+            return 1;
+        }
+    };
+
+    let _guard = DISPATCH_LIST_LOCK.lock().await;
+    let _installed = ScopedEnvVar::set(LIST_INSTALLED_OLLAMA_ENV, &installed_json);
+    let _installed_only = ScopedEnvVar::set(
+        LIST_INSTALLED_ONLY_ENV,
+        if args.installed_only { "1" } else { "0" },
+    );
+    let _provider = ScopedEnvVar::set(LIST_PROVIDER_ENV, args.provider.as_deref().unwrap_or(""));
+
+    let outcome = dispatch::run_embedded_script("models/list", Vec::new(), args.json).await;
+    if !outcome.stderr.is_empty() {
+        let _ = std::io::stderr().write_all(outcome.stderr.as_bytes());
+    }
+    if !outcome.stdout.is_empty() {
+        let _ = std::io::stdout().write_all(outcome.stdout.as_bytes());
+    }
+    outcome.exit_code
+}
+
+/// Legacy direct-render path. Kept verbatim for the parity-snapshot
+/// harness (#2299) until C1 (#2314) deletes it.
+async fn run_legacy(args: ModelsListArgs) {
     let installed_ollama = detect_installed_ollama_models().await;
 
     // Build provider -> Vec<(id, tags, installed)>.

--- a/crates/harn-cli/src/commands/models/mod.rs
+++ b/crates/harn-cli/src/commands/models/mod.rs
@@ -11,7 +11,7 @@ pub(crate) async fn run(args: ModelsArgs) {
     match args.command {
         ModelsCommand::List(args) => list::run(args).await,
         ModelsCommand::Install(args) => install::run(args).await,
-        ModelsCommand::Recommend(args) => recommend::run(&args),
+        ModelsCommand::Recommend(args) => recommend::run(&args).await,
         ModelsCommand::Test(args) => test::run(&args).await,
     }
 }

--- a/crates/harn-cli/src/commands/models/recommend.rs
+++ b/crates/harn-cli/src/commands/models/recommend.rs
@@ -1,4 +1,24 @@
+//! `harn models recommend` — pick a starter model for the current
+//! machine and credentials.
+//!
+//! ## .harn dispatch (W9 — see harn#2309)
+//!
+//! The rule-lookup + rendering pipeline lives in
+//! `crates/harn-stdlib/src/stdlib/cli/models/recommend.harn`. Hardware
+//! probing (`sysctl` / `/proc/meminfo` / `nvidia-smi` /
+//! `MetalPerformanceShaders`), provider credential detection
+//! (`llm_config::provider_key_available`), and parsing
+//! `data/model_recommendations.toml` all stay in Rust — none of those
+//! capabilities are exposed to script-land today, and the sandbox
+//! would block the subprocess calls. The Rust shim collects everything
+//! into a single JSON payload and hands it across; the script picks
+//! the matching rule and formats the output.
+//!
+//! `HARN_CLI_IMPL=rust` keeps the legacy direct path for the
+//! parity-snapshot harness (#2299) until the C1 ratchet (#2314) lands.
+
 use std::collections::BTreeSet;
+use std::io::Write as _;
 
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +26,8 @@ use crate::cli::ModelRecommendArgs;
 use crate::commands::hardware::{
     bytes_to_gib_floor, bytes_to_gib_rounded, collect_hardware_snapshot, GpuKind, HardwareSnapshot,
 };
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
 
 const RECOMMENDATIONS_TOML: &str = include_str!("../../../data/model_recommendations.toml");
 const CLOUD_DEFAULT_SENTINEL: &str = "$cloud_default";
@@ -20,6 +42,16 @@ const GPU_KEYS: [RecommendationGpu; 3] = [
     RecommendationGpu::Mps,
     RecommendationGpu::Cuda,
 ];
+
+/// Env var carrying the full recommend payload (hardware snapshot,
+/// has-provider-key flag, cloud-model resolution, parsed recommendation
+/// table) handed to the embedded `cli/models/recommend` script.
+const RECOMMEND_PAYLOAD_ENV: &str = "HARN_MODELS_RECOMMEND_PAYLOAD_JSON";
+
+/// Serialises the dispatch path so concurrent in-process callers don't
+/// race on the global env var. Same pattern as other partial-port
+/// commands (see harn#2305 / #2306).
+static DISPATCH_RECOMMEND_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -87,7 +119,7 @@ struct RecommendationTable {
     recommendations: Vec<RecommendationRule>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 struct RecommendationRule {
     ram_bucket: RamBucket,
     gpu: RecommendationGpu,
@@ -96,7 +128,7 @@ struct RecommendationRule {
     model_id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct CloudModel {
     provider: String,
     model_id: String,
@@ -114,7 +146,73 @@ struct ModelRecommendation {
     hardware: HardwareSnapshot,
 }
 
-pub(crate) fn run(args: &ModelRecommendArgs) {
+/// JSON payload handed to the embedded `cli/models/recommend` script.
+/// The script picks the matching rule and renders — see the script's
+/// docstring for the input contract.
+#[derive(Debug, Serialize)]
+struct RecommendDispatchPayload<'a> {
+    hardware: &'a HardwareSnapshot,
+    has_provider_key: bool,
+    cloud_model: Option<&'a CloudModel>,
+    recommendations: &'a [RecommendationRule],
+}
+
+pub(crate) async fn run(args: &ModelRecommendArgs) {
+    if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
+        run_legacy(args);
+        return;
+    }
+    let exit_code = run_dispatch(args).await;
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+}
+
+async fn run_dispatch(args: &ModelRecommendArgs) -> i32 {
+    let snapshot = collect_hardware_snapshot();
+    let cloud_model = detect_cloud_model();
+    let has_provider_key = cloud_model.is_some();
+    let table = match load_recommendation_table() {
+        Ok(table) => table,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    if let Err(error) = validate_recommendation_table(&table) {
+        eprintln!("error: {error}");
+        return 1;
+    }
+
+    let payload = RecommendDispatchPayload {
+        hardware: &snapshot,
+        has_provider_key,
+        cloud_model: cloud_model.as_ref(),
+        recommendations: &table.recommendations,
+    };
+    let payload_json = match serde_json::to_string(&payload) {
+        Ok(json) => json,
+        Err(error) => {
+            eprintln!("error: failed to serialise recommend payload: {error}");
+            return 1;
+        }
+    };
+
+    let _guard = DISPATCH_RECOMMEND_LOCK.lock().await;
+    let _payload_guard = ScopedEnvVar::set(RECOMMEND_PAYLOAD_ENV, &payload_json);
+    let outcome = dispatch::run_embedded_script("models/recommend", Vec::new(), args.json).await;
+    if !outcome.stderr.is_empty() {
+        let _ = std::io::stderr().write_all(outcome.stderr.as_bytes());
+    }
+    if !outcome.stdout.is_empty() {
+        let _ = std::io::stdout().write_all(outcome.stdout.as_bytes());
+    }
+    outcome.exit_code
+}
+
+/// Legacy direct-render path. Kept verbatim for the parity-snapshot
+/// harness (#2299) until C1 (#2314) deletes it.
+fn run_legacy(args: &ModelRecommendArgs) {
     let snapshot = collect_hardware_snapshot();
     let cloud_model = detect_cloud_model();
     let has_provider_key = cloud_model.is_some();

--- a/crates/harn-cli/src/commands/models/test.rs
+++ b/crates/harn-cli/src/commands/models/test.rs
@@ -1,8 +1,107 @@
+//! `harn models test` — round-trip a small prompt through a model.
+//!
+//! ## .harn dispatch (W9 partial port — see harn#2309)
+//!
+//! **The actual smoke test stays in Rust.** `run_model_smoke_test`
+//! reaches into `vm_call_llm_full_streaming` with bespoke
+//! `LlmCallOptions`, probes provider readiness, drives a streaming
+//! callback for first-token-ms, and computes pricing — none of that is
+//! reachable from script-land today without exposing a much wider VM
+//! surface than W9 should ship. The Rust shim runs the test and
+//! captures either a success result or an error.
+//!
+//! The **rendering layer** delegates to
+//! `crates/harn-stdlib/src/stdlib/cli/models/test.harn`, which owns
+//! both the human-readable line and the JSON envelope (success +
+//! failure shapes). That's the surface a user actually reads or parses,
+//! so it's the surface we want to ratchet onto .harn.
+//!
+//! `HARN_CLI_IMPL=rust` keeps the legacy direct-render path for the
+//! parity-snapshot harness (#2299) until the C1 ratchet (#2314) lands.
+
+use std::io::Write as _;
 use std::process;
 
+use serde::Serialize;
+
 use crate::cli::ModelsTestArgs;
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
+
+/// Env var carrying the smoke-test outcome (success result or error)
+/// handed to the embedded `cli/models/test` script. The script picks
+/// the rendering format based on `HARN_OUTPUT_JSON`.
+const TEST_RESULT_ENV: &str = "HARN_MODELS_TEST_RESULT_JSON";
+
+/// Serialises the dispatch path so concurrent in-process callers don't
+/// race on the global env var.
+static DISPATCH_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Envelope the Rust shim hands to the .harn script. Mirrors the
+/// success / failure split the legacy impl branches on.
+#[derive(Debug, Serialize)]
+struct TestEnvelope<'a> {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<&'a harn_vm::llm::ModelSmokeTestResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<&'a str>,
+}
 
 pub(crate) async fn run(args: &ModelsTestArgs) {
+    if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
+        run_legacy(args).await;
+        return;
+    }
+    let exit_code = run_dispatch(args).await;
+    if exit_code != 0 {
+        process::exit(exit_code);
+    }
+}
+
+async fn run_dispatch(args: &ModelsTestArgs) -> i32 {
+    let result = harn_vm::llm::run_model_smoke_test(harn_vm::llm::ModelSmokeTestOptions {
+        model: args.model.clone(),
+        provider: args.provider.clone(),
+        prompt: args.prompt.clone(),
+    })
+    .await;
+
+    let envelope = match &result {
+        Ok(value) => TestEnvelope {
+            ok: true,
+            result: Some(value),
+            error: None,
+        },
+        Err(error) => TestEnvelope {
+            ok: false,
+            result: None,
+            error: Some(error.as_str()),
+        },
+    };
+    let envelope_json = match serde_json::to_string(&envelope) {
+        Ok(json) => json,
+        Err(error) => {
+            eprintln!("error: failed to serialise models-test envelope: {error}");
+            return 1;
+        }
+    };
+
+    let _guard = DISPATCH_TEST_LOCK.lock().await;
+    let _payload = ScopedEnvVar::set(TEST_RESULT_ENV, &envelope_json);
+    let outcome = dispatch::run_embedded_script("models/test", Vec::new(), args.json).await;
+    if !outcome.stderr.is_empty() {
+        let _ = std::io::stderr().write_all(outcome.stderr.as_bytes());
+    }
+    if !outcome.stdout.is_empty() {
+        let _ = std::io::stdout().write_all(outcome.stdout.as_bytes());
+    }
+    outcome.exit_code
+}
+
+/// Legacy direct-render path. Kept verbatim for the parity-snapshot
+/// harness (#2299) until C1 (#2314) deletes it.
+async fn run_legacy(args: &ModelsTestArgs) {
     let result = harn_vm::llm::run_model_smoke_test(harn_vm::llm::ModelSmokeTestOptions {
         model: args.model.clone(),
         provider: args.provider.clone(),

--- a/crates/harn-cli/tests/models_dispatch.rs
+++ b/crates/harn-cli/tests/models_dispatch.rs
@@ -1,0 +1,408 @@
+#![recursion_limit = "256"]
+
+//! Partial-port verification for `harn models list` / `recommend` /
+//! `test` (harn#2309 / W9).
+//!
+//! Each subcommand's render pipeline now lives in
+//! `crates/harn-stdlib/src/stdlib/cli/models/*.harn`. The Rust
+//! dispatch shims keep doing the host-only work (Ollama subprocess
+//! probe for list, hardware snapshot + cloud-cred probe for recommend,
+//! the actual smoke-test for test) and hand a JSON payload across the
+//! dispatch wedge to the script for formatting.
+//!
+//! The `HARN_CLI_IMPL=rust` escape hatch keeps the legacy direct path
+//! so this test can compare both impls at runtime until the C1 ratchet
+//! (#2314) deletes it.
+//!
+//! Parity bar:
+//!   * Human text: byte-for-byte identity.
+//!   * JSON envelopes: structural identity (Harn's
+//!     `json_stringify_pretty` sorts dict keys alphabetically; serde
+//!     emits struct fields in declaration order, so wire byte order
+//!     differs but the parsed shape must match).
+
+use std::process::{Command, Output};
+
+fn harn_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_harn")
+}
+
+struct SubprocessOutcome {
+    stdout: String,
+    stderr: String,
+    exit_code: i32,
+}
+
+fn run(argv: &[&str], extra_env: &[(&str, &str)]) -> SubprocessOutcome {
+    let mut cmd = Command::new(harn_binary());
+    for arg in argv {
+        cmd.arg(arg);
+    }
+    // Strip ambient HARN_CLI_IMPL so the test controls the dispatch
+    // path, and strip NO_COLOR / HARN_COLOR so terminal-detection env
+    // vars don't perturb the renders across the two subprocess calls.
+    for key in ["HARN_CLI_IMPL", "NO_COLOR", "HARN_COLOR"] {
+        cmd.env_remove(key);
+    }
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let Output {
+        status,
+        stdout,
+        stderr,
+    } = cmd.output().expect("spawn harn");
+    SubprocessOutcome {
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        exit_code: status.code().unwrap_or(-1),
+    }
+}
+
+fn parse_json(s: &str, label: &str) -> serde_json::Value {
+    serde_json::from_str(s).unwrap_or_else(|err| {
+        panic!("{label} stdout is not valid JSON: {err}\n--- payload ---\n{s}")
+    })
+}
+
+// ─── models list ─────────────────────────────────────────────────────────
+
+#[test]
+fn models_list_human_text_is_byte_identical_between_impls() {
+    let harn = run(&["models", "list"], &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    let rust = run(&["models", "list"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "models list human stdout diverged"
+    );
+}
+
+#[test]
+fn models_list_provider_filter_byte_identical_between_impls() {
+    let harn = run(&["models", "list", "--provider", "openai"], &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    let rust = run(
+        &["models", "list", "--provider", "openai"],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "models list --provider stdout diverged"
+    );
+}
+
+#[test]
+fn models_list_installed_only_byte_identical_between_impls() {
+    // --installed-only with no installed ollama models prints
+    // `(no models match)` on both paths; the test machine may or may
+    // not have ollama installed but the shim hands the same set to
+    // both impls so the output should be identical regardless.
+    let harn = run(&["models", "list", "--installed-only"], &[]);
+    let rust = run(
+        &["models", "list", "--installed-only"],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "models list --installed-only stdout diverged"
+    );
+}
+
+#[test]
+fn models_list_json_is_structurally_identical_between_impls() {
+    let harn = run(&["models", "list", "--json"], &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    let rust = run(&["models", "list", "--json"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    let harn_value = parse_json(&harn.stdout, "harn");
+    let rust_value = parse_json(&rust.stdout, "rust");
+    assert_eq!(
+        rust_value, harn_value,
+        "models list --json shape diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust.stdout, harn.stdout
+    );
+}
+
+// ─── models recommend ───────────────────────────────────────────────────
+
+/// Recommendation output depends on the current machine's RAM /
+/// GPU / installed credentials. Compare the two impls back-to-back
+/// without rationalising — they must agree on whatever the host
+/// reports.
+#[test]
+fn models_recommend_human_text_is_byte_identical_between_impls() {
+    let harn = run(&["models", "recommend"], &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    let rust = run(&["models", "recommend"], &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "models recommend human stdout diverged"
+    );
+}
+
+#[test]
+fn models_recommend_json_shape_is_identical_between_impls() {
+    let harn = run(&["models", "recommend", "--json"], &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    let rust = run(
+        &["models", "recommend", "--json"],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    let harn_value = parse_json(&harn.stdout, "harn");
+    let rust_value = parse_json(&rust.stdout, "rust");
+    // The two impls run separate hardware probes so floating numbers
+    // like `available_bytes` may differ by a tiny amount between back-
+    // to-back invocations. Compare the structural keyset + the fields
+    // that don't depend on a fresh snapshot.
+    for key in [
+        "model_id",
+        "harn_selector",
+        "provider",
+        "rationale",
+        "ram_bucket",
+        "gpu",
+        "has_provider_key",
+    ] {
+        assert_eq!(
+            rust_value[key], harn_value[key],
+            "recommend.{key} diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+            rust.stdout, harn.stdout
+        );
+    }
+    // Hardware sub-object should at least carry the same shape — ram /
+    // gpu / disk top-level keys and the gpu kind. Numeric values
+    // intentionally not compared because the host can shift them
+    // between back-to-back probes.
+    let harn_hw = &harn_value["hardware"];
+    let rust_hw = &rust_value["hardware"];
+    for key in ["ram", "gpu", "disk"] {
+        assert!(
+            harn_hw[key].is_object(),
+            "harn hardware.{key} should be an object"
+        );
+        assert!(
+            rust_hw[key].is_object(),
+            "rust hardware.{key} should be an object"
+        );
+    }
+    assert_eq!(
+        rust_hw["gpu"]["kind"], harn_hw["gpu"]["kind"],
+        "hardware.gpu.kind diverged"
+    );
+    assert_eq!(
+        rust_hw["disk"]["path"], harn_hw["disk"]["path"],
+        "hardware.disk.path diverged"
+    );
+}
+
+// ─── models test ────────────────────────────────────────────────────────
+
+#[test]
+fn models_test_mock_human_line_is_byte_identical_between_impls() {
+    // Mock provider runs offline and is deterministic enough to
+    // compare back-to-back — the only fields that can vary are
+    // `latency_ms` and `first_token_ms`. Verify the line shape rather
+    // than full text identity, and tolerate the timing fields.
+    let harn = run(&["models", "test", "mock", "--provider", "mock"], &[]);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    let rust = run(
+        &["models", "test", "mock", "--provider", "mock"],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    for fragment in [
+        "model_id=mock",
+        "provider=mock",
+        "latency_ms=",
+        "first_token_ms=",
+        "input_tokens=",
+        "output_tokens=",
+        "estimated_cost_usd=0.000000",
+    ] {
+        assert!(
+            harn.stdout.contains(fragment),
+            "harn stdout missing {fragment}: {}",
+            harn.stdout
+        );
+        assert!(
+            rust.stdout.contains(fragment),
+            "rust stdout missing {fragment}: {}",
+            rust.stdout
+        );
+    }
+    // Pin the exact key order (`model_id=` first, then `provider=`,
+    // …) so a future renderer change can't silently drop a column.
+    let harn_keys = test_line_keys(&harn.stdout);
+    let rust_keys = test_line_keys(&rust.stdout);
+    assert_eq!(
+        rust_keys, harn_keys,
+        "models test stdout key order diverged"
+    );
+}
+
+#[test]
+fn models_test_mock_json_shape_is_identical_between_impls() {
+    let harn = run(
+        &["models", "test", "mock", "--provider", "mock", "--json"],
+        &[],
+    );
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
+    let rust = run(
+        &["models", "test", "mock", "--provider", "mock", "--json"],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
+    let harn_value = parse_json(&harn.stdout, "harn");
+    let rust_value = parse_json(&rust.stdout, "rust");
+    for key in [
+        "model_id",
+        "provider",
+        "input_tokens",
+        "output_tokens",
+        "estimated_cost_usd",
+    ] {
+        assert_eq!(
+            rust_value[key], harn_value[key],
+            "models test --json {key} diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+            rust.stdout, harn.stdout
+        );
+    }
+    // `latency_ms` and `first_token_ms` are timing-dependent — just
+    // verify `latency_ms` is integer-shaped on both impls so a future
+    // drift to string would fail the test. `first_token_ms` is
+    // optional (absent when the stream never delivered a delta) so
+    // the parity test treats its presence as best-effort.
+    let latency_key = "latency_ms";
+    assert!(
+        harn_value[latency_key].is_u64() || harn_value[latency_key].is_i64(),
+        "harn {latency_key} should be integer; got: {}",
+        harn_value[latency_key]
+    );
+    assert!(
+        rust_value[latency_key].is_u64() || rust_value[latency_key].is_i64(),
+        "rust {latency_key} should be integer; got: {}",
+        rust_value[latency_key]
+    );
+}
+
+#[test]
+fn models_test_failure_json_envelope_is_byte_identical_between_impls() {
+    // Drop every provider credential env var so the smoke-test fails
+    // deterministically on both impls with the missing-API-key error.
+    // The failure JSON path is the most-tested branch in the field
+    // because users probe new provider configs by running `models
+    // test` with the wrong selector — parity here actually matters.
+    let scrubbers: Vec<(&str, &str)> = vec![
+        ("OPENAI_API_KEY", ""),
+        ("ANTHROPIC_API_KEY", ""),
+        ("GEMINI_API_KEY", ""),
+        ("GOOGLE_API_KEY", ""),
+        ("AZURE_OPENAI_API_KEY", ""),
+        ("AZURE_OPENAI_AD_TOKEN", ""),
+        ("AZURE_OPENAI_BEARER_TOKEN", ""),
+        ("CEREBRAS_API_KEY", ""),
+        ("DASHSCOPE_API_KEY", ""),
+        ("DEEPSEEK_API_KEY", ""),
+        ("FIREWORKS_API_KEY", ""),
+        ("GOOGLE_APPLICATION_CREDENTIALS", ""),
+        ("GOOGLE_OAUTH_ACCESS_TOKEN", ""),
+        ("GROQ_API_KEY", ""),
+        ("HF_TOKEN", ""),
+        ("HUGGINGFACE_API_KEY", ""),
+        ("OPENROUTER_API_KEY", ""),
+        ("TOGETHER_AI_API_KEY", ""),
+        ("VERTEX_AI_ACCESS_TOKEN", ""),
+        ("HARN_LLM_PROVIDER", ""),
+        ("LLM_PROVIDER", ""),
+    ];
+    let harn_env: Vec<(&str, &str)> = scrubbers.clone();
+    let mut rust_env: Vec<(&str, &str)> = scrubbers;
+    rust_env.push(("HARN_CLI_IMPL", "rust"));
+
+    let harn = run_with_clean_env(
+        &[
+            "models",
+            "test",
+            "foo-not-real",
+            "--provider",
+            "openai",
+            "--json",
+        ],
+        &harn_env,
+    );
+    let rust = run_with_clean_env(
+        &[
+            "models",
+            "test",
+            "foo-not-real",
+            "--provider",
+            "openai",
+            "--json",
+        ],
+        &rust_env,
+    );
+    assert_eq!(
+        harn.exit_code, 1,
+        "harn should fail; stderr={}",
+        harn.stderr
+    );
+    assert_eq!(
+        rust.exit_code, 1,
+        "rust should fail; stderr={}",
+        rust.stderr
+    );
+    let harn_value = parse_json(&harn.stdout, "harn");
+    let rust_value = parse_json(&rust.stdout, "rust");
+    assert_eq!(
+        rust_value, harn_value,
+        "models test failure JSON diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust.stdout, harn.stdout
+    );
+    assert_eq!(harn_value["ok"], serde_json::Value::Bool(false));
+    assert!(
+        harn_value["error"].is_string(),
+        "failure envelope missing 'error' string field"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────
+
+fn run_with_clean_env(argv: &[&str], env: &[(&str, &str)]) -> SubprocessOutcome {
+    let mut cmd = Command::new(harn_binary());
+    for arg in argv {
+        cmd.arg(arg);
+    }
+    for key in ["HARN_CLI_IMPL", "NO_COLOR", "HARN_COLOR"] {
+        cmd.env_remove(key);
+    }
+    for (k, v) in env {
+        if v.is_empty() {
+            cmd.env_remove(k);
+        } else {
+            cmd.env(k, v);
+        }
+    }
+    let Output {
+        status,
+        stdout,
+        stderr,
+    } = cmd.output().expect("spawn harn");
+    SubprocessOutcome {
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        exit_code: status.code().unwrap_or(-1),
+    }
+}
+
+fn test_line_keys(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .filter_map(|kv| kv.split('=').next().map(str::to_string))
+        .collect()
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -818,6 +818,18 @@ pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
         source: include_str!("stdlib/cli/explain.harn"),
     },
     StdlibCliScript {
+        name: "models/list",
+        source: include_str!("stdlib/cli/models/list.harn"),
+    },
+    StdlibCliScript {
+        name: "models/recommend",
+        source: include_str!("stdlib/cli/models/recommend.harn"),
+    },
+    StdlibCliScript {
+        name: "models/test",
+        source: include_str!("stdlib/cli/models/test.harn"),
+    },
+    StdlibCliScript {
         name: "scaffold/init",
         source: include_str!("stdlib/cli/scaffold/init.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/models/list.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/models/list.harn
@@ -1,0 +1,297 @@
+/**
+ * `harn models list` ported to .harn — see harn#2309 (W9).
+ *
+ * The Rust dispatch shim in
+ * `crates/harn-cli/src/commands/models/list.rs` detects installed Ollama
+ * models out-of-process (sandboxed scripts can't run `ollama list`
+ * directly) and hands off the discovered model ids plus the parsed
+ * filter args as env vars. The catalog itself comes from the
+ * `llm_catalog()` free builtin landed in G4 (#2297 / #2343), so the
+ * script owns the entire filter + render pipeline end-to-end.
+ *
+ * Inputs (from the dispatch shim):
+ *   HARN_MODELS_LIST_PROVIDER       — optional provider filter ("" = all).
+ *   HARN_MODELS_LIST_INSTALLED_ONLY — "1" iff `--installed-only`.
+ *   HARN_MODELS_INSTALLED_OLLAMA    — JSON list<string> of installed
+ *                                     Ollama model ids (may be empty).
+ *   HARN_OUTPUT_JSON                — "1" for the JSON envelope, else
+ *                                     human-readable table.
+ */
+fn __dict_get_list(d: dict, key: string) -> list {
+  let v = d[key]
+  if type_of(v) == "list" {
+    return v
+  }
+  return []
+}
+
+fn __dict_get_string(d: dict, key: string, fallback: string) -> string {
+  let v = d[key]
+  if type_of(v) == "string" {
+    return v
+  }
+  return fallback
+}
+
+fn __dict_get_bool(d: dict, key: string, fallback: bool) -> bool {
+  let v = d[key]
+  if type_of(v) == "bool" {
+    return v
+  }
+  return fallback
+}
+
+/**
+ * Build a set-like dict from a list of strings for O(1) membership.
+ * Harn lists don't expose `contains`, so the alternative is a linear
+ * scan per lookup — fine at today's catalog sizes, but the dict avoids
+ * a quadratic blowup if the catalog grows.
+ */
+fn __string_set(items: list) -> dict {
+  var out = {}
+  for item in items {
+    if type_of(item) == "string" {
+      out = out + {[item]: true}
+    }
+  }
+  return out
+}
+
+/**
+ * Group catalog entries by provider, dropping anything the filters
+ * exclude. Returns a dict whose keys are provider names and whose
+ * values are lists of `{id, capabilities, installed}` dicts.
+ *
+ * `installed` is only meaningful for ollama (and follows the legacy
+ * Rust impl's gating). The downstream renderers decide whether to
+ * surface the flag.
+ */
+fn __group_by_provider(
+  catalog: list,
+  provider_filter: string,
+  installed_only: bool,
+  installed_ollama: dict,
+) -> dict {
+  var groups = {}
+  for entry in catalog {
+    if type_of(entry) != "dict" {
+      continue
+    }
+    let provider = __dict_get_string(entry, "provider", "")
+    let id = __dict_get_string(entry, "id", "")
+    if provider == "" || id == "" {
+      continue
+    }
+    if provider_filter != "" && provider != provider_filter {
+      continue
+    }
+    let installed = provider == "ollama" && installed_ollama[id] ?? false
+    if installed_only && !installed {
+      continue
+    }
+    let capabilities = __dict_get_list(entry, "capabilities")
+    let item = {id: id, capabilities: capabilities, installed: installed}
+    let prior = if groups[provider] == nil {
+      []
+    } else {
+      groups[provider]
+    }
+    groups = groups + {[provider]: prior.push(item)}
+  }
+  return groups
+}
+
+/**
+ * Synthesize installed Ollama models the catalog hasn't listed yet —
+ * matches the legacy Rust impl's "list whatever the user has pulled,
+ * even if we haven't curated metadata for it" behavior.
+ */
+fn __augment_with_unknown_ollama(groups: dict, provider_filter: string, installed_ollama_list: list) -> dict {
+  let show_ollama = provider_filter == "" || provider_filter == "ollama"
+  if !show_ollama {
+    return groups
+  }
+  let existing = if groups["ollama"] == nil {
+    []
+  } else {
+    groups["ollama"]
+  }
+  var known_ids = {}
+  for item in existing {
+    if type_of(item) == "dict" {
+      let id = __dict_get_string(item, "id", "")
+      if id != "" {
+        known_ids = known_ids + {[id]: true}
+      }
+    }
+  }
+  var augmented = existing
+  for id in installed_ollama_list {
+    if type_of(id) != "string" {
+      continue
+    }
+    if known_ids[id] ?? false {
+      continue
+    }
+    augmented = augmented.push({id: id, capabilities: ["local"], installed: true})
+  }
+  if len(augmented) == 0 {
+    return groups
+  }
+  return groups + {ollama: augmented}
+}
+
+/**
+ * Sort a list of strings lexicographically with an insertion sort.
+ * Tiny lists (~tens of provider names; hundreds of model ids per
+ * provider) keep this cheap and avoids depending on a comparator
+ * the stdlib doesn't expose to scripts yet.
+ */
+fn __sorted_strings(items: list) -> list {
+  var out = []
+  for item in items {
+    var idx = 0
+    while idx < len(out) && out[idx] < item {
+      idx = idx + 1
+    }
+    let head = out[0:idx]
+    let tail = out[idx:len(out)]
+    out = head.push(item) + tail
+  }
+  return out
+}
+
+fn __sort_models_by_id(models: list) -> list {
+  var out = []
+  for model in models {
+    let id = if type_of(model) == "dict" {
+      __dict_get_string(model, "id", "")
+    } else {
+      ""
+    }
+    var idx = 0
+    while idx < len(out) {
+      let other_id = if type_of(out[idx]) == "dict" {
+        __dict_get_string(out[idx], "id", "")
+      } else {
+        ""
+      }
+      if other_id >= id {
+        break
+      }
+      idx = idx + 1
+    }
+    let head = out[0:idx]
+    let tail = out[idx:len(out)]
+    out = head.push(model) + tail
+  }
+  return out
+}
+
+/**
+ * Render the human-readable table. The legacy Rust impl iterates a
+ * BTreeMap (so providers are in lexicographic order) and for each
+ * provider prints its name, then each model with its tags / installed
+ * marker, then a blank line. Keep that shape byte-for-byte.
+ */
+fn __render_human(groups: dict) -> string {
+  let provider_names = __sorted_strings(keys(groups))
+  if len(provider_names) == 0 {
+    return "(no models match)\n"
+  }
+  var out = ""
+  for provider in provider_names {
+    out = out + provider + "\n"
+    let models = __sort_models_by_id(groups[provider])
+    for model in models {
+      let id = __dict_get_string(model, "id", "")
+      let installed = __dict_get_bool(model, "installed", false)
+      let suffix = if installed {
+        " [installed]"
+      } else {
+        ""
+      }
+      let tags = __dict_get_list(model, "capabilities")
+      let tag_text = if len(tags) == 0 {
+        ""
+      } else {
+        "  (" + join(tags, ", ") + ")"
+      }
+      out = out + "  " + id + suffix + tag_text + "\n"
+    }
+    out = out + "\n"
+  }
+  return out
+}
+
+/**
+ * Build the JSON envelope. The legacy Rust impl emits
+ * `{"providers": [{"name": ..., "models": [{"id", "tags", ["installed"]}]}]}`,
+ * with `installed` only present for ollama entries. Provider order is
+ * lexicographic (Rust uses a BTreeMap); model order within each
+ * provider preserves catalog order.
+ */
+fn __render_envelope(groups: dict) -> string {
+  let provider_names = __sorted_strings(keys(groups))
+  var provider_list = []
+  for name in provider_names {
+    let models = groups[name]
+    var rendered = []
+    for model in models {
+      let id = __dict_get_string(model, "id", "")
+      let tags = __dict_get_list(model, "capabilities")
+      let entry = if name == "ollama" {
+        {id: id, tags: tags, installed: __dict_get_bool(model, "installed", false)}
+      } else {
+        {id: id, tags: tags}
+      }
+      rendered = rendered.push(entry)
+    }
+    provider_list = provider_list.push({name: name, models: rendered})
+  }
+  return json_stringify_pretty({providers: provider_list})
+}
+
+fn main(harness: Harness) -> int {
+  let catalog = llm_catalog()
+  let provider_filter = harness.env.get_or("HARN_MODELS_LIST_PROVIDER", "")
+  let installed_only = harness.env.get_or("HARN_MODELS_LIST_INSTALLED_ONLY", "0") == "1"
+  let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"
+  let installed_raw = harness.env.get_or("HARN_MODELS_INSTALLED_OLLAMA", "[]")
+  let installed_ollama_list = try {
+    json_parse(installed_raw)
+  } catch (e) {
+    harness.stdio
+      .eprintln("internal error: failed to parse HARN_MODELS_INSTALLED_OLLAMA: " + to_string(e))
+    return 70
+  }
+  if type_of(installed_ollama_list) != "list" {
+    harness.stdio.eprintln("internal error: HARN_MODELS_INSTALLED_OLLAMA must be a JSON list")
+    return 70
+  }
+  let installed_ollama_set = __string_set(installed_ollama_list)
+  let grouped = __group_by_provider(catalog, provider_filter, installed_only, installed_ollama_set)
+  // The legacy impl runs the synthesis pass unconditionally — the
+  // synthesised entries are themselves installed, so they pass
+  // `--installed-only` too. Run the same pass here regardless of the
+  // flag; the dedup inside `__augment_with_unknown_ollama` keeps it
+  // idempotent.
+  let augmented = __augment_with_unknown_ollama(grouped, provider_filter, installed_ollama_list)
+  if json_mode {
+    harness.stdio.println(__render_envelope(augmented))
+    return 0
+  }
+  let text = __render_human(augmented)
+  // The legacy renderer always ends with a blank line (a trailing
+  // `println!()`) when it printed any provider; `(no models match)` is
+  // emitted by a single `println!` with no blank line after it. Strip
+  // the final newline so `harness.stdio.println` can re-add exactly
+  // one and the bytes match the Rust path.
+  let trimmed = if len(text) > 0 && text[len(text) - 1] == "\n" {
+    text[0:len(text) - 1]
+  } else {
+    text
+  }
+  harness.stdio.println(trimmed)
+  return 0
+}

--- a/crates/harn-stdlib/src/stdlib/cli/models/recommend.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/models/recommend.harn
@@ -1,0 +1,264 @@
+/**
+ * `harn models recommend` ported to .harn — see harn#2309 (W9).
+ *
+ * **Aggregation in Rust, render + lookup in .harn.** The Rust dispatch
+ * shim does the work that needs OS-level capabilities — hardware
+ * probing (`sysctl` / `/proc/meminfo` / `nvidia-smi` / `MetalPerformanceShaders`),
+ * provider credential detection (which reaches into
+ * `llm_config::provider_key_available`), and parsing the bundled
+ * `model_recommendations.toml`. It hands the result over as a single
+ * JSON payload here, and this script picks the matching rule from the
+ * recommendation table and renders it.
+ *
+ * The recommendation table itself ships pre-parsed — the script could
+ * read the TOML through `harness.fs`, but the file lives inside the
+ * CLI crate's `data/` and isn't part of the script sandbox's
+ * workspace_roots. Forwarding the parsed table keeps the script
+ * independent of the on-disk layout while still leaving the
+ * recommendation policy auditable from a single .harn source.
+ *
+ * Inputs (from the dispatch shim):
+ *   HARN_MODELS_RECOMMEND_PAYLOAD_JSON — JSON envelope:
+ *     {
+ *       "hardware": HardwareSnapshot,    // ram/gpu/disk
+ *       "has_provider_key": bool,
+ *       "cloud_model": {provider, model_id} | null,
+ *       "recommendations": [             // parsed model_recommendations.toml
+ *         {ram_bucket, gpu, has_provider_key, provider, model_id},
+ *         ...
+ *       ]
+ *     }
+ *   HARN_OUTPUT_JSON — "1" for the JSON envelope, else human text.
+ */
+const GIB: int = 1073741824
+
+const CLOUD_DEFAULT_SENTINEL: string = "$cloud_default"
+
+fn __safe_string(value, fallback: string) -> string {
+  if type_of(value) == "string" {
+    return value
+  }
+  return fallback
+}
+
+fn __safe_dict(value) -> dict {
+  if type_of(value) == "dict" {
+    return value
+  }
+  return {}
+}
+
+fn __safe_list(value) -> list {
+  if type_of(value) == "list" {
+    return value
+  }
+  return []
+}
+
+fn __safe_bool(value, fallback: bool) -> bool {
+  if type_of(value) == "bool" {
+    return value
+  }
+  return fallback
+}
+
+fn __safe_int(value) -> int? {
+  if type_of(value) == "int" {
+    return value
+  }
+  return nil
+}
+
+/**
+ * Mirror the Rust impl's `bytes_to_gib_floor` (integer division). The
+ * Rust impl gates on `RamBucket::from_available_bytes`:
+ *   None         → "lt8"
+ *   0..=7  GiB   → "lt8"
+ *   8..=15 GiB   → "8_16"
+ *   16..=31 GiB  → "16_32"
+ *   _            → "32_plus"
+ */
+fn __ram_bucket_from_bytes(available_bytes) -> string {
+  let bytes = __safe_int(available_bytes)
+  if bytes == nil {
+    return "lt8"
+  }
+  let gib = bytes / GIB
+  if gib <= 7 {
+    return "lt8"
+  }
+  if gib <= 15 {
+    return "8_16"
+  }
+  if gib <= 31 {
+    return "16_32"
+  }
+  return "32_plus"
+}
+
+/**
+ * Round half-up GiB conversion. Matches `bytes_to_gib_rounded` in the
+ * Rust impl — used only for the human rationale string.
+ */
+fn __ram_gib_rounded(bytes) -> int {
+  let b = __safe_int(bytes) ?? 0
+  return (b + GIB / 2) / GIB
+}
+
+fn __gpu_label(gpu: string) -> string {
+  if gpu == "cuda" {
+    return "CUDA available"
+  }
+  if gpu == "mps" {
+    return "MPS available"
+  }
+  return "no GPU acceleration"
+}
+
+/**
+ * Find the rule matching `(ram_bucket, gpu, has_provider_key)`. The
+ * Rust impl already validates uniqueness + full coverage of the
+ * cross-product at table-load time; the script trusts that gate and
+ * uses a linear scan. Returns nil when no match exists (the dispatch
+ * shim treats that as an internal error since the table is bundled
+ * pre-validated).
+ */
+fn __find_rule(rules: list, ram_bucket: string, gpu: string, has_provider_key: bool) -> dict? {
+  for rule in rules {
+    if type_of(rule) != "dict" {
+      continue
+    }
+    let r_ram = __safe_string(rule["ram_bucket"], "")
+    let r_gpu = __safe_string(rule["gpu"], "")
+    let r_key = __safe_bool(rule["has_provider_key"], false)
+    if r_ram == ram_bucket && r_gpu == gpu && r_key == has_provider_key {
+      return rule
+    }
+  }
+  return nil
+}
+
+/**
+ * Normalize a `(provider, model_id)` pair to the selector the user
+ * passes to `--model`. Matches the Rust impl's `harn_selector_for`
+ * exactly:
+ *   * For ollama, `ollama/foo:bar` → `ollama:foo:bar`; otherwise pass
+ *     through (already in `provider:model` form).
+ *   * Otherwise strip the leading `provider/` if present.
+ */
+fn __harn_selector_for(provider: string, model_id: string) -> string {
+  if provider == "ollama" {
+    let prefix = "ollama/"
+    if len(model_id) >= len(prefix) && model_id[0:len(prefix)] == prefix {
+      return "ollama:" + model_id[len(prefix):len(model_id)]
+    }
+    return model_id
+  }
+  let prefix = provider + "/"
+  if len(model_id) >= len(prefix) && model_id[0:len(prefix)] == prefix {
+    return model_id[len(prefix):len(model_id)]
+  }
+  return model_id
+}
+
+fn __rationale(ram_bytes, gpu: string, has_provider_key: bool, model_id: string) -> string {
+  let ram = if __safe_int(ram_bytes) == nil {
+    "unknown free RAM"
+  } else {
+    to_string(__ram_gib_rounded(ram_bytes)) + " GB free"
+  }
+  let creds = if has_provider_key {
+    "cloud creds available"
+  } else {
+    "no cloud creds"
+  }
+  return ram + ", " + __gpu_label(gpu) + ", " + creds + " -> " + model_id
+}
+
+/**
+ * Resolve a rule against the optional cloud model. Returns
+ * `{provider, model_id}` (model_id already in display form, e.g.
+ * `openai/gpt-4o-mini` for cloud entries). Returns nil when the rule
+ * asks for a cloud default but no cloud model was detected — the Rust
+ * shim treats nil as a hard error since the table coverage gate
+ * guarantees the cloud branch only fires when `has_provider_key` is
+ * also true.
+ */
+fn __resolve_rule(rule: dict, cloud_model) -> dict? {
+  let model_id = __safe_string(rule["model_id"], "")
+  if model_id != CLOUD_DEFAULT_SENTINEL {
+    return {provider: __safe_string(rule["provider"], ""), model_id: model_id}
+  }
+  if type_of(cloud_model) != "dict" {
+    return nil
+  }
+  let provider = __safe_string(cloud_model["provider"], "")
+  let cloud_model_id = __safe_string(cloud_model["model_id"], "")
+  if provider == "" || cloud_model_id == "" {
+    return nil
+  }
+  return {provider: provider, model_id: provider + "/" + cloud_model_id}
+}
+
+fn main(harness: Harness) -> int {
+  let raw = harness.env.get_or("HARN_MODELS_RECOMMEND_PAYLOAD_JSON", "")
+  if raw == "" {
+    harness.stdio
+      .eprintln("internal error: HARN_MODELS_RECOMMEND_PAYLOAD_JSON not set by dispatch shim")
+    return 70
+  }
+  let payload = try {
+    json_parse(raw)
+  } catch (e) {
+    harness.stdio.eprintln("internal error: failed to parse recommend payload: " + to_string(e))
+    return 70
+  }
+  let hardware = __safe_dict(payload["hardware"])
+  let ram = __safe_dict(hardware["ram"])
+  let gpu_snap = __safe_dict(hardware["gpu"])
+  let gpu = __safe_string(gpu_snap["kind"], "none")
+  let has_provider_key = __safe_bool(payload["has_provider_key"], false)
+  let cloud_model = payload["cloud_model"]
+  let rules = __safe_list(payload["recommendations"])
+  let ram_bucket = __ram_bucket_from_bytes(ram["available_bytes"])
+  let rule = __find_rule(rules, ram_bucket, gpu, has_provider_key)
+  if rule == nil {
+    harness.stdio
+      .eprintln(
+      "no model recommendation for ram_bucket=" + ram_bucket
+        + " gpu="
+        + gpu
+        + " has_provider_key="
+        + to_string(has_provider_key),
+    )
+    return 1
+  }
+  let resolved = __resolve_rule(rule, cloud_model)
+  if resolved == nil {
+    harness.stdio
+      .eprintln("recommendation table requested a cloud default without cloud credentials")
+    return 1
+  }
+  let provider = resolved["provider"]
+  let model_id = resolved["model_id"]
+  let harn_selector = __harn_selector_for(provider, model_id)
+  let rationale = __rationale(ram["available_bytes"], gpu, has_provider_key, model_id)
+  let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"
+  if json_mode {
+    let envelope = {
+      model_id: model_id,
+      harn_selector: harn_selector,
+      provider: provider,
+      rationale: rationale,
+      ram_bucket: ram_bucket,
+      gpu: gpu,
+      has_provider_key: has_provider_key,
+      hardware: hardware,
+    }
+    harness.stdio.println(json_stringify_pretty(envelope))
+    return 0
+  }
+  harness.stdio.println(model_id)
+  harness.stdio.println(rationale)
+  return 0
+}

--- a/crates/harn-stdlib/src/stdlib/cli/models/test.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/models/test.harn
@@ -1,0 +1,164 @@
+/**
+ * `harn models test` rendering layer ported to .harn — see harn#2309
+ * (W9).
+ *
+ * **Pragmatic partial port.** The actual smoke test runs in Rust —
+ * `harn_vm::llm::run_model_smoke_test` builds bespoke
+ * `LlmCallOptions`, streams via `vm_call_llm_full_streaming`, probes
+ * provider readiness, and computes pricing. None of that is reachable
+ * from script-land today without a wider VM surface than W9 should
+ * ship. The Rust shim runs the smoke test, captures the result (or
+ * error), and hands a single JSON envelope here for formatting.
+ *
+ * Inputs (from the dispatch shim):
+ *   HARN_MODELS_TEST_RESULT_JSON — JSON envelope. On success:
+ *     {
+ *       "ok": true,
+ *       "result": {
+ *         "model_id", "provider", "latency_ms", "first_token_ms"?,
+ *         "input_tokens", "output_tokens", "estimated_cost_usd"
+ *       }
+ *     }
+ *     On failure:
+ *     {"ok": false, "error": "..."}
+ *   HARN_OUTPUT_JSON — "1" for JSON output, else human text.
+ */
+fn __safe_string(value, fallback: string) -> string {
+  if type_of(value) == "string" {
+    return value
+  }
+  return fallback
+}
+
+fn __safe_dict(value) -> dict {
+  if type_of(value) == "dict" {
+    return value
+  }
+  return {}
+}
+
+/**
+ * Format a float as `"X.YYYYYY"` (6 decimals, half-up padded). Matches
+ * Rust's `format!("{:.6}", x)` for the legacy text-output cost field.
+ */
+fn __format_float_6(value) -> string {
+  let f = to_float(value) ?? 0.0
+  let negative = f < 0.0
+  let abs_f = if negative {
+    -f
+  } else {
+    f
+  }
+  let scaled = to_int(round(abs_f * 1000000.0)) ?? 0
+  let whole = scaled / 1000000
+  let frac = scaled - whole * 1000000
+  var frac_str = to_string(frac)
+  while len(frac_str) < 6 {
+    frac_str = "0" + frac_str
+  }
+  let sign = if negative && (whole != 0 || frac != 0) {
+    "-"
+  } else {
+    ""
+  }
+  return sign + to_string(whole) + "." + frac_str
+}
+
+/**
+ * Render the success line. Order matches the legacy Rust impl:
+ * `model_id=... provider=... latency_ms=... first_token_ms=... \
+ *  input_tokens=... output_tokens=... estimated_cost_usd={:.6}`.
+ * `first_token_ms` is `"-"` when the streaming probe didn't see a
+ * delta in time.
+ */
+fn __render_success_line(result: dict) -> string {
+  let first_token = if result["first_token_ms"] == nil {
+    "-"
+  } else {
+    to_string(result["first_token_ms"])
+  }
+  return "model_id=" + __safe_string(result["model_id"], "")
+    + " provider="
+    + __safe_string(result["provider"], "")
+    + " latency_ms="
+    + to_string(result["latency_ms"] ?? 0)
+    + " first_token_ms="
+    + first_token
+    + " input_tokens="
+    + to_string(result["input_tokens"] ?? 0)
+    + " output_tokens="
+    + to_string(result["output_tokens"] ?? 0)
+    + " estimated_cost_usd="
+    + __format_float_6(result["estimated_cost_usd"] ?? 0.0)
+}
+
+/**
+ * Build the success JSON envelope. The legacy Rust impl emits
+ * `serde_json::to_string_pretty(&result)` directly — fields are:
+ * `model_id`, `provider`, `latency_ms`, `first_token_ms?`,
+ * `input_tokens`, `output_tokens`, `estimated_cost_usd`. The
+ * `#[serde(skip_serializing_if = "Option::is_none")]` attribute on
+ * `first_token_ms` means absent when nil; mirror that here so the
+ * parity test's structural compare lines up.
+ */
+fn __render_success_envelope(result: dict) -> string {
+  var envelope = {
+    model_id: __safe_string(result["model_id"], ""),
+    provider: __safe_string(result["provider"], ""),
+    latency_ms: result["latency_ms"] ?? 0,
+    input_tokens: result["input_tokens"] ?? 0,
+    output_tokens: result["output_tokens"] ?? 0,
+    estimated_cost_usd: result["estimated_cost_usd"] ?? 0.0,
+  }
+  if result["first_token_ms"] != nil {
+    envelope = envelope + {first_token_ms: result["first_token_ms"]}
+  }
+  return json_stringify_pretty(envelope)
+}
+
+/**
+ * Render the failure JSON envelope. Matches the legacy
+ * `serde_json::json!({ "ok": false, "error": error })` — note that
+ * the Rust impl uses `to_string()` (compact, no trailing newline)
+ * for this branch, not `to_string_pretty`. Replicate the compact
+ * form so the parity test's structural compare lines up regardless.
+ */
+fn __render_failure_envelope(error: string) -> string {
+  return json_stringify({ok: false, error: error})
+}
+
+fn main(harness: Harness) -> int {
+  let raw = harness.env.get_or("HARN_MODELS_TEST_RESULT_JSON", "")
+  if raw == "" {
+    harness.stdio
+      .eprintln("internal error: HARN_MODELS_TEST_RESULT_JSON not set by dispatch shim")
+    return 70
+  }
+  let envelope = try {
+    json_parse(raw)
+  } catch (e) {
+    harness.stdio.eprintln("internal error: failed to parse models-test result: " + to_string(e))
+    return 70
+  }
+  let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"
+  let ok = envelope["ok"] ?? false
+  if ok {
+    let result = __safe_dict(envelope["result"])
+    if json_mode {
+      harness.stdio.println(__render_success_envelope(result))
+    } else {
+      harness.stdio.println(__render_success_line(result))
+    }
+    return 0
+  }
+  let error = __safe_string(envelope["error"], "unknown error")
+  if json_mode {
+    // Legacy impl writes the compact `{ok, error}` to STDOUT (not
+    // stderr) with `println!` and then `process::exit(1)`. Mirror
+    // that — the channel split matters for shells piping `--json`.
+    harness.stdio.println(__render_failure_envelope(error))
+  } else {
+    harness.stdio.eprintln(error)
+  }
+  return 1
+}

--- a/scripts/ported_handlers.toml
+++ b/scripts/ported_handlers.toml
@@ -42,3 +42,15 @@ max_loc = 1201
 [[handler]]
 path = "crates/harn-cli/src/lib.rs"
 max_loc = 3120
+
+[[handler]]
+path = "crates/harn-cli/src/commands/models/list.rs"
+max_loc = 222
+
+[[handler]]
+path = "crates/harn-cli/src/commands/models/recommend.rs"
+max_loc = 500
+
+[[handler]]
+path = "crates/harn-cli/src/commands/models/test.rs"
+max_loc = 150


### PR DESCRIPTION
## Summary

Closes #2309. Part of the #2293 self-host epic — W9 of the port waves. Builds on G4 (#2297 / #2343) which landed `llm_catalog()` and `llm_provider_status()` as free builtins last cycle.

Three new embedded scripts under `crates/harn-stdlib/src/stdlib/cli/models/`:

- `list.harn` — **full port.** The Rust shim only probes installed Ollama models out-of-process (the sandbox blocks the `tokio::process::Command::new("ollama")` call from script-land); the script owns filter + group + render via `llm_catalog()`. Synthesises installed-but-uncurated Ollama models to match the legacy behavior.
- `recommend.harn` — **full port.** Hardware probing (`sysctl` / `/proc/meminfo` / `nvidia-smi` / `MetalPerformanceShaders`) and cloud-cred detection (`llm_config::provider_key_available`) stay in Rust because they're not script-reachable. The shim collects them into a single JSON envelope with the parsed `model_recommendations.toml` table; the script picks the matching rule, resolves the `$cloud_default` sentinel, and renders both the human and JSON forms.
- `test.harn` — **partial port (rendering only).** The smoke test itself stays on `harn_vm::llm::run_model_smoke_test` — it reaches into `vm_call_llm_full_streaming` with bespoke `LlmCallOptions` for the readiness probe, first-token-ms streaming callback, and pricing calc. The script owns the success/failure JSON envelopes plus the human one-line summary.

## Boundary decisions

- **`models install` stays in Rust** per the W9 ticket. The handler is process-management-heavy (`ollama pull` subprocess streaming, size confirmation prompts, llamacpp / mlx setup-plan flow) and would require a much wider host-cap surface than W9 should ship.
- **The recommendation table is forwarded pre-parsed.** The `data/model_recommendations.toml` file lives inside the harn-cli crate, not in the script's `workspace_roots`, so reading it via `harness.fs.read_text` isn't an option. The Rust shim parses + sanity-checks it (uniqueness + full cross-product coverage stay enforced by the existing Rust gate) and hands the array across.
- **`HARN_CLI_IMPL=rust` is retained on all three.** The escape hatch keeps the legacy direct-render path live for the parity-snapshot harness (#2299) and the runtime parity tests until the C1 ratchet (#2314, already merged) extends to delete this wave's branches.
- **`recommend::run` is now async.** The dispatch path needs to drive the `harn run` pipeline; `models/mod.rs` was updated to `await` it. All non-dispatch callers were `recommend::run(&args)` from inside `models::run` which already runs under the tokio runtime.
- **Failure JSON channel matches legacy.** `models test --json` writes the `{ok: false, error: ...}` envelope to *stdout* on failure (matching the legacy `println!`), not stderr — the test script's `harness.stdio.println` plus `return 1` mirrors that.

## Test plan

- [x] `cargo test -p harn-cli --test models_dispatch` — 9/9 pass (4 list + 2 recommend + 3 test parity tests)
- [x] `cargo test -p harn-cli --lib commands::models` — 8/8 pass (no regression on pre-existing recommend table coverage)
- [x] `cargo test -p harn-cli --test dispatch_echo --test explain_dispatch --test parity_dispatch` — 5/5 pass (G1 wedge + W4 unaffected)
- [x] `cargo test -p harn-cli --lib` — 755/755 pass
- [x] `cargo test -p harn-stdlib --lib` — 16/16 pass
- [x] `cargo clippy -p harn-cli -p harn-stdlib --no-deps --tests` — clean
- [x] `harn lint` / `harn fmt --check` on the three new scripts — clean
- [x] `make check-ported-handler-loc` — 10 handlers within budget
- [x] Manual: human + `--json` parity vs `HARN_CLI_IMPL=rust` on a live macOS / MPS / no-cloud-cred host — byte-identical for human text and structurally-equal for JSON (only the hardware-probe `available_bytes` field differs across back-to-back invocations, which the parity test already tolerates)

## Out of scope

- `models install` (process-management-heavy, intentionally retained in Rust per the W9 ticket)
- Replacing the Rust smoke-test pipeline with a pure-.harn driver — would require exposing `vm_call_llm_full_streaming` (or a parameterised `llm_call`) to script-land. Tracks alongside G4 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)