### PR TITLE
[TM-03] Promote tool parity from evals

### DIFF
--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -153,7 +153,8 @@ pub(crate) use portal::PortalArgs;
 pub use precompile::PrecompileArgs;
 pub(crate) use profile::ProfileArgs;
 pub(crate) use provider::{
-    ModelInfoArgs, ProviderArgs, ProviderCapabilitiesCommand, ProviderCatalogArgs, ProviderCommand,
+    ModelInfoArgs, ProviderArgs, ProviderCapabilitiesCommand,
+    ProviderCapabilitiesPromoteFromEvalArgs, ProviderCatalogArgs, ProviderCommand,
     ProviderProbeArgs, ProviderReadyArgs, ProviderToolProbeArgs, ProviderToolProbeModeArg,
 };
 pub(crate) use providers::{

--- a/crates/harn-cli/src/cli/provider.rs
+++ b/crates/harn-cli/src/cli/provider.rs
@@ -26,6 +26,8 @@ pub(crate) struct ProviderCapabilitiesArgs {
 pub(crate) enum ProviderCapabilitiesCommand {
     /// Audit catalogued priced chat models for explicit tool capability fields.
     Audit(ProviderCapabilitiesAuditArgs),
+    /// Apply a generated parity overlay to the capability catalog.
+    PromoteFromEval(ProviderCapabilitiesPromoteFromEvalArgs),
 }
 
 #[derive(Debug, Args)]
@@ -33,6 +35,15 @@ pub(crate) struct ProviderCapabilitiesAuditArgs {
     /// Emit the structured audit report as JSON.
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ProviderCapabilitiesPromoteFromEvalArgs {
+    /// Generated overlay TOML from `harn eval coding-agent`.
+    pub overlay_path: PathBuf,
+    /// Capability catalog TOML to update in place.
+    #[arg(long, default_value = "crates/harn-vm/src/llm/capabilities.toml")]
+    pub catalog: PathBuf,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -92,8 +92,33 @@ fn test_parses_provider_capabilities_audit_json() {
         panic!("expected provider command");
     };
     let ProviderCommand::Capabilities(capabilities) = args.command;
-    let ProviderCapabilitiesCommand::Audit(audit) = capabilities.command;
+    let ProviderCapabilitiesCommand::Audit(audit) = capabilities.command else {
+        panic!("expected audit command");
+    };
     assert!(audit.json);
+}
+
+#[test]
+fn test_parses_provider_capabilities_promote_from_eval() {
+    let cli = Cli::parse_from([
+        "harn",
+        "provider",
+        "capabilities",
+        "promote-from-eval",
+        "overlay.toml",
+        "--catalog",
+        "custom-capabilities.toml",
+    ]);
+
+    let Command::Provider(args) = cli.command.unwrap() else {
+        panic!("expected provider command");
+    };
+    let ProviderCommand::Capabilities(capabilities) = args.command;
+    let ProviderCapabilitiesCommand::PromoteFromEval(promote) = capabilities.command else {
+        panic!("expected promote-from-eval command");
+    };
+    assert_eq!(promote.overlay_path, PathBuf::from("overlay.toml"));
+    assert_eq!(promote.catalog, PathBuf::from("custom-capabilities.toml"));
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -54,6 +54,10 @@ use crate::commands::local_readiness;
 use crate::commands::run::{
     execute_run_with_sandbox_options, CliLlmMockMode, RunProfileOptions, RunSandboxOptions,
 };
+use crate::commands::tool_mode_parity::{
+    self, ToolModeParityObservation, TOOL_MODE_PARITY_FIXTURE_SUITE,
+    TOOL_MODE_PARITY_OVERLAY_FILENAME,
+};
 use crate::dispatch;
 use crate::env_guard::ScopedEnvVar;
 
@@ -1587,15 +1591,44 @@ fn write_json_artifacts(output_dir: &Path, summary: &EvalSummary) -> Result<(), 
         output_dir.display().to_string(),
     )?;
     write_json_pretty(&output_dir.join("local_readiness.json"), &readiness)?;
+    let generated_at = RealClock::new()
+        .now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .map_err(|error| format!("failed to format parity overlay timestamp: {error}"))?;
+    let observations = summary
+        .runs
+        .iter()
+        .map(|run| ToolModeParityObservation {
+            provider: run.selector.provider.clone(),
+            model: run.selector.model.clone(),
+            fixture_id: run.fixture_id.clone(),
+            run_id: run.run_id.clone(),
+            tool_format: run.tool_format.clone(),
+            passed: run.passed,
+            skipped: run.skipped,
+            verification_success: run.verification_success,
+        })
+        .collect::<Vec<_>>();
+    let overlay = tool_mode_parity::build_overlay(
+        &observations,
+        &generated_at,
+        TOOL_MODE_PARITY_FIXTURE_SUITE,
+        output_dir,
+    );
+    tool_mode_parity::write_overlay(
+        &output_dir.join(TOOL_MODE_PARITY_OVERLAY_FILENAME),
+        &overlay,
+    )?;
     Ok(())
 }
 
 fn announce_output_paths(output_dir: &Path) {
     eprintln!(
-        "wrote {}, {}, {}, {}, and {}",
+        "wrote {}, {}, {}, {}, {}, and {}",
         output_dir.join("summary.json").display(),
         output_dir.join("per_run.jsonl").display(),
         output_dir.join("local_readiness.json").display(),
+        output_dir.join(TOOL_MODE_PARITY_OVERLAY_FILENAME).display(),
         output_dir.join("summary.md").display(),
         output_dir.join("followups.md").display()
     );

--- a/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
@@ -112,6 +112,124 @@ fn markdown_escapes_model_table_pipes() {
 }
 
 #[test]
+fn write_json_artifacts_emits_tool_mode_parity_overlay() {
+    let selector = ModelSelector {
+        selector: "openrouter:qwen/qwen3-coder".to_string(),
+        provider: "openrouter".to_string(),
+        model: "qwen/qwen3-coder".to_string(),
+    };
+    let summary = EvalSummary {
+        schema_version: 2,
+        fixture_ids: vec!["python-add".to_string()],
+        fixtures: vec![FixtureReport {
+            id: "python-add".to_string(),
+            name: "Python add repair".to_string(),
+            tool_sequence: "multi-tool".to_string(),
+            description: "One-file Python bug fix verified by unittest output.".to_string(),
+        }],
+        output_dir: "out".to_string(),
+        models: vec![selector.clone()],
+        tool_formats: vec!["native".to_string(), "text".to_string()],
+        env_keys_loaded: Vec::new(),
+        total_runs: 2,
+        passed_runs: 1,
+        failed_runs: 1,
+        skipped_runs: 0,
+        diverged_comparisons: 1,
+        total_cost_usd: 0.0,
+        rollups: EvalRollups {
+            by_fixture: Vec::new(),
+            by_provider: Vec::new(),
+            by_model: Vec::new(),
+            by_tool_format: Vec::new(),
+            by_tool_sequence: Vec::new(),
+        },
+        runs: vec![
+            RunReport {
+                run_id: "native".to_string(),
+                fixture_id: "python-add".to_string(),
+                fixture_name: "Python add repair".to_string(),
+                fixture_tool_sequence: "multi-tool".to_string(),
+                selector: selector.clone(),
+                tool_format: "native".to_string(),
+                status: "failed".to_string(),
+                passed: false,
+                skipped: false,
+                skipped_reason: None,
+                output_dir: "out/native".to_string(),
+                transcript_events_path: "out/native/transcript_events.jsonl".to_string(),
+                workspace_root: None,
+                elapsed_ms: 1,
+                duration_ms: 1,
+                iterations: 1,
+                input_tokens: 1,
+                output_tokens: 1,
+                cost_usd: 0.0,
+                pricing_known: false,
+                tool_calls: 0,
+                rejected_tool_calls: 0,
+                tool_sequence: Vec::new(),
+                successful_tools: Vec::new(),
+                transcript_event_count: 0,
+                verification_success: false,
+                harn_exit_code: 1,
+                error: None,
+                stderr_excerpt: None,
+                local_cleanup: None,
+            },
+            RunReport {
+                run_id: "text".to_string(),
+                fixture_id: "python-add".to_string(),
+                fixture_name: "Python add repair".to_string(),
+                fixture_tool_sequence: "multi-tool".to_string(),
+                selector,
+                tool_format: "text".to_string(),
+                status: "passed".to_string(),
+                passed: true,
+                skipped: false,
+                skipped_reason: None,
+                output_dir: "out/text".to_string(),
+                transcript_events_path: "out/text/transcript_events.jsonl".to_string(),
+                workspace_root: None,
+                elapsed_ms: 1,
+                duration_ms: 1,
+                iterations: 1,
+                input_tokens: 1,
+                output_tokens: 1,
+                cost_usd: 0.0,
+                pricing_known: false,
+                tool_calls: 0,
+                rejected_tool_calls: 0,
+                tool_sequence: Vec::new(),
+                successful_tools: Vec::new(),
+                transcript_event_count: 0,
+                verification_success: true,
+                harn_exit_code: 0,
+                error: None,
+                stderr_excerpt: None,
+                local_cleanup: None,
+            },
+        ],
+        comparisons: Vec::new(),
+        followups: Vec::new(),
+        step_judge_preset: None,
+        run_label: String::new(),
+        baseline_comparison: None,
+    };
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    write_json_artifacts(temp.path(), &summary).expect("write artifacts");
+
+    let overlay = crate::commands::tool_mode_parity::read_overlay(
+        &temp.path().join(TOOL_MODE_PARITY_OVERLAY_FILENAME),
+    )
+    .expect("read overlay");
+    assert_eq!(overlay.fixture_suite, TOOL_MODE_PARITY_FIXTURE_SUITE);
+    assert_eq!(overlay.rows.len(), 1);
+    assert_eq!(overlay.rows[0].preferred_tool_format, "text");
+}
+
+#[test]
 fn tool_format_override_warning_line_extracts_first_match() {
     let stderr = "\
 debug noise

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -63,6 +63,7 @@ pub(crate) mod test;
 pub mod test_bench;
 pub mod time;
 pub(crate) mod tool;
+pub(crate) mod tool_mode_parity;
 pub(crate) mod trace;
 pub mod trigger;
 pub(crate) mod trust;

--- a/crates/harn-cli/src/commands/provider_capabilities.rs
+++ b/crates/harn-cli/src/commands/provider_capabilities.rs
@@ -1,9 +1,18 @@
-use crate::cli::{ProviderArgs, ProviderCapabilitiesCommand, ProviderCommand};
+use std::fs;
+
+use crate::cli::{
+    ProviderArgs, ProviderCapabilitiesCommand, ProviderCapabilitiesPromoteFromEvalArgs,
+    ProviderCommand,
+};
+use crate::commands::tool_mode_parity::{self, ToolModeParityOverlay, ToolModeParityOverlayRow};
 
 pub(crate) fn run(args: ProviderArgs) -> Result<(), String> {
     match args.command {
         ProviderCommand::Capabilities(capabilities) => match capabilities.command {
             ProviderCapabilitiesCommand::Audit(audit) => run_audit(audit.json),
+            ProviderCapabilitiesCommand::PromoteFromEval(promote) => {
+                run_promote_from_eval(&promote)
+            }
         },
     }
 }
@@ -29,4 +38,345 @@ fn run_audit(json: bool) -> Result<(), String> {
         .ok()
         .then_some(())
         .ok_or_else(|| "provider capability audit failed".to_string())
+}
+
+fn run_promote_from_eval(args: &ProviderCapabilitiesPromoteFromEvalArgs) -> Result<(), String> {
+    let overlay = tool_mode_parity::read_overlay(&args.overlay_path)?;
+    let current = fs::read_to_string(&args.catalog)
+        .map_err(|error| format!("failed to read {}: {error}", args.catalog.display()))?;
+    let updated = apply_overlay_to_catalog(&current, &overlay)?;
+    if updated == current {
+        println!(
+            "provider capability catalog already matches {}",
+            args.overlay_path.display()
+        );
+        return Ok(());
+    }
+    fs::write(&args.catalog, updated)
+        .map_err(|error| format!("failed to write {}: {error}", args.catalog.display()))?;
+    println!(
+        "updated {} from {}",
+        args.catalog.display(),
+        args.overlay_path.display()
+    );
+    Ok(())
+}
+
+fn apply_overlay_to_catalog(raw: &str, overlay: &ToolModeParityOverlay) -> Result<String, String> {
+    let mut rows = overlay.rows.clone();
+    rows.sort_by(|left, right| {
+        left.provider
+            .cmp(&right.provider)
+            .then_with(|| left.model.cmp(&right.model))
+    });
+
+    let mut out = raw.to_string();
+    for row in &rows {
+        if row.native.total_runs == 0 || row.text.total_runs == 0 {
+            continue;
+        }
+        out = apply_overlay_row(&out, row)?;
+    }
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+fn apply_overlay_row(raw: &str, row: &ToolModeParityOverlayRow) -> Result<String, String> {
+    let mut lines = raw.lines().map(str::to_string).collect::<Vec<_>>();
+    let blocks = scan_blocks(&lines)?;
+    let note = tool_mode_parity::render_promotion_note(row);
+
+    if let Some(block) = blocks.iter().find(|block| {
+        block.provider == row.provider
+            && block
+                .model_match
+                .as_deref()
+                .is_some_and(|model| model == row.model)
+    }) {
+        let mut block_lines = lines[block.start..block.end].to_vec();
+        upsert_field(
+            &mut block_lines,
+            "native_tools",
+            format!("native_tools = {}", true),
+            &["model_match"],
+        );
+        upsert_field(
+            &mut block_lines,
+            "preferred_tool_format",
+            format!(
+                "preferred_tool_format = {}",
+                toml_string(&row.preferred_tool_format)
+            ),
+            &["native_tools", "model_match"],
+        );
+        upsert_field(
+            &mut block_lines,
+            "tool_mode_parity",
+            format!("tool_mode_parity = {}", toml_string(&row.tool_mode_parity)),
+            &["preferred_tool_format", "native_tools", "model_match"],
+        );
+        upsert_field(
+            &mut block_lines,
+            "tool_mode_parity_notes",
+            format!("tool_mode_parity_notes = {}", toml_string(&note)),
+            &["tool_mode_parity", "preferred_tool_format", "native_tools"],
+        );
+        lines.splice(block.start..block.end, block_lines);
+    } else {
+        let insert_at = blocks
+            .iter()
+            .find(|block| block.provider == row.provider)
+            .map(|block| block.start)
+            .unwrap_or(lines.len());
+        lines.splice(insert_at..insert_at, render_new_block(row, &note));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn render_new_block(row: &ToolModeParityOverlayRow, note: &str) -> Vec<String> {
+    vec![
+        format!("[[provider.{}]]", row.provider),
+        format!("model_match = {}", toml_string(&row.model)),
+        "native_tools = true".to_string(),
+        format!(
+            "preferred_tool_format = {}",
+            toml_string(&row.preferred_tool_format)
+        ),
+        format!("tool_mode_parity = {}", toml_string(&row.tool_mode_parity)),
+        format!("tool_mode_parity_notes = {}", toml_string(note)),
+        String::new(),
+    ]
+}
+
+fn upsert_field(block_lines: &mut Vec<String>, key: &str, rendered: String, after_keys: &[&str]) {
+    if let Some(index) = field_index(block_lines, key) {
+        block_lines[index] = rendered;
+        return;
+    }
+
+    let insert_after = after_keys
+        .iter()
+        .find_map(|candidate| field_index(block_lines, candidate))
+        .unwrap_or(0);
+    block_lines.insert(insert_after + 1, rendered);
+}
+
+fn field_index(lines: &[String], key: &str) -> Option<usize> {
+    lines.iter().position(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with(key) && trimmed[key.len()..].trim_start().starts_with('=')
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ProviderBlock {
+    provider: String,
+    start: usize,
+    end: usize,
+    model_match: Option<String>,
+}
+
+fn scan_blocks(lines: &[String]) -> Result<Vec<ProviderBlock>, String> {
+    let mut starts = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("[[provider.") && trimmed.ends_with("]]") {
+            starts.push((index, parse_provider_header(trimmed)?));
+        }
+    }
+
+    let mut blocks = Vec::new();
+    for (offset, (start, provider)) in starts.iter().enumerate() {
+        let end = starts
+            .get(offset + 1)
+            .map(|(next, _)| *next)
+            .unwrap_or(lines.len());
+        let model_match = lines[*start..end]
+            .iter()
+            .find_map(|line| parse_string_field(line, "model_match"));
+        blocks.push(ProviderBlock {
+            provider: provider.clone(),
+            start: *start,
+            end,
+            model_match,
+        });
+    }
+    Ok(blocks)
+}
+
+fn parse_provider_header(line: &str) -> Result<String, String> {
+    line.strip_prefix("[[provider.")
+        .and_then(|rest| rest.strip_suffix("]]"))
+        .map(str::to_string)
+        .ok_or_else(|| format!("invalid provider capability header `{line}`"))
+}
+
+fn parse_string_field(line: &str, key: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let remainder = trimmed.strip_prefix(key)?.trim_start();
+    let raw = remainder.strip_prefix('=')?.trim();
+    raw.parse::<toml::Value>()
+        .ok()?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn toml_string(value: &str) -> String {
+    toml::Value::String(value.to_string()).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn overlay_row() -> ToolModeParityOverlayRow {
+        ToolModeParityOverlayRow {
+            provider: "openrouter".to_string(),
+            model: "qwen/qwen3-coder".to_string(),
+            tool_mode_parity: "native_unreliable".to_string(),
+            preferred_tool_format: "text".to_string(),
+            confidence: "low".to_string(),
+            sample_size: 5,
+            last_updated: "2026-05-24T00:00:00Z".to_string(),
+            evidence_path: ".harn-runs/coding-agent-bench/latest".to_string(),
+            verifier_divergence_rate: 0.8,
+            native: tool_mode_parity::ToolModeParityFormatStats {
+                total_runs: 5,
+                passed_runs: 1,
+                unique_fixtures: 5,
+                replicate_count: 1,
+                pass_rate: 0.2,
+            },
+            text: tool_mode_parity::ToolModeParityFormatStats {
+                total_runs: 5,
+                passed_runs: 5,
+                unique_fixtures: 5,
+                replicate_count: 1,
+                pass_rate: 1.0,
+            },
+        }
+    }
+
+    #[test]
+    fn apply_overlay_inserts_specific_rule_before_wildcard() {
+        let raw = r#"
+[[provider.openrouter]]
+model_match = "qwen/*"
+native_tools = true
+preferred_tool_format = "native"
+"#;
+
+        let overlay = ToolModeParityOverlay {
+            schema_version: 1,
+            generated_at: "2026-05-24T00:00:00Z".to_string(),
+            fixture_suite: "coding-agent".to_string(),
+            rows: vec![overlay_row()],
+        };
+
+        let updated = apply_overlay_to_catalog(raw, &overlay).expect("apply");
+        let first = updated
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .expect("first non-empty line");
+        assert_eq!(first, "[[provider.openrouter]]");
+        assert!(updated.contains("model_match = \"qwen/qwen3-coder\""));
+        assert!(updated.contains("tool_mode_parity = \"native_unreliable\""));
+        let wildcard_index = updated.find("model_match = \"qwen/*\"").expect("wildcard");
+        let exact_index = updated
+            .find("model_match = \"qwen/qwen3-coder\"")
+            .expect("exact");
+        assert!(exact_index < wildcard_index);
+    }
+
+    #[test]
+    fn apply_overlay_updates_existing_exact_rule_idempotently() {
+        let raw = r#"
+[[provider.openrouter]]
+model_match = "qwen/qwen3-coder"
+native_tools = true
+preferred_tool_format = "native"
+
+[[provider.openrouter]]
+model_match = "qwen/*"
+native_tools = true
+preferred_tool_format = "native"
+"#;
+
+        let overlay = ToolModeParityOverlay {
+            schema_version: 1,
+            generated_at: "2026-05-24T00:00:00Z".to_string(),
+            fixture_suite: "coding-agent".to_string(),
+            rows: vec![overlay_row()],
+        };
+
+        let updated = apply_overlay_to_catalog(raw, &overlay).expect("apply");
+        assert!(updated.contains("preferred_tool_format = \"text\""));
+        assert!(updated.contains("tool_mode_parity = \"native_unreliable\""));
+
+        let updated_again = apply_overlay_to_catalog(&updated, &overlay).expect("reapply");
+        assert_eq!(updated, updated_again);
+    }
+
+    #[test]
+    fn promote_from_eval_skips_rows_without_both_formats() {
+        let raw = r#"
+[[provider.openrouter]]
+model_match = "qwen/*"
+native_tools = true
+preferred_tool_format = "native"
+"#;
+
+        let mut row = overlay_row();
+        row.native.total_runs = 0;
+        let overlay = ToolModeParityOverlay {
+            schema_version: 1,
+            generated_at: "2026-05-24T00:00:00Z".to_string(),
+            fixture_suite: "coding-agent".to_string(),
+            rows: vec![row],
+        };
+
+        let updated = apply_overlay_to_catalog(raw, &overlay).expect("apply");
+        assert!(!updated.contains("tool_mode_parity"));
+        assert_eq!(updated.trim(), raw.trim());
+    }
+
+    #[test]
+    fn run_promote_from_eval_updates_catalog_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let catalog = temp.path().join("capabilities.toml");
+        let overlay_path = temp.path().join("overlay.toml");
+        fs::write(
+            &catalog,
+            r#"
+[[provider.openrouter]]
+model_match = "qwen/*"
+native_tools = true
+preferred_tool_format = "native"
+"#,
+        )
+        .expect("write catalog");
+        tool_mode_parity::write_overlay(
+            &overlay_path,
+            &ToolModeParityOverlay {
+                schema_version: 1,
+                generated_at: "2026-05-24T00:00:00Z".to_string(),
+                fixture_suite: "coding-agent".to_string(),
+                rows: vec![overlay_row()],
+            },
+        )
+        .expect("write overlay");
+
+        run_promote_from_eval(&ProviderCapabilitiesPromoteFromEvalArgs {
+            overlay_path: overlay_path.clone(),
+            catalog: catalog.clone(),
+        })
+        .expect("promote");
+
+        let updated = fs::read_to_string(&catalog).expect("read updated catalog");
+        assert!(updated.contains("model_match = \"qwen/qwen3-coder\""));
+        assert!(updated.contains("tool_mode_parity = \"native_unreliable\""));
+    }
 }

--- a/crates/harn-cli/src/commands/tool_mode_parity.rs
+++ b/crates/harn-cli/src/commands/tool_mode_parity.rs
@@ -1,0 +1,362 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const TOOL_MODE_PARITY_OVERLAY_SCHEMA_VERSION: u32 = 1;
+pub(crate) const TOOL_MODE_PARITY_FIXTURE_SUITE: &str = "coding-agent";
+pub(crate) const TOOL_MODE_PARITY_OVERLAY_FILENAME: &str = "tool_mode_parity_overlay.toml";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolModeParityObservation {
+    pub provider: String,
+    pub model: String,
+    pub fixture_id: String,
+    pub run_id: String,
+    pub tool_format: String,
+    pub passed: bool,
+    pub skipped: bool,
+    pub verification_success: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ToolModeParityOverlay {
+    pub schema_version: u32,
+    pub generated_at: String,
+    pub fixture_suite: String,
+    pub rows: Vec<ToolModeParityOverlayRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ToolModeParityOverlayRow {
+    pub provider: String,
+    pub model: String,
+    pub tool_mode_parity: String,
+    pub preferred_tool_format: String,
+    pub confidence: String,
+    pub sample_size: usize,
+    pub last_updated: String,
+    pub evidence_path: String,
+    pub verifier_divergence_rate: f64,
+    pub native: ToolModeParityFormatStats,
+    pub text: ToolModeParityFormatStats,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ToolModeParityFormatStats {
+    pub total_runs: usize,
+    pub passed_runs: usize,
+    pub unique_fixtures: usize,
+    pub replicate_count: usize,
+    pub pass_rate: f64,
+}
+
+pub(crate) fn build_overlay(
+    observations: &[ToolModeParityObservation],
+    generated_at: &str,
+    fixture_suite: &str,
+    evidence_path: &Path,
+) -> ToolModeParityOverlay {
+    let mut grouped: BTreeMap<(String, String), Vec<&ToolModeParityObservation>> = BTreeMap::new();
+    for observation in observations {
+        grouped
+            .entry((observation.provider.clone(), observation.model.clone()))
+            .or_default()
+            .push(observation);
+    }
+
+    let rows = grouped
+        .into_iter()
+        .map(|((provider, model), bucket)| {
+            let native = format_stats(&bucket, "native");
+            let text = format_stats(&bucket, "text");
+            let sample_size = native.unique_fixtures.min(text.unique_fixtures);
+            let verifier_divergence_rate = verifier_divergence_rate(&bucket);
+            let tool_mode_parity =
+                classify_tool_mode_parity(sample_size, native.pass_rate, text.pass_rate);
+            let preferred_tool_format =
+                preferred_tool_format(&tool_mode_parity, native.pass_rate, text.pass_rate);
+            let confidence = parity_confidence(sample_size, &native, &text);
+
+            ToolModeParityOverlayRow {
+                provider,
+                model,
+                tool_mode_parity,
+                preferred_tool_format,
+                confidence,
+                sample_size,
+                last_updated: generated_at.to_string(),
+                evidence_path: evidence_path.display().to_string(),
+                verifier_divergence_rate,
+                native,
+                text,
+            }
+        })
+        .collect();
+
+    ToolModeParityOverlay {
+        schema_version: TOOL_MODE_PARITY_OVERLAY_SCHEMA_VERSION,
+        generated_at: generated_at.to_string(),
+        fixture_suite: fixture_suite.to_string(),
+        rows,
+    }
+}
+
+pub(crate) fn write_overlay(path: &Path, overlay: &ToolModeParityOverlay) -> Result<(), String> {
+    let body = toml::to_string_pretty(overlay)
+        .map_err(|error| format!("failed to render {}: {error}", path.display()))?;
+    fs::write(path, body).map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+pub(crate) fn read_overlay(path: &Path) -> Result<ToolModeParityOverlay, String> {
+    let raw = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    toml::from_str(&raw).map_err(|error| format!("failed to parse {}: {error}", path.display()))
+}
+
+pub(crate) fn render_promotion_note(row: &ToolModeParityOverlayRow) -> String {
+    format!(
+        "Empirical coding-agent parity overlay at {} observed native {:.1}% ({}/{}) vs text {:.1}% ({}/{}) across {} fixtures; verifier divergence {:.1}%; confidence {}; updated {}.",
+        row.evidence_path,
+        row.native.pass_rate * 100.0,
+        row.native.passed_runs,
+        row.native.total_runs,
+        row.text.pass_rate * 100.0,
+        row.text.passed_runs,
+        row.text.total_runs,
+        row.sample_size,
+        row.verifier_divergence_rate * 100.0,
+        row.confidence,
+        row.last_updated
+    )
+}
+
+fn format_stats(
+    observations: &[&ToolModeParityObservation],
+    tool_format: &str,
+) -> ToolModeParityFormatStats {
+    let filtered = observations
+        .iter()
+        .copied()
+        .filter(|observation| observation.tool_format == tool_format && !observation.skipped)
+        .collect::<Vec<_>>();
+    if filtered.is_empty() {
+        return ToolModeParityFormatStats::default();
+    }
+
+    let total_runs = filtered.len();
+    let passed_runs = filtered
+        .iter()
+        .filter(|observation| observation.passed)
+        .count();
+    let mut by_fixture: BTreeMap<&str, usize> = BTreeMap::new();
+    for observation in &filtered {
+        *by_fixture
+            .entry(observation.fixture_id.as_str())
+            .or_insert(0) += 1;
+    }
+
+    ToolModeParityFormatStats {
+        total_runs,
+        passed_runs,
+        unique_fixtures: by_fixture.len(),
+        replicate_count: by_fixture.values().copied().min().unwrap_or(0),
+        pass_rate: ratio(passed_runs, total_runs),
+    }
+}
+
+fn verifier_divergence_rate(observations: &[&ToolModeParityObservation]) -> f64 {
+    let mut native_by_fixture: BTreeMap<&str, Vec<&ToolModeParityObservation>> = BTreeMap::new();
+    let mut text_by_fixture: BTreeMap<&str, Vec<&ToolModeParityObservation>> = BTreeMap::new();
+    for observation in observations.iter().copied().filter(|obs| !obs.skipped) {
+        match observation.tool_format.as_str() {
+            "native" => native_by_fixture
+                .entry(observation.fixture_id.as_str())
+                .or_default()
+                .push(observation),
+            "text" => text_by_fixture
+                .entry(observation.fixture_id.as_str())
+                .or_default()
+                .push(observation),
+            _ => {}
+        }
+    }
+
+    let shared = native_by_fixture
+        .keys()
+        .filter(|fixture| text_by_fixture.contains_key(**fixture))
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut compared = 0usize;
+    let mut diverged = 0usize;
+    for fixture in shared {
+        let mut native = native_by_fixture.remove(fixture).unwrap_or_default();
+        let mut text = text_by_fixture.remove(fixture).unwrap_or_default();
+        native.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+        text.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+        for (native, text) in native.iter().zip(text.iter()) {
+            compared += 1;
+            if native.verification_success != text.verification_success {
+                diverged += 1;
+            }
+        }
+    }
+    ratio(diverged, compared)
+}
+
+fn classify_tool_mode_parity(
+    sample_size: usize,
+    native_pass_rate: f64,
+    text_pass_rate: f64,
+) -> String {
+    if sample_size < 5 {
+        return "unknown".to_string();
+    }
+    if native_pass_rate > text_pass_rate && native_pass_rate >= text_pass_rate * 1.5 {
+        return "text_unreliable".to_string();
+    }
+    if text_pass_rate > native_pass_rate && text_pass_rate >= native_pass_rate * 1.5 {
+        return "native_unreliable".to_string();
+    }
+    let high = native_pass_rate.max(text_pass_rate);
+    if high == 0.0 || ((native_pass_rate - text_pass_rate).abs() / high) <= 0.2 {
+        return "interchangeable".to_string();
+    }
+    "unknown".to_string()
+}
+
+fn preferred_tool_format(
+    tool_mode_parity: &str,
+    native_pass_rate: f64,
+    text_pass_rate: f64,
+) -> String {
+    match tool_mode_parity {
+        "text_unreliable" => "native".to_string(),
+        "native_unreliable" => "text".to_string(),
+        _ if text_pass_rate > native_pass_rate => "text".to_string(),
+        _ => "native".to_string(),
+    }
+}
+
+fn parity_confidence(
+    sample_size: usize,
+    native: &ToolModeParityFormatStats,
+    text: &ToolModeParityFormatStats,
+) -> String {
+    if sample_size >= 5 && native.replicate_count >= 2 && text.replicate_count >= 2 {
+        "high".to_string()
+    } else {
+        "low".to_string()
+    }
+}
+
+fn ratio(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        (((numerator as f64 / denominator as f64) * 10_000.0).round()) / 10_000.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observation(
+        fixture_id: &str,
+        run_id: &str,
+        tool_format: &str,
+        passed: bool,
+        verification_success: bool,
+    ) -> ToolModeParityObservation {
+        ToolModeParityObservation {
+            provider: "openrouter".to_string(),
+            model: "qwen/qwen3-coder".to_string(),
+            fixture_id: fixture_id.to_string(),
+            run_id: run_id.to_string(),
+            tool_format: tool_format.to_string(),
+            passed,
+            skipped: false,
+            verification_success,
+        }
+    }
+
+    #[test]
+    fn overlay_classifies_native_unreliable_and_low_confidence() {
+        let overlay = build_overlay(
+            &[
+                observation("a", "a-native", "native", false, false),
+                observation("a", "a-text", "text", true, true),
+                observation("b", "b-native", "native", false, false),
+                observation("b", "b-text", "text", true, true),
+                observation("c", "c-native", "native", false, false),
+                observation("c", "c-text", "text", true, true),
+                observation("d", "d-native", "native", true, true),
+                observation("d", "d-text", "text", true, true),
+                observation("e", "e-native", "native", false, false),
+                observation("e", "e-text", "text", true, true),
+            ],
+            "2026-05-24T00:00:00Z",
+            TOOL_MODE_PARITY_FIXTURE_SUITE,
+            Path::new(".harn-runs/coding-agent-bench/latest"),
+        );
+
+        let row = overlay.rows.first().expect("row");
+        assert_eq!(row.sample_size, 5);
+        assert_eq!(row.tool_mode_parity, "native_unreliable");
+        assert_eq!(row.preferred_tool_format, "text");
+        assert_eq!(row.confidence, "low");
+        assert_eq!(row.native.pass_rate, 0.2);
+        assert_eq!(row.text.pass_rate, 1.0);
+        assert_eq!(row.verifier_divergence_rate, 0.8);
+    }
+
+    #[test]
+    fn overlay_requires_two_replicates_for_high_confidence() {
+        let mut observations = Vec::new();
+        for fixture in ["a", "b", "c", "d", "e"] {
+            observations.push(observation(
+                fixture,
+                &format!("{fixture}-native-1"),
+                "native",
+                true,
+                true,
+            ));
+            observations.push(observation(
+                fixture,
+                &format!("{fixture}-native-2"),
+                "native",
+                true,
+                true,
+            ));
+            observations.push(observation(
+                fixture,
+                &format!("{fixture}-text-1"),
+                "text",
+                true,
+                true,
+            ));
+            observations.push(observation(
+                fixture,
+                &format!("{fixture}-text-2"),
+                "text",
+                true,
+                true,
+            ));
+        }
+
+        let overlay = build_overlay(
+            &observations,
+            "2026-05-24T00:00:00Z",
+            TOOL_MODE_PARITY_FIXTURE_SUITE,
+            Path::new(".harn-runs/coding-agent-bench/latest"),
+        );
+
+        let row = overlay.rows.first().expect("row");
+        assert_eq!(row.confidence, "high");
+        assert_eq!(row.tool_mode_parity, "interchangeable");
+        assert_eq!(row.native.replicate_count, 2);
+        assert_eq!(row.text.replicate_count, 2);
+    }
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1097,9 +1097,15 @@ explicit capability rule for both `native_tools` and `preferred_tool_format`.
 The command exits non-zero and lists suggested defaults when catalog rows need
 coverage.
 
+`promote-from-eval` ingests the parity overlay emitted by
+`harn eval coding-agent` and updates `crates/harn-vm/src/llm/capabilities.toml`
+with exact-model `preferred_tool_format`, `tool_mode_parity`, and
+`tool_mode_parity_notes` rows. The edit is idempotent.
+
 ```bash
 harn provider capabilities audit
 harn provider capabilities audit --json
+harn provider capabilities promote-from-eval .harn-runs/coding-agent-bench/latest/tool_mode_parity_overlay.toml
 ```
 
 ## harn provider-probe

--- a/docs/src/llm/coding-agent-benchmark.md
+++ b/docs/src/llm/coding-agent-benchmark.md
@@ -19,6 +19,8 @@ Artifacts are written to `.harn-runs/coding-agent-bench/latest/` by default:
 - `local_readiness.json`: local-provider recommendation evidence derived from
   local runs, with provider transport failures, unsupported capability
   failures, and behavioral task failures separated.
+- `tool_mode_parity_overlay.toml`: generated `(provider, model)` parity verdicts
+  with pass-rate, divergence, confidence, and evidence metadata for catalog promotion.
 - `<run_id>/summary.json`: the Harn harness result for one run.
 - `<run_id>/transcript_events.jsonl`: canonical transcript events from `transcript_events(...)`.
 - `summary.md`: a readable table for sharing results.
@@ -97,6 +99,13 @@ harn providers support \
 
 The checked-in page stays deterministic when no empirical input is supplied, so
 CI can run `make check-provider-support` without depending on local API keys.
+
+To promote the latest parity verdicts into the provider capability matrix:
+
+```sh
+harn provider capabilities promote-from-eval \
+  .harn-runs/coding-agent-bench/latest/tool_mode_parity_overlay.toml
+```
 
 ## Reading Results
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -252,6 +252,12 @@ unreliable side. Model-catalog display tags are derived from this matrix too;
 legacy `models.*.capabilities` entries are parsed for backwards compatibility
 but do not override runtime capability resolution.
 
+`harn eval coding-agent` now emits
+`.harn-runs/coding-agent-bench/latest/tool_mode_parity_overlay.toml`, and
+`harn provider capabilities promote-from-eval <overlay>` applies those
+deterministic parity verdicts back into
+`crates/harn-vm/src/llm/capabilities.toml`.
+
 The matrix also records format preferences that prompt renderers can use
 without branching on provider names: XML vs. Markdown section scaffolding,
 native JSON vs. delimited/XML-tagged structured-output preference, assistant


### PR DESCRIPTION
## Summary
- emit a generated tool-mode parity overlay from harn eval coding-agent
- add harn provider capabilities promote-from-eval to apply deterministic parity verdicts back into the capability catalog
- document the new overlay artifact and promotion flow

## Testing
- CARGO_TARGET_DIR=/tmp/harn-target-2361 cargo test -p harn-cli tool_mode_parity -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-2361 cargo test -p harn-cli provider_capabilities -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-2361 cargo test -p harn-cli write_json_artifacts_emits_tool_mode_parity_overlay -- --nocapture
- cargo fmt --check --all -- crates/harn-cli/src/commands/eval_coding_agent.rs crates/harn-cli/src/commands/provider_capabilities.rs crates/harn-cli/src/commands/tool_mode_parity.rs crates/harn-cli/src/cli/provider.rs crates/harn-cli/src/cli/tests.rs crates/harn-cli/src/cli/mod.rs