### PR TITLE
Emit tool format override transcript events

### DIFF
--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -334,6 +334,20 @@
       "jsonrpc": "2.0",
       "method": "_harn/agentEvent",
       "params": {
+        "catalogParity": "native_unreliable",
+        "kind": "tool_format_override",
+        "model": "qwen/qwen3-coder",
+        "overrideReason": "cross-check provider regression",
+        "provider": "openrouter",
+        "recommendedFormat": "text",
+        "requestedFormat": "native",
+        "sessionId": "session-1"
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
         "audit": {
           "consent": "not_required",
           "summary": "Read project context"

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -94,6 +94,7 @@
                 "step_judge_decision",
                 "structural_validator_decision",
                 "tool_call_audit",
+                "tool_format_override",
                 "typed_checkpoint",
                 "turn_end",
                 "turn_start"

--- a/conformance/tests/agents/agent_loop_tool_format_capabilities.expected
+++ b/conformance/tests/agents/agent_loop_tool_format_capabilities.expected
@@ -9,3 +9,23 @@ testcatalog
 uncatalogued-model
 preferred_tool_format
 text
+format=text
+1
+testcatalog
+catalogued-native
+text
+native
+interchangeable
+true
+format=native
+1
+native
+text
+native_unreliable
+true
+format=native
+1
+native
+text
+native_unreliable
+cross-check native parser drift

--- a/conformance/tests/agents/agent_loop_tool_format_capabilities.harn
+++ b/conformance/tests/agents/agent_loop_tool_format_capabilities.harn
@@ -32,17 +32,20 @@ fn format_echo_caller() {
 }
 
 fn run_format(options) {
-  let result = agent_loop(
+  return agent_loop(
     "Report the selected format.",
     nil,
     options
       + {tools: sample_tools(), llm_caller: format_echo_caller(), max_iterations: 1, done_judge: false},
   )
-  return result.text
 }
 
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
+}
+
+fn transcript_events_of(result, kind) {
+  return transcript_events(result?.transcript).filter({ event -> event.kind == kind })
 }
 
 pipeline default() {
@@ -52,6 +55,13 @@ pipeline default() {
 model_match = "catalogued-*"
 native_tools = true
 preferred_tool_format = "native"
+tool_mode_parity = "interchangeable"
+
+[[provider.testcatalog]]
+model_match = "native-unreliable-*"
+native_tools = true
+preferred_tool_format = "text"
+tool_mode_parity = "native_unreliable"
 """,
   )
   defer {
@@ -62,7 +72,7 @@ preferred_tool_format = "native"
     preferred_session,
     fn() { return run_format({provider: "testcatalog", model: "catalogued-native", session_id: preferred_session}) },
   )
-  __io_println(preferred.result)
+  __io_println(preferred.result.text)
   __io_println(len(events_of(preferred.events, "capability_gap")))
   let auto_session = "tool-format-auto-" + uuid()
   let auto = agent_capture_events(
@@ -71,7 +81,7 @@ preferred_tool_format = "native"
       {provider: "testcatalog", model: "catalogued-native", session_id: auto_session, tool_format: "auto"},
     ) },
   )
-  __io_println(auto.result)
+  __io_println(auto.result.text)
   __io_println(len(events_of(auto.events, "capability_gap")))
   let fallback_session = "tool-format-fallback-" + uuid()
   let fallback = agent_capture_events(
@@ -79,11 +89,71 @@ preferred_tool_format = "native"
     fn() { return run_format({provider: "testcatalog", model: "uncatalogued-model", session_id: fallback_session}) },
   )
   let gaps = events_of(fallback.events, "capability_gap")
-  __io_println(fallback.result)
+  __io_println(fallback.result.text)
   __io_println(len(gaps))
   __io_println(gaps[0].level)
   __io_println(gaps[0].provider)
   __io_println(gaps[0].model)
   __io_println(gaps[0].capability)
   __io_println(gaps[0].fallback_tool_format)
+  let override_session = "tool-format-override-" + uuid()
+  let override_capture = agent_capture_events(
+    override_session,
+    fn() { return run_format(
+      {
+        provider: "testcatalog",
+        model: "catalogued-native",
+        session_id: override_session,
+        tool_format: "text",
+      },
+    ) },
+  )
+  let override_events = transcript_events_of(override_capture.result, "tool_format_override")
+  __io_println(override_capture.result.text)
+  __io_println(len(override_events))
+  __io_println(override_events[0].metadata?.provider)
+  __io_println(override_events[0].metadata?.model)
+  __io_println(override_events[0].metadata?.requested_format)
+  __io_println(override_events[0].metadata?.recommended_format)
+  __io_println(override_events[0].metadata?.catalog_parity)
+  __io_println(override_events[0].metadata?.override_reason == nil)
+  let missing_reason_session = "tool-format-native-unreliable-missing-" + uuid()
+  let missing_reason = agent_capture_events(
+    missing_reason_session,
+    fn() { return run_format(
+      {
+        provider: "testcatalog",
+        model: "native-unreliable-route",
+        session_id: missing_reason_session,
+        tool_format: "native",
+      },
+    ) },
+  )
+  let missing_reason_events = transcript_events_of(missing_reason.result, "tool_format_override")
+  __io_println(missing_reason.result.text)
+  __io_println(len(missing_reason_events))
+  __io_println(missing_reason_events[0].metadata?.requested_format)
+  __io_println(missing_reason_events[0].metadata?.recommended_format)
+  __io_println(missing_reason_events[0].metadata?.catalog_parity)
+  __io_println(missing_reason_events[0].metadata?.override_reason == nil)
+  let with_reason_session = "tool-format-native-unreliable-reason-" + uuid()
+  let with_reason = agent_capture_events(
+    with_reason_session,
+    fn() { return run_format(
+      {
+        provider: "testcatalog",
+        model: "native-unreliable-route",
+        session_id: with_reason_session,
+        tool_format: "native",
+        tool_format_override_reason: "cross-check native parser drift",
+      },
+    ) },
+  )
+  let with_reason_events = transcript_events_of(with_reason.result, "tool_format_override")
+  __io_println(with_reason.result.text)
+  __io_println(len(with_reason_events))
+  __io_println(with_reason_events[0].metadata?.requested_format)
+  __io_println(with_reason_events[0].metadata?.recommended_format)
+  __io_println(with_reason_events[0].metadata?.catalog_parity)
+  __io_println(with_reason_events[0].metadata?.override_reason)
 }

--- a/crates/harn-cli/assets/evals/coding_agent_suite.harn
+++ b/crates/harn-cli/assets/evals/coding_agent_suite.harn
@@ -4,6 +4,7 @@
 // differences are visible without turning this command into a full coding
 // benchmark.
 import { agent_host_tools } from "std/agent/host_tools"
+import { agent_first_tool_format_override_warning_text } from "std/agent/options"
 import { audit_agent, repair_agent, summary_agent } from "std/agent/presets"
 import { parse_args } from "std/cli"
 import { command_run } from "std/command"
@@ -803,6 +804,7 @@ fn __run_fixture_agent(
   tools,
   max_iterations: int,
   step_judge_config,
+  override_reason = nil,
 ) {
   let done_sentinel = if tool_format == "text" {
     "##DONE##"
@@ -823,6 +825,9 @@ fn __run_fixture_agent(
   }
   if step_judge_config != nil {
     options = options + {step_judge: step_judge_config}
+  }
+  if override_reason != nil && trim(to_string(override_reason)) != "" {
+    options = options + {tool_format_override_reason: trim(to_string(override_reason))}
   }
   if fixture == "read-only-audit" {
     return audit_agent(task, options)
@@ -918,6 +923,7 @@ fn main(harness: Harness) {
       {kind: "option", name: "python", flags: ["--python"], default: "python3"},
       {kind: "flag", name: "seed_mock", flags: ["--seed-mock"]},
       {kind: "option", name: "step_judge_json", flags: ["--step-judge-json"], default: ""},
+      {kind: "option", name: "override_reason", flags: ["--override-reason"], default: ""},
     ],
   )
   if len(args._errors) > 0 {
@@ -945,7 +951,12 @@ fn main(harness: Harness) {
     __fixture_tools(harness, root, args.python, args.fixture),
     args.max_iterations,
     step_judge_config,
+    args.override_reason,
   )
+  let override_warning = agent_first_tool_format_override_warning_text(transcript_events(result?.transcript))
+  if override_warning != nil {
+    __io_eprintln(override_warning)
+  }
   let duration_ms = harness.clock.now_ms() - started_ms
   let verify = __verify_fixture(harness, root, args.fixture, args.python, result)
   let summary = __summary(

--- a/crates/harn-cli/build.rs
+++ b/crates/harn-cli/build.rs
@@ -51,6 +51,26 @@ fn main() {
     println!("cargo:rerun-if-changed=portal-dist");
 }
 
+fn emit_rerun_if_changed_recursive(path: &Path) {
+    println!("cargo:rerun-if-changed={}", path.display());
+
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    let mut children: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    children.sort();
+
+    for child in children {
+        if child.is_dir() {
+            emit_rerun_if_changed_recursive(&child);
+        } else {
+            println!("cargo:rerun-if-changed={}", child.display());
+        }
+    }
+}
+
 /// Self-heal `core.hooksPath` to `.githooks` when building inside the
 /// Harn working tree. Without this, contributors who set up the repo
 /// before `make install-hooks` existed (or whose config drifted to the
@@ -144,7 +164,7 @@ fn emit_cli_script_bytecode() {
         .join("src")
         .join("stdlib")
         .join("cli");
-    println!("cargo:rerun-if-changed={}", cli_scripts_dir.display());
+    emit_rerun_if_changed_recursive(&cli_scripts_dir);
     // Watch the stdlib lib.rs too because that's where script registration
     // lives — adding/removing entries from STDLIB_CLI_SCRIPTS must rerun
     // this build script even if no `.harn` file changed.

--- a/crates/harn-cli/src/cli/eval.rs
+++ b/crates/harn-cli/src/cli/eval.rs
@@ -135,6 +135,9 @@ pub struct EvalCodingAgentArgs {
     /// Use the adversarial rubric variant.
     #[arg(long = "step-judge-adversarial")]
     pub step_judge_adversarial: bool,
+    /// Free-form reason attached when forcing a tool format against catalog guidance.
+    #[arg(long = "override-reason")]
+    pub override_reason: Option<String>,
     /// Free-form label persisted in summary.json for grouping repeat runs
     /// (e.g. "replicate-1", "probe-judge-arch-gpt"). Defaults to empty.
     #[arg(long = "run-label", default_value = "")]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1957,13 +1957,28 @@ fn test_parses_playground_args() {
 
 #[test]
 fn test_parses_try_command() {
-    let cli = Cli::parse_from(["harn", "try", "hi", "--max-iterations", "7"]);
+    let cli = Cli::parse_from([
+        "harn",
+        "try",
+        "hi",
+        "--max-iterations",
+        "7",
+        "--tool-format",
+        "text",
+        "--override-reason",
+        "compare native drift",
+    ]);
 
     let Command::Try(args) = cli.command.unwrap() else {
         panic!("expected try command");
     };
     assert_eq!(args.prompt, "hi");
     assert_eq!(args.max_iterations, 7);
+    assert_eq!(args.tool_format.as_deref(), Some("text"));
+    assert_eq!(
+        args.override_reason.as_deref(),
+        Some("compare native drift")
+    );
 }
 
 #[test]

--- a/crates/harn-cli/src/cli/try_cmd.rs
+++ b/crates/harn-cli/src/cli/try_cmd.rs
@@ -7,4 +7,10 @@ pub(crate) struct TryArgs {
     /// Maximum agent iterations (default 5).
     #[arg(long, default_value_t = 5)]
     pub max_iterations: u32,
+    /// Force the agent tool format (`native`, `text`, or `auto`).
+    #[arg(long = "tool-format")]
+    pub tool_format: Option<String>,
+    /// Reason for intentionally overriding the catalog-recommended tool format.
+    #[arg(long = "override-reason")]
+    pub override_reason: Option<String>,
 }

--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -84,6 +84,7 @@ const CODING_AGENT_MODE_ENV: &str = "HARN_EVAL_CODING_AGENT_MODE";
 static DISPATCH_RENDER_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 const CODING_AGENT_SUITE_HARN: &str = include_str!("../../assets/evals/coding_agent_suite.harn");
+const TOOL_FORMAT_OVERRIDE_WARNING_PREFIX: &str = "warning: tool_format override:";
 
 #[derive(Debug, Clone, Copy)]
 struct FixtureDefinition {
@@ -535,6 +536,9 @@ async fn run_matrix_entry(
         RunSandboxOptions::default().with_workspace_root(run_dir.clone()),
     )
     .await;
+    if let Some(line) = tool_format_override_warning_line(&outcome.stderr) {
+        eprintln!("{line}");
+    }
     let elapsed_ms = clock
         .monotonic_ms()
         .saturating_sub(started_ms)
@@ -802,7 +806,23 @@ fn script_argv(
         argv.push("--step-judge-json".to_string());
         argv.push(json);
     }
+    if let Some(reason) = args
+        .override_reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+    {
+        argv.push("--override-reason".to_string());
+        argv.push(reason.to_string());
+    }
     argv
+}
+
+fn tool_format_override_warning_line(stderr: &str) -> Option<&str> {
+    stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with(TOOL_FORMAT_OVERRIDE_WARNING_PREFIX))
 }
 
 /// Translate the `--step-judge <preset>` CLI flag into a JSON object the
@@ -2087,300 +2107,5 @@ fn expand_home(path: &Path) -> PathBuf {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn dotenv_parser_strips_export_and_quotes_without_leaking_values() {
-        let parsed = parse_env_line("export TOGETHER_API_KEY=\"secret\"")
-            .unwrap()
-            .unwrap();
-        assert_eq!(parsed.0, "TOGETHER_API_KEY");
-        assert_eq!(parsed.1, "secret");
-        assert!(parse_env_line("# comment").unwrap().is_none());
-    }
-
-    #[test]
-    fn model_selector_args_rejoin_provider_model_kv_after_clap_delimiter_split() {
-        let normalized = normalize_model_selector_args(&[
-            "mock:mock".to_string(),
-            "provider=openrouter".to_string(),
-            "model=qwen/qwen3-coder-flash".to_string(),
-            "provider=together".to_string(),
-            "model=Qwen/Qwen3-Coder-Next-FP8".to_string(),
-        ]);
-        assert_eq!(
-            normalized,
-            vec![
-                "mock:mock",
-                "provider=openrouter,model=qwen/qwen3-coder-flash",
-                "provider=together,model=Qwen/Qwen3-Coder-Next-FP8",
-            ]
-        );
-    }
-
-    #[test]
-    fn markdown_escapes_model_table_pipes() {
-        let selector = ModelSelector {
-            selector: "provider:a|b".to_string(),
-            provider: "provider".to_string(),
-            model: "a|b".to_string(),
-        };
-        let summary = EvalSummary {
-            schema_version: 2,
-            fixture_ids: vec!["python-add".to_string()],
-            fixtures: vec![FixtureReport {
-                id: "python-add".to_string(),
-                name: "Python add repair".to_string(),
-                tool_sequence: "multi-tool".to_string(),
-                description: "One-file Python bug fix verified by unittest output.".to_string(),
-            }],
-            output_dir: "out".to_string(),
-            models: vec![selector.clone()],
-            tool_formats: vec!["native".to_string()],
-            env_keys_loaded: Vec::new(),
-            total_runs: 1,
-            passed_runs: 1,
-            failed_runs: 0,
-            skipped_runs: 0,
-            diverged_comparisons: 0,
-            total_cost_usd: 0.0,
-            rollups: EvalRollups {
-                by_fixture: vec![RollupReport {
-                    key: "python-add".to_string(),
-                    total_runs: 1,
-                    passed_runs: 1,
-                    failed_runs: 0,
-                    skipped_runs: 0,
-                    total_cost_usd: 0.0,
-                }],
-                by_provider: Vec::new(),
-                by_model: Vec::new(),
-                by_tool_format: Vec::new(),
-                by_tool_sequence: Vec::new(),
-            },
-            runs: vec![RunReport {
-                run_id: "r".to_string(),
-                fixture_id: "python-add".to_string(),
-                fixture_name: "Python add repair".to_string(),
-                fixture_tool_sequence: "multi-tool".to_string(),
-                selector,
-                tool_format: "native".to_string(),
-                status: "passed".to_string(),
-                passed: true,
-                skipped: false,
-                skipped_reason: None,
-                output_dir: "out/r".to_string(),
-                transcript_events_path: "out/r/transcript_events.jsonl".to_string(),
-                workspace_root: None,
-                elapsed_ms: 1,
-                duration_ms: 1,
-                iterations: 1,
-                input_tokens: 1,
-                output_tokens: 1,
-                cost_usd: 0.0,
-                pricing_known: false,
-                tool_calls: 0,
-                rejected_tool_calls: 0,
-                tool_sequence: Vec::new(),
-                successful_tools: Vec::new(),
-                transcript_event_count: 0,
-                verification_success: true,
-                harn_exit_code: 0,
-                error: None,
-                stderr_excerpt: None,
-                local_cleanup: None,
-            }],
-            comparisons: Vec::new(),
-            followups: Vec::new(),
-            step_judge_preset: None,
-            run_label: String::new(),
-            baseline_comparison: None,
-        };
-        let md = render_markdown(&summary);
-        assert!(md.contains("a\\|b"));
-    }
-
-    #[test]
-    fn baseline_comparison_reports_regressions_and_recoveries() {
-        // Synthetic baseline summary.json — two fixtures, both passed.
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let baseline_path = tmp.path().join("baseline_summary.json");
-        let baseline = serde_json::json!({
-            "schema_version": 2,
-            "runs": [
-                {"fixture_id": "python-add", "passed": true, "skipped": false},
-                {"fixture_id": "cli-help-flag", "passed": true, "skipped": false},
-                {"fixture_id": "test-output-first", "passed": false, "skipped": false},
-            ],
-        });
-        std::fs::write(&baseline_path, serde_json::to_string(&baseline).unwrap())
-            .expect("write baseline");
-
-        // Cell run: cli-help-flag REGRESSED (was passing), test-output-first RECOVERED.
-        let selector = ModelSelector {
-            selector: "mock:mock".to_string(),
-            provider: "mock".to_string(),
-            model: "mock".to_string(),
-        };
-        let runs = vec![
-            RunReport {
-                run_id: "r1".to_string(),
-                fixture_id: "python-add".to_string(),
-                fixture_name: "Python add".to_string(),
-                fixture_tool_sequence: "multi-tool".to_string(),
-                selector: selector.clone(),
-                tool_format: "native".to_string(),
-                status: "passed".to_string(),
-                passed: true,
-                skipped: false,
-                skipped_reason: None,
-                output_dir: "out/r1".to_string(),
-                transcript_events_path: "out/r1/t.jsonl".to_string(),
-                workspace_root: None,
-                elapsed_ms: 0,
-                duration_ms: 0,
-                iterations: 0,
-                input_tokens: 0,
-                output_tokens: 0,
-                cost_usd: 0.0,
-                pricing_known: false,
-                tool_calls: 0,
-                rejected_tool_calls: 0,
-                tool_sequence: Vec::new(),
-                successful_tools: Vec::new(),
-                transcript_event_count: 0,
-                verification_success: true,
-                harn_exit_code: 0,
-                error: None,
-                stderr_excerpt: None,
-                local_cleanup: None,
-            },
-            RunReport {
-                run_id: "r2".to_string(),
-                fixture_id: "cli-help-flag".to_string(),
-                fixture_name: "CLI help flag".to_string(),
-                fixture_tool_sequence: "multi-tool".to_string(),
-                selector: selector.clone(),
-                tool_format: "native".to_string(),
-                status: "failed".to_string(),
-                passed: false,
-                skipped: false,
-                skipped_reason: None,
-                output_dir: "out/r2".to_string(),
-                transcript_events_path: "out/r2/t.jsonl".to_string(),
-                workspace_root: None,
-                elapsed_ms: 0,
-                duration_ms: 0,
-                iterations: 0,
-                input_tokens: 0,
-                output_tokens: 0,
-                cost_usd: 0.0,
-                pricing_known: false,
-                tool_calls: 0,
-                rejected_tool_calls: 0,
-                tool_sequence: Vec::new(),
-                successful_tools: Vec::new(),
-                transcript_event_count: 0,
-                verification_success: false,
-                harn_exit_code: 1,
-                error: None,
-                stderr_excerpt: None,
-                local_cleanup: None,
-            },
-            RunReport {
-                run_id: "r3".to_string(),
-                fixture_id: "test-output-first".to_string(),
-                fixture_name: "Test output first".to_string(),
-                fixture_tool_sequence: "multi-tool".to_string(),
-                selector,
-                tool_format: "native".to_string(),
-                status: "passed".to_string(),
-                passed: true,
-                skipped: false,
-                skipped_reason: None,
-                output_dir: "out/r3".to_string(),
-                transcript_events_path: "out/r3/t.jsonl".to_string(),
-                workspace_root: None,
-                elapsed_ms: 0,
-                duration_ms: 0,
-                iterations: 0,
-                input_tokens: 0,
-                output_tokens: 0,
-                cost_usd: 0.0,
-                pricing_known: false,
-                tool_calls: 0,
-                rejected_tool_calls: 0,
-                tool_sequence: Vec::new(),
-                successful_tools: Vec::new(),
-                transcript_event_count: 0,
-                verification_success: true,
-                harn_exit_code: 0,
-                error: None,
-                stderr_excerpt: None,
-                local_cleanup: None,
-            },
-        ];
-        let comparison = load_baseline_comparison(&baseline_path, &runs).expect("compare");
-        assert_eq!(comparison.regressions_count, 1);
-        assert_eq!(comparison.regressions[0].fixture_id, "cli-help-flag");
-        assert_eq!(comparison.recoveries_count, 1);
-        assert_eq!(comparison.recoveries[0].fixture_id, "test-output-first");
-        assert_eq!(comparison.unchanged_passes, vec!["python-add".to_string()]);
-        assert_eq!(
-            comparison.net_lift_pp, 0.0,
-            "+1 recovery and -1 regression should net to 0pp lift across 3 compared fixtures"
-        );
-    }
-
-    #[test]
-    fn fixture_selection_supports_all_and_specific_ids() {
-        let all = resolve_fixtures(&["all".to_string()]).expect("all fixtures resolve");
-        assert_eq!(all.len(), FIXTURE_DEFINITIONS.len());
-
-        let selected = resolve_fixtures(&[
-            "python-add".to_string(),
-            "python-add".to_string(),
-            "read-only-audit".to_string(),
-        ])
-        .expect("specific fixtures resolve");
-        assert_eq!(
-            selected
-                .iter()
-                .map(|fixture| fixture.id)
-                .collect::<Vec<_>>(),
-            vec!["python-add", "read-only-audit"],
-        );
-
-        let error = resolve_fixtures(&["missing".to_string()]).expect_err("unknown fixture fails");
-        assert!(error.contains("unsupported --fixture `missing`"));
-    }
-
-    #[test]
-    fn matrix_max_runs_bounds_fixture_model_tool_product() {
-        let fixtures = resolve_fixtures(&["all".to_string()]).expect("fixtures");
-        let selector = ModelSelector {
-            selector: "mock:mock".to_string(),
-            provider: "mock".to_string(),
-            model: "mock".to_string(),
-        };
-        let selectors = vec![selector];
-        let tool_formats = vec!["native".to_string(), "text".to_string()];
-        let matrix = build_matrix(&fixtures, &selectors, &tool_formats, Some(3));
-        assert_eq!(matrix.len(), 3);
-        assert_eq!(
-            matrix
-                .iter()
-                .map(|(fixture, _selector, tool_format)| (fixture.id, tool_format.as_str()))
-                .collect::<Vec<_>>(),
-            vec![
-                ("python-add", "native"),
-                ("python-add", "text"),
-                ("cli-help-flag", "native"),
-            ],
-        );
-
-        let empty = build_matrix(&fixtures, &selectors, &tool_formats, Some(0));
-        assert!(empty.is_empty());
-    }
-}
+#[path = "eval_coding_agent_tests.rs"]
+mod tests;

--- a/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
@@ -1,0 +1,310 @@
+use super::*;
+
+#[test]
+fn dotenv_parser_strips_export_and_quotes_without_leaking_values() {
+    let parsed = parse_env_line("export TOGETHER_API_KEY=\"secret\"")
+        .unwrap()
+        .unwrap();
+    assert_eq!(parsed.0, "TOGETHER_API_KEY");
+    assert_eq!(parsed.1, "secret");
+    assert!(parse_env_line("# comment").unwrap().is_none());
+}
+
+#[test]
+fn model_selector_args_rejoin_provider_model_kv_after_clap_delimiter_split() {
+    let normalized = normalize_model_selector_args(&[
+        "mock:mock".to_string(),
+        "provider=openrouter".to_string(),
+        "model=qwen/qwen3-coder-flash".to_string(),
+        "provider=together".to_string(),
+        "model=Qwen/Qwen3-Coder-Next-FP8".to_string(),
+    ]);
+    assert_eq!(
+        normalized,
+        vec![
+            "mock:mock",
+            "provider=openrouter,model=qwen/qwen3-coder-flash",
+            "provider=together,model=Qwen/Qwen3-Coder-Next-FP8",
+        ]
+    );
+}
+
+#[test]
+fn markdown_escapes_model_table_pipes() {
+    let selector = ModelSelector {
+        selector: "provider:a|b".to_string(),
+        provider: "provider".to_string(),
+        model: "a|b".to_string(),
+    };
+    let summary = EvalSummary {
+        schema_version: 2,
+        fixture_ids: vec!["python-add".to_string()],
+        fixtures: vec![FixtureReport {
+            id: "python-add".to_string(),
+            name: "Python add repair".to_string(),
+            tool_sequence: "multi-tool".to_string(),
+            description: "One-file Python bug fix verified by unittest output.".to_string(),
+        }],
+        output_dir: "out".to_string(),
+        models: vec![selector.clone()],
+        tool_formats: vec!["native".to_string()],
+        env_keys_loaded: Vec::new(),
+        total_runs: 1,
+        passed_runs: 1,
+        failed_runs: 0,
+        skipped_runs: 0,
+        diverged_comparisons: 0,
+        total_cost_usd: 0.0,
+        rollups: EvalRollups {
+            by_fixture: vec![RollupReport {
+                key: "python-add".to_string(),
+                total_runs: 1,
+                passed_runs: 1,
+                failed_runs: 0,
+                skipped_runs: 0,
+                total_cost_usd: 0.0,
+            }],
+            by_provider: Vec::new(),
+            by_model: Vec::new(),
+            by_tool_format: Vec::new(),
+            by_tool_sequence: Vec::new(),
+        },
+        runs: vec![RunReport {
+            run_id: "r".to_string(),
+            fixture_id: "python-add".to_string(),
+            fixture_name: "Python add repair".to_string(),
+            fixture_tool_sequence: "multi-tool".to_string(),
+            selector,
+            tool_format: "native".to_string(),
+            status: "passed".to_string(),
+            passed: true,
+            skipped: false,
+            skipped_reason: None,
+            output_dir: "out/r".to_string(),
+            transcript_events_path: "out/r/transcript_events.jsonl".to_string(),
+            workspace_root: None,
+            elapsed_ms: 1,
+            duration_ms: 1,
+            iterations: 1,
+            input_tokens: 1,
+            output_tokens: 1,
+            cost_usd: 0.0,
+            pricing_known: false,
+            tool_calls: 0,
+            rejected_tool_calls: 0,
+            tool_sequence: Vec::new(),
+            successful_tools: Vec::new(),
+            transcript_event_count: 0,
+            verification_success: true,
+            harn_exit_code: 0,
+            error: None,
+            stderr_excerpt: None,
+            local_cleanup: None,
+        }],
+        comparisons: Vec::new(),
+        followups: Vec::new(),
+        step_judge_preset: None,
+        run_label: String::new(),
+        baseline_comparison: None,
+    };
+    let md = render_markdown(&summary);
+    assert!(md.contains("a\\|b"));
+}
+
+#[test]
+fn tool_format_override_warning_line_extracts_first_match() {
+    let stderr = "\
+debug noise
+warning: tool_format override: openrouter:qwen requested native over recommended text (parity: native_unreliable)
+warning: something else
+";
+    assert_eq!(
+            tool_format_override_warning_line(stderr),
+            Some(
+                "warning: tool_format override: openrouter:qwen requested native over recommended text (parity: native_unreliable)"
+            )
+        );
+}
+
+#[test]
+fn baseline_comparison_reports_regressions_and_recoveries() {
+    // Synthetic baseline summary.json — two fixtures, both passed.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let baseline_path = tmp.path().join("baseline_summary.json");
+    let baseline = serde_json::json!({
+        "schema_version": 2,
+        "runs": [
+            {"fixture_id": "python-add", "passed": true, "skipped": false},
+            {"fixture_id": "cli-help-flag", "passed": true, "skipped": false},
+            {"fixture_id": "test-output-first", "passed": false, "skipped": false},
+        ],
+    });
+    std::fs::write(&baseline_path, serde_json::to_string(&baseline).unwrap())
+        .expect("write baseline");
+
+    // Cell run: cli-help-flag REGRESSED (was passing), test-output-first RECOVERED.
+    let selector = ModelSelector {
+        selector: "mock:mock".to_string(),
+        provider: "mock".to_string(),
+        model: "mock".to_string(),
+    };
+    let runs = vec![
+        RunReport {
+            run_id: "r1".to_string(),
+            fixture_id: "python-add".to_string(),
+            fixture_name: "Python add".to_string(),
+            fixture_tool_sequence: "multi-tool".to_string(),
+            selector: selector.clone(),
+            tool_format: "native".to_string(),
+            status: "passed".to_string(),
+            passed: true,
+            skipped: false,
+            skipped_reason: None,
+            output_dir: "out/r1".to_string(),
+            transcript_events_path: "out/r1/t.jsonl".to_string(),
+            workspace_root: None,
+            elapsed_ms: 0,
+            duration_ms: 0,
+            iterations: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+            pricing_known: false,
+            tool_calls: 0,
+            rejected_tool_calls: 0,
+            tool_sequence: Vec::new(),
+            successful_tools: Vec::new(),
+            transcript_event_count: 0,
+            verification_success: true,
+            harn_exit_code: 0,
+            error: None,
+            stderr_excerpt: None,
+            local_cleanup: None,
+        },
+        RunReport {
+            run_id: "r2".to_string(),
+            fixture_id: "cli-help-flag".to_string(),
+            fixture_name: "CLI help flag".to_string(),
+            fixture_tool_sequence: "multi-tool".to_string(),
+            selector: selector.clone(),
+            tool_format: "native".to_string(),
+            status: "failed".to_string(),
+            passed: false,
+            skipped: false,
+            skipped_reason: None,
+            output_dir: "out/r2".to_string(),
+            transcript_events_path: "out/r2/t.jsonl".to_string(),
+            workspace_root: None,
+            elapsed_ms: 0,
+            duration_ms: 0,
+            iterations: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+            pricing_known: false,
+            tool_calls: 0,
+            rejected_tool_calls: 0,
+            tool_sequence: Vec::new(),
+            successful_tools: Vec::new(),
+            transcript_event_count: 0,
+            verification_success: false,
+            harn_exit_code: 1,
+            error: None,
+            stderr_excerpt: None,
+            local_cleanup: None,
+        },
+        RunReport {
+            run_id: "r3".to_string(),
+            fixture_id: "test-output-first".to_string(),
+            fixture_name: "Test output first".to_string(),
+            fixture_tool_sequence: "multi-tool".to_string(),
+            selector,
+            tool_format: "native".to_string(),
+            status: "passed".to_string(),
+            passed: true,
+            skipped: false,
+            skipped_reason: None,
+            output_dir: "out/r3".to_string(),
+            transcript_events_path: "out/r3/t.jsonl".to_string(),
+            workspace_root: None,
+            elapsed_ms: 0,
+            duration_ms: 0,
+            iterations: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+            pricing_known: false,
+            tool_calls: 0,
+            rejected_tool_calls: 0,
+            tool_sequence: Vec::new(),
+            successful_tools: Vec::new(),
+            transcript_event_count: 0,
+            verification_success: true,
+            harn_exit_code: 0,
+            error: None,
+            stderr_excerpt: None,
+            local_cleanup: None,
+        },
+    ];
+    let comparison = load_baseline_comparison(&baseline_path, &runs).expect("compare");
+    assert_eq!(comparison.regressions_count, 1);
+    assert_eq!(comparison.regressions[0].fixture_id, "cli-help-flag");
+    assert_eq!(comparison.recoveries_count, 1);
+    assert_eq!(comparison.recoveries[0].fixture_id, "test-output-first");
+    assert_eq!(comparison.unchanged_passes, vec!["python-add".to_string()]);
+    assert_eq!(
+        comparison.net_lift_pp, 0.0,
+        "+1 recovery and -1 regression should net to 0pp lift across 3 compared fixtures"
+    );
+}
+
+#[test]
+fn fixture_selection_supports_all_and_specific_ids() {
+    let all = resolve_fixtures(&["all".to_string()]).expect("all fixtures resolve");
+    assert_eq!(all.len(), FIXTURE_DEFINITIONS.len());
+
+    let selected = resolve_fixtures(&[
+        "python-add".to_string(),
+        "python-add".to_string(),
+        "read-only-audit".to_string(),
+    ])
+    .expect("specific fixtures resolve");
+    assert_eq!(
+        selected
+            .iter()
+            .map(|fixture| fixture.id)
+            .collect::<Vec<_>>(),
+        vec!["python-add", "read-only-audit"],
+    );
+
+    let error = resolve_fixtures(&["missing".to_string()]).expect_err("unknown fixture fails");
+    assert!(error.contains("unsupported --fixture `missing`"));
+}
+
+#[test]
+fn matrix_max_runs_bounds_fixture_model_tool_product() {
+    let fixtures = resolve_fixtures(&["all".to_string()]).expect("fixtures");
+    let selector = ModelSelector {
+        selector: "mock:mock".to_string(),
+        provider: "mock".to_string(),
+        model: "mock".to_string(),
+    };
+    let selectors = vec![selector];
+    let tool_formats = vec!["native".to_string(), "text".to_string()];
+    let matrix = build_matrix(&fixtures, &selectors, &tool_formats, Some(3));
+    assert_eq!(matrix.len(), 3);
+    assert_eq!(
+        matrix
+            .iter()
+            .map(|(fixture, _selector, tool_format)| (fixture.id, tool_format.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("python-add", "native"),
+            ("python-add", "text"),
+            ("cli-help-flag", "native"),
+        ],
+    );
+
+    let empty = build_matrix(&fixtures, &selectors, &tool_formats, Some(0));
+    assert!(empty.is_empty());
+}

--- a/crates/harn-cli/src/commands/try_cmd.rs
+++ b/crates/harn-cli/src/commands/try_cmd.rs
@@ -13,18 +13,33 @@ use crate::cli::TryArgs;
 use crate::dispatch;
 use crate::env_guard::ScopedEnvVar;
 
+#[path = "try_cmd_legacy.rs"]
+mod legacy;
+
 pub(crate) async fn run(args: TryArgs) {
     if !mock_provider_active() && llm_config::available_provider_names().is_empty() {
         eprintln!("{}", crate::commands::doctor::no_credentials_hint());
         std::process::exit(1);
     }
 
+    let resolved = resolve_try_model();
+
     if std::env::var("HARN_CLI_IMPL").as_deref() == Ok("rust") {
-        run_via_legacy_synth(args).await;
+        legacy::run(args, &resolved.provider, &resolved.model).await;
         return;
     }
 
     let _max = ScopedEnvVar::set("HARN_TRY_MAX_ITERS", &args.max_iterations.to_string());
+    let _provider = ScopedEnvVar::set("HARN_TRY_PROVIDER", &resolved.provider);
+    let _model = ScopedEnvVar::set("HARN_TRY_MODEL", &resolved.model);
+    let _tool_format = args
+        .tool_format
+        .as_deref()
+        .map(|value| ScopedEnvVar::set("HARN_TRY_TOOL_FORMAT", value));
+    let _override_reason = args
+        .override_reason
+        .as_deref()
+        .map(|value| ScopedEnvVar::set("HARN_TRY_OVERRIDE_REASON", value));
     let exit =
         dispatch::dispatch_to_embedded_script("try", vec![args.prompt], /* json_mode */ false)
             .await;
@@ -39,69 +54,32 @@ fn mock_provider_active() -> bool {
         .unwrap_or(false)
 }
 
-/// Legacy synth-into-tempfile-then-`execute_run` path, retained so the
-/// parity-snapshot harness can pin the new dispatch against it. The
-/// C1 ratchet (#2314) removes this once the .harn impl is the
-/// production default everywhere.
-async fn run_via_legacy_synth(args: TryArgs) {
-    use std::collections::HashSet;
-    use std::fs;
-
-    use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
-
-    let escaped = escape_for_harn_string(&args.prompt);
-    let max_iters = args.max_iterations;
-    let script = format!(
-        "let result = agent_loop(\"{escaped}\", nil, {{\n    max_iterations: {max_iters},\n    llm_retries: 2\n}})\n__io_println(result.text)\n"
-    );
-
-    let tmp = match tempfile::Builder::new()
-        .prefix("harn-try-")
-        .suffix(".harn")
-        .tempfile()
-    {
-        Ok(t) => t,
-        Err(error) => {
-            eprintln!("failed to create temp file: {error}");
-            std::process::exit(1);
-        }
-    };
-    let path = tmp.path().to_path_buf();
-    let wrapped = format!("pipeline main(task) {{\n{script}}}\n");
-    if let Err(error) = fs::write(&path, &wrapped) {
-        eprintln!("failed to write temp file: {error}");
-        std::process::exit(1);
-    }
-
-    let outcome: RunOutcome = execute_run(
-        &path.to_string_lossy(),
-        false,
-        HashSet::new(),
-        Vec::new(),
-        Vec::new(),
-        CliLlmMockMode::Off,
-        None,
-        RunProfileOptions::default(),
-    )
-    .await;
-
-    if !outcome.stderr.is_empty() {
-        eprint!("{}", outcome.stderr);
-    }
-    if !outcome.stdout.is_empty() {
-        print!("{}", outcome.stdout);
-    }
-
-    drop(tmp);
-    if outcome.exit_code != 0 {
-        std::process::exit(outcome.exit_code);
-    }
+struct ResolvedTryModel {
+    provider: String,
+    model: String,
 }
 
-fn escape_for_harn_string(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
+fn resolve_try_model() -> ResolvedTryModel {
+    if let Ok(provider) = std::env::var("HARN_LLM_PROVIDER") {
+        let provider = provider.trim().to_string();
+        if !provider.is_empty() && !provider.eq_ignore_ascii_case("auto") {
+            let model = std::env::var("HARN_LLM_MODEL")
+                .ok()
+                .map(|raw| harn_vm::llm_config::resolve_model(&raw).0)
+                .unwrap_or_else(|| harn_vm::llm_config::default_model_for_provider(&provider));
+            return ResolvedTryModel { provider, model };
+        }
+    }
+
+    if let Ok(raw_model) = std::env::var("HARN_LLM_MODEL") {
+        let resolved = harn_vm::llm_config::resolve_model_info(&raw_model);
+        return ResolvedTryModel {
+            provider: resolved.provider,
+            model: resolved.id,
+        };
+    }
+
+    let provider = harn_vm::llm_config::default_provider();
+    let model = harn_vm::llm_config::default_model_for_provider(&provider);
+    ResolvedTryModel { provider, model }
 }

--- a/crates/harn-cli/src/commands/try_cmd_legacy.rs
+++ b/crates/harn-cli/src/commands/try_cmd_legacy.rs
@@ -1,0 +1,87 @@
+use crate::cli::TryArgs;
+
+/// Legacy synth-into-tempfile-then-`execute_run` path, retained so the
+/// parity-snapshot harness can pin the new dispatch against it. The
+/// C1 ratchet (#2314) removes this once the .harn impl is the
+/// production default everywhere.
+pub(super) async fn run(args: TryArgs, provider: &str, model: &str) {
+    use std::collections::HashSet;
+    use std::fs;
+
+    use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
+
+    let escaped = escape_for_harn_string(&args.prompt);
+    let max_iters = args.max_iterations;
+    let provider = escape_for_harn_string(provider);
+    let model = escape_for_harn_string(model);
+    let tool_format_line = args
+        .tool_format
+        .as_deref()
+        .map(|value| format!("    tool_format: \"{}\",\n", escape_for_harn_string(value)))
+        .unwrap_or_default();
+    let override_reason_line = args
+        .override_reason
+        .as_deref()
+        .map(|value| {
+            format!(
+                "    tool_format_override_reason: \"{}\",\n",
+                escape_for_harn_string(value)
+            )
+        })
+        .unwrap_or_default();
+    let script = format!(
+        "let result = agent_loop(\"{escaped}\", nil, {{\n    max_iterations: {max_iters},\n    llm_retries: 2,\n    provider: \"{provider}\",\n    model: \"{model}\",\n{tool_format_line}{override_reason_line}}})\nlet warning = agent_first_tool_format_override_warning_text(transcript_events(result?.transcript))\nif warning != nil {{\n    __io_eprintln(warning)\n}}\n__io_println(result.text)\n"
+    );
+
+    let tmp = match tempfile::Builder::new()
+        .prefix("harn-try-")
+        .suffix(".harn")
+        .tempfile()
+    {
+        Ok(t) => t,
+        Err(error) => {
+            eprintln!("failed to create temp file: {error}");
+            std::process::exit(1);
+        }
+    };
+    let path = tmp.path().to_path_buf();
+    let wrapped = format!(
+        "import {{ agent_first_tool_format_override_warning_text }} from \"std/agent/options\"\n\npipeline main(task) {{\n{script}}}\n"
+    );
+    if let Err(error) = fs::write(&path, &wrapped) {
+        eprintln!("failed to write temp file: {error}");
+        std::process::exit(1);
+    }
+
+    let outcome: RunOutcome = execute_run(
+        &path.to_string_lossy(),
+        false,
+        HashSet::new(),
+        Vec::new(),
+        Vec::new(),
+        CliLlmMockMode::Off,
+        None,
+        RunProfileOptions::default(),
+    )
+    .await;
+
+    if !outcome.stderr.is_empty() {
+        eprint!("{}", outcome.stderr);
+    }
+    if !outcome.stdout.is_empty() {
+        print!("{}", outcome.stdout);
+    }
+
+    drop(tmp);
+    if outcome.exit_code != 0 {
+        std::process::exit(outcome.exit_code);
+    }
+}
+
+fn escape_for_harn_string(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}

--- a/crates/harn-cli/tests/eval_coding_agent_cli.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_cli.rs
@@ -57,6 +57,7 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
         step_judge_on_veto: None,
         step_judge_adversarial: false,
         run_label: String::new(),
+        override_reason: None,
         baseline_comparison_against: None,
     };
 
@@ -204,5 +205,66 @@ fn read_only_audit_verifier_accepts_repeated_read_file_calls() {
     assert_eq!(
         outcome.stdout,
         "repeated_reads=true\nno_read=false\nedit_attempt=false\nparent_path=false\nchanged_readme=false\n"
+    );
+}
+
+#[test]
+fn coding_agent_suite_records_tool_format_override_transcript_event() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let workspace = tmp.path().join("workspace");
+    fs::create_dir_all(&workspace).expect("workspace");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let suite = manifest_dir.join("assets/evals/coding_agent_suite.harn");
+    let output_dir = workspace.join("out");
+    let output_dir_for_run = output_dir.clone();
+    let outcome: RunOutcome = run_in_harn_runtime(move || async move {
+        let _env_guard = env_lock::lock_env().lock().await;
+        harn_vm::reset_thread_local_state();
+        execute_run_with_sandbox_options(
+            &suite.to_string_lossy(),
+            false,
+            HashSet::new(),
+            vec![
+                "--fixture".to_string(),
+                "read-only-audit".to_string(),
+                "--output-dir".to_string(),
+                output_dir_for_run.display().to_string(),
+                "--provider".to_string(),
+                "mock".to_string(),
+                "--model".to_string(),
+                "claude-opus-4-7".to_string(),
+                "--tool-format".to_string(),
+                "text".to_string(),
+                "--override-reason".to_string(),
+                "compare text trace".to_string(),
+                "--python".to_string(),
+                "python3".to_string(),
+                "--seed-mock".to_string(),
+            ],
+            Vec::new(),
+            CliLlmMockMode::Off,
+            None,
+            RunProfileOptions::default(),
+            RunSandboxOptions::default().with_workspace_root(workspace),
+        )
+        .await
+    });
+    assert_eq!(
+        outcome.exit_code, 0,
+        "suite failed\nstdout={}\nstderr={}",
+        outcome.stdout, outcome.stderr
+    );
+    let transcript = fs::read_to_string(output_dir.join("transcript_events.jsonl"))
+        .expect("transcript events exist");
+    assert!(
+        transcript.contains("\"kind\":\"tool_format_override\""),
+        "transcript should record the override event; got:\n{}",
+        transcript
+    );
+    assert!(
+        transcript.contains("\"recommended_format\":\"native\""),
+        "transcript should preserve the catalog recommendation; got:\n{}",
+        transcript
     );
 }

--- a/crates/harn-cli/tests/eval_coding_agent_dispatch.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_dispatch.rs
@@ -280,3 +280,40 @@ fn run_harn(argv: &[String], extra_env: &[(&str, &str)]) -> ProcessOutcome {
         exit_code: output.status.code().unwrap_or(-1),
     }
 }
+
+#[test]
+fn eval_coding_agent_surfaces_tool_format_override_warning() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = tmp.path().join("bench");
+    let argv = vec![
+        "eval".to_string(),
+        "coding-agent".to_string(),
+        "--fixture".to_string(),
+        "no-tool-diagnosis".to_string(),
+        "--model".to_string(),
+        "mock:claude-opus-4-7".to_string(),
+        "--tool-format".to_string(),
+        "text".to_string(),
+        "--max-runs".to_string(),
+        "1".to_string(),
+        "--max-iterations".to_string(),
+        "1".to_string(),
+        "--override-reason".to_string(),
+        "compare text trace".to_string(),
+        "--output".to_string(),
+        output.display().to_string(),
+    ];
+    let outcome = run_harn(&argv, &[]);
+    assert_eq!(
+        outcome.exit_code, 0,
+        "eval failed\nstdout={}\nstderr={}",
+        outcome.stdout, outcome.stderr
+    );
+    assert!(
+        outcome.stderr.contains(
+            "warning: tool_format override: mock:claude-opus-4-7 requested text over recommended native"
+        ),
+        "stderr should surface the override warning; got:\n{}",
+        outcome.stderr
+    );
+}

--- a/crates/harn-cli/tests/try_dispatch.rs
+++ b/crates/harn-cli/tests/try_dispatch.rs
@@ -1,0 +1,41 @@
+#![recursion_limit = "256"]
+
+//! Dispatch coverage for `harn try`.
+
+use std::process::Command;
+
+#[test]
+fn try_dispatch_surfaces_tool_format_override_warning() {
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .env("HARN_LLM_PROVIDER", "mock")
+        .env("HARN_LLM_MODEL", "claude-opus-4-7")
+        .arg("try")
+        .arg("--tool-format")
+        .arg("text")
+        .arg("--override-reason")
+        .arg("compare text trace")
+        .arg("Say hello.")
+        .output()
+        .expect("spawn harn try");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    assert_eq!(
+        output.status.code().unwrap_or(-1),
+        0,
+        "try failed\nstdout={}\nstderr={}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stderr.contains(
+            "warning: tool_format override: mock:claude-opus-4-7 requested text over recommended native"
+        ),
+        "stderr should surface the override warning; got:\n{}",
+        stderr
+    );
+    assert!(
+        !stdout.trim().is_empty(),
+        "stdout should still include the assistant response"
+    );
+}

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1137,6 +1137,27 @@ impl AgentEventSink for AcpAgentEventSink {
                 }
                 self.emit_agent_event_ext("capability_gap", session_id, payload);
             }
+            AgentEvent::ToolFormatOverride {
+                session_id,
+                provider,
+                model,
+                requested_format,
+                recommended_format,
+                catalog_parity,
+                override_reason,
+            } => {
+                let mut payload = serde_json::json!({
+                    "provider": provider,
+                    "model": model,
+                    "requestedFormat": requested_format,
+                    "recommendedFormat": recommended_format,
+                    "catalogParity": catalog_parity,
+                });
+                if let Some(reason) = override_reason {
+                    payload["overrideReason"] = serde_json::Value::String(reason.clone());
+                }
+                self.emit_agent_event_ext("tool_format_override", session_id, payload);
+            }
             AgentEvent::ToolCallAudit {
                 session_id,
                 tool_call_id,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -473,6 +473,15 @@ fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
             reason: "verification still running".to_string(),
             status: "working".to_string(),
         },
+        AgentEvent::ToolFormatOverride {
+            session_id: "session-1".to_string(),
+            provider: "openrouter".to_string(),
+            model: "qwen/qwen3-coder".to_string(),
+            requested_format: "native".to_string(),
+            recommended_format: "text".to_string(),
+            catalog_parity: "native_unreliable".to_string(),
+            override_reason: Some("cross-check provider regression".to_string()),
+        },
         AgentEvent::ToolCallAudit {
             session_id: "session-1".to_string(),
             tool_call_id: "tool-1".to_string(),
@@ -594,6 +603,32 @@ async fn structural_validator_decision_agent_event_carries_retry_shape() {
     assert_eq!(params["attempts"], 1);
     assert_eq!(params["maxAttempts"], 3);
     assert_eq!(params["vetoed"], true);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tool_format_override_agent_event_uses_camel_case_fields() {
+    let actual = collect_notifications(vec![AgentEvent::ToolFormatOverride {
+        session_id: "session-1".to_string(),
+        provider: "openrouter".to_string(),
+        model: "qwen/qwen3-coder".to_string(),
+        requested_format: "native".to_string(),
+        recommended_format: "text".to_string(),
+        catalog_parity: "native_unreliable".to_string(),
+        override_reason: Some("cross-check provider regression".to_string()),
+    }])
+    .await;
+
+    let notification = &actual[0];
+    assert_eq!(notification["method"], HARN_AGENT_EVENT_METHOD);
+    let params = &notification["params"];
+    assert_eq!(params["kind"], "tool_format_override");
+    assert_eq!(params["sessionId"], "session-1");
+    assert_eq!(params["provider"], "openrouter");
+    assert_eq!(params["model"], "qwen/qwen3-coder");
+    assert_eq!(params["requestedFormat"], "native");
+    assert_eq!(params["recommendedFormat"], "text");
+    assert_eq!(params["catalogParity"], "native_unreliable");
+    assert_eq!(params["overrideReason"], "cross-check provider regression");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -67,6 +67,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "structural_validator_decision",
     "step_judge_decision",
     "tool_call_audit",
+    "tool_format_override",
     "typed_checkpoint",
     "turn_end",
     "turn_start",

--- a/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
+++ b/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
@@ -329,6 +329,20 @@
     "jsonrpc": "2.0",
     "method": "_harn/agentEvent",
     "params": {
+      "catalogParity": "native_unreliable",
+      "kind": "tool_format_override",
+      "model": "qwen/qwen3-coder",
+      "overrideReason": "cross-check provider regression",
+      "provider": "openrouter",
+      "recommendedFormat": "text",
+      "requestedFormat": "native",
+      "sessionId": "session-1"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
       "audit": {
         "consent": "not_required",
         "summary": "Read project context"

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1705,6 +1705,9 @@ pub fn agent_loop(message, system_prompt = nil, options = nil) {
   if session?.done {
     return session.result
   }
+  if opts?._tool_format_override != nil {
+    agent_emit_event(session.session_id, "tool_format_override", opts._tool_format_override)
+  }
   if opts?._tool_format_capability_gap != nil {
     agent_emit_event(session.session_id, "capability_gap", opts._tool_format_capability_gap)
   }

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -121,6 +121,141 @@ fn __valid_tool_format(value) {
   return nil
 }
 
+fn __optional_text(value) {
+  if value == nil {
+    return nil
+  }
+  let text = trim(to_string(value))
+  if text == "" {
+    return nil
+  }
+  return text
+}
+
+fn __catalog_parity(value) {
+  let text = __optional_text(value)
+  if text == nil {
+    return "unknown"
+  }
+  return lowercase(text)
+}
+
+fn __parity_recommended_tool_format(parity) {
+  if parity == "native_unreliable" || parity == "text_only" {
+    return "text"
+  }
+  if parity == "text_unreliable" || parity == "native_only" {
+    return "native"
+  }
+  return nil
+}
+
+fn __parity_conflicts_with_requested(parity, requested) {
+  if parity == "native_unreliable" {
+    return requested == "native"
+  }
+  if parity == "text_unreliable" {
+    return requested == "text"
+  }
+  if parity == "native_only" {
+    return requested == "text"
+  }
+  if parity == "text_only" {
+    return requested == "native"
+  }
+  return false
+}
+
+fn __tool_format_override_event(pair, requested, preferred, parity, override_reason) {
+  if pair == nil {
+    return nil
+  }
+  let requested_format = __valid_tool_format(requested)
+  if requested_format == nil {
+    return nil
+  }
+  let catalog_parity = __catalog_parity(parity)
+  let recommended = preferred ?? __parity_recommended_tool_format(catalog_parity)
+  if recommended == nil {
+    return nil
+  }
+  let conflicts_with_recommendation = requested_format != recommended
+  let conflicts_with_parity = __parity_conflicts_with_requested(catalog_parity, requested_format)
+  if !conflicts_with_recommendation && !conflicts_with_parity {
+    return nil
+  }
+  let event = {
+    provider: pair.provider,
+    model: pair.model,
+    requested_format: requested_format,
+    recommended_format: recommended,
+    catalog_parity: catalog_parity,
+  }
+  if override_reason != nil {
+    return event + {override_reason: override_reason}
+  }
+  return event
+}
+
+/**
+ * Render one `tool_format_override` event as the CLI's single-line warning.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_tool_format_override_warning_text(event)
+ */
+pub fn agent_tool_format_override_warning_text(event) {
+  if event == nil {
+    return nil
+  }
+  let payload = event?.metadata ?? event
+  let provider = payload?.provider ?? "unknown"
+  let model = payload?.model ?? "unknown"
+  let requested = payload?.requested_format ?? "unknown"
+  let recommended = payload?.recommended_format ?? "unknown"
+  let parity = payload?.catalog_parity ?? "unknown"
+  let override_reason = trim(to_string(payload?.override_reason ?? ""))
+  let needs_reason = (parity == "native_unreliable" && requested == "native")
+    || (parity == "text_unreliable" && requested == "text")
+  var line = "warning: tool_format override: "
+    + provider
+    + ":"
+    + model
+    + " requested "
+    + requested
+    + " over recommended "
+    + recommended
+    + " (parity: "
+    + parity
+    + ")"
+  if override_reason != "" {
+    line = line + "; reason: " + override_reason
+  } else if needs_reason {
+    line = line + "; missing --override-reason while forcing the catalog-marked unreliable side"
+  }
+  return line
+}
+
+/**
+ * Render the first `tool_format_override` event in an event list, if present.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_first_tool_format_override_warning_text(events)
+ */
+pub fn agent_first_tool_format_override_warning_text(events) {
+  for event in events {
+    if event?.kind == "tool_format_override" || event?.type == "tool_format_override" {
+      return agent_tool_format_override_warning_text(event)
+    }
+  }
+  return nil
+}
+
 fn __capability_gap_event(pair, requested, fallback) {
   return {
     level: "warning",
@@ -148,7 +283,31 @@ pub fn agent_tool_format_resolution(options = nil) {
   let opts = options ?? {}
   let explicit = __explicit_tool_format(opts)
   if explicit != nil {
-    return {tool_format: explicit, source: "explicit", capability_gap_event: nil}
+    let pair = __tool_format_pair(opts)
+    var preferred = nil
+    var parity = nil
+    if pair != nil {
+      let caps = try {
+        provider_capabilities(pair.provider, pair.model)
+      }
+      if !is_err(caps) {
+        let resolved_caps = unwrap(caps)
+        preferred = __valid_tool_format(resolved_caps?.preferred_tool_format)
+        parity = resolved_caps?.tool_mode_parity
+      }
+    }
+    return {
+      tool_format: explicit,
+      source: "explicit",
+      capability_gap_event: nil,
+      tool_format_override_event: __tool_format_override_event(
+        pair,
+        explicit,
+        preferred,
+        parity,
+        __optional_text(opts?.tool_format_override_reason),
+      ),
+    }
   }
   let pair = __tool_format_pair(opts)
   if pair != nil {
@@ -164,6 +323,7 @@ pub fn agent_tool_format_resolution(options = nil) {
           provider: pair.provider,
           model: pair.model,
           capability_gap_event: nil,
+          tool_format_override_event: nil,
         }
       }
     }
@@ -174,12 +334,18 @@ pub fn agent_tool_format_resolution(options = nil) {
       provider: pair.provider,
       model: pair.model,
       capability_gap_event: __capability_gap_event(pair, opts?.tool_format, fallback),
+      tool_format_override_event: nil,
     }
   }
   if __has_key(opts, "tool_format") {
-    return {tool_format: __fallback_tool_format(), source: "fallback", capability_gap_event: nil}
+    return {
+      tool_format: __fallback_tool_format(),
+      source: "fallback",
+      capability_gap_event: nil,
+      tool_format_override_event: nil,
+    }
   }
-  return {tool_format: nil, source: "unresolved", capability_gap_event: nil}
+  return {tool_format: nil, source: "unresolved", capability_gap_event: nil, tool_format_override_event: nil}
 }
 
 /**
@@ -509,6 +675,9 @@ fn __with_resolved_tool_format(opts, resolution) {
   var next = opts + {tool_format: resolution.tool_format}
   if resolution?.capability_gap_event != nil {
     next = next + {_tool_format_capability_gap: resolution.capability_gap_event}
+  }
+  if resolution?.tool_format_override_event != nil {
+    next = next + {_tool_format_override: resolution.tool_format_override_event}
   }
   return next
 }

--- a/crates/harn-stdlib/src/stdlib/cli/try.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/try.harn
@@ -1,3 +1,5 @@
+import { agent_first_tool_format_override_warning_text } from "std/agent/options"
+
 /**
  * `harn try "<prompt>"` ported to .harn — see harn#2302 (W2).
  *
@@ -9,7 +11,19 @@
  * Inputs (from the dispatch shim in crates/harn-cli/src/commands/try_cmd.rs):
  *   argv[0]            — prompt text
  *   HARN_TRY_MAX_ITERS — max agent_loop iterations (default 5)
+ *   HARN_TRY_PROVIDER  — resolved provider for this invocation
+ *   HARN_TRY_MODEL     — resolved model for this invocation
+ *   HARN_TRY_TOOL_FORMAT — optional forced tool_format
+ *   HARN_TRY_OVERRIDE_REASON — optional rationale for a forced tool_format
  */
+fn __trimmed_env(harness: Harness, key: string) {
+  let value = trim(harness.env.get_or(key, ""))
+  if value == "" {
+    return nil
+  }
+  return value
+}
+
 fn main(harness: Harness) {
   if len(argv) < 1 {
     harness.stdio.eprintln("try: prompt is required")
@@ -21,6 +35,24 @@ fn main(harness: Harness) {
   // not bare identifiers, and `harn try` is meant to be a zero-config
   // smoke test. Users wanting tool-augmented loops should use `harn
   // run` with a script that builds the options explicitly.
-  let result = agent_loop(prompt, nil, {max_iterations: max_iters, llm_retries: 2})
+  var options = {max_iterations: max_iters, llm_retries: 2}
+  let provider = __trimmed_env(harness, "HARN_TRY_PROVIDER")
+  let model = __trimmed_env(harness, "HARN_TRY_MODEL")
+  if provider != nil && model != nil {
+    options = options + {provider: provider, model: model}
+  }
+  let tool_format = __trimmed_env(harness, "HARN_TRY_TOOL_FORMAT")
+  if tool_format != nil {
+    options = options + {tool_format: tool_format}
+  }
+  let override_reason = __trimmed_env(harness, "HARN_TRY_OVERRIDE_REASON")
+  if override_reason != nil {
+    options = options + {tool_format_override_reason: override_reason}
+  }
+  let result = agent_loop(prompt, nil, options)
+  let warning = agent_first_tool_format_override_warning_text(transcript_events(result?.transcript))
+  if warning != nil {
+    __io_eprintln(warning)
+  }
   harness.stdio.println(result.text)
 }

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -734,6 +734,19 @@ pub enum AgentEvent {
         requested_tool_format: Option<String>,
         message: String,
     },
+    /// Emitted when a caller explicitly forces a tool format that
+    /// differs from the capability catalog's recommendation or known
+    /// native/text parity guidance.
+    ToolFormatOverride {
+        session_id: String,
+        provider: String,
+        model: String,
+        requested_format: String,
+        recommended_format: String,
+        catalog_parity: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        override_reason: Option<String>,
+    },
     /// Emitted when a `tool_caller` middleware (see std/llm/tool_middleware)
     /// attaches structured audit metadata to a tool call — typically a
     /// user-facing `summary`, a `description`, an ACP-style `kind`, an MCP
@@ -880,6 +893,7 @@ impl AgentEvent {
             | Self::LoopControlDecision { session_id, .. }
             | Self::AgentLoopStallWarning { session_id, .. }
             | Self::CapabilityGap { session_id, .. }
+            | Self::ToolFormatOverride { session_id, .. }
             | Self::ToolCallAudit { session_id, .. }
             | Self::CacheHit { session_id, .. }
             | Self::CacheMiss { session_id, .. }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1361,6 +1361,7 @@ async fn host_agent_emit_event(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             | "tool_search_result"
             | "typed_checkpoint"
             | "agent_loop_stall_warning"
+            | "tool_format_override"
             | "tool_call_audit"
             | "loop_checkpoint"
     ) {
@@ -1571,6 +1572,15 @@ fn build_agent_event(
             fallback_tool_format: get_string("fallback_tool_format"),
             requested_tool_format: get_opt_string("requested_tool_format"),
             message: get_string("message"),
+        }),
+        "tool_format_override" => Ok(AgentEvent::ToolFormatOverride {
+            session_id: session_id.to_string(),
+            provider: get_string("provider"),
+            model: get_string("model"),
+            requested_format: get_string("requested_format"),
+            recommended_format: get_string("recommended_format"),
+            catalog_parity: get_string("catalog_parity"),
+            override_reason: get_opt_string("override_reason"),
         }),
         "tool_call_audit" => {
             let receipt = payload_obj

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1271,6 +1271,10 @@ let caps = provider_capabilities("anthropic", "claude-opus-4-7")
 // `agent_loop` also uses this field for `tool_format: "auto"`; if a concrete
 // provider/model pair has no recommendation, it falls back to text tools and
 // emits a `capability_gap` warning event.
+// An explicit `tool_format` that disagrees with `preferred_tool_format` or
+// chooses the catalog-marked unreliable side emits a `tool_format_override`
+// transcript event. Pass `tool_format_override_reason` when you intentionally
+// force `native_unreliable` or `text_unreliable` routes.
 
 if "bm25" in caps.tool_search {
   // opt into progressive disclosure

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -245,7 +245,10 @@ tool mode for that provider/model route. Rows that do not set it infer
 `text_tool_wire_format_supported = true` for runtimes where Harn's text-tool
 contract is the reliable tool path, and can mark `tool_mode_parity` /
 `tool_mode_parity_notes` when native and text modes are known not to be
-interchangeable. Model-catalog display tags are derived from this matrix too;
+interchangeable. If a caller explicitly forces a conflicting `tool_format`,
+the agent loop emits a `tool_format_override` transcript event; pass
+`tool_format_override_reason` when intentionally forcing a catalog-marked
+unreliable side. Model-catalog display tags are derived from this matrix too;
 legacy `models.*.capabilities` entries are parsed for backwards compatibility
 but do not override runtime capability resolution.
 

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -87,6 +87,7 @@ public enum HarnProtocolConstants {
         "structural_validator_decision",
         "step_judge_decision",
         "tool_call_audit",
+        "tool_format_override",
         "typed_checkpoint",
         "turn_end",
         "turn_start",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -165,6 +165,7 @@ var HarnAgentEventKinds = []HarnAgentEventKind{
 	"structural_validator_decision",
 	"step_judge_decision",
 	"tool_call_audit",
+	"tool_format_override",
 	"typed_checkpoint",
 	"turn_end",
 	"turn_start",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -129,6 +129,7 @@ export const HARN_AGENT_EVENT_KINDS = [
   "structural_validator_decision",
   "step_judge_decision",
   "tool_call_audit",
+  "tool_format_override",
   "typed_checkpoint",
   "turn_end",
   "turn_start",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -92,6 +92,7 @@
       "structural_validator_decision",
       "step_judge_decision",
       "tool_call_audit",
+      "tool_format_override",
       "typed_checkpoint",
       "turn_end",
       "turn_start"

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -217,6 +217,7 @@ HARN_AGENT_EVENT_KINDS: tuple = (
     "structural_validator_decision",
     "step_judge_decision",
     "tool_call_audit",
+    "tool_format_override",
     "typed_checkpoint",
     "turn_end",
     "turn_start",

--- a/spec/protocol-artifacts/schemas/acp-session-update.schema.json
+++ b/spec/protocol-artifacts/schemas/acp-session-update.schema.json
@@ -94,6 +94,7 @@
                 "step_judge_decision",
                 "structural_validator_decision",
                 "tool_call_audit",
+                "tool_format_override",
                 "typed_checkpoint",
                 "turn_end",
                 "turn_start"


### PR DESCRIPTION
## Summary
- emit `tool_format_override` transcript events when explicit tool format choices contradict catalog recommendations or parity guidance
- surface the first override warning line in `harn try` and `harn eval coding-agent`, and thread `--override-reason` through both paths
- refresh ACP fixtures and generated protocol artifacts for the new agent event kind

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2360-fix1 cargo test -p harn-cli --test try_dispatch -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2360-fix1 cargo test -p harn-cli --test eval_coding_agent_dispatch eval_coding_agent_surfaces_tool_format_override_warning -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2360-fix1 cargo test -p harn-cli --test eval_coding_agent_cli coding_agent_suite_records_tool_format_override_transcript_event -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2360-fix1 cargo test -p harn-serve tool_format_override_agent_event_uses_camel_case_fields -- --nocapture`
- `/tmp/harn-target-2360-fix1/debug/harn test conformance --filter agent_loop_tool_format_capabilities`
- `/tmp/harn-target-2360-fix1/debug/harn fmt --check crates/harn-stdlib/src/stdlib/agent/options.harn crates/harn-stdlib/src/stdlib/agent/loop.harn crates/harn-stdlib/src/stdlib/cli/try.harn crates/harn-cli/assets/evals/coding_agent_suite.harn conformance/tests/agents/agent_loop_tool_format_capabilities.harn`
- `/tmp/harn-target-2360-fix1/debug/harn lint crates/harn-stdlib/src/stdlib/agent/options.harn crates/harn-stdlib/src/stdlib/agent/loop.harn crates/harn-stdlib/src/stdlib/cli/try.harn crates/harn-cli/assets/evals/coding_agent_suite.harn conformance/tests/agents/agent_loop_tool_format_capabilities.harn`
- `/tmp/harn-target-2360-fix1/debug/harn check crates/harn-stdlib/src/stdlib/agent/options.harn crates/harn-stdlib/src/stdlib/agent/loop.harn crates/harn-stdlib/src/stdlib/cli/try.harn crates/harn-cli/assets/evals/coding_agent_suite.harn conformance/tests/agents/agent_loop_tool_format_capabilities.harn`
- `make gen-protocol-artifacts`
- `make check-protocol-artifacts`
