### PR TITLE
[codex] Resolve agent loop tool format from capabilities

### DIFF
--- a/conformance/tests/agents/agent_loop_tool_format_capabilities.expected
+++ b/conformance/tests/agents/agent_loop_tool_format_capabilities.expected
@@ -1,0 +1,11 @@
+format=native
+0
+format=native
+0
+format=text
+1
+warning
+testcatalog
+uncatalogued-model
+preferred_tool_format
+text

--- a/conformance/tests/agents/agent_loop_tool_format_capabilities.harn
+++ b/conformance/tests/agents/agent_loop_tool_format_capabilities.harn
@@ -1,0 +1,89 @@
+import { agent_capture_events } from "std/agent/events"
+
+fn sample_tools() {
+  let tools = tool_registry()
+  return tool_define(
+    tools,
+    "noop",
+    "Return a deterministic result",
+    {
+      handler: { _args -> return "ok" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+}
+
+fn format_echo_caller() {
+  return { call ->
+    let format = to_string(call?.opts?.tool_format ?? "")
+    return {
+      ok: true,
+      value: {
+        text: "format=" + format,
+        provider: call?.opts?.provider ?? "",
+        model: call?.opts?.model ?? "",
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    }
+  }
+}
+
+fn run_format(options) {
+  let result = agent_loop(
+    "Report the selected format.",
+    nil,
+    options
+      + {tools: sample_tools(), llm_caller: format_echo_caller(), max_iterations: 1, done_judge: false},
+  )
+  return result.text
+}
+
+fn events_of(events, kind) {
+  return events.filter({ event -> event.type == kind })
+}
+
+pipeline default() {
+  provider_capabilities_install(
+    """
+[[provider.testcatalog]]
+model_match = "catalogued-*"
+native_tools = true
+preferred_tool_format = "native"
+""",
+  )
+  defer {
+    provider_capabilities_clear()
+  }
+  let preferred_session = "tool-format-preferred-" + uuid()
+  let preferred = agent_capture_events(
+    preferred_session,
+    fn() { return run_format({provider: "testcatalog", model: "catalogued-native", session_id: preferred_session}) },
+  )
+  __io_println(preferred.result)
+  __io_println(len(events_of(preferred.events, "capability_gap")))
+  let auto_session = "tool-format-auto-" + uuid()
+  let auto = agent_capture_events(
+    auto_session,
+    fn() { return run_format(
+      {provider: "testcatalog", model: "catalogued-native", session_id: auto_session, tool_format: "auto"},
+    ) },
+  )
+  __io_println(auto.result)
+  __io_println(len(events_of(auto.events, "capability_gap")))
+  let fallback_session = "tool-format-fallback-" + uuid()
+  let fallback = agent_capture_events(
+    fallback_session,
+    fn() { return run_format({provider: "testcatalog", model: "uncatalogued-model", session_id: fallback_session}) },
+  )
+  let gaps = events_of(fallback.events, "capability_gap")
+  __io_println(fallback.result)
+  __io_println(len(gaps))
+  __io_println(gaps[0].level)
+  __io_println(gaps[0].provider)
+  __io_println(gaps[0].model)
+  __io_println(gaps[0].capability)
+  __io_println(gaps[0].fallback_tool_format)
+}

--- a/conformance/tests/integration/provider_capabilities_basic.harn
+++ b/conformance/tests/integration/provider_capabilities_basic.harn
@@ -145,5 +145,6 @@ pipeline test(task) {
   assert(len(unknown.tool_search) == 0, "unknown provider has no tool_search")
   assert(len(unknown.thinking_modes) == 0, "unknown provider has no thinking modes")
   assert(unknown.max_tools == nil, "unknown provider has no max_tools cap")
+  assert(unknown.preferred_tool_format == nil, "unknown provider has no preferred tool format")
   log("provider_capabilities_basic tests passed")
 }

--- a/crates/harn-cli/src/commands/orchestrator/listener/routes.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/routes.rs
@@ -370,6 +370,8 @@ struct IngestBackpressure {
 pub(crate) struct IngestBackpressureConfig {
     pub(crate) global_capacity: u32,
     pub(crate) per_source_capacity: u32,
+    /// Refill rate for admitted webhook tokens. A value of zero disables
+    /// automatic refill for fixed-window drains.
     pub(crate) refill_per_sec: u32,
 }
 
@@ -390,7 +392,7 @@ impl IngestBackpressure {
         let config = IngestBackpressureConfig {
             global_capacity: config.global_capacity.max(1),
             per_source_capacity: config.per_source_capacity.max(1),
-            refill_per_sec: config.refill_per_sec.max(1),
+            refill_per_sec: config.refill_per_sec,
         };
         let now = Instant::now();
         Self {
@@ -484,9 +486,11 @@ impl IngestBucket {
     }
 
     fn refill(&mut self, capacity: u32, refill_per_sec: u32, now: Instant) {
+        if refill_per_sec == 0 {
+            return;
+        }
         let elapsed = now.duration_since(self.last_refill).as_secs_f64();
-        self.tokens =
-            (self.tokens + elapsed * refill_per_sec.max(1) as f64).min(capacity.max(1) as f64);
+        self.tokens = (self.tokens + elapsed * refill_per_sec as f64).min(capacity.max(1) as f64);
         self.last_refill = now;
     }
 
@@ -494,7 +498,10 @@ impl IngestBucket {
         if self.tokens >= 1.0 {
             return Duration::ZERO;
         }
-        Duration::from_secs_f64(((1.0 - self.tokens) / refill_per_sec.max(1) as f64).max(0.001))
+        if refill_per_sec == 0 {
+            return Duration::from_secs(1);
+        }
+        Duration::from_secs_f64(((1.0 - self.tokens) / refill_per_sec as f64).max(0.001))
     }
 }
 

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -950,7 +950,7 @@ async fn webhook_ingest_saturation_returns_retry_after() {
         ListenerRuntimeEnv::for_test().with_ingest_backpressure(IngestBackpressureConfig {
             global_capacity: 100,
             per_source_capacity: 1,
-            refill_per_sec: 1,
+            refill_per_sec: 0,
         }),
     )
     .await

--- a/crates/harn-cli/src/package/test_support.rs
+++ b/crates/harn-cli/src/package/test_support.rs
@@ -69,10 +69,22 @@ pub(crate) fn run_git(repo: &Path, args: &[&str]) -> String {
 pub(crate) fn test_git_command(repo: &Path) -> process::Command {
     let mut command = process::Command::new("git");
     command
+        // Package tests create disposable repos. Keep ambient developer Git
+        // policy from invoking hooks or signing prompts inside nextest workers.
+        .args([
+            "-c",
+            "commit.gpgSign=false",
+            "-c",
+            "tag.gpgSign=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+        ])
         .current_dir(repo)
+        .env("GIT_TERMINAL_PROMPT", "0")
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE");
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_ASKPASS");
     command
 }
 

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1080,6 +1080,29 @@ impl AgentEventSink for AcpAgentEventSink {
             } => {
                 self.emit_agent_event_ext("agent_loop_stall_warning", session_id, warning.clone());
             }
+            AgentEvent::CapabilityGap {
+                session_id,
+                level,
+                capability,
+                provider,
+                model,
+                fallback_tool_format,
+                requested_tool_format,
+                message,
+            } => {
+                let mut payload = serde_json::json!({
+                    "level": level,
+                    "capability": capability,
+                    "provider": provider,
+                    "model": model,
+                    "fallbackToolFormat": fallback_tool_format,
+                    "message": message,
+                });
+                if let Some(requested) = requested_tool_format {
+                    payload["requestedToolFormat"] = serde_json::Value::String(requested.clone());
+                }
+                self.emit_agent_event_ext("capability_gap", session_id, payload);
+            }
             AgentEvent::ToolCallAudit {
                 session_id,
                 tool_call_id,

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1559,6 +1559,9 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
   if session?.done {
     return session.result
   }
+  if opts?._tool_format_capability_gap != nil {
+    agent_emit_event(session.session_id, "capability_gap", opts._tool_format_capability_gap)
+  }
   defer {
     try {
       __host_mcp_disconnect(session.session_id)

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -52,17 +52,151 @@ fn __client_tool_search_requested(value) {
   return type_of(value) == "dict" && value?.mode == "client"
 }
 
-fn __model_tool_format(opts) {
-  if opts?.model == nil {
+fn __fallback_tool_format() {
+  return "text"
+}
+
+fn __tool_format_auto(value) {
+  if value == nil {
+    return true
+  }
+  let text = lowercase(trim(to_string(value)))
+  return text == "" || text == "auto"
+}
+
+fn __explicit_tool_format(opts) {
+  if !__has_key(opts, "tool_format") || __tool_format_auto(opts?.tool_format) {
     return nil
   }
+  return lowercase(trim(to_string(opts.tool_format)))
+}
+
+fn __explicit_provider(opts) {
+  let provider = trim(to_string(opts?.provider ?? ""))
+  if provider == "" || lowercase(provider) == "auto" {
+    return nil
+  }
+  return provider
+}
+
+fn __resolved_model_id(model) {
   let resolved = try {
-    llm_resolve_model(opts.model)
+    llm_resolve_model(model)
+  }
+  if is_err(resolved) {
+    return to_string(model)
+  }
+  return unwrap(resolved)?.id ?? to_string(model)
+}
+
+fn __tool_format_pair(opts) {
+  let raw_model = opts?.model
+  if raw_model == nil || trim(to_string(raw_model)) == "" {
+    return nil
+  }
+  let provider = __explicit_provider(opts)
+  if provider != nil {
+    return {provider: provider, model: __resolved_model_id(raw_model)}
+  }
+  let resolved = try {
+    llm_resolve_model(raw_model)
   }
   if is_err(resolved) {
     return nil
   }
-  return unwrap(resolved)?.tool_format
+  let info = unwrap(resolved)
+  let inferred_provider = trim(to_string(info?.provider ?? ""))
+  let model = trim(to_string(info?.id ?? ""))
+  if inferred_provider == "" || model == "" {
+    return nil
+  }
+  return {provider: inferred_provider, model: model}
+}
+
+fn __valid_tool_format(value) {
+  let format = lowercase(trim(to_string(value ?? "")))
+  if format == "native" || format == "text" {
+    return format
+  }
+  return nil
+}
+
+fn __capability_gap_event(pair, requested, fallback) {
+  return {
+    level: "warning",
+    capability: "preferred_tool_format",
+    provider: pair.provider,
+    model: pair.model,
+    requested_tool_format: requested,
+    fallback_tool_format: fallback,
+    message: "No preferred_tool_format recommendation for provider/model; using fallback tool_format.",
+  }
+}
+
+/**
+ * Resolve the effective agent tool format without mutating the caller's
+ * options. `tool_format: "auto"` is intentionally treated the same as an
+ * omitted value.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_tool_format_resolution(options)
+ */
+pub fn agent_tool_format_resolution(options = nil) {
+  let opts = options ?? {}
+  let explicit = __explicit_tool_format(opts)
+  if explicit != nil {
+    return {tool_format: explicit, source: "explicit", capability_gap_event: nil}
+  }
+  let pair = __tool_format_pair(opts)
+  if pair != nil {
+    let caps = try {
+      provider_capabilities(pair.provider, pair.model)
+    }
+    if !is_err(caps) {
+      let preferred = __valid_tool_format(unwrap(caps)?.preferred_tool_format)
+      if preferred != nil {
+        return {
+          tool_format: preferred,
+          source: "capabilities",
+          provider: pair.provider,
+          model: pair.model,
+          capability_gap_event: nil,
+        }
+      }
+    }
+    let fallback = __fallback_tool_format()
+    return {
+      tool_format: fallback,
+      source: "fallback",
+      provider: pair.provider,
+      model: pair.model,
+      capability_gap_event: __capability_gap_event(pair, opts?.tool_format, fallback),
+    }
+  }
+  if __has_key(opts, "tool_format") {
+    return {tool_format: __fallback_tool_format(), source: "fallback", capability_gap_event: nil}
+  }
+  return {tool_format: nil, source: "unresolved", capability_gap_event: nil}
+}
+
+/**
+ * Return the concrete tool format a prompt-building helper should use.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_tool_format(options)
+ */
+pub fn agent_tool_format(options = nil) {
+  let resolved = agent_tool_format_resolution(options)
+  if resolved?.tool_format != nil {
+    return resolved.tool_format
+  }
+  return __fallback_tool_format()
 }
 
 fn __native_tools_complete_naturally(opts) {
@@ -356,6 +490,17 @@ fn __normalize_reminder_provider_options(opts) {
   return opts
 }
 
+fn __with_resolved_tool_format(opts, resolution) {
+  if resolution?.tool_format == nil {
+    return opts
+  }
+  var next = opts + {tool_format: resolution.tool_format}
+  if resolution?.capability_gap_event != nil {
+    next = next + {_tool_format_capability_gap: resolution.capability_gap_event}
+  }
+  return next
+}
+
 fn __normalize_iteration_budget(opts) {
   let raw = opts?.iteration_budget
   let legacy = opts?.max_iterations
@@ -481,15 +626,13 @@ pub fn agent_loop_options(options = nil) {
   let profile = opts?.profile ?? "tool_using"
   let defaults = __profile_defaults(profile)
   opts = defaults + opts
-  if !__has_key(opts, "tool_format") && opts?.tools != nil {
-    let model_tool_format = __model_tool_format(opts)
-    if model_tool_format != nil {
-      opts = opts + {tool_format: model_tool_format}
-    }
+  let tool_format_resolution = agent_tool_format_resolution(opts)
+  if __has_key(opts, "tool_format") || opts?.tools != nil {
+    opts = __with_resolved_tool_format(opts, tool_format_resolution)
   }
   if !__has_key(opts, "tool_format")
     && (opts?.tools == nil || __client_tool_search_requested(opts?.tool_search)) {
-    opts = opts + {tool_format: "text"}
+    opts = opts + {tool_format: __fallback_tool_format()}
   }
   if opts?.loop_until_done ?? false && !__has_key(opts, "done_sentinel") {
     opts = opts

--- a/crates/harn-stdlib/src/stdlib/agent/preflight.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/preflight.harn
@@ -1,3 +1,4 @@
+import { agent_tool_format } from "std/agent/options"
 import { loop_until_done_system_prompt, render_agent_prompt_id } from "std/agent/prompts"
 import { agent_session_messages, agent_session_project_turn } from "std/agent/state"
 
@@ -10,21 +11,7 @@ fn __agent_done_sentinel(opts) {
 }
 
 fn __agent_tool_format(opts) {
-  if opts?.tool_format != nil {
-    return opts.tool_format
-  }
-  if opts?.model != nil {
-    let resolved = try {
-      llm_resolve_model(opts.model)
-    }
-    if !is_err(resolved) {
-      let info = unwrap(resolved)
-      if info?.tool_format != nil {
-        return info.tool_format
-      }
-    }
-  }
-  return "text"
+  return agent_tool_format(opts)
 }
 
 fn __agent_has_tools(opts) {

--- a/crates/harn-stdlib/src/stdlib/agent/presets.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/presets.harn
@@ -11,6 +11,7 @@
 // re-deriving the knobs at every call site. All defaults remain
 // caller-overridable.
 import { agent_loop } from "std/agent/loop"
+import { agent_tool_format_resolution } from "std/agent/options"
 import { compose, default_llm_caller, with_logging, with_routing } from "std/llm/handlers"
 import {
   compose_tool_callers,
@@ -235,52 +236,18 @@ fn __tool_using_defaults(kind) {
   }
 }
 
-/**
- * Resolve `tool_format` from the model capability matrix before downstream
- * stdlib helpers decide whether to use native tools or text-tool prompts.
- */
-fn __preset_default_tool_format(opts) {
-  if opts?.tool_format != nil {
-    return opts.tool_format
-  }
-  let model = opts?.model
-  if model == nil || model == "" {
-    return nil
-  }
-  // When the caller explicitly named a provider, consult the capability
-  // matrix directly. `llm_resolve_model` infers provider from the model id
-  // and would misclassify provider-specific identifiers like
-  // `qwen3.6:35b-a3b-coding-nvfp4` (Ollama) by defaulting them to the
-  // global default provider.
-  if opts?.provider != nil && opts.provider != "auto" && opts.provider != "" {
-    let caps = provider_capabilities(opts.provider, model)
-    if caps?.native_tools ?? false {
-      return "native"
-    }
-    return "text"
-  }
-  let resolved = try {
-    llm_resolve_model(model)
-  }
-  if is_err(resolved) {
-    return nil
-  }
-  let info = unwrap(resolved)
-  if info?.tool_format != nil {
-    return info.tool_format
-  }
-  return nil
-}
-
 fn __apply_tool_format(opts, kind) {
   if kind == "summary" || kind == "verify" {
     return opts
   }
-  let resolved = __preset_default_tool_format(opts)
-  if resolved == nil {
+  let resolved = agent_tool_format_resolution(opts)
+  if resolved?.tool_format == nil {
     return opts
   }
-  return opts + {tool_format: resolved}
+  if resolved?.capability_gap_event != nil {
+    return opts
+  }
+  return opts + {tool_format: resolved.tool_format}
 }
 
 fn __kind_defaults(kind, opts) {

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -697,6 +697,19 @@ pub enum AgentEvent {
         session_id: String,
         warning: serde_json::Value,
     },
+    /// Emitted when a concrete provider/model pair lacks a catalog
+    /// recommendation for a capability and the runtime chooses a fallback.
+    CapabilityGap {
+        session_id: String,
+        level: String,
+        capability: String,
+        provider: String,
+        model: String,
+        fallback_tool_format: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        requested_tool_format: Option<String>,
+        message: String,
+    },
     /// Emitted when a `tool_caller` middleware (see std/llm/tool_middleware)
     /// attaches structured audit metadata to a tool call — typically a
     /// user-facing `summary`, a `description`, an ACP-style `kind`, an MCP
@@ -841,6 +854,7 @@ impl AgentEvent {
             | Self::HitlResolved { session_id, .. }
             | Self::LoopControlDecision { session_id, .. }
             | Self::AgentLoopStallWarning { session_id, .. }
+            | Self::CapabilityGap { session_id, .. }
             | Self::ToolCallAudit { session_id, .. }
             | Self::CacheHit { session_id, .. }
             | Self::CacheMiss { session_id, .. }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1538,6 +1538,16 @@ fn build_agent_event(
             session_id: session_id.to_string(),
             warning: payload.clone(),
         }),
+        "capability_gap" => Ok(AgentEvent::CapabilityGap {
+            session_id: session_id.to_string(),
+            level: get_string("level"),
+            capability: get_string("capability"),
+            provider: get_string("provider"),
+            model: get_string("model"),
+            fallback_tool_format: get_string("fallback_tool_format"),
+            requested_tool_format: get_opt_string("requested_tool_format"),
+            message: get_string("message"),
+        }),
         "tool_call_audit" => {
             let receipt = payload_obj
                 .and_then(|m| m.get("receipt"))

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -1093,13 +1093,9 @@ mod tests {
                 .run_until(async {
                     let opts = base_opts("ollama");
                     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-                    let result = tokio::time::timeout(
-                        std::time::Duration::from_secs(5),
-                        vm_call_llm_full_streaming_offthread(&opts, tx),
-                    )
-                    .await
-                    .expect("llm call timed out")
-                    .expect("llm call should succeed");
+                    let result = vm_call_llm_full_streaming_offthread(&opts, tx)
+                        .await
+                        .expect("llm call should succeed");
 
                     let mut deltas = Vec::new();
                     while let Ok(delta) = rx.try_recv() {
@@ -1153,13 +1149,9 @@ mod tests {
                 .run_until(async {
                     let opts = base_opts("ollama");
                     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-                    let result = tokio::time::timeout(
-                        std::time::Duration::from_secs(5),
-                        vm_call_llm_full_streaming_offthread(&opts, tx),
-                    )
-                    .await
-                    .expect("llm call timed out")
-                    .expect("retry should recover from empty done frame");
+                    let result = vm_call_llm_full_streaming_offthread(&opts, tx)
+                        .await
+                        .expect("retry should recover from empty done frame");
 
                     let mut deltas = Vec::new();
                     while let Ok(delta) = rx.try_recv() {

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -862,7 +862,10 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         thinking_disable_directive: None,
         auto_reasoning_overrides: None,
     };
-    rule_to_caps(&empty, defaults)
+    let mut caps = rule_to_caps(&empty, defaults);
+    caps.preferred_tool_format = None;
+    caps.tool_mode_parity = None;
+    caps
 }
 
 fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilities {

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1265,6 +1265,9 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // Inspect `native_tools` or `text_tool_wire_format_supported` directly when
 // you need to distinguish. Presets use `preferred_tool_format` when it is
 // present, so known native/text divergences stay data-driven.
+// `agent_loop` also uses this field for `tool_format: "auto"`; if a concrete
+// provider/model pair has no recommendation, it falls back to text tools and
+// emits a `capability_gap` warning event.
 
 if "bm25" in caps.tool_search {
   // opt into progressive disclosure

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -223,6 +223,8 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // `text_tool_wire_format_supported` directly when you need to distinguish.
 // Presets use `preferred_tool_format` when it is present, which keeps known
 // native/text divergences in capability data instead of provider-name branches.
+// `agent_loop` uses the same field when `tool_format` is unset or `"auto"`;
+// missing recommendations fall back to text tools and emit `capability_gap`.
 if caps.tools && "bm25" in caps.tool_search {
   llm_call(prompt, sys, {
     tools: registry,


### PR DESCRIPTION
## Summary
- Resolve `agent_loop` tool format through explicit option, provider/model `preferred_tool_format`, then text fallback, treating `auto` as unresolved.
- Emit typed `capability_gap` warning events when a concrete provider/model pair lacks a preferred tool-format recommendation.
- Add conformance coverage for catalogued preferred native format and uncatalogued text fallback, plus polish for flaky package/listener/Ollama tests found during the finish pass.

Closes #2359

## Verification
- `cargo run --quiet --bin harn -- test conformance --filter agent_loop_tool_format_capabilities`
- `cargo run --quiet --bin harn -- test conformance --filter provider_capabilities_basic`
- `cargo test -p harn-cli --lib commands::orchestrator::listener::tests::webhook_ingest_saturation_returns_retry_after -- --nocapture`
- `cargo test -p harn-vm --lib llm::api::tests::ollama_empty_content_done_frame_retries_once -- --nocapture`
- `cargo fmt --check`
- `make fmt-harn`
- `make lint-harn`
- `make lint-test-patterns`
- `make check-docs-snippets`
- `make test` (5170 passed, 2 skipped)
- pre-commit and pre-push hooks passed
