### PR TITLE
Add harn run summary JSON output

### DIFF
--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use std::path::PathBuf;
 
 use super::ProfileArgs;
 
@@ -92,6 +93,27 @@ pub(crate) struct RunArgs {
     /// events still flow.
     #[arg(long = "quiet", action = clap::ArgAction::SetTrue, requires = "json")]
     pub quiet: bool,
+    /// Emit one terminal run-summary JSON object as a single NDJSON line.
+    /// Defaults to stderr; use --summary-file or --summary-fd to keep the
+    /// summary separate from the script's own stderr.
+    #[arg(long = "emit-summary-json", action = clap::ArgAction::SetTrue)]
+    pub emit_summary_json: bool,
+    /// Write --emit-summary-json output to this file instead of stderr.
+    #[arg(
+        long = "summary-file",
+        value_name = "PATH",
+        requires = "emit_summary_json",
+        conflicts_with = "summary_fd"
+    )]
+    pub summary_file: Option<PathBuf>,
+    /// Write --emit-summary-json output to this already-open file descriptor.
+    #[arg(
+        long = "summary-fd",
+        value_name = "FD",
+        requires = "emit_summary_json",
+        conflicts_with = "summary_file"
+    )]
+    pub summary_fd: Option<i32>,
     /// Path to the .harn file to execute.
     pub file: Option<String>,
     /// Positional arguments passed to the pipeline as the global `argv`

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -245,6 +245,41 @@ fn test_parses_run_llm_mock_flags() {
 }
 
 #[test]
+fn test_parses_run_summary_flags() {
+    let cli = Cli::parse_from([
+        "harn",
+        "run",
+        "--emit-summary-json",
+        "--summary-file",
+        "summary.jsonl",
+        "main.harn",
+    ]);
+
+    let Command::Run(args) = cli.command.unwrap() else {
+        panic!("expected run command");
+    };
+    assert!(args.emit_summary_json);
+    assert_eq!(
+        args.summary_file.as_deref(),
+        Some(std::path::Path::new("summary.jsonl"))
+    );
+    assert_eq!(args.summary_fd, None);
+
+    let cli = Cli::parse_from([
+        "harn",
+        "run",
+        "--emit-summary-json",
+        "--summary-fd",
+        "3",
+        "main.harn",
+    ]);
+    let Command::Run(args) = cli.command.unwrap() else {
+        panic!("expected run command");
+    };
+    assert_eq!(args.summary_fd, Some(3));
+}
+
+#[test]
 fn test_parses_eval_tool_calls_args() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 
 use harn_parser::DiagnosticSeverity;
 use harn_vm::event_log::EventLog;
+use serde::Serialize;
 
 use crate::commands::mcp::{self, AuthResolution};
 use crate::commands::time::RunTiming;
@@ -32,6 +33,58 @@ pub struct RunJsonOptions {
     /// Suppress `stdout` / `stderr` events. Transcript, tool, hook,
     /// persona, and the terminal result/error events still flow.
     pub quiet: bool,
+}
+
+/// Post-run summary configuration for `harn run --emit-summary-json`.
+#[derive(Clone, Debug)]
+pub struct RunSummaryOptions {
+    pub sink: RunSummarySink,
+}
+
+#[derive(Clone, Debug)]
+pub enum RunSummarySink {
+    /// Append the summary to the captured stderr buffer so it remains
+    /// terminal after all diagnostics that `run_file_with_skill_dirs`
+    /// flushes on return.
+    Stderr,
+    File(PathBuf),
+    Fd(i32),
+}
+
+#[derive(Serialize)]
+struct RunSummary<'a> {
+    schema_version: u32,
+    event: &'static str,
+    wall_time_ms: u64,
+    exit_code: i32,
+    llm: RunSummaryLlm,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    profile: Option<&'a harn_vm::profile::RunProfile>,
+}
+
+#[derive(Serialize)]
+struct RunSummaryLlm {
+    call_count: i64,
+    input_tokens: i64,
+    output_tokens: i64,
+    time_ms: i64,
+    cost_usd: f64,
+}
+
+pub const RUN_SUMMARY_SCHEMA_VERSION: u32 = 1;
+
+pub(crate) fn run_summary_options_from_args(
+    args: &crate::cli::RunArgs,
+) -> Option<RunSummaryOptions> {
+    args.emit_summary_json.then(|| RunSummaryOptions {
+        sink: if let Some(path) = args.summary_file.clone() {
+            RunSummarySink::File(path)
+        } else if let Some(fd) = args.summary_fd {
+            RunSummarySink::Fd(fd)
+        } else {
+            RunSummarySink::Stderr
+        },
+    })
 }
 
 pub(crate) enum RunFileMcpServeMode {
@@ -169,8 +222,7 @@ pub(crate) fn compile_or_load_chunk_with_timing(
     }
 
     let parse_start = Instant::now();
-    let (parsed_source, program) = parse_source_file(path);
-    debug_assert_eq!(parsed_source, source, "parse_source_file re-read drifted");
+    let program = parse_source_for_run(path, &source, stderr)?;
     if let Some(t) = timing.as_deref_mut() {
         t.parse = parse_start.elapsed();
     }
@@ -215,6 +267,81 @@ pub(crate) fn compile_or_load_chunk_with_timing(
     }
 
     Some(LoadedChunk { source, chunk })
+}
+
+fn parse_source_for_run(
+    path: &str,
+    source: &str,
+    stderr: &mut String,
+) -> Option<Vec<harn_parser::SNode>> {
+    let mut lexer = harn_lexer::Lexer::new(source);
+    let tokens = match lexer.tokenize() {
+        Ok(tokens) => tokens,
+        Err(error) => {
+            let diagnostic = harn_parser::diagnostic::render_diagnostic_with_code(
+                source,
+                path,
+                &error_span_from_lex(&error),
+                "error",
+                harn_parser::diagnostic::lexer_error_code(&error),
+                &error.to_string(),
+                Some("here"),
+                None,
+            );
+            stderr.push_str(&diagnostic);
+            return None;
+        }
+    };
+
+    let mut parser = harn_parser::Parser::new(tokens);
+    match parser.parse() {
+        Ok(program) => Some(program),
+        Err(error) => {
+            if parser.all_errors().is_empty() {
+                render_parse_error(path, source, &error, stderr);
+            } else {
+                for error in parser.all_errors() {
+                    render_parse_error(path, source, error, stderr);
+                }
+            }
+            None
+        }
+    }
+}
+
+fn render_parse_error(
+    path: &str,
+    source: &str,
+    error: &harn_parser::ParserError,
+    stderr: &mut String,
+) {
+    let span = error_span_from_parse(error);
+    let diagnostic = harn_parser::diagnostic::render_diagnostic_with_code(
+        source,
+        path,
+        &span,
+        "error",
+        harn_parser::diagnostic::parser_error_code(error),
+        &harn_parser::diagnostic::parser_error_message(error),
+        Some(harn_parser::diagnostic::parser_error_label(error)),
+        harn_parser::diagnostic::parser_error_help(error),
+    );
+    stderr.push_str(&diagnostic);
+}
+
+fn error_span_from_lex(error: &harn_lexer::LexerError) -> harn_lexer::Span {
+    match error {
+        harn_lexer::LexerError::UnexpectedCharacter(_, span)
+        | harn_lexer::LexerError::UnterminatedString(span)
+        | harn_lexer::LexerError::UnterminatedBlockComment(span) => *span,
+    }
+}
+
+fn error_span_from_parse(error: &harn_parser::ParserError) -> harn_lexer::Span {
+    match error {
+        harn_parser::ParserError::Unexpected { span, .. } => *span,
+        harn_parser::ParserError::UnexpectedEof { span, .. } => *span,
+    }
 }
 
 /// Run the static type checker against `program` with cross-module
@@ -426,6 +553,7 @@ struct ExecuteRunInputs<'a> {
     sandbox: RunSandboxOptions,
     interrupt_tokens: Option<RunInterruptTokens>,
     json: Option<(RunJsonOptions, Box<dyn io::Write + Send>)>,
+    summary: Option<RunSummaryOptions>,
     timing: Option<&'a mut RunTiming>,
     harnpack: HarnpackRunOptions,
 }
@@ -504,6 +632,7 @@ pub(crate) async fn run_file(
         profile,
         RunSandboxOptions::default(),
         None,
+        None,
         HarnpackRunOptions::default(),
     )
     .await;
@@ -534,6 +663,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     profile: RunProfileOptions,
     sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
+    summary: Option<RunSummaryOptions>,
     harnpack: HarnpackRunOptions,
 ) {
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
@@ -554,6 +684,7 @@ pub(crate) async fn run_file_with_skill_dirs(
         sandbox,
         interrupt_tokens: Some(interrupt_tokens.clone()),
         json: json_with_stdout,
+        summary,
         timing: None,
         harnpack,
     })
@@ -589,6 +720,7 @@ pub(crate) async fn run_resume_with_skill_dirs(
     profile: RunProfileOptions,
     sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
+    summary: Option<RunSummaryOptions>,
 ) {
     let source = r#"import { resume_agent, wait_agent } from "std/agent/workers"
 
@@ -626,6 +758,7 @@ pipeline main(task) {
         profile,
         sandbox,
         json,
+        summary,
         HarnpackRunOptions::default(),
     )
     .await;
@@ -969,6 +1102,7 @@ async fn execute_run_with_harnpack_and_sandbox_options(
         sandbox,
         interrupt_tokens: None,
         json: None,
+        summary: None,
         timing: None,
         harnpack,
     })
@@ -1005,6 +1139,7 @@ pub async fn execute_run_json(
         sandbox: RunSandboxOptions::default(),
         interrupt_tokens: None,
         json: Some((options, out)),
+        summary: None,
         timing: None,
         harnpack: HarnpackRunOptions::default(),
     })
@@ -1032,6 +1167,7 @@ pub(crate) async fn execute_run_with_timing(
         sandbox,
         interrupt_tokens: None,
         json: None,
+        summary: None,
         timing,
         harnpack: HarnpackRunOptions::default(),
     })
@@ -1054,9 +1190,11 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         sandbox,
         interrupt_tokens,
         json,
+        summary,
         mut timing,
         harnpack,
     } = inputs;
+    let run_started = Instant::now();
 
     // `--json` installs an in-process sink that diverts every
     // observable VM event (stdout, stderr, transcript, tool, hook,
@@ -1076,7 +1214,15 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     let resolved_path: &str = if harnpack::looks_like_harnpack(Path::new(path)) {
         let outcome = match harnpack::prepare_harnpack(Path::new(path), &harnpack, &mut stderr) {
             Ok(prepared) => prepared,
-            Err(err) => return finalize_harnpack_error(stderr, json_session, err),
+            Err(err) => {
+                return finalize_harnpack_error(
+                    stderr,
+                    json_session,
+                    summary.as_ref(),
+                    run_started,
+                    err,
+                );
+            }
         };
         harn_vm::run_events::emit(harn_vm::run_events::RunEvent::PackRun {
             bundle_hash: outcome.bundle_hash.clone(),
@@ -1086,7 +1232,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             dry_run_verify: harnpack.dry_run_verify,
         });
         if harnpack.dry_run_verify {
-            return finalize_harnpack_dry_run(stderr, json_session, &outcome);
+            return finalize_harnpack_dry_run(
+                stderr,
+                json_session,
+                summary.as_ref(),
+                run_started,
+                &outcome,
+            );
         }
         owned_run_path = outcome.entrypoint_path.to_string_lossy().into_owned();
         owned_run_path.as_str()
@@ -1097,14 +1249,17 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     let Some(LoadedChunk { source, chunk }) =
         compile_or_load_chunk_with_timing(resolved_path, &mut stderr, timing.as_deref_mut())
     else {
-        if let Some(session) = json_session {
-            return session.finalize_error("compile_error", stderr, 1);
-        }
-        return RunOutcome {
+        let message = stderr.clone();
+        return finalize_run_error(
             stdout,
             stderr,
-            exit_code: 1,
-        };
+            json_session,
+            summary.as_ref(),
+            run_started,
+            None,
+            "compile_error",
+            message,
+        );
     };
     let path = resolved_path;
 
@@ -1113,7 +1268,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     // instruction; `run_main` covers `vm.execute` proper.
     let setup_start = Instant::now();
 
-    if trace {
+    if trace || summary.is_some() {
         harn_vm::llm::enable_tracing();
     }
     if profile.is_enabled() {
@@ -1121,14 +1276,16 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     }
     if let Err(error) = install_cli_llm_mock_mode(&llm_mock_mode) {
         stderr.push_str(&format!("error: {error}\n"));
-        if let Some(session) = json_session {
-            return session.finalize_error("llm_mock_install", error, 1);
-        }
-        return RunOutcome {
+        return finalize_run_error(
             stdout,
             stderr,
-            exit_code: 1,
-        };
+            json_session,
+            summary.as_ref(),
+            run_started,
+            None,
+            "llm_mock_install",
+            error,
+        );
     }
 
     let mut vm = harn_vm::Vm::new();
@@ -1226,27 +1383,31 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         stderr.push_str(&format!(
             "error: failed to install manifest triggers: {error}\n"
         ));
-        if let Some(session) = json_session {
-            return session.finalize_error("manifest_triggers", error.to_string(), 1);
-        }
-        return RunOutcome {
+        return finalize_run_error(
             stdout,
             stderr,
-            exit_code: 1,
-        };
+            json_session,
+            summary.as_ref(),
+            run_started,
+            None,
+            "manifest_triggers",
+            error.to_string(),
+        );
     }
     if let Err(error) = package::install_manifest_hooks(&mut vm, &extensions).await {
         stderr.push_str(&format!(
             "error: failed to install manifest hooks: {error}\n"
         ));
-        if let Some(session) = json_session {
-            return session.finalize_error("manifest_hooks", error.to_string(), 1);
-        }
-        return RunOutcome {
+        return finalize_run_error(
             stdout,
             stderr,
-            exit_code: 1,
-        };
+            json_session,
+            summary.as_ref(),
+            run_started,
+            None,
+            "manifest_hooks",
+            error.to_string(),
+        );
     }
 
     // Run inside a LocalSet so spawn_local works for concurrency builtins.
@@ -1268,14 +1429,21 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     }
     if let Err(error) = persist_cli_llm_mock_recording(&llm_mock_mode) {
         stderr.push_str(&format!("error: {error}\n"));
-        if let Some(session) = json_session {
-            return session.finalize_error("llm_mock_record", error, 1);
-        }
-        return RunOutcome {
+        let profile_rollup = if profile.is_enabled() {
+            Some(harn_vm::profile::build(&harn_vm::tracing::peek_spans()))
+        } else {
+            None
+        };
+        return finalize_run_error(
             stdout,
             stderr,
-            exit_code: 1,
-        };
+            json_session,
+            summary.as_ref(),
+            run_started,
+            profile_rollup.as_ref(),
+            "llm_mock_record",
+            error,
+        );
     }
 
     // Always drain any captured stderr accumulated during execution.
@@ -1302,14 +1470,21 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             stderr.push_str(&format!(
                 "error: failed to emit provenance receipt: {error}\n"
             ));
-            if let Some(session) = json_session {
-                return session.finalize_error("attestation", error.to_string(), 1);
-            }
-            return RunOutcome {
+            let profile_rollup = if profile.is_enabled() {
+                Some(harn_vm::profile::build(&harn_vm::tracing::peek_spans()))
+            } else {
+                None
+            };
+            return finalize_run_error(
                 stdout,
                 stderr,
-                exit_code: 1,
-            };
+                json_session,
+                summary.as_ref(),
+                run_started,
+                profile_rollup.as_ref(),
+                "attestation",
+                error.to_string(),
+            );
         }
         harn_vm::event_log::reset_active_event_log();
     }
@@ -1317,54 +1492,100 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     match execution {
         Ok((output, return_value)) => {
             stdout.push_str(output);
+            let profile_rollup = if profile.is_enabled() {
+                Some(harn_vm::profile::build(&harn_vm::tracing::peek_spans()))
+            } else {
+                None
+            };
+            let summary_llm = summary.as_ref().map(|_| run_summary_llm_snapshot());
             if trace {
                 stderr.push_str(&render_trace_summary());
             }
-            if profile.is_enabled() {
-                if let Err(error) = render_and_persist_profile(&profile, &mut stderr) {
+            if let Some(profile_rollup) = profile_rollup.as_ref() {
+                if let Err(error) =
+                    render_and_persist_profile_rollup(&profile, profile_rollup, &mut stderr)
+                {
                     stderr.push_str(&format!("warning: failed to write profile: {error}\n"));
                 }
             }
             if exit_code != 0 {
                 stderr.push_str(&render_return_value_error(&return_value));
             }
+            let summary_emission = emit_run_summary_for_exit(
+                summary.as_ref(),
+                run_started,
+                exit_code,
+                profile_rollup.as_ref(),
+                summary_llm,
+                json_session.is_some(),
+                &mut stderr,
+            );
             if let Some(session) = json_session {
+                if let Some(error) = summary_emission.error {
+                    let mut outcome = session.finalize_error(
+                        "summary",
+                        format!("failed to emit run summary: {error}"),
+                        1,
+                    );
+                    outcome.stderr = summary_emission.stderr;
+                    return outcome;
+                }
                 let value = harn_vm::llm::vm_value_to_json(&return_value);
-                return session.finalize_result(value, exit_code);
+                let mut outcome = session.finalize_result(value, summary_emission.exit_code);
+                outcome.stderr = summary_emission.stderr;
+                return outcome;
             }
             RunOutcome {
                 stdout,
                 stderr,
-                exit_code,
+                exit_code: summary_emission.exit_code,
             }
         }
         Err(rendered_error) => {
             stderr.push_str(&rendered_error);
-            if profile.is_enabled() {
-                if let Err(error) = render_and_persist_profile(&profile, &mut stderr) {
+            let profile_rollup = if profile.is_enabled() {
+                Some(harn_vm::profile::build(&harn_vm::tracing::peek_spans()))
+            } else {
+                None
+            };
+            if let Some(profile_rollup) = profile_rollup.as_ref() {
+                if let Err(error) =
+                    render_and_persist_profile_rollup(&profile, profile_rollup, &mut stderr)
+                {
                     stderr.push_str(&format!("warning: failed to write profile: {error}\n"));
                 }
             }
+            let summary_emission = emit_run_summary_for_exit(
+                summary.as_ref(),
+                run_started,
+                1,
+                profile_rollup.as_ref(),
+                None,
+                json_session.is_some(),
+                &mut stderr,
+            );
             if let Some(session) = json_session {
-                return session.finalize_error("runtime", rendered_error, 1);
+                let mut outcome =
+                    session.finalize_error("runtime", rendered_error, summary_emission.exit_code);
+                outcome.stderr = summary_emission.stderr;
+                return outcome;
             }
             RunOutcome {
                 stdout,
                 stderr,
-                exit_code: 1,
+                exit_code: summary_emission.exit_code,
             }
         }
     }
 }
 
-fn render_and_persist_profile(
+fn render_and_persist_profile_rollup(
     options: &RunProfileOptions,
+    profile: &harn_vm::profile::RunProfile,
     stderr: &mut String,
 ) -> Result<(), String> {
-    let spans = harn_vm::tracing::peek_spans();
-    let profile = harn_vm::profile::build(&spans);
     if options.text {
-        stderr.push_str(&harn_vm::profile::render(&profile));
+        stderr.push_str(&harn_vm::profile::render(profile));
     }
     if let Some(path) = options.json_path.as_ref() {
         if let Some(parent) = path.parent() {
@@ -1373,11 +1594,136 @@ fn render_and_persist_profile(
                     .map_err(|error| format!("create {}: {error}", parent.display()))?;
             }
         }
-        let json = serde_json::to_string_pretty(&profile)
+        let json = serde_json::to_string_pretty(profile)
             .map_err(|error| format!("serialize profile: {error}"))?;
         fs::write(path, json).map_err(|error| format!("write {}: {error}", path.display()))?;
     }
     Ok(())
+}
+
+fn build_run_summary<'a>(
+    started: Instant,
+    exit_code: i32,
+    profile: Option<&'a harn_vm::profile::RunProfile>,
+    llm: RunSummaryLlm,
+) -> RunSummary<'a> {
+    RunSummary {
+        schema_version: RUN_SUMMARY_SCHEMA_VERSION,
+        event: "run_summary",
+        wall_time_ms: started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        exit_code,
+        llm,
+        profile,
+    }
+}
+
+fn run_summary_llm_snapshot() -> RunSummaryLlm {
+    let (input_tokens, output_tokens, time_ms, call_count) = harn_vm::llm::peek_trace_summary();
+    let cost_usd = harn_vm::llm::peek_total_cost();
+    RunSummaryLlm {
+        call_count,
+        input_tokens,
+        output_tokens,
+        time_ms,
+        cost_usd: if cost_usd.is_finite() { cost_usd } else { 0.0 },
+    }
+}
+
+struct RunSummaryEmission {
+    stderr: String,
+    exit_code: i32,
+    error: Option<String>,
+}
+
+fn emit_run_summary_for_exit(
+    options: Option<&RunSummaryOptions>,
+    started: Instant,
+    exit_code: i32,
+    profile: Option<&harn_vm::profile::RunProfile>,
+    llm: Option<RunSummaryLlm>,
+    json_mode: bool,
+    stderr: &mut String,
+) -> RunSummaryEmission {
+    let mut summary_stderr = String::new();
+    let mut final_exit_code = exit_code;
+    let mut summary_error = None;
+
+    if let Some(options) = options {
+        let llm = llm.unwrap_or_else(run_summary_llm_snapshot);
+        let summary = build_run_summary(started, exit_code, profile, llm);
+        let summary_target = if json_mode {
+            &mut summary_stderr
+        } else {
+            stderr
+        };
+        if let Err(error) = emit_run_summary(options, &summary, summary_target) {
+            summary_target.push_str(&format!("error: failed to emit run summary: {error}\n"));
+            if final_exit_code == 0 {
+                final_exit_code = 1;
+                summary_error = Some(error);
+            }
+        }
+    }
+
+    RunSummaryEmission {
+        stderr: summary_stderr,
+        exit_code: final_exit_code,
+        error: summary_error,
+    }
+}
+
+fn emit_run_summary(
+    options: &RunSummaryOptions,
+    summary: &RunSummary<'_>,
+    stderr: &mut String,
+) -> Result<(), String> {
+    let line = serde_json::to_string(summary)
+        .map_err(|error| format!("serialize run summary: {error}"))?
+        + "\n";
+    match &options.sink {
+        RunSummarySink::Stderr => {
+            stderr.push_str(&line);
+            Ok(())
+        }
+        RunSummarySink::File(path) => write_run_summary_file(path, &line),
+        RunSummarySink::Fd(fd) => write_run_summary_fd(*fd, &line),
+    }
+}
+
+fn write_run_summary_file(path: &Path, line: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("create {}: {error}", parent.display()))?;
+        }
+    }
+    fs::write(path, line).map_err(|error| format!("write {}: {error}", path.display()))
+}
+
+#[cfg(unix)]
+fn write_run_summary_fd(fd: i32, line: &str) -> Result<(), String> {
+    use std::fs::File;
+    use std::os::unix::io::FromRawFd;
+
+    if fd < 0 {
+        return Err(format!("invalid --summary-fd {fd}: must be non-negative"));
+    }
+    let duped = unsafe { libc::dup(fd) };
+    if duped < 0 {
+        return Err(format!(
+            "duplicate --summary-fd {fd}: {}",
+            io::Error::last_os_error()
+        ));
+    }
+    let mut file = unsafe { File::from_raw_fd(duped) };
+    file.write_all(line.as_bytes())
+        .and_then(|_| file.flush())
+        .map_err(|error| format!("write --summary-fd {fd}: {error}"))
+}
+
+#[cfg(not(unix))]
+fn write_run_summary_fd(_fd: i32, _line: &str) -> Result<(), String> {
+    Err("--summary-fd is only supported on Unix platforms".to_string())
 }
 
 async fn append_run_provenance_event(
@@ -1550,6 +1896,38 @@ impl Drop for JsonRunSession {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn finalize_run_error(
+    stdout: String,
+    mut stderr: String,
+    json_session: Option<JsonRunSession>,
+    summary: Option<&RunSummaryOptions>,
+    started: Instant,
+    profile: Option<&harn_vm::profile::RunProfile>,
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> RunOutcome {
+    let summary_emission = emit_run_summary_for_exit(
+        summary,
+        started,
+        1,
+        profile,
+        None,
+        json_session.is_some(),
+        &mut stderr,
+    );
+    if let Some(session) = json_session {
+        let mut outcome = session.finalize_error(code, message, summary_emission.exit_code);
+        outcome.stderr = summary_emission.stderr;
+        return outcome;
+    }
+    RunOutcome {
+        stdout,
+        stderr,
+        exit_code: summary_emission.exit_code,
+    }
+}
+
 /// Translate a preflight failure into either the `--json` error event
 /// stream or a plain stderr message plus exit-code 1. Keeps the
 /// `.harnpack` verify path's error reporting consistent with the rest
@@ -1557,17 +1935,23 @@ impl Drop for JsonRunSession {
 fn finalize_harnpack_error(
     mut stderr: String,
     json_session: Option<JsonRunSession>,
+    summary: Option<&RunSummaryOptions>,
+    started: Instant,
     err: HarnpackError,
 ) -> RunOutcome {
-    stderr.push_str(&format!("error: {}\n", err.message));
-    if let Some(session) = json_session {
-        return session.finalize_error(err.code, err.message, 1);
-    }
-    RunOutcome {
-        stdout: String::new(),
+    let code = err.code;
+    let message = err.message;
+    stderr.push_str(&format!("error: {message}\n"));
+    finalize_run_error(
+        String::new(),
         stderr,
-        exit_code: 1,
-    }
+        json_session,
+        summary,
+        started,
+        None,
+        code,
+        message,
+    )
 }
 
 /// Successful `--dry-run-verify` path. Reports the bundle hash and
@@ -1577,6 +1961,8 @@ fn finalize_harnpack_error(
 fn finalize_harnpack_dry_run(
     mut stderr: String,
     json_session: Option<JsonRunSession>,
+    summary_options: Option<&RunSummaryOptions>,
+    started: Instant,
     prepared: &PreparedHarnpack,
 ) -> RunOutcome {
     let summary = format!(
@@ -1584,7 +1970,25 @@ fn finalize_harnpack_dry_run(
         prepared.bundle_hash, prepared.signature_verified, prepared.cache_hit
     );
     stderr.push_str(&summary);
+    let summary_emission = emit_run_summary_for_exit(
+        summary_options,
+        started,
+        0,
+        None,
+        None,
+        json_session.is_some(),
+        &mut stderr,
+    );
     if let Some(session) = json_session {
+        if let Some(error) = summary_emission.error {
+            let mut outcome = session.finalize_error(
+                "summary",
+                format!("failed to emit run summary: {error}"),
+                1,
+            );
+            outcome.stderr = summary_emission.stderr;
+            return outcome;
+        }
         let value = serde_json::json!({
             "bundle_hash": prepared.bundle_hash,
             "signature_verified": prepared.signature_verified,
@@ -1592,12 +1996,14 @@ fn finalize_harnpack_dry_run(
             "cache_hit": prepared.cache_hit,
             "dry_run_verify": true,
         });
-        return session.finalize_result(value, 0);
+        let mut outcome = session.finalize_result(value, summary_emission.exit_code);
+        outcome.stderr = summary_emission.stderr;
+        return outcome;
     }
     RunOutcome {
         stdout: String::new(),
         stderr,
-        exit_code: 0,
+        exit_code: summary_emission.exit_code,
     }
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -229,6 +229,7 @@ async fn async_main() {
             let json_options = args
                 .json
                 .then_some(commands::run::RunJsonOptions { quiet: args.quiet });
+            let summary_options = commands::run::run_summary_options_from_args(&args);
             let harnpack_options = commands::run::harnpack::HarnpackRunOptions {
                 allow_unsigned: args.allow_unsigned,
                 dry_run_verify: args.dry_run_verify,
@@ -246,6 +247,7 @@ async fn async_main() {
                     profile_options,
                     sandbox_options.clone(),
                     json_options,
+                    summary_options,
                 )
                 .await;
                 return;
@@ -280,6 +282,7 @@ async fn async_main() {
                             profile_options.clone(),
                             sandbox_options.clone(),
                             json_options.clone(),
+                            summary_options.clone(),
                             harnpack_options.clone(),
                         )
                         .await;
@@ -301,6 +304,7 @@ async fn async_main() {
                             profile_options,
                             sandbox_options,
                             json_options,
+                            summary_options,
                             harnpack_options,
                         )
                         .await

--- a/crates/harn-cli/tests/run_json_cli.rs
+++ b/crates/harn-cli/tests/run_json_cli.rs
@@ -6,7 +6,7 @@
 
 use std::process::Command;
 
-use harn_cli::commands::run::json_events::RUN_JSON_SCHEMA_VERSION;
+use harn_cli::commands::run::{json_events::RUN_JSON_SCHEMA_VERSION, RUN_SUMMARY_SCHEMA_VERSION};
 use harn_cli::tests::common::json_envelope::assert_envelope;
 use serde_json::Value;
 
@@ -29,6 +29,38 @@ fn parse_ndjson(stdout: &[u8]) -> Vec<Value> {
                 .unwrap_or_else(|error| panic!("ndjson line not valid JSON ({error}): {line}"))
         })
         .collect()
+}
+
+fn last_json_line(bytes: &[u8]) -> Value {
+    let text = String::from_utf8_lossy(bytes);
+    let line = text
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_else(|| panic!("expected at least one stderr line, got: {text:?}"));
+    serde_json::from_str(line).unwrap_or_else(|error| {
+        panic!("last stderr line is not valid JSON ({error}): {line}\nfull stderr:\n{text}")
+    })
+}
+
+fn write_llm_summary_script(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    write_script(
+        dir,
+        name,
+        r#"
+pipeline main(_) {
+    llm_mock_clear()
+    llm_mock({
+      text: "pong",
+      input_tokens: 7,
+      output_tokens: 5,
+      model: "mock",
+    })
+    let response = llm_call("ping", nil, {provider: "mock"})
+    __io_println(response.text)
+}
+"#,
+    )
 }
 
 #[test]
@@ -112,6 +144,287 @@ pipeline main(_) {
     let last = lines.last().expect("at least one event");
     assert_eq!(last["data"]["event_type"], "result");
     assert_eq!(last["data"]["exit_code"], 0);
+}
+
+#[test]
+fn run_emit_summary_json_defaults_to_terminal_stderr_and_reports_llm_metrics() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_llm_summary_script(tmp.path(), "summary_llm.harn");
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--emit-summary-json")
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --emit-summary-json");
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "pong\n");
+
+    let summary = last_json_line(&output.stderr);
+    assert_eq!(
+        summary["schema_version"].as_u64(),
+        Some(u64::from(RUN_SUMMARY_SCHEMA_VERSION))
+    );
+    assert_eq!(summary["event"], "run_summary");
+    assert_eq!(summary["exit_code"].as_i64(), Some(0));
+    assert!(
+        summary["wall_time_ms"].as_u64().is_some(),
+        "summary: {summary}"
+    );
+    assert_eq!(summary["llm"]["call_count"].as_i64(), Some(1));
+    assert_eq!(summary["llm"]["input_tokens"].as_i64(), Some(7));
+    assert_eq!(summary["llm"]["output_tokens"].as_i64(), Some(5));
+    assert!(summary["llm"]["time_ms"].as_i64().is_some());
+    assert!(summary["llm"]["cost_usd"].as_f64().is_some());
+}
+
+#[test]
+fn run_emit_summary_json_keeps_llm_metrics_when_trace_is_rendered() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_llm_summary_script(tmp.path(), "summary_llm_trace.harn");
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--trace")
+        .arg("--emit-summary-json")
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn traced harn run --emit-summary-json");
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "pong\n");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("LLM trace"),
+        "expected human trace before summary: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let summary = last_json_line(&output.stderr);
+    assert_eq!(summary["event"], "run_summary");
+    assert_eq!(summary["llm"]["call_count"].as_i64(), Some(1));
+    assert_eq!(summary["llm"]["input_tokens"].as_i64(), Some(7));
+    assert_eq!(summary["llm"]["output_tokens"].as_i64(), Some(5));
+}
+
+#[test]
+fn run_emit_summary_json_file_sink_does_not_change_run_json_stdout() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(
+        tmp.path(),
+        "summary_file.harn",
+        r#"
+pipeline main(_) {
+    __io_println("hello")
+}
+"#,
+    );
+    let summary_path = tmp.path().join("run-summary.jsonl");
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--json")
+        .arg("--emit-summary-json")
+        .arg("--summary-file")
+        .arg(&summary_path)
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --json --emit-summary-json");
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "summary-file should keep stderr clean: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let lines = parse_ndjson(&output.stdout);
+    assert_eq!(
+        lines.last().unwrap()["data"]["event_type"],
+        "result",
+        "stdout NDJSON must remain the run event stream: {lines:?}"
+    );
+    assert!(
+        lines
+            .iter()
+            .all(|line| line["data"]["event_type"].as_str() != Some("run_summary")),
+        "summary must not be mixed into --json stdout: {lines:?}"
+    );
+
+    let summary_text = std::fs::read_to_string(&summary_path).expect("read summary file");
+    let summary: Value = serde_json::from_str(summary_text.trim()).expect("summary json");
+    assert_eq!(
+        summary["schema_version"].as_u64(),
+        Some(u64::from(RUN_SUMMARY_SCHEMA_VERSION))
+    );
+    assert_eq!(summary["event"], "run_summary");
+    assert_eq!(summary["exit_code"].as_i64(), Some(0));
+}
+
+#[cfg(unix)]
+#[test]
+fn run_emit_summary_json_fd_sink_writes_inherited_descriptor() {
+    use std::os::fd::AsRawFd;
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(
+        tmp.path(),
+        "summary_fd.harn",
+        r#"
+pipeline main(_) {
+    __io_println("fd")
+}
+"#,
+    );
+    let summary_path = tmp.path().join("summary-fd.jsonl");
+    let summary_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(true)
+        .open(&summary_path)
+        .expect("open summary fd");
+    let fd = summary_file.as_raw_fd();
+
+    // Rust opens files close-on-exec. Clear the bit around this spawn so the
+    // child can exercise the real --summary-fd path without changing stdio.
+    // SAFETY: `fd` comes from a live `File`, and `fcntl` does not take ownership.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    assert!(
+        flags >= 0,
+        "fcntl(F_GETFD): {}",
+        std::io::Error::last_os_error()
+    );
+    // SAFETY: `fd` is still owned by `summary_file`; this only updates its
+    // close-on-exec flag until we restore the original flag set below.
+    let clear_result = unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
+    assert!(
+        clear_result >= 0,
+        "fcntl(F_SETFD clear CLOEXEC): {}",
+        std::io::Error::last_os_error()
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--emit-summary-json")
+        .arg("--summary-fd")
+        .arg(fd.to_string())
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --summary-fd");
+
+    // SAFETY: `fd` is still open, and restoring the saved flag set preserves
+    // the descriptor's ownership and offset.
+    let restore_result = unsafe { libc::fcntl(fd, libc::F_SETFD, flags) };
+    assert!(
+        restore_result >= 0,
+        "fcntl(F_SETFD restore): {}",
+        std::io::Error::last_os_error()
+    );
+    drop(summary_file);
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "fd\n");
+    assert!(
+        output.stderr.is_empty(),
+        "--summary-fd should keep stderr clean: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let summary_text = std::fs::read_to_string(&summary_path).expect("read summary fd file");
+    let summary: Value = serde_json::from_str(summary_text.trim()).expect("summary json");
+    assert_eq!(
+        summary["schema_version"].as_u64(),
+        Some(u64::from(RUN_SUMMARY_SCHEMA_VERSION))
+    );
+    assert_eq!(summary["event"], "run_summary");
+    assert_eq!(summary["exit_code"].as_i64(), Some(0));
+}
+
+#[test]
+fn run_emit_summary_json_reports_runtime_failure_exit_code() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(
+        tmp.path(),
+        "summary_failure.harn",
+        r#"
+pipeline main(_) {
+    throw "boom"
+}
+"#,
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--emit-summary-json")
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn failing harn run --emit-summary-json");
+
+    assert_eq!(output.status.code(), Some(1));
+    let summary = last_json_line(&output.stderr);
+    assert_eq!(
+        summary["schema_version"].as_u64(),
+        Some(u64::from(RUN_SUMMARY_SCHEMA_VERSION))
+    );
+    assert_eq!(summary["event"], "run_summary");
+    assert_eq!(summary["exit_code"].as_i64(), Some(1));
+}
+
+#[test]
+fn run_emit_summary_json_reports_compile_failure_exit_code() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(
+        tmp.path(),
+        "summary_compile_failure.harn",
+        r#"
+pipeline main(_) {
+    let =
+}
+"#,
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--emit-summary-json")
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn compile-failing harn run --emit-summary-json");
+
+    assert_eq!(output.status.code(), Some(1));
+    let summary = last_json_line(&output.stderr);
+    assert_eq!(
+        summary["schema_version"].as_u64(),
+        Some(u64::from(RUN_SUMMARY_SCHEMA_VERSION))
+    );
+    assert_eq!(summary["event"], "run_summary");
+    assert_eq!(summary["exit_code"].as_i64(), Some(1));
 }
 
 #[test]

--- a/docs/src/cli-json-contract.md
+++ b/docs/src/cli-json-contract.md
@@ -54,6 +54,12 @@ per line) rather than a single document. Today this set is `harn run
 --json` and `harn dev --watch --json`. Each line still carries
 `schemaVersion`; consumers can `jq -c` over the stream.
 
+`harn run --emit-summary-json` is intentionally separate from this
+envelope stream. It emits one raw NDJSON object to stderr by default
+or to `--summary-file` / `--summary-fd` when supplied, so wrappers can
+read aggregate metrics without changing the `harn run --json` stdout
+contract.
+
 ## Supported commands
 
 These commands accept `--json` and emit a stable, schema-versioned
@@ -70,6 +76,7 @@ versions.
 | `harn parse --json`            | Tagged Harn AST with byte spans                          |
 | `harn tokens --json`           | Lexer token stream with source lexemes                   |
 | `harn run --json`              | Streaming NDJSON event log (stdout/stderr/tool/result)   |
+| `harn run --emit-summary-json` | One terminal raw NDJSON summary object on stderr/file/fd  |
 | `harn replay --json`           | Per-stage replay summary + embedded fixture verdict      |
 | `harn test conformance --json` | Conformance results with xfail accounting                |
 | `harn graph --json`            | Static module graph: symbols, imports, capabilities      |
@@ -150,6 +157,43 @@ plus the embedded replay-fixture verdict. `ok: false` with
 `error.code: "replay_fixture_failed"` indicates the fixture did not
 pass; the same envelope still includes the full `data` payload so
 callers can diff.
+
+### `harn run --emit-summary-json`
+
+The post-run summary is a raw NDJSON line, not a `JsonEnvelope`, because
+it is an auxiliary sink rather than the command's primary stdout JSON
+mode. `--summary-file <path>` overwrites the file with the one-line
+summary; `--summary-fd <fd>` writes the same line to an already-open
+Unix file descriptor.
+
+```json
+{
+  "schema_version": 1,
+  "event": "run_summary",
+  "wall_time_ms": 1234,
+  "exit_code": 0,
+  "llm": {
+    "call_count": 2,
+    "input_tokens": 1024,
+    "output_tokens": 256,
+    "time_ms": 480,
+    "cost_usd": 0.0042
+  },
+  "profile": {
+    "total_wall_ms": 1234,
+    "by_kind": [],
+    "residual_ms": 12,
+    "top_llm_calls": [],
+    "top_tool_calls": [],
+    "steps": []
+  }
+}
+```
+
+`profile` is omitted unless `--profile` or `--profile-json` is active.
+The LLM counters are enabled by the summary flag itself, so callers do
+not need to add `--trace` to receive `llm.call_count`, token totals,
+LLM time, and accumulated cost.
 
 ## Compatibility
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -46,6 +46,9 @@ harn run --resume .harn/workers/worker_...json
 | `--attest-agent <id>` | Agent id used to load or create the Ed25519 signing key |
 | `--json` | Emit a versioned NDJSON event stream on stdout instead of mixed pipeline output |
 | `--quiet` | When `--json` is set, drop `stdout` and `stderr` events (transcript/tool/hook/persona/result still flow) |
+| `--emit-summary-json` | Emit one terminal `run_summary` JSON object as a single NDJSON line; defaults to stderr |
+| `--summary-file <path>` | Write `--emit-summary-json` output to a file instead of stderr |
+| `--summary-fd <fd>` | Write `--emit-summary-json` output to an already-open Unix file descriptor |
 | `--allow-unsigned` | When running a `.harnpack`, accept bundles that carry no Ed25519 signature (local-dev override) |
 | `--dry-run-verify` | When running a `.harnpack`, verify the signature and replay into the cache without executing the entrypoint |
 
@@ -79,6 +82,45 @@ through `jq -c .` for live filtering:
 ```bash
 harn run --json examples/hello.harn | jq -c '.data | {seq, event_type}'
 ```
+
+### Post-run summary JSON
+
+`harn run --emit-summary-json <file>` emits one raw JSON object after
+the run finishes. This is a separate opt-in sink from `harn run --json`
+so consumers that need aggregate metrics can keep the event stream
+contract unchanged. By default the line is appended to stderr after
+human diagnostics; use `--summary-file <path>` or `--summary-fd <fd>`
+to isolate it from the script's own stderr.
+
+Shape (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "event": "run_summary",
+  "wall_time_ms": 1234,
+  "exit_code": 0,
+  "llm": {
+    "call_count": 2,
+    "input_tokens": 1024,
+    "output_tokens": 256,
+    "time_ms": 480,
+    "cost_usd": 0.0042
+  },
+  "profile": {
+    "total_wall_ms": 1234,
+    "by_kind": [],
+    "residual_ms": 12,
+    "top_llm_calls": [],
+    "top_tool_calls": [],
+    "steps": []
+  }
+}
+```
+
+`profile` is present only when the run enables profiling with
+`--profile` or `--profile-json`. The LLM metrics are collected whenever
+summary JSON is requested, even without `--trace`.
 
 You can also run a file directly without the `run` subcommand:
 


### PR DESCRIPTION
## Summary
- Add `harn run --emit-summary-json` with schema-versioned `run_summary` output and stderr/file/fd sinks.
- Preserve the existing `harn run --json` stdout event stream by keeping summary output on an auxiliary sink.
- Route run parse failures through non-exiting diagnostics so JSON and summary finalization still happen on compile failures.
- Document the raw summary contract and cover LLM metrics, file/fd sinks, runtime failures, and compile failures.

Fixes #2348

## Verification
- `cargo test -p harn-cli --test run_json_cli -- --nocapture --test-threads=1`
- `cargo test -p harn-cli --lib commands::run:: -- --nocapture`
- `cargo test -p harn-cli --lib cli::tests::test_parses_run_summary_flags -- --nocapture`
- `git diff --check`
- pre-commit hook
- pre-push hook