### PR TITLE
[codex] Fix read-only audit native verifier

### DIFF
--- a/crates/harn-cli/assets/evals/coding_agent_suite.harn
+++ b/crates/harn-cli/assets/evals/coding_agent_suite.harn
@@ -11,6 +11,10 @@ import { edit_apply_old_new_patch } from "std/edit"
 import { write_json } from "std/fs"
 import { write_jsonl } from "std/jsonl"
 
+let __READ_ONLY_AUDIT_SETTINGS = "DEFAULT_TIMEOUT_SECONDS = 30\n"
+
+let __READ_ONLY_AUDIT_README = "# Settings\n\nThe default timeout is 30 seconds.\n"
+
 fn __has_parent_segment(path: string) -> bool {
   for segment in split(path ?? "", "/") {
     if segment == ".." {
@@ -97,9 +101,8 @@ fn __seed_docs_symbol_rename(harness: Harness, root: string) {
 }
 
 fn __seed_read_only_audit(harness: Harness, root: string) {
-  harness.fs.write_text(path_join(root, "settings.py"), "DEFAULT_TIMEOUT_SECONDS = 30\n")
-  harness.fs
-    .write_text(path_join(root, "README.md"), "# Settings\n\nThe default timeout is 30 seconds.\n")
+  harness.fs.write_text(path_join(root, "settings.py"), __READ_ONLY_AUDIT_SETTINGS)
+  harness.fs.write_text(path_join(root, "README.md"), __READ_ONLY_AUDIT_README)
 }
 
 fn __seed_workspace(harness: Harness, root: string, fixture: string) {
@@ -472,16 +475,12 @@ fn __seed_read_only_audit_native_mock() {
   llm_mock(
     {text: "", tool_calls: [{id: "read_readme", name: "read_file", arguments: {path: "README.md"}}]},
   )
-  llm_mock({text: "AUDIT_OK: README matches the configured default timeout; no edits are needed."})
+  llm_mock({text: "AUDIT_OK"})
 }
 
 fn __seed_read_only_audit_text_mock() {
   llm_mock({text: "<tool_call>\nread_file({ path: \"README.md\" })\n</tool_call>"})
-  llm_mock(
-    {
-      text: "<user_response>AUDIT_OK: README matches the configured default timeout; no edits are needed.</user_response>\n<done>##DONE##</done>",
-    },
-  )
+  llm_mock({text: "<user_response>AUDIT_OK</user_response>\n<done>##DONE##</done>"})
 }
 
 fn __seed_no_tool_native_mock() {
@@ -645,18 +644,69 @@ fn __tool_call_count(result) -> int {
   return len(result?.tools?.calls ?? [])
 }
 
+fn __tool_call_name(call) -> string {
+  return to_string(call?.name ?? call?.tool_name ?? "")
+}
+
+fn __tool_call_args(call) {
+  let args = call?.arguments ?? call?.args ?? call?.tool_args
+  if type_of(args) == "dict" {
+    return args
+  }
+  return {}
+}
+
+fn __normalized_tool_path(path) -> string {
+  var normalized = replace(trim(to_string(path ?? "")), "\\", "/")
+  while starts_with(normalized, "./") {
+    normalized = normalized[2:]
+  }
+  return normalized
+}
+
+fn __read_only_audit_tool_calls_are_valid(result) -> bool {
+  let calls = result?.tools?.calls ?? []
+  if len(calls) == 0 {
+    return false
+  }
+  var saw_readme = false
+  for call in calls {
+    if __tool_call_name(call) != "read_file" {
+      return false
+    }
+    let path = __normalized_tool_path(__tool_call_args(call)?.path)
+    if path == "" || starts_with(path, "/") || __has_parent_segment(path) {
+      return false
+    }
+    if path == "README.md" {
+      saw_readme = true
+    }
+  }
+  return saw_readme
+}
+
 fn __final_text(result) -> string {
   return result.visible_text ?? result.text ?? ""
+}
+
+/**
+ * Pure verifier for the read-only-audit fixture.
+ *
+ * Accepts native providers that make redundant read calls, but still requires
+ * a README read, no non-read tools, the final audit token, and unchanged files.
+ */
+pub fn coding_agent_read_only_audit_verification_success(readme: string, settings: string, result) -> bool {
+  return __read_only_audit_tool_calls_are_valid(result)
+    && contains(__final_text(result), "AUDIT_OK")
+    && readme == __READ_ONLY_AUDIT_README
+    && settings == __READ_ONLY_AUDIT_SETTINGS
 }
 
 fn __verify_read_only_audit(harness: Harness, root: string, result) {
   let readme = harness.fs.read_text(path_join(root, "README.md"))
   let settings = harness.fs.read_text(path_join(root, "settings.py"))
   let final_text = __final_text(result)
-  let success = __tool_call_count(result) == 1
-    && contains(final_text, "AUDIT_OK")
-    && contains(readme, "30 seconds")
-    && contains(settings, "DEFAULT_TIMEOUT_SECONDS = 30")
+  let success = coding_agent_read_only_audit_verification_success(readme, settings, result)
   return __command_verification(
     success,
     if success {
@@ -729,7 +779,7 @@ fn __task_prompt(fixture: string, python: string) -> string {
     return "The public helper was renamed to `format_greeting`. Update the docs and example to use the renamed symbol. Do not edit `greeter.py`; verify the example runs."
   }
   if fixture == "read-only-audit" {
-    return "Read README.md and decide whether it matches the configured default timeout. Do not edit files. If no edits are needed, include the exact token AUDIT_OK in your final answer."
+    return "Read README.md. If README.md says the default timeout is 30 seconds, do not edit files and reply exactly AUDIT_OK."
   }
   if fixture == "no-tool-diagnosis" {
     return "No tools are available. Given this snippet: `def add(a, b): return a - b`, and this failing expectation: `add(2, 3) == 5`, state the smallest code change. Include the exact token PATCH_HINT."

--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -51,7 +51,9 @@ use crate::commands::local::runtime::{
     local_provider_ids, ollama_unload_model, snapshot_provider, LocalProviderSnapshot,
 };
 use crate::commands::local_readiness;
-use crate::commands::run::{execute_run, CliLlmMockMode, RunProfileOptions};
+use crate::commands::run::{
+    execute_run_with_sandbox_options, CliLlmMockMode, RunProfileOptions, RunSandboxOptions,
+};
 use crate::dispatch;
 use crate::env_guard::ScopedEnvVar;
 
@@ -521,7 +523,7 @@ async fn run_matrix_entry(
     let argv = script_argv(args, fixture, &selector, &tool_format, &run_dir);
     let clock = RealClock::new();
     let started_ms = clock.monotonic_ms();
-    let outcome = execute_run(
+    let outcome = execute_run_with_sandbox_options(
         &script_path.to_string_lossy(),
         false,
         HashSet::new(),
@@ -530,6 +532,7 @@ async fn run_matrix_entry(
         CliLlmMockMode::Off,
         None,
         RunProfileOptions::default(),
+        RunSandboxOptions::default().with_workspace_root(run_dir.clone()),
     )
     .await;
     let elapsed_ms = clock

--- a/crates/harn-cli/tests/eval_coding_agent_cli.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_cli.rs
@@ -2,10 +2,16 @@
 
 //! In-process coverage for `harn eval coding-agent`.
 
+use std::collections::HashSet;
 use std::fs;
+use std::path::PathBuf;
 use std::thread;
 
 use harn_cli::cli::EvalCodingAgentArgs;
+use harn_cli::commands::run::{
+    execute_run_with_sandbox_options, CliLlmMockMode, RunOutcome, RunProfileOptions,
+    RunSandboxOptions,
+};
 use harn_cli::tests::common::env_lock;
 
 fn run_in_harn_runtime<F, Fut, R>(future_factory: F) -> R
@@ -168,4 +174,35 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
         .exists());
     assert!(output.join("summary.md").exists());
     assert!(output.join("followups.md").exists());
+}
+
+#[test]
+fn read_only_audit_verifier_accepts_repeated_read_file_calls() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = manifest_dir.join("tests/fixtures/read_only_audit_verifier.harn");
+    let outcome: RunOutcome = run_in_harn_runtime(move || async move {
+        let _env_guard = env_lock::lock_env().lock().await;
+        harn_vm::reset_thread_local_state();
+        execute_run_with_sandbox_options(
+            &fixture.to_string_lossy(),
+            false,
+            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+            RunSandboxOptions::default().with_workspace_root(manifest_dir),
+        )
+        .await
+    });
+    assert_eq!(
+        outcome.exit_code, 0,
+        "fixture failed\nstdout={}\nstderr={}",
+        outcome.stdout, outcome.stderr
+    );
+    assert_eq!(
+        outcome.stdout,
+        "repeated_reads=true\nno_read=false\nedit_attempt=false\nparent_path=false\nchanged_readme=false\n"
+    );
 }

--- a/crates/harn-cli/tests/eval_coding_agent_dispatch.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_dispatch.rs
@@ -39,7 +39,7 @@ use std::path::Path;
 use std::process::Command;
 
 #[test]
-fn summary_md_is_byte_identical_between_impls() {
+fn summary_md_is_byte_identical_between_impls_after_normalizing_metrics() {
     // Use a single shared output dir for both impls. The aggregated
     // report bakes the output_dir + per-run transcript paths into the
     // rendered tables, so reusing the same dir keeps those strings
@@ -49,13 +49,15 @@ fn summary_md_is_byte_identical_between_impls() {
     let shared_out = dir.path().join("bench");
 
     let harn = run_eval_coding_agent(&shared_out, false, &[]);
-    assert_eq!(harn.exit_code, 1, "harn stderr={}", harn.stderr);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
     let harn_md = fs::read_to_string(shared_out.join("summary.md")).expect("harn summary.md");
 
     let rust = run_eval_coding_agent(&shared_out, false, &[("HARN_CLI_IMPL", "rust")]);
-    assert_eq!(rust.exit_code, 1, "rust stderr={}", rust.stderr);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
     let rust_md = fs::read_to_string(shared_out.join("summary.md")).expect("rust summary.md");
 
+    let harn_md = normalize_summary_markdown_metrics(&harn_md);
+    let rust_md = normalize_summary_markdown_metrics(&rust_md);
     assert_eq!(
         harn_md, rust_md,
         "summary.md diverged\n--- rust ---\n{}\n--- harn ---\n{}",
@@ -69,11 +71,11 @@ fn followups_md_is_byte_identical_between_impls() {
     let shared_out = dir.path().join("bench");
 
     let harn = run_eval_coding_agent(&shared_out, false, &[]);
-    assert_eq!(harn.exit_code, 1, "harn stderr={}", harn.stderr);
+    assert_eq!(harn.exit_code, 0, "harn stderr={}", harn.stderr);
     let harn_md = fs::read_to_string(shared_out.join("followups.md")).expect("harn followups.md");
 
     let rust = run_eval_coding_agent(&shared_out, false, &[("HARN_CLI_IMPL", "rust")]);
-    assert_eq!(rust.exit_code, 1, "rust stderr={}", rust.stderr);
+    assert_eq!(rust.exit_code, 0, "rust stderr={}", rust.stderr);
     let rust_md = fs::read_to_string(shared_out.join("followups.md")).expect("rust followups.md");
 
     assert_eq!(
@@ -106,11 +108,10 @@ fn json_stdout_is_structurally_identical_between_impls() {
     // parsed shapes match — assert structural equality, not byte
     // identity, for the JSON path.
     //
-    // We normalise `elapsed_ms` to 0 across both runs because the
-    // matrix executor measures wall-clock per cell and the two
-    // subprocess invocations naturally produce different millisecond
-    // counts; everything else in the report is deterministic when the
-    // output dir is reused.
+    // We normalise volatile execution metrics across both runs because
+    // the matrix executor measures wall-clock per cell and fresh agent
+    // session ids can perturb token estimates by a token or two. The
+    // fields owned by the renderer remain structurally compared.
     let dir = tempfile::tempdir().expect("tempdir");
     let shared_out = dir.path().join("bench");
 
@@ -121,8 +122,8 @@ fn json_stdout_is_structurally_identical_between_impls() {
         serde_json::from_str(&harn.stdout).expect("harn --json stdout parses");
     let mut rust_value: serde_json::Value =
         serde_json::from_str(&rust.stdout).expect("rust --json stdout parses");
-    zero_timing_fields(&mut harn_value);
-    zero_timing_fields(&mut rust_value);
+    zero_volatile_metrics(&mut harn_value);
+    zero_volatile_metrics(&mut rust_value);
     assert_eq!(
         rust_value, harn_value,
         "--json stdout diverged structurally"
@@ -168,37 +169,63 @@ fn summary_json_artifact_keeps_serde_struct_field_order_across_impls() {
         serde_json::from_str(&harn_json).expect("harn summary.json parses");
     let mut rust_value: serde_json::Value =
         serde_json::from_str(&rust_json).expect("rust summary.json parses");
-    zero_timing_fields(&mut harn_value);
-    zero_timing_fields(&mut rust_value);
+    zero_volatile_metrics(&mut harn_value);
+    zero_volatile_metrics(&mut rust_value);
     assert_eq!(harn_value, rust_value, "summary.json diverged structurally");
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────
 
-/// Walk a `serde_json::Value` tree and zero any `elapsed_ms` /
-/// `duration_ms` fields so two invocations of the same coding-agent
-/// matrix produce structurally equal reports. The matrix executor
-/// measures wall-clock per cell and the two subprocess runs naturally
-/// produce different millisecond counts — every other field in the
-/// rendered report is deterministic once the output dir is reused.
-fn zero_timing_fields(value: &mut serde_json::Value) {
+/// Walk a `serde_json::Value` tree and zero volatile metrics so two
+/// invocations of the same coding-agent matrix produce structurally
+/// equal reports. The renderer parity tests compare presentation-owned
+/// fields; wall-clock timings and token estimates belong to execution.
+fn zero_volatile_metrics(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
             for (key, child) in map.iter_mut() {
-                if key == "elapsed_ms" || key == "duration_ms" {
+                if matches!(
+                    key.as_str(),
+                    "elapsed_ms"
+                        | "duration_ms"
+                        | "input_tokens"
+                        | "output_tokens"
+                        | "token_delta_text_minus_native"
+                ) {
                     *child = serde_json::Value::Number(serde_json::Number::from(0));
                 } else {
-                    zero_timing_fields(child);
+                    zero_volatile_metrics(child);
                 }
             }
         }
         serde_json::Value::Array(items) => {
             for item in items {
-                zero_timing_fields(item);
+                zero_volatile_metrics(item);
             }
         }
         _ => {}
     }
+}
+
+fn normalize_summary_markdown_metrics(markdown: &str) -> String {
+    let mut out = String::new();
+    for line in markdown.lines() {
+        if line.starts_with("| `") {
+            let mut cells = line.split('|').collect::<Vec<_>>();
+            match cells.len() {
+                // Runs table: normalize the `tokens` column.
+                15 => cells[10] = " <tokens> ",
+                // Native/Text Comparison table: normalize `token delta`.
+                13 => cells[9] = " <token-delta> ",
+                _ => {}
+            }
+            out.push_str(&cells.join("|"));
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out
 }
 
 struct ProcessOutcome {
@@ -208,10 +235,8 @@ struct ProcessOutcome {
 }
 
 /// Invoke `harn eval coding-agent` in mock-only matrix mode. The mock
-/// provider has no LLM credentials and the in-process driver may
-/// either pass (CI w/ python3 + the embedded coding_agent_suite.harn
-/// driver round-tripping) or fail with infra_error rows. Either way
-/// the rendered outputs must match across impls.
+/// provider has no LLM credentials, so this should pass without network
+/// or provider setup; the rendered outputs must match across impls.
 fn run_eval_coding_agent(output: &Path, json: bool, extra_env: &[(&str, &str)]) -> ProcessOutcome {
     let mut argv = vec![
         "eval".to_string(),

--- a/crates/harn-cli/tests/fixtures/read_only_audit_verifier.harn
+++ b/crates/harn-cli/tests/fixtures/read_only_audit_verifier.harn
@@ -1,0 +1,54 @@
+import {
+  coding_agent_read_only_audit_verification_success,
+} from "../../assets/evals/coding_agent_suite.harn"
+
+let README = "# Settings\n\nThe default timeout is 30 seconds.\n"
+
+let SETTINGS = "DEFAULT_TIMEOUT_SECONDS = 30\n"
+
+fn result(calls, text: string) {
+  return {visible_text: text, tools: {calls: calls}}
+}
+
+pipeline main() {
+  let repeated_reads = result(
+    [
+      {name: "read_file", arguments: {path: "README.md"}},
+      {name: "read_file", arguments: {path: "settings.py"}},
+      {name: "read_file", arguments: {path: "./README.md"}},
+    ],
+    "AUDIT_OK: README matches the configured default timeout; no edits are needed.",
+  )
+  let no_read = result([], "AUDIT_OK: no edits are needed.")
+  let edit_attempt = result(
+    [{name: "replace_in_file", arguments: {path: "README.md"}}],
+    "AUDIT_OK: no edits are needed.",
+  )
+  let parent_path = result([{name: "read_file", arguments: {path: "../README.md"}}], "AUDIT_OK: no edits are needed.")
+  __io_println(
+    "repeated_reads="
+      + to_string(coding_agent_read_only_audit_verification_success(README, SETTINGS, repeated_reads)),
+  )
+  __io_println(
+    "no_read="
+      + to_string(coding_agent_read_only_audit_verification_success(README, SETTINGS, no_read)),
+  )
+  __io_println(
+    "edit_attempt="
+      + to_string(coding_agent_read_only_audit_verification_success(README, SETTINGS, edit_attempt)),
+  )
+  __io_println(
+    "parent_path="
+      + to_string(coding_agent_read_only_audit_verification_success(README, SETTINGS, parent_path)),
+  )
+  __io_println(
+    "changed_readme="
+      + to_string(
+      coding_agent_read_only_audit_verification_success(
+        README + "Extra note.\n",
+        SETTINGS,
+        repeated_reads,
+      ),
+    ),
+  )
+}


### PR DESCRIPTION
Fixes #2370.

## Summary
- Relaxed the `read-only-audit` verifier so native-tool runs can make repeated `read_file` calls while still requiring a README read, `AUDIT_OK`, read-only behavior, unchanged fixture files, and no unsafe path attempts.
- Simplified the fixture prompt and mocks to use an exact `AUDIT_OK` completion contract after reading `README.md`.
- Fixed coding-agent eval execution to sandbox generated per-run scripts against their output run directory, and updated mock parity tests for now-passing matrix rows plus volatile token/timing fields.

## Verification
- `cargo fmt --check --package harn-cli`
- `harn fmt --check crates/harn-cli/assets/evals/coding_agent_suite.harn crates/harn-cli/tests/fixtures/read_only_audit_verifier.harn`
- `harn check crates/harn-cli/assets/evals/coding_agent_suite.harn`
- `harn check crates/harn-cli/tests/fixtures/read_only_audit_verifier.harn`
- `cargo test -p harn-cli --test eval_coding_agent_cli -- --nocapture`
- `cargo test -p harn-cli --test eval_coding_agent_dispatch -- --nocapture`
- `make fmt-harn`
- `make lint-harn`
- Focused live v3 rerun for `read-only-audit` native cells: baseline, symmetric-cheap, asymmetric, and symmetric-strong all passed (`/tmp/harn-2370-live-v3-exact.mAT0Pg`).
- Pre-commit and pre-push hooks passed.