### PR TITLE
Promote spawn_captured to harness.process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ condensed series summaries instead of full per-patch history.
   `xdg_cache_home(app_name)`. The pure-Harn helpers honor absolute XDG
   env vars, ignore relative XDG values, validate app-name segments, use
   macOS Library fallbacks, and leave directory creation to callers.
+- **`harness.process.spawn_captured` (#2338).** Added a `process`
+  sub-handle to `Harness` so Harn-native CLI scripts can run synchronous
+  subprocess captures through the explicit capability surface. The existing
+  `spawn_captured(opts)` builtin now shares the same implementation as the
+  harness method.
 
 ## v0.8.35
 

--- a/conformance/tests/runtime/cli_host_caps_spawn_captured.harn
+++ b/conformance/tests/runtime/cli_host_caps_spawn_captured.harn
@@ -1,6 +1,5 @@
-// Free-builtin landing site for the deferred `harness.process.spawn_captured`
-// sub-handle (see #2297). Verifies the synchronous capture shape returns
-// `{exit_code, stdout, stderr, duration_ms, success, timed_out}`.
+// Legacy free-builtin alias for `harness.process.spawn_captured`.
+// Verifies the synchronous capture shape stays shared by both surfaces.
 let ok = spawn_captured({cmd: "printf", args: ["hi"]})
 
 __io_println(ok.exit_code)

--- a/conformance/tests/runtime/harness_process_spawn_captured.expected
+++ b/conformance/tests/runtime/harness_process_spawn_captured.expected
@@ -1,0 +1,8 @@
+0
+true
+true
+true
+false
+true
+7
+false

--- a/conformance/tests/runtime/harness_process_spawn_captured.harn
+++ b/conformance/tests/runtime/harness_process_spawn_captured.harn
@@ -1,0 +1,12 @@
+fn main(harness: Harness) {
+  let ok = harness.process.spawn_captured({cmd: "printf", args: ["hi\n"]})
+  harness.stdio.println(ok.exit_code)
+  harness.stdio.println(ok.stdout == "hi\n")
+  harness.stdio.println(ok.stderr == "")
+  harness.stdio.println(ok.success)
+  harness.stdio.println(ok.timed_out)
+  harness.stdio.println(ok.duration_ms >= 0)
+  let fail = harness.process.spawn_captured({cmd: "sh", args: ["-c", "exit 7"]})
+  harness.stdio.println(fail.exit_code)
+  harness.stdio.println(fail.success)
+}

--- a/crates/harn-cli/src/commands/graph.rs
+++ b/crates/harn-cli/src/commands/graph.rs
@@ -310,7 +310,7 @@ fn direct_capabilities(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
         | "websocket_server" => {
             out.insert("network.http".to_string());
         }
-        "exec" | "exec_at" | "shell" | "shell_at" => {
+        "exec" | "exec_at" | "shell" | "shell_at" | "spawn_captured" => {
             out.insert("process.exec".to_string());
         }
         "llm_call"

--- a/crates/harn-cli/src/commands/routes.rs
+++ b/crates/harn-cli/src/commands/routes.rs
@@ -366,7 +366,7 @@ fn direct_call_capabilities(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
         | "websocket_server" => {
             capabilities.insert("network.http".to_string());
         }
-        "exec" | "exec_at" | "shell" | "shell_at" => {
+        "exec" | "exec_at" | "shell" | "shell_at" | "spawn_captured" => {
             capabilities.insert("process.exec".to_string());
         }
         "llm_call"

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -2019,7 +2019,9 @@ fn harness_sub_handle_for(object: &SNode, method: &str) -> Option<(&'static str,
         })
 }
 
-const HARNESS_SUB_HANDLES: &[&str] = &["stdio", "clock", "fs", "env", "random", "net"];
+const HARNESS_SUB_HANDLES: &[&str] = &[
+    "stdio", "clock", "fs", "env", "random", "net", "process", "system",
+];
 
 fn classify_call(name: &str, args: &[SNode]) -> CallSemantics {
     let literal_args = args.iter().map(literal_value).collect::<Vec<_>>();
@@ -2053,7 +2055,7 @@ fn classify_call(name: &str, args: &[SNode]) -> CallSemantics {
                 path,
             )])
         }
-        "exec" | "exec_at" | "shell" | "shell_at" => {
+        "exec" | "exec_at" | "shell" | "shell_at" | "spawn_captured" => {
             capability_classification(vec![CapabilityEffect::new(
                 Capability::CommandExecution,
                 name,
@@ -2549,6 +2551,23 @@ fn main(harness: Harness) {
         assert!(
             calls.iter().any(|name| name == "http_get"),
             "expected harness.net.get to lower to ambient http_get, got: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn harness_process_method_call_is_attributed_to_spawn_captured() {
+        let report = analyze(
+            r#"
+fn main(harness: Harness) {
+  harness.process.spawn_captured({cmd: "printf", args: ["hi"]})
+}
+"#,
+        );
+
+        let calls = handler_call_names(&report);
+        assert!(
+            calls.iter().any(|name| name == "spawn_captured"),
+            "expected harness.process.spawn_captured to lower to ambient spawn_captured, got: {calls:?}"
         );
     }
 

--- a/crates/harn-parser/src/harness_methods.rs
+++ b/crates/harn-parser/src/harness_methods.rs
@@ -81,6 +81,13 @@ pub fn harness_net_ambient(method: &str) -> Option<&'static str> {
     }
 }
 
+pub fn harness_process_ambient(method: &str) -> Option<&'static str> {
+    match method {
+        "spawn_captured" => Some("spawn_captured"),
+        _ => None,
+    }
+}
+
 pub fn harness_system_ambient(method: &str) -> Option<&'static str> {
     match method {
         "platform" => Some("system_platform"),
@@ -101,6 +108,7 @@ pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'st
         "env" => harness_env_ambient(method),
         "random" => harness_random_ambient(method),
         "net" => harness_net_ambient(method),
+        "process" => harness_process_ambient(method),
         "system" => harness_system_ambient(method),
         _ => None,
     }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -898,6 +898,7 @@ impl TypeChecker {
                 "env" => Some(TypeExpr::Named("HarnessEnv".into())),
                 "random" => Some(TypeExpr::Named("HarnessRandom".into())),
                 "net" => Some(TypeExpr::Named("HarnessNet".into())),
+                "process" => Some(TypeExpr::Named("HarnessProcess".into())),
                 "system" => Some(TypeExpr::Named("HarnessSystem".into())),
                 _ if optional => Some(TypeExpr::Named("nil".into())),
                 _ => None,

--- a/crates/harn-stdlib/src/stdlib/cli/precompile.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/precompile.harn
@@ -93,7 +93,7 @@ fn __ensure_parent(harness: Harness, path: string) {
   }
 }
 
-fn __spawn_precompile(bin: string, source_path: string, per_file_out: string) -> dict {
+fn __spawn_precompile(harness: Harness, bin: string, source_path: string, per_file_out: string) -> dict {
   // Always force the child onto the Rust path: this script IS the .harn
   // dispatch target, so leaving HARN_CLI_IMPL unset would re-enter us
   // and spin forever. HARN_CLI_IMPL=rust short-circuits the dispatch
@@ -108,7 +108,7 @@ fn __spawn_precompile(bin: string, source_path: string, per_file_out: string) ->
     args = args.push(per_file_out)
   }
   let env = {HARN_CLI_IMPL: "rust"}
-  return spawn_captured({cmd: bin, args: args, env: env})
+  return harness.process.spawn_captured({cmd: bin, args: args, env: env})
 }
 
 fn __render_failure(source: string, child: dict) -> string {
@@ -174,7 +174,7 @@ fn main(harness: Harness) {
       __ensure_parent(harness, dest)
       path_parent(dest)
     }
-    let child = __spawn_precompile(bin, source, per_file_out)
+    let child = __spawn_precompile(harness, bin, source, per_file_out)
     let exit_code = child["exit_code"] ?? -1
     if exit_code == 0 {
       compiled = compiled + 1

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -3,13 +3,13 @@
 //!
 //! `Harness` is the Harn-language analog of an explicit-capability handle: a
 //! single value the runtime hands to a script's `main` so that stdio, clock,
-//! filesystem, environment, randomness, and network access become surface in
+//! filesystem, environment, randomness, network, process, and system access become surface in
 //! the type system instead of ambient globals. Each sub-handle (`stdio`,
-//! `clock`, `fs`, `env`, `random`, `net`) is a distinct named type that
+//! `clock`, `fs`, `env`, `random`, `net`, `process`, `system`) is a distinct named type that
 //! anchors the surface for its capability slice.
 //!
 //! This module defines:
-//!   * The runtime [`Harness`] value (and six sub-handle wrappers).
+//!   * The runtime [`Harness`] value (and its sub-handle wrappers).
 //!   * [`Harness::real`], the production constructor that wraps wall-clock
 //!     time, `tokio::fs`, `std::env`, `rand::thread_rng`, and `reqwest`. The
 //!     downstream migration tickets (E4.2-E4.4) populate the per-handle
@@ -30,7 +30,7 @@ use async_trait::async_trait;
 use harn_clock::{Clock, PausedClock, RealClock};
 use time::OffsetDateTime;
 
-/// Seven capability slices exposed by a [`Harness`].
+/// Capability slices exposed by a [`Harness`].
 ///
 /// `Root` is the parent handle; the others are the typed sub-handles users
 /// reach through field access (`harness.stdio`, `harness.clock`, ...).
@@ -43,6 +43,7 @@ pub enum HarnessKind {
     Env,
     Random,
     Net,
+    Process,
     System,
 }
 
@@ -59,6 +60,7 @@ impl HarnessKind {
             HarnessKind::Env => "HarnessEnv",
             HarnessKind::Random => "HarnessRandom",
             HarnessKind::Net => "HarnessNet",
+            HarnessKind::Process => "HarnessProcess",
             HarnessKind::System => "HarnessSystem",
         }
     }
@@ -74,6 +76,7 @@ impl HarnessKind {
             HarnessKind::Env => Some("env"),
             HarnessKind::Random => Some("random"),
             HarnessKind::Net => Some("net"),
+            HarnessKind::Process => Some("process"),
             HarnessKind::System => Some("system"),
         }
     }
@@ -87,12 +90,13 @@ impl HarnessKind {
             "env" => Some(HarnessKind::Env),
             "random" => Some(HarnessKind::Random),
             "net" => Some(HarnessKind::Net),
+            "process" => Some(HarnessKind::Process),
             "system" => Some(HarnessKind::System),
             _ => None,
         }
     }
 
-    /// All seven sub-handle kinds, in the canonical field order.
+    /// All sub-handle kinds, in the canonical field order.
     pub const SUB_HANDLES: &'static [HarnessKind] = &[
         HarnessKind::Stdio,
         HarnessKind::Clock,
@@ -100,6 +104,7 @@ impl HarnessKind {
         HarnessKind::Env,
         HarnessKind::Random,
         HarnessKind::Net,
+        HarnessKind::Process,
         HarnessKind::System,
     ];
 
@@ -112,6 +117,7 @@ impl HarnessKind {
         HarnessKind::Env,
         HarnessKind::Random,
         HarnessKind::Net,
+        HarnessKind::Process,
         HarnessKind::System,
     ];
 }
@@ -605,6 +611,13 @@ impl Harness {
         }
     }
 
+    /// Field access for `harness.process`.
+    pub fn process(&self) -> HarnessProcess {
+        HarnessProcess {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
     /// Field access for `harness.system`.
     pub fn system(&self) -> HarnessSystem {
         HarnessSystem {
@@ -682,6 +695,12 @@ pub struct HarnessNet {
     inner: Arc<HarnessInner>,
 }
 
+/// process sub-handle: `spawn_captured`.
+#[derive(Debug, Clone)]
+pub struct HarnessProcess {
+    inner: Arc<HarnessInner>,
+}
+
 /// system sub-handle: `cpu`, `memory`, `gpus`, `temperature`, `platform`,
 /// `processes`. Read-only host introspection — no side effects on the host
 /// system. Gated by the harness handle so scripts running under
@@ -710,6 +729,7 @@ sub_handle_inner!(
     HarnessEnv,
     HarnessRandom,
     HarnessNet,
+    HarnessProcess,
     HarnessSystem,
 );
 
@@ -722,7 +742,7 @@ impl HarnessClock {
 
 /// Compact `VmValue` payload for a `Harness` or any of its sub-handles.
 ///
-/// All seven variants share one `Arc<HarnessInner>`; `kind` discriminates the
+/// All variants share one `Arc<HarnessInner>`; `kind` discriminates the
 /// surface the VM exposes for property access and method dispatch.
 #[derive(Clone)]
 pub struct VmHarness {
@@ -903,6 +923,7 @@ mod tests {
             r#"fn main(harness: Harness) { harness.env.get("KEY") }"#,
             r#"fn main(harness: Harness) { harness.random.gen_u64() }"#,
             r#"fn main(harness: Harness) { harness.net.get("https://example.test") }"#,
+            r#"fn main(harness: Harness) { harness.process.spawn_captured({cmd: "printf", args: ["x"]}) }"#,
             r#"fn main(harness: Harness) { harness.system.cpu() }"#,
         ] {
             let error = run_harness_source(source, harness.clone()).expect_err("call denied");
@@ -926,6 +947,7 @@ mod tests {
                 (HarnessKind::Env, "get"),
                 (HarnessKind::Random, "gen_u64"),
                 (HarnessKind::Net, "get"),
+                (HarnessKind::Process, "spawn_captured"),
                 (HarnessKind::System, "cpu"),
             ]
         );
@@ -1028,6 +1050,10 @@ fn main(harness: Harness) {
             (
                 r#"fn main(harness: Harness) { harness.net.get("https://missing.test") }"#,
                 "MockHarness has no net_get response for https://missing.test",
+            ),
+            (
+                r#"fn main(harness: Harness) { harness.process.spawn_captured({cmd: "printf", args: ["x"]}) }"#,
+                "MockHarness has no process spawn response",
             ),
         ];
 

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -145,7 +145,8 @@ pub use corrections::{
 };
 pub use harness::{
     DenyEvent, Harness, HarnessCall, HarnessClock, HarnessEnv, HarnessFs, HarnessKind, HarnessNet,
-    HarnessRandom, HarnessStdio, HarnessSystem, MockAwareClock, MockHarnessBuilder, VmHarness,
+    HarnessProcess, HarnessRandom, HarnessStdio, HarnessSystem, MockAwareClock, MockHarnessBuilder,
+    VmHarness,
 };
 pub use harness_net::{
     bypass_enabled as net_policy_bypass_enabled, NetMatcher, NetPolicy, NetPolicyAudit,

--- a/crates/harn-vm/src/orchestration/policy/effects.rs
+++ b/crates/harn-vm/src/orchestration/policy/effects.rs
@@ -138,10 +138,8 @@ pub fn compute_handoff_effects(
         }
     }
 
-    // Harness sub-handle method calls aren't builtin invocations, so the
-    // IR doesn't see them. Walk the AST directly to lift them into the
-    // same shape — keeps producer-side analysis consistent with what the
-    // dispatcher will need to enforce.
+    // Keep harness sub-handle effects visible even for policy callers
+    // that work from raw ASTs rather than the lowered IR call surface.
     for node in &program {
         walk_for_harness_effects(node, &mut collected);
     }
@@ -431,6 +429,12 @@ fn harness_method_effect(node: &SNode) -> Option<EffectRecord> {
         ("fs", "delete_file" | "delete" | "remove") => (EffectKind::Fs, EffectScope::Mutate),
         ("fs", _) => (EffectKind::Fs, EffectScope::Read),
         ("net", _) => (EffectKind::Net, EffectScope::Write),
+        ("process", "spawn_captured") => (
+            EffectKind::Hostcall {
+                name: "process.spawn_captured".to_string(),
+            },
+            EffectScope::Write,
+        ),
         // System-introspection methods (`cpu`, `memory`, `gpus`,
         // `temperature`, `platform`, `processes`) are pure host reads
         // — no state mutation, no resource consumed. They're gated by
@@ -899,6 +903,22 @@ mod tests {
                 .any(|effect| matches!(effect.kind, EffectKind::Net)
                     && effect.scope == EffectScope::Write),
             "expected Net write effect, got {effects:?}"
+        );
+    }
+
+    #[test]
+    fn harness_process_spawn_captured_yields_process_hostcall_effect() {
+        let source =
+            r#"fn main(harness: Harness) { harness.process.spawn_captured({cmd: "printf"}) }"#;
+        let effects = compute_handoff_effects(source, None);
+        assert!(
+            effects.iter().any(|effect| {
+                matches!(
+                    &effect.kind,
+                    EffectKind::Hostcall { name } if name == "process.spawn_captured"
+                ) && effect.scope == EffectScope::Write
+            }),
+            "expected process hostcall write effect, got {effects:?}"
         );
     }
 

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -368,226 +368,7 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
         Ok(VmValue::Dict(Rc::new(paths)))
     });
 
-    // `spawn_captured(opts)` runs an external command synchronously and
-    // returns its captured output. Unlike `exec(...)` (which is variadic
-    // positional and inherits the parent's stdin), this builtin takes a
-    // structured options dict and supports feeding a stdin payload,
-    // overriding the cwd/env, and bounding execution time:
-    //
-    //   spawn_captured({
-    //     cmd: "git",
-    //     args: ["log", "--oneline", "-n", "5"],
-    //     cwd: "/path/to/repo",       // optional
-    //     env: {KEY: "value"},        // optional, merged onto inherited env
-    //     stdin: "payload",           // optional string or bytes
-    //     timeout_ms: 5000,           // optional, kills child on expiry
-    //   })
-    //
-    // Returns `{exit_code: int, stdout: string, stderr: string,
-    // duration_ms: int, success: bool, timed_out: bool}`. When the
-    // process times out, `exit_code` is -1, `success` is false, and
-    // `timed_out` is true. This is the free-builtin landing site for
-    // the deferred `harness.process.spawn_captured` sub-handle
-    // (see #2297).
-    vm.register_builtin("spawn_captured", |args, _out| {
-        let opts = match args.first() {
-            Some(VmValue::Dict(opts)) => opts.clone(),
-            _ => {
-                return Err(VmError::Runtime(
-                    "spawn_captured: options dict is required".to_string(),
-                ));
-            }
-        };
-        let cmd = match opts.get("cmd").map(|v| v.display()).unwrap_or_default() {
-            s if s.is_empty() => {
-                return Err(VmError::Runtime(
-                    "spawn_captured: opts.cmd is required".to_string(),
-                ));
-            }
-            s => s,
-        };
-        let cmd_args: Vec<String> = match opts.get("args") {
-            Some(VmValue::List(items)) => items.iter().map(|v| v.display()).collect(),
-            None | Some(VmValue::Nil) => Vec::new(),
-            Some(other) => {
-                return Err(VmError::Runtime(format!(
-                    "spawn_captured: opts.args must be a list of strings, got {}",
-                    other.type_name()
-                )));
-            }
-        };
-        let cwd = opts
-            .get("cwd")
-            .map(|v| v.display())
-            .filter(|s| !s.is_empty());
-        let env_overrides: Vec<(String, String)> = match opts.get("env") {
-            Some(VmValue::Dict(env)) => env.iter().map(|(k, v)| (k.clone(), v.display())).collect(),
-            None | Some(VmValue::Nil) => Vec::new(),
-            Some(other) => {
-                return Err(VmError::Runtime(format!(
-                    "spawn_captured: opts.env must be a dict, got {}",
-                    other.type_name()
-                )));
-            }
-        };
-        let stdin_bytes: Option<Vec<u8>> = match opts.get("stdin") {
-            Some(VmValue::Bytes(bytes)) => Some(bytes.as_slice().to_vec()),
-            Some(VmValue::String(s)) => Some(s.as_bytes().to_vec()),
-            None | Some(VmValue::Nil) => None,
-            Some(other) => {
-                return Err(VmError::Runtime(format!(
-                    "spawn_captured: opts.stdin must be string or bytes, got {}",
-                    other.type_name()
-                )));
-            }
-        };
-        let timeout = opts
-            .get("timeout_ms")
-            .and_then(|v| v.as_int())
-            .filter(|n| *n > 0)
-            .map(|n| Duration::from_millis(n as u64));
-
-        let mut command = std::process::Command::new(&cmd);
-        command.args(&cmd_args);
-        if let Some(cwd) = cwd.as_ref() {
-            command.current_dir(cwd);
-        }
-        for (key, value) in &env_overrides {
-            command.env(key, value);
-        }
-        command.stdout(Stdio::piped()).stderr(Stdio::piped());
-        if stdin_bytes.is_some() {
-            command.stdin(Stdio::piped());
-        } else {
-            command.stdin(Stdio::null());
-        }
-
-        let started = Instant::now();
-        let mut child = command.spawn().map_err(|error| {
-            VmError::Thrown(VmValue::String(Rc::from(format!(
-                "spawn_captured: failed to spawn '{cmd}': {error}"
-            ))))
-        })?;
-
-        if let (Some(payload), Some(mut stdin)) = (stdin_bytes, child.stdin.take()) {
-            // Best-effort write; if the child closes stdin early we still
-            // surface stdout/stderr/exit_code rather than failing outright.
-            let _ = stdin.write_all(&payload);
-        }
-
-        let (output, timed_out) = match timeout {
-            None => match child.wait_with_output() {
-                Ok(output) => (output, false),
-                Err(error) => {
-                    return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                        "spawn_captured: wait failed: {error}"
-                    )))));
-                }
-            },
-            Some(limit) => {
-                // Poll via a small `try_wait` loop instead of pulling in
-                // a full async runtime. This keeps the builtin
-                // dependency-free and matches the synchronous shape that
-                // ported `.harn` scripts expect.
-                let deadline = started + limit;
-                let mut timed_out = false;
-                loop {
-                    match child.try_wait() {
-                        Ok(Some(_)) => break,
-                        Ok(None) => {
-                            if Instant::now() >= deadline {
-                                let _ = child.kill();
-                                let _ = child.wait();
-                                timed_out = true;
-                                break;
-                            }
-                            std::thread::sleep(Duration::from_millis(10));
-                        }
-                        Err(error) => {
-                            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                                "spawn_captured: poll failed: {error}"
-                            )))));
-                        }
-                    }
-                }
-                if timed_out {
-                    // Drain pipes via channels so a slow stderr reader
-                    // doesn't block forever after we've killed the child.
-                    let stdout_handle = child.stdout.take();
-                    let stderr_handle = child.stderr.take();
-                    let (tx_out, rx_out) = mpsc::channel::<Vec<u8>>();
-                    let (tx_err, rx_err) = mpsc::channel::<Vec<u8>>();
-                    if let Some(mut s) = stdout_handle {
-                        std::thread::spawn(move || {
-                            use std::io::Read as _;
-                            let mut buf = Vec::new();
-                            let _ = s.read_to_end(&mut buf);
-                            let _ = tx_out.send(buf);
-                        });
-                    }
-                    if let Some(mut s) = stderr_handle {
-                        std::thread::spawn(move || {
-                            use std::io::Read as _;
-                            let mut buf = Vec::new();
-                            let _ = s.read_to_end(&mut buf);
-                            let _ = tx_err.send(buf);
-                        });
-                    }
-                    let stdout = rx_out
-                        .recv_timeout(Duration::from_millis(100))
-                        .unwrap_or_default();
-                    let stderr = rx_err
-                        .recv_timeout(Duration::from_millis(100))
-                        .unwrap_or_default();
-                    (
-                        std::process::Output {
-                            status: std::process::ExitStatus::default(),
-                            stdout,
-                            stderr,
-                        },
-                        true,
-                    )
-                } else {
-                    // The child has already exited; wait_with_output
-                    // reaps + drains the pipes in one call.
-                    match child.wait_with_output() {
-                        Ok(output) => (output, false),
-                        Err(error) => {
-                            return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                                "spawn_captured: wait failed: {error}"
-                            )))));
-                        }
-                    }
-                }
-            }
-        };
-
-        let duration_ms = started.elapsed().as_millis() as i64;
-        let exit_code = if timed_out {
-            -1
-        } else {
-            output.status.code().unwrap_or(-1) as i64
-        };
-        let success = if timed_out {
-            false
-        } else {
-            output.status.success()
-        };
-        let mut result = BTreeMap::new();
-        result.insert("exit_code".to_string(), VmValue::Int(exit_code));
-        result.insert(
-            "stdout".to_string(),
-            VmValue::String(Rc::from(String::from_utf8_lossy(&output.stdout).as_ref())),
-        );
-        result.insert(
-            "stderr".to_string(),
-            VmValue::String(Rc::from(String::from_utf8_lossy(&output.stderr).as_ref())),
-        );
-        result.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
-        result.insert("success".to_string(), VmValue::Bool(success));
-        result.insert("timed_out".to_string(), VmValue::Bool(timed_out));
-        Ok(VmValue::Dict(Rc::new(result)))
-    });
+    vm.register_builtin("spawn_captured", |args, _out| spawn_captured_value(args));
 
     // `term_width()` / `term_height()` return the current terminal
     // dimensions in columns and rows. Reads `COLUMNS` / `LINES` env vars
@@ -605,6 +386,201 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
     vm.register_builtin("term_height", |_args, _out| {
         Ok(VmValue::Int(read_term_dimension("LINES", false) as i64))
     });
+}
+
+/// Run an external command synchronously and return captured output.
+///
+/// Shared by the legacy free builtin and `harness.process.spawn_captured` so
+/// subprocess capture has one implementation and one result shape.
+pub(crate) fn spawn_captured_value(args: &[VmValue]) -> Result<VmValue, VmError> {
+    let opts = match args.first() {
+        Some(VmValue::Dict(opts)) => opts.clone(),
+        _ => {
+            return Err(VmError::Runtime(
+                "spawn_captured: options dict is required".to_string(),
+            ));
+        }
+    };
+    let cmd = match opts.get("cmd").map(|v| v.display()).unwrap_or_default() {
+        s if s.is_empty() => {
+            return Err(VmError::Runtime(
+                "spawn_captured: opts.cmd is required".to_string(),
+            ));
+        }
+        s => s,
+    };
+    let cmd_args: Vec<String> = match opts.get("args") {
+        Some(VmValue::List(items)) => items.iter().map(|v| v.display()).collect(),
+        None | Some(VmValue::Nil) => Vec::new(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "spawn_captured: opts.args must be a list of strings, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let cwd = opts
+        .get("cwd")
+        .map(|v| v.display())
+        .filter(|s| !s.is_empty());
+    let env_overrides: Vec<(String, String)> = match opts.get("env") {
+        Some(VmValue::Dict(env)) => env.iter().map(|(k, v)| (k.clone(), v.display())).collect(),
+        None | Some(VmValue::Nil) => Vec::new(),
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "spawn_captured: opts.env must be a dict, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let stdin_bytes: Option<Vec<u8>> = match opts.get("stdin") {
+        Some(VmValue::Bytes(bytes)) => Some(bytes.as_slice().to_vec()),
+        Some(VmValue::String(s)) => Some(s.as_bytes().to_vec()),
+        None | Some(VmValue::Nil) => None,
+        Some(other) => {
+            return Err(VmError::Runtime(format!(
+                "spawn_captured: opts.stdin must be string or bytes, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let timeout = opts
+        .get("timeout_ms")
+        .and_then(|v| v.as_int())
+        .filter(|n| *n > 0)
+        .map(|n| Duration::from_millis(n as u64));
+
+    let mut command = std::process::Command::new(&cmd);
+    command.args(&cmd_args);
+    if let Some(cwd) = cwd.as_ref() {
+        command.current_dir(cwd);
+    }
+    for (key, value) in &env_overrides {
+        command.env(key, value);
+    }
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    if stdin_bytes.is_some() {
+        command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
+    }
+
+    let started = Instant::now();
+    let mut child = command.spawn().map_err(|error| {
+        VmError::Thrown(VmValue::String(Rc::from(format!(
+            "spawn_captured: failed to spawn '{cmd}': {error}"
+        ))))
+    })?;
+
+    if let (Some(payload), Some(mut stdin)) = (stdin_bytes, child.stdin.take()) {
+        // Children may close stdin early while still producing useful output.
+        let _ = stdin.write_all(&payload);
+    }
+
+    let (output, timed_out) = match timeout {
+        None => match child.wait_with_output() {
+            Ok(output) => (output, false),
+            Err(error) => {
+                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                    "spawn_captured: wait failed: {error}"
+                )))));
+            }
+        },
+        Some(limit) => {
+            let deadline = started + limit;
+            let mut timed_out = false;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) => {
+                        if Instant::now() >= deadline {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                            timed_out = true;
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => {
+                        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                            "spawn_captured: poll failed: {error}"
+                        )))));
+                    }
+                }
+            }
+            if timed_out {
+                let stdout_handle = child.stdout.take();
+                let stderr_handle = child.stderr.take();
+                let (tx_out, rx_out) = mpsc::channel::<Vec<u8>>();
+                let (tx_err, rx_err) = mpsc::channel::<Vec<u8>>();
+                if let Some(mut s) = stdout_handle {
+                    std::thread::spawn(move || {
+                        use std::io::Read as _;
+                        let mut buf = Vec::new();
+                        let _ = s.read_to_end(&mut buf);
+                        let _ = tx_out.send(buf);
+                    });
+                }
+                if let Some(mut s) = stderr_handle {
+                    std::thread::spawn(move || {
+                        use std::io::Read as _;
+                        let mut buf = Vec::new();
+                        let _ = s.read_to_end(&mut buf);
+                        let _ = tx_err.send(buf);
+                    });
+                }
+                let stdout = rx_out
+                    .recv_timeout(Duration::from_millis(100))
+                    .unwrap_or_default();
+                let stderr = rx_err
+                    .recv_timeout(Duration::from_millis(100))
+                    .unwrap_or_default();
+                (
+                    std::process::Output {
+                        status: std::process::ExitStatus::default(),
+                        stdout,
+                        stderr,
+                    },
+                    true,
+                )
+            } else {
+                match child.wait_with_output() {
+                    Ok(output) => (output, false),
+                    Err(error) => {
+                        return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
+                            "spawn_captured: wait failed: {error}"
+                        )))));
+                    }
+                }
+            }
+        }
+    };
+
+    let duration_ms = started.elapsed().as_millis() as i64;
+    let exit_code = if timed_out {
+        -1
+    } else {
+        output.status.code().unwrap_or(-1) as i64
+    };
+    let success = if timed_out {
+        false
+    } else {
+        output.status.success()
+    };
+    let mut result = BTreeMap::new();
+    result.insert("exit_code".to_string(), VmValue::Int(exit_code));
+    result.insert(
+        "stdout".to_string(),
+        VmValue::String(Rc::from(String::from_utf8_lossy(&output.stdout).as_ref())),
+    );
+    result.insert(
+        "stderr".to_string(),
+        VmValue::String(Rc::from(String::from_utf8_lossy(&output.stderr).as_ref())),
+    );
+    result.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
+    result.insert("success".to_string(), VmValue::Bool(success));
+    result.insert("timed_out".to_string(), VmValue::Bool(timed_out));
+    Ok(VmValue::Dict(Rc::new(result)))
 }
 
 const DEFAULT_TERM_WIDTH: usize = 80;

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -1,6 +1,7 @@
-//! Method dispatch for the `Harness` capability handle and its six
+//! Method dispatch for the `Harness` capability handle and its
 //! sub-handles. Every sub-handle (`stdio`, `clock`, `fs`, `env`,
-//! `random`, `net`) is wired end-to-end in real, mock, and null modes;
+//! `random`, `net`, `process`, `system`) is wired end-to-end in real,
+//! mock, and null modes;
 //! sandbox / egress rejections raised inside a sub-handle method are
 //! tagged with the `HARN-CAP-201` diagnostic code so callers can
 //! attribute the error to the active capability profile rather than an
@@ -82,6 +83,7 @@ impl crate::vm::Vm {
             HarnessKind::Env => self.call_harness_env_method(handle, method, args),
             HarnessKind::Random => self.call_harness_random_method(handle, method, args),
             HarnessKind::Net => self.call_harness_net_method(handle, method, args).await,
+            HarnessKind::Process => self.call_harness_process_method(handle, method, args),
         }
     }
 
@@ -589,6 +591,18 @@ impl crate::vm::Vm {
         }
     }
 
+    fn call_harness_process_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        match method {
+            "spawn_captured" => crate::stdlib::process::spawn_captured_value(args),
+            _ => Err(method_unsupported(handle, method)),
+        }
+    }
+
     async fn call_mock_harness_method(
         &mut self,
         handle: &VmHarness,
@@ -710,6 +724,13 @@ impl crate::vm::Vm {
                         }
                     })?)
                 }
+                _ => Err(method_unsupported(handle, method)),
+            },
+            HarnessKind::Process => match method {
+                "spawn_captured" => Err(VmError::CategorizedError {
+                    message: "MockHarness has no process spawn response".to_string(),
+                    category: ErrorCategory::NotFound,
+                }),
                 _ => Err(method_unsupported(handle, method)),
             },
             HarnessKind::System => {

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -279,6 +279,9 @@ menu, and honors `mock_stdin` under `prefer_external: "none"`.
 Use `std/command` for script-side harness commands. It runs through the same
 host command substrate as model-facing tools, but returns deterministic Harn
 records for retries, artifacts, tails, classification, and recovery hints.
+Use `harness.process.spawn_captured({cmd, args?, cwd?, env?, stdin?, timeout_ms?})`
+when you only need one synchronous subprocess capture record:
+`{exit_code, stdout, stderr, duration_ms, success, timed_out}`.
 
 ```harn,ignore
 import { command_json, command_json_step, command_try } from "std/command"

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -576,7 +576,8 @@ filesystem builtins remain supported as thin aliases for existing scripts.
 | `exec_at(dir, cmd, args...)` | dir: string, cmd: string, args: strings | dict | Execute external command inside a specific directory |
 | `shell(cmd)` | cmd: string | dict | Execute command via shell. Returns stdout/stderr plus status metadata and `success` |
 | `shell_at(dir, cmd)` | dir: string, cmd: string | dict | Execute shell command inside a specific directory |
-| `spawn_captured(opts)` | opts: dict | dict | Run an external command synchronously with structured options. Unlike `exec(...)` this takes a dict of `{cmd, args?, cwd?, env?, stdin?, timeout_ms?}` and supports feeding a stdin payload plus a per-call timeout. Returns `{exit_code, stdout, stderr, duration_ms, success, timed_out}`. On timeout the child is killed, `exit_code = -1`, `success = false`, and `timed_out = true` |
+| `harness.process.spawn_captured(opts)` | opts: dict | dict | Run an external command synchronously through the `Harness` process capability. `opts` is `{cmd, args?, cwd?, env?, stdin?, timeout_ms?}` and supports feeding a stdin payload plus a per-call timeout. Returns `{exit_code, stdout, stderr, duration_ms, success, timed_out}`. On timeout the child is killed, `exit_code = -1`, `success = false`, and `timed_out = true` |
+| `spawn_captured(opts)` | opts: dict | dict | Legacy alias for `harness.process.spawn_captured(opts)` when no `Harness` handle is available |
 | `term_width()` | none | int | Current terminal column count. Reads `COLUMNS` env first (so harnesses can pin a value), falls back to the platform window size, then to `80` |
 | `term_height()` | none | int | Current terminal row count. Reads `LINES` env first, falls back to the platform window size, then to `24` |
 | `exit(code)` | code: int (default 0) | never | Terminate the process |

--- a/docs/src/cli-extending-in-harn.md
+++ b/docs/src/cli-extending-in-harn.md
@@ -366,11 +366,12 @@ the directory.
 When a port discovers a gap in the `harness.*` namespace — something
 the Rust handler does that no `.harn` script can — the answer is a new
 builtin via the G4 pattern ([#2297][g4]). G4 landed a first round of
-free builtins (`sha256_hex`, `spawn_captured`, `term_width`,
+free builtins (`sha256_hex`, `term_width`,
 `term_height`, `mkdtemp`, `glob`, `llm_catalog`,
 `llm_provider_status`) that today live as top-level functions so the
 ports could move. Directory policy that can be expressed from env vars
-belongs in `std/cli/paths` instead of a host capability. The long-term
+belongs in `std/cli/paths` instead of a host capability. `spawn_captured`
+has since moved to `harness.process.spawn_captured`. The long-term
 direction promotes each remaining free builtin to its
 `harness.X.Y` sub-handle through follow-up issues
 [#2337][f7]-[#2340][f10] and [#2342][f12]. Add new capabilities the same way:


### PR DESCRIPTION
Closes #2338.

## Summary
- add HarnessProcess / harness.process dispatch for spawn_captured while keeping the free builtin as a legacy alias
- route IR, graph/routes, and handoff-effect analysis through the new process capability surface
- update CLI precompile script, docs, changelog, and conformance coverage

## Verification
- cargo test -p harn-ir harness_process_method_call_is_attributed_to_spawn_captured
- cargo test -p harn-vm harness::tests::
- cargo test -p harn-vm orchestration::policy::effects::tests::harness_process_spawn_captured_yields_process_hostcall_effect
- cargo run --quiet --bin harn -- test conformance --filter harness_process_spawn_captured
- cargo run --quiet --bin harn -- check conformance/tests/runtime/harness_process_spawn_captured.harn
- cargo run --quiet --bin harn -- graph --json conformance/tests/runtime/harness_process_spawn_captured.harn
- cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/cli/precompile.harn conformance/tests/runtime/harness_process_spawn_captured.harn conformance/tests/runtime/cli_host_caps_spawn_captured.harn
- cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/cli/precompile.harn conformance/tests/runtime/harness_process_spawn_captured.harn conformance/tests/runtime/cli_host_caps_spawn_captured.harn
- make lint-test-patterns
- make fmt-harn
- make lint-harn
- pre-commit hook
- pre-push hook