### PR TITLE
Promote LLM catalog to harness handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ condensed series summaries instead of full per-patch history.
   subprocess captures through the explicit capability surface. The existing
   `spawn_captured(opts)` builtin now shares the same implementation as the
   harness method.
+- **LLM catalog harness handle (#2342).** Added `harness.llm.catalog()` and
+  `harness.llm.providers()` as the canonical read-only model/provider catalog
+  surface. The legacy `llm_catalog()` and `llm_provider_status()` builtins
+  remain aliases for scripts that do not receive a `Harness` parameter.
 
 ## v0.8.35
 

--- a/conformance/tests/runtime/cli_host_caps_llm_catalog.harn
+++ b/conformance/tests/runtime/cli_host_caps_llm_catalog.harn
@@ -1,7 +1,7 @@
-// Free-builtin landing site for the deferred `harness.llm.catalog`
-// sub-handle (see #2297). Verifies the catalog returns a list of
-// dicts with the expected shape. Doesn't assert specific model ids
-// (the catalog evolves with provider releases) — just shape.
+// Free-builtin alias for `harness.llm.catalog()`. Verifies the catalog
+// returns a list of dicts with the expected shape. Doesn't assert
+// specific model ids (the catalog evolves with provider releases) —
+// just shape.
 let entries = llm_catalog()
 
 __io_println(len(entries) > 0)

--- a/conformance/tests/runtime/cli_host_caps_llm_provider_status.harn
+++ b/conformance/tests/runtime/cli_host_caps_llm_provider_status.harn
@@ -1,8 +1,7 @@
-// Free-builtin landing site for the deferred `harness.llm.providers`
-// sub-handle (see #2297). Verifies the per-provider status list shape.
-// Doesn't pin specific provider names (the catalog evolves) — just
-// asserts that every entry carries the documented fields with valid
-// types.
+// Free-builtin alias for `harness.llm.providers()`. Verifies the
+// per-provider status list shape. Doesn't pin specific provider names
+// (the catalog evolves) — just asserts that every entry carries the
+// documented fields with valid types.
 let entries = llm_provider_status()
 
 __io_println(len(entries) > 0)

--- a/conformance/tests/runtime/harness_llm_catalog.expected
+++ b/conformance/tests/runtime/harness_llm_catalog.expected
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/runtime/harness_llm_catalog.harn
+++ b/conformance/tests/runtime/harness_llm_catalog.harn
@@ -1,0 +1,10 @@
+fn main(harness: Harness) {
+  let entries = harness.llm.catalog()
+  __io_println(len(entries) > 0)
+  let first = entries[0]
+  __io_println(first.id != nil)
+  __io_println(first.name != nil)
+  __io_println(first.provider != nil)
+  __io_println(first.capabilities != nil)
+  __io_println(first.context_window >= 0)
+}

--- a/conformance/tests/runtime/harness_llm_providers.expected
+++ b/conformance/tests/runtime/harness_llm_providers.expected
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/conformance/tests/runtime/harness_llm_providers.harn
+++ b/conformance/tests/runtime/harness_llm_providers.harn
@@ -1,0 +1,16 @@
+fn main(harness: Harness) {
+  let entries = harness.llm.providers()
+  __io_println(len(entries) > 0)
+  let first = entries[0]
+  __io_println(first.name != nil)
+  __io_println(first.available || !first.available)
+  __io_println(first.credential_status != nil)
+  var all_valid = true
+  for entry in entries {
+    let s = entry.credential_status
+    if s != "ok" && s != "missing" && s != "not_required" && s != "deferred" {
+      all_valid = false
+    }
+  }
+  __io_println(all_valid)
+}

--- a/crates/harn-cli/src/commands/graph.rs
+++ b/crates/harn-cli/src/commands/graph.rs
@@ -325,6 +325,9 @@ fn direct_capabilities(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
         | "agent_loop" => {
             out.insert("llm.call".to_string());
         }
+        "llm_catalog" | "llm_provider_status" => {
+            out.insert("llm.catalog".to_string());
+        }
         "spawn_agent" | "send_input" | "resume_agent" | "wait_agent" | "close_agent"
         | "worker_trigger" => {
             out.insert("worker.dispatch".to_string());
@@ -358,6 +361,7 @@ fn direct_effects(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
             "network.http" => "net.http".to_string(),
             "process.exec" => "process.exec".to_string(),
             "llm.call" => "llm.call".to_string(),
+            "llm.catalog" => "llm.catalog".to_string(),
             "worker.dispatch" => "worker.dispatch".to_string(),
             "human.approval" => "human.approval".to_string(),
             "template.render" => "template.render".to_string(),

--- a/crates/harn-cli/src/commands/models/list.rs
+++ b/crates/harn-cli/src/commands/models/list.rs
@@ -4,11 +4,11 @@
 //!
 //! The filter + render pipeline lives in
 //! `crates/harn-stdlib/src/stdlib/cli/models/list.harn`. The catalog
-//! itself comes from the `llm_catalog()` free builtin landed in G4
-//! (#2297 / #2343), so the script owns the entire data-shape
-//! transformation end-to-end. The Rust shim's only contribution is
-//! detecting installed Ollama models out-of-process (sandboxed scripts
-//! can't run `ollama list`) and threading the parsed `--provider` /
+//! itself comes from the read-only `harness.llm.catalog()` handle, so the
+//! script owns the entire data-shape transformation end-to-end. The Rust
+//! shim's only contribution is detecting installed Ollama models
+//! out-of-process (sandboxed scripts can't run `ollama list`) and threading
+//! the parsed `--provider` /
 //! `--installed-only` flags through env vars.
 //!
 //! `HARN_CLI_IMPL=rust` keeps the legacy direct path for the

--- a/crates/harn-cli/src/commands/routes.rs
+++ b/crates/harn-cli/src/commands/routes.rs
@@ -381,6 +381,9 @@ fn direct_call_capabilities(call: &harn_ir::CallSemantics) -> BTreeSet<String> {
         | "agent_loop" => {
             capabilities.insert("llm.call".to_string());
         }
+        "llm_catalog" | "llm_provider_status" => {
+            capabilities.insert("llm.catalog".to_string());
+        }
         "spawn_agent" | "send_input" | "resume_agent" | "wait_agent" | "close_agent"
         | "worker_trigger" => {
             capabilities.insert("worker.dispatch".to_string());

--- a/crates/harn-cli/src/package/test_support.rs
+++ b/crates/harn-cli/src/package/test_support.rs
@@ -78,9 +78,18 @@ pub(crate) fn test_git_command(repo: &Path) -> process::Command {
             "tag.gpgSign=false",
             "-c",
             "core.hooksPath=/dev/null",
+            "-c",
+            "core.editor=true",
         ])
         .current_dir(repo)
         .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_GLOBAL", repo.join(".gitconfig-test"))
+        .env("GIT_CONFIG_SYSTEM", repo.join(".gitconfig-system-test"))
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_EDITOR", "true")
+        .env("GIT_SEQUENCE_EDITOR", "true")
+        .env("GIT_MERGE_AUTOEDIT", "no")
+        .env("GIT_PAGER", "cat")
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_INDEX_FILE")

--- a/crates/harn-cli/tests/graph_cli.rs
+++ b/crates/harn-cli/tests/graph_cli.rs
@@ -202,6 +202,8 @@ fn main(harness: Harness) {
   let body = harness.fs.read_text("README.md")
   harness.fs.mkdtemp("harn-graph-")
   harness.net.get("https://example.test/data")
+  harness.llm.catalog()
+  harness.llm.providers()
   harness.stdio.println(body)
 }
 "#,
@@ -237,6 +239,23 @@ fn main(harness: Harness) {
     assert!(
         cap_strings.contains(&"network.http"),
         "expected harness.net.get to produce network.http capability, got: {cap_strings:?}"
+    );
+    assert!(
+        cap_strings.contains(&"llm.catalog"),
+        "expected harness.llm.* to produce llm.catalog capability, got: {cap_strings:?}"
+    );
+    let effects = main["effects"].as_array().expect("effects array");
+    let effect_strings: Vec<&str> = effects.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        effect_strings.contains(&"llm.catalog"),
+        "expected harness.llm.* to produce llm.catalog effect, got: {effect_strings:?}"
+    );
+    let host_calls = main["host_calls"].as_array().expect("host_calls array");
+    let host_call_strings: Vec<&str> = host_calls.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        host_call_strings.contains(&"harness.llm.catalog")
+            && host_call_strings.contains(&"harness.llm.providers"),
+        "expected harness.llm.* host calls, got: {host_call_strings:?}"
     );
 }
 

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -2020,7 +2020,7 @@ fn harness_sub_handle_for(object: &SNode, method: &str) -> Option<(&'static str,
 }
 
 const HARNESS_SUB_HANDLES: &[&str] = &[
-    "stdio", "clock", "fs", "env", "random", "net", "process", "system",
+    "stdio", "clock", "fs", "env", "random", "net", "process", "system", "llm",
 ];
 
 fn classify_call(name: &str, args: &[SNode]) -> CallSemantics {
@@ -2568,6 +2568,28 @@ fn main(harness: Harness) {
         assert!(
             calls.iter().any(|name| name == "spawn_captured"),
             "expected harness.process.spawn_captured to lower to ambient spawn_captured, got: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn harness_llm_method_calls_are_attributed_to_llm_catalog_builtins() {
+        let report = analyze(
+            r#"
+fn main(harness: Harness) {
+  harness.llm.catalog()
+  harness.llm.providers()
+}
+"#,
+        );
+
+        let calls = handler_call_names(&report);
+        assert!(
+            calls.iter().any(|name| name == "llm_catalog"),
+            "expected harness.llm.catalog to lower to llm_catalog, got: {calls:?}"
+        );
+        assert!(
+            calls.iter().any(|name| name == "llm_provider_status"),
+            "expected harness.llm.providers to lower to llm_provider_status, got: {calls:?}"
         );
     }
 

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-201.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-CAP-201.md
@@ -2,8 +2,9 @@
 
 ## What it means
 
-A `harness.fs.*`, `harness.env.*`, `harness.random.*`, or
-`harness.net.*` method was rejected by the active sandbox profile.
+A `harness.fs.*`, `harness.env.*`, `harness.random.*`, `harness.net.*`,
+`harness.system.*`, or `harness.llm.*` method was rejected by the active
+sandbox profile.
 Examples:
 
 - `harness.fs.write_text("/etc/passwd", ...)` from a script whose

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-101.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-NAM-101.md
@@ -14,10 +14,11 @@ non-`Harness` type annotation, extra parameters, or a default value) fails
 this check before bytecode is emitted, so the runtime never tries to bind a
 mismatched signature.
 
-The `Harness` value gives the script typed access to its six capability
+The `Harness` value gives the script typed access to its capability
 slices via field access (`harness.stdio`, `harness.clock`, `harness.fs`,
-`harness.env`, `harness.random`, `harness.net`). Threading the handle through
-`main` replaces every ambient stdio/clock/fs/env/random/net global.
+`harness.env`, `harness.random`, `harness.net`, `harness.system`,
+`harness.llm`). Threading the handle through `main` makes host access explicit
+instead of relying on ambient globals and free builtins.
 
 ## How to fix
 

--- a/crates/harn-parser/src/harness_methods.rs
+++ b/crates/harn-parser/src/harness_methods.rs
@@ -100,6 +100,14 @@ pub fn harness_system_ambient(method: &str) -> Option<&'static str> {
     }
 }
 
+pub fn harness_llm_ambient(method: &str) -> Option<&'static str> {
+    match method {
+        "catalog" => Some("llm_catalog"),
+        "providers" => Some("llm_provider_status"),
+        _ => None,
+    }
+}
+
 pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'static str> {
     match sub_handle {
         "stdio" => harness_stdio_ambient(method),
@@ -110,6 +118,22 @@ pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'st
         "net" => harness_net_ambient(method),
         "process" => harness_process_ambient(method),
         "system" => harness_system_ambient(method),
+        "llm" => harness_llm_ambient(method),
+        _ => None,
+    }
+}
+
+pub fn harness_type_sub_handle(type_name: &str) -> Option<&'static str> {
+    match type_name {
+        "HarnessStdio" => Some("stdio"),
+        "HarnessClock" => Some("clock"),
+        "HarnessFs" => Some("fs"),
+        "HarnessEnv" => Some("env"),
+        "HarnessRandom" => Some("random"),
+        "HarnessNet" => Some("net"),
+        "HarnessProcess" => Some("process"),
+        "HarnessSystem" => Some("system"),
+        "HarnessLlm" => Some("llm"),
         _ => None,
     }
 }

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -407,7 +407,7 @@ impl TypeChecker {
         }
     }
 
-    pub(in crate::typechecker) fn check_harness_fs_method_call(
+    pub(in crate::typechecker) fn check_harness_method_call(
         &mut self,
         object: &SNode,
         method: &str,
@@ -421,16 +421,18 @@ impl TypeChecker {
         let TypeExpr::Named(type_name) = self.resolve_alias(&raw_type, scope) else {
             return false;
         };
-        if type_name != "HarnessFs" {
+        let Some(sub_handle) = crate::harness_methods::harness_type_sub_handle(type_name.as_str())
+        else {
             return false;
-        }
-        let Some(ambient) = crate::harness_methods::harness_fs_ambient(method) else {
+        };
+        let Some(ambient) = crate::harness_methods::harness_sub_handle_ambient(sub_handle, method)
+        else {
             return false;
         };
         let Some(sig) = builtin_signatures::lookup(ambient) else {
             return false;
         };
-        let display_name = format!("harness.fs.{method}");
+        let display_name = format!("harness.{sub_handle}.{method}");
         let has_spread = args.iter().any(|arg| matches!(&arg.node, Node::Spread(_)));
         self.check_builtin_signature_call(&display_name, sig, &[], args, has_spread, scope, span);
         true

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -587,17 +587,10 @@ impl TypeChecker {
                         .as_ref()
                         .is_some_and(|ty| self.type_may_include_nil(ty, scope));
                 let result = |ty| Self::optional_method_result_type(ty, include_optional_nil);
-                if let Some(ambient) =
-                    obj_type
-                        .as_ref()
-                        .and_then(|ty| match self.resolve_alias(ty, scope) {
-                            TypeExpr::Named(name) if name == "HarnessFs" => {
-                                crate::harness_methods::harness_fs_ambient(method)
-                            }
-                            _ => None,
-                        })
+                if let Some(ty) =
+                    self.harness_method_result_type(obj_type.as_ref(), method.as_str(), scope)
                 {
-                    return builtin_return_type(ambient).map(result);
+                    return Some(result(ty));
                 }
                 // Iter<T> receiver: combinators preserve or transform T; sinks
                 // materialize. This must come before the shared-method match
@@ -900,6 +893,7 @@ impl TypeChecker {
                 "net" => Some(TypeExpr::Named("HarnessNet".into())),
                 "process" => Some(TypeExpr::Named("HarnessProcess".into())),
                 "system" => Some(TypeExpr::Named("HarnessSystem".into())),
+                "llm" => Some(TypeExpr::Named("HarnessLlm".into())),
                 _ if optional => Some(TypeExpr::Named("nil".into())),
                 _ => None,
             },
@@ -1223,6 +1217,24 @@ impl TypeChecker {
             simplify_union(vec![ty, TypeExpr::Named("nil".into())])
         } else {
             ty
+        }
+    }
+
+    fn harness_method_result_type(
+        &self,
+        receiver: Option<&TypeExpr>,
+        method: &str,
+        scope: &TypeScope,
+    ) -> InferredType {
+        let receiver = receiver?;
+        match self.resolve_alias(receiver, scope) {
+            TypeExpr::Named(name) => {
+                let sub_handle = crate::harness_methods::harness_type_sub_handle(name.as_str())?;
+                let ambient =
+                    crate::harness_methods::harness_sub_handle_ambient(sub_handle, method)?;
+                builtin_return_type(ambient)
+            }
+            _ => None,
         }
     }
 

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -1324,7 +1324,7 @@ impl TypeChecker {
                 ..
             } => {
                 self.check_node(object, scope);
-                if self.check_harness_fs_method_call(object, method, args, scope, span) {
+                if self.check_harness_method_call(object, method, args, scope, span) {
                     return;
                 }
                 for arg in args {
@@ -1340,7 +1340,7 @@ impl TypeChecker {
             } => {
                 self.check_unnecessary_safe_method_call(snode, object, scope);
                 self.check_node(object, scope);
-                if self.check_harness_fs_method_call(object, method, args, scope, span) {
+                if self.check_harness_method_call(object, method, args, scope, span) {
                     return;
                 }
                 for arg in args {

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -1049,6 +1049,31 @@ fn test_harness_fs_method_arg_type_mismatch() {
 }
 
 #[test]
+fn test_harness_llm_method_return_type_inference() {
+    let errs = errors(
+        r#"fn main(harness: Harness) {
+  let catalog: list = harness.llm.catalog()
+  let providers: list = harness.llm.providers()
+}"#,
+    );
+    assert!(errs.is_empty(), "unexpected type errors: {errs:?}");
+}
+
+#[test]
+fn test_harness_llm_method_arg_type_mismatch() {
+    let warns = warnings(
+        r#"fn main(harness: Harness) {
+  harness.llm.catalog("extra")
+}"#,
+    );
+    assert_eq!(warns.len(), 1, "expected one warning, got: {warns:?}");
+    assert!(
+        warns[0].contains("Builtin function 'harness.llm.catalog' expects 0 arguments, got 1"),
+        "{warns:?}"
+    );
+}
+
+#[test]
 fn test_len_accepts_nil_like_runtime() {
     let errs = errors(r#"pipeline t(task) { let n: int = len(nil) }"#);
     assert!(errs.is_empty(), "got errors: {errs:?}");

--- a/crates/harn-stdlib/src/stdlib/cli/models/list.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/models/list.harn
@@ -5,9 +5,9 @@
  * `crates/harn-cli/src/commands/models/list.rs` detects installed Ollama
  * models out-of-process (sandboxed scripts can't run `ollama list`
  * directly) and hands off the discovered model ids plus the parsed
- * filter args as env vars. The catalog itself comes from the
- * `llm_catalog()` free builtin landed in G4 (#2297 / #2343), so the
- * script owns the entire filter + render pipeline end-to-end.
+ * filter args as env vars. The catalog itself comes from the read-only
+ * `harness.llm.catalog()` handle, so the script owns the entire filtering
+ * and rendering pipeline end-to-end.
  *
  * Inputs (from the dispatch shim):
  *   HARN_MODELS_LIST_PROVIDER       — optional provider filter ("" = all).
@@ -253,7 +253,7 @@ fn __render_envelope(groups: dict) -> string {
 }
 
 fn main(harness: Harness) -> int {
-  let catalog = llm_catalog()
+  let catalog = harness.llm.catalog()
   let provider_filter = harness.env.get_or("HARN_MODELS_LIST_PROVIDER", "")
   let installed_only = harness.env.get_or("HARN_MODELS_LIST_INSTALLED_ONLY", "0") == "1"
   let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -3,19 +3,16 @@
 //!
 //! `Harness` is the Harn-language analog of an explicit-capability handle: a
 //! single value the runtime hands to a script's `main` so that stdio, clock,
-//! filesystem, environment, randomness, network, process, and system access become surface in
-//! the type system instead of ambient globals. Each sub-handle (`stdio`,
-//! `clock`, `fs`, `env`, `random`, `net`, `process`, `system`) is a distinct named type that
-//! anchors the surface for its capability slice.
+//! filesystem, environment, randomness, network, process, system, and LLM
+//! catalog access become surface in the type system instead of ambient
+//! globals. Each sub-handle (`stdio`, `clock`, `fs`, `env`, `random`, `net`,
+//! `process`, `system`, `llm`) is a distinct named type that anchors the
+//! surface for its capability slice.
 //!
 //! This module defines:
 //!   * The runtime [`Harness`] value (and its sub-handle wrappers).
-//!   * [`Harness::real`], the production constructor that wraps wall-clock
-//!     time, `tokio::fs`, `std::env`, `rand::thread_rng`, and `reqwest`. The
-//!     downstream migration tickets (E4.2-E4.4) populate the per-handle
-//!     method surface against this concrete state; the E4.2 stdio surface is
-//!     wired while filesystem, environment, randomness, and network methods
-//!     still land in later slices.
+//!   * [`Harness::real`], the production constructor that wraps the concrete
+//!     host state used by the sub-handle method dispatchers.
 //!   * [`VmHarness`], the compact `VmValue` payload that carries the same
 //!     state through the bytecode VM and distinguishes the root handle from
 //!     its sub-handles via [`HarnessKind`].
@@ -45,6 +42,7 @@ pub enum HarnessKind {
     Net,
     Process,
     System,
+    Llm,
 }
 
 impl HarnessKind {
@@ -62,6 +60,7 @@ impl HarnessKind {
             HarnessKind::Net => "HarnessNet",
             HarnessKind::Process => "HarnessProcess",
             HarnessKind::System => "HarnessSystem",
+            HarnessKind::Llm => "HarnessLlm",
         }
     }
 
@@ -78,6 +77,7 @@ impl HarnessKind {
             HarnessKind::Net => Some("net"),
             HarnessKind::Process => Some("process"),
             HarnessKind::System => Some("system"),
+            HarnessKind::Llm => Some("llm"),
         }
     }
 
@@ -92,6 +92,7 @@ impl HarnessKind {
             "net" => Some(HarnessKind::Net),
             "process" => Some(HarnessKind::Process),
             "system" => Some(HarnessKind::System),
+            "llm" => Some(HarnessKind::Llm),
             _ => None,
         }
     }
@@ -106,6 +107,7 @@ impl HarnessKind {
         HarnessKind::Net,
         HarnessKind::Process,
         HarnessKind::System,
+        HarnessKind::Llm,
     ];
 
     /// Every kind a Harn-script type annotation may reference.
@@ -119,6 +121,7 @@ impl HarnessKind {
         HarnessKind::Net,
         HarnessKind::Process,
         HarnessKind::System,
+        HarnessKind::Llm,
     ];
 }
 
@@ -625,6 +628,13 @@ impl Harness {
         }
     }
 
+    /// Field access for `harness.llm`.
+    pub fn llm(&self) -> HarnessLlm {
+        HarnessLlm {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
     /// Lower this handle into the `VmValue::Harness` payload.
     pub fn into_vm_value(self) -> crate::value::VmValue {
         crate::value::VmValue::harness(VmHarness {
@@ -711,6 +721,12 @@ pub struct HarnessSystem {
     inner: Arc<HarnessInner>,
 }
 
+/// llm sub-handle: `catalog`, `providers`.
+#[derive(Debug, Clone)]
+pub struct HarnessLlm {
+    inner: Arc<HarnessInner>,
+}
+
 macro_rules! sub_handle_inner {
     ($($ty:ty),* $(,)?) => {
         $(
@@ -731,6 +747,7 @@ sub_handle_inner!(
     HarnessNet,
     HarnessProcess,
     HarnessSystem,
+    HarnessLlm,
 );
 
 impl HarnessClock {
@@ -925,6 +942,7 @@ mod tests {
             r#"fn main(harness: Harness) { harness.net.get("https://example.test") }"#,
             r#"fn main(harness: Harness) { harness.process.spawn_captured({cmd: "printf", args: ["x"]}) }"#,
             r#"fn main(harness: Harness) { harness.system.cpu() }"#,
+            r#"fn main(harness: Harness) { harness.llm.catalog() }"#,
         ] {
             let error = run_harness_source(source, harness.clone()).expect_err("call denied");
             assert!(
@@ -949,6 +967,7 @@ mod tests {
                 (HarnessKind::Net, "get"),
                 (HarnessKind::Process, "spawn_captured"),
                 (HarnessKind::System, "cpu"),
+                (HarnessKind::Llm, "catalog"),
             ]
         );
         assert_eq!(events[0].args, vec!["blocked"]);
@@ -979,6 +998,7 @@ fn main(harness: Harness) {
   __io_println(harness.fs.exists("/missing"))
   __io_println(harness.random.gen_u64())
   __io_println(harness.net.get("https://example.test"))
+  __io_println(len(harness.llm.catalog()) > 0)
 }
 "#,
             harness.clone(),
@@ -988,7 +1008,7 @@ fn main(harness: Harness) {
         assert_eq!(harness.captured_stdio(), "partial line\n");
         assert_eq!(
             output,
-            "1700000000000\n1700000000250\n250\nvalue\ndata\nfalse\n42\nbody\n"
+            "1700000000000\n1700000000250\n250\nvalue\ndata\nfalse\n42\nbody\ntrue\n"
         );
         let observed: Vec<_> = harness
             .calls()
@@ -1009,6 +1029,7 @@ fn main(harness: Harness) {
                 (HarnessKind::Fs, "exists".to_string()),
                 (HarnessKind::Random, "gen_u64".to_string()),
                 (HarnessKind::Net, "get".to_string()),
+                (HarnessKind::Llm, "catalog".to_string()),
             ]
         );
     }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -144,9 +144,9 @@ pub use corrections::{
     CORRECTION_EVENT_KIND, CORRECTION_SCHEMA_V0,
 };
 pub use harness::{
-    DenyEvent, Harness, HarnessCall, HarnessClock, HarnessEnv, HarnessFs, HarnessKind, HarnessNet,
-    HarnessProcess, HarnessRandom, HarnessStdio, HarnessSystem, MockAwareClock, MockHarnessBuilder,
-    VmHarness,
+    DenyEvent, Harness, HarnessCall, HarnessClock, HarnessEnv, HarnessFs, HarnessKind, HarnessLlm,
+    HarnessNet, HarnessProcess, HarnessRandom, HarnessStdio, HarnessSystem, MockAwareClock,
+    MockHarnessBuilder, VmHarness,
 };
 pub use harness_net::{
     bypass_enabled as net_policy_bypass_enabled, NetMatcher, NetPolicy, NetPolicyAudit,

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -110,9 +110,8 @@ const LLM_CONFIG_SYNC_BUILTINS: &[SyncBuiltin] = &[
             "Return the full configured model catalog as a list of dicts: \
              `[{id, name, provider, context_window, runtime_context_window, capabilities, \
              quality_tags, pricing, availability, deprecated, deprecation_note, ...}, ...]`. \
-             Read-only view of `llm_config::model_catalog_entries()` used by `harn models list` \
-             and `harn models recommend`. Free-builtin landing site for the deferred \
-             `harness.llm.catalog` sub-handle (see #2297).",
+             Alias for the read-only `harness.llm.catalog()` handle method, available for \
+             scripts that do not receive a `Harness` parameter.",
         ),
     SyncBuiltin::new("llm_provider_status", llm_provider_status_builtin)
         .signature("llm_provider_status()")
@@ -122,9 +121,9 @@ const LLM_CONFIG_SYNC_BUILTINS: &[SyncBuiltin] = &[
              configured provider plus runtime-registered names. `available` is true when \
              credentials resolve via the configured env vars (or when the provider uses \
              multi-step auth like Bedrock/Vertex). `credential_status` is one of \
-             `\"ok\"`, `\"missing\"`, `\"not_required\"`, `\"deferred\"`. Used by `harn providers` \
-             and `harn doctor`. Free-builtin landing site for the deferred \
-             `harness.llm.providers` sub-handle (see #2297).",
+             `\"ok\"`, `\"missing\"`, `\"not_required\"`, `\"deferred\"`. Alias for the \
+             read-only `harness.llm.providers()` handle method, available for scripts that \
+             do not receive a `Harness` parameter.",
         ),
 ];
 
@@ -381,15 +380,19 @@ fn provider_register_builtin(args: &[VmValue], _out: &mut String) -> Result<VmVa
     Ok(VmValue::Bool(true))
 }
 
-fn llm_catalog_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+pub(crate) fn llm_catalog_value() -> VmValue {
     let entries: Vec<VmValue> = llm_config::model_catalog_entries()
         .into_iter()
         .map(|(id, model)| model_def_to_vm_value(&id, &model))
         .collect();
-    Ok(VmValue::List(Rc::new(entries)))
+    VmValue::List(Rc::new(entries))
 }
 
-fn llm_provider_status_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+fn llm_catalog_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(llm_catalog_value())
+}
+
+pub(crate) fn llm_provider_status_value() -> VmValue {
     // Mirror `llm_providers()` for the name set so runtime-registered
     // providers also show up, but enrich each entry with a credential
     // probe so callers like `harn providers` and `harn doctor` can
@@ -437,7 +440,11 @@ fn llm_provider_status_builtin(_args: &[VmValue], _out: &mut String) -> Result<V
         );
         entries.push(VmValue::Dict(Rc::new(entry)));
     }
-    Ok(VmValue::List(Rc::new(entries)))
+    VmValue::List(Rc::new(entries))
+}
+
+fn llm_provider_status_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    Ok(llm_provider_status_value())
 }
 
 fn llm_config_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/orchestration/policy/effects.rs
+++ b/crates/harn-vm/src/orchestration/policy/effects.rs
@@ -8,11 +8,9 @@
 //!
 //! Computation at spawn time walks the child's entrypoint module via the
 //! same capability analysis `harn graph --json` uses (issue HARN-#1758),
-//! plus a recursive AST walker that lifts harness sub-handle method calls
-//! (`harness.net.get(...)`, `harness.fs.write_file(...)`, ...) into the
-//! same effect shape. The two extraction paths feed one canonicalization
-//! step so downstream consumers see a single deduped, deterministically
-//! ordered list.
+//! plus a conservative AST walker for harness calls embedded in inline spawn
+//! configs. The two extraction paths feed one canonicalization step so
+//! downstream consumers see a single deduped, deterministically ordered list.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -104,10 +102,9 @@ impl EffectRecord {
 /// Compute the effect set for a child agent's entrypoint module.
 ///
 /// Parses `source`, walks the resulting AST via the same `harn_ir`
-/// capability analyzer that backs `harn graph --json`, and also lifts
-/// harness sub-handle method calls (`harness.net.get(...)`, etc.) into
-/// the same effect shape. The result is deterministically ordered and
-/// deduplicated.
+/// capability analyzer that backs `harn graph --json`, and supplements it with
+/// a direct walk for harness calls in inline spawn configs. The result is
+/// deterministically ordered and deduplicated.
 ///
 /// When `ceiling` is provided, the result is clamped to it: an effect
 /// is dropped if the ceiling's `capabilities` map is non-empty and does
@@ -138,8 +135,9 @@ pub fn compute_handoff_effects(
         }
     }
 
-    // Keep harness sub-handle effects visible even for policy callers
-    // that work from raw ASTs rather than the lowered IR call surface.
+    // Spawn preflight also wraps object-literal configs and inline closures
+    // where the IR handler pass cannot always attribute harness calls. Keep
+    // this broad direct pass so parent/child effect checks stay conservative.
     for node in &program {
         walk_for_harness_effects(node, &mut collected);
     }
@@ -189,7 +187,7 @@ fn builtin_effect(name: &str) -> Option<EffectRecord> {
         "print" | "println" | "eprint" | "eprintln" | "write_stdout" | "write_stderr"
         | "__io_print" | "__io_println" | "__io_eprint" | "__io_eprintln" | "__io_write_stdout"
         | "__io_write_stderr" => Some(EffectRecord::new(EffectKind::Stdio, EffectScope::Observe)),
-        "read_stdin" | "__io_read_line" => {
+        "read_line" | "read_stdin" | "prompt_user" | "__io_read_line" => {
             Some(EffectRecord::new(EffectKind::Stdio, EffectScope::Read))
         }
 
@@ -263,6 +261,13 @@ fn builtin_effect(name: &str) -> Option<EffectRecord> {
                 model: None,
             },
             EffectScope::Write,
+        )),
+        "llm_catalog" | "llm_provider_status" => Some(EffectRecord::new(
+            EffectKind::Llm {
+                provider: None,
+                model: None,
+            },
+            EffectScope::Read,
         )),
 
         // spawn / worker dispatch
@@ -442,6 +447,14 @@ fn harness_method_effect(node: &SNode) -> Option<EffectRecord> {
         // policies still block them, but they don't produce a typed
         // effect record for child grant enforcement.
         ("system", _) => return None,
+        ("llm", "catalog" | "providers") => (
+            EffectKind::Llm {
+                provider: None,
+                model: None,
+            },
+            EffectScope::Read,
+        ),
+        ("llm", _) => return None,
         _ => return None,
     };
     Some(EffectRecord::new(kind, scope))
@@ -708,6 +721,7 @@ fn effect_capability_op(effect: &EffectRecord) -> (&'static str, &'static str) {
         (EffectKind::Fs, EffectScope::Mutate) => ("workspace", "apply_edit"),
         (EffectKind::Fs, EffectScope::Observe) => ("workspace", "exists"),
         (EffectKind::Net, _) => ("network", "http"),
+        (EffectKind::Llm { .. }, EffectScope::Read) => ("llm", "catalog"),
         (EffectKind::Llm { .. }, _) => ("llm", "call"),
         (EffectKind::Tool { .. }, _) => ("host", "tool_call"),
         (EffectKind::Hostcall { .. }, _) => ("connector", "call"),
@@ -722,6 +736,7 @@ fn side_effect_level_for(effect: &EffectRecord) -> &'static str {
         (EffectKind::Fs, EffectScope::Read | EffectScope::Observe) => "read_only",
         (EffectKind::Fs, _) => "workspace_write",
         (EffectKind::Net, _) => "network",
+        (EffectKind::Llm { .. }, EffectScope::Read) => "read_only",
         (EffectKind::Llm { .. }, _) => "network",
         (EffectKind::Tool { .. }, _) => "workspace_write",
         (EffectKind::Hostcall { name }, _) if name.starts_with("process.") => "process_exec",
@@ -961,6 +976,19 @@ mod tests {
     }
 
     #[test]
+    fn harness_stdio_read_line_yields_stdio_read_effect() {
+        let source = r#"fn main(harness: Harness) { harness.stdio.read_line() }"#;
+        let effects = compute_handoff_effects(source, None);
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect.kind, EffectKind::Stdio)
+                    && effect.scope == EffectScope::Read),
+            "expected Stdio read effect, got {effects:?}"
+        );
+    }
+
+    #[test]
     fn llm_call_emits_llm_effect_with_provider_and_model() {
         let source = r#"fn main() {
             llm_call("summarize", { provider: "anthropic", model: "claude-3-5-sonnet" })
@@ -975,6 +1003,22 @@ mod tests {
         };
         assert_eq!(provider.as_deref(), Some("anthropic"));
         assert_eq!(model.as_deref(), Some("claude-3-5-sonnet"));
+    }
+
+    #[test]
+    fn harness_llm_catalog_yields_read_effect() {
+        let source = r#"fn main(harness: Harness) {
+            harness.llm.catalog()
+            harness.llm.providers()
+        }"#;
+        let effects = compute_handoff_effects(source, None);
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect.kind, EffectKind::Llm { .. })
+                    && effect.scope == EffectScope::Read),
+            "expected LLM read effect, got {effects:?}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -1,7 +1,7 @@
 //! Method dispatch for the `Harness` capability handle and its
 //! sub-handles. Every sub-handle (`stdio`, `clock`, `fs`, `env`,
-//! `random`, `net`, `process`, `system`) is wired end-to-end in real,
-//! mock, and null modes;
+//! `random`, `net`, `process`, `system`, `llm`) is wired end-to-end in
+//! real, mock, and null modes;
 //! sandbox / egress rejections raised inside a sub-handle method are
 //! tagged with the `HARN-CAP-201` diagnostic code so callers can
 //! attribute the error to the active capability profile rather than an
@@ -84,6 +84,7 @@ impl crate::vm::Vm {
             HarnessKind::Random => self.call_harness_random_method(handle, method, args),
             HarnessKind::Net => self.call_harness_net_method(handle, method, args).await,
             HarnessKind::Process => self.call_harness_process_method(handle, method, args),
+            HarnessKind::Llm => self.call_harness_llm_method(handle, method),
         }
     }
 
@@ -250,6 +251,18 @@ impl crate::vm::Vm {
             _ => return Err(method_unsupported(handle, method)),
         };
         Ok(crate::stdlib::json_to_vm_value(&json))
+    }
+
+    fn call_harness_llm_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+    ) -> Result<VmValue, VmError> {
+        match method {
+            "catalog" => Ok(crate::llm::config_builtins::llm_catalog_value()),
+            "providers" => Ok(crate::llm::config_builtins::llm_provider_status_value()),
+            _ => Err(method_unsupported(handle, method)),
+        }
     }
 
     async fn call_harness_root_method(
@@ -779,6 +792,7 @@ impl crate::vm::Vm {
                 };
                 Ok(crate::stdlib::json_to_vm_value(&json))
             }
+            HarnessKind::Llm => self.call_harness_llm_method(handle, method),
         }
     }
 }

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1679,12 +1679,14 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 | `llm_apply_reasoning_policy(opts)` | opts: dict | dict | Apply Harn's provider-aware `reasoning_policy` / `thinking_policy` lowering to an `llm_call` option dict, preserving caller-supplied `thinking` or `reasoning_effort` |
 | `llm_rate_limit(provider, options?)` | provider: string, options: dict | int/nil/bool | Set (`{rpm: N}`), query, or clear (`{rpm: 0}`) per-provider rate limit |
 | `llm_providers()` | — | list | List all configured provider names |
-| `llm_provider_status()` | — | list | Per-provider availability + credential snapshot: `[{name, available, credential_status}, ...]`. `credential_status` is one of `"ok"`, `"missing"`, `"not_required"`, `"deferred"`. Used by `harn providers` and `harn doctor` to render a single combined table |
+| `harness.llm.providers()` | — | list | Per-provider availability + credential snapshot: `[{name, available, credential_status}, ...]`. `credential_status` is one of `"ok"`, `"missing"`, `"not_required"`, `"deferred"` |
+| `llm_provider_status()` | — | list | Free-builtin alias for `harness.llm.providers()`, available to scripts that do not receive a `Harness` parameter |
 | `llm_available_providers()` | — | list | List providers usable in the current environment (auth configured or no auth required) |
 | `llm_known_models()` | — | list | List configured model alias names |
 | `llm_qc_default_model(provider)` | provider: string | string/nil | Return the configured cheap QC/repair model for a provider, honoring `BURIN_QC_MODEL` |
 | `llm_provider_catalog()` | — | dict | Return the loaded provider/model catalog: providers, aliases, model metadata, pricing, QC defaults, and availability |
-| `llm_catalog()` | — | list | Return the full configured model catalog as a list of dicts: `[{id, name, provider, context_window, runtime_context_window, capabilities, quality_tags, pricing, availability, deprecated, deprecation_note, ...}, ...]`. Read-only view used by `harn models list` / `harn models recommend` |
+| `harness.llm.catalog()` | — | list | Return the full configured model catalog as a list of dicts: `[{id, name, provider, context_window, runtime_context_window, capabilities, quality_tags, pricing, availability, deprecated, deprecation_note, ...}, ...]`. Read-only view used by `harn models list` / `harn models recommend` |
+| `llm_catalog()` | — | list | Free-builtin alias for `harness.llm.catalog()`, available to scripts that do not receive a `Harness` parameter |
 | `llm_config(provider?)` | provider: string | dict | Get provider config (base_url, auth_style, etc.) |
 | `llm_cost(model, input_tokens, output_tokens)` | model: string, input_tokens: int, output_tokens: int | float | Estimate USD cost from catalog pricing, falling back to embedded pricing |
 | `llm_session_cost()` | — | dict | Session totals: `{total_cost, input_tokens, output_tokens, call_count}` |

--- a/docs/src/cli-extending-in-harn.md
+++ b/docs/src/cli-extending-in-harn.md
@@ -371,10 +371,12 @@ free builtins (`sha256_hex`, `term_width`,
 `llm_provider_status`) that today live as top-level functions so the
 ports could move. Directory policy that can be expressed from env vars
 belongs in `std/cli/paths` instead of a host capability. `spawn_captured`
-has since moved to `harness.process.spawn_captured`. The long-term
-direction promotes each remaining free builtin to its
-`harness.X.Y` sub-handle through follow-up issues
-[#2337][f7]-[#2340][f10] and [#2342][f12]. Add new capabilities the same way:
+has since moved to `harness.process.spawn_captured`, and the LLM catalog
+helpers have moved to `harness.llm.catalog()` and
+`harness.llm.providers()`. Prefer the canonical `harness.X.Y` sub-handle
+when the script receives a `Harness` parameter; top-level helpers remain
+aliases for scripts that run outside that shape. Add new capabilities the
+same way:
 
 1. Register the builtin in `crates/harn-vm/src/stdlib/<area>.rs` with
    `register_builtin` and the matching `Harness` accessor.
@@ -430,6 +432,3 @@ per-call allocation off the hot path.
 [c1-ratchet]: https://github.com/burin-labs/harn/issues/2314
 [g4]: https://github.com/burin-labs/harn/issues/2297
 [g5]: https://github.com/burin-labs/harn/issues/2298
-[f7]: https://github.com/burin-labs/harn/issues/2337
-[f10]: https://github.com/burin-labs/harn/issues/2340
-[f12]: https://github.com/burin-labs/harn/issues/2342

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -877,10 +877,11 @@ non-`Harness` type annotation, extra parameters, or a default value) fails
 this check before bytecode is emitted, so the runtime never tries to bind a
 mismatched signature.
 
-The `Harness` value gives the script typed access to its six capability
+The `Harness` value gives the script typed access to its capability
 slices via field access (`harness.stdio`, `harness.clock`, `harness.fs`,
-`harness.env`, `harness.random`, `harness.net`). Threading the handle through
-`main` replaces every ambient stdio/clock/fs/env/random/net global.
+`harness.env`, `harness.random`, `harness.net`, `harness.system`,
+`harness.llm`). Threading the handle through `main` makes host access explicit
+instead of relying on ambient globals and free builtins.
 
 #### How to fix
 
@@ -1005,8 +1006,9 @@ harness capability denied by active sandbox profile
 
 #### What it means
 
-A `harness.fs.*`, `harness.env.*`, `harness.random.*`, or
-`harness.net.*` method was rejected by the active sandbox profile.
+A `harness.fs.*`, `harness.env.*`, `harness.random.*`, `harness.net.*`,
+`harness.system.*`, or `harness.llm.*` method was rejected by the active
+sandbox profile.
 Examples:
 
 - `harness.fs.write_text("/etc/passwd", ...)` from a script whose


### PR DESCRIPTION
## Summary

- Add `harness.llm.catalog()` and `harness.llm.providers()` as the canonical read-only LLM catalog/provider harness sub-handle surface, keeping `llm_catalog()` and `llm_provider_status()` as aliases.
- Wire the new handle through VM dispatch, mock/null harnesses, type inference, IR graph attribution, route/capability mapping, static handoff effects, docs, and conformance.
- Harden package-test Git helpers against interactive local Git config after the broad test run exposed editor-opening tag commands.

Closes #2342.

## Verification

- `make test`
- `cargo fmt --check && git diff --check`
- `make lint-test-patterns`
- `cargo test -p harn-ir harness_llm_method_calls_are_attributed_to_llm_catalog_builtins`
- `cargo test -p harn-cli --test graph_cli graph_json_attributes_harness_sub_handle_calls_to_capabilities`
- `harn fmt --check crates/harn-stdlib/src/stdlib/cli/models/list.harn conformance/tests/runtime/harness_llm_catalog.harn conformance/tests/runtime/harness_llm_providers.harn conformance/tests/runtime/cli_host_caps_llm_catalog.harn conformance/tests/runtime/cli_host_caps_llm_provider_status.harn`
- `harn test conformance --filter harness_llm`
- `harn test conformance --filter cli_host_caps_llm`
- `harn check crates/harn-stdlib/src/stdlib/cli/models/list.harn`
- `cargo test -p harn-cli --lib package::`
- `make check-diagnostics-catalog`
