### PR TITLE
Trim CLI dependencies after self-host epic (#2316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,14 @@ condensed series summaries instead of full per-patch history.
   `TranscriptProjected` agent event surfaced over ACP as the
   `transcript_projected` session update so Burin Code and other hosts can
   render raw vs. projected side-by-side.
+- **Internal: trimmed CLI dependencies after self-host epic (#2293).**
+  Audited every direct dependency in `crates/harn-cli/Cargo.toml` against
+  the post-port handler tree (G1-G6, W1-W12 ports + W13 partial). All
+  current deps remain in use — legacy Rust handler paths kept behind
+  `HARN_CLI_IMPL=rust` for the parity-test contract still exercise them,
+  per the C1 ratchet. No dependency drops shipped in this pass; rerun the
+  audit after C1's follow-up promotes the `.harn` implementations to
+  default-everywhere and the legacy Rust paths can be deleted.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

C3 (final ticket) of the `harn-cli` self-host epic (#2293).

Audited every direct dep in `crates/harn-cli/Cargo.toml` after the W1-W13 + G1-G6 ports. `cargo machete crates/harn-cli/` returned clean; spot-checked each dep with `grep -rE '(^|[^a-zA-Z0-9_])<dep>(::|\s*=|\s*\{)' crates/harn-cli/src/` and every direct + dev dep has live call sites.

**Result: 0 deps removed.** Most ported handlers keep the legacy Rust impl behind `HARN_CLI_IMPL=rust` for the parity-test contract (per the C1 ratchet), so the deps those handlers reach for must stay until the `.harn` implementations promote to default-everywhere and the legacy Rust paths can be deleted. The audit + CHANGELOG note are the deliverable; removal is a happy side effect that didn't materialize this pass.

## Audited (all kept; live-usage counts in `crates/harn-cli/src/`)

| dep | uses | dep | uses | dep | uses |
| --- | --- | --- | --- | --- | --- |
| async-trait | 4 | axum | 123 | axum-server | 4 |
| tokio | 371 | serde_json | 757 | serde_yml | 1 |
| semver | 1 | reedline | 17 | nu-ansi-term | 8 |
| toml | 84 | serde | 100 | notify | 23 |
| reqwest | 53 | futures | 27 | blake3 | 5 |
| sha2 | 8 | hmac | 6 | tar | 2 |
| flate2 | 1 | subtle | 1 | base64 | 16 |
| ed25519-dalek | 5 | url | 59 | webbrowser | 4 |
| rand | 3 | regex | 5 | jsonschema | 4 |
| jsonwebtoken | 2 | clap | 82 | clap_complete | 5 |
| rpassword | 2 | tower | 3 | time | 216 |
| tempfile | 256 | include_dir | 1 | uuid | 11 |
| chrono-tz | 1 | croner | 1 | jmespath | 1 |
| rustls | 2 | tracing | 18 | fs2 | 2 |
| thiserror | 2 | which | 9 | libc | 6 |
| rcgen (dev) | 2 | tokio-tungstenite (dev) | 26 | wat (dev) | 2 |

Even the lowest-count deps are non-vestigial:
- `flate2(1)` / `tar(2)` — registry tarball extraction
- `chrono-tz(1)` — timezone-aware scheduler
- `croner(1)` — cron triggers
- `jmespath(1)` — connector payload selectors
- `subtle(1)` — constant-time HMAC compare
- `serde_yml(1)` — YAML config ingest
- `include_dir(1)` — portal-dist embed (see `build.rs`)
- `semver(1)` — `harn doctor` / version surfaces

## Verification

- `cargo machete crates/harn-cli/` returns `Good job!` (no findings).
- Manual grep audit per-dep over `crates/harn-cli/src/` — every dep has >=1 hit.
- `cargo build --release -p harn-cli` succeeds.

## Follow-up

After C1's follow-up promotes the `.harn` handlers to default-everywhere and deletes the legacy Rust paths gated by `HARN_CLI_IMPL=rust`, rerun this audit — that's the realistic point where deps actually become removable.

## Test plan

- [x] `cargo machete crates/harn-cli/`
- [x] `cargo build --release -p harn-cli`
- [ ] CI green

Closes #2316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)