### PR TITLE
Add harness.term terminal capability surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ condensed series summaries instead of full per-patch history.
   over strings or bytes. `sha256_hex(...)` remains as a compatibility alias,
   and `harn graph --json` now surfaces `harness.crypto.sha256` in
   `host_calls`.
+- **Harness terminal capability sub-handle (#2339).** Added
+  `harness.term.width()`, `harness.term.height()`, and
+  `harness.term.read_password(prompt?)` so terminal dimensions and no-echo
+  password reads are available through the typed harness surface. The existing
+  `term_width()` and `term_height()` free builtins now share the same
+  implementation and remain aliases for compatibility.
 
 ## v0.8.35
 

--- a/conformance/tests/runtime/cli_host_caps_term_dimensions.harn
+++ b/conformance/tests/runtime/cli_host_caps_term_dimensions.harn
@@ -1,8 +1,7 @@
-// Free-builtin landing sites for the deferred `harness.term.width` /
-// `harness.term.height` sub-handles (see #2297). Pinning COLUMNS /
-// LINES via env keeps this test deterministic across CI runners. The
-// builtins also fall back to a default 80x24 when reading fails — we
-// assert that the env-pinned values flow through.
+// Free-builtin aliases for `harness.term.width()` and
+// `harness.term.height()`. They fall back to a default 80x24 when the
+// host cannot report terminal dimensions, so this fixture only asserts
+// positive values.
 __io_println(term_width() > 0)
 
 __io_println(term_height() > 0)

--- a/conformance/tests/runtime/harness_term_dimensions.expected
+++ b/conformance/tests/runtime/harness_term_dimensions.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true

--- a/conformance/tests/runtime/harness_term_dimensions.harn
+++ b/conformance/tests/runtime/harness_term_dimensions.harn
@@ -1,0 +1,11 @@
+fn main(harness: Harness) {
+  harness.stdio.println(harness.term.width() > 0)
+  harness.stdio.println(harness.term.height() > 0)
+  mock_stdin("s3cr3t\n")
+  capture_stderr_start()
+  let password = harness.term.read_password("password: ")
+  let prompt = capture_stderr_take()
+  harness.stdio.println(password == "s3cr3t")
+  harness.stdio.println(prompt == "password: ")
+  unmock_stdin()
+}

--- a/crates/harn-cli/src/commands/graph.rs
+++ b/crates/harn-cli/src/commands/graph.rs
@@ -74,13 +74,9 @@ pub(crate) struct GraphEdge {
 /// `HARN_CLI_IMPL=rust` escape hatch keeps the legacy direct render
 /// path for the parity-snapshot harness (#2299) until the C1 ratchet
 /// (#2314) deletes it.
-///
-/// The module-graph extraction itself (collect_harn_targets +
-/// build_module_graph + IR walk) stays in Rust — porting it would
-/// require a new `harness.modules.compile_view` host capability the
-/// W11 spec calls out as future scope. On extraction failure the shim
-/// renders the same error envelope / stderr line the legacy path
-/// emits so behavior is identical regardless of the dispatch mode.
+/// The module-graph extraction itself stays in Rust until Harn exposes a
+/// `harness.modules.compile_view` host capability. Extraction failures render
+/// the same error envelope / stderr line in both modes.
 pub(crate) async fn run(args: GraphArgs) -> i32 {
     let report = match analyze_graph(&args.root, args.module.as_deref()) {
         Ok(report) => report,
@@ -295,6 +291,8 @@ fn direct_capabilities(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
         "apply_edit" => {
             out.insert("workspace.apply_edit".to_string());
         }
+        "term_width" | "term_height" => out.extend(["terminal.dimensions".to_string()]),
+        "read_password" => out.extend(["terminal.read_password".to_string()]),
         "http_get"
         | "http_post"
         | "http_put"
@@ -365,6 +363,7 @@ fn direct_effects(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
             "worker.dispatch" => "worker.dispatch".to_string(),
             "human.approval" => "human.approval".to_string(),
             "template.render" => "template.render".to_string(),
+            "terminal.dimensions" | "terminal.read_password" => "terminal.read".to_string(),
             other if other.starts_with("connector.") => "connector.call".to_string(),
             other => other.to_string(),
         })

--- a/crates/harn-cli/tests/graph_cli.rs
+++ b/crates/harn-cli/tests/graph_cli.rs
@@ -203,10 +203,13 @@ fn main(harness: Harness) {
   let digest = harness.crypto.sha256(body)
   harness.fs.mkdtemp("harn-graph-")
   harness.net.get("https://example.test/data")
+  let columns = harness.term.width()
+  harness.term.read_password("password: ")
   harness.llm.catalog()
   harness.llm.providers()
   harness.stdio.println(body)
   harness.stdio.println(digest)
+  harness.stdio.println(columns)
 }
 "#,
     )
@@ -246,6 +249,14 @@ fn main(harness: Harness) {
         cap_strings.contains(&"llm.catalog"),
         "expected harness.llm.* to produce llm.catalog capability, got: {cap_strings:?}"
     );
+    assert!(
+        cap_strings.contains(&"terminal.dimensions"),
+        "expected harness.term.width to produce terminal.dimensions capability, got: {cap_strings:?}"
+    );
+    assert!(
+        cap_strings.contains(&"terminal.read_password"),
+        "expected harness.term.read_password to produce terminal.read_password capability, got: {cap_strings:?}"
+    );
     let effects = main["effects"].as_array().expect("effects array");
     let effect_strings: Vec<&str> = effects.iter().filter_map(|v| v.as_str()).collect();
     assert!(
@@ -259,6 +270,14 @@ fn main(harness: Harness) {
             && host_call_strings.contains(&"harness.llm.providers")
             && host_call_strings.contains(&"harness.crypto.sha256"),
         "expected harness.llm.* and harness.crypto.sha256 host calls, got: {host_call_strings:?}"
+    );
+    assert!(
+        host_call_strings.contains(&"harness.term.width"),
+        "expected harness.term.width host call, got: {host_call_strings:?}"
+    );
+    assert!(
+        host_call_strings.contains(&"harness.term.read_password"),
+        "expected harness.term.read_password host call, got: {host_call_strings:?}"
     );
 }
 

--- a/crates/harn-cli/tests/routes_graph_dispatch.rs
+++ b/crates/harn-cli/tests/routes_graph_dispatch.rs
@@ -367,6 +367,7 @@ fn main(harness: Harness) {
   let body = harness.fs.read_text("README.md")
   harness.fs.mkdtemp("harn-graph-")
   harness.net.get("https://example.test/data")
+  harness.term.width()
   harness.stdio.println(body)
 }
 "#,

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -2020,7 +2020,7 @@ fn harness_sub_handle_for(object: &SNode, method: &str) -> Option<(&'static str,
 }
 
 const HARNESS_SUB_HANDLES: &[&str] = &[
-    "stdio", "clock", "fs", "env", "random", "net", "process", "crypto", "system", "llm",
+    "stdio", "term", "clock", "fs", "env", "random", "net", "process", "crypto", "system", "llm",
 ];
 
 fn classify_call(name: &str, args: &[SNode]) -> CallSemantics {
@@ -2551,6 +2551,33 @@ fn main(harness: Harness) {
         assert!(
             calls.iter().any(|name| name == "http_get"),
             "expected harness.net.get to lower to ambient http_get, got: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn harness_term_method_calls_are_attributed_to_terminal_builtins() {
+        let report = analyze(
+            r#"
+fn main(harness: Harness) {
+  harness.term.width()
+  harness.term.height()
+  harness.term.read_password("password: ")
+}
+"#,
+        );
+
+        let calls = handler_call_names(&report);
+        assert!(
+            calls.iter().any(|name| name == "term_width"),
+            "expected harness.term.width to lower to ambient term_width, got: {calls:?}"
+        );
+        assert!(
+            calls.iter().any(|name| name == "term_height"),
+            "expected harness.term.height to lower to ambient term_height, got: {calls:?}"
+        );
+        assert!(
+            calls.iter().any(|name| name == "read_password"),
+            "expected harness.term.read_password to lower to read_password, got: {calls:?}"
         );
     }
 

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-101.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-101.md
@@ -14,12 +14,13 @@ non-`Harness` type annotation, extra parameters, or a default value) fails
 this check before bytecode is emitted, so the runtime never tries to bind a
 mismatched signature.
 
-The `Harness` value gives the script typed access to its capability
-slices via field access (`harness.stdio`, `harness.clock`, `harness.fs`,
-`harness.env`, `harness.random`, `harness.net`, `harness.process`,
-`harness.crypto`, `harness.system`, `harness.llm`). Threading the handle
-through `main` makes host access explicit
-instead of relying on ambient globals and free builtins.
+The `Harness` value gives the script typed access to its capability sub-handles
+via field access (`harness.stdio`, `harness.term`, `harness.clock`,
+`harness.fs`, `harness.env`, `harness.random`, `harness.net`,
+`harness.process`, `harness.crypto`, `harness.system`, `harness.llm`).
+Threading the handle through `main` replaces ambient stdio, terminal, clock,
+filesystem, environment, randomness, network, process, crypto, system, and LLM
+catalog globals.
 
 ## How to fix
 

--- a/crates/harn-parser/src/harness_methods.rs
+++ b/crates/harn-parser/src/harness_methods.rs
@@ -14,6 +14,15 @@ pub fn harness_stdio_ambient(method: &str) -> Option<&'static str> {
     }
 }
 
+pub fn harness_term_ambient(method: &str) -> Option<&'static str> {
+    match method {
+        "width" => Some("term_width"),
+        "height" => Some("term_height"),
+        "read_password" => Some("read_password"),
+        _ => None,
+    }
+}
+
 pub fn harness_clock_ambient(method: &str) -> Option<&'static str> {
     match method {
         "now_ms" => Some("now_ms"),
@@ -118,6 +127,7 @@ pub fn harness_llm_ambient(method: &str) -> Option<&'static str> {
 pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'static str> {
     match sub_handle {
         "stdio" => harness_stdio_ambient(method),
+        "term" => harness_term_ambient(method),
         "clock" => harness_clock_ambient(method),
         "fs" => harness_fs_ambient(method),
         "env" => harness_env_ambient(method),
@@ -134,6 +144,7 @@ pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'st
 pub fn harness_type_sub_handle(type_name: &str) -> Option<&'static str> {
     match type_name {
         "HarnessStdio" => Some("stdio"),
+        "HarnessTerm" => Some("term"),
         "HarnessClock" => Some("clock"),
         "HarnessFs" => Some("fs"),
         "HarnessEnv" => Some("env"),

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -587,10 +587,11 @@ impl TypeChecker {
                         .as_ref()
                         .is_some_and(|ty| self.type_may_include_nil(ty, scope));
                 let result = |ty| Self::optional_method_result_type(ty, include_optional_nil);
-                if let Some(ty) =
-                    self.harness_method_result_type(obj_type.as_ref(), method.as_str(), scope)
+                if let Some(method_type) = obj_type
+                    .as_ref()
+                    .and_then(|ty| self.harness_method_return_type(ty, method.as_str(), scope))
                 {
-                    return Some(result(ty));
+                    return Some(result(method_type));
                 }
                 // Iter<T> receiver: combinators preserve or transform T; sinks
                 // materialize. This must come before the shared-method match
@@ -886,6 +887,7 @@ impl TypeChecker {
             TypeExpr::Named(name) if name == "dict" => None,
             TypeExpr::Named(name) if name == "Harness" => match property {
                 "stdio" => Some(TypeExpr::Named("HarnessStdio".into())),
+                "term" => Some(TypeExpr::Named("HarnessTerm".into())),
                 "clock" => Some(TypeExpr::Named("HarnessClock".into())),
                 "fs" => Some(TypeExpr::Named("HarnessFs".into())),
                 "env" => Some(TypeExpr::Named("HarnessEnv".into())),
@@ -1221,19 +1223,21 @@ impl TypeChecker {
         }
     }
 
-    fn harness_method_result_type(
+    fn harness_method_return_type(
         &self,
-        receiver: Option<&TypeExpr>,
+        receiver: &TypeExpr,
         method: &str,
         scope: &TypeScope,
     ) -> InferredType {
-        let receiver = receiver?;
-        match self.resolve_alias(receiver, scope) {
+        let receiver = self.resolve_alias(receiver, scope);
+        match receiver {
             TypeExpr::Named(name) => {
                 let sub_handle = crate::harness_methods::harness_type_sub_handle(name.as_str())?;
-                let ambient =
-                    crate::harness_methods::harness_sub_handle_ambient(sub_handle, method)?;
-                builtin_return_type(ambient)
+                if sub_handle == "term" && method == "read_password" {
+                    return Some(TypeExpr::Named("string".into()));
+                }
+                crate::harness_methods::harness_sub_handle_ambient(sub_handle, method)
+                    .and_then(builtin_return_type)
             }
             _ => None,
         }

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -1614,6 +1614,42 @@ pipeline t(task) {
 }
 
 #[test]
+fn test_harness_term_methods_infer_concrete_types() {
+    let errs = errors(
+        r#"
+fn main(harness: Harness) {
+    let width: int = harness.term.width()
+    let height: int = harness.term.height()
+    let password: string = harness.term.read_password("password: ")
+}
+"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+
+    let bad_errs = errors(
+        r#"
+fn main(harness: Harness) {
+    let width: string = harness.term.width()
+    let password: int = harness.term.read_password("password: ")
+}
+"#,
+    );
+    assert_eq!(bad_errs.len(), 2, "expected two errors: {bad_errs:?}");
+    assert!(
+        bad_errs
+            .iter()
+            .any(|error| error.contains("expected string") && error.contains("found int")),
+        "expected width mismatch, got: {bad_errs:?}"
+    );
+    assert!(
+        bad_errs
+            .iter()
+            .any(|error| error.contains("expected int") && error.contains("found string")),
+        "expected password mismatch, got: {bad_errs:?}"
+    );
+}
+
+#[test]
 fn test_generic_alias_distribution_preserves_non_union_arg() {
     // Non-union arguments still substitute plainly: `ActionContainer<int>`
     // expands to `{ action: int, process_action: fn(int) -> nil }` with no

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -2,17 +2,17 @@
 //! parameter of `main`.
 //!
 //! `Harness` is the Harn-language analog of an explicit-capability handle: a
-//! single value the runtime hands to a script's `main` so that stdio, clock,
-//! filesystem, environment, randomness, network, process, crypto, system, and LLM
-//! catalog access become surface in the type system instead of ambient
-//! globals. Each sub-handle (`stdio`, `clock`, `fs`, `env`, `random`, `net`,
-//! `process`, `crypto`, `system`, `llm`) is a distinct named type that anchors the
-//! surface for its capability slice.
+//! single value the runtime hands to a script's `main` so that stdio,
+//! terminal, clock, filesystem, environment, randomness, network, process,
+//! crypto, system, and LLM catalog access become surface in the type system
+//! instead of ambient globals. Each sub-handle (`stdio`, `term`, `clock`, `fs`,
+//! `env`, `random`, `net`, `process`, `crypto`, `system`, `llm`) is a distinct
+//! named type that anchors the surface for its capability slice.
 //!
 //! This module defines:
-//!   * The runtime [`Harness`] value (and its sub-handle wrappers).
-//!   * [`Harness::real`], the production constructor that wraps the concrete
-//!     host state used by the sub-handle method dispatchers.
+//!   * The runtime [`Harness`] value and its sub-handle wrappers.
+//!   * [`Harness::real`], the production constructor that installs the backing
+//!     state used by concrete sub-handle methods.
 //!   * [`VmHarness`], the compact `VmValue` payload that carries the same
 //!     state through the bytecode VM and distinguishes the root handle from
 //!     its sub-handles via [`HarnessKind`].
@@ -35,6 +35,7 @@ use time::OffsetDateTime;
 pub enum HarnessKind {
     Root,
     Stdio,
+    Term,
     Clock,
     Fs,
     Env,
@@ -54,6 +55,7 @@ impl HarnessKind {
         match self {
             HarnessKind::Root => "Harness",
             HarnessKind::Stdio => "HarnessStdio",
+            HarnessKind::Term => "HarnessTerm",
             HarnessKind::Clock => "HarnessClock",
             HarnessKind::Fs => "HarnessFs",
             HarnessKind::Env => "HarnessEnv",
@@ -72,6 +74,7 @@ impl HarnessKind {
         match self {
             HarnessKind::Root => None,
             HarnessKind::Stdio => Some("stdio"),
+            HarnessKind::Term => Some("term"),
             HarnessKind::Clock => Some("clock"),
             HarnessKind::Fs => Some("fs"),
             HarnessKind::Env => Some("env"),
@@ -88,6 +91,7 @@ impl HarnessKind {
     pub fn from_field_name(name: &str) -> Option<Self> {
         match name {
             "stdio" => Some(HarnessKind::Stdio),
+            "term" => Some(HarnessKind::Term),
             "clock" => Some(HarnessKind::Clock),
             "fs" => Some(HarnessKind::Fs),
             "env" => Some(HarnessKind::Env),
@@ -104,6 +108,7 @@ impl HarnessKind {
     /// All sub-handle kinds, in the canonical field order.
     pub const SUB_HANDLES: &'static [HarnessKind] = &[
         HarnessKind::Stdio,
+        HarnessKind::Term,
         HarnessKind::Clock,
         HarnessKind::Fs,
         HarnessKind::Env,
@@ -119,6 +124,7 @@ impl HarnessKind {
     pub const ALL: &'static [HarnessKind] = &[
         HarnessKind::Root,
         HarnessKind::Stdio,
+        HarnessKind::Term,
         HarnessKind::Clock,
         HarnessKind::Fs,
         HarnessKind::Env,
@@ -585,6 +591,13 @@ impl Harness {
         }
     }
 
+    /// Field access for `harness.term`.
+    pub fn term(&self) -> HarnessTerm {
+        HarnessTerm {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
     /// Field access for `harness.clock`.
     pub fn clock(&self) -> HarnessClock {
         HarnessClock {
@@ -681,6 +694,12 @@ pub struct HarnessStdio {
     inner: Arc<HarnessInner>,
 }
 
+/// term sub-handle: `width`, `height`, `read_password`.
+#[derive(Debug, Clone)]
+pub struct HarnessTerm {
+    inner: Arc<HarnessInner>,
+}
+
 /// clock sub-handle: `now`, `monotonic_now`, `sleep`.
 #[derive(Debug, Clone)]
 pub struct HarnessClock {
@@ -760,6 +779,7 @@ macro_rules! sub_handle_inner {
 }
 sub_handle_inner!(
     HarnessStdio,
+    HarnessTerm,
     HarnessFs,
     HarnessEnv,
     HarnessRandom,
@@ -779,7 +799,7 @@ impl HarnessClock {
 
 /// Compact `VmValue` payload for a `Harness` or any of its sub-handles.
 ///
-/// All variants share one `Arc<HarnessInner>`; `kind` discriminates the
+/// All handle variants share one `Arc<HarnessInner>`; `kind` discriminates the
 /// surface the VM exposes for property access and method dispatch.
 #[derive(Clone)]
 pub struct VmHarness {
@@ -955,6 +975,7 @@ mod tests {
         let harness = Harness::null();
         for source in [
             r#"fn main(harness: Harness) { harness.stdio.println("blocked") }"#,
+            r#"fn main(harness: Harness) { harness.term.width() }"#,
             r#"fn main(harness: Harness) { harness.clock.now_ms() }"#,
             r#"fn main(harness: Harness) { harness.fs.read_text("/x") }"#,
             r#"fn main(harness: Harness) { harness.env.get("KEY") }"#,
@@ -981,6 +1002,7 @@ mod tests {
             observed,
             vec![
                 (HarnessKind::Stdio, "println"),
+                (HarnessKind::Term, "width"),
                 (HarnessKind::Clock, "now_ms"),
                 (HarnessKind::Fs, "read_text"),
                 (HarnessKind::Env, "get"),
@@ -993,7 +1015,7 @@ mod tests {
             ]
         );
         assert_eq!(events[0].args, vec!["blocked"]);
-        assert_eq!(events[2].args, vec!["/x"]);
+        assert_eq!(events[3].args, vec!["/x"]);
     }
 
     #[test]
@@ -1011,6 +1033,8 @@ mod tests {
 fn main(harness: Harness) {
   harness.stdio.print("partial ")
   harness.stdio.println("line")
+  __io_println(harness.term.width())
+  __io_println(harness.term.height())
   __io_println(harness.clock.now_ms())
   harness.clock.sleep_ms(250)
   __io_println(harness.clock.now_ms())
@@ -1031,7 +1055,7 @@ fn main(harness: Harness) {
         assert_eq!(harness.captured_stdio(), "partial line\n");
         assert_eq!(
             output,
-            "1700000000000\n1700000000250\n250\nvalue\ndata\nfalse\n42\nbody\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\ntrue\n"
+            "80\n24\n1700000000000\n1700000000250\n250\nvalue\ndata\nfalse\n42\nbody\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\ntrue\n"
         );
         let observed: Vec<_> = harness
             .calls()
@@ -1043,6 +1067,8 @@ fn main(harness: Harness) {
             vec![
                 (HarnessKind::Stdio, "print".to_string()),
                 (HarnessKind::Stdio, "println".to_string()),
+                (HarnessKind::Term, "width".to_string()),
+                (HarnessKind::Term, "height".to_string()),
                 (HarnessKind::Clock, "now_ms".to_string()),
                 (HarnessKind::Clock, "sleep_ms".to_string()),
                 (HarnessKind::Clock, "now_ms".to_string()),
@@ -1171,6 +1197,32 @@ fn main(harness: Harness) {
         // All stdio writes route to the mock capture buffer; vm.output stays empty.
         assert_eq!(output, "");
         assert_eq!(harness.captured_stdio(), "first\nanswer: second\neof\n");
+    }
+
+    #[test]
+    fn mock_harness_replays_password_input_without_stdout_echo() {
+        let harness = Harness::mock().stdin_line("secret").build();
+        let output = run_harness_source(
+            r#"
+fn main(harness: Harness) {
+  __io_println(harness.term.read_password("password: "))
+}
+"#,
+            harness.clone(),
+        )
+        .expect("stdin replay succeeds");
+
+        assert_eq!(output, "secret\n");
+        assert_eq!(harness.captured_stdio(), "");
+        assert_eq!(harness.captured_stderr(), "password: ");
+        assert_eq!(
+            harness.calls(),
+            vec![HarnessCall {
+                sub_handle: HarnessKind::Term,
+                method: "read_password".to_string(),
+                args: vec!["password: ".to_string()],
+            }]
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -77,6 +77,7 @@ pub mod step_runtime;
 pub mod store;
 pub(crate) mod synchronization;
 pub mod tenant;
+pub(crate) mod term;
 pub mod testbench;
 pub mod tool_annotations;
 pub mod tool_call_cancellations;
@@ -147,7 +148,7 @@ pub use corrections::{
 pub use harness::{
     DenyEvent, Harness, HarnessCall, HarnessClock, HarnessCrypto, HarnessEnv, HarnessFs,
     HarnessKind, HarnessLlm, HarnessNet, HarnessProcess, HarnessRandom, HarnessStdio,
-    HarnessSystem, MockAwareClock, MockHarnessBuilder, VmHarness,
+    HarnessSystem, HarnessTerm, MockAwareClock, MockHarnessBuilder, VmHarness,
 };
 pub use harness_net::{
     bypass_enabled as net_policy_bypass_enabled, NetMatcher, NetPolicy, NetPolicyAudit,

--- a/crates/harn-vm/src/orchestration/policy/effects.rs
+++ b/crates/harn-vm/src/orchestration/policy/effects.rs
@@ -411,6 +411,7 @@ fn harness_method_effect(node: &SNode) -> Option<EffectRecord> {
             (EffectKind::Stdio, EffectScope::Observe)
         }
         ("stdio", "read_line" | "prompt") => (EffectKind::Stdio, EffectScope::Read),
+        ("term", "width" | "height" | "read_password") => (EffectKind::Stdio, EffectScope::Read),
         ("clock", _) => return None,
         ("env", "set" | "unset") => (
             EffectKind::Hostcall {
@@ -960,6 +961,19 @@ mod tests {
                 .any(|effect| matches!(effect.kind, EffectKind::Fs)
                     && effect.scope == EffectScope::Write),
             "expected Fs write effect, got {effects:?}"
+        );
+    }
+
+    #[test]
+    fn harness_term_read_password_yields_stdio_read_effect() {
+        let source = r#"fn main(harness: Harness) { harness.term.read_password("password: ") }"#;
+        let effects = compute_handoff_effects(source, None);
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect.kind, EffectKind::Stdio)
+                    && effect.scope == EffectScope::Read),
+            "expected Stdio read effect, got {effects:?}"
         );
     }
 

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -911,6 +911,32 @@ pub(crate) fn prompt_user_value(args: &[VmValue], out: &mut String) -> Result<Vm
     }
 }
 
+pub(crate) fn read_password_legacy_value(prompt: &str) -> Result<VmValue, VmError> {
+    let options = ReadLineOptions {
+        prompt: prompt.to_string(),
+        trim: false,
+        echo: false,
+        ..ReadLineOptions::default()
+    };
+    match read_line_from_mock_or_real(&options) {
+        ReadLineOutcome::Ok(line) => Ok(VmValue::String(Rc::from(line))),
+        ReadLineOutcome::Eof => Err(VmError::Runtime(
+            "HarnessTerm.read_password: stdin reached EOF".to_string(),
+        )),
+        #[cfg(unix)]
+        ReadLineOutcome::Timeout => Err(VmError::Runtime(
+            "HarnessTerm.read_password: stdin read timed out".to_string(),
+        )),
+        #[cfg(unix)]
+        ReadLineOutcome::Interrupt => Err(VmError::Runtime(
+            "HarnessTerm.read_password: stdin read was interrupted".to_string(),
+        )),
+        ReadLineOutcome::Error(error) => Err(VmError::Runtime(format!(
+            "HarnessTerm.read_password: {error}"
+        ))),
+    }
+}
+
 fn log_debug_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
     vm_write_log("debug", 0, args, out);
     Ok(VmValue::Nil)

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -375,16 +375,15 @@ pub(crate) fn register_process_builtins(vm: &mut Vm) {
     // first (so test harnesses can pin a value), falls back to the
     // platform `ioctl` size, and finally defaults to 80x24 when neither
     // is available (e.g. when stdout is not a TTY). These are the
-    // free-builtin landing sites for the deferred `harness.term.*`
-    // sub-handles (see #2297). `std/tui` already exposes
-    // `__tui_terminal_width` for its renderer; these builtins give
-    // ported subcommands a stable, non-prefixed name they can call
-    // without importing the tui module.
+    // free-builtin aliases for `harness.term.width()` /
+    // `harness.term.height()`. `std/tui` already exposes
+    // `__tui_terminal_width` for its renderer; these aliases keep
+    // ported subcommands working without importing the tui module.
     vm.register_builtin("term_width", |_args, _out| {
-        Ok(VmValue::Int(read_term_dimension("COLUMNS", true) as i64))
+        Ok(VmValue::Int(crate::term::width() as i64))
     });
     vm.register_builtin("term_height", |_args, _out| {
-        Ok(VmValue::Int(read_term_dimension("LINES", false) as i64))
+        Ok(VmValue::Int(crate::term::height() as i64))
     });
 }
 
@@ -581,45 +580,6 @@ pub(crate) fn spawn_captured_value(args: &[VmValue]) -> Result<VmValue, VmError>
     result.insert("success".to_string(), VmValue::Bool(success));
     result.insert("timed_out".to_string(), VmValue::Bool(timed_out));
     Ok(VmValue::Dict(Rc::new(result)))
-}
-
-const DEFAULT_TERM_WIDTH: usize = 80;
-const DEFAULT_TERM_HEIGHT: usize = 24;
-
-fn read_term_dimension(env_var: &str, is_width: bool) -> usize {
-    if let Ok(raw) = std::env::var(env_var) {
-        if let Ok(parsed) = raw.trim().parse::<usize>() {
-            if parsed > 0 {
-                return parsed;
-            }
-        }
-    }
-    platform_term_dimensions()
-        .map(|(w, h)| if is_width { w } else { h })
-        .unwrap_or(if is_width {
-            DEFAULT_TERM_WIDTH
-        } else {
-            DEFAULT_TERM_HEIGHT
-        })
-}
-
-#[cfg(unix)]
-fn platform_term_dimensions() -> Option<(usize, usize)> {
-    let mut winsize = std::mem::MaybeUninit::<libc::winsize>::zeroed();
-    let rc = unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, winsize.as_mut_ptr()) };
-    if rc != 0 {
-        return None;
-    }
-    let winsize = unsafe { winsize.assume_init() };
-    if winsize.ws_col == 0 && winsize.ws_row == 0 {
-        return None;
-    }
-    Some((winsize.ws_col as usize, winsize.ws_row as usize))
-}
-
-#[cfg(not(unix))]
-fn platform_term_dimensions() -> Option<(usize, usize)> {
-    None
 }
 
 /// Find the project root by walking up from a base directory looking for harn.toml.

--- a/crates/harn-vm/src/term.rs
+++ b/crates/harn-vm/src/term.rs
@@ -1,0 +1,64 @@
+const DEFAULT_TERM_WIDTH: usize = 80;
+const DEFAULT_TERM_HEIGHT: usize = 24;
+
+pub(crate) fn width() -> usize {
+    read_dimension("COLUMNS", true)
+}
+
+pub(crate) fn height() -> usize {
+    read_dimension("LINES", false)
+}
+
+fn read_dimension(env_var: &str, is_width: bool) -> usize {
+    if let Some(value) = dimension_from_env(std::env::var(env_var).ok().as_deref()) {
+        return value;
+    }
+    platform_dimensions()
+        .map(|(w, h)| if is_width { w } else { h })
+        .unwrap_or(if is_width {
+            DEFAULT_TERM_WIDTH
+        } else {
+            DEFAULT_TERM_HEIGHT
+        })
+}
+
+pub(crate) fn dimension_from_env(raw: Option<&str>) -> Option<usize> {
+    raw?.trim().parse::<usize>().ok().filter(|value| *value > 0)
+}
+
+#[cfg(unix)]
+fn platform_dimensions() -> Option<(usize, usize)> {
+    let mut winsize = std::mem::MaybeUninit::<libc::winsize>::zeroed();
+    // SAFETY: `winsize` points to valid writable storage and `TIOCGWINSZ`
+    // initializes it without retaining the pointer.
+    let rc = unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, winsize.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
+    }
+    // SAFETY: a zero return from `ioctl(TIOCGWINSZ)` means the kernel wrote
+    // the `winsize` structure.
+    let winsize = unsafe { winsize.assume_init() };
+    if winsize.ws_col == 0 || winsize.ws_row == 0 {
+        return None;
+    }
+    Some((winsize.ws_col as usize, winsize.ws_row as usize))
+}
+
+#[cfg(not(unix))]
+fn platform_dimensions() -> Option<(usize, usize)> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dimension_from_env;
+
+    #[test]
+    fn dimensions_ignore_invalid_env_values() {
+        assert_eq!(dimension_from_env(Some("132")), Some(132));
+        assert_eq!(dimension_from_env(Some(" 48 ")), Some(48));
+        assert_eq!(dimension_from_env(Some("0")), None);
+        assert_eq!(dimension_from_env(Some("wide")), None);
+        assert_eq!(dimension_from_env(None), None);
+    }
+}

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -77,6 +77,7 @@ impl crate::vm::Vm {
         match handle.kind() {
             HarnessKind::Root => self.call_harness_root_method(handle, method, args).await,
             HarnessKind::Stdio => self.call_harness_stdio_method(handle, method, args),
+            HarnessKind::Term => self.call_harness_term_method(handle, method, args),
             HarnessKind::Clock => self.call_harness_clock_method(handle, method, args).await,
             HarnessKind::System => self.call_harness_system_method(handle, method, args),
             HarnessKind::Fs => self.call_harness_fs_method(handle, method, args).await,
@@ -415,6 +416,28 @@ impl crate::vm::Vm {
         }
     }
 
+    fn call_harness_term_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        match method {
+            "width" => Ok(VmValue::Int(crate::term::width() as i64)),
+            "height" => Ok(VmValue::Int(crate::term::height() as i64)),
+            "read_password" => {
+                let prompt = optional_string_arg(args, 0, "HarnessTerm.read_password")?;
+                if args.len() > 1 {
+                    return Err(VmError::TypeError(
+                        "HarnessTerm.read_password expects at most one prompt argument".to_string(),
+                    ));
+                }
+                crate::stdlib::io::read_password_legacy_value(prompt)
+            }
+            _ => Err(method_unsupported(handle, method)),
+        }
+    }
+
     async fn call_harness_clock_method(
         &mut self,
         handle: &VmHarness,
@@ -667,6 +690,30 @@ impl crate::vm::Vm {
                     let msg = args.first().map(|a| a.display()).unwrap_or_default();
                     state.push_stdio(&msg);
                     Ok(mock_read_line_value(state, &[]))
+                }
+                _ => Err(method_unsupported(handle, method)),
+            },
+            HarnessKind::Term => match method {
+                "width" => Ok(VmValue::Int(
+                    mock_term_dimension(state.env_get("COLUMNS"), 80) as i64,
+                )),
+                "height" => Ok(VmValue::Int(
+                    mock_term_dimension(state.env_get("LINES"), 24) as i64,
+                )),
+                "read_password" => {
+                    let prompt = optional_string_arg(args, 0, "HarnessTerm.read_password")?;
+                    if args.len() > 1 {
+                        return Err(VmError::TypeError(
+                            "HarnessTerm.read_password expects at most one prompt argument"
+                                .to_string(),
+                        ));
+                    }
+                    if !prompt.is_empty() {
+                        state.push_stderr(prompt);
+                    }
+                    state.pop_stdin_line().map(vm_string).ok_or_else(|| {
+                        VmError::Runtime("HarnessTerm.read_password: stdin reached EOF".to_string())
+                    })
                 }
                 _ => Err(method_unsupported(handle, method)),
             },
@@ -1479,6 +1526,26 @@ fn string_arg<'a>(args: &'a [VmValue], index: usize, callee: &str) -> Result<&'a
             index + 1
         ))),
     }
+}
+
+fn optional_string_arg<'a>(
+    args: &'a [VmValue],
+    index: usize,
+    callee: &str,
+) -> Result<&'a str, VmError> {
+    match args.get(index) {
+        None | Some(VmValue::Nil) => Ok(""),
+        Some(VmValue::String(value)) => Ok(value.as_ref()),
+        Some(other) => Err(VmError::TypeError(format!(
+            "{callee} expects string argument {}, got {}",
+            index + 1,
+            other.type_name()
+        ))),
+    }
+}
+
+fn mock_term_dimension(raw: Option<&str>, fallback: usize) -> usize {
+    crate::term::dimension_from_env(raw).unwrap_or(fallback)
 }
 
 /// Mock variant of `harness.stdio.read_line` / `prompt`. When called with

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -238,6 +238,9 @@ in `crates/harn-vm/src/orchestration/playground/manifest.rs`.
   `harness.stdio.eprint(s)` / `harness.stdio.eprintln(s)` for stderr,
   and `harness.stdio.read_line()` / `harness.stdio.prompt(msg?)` for
   interactive input.
+- Terminal capability calls also route through `Harness`: use
+  `harness.term.width()` / `harness.term.height()` for dimensions and
+  `harness.term.read_password(prompt?)` for no-echo password input.
 - `read_stdin()` slurps the rest of stdin to a `string` and returns `nil`
   at EOF.
 - `is_stdin_tty()`, `is_stdout_tty()`, `is_stderr_tty()` — `bool`,

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -578,8 +578,8 @@ filesystem builtins remain supported as thin aliases for existing scripts.
 | `shell_at(dir, cmd)` | dir: string, cmd: string | dict | Execute shell command inside a specific directory |
 | `harness.process.spawn_captured(opts)` | opts: dict | dict | Run an external command synchronously through the `Harness` process capability. `opts` is `{cmd, args?, cwd?, env?, stdin?, timeout_ms?}` and supports feeding a stdin payload plus a per-call timeout. Returns `{exit_code, stdout, stderr, duration_ms, success, timed_out}`. On timeout the child is killed, `exit_code = -1`, `success = false`, and `timed_out = true` |
 | `spawn_captured(opts)` | opts: dict | dict | Legacy alias for `harness.process.spawn_captured(opts)` when no `Harness` handle is available |
-| `term_width()` | none | int | Current terminal column count. Reads `COLUMNS` env first (so harnesses can pin a value), falls back to the platform window size, then to `80` |
-| `term_height()` | none | int | Current terminal row count. Reads `LINES` env first, falls back to the platform window size, then to `24` |
+| `term_width()` | none | int | Current terminal column count. Alias for the canonical `harness.term.width()` surface; reads `COLUMNS` env first, falls back to the platform window size, then to `80` |
+| `term_height()` | none | int | Current terminal row count. Alias for the canonical `harness.term.height()` surface; reads `LINES` env first, falls back to the platform window size, then to `24` |
 | `exit(code)` | code: int (default 0) | never | Terminate the process |
 | `username()` | none | string | Current OS username |
 | `hostname()` | none | string | Machine hostname |
@@ -1381,9 +1381,12 @@ examples.
 Ambient stdio helpers were removed. Use `harness.stdio.print`,
 `harness.stdio.println`, `harness.stdio.eprint`,
 `harness.stdio.eprintln`, `harness.stdio.read_line`, and
-`harness.stdio.prompt` from code that already has a `Harness` handle. For
-structured interactive input outside a harness entrypoint, import
-`read_line`, `read_password`, `is_tty`, and `write_stderr` from `std/io`.
+`harness.stdio.prompt` from code that already has a `Harness` handle. Use
+`harness.term.width()`, `harness.term.height()`, and
+`harness.term.read_password(prompt?)` for terminal dimensions and no-echo
+password input. For structured interactive input outside a harness entrypoint,
+import `read_line`, `read_password`, `is_tty`, and `write_stderr` from
+`std/io`.
 
 ## Host interop
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -877,12 +877,13 @@ non-`Harness` type annotation, extra parameters, or a default value) fails
 this check before bytecode is emitted, so the runtime never tries to bind a
 mismatched signature.
 
-The `Harness` value gives the script typed access to its capability
-slices via field access (`harness.stdio`, `harness.clock`, `harness.fs`,
-`harness.env`, `harness.random`, `harness.net`, `harness.process`,
-`harness.crypto`, `harness.system`, `harness.llm`). Threading the handle
-through `main` makes host access explicit
-instead of relying on ambient globals and free builtins.
+The `Harness` value gives the script typed access to its capability sub-handles
+via field access (`harness.stdio`, `harness.term`, `harness.clock`,
+`harness.fs`, `harness.env`, `harness.random`, `harness.net`,
+`harness.process`, `harness.crypto`, `harness.system`, `harness.llm`).
+Threading the handle through `main` replaces ambient stdio, terminal, clock,
+filesystem, environment, randomness, network, process, crypto, system, and LLM
+catalog globals.
 
 #### How to fix
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2328,6 +2328,19 @@ registries (suspended subagents, partial handoffs, in-flight LLM
 calls, pool pending tasks) and from event-log records (queued
 trigger inbox + worker queue items).
 
+Capability sub-handles are exposed by field access on the harness:
+
+| Field | Type | Primary methods |
+|---|---|---|
+| `harness.stdio` | `HarnessStdio` | `print`, `println`, `eprint`, `eprintln`, `read_line`, `prompt` |
+| `harness.term` | `HarnessTerm` | `width`, `height`, `read_password` |
+| `harness.clock` | `HarnessClock` | `now_ms`, `timestamp`, `monotonic_ms`, `elapsed`, `sleep_ms` |
+| `harness.fs` | `HarnessFs` | `read_text`, `write_text`, `append_text`, `exists`, `list_dir` |
+| `harness.env` | `HarnessEnv` | `get`, `set`, `unset`, `list` |
+| `harness.random` | `HarnessRandom` | `gen_u64`, `uuid`, `bytes` |
+| `harness.net` | `HarnessNet` | `get`, `post` |
+| `harness.system` | `HarnessSystem` | `platform`, `arch`, `cpu`, `memory`, `cwd`, `pid` |
+
 Write-side actions:
 
 | Method | Effect |

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2326,6 +2326,19 @@ registries (suspended subagents, partial handoffs, in-flight LLM
 calls, pool pending tasks) and from event-log records (queued
 trigger inbox + worker queue items).
 
+Capability sub-handles are exposed by field access on the harness:
+
+| Field | Type | Primary methods |
+|---|---|---|
+| `harness.stdio` | `HarnessStdio` | `print`, `println`, `eprint`, `eprintln`, `read_line`, `prompt` |
+| `harness.term` | `HarnessTerm` | `width`, `height`, `read_password` |
+| `harness.clock` | `HarnessClock` | `now_ms`, `timestamp`, `monotonic_ms`, `elapsed`, `sleep_ms` |
+| `harness.fs` | `HarnessFs` | `read_text`, `write_text`, `append_text`, `exists`, `list_dir` |
+| `harness.env` | `HarnessEnv` | `get`, `set`, `unset`, `list` |
+| `harness.random` | `HarnessRandom` | `gen_u64`, `uuid`, `bytes` |
+| `harness.net` | `HarnessNet` | `get`, `post` |
+| `harness.system` | `HarnessSystem` | `platform`, `arch`, `cpu`, `memory`, `cwd`, `pid` |
+
 Write-side actions:
 
 | Method | Effect |


### PR DESCRIPTION
## Summary
- add `HarnessKind::Term`, `HarnessTerm`, and runtime dispatch for `harness.term.width()`, `height()`, and `read_password(prompt?)`
- share terminal dimension resolution with the existing `term_width()` / `term_height()` aliases
- teach type inference, effects, IR graph lowering, CLI graph capabilities, conformance, and docs about the new terminal sub-handle

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-parser test_harness_term_methods_infer_concrete_types`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-vm --lib harness_term`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-vm --lib mock_harness_replays_password_input_without_stdout_echo`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-vm --lib dimensions_ignore_invalid_env_values`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-vm --lib mock_harness_replays_canned_responses_and_records_calls`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-vm --lib null_harness_records_deny_events_for_every_sub_handle`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-ir harness_term_method_calls_are_attributed_to_terminal_builtins`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-cli --test graph_cli graph_json_attributes_harness_sub_handle_calls_to_capabilities`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 cargo test -p harn-cli --test routes_graph_dispatch graph_harness_sub_calls_byte_identical_between_impls`
- `/tmp/harn-target-2339/debug/harn test conformance --filter harness_term_dimensions`
- `/tmp/harn-target-2339/debug/harn fmt --check conformance/tests/runtime/harness_term_dimensions.harn conformance/tests/runtime/cli_host_caps_term_dimensions.harn`
- `/tmp/harn-target-2339/debug/harn lint conformance/tests/runtime/harness_term_dimensions.harn conformance/tests/runtime/cli_host_caps_term_dimensions.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 make check-language-spec check-diagnostics-catalog`
- `CARGO_TARGET_DIR=/tmp/harn-target-2339 make lint-test-patterns`
- pre-commit hook
- pre-push hook

Closes #2339