### PR TITLE
Add MCP RC compatibility harness (#2187)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "harn-ir",
  "harn-lexer",
  "harn-lint",
+ "harn-mcp-rc-compat",
  "harn-modules",
  "harn-parser",
  "harn-serve",
@@ -2325,6 +2326,21 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower-lsp",
+]
+
+[[package]]
+name = "harn-mcp-rc-compat"
+version = "0.8.35"
+dependencies = [
+ "axum",
+ "futures",
+ "harn-serve",
+ "harn-vm",
+ "jsonschema",
+ "reqwest",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/harn-fmt",
     "crates/harn-lint",
     "crates/harn-hostlib",
+    "crates/harn-mcp-rc-compat",
     "perf/llm",
     "perf/vm",
     "perf/orchestration",

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration bench-cli-cold-start all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration bench-cli-cold-start all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift portal-check
 
 check: all
 
@@ -79,6 +79,24 @@ conformance:
 
 protocol-conformance:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols
+
+# MCP RC compatibility harness: exercises Harn's MCP client against fake
+# RC servers, fake RC clients against the generic and orchestrator
+# servers, and validates the published wire fixtures + JSON Schema
+# 2020-12 recursive `$defs` handling.
+#
+# Failures are scoped per surface so CI breakage attribution is
+# unambiguous:
+#   - tests/client.rs           — fake-server self-consistency
+#   - tests/generic_server.rs   — generic harn-serve MCP server
+#   - tests/legacy_compat.rs    — 2025-11-25 wire compat regression
+#   - tests/artifacts.rs        — published fixtures + recursive $defs
+#   - harn-cli mcp_rc_compat_tests — orchestrator MCP server
+mcp-rc-conformance:
+	@echo "=== MCP RC harness: harn-mcp-rc-compat suite (client / generic_server / legacy_compat / artifacts) ==="
+	HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-mcp-rc-compat --tests
+	@echo "=== MCP RC harness: orchestrator server (harn-cli mcp_rc_compat_tests) ==="
+	HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --lib mcp_rc_compat_tests
 
 replay-oracle:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- orchestrator replay-oracle

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -117,6 +117,7 @@ default = ["hostlib"]
 hostlib = ["dep:harn-hostlib", "harn-serve/hostlib"]
 
 [dev-dependencies]
+harn-mcp-rc-compat = { path = "../harn-mcp-rc-compat" }
 rcgen = "0.14"
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 wat = "1"

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -438,7 +438,13 @@ fn generate_readme() -> String {
          - `go/harnprotocol/harnprotocol.go`: Go package with structs, typed string\n\
            aliases, and constants mirroring the Python and Swift bindings.\n\
          - `fixtures/round_trip.json`: representative JSON envelopes used by\n\
-           `make check-bindings` to exercise Python and Go round-trips.\n\n\
+           `make check-bindings` to exercise Python and Go round-trips.\n\
+         - `fixtures/mcp-rc/`: hand-authored MCP DRAFT-2026-v1 wire fixtures\n\
+           (modern success, unsupported-version retry, cache hints,\n\
+           input-required, header mismatch, no-session HTTP, recursive\n\
+           `$defs` tool schema, legacy 2025-11-25 compat) replayed by\n\
+           `make mcp-rc-conformance` and republished here for Burin Code\n\
+           and harn-cloud test suites.\n\n\
          Compatibility rule: additive enum values and optional fields are minor-version\n\
          compatible; removing or renaming a wire value requires a Harn minor-version\n\
          migration note and a regenerated artifact diff.\n",

--- a/crates/harn-cli/src/commands/mcp/mcp_rc_compat_tests.rs
+++ b/crates/harn-cli/src/commands/mcp/mcp_rc_compat_tests.rs
@@ -1,0 +1,197 @@
+//! Orchestrator-server RC compatibility tests.
+//!
+//! Drives the shared `harn-mcp-rc-compat` fixtures + fake-client helpers
+//! against the in-process `McpOrchestratorService`. Failures here
+//! localize to the **orchestrator-server** surface — see
+//! `crates/harn-mcp-rc-compat/tests/generic_server.rs` for the parallel
+//! coverage on the generic `harn-serve` MCP wrapper.
+//!
+//! The in-process drive avoids the 30–40 s cold-start the subprocess
+//! tests pay so this suite stays in the fast `make test` path.
+
+#![allow(clippy::await_holding_lock)]
+
+use super::*;
+use std::fs;
+use std::path::Path;
+
+use harn_mcp_rc_compat::fake_client::{legacy_request, rc_meta, rc_request};
+use harn_mcp_rc_compat::fixtures::{load_named, WireFixtureKind};
+use serde_json::json;
+use tempfile::TempDir;
+
+use crate::tests::common::harn_state_lock::lock_harn_state;
+
+fn write_file(dir: &Path, relative: &str, contents: &str) {
+    let path = dir.join(relative);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, contents).unwrap();
+}
+
+fn write_minimal_fixture(temp: &TempDir) {
+    write_file(
+        temp.path(),
+        "harn.toml",
+        r#"
+[package]
+name = "rc-compat-fixture"
+
+[exports]
+handlers = "lib.harn"
+"#,
+    );
+    write_file(
+        temp.path(),
+        "lib.harn",
+        r#"
+pub fn ping() -> string {
+  return "pong"
+}
+"#,
+    );
+}
+
+fn fixture_args(temp: &TempDir) -> McpServeArgs {
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    McpServeArgs {
+        local: OrchestratorLocalArgs {
+            config: temp.path().join("harn.toml"),
+            state_dir,
+        },
+        transport: McpServeTransport::Stdio,
+        bind: "127.0.0.1:0".parse().unwrap(),
+        path: "/mcp".to_string(),
+        sse_path: "/sse".to_string(),
+        messages_path: "/messages".to_string(),
+    }
+}
+
+async fn fresh_service() -> (McpOrchestratorService, TempDir) {
+    let temp = TempDir::new().unwrap();
+    write_minimal_fixture(&temp);
+    let args = fixture_args(&temp);
+    let service = McpOrchestratorService::new_local(args.local.clone()).unwrap();
+    (service, temp)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orchestrator_modern_tools_list_carries_rc_envelope_and_cache_hint() {
+    let _guard = lock_harn_state();
+    let (service, _temp) = fresh_service().await;
+    let mut session = ConnectionState::default();
+    let request = rc_request(1, "tools/list", json!({}), "harn-rc-compat-client");
+    let response = service.handle_request(&mut session, request).await;
+    let result = response.get("result").expect("tools/list result");
+    assert_eq!(result["resultType"], json!("complete"));
+    assert!(
+        result.get("ttlMs").is_some(),
+        "modern tools/list must include cache hint"
+    );
+    assert_eq!(result["cacheScope"], json!("private"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orchestrator_unsupported_meta_version_returns_minus_32004() {
+    let _guard = lock_harn_state();
+    let (service, _temp) = fresh_service().await;
+    let mut session = ConnectionState::default();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/list",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2099-01-01",
+                "io.modelcontextprotocol/clientInfo": {"name": "fuzz", "version": "1"},
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }
+    });
+    let response = service.handle_request(&mut session, request).await;
+    let error = response.get("error").expect("error response");
+    assert_eq!(error["code"], json!(-32004));
+    let supported = error["data"]["supported"]
+        .as_array()
+        .expect("supported array");
+    assert!(supported.iter().any(|v| v == &json!("DRAFT-2026-v1")));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orchestrator_server_discover_returns_capabilities_and_skips_initialize() {
+    let _guard = lock_harn_state();
+    let (service, _temp) = fresh_service().await;
+    let mut session = ConnectionState::default();
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {"_meta": rc_meta("harn-rc-compat-client")}
+    });
+    let response = service.handle_request(&mut session, request).await;
+    let result = response.get("result").expect("discover result");
+    assert_eq!(result["resultType"], json!("complete"));
+    let supported = result["supportedVersions"]
+        .as_array()
+        .expect("supportedVersions array");
+    assert!(supported.iter().any(|v| v == &json!("DRAFT-2026-v1")));
+    assert!(supported.iter().any(|v| v == &json!("2025-11-25")));
+    assert!(session.initialized);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orchestrator_legacy_initialize_omits_rc_envelope() {
+    let _guard = lock_harn_state();
+    let (service, _temp) = fresh_service().await;
+    let mut session = ConnectionState::default();
+    let request = legacy_request(
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "legacy", "version": "1"}
+        }),
+    );
+    let response = service.handle_request(&mut session, request).await;
+    let result = response.get("result").expect("legacy initialize result");
+    assert_eq!(result["protocolVersion"], json!("2025-11-25"));
+    assert!(
+        result.get("resultType").is_none(),
+        "legacy initialize must not include RC envelope: {result}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn orchestrator_replays_published_modern_success_fixture() {
+    let _guard = lock_harn_state();
+    let (service, _temp) = fresh_service().await;
+    let fixture = load_named("modern_success.json");
+    assert_eq!(fixture.kind, WireFixtureKind::Exchange);
+    let mut session = ConnectionState::default();
+    for pair in fixture.documents.chunks(2) {
+        if pair.len() != 2 {
+            continue;
+        }
+        let request = pair[0].clone();
+        let expected = &pair[1];
+        let method = request["method"].as_str().unwrap_or_default().to_string();
+        // The orchestrator does not host a `tools/call` for the harness
+        // fixture's `echo` tool; skip the call step (the response shape
+        // is exercised against the generic server instead). Discover +
+        // list still validate the orchestrator's RC envelope/cache hint
+        // semantics against the published fixture.
+        if method == "tools/call" {
+            continue;
+        }
+        let response = service.handle_request(&mut session, request).await;
+        let result = response.get("result").expect("result");
+        let expected_result = expected.get("result").expect("expected result");
+        assert_eq!(
+            result["resultType"], expected_result["resultType"],
+            "{method} resultType drift against published fixture"
+        );
+    }
+}

--- a/crates/harn-cli/src/commands/mcp/serve/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/mod.rs
@@ -53,6 +53,10 @@ pub(in crate::commands::mcp::serve) use {
 #[path = "../serve_tests.rs"]
 mod serve_tests;
 
+#[cfg(test)]
+#[path = "../mcp_rc_compat_tests.rs"]
+mod mcp_rc_compat_tests;
+
 pub(super) const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 pub(super) const MCP_SESSION_HEADER: &str = "mcp-session-id";
 pub(super) const MCP_PROTOCOL_HEADER: &str = "mcp-protocol-version";

--- a/crates/harn-mcp-rc-compat/Cargo.toml
+++ b/crates/harn-mcp-rc-compat/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "harn-mcp-rc-compat"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "MCP DRAFT-2026-v1 release-candidate compatibility harness: fake clients, fake servers, and wire fixtures shared across Harn's MCP surfaces and downstream consumers"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+axum = "0.8"
+futures = "0.3"
+harn-serve = { path = "../harn-serve", version = "0.8" }
+harn-vm = { path = "../harn-vm", version = "0.8" }
+jsonschema = { version = "0.46.4", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde_json = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }

--- a/crates/harn-mcp-rc-compat/src/fake_client.rs
+++ b/crates/harn-mcp-rc-compat/src/fake_client.rs
@@ -1,0 +1,186 @@
+//! Fake RC MCP clients used to validate Harn's MCP server behavior.
+//!
+//! Two flavors: a JSON-only "wire builder" that constructs RC-tagged
+//! request payloads with `_meta` blocks, and an HTTP driver that posts
+//! those payloads at a running Harn MCP HTTP server and asserts on the
+//! response. The wire builder is reused by stdio-flavored tests that
+//! pipe the same payloads into a process or in-process service.
+
+use harn_vm::mcp_protocol::{
+    self, DRAFT_PROTOCOL_VERSION, PROTOCOL_VERSION, RC_HEADER_METHOD, RC_HEADER_NAME,
+    RC_HEADER_PROTOCOL_VERSION, RC_META_KEY_CLIENT_CAPABILITIES, RC_META_KEY_CLIENT_INFO,
+    RC_META_KEY_PROTOCOL_VERSION,
+};
+use serde_json::{json, Value as JsonValue};
+
+/// Build an RC `_meta` block targeting the draft protocol version. The
+/// trio of keys is the minimum every RC client must send so servers can
+/// negotiate per-request without sticky state.
+pub fn rc_meta(client_name: &str) -> JsonValue {
+    json!({
+        RC_META_KEY_PROTOCOL_VERSION: DRAFT_PROTOCOL_VERSION,
+        RC_META_KEY_CLIENT_INFO: {"name": client_name, "version": "0.1.0"},
+        RC_META_KEY_CLIENT_CAPABILITIES: {},
+    })
+}
+
+/// Build a request body for the given method with RC metadata folded
+/// in. Pass `params` for additional fields; `_meta` is merged in.
+pub fn rc_request(id: u64, method: &str, params: JsonValue, client_name: &str) -> JsonValue {
+    let mut params = params;
+    let meta = rc_meta(client_name);
+    if let Some(object) = params.as_object_mut() {
+        object.insert("_meta".to_string(), meta);
+    } else {
+        params = json!({"_meta": meta});
+    }
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+}
+
+/// Build a legacy 2025-11-25 request body (no `_meta`). Used by the
+/// legacy-compat tests to verify the existing wire still works.
+pub fn legacy_request(id: u64, method: &str, params: JsonValue) -> JsonValue {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+}
+
+/// Compose the RC HTTP header set a Modern client sends with a
+/// JSON-RPC body. Includes `MCP-Protocol-Version`, `Mcp-Method`, and
+/// the optional `Mcp-Name` derived from the body via the spec helper.
+pub fn rc_headers(method: &str, params: &JsonValue) -> Vec<(&'static str, String)> {
+    let mut headers = vec![
+        (
+            RC_HEADER_PROTOCOL_VERSION,
+            DRAFT_PROTOCOL_VERSION.to_string(),
+        ),
+        (RC_HEADER_METHOD, method.to_string()),
+    ];
+    if let Some(name) = mcp_protocol::rc_name_header_value(method, params) {
+        headers.push((RC_HEADER_NAME, name));
+    }
+    headers
+}
+
+/// HTTP driver: POST `body` to `url` with `headers`, return the parsed
+/// JSON response and the protocol header the server echoed back.
+///
+/// Servers are allowed to answer JSON-RPC POSTs with either
+/// `application/json` or an SSE stream that carries the response as a
+/// `message` event (per MCP Streamable HTTP). The driver advertises
+/// both, then dispatches on the response `Content-Type` so the test
+/// surface looks identical to the caller regardless of which the
+/// server chose.
+pub async fn post_rc(
+    url: &str,
+    body: &JsonValue,
+    headers: &[(&'static str, String)],
+) -> RcResponse {
+    let client = reqwest::Client::new();
+    let mut request = client
+        .post(url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream");
+    for (name, value) in headers {
+        request = request.header(*name, value);
+    }
+    let response = request.json(body).send().await.expect("post rc request");
+    let status = response.status().as_u16();
+    let echoed_protocol = response
+        .headers()
+        .get(RC_HEADER_PROTOCOL_VERSION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let echoed_session = response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+        .unwrap_or_default();
+    let body = if content_type.contains("text/event-stream") {
+        let text = response.text().await.expect("read sse body");
+        parse_sse_message_body(&text)
+    } else {
+        response.json::<JsonValue>().await.expect("parse json body")
+    };
+    RcResponse {
+        status,
+        echoed_protocol,
+        echoed_session,
+        body,
+    }
+}
+
+/// Extract the JSON body of the first `message` event from an SSE
+/// stream. Tests only need the response payload, so we ignore everything
+/// else — keep-alives, comments, the priming empty event, etc.
+fn parse_sse_message_body(text: &str) -> JsonValue {
+    let mut data = String::new();
+    let mut current_event: Option<String> = None;
+    for line in text.lines() {
+        if line.is_empty() {
+            if current_event.as_deref() == Some("message") && !data.is_empty() {
+                if let Ok(value) = serde_json::from_str(&data) {
+                    return value;
+                }
+            }
+            current_event = None;
+            data.clear();
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("event:") {
+            current_event = Some(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            if !data.is_empty() {
+                data.push('\n');
+            }
+            data.push_str(rest.trim_start());
+        }
+    }
+    // Trailing event without blank-line terminator.
+    if current_event.as_deref() == Some("message") && !data.is_empty() {
+        if let Ok(value) = serde_json::from_str(&data) {
+            return value;
+        }
+    }
+    panic!("SSE stream contained no parseable message event; raw: {text:?}");
+}
+
+/// Inspect a JSON-RPC result and assert the RC envelope fields are
+/// present. Returns the original result body for chained assertions.
+pub fn assert_rc_envelope(result: &JsonValue) -> &JsonValue {
+    let result_obj = result.get("result").expect("result object");
+    assert_eq!(
+        result_obj.get("resultType").and_then(JsonValue::as_str),
+        Some("complete"),
+        "RC result must carry resultType=complete"
+    );
+    result_obj
+}
+
+#[derive(Debug)]
+pub struct RcResponse {
+    pub status: u16,
+    pub echoed_protocol: Option<String>,
+    pub echoed_session: Option<String>,
+    pub body: JsonValue,
+}
+
+/// Re-export for tests that want to label outbound clients clearly in
+/// fixture metadata.
+pub fn legacy_protocol_version() -> &'static str {
+    PROTOCOL_VERSION
+}

--- a/crates/harn-mcp-rc-compat/src/fake_server.rs
+++ b/crates/harn-mcp-rc-compat/src/fake_server.rs
@@ -1,0 +1,451 @@
+//! Fake RC MCP servers used to validate Harn's MCP client behavior.
+//!
+//! Both transports (HTTP Streamable and stdio) are implemented in-process
+//! so tests can exercise the full request/response cycle without
+//! standing up a real network service. The behavior matrix is keyed by
+//! [`FakeServerBehavior`] so a single test driver can fan out across the
+//! seven RC compatibility cases (modern success, unsupported-version
+//! retry, server/discover, cache hints, MRTR/input-required, header
+//! mismatch, no-session HTTP) plus the legacy 2025-11-25 baseline.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use harn_vm::mcp_protocol::{
+    self, server_discover_result, DRAFT_PROTOCOL_VERSION, PROTOCOL_VERSION, RC_HEADER_METHOD,
+    RC_HEADER_NAME, RC_HEADER_PROTOCOL_VERSION, RC_META_KEY_PROTOCOL_VERSION,
+};
+use serde_json::{json, Value as JsonValue};
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
+
+use crate::recursive_schema::recursive_tree_input_schema;
+
+/// Behaviors the fake server can emulate. Each is a slice of the RC's
+/// observable surface; combining several into one fixture is fine, but
+/// the individual tests typically pick one per scenario to keep the
+/// failure attribution sharp.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FakeServerBehavior {
+    /// Accept `server/discover`, return Modern `tools/list`/`tools/call`
+    /// results with the RC envelope (resultType + cache hint).
+    ModernSuccess,
+    /// First `server/discover` answers with `-32004` and a `supported`
+    /// list; second discover with the legacy version succeeds.
+    UnsupportedVersionRetry,
+    /// `server/discover` advertises both supported versions; client
+    /// chooses Modern.
+    ServerDiscover,
+    /// `tools/list` answers with explicit `ttlMs` + `cacheScope` cache
+    /// hints (overrides the conservative defaults).
+    CacheHints,
+    /// First `tools/call` returns `resultType: input_required` with an
+    /// elicitation request; client must resolve the elicitation and
+    /// re-issue the call carrying `inputResponses`.
+    InputRequired,
+    /// HTTP server returns `-32600` when `Mcp-Method` header disagrees
+    /// with the body method.
+    HeaderMismatch,
+    /// HTTP server refuses to emit `Mcp-Session-Id` and rejects any
+    /// request that includes one. Validates session-less RC routing.
+    NoSessionHttp,
+    /// Pre-RC `2025-11-25` server: only `initialize` works, no
+    /// `server/discover`, no envelope, no cache hints. Used for legacy
+    /// compat regression.
+    Legacy202511,
+    /// Modern tool schema includes a recursive `$defs` reference so the
+    /// client must accept JSON Schema 2020-12 dialect.
+    RecursiveDefsTool,
+}
+
+/// One inbound request observed by the fake server. Tests assert on
+/// these to verify the client emitted the right headers, body, and
+/// metadata.
+#[derive(Clone, Debug)]
+pub struct RecordedRequest {
+    pub headers: BTreeMap<String, String>,
+    pub body: JsonValue,
+}
+
+#[derive(Default)]
+struct ServerState {
+    behavior: Option<FakeServerBehavior>,
+    requests: Vec<RecordedRequest>,
+    /// Tracks how many `server/discover` calls have been seen so the
+    /// retry case can answer the first with `-32004` and the second
+    /// with a success.
+    discover_count: usize,
+    /// Tracks how many `tools/call` calls have been seen so the
+    /// input-required case can hand the second call back as completed.
+    call_count: usize,
+}
+
+/// Handle returned from [`spawn_fake_http_server`]. Drop it (or call
+/// [`Self::shutdown`]) to tear the server down.
+pub struct FakeHttpServer {
+    pub base_url: String,
+    state: Arc<Mutex<ServerState>>,
+    shutdown: Option<oneshot::Sender<()>>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl FakeHttpServer {
+    pub async fn recorded(&self) -> Vec<RecordedRequest> {
+        self.state.lock().await.requests.clone()
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.join.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for FakeHttpServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Spawn a fake RC HTTP MCP server on `127.0.0.1:0`. Returns the URL
+/// of the `/mcp` endpoint plus a [`FakeHttpServer`] handle for
+/// observation and shutdown.
+pub async fn spawn_fake_http_server(behavior: FakeServerBehavior) -> FakeHttpServer {
+    let state = Arc::new(Mutex::new(ServerState {
+        behavior: Some(behavior),
+        ..ServerState::default()
+    }));
+    let router = Router::new()
+        .route("/mcp", post(post_mcp).get(get_mcp))
+        .with_state(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake server");
+    let local = listener.local_addr().expect("local addr");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let join = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("fake server serve");
+    });
+    FakeHttpServer {
+        base_url: format!("http://{local}"),
+        state,
+        shutdown: Some(shutdown_tx),
+        join: Some(join),
+    }
+}
+
+async fn post_mcp(
+    State(state): State<Arc<Mutex<ServerState>>>,
+    headers: HeaderMap,
+    Json(body): Json<JsonValue>,
+) -> Response {
+    let recorded = RecordedRequest {
+        headers: headers
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+            })
+            .collect(),
+        body: body.clone(),
+    };
+    let mut guard = state.lock().await;
+    guard.requests.push(recorded.clone());
+    let behavior = guard.behavior.expect("behavior set");
+    let id = body.get("id").cloned().unwrap_or(JsonValue::Null);
+    let method = body
+        .get("method")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let response = handle_request(&mut guard, behavior, &id, &method, &body);
+    drop(guard);
+    match response {
+        Some(value) => {
+            let protocol = if behavior == FakeServerBehavior::Legacy202511 {
+                PROTOCOL_VERSION
+            } else {
+                DRAFT_PROTOCOL_VERSION
+            };
+            json_response_with_protocol(value, protocol)
+        }
+        None => StatusCode::ACCEPTED.into_response(),
+    }
+}
+
+async fn get_mcp() -> Response {
+    StatusCode::METHOD_NOT_ALLOWED.into_response()
+}
+
+fn json_response_with_protocol(body: JsonValue, protocol: &str) -> Response {
+    let mut response = Json(body).into_response();
+    if let Ok(value) = HeaderValue::from_str(protocol) {
+        response
+            .headers_mut()
+            .insert(HeaderName::from_static(RC_HEADER_PROTOCOL_VERSION), value);
+    }
+    response
+}
+
+fn handle_request(
+    state: &mut ServerState,
+    behavior: FakeServerBehavior,
+    id: &JsonValue,
+    method: &str,
+    body: &JsonValue,
+) -> Option<JsonValue> {
+    body.get("id")?;
+    match method {
+        m if m == mcp_protocol::METHOD_SERVER_DISCOVER => {
+            state.discover_count += 1;
+            Some(handle_discover(behavior, id, state.discover_count, body))
+        }
+        "initialize" => Some(handle_initialize(behavior, id, body)),
+        "tools/list" => Some(handle_tools_list(behavior, id)),
+        "tools/call" => {
+            state.call_count += 1;
+            Some(handle_tools_call(behavior, id, body, state.call_count))
+        }
+        _ => Some(harn_vm::jsonrpc::error_response(
+            id.clone(),
+            -32601,
+            &format!("Method not found: {method}"),
+        )),
+    }
+}
+
+fn handle_discover(
+    behavior: FakeServerBehavior,
+    id: &JsonValue,
+    discover_count: usize,
+    body: &JsonValue,
+) -> JsonValue {
+    match behavior {
+        FakeServerBehavior::Legacy202511 => harn_vm::jsonrpc::error_response(
+            id.clone(),
+            -32601,
+            "Method not found: server/discover",
+        ),
+        FakeServerBehavior::UnsupportedVersionRetry if discover_count == 1 => {
+            let requested = body
+                .pointer("/params/_meta")
+                .and_then(JsonValue::as_object)
+                .and_then(|meta| meta.get(RC_META_KEY_PROTOCOL_VERSION))
+                .and_then(JsonValue::as_str)
+                .unwrap_or(DRAFT_PROTOCOL_VERSION);
+            mcp_protocol::unsupported_protocol_version_response(id.clone(), requested)
+        }
+        _ => harn_vm::jsonrpc::response(
+            id.clone(),
+            server_discover_result(
+                json!({"tools": {}}),
+                json!({"name": "fake-rc-server", "version": "0.1.0"}),
+                Some("Fake RC server for compat harness."),
+            ),
+        ),
+    }
+}
+
+fn handle_initialize(behavior: FakeServerBehavior, id: &JsonValue, body: &JsonValue) -> JsonValue {
+    let requested = body
+        .pointer("/params/protocolVersion")
+        .and_then(JsonValue::as_str)
+        .unwrap_or(PROTOCOL_VERSION);
+    let target = match behavior {
+        FakeServerBehavior::Legacy202511 => PROTOCOL_VERSION,
+        _ => DRAFT_PROTOCOL_VERSION,
+    };
+    if requested != target && !matches!(behavior, FakeServerBehavior::Legacy202511) {
+        return mcp_protocol::unsupported_protocol_version_response(id.clone(), requested);
+    }
+    harn_vm::jsonrpc::response(
+        id.clone(),
+        json!({
+            "protocolVersion": target,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "fake-rc-server", "version": "0.1.0"},
+        }),
+    )
+}
+
+fn handle_tools_list(behavior: FakeServerBehavior, id: &JsonValue) -> JsonValue {
+    let tool = if behavior == FakeServerBehavior::RecursiveDefsTool {
+        json!({
+            "name": "tree_summarize",
+            "title": "Summarize tree",
+            "description": "Walk a recursive tree and return a summary.",
+            "inputSchema": recursive_tree_input_schema(),
+        })
+    } else {
+        json!({
+            "name": "echo",
+            "title": "Echo",
+            "description": "Return the input string back to the caller.",
+            "inputSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                    "message": {"type": "string"}
+                },
+                "required": ["message"],
+            },
+        })
+    };
+    let mut result = json!({
+        "resultType": "complete",
+        "tools": [tool],
+    });
+    if matches!(
+        behavior,
+        FakeServerBehavior::ModernSuccess
+            | FakeServerBehavior::CacheHints
+            | FakeServerBehavior::RecursiveDefsTool
+            | FakeServerBehavior::ServerDiscover
+            | FakeServerBehavior::InputRequired
+            | FakeServerBehavior::HeaderMismatch
+            | FakeServerBehavior::NoSessionHttp
+            | FakeServerBehavior::UnsupportedVersionRetry
+    ) {
+        let (ttl, scope) = if behavior == FakeServerBehavior::CacheHints {
+            (300_000_u64, "public")
+        } else {
+            (5_000_u64, "private")
+        };
+        result["ttlMs"] = json!(ttl);
+        result["cacheScope"] = json!(scope);
+    }
+    if behavior == FakeServerBehavior::Legacy202511 {
+        // Legacy responses omit RC envelope fields entirely.
+        result = json!({"tools": [tool]});
+    }
+    harn_vm::jsonrpc::response(id.clone(), result)
+}
+
+fn handle_tools_call(
+    behavior: FakeServerBehavior,
+    id: &JsonValue,
+    body: &JsonValue,
+    call_count: usize,
+) -> JsonValue {
+    if behavior == FakeServerBehavior::InputRequired && call_count == 1 {
+        // Spec: input-required result returns an opaque `requestState`
+        // plus a map of `inputRequests` keyed by client-chosen names.
+        return harn_vm::jsonrpc::response(
+            id.clone(),
+            json!({
+                "resultType": "input_required",
+                "requestState": "opaque-server-state",
+                "inputRequests": {
+                    "approve": {
+                        "method": "elicitation/create",
+                        "params": {
+                            "mode": "form",
+                            "message": "Approve the call?",
+                            "requestedSchema": {
+                                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                "type": "object",
+                                "properties": {
+                                    "approved": {"type": "boolean"}
+                                },
+                                "required": ["approved"],
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+    }
+    let args = body
+        .pointer("/params/arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let mut result = json!({
+        "resultType": "complete",
+        "content": [{"type": "text", "text": format!("ok:{}", args)}],
+        "isError": false,
+    });
+    if behavior == FakeServerBehavior::Legacy202511 {
+        result = json!({
+            "content": [{"type": "text", "text": format!("ok:{}", args)}],
+            "isError": false,
+        });
+    }
+    harn_vm::jsonrpc::response(id.clone(), result)
+}
+
+// ----- stdio fake server ---------------------------------------------------
+
+/// One stdio fake server: receives lines on `stdin_rx`, emits lines on
+/// `stdout_tx`. Drop both channels to shut it down.
+pub struct FakeStdioServer {
+    pub stdin_tx: mpsc::UnboundedSender<String>,
+    pub stdout_rx: mpsc::UnboundedReceiver<String>,
+    pub join: JoinHandle<()>,
+}
+
+/// Spawn an in-process stdio fake server with the given behavior. The
+/// returned channels mimic the stdin/stdout pipes a real child would
+/// have, so client-side tests can drive the wire without a subprocess.
+pub fn spawn_fake_stdio_server(behavior: FakeServerBehavior) -> FakeStdioServer {
+    let (stdin_tx, mut stdin_rx) = mpsc::unbounded_channel::<String>();
+    let (stdout_tx, stdout_rx) = mpsc::unbounded_channel::<String>();
+    let state = Arc::new(Mutex::new(ServerState {
+        behavior: Some(behavior),
+        ..ServerState::default()
+    }));
+    let join = tokio::spawn(async move {
+        while let Some(line) = stdin_rx.recv().await {
+            let trimmed = line.trim().to_string();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(body) = serde_json::from_str::<JsonValue>(&trimmed) else {
+                continue;
+            };
+            let mut guard = state.lock().await;
+            let id = body.get("id").cloned().unwrap_or(JsonValue::Null);
+            let method = body
+                .get("method")
+                .and_then(JsonValue::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if let Some(response) = handle_request(&mut guard, behavior, &id, &method, &body) {
+                let mut encoded = serde_json::to_string(&response).unwrap_or_default();
+                encoded.push('\n');
+                let _ = stdout_tx.send(encoded);
+            }
+        }
+    });
+    FakeStdioServer {
+        stdin_tx,
+        stdout_rx,
+        join,
+    }
+}
+
+/// Header-name constants re-exported so test files don't need to
+/// depend on `harn-vm::mcp_protocol` directly for the RC routing
+/// headers.
+pub mod headers {
+    pub const PROTOCOL: &str = super::RC_HEADER_PROTOCOL_VERSION;
+    pub const METHOD: &str = super::RC_HEADER_METHOD;
+    pub const NAME: &str = super::RC_HEADER_NAME;
+}

--- a/crates/harn-mcp-rc-compat/src/fixtures.rs
+++ b/crates/harn-mcp-rc-compat/src/fixtures.rs
@@ -1,0 +1,106 @@
+//! Shared wire fixtures used by both directions of the RC harness.
+//!
+//! Each fixture is a deterministic JSON document loaded from disk so the
+//! same request/response shapes can be replayed by Rust tests, Burin
+//! Code consumers, and harn-cloud test suites without diverging.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value as JsonValue;
+
+use crate::FIXTURE_ROOT;
+
+/// One wire fixture: a name, an exchange of one or more JSON-RPC
+/// documents, and a short description of why the case exists. The
+/// `documents` array is interpreted by the loading test — server tests
+/// replay requests and assert responses, client tests do the inverse.
+#[derive(Clone, Debug)]
+pub struct WireFixture {
+    pub name: String,
+    pub description: String,
+    pub kind: WireFixtureKind,
+    pub documents: Vec<JsonValue>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WireFixtureKind {
+    /// Exchange of `request → response` (and optional notifications).
+    /// Tests can assert the server returns the expected response when
+    /// sent the request, or the client emits the expected request when
+    /// driven into the matching state.
+    Exchange,
+    /// HTTP-only fixture: documents alternate `headers → body` so a
+    /// fake server can assert the streamable HTTP routing headers are
+    /// validated against the JSON-RPC body.
+    HttpHeaderExchange,
+    /// Schema-only fixture (used by the recursive `$defs` check).
+    Schema,
+}
+
+/// Resolve a fixture path relative to the workspace root. Walks up from
+/// the current crate manifest so tests can be run from any working
+/// directory.
+pub fn fixture_path(name: &str) -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // `crates/harn-mcp-rc-compat` → workspace root is two parents up.
+    manifest
+        .parent()
+        .and_then(Path::parent)
+        .map(|root| root.join(FIXTURE_ROOT).join(name))
+        .expect("workspace root")
+}
+
+/// Load and parse every fixture under `spec/protocol-artifacts/fixtures/mcp-rc/`.
+/// Returns them sorted by name so iteration order is deterministic.
+pub fn all_fixtures() -> Vec<WireFixture> {
+    let root = fixture_path("");
+    let mut entries: Vec<PathBuf> = fs::read_dir(&root)
+        .unwrap_or_else(|err| panic!("read fixture root {}: {err}", root.display()))
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    entries.sort();
+    entries.into_iter().map(load_fixture).collect()
+}
+
+pub fn load_fixture(path: PathBuf) -> WireFixture {
+    let text = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("read fixture {}: {err}", path.display()));
+    let value: JsonValue = serde_json::from_str(&text)
+        .unwrap_or_else(|err| panic!("parse fixture {}: {err}", path.display()));
+    let name = value
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| panic!("fixture {} missing name", path.display()))
+        .to_string();
+    let description = value
+        .get("description")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_else(|| panic!("fixture {} missing description", path.display()))
+        .to_string();
+    let kind = match value.get("kind").and_then(JsonValue::as_str) {
+        Some("exchange") => WireFixtureKind::Exchange,
+        Some("http_header_exchange") => WireFixtureKind::HttpHeaderExchange,
+        Some("schema") => WireFixtureKind::Schema,
+        Some(other) => panic!("fixture {} has unknown kind {other:?}", path.display()),
+        None => panic!("fixture {} missing kind", path.display()),
+    };
+    let documents = value
+        .get("documents")
+        .and_then(JsonValue::as_array)
+        .unwrap_or_else(|| panic!("fixture {} missing documents", path.display()))
+        .clone();
+    WireFixture {
+        name,
+        description,
+        kind,
+        documents,
+    }
+}
+
+/// Convenience accessor that panics if the named fixture does not load.
+/// Tests call this for the small set of well-known fixtures.
+pub fn load_named(file_name: &str) -> WireFixture {
+    load_fixture(fixture_path(file_name))
+}

--- a/crates/harn-mcp-rc-compat/src/generic_server_harness.rs
+++ b/crates/harn-mcp-rc-compat/src/generic_server_harness.rs
@@ -1,0 +1,76 @@
+//! Shared in-process spawner for the generic `harn-serve::McpServer`.
+//!
+//! The spawner pre-binds the TCP listener so the test knows the URL
+//! up-front and hands the listener directly to
+//! [`McpServer::run_http_from_listener`]. That means the kernel has
+//! already accepted the bind by the time we return — there is no
+//! drop/rebind window, no poll-until-listening loop, and no wall-clock
+//! deadline. Tests get a fully-described `base_url` they can hit
+//! immediately.
+
+use std::sync::Arc;
+
+use harn_serve::{
+    bind_listener, DispatchCore, DispatchCoreConfig, HttpTlsConfig, McpHttpServeOptions, McpServer,
+    McpServerConfig,
+};
+use tempfile::TempDir;
+use tokio::task::JoinHandle;
+
+/// Default tool surface every spawned server exposes — a plain `echo`
+/// function so tests can exercise the full `tools/list` and `tools/call`
+/// wire without standing up project-specific .harn fixtures.
+pub const DEFAULT_ECHO_SCRIPT: &str = r#"
+pub fn echo(message: string) -> string {
+  return message
+}
+"#;
+
+/// Running generic MCP server. Dropping it aborts the spawned task;
+/// the held `TempDir` survives until then so the script file stays
+/// valid for the duration of the server's lifetime.
+pub struct GenericMcpServer {
+    pub base_url: String,
+    join: JoinHandle<Result<(), String>>,
+    _temp: TempDir,
+}
+
+impl Drop for GenericMcpServer {
+    fn drop(&mut self) {
+        self.join.abort();
+    }
+}
+
+/// Spawn a generic MCP server backed by [`DEFAULT_ECHO_SCRIPT`] on an
+/// ephemeral 127.0.0.1 port.
+pub async fn spawn() -> GenericMcpServer {
+    spawn_with_script(DEFAULT_ECHO_SCRIPT).await
+}
+
+/// Spawn a generic MCP server backed by an arbitrary `.harn` source.
+pub async fn spawn_with_script(script_source: &str) -> GenericMcpServer {
+    let temp = TempDir::new().expect("tempdir");
+    let script = temp.path().join("server.harn");
+    std::fs::write(&script, script_source).expect("write script");
+    let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+    let server = Arc::new(McpServer::new(McpServerConfig::new(core)));
+
+    let listener = bind_listener("127.0.0.1:0".parse().expect("bind addr")).expect("bind listener");
+    let local_addr = listener.local_addr().expect("local addr");
+    let base_url = format!("http://{local_addr}/mcp");
+
+    let options = McpHttpServeOptions {
+        bind: local_addr,
+        path: "/mcp".to_string(),
+        sse_path: "/sse".to_string(),
+        messages_path: "/messages".to_string(),
+        tls: HttpTlsConfig::plain(),
+    };
+    let join = tokio::spawn(async move { server.run_http_from_listener(listener, options).await });
+
+    GenericMcpServer {
+        base_url,
+        join,
+        _temp: temp,
+    }
+}

--- a/crates/harn-mcp-rc-compat/src/lib.rs
+++ b/crates/harn-mcp-rc-compat/src/lib.rs
@@ -1,0 +1,32 @@
+//! MCP DRAFT-2026-v1 release-candidate compatibility harness.
+//!
+//! This crate provides three building blocks that together exercise the
+//! wire surface every Harn MCP component has to agree on:
+//!
+//! - [`fake_server`] spins up an in-process RC MCP server (HTTP or stdio)
+//!   that intentionally covers modern success, unsupported-version retry,
+//!   `server/discover`, cache hints, MRTR/input-required, header
+//!   mismatch, and no-session HTTP. Drives Harn's MCP **client**.
+//! - [`fake_client`] drives any Harn MCP server (the generic
+//!   `harn-serve::McpServer` and the orchestrator both implement the
+//!   same wire) with RC request sequences. Used to validate **server**
+//!   behavior end-to-end.
+//! - [`fixtures`] is the checked-in wire vocabulary every test loads
+//!   from. The same JSON is exported under
+//!   `spec/protocol-artifacts/fixtures/mcp-rc/` so Burin Code and
+//!   harn-cloud can replay the same flows in their own test suites.
+//!
+//! Failures are surfaced per-surface (client, generic server,
+//! orchestrator server, artifacts, downstream-consumers) so CI breakage
+//! attribution is unambiguous.
+
+pub mod fake_client;
+pub mod fake_server;
+pub mod fixtures;
+pub mod generic_server_harness;
+pub mod recursive_schema;
+
+/// Workspace-relative path to the canonical wire fixture root. Tests
+/// from any crate in the workspace can load fixtures by joining a
+/// fixture name onto this root.
+pub const FIXTURE_ROOT: &str = "spec/protocol-artifacts/fixtures/mcp-rc";

--- a/crates/harn-mcp-rc-compat/src/recursive_schema.rs
+++ b/crates/harn-mcp-rc-compat/src/recursive_schema.rs
@@ -1,0 +1,84 @@
+//! JSON Schema 2020-12 fixture with recursive `$defs` references.
+//!
+//! The RC profile pins `https://json-schema.org/draft/2020-12/schema`
+//! as the dialect for every tool input schema. Recursive references are
+//! the common stress case (e.g. trees, linked lists, ASTs) and the one
+//! that trips draft 4 / draft 7 validators. Wiring at least one fixture
+//! through `jsonschema::draft202012` is what the acceptance criteria
+//! call out.
+
+use serde_json::{json, Value as JsonValue};
+
+/// Build a tool input schema that uses `$defs/Node` with a `children`
+/// array of `$ref: "#/$defs/Node"` — the canonical recursive shape.
+pub fn recursive_tree_input_schema() -> JsonValue {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://harnlang.com/mcp-rc/recursive-tree.input.schema.json",
+        "title": "RecursiveTreeInput",
+        "type": "object",
+        "properties": {
+            "root": { "$ref": "#/$defs/Node" }
+        },
+        "required": ["root"],
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "minLength": 1 },
+                    "children": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/Node" }
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+/// A valid recursive instance: a 3-level tree.
+pub fn valid_tree_instance() -> JsonValue {
+    json!({
+        "root": {
+            "name": "root",
+            "children": [
+                { "name": "a", "children": [
+                    { "name": "a.1" }
+                ]},
+                { "name": "b" }
+            ]
+        }
+    })
+}
+
+/// An invalid instance: a nested child is missing the required `name`.
+pub fn invalid_tree_instance() -> JsonValue {
+    json!({
+        "root": {
+            "name": "root",
+            "children": [
+                { "children": [] }
+            ]
+        }
+    })
+}
+
+/// Validate `instance` against [`recursive_tree_input_schema`] using
+/// draft 2020-12. Returns `Ok` on success or an error message that
+/// concatenates every validation failure.
+pub fn validate(instance: &JsonValue) -> Result<(), String> {
+    let schema = recursive_tree_input_schema();
+    let validator = jsonschema::draft202012::new(&schema)
+        .map_err(|err| format!("compile recursive schema: {err}"))?;
+    let errors: Vec<String> = validator
+        .iter_errors(instance)
+        .map(|err| format!("{err}"))
+        .collect();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}

--- a/crates/harn-mcp-rc-compat/tests/artifacts.rs
+++ b/crates/harn-mcp-rc-compat/tests/artifacts.rs
@@ -1,0 +1,144 @@
+//! Downstream-consumer fixture parity + recursive `$defs` validation.
+//!
+//! Two acceptance bars live here:
+//!
+//! 1. Every wire fixture published under
+//!    `spec/protocol-artifacts/fixtures/mcp-rc/` parses, has the
+//!    required metadata fields (name, description, kind, documents),
+//!    and round-trips through Harn's helper API where applicable.
+//! 2. At least one fixture uses a JSON Schema 2020-12 schema with
+//!    recursive `$defs` so the dialect handling is exercised end-to-end
+//!    by `jsonschema::draft202012`. The recursive case is the one that
+//!    has historically tripped pre-2020-12 validators.
+//!
+//! Failures here localize to the **artifact / downstream-consumer**
+//! surface.
+
+use harn_mcp_rc_compat::fixtures::{all_fixtures, load_named, WireFixtureKind};
+use harn_mcp_rc_compat::recursive_schema::{
+    invalid_tree_instance, recursive_tree_input_schema, valid_tree_instance, validate,
+};
+use serde_json::{json, Value as JsonValue};
+
+#[test]
+fn every_published_fixture_loads_with_required_metadata() {
+    let fixtures = all_fixtures();
+    assert!(
+        fixtures.len() >= 7,
+        "expected at least seven RC fixtures, got {}",
+        fixtures.len()
+    );
+    for fixture in fixtures {
+        assert!(
+            !fixture.name.is_empty(),
+            "fixture missing name: {fixture:?}"
+        );
+        assert!(
+            !fixture.description.is_empty(),
+            "fixture {} missing description",
+            fixture.name
+        );
+        assert!(
+            !fixture.documents.is_empty(),
+            "fixture {} has no documents",
+            fixture.name
+        );
+        assert!(
+            fixture.name.starts_with("harn.mcp_rc."),
+            "fixture name {} must use the harn.mcp_rc.* namespace",
+            fixture.name
+        );
+    }
+}
+
+#[test]
+fn recursive_defs_schema_validates_valid_tree() {
+    validate(&valid_tree_instance()).expect("valid tree must pass draft 2020-12 validation");
+}
+
+#[test]
+fn recursive_defs_schema_rejects_missing_required_field() {
+    let err = validate(&invalid_tree_instance())
+        .expect_err("missing required `name` must fail validation");
+    assert!(
+        err.contains("name") || err.to_lowercase().contains("required"),
+        "expected validator to mention the missing required field, got {err}"
+    );
+}
+
+#[test]
+fn recursive_defs_schema_carries_self_referential_ref() {
+    let schema = recursive_tree_input_schema();
+    let self_ref = &schema["$defs"]["Node"]["properties"]["children"]["items"]["$ref"];
+    assert_eq!(self_ref, &json!("#/$defs/Node"));
+    assert_eq!(
+        schema["$schema"],
+        json!("https://json-schema.org/draft/2020-12/schema"),
+        "fixture must pin draft 2020-12 so callers know which dialect they're consuming"
+    );
+}
+
+#[test]
+fn published_recursive_schema_fixture_matches_harness_helper() {
+    let fixture = load_named("recursive_schema_tool.json");
+    assert_eq!(fixture.kind, WireFixtureKind::Schema);
+    assert_eq!(fixture.documents.len(), 1);
+    let published = &fixture.documents[0];
+    let helper = recursive_tree_input_schema();
+    // The published fixture must round-trip with the helper byte-for-byte
+    // so downstream consumers vendoring the JSON file see the same shape
+    // Harn validates against internally.
+    assert_eq!(
+        published, &helper,
+        "published fixture drifted from harness helper; rerun the test to refresh"
+    );
+}
+
+#[test]
+fn modern_success_fixture_has_three_round_trips() {
+    let fixture = load_named("modern_success.json");
+    assert_eq!(fixture.kind, WireFixtureKind::Exchange);
+    // 3 request/response pairs = 6 documents (discover, list, call).
+    assert_eq!(
+        fixture.documents.len(),
+        6,
+        "modern_success must cover discover + list + call"
+    );
+    let methods: Vec<&str> = fixture
+        .documents
+        .iter()
+        .step_by(2)
+        .filter_map(|doc| doc.get("method").and_then(JsonValue::as_str))
+        .collect();
+    assert_eq!(methods, vec!["server/discover", "tools/list", "tools/call"]);
+}
+
+#[test]
+fn unsupported_version_retry_fixture_demonstrates_first_failure_then_retry() {
+    let fixture = load_named("unsupported_version_retry.json");
+    // First response must be -32004.
+    assert_eq!(fixture.documents[1]["error"]["code"], json!(-32004));
+    // Second response must succeed.
+    assert!(fixture.documents[3]["result"].is_object());
+}
+
+#[test]
+fn header_mismatch_fixture_is_http_header_exchange() {
+    let fixture = load_named("header_mismatch.json");
+    assert_eq!(fixture.kind, WireFixtureKind::HttpHeaderExchange);
+    let headers = &fixture.documents[0];
+    let body = &fixture.documents[1];
+    assert_eq!(headers["Mcp-Method"], json!("tools/list"));
+    assert_eq!(body["method"], json!("tools/call"));
+}
+
+#[test]
+fn input_required_fixture_uses_resolved_request_state_on_retry() {
+    let fixture = load_named("input_required.json");
+    // First response is input-required; second request must echo
+    // the requestState from the first.
+    let first_state = &fixture.documents[1]["result"]["requestState"];
+    let retry_state = &fixture.documents[2]["params"]["requestState"];
+    assert!(first_state.is_string());
+    assert_eq!(first_state, retry_state);
+}

--- a/crates/harn-mcp-rc-compat/tests/client.rs
+++ b/crates/harn-mcp-rc-compat/tests/client.rs
@@ -1,0 +1,231 @@
+//! Harness self-consistency tests for the fake RC servers.
+//!
+//! The fake servers in [`harn_mcp_rc_compat::fake_server`] are the
+//! reference fixtures that Harn's MCP client gets tested against (see
+//! `crates/harn-vm/src/mcp.rs` for the in-process client wire tests).
+//! This test file proves the fakes themselves agree with the published
+//! JSON fixtures so the same wire shape is what downstream consumers
+//! (Burin Code, harn-cloud) replay in their own suites.
+//!
+//! Failures here localize to the **client-facing fake-server surface**:
+//! either the fakes have drifted, or the published fixtures have.
+
+use harn_mcp_rc_compat::fake_client::{post_rc, rc_headers, rc_meta};
+use harn_mcp_rc_compat::fake_server::{
+    spawn_fake_http_server, spawn_fake_stdio_server, FakeServerBehavior,
+};
+use harn_mcp_rc_compat::fixtures::load_named;
+use serde_json::{json, Value as JsonValue};
+use tokio::time::{timeout, Duration};
+
+const RECV_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[tokio::test]
+async fn modern_success_fake_server_emits_envelope_and_cache_hint() {
+    let server = spawn_fake_http_server(FakeServerBehavior::ModernSuccess).await;
+    let url = format!("{}/mcp", server.base_url);
+    let discover = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {"_meta": rc_meta("client.rs")},
+    });
+    let response = post_rc(
+        &url,
+        &discover,
+        &rc_headers("server/discover", &discover["params"]),
+    )
+    .await;
+    assert_eq!(response.status, 200);
+    let result = &response.body["result"];
+    assert_eq!(result["resultType"], json!("complete"));
+    assert!(result["supportedVersions"]
+        .as_array()
+        .expect("supportedVersions")
+        .iter()
+        .any(|v| v == &json!("DRAFT-2026-v1")));
+
+    let list = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {"_meta": rc_meta("client.rs")},
+    });
+    let list_resp = post_rc(&url, &list, &rc_headers("tools/list", &list["params"])).await;
+    let list_result = &list_resp.body["result"];
+    assert_eq!(list_result["resultType"], json!("complete"));
+    assert!(list_result.get("ttlMs").is_some());
+}
+
+#[tokio::test]
+async fn unsupported_version_fake_server_returns_minus_32004_then_succeeds() {
+    let server = spawn_fake_http_server(FakeServerBehavior::UnsupportedVersionRetry).await;
+    let url = format!("{}/mcp", server.base_url);
+
+    let first = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {"_meta": rc_meta("client.rs")},
+    });
+    let first_resp = post_rc(
+        &url,
+        &first,
+        &rc_headers("server/discover", &first["params"]),
+    )
+    .await;
+    assert_eq!(first_resp.body["error"]["code"], json!(-32004));
+
+    let second = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "server/discover",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+                "io.modelcontextprotocol/clientInfo": {"name": "client.rs", "version": "0.1.0"},
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }
+    });
+    let second_resp = post_rc(&url, &second, &[]).await;
+    assert_eq!(second_resp.body["result"]["resultType"], json!("complete"));
+}
+
+#[tokio::test]
+async fn input_required_fake_server_returns_input_required_then_complete() {
+    let server = spawn_fake_http_server(FakeServerBehavior::InputRequired).await;
+    let url = format!("{}/mcp", server.base_url);
+
+    let first = json!({
+        "jsonrpc": "2.0",
+        "id": 10,
+        "method": "tools/call",
+        "params": {
+            "name": "needs_input",
+            "arguments": {"prompt": "continue"},
+            "_meta": rc_meta("client.rs"),
+        }
+    });
+    let first_resp = post_rc(&url, &first, &rc_headers("tools/call", &first["params"])).await;
+    let first_result = &first_resp.body["result"];
+    assert_eq!(first_result["resultType"], json!("input_required"));
+    assert!(first_result["requestState"].is_string());
+    assert!(first_result["inputRequests"].is_object());
+
+    let second = json!({
+        "jsonrpc": "2.0",
+        "id": 11,
+        "method": "tools/call",
+        "params": {
+            "name": "needs_input",
+            "arguments": {"prompt": "continue"},
+            "requestState": first_result["requestState"].clone(),
+            "inputResponses": {
+                "approve": {"action": "accept", "content": {"approved": true}}
+            },
+            "_meta": rc_meta("client.rs"),
+        }
+    });
+    let second_resp = post_rc(&url, &second, &rc_headers("tools/call", &second["params"])).await;
+    assert_eq!(second_resp.body["result"]["resultType"], json!("complete"));
+}
+
+#[tokio::test]
+async fn cache_hints_fake_server_advertises_explicit_ttl_and_scope() {
+    let server = spawn_fake_http_server(FakeServerBehavior::CacheHints).await;
+    let url = format!("{}/mcp", server.base_url);
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/list",
+        "params": {"_meta": rc_meta("client.rs")},
+    });
+    let response = post_rc(&url, &body, &rc_headers("tools/list", &body["params"])).await;
+    let result = &response.body["result"];
+    assert_eq!(result["ttlMs"], json!(300_000_u64));
+    assert_eq!(result["cacheScope"], json!("public"));
+}
+
+#[tokio::test]
+async fn recursive_defs_fake_server_advertises_recursive_schema() {
+    let server = spawn_fake_http_server(FakeServerBehavior::RecursiveDefsTool).await;
+    let url = format!("{}/mcp", server.base_url);
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/list",
+        "params": {"_meta": rc_meta("client.rs")},
+    });
+    let response = post_rc(&url, &body, &rc_headers("tools/list", &body["params"])).await;
+    let tool = &response.body["result"]["tools"][0];
+    assert_eq!(tool["name"], json!("tree_summarize"));
+    let schema = &tool["inputSchema"];
+    assert_eq!(
+        schema["$schema"],
+        json!("https://json-schema.org/draft/2020-12/schema")
+    );
+    assert!(schema["$defs"]["Node"].is_object());
+    assert_eq!(
+        schema["$defs"]["Node"]["properties"]["children"]["items"]["$ref"],
+        json!("#/$defs/Node")
+    );
+}
+
+#[tokio::test]
+async fn stdio_fake_server_round_trips_modern_request() {
+    let mut handle = spawn_fake_stdio_server(FakeServerBehavior::ModernSuccess);
+    let discover = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {"_meta": rc_meta("client.rs")},
+    });
+    handle
+        .stdin_tx
+        .send(format!("{discover}\n"))
+        .expect("send line");
+    let response_line = timeout(RECV_TIMEOUT, handle.stdout_rx.recv())
+        .await
+        .expect("recv timed out")
+        .expect("server hung up");
+    let response: JsonValue = serde_json::from_str(response_line.trim()).expect("parse json");
+    let result = &response["result"];
+    assert_eq!(result["resultType"], json!("complete"));
+    assert!(result["supportedVersions"]
+        .as_array()
+        .expect("supportedVersions")
+        .iter()
+        .any(|v| v == &json!("DRAFT-2026-v1")));
+}
+
+#[tokio::test]
+async fn fake_server_published_fixtures_round_trip_through_fake_server() {
+    // The published modern_success fixture has to remain executable as a
+    // request/response sequence — otherwise downstream consumers replay
+    // against drift the moment they upgrade.
+    let fixture = load_named("modern_success.json");
+    let server = spawn_fake_http_server(FakeServerBehavior::ModernSuccess).await;
+    let url = format!("{}/mcp", server.base_url);
+
+    for pair in fixture.documents.chunks(2) {
+        if pair.len() != 2 {
+            continue;
+        }
+        let request = &pair[0];
+        let expected = &pair[1];
+        let method = request["method"].as_str().unwrap_or_default();
+        let headers = rc_headers(method, &request["params"]);
+        let response = post_rc(&url, request, &headers).await;
+        let result_type = response
+            .body
+            .get("result")
+            .and_then(|r| r.get("resultType"))
+            .cloned()
+            .unwrap_or(JsonValue::Null);
+        assert_eq!(
+            result_type, expected["result"]["resultType"],
+            "{method} resultType drift"
+        );
+    }
+}

--- a/crates/harn-mcp-rc-compat/tests/generic_server.rs
+++ b/crates/harn-mcp-rc-compat/tests/generic_server.rs
@@ -1,0 +1,204 @@
+//! Fake RC MCP client driven against the generic `harn-serve::McpServer`.
+//!
+//! Failures in this file localize to the **generic-server** surface:
+//! they tell you the bundled MCP wrapper around an arbitrary `.harn`
+//! script regressed an RC behavior. The orchestrator's RC handling is
+//! covered in `harn-cli`'s `mcp_rc_compat_tests`.
+
+use harn_mcp_rc_compat::fake_client::{legacy_request, post_rc, rc_headers, rc_meta, rc_request};
+use harn_mcp_rc_compat::fixtures::{load_named, WireFixtureKind};
+use harn_mcp_rc_compat::generic_server_harness;
+use serde_json::json;
+
+#[tokio::test]
+async fn modern_tools_list_returns_rc_envelope_and_cache_hint() {
+    let server = generic_server_harness::spawn().await;
+    let body = rc_request(1, "tools/list", json!({}), "harn-rc-compat-client");
+    let headers = rc_headers("tools/list", &body["params"]);
+    let response = post_rc(&server.base_url, &body, &headers).await;
+
+    assert_eq!(response.status, 200, "modern tools/list must return 200");
+    assert_eq!(
+        response.echoed_protocol.as_deref(),
+        Some("DRAFT-2026-v1"),
+        "server must echo the negotiated protocol"
+    );
+    assert!(
+        response.echoed_session.is_none(),
+        "modern responses must not mint a session id; got {:?}",
+        response.echoed_session
+    );
+
+    let result = response
+        .body
+        .get("result")
+        .expect("tools/list result present");
+    assert_eq!(result["resultType"], json!("complete"));
+    assert!(
+        result.get("ttlMs").is_some(),
+        "tools/list must carry a cache TTL hint, got {result}"
+    );
+    assert_eq!(result["cacheScope"], json!("private"));
+    let tools = result["tools"].as_array().expect("tools array");
+    assert!(tools.iter().any(|tool| tool["name"] == json!("echo")));
+}
+
+#[tokio::test]
+async fn modern_tools_call_returns_rc_envelope() {
+    let server = generic_server_harness::spawn().await;
+    let body = rc_request(
+        2,
+        "tools/call",
+        json!({"name": "echo", "arguments": {"message": "hi"}}),
+        "harn-rc-compat-client",
+    );
+    let headers = rc_headers("tools/call", &body["params"]);
+    let response = post_rc(&server.base_url, &body, &headers).await;
+
+    assert_eq!(response.status, 200);
+    let result = response
+        .body
+        .get("result")
+        .expect("tools/call result present");
+    assert_eq!(result["resultType"], json!("complete"));
+    assert_eq!(result["isError"], json!(false));
+    assert!(
+        result["content"][0]["text"]
+            .as_str()
+            .map(|t| t.contains("hi"))
+            .unwrap_or(false),
+        "tool output must echo the input message, got {result}"
+    );
+}
+
+#[tokio::test]
+async fn server_discover_returns_both_supported_versions() {
+    let server = generic_server_harness::spawn().await;
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {"_meta": rc_meta("harn-rc-compat-client")},
+    });
+    let headers = rc_headers("server/discover", &body["params"]);
+    let response = post_rc(&server.base_url, &body, &headers).await;
+
+    assert_eq!(response.status, 200);
+    let result = &response.body["result"];
+    assert_eq!(result["resultType"], json!("complete"));
+    let supported = result["supportedVersions"]
+        .as_array()
+        .expect("supportedVersions array");
+    assert!(supported.iter().any(|v| v == &json!("DRAFT-2026-v1")));
+    assert!(supported.iter().any(|v| v == &json!("2025-11-25")));
+}
+
+#[tokio::test]
+async fn unsupported_version_request_returns_minus_32004() {
+    let server = generic_server_harness::spawn().await;
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "tools/list",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2099-01-01",
+                "io.modelcontextprotocol/clientInfo": {"name": "fuzz", "version": "1"},
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }
+    });
+    let response = post_rc(&server.base_url, &body, &[]).await;
+    let error = response.body.get("error").expect("error response");
+    assert_eq!(error["code"], json!(-32004));
+    let supported = error["data"]["supported"]
+        .as_array()
+        .expect("supported array");
+    assert!(supported.iter().any(|v| v == &json!("DRAFT-2026-v1")));
+}
+
+#[tokio::test]
+async fn header_method_mismatch_returns_minus_32600() {
+    let server = generic_server_harness::spawn().await;
+    let body = rc_request(
+        42,
+        "tools/call",
+        json!({"name": "echo", "arguments": {"message": "spoofed"}}),
+        "harn-rc-compat-client",
+    );
+    // Deliberately mismatch the Mcp-Method header against the body.
+    let bad_headers = vec![
+        ("mcp-protocol-version", "DRAFT-2026-v1".to_string()),
+        ("mcp-method", "tools/list".to_string()),
+    ];
+    let response = post_rc(&server.base_url, &body, &bad_headers).await;
+    let error = response.body.get("error").expect("error response");
+    assert_eq!(error["code"], json!(-32600));
+    assert_eq!(error["data"]["headerValue"], json!("tools/list"));
+    assert_eq!(error["data"]["bodyMethod"], json!("tools/call"));
+}
+
+#[tokio::test]
+async fn legacy_initialize_omits_rc_envelope() {
+    let server = generic_server_harness::spawn().await;
+    let init = legacy_request(
+        1,
+        "initialize",
+        json!({"protocolVersion": "2025-11-25", "clientInfo": {"name": "legacy", "version": "1"}}),
+    );
+    let response = post_rc(&server.base_url, &init, &[]).await;
+    assert_eq!(response.status, 200);
+    let result = response.body.get("result").expect("initialize result");
+    assert_eq!(result["protocolVersion"], json!("2025-11-25"));
+    assert!(
+        result.get("resultType").is_none(),
+        "legacy initialize must not carry resultType; got {result}"
+    );
+    assert!(
+        result.get("ttlMs").is_none(),
+        "legacy initialize must not carry cache hints; got {result}"
+    );
+}
+
+#[tokio::test]
+async fn published_modern_success_fixture_matches_server_responses() {
+    let server = generic_server_harness::spawn().await;
+    let fixture = load_named("modern_success.json");
+    assert_eq!(fixture.kind, WireFixtureKind::Exchange);
+
+    // Replay each (request, response) pair. The published fixture lets
+    // downstream consumers (Burin Code, harn-cloud) drive identical
+    // sequences and assert the same envelope/cache shape Harn does.
+    for pair in fixture.documents.chunks(2) {
+        if pair.len() != 2 {
+            continue;
+        }
+        let request = &pair[0];
+        let expected = &pair[1];
+        let method = request["method"].as_str().unwrap_or_default();
+        if method == "server/discover" || method.starts_with("tools/") {
+            let headers = rc_headers(method, &request["params"]);
+            let response = post_rc(&server.base_url, request, &headers).await;
+            let result = response.body.get("result").expect("result present");
+            let expected_result = expected.get("result").expect("expected result");
+            assert_eq!(
+                result["resultType"], expected_result["resultType"],
+                "resultType drift on {method}: got {result}, expected {expected_result}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn modern_request_without_session_id_succeeds_without_minting_one() {
+    let server = generic_server_harness::spawn().await;
+    let body = rc_request(1, "tools/list", json!({}), "harn-rc-compat-client");
+    let headers = rc_headers("tools/list", &body["params"]);
+    let response = post_rc(&server.base_url, &body, &headers).await;
+    assert_eq!(response.status, 200);
+    assert!(
+        response.echoed_session.is_none(),
+        "modern responses must stay session-less; got {:?}",
+        response.echoed_session
+    );
+}

--- a/crates/harn-mcp-rc-compat/tests/legacy_compat.rs
+++ b/crates/harn-mcp-rc-compat/tests/legacy_compat.rs
@@ -1,0 +1,140 @@
+//! Legacy 2025-11-25 wire-compat regression for both directions.
+//!
+//! These tests guarantee that the RC enablement work has not silently
+//! changed the byte-for-byte wire shape pre-RC clients see. Failures
+//! here localize to the **legacy-compat** surface: either a Harn server
+//! started leaking RC envelope fields into legacy responses, or the
+//! fake legacy fixture itself drifted from spec.
+
+use harn_mcp_rc_compat::fake_client::{legacy_request, post_rc};
+use harn_mcp_rc_compat::fake_server::{spawn_fake_http_server, FakeServerBehavior};
+use harn_mcp_rc_compat::fixtures::{load_named, WireFixtureKind};
+use harn_mcp_rc_compat::generic_server_harness;
+use serde_json::json;
+
+#[tokio::test]
+async fn legacy_initialize_against_generic_server_omits_rc_envelope_and_returns_session_id() {
+    let server = generic_server_harness::spawn().await;
+    let request = legacy_request(
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2025-11-25",
+            "clientInfo": {"name": "harn-rc-compat-legacy", "version": "0.1.0"},
+            "capabilities": {}
+        }),
+    );
+    let response = post_rc(&server.base_url, &request, &[]).await;
+    assert_eq!(response.status, 200);
+
+    let result = response
+        .body
+        .get("result")
+        .expect("legacy initialize must return a result");
+    assert_eq!(result["protocolVersion"], json!("2025-11-25"));
+    assert!(
+        result.get("resultType").is_none(),
+        "legacy initialize must not include resultType, got {result}"
+    );
+    assert!(
+        result.get("ttlMs").is_none(),
+        "legacy initialize must not include ttlMs, got {result}"
+    );
+    assert!(
+        response.echoed_session.is_some(),
+        "legacy initialize must mint Mcp-Session-Id"
+    );
+    assert_eq!(
+        response.echoed_protocol.as_deref(),
+        Some("2025-11-25"),
+        "legacy initialize must echo the stable protocol version"
+    );
+}
+
+#[tokio::test]
+async fn legacy_initialize_against_fake_legacy_server_round_trips() {
+    let server = spawn_fake_http_server(FakeServerBehavior::Legacy202511).await;
+    let url = format!("{}/mcp", server.base_url);
+    let request = legacy_request(
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2025-11-25",
+            "clientInfo": {"name": "legacy", "version": "1"},
+            "capabilities": {}
+        }),
+    );
+    let response = post_rc(&url, &request, &[]).await;
+    let result = response.body.get("result").expect("initialize result");
+    assert_eq!(result["protocolVersion"], json!("2025-11-25"));
+    assert!(result.get("resultType").is_none());
+}
+
+#[tokio::test]
+async fn legacy_tools_list_against_fake_legacy_server_omits_envelope() {
+    let server = spawn_fake_http_server(FakeServerBehavior::Legacy202511).await;
+    let url = format!("{}/mcp", server.base_url);
+    let request = legacy_request(2, "tools/list", json!({}));
+    let response = post_rc(&url, &request, &[]).await;
+    let result = response.body.get("result").expect("result");
+    assert!(
+        result.get("resultType").is_none(),
+        "legacy tools/list result must not include resultType"
+    );
+    assert!(result["tools"].is_array());
+}
+
+#[tokio::test]
+async fn fake_legacy_server_does_not_advertise_server_discover() {
+    let server = spawn_fake_http_server(FakeServerBehavior::Legacy202511).await;
+    let url = format!("{}/mcp", server.base_url);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "server/discover",
+        "params": {}
+    });
+    let response = post_rc(&url, &request, &[]).await;
+    let error = response.body.get("error").expect("error response");
+    assert_eq!(error["code"], json!(-32601));
+}
+
+#[tokio::test]
+async fn published_legacy_fixture_round_trips_against_generic_server() {
+    let server = generic_server_harness::spawn().await;
+    let fixture = load_named("legacy_2025_11_25.json");
+    assert_eq!(fixture.kind, WireFixtureKind::Exchange);
+    // Legacy clients open a session on `initialize` and replay the
+    // assigned `Mcp-Session-Id` on every subsequent request, so we
+    // capture it here and thread it through.
+    let mut session_header: Option<String> = None;
+    for pair in fixture.documents.chunks(2) {
+        if pair.len() != 2 {
+            continue;
+        }
+        let request = &pair[0];
+        let expected = &pair[1];
+        let mut headers = Vec::new();
+        if let Some(session) = &session_header {
+            headers.push(("mcp-session-id", session.clone()));
+        }
+        let response = post_rc(&server.base_url, request, &headers).await;
+        if let Some(session) = response.echoed_session.clone() {
+            session_header = Some(session);
+        }
+        let result = response.body.get("result").expect("legacy result");
+        let expected_result = expected.get("result").expect("expected result");
+        for forbidden in ["resultType", "ttlMs", "cacheScope"] {
+            assert!(
+                result.get(forbidden).is_none(),
+                "{} sprouted RC field {forbidden}: {result}",
+                request["method"]
+            );
+            assert!(
+                expected_result.get(forbidden).is_none(),
+                "fixture {} unexpectedly carries {forbidden}",
+                fixture.name
+            );
+        }
+    }
+}

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -37,7 +37,11 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::{stream, StreamExt};
-use harn_vm::mcp_protocol;
+use harn_vm::mcp_protocol::{
+    self, apply_rc_result_envelope, enforce_request_protocol_version, negotiate_rc_http_request,
+    parse_request_metadata, rc_name_header_value, server_discover_result, McpCacheHint,
+    McpProtocolMode, DRAFT_PROTOCOL_VERSION,
+};
 use serde_json::{json, Value as JsonValue};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
@@ -50,9 +54,11 @@ use crate::{
     ExportCatalog, HttpTlsConfig, TransportAdapter,
 };
 
-pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+pub const MCP_PROTOCOL_VERSION: &str = mcp_protocol::PROTOCOL_VERSION;
 
-const MCP_PROTOCOL_HEADER: &str = "mcp-protocol-version";
+const MCP_PROTOCOL_HEADER: &str = mcp_protocol::RC_HEADER_PROTOCOL_VERSION;
+const MCP_METHOD_HEADER: &str = mcp_protocol::RC_HEADER_METHOD;
+const MCP_NAME_HEADER: &str = mcp_protocol::RC_HEADER_NAME;
 const MCP_SESSION_HEADER: &str = "mcp-session-id";
 const DEPRECATION_HEADER: &str = "deprecation";
 
@@ -114,6 +120,10 @@ pub struct McpServer {
 struct ConnectionState {
     initialized: bool,
     client_identity: String,
+    /// Sticky protocol mode pinned by the first negotiated request on this
+    /// session. Modern RC requests can promote a session without an
+    /// `initialize`; legacy `initialize` keeps it at the stable version.
+    protocol_mode: McpProtocolMode,
 }
 
 impl Default for ConnectionState {
@@ -121,6 +131,7 @@ impl Default for ConnectionState {
         Self {
             initialized: false,
             client_identity: "unknown".to_string(),
+            protocol_mode: McpProtocolMode::Legacy,
         }
     }
 }
@@ -160,6 +171,16 @@ impl SharedSession {
 
     fn update_connection(&self, connection: ConnectionState) {
         self.inner.lock().expect("session poisoned").connection = connection;
+    }
+
+    /// Promote a session to Modern. Sticky once set: any later request
+    /// on the same session inherits Modern envelopes even if it omits the
+    /// `_meta` block. `server/discover` and any RC-tagged request both
+    /// call this; legacy `initialize` does not.
+    fn promote_to_modern(&self) {
+        let mut guard = self.inner.lock().expect("session poisoned");
+        guard.connection.initialized = true;
+        guard.connection.protocol_mode = McpProtocolMode::Modern;
     }
 
     fn insert_call(&self, request_id: String, active: ActiveCall) {
@@ -319,6 +340,18 @@ impl McpServer {
     }
 
     pub async fn run_http(self: Arc<Self>, options: McpHttpServeOptions) -> Result<(), String> {
+        let listener = crate::tls::bind_listener(options.bind)?;
+        self.run_http_from_listener(listener, options).await
+    }
+
+    /// Serve over a pre-bound TCP listener. Tests use this entry point
+    /// so they can capture the assigned ephemeral port before starting
+    /// the server and avoid bind/poll handshakes.
+    pub async fn run_http_from_listener(
+        self: Arc<Self>,
+        listener: std::net::TcpListener,
+        options: McpHttpServeOptions,
+    ) -> Result<(), String> {
         let state = HttpState {
             server: self,
             options: options.clone(),
@@ -339,7 +372,6 @@ impl McpServer {
             .layer(DefaultBodyLimit::max(crate::DEFAULT_HTTP_BODY_LIMIT_BYTES))
             .with_state(state.clone());
         let router = crate::tls::apply_security_headers(router, &options.tls);
-        let listener = crate::tls::bind_listener(options.bind)?;
         let local_addr = listener
             .local_addr()
             .map_err(|error| format!("failed to read local addr: {error}"))?;
@@ -396,8 +428,32 @@ impl McpServer {
             return ImmediateResult::Accepted;
         }
 
+        // RC per-request negotiation. Modern clients tag every payload
+        // with `_meta.io.modelcontextprotocol/protocolVersion`; legacy
+        // payloads simply omit it. Reject the request up front when the
+        // version is recognized but unsupported (-32004), so peers can
+        // retry with a mutually supported version.
+        let metadata = parse_request_metadata(&params);
+        let request_mode = match enforce_request_protocol_version(&id, &metadata) {
+            Ok(Some(mode)) => mode,
+            Ok(None) => McpProtocolMode::Legacy,
+            Err(response) => return ImmediateResult::Response(response),
+        };
+
+        if method == mcp_protocol::METHOD_SERVER_DISCOVER {
+            session.promote_to_modern();
+            return ImmediateResult::Response(self.handle_server_discover(id));
+        }
+
         if method == "initialize" {
             return ImmediateResult::Response(self.handle_initialize(id, &session, &params));
+        }
+
+        // RC requests implicitly bootstrap a session: a Modern peer can
+        // skip `initialize` entirely and the connection is pinned forward
+        // by the first RC-tagged request.
+        if request_mode.is_modern() {
+            session.promote_to_modern();
         }
 
         let connection = session.connection();
@@ -408,6 +464,7 @@ impl McpServer {
                 "server not initialized",
             ));
         }
+        let mode = connection.protocol_mode;
 
         if let Err(response) = self
             .authorize_protocol_method(id.clone(), method, &auth)
@@ -427,31 +484,45 @@ impl McpServer {
             "logging/setLevel" => {
                 ImmediateResult::Response(harn_vm::jsonrpc::response(id, json!({})))
             }
-            "tools/list" => ImmediateResult::Response(harn_vm::jsonrpc::response(
-                id,
-                self.tools_list_result(&params),
+            "tools/list" => ImmediateResult::Response(envelope(
+                harn_vm::jsonrpc::response(id, self.tools_list_result(&params)),
+                mode,
+                Some(McpCacheHint::list_default()),
             )),
             "tools/call" => match self.prepare_stream_job(id, params, session, connection, auth) {
                 Ok(job) => ImmediateResult::Stream(Box::new(job)),
                 Err(response) => ImmediateResult::Response(response),
             },
-            "resources/list" => ImmediateResult::Response(harn_vm::jsonrpc::response(
-                id,
-                self.resources_list_result(&params),
+            "resources/list" => ImmediateResult::Response(envelope(
+                harn_vm::jsonrpc::response(id, self.resources_list_result(&params)),
+                mode,
+                Some(McpCacheHint::list_default()),
             )),
-            "resources/read" => ImmediateResult::Response(self.handle_resources_read(id, &params)),
-            "resources/templates/list" => ImmediateResult::Response(harn_vm::jsonrpc::response(
-                id,
-                self.resources_templates_list_result(&params),
+            "resources/read" => ImmediateResult::Response(envelope(
+                self.handle_resources_read(id, &params),
+                mode,
+                Some(McpCacheHint::read_default()),
             )),
-            "prompts/list" => ImmediateResult::Response(harn_vm::jsonrpc::response(
-                id,
-                self.prompts_list_result(&params),
+            "resources/templates/list" => ImmediateResult::Response(envelope(
+                harn_vm::jsonrpc::response(id, self.resources_templates_list_result(&params)),
+                mode,
+                Some(McpCacheHint::list_default()),
             )),
-            "prompts/get" => ImmediateResult::Response(self.handle_prompts_get(id, &params)),
-            mcp_protocol::METHOD_COMPLETION_COMPLETE => {
-                ImmediateResult::Response(self.handle_completion_complete(id, &params))
-            }
+            "prompts/list" => ImmediateResult::Response(envelope(
+                harn_vm::jsonrpc::response(id, self.prompts_list_result(&params)),
+                mode,
+                Some(McpCacheHint::list_default()),
+            )),
+            "prompts/get" => ImmediateResult::Response(envelope(
+                self.handle_prompts_get(id, &params),
+                mode,
+                None,
+            )),
+            mcp_protocol::METHOD_COMPLETION_COMPLETE => ImmediateResult::Response(envelope(
+                self.handle_completion_complete(id, &params),
+                mode,
+                None,
+            )),
             _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
                 ImmediateResult::Response(
                     mcp_protocol::unsupported_latest_spec_method_response(id, method)
@@ -476,17 +547,13 @@ impl McpServer {
             .get("protocolVersion")
             .and_then(JsonValue::as_str)
             .unwrap_or_default();
-        if !requested.is_empty() && requested != MCP_PROTOCOL_VERSION {
-            return harn_vm::jsonrpc::error_response_with_data(
-                id,
-                -32602,
-                "Unsupported protocol version",
-                json!({
-                    "supported": [MCP_PROTOCOL_VERSION],
-                    "requested": requested,
-                }),
-            );
-        }
+        let negotiated = if requested.is_empty() {
+            MCP_PROTOCOL_VERSION
+        } else if mcp_protocol::is_supported_protocol_version(requested) {
+            requested
+        } else {
+            return mcp_protocol::unsupported_protocol_version_response(id, requested);
+        };
 
         let client_name = params
             .pointer("/clientInfo/name")
@@ -496,11 +563,41 @@ impl McpServer {
             .pointer("/clientInfo/version")
             .and_then(JsonValue::as_str)
             .unwrap_or("unknown");
+        let protocol_mode = if negotiated == DRAFT_PROTOCOL_VERSION {
+            McpProtocolMode::Modern
+        } else {
+            McpProtocolMode::Legacy
+        };
         session.update_connection(ConnectionState {
             initialized: true,
             client_identity: format!("{client_name}/{client_version}"),
+            protocol_mode,
         });
 
+        envelope(
+            harn_vm::jsonrpc::response(
+                id,
+                json!({
+                    "protocolVersion": negotiated,
+                    "capabilities": self.server_capabilities(),
+                    "serverInfo": self.server_info(),
+                }),
+            ),
+            protocol_mode,
+            None,
+        )
+    }
+
+    fn handle_server_discover(&self, id: JsonValue) -> JsonValue {
+        let result = server_discover_result(
+            JsonValue::Object(self.server_capabilities()),
+            self.server_info(),
+            None,
+        );
+        harn_vm::jsonrpc::response(id, result)
+    }
+
+    fn server_capabilities(&self) -> serde_json::Map<String, JsonValue> {
         let mut capabilities = serde_json::Map::new();
         if !self.catalog.functions.is_empty() {
             capabilities.insert("tools".to_string(), json!({}));
@@ -518,7 +615,10 @@ impl McpServer {
                 mcp_protocol::completions_capability(),
             );
         }
+        capabilities
+    }
 
+    fn server_info(&self) -> JsonValue {
         let mut server_info = json!({
             "name": self.server_name,
             "version": env!("CARGO_PKG_VERSION"),
@@ -526,15 +626,7 @@ impl McpServer {
         if let Some(card) = &self.server_card {
             server_info["card"] = card.clone();
         }
-
-        harn_vm::jsonrpc::response(
-            id,
-            json!({
-                "protocolVersion": MCP_PROTOCOL_VERSION,
-                "capabilities": capabilities,
-                "serverInfo": server_info,
-            }),
-        )
+        server_info
     }
 
     fn handle_cancel_notification(&self, session: &SharedSession, params: &JsonValue) {
@@ -629,6 +721,7 @@ impl McpServer {
     ) {
         let cancel_token = Arc::new(AtomicBool::new(false));
         let cancelled = Arc::new(AtomicBool::new(false));
+        let mode = job.context.connection.protocol_mode;
         job.context.session.insert_call(
             job.request_key.clone(),
             ActiveCall {
@@ -669,34 +762,31 @@ impl McpServer {
             return;
         }
 
-        match result {
-            Ok(response) => notify(harn_vm::jsonrpc::response(
-                job.request_id,
-                tool_call_success(response),
-            )),
-            Err(DispatchError::Validation(message)) => notify(harn_vm::jsonrpc::error_response(
-                job.request_id,
-                -32602,
-                &message,
-            )),
-            Err(DispatchError::Unauthorized(message)) => notify(harn_vm::jsonrpc::error_response(
-                job.request_id,
-                -32001,
-                &message,
-            )),
-            Err(DispatchError::MissingExport(message)) => notify(harn_vm::jsonrpc::error_response(
-                job.request_id,
-                -32602,
-                &message,
-            )),
+        let response = match result {
+            Ok(response) => envelope(
+                harn_vm::jsonrpc::response(job.request_id, tool_call_success(response)),
+                mode,
+                None,
+            ),
+            Err(DispatchError::Validation(message)) => {
+                harn_vm::jsonrpc::error_response(job.request_id, -32602, &message)
+            }
+            Err(DispatchError::Unauthorized(message)) => {
+                harn_vm::jsonrpc::error_response(job.request_id, -32001, &message)
+            }
+            Err(DispatchError::MissingExport(message)) => {
+                harn_vm::jsonrpc::error_response(job.request_id, -32602, &message)
+            }
             Err(DispatchError::Execution(message))
             | Err(DispatchError::Cancelled(message))
             | Err(DispatchError::Io(message))
-            | Err(DispatchError::Cache(message)) => notify(harn_vm::jsonrpc::response(
-                job.request_id,
-                tool_call_error(message),
-            )),
-        }
+            | Err(DispatchError::Cache(message)) => envelope(
+                harn_vm::jsonrpc::response(job.request_id, tool_call_error(message)),
+                mode,
+                None,
+            ),
+        };
+        notify(response);
     }
 
     fn tools_list_result(&self, params: &JsonValue) -> JsonValue {
@@ -845,6 +935,21 @@ impl McpServer {
             ),
         }
     }
+}
+
+/// Wrap a JSON-RPC response in the RC envelope (resultType + optional
+/// cache hints) when the connection has been promoted to Modern. Legacy
+/// responses pass through byte-for-byte so existing 2025-11-25 clients
+/// see no wire change.
+fn envelope(
+    mut response: JsonValue,
+    mode: McpProtocolMode,
+    cache: Option<McpCacheHint>,
+) -> JsonValue {
+    if let Some(result) = response.get_mut("result") {
+        apply_rc_result_envelope(result, mode, cache.as_ref());
+    }
+    response
 }
 
 fn requires_protocol_auth(method: &str) -> bool {

--- a/crates/harn-serve/src/adapters/mcp/auth.rs
+++ b/crates/harn-serve/src/adapters/mcp/auth.rs
@@ -44,6 +44,15 @@ pub(super) fn lookup_or_create_session(
         }
         return Err(Box::new(StatusCode::NOT_FOUND.into_response()));
     }
+    // Modern clients are session-less: every request carries its own
+    // `_meta.protocolVersion` and `Mcp-*` headers, so the server never
+    // mints a sticky session id for them. Legacy clients still bootstrap
+    // a session on `initialize` and must replay the assigned
+    // `Mcp-Session-Id` on subsequent calls.
+    if is_session_less_method(method) || is_modern_request(request) {
+        let session = SharedSession::new();
+        return Ok((String::new(), session, false));
+    }
     if method != "initialize" {
         return Err(Box::new(StatusCode::BAD_REQUEST.into_response()));
     }
@@ -51,6 +60,23 @@ pub(super) fn lookup_or_create_session(
     let session = SharedSession::new();
     sessions.insert(session_id.clone(), session.clone());
     Ok((session_id, session, true))
+}
+
+fn is_session_less_method(method: &str) -> bool {
+    method == mcp_protocol::METHOD_SERVER_DISCOVER
+}
+
+fn is_modern_request(request: &JsonValue) -> bool {
+    // Any request that ships `_meta.protocolVersion` is RC-shaped, even
+    // if the named version is one we cannot speak. The dispatch layer
+    // emits the canonical `-32004` reply in that case; we must accept
+    // the request here so the JSON body actually reaches dispatch
+    // instead of getting bounced as a 400.
+    request
+        .pointer("/params/_meta")
+        .and_then(JsonValue::as_object)
+        .map(|meta| meta.contains_key(mcp_protocol::RC_META_KEY_PROTOCOL_VERSION))
+        .unwrap_or(false)
 }
 
 pub(super) fn attach_http_headers(
@@ -105,11 +131,36 @@ pub(super) fn validate_protocol_header(headers: &HeaderMap) -> Result<(), Box<Re
     else {
         return Ok(());
     };
-    if value == MCP_PROTOCOL_VERSION || value == "2025-03-26" {
+    // Accept the stable version, the RC profile, and the prior stable
+    // (`2025-03-26`) for clients still in the lifecycle's compatibility
+    // window. Anything else is a hard 400 so a fuzzed or wrong-product
+    // header never falls through.
+    if value == "2025-03-26" || mcp_protocol::is_supported_protocol_version(value) {
         Ok(())
     } else {
         Err(Box::new(StatusCode::BAD_REQUEST.into_response()))
     }
+}
+
+/// Cross-check the RC-required `Mcp-Method` / `Mcp-Name` headers against
+/// the parsed JSON-RPC body. A mismatch is a JSON-RPC `-32600` error so
+/// the caller can ship it back as either an HTTP 200 with the error body
+/// (RC spec) or an HTTP 400.
+pub(super) fn validate_rc_routing_headers(
+    headers: &HeaderMap,
+    request: &JsonValue,
+) -> Result<(), JsonValue> {
+    let id = request.get("id").cloned().unwrap_or(JsonValue::Null);
+    let method = request.get("method").and_then(JsonValue::as_str);
+    let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+    let name = method.and_then(|m| rc_name_header_value(m, &params));
+    negotiate_rc_http_request(
+        |key| headers.get(key).and_then(|value| value.to_str().ok()),
+        method,
+        name.as_deref(),
+        &id,
+    )
+    .map(|_| ())
 }
 
 pub(super) fn validate_origin(headers: &HeaderMap) -> Result<(), Box<Response>> {

--- a/crates/harn-serve/src/adapters/mcp/transport.rs
+++ b/crates/harn-serve/src/adapters/mcp/transport.rs
@@ -2,7 +2,7 @@
 use super::auth::{
     accepts_media, attach_http_headers, attach_legacy_deprecation_headers, http_auth_request,
     lookup_or_create_session, should_stream_post_response, validate_origin,
-    validate_protocol_header,
+    validate_protocol_header, validate_rc_routing_headers,
 };
 use super::schema::parse_error_response;
 use super::*;
@@ -30,6 +30,15 @@ pub(super) async fn http_post_request(
                 .into_response()
         }
     };
+    // RC Streamable HTTP cross-checks the routing headers against the
+    // JSON-RPC body so a fuzzed or spoofed peer can't smuggle a tools/call
+    // past a header-only audit. A mismatch is `-32600`; we ship it as a
+    // 200 with the JSON-RPC body so the client sees the diagnostic.
+    if let Err(error_body) = validate_rc_routing_headers(&headers, &request) {
+        let mut http = Json(error_body).into_response();
+        attach_http_headers(&mut http, None, MCP_PROTOCOL_VERSION);
+        return http;
+    }
     let header_session = headers
         .get(MCP_SESSION_HEADER)
         .and_then(|value| value.to_str().ok())
@@ -40,6 +49,7 @@ pub(super) async fn http_post_request(
             Err(response) => return *response,
         };
     let auth = http_auth_request(method, &state.options.path, body.to_vec(), &headers);
+    let response_protocol = response_protocol_version(&headers, &request);
 
     match state.server.process_message(request, session, auth).await {
         ImmediateResult::Accepted => StatusCode::ACCEPTED.into_response(),
@@ -52,7 +62,7 @@ pub(super) async fn http_post_request(
             attach_http_headers(
                 &mut http,
                 created.then_some(session_id.as_str()),
-                MCP_PROTOCOL_VERSION,
+                response_protocol,
             );
             http
         }
@@ -62,11 +72,38 @@ pub(super) async fn http_post_request(
             attach_http_headers(
                 &mut http,
                 created.then_some(session_id.as_str()),
-                MCP_PROTOCOL_VERSION,
+                response_protocol,
             );
             http
         }
     }
+}
+
+/// Pick the protocol version we echo back on this response. Modern
+/// requests (RC `_meta` or RC header) get the draft version so the peer
+/// can confirm both sides agreed on the same wire profile.
+fn response_protocol_version(headers: &HeaderMap, request: &JsonValue) -> &'static str {
+    if let Some(value) = headers
+        .get(MCP_PROTOCOL_HEADER)
+        .and_then(|value| value.to_str().ok())
+    {
+        if value == mcp_protocol::DRAFT_PROTOCOL_VERSION {
+            return mcp_protocol::DRAFT_PROTOCOL_VERSION;
+        }
+    }
+    if headers.contains_key(MCP_METHOD_HEADER) || headers.contains_key(MCP_NAME_HEADER) {
+        return mcp_protocol::DRAFT_PROTOCOL_VERSION;
+    }
+    if request
+        .pointer("/params/_meta")
+        .and_then(JsonValue::as_object)
+        .and_then(|meta| meta.get(mcp_protocol::RC_META_KEY_PROTOCOL_VERSION))
+        .and_then(JsonValue::as_str)
+        == Some(mcp_protocol::DRAFT_PROTOCOL_VERSION)
+    {
+        return mcp_protocol::DRAFT_PROTOCOL_VERSION;
+    }
+    MCP_PROTOCOL_VERSION
 }
 
 pub(super) async fn http_get_stream(

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -42,4 +42,4 @@ pub use error::DispatchError;
 pub use exports::{ExportCatalog, ExportedCallableKind, ExportedFunction, ExportedParam};
 pub use mcp_prompts::FilePromptCatalog;
 pub use replay::{InMemoryReplayCache, ReplayCache, ReplayCacheEntry, ReplayKey};
-pub use tls::{HstsConfig, HttpTlsConfig};
+pub use tls::{bind_listener, HstsConfig, HttpTlsConfig};

--- a/spec/protocol-artifacts/README.md
+++ b/spec/protocol-artifacts/README.md
@@ -42,6 +42,12 @@ the same host-facing surface (Python 3.9+, stdlib-only).
 aliases, and constants mirroring the Python and Swift bindings.
 - `fixtures/round_trip.json`: representative JSON envelopes used by
 `make check-bindings` to exercise Python and Go round-trips.
+- `fixtures/mcp-rc/`: hand-authored MCP DRAFT-2026-v1 wire fixtures
+(modern success, unsupported-version retry, cache hints,
+input-required, header mismatch, no-session HTTP, recursive
+`$defs` tool schema, legacy 2025-11-25 compat) replayed by
+`make mcp-rc-conformance` and republished here for Burin Code
+and harn-cloud test suites.
 
 Compatibility rule: additive enum values and optional fields are minor-version
 compatible; removing or renaming a wire value requires a Harn minor-version

--- a/spec/protocol-artifacts/fixtures/mcp-rc/README.md
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/README.md
@@ -1,0 +1,28 @@
+# MCP DRAFT-2026-v1 wire fixtures
+
+Hand-authored JSON request/response fixtures used by Harn's MCP RC
+compatibility harness. The same fixtures are published here so Burin
+Code and harn-cloud test suites can replay the canonical flows in their
+own tests instead of copy-pasting wire shapes.
+
+Each fixture file has the shape:
+
+```json
+{
+  "name": "harn.mcp_rc.<scenario>",
+  "description": "Human-readable summary of the scenario.",
+  "kind": "exchange | http_header_exchange | schema",
+  "documents": [ ... ]
+}
+```
+
+`documents` is interpreted by the loading test: request → response
+sequences for `exchange`, header set → body pairs for
+`http_header_exchange`, a single schema object for `schema`.
+
+Sources:
+
+- [MCP RC blog](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [Lifecycle](https://modelcontextprotocol.io/specification/draft/basic/lifecycle)
+- [Transports](https://modelcontextprotocol.io/specification/draft/basic/transports)
+- [JSON Schema 2020-12](https://json-schema.org/draft/2020-12)

--- a/spec/protocol-artifacts/fixtures/mcp-rc/cache_hints.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/cache_hints.json
@@ -1,0 +1,41 @@
+{
+  "name": "harn.mcp_rc.cache_hints",
+  "description": "Modern tools/list answers with overridden ttlMs and cacheScope values so clients can cache aggressively for the advertised window.",
+  "kind": "exchange",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 5,
+      "method": "tools/list",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 5,
+      "result": {
+        "resultType": "complete",
+        "ttlMs": 300000,
+        "cacheScope": "public",
+        "tools": [
+          {
+            "name": "echo",
+            "title": "Echo",
+            "description": "Return the input string back to the caller.",
+            "inputSchema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {"message": {"type": "string"}},
+              "required": ["message"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/protocol-artifacts/fixtures/mcp-rc/header_mismatch.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/header_mismatch.json
@@ -1,0 +1,38 @@
+{
+  "name": "harn.mcp_rc.header_mismatch",
+  "description": "Streamable HTTP request whose Mcp-Method header disagrees with the JSON-RPC body. RC servers must answer with -32600 instead of dispatching the wrong handler.",
+  "kind": "http_header_exchange",
+  "documents": [
+    {
+      "MCP-Protocol-Version": "DRAFT-2026-v1",
+      "Mcp-Method": "tools/list",
+      "Mcp-Name": ""
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 42,
+      "method": "tools/call",
+      "params": {
+        "name": "echo",
+        "arguments": {"message": "spoofed"},
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 42,
+      "error": {
+        "code": -32600,
+        "message": "Mcp-Method header does not match request body",
+        "data": {
+          "headerValue": "tools/list",
+          "bodyMethod": "tools/call"
+        }
+      }
+    }
+  ]
+}

--- a/spec/protocol-artifacts/fixtures/mcp-rc/input_required.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/input_required.json
@@ -1,0 +1,71 @@
+{
+  "name": "harn.mcp_rc.input_required",
+  "description": "Modern tools/call returns resultType=input_required with an elicitation request; client resolves the elicitation and resubmits the call with inputResponses.",
+  "kind": "exchange",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 10,
+      "method": "tools/call",
+      "params": {
+        "name": "needs_input",
+        "arguments": {"prompt": "continue"},
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 10,
+      "result": {
+        "resultType": "input_required",
+        "requestState": "opaque-server-state",
+        "inputRequests": {
+          "approve": {
+            "method": "elicitation/create",
+            "params": {
+              "mode": "form",
+              "message": "Approve the call?",
+              "requestedSchema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {"approved": {"type": "boolean"}},
+                "required": ["approved"]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 11,
+      "method": "tools/call",
+      "params": {
+        "name": "needs_input",
+        "arguments": {"prompt": "continue"},
+        "requestState": "opaque-server-state",
+        "inputResponses": {
+          "approve": {"action": "accept", "content": {"approved": true}}
+        },
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 11,
+      "result": {
+        "resultType": "complete",
+        "content": [{"type": "text", "text": "done"}],
+        "isError": false
+      }
+    }
+  ]
+}

--- a/spec/protocol-artifacts/fixtures/mcp-rc/legacy_2025_11_25.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/legacy_2025_11_25.json
@@ -1,0 +1,39 @@
+{
+  "name": "harn.mcp_rc.legacy_2025_11_25",
+  "description": "Pre-RC client posts initialize + tools/list. Responses must not include any RC envelope fields (resultType, ttlMs, cacheScope) so existing 2025-11-25 clients stay byte-for-byte compatible.",
+  "kind": "exchange",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {
+        "protocolVersion": "2025-11-25",
+        "clientInfo": {"name": "harn-rc-compat-legacy", "version": "0.1.0"},
+        "capabilities": {}
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "protocolVersion": "2025-11-25",
+        "capabilities": {"tools": {}, "logging": {}},
+        "serverInfo": {"name": "harn-server", "version": "0.0.0"}
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "tools/list",
+      "params": {}
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "tools": []
+      }
+    }
+  ]
+}

--- a/spec/protocol-artifacts/fixtures/mcp-rc/modern_success.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/modern_success.json
@@ -1,0 +1,87 @@
+{
+  "name": "harn.mcp_rc.modern_success",
+  "description": "Modern client posts server/discover, then tools/list, then tools/call. Every response carries resultType=complete and the conservative cache hints.",
+  "kind": "exchange",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "server/discover",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "resultType": "complete",
+        "protocolVersion": "DRAFT-2026-v1",
+        "supportedVersions": ["DRAFT-2026-v1", "2025-11-25"],
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": "harn-rc-compat-server", "version": "0.1.0"}
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "tools/list",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "resultType": "complete",
+        "ttlMs": 5000,
+        "cacheScope": "private",
+        "tools": [
+          {
+            "name": "echo",
+            "title": "Echo",
+            "description": "Return the input string back to the caller.",
+            "inputSchema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {"message": {"type": "string"}},
+              "required": ["message"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "method": "tools/call",
+      "params": {
+        "name": "echo",
+        "arguments": {"message": "hi"},
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 3,
+      "result": {
+        "resultType": "complete",
+        "content": [{"type": "text", "text": "ok:{\"message\":\"hi\"}"}],
+        "isError": false
+      }
+    }
+  ]
+}

--- a/spec/protocol-artifacts/fixtures/mcp-rc/no_session_http.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/no_session_http.json
@@ -1,0 +1,34 @@
+{
+  "name": "harn.mcp_rc.no_session_http",
+  "description": "Modern tools/list posted to an HTTP MCP server without an Mcp-Session-Id. The server must accept the request and the response must not echo a session id back.",
+  "kind": "http_header_exchange",
+  "documents": [
+    {
+      "MCP-Protocol-Version": "DRAFT-2026-v1",
+      "Mcp-Method": "tools/list",
+      "Mcp-Name": ""
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 7,
+      "method": "tools/list",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 7,
+      "result": {
+        "resultType": "complete",
+        "ttlMs": 5000,
+        "cacheScope": "private",
+        "tools": []
+      }
+    }
+  ]
+}

--- a/spec/protocol-artifacts/fixtures/mcp-rc/recursive_schema_tool.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/recursive_schema_tool.json
@@ -1,0 +1,31 @@
+{
+  "name": "harn.mcp_rc.recursive_schema_tool",
+  "description": "Tool input schema that exercises JSON Schema 2020-12 $defs with a self-referential $ref. Used to validate clients accept recursive schemas without bailing.",
+  "kind": "schema",
+  "documents": [
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://harnlang.com/mcp-rc/recursive-tree.input.schema.json",
+      "title": "RecursiveTreeInput",
+      "type": "object",
+      "properties": {
+        "root": {"$ref": "#/$defs/Node"}
+      },
+      "required": ["root"],
+      "$defs": {
+        "Node": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "children": {
+              "type": "array",
+              "items": {"$ref": "#/$defs/Node"}
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      }
+    }
+  ]
+}

--- a/spec/protocol-artifacts/fixtures/mcp-rc/unsupported_version_retry.json
+++ b/spec/protocol-artifacts/fixtures/mcp-rc/unsupported_version_retry.json
@@ -1,0 +1,54 @@
+{
+  "name": "harn.mcp_rc.unsupported_version_retry",
+  "description": "Client posts server/discover targeting a draft the server does not understand; server returns -32004 with the supported list; client retries with the negotiated version.",
+  "kind": "exchange",
+  "documents": [
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "server/discover",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "DRAFT-2026-v1",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "error": {
+        "code": -32004,
+        "message": "Unsupported protocol version",
+        "data": {
+          "requested": "DRAFT-2026-v1",
+          "supported": ["2025-11-25"]
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "server/discover",
+      "params": {
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+          "io.modelcontextprotocol/clientInfo": {"name": "harn-rc-compat-client", "version": "0.1.0"},
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "id": 2,
+      "result": {
+        "resultType": "complete",
+        "protocolVersion": "DRAFT-2026-v1",
+        "supportedVersions": ["DRAFT-2026-v1", "2025-11-25"],
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": "fake-rc-server", "version": "0.1.0"}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Stand up a per-surface MCP DRAFT-2026-v1 compatibility harness so CI failures attribute to one of: client, generic server, orchestrator server, published fixtures, or downstream consumers.
- Wire RC support into the generic `harn-serve::McpServer` (server/discover, per-request `_meta` mode negotiation, RC envelope on streamed + immediate results, session-less HTTP, header validation) using existing `harn-vm::mcp_protocol` helpers — both Harn server implementations now speak the same RC profile.
- Publish hand-authored wire fixtures under `spec/protocol-artifacts/fixtures/mcp-rc/` so Burin Code and harn-cloud can replay identical request/response sequences from their own suites. Includes a JSON Schema 2020-12 tool schema with self-referential \`\$defs\`.
- Add \`make mcp-rc-conformance\` (wired into \`make all\`) that runs the whole suite without live network services.

## Closes

Closes burin-labs/harn#2187.

## Surface map

| Surface | Test target | Notes |
|---|---|---|
| Client fake-server self-consistency | \`harn-mcp-rc-compat/tests/client.rs\` | 7 tests covering all RC behaviors via in-process HTTP + stdio fakes. |
| Generic \`harn-serve\` MCP server | \`harn-mcp-rc-compat/tests/generic_server.rs\` | 8 tests; drives real \`McpServer\` over HTTP with fake RC client. |
| 2025-11-25 wire-compat regression | \`harn-mcp-rc-compat/tests/legacy_compat.rs\` | 5 tests; verifies pre-RC clients still see byte-for-byte legacy responses. |
| Published artifacts + recursive \`\$defs\` | \`harn-mcp-rc-compat/tests/artifacts.rs\` | 9 tests; loads fixtures, validates draft 2020-12 recursive schema via \`jsonschema::draft202012\`. |
| Orchestrator MCP server | \`harn-cli\` \`mcp_rc_compat_tests\` | 5 tests; in-process drive of \`McpOrchestratorService\` using harness fakes + fixtures. |

34 tests total. Pre-existing \`harn-vm\` client RC tests (140) continue to pass.

## Test plan

- [x] \`make mcp-rc-conformance\` — all 34 RC harness tests green.
- [x] \`cargo test -p harn-serve --lib\` — 203 pass; existing generic server tests unaffected.
- [x] \`cargo test -p harn-vm --lib mcp\` — 140 pass; existing client RC tests unaffected.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`make protocol-conformance\` — 34 static-schema fixtures still validate.
- [x] \`cargo run -p harn-cli -- dump-protocol-artifacts --check\` — no artifact drift after regenerating README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)