### PR TITLE
fix(cli): escape Swift reserved keywords in protocol artifact enums

### DIFF
--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -3647,10 +3647,71 @@ fn swift_case_name(value: &str) -> String {
         "unknown".to_string()
     } else if out.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
         format!("_{}", out)
+    } else if SWIFT_RESERVED_KEYWORDS.contains(&out.as_str()) {
+        format!("`{}`", out)
     } else {
         out
     }
 }
+
+/// Swift reserved keywords that cannot appear as bare identifiers in a `case`
+/// declaration. Wire values like `private` / `public` (e.g. on
+/// `HarnMCPCacheScope`) camelCase down to themselves, so without escaping they
+/// land in the generated Swift as `case private = "private"`, which fails to
+/// compile.
+const SWIFT_RESERVED_KEYWORDS: &[&str] = &[
+    "associatedtype",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "continue",
+    "default",
+    "defer",
+    "deinit",
+    "do",
+    "else",
+    "enum",
+    "extension",
+    "fallthrough",
+    "false",
+    "fileprivate",
+    "for",
+    "func",
+    "guard",
+    "if",
+    "import",
+    "in",
+    "init",
+    "inout",
+    "internal",
+    "is",
+    "let",
+    "nil",
+    "open",
+    "operator",
+    "private",
+    "protocol",
+    "public",
+    "repeat",
+    "return",
+    "rethrows",
+    "self",
+    "Self",
+    "static",
+    "struct",
+    "subscript",
+    "super",
+    "switch",
+    "throw",
+    "throws",
+    "true",
+    "try",
+    "typealias",
+    "var",
+    "where",
+    "while",
+];
 
 fn all_acp_session_updates() -> Vec<String> {
     unique_ordered(
@@ -3837,6 +3898,36 @@ mod tests {
         assert!(ts.contains("HARN_WORKER_STATUSES"));
         assert!(ts.contains("export interface ToolCallReceipt"));
         assert!(ts.contains("HARN_TOOL_CALL_RECEIPT_STATUSES"));
+    }
+
+    #[test]
+    fn swift_case_name_escapes_reserved_keywords() {
+        // Bare `case private = ...` / `case public = ...` won't compile in
+        // Swift — both are reserved keywords. The wire vocabulary uses these
+        // (e.g. MCPCacheScope) so the emitter has to backtick them.
+        assert_eq!(swift_case_name("private"), "`private`");
+        assert_eq!(swift_case_name("public"), "`public`");
+        assert_eq!(swift_case_name("class"), "`class`");
+        // Non-keyword identifiers should pass through unchanged.
+        assert_eq!(swift_case_name("application_type"), "applicationType");
+        assert_eq!(swift_case_name("session/close"), "sessionClose");
+        // CamelCased compounds that happen to start with a keyword fragment
+        // (e.g. "private_room" -> "privateRoom") are valid identifiers and
+        // must not be escaped.
+        assert_eq!(swift_case_name("private_room"), "privateRoom");
+        // The full emitted Swift artifact should contain the escaped form for
+        // any enum whose wire value lands on a reserved keyword.
+        let swift = generate_swift();
+        assert!(
+            !swift.contains("case private = "),
+            "Swift artifact contains unescaped `case private = ...`"
+        );
+        assert!(
+            !swift.contains("case public = "),
+            "Swift artifact contains unescaped `case public = ...`"
+        );
+        assert!(swift.contains("case `private` = \"private\""));
+        assert!(swift.contains("case `public` = \"public\""));
     }
 
     #[test]

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -461,8 +461,8 @@ public enum HarnMCPMethod: String, Codable, Sendable, CaseIterable {
 }
 
 public enum HarnMCPCacheScope: String, Codable, Sendable, CaseIterable {
-    case private = "private"
-    case public = "public"
+    case `private` = "private"
+    case `public` = "public"
 
     public static let allCases: [Self] = [
         "private",


### PR DESCRIPTION
## Summary
- `swift_case_name` in `dump-protocol-artifacts` now wraps Swift reserved keywords in backticks, so enums like `HarnMCPCacheScope` with wire values `private` / `public` emit valid Swift
- Regenerate vendored `spec/protocol-artifacts/HarnProtocol.swift` to match the new emitter output
- Add a unit test that pins the escape for `private` / `public` / `class`, leaves non-keywords (`application_type`, `session/close`, `private_room`) alone, and asserts no bare `case private =` / `case public =` lines remain in the full Swift artifact

## Why

In v0.8.35 `HarnMCPCacheScope` lands two enum cases whose camelCased identifiers are literally Swift keywords:

```swift
public enum HarnMCPCacheScope: String, Codable, Sendable, CaseIterable {
    case private = "private"
    case public = "public"
    ...
}
```

Swift rejects these with `keyword 'private' cannot be used as an identifier here`, breaking any downstream that vendors the artifact. burin-code at v0.8.35 hit this on every platform; PR burin-labs/burin-code#1173 had to patch in a local post-processing shim to escape the keywords.

The right fix is upstream — let the emitter produce valid Swift directly so downstream hosts don't have to mirror the keyword list. After this lands and a fresh harn release cuts, the burin-code shim can come back out.

## Verification
- `cargo test -p harn-cli dump_protocol` — 8/8 pass including the new `swift_case_name_escapes_reserved_keywords` and the existing `committed_protocol_artifacts_match_generator` (regenerated `HarnProtocol.swift` matches)
- The full keyword list is the standard Swift reserved set; non-keyword identifiers are pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)