### PR TITLE
[SV-1] Structural validator middleware + first rule

### DIFF
--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -250,6 +250,24 @@
       "jsonrpc": "2.0",
       "method": "_harn/agentEvent",
       "params": {
+        "attempts": 0,
+        "diagnostic": "Assistant emitted no tool calls while writable tools were available.",
+        "iteration": 1,
+        "kind": "structural_validator_decision",
+        "maxAttempts": 3,
+        "onFailure": "regenerate_with_feedback",
+        "reason": null,
+        "recommendedAction": "Emit the concrete write or edit tool call needed for the task, or only mark the task done after that work is complete.",
+        "rule": "non_empty_when_writes_expected",
+        "sessionId": "session-1",
+        "skipped": false,
+        "vetoed": true
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
         "checkpoint": {
           "stage": "verify",
           "type": "stage_gate"

--- a/conformance/tests/agents/agent_loop_structural_validator.expected
+++ b/conformance/tests/agents/agent_loop_structural_validator.expected
@@ -1,0 +1,11 @@
+done
+true
+1
+non_empty_when_writes_expected
+true
+true
+true
+true
+true
+caught
+true

--- a/conformance/tests/agents/agent_loop_structural_validator.harn
+++ b/conformance/tests/agents/agent_loop_structural_validator.harn
@@ -1,0 +1,79 @@
+import { agent_capture_events } from "std/agent/events"
+import { with_structural_validator } from "std/llm/structural_validator"
+import { compose_tool_callers } from "std/llm/tool_middleware"
+
+fn events_of(events, kind) {
+  return events.filter({ event -> event.type == kind })
+}
+
+fn write_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note",
+    {
+      handler: { args -> "wrote " + args.path },
+      parameters: {path: {type: "string", description: "Path to write"}},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+  return tools
+}
+
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({text: "I fixed it already."})
+  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]})
+  llm_mock({text: "<done>##DONE##</done>"})
+  let session = "structural-validator-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "Update notes.txt and then finish.",
+      nil,
+      {
+        provider: "mock",
+        tool_format: "native",
+        loop_until_done: true,
+        max_iterations: 4,
+        session_id: session,
+        tools: write_tools(),
+        tool_caller: compose_tool_callers([with_structural_validator()]),
+      },
+    ) },
+  )
+  let decisions = events_of(captured.events, "structural_validator_decision")
+  require len(decisions) == 1, "validator should emit exactly one decision"
+  __io_println(captured.result.status)
+  __io_println(captured.result.tools.successful[0] == "write_note")
+  __io_println(len(decisions))
+  __io_println(decisions[0].rule)
+  __io_println(decisions[0].vetoed)
+  __io_println(decisions[0].recommended_action.contains("tool call"))
+  let regen_messages = json_stringify(llm_mock_calls()[1].messages)
+  __io_println(!regen_messages.contains("I fixed it already."))
+  __io_println(regen_messages.contains("structural_validator"))
+  __io_println(regen_messages.contains("non_empty_when_writes_expected"))
+  llm_mock_clear()
+  llm_mock({text: "Still done without tools."})
+  try {
+    agent_loop(
+      "Update notes.txt and then finish.",
+      nil,
+      {
+        provider: "mock",
+        tool_format: "native",
+        loop_until_done: true,
+        max_iterations: 2,
+        tools: write_tools(),
+        tool_caller: compose_tool_callers([with_structural_validator({on_failure: "raise"})]),
+      },
+    )
+    __io_println("no-throw")
+  } catch (e) {
+    __io_println("caught")
+    __io_println(contains(to_string(e), "Assistant emitted no tool calls"))
+  }
+}

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -962,6 +962,36 @@ impl AgentEventSink for AcpAgentEventSink {
                     }),
                 );
             }
+            AgentEvent::StructuralValidatorDecision {
+                session_id,
+                iteration,
+                rule,
+                diagnostic,
+                recommended_action,
+                vetoed,
+                skipped,
+                reason,
+                on_failure,
+                attempts,
+                max_attempts,
+            } => {
+                self.emit_agent_event_ext(
+                    "structural_validator_decision",
+                    session_id,
+                    serde_json::json!({
+                        "iteration": iteration,
+                        "rule": rule,
+                        "diagnostic": diagnostic,
+                        "recommendedAction": recommended_action,
+                        "vetoed": vetoed,
+                        "skipped": skipped,
+                        "reason": reason,
+                        "onFailure": on_failure,
+                        "attempts": attempts,
+                        "maxAttempts": max_attempts,
+                    }),
+                );
+            }
             AgentEvent::TypedCheckpoint {
                 session_id,
                 checkpoint,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -421,6 +421,22 @@ fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
             judge_duration_ms: 42,
             trigger: Some("stalled".to_string()),
         },
+        AgentEvent::StructuralValidatorDecision {
+            session_id: "session-1".to_string(),
+            iteration: 1,
+            rule: "non_empty_when_writes_expected".to_string(),
+            diagnostic: "Assistant emitted no tool calls while writable tools were available."
+                .to_string(),
+            recommended_action:
+                "Emit the concrete write or edit tool call needed for the task, or only mark the task done after that work is complete."
+                    .to_string(),
+            vetoed: true,
+            skipped: false,
+            reason: None,
+            on_failure: "regenerate_with_feedback".to_string(),
+            attempts: 0,
+            max_attempts: 3,
+        },
         AgentEvent::TypedCheckpoint {
             session_id: "session-1".to_string(),
             checkpoint: serde_json::json!({
@@ -547,6 +563,37 @@ async fn step_judge_decision_agent_event_marks_skipped_reason() {
     assert_eq!(params["skipped"], true);
     assert_eq!(params["reason"], "low_iteration_budget");
     assert_eq!(params["vetoed"], false);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn structural_validator_decision_agent_event_carries_retry_shape() {
+    let actual = collect_notifications(vec![AgentEvent::StructuralValidatorDecision {
+        session_id: "session-1".to_string(),
+        iteration: 2,
+        rule: "non_empty_when_writes_expected".to_string(),
+        diagnostic: "Assistant emitted no tool calls while writable tools were available."
+            .to_string(),
+        recommended_action: "Emit the concrete write or edit tool call needed for the task."
+            .to_string(),
+        vetoed: true,
+        skipped: false,
+        reason: None,
+        on_failure: "regenerate_with_feedback".to_string(),
+        attempts: 1,
+        max_attempts: 3,
+    }])
+    .await;
+
+    let notification = &actual[0];
+    assert_eq!(notification["method"], HARN_AGENT_EVENT_METHOD);
+    let params = &notification["params"];
+    assert_eq!(params["kind"], "structural_validator_decision");
+    assert_eq!(params["sessionId"], "session-1");
+    assert_eq!(params["rule"], "non_empty_when_writes_expected");
+    assert_eq!(params["onFailure"], "regenerate_with_feedback");
+    assert_eq!(params["attempts"], 1);
+    assert_eq!(params["maxAttempts"], 3);
+    assert_eq!(params["vetoed"], true);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -64,6 +64,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "loop_stuck",
     "progress_reported",
     "session_closed",
+    "structural_validator_decision",
     "step_judge_decision",
     "tool_call_audit",
     "typed_checkpoint",

--- a/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
+++ b/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
@@ -245,6 +245,24 @@
     "jsonrpc": "2.0",
     "method": "_harn/agentEvent",
     "params": {
+      "attempts": 0,
+      "diagnostic": "Assistant emitted no tool calls while writable tools were available.",
+      "iteration": 1,
+      "kind": "structural_validator_decision",
+      "maxAttempts": 3,
+      "onFailure": "regenerate_with_feedback",
+      "reason": null,
+      "recommendedAction": "Emit the concrete write or edit tool call needed for the task, or only mark the task done after that work is complete.",
+      "rule": "non_empty_when_writes_expected",
+      "sessionId": "session-1",
+      "skipped": false,
+      "vetoed": true
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
       "checkpoint": {
         "stage": "verify",
         "type": "stage_gate"

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -302,6 +302,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/llm/tool_binder.harn"),
     },
     StdlibSource {
+        module: "llm/structural_validator",
+        source: include_str!("stdlib/llm/structural_validator.harn"),
+    },
+    StdlibSource {
         module: "llm/refine",
         source: include_str!("stdlib/llm/refine.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -329,6 +329,92 @@ fn __middleware_exception_result(envelope, err) {
   }
 }
 
+fn __structural_validator_tool_name() -> string {
+  return "__structural_validator_turn__"
+}
+
+fn __structural_validator_pass_result(envelope) {
+  return {
+    ok: true,
+    status: "ok",
+    tool_name: envelope.tool_name,
+    tool_call_id: envelope.call_id,
+    arguments: envelope.tool_args,
+    result: {configured: false, vetoed: false, skipped: true, reason: "not_configured"},
+    rendered_result: "",
+    observation: "",
+    error: nil,
+    error_category: nil,
+    executor: "harn",
+  }
+}
+
+fn __run_structural_validator(
+  caller,
+  session_id,
+  llm_result,
+  tool_calls,
+  parsed,
+  turn_opts,
+  attempts,
+) {
+  if caller == nil {
+    return {configured: false, vetoed: false, skipped: true, reason: "not_configured"}
+  }
+  let envelope = {
+    tool_name: __structural_validator_tool_name(),
+    tool_args: {
+      session_id: session_id,
+      iteration: turn_opts?._turn_iteration ?? 0,
+      attempts: attempts,
+      tool_calls: tool_calls,
+      tools: turn_opts?.tools,
+      policy: turn_opts?.policy,
+      assistant_text: llm_result?.visible_text ?? llm_result?.text ?? "",
+      raw_text: llm_result?.raw_text ?? llm_result?.text ?? "",
+      parsed_done_marker: parsed?.done_marker ?? "",
+      output_tokens: llm_result?.output_tokens ?? 0,
+      provider: llm_result?.provider ?? "",
+      model: llm_result?.model ?? "",
+    },
+    call_id: "structural-validator-turn-" + to_string(turn_opts?._turn_iteration ?? 0),
+    declared_executor: "harn",
+    schema: nil,
+    annotations: nil,
+    description: "Internal structural validator probe",
+    turn: {
+      iteration: turn_opts?._turn_iteration ?? 0,
+      session_id: session_id,
+      run_id: turn_opts?.run_id ?? turn_opts?._run_id,
+      model: turn_opts?.model,
+      provider: turn_opts?.provider,
+      tool_call_index: 0,
+      max_concurrent_tools: 1,
+      prefetch_next_turn: false,
+    },
+  }
+  let next = { env_in -> __structural_validator_pass_result(env_in) }
+  let outcome = try {
+    caller(envelope, next)
+  }
+  if is_err(outcome) {
+    let err = unwrap_err(outcome)
+    if error_category(err) == "cancelled" {
+      throw err
+    }
+    throw "agent_loop: structural validator failed: " + to_string(err)
+  }
+  let result = unwrap(outcome)
+  if type_of(result) != "dict" {
+    throw "agent_loop: structural validator must return a dict; got " + type_of(result)
+  }
+  return if type_of(result?.result) == "dict" {
+    result.result
+  } else {
+    {}
+  }
+}
+
 fn __invoke_tool(call, tools, options) {
   let caller = options?._tool_caller
   if caller == nil {
@@ -1112,6 +1198,7 @@ fn __agent_loop_run(message, session, initial_opts) {
     var verify_attempts = 0
     var done_judge_invocations = 0
     var step_judge_attempts = 0
+    var structural_validator_attempts = 0
     var consecutive_text_only = 0
     var fallback_index = 0
     var successful_tools_seen = []
@@ -1235,6 +1322,45 @@ fn __agent_loop_run(message, session, initial_opts) {
       stall_state = stall_observation.state
       stall_enabled_seen = stall_enabled_seen || stall_observation.enabled
       let stall_warning = stall_observation.warning
+      let structural_verdict = __run_structural_validator(
+        opts?._tool_caller,
+        session.session_id,
+        normalized + {raw_text: raw_text},
+        tool_calls,
+        parsed,
+        turn_opts,
+        structural_validator_attempts,
+      )
+      if structural_verdict.vetoed {
+        let on_failure = structural_verdict?.on_failure ?? "regenerate_with_feedback"
+        if on_failure == "raise" {
+          throw structural_verdict?.diagnostic
+            ?? "structural validator rejected assistant turn"
+        }
+        structural_validator_attempts = structural_validator_attempts + 1
+        agent_session_pop_last_assistant(session.session_id)
+        let feedback = to_string(structural_verdict?.feedback ?? "")
+        if feedback != "" {
+          agent_session_inject_feedback(session.session_id, "structural_validator", feedback)
+        }
+        agent_emit_event(
+          session.session_id,
+          "turn_end",
+          {
+            iteration: turn_index + 1,
+            turn_info: __turn_info_payload(llm_result, 0, visible_text)
+              + {
+              dispatch_skipped: true,
+              skip_reason: "structural_validator_revise",
+              structural_validator_attempts: structural_validator_attempts,
+              structural_validator_rule: structural_verdict?.rule ?? "",
+            },
+          },
+        )
+        continue
+      } else if !(structural_verdict?.skipped ?? false) {
+        structural_validator_attempts = 0
+      }
       if stall_judge_due && stall_warning != nil {
         let stall_verify_opts = turn_opts
           + {_done_judge_due: true, _done_judge_trigger: "stalled"}

--- a/crates/harn-stdlib/src/stdlib/llm/structural_validator.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/structural_validator.harn
@@ -1,0 +1,268 @@
+// @harn-entrypoint-category llm.stdlib
+//
+// std/llm/structural_validator - deterministic pre-dispatch turn checks.
+//
+// Opt in via `compose_tool_callers([with_structural_validator({...})])`.
+// The middleware intercepts the agent loop's internal
+// `__structural_validator_turn__` pre-dispatch probe, emits a
+// `structural_validator_decision` event, and either regenerates with
+// feedback or raises.
+import { agent_emit_event } from "std/agent/state"
+
+fn __sv_tool_name() -> string {
+  return "__structural_validator_turn__"
+}
+
+fn __sv_dict(value) -> dict {
+  if type_of(value) == "dict" {
+    return value
+  }
+  return {}
+}
+
+fn __sv_list(value) -> list {
+  if type_of(value) == "list" {
+    return value
+  }
+  return []
+}
+
+fn __sv_string(value) -> string {
+  if value == nil {
+    return ""
+  }
+  return to_string(value)
+}
+
+fn __sv_positive_int(value, default_value, name) -> int {
+  if value == nil {
+    return default_value
+  }
+  let parsed = to_int(value)
+  if parsed == nil {
+    throw "with_structural_validator: `" + name + "` must be an integer; got " + type_of(value)
+  }
+  if parsed <= 0 {
+    throw "with_structural_validator: `" + name + "` must be > 0; got " + to_string(parsed)
+  }
+  return parsed
+}
+
+fn __sv_normalize_rules(value) {
+  if value == nil {
+    return ["non_empty_when_writes_expected"]
+  }
+  let raw = __sv_list(value)
+  if len(raw) == 0 {
+    return ["non_empty_when_writes_expected"]
+  }
+  var rules = []
+  for item in raw {
+    let name = trim(__sv_string(item))
+    if name != "" && !contains(rules, name) {
+      rules = rules.push(name)
+    }
+  }
+  if len(rules) == 0 {
+    return ["non_empty_when_writes_expected"]
+  }
+  return rules
+}
+
+fn __sv_validate_opts(opts) {
+  let cfg = __sv_dict(opts)
+  let on_failure = __sv_string(cfg?.on_failure ?? "regenerate_with_feedback")
+  if on_failure != "regenerate_with_feedback" && on_failure != "raise" {
+    throw "with_structural_validator: `on_failure` must be regenerate_with_feedback|raise; got "
+      + on_failure
+  }
+  let rules = __sv_normalize_rules(cfg?.rules)
+  for rule in rules {
+    if rule != "non_empty_when_writes_expected" {
+      throw "with_structural_validator: unknown rule `" + rule + "`"
+    }
+  }
+  return {
+    on_failure: on_failure,
+    max_attempts: __sv_positive_int(cfg?.max_attempts, 3, "max_attempts"),
+    rules: rules,
+  }
+}
+
+fn __sv_tool_annotations(entry) {
+  let direct = entry?.annotations
+  if type_of(direct) == "dict" {
+    return direct
+  }
+  let func = entry?.function
+  if type_of(func) == "dict" && type_of(func?.annotations) == "dict" {
+    return func.annotations
+  }
+  return {}
+}
+
+fn __sv_tool_entry_has_write_capability(entry) -> bool {
+  let annotations = __sv_tool_annotations(entry)
+  let side_effect_level = lowercase(__sv_string(annotations?.side_effect_level ?? annotations?.sideEffectLevel))
+  if side_effect_level == "none" || side_effect_level == "read_only" {
+    return false
+  }
+  let kind = lowercase(__sv_string(annotations?.kind))
+  if contains(["read", "search", "think", "fetch"], kind) {
+    return false
+  }
+  return true
+}
+
+fn __sv_workspace_has_write_capability(payload) -> bool {
+  let policy = __sv_dict(payload?.policy)
+  let ceiling = lowercase(__sv_string(policy?.side_effect_level))
+  if ceiling == "none" || ceiling == "read_only" {
+    return false
+  }
+  let tools = __sv_dict(payload?.tools)
+  let entries = __sv_list(tools?.tools)
+  for entry in entries {
+    if type_of(entry) == "dict" && __sv_tool_entry_has_write_capability(entry) {
+      return true
+    }
+  }
+  return false
+}
+
+fn __sv_done_marker_present(payload) -> bool {
+  return trim(__sv_string(payload?.parsed_done_marker)) != ""
+}
+
+fn __sv_non_empty_when_writes_expected(payload) {
+  if !__sv_workspace_has_write_capability(payload) {
+    return nil
+  }
+  if len(__sv_list(payload?.tool_calls)) > 0 {
+    return nil
+  }
+  if __sv_done_marker_present(payload) {
+    return nil
+  }
+  return {
+    rule: "non_empty_when_writes_expected",
+    diagnostic: "Assistant emitted no tool calls while writable tools were available.",
+    recommended_action: "Emit the concrete write or edit tool call needed for the task, or only mark the task done after that work is complete.",
+  }
+}
+
+fn __sv_feedback_payload(verdict) {
+  return json_stringify(
+    {rule: verdict.rule, diagnostic: verdict.diagnostic, recommended_action: verdict.recommended_action},
+  )
+}
+
+fn __sv_emit_decision(session_id, iteration, cfg, verdict, attempts, skipped = false, reason = nil) {
+  agent_emit_event(
+    session_id,
+    "structural_validator_decision",
+    {
+      iteration: iteration,
+      rule: verdict?.rule ?? "",
+      diagnostic: verdict?.diagnostic ?? "",
+      recommended_action: verdict?.recommended_action ?? "",
+      vetoed: verdict != nil,
+      skipped: skipped,
+      reason: reason,
+      on_failure: cfg.on_failure,
+      attempts: attempts,
+      max_attempts: cfg.max_attempts,
+    },
+  )
+}
+
+fn __sv_pass_result(call, configured, skipped = false, reason = nil) {
+  return {
+    ok: true,
+    status: "ok",
+    tool_name: call.tool_name,
+    tool_call_id: call.call_id,
+    arguments: call.tool_args,
+    result: {configured: configured, vetoed: false, skipped: skipped, reason: reason},
+    rendered_result: "",
+    observation: "",
+    error: nil,
+    error_category: nil,
+    executor: "harn",
+  }
+}
+
+fn __sv_veto_result(call, cfg, verdict) {
+  return {
+    ok: true,
+    status: "ok",
+    tool_name: call.tool_name,
+    tool_call_id: call.call_id,
+    arguments: call.tool_args,
+    result: {
+      configured: true,
+      vetoed: true,
+      skipped: false,
+      rule: verdict.rule,
+      diagnostic: verdict.diagnostic,
+      recommended_action: verdict.recommended_action,
+      feedback: __sv_feedback_payload(verdict),
+      on_failure: cfg.on_failure,
+    },
+    rendered_result: verdict.diagnostic,
+    observation: "",
+    error: nil,
+    error_category: nil,
+    executor: "harn",
+  }
+}
+
+fn __sv_handle_turn(call, cfg) {
+  let payload = __sv_dict(call?.tool_args)
+  let session_id = __sv_string(payload?.session_id ?? call?.turn?.session_id)
+  let iteration = to_int(payload?.iteration ?? call?.turn?.iteration) ?? 0
+  let attempts = to_int(payload?.attempts) ?? 0
+  if attempts >= cfg.max_attempts {
+    __sv_emit_decision(session_id, iteration, cfg, nil, attempts, true, "max_attempts_reached")
+    return __sv_pass_result(call, true, true, "max_attempts_reached")
+  }
+  for rule in cfg.rules {
+    let verdict = if rule == "non_empty_when_writes_expected" {
+      __sv_non_empty_when_writes_expected(payload)
+    } else {
+      nil
+    }
+    if verdict != nil {
+      __sv_emit_decision(session_id, iteration, cfg, verdict, attempts)
+      return __sv_veto_result(call, cfg, verdict)
+    }
+  }
+  return __sv_pass_result(call, true)
+}
+
+/**
+ * with_structural_validator(opts) -> caller
+ *
+ * Deterministic pre-dispatch turn validator. The current landable rule
+ * is `non_empty_when_writes_expected`.
+ *
+ * Options:
+ *   on_failure:  "regenerate_with_feedback" | "raise"
+ *   max_attempts: int > 0 (default 3)
+ *   rules: ["non_empty_when_writes_expected"]
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [runtime]
+ * @api_stability: experimental
+ * @example: with_structural_validator({on_failure: "regenerate_with_feedback"})
+ */
+pub fn with_structural_validator(opts = nil) {
+  let cfg = __sv_validate_opts(opts)
+  return { call, next ->
+    if call?.tool_name != __sv_tool_name() {
+      return next(call)
+    }
+    return __sv_handle_turn(call, cfg)
+  }
+}

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -486,6 +486,24 @@ pub enum AgentEvent {
         provider: String,
         model: String,
     },
+    /// Deterministic pre-dispatch critique emitted by the structural
+    /// validator middleware. Fires before any LLM-backed judge so hosts
+    /// can distinguish "$0 structural retry" from semantic critique.
+    StructuralValidatorDecision {
+        session_id: String,
+        iteration: usize,
+        rule: String,
+        diagnostic: String,
+        recommended_action: String,
+        vetoed: bool,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        skipped: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        on_failure: String,
+        attempts: usize,
+        max_attempts: usize,
+    },
     TypedCheckpoint {
         session_id: String,
         checkpoint: serde_json::Value,
@@ -839,6 +857,7 @@ impl AgentEvent {
             | Self::SessionClosed { session_id, .. }
             | Self::JudgeDecision { session_id, .. }
             | Self::StepJudgeDecision { session_id, .. }
+            | Self::StructuralValidatorDecision { session_id, .. }
             | Self::TypedCheckpoint { session_id, .. }
             | Self::FeedbackInjected { session_id, .. }
             | Self::BudgetExhausted { session_id, .. }
@@ -1584,6 +1603,76 @@ mod tests {
         }
         let value: serde_json::Value = serde_json::from_str(&line).unwrap();
         assert_eq!(value["type"], "judge_decision");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn structural_validator_decision_round_trips_through_jsonl_sink() {
+        use std::io::{BufRead, BufReader};
+        let dir = std::env::temp_dir().join(format!(
+            "harn-structural-validator-event-log-{}",
+            uuid::Uuid::now_v7()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("event_log.jsonl");
+        let sink = JsonlEventSink::open(&path).unwrap();
+        sink.handle_event(&AgentEvent::StructuralValidatorDecision {
+            session_id: "s".into(),
+            iteration: 2,
+            rule: "non_empty_when_writes_expected".into(),
+            diagnostic: "Assistant emitted no tool calls while writable tools were available."
+                .into(),
+            recommended_action: "Emit the concrete write or edit tool call needed for the task."
+                .into(),
+            vetoed: true,
+            skipped: false,
+            reason: None,
+            on_failure: "regenerate_with_feedback".into(),
+            attempts: 1,
+            max_attempts: 3,
+        });
+        sink.flush().unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let line = BufReader::new(file).lines().next().unwrap().unwrap();
+        let recovered: PersistedAgentEvent = serde_json::from_str(&line).unwrap();
+        match recovered.event {
+            AgentEvent::StructuralValidatorDecision {
+                session_id,
+                iteration,
+                rule,
+                diagnostic,
+                recommended_action,
+                vetoed,
+                skipped,
+                reason,
+                on_failure,
+                attempts,
+                max_attempts,
+            } => {
+                assert_eq!(session_id, "s");
+                assert_eq!(iteration, 2);
+                assert_eq!(rule, "non_empty_when_writes_expected");
+                assert_eq!(
+                    diagnostic,
+                    "Assistant emitted no tool calls while writable tools were available."
+                );
+                assert_eq!(
+                    recommended_action,
+                    "Emit the concrete write or edit tool call needed for the task."
+                );
+                assert!(vetoed);
+                assert!(!skipped);
+                assert!(reason.is_none());
+                assert_eq!(on_failure, "regenerate_with_feedback");
+                assert_eq!(attempts, 1);
+                assert_eq!(max_attempts, 3);
+            }
+            other => panic!("expected StructuralValidatorDecision, got {other:?}"),
+        }
+        let value: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(value["type"], "structural_validator_decision");
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_dir(&dir);
     }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1480,6 +1480,25 @@ fn build_agent_event(
             provider: get_string("provider"),
             model: get_string("model"),
         }),
+        "structural_validator_decision" => Ok(AgentEvent::StructuralValidatorDecision {
+            session_id: session_id.to_string(),
+            iteration: get_usize("iteration"),
+            rule: get_string("rule"),
+            diagnostic: get_string("diagnostic"),
+            recommended_action: get_string("recommended_action"),
+            vetoed: payload_obj
+                .and_then(|m| m.get("vetoed"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            skipped: payload_obj
+                .and_then(|m| m.get("skipped"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            reason: get_opt_string("reason"),
+            on_failure: get_string("on_failure"),
+            attempts: get_usize("attempts"),
+            max_attempts: get_usize("max_attempts"),
+        }),
         "typed_checkpoint" => Ok(AgentEvent::TypedCheckpoint {
             session_id: session_id.to_string(),
             checkpoint: payload.clone(),

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -84,6 +84,7 @@ public enum HarnProtocolConstants {
         "loop_stuck",
         "progress_reported",
         "session_closed",
+        "structural_validator_decision",
         "step_judge_decision",
         "tool_call_audit",
         "typed_checkpoint",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -162,6 +162,7 @@ var HarnAgentEventKinds = []HarnAgentEventKind{
 	"loop_stuck",
 	"progress_reported",
 	"session_closed",
+	"structural_validator_decision",
 	"step_judge_decision",
 	"tool_call_audit",
 	"typed_checkpoint",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -126,6 +126,7 @@ export const HARN_AGENT_EVENT_KINDS = [
   "loop_stuck",
   "progress_reported",
   "session_closed",
+  "structural_validator_decision",
   "step_judge_decision",
   "tool_call_audit",
   "typed_checkpoint",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -89,6 +89,7 @@
       "loop_stuck",
       "progress_reported",
       "session_closed",
+      "structural_validator_decision",
       "step_judge_decision",
       "tool_call_audit",
       "typed_checkpoint",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -214,6 +214,7 @@ HARN_AGENT_EVENT_KINDS: tuple = (
     "loop_stuck",
     "progress_reported",
     "session_closed",
+    "structural_validator_decision",
     "step_judge_decision",
     "tool_call_audit",
     "typed_checkpoint",


### PR DESCRIPTION
Closes #2366

## Summary
- add experimental `with_structural_validator(opts)` middleware with the first `non_empty_when_writes_expected` rule
- wire `agent_loop` to run the pre-dispatch structural validator probe, pop rejected assistant turns, and inject structural validator feedback before regeneration
- add `structural_validator_decision` events plus ACP fixture/protocol artifact updates and conformance coverage for regenerate and raise paths

## Verification
- `cargo fmt --all --check`
- `/tmp/harn-target-2366/debug/harn fmt --check crates/harn-stdlib/src/stdlib/llm/structural_validator.harn crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_loop_structural_validator.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2366 cargo test -p harn-vm structural_validator_decision_round_trips_through_jsonl_sink --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2366 cargo test -p harn-serve structural_validator_decision_agent_event_carries_retry_shape`
- `CARGO_TARGET_DIR=/tmp/harn-target-2366 cargo test -p harn-serve agent_event_ext_notification_fixtures_are_pinned`
- `CARGO_TARGET_DIR=/tmp/harn-target-2366 cargo test -p harn-serve protocol_conformance_agent_event_fixture_is_adapter_generated`
- `CARGO_TARGET_DIR=/tmp/harn-target-2366 cargo run --quiet --bin harn -- test conformance --filter agent_loop_structural_validator`
- `CARGO_TARGET_DIR=/tmp/harn-target-2366 cargo run --quiet -p harn-cli -- dump-protocol-artifacts --check`