### PR TITLE
Add provider capability audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ condensed series summaries instead of full per-patch history.
   `harness.llm.providers()` as the canonical read-only model/provider catalog
   surface. The legacy `llm_catalog()` and `llm_provider_status()` builtins
   remain aliases for scripts that do not receive a `Harness` parameter.
+- **Provider tool-capability coverage audit (#2362).** Added
+  `harn provider capabilities audit` plus a VM unit gate that fails when a
+  priced catalog model lacks explicit `native_tools` and
+  `preferred_tool_format` coverage in the capability rules.
 
 ## v0.8.35
 

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -153,8 +153,8 @@ pub(crate) use portal::PortalArgs;
 pub use precompile::PrecompileArgs;
 pub(crate) use profile::ProfileArgs;
 pub(crate) use provider::{
-    ModelInfoArgs, ProviderCatalogArgs, ProviderProbeArgs, ProviderReadyArgs,
-    ProviderToolProbeArgs, ProviderToolProbeModeArg,
+    ModelInfoArgs, ProviderArgs, ProviderCapabilitiesCommand, ProviderCatalogArgs, ProviderCommand,
+    ProviderProbeArgs, ProviderReadyArgs, ProviderToolProbeArgs, ProviderToolProbeModeArg,
 };
 pub(crate) use providers::{
     ProvidersArgs, ProvidersCommand, ProvidersExportArgs, ProvidersMatrixArgs,
@@ -451,6 +451,8 @@ SCRIPTING
     Local(LocalArgs),
     /// Validate and generate provider/model catalog artifacts.
     Providers(ProvidersArgs),
+    /// Inspect provider/model capabilities.
+    Provider(ProviderArgs),
     /// Print the provider/model catalog Harn loaded as JSON.
     ProviderCatalog(ProviderCatalogArgs),
     /// Probe a provider's /models endpoint and optionally verify a served model.

--- a/crates/harn-cli/src/cli/provider.rs
+++ b/crates/harn-cli/src/cli/provider.rs
@@ -1,8 +1,39 @@
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args};
+use clap::{ArgAction, Args, Subcommand};
 
 use super::util::{llm_model_completion_parser, llm_provider_completion_parser};
+
+#[derive(Debug, Args)]
+pub(crate) struct ProviderArgs {
+    #[command(subcommand)]
+    pub command: ProviderCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ProviderCommand {
+    /// Inspect provider/model capability metadata.
+    Capabilities(ProviderCapabilitiesArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ProviderCapabilitiesArgs {
+    #[command(subcommand)]
+    pub command: ProviderCapabilitiesCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ProviderCapabilitiesCommand {
+    /// Audit catalogued priced chat models for explicit tool capability fields.
+    Audit(ProviderCapabilitiesAuditArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ProviderCapabilitiesAuditArgs {
+    /// Emit the structured audit report as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
 
 #[derive(Debug, Args)]
 pub(crate) struct ModelInfoArgs {

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -8,9 +8,10 @@ use super::{
     OrchestratorCommand, OrchestratorDeployProvider, OrchestratorLogFormat,
     OrchestratorQueueCommand, OrchestratorTenantCommand, PackageArtifactsCommand,
     PackageCacheCommand, PackageCommand, PackageScaffoldCommand, PersonaCommand, ProjectTemplate,
-    ProviderToolProbeModeArg, ProvidersCommand, PublishArgs, RunsCommand, SessionCommand,
-    SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand, ToolCommand, TraceCommand,
-    TriggerCommand, TrustCommand, TrustOutcomeArg, TrustTierArg,
+    ProviderCapabilitiesCommand, ProviderCommand, ProviderToolProbeModeArg, ProvidersCommand,
+    PublishArgs, RunsCommand, SessionCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
+    SkillsCommand, ToolCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg,
+    TrustTierArg,
 };
 use clap::{CommandFactory, Parser};
 
@@ -81,6 +82,18 @@ fn test_parses_config_validate_and_schema() {
         panic!("expected schema command");
     };
     assert_eq!(schema.output, Some(PathBuf::from("schema.json")));
+}
+
+#[test]
+fn test_parses_provider_capabilities_audit_json() {
+    let cli = Cli::parse_from(["harn", "provider", "capabilities", "audit", "--json"]);
+
+    let Command::Provider(args) = cli.command.unwrap() else {
+        panic!("expected provider command");
+    };
+    let ProviderCommand::Capabilities(capabilities) = args.command;
+    let ProviderCapabilitiesCommand::Audit(audit) = capabilities.command;
+    assert!(audit.json);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod portal;
 pub mod precompile;
 pub(crate) mod protocol_conformance;
 pub(crate) mod provider;
+pub(crate) mod provider_capabilities;
 pub(crate) mod provider_support;
 pub(crate) mod providers;
 pub(crate) mod quickstart;

--- a/crates/harn-cli/src/commands/provider_capabilities.rs
+++ b/crates/harn-cli/src/commands/provider_capabilities.rs
@@ -1,0 +1,32 @@
+use crate::cli::{ProviderArgs, ProviderCapabilitiesCommand, ProviderCommand};
+
+pub(crate) fn run(args: ProviderArgs) -> Result<(), String> {
+    match args.command {
+        ProviderCommand::Capabilities(capabilities) => match capabilities.command {
+            ProviderCapabilitiesCommand::Audit(audit) => run_audit(audit.json),
+        },
+    }
+}
+
+pub(crate) fn run_or_exit(args: ProviderArgs) {
+    run(args).unwrap_or_else(|error| crate::command_error(&error));
+}
+
+fn run_audit(json: bool) -> Result<(), String> {
+    let report = harn_vm::llm::capabilities::audit_catalogued_chat_model_tool_capabilities();
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report)
+                .map_err(|error| format!("failed to render capability audit JSON: {error}"))?
+        );
+    } else if report.ok() {
+        println!("{}", report.render_human());
+    } else {
+        eprintln!("{}", report.render_human());
+    }
+    report
+        .ok()
+        .then_some(())
+        .ok_or_else(|| "provider capability audit failed".to_string())
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -956,6 +956,7 @@ async fn async_main() {
                 }
             }
         },
+        Command::Provider(args) => commands::provider_capabilities::run_or_exit(args),
         Command::Try(args) => commands::try_cmd::run(args).await,
         Command::Quickstart(args) => {
             if let Err(error) = commands::quickstart::run_quickstart(&args).await {

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -19,7 +19,7 @@
 //! boolean gates that used to live alongside them are now data.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
@@ -29,6 +29,7 @@ use super::providers::openai_compat::gpt_generation;
 
 /// Shipped default rules. Compiled into the binary at build time.
 const BUILTIN_TOML: &str = include_str!("capabilities.toml");
+const BUILTIN_PROVIDERS_TOML: &str = include_str!("providers.toml");
 
 /// Parsed on-disk capabilities schema. Public so harn-cli can
 /// construct one directly when wiring harn.toml overrides.
@@ -536,6 +537,61 @@ pub struct ProviderCapabilityMatrixRow {
     pub source: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolCapabilityAuditReport {
+    pub audited_models: usize,
+    pub gaps: Vec<ToolCapabilityAuditGap>,
+}
+
+impl ToolCapabilityAuditReport {
+    pub fn ok(&self) -> bool {
+        self.gaps.is_empty()
+    }
+
+    pub fn render_human(&self) -> String {
+        if self.gaps.is_empty() {
+            return format!(
+                "provider capability audit OK: {} priced chat models have explicit native_tools and preferred_tool_format rules",
+                self.audited_models
+            );
+        }
+
+        let mut out = format!(
+            "provider capability audit found {} catalog gaps among {} priced chat models:",
+            self.gaps.len(),
+            self.audited_models
+        );
+        for gap in &self.gaps {
+            let matched = match (&gap.rule_provider, &gap.rule_model_match) {
+                (Some(provider), Some(model_match)) => {
+                    format!("provider.{provider} model_match=\"{model_match}\"")
+                }
+                _ => "no matching rule".to_string(),
+            };
+            out.push_str(&format!(
+                "\n- {}:{} ({matched}) missing {}; suggest native_tools = {}, preferred_tool_format = \"{}\"",
+                gap.provider,
+                gap.model,
+                gap.missing_fields.join(", "),
+                gap.suggested_native_tools,
+                gap.suggested_preferred_tool_format,
+            ));
+        }
+        out
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolCapabilityAuditGap {
+    pub provider: String,
+    pub model: String,
+    pub rule_provider: Option<String>,
+    pub rule_model_match: Option<String>,
+    pub missing_fields: Vec<String>,
+    pub suggested_native_tools: bool,
+    pub suggested_preferred_tool_format: String,
+}
+
 thread_local! {
     /// Per-thread user overrides installed by the CLI at startup. Kept
     /// thread-local (not process-static) to match the rest of the VM
@@ -631,6 +687,187 @@ pub fn matrix_rows() -> Vec<ProviderCapabilityMatrixRow> {
     }
     push_matrix_rows(&mut rows, builtin(), "builtin");
     rows
+}
+
+/// Audit the currently effective provider/model catalog against the currently
+/// effective capability rules. This is the user-facing path used by the CLI
+/// when authors are adding provider catalog or capability override rows.
+pub fn audit_catalogued_chat_model_tool_capabilities() -> ToolCapabilityAuditReport {
+    let user = USER_OVERRIDES.with(|cell| cell.borrow().clone());
+    audit_tool_capability_coverage(
+        crate::llm_config::model_catalog_entries(),
+        builtin(),
+        user.as_ref(),
+    )
+}
+
+/// Audit the built-in catalog only. The CI test uses this path so external
+/// provider config cannot hide a gap in the shipped TOML assets.
+pub fn audit_builtin_catalogued_chat_model_tool_capabilities() -> ToolCapabilityAuditReport {
+    let catalog = crate::llm_config::parse_config_toml(BUILTIN_PROVIDERS_TOML)
+        .expect("providers.toml must parse at build time");
+    audit_tool_capability_coverage(catalog.models, builtin(), None)
+}
+
+fn audit_tool_capability_coverage<I>(
+    models: I,
+    builtin: &CapabilitiesFile,
+    user: Option<&CapabilitiesFile>,
+) -> ToolCapabilityAuditReport
+where
+    I: IntoIterator<Item = (String, crate::llm_config::ModelDef)>,
+{
+    let mut gaps = Vec::new();
+    let mut audited_models = 0;
+
+    for (model_id, model) in models {
+        if model.pricing.is_none() {
+            continue;
+        }
+        audited_models += 1;
+        let matched = first_matching_rule(user, builtin, &model.provider, &model_id);
+        let mut missing_fields = Vec::new();
+        match matched.as_ref().map(|matched| matched.rule) {
+            Some(rule) => {
+                if rule.native_tools.is_none() {
+                    missing_fields.push("native_tools".to_string());
+                }
+                if rule.preferred_tool_format.is_none() {
+                    missing_fields.push("preferred_tool_format".to_string());
+                }
+            }
+            None => {
+                missing_fields.push("native_tools".to_string());
+                missing_fields.push("preferred_tool_format".to_string());
+            }
+        }
+        if missing_fields.is_empty() {
+            continue;
+        }
+
+        let (suggested_native_tools, suggested_preferred_tool_format) =
+            suggested_tool_capability_defaults(
+                &model.provider,
+                &model_id,
+                &model,
+                matched.as_ref(),
+            );
+        gaps.push(ToolCapabilityAuditGap {
+            provider: model.provider,
+            model: model_id,
+            rule_provider: matched.as_ref().map(|matched| matched.provider.clone()),
+            rule_model_match: matched.map(|matched| matched.rule.model_match.clone()),
+            missing_fields,
+            suggested_native_tools,
+            suggested_preferred_tool_format,
+        });
+    }
+
+    gaps.sort_by(|left, right| {
+        left.provider
+            .cmp(&right.provider)
+            .then_with(|| left.model.cmp(&right.model))
+    });
+    ToolCapabilityAuditReport {
+        audited_models,
+        gaps,
+    }
+}
+
+struct MatchedCapabilityRule<'a> {
+    provider: String,
+    rule: &'a ProviderRule,
+}
+
+fn first_matching_rule<'a>(
+    user: Option<&'a CapabilitiesFile>,
+    builtin: &'a CapabilitiesFile,
+    provider: &str,
+    model: &str,
+) -> Option<MatchedCapabilityRule<'a>> {
+    let mut current = provider.to_string();
+    let mut visited = HashSet::new();
+    while visited.insert(current.clone()) {
+        if let Some(rule) = user
+            .and_then(|file| first_matching_rule_in_file(file, &current, model))
+            .or_else(|| first_matching_rule_in_file(builtin, &current, model))
+        {
+            return Some(MatchedCapabilityRule {
+                provider: current,
+                rule,
+            });
+        }
+        let next = user
+            .and_then(|file| file.provider_family.get(&current))
+            .or_else(|| builtin.provider_family.get(&current))
+            .cloned();
+        current = next?;
+    }
+    None
+}
+
+fn first_matching_rule_in_file<'a>(
+    file: &'a CapabilitiesFile,
+    provider: &str,
+    model: &str,
+) -> Option<&'a ProviderRule> {
+    file.provider
+        .get(provider)?
+        .iter()
+        .find(|rule| rule_matches(rule, model))
+}
+
+fn suggested_tool_capability_defaults(
+    provider: &str,
+    model_id: &str,
+    model: &crate::llm_config::ModelDef,
+    matched: Option<&MatchedCapabilityRule<'_>>,
+) -> (bool, String) {
+    if let Some(rule) = matched.map(|matched| matched.rule) {
+        let native_tools =
+            rule.native_tools
+                .unwrap_or_else(|| match rule.preferred_tool_format.as_deref() {
+                    Some("native") => true,
+                    Some("text") => false,
+                    _ => suggested_native_tools(provider, model_id, model),
+                });
+        let preferred_tool_format = rule
+            .preferred_tool_format
+            .clone()
+            .unwrap_or_else(|| tool_format_for_native(native_tools));
+        return (native_tools, preferred_tool_format);
+    }
+
+    let native_tools = suggested_native_tools(provider, model_id, model);
+    (native_tools, tool_format_for_native(native_tools))
+}
+
+fn suggested_native_tools(
+    provider: &str,
+    model_id: &str,
+    model: &crate::llm_config::ModelDef,
+) -> bool {
+    if provider == "anthropic" || model_id.contains("claude") {
+        return true;
+    }
+    if matches!(
+        provider,
+        "openai" | "gemini" | "cerebras" | "bedrock" | "azure_openai" | "vertex"
+    ) {
+        return true;
+    }
+    model
+        .capabilities
+        .iter()
+        .any(|capability| capability == "tools")
+}
+
+fn tool_format_for_native(native_tools: bool) -> String {
+    if native_tools {
+        "native".to_string()
+    } else {
+        "text".to_string()
+    }
 }
 
 fn push_matrix_rows(
@@ -1076,6 +1313,61 @@ mod tests {
 
     fn reset() {
         clear_user_overrides();
+    }
+
+    #[test]
+    fn every_catalogued_chat_model_has_explicit_tool_capabilities() {
+        reset();
+        let report = audit_builtin_catalogued_chat_model_tool_capabilities();
+        assert!(report.ok(), "{}", report.render_human());
+    }
+
+    #[test]
+    fn tool_capability_audit_reports_suggested_defaults() {
+        reset();
+        let capabilities: CapabilitiesFile = toml::from_str(
+            r#"
+[[provider.acme]]
+model_match = "acme-good-*"
+preferred_tool_format = "native"
+"#,
+        )
+        .unwrap();
+        let report = audit_tool_capability_coverage(
+            vec![(
+                "acme-good-1".to_string(),
+                crate::llm_config::ModelDef {
+                    name: "Acme Good".to_string(),
+                    provider: "acme".to_string(),
+                    context_window: 128_000,
+                    runtime_context_window: None,
+                    stream_timeout: None,
+                    capabilities: Vec::new(),
+                    pricing: Some(crate::llm_config::ModelPricing {
+                        input_per_mtok: 1.0,
+                        output_per_mtok: 2.0,
+                        cache_read_per_mtok: None,
+                        cache_write_per_mtok: None,
+                    }),
+                    deprecated: false,
+                    deprecation_note: None,
+                    quality_tags: Vec::new(),
+                    availability: crate::llm_config::ModelAvailability::Serverless,
+                },
+            )],
+            &capabilities,
+            None,
+        );
+
+        assert!(!report.ok());
+        assert_eq!(report.audited_models, 1);
+        assert_eq!(report.gaps.len(), 1);
+        assert_eq!(report.gaps[0].missing_fields, ["native_tools"]);
+        assert!(report.gaps[0].suggested_native_tools);
+        assert_eq!(report.gaps[0].suggested_preferred_tool_format, "native");
+        assert!(report.render_human().contains(
+            "acme:acme-good-1 (provider.acme model_match=\"acme-good-*\") missing native_tools; suggest native_tools = true, preferred_tool_format = \"native\""
+        ));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -150,6 +150,7 @@ files_api_supported = true
 model_match = "claude-haiku-*"
 version_min = [4, 7]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -173,6 +174,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "claude-opus-*"
 version_min = [4, 7]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -197,6 +199,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "claude-sonnet-*"
 version_min = [4, 7]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -221,6 +224,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "claude-haiku-*"
 version_min = [4, 5]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -245,6 +249,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "claude-opus-*"
 version_min = [4, 6]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -269,6 +274,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "claude-opus-*"
 version_min = [4, 0]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -293,6 +299,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "claude-sonnet-*"
 version_min = [4, 6]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -317,6 +324,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "claude-sonnet-*"
 version_min = [4, 0]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -341,6 +349,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-haiku-*"
 version_min = [4, 7]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -364,6 +373,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-opus-*"
 version_min = [4, 7]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -388,6 +398,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-sonnet-*"
 version_min = [4, 7]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -411,6 +422,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-haiku-*"
 version_min = [4, 5]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -434,6 +446,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-opus-*"
 version_min = [4, 6]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -458,6 +471,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-opus-*"
 version_min = [4, 0]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -481,6 +495,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-sonnet-*"
 version_min = [4, 6]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -504,6 +519,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-sonnet-*"
 version_min = [4, 0]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["bm25", "regex"]
 max_tools = 10000
@@ -528,6 +544,7 @@ thinking_block_style = "thinking_blocks"
 [[provider.anthropic]]
 model_match = "claude-*"
 native_tools = true
+preferred_tool_format = "native"
 prompt_caching = true
 vision = true
 audio_supported = true
@@ -555,6 +572,7 @@ thinking_block_style = "thinking_blocks"
 [[provider.openai]]
 model_match = "gpt-4o*"
 native_tools = true
+preferred_tool_format = "native"
 vision = true
 audio_supported = true
 structured_output = "native"
@@ -570,6 +588,7 @@ thinking_block_style = "none"
 [[provider.openai]]
 model_match = "gpt-4.1*"
 native_tools = true
+preferred_tool_format = "native"
 vision_supported = true
 structured_output = "native"
 prefers_xml_scaffolding = false
@@ -585,6 +604,7 @@ thinking_block_style = "none"
 model_match = "gpt-*"
 version_min = [5, 4]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["hosted", "client"]
 responses_api = true
@@ -611,6 +631,7 @@ thinking_block_style = "reasoning_summary"
 model_match = "gpt-*"
 version_min = [5, 1]
 native_tools = true
+preferred_tool_format = "native"
 vision_supported = true
 structured_output = "native"
 thinking_modes = ["effort"]
@@ -628,6 +649,7 @@ thinking_block_style = "reasoning_summary"
 model_match = "gpt-*"
 version_min = [5, 0]
 native_tools = true
+preferred_tool_format = "native"
 vision_supported = true
 structured_output = "native"
 thinking_modes = ["effort"]
@@ -644,6 +666,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openai]]
 model_match = "gpt-*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
@@ -657,6 +680,7 @@ thinking_block_style = "none"
 [[provider.openai]]
 model_match = "o1*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["effort"]
 requires_completion_tokens = true
@@ -672,6 +696,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openai]]
 model_match = "o3*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["effort"]
 requires_completion_tokens = true
@@ -687,6 +712,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openai]]
 model_match = "o4*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["effort"]
 vision_supported = true
@@ -704,6 +730,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openai]]
 model_match = "openai/gpt-4o*"
 native_tools = true
+preferred_tool_format = "native"
 vision = true
 audio_supported = true
 structured_output = "native"
@@ -719,6 +746,7 @@ thinking_block_style = "none"
 [[provider.openai]]
 model_match = "openai/gpt-4.1*"
 native_tools = true
+preferred_tool_format = "native"
 vision_supported = true
 structured_output = "native"
 prefers_xml_scaffolding = false
@@ -733,6 +761,7 @@ thinking_block_style = "none"
 model_match = "openai/gpt-*"
 version_min = [5, 4]
 native_tools = true
+preferred_tool_format = "native"
 defer_loading = true
 tool_search = ["hosted", "client"]
 responses_api = true
@@ -759,6 +788,7 @@ thinking_block_style = "reasoning_summary"
 model_match = "openai/gpt-*"
 version_min = [5, 1]
 native_tools = true
+preferred_tool_format = "native"
 json_schema = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
@@ -775,6 +805,7 @@ thinking_block_style = "reasoning_summary"
 model_match = "openai/gpt-*"
 version_min = [5, 0]
 native_tools = true
+preferred_tool_format = "native"
 json_schema = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
@@ -789,6 +820,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openai]]
 model_match = "openai/gpt-*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
@@ -801,6 +833,7 @@ thinking_block_style = "none"
 [[provider.openai]]
 model_match = "openai/o1*"
 native_tools = true
+preferred_tool_format = "native"
 json_schema = "native"
 thinking_modes = ["effort"]
 requires_completion_tokens = true
@@ -816,6 +849,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openai]]
 model_match = "openai/o3*"
 native_tools = true
+preferred_tool_format = "native"
 json_schema = "native"
 thinking_modes = ["effort"]
 requires_completion_tokens = true
@@ -831,6 +865,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openai]]
 model_match = "openai/o4*"
 native_tools = true
+preferred_tool_format = "native"
 json_schema = "native"
 thinking_modes = ["effort"]
 vision_supported = true
@@ -911,6 +946,7 @@ thinking_block_style = "none"
 [[provider.ollama]]
 model_match = "qwen3.6*"
 native_tools = false
+preferred_tool_format = "text"
 structured_output = "format_kw"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -931,6 +967,7 @@ thinking_block_style = "inline"
 [[provider.ollama]]
 model_match = "qwen3*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "format_kw"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -955,6 +992,7 @@ thinking_block_style = "inline"
 [[provider.llamacpp]]
 model_match = "*qwen3.6*"
 native_tools = false
+preferred_tool_format = "text"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -975,6 +1013,7 @@ thinking_block_style = "inline"
 [[provider.llamacpp]]
 model_match = "*qwen3*"
 native_tools = false
+preferred_tool_format = "text"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -994,6 +1033,7 @@ thinking_block_style = "inline"
 [[provider.llamacpp]]
 model_match = "*devstral-small-2*"
 native_tools = false
+preferred_tool_format = "text"
 structured_output = "native"
 server_parser = "none"
 honors_chat_template_kwargs = true
@@ -1010,6 +1050,7 @@ thinking_block_style = "none"
 [[provider.ollama]]
 model_match = "devstral-small-2*"
 native_tools = false
+preferred_tool_format = "text"
 structured_output = "format_kw"
 server_parser = "none"
 honors_chat_template_kwargs = false
@@ -1029,6 +1070,7 @@ thinking_block_style = "none"
 [[provider.local]]
 model_match = "*qwen3.6*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1049,6 +1091,7 @@ thinking_block_style = "inline"
 [[provider.local]]
 model_match = "*qwen3*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1086,6 +1129,7 @@ thinking_block_style = "inline"
 [[provider.mlx]]
 model_match = "*qwen3.6*"
 native_tools = true
+preferred_tool_format = "native"
 vision = true
 structured_output = "native"
 thinking_modes = ["enabled"]
@@ -1107,6 +1151,7 @@ thinking_block_style = "inline"
 [[provider.mlx]]
 model_match = "*qwen3*"
 native_tools = true
+preferred_tool_format = "native"
 vision = true
 structured_output = "native"
 thinking_modes = ["enabled"]
@@ -1136,6 +1181,7 @@ thinking_block_style = "inline"
 [[provider.dashscope]]
 model_match = "qwen3.6*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1156,6 +1202,7 @@ thinking_block_style = "inline"
 [[provider.dashscope]]
 model_match = "qwen*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 server_parser = "none"
@@ -1174,6 +1221,7 @@ thinking_block_style = "inline"
 [[provider.fireworks]]
 model_match = "*qwen3.6*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1196,6 +1244,7 @@ thinking_block_style = "inline"
 [[provider.fireworks]]
 model_match = "*qwen3p6*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1216,6 +1265,7 @@ thinking_block_style = "inline"
 [[provider.fireworks]]
 model_match = "*qwen*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 server_parser = "none"
@@ -1271,6 +1321,7 @@ thinking_block_style = "inline"
 model_match = "anthropic/claude-haiku-*"
 version_min = [4, 5]
 native_tools = true
+preferred_tool_format = "native"
 prompt_caching = true
 structured_output = "tool_use"
 thinking_modes = ["enabled"]
@@ -1287,6 +1338,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-sonnet-*"
 version_min = [4, 6]
 native_tools = true
+preferred_tool_format = "native"
 prompt_caching = true
 structured_output = "tool_use"
 thinking_modes = ["adaptive"]
@@ -1303,6 +1355,7 @@ thinking_block_style = "thinking_blocks"
 model_match = "anthropic/claude-opus-*"
 version_min = [4, 6]
 native_tools = true
+preferred_tool_format = "native"
 prompt_caching = true
 structured_output = "tool_use"
 thinking_modes = ["adaptive"]
@@ -1318,6 +1371,7 @@ thinking_block_style = "thinking_blocks"
 [[provider.openrouter]]
 model_match = "qwen/qwen3.6*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 reasoning_none_supported = true
@@ -1358,6 +1412,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "qwen/*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 reasoning_none_supported = true
@@ -1380,6 +1435,7 @@ thinking_block_style = "inline"
 [[provider.huggingface]]
 model_match = "qwen/qwen3.6*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1400,6 +1456,7 @@ thinking_block_style = "inline"
 [[provider.huggingface]]
 model_match = "qwen/qwen3-coder*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 server_parser = "none"
 honors_chat_template_kwargs = true
@@ -1416,6 +1473,7 @@ thinking_block_style = "none"
 [[provider.huggingface]]
 model_match = "qwen/*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 server_parser = "none"
@@ -1434,6 +1492,7 @@ thinking_block_style = "inline"
 [[provider.together]]
 model_match = "qwen/qwen3.6*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1454,6 +1513,7 @@ thinking_block_style = "inline"
 [[provider.together]]
 model_match = "qwen/qwen3-coder*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 server_parser = "none"
 honors_chat_template_kwargs = true
@@ -1470,6 +1530,7 @@ thinking_block_style = "none"
 [[provider.together]]
 model_match = "qwen/*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 server_parser = "none"
@@ -1496,6 +1557,7 @@ thinking_block_style = "inline"
 [[provider.together]]
 model_match = "deepseek-ai/deepseek-v3*"
 native_tools = true
+preferred_tool_format = "native"
 thinking_modes = ["enabled"]
 prompt_caching = true
 structured_output = "native"
@@ -1512,6 +1574,7 @@ thinking_block_style = "inline"
 [[provider.huggingface]]
 model_match = "deepseek-ai/deepseek-v3*"
 native_tools = true
+preferred_tool_format = "native"
 thinking_modes = ["enabled"]
 prompt_caching = true
 structured_output = "native"
@@ -1528,6 +1591,7 @@ thinking_block_style = "inline"
 [[provider.openrouter]]
 model_match = "deepseek/deepseek-v4*"
 native_tools = true
+preferred_tool_format = "native"
 thinking_modes = ["enabled", "effort"]
 prompt_caching = true
 structured_output = "native"
@@ -1565,6 +1629,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openrouter]]
 model_match = "deepseek/deepseek-v3*"
 native_tools = true
+preferred_tool_format = "native"
 thinking_modes = ["enabled", "effort"]
 prompt_caching = true
 structured_output = "native"
@@ -1582,6 +1647,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.openrouter]]
 model_match = "mistralai/mistral*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 server_parser = "none"
 honors_chat_template_kwargs = false
@@ -1596,6 +1662,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "mistralai/devstral*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 server_parser = "none"
 honors_chat_template_kwargs = false
@@ -1607,6 +1674,22 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
 
+[[provider.openrouter]]
+model_match = "moonshotai/kimi-k2*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+server_parser = "none"
+honors_chat_template_kwargs = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
 # ---------- Google Gemini + Gemma 4 (via OpenRouter) -------------------------
 #
 # Gemini 2.5 exposes thinking budgets through OpenRouter's `reasoning`
@@ -1616,6 +1699,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "google/gemini-2.5*"
 native_tools = true
+preferred_tool_format = "native"
 thinking_modes = ["enabled", "effort"]
 prompt_caching = true
 vision_supported = true
@@ -1634,6 +1718,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.gemini]]
 model_match = "gemini-2.5*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled", "adaptive", "effort"]
 vision_supported = true
@@ -1651,6 +1736,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.gemini]]
 model_match = "models/gemini-2.5*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled", "adaptive", "effort"]
 vision_supported = true
@@ -1668,6 +1754,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.gemini]]
 model_match = "gemini-*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 vision_supported = true
 audio_supported = true
@@ -1684,6 +1771,7 @@ thinking_block_style = "none"
 [[provider.gemini]]
 model_match = "models/gemini-*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 vision_supported = true
 audio_supported = true
@@ -1700,6 +1788,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "google/gemma-4*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 top_k_supported = true
 prefers_xml_scaffolding = false
@@ -1718,6 +1807,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "meta-llama/llama-4*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 top_k_supported = true
 prefers_xml_scaffolding = false
@@ -1731,6 +1821,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "meta-llama/llama-3*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
@@ -1765,6 +1856,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.together]]
 model_match = "deepseek-ai/deepseek-v4*"
 native_tools = true
+preferred_tool_format = "native"
 thinking_modes = ["enabled", "effort"]
 reasoning_effort_supported = true
 prompt_caching = true
@@ -1782,6 +1874,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.together]]
 model_match = "moonshotai/kimi-k2*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 honors_chat_template_kwargs = false
@@ -1796,6 +1889,7 @@ thinking_block_style = "inline"
 [[provider.together]]
 model_match = "zai-org/glm-5*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 honors_chat_template_kwargs = false
@@ -1810,6 +1904,7 @@ thinking_block_style = "inline"
 [[provider.together]]
 model_match = "google/gemma-4*"
 native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
 honors_chat_template_kwargs = false
@@ -1824,6 +1919,50 @@ thinking_block_style = "inline"
 [[provider.together]]
 model_match = "moonshotai/*"
 native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+# ---------- Cerebras ----------------------------------------------------------
+
+[[provider.cerebras]]
+model_match = "gpt-oss-*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
+[[provider.cerebras]]
+model_match = "llama-*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+[[provider.cerebras]]
+model_match = "qwen-*"
+native_tools = true
+preferred_tool_format = "native"
 structured_output = "native"
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
@@ -1846,6 +1985,7 @@ thinking_block_style = "none"
 [[provider.bedrock]]
 model_match = "anthropic.claude-*"
 native_tools = true
+preferred_tool_format = "native"
 message_wire_format = "anthropic"
 native_tool_wire_format = "anthropic"
 recommended_endpoint = "/model/{model}/converse"
@@ -1861,6 +2001,7 @@ thinking_block_style = "thinking_blocks"
 [[provider.bedrock]]
 model_match = "*claude*"
 native_tools = true
+preferred_tool_format = "native"
 recommended_endpoint = "/model/{model}/converse"
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = true
@@ -1874,6 +2015,7 @@ thinking_block_style = "thinking_blocks"
 [[provider.bedrock]]
 model_match = "*"
 native_tools = true
+preferred_tool_format = "native"
 recommended_endpoint = "/model/{model}/converse"
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
@@ -1890,6 +2032,7 @@ thinking_block_style = "none"
 [[provider.azure_openai]]
 model_match = "gpt-*"
 native_tools = true
+preferred_tool_format = "native"
 recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
@@ -1903,6 +2046,7 @@ thinking_block_style = "none"
 [[provider.azure_openai]]
 model_match = "o1*"
 native_tools = true
+preferred_tool_format = "native"
 recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
@@ -1916,6 +2060,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.azure_openai]]
 model_match = "o3*"
 native_tools = true
+preferred_tool_format = "native"
 recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
@@ -1929,6 +2074,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.azure_openai]]
 model_match = "o4*"
 native_tools = true
+preferred_tool_format = "native"
 recommended_endpoint = "/openai/deployments/{deployment}/chat/completions"
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
@@ -1945,6 +2091,7 @@ thinking_block_style = "reasoning_summary"
 [[provider.vertex]]
 model_match = "gemini-*"
 native_tools = true
+preferred_tool_format = "native"
 recommended_endpoint = "/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent"
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -195,7 +195,10 @@
         "structured_output_transport": "native",
         "structured_output_mode": "native_json",
         "streaming": true,
-        "reasoning_knobs": [],
+        "reasoning_knobs": [
+          "effort",
+          "reasoning_effort"
+        ],
         "prompt_or_context_cache": false,
         "usage_accounting_confidence": "high"
       },

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1090,6 +1090,18 @@ unparsable model listings, and missing models. It does not run local launcher
 scripts; host applications that auto-start local servers should report launch
 failures themselves and then call this probe again.
 
+## harn provider capabilities audit
+
+Check that every priced chat model in the loaded provider catalog has an
+explicit capability rule for both `native_tools` and `preferred_tool_format`.
+The command exits non-zero and lists suggested defaults when catalog rows need
+coverage.
+
+```bash
+harn provider capabilities audit
+harn provider capabilities audit --json
+```
+
 ## harn provider-probe
 
 Snapshot a provider's readiness and local loaded-model state as JSON. For

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -35,6 +35,9 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `bedrock` | `anthropic.claude-*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
 | `bedrock` | `*claude*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
 | `bedrock` | `*` | `any` | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `cerebras` | `gpt-oss-*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `cerebras` | `llama-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `cerebras` | `qwen-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `dashscope` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `dashscope` | `qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
@@ -93,6 +96,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `deepseek/deepseek-v3*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `mistralai/mistral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `google/gemma-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -14,7 +14,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Anthropic` | Anthropic Messages API | `haiku` | `native` | yes | yes | `tool_use` / `xml_tagged` | `enabled` | yes | `high` | `not_recorded` |
 | `Azure Openai` | OpenAI-compatible chat completions | `azure_openai:gpt-*` | `native` | yes | yes | `none` / `native_json` | none | no | `provider_default` | `not_recorded` |
 | `Bedrock` | AWS Bedrock Converse | `bedrock:anthropic.claude-*` | `native` | yes | yes | `none` / `xml_tagged` | none | no | `provider_default` | `not_recorded` |
-| `Cerebras` | OpenAI-compatible chat completions | `cerebras:gpt-oss-120b` | `native` | yes | yes | `native` / `native_json` | none | no | `high` | `not_recorded` |
+| `Cerebras` | OpenAI-compatible chat completions | `cerebras:gpt-oss-120b` | `native` | yes | yes | `native` / `native_json` | `effort,reasoning_effort` | no | `high` | `not_recorded` |
 | `Dashscope` | OpenAI-compatible chat completions | `dashscope:qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
 | `Deepseek` | OpenAI-compatible chat completions | `deepseek` | `text` | no | yes | `none` / `none` | none | no | `provider_default` | `not_recorded` |
 | `Fireworks` | OpenAI-compatible chat completions | `fireworks:*qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -1699,11 +1699,13 @@ public let harnProviderCatalogJSON = #"""
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "reasoning_summary"
       },
       "reasoning": {
-        "modes": [],
-        "effort_supported": false,
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
         "none_supported": false,
         "interleaved_supported": false,
         "preserve_thinking": false
@@ -1723,6 +1725,8 @@ public let harnProviderCatalogJSON = #"""
       "capability_tags": [
         "streaming",
         "tools",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ]
     },
@@ -1741,17 +1745,17 @@ public let harnProviderCatalogJSON = #"""
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
@@ -1778,7 +1782,8 @@ public let harnProviderCatalogJSON = #"""
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "structured_output"
       ]
     },
     {
@@ -1796,17 +1801,17 @@ public let harnProviderCatalogJSON = #"""
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
@@ -1833,7 +1838,8 @@ public let harnProviderCatalogJSON = #"""
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "structured_output"
       ]
     },
     {
@@ -2577,8 +2583,6 @@ public let harnProviderCatalogJSON = #"""
       "tool_support": {
         "native": false,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3533,24 +3537,26 @@ public let harnProviderCatalogJSON = #"""
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "inline"
       },
       "reasoning": {
-        "modes": [],
+        "modes": [
+          "enabled"
+        ],
         "effort_supported": false,
         "none_supported": false,
         "interleaved_supported": false,
@@ -3570,7 +3576,9 @@ public let harnProviderCatalogJSON = #"""
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "thinking",
+        "structured_output"
       ]
     },
     {

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -1593,11 +1593,13 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "reasoning_summary"
       },
       "reasoning": {
-        "modes": [],
-        "effort_supported": false,
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
         "none_supported": false,
         "interleaved_supported": false,
         "preserve_thinking": false
@@ -1617,6 +1619,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "capability_tags": [
         "streaming",
         "tools",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ]
     },
@@ -1635,17 +1639,17 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
@@ -1672,7 +1676,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "structured_output"
       ]
     },
     {
@@ -1690,17 +1695,17 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
@@ -1727,7 +1732,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "structured_output"
       ]
     },
     {
@@ -2471,8 +2477,6 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_support": {
         "native": false,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3427,24 +3431,26 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "inline"
       },
       "reasoning": {
-        "modes": [],
+        "modes": [
+          "enabled"
+        ],
         "effort_supported": false,
         "none_supported": false,
         "interleaved_supported": false,
@@ -3464,7 +3470,9 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "thinking",
+        "structured_output"
       ]
     },
     {

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -1449,11 +1449,13 @@
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "reasoning_summary"
       },
       "reasoning": {
-        "modes": [],
-        "effort_supported": false,
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
         "none_supported": false,
         "interleaved_supported": false,
         "preserve_thinking": false
@@ -1473,6 +1475,8 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ]
     },
@@ -1491,17 +1495,17 @@
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
@@ -1528,7 +1532,8 @@
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "structured_output"
       ]
     },
     {
@@ -1546,17 +1551,17 @@
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
@@ -1583,7 +1588,8 @@
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "structured_output"
       ]
     },
     {
@@ -2327,8 +2333,6 @@
       "tool_support": {
         "native": false,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "none",
@@ -3283,24 +3287,26 @@
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
-        "preferred_format": "text",
-        "parity": "text_only",
+        "preferred_format": "native",
+        "parity": "unknown",
         "tool_search": []
       },
-      "structured_output": "none",
+      "structured_output": "native",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
-        "structured_output_mode": "none",
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "inline"
       },
       "reasoning": {
-        "modes": [],
+        "modes": [
+          "enabled"
+        ],
         "effort_supported": false,
         "none_supported": false,
         "interleaved_supported": false,
@@ -3320,7 +3326,9 @@
       "quality_tags": [],
       "capability_tags": [
         "streaming",
-        "tools"
+        "tools",
+        "thinking",
+        "structured_output"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- add a VM audit report and CI-facing test for priced catalog model tool-capability coverage
- add `harn provider capabilities audit` with JSON and human report output
- make catalogued capability rules explicit for `native_tools` and `preferred_tool_format`, including current OpenRouter/Cerebras gaps

Fixes #2362

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-2362-nosccache cargo test -p harn-vm capabilities::tests:: -- --nocapture`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-2362-nosccache cargo test -p harn-cli test_parses_provider_capabilities_audit_json -- --nocapture`
- `/tmp/harn-target-2362-nosccache/debug/harn provider capabilities audit --json`
- pre-commit hook: formatting, changed-package clippy, CI ratchets, markdown lint
- pre-push hook: targeted checks, markdown lint, changelog retroactive-edit check