### PR TITLE
Port `harn eval coding-agent` (rendering layer) to .harn (#2307)

### DIFF
--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -1,9 +1,42 @@
 //! `harn eval coding-agent` — empirical preset/provider benchmark for a
 //! small coding-agent fixture suite.
+//!
+//! ## .harn dispatch (W7 partial port — see harn#2307)
+//!
+//! The **matrix execution pipeline** (fixture resolution, model
+//! discovery, per-cell `execute_run` invocation, Ollama snapshot/
+//! cleanup, scoring, rollups, native/text comparisons, follow-up
+//! generation, baseline diff) stays in Rust. Every cell drives the
+//! embedded `coding_agent_suite.harn` driver through `execute_run`,
+//! which itself reaches into VM internals (`commands::run`,
+//! `harn_vm::llm`, `commands::local::runtime`) that aren't reachable
+//! from script-land today — the same constraint that shaped W5 / W6.
+//!
+//! The **rendering layer** (the `summary.md` body, the `followups.md`
+//! body, the one-line human stdout summary, the `--json` pretty form)
+//! is delegated to
+//! `crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn`. The
+//! Rust shim pre-serialises the assembled `EvalSummary` to JSON,
+//! forwards it via [`CODING_AGENT_SUMMARY_ENV`], dispatches four
+//! times (markdown for `summary.md`, followups for `followups.md`,
+//! then either the summary line or the `--json` pretty form for
+//! stdout), and writes the captured payloads to disk / real stdout.
+//!
+//! The on-disk JSON artifacts (`summary.json`, `per_run.jsonl`,
+//! `local_readiness.json`) stay on the serde-driven Rust path because
+//! Harn's `json_stringify_pretty` sorts dict keys alphabetically and
+//! the on-disk format is consumed by the experiment driver in
+//! `experiments/step-judge/run.sh`, the local-readiness regression
+//! check, and hosted ingestion — all of which depend on the serde
+//! struct-field byte order.
+//!
+//! `HARN_CLI_IMPL=rust` keeps the legacy direct-render path for the
+//! parity-snapshot harness (#2299) until the C1 ratchet (#2314) lands.
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ffi::OsString;
 use std::fs;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use harn_vm::clock::{Clock, RealClock};
@@ -19,6 +52,34 @@ use crate::commands::local::runtime::{
 };
 use crate::commands::local_readiness;
 use crate::commands::run::{execute_run, CliLlmMockMode, RunProfileOptions};
+use crate::dispatch;
+use crate::env_guard::ScopedEnvVar;
+
+/// Env var the embedded `cli/eval/coding_agent` script reads to pick
+/// up the pre-serialised [`EvalSummary`]. The Rust shim does all the
+/// matrix execution and scoring and hands the script the assembled
+/// summary so it only has to format it.
+const CODING_AGENT_SUMMARY_ENV: &str = "HARN_EVAL_CODING_AGENT_SUMMARY_JSON";
+
+/// Env var the script reads to pick the rendering mode — one of
+/// `"markdown"` (summary.md body), `"followups"` (followups.md body),
+/// `"summary"` (one-line stdout summary), or `"json"` (--json pretty
+/// form). Defaulted to `"summary"` if unset so the script stays robust
+/// against future Rust-side bugs.
+const CODING_AGENT_MODE_ENV: &str = "HARN_EVAL_CODING_AGENT_MODE";
+
+/// Serialises the dispatch-render path so concurrent in-process
+/// callers (the existing `eval_coding_agent_cli` integration test plus
+/// any future fanout caller) don't race on the global env vars the
+/// Rust shim sets to hand the report off to the .harn script. The CLI
+/// binary itself is single-call, so this mutex is uncontended in
+/// production; in tests it serialises the dispatch window only —
+/// matrix execution still parallelises freely.
+///
+/// Mirrors the pattern W5's `eval_prompt.rs` and W6's `eval_context.rs`
+/// / `eval_tool_calls.rs` use (see harn#2305 / #2306) so the cross-
+/// script env-var hand-off stays consistent across the eval cluster.
+static DISPATCH_RENDER_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 const CODING_AGENT_SUITE_HARN: &str = include_str!("../../assets/evals/coding_agent_suite.harn");
 
@@ -368,28 +429,45 @@ pub async fn run(args: EvalCodingAgentArgs) -> i32 {
         args.run_label.clone(),
         baseline_comparison,
     );
-    if let Err(error) = write_outputs(&output_dir, &summary) {
+    // The JSON artifacts (summary.json, per_run.jsonl,
+    // local_readiness.json) always stay on the serde-driven Rust path —
+    // see module docstring for the byte-format rationale. They write
+    // before any rendering so a render failure doesn't leave a partially
+    // written report directory.
+    if let Err(error) = write_json_artifacts(&output_dir, &summary) {
         eprintln!("error: failed to write benchmark outputs: {error}");
         return 1;
     }
-    eprintln!(
-        "wrote {}, {}, {}, {}, and {}",
-        output_dir.join("summary.json").display(),
-        output_dir.join("per_run.jsonl").display(),
-        output_dir.join("local_readiness.json").display(),
-        output_dir.join("summary.md").display(),
-        output_dir.join("followups.md").display()
-    );
-    if args.json {
-        match serde_json::to_string_pretty(&summary) {
-            Ok(payload) => println!("{payload}"),
-            Err(error) => eprintln!("warning: failed to render summary JSON: {error}"),
+
+    // `HARN_CLI_IMPL=rust` keeps the legacy direct-render path so the
+    // parity-snapshot harness (#2299) can compare both impls until C1
+    // (#2314) deletes this escape hatch.
+    let use_legacy = std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust");
+
+    if use_legacy {
+        if let Err(error) = write_markdown_artifacts_legacy(&output_dir, &summary) {
+            eprintln!("error: {error}");
+            return 1;
         }
-    } else {
-        println!(
-            "coding-agent eval: {}/{} passed, {} skipped, total_cost_usd={:.6}",
-            summary.passed_runs, summary.total_runs, summary.skipped_runs, summary.total_cost_usd
-        );
+        announce_output_paths(&output_dir);
+        if args.json {
+            print_json_legacy(&summary);
+        } else {
+            print_summary_legacy(&summary);
+        }
+        return if had_error { 1 } else { 0 };
+    }
+
+    if let Err(code) = write_markdown_artifacts_dispatch(&output_dir, &summary).await {
+        return code;
+    }
+    announce_output_paths(&output_dir);
+    if args.json {
+        if let Err(code) = print_json_dispatch(&summary).await {
+            return code;
+        }
+    } else if let Err(code) = print_summary_dispatch(&summary).await {
+        return code;
     }
 
     if had_error {
@@ -1477,7 +1555,7 @@ fn suggest_followups(
     out
 }
 
-fn write_outputs(output_dir: &Path, summary: &EvalSummary) -> Result<(), String> {
+fn write_json_artifacts(output_dir: &Path, summary: &EvalSummary) -> Result<(), String> {
     write_json_pretty(&output_dir.join("summary.json"), summary)?;
     write_jsonl(&output_dir.join("per_run.jsonl"), &summary.runs)?;
     let summary_value = serde_json::to_value(summary).map_err(|error| error.to_string())?;
@@ -1486,11 +1564,112 @@ fn write_outputs(output_dir: &Path, summary: &EvalSummary) -> Result<(), String>
         output_dir.display().to_string(),
     )?;
     write_json_pretty(&output_dir.join("local_readiness.json"), &readiness)?;
-    fs::write(output_dir.join("summary.md"), render_markdown(summary))
-        .map_err(|error| error.to_string())?;
-    fs::write(output_dir.join("followups.md"), render_followups(summary))
-        .map_err(|error| error.to_string())?;
     Ok(())
+}
+
+fn announce_output_paths(output_dir: &Path) {
+    eprintln!(
+        "wrote {}, {}, {}, {}, and {}",
+        output_dir.join("summary.json").display(),
+        output_dir.join("per_run.jsonl").display(),
+        output_dir.join("local_readiness.json").display(),
+        output_dir.join("summary.md").display(),
+        output_dir.join("followups.md").display()
+    );
+}
+
+// ─── Legacy direct-render path (gated by HARN_CLI_IMPL=rust) ────────────
+
+fn write_markdown_artifacts_legacy(output_dir: &Path, summary: &EvalSummary) -> Result<(), String> {
+    fs::write(output_dir.join("summary.md"), render_markdown(summary))
+        .map_err(|error| format!("failed to write summary.md: {error}"))?;
+    fs::write(output_dir.join("followups.md"), render_followups(summary))
+        .map_err(|error| format!("failed to write followups.md: {error}"))?;
+    Ok(())
+}
+
+fn print_summary_legacy(summary: &EvalSummary) {
+    println!(
+        "coding-agent eval: {}/{} passed, {} skipped, total_cost_usd={:.6}",
+        summary.passed_runs, summary.total_runs, summary.skipped_runs, summary.total_cost_usd
+    );
+}
+
+fn print_json_legacy(summary: &EvalSummary) {
+    match serde_json::to_string_pretty(summary) {
+        Ok(payload) => println!("{payload}"),
+        Err(error) => eprintln!("warning: failed to render summary JSON: {error}"),
+    }
+}
+
+// ─── Dispatch (.harn) render path ────────────────────────────────────────
+
+async fn write_markdown_artifacts_dispatch(
+    output_dir: &Path,
+    summary: &EvalSummary,
+) -> Result<(), i32> {
+    let markdown = render_via_dispatch(summary, "markdown").await?;
+    if let Err(error) = fs::write(output_dir.join("summary.md"), markdown) {
+        eprintln!("error: failed to write summary.md: {error}");
+        return Err(1);
+    }
+    let followups = render_via_dispatch(summary, "followups").await?;
+    if let Err(error) = fs::write(output_dir.join("followups.md"), followups) {
+        eprintln!("error: failed to write followups.md: {error}");
+        return Err(1);
+    }
+    Ok(())
+}
+
+async fn print_summary_dispatch(summary: &EvalSummary) -> Result<(), i32> {
+    let payload = render_via_dispatch(summary, "summary").await?;
+    print!("{payload}");
+    // The script emits exactly the legacy summary line (no trailing
+    // newline); add one to match the legacy `println!` semantics.
+    if !payload.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
+async fn print_json_dispatch(summary: &EvalSummary) -> Result<(), i32> {
+    let payload = render_via_dispatch(summary, "json").await?;
+    print!("{payload}");
+    if !payload.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
+/// Dispatch to the embedded `cli/eval/coding_agent.harn` script for one
+/// of the four rendering modes (markdown / followups / summary / json).
+/// Returns the captured stdout on success, or a propagated exit code
+/// on failure.
+///
+/// **Concurrency.** Held under [`DISPATCH_RENDER_LOCK`] so concurrent
+/// in-process callers don't race on the global env vars the Rust shim
+/// sets to hand the report to the script. See the lock's docstring
+/// for the trade-off rationale.
+async fn render_via_dispatch(summary: &EvalSummary, mode: &str) -> Result<String, i32> {
+    let summary_json = match serde_json::to_string(summary) {
+        Ok(json) => json,
+        Err(error) => {
+            eprintln!("error: failed to serialise EvalSummary for dispatch: {error}");
+            return Err(1);
+        }
+    };
+    let _guard = DISPATCH_RENDER_LOCK.lock().await;
+    let _summary = ScopedEnvVar::set(CODING_AGENT_SUMMARY_ENV, &summary_json);
+    let _mode = ScopedEnvVar::set(CODING_AGENT_MODE_ENV, mode);
+
+    let outcome = dispatch::run_embedded_script("eval/coding_agent", Vec::new(), false).await;
+    if !outcome.stderr.is_empty() {
+        let _ = std::io::stderr().write_all(outcome.stderr.as_bytes());
+    }
+    if outcome.exit_code != 0 {
+        return Err(outcome.exit_code);
+    }
+    Ok(outcome.stdout)
 }
 
 fn write_json_pretty<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {

--- a/crates/harn-cli/tests/eval_coding_agent_dispatch.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_dispatch.rs
@@ -1,0 +1,257 @@
+#![recursion_limit = "256"]
+
+//! `harn eval coding-agent` partial-port verification (harn#2307 / W7).
+//!
+//! The rendering layer for `harn eval coding-agent` ships in
+//! `crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn`. This
+//! test asserts parity against the legacy Rust render path on every
+//! output the wedge actually owns:
+//!
+//!   * `summary.md` — byte-identical (the .harn renderer mirrors the
+//!     Rust markdown writer line-for-line).
+//!   * `followups.md` — byte-identical (same reasoning).
+//!   * The post-run one-line stdout summary
+//!     (`coding-agent eval: ...`) — byte-identical.
+//!   * The `--json` pretty stdout payload — structurally identical
+//!     (Harn's `json_stringify_pretty` sorts dict keys alphabetically;
+//!     serde emits struct fields in declaration order).
+//!   * The on-disk `summary.json` artifact — byte-identical across
+//!     impls (the artifact always stays on the serde-driven Rust path
+//!     because hosted ingestion + the experiment driver in
+//!     `experiments/step-judge/run.sh` both depend on the serde
+//!     struct-field byte order). This guards against an accidental
+//!     future port that routes the JSON artifact through Harn's
+//!     alphabetical-key serialiser.
+//!
+//! Aggregation (matrix execution, `execute_run` fanout, scoring,
+//! rollups, comparisons, follow-up suggestions, Ollama snapshot) stays
+//! in Rust on both impls — only the formatting differs — so the
+//! parity bar is byte-identity for text/markdown surfaces and
+//! structural equality for the JSON stdout path.
+//!
+//! `HARN_CLI_IMPL=rust` keeps the legacy direct-render path so this
+//! test can compare both sides at runtime until the C1 ratchet (#2314)
+//! deletes it.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn summary_md_is_byte_identical_between_impls() {
+    // Use a single shared output dir for both impls. The aggregated
+    // report bakes the output_dir + per-run transcript paths into the
+    // rendered tables, so reusing the same dir keeps those strings
+    // identical between the two subprocess runs. Sequential reset_dir
+    // handles the per-run dir overwrites without interfering.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let shared_out = dir.path().join("bench");
+
+    let harn = run_eval_coding_agent(&shared_out, false, &[]);
+    assert_eq!(harn.exit_code, 1, "harn stderr={}", harn.stderr);
+    let harn_md = fs::read_to_string(shared_out.join("summary.md")).expect("harn summary.md");
+
+    let rust = run_eval_coding_agent(&shared_out, false, &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 1, "rust stderr={}", rust.stderr);
+    let rust_md = fs::read_to_string(shared_out.join("summary.md")).expect("rust summary.md");
+
+    assert_eq!(
+        harn_md, rust_md,
+        "summary.md diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust_md, harn_md
+    );
+}
+
+#[test]
+fn followups_md_is_byte_identical_between_impls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let shared_out = dir.path().join("bench");
+
+    let harn = run_eval_coding_agent(&shared_out, false, &[]);
+    assert_eq!(harn.exit_code, 1, "harn stderr={}", harn.stderr);
+    let harn_md = fs::read_to_string(shared_out.join("followups.md")).expect("harn followups.md");
+
+    let rust = run_eval_coding_agent(&shared_out, false, &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(rust.exit_code, 1, "rust stderr={}", rust.stderr);
+    let rust_md = fs::read_to_string(shared_out.join("followups.md")).expect("rust followups.md");
+
+    assert_eq!(
+        harn_md, rust_md,
+        "followups.md diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust_md, harn_md
+    );
+}
+
+#[test]
+fn stdout_summary_line_is_byte_identical_between_impls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let harn_out = dir.path().join("harn");
+    let rust_out = dir.path().join("rust");
+
+    let harn = run_eval_coding_agent(&harn_out, false, &[]);
+    let rust = run_eval_coding_agent(&rust_out, false, &[("HARN_CLI_IMPL", "rust")]);
+    assert_eq!(
+        harn.stdout, rust.stdout,
+        "stdout summary line diverged\n--- rust ---\n{}\n--- harn ---\n{}",
+        rust.stdout, harn.stdout
+    );
+}
+
+#[test]
+fn json_stdout_is_structurally_identical_between_impls() {
+    // Harn's `json_stringify_pretty` sorts dict keys alphabetically;
+    // serde's `to_string_pretty` emits struct fields in declaration
+    // order. The wire byte order can therefore differ even though the
+    // parsed shapes match — assert structural equality, not byte
+    // identity, for the JSON path.
+    //
+    // We normalise `elapsed_ms` to 0 across both runs because the
+    // matrix executor measures wall-clock per cell and the two
+    // subprocess invocations naturally produce different millisecond
+    // counts; everything else in the report is deterministic when the
+    // output dir is reused.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let shared_out = dir.path().join("bench");
+
+    let harn = run_eval_coding_agent(&shared_out, true, &[]);
+    let rust = run_eval_coding_agent(&shared_out, true, &[("HARN_CLI_IMPL", "rust")]);
+
+    let mut harn_value: serde_json::Value =
+        serde_json::from_str(&harn.stdout).expect("harn --json stdout parses");
+    let mut rust_value: serde_json::Value =
+        serde_json::from_str(&rust.stdout).expect("rust --json stdout parses");
+    zero_timing_fields(&mut harn_value);
+    zero_timing_fields(&mut rust_value);
+    assert_eq!(
+        rust_value, harn_value,
+        "--json stdout diverged structurally"
+    );
+}
+
+#[test]
+fn summary_json_artifact_keeps_serde_struct_field_order_across_impls() {
+    // The on-disk `summary.json` is consumed by hosted ingestion + the
+    // experiment driver in `experiments/step-judge/run.sh`, both of
+    // which depend on serde's struct-field order. The .harn rendering
+    // port intentionally leaves this artifact on the Rust path — this
+    // test guards against an accidental future port that routes the
+    // JSON artifact through Harn's alphabetical-key serialiser.
+    //
+    // We assert that the top-level keys appear in serde declaration
+    // order (not alphabetical) on both impls. We also assert structural
+    // equality (with timing fields zeroed) so a future divergence in
+    // any field surfaces here.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let shared_out = dir.path().join("bench");
+
+    run_eval_coding_agent(&shared_out, false, &[]);
+    let harn_json = fs::read_to_string(shared_out.join("summary.json")).expect("harn summary.json");
+
+    run_eval_coding_agent(&shared_out, false, &[("HARN_CLI_IMPL", "rust")]);
+    let rust_json = fs::read_to_string(shared_out.join("summary.json")).expect("rust summary.json");
+
+    // Both files should start with `schema_version` (the first
+    // serde-declared field on EvalSummary) and `fixture_ids` second —
+    // confirming serde struct-field order, not alphabetical-key order.
+    for (label, body) in [("harn", &harn_json), ("rust", &rust_json)] {
+        let first_field_pos = body.find("\"schema_version\"").unwrap_or(usize::MAX);
+        let fixture_ids_pos = body.find("\"fixture_ids\"").unwrap_or(usize::MAX);
+        assert!(
+            first_field_pos < fixture_ids_pos,
+            "{label} summary.json top-level keys should follow serde struct-field order \
+             (schema_version before fixture_ids), but got {body}"
+        );
+    }
+
+    let mut harn_value: serde_json::Value =
+        serde_json::from_str(&harn_json).expect("harn summary.json parses");
+    let mut rust_value: serde_json::Value =
+        serde_json::from_str(&rust_json).expect("rust summary.json parses");
+    zero_timing_fields(&mut harn_value);
+    zero_timing_fields(&mut rust_value);
+    assert_eq!(harn_value, rust_value, "summary.json diverged structurally");
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+/// Walk a `serde_json::Value` tree and zero any `elapsed_ms` /
+/// `duration_ms` fields so two invocations of the same coding-agent
+/// matrix produce structurally equal reports. The matrix executor
+/// measures wall-clock per cell and the two subprocess runs naturally
+/// produce different millisecond counts — every other field in the
+/// rendered report is deterministic once the output dir is reused.
+fn zero_timing_fields(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if key == "elapsed_ms" || key == "duration_ms" {
+                    *child = serde_json::Value::Number(serde_json::Number::from(0));
+                } else {
+                    zero_timing_fields(child);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                zero_timing_fields(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+struct ProcessOutcome {
+    stdout: String,
+    stderr: String,
+    exit_code: i32,
+}
+
+/// Invoke `harn eval coding-agent` in mock-only matrix mode. The mock
+/// provider has no LLM credentials and the in-process driver may
+/// either pass (CI w/ python3 + the embedded coding_agent_suite.harn
+/// driver round-tripping) or fail with infra_error rows. Either way
+/// the rendered outputs must match across impls.
+fn run_eval_coding_agent(output: &Path, json: bool, extra_env: &[(&str, &str)]) -> ProcessOutcome {
+    let mut argv = vec![
+        "eval".to_string(),
+        "coding-agent".to_string(),
+        "--model".to_string(),
+        "mock:mock".to_string(),
+        "--tool-format".to_string(),
+        "native,text".to_string(),
+        "--max-runs".to_string(),
+        "2".to_string(),
+        "--output".to_string(),
+        output.display().to_string(),
+    ];
+    if json {
+        argv.push("--json".to_string());
+    }
+    run_harn(&argv, extra_env)
+}
+
+fn run_harn(argv: &[String], extra_env: &[(&str, &str)]) -> ProcessOutcome {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harn"));
+    for arg in argv {
+        cmd.arg(arg);
+    }
+    // Drop ambient env that could perturb the renders across the two
+    // subprocess invocations.
+    for key in ["NO_COLOR", "HARN_COLOR", "HARN_CLI_IMPL"] {
+        cmd.env_remove(key);
+    }
+    let mut env_map: BTreeMap<&str, &str> = BTreeMap::new();
+    for (k, v) in extra_env {
+        env_map.insert(*k, *v);
+    }
+    for (k, v) in &env_map {
+        cmd.env(*k, *v);
+    }
+    let output = cmd.output().expect("spawn harn eval coding-agent");
+    ProcessOutcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code().unwrap_or(-1),
+    }
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -810,6 +810,10 @@ pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
         source: include_str!("stdlib/cli/echo.harn"),
     },
     StdlibCliScript {
+        name: "eval/coding_agent",
+        source: include_str!("stdlib/cli/eval/coding_agent.harn"),
+    },
+    StdlibCliScript {
         name: "eval/prompt",
         source: include_str!("stdlib/cli/eval/prompt.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn
@@ -1,0 +1,518 @@
+/**
+ * `harn eval coding-agent` rendering layer ported to .harn — see
+ * harn#2307 (W7).
+ *
+ * **Pragmatic partial port.** The Rust handler in
+ * `crates/harn-cli/src/commands/eval_coding_agent.rs` is ~2.2k LOC and
+ * is tightly entangled with VM internals: it builds a fixture/model/
+ * tool-format matrix, invokes `execute_run` per cell (which spins up
+ * the embedded coding-agent driver against live or mock provider
+ * credentials), snapshots Ollama state via `local::runtime`, fans out
+ * step-judge presets, scores per-run summaries, builds rollups + a
+ * native/text comparison + follow-up suggestions, and writes
+ * `summary.json`, `per_run.jsonl`, and `local_readiness.json` to disk.
+ * None of that is reachable from script-land today without exposing a
+ * wider VM surface than W7 should land — the same constraint that
+ * shaped W5 / W6.
+ *
+ * What this script owns: the **rendering / reporting layer** — the
+ * `summary.md` body, the `followups.md` body, the post-run human one-
+ * line summary, and the `--json` pretty form of the assembled
+ * `EvalSummary`. The Rust shim does all the matrix execution, run
+ * scoring, rollup, comparison, and follow-up generation, collects the
+ * result into an `EvalSummary`, serialises it to JSON, and hands it
+ * off here.
+ *
+ * The on-disk JSON artifacts (`summary.json`, `per_run.jsonl`,
+ * `local_readiness.json`) stay on the serde-driven Rust path because
+ * Harn's `json_stringify_pretty` sorts dict keys alphabetically while
+ * serde emits struct fields in declaration order — and those artifacts
+ * are consumed by regression-check / hosted ingestion / the
+ * experiment driver in `experiments/step-judge/run.sh`, which depend
+ * on the serde struct-field byte order.
+ *
+ * Inputs (from the dispatch shim in crates/harn-cli/src/commands/eval_coding_agent.rs):
+ *   HARN_EVAL_CODING_AGENT_SUMMARY_JSON — serialised `EvalSummary`.
+ *   HARN_EVAL_CODING_AGENT_MODE — one of:
+ *     "markdown"  — render the summary.md body to stdout.
+ *     "followups" — render the followups.md body to stdout.
+ *     "summary"   — render the one-line human summary to stdout.
+ *     "json"      — render the JSON pretty form to stdout for `--json`.
+ *
+ * The Rust shim serialises these env vars under a tokio Mutex so
+ * concurrent in-process callers (the existing eval_coding_agent_cli
+ * test plus any future fanout caller) don't clobber each other mid-
+ * dispatch. Pattern mirrors W5 / W6.
+ *
+ * The wider port (replacing the Rust shim) is gated on G4 (#2297)
+ * exposing `execute_run`, `snapshot_provider`, `llm_pricing_per_1k`,
+ * and `provider_key_available` to script-land. C1 (#2314) will delete
+ * the `HARN_CLI_IMPL=rust` escape hatch.
+ */
+fn __safe_string(value, fallback: string) -> string {
+  if type_of(value) == "string" {
+    return value
+  }
+  return fallback
+}
+
+fn __safe_list(value) -> list {
+  if type_of(value) == "list" {
+    return value
+  }
+  return []
+}
+
+fn __safe_dict(value) -> dict {
+  if type_of(value) == "dict" {
+    return value
+  }
+  return {}
+}
+
+/**
+ * Format a float as `"X.YYYYYY"` (6 decimals, half-up padded). Mirrors
+ * Rust's `format!("{:.6}", x)` rounding/padding so the rendered
+ * markdown/summary lines stay byte-identical with the legacy path.
+ */
+fn __format_float_6(value) -> string {
+  let f = to_float(value) ?? 0.0
+  let negative = f < 0.0
+  let abs_f = if negative {
+    -f
+  } else {
+    f
+  }
+  let scaled = to_int(round(abs_f * 1000000.0)) ?? 0
+  let whole = scaled / 1000000
+  let frac = scaled - whole * 1000000
+  var frac_str = to_string(frac)
+  while len(frac_str) < 6 {
+    frac_str = "0" + frac_str
+  }
+  let sign = if negative && (whole != 0 || frac != 0) {
+    "-"
+  } else {
+    ""
+  }
+  return sign + to_string(whole) + "." + frac_str
+}
+
+/**
+ * Format a float as `"+X.Y"` / `"-X.Y"` (1 decimal, always signed,
+ * half-up padded). Mirrors Rust's `format!("{:+.1}", x)` for the
+ * baseline-comparison `net lift: **{:+.1}pp**` line.
+ */
+fn __format_float_signed_1(value) -> string {
+  let f = to_float(value) ?? 0.0
+  let negative = f < 0.0
+  let abs_f = if negative {
+    -f
+  } else {
+    f
+  }
+  let scaled = to_int(round(abs_f * 10.0)) ?? 0
+  let whole = scaled / 10
+  let frac = scaled - whole * 10
+  let frac_str = to_string(frac)
+  // Rust's `{:+.1}` prints a `+` for zero (and positive values), `-` for
+  // negative — match that even when the rounded value is 0.0.
+  let sign = if negative && (whole != 0 || frac != 0) {
+    "-"
+  } else {
+    "+"
+  }
+  return sign + to_string(whole) + "." + frac_str
+}
+
+/**
+ * Escape Markdown table cell content by replacing `|` with `\|`.
+ * Mirrors Rust's `value.replace('|', "\\|")`.
+ */
+fn __md_escape(s: string) -> string {
+  return s.replace("|", "\\|")
+}
+
+/**
+ * Build the `selector_label` string the way Rust's `selector_label`
+ * helper does — the serialised `EvalSummary` already emits a
+ * `selector.selector` field that matches the label, so prefer that
+ * when present and fall back to `"provider:model"`.
+ */
+fn __selector_label(selector: dict) -> string {
+  let raw = selector["selector"]
+  if type_of(raw) == "string" {
+    return raw
+  }
+  return __safe_string(selector["provider"], "")
+    + ":"
+    + __safe_string(selector["model"], "")
+}
+
+/**
+ * Format an `Option<i64>` as the rendered `i64.to_string()` or `"-"`
+ * for `None`. Mirrors the legacy
+ * `value.map(|v| v.to_string()).unwrap_or_else(|| "-".to_string())`
+ * pattern used in the native/text comparison table.
+ */
+fn __optional_int_mark(value) -> string {
+  if type_of(value) == "int" {
+    return to_string(value)
+  }
+  if type_of(value) == "float" {
+    return to_string(to_int(value) ?? 0)
+  }
+  return "-"
+}
+
+/**
+ * Format an `Option<bool>` as `"yes"` / `"no"` / `"-"`. Mirrors Rust's
+ * `optional_bool_mark`.
+ */
+fn __optional_bool_mark(value) -> string {
+  if type_of(value) == "bool" {
+    if value {
+      return "yes"
+    }
+    return "no"
+  }
+  return "-"
+}
+
+/**
+ * URL-encode a markdown link target the way Rust's `markdown_link`
+ * does: replace `' '` with `%20`, `'('` with `%28`, `')'` with `%29`.
+ * The label gets its `|` characters escaped for the table cell.
+ */
+fn __markdown_link(label: string, target: string) -> string {
+  let target_encoded = target
+    .replace(" ", "%20")
+    .replace("(", "%28")
+    .replace(")", "%29")
+  return "[" + __md_escape(label) + "](" + target_encoded + ")"
+}
+
+fn __comparison_evidence_links(comparison: dict) -> string {
+  var links = []
+  let native = comparison["native_evidence_path"]
+  if type_of(native) == "string" {
+    links = links + [__markdown_link("native", native)]
+  }
+  let text = comparison["text_evidence_path"]
+  if type_of(text) == "string" {
+    links = links + [__markdown_link("text", text)]
+  }
+  if len(links) == 0 {
+    return "-"
+  }
+  return join(links, "<br>")
+}
+
+fn __render_rollup_table(title: string, rollups) -> string {
+  var out = "## " + title + "\n\n"
+  out = out + "| key | passed | failed | skipped | total | cost |\n"
+  out = out + "|---|---:|---:|---:|---:|---:|\n"
+  for rollup in __safe_list(rollups) {
+    let rd = __safe_dict(rollup)
+    out = out + "| `"
+      + __md_escape(__safe_string(rd["key"], ""))
+      + "` | "
+      + to_string(rd["passed_runs"] ?? 0)
+      + " | "
+      + to_string(rd["failed_runs"] ?? 0)
+      + " | "
+      + to_string(rd["skipped_runs"] ?? 0)
+      + " | "
+      + to_string(rd["total_runs"] ?? 0)
+      + " | "
+      + __format_float_6(rd["total_cost_usd"] ?? 0.0)
+      + " |\n"
+  }
+  out = out + "\n"
+  return out
+}
+
+fn __render_runs_table(runs) -> string {
+  var out = "\n## Runs\n\n"
+  out = out
+    + "| fixture | run | provider | model | tool format | fixture sequence | tool calls | status | iterations | tokens | cost | transcript | output |\n"
+  out = out + "|---|---|---|---|---|---|---|---|---:|---:|---:|---|---|\n"
+  for run in __safe_list(runs) {
+    let rd = __safe_dict(run)
+    let selector = __safe_dict(rd["selector"])
+    let sequence = __safe_list(rd["tool_sequence"])
+    let tool_sequence = if len(sequence) == 0 {
+      "-"
+    } else {
+      __md_escape(join(sequence, ", "))
+    }
+    let input_tokens = rd["input_tokens"] ?? 0
+    let output_tokens = rd["output_tokens"] ?? 0
+    out = out + "| `"
+      + __safe_string(rd["fixture_id"], "")
+      + "` | `"
+      + __safe_string(rd["run_id"], "")
+      + "` | `"
+      + __safe_string(selector["provider"], "")
+      + "` | `"
+      + __md_escape(__safe_string(selector["model"], ""))
+      + "` | `"
+      + __safe_string(rd["tool_format"], "")
+      + "` | `"
+      + __safe_string(rd["fixture_tool_sequence"], "")
+      + "` | `"
+      + tool_sequence
+      + "` | "
+      + __safe_string(rd["status"], "")
+      + " | "
+      + to_string(rd["iterations"] ?? 0)
+      + " | "
+      + to_string(input_tokens + output_tokens)
+      + " | "
+      + __format_float_6(rd["cost_usd"] ?? 0.0)
+      + " | "
+      + __markdown_link(
+      to_string(rd["transcript_event_count"] ?? 0),
+      __safe_string(rd["transcript_events_path"], ""),
+    )
+      + " | `"
+      + __safe_string(rd["output_dir"], "")
+      + "` |\n"
+  }
+  return out
+}
+
+fn __render_baseline_comparison(comparison: dict) -> string {
+  var out = "\n## Baseline Comparison\n\n"
+  let label = __safe_string(comparison["baseline_label"], "")
+  let label_suffix = if label == "" {
+    ""
+  } else {
+    " (label: `" + label + "`)"
+  }
+  out = out + "Compared against `"
+    + __safe_string(comparison["baseline_path"], "")
+    + "`"
+    + label_suffix
+    + ".\n\n"
+  out = out + "- regressions: **"
+    + to_string(comparison["regressions_count"] ?? 0)
+    + "** (baseline passed, this cell failed)\n"
+    + "- recoveries: **"
+    + to_string(comparison["recoveries_count"] ?? 0)
+    + "** (baseline failed, this cell passed)\n"
+    + "- net lift: **"
+    + __format_float_signed_1(comparison["net_lift_pp"] ?? 0.0)
+    + "pp**\n\n"
+  let regressions = __safe_list(comparison["regressions"])
+  if len(regressions) > 0 {
+    out = out + "### Regressions\n\n"
+    for delta in regressions {
+      let dd = __safe_dict(delta)
+      out = out + "- `"
+        + __safe_string(dd["fixture_id"], "")
+        + "`: `"
+        + __safe_string(dd["baseline_status"], "")
+        + "` → `"
+        + __safe_string(dd["cell_status"], "")
+        + "`\n"
+    }
+    out = out + "\n"
+  }
+  let recoveries = __safe_list(comparison["recoveries"])
+  if len(recoveries) > 0 {
+    out = out + "### Recoveries\n\n"
+    for delta in recoveries {
+      let dd = __safe_dict(delta)
+      out = out + "- `"
+        + __safe_string(dd["fixture_id"], "")
+        + "`: `"
+        + __safe_string(dd["baseline_status"], "")
+        + "` → `"
+        + __safe_string(dd["cell_status"], "")
+        + "`\n"
+    }
+    out = out + "\n"
+  }
+  return out
+}
+
+fn __render_comparison_table(comparisons) -> string {
+  var out = "\n## Native/Text Comparison\n\n"
+  out = out
+    + "| fixture | selector | native | text | equivalent | verifier | tools | rejected delta | token delta | iteration delta | evidence |\n"
+  out = out + "|---|---|---|---|---|---|---|---:|---:|---:|---|\n"
+  for comparison in __safe_list(comparisons) {
+    let cd = __safe_dict(comparison)
+    let selector = __safe_dict(cd["selector"])
+    let native_status = if type_of(cd["native_status"]) == "string" {
+      cd["native_status"]
+    } else {
+      "-"
+    }
+    let text_status = if type_of(cd["text_status"]) == "string" {
+      cd["text_status"]
+    } else {
+      "-"
+    }
+    out = out + "| `"
+      + __safe_string(cd["fixture_id"], "")
+      + "` | `"
+      + __selector_label(selector)
+      + "` | "
+      + native_status
+      + " | "
+      + text_status
+      + " | "
+      + __optional_bool_mark(cd["equivalent"])
+      + " | "
+      + __optional_bool_mark(cd["verifier_match"])
+      + " | "
+      + __optional_bool_mark(cd["tool_sequence_match"])
+      + " | "
+      + __optional_int_mark(cd["rejected_tool_call_delta_text_minus_native"])
+      + " | "
+      + __optional_int_mark(cd["token_delta_text_minus_native"])
+      + " | "
+      + __optional_int_mark(cd["iteration_delta_text_minus_native"])
+      + " | "
+      + __comparison_evidence_links(cd)
+      + " |\n"
+  }
+  return out
+}
+
+fn __render_divergence_evidence(comparisons) -> string {
+  var diverged = []
+  for comparison in __safe_list(comparisons) {
+    let cd = __safe_dict(comparison)
+    if len(__safe_list(cd["divergence_reasons"])) > 0 {
+      diverged = diverged + [cd]
+    }
+  }
+  if len(diverged) == 0 {
+    return ""
+  }
+  var out = "\n## Native/Text Divergence Evidence\n\n"
+  for comparison in diverged {
+    let selector = __safe_dict(comparison["selector"])
+    out = out + "- `"
+      + __safe_string(comparison["fixture_id"], "")
+      + "` `"
+      + __selector_label(selector)
+      + "`: "
+      + join(__safe_list(comparison["divergence_reasons"]), "; ")
+      + "\n"
+    if len(__safe_list(comparison["evidence_paths"])) > 0 {
+      out = out + "  Evidence: "
+        + __comparison_evidence_links(comparison)
+        + "\n"
+    }
+  }
+  return out
+}
+
+fn __render_markdown(summary: dict) -> string {
+  let fixture_ids = __safe_list(summary["fixture_ids"])
+  var out = "# Coding Agent Harness Quality Suite\n\n"
+  out = out + "- fixtures: `"
+    + join(fixture_ids, "`, `")
+    + "`\n- passed: "
+    + to_string(summary["passed_runs"] ?? 0)
+    + "/"
+    + to_string(summary["total_runs"] ?? 0)
+    + "\n- skipped: "
+    + to_string(summary["skipped_runs"] ?? 0)
+    + "\n- total_cost_usd: "
+    + __format_float_6(summary["total_cost_usd"] ?? 0.0)
+    + "\n\n"
+  let rollups = __safe_dict(summary["rollups"])
+  out = out + __render_rollup_table("By Fixture", rollups["by_fixture"])
+  out = out + __render_rollup_table("By Provider", rollups["by_provider"])
+  out = out + __render_rollup_table("By Model", rollups["by_model"])
+  out = out + __render_rollup_table("By Tool Format", rollups["by_tool_format"])
+  out = out + __render_rollup_table("By Tool Sequence", rollups["by_tool_sequence"])
+  out = out + __render_runs_table(summary["runs"])
+  let baseline = summary["baseline_comparison"]
+  if type_of(baseline) == "dict" {
+    out = out + __render_baseline_comparison(baseline)
+  }
+  let comparisons = __safe_list(summary["comparisons"])
+  if len(comparisons) > 0 {
+    out = out + __render_comparison_table(comparisons)
+  }
+  out = out + __render_divergence_evidence(comparisons)
+  return out
+}
+
+fn __render_followups(summary: dict) -> string {
+  var out = "# Follow-up Issue Candidates\n\n"
+  let followups = __safe_list(summary["followups"])
+  if len(followups) == 0 {
+    out = out + "No follow-up issue candidates were generated from this run.\n"
+    return out
+  }
+  for followup in followups {
+    let fd = __safe_dict(followup)
+    out = out + "## "
+      + __safe_string(fd["title"], "")
+      + "\n\n"
+      + __safe_string(fd["body"], "")
+      + "\n\n"
+    let run_ids = __safe_list(fd["run_ids"])
+    if len(run_ids) > 0 {
+      out = out + "- run_ids: `" + join(run_ids, "`, `") + "`\n"
+    }
+    let labels = __safe_list(fd["labels"])
+    if len(labels) > 0 {
+      out = out + "- labels: `" + join(labels, "`, `") + "`\n"
+    }
+    out = out + "\n"
+  }
+  return out
+}
+
+fn __render_summary_line(summary: dict) -> string {
+  return "coding-agent eval: "
+    + to_string(summary["passed_runs"] ?? 0)
+    + "/"
+    + to_string(summary["total_runs"] ?? 0)
+    + " passed, "
+    + to_string(summary["skipped_runs"] ?? 0)
+    + " skipped, total_cost_usd="
+    + __format_float_6(summary["total_cost_usd"] ?? 0.0)
+}
+
+/**
+ * Entrypoint. Returns an integer exit code rather than calling
+ * `exit()` so the dispatch wedge's captured stdout/stderr buffers
+ * flush back to the Rust shim — `exit()` in the embedded `harn run`
+ * pipeline calls `std::process::exit` which terminates the host
+ * binary mid-render and drops the captured streams.
+ */
+fn main(harness: Harness) -> int {
+  let raw = harness.env.get_or("HARN_EVAL_CODING_AGENT_SUMMARY_JSON", "")
+  if raw == "" {
+    harness.stdio
+      .eprintln("internal error: HARN_EVAL_CODING_AGENT_SUMMARY_JSON not set by dispatch shim")
+    return 70
+  }
+  let summary = try {
+    json_parse(raw)
+  } catch (e) {
+    harness.stdio.eprintln("internal error: failed to parse EvalSummary: " + to_string(e))
+    return 70
+  }
+  let mode = harness.env.get_or("HARN_EVAL_CODING_AGENT_MODE", "summary")
+  let payload = if mode == "markdown" {
+    __render_markdown(summary)
+  } else if mode == "followups" {
+    __render_followups(summary)
+  } else if mode == "json" {
+    json_stringify_pretty(summary)
+  } else {
+    __render_summary_line(summary)
+  }
+  __io_print(payload)
+  return 0
+}

--- a/scripts/ported_handlers.toml
+++ b/scripts/ported_handlers.toml
@@ -40,5 +40,9 @@ path = "crates/harn-cli/src/commands/eval_prompt.rs"
 max_loc = 1201
 
 [[handler]]
+path = "crates/harn-cli/src/commands/eval_coding_agent.rs"
+max_loc = 2391
+
+[[handler]]
 path = "crates/harn-cli/src/lib.rs"
 max_loc = 3120


### PR DESCRIPTION
## Summary

- Ports the four rendering outputs of `harn eval coding-agent` —
  `summary.md`, `followups.md`, the one-line stdout summary, and the
  `--json` pretty form — to
  `crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn`, following
  the W5/W6 partial-port pattern. Aggregation (matrix execution,
  `execute_run` fanout, scoring, rollups, native/text comparisons,
  follow-up generation, Ollama snapshot/cleanup) stays in Rust because
  every cell reaches into VM internals that aren't script-reachable
  today.
- The Rust shim serialises the assembled `EvalSummary` to JSON, hands
  it off via `HARN_EVAL_CODING_AGENT_SUMMARY_JSON` +
  `HARN_EVAL_CODING_AGENT_MODE` under a `tokio::sync::Mutex`,
  dispatches the script four times (markdown / followups / summary /
  json), and writes the captured payloads to disk and real stdout.
  `summary.json`, `per_run.jsonl`, and `local_readiness.json` stay on
  the serde-driven Rust path so the on-disk byte format keeps the
  struct-field order that the experiment driver in
  `experiments/step-judge/run.sh` and hosted ingestion depend on.
- `HARN_CLI_IMPL=rust` keeps the legacy direct-render path for the
  parity-snapshot harness (#2299) until the C1 ratchet (#2314) deletes
  it. New parity tests in
  `crates/harn-cli/tests/eval_coding_agent_dispatch.rs` cover byte-
  identity for the markdown surfaces + summary line, structural
  equality for the `--json` payload (with `elapsed_ms`/`duration_ms`
  zeroed since wall-clock differs across the two subprocess runs), and
  a struct-field-order assertion on the on-disk `summary.json` so a
  future port can't accidentally route the artifact through Harn's
  alphabetical-key serialiser.

Tracks epic #2293 (self-host the CLI in `.harn`).

## Boundary decisions

- **What stayed in Rust** — `execute_run` invocations per matrix cell,
  Ollama snapshot/cleanup, llm pricing lookups, env-file loading,
  step-judge preset expansion, baseline diffing, rollups + follow-up
  suggestions + native/text comparisons, and the three on-disk JSON
  artifacts (`summary.json`, `per_run.jsonl`, `local_readiness.json`).
- **What moved to `.harn`** — the four formatter surfaces. The Rust
  handler stayed roughly the same size (~2.2k → 2.4k LOC) since the
  legacy-direct-render path is kept side-by-side under the
  `HARN_CLI_IMPL=rust` escape hatch; once C1 (#2314) deletes that hatch
  the handler will shed those ~200 lines plus the markdown writers.
- **Helpers inlined**, not shared with W6's `_runner.harn` — W6 (#2344)
  is still open, and once it merges a follow-up PR can DRY the common
  `__safe_*`, `__format_float_*`, `__md_escape`, `__optional_*`, and
  `__markdown_link` helpers via that shared module. Kept inline for now
  to avoid the merge conflict and so this PR stands on its own.

## Test plan

- [x] `cargo test -p harn-cli --test eval_coding_agent_dispatch` — 5/5
  pass (all four rendering surfaces parity-checked across impls + the
  on-disk struct-field-order assertion).
- [x] `cargo clippy -p harn-cli -p harn-stdlib --all-targets -- -D warnings`
  — clean.
- [x] `cargo fmt --check -p harn-cli -p harn-stdlib` — clean.
- [x] `cargo test -p harn-stdlib` — 16/16 pass (CLI script registration
  picks up the new entry).
- [x] `cargo test -p harn-cli --lib` — 755/755 pass.
- [x] `harn check crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn`
  — ok.
- [x] `harn run scripts/check_ported_handler_loc.harn` — 8 handler(s)
  within budget (new entry added with current+8 slack: 2383 LOC under
  the 2391 budget).
- [ ] CI on the PR — full sweep including `eval_coding_agent_cli`
  end-to-end mock matrix.

Generated with [Claude Code](https://claude.com/claude-code).