### PR TITLE
[TM-05] Emit per-fixture parity.json

### DIFF
--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -58,8 +58,8 @@ use crate::commands::run::{
     execute_run_with_sandbox_options, CliLlmMockMode, RunProfileOptions, RunSandboxOptions,
 };
 use crate::commands::tool_mode_parity::{
-    self, ToolModeParityObservation, TOOL_MODE_PARITY_FIXTURE_SUITE,
-    TOOL_MODE_PARITY_OVERLAY_FILENAME,
+    self, ToolModeParityFixtureInput, ToolModeParityPairSummary, TOOL_MODE_PARITY_DIRECTORY,
+    TOOL_MODE_PARITY_FIXTURE_SUITE, TOOL_MODE_PARITY_OVERLAY_FILENAME,
 };
 use crate::dispatch;
 use crate::env_guard::ScopedEnvVar;
@@ -223,6 +223,10 @@ struct FormatComparison {
     text_status: Option<String>,
     native_passed: Option<bool>,
     text_passed: Option<bool>,
+    native_tool_call_count: Option<usize>,
+    text_tool_call_count: Option<usize>,
+    native_rejected_tool_call_count: Option<usize>,
+    text_rejected_tool_call_count: Option<usize>,
     verifier_match: Option<bool>,
     tool_sequence_match: Option<bool>,
     rejected_tool_call_delta_text_minus_native: Option<i64>,
@@ -286,6 +290,7 @@ struct EvalSummary {
     rollups: EvalRollups,
     runs: Vec<RunReport>,
     comparisons: Vec<FormatComparison>,
+    parity_by_pair: Vec<ToolModeParityPairSummary>,
     followups: Vec<FollowupSuggestion>,
     /// Step-judge preset applied to all runs in this invocation, if any.
     /// Used by the experiment driver (experiments/step-judge/run.sh) to
@@ -1118,13 +1123,14 @@ fn build_summary(
     let total_cost_usd = runs.iter().map(|run| run.cost_usd).sum();
     let rollups = build_rollups(&runs);
     let comparisons = compare_formats(&runs);
+    let parity_by_pair = build_parity_by_pair(&comparisons);
     let diverged_comparisons = comparisons
         .iter()
         .filter(|comparison| !comparison.divergence_reasons.is_empty())
         .count();
     let followups = suggest_followups(&runs, &comparisons);
     EvalSummary {
-        schema_version: 2,
+        schema_version: 3,
         fixture_ids: fixtures
             .iter()
             .map(|fixture| fixture.id.to_string())
@@ -1151,6 +1157,7 @@ fn build_summary(
         rollups,
         runs,
         comparisons,
+        parity_by_pair,
         followups,
         step_judge_preset,
         run_label,
@@ -1397,6 +1404,10 @@ fn compare_formats(runs: &[RunReport]) -> Vec<FormatComparison> {
             text_status: text.map(|run| run.status.clone()),
             native_passed: native.map(|run| run.passed),
             text_passed: text.map(|run| run.passed),
+            native_tool_call_count: native.map(|run| run.tool_calls),
+            text_tool_call_count: text.map(|run| run.tool_calls),
+            native_rejected_tool_call_count: native.map(|run| run.rejected_tool_calls),
+            text_rejected_tool_call_count: text.map(|run| run.rejected_tool_calls),
             verifier_match: pair
                 .map(|(native, text)| native.verification_success == text.verification_success),
             tool_sequence_match: pair
@@ -1423,6 +1434,35 @@ fn compare_formats(runs: &[RunReport]) -> Vec<FormatComparison> {
         });
     }
     out
+}
+
+fn build_parity_by_pair(comparisons: &[FormatComparison]) -> Vec<ToolModeParityPairSummary> {
+    let fixture_inputs = comparisons
+        .iter()
+        .filter_map(parity_fixture_input)
+        .collect::<Vec<_>>();
+    let fixture_reports = tool_mode_parity::build_fixture_reports(&fixture_inputs);
+    tool_mode_parity::build_pair_summaries(&fixture_reports)
+}
+
+fn parity_fixture_input(comparison: &FormatComparison) -> Option<ToolModeParityFixtureInput> {
+    Some(ToolModeParityFixtureInput {
+        provider: comparison.selector.provider.clone(),
+        model: comparison.selector.model.clone(),
+        fixture_id: comparison.fixture_id.clone(),
+        native_verdict: comparison.native_status.clone()?,
+        text_verdict: comparison.text_status.clone()?,
+        native_passed: comparison.native_passed?,
+        text_passed: comparison.text_passed?,
+        agreement: comparison.equivalent?,
+        verifier_agreement: comparison.verifier_match?,
+        native_tool_call_count: comparison.native_tool_call_count?,
+        text_tool_call_count: comparison.text_tool_call_count?,
+        native_rejected_tool_call_count: comparison.native_rejected_tool_call_count?,
+        text_rejected_tool_call_count: comparison.text_rejected_tool_call_count?,
+        native_evidence_path: comparison.native_evidence_path.clone()?,
+        text_evidence_path: comparison.text_evidence_path.clone()?,
+    })
 }
 
 fn suggest_followups(
@@ -1528,22 +1568,25 @@ fn write_json_artifacts(output_dir: &Path, summary: &EvalSummary) -> Result<(), 
         .now_utc()
         .format(&time::format_description::well_known::Rfc3339)
         .map_err(|error| format!("failed to format parity overlay timestamp: {error}"))?;
-    let observations = summary
-        .runs
-        .iter()
-        .map(|run| ToolModeParityObservation {
-            provider: run.selector.provider.clone(),
-            model: run.selector.model.clone(),
-            fixture_id: run.fixture_id.clone(),
-            run_id: run.run_id.clone(),
-            tool_format: run.tool_format.clone(),
-            passed: run.passed,
-            skipped: run.skipped,
-            verification_success: run.verification_success,
-        })
-        .collect::<Vec<_>>();
+    let parity_dir = output_dir.join(TOOL_MODE_PARITY_DIRECTORY);
+    let parity_reports = tool_mode_parity::build_fixture_reports(
+        &summary
+            .comparisons
+            .iter()
+            .filter_map(parity_fixture_input)
+            .collect::<Vec<_>>(),
+    );
+    for report in &parity_reports {
+        let path = parity_dir
+            .join(sanitize_id(&format!(
+                "{}__{}:{}",
+                report.fixture_id, report.provider, report.model
+            )))
+            .join("parity.json");
+        tool_mode_parity::write_fixture_report(&path, report)?;
+    }
     let overlay = tool_mode_parity::build_overlay(
-        &observations,
+        &summary.parity_by_pair,
         &generated_at,
         TOOL_MODE_PARITY_FIXTURE_SUITE,
         output_dir,
@@ -1557,10 +1600,11 @@ fn write_json_artifacts(output_dir: &Path, summary: &EvalSummary) -> Result<(), 
 
 fn announce_output_paths(output_dir: &Path) {
     eprintln!(
-        "wrote {}, {}, {}, {}, {}, and {}",
+        "wrote {}, {}, {}, {}, {}, {}, and {}",
         output_dir.join("summary.json").display(),
         output_dir.join("per_run.jsonl").display(),
         output_dir.join("local_readiness.json").display(),
+        output_dir.join(TOOL_MODE_PARITY_DIRECTORY).display(),
         output_dir.join(TOOL_MODE_PARITY_OVERLAY_FILENAME).display(),
         output_dir.join("summary.md").display(),
         output_dir.join("followups.md").display()
@@ -1797,6 +1841,30 @@ fn render_markdown(summary: &EvalSummary) -> String {
                     .map(|v| v.to_string())
                     .unwrap_or_else(|| "-".to_string()),
                 comparison_evidence_links(comparison)
+            ));
+        }
+    }
+    if !summary.parity_by_pair.is_empty() {
+        out.push_str("\n## Parity report — native vs text\n\n");
+        out.push_str("| selector | sample | native pass | text pass | agreement | verifier divergence | native_only | text_only | both_pass | both_fail |\n");
+        out.push_str("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n");
+        for pair in &summary.parity_by_pair {
+            out.push_str(&format!(
+                "| `{}` | {} | {:.1}% | {:.1}% | {:.1}% | {:.1}% | {} | {} | {} | {} |\n",
+                selector_label(&ModelSelector {
+                    selector: format!("{}:{}", pair.provider, pair.model),
+                    provider: pair.provider.clone(),
+                    model: pair.model.clone(),
+                }),
+                pair.sample_size,
+                pair.native.pass_rate * 100.0,
+                pair.text.pass_rate * 100.0,
+                pair.agreement_rate * 100.0,
+                pair.verifier_divergence_rate * 100.0,
+                pair.divergence_counts.native_only_pass,
+                pair.divergence_counts.text_only_pass,
+                pair.divergence_counts.both_pass,
+                pair.divergence_counts.both_fail,
             ));
         }
     }

--- a/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
@@ -37,7 +37,7 @@ fn markdown_escapes_model_table_pipes() {
         model: "a|b".to_string(),
     };
     let summary = EvalSummary {
-        schema_version: 2,
+        schema_version: 3,
         fixture_ids: vec!["python-add".to_string()],
         fixtures: vec![FixtureReport {
             id: "python-add".to_string(),
@@ -102,6 +102,7 @@ fn markdown_escapes_model_table_pipes() {
             local_cleanup: None,
         }],
         comparisons: Vec::new(),
+        parity_by_pair: Vec::new(),
         followups: Vec::new(),
         step_judge_preset: None,
         run_label: String::new(),
@@ -119,7 +120,7 @@ fn write_json_artifacts_emits_tool_mode_parity_overlay() {
         model: "qwen/qwen3-coder".to_string(),
     };
     let summary = EvalSummary {
-        schema_version: 2,
+        schema_version: 3,
         fixture_ids: vec!["python-add".to_string()],
         fixtures: vec![FixtureReport {
             id: "python-add".to_string(),
@@ -210,7 +211,68 @@ fn write_json_artifacts_emits_tool_mode_parity_overlay() {
                 local_cleanup: None,
             },
         ],
-        comparisons: Vec::new(),
+        comparisons: vec![FormatComparison {
+            fixture_id: "python-add".to_string(),
+            selector: ModelSelector {
+                selector: "openrouter:qwen/qwen3-coder".to_string(),
+                provider: "openrouter".to_string(),
+                model: "qwen/qwen3-coder".to_string(),
+            },
+            native_run_id: Some("native".to_string()),
+            text_run_id: Some("text".to_string()),
+            native_evidence_path: Some("out/native/transcript_events.jsonl".to_string()),
+            text_evidence_path: Some("out/text/transcript_events.jsonl".to_string()),
+            native_status: Some("failed".to_string()),
+            text_status: Some("passed".to_string()),
+            native_passed: Some(false),
+            text_passed: Some(true),
+            native_tool_call_count: Some(0),
+            text_tool_call_count: Some(0),
+            native_rejected_tool_call_count: Some(0),
+            text_rejected_tool_call_count: Some(0),
+            verifier_match: Some(false),
+            tool_sequence_match: Some(true),
+            rejected_tool_call_delta_text_minus_native: Some(0),
+            token_delta_text_minus_native: Some(0),
+            iteration_delta_text_minus_native: Some(0),
+            equivalent: Some(false),
+            divergence_reasons: vec!["pass result differs: native=false text=true".to_string()],
+            evidence_paths: vec![
+                "out/native/transcript_events.jsonl".to_string(),
+                "out/text/transcript_events.jsonl".to_string(),
+            ],
+        }],
+        parity_by_pair: vec![ToolModeParityPairSummary {
+            provider: "openrouter".to_string(),
+            model: "qwen/qwen3-coder".to_string(),
+            sample_size: 1,
+            agreement_rate: 0.0,
+            verifier_divergence_rate: 1.0,
+            native: tool_mode_parity::ToolModeParityFormatStats {
+                total_runs: 1,
+                passed_runs: 0,
+                unique_fixtures: 1,
+                replicate_count: 1,
+                pass_rate: 0.0,
+            },
+            text: tool_mode_parity::ToolModeParityFormatStats {
+                total_runs: 1,
+                passed_runs: 1,
+                unique_fixtures: 1,
+                replicate_count: 1,
+                pass_rate: 1.0,
+            },
+            divergence_counts: tool_mode_parity::ToolModeParityDivergenceCounts {
+                native_only_pass: 0,
+                text_only_pass: 1,
+                both_pass: 0,
+                both_fail: 0,
+            },
+            evidence_paths: vec![
+                "out/native/transcript_events.jsonl".to_string(),
+                "out/text/transcript_events.jsonl".to_string(),
+            ],
+        }],
         followups: Vec::new(),
         step_judge_preset: None,
         run_label: String::new(),
@@ -227,6 +289,12 @@ fn write_json_artifacts_emits_tool_mode_parity_overlay() {
     assert_eq!(overlay.fixture_suite, TOOL_MODE_PARITY_FIXTURE_SUITE);
     assert_eq!(overlay.rows.len(), 1);
     assert_eq!(overlay.rows[0].preferred_tool_format, "text");
+    assert!(temp
+        .path()
+        .join(TOOL_MODE_PARITY_DIRECTORY)
+        .join("python-add__openrouter_qwen_qwen3-coder")
+        .join("parity.json")
+        .exists());
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/tool_mode_parity.rs
+++ b/crates/harn-cli/src/commands/tool_mode_parity.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -7,17 +7,80 @@ use serde::{Deserialize, Serialize};
 pub(crate) const TOOL_MODE_PARITY_OVERLAY_SCHEMA_VERSION: u32 = 1;
 pub(crate) const TOOL_MODE_PARITY_FIXTURE_SUITE: &str = "coding-agent";
 pub(crate) const TOOL_MODE_PARITY_OVERLAY_FILENAME: &str = "tool_mode_parity_overlay.toml";
+pub(crate) const TOOL_MODE_PARITY_DIRECTORY: &str = "parity";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ToolModeParityObservation {
+pub(crate) struct ToolModeParityFixtureInput {
     pub provider: String,
     pub model: String,
     pub fixture_id: String,
-    pub run_id: String,
-    pub tool_format: String,
-    pub passed: bool,
-    pub skipped: bool,
-    pub verification_success: bool,
+    pub native_verdict: String,
+    pub text_verdict: String,
+    pub native_passed: bool,
+    pub text_passed: bool,
+    pub agreement: bool,
+    pub verifier_agreement: bool,
+    pub native_tool_call_count: usize,
+    pub text_tool_call_count: usize,
+    pub native_rejected_tool_call_count: usize,
+    pub text_rejected_tool_call_count: usize,
+    pub native_evidence_path: String,
+    pub text_evidence_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ToolModeParityEvidencePaths {
+    pub native: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ToolModeParityFixtureReport {
+    pub fixture_id: String,
+    pub provider: String,
+    pub model: String,
+    pub native_verdict: String,
+    pub text_verdict: String,
+    pub native_passed: bool,
+    pub text_passed: bool,
+    pub agreement: bool,
+    pub verifier_agreement: bool,
+    pub divergence_class: String,
+    pub native_tool_call_count: usize,
+    pub text_tool_call_count: usize,
+    pub native_rejected_tool_call_count: usize,
+    pub text_rejected_tool_call_count: usize,
+    pub evidence_paths: ToolModeParityEvidencePaths,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ToolModeParityDivergenceCounts {
+    pub native_only_pass: usize,
+    pub text_only_pass: usize,
+    pub both_pass: usize,
+    pub both_fail: usize,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ToolModeParityFormatStats {
+    pub total_runs: usize,
+    pub passed_runs: usize,
+    pub unique_fixtures: usize,
+    pub replicate_count: usize,
+    pub pass_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ToolModeParityPairSummary {
+    pub provider: String,
+    pub model: String,
+    pub sample_size: usize,
+    pub agreement_rate: f64,
+    pub verifier_divergence_rate: f64,
+    pub native: ToolModeParityFormatStats,
+    pub text: ToolModeParityFormatStats,
+    pub divergence_counts: ToolModeParityDivergenceCounts,
+    pub evidence_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -43,54 +106,140 @@ pub(crate) struct ToolModeParityOverlayRow {
     pub text: ToolModeParityFormatStats,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-pub(crate) struct ToolModeParityFormatStats {
-    pub total_runs: usize,
-    pub passed_runs: usize,
-    pub unique_fixtures: usize,
-    pub replicate_count: usize,
-    pub pass_rate: f64,
+pub(crate) fn build_fixture_reports(
+    inputs: &[ToolModeParityFixtureInput],
+) -> Vec<ToolModeParityFixtureReport> {
+    inputs
+        .iter()
+        .map(|input| ToolModeParityFixtureReport {
+            fixture_id: input.fixture_id.clone(),
+            provider: input.provider.clone(),
+            model: input.model.clone(),
+            native_verdict: input.native_verdict.clone(),
+            text_verdict: input.text_verdict.clone(),
+            native_passed: input.native_passed,
+            text_passed: input.text_passed,
+            agreement: input.agreement,
+            verifier_agreement: input.verifier_agreement,
+            divergence_class: divergence_class(input.native_passed, input.text_passed),
+            native_tool_call_count: input.native_tool_call_count,
+            text_tool_call_count: input.text_tool_call_count,
+            native_rejected_tool_call_count: input.native_rejected_tool_call_count,
+            text_rejected_tool_call_count: input.text_rejected_tool_call_count,
+            evidence_paths: ToolModeParityEvidencePaths {
+                native: input.native_evidence_path.clone(),
+                text: input.text_evidence_path.clone(),
+            },
+        })
+        .collect()
+}
+
+pub(crate) fn build_pair_summaries(
+    reports: &[ToolModeParityFixtureReport],
+) -> Vec<ToolModeParityPairSummary> {
+    let mut grouped: BTreeMap<(String, String), Vec<&ToolModeParityFixtureReport>> =
+        BTreeMap::new();
+    for report in reports {
+        grouped
+            .entry((report.provider.clone(), report.model.clone()))
+            .or_default()
+            .push(report);
+    }
+
+    grouped
+        .into_iter()
+        .map(|((provider, model), bucket)| {
+            let sample_size = bucket.len();
+            let native = format_stats(&bucket, true);
+            let text = format_stats(&bucket, false);
+            let agreement_rate = ratio(
+                bucket.iter().filter(|report| report.agreement).count(),
+                sample_size,
+            );
+            let verifier_divergence_rate = ratio(
+                bucket
+                    .iter()
+                    .filter(|report| !report.verifier_agreement)
+                    .count(),
+                sample_size,
+            );
+            let mut evidence_paths = bucket
+                .iter()
+                .flat_map(|report| {
+                    [
+                        report.evidence_paths.native.clone(),
+                        report.evidence_paths.text.clone(),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            evidence_paths.sort();
+            evidence_paths.dedup();
+
+            ToolModeParityPairSummary {
+                provider,
+                model,
+                sample_size,
+                agreement_rate,
+                verifier_divergence_rate,
+                native,
+                text,
+                divergence_counts: ToolModeParityDivergenceCounts {
+                    native_only_pass: bucket
+                        .iter()
+                        .filter(|report| report.divergence_class == "native_only_pass")
+                        .count(),
+                    text_only_pass: bucket
+                        .iter()
+                        .filter(|report| report.divergence_class == "text_only_pass")
+                        .count(),
+                    both_pass: bucket
+                        .iter()
+                        .filter(|report| report.divergence_class == "both_pass")
+                        .count(),
+                    both_fail: bucket
+                        .iter()
+                        .filter(|report| report.divergence_class == "both_fail")
+                        .count(),
+                },
+                evidence_paths,
+            }
+        })
+        .collect()
 }
 
 pub(crate) fn build_overlay(
-    observations: &[ToolModeParityObservation],
+    parity_by_pair: &[ToolModeParityPairSummary],
     generated_at: &str,
     fixture_suite: &str,
     evidence_path: &Path,
 ) -> ToolModeParityOverlay {
-    let mut grouped: BTreeMap<(String, String), Vec<&ToolModeParityObservation>> = BTreeMap::new();
-    for observation in observations {
-        grouped
-            .entry((observation.provider.clone(), observation.model.clone()))
-            .or_default()
-            .push(observation);
-    }
-
-    let rows = grouped
-        .into_iter()
-        .map(|((provider, model), bucket)| {
-            let native = format_stats(&bucket, "native");
-            let text = format_stats(&bucket, "text");
-            let sample_size = native.unique_fixtures.min(text.unique_fixtures);
-            let verifier_divergence_rate = verifier_divergence_rate(&bucket);
-            let tool_mode_parity =
-                classify_tool_mode_parity(sample_size, native.pass_rate, text.pass_rate);
-            let preferred_tool_format =
-                preferred_tool_format(&tool_mode_parity, native.pass_rate, text.pass_rate);
-            let confidence = parity_confidence(sample_size, &native, &text);
+    let rows = parity_by_pair
+        .iter()
+        .map(|summary| {
+            let tool_mode_parity = classify_tool_mode_parity(
+                summary.sample_size,
+                summary.native.pass_rate,
+                summary.text.pass_rate,
+            );
+            let preferred_tool_format = preferred_tool_format(
+                &tool_mode_parity,
+                summary.native.pass_rate,
+                summary.text.pass_rate,
+            );
+            let confidence = parity_confidence(summary.sample_size, &summary.native, &summary.text);
 
             ToolModeParityOverlayRow {
-                provider,
-                model,
+                provider: summary.provider.clone(),
+                model: summary.model.clone(),
                 tool_mode_parity,
                 preferred_tool_format,
                 confidence,
-                sample_size,
+                sample_size: summary.sample_size,
                 last_updated: generated_at.to_string(),
                 evidence_path: evidence_path.display().to_string(),
-                verifier_divergence_rate,
-                native,
-                text,
+                verifier_divergence_rate: summary.verifier_divergence_rate,
+                native: summary.native.clone(),
+                text: summary.text.clone(),
             }
         })
         .collect();
@@ -101,6 +250,20 @@ pub(crate) fn build_overlay(
         fixture_suite: fixture_suite.to_string(),
         rows,
     }
+}
+
+pub(crate) fn write_fixture_report(
+    path: &Path,
+    report: &ToolModeParityFixtureReport,
+) -> Result<(), String> {
+    let body = serde_json::to_string_pretty(report)
+        .map_err(|error| format!("failed to render {}: {error}", path.display()))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    fs::write(path, format!("{body}\n"))
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
 }
 
 pub(crate) fn write_overlay(path: &Path, overlay: &ToolModeParityOverlay) -> Result<(), String> {
@@ -132,29 +295,37 @@ pub(crate) fn render_promotion_note(row: &ToolModeParityOverlayRow) -> String {
     )
 }
 
+fn divergence_class(native_passed: bool, text_passed: bool) -> String {
+    match (native_passed, text_passed) {
+        (true, false) => "native_only_pass".to_string(),
+        (false, true) => "text_only_pass".to_string(),
+        (true, true) => "both_pass".to_string(),
+        (false, false) => "both_fail".to_string(),
+    }
+}
+
 fn format_stats(
-    observations: &[&ToolModeParityObservation],
-    tool_format: &str,
+    reports: &[&ToolModeParityFixtureReport],
+    native: bool,
 ) -> ToolModeParityFormatStats {
-    let filtered = observations
-        .iter()
-        .copied()
-        .filter(|observation| observation.tool_format == tool_format && !observation.skipped)
-        .collect::<Vec<_>>();
-    if filtered.is_empty() {
+    if reports.is_empty() {
         return ToolModeParityFormatStats::default();
     }
 
-    let total_runs = filtered.len();
-    let passed_runs = filtered
+    let total_runs = reports.len();
+    let passed_runs = reports
         .iter()
-        .filter(|observation| observation.passed)
+        .filter(|report| {
+            if native {
+                report.native_passed
+            } else {
+                report.text_passed
+            }
+        })
         .count();
     let mut by_fixture: BTreeMap<&str, usize> = BTreeMap::new();
-    for observation in &filtered {
-        *by_fixture
-            .entry(observation.fixture_id.as_str())
-            .or_insert(0) += 1;
+    for report in reports {
+        *by_fixture.entry(report.fixture_id.as_str()).or_insert(0) += 1;
     }
 
     ToolModeParityFormatStats {
@@ -164,45 +335,6 @@ fn format_stats(
         replicate_count: by_fixture.values().copied().min().unwrap_or(0),
         pass_rate: ratio(passed_runs, total_runs),
     }
-}
-
-fn verifier_divergence_rate(observations: &[&ToolModeParityObservation]) -> f64 {
-    let mut native_by_fixture: BTreeMap<&str, Vec<&ToolModeParityObservation>> = BTreeMap::new();
-    let mut text_by_fixture: BTreeMap<&str, Vec<&ToolModeParityObservation>> = BTreeMap::new();
-    for observation in observations.iter().copied().filter(|obs| !obs.skipped) {
-        match observation.tool_format.as_str() {
-            "native" => native_by_fixture
-                .entry(observation.fixture_id.as_str())
-                .or_default()
-                .push(observation),
-            "text" => text_by_fixture
-                .entry(observation.fixture_id.as_str())
-                .or_default()
-                .push(observation),
-            _ => {}
-        }
-    }
-
-    let shared = native_by_fixture
-        .keys()
-        .filter(|fixture| text_by_fixture.contains_key(**fixture))
-        .copied()
-        .collect::<BTreeSet<_>>();
-    let mut compared = 0usize;
-    let mut diverged = 0usize;
-    for fixture in shared {
-        let mut native = native_by_fixture.remove(fixture).unwrap_or_default();
-        let mut text = text_by_fixture.remove(fixture).unwrap_or_default();
-        native.sort_by(|left, right| left.run_id.cmp(&right.run_id));
-        text.sort_by(|left, right| left.run_id.cmp(&right.run_id));
-        for (native, text) in native.iter().zip(text.iter()) {
-            compared += 1;
-            if native.verification_success != text.verification_success {
-                diverged += 1;
-            }
-        }
-    }
-    ratio(diverged, compared)
 }
 
 fn classify_tool_mode_parity(
@@ -263,40 +395,89 @@ fn ratio(numerator: usize, denominator: usize) -> f64 {
 mod tests {
     use super::*;
 
-    fn observation(
+    fn fixture_input(
         fixture_id: &str,
-        run_id: &str,
-        tool_format: &str,
-        passed: bool,
-        verification_success: bool,
-    ) -> ToolModeParityObservation {
-        ToolModeParityObservation {
+        native_passed: bool,
+        text_passed: bool,
+        verifier_agreement: bool,
+    ) -> ToolModeParityFixtureInput {
+        ToolModeParityFixtureInput {
             provider: "openrouter".to_string(),
             model: "qwen/qwen3-coder".to_string(),
             fixture_id: fixture_id.to_string(),
-            run_id: run_id.to_string(),
-            tool_format: tool_format.to_string(),
-            passed,
-            skipped: false,
-            verification_success,
+            native_verdict: if native_passed {
+                "passed".to_string()
+            } else {
+                "failed".to_string()
+            },
+            text_verdict: if text_passed {
+                "passed".to_string()
+            } else {
+                "failed".to_string()
+            },
+            native_passed,
+            text_passed,
+            agreement: native_passed == text_passed,
+            verifier_agreement,
+            native_tool_call_count: 1,
+            text_tool_call_count: 2,
+            native_rejected_tool_call_count: 0,
+            text_rejected_tool_call_count: 1,
+            native_evidence_path: format!("native/{fixture_id}.jsonl"),
+            text_evidence_path: format!("text/{fixture_id}.jsonl"),
         }
     }
 
     #[test]
-    fn overlay_classifies_native_unreliable_and_low_confidence() {
+    fn fixture_reports_capture_divergence_classes() {
+        let reports = build_fixture_reports(&[
+            fixture_input("a", true, false, false),
+            fixture_input("b", false, true, true),
+            fixture_input("c", true, true, true),
+            fixture_input("d", false, false, true),
+        ]);
+
+        assert_eq!(reports[0].divergence_class, "native_only_pass");
+        assert_eq!(reports[1].divergence_class, "text_only_pass");
+        assert_eq!(reports[2].divergence_class, "both_pass");
+        assert_eq!(reports[3].divergence_class, "both_fail");
+    }
+
+    #[test]
+    fn pair_summary_aggregates_rates_and_divergence_counts() {
+        let reports = build_fixture_reports(&[
+            fixture_input("a", false, true, false),
+            fixture_input("b", false, true, true),
+            fixture_input("c", false, true, false),
+            fixture_input("d", true, true, true),
+            fixture_input("e", false, true, false),
+        ]);
+        let summaries = build_pair_summaries(&reports);
+        let summary = summaries.first().expect("summary");
+
+        assert_eq!(summary.sample_size, 5);
+        assert_eq!(summary.native.pass_rate, 0.2);
+        assert_eq!(summary.text.pass_rate, 1.0);
+        assert_eq!(summary.agreement_rate, 0.2);
+        assert_eq!(summary.verifier_divergence_rate, 0.6);
+        assert_eq!(summary.divergence_counts.native_only_pass, 0);
+        assert_eq!(summary.divergence_counts.text_only_pass, 4);
+        assert_eq!(summary.divergence_counts.both_pass, 1);
+        assert_eq!(summary.divergence_counts.both_fail, 0);
+    }
+
+    #[test]
+    fn overlay_uses_pair_summary_for_classification_and_confidence() {
+        let reports = build_fixture_reports(&[
+            fixture_input("a", false, true, false),
+            fixture_input("b", false, true, true),
+            fixture_input("c", false, true, false),
+            fixture_input("d", true, true, true),
+            fixture_input("e", false, true, false),
+        ]);
+        let summaries = build_pair_summaries(&reports);
         let overlay = build_overlay(
-            &[
-                observation("a", "a-native", "native", false, false),
-                observation("a", "a-text", "text", true, true),
-                observation("b", "b-native", "native", false, false),
-                observation("b", "b-text", "text", true, true),
-                observation("c", "c-native", "native", false, false),
-                observation("c", "c-text", "text", true, true),
-                observation("d", "d-native", "native", true, true),
-                observation("d", "d-text", "text", true, true),
-                observation("e", "e-native", "native", false, false),
-                observation("e", "e-text", "text", true, true),
-            ],
+            &summaries,
             "2026-05-24T00:00:00Z",
             TOOL_MODE_PARITY_FIXTURE_SUITE,
             Path::new(".harn-runs/coding-agent-bench/latest"),
@@ -307,56 +488,6 @@ mod tests {
         assert_eq!(row.tool_mode_parity, "native_unreliable");
         assert_eq!(row.preferred_tool_format, "text");
         assert_eq!(row.confidence, "low");
-        assert_eq!(row.native.pass_rate, 0.2);
-        assert_eq!(row.text.pass_rate, 1.0);
-        assert_eq!(row.verifier_divergence_rate, 0.8);
-    }
-
-    #[test]
-    fn overlay_requires_two_replicates_for_high_confidence() {
-        let mut observations = Vec::new();
-        for fixture in ["a", "b", "c", "d", "e"] {
-            observations.push(observation(
-                fixture,
-                &format!("{fixture}-native-1"),
-                "native",
-                true,
-                true,
-            ));
-            observations.push(observation(
-                fixture,
-                &format!("{fixture}-native-2"),
-                "native",
-                true,
-                true,
-            ));
-            observations.push(observation(
-                fixture,
-                &format!("{fixture}-text-1"),
-                "text",
-                true,
-                true,
-            ));
-            observations.push(observation(
-                fixture,
-                &format!("{fixture}-text-2"),
-                "text",
-                true,
-                true,
-            ));
-        }
-
-        let overlay = build_overlay(
-            &observations,
-            "2026-05-24T00:00:00Z",
-            TOOL_MODE_PARITY_FIXTURE_SUITE,
-            Path::new(".harn-runs/coding-agent-bench/latest"),
-        );
-
-        let row = overlay.rows.first().expect("row");
-        assert_eq!(row.confidence, "high");
-        assert_eq!(row.tool_mode_parity, "interchangeable");
-        assert_eq!(row.native.replicate_count, 2);
-        assert_eq!(row.text.replicate_count, 2);
+        assert_eq!(row.verifier_divergence_rate, 0.6);
     }
 }

--- a/crates/harn-cli/tests/eval_coding_agent_cli.rs
+++ b/crates/harn-cli/tests/eval_coding_agent_cli.rs
@@ -14,6 +14,9 @@ use harn_cli::commands::run::{
 };
 use harn_cli::tests::common::env_lock;
 
+const PARITY_DIRECTORY: &str = "parity";
+const PARITY_OVERLAY_FILENAME: &str = "tool_mode_parity_overlay.toml";
+
 fn run_in_harn_runtime<F, Fut, R>(future_factory: F) -> R
 where
     F: FnOnce() -> Fut + Send + 'static,
@@ -71,7 +74,7 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
     let summary_raw = fs::read_to_string(output.join("summary.json")).expect("summary exists");
     let summary: serde_json::Value =
         serde_json::from_str(&summary_raw).expect("summary parses as JSON");
-    assert_eq!(summary["schema_version"], 2);
+    assert_eq!(summary["schema_version"], 3);
     assert_eq!(summary["fixture_ids"].as_array().map(Vec::len), Some(6));
     assert_eq!(summary["total_runs"], 12);
     assert_eq!(summary["passed_runs"], 12);
@@ -111,6 +114,15 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
             .as_array()
             .is_some_and(|paths| paths.len() == 2));
     }
+    let parity_by_pair = summary["parity_by_pair"]
+        .as_array()
+        .expect("parity_by_pair should be an array");
+    assert_eq!(parity_by_pair.len(), 1);
+    assert_eq!(parity_by_pair[0]["sample_size"], 6);
+    assert_eq!(parity_by_pair[0]["native"]["pass_rate"], 1.0);
+    assert_eq!(parity_by_pair[0]["text"]["pass_rate"], 1.0);
+    assert_eq!(parity_by_pair[0]["agreement_rate"], 1.0);
+    assert_eq!(parity_by_pair[0]["verifier_divergence_rate"], 0.0);
     assert_eq!(
         summary
             .pointer("/rollups/by_fixture")
@@ -174,8 +186,29 @@ fn mock_matrix_writes_artifacts_for_native_and_text_tools() {
     assert!(output
         .join("no-tool-diagnosis__mock_mock__native/transcript_events.jsonl")
         .exists());
+    assert!(output
+        .join(PARITY_DIRECTORY)
+        .join("python-add__mock_mock")
+        .join("parity.json")
+        .exists());
+    let parity_raw = fs::read_to_string(
+        output
+            .join(PARITY_DIRECTORY)
+            .join("python-add__mock_mock")
+            .join("parity.json"),
+    )
+    .expect("parity report exists");
+    let parity: serde_json::Value = serde_json::from_str(&parity_raw).expect("parity parses");
+    assert_eq!(parity["native_verdict"], "passed");
+    assert_eq!(parity["text_verdict"], "passed");
+    assert_eq!(parity["agreement"], true);
+    assert_eq!(parity["divergence_class"], "both_pass");
+    assert!(output.join(PARITY_OVERLAY_FILENAME).exists());
     assert!(output.join("summary.md").exists());
     assert!(output.join("followups.md").exists());
+    let summary_md =
+        fs::read_to_string(output.join("summary.md")).expect("summary markdown exists");
+    assert!(summary_md.contains("Parity report — native vs text"));
 }
 
 #[test]

--- a/crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn
@@ -126,6 +126,30 @@ fn __format_float_signed_1(value) -> string {
 }
 
 /**
+ * Format a float as `"X.Y"` (1 decimal, half-up padded). Used for the
+ * parity summary percentages to mirror Rust's `"{:.1}%"`.
+ */
+fn __format_float_1(value) -> string {
+  let f = to_float(value) ?? 0.0
+  let negative = f < 0.0
+  let abs_f = if negative {
+    -f
+  } else {
+    f
+  }
+  let scaled = to_int(round(abs_f * 10.0)) ?? 0
+  let whole = scaled / 10
+  let frac = scaled - whole * 10
+  let frac_str = to_string(frac)
+  let sign = if negative && (whole != 0 || frac != 0) {
+    "-"
+  } else {
+    ""
+  }
+  return sign + to_string(whole) + "." + frac_str
+}
+
+/**
  * Escape Markdown table cell content by replacing `|` with `\|`.
  * Mirrors Rust's `value.replace('|', "\\|")`.
  */
@@ -412,6 +436,46 @@ fn __render_divergence_evidence(comparisons) -> string {
   return out
 }
 
+fn __render_parity_report(parity_by_pair) -> string {
+  var out = "\n## Parity report — native vs text\n\n"
+  out = out
+    + "| selector | sample | native pass | text pass | agreement | verifier divergence | native_only | text_only | both_pass | both_fail |\n"
+  out = out + "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n"
+  for pair in __safe_list(parity_by_pair) {
+    let pd = __safe_dict(pair)
+    let selector = {
+      selector: __safe_string(pd["provider"], "") + ":" + __safe_string(pd["model"], ""),
+      provider: __safe_string(pd["provider"], ""),
+      model: __safe_string(pd["model"], ""),
+    }
+    let divergence_counts = __safe_dict(pd["divergence_counts"])
+    let native = __safe_dict(pd["native"])
+    let text = __safe_dict(pd["text"])
+    out = out + "| `"
+      + __selector_label(selector)
+      + "` | "
+      + to_string(pd["sample_size"] ?? 0)
+      + " | "
+      + __format_float_1((to_float(native["pass_rate"]) ?? 0.0) * 100.0)
+      + "% | "
+      + __format_float_1((to_float(text["pass_rate"]) ?? 0.0) * 100.0)
+      + "% | "
+      + __format_float_1((to_float(pd["agreement_rate"]) ?? 0.0) * 100.0)
+      + "% | "
+      + __format_float_1((to_float(pd["verifier_divergence_rate"]) ?? 0.0) * 100.0)
+      + "% | "
+      + to_string(divergence_counts["native_only_pass"] ?? 0)
+      + " | "
+      + to_string(divergence_counts["text_only_pass"] ?? 0)
+      + " | "
+      + to_string(divergence_counts["both_pass"] ?? 0)
+      + " | "
+      + to_string(divergence_counts["both_fail"] ?? 0)
+      + " |\n"
+  }
+  return out
+}
+
 fn __render_markdown(summary: dict) -> string {
   let fixture_ids = __safe_list(summary["fixture_ids"])
   var out = "# Coding Agent Harness Quality Suite\n\n"
@@ -440,6 +504,10 @@ fn __render_markdown(summary: dict) -> string {
   let comparisons = __safe_list(summary["comparisons"])
   if len(comparisons) > 0 {
     out = out + __render_comparison_table(comparisons)
+  }
+  let parity_by_pair = __safe_list(summary["parity_by_pair"])
+  if len(parity_by_pair) > 0 {
+    out = out + __render_parity_report(parity_by_pair)
   }
   out = out + __render_divergence_evidence(comparisons)
   return out


### PR DESCRIPTION
## Summary
- emit per-fixture `parity.json` reports under the eval output `parity/` tree
- aggregate `parity_by_pair` into `summary.json` and feed the overlay generator from those summaries
- render the parity report consistently in both the Rust fallback and Harn dispatch markdown paths

## Testing
- `CARGO_TARGET_DIR=/tmp/harn-target-2363 cargo test -p harn-cli mock_matrix_writes_artifacts_for_native_and_text_tools --test eval_coding_agent_cli -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2363 cargo test -p harn-cli write_json_artifacts_emits_tool_mode_parity_overlay -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2363 cargo test -p harn-cli tool_mode_parity -- --nocapture`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/cli/eval/coding_agent.harn`
- `cargo fmt --check --all -- crates/harn-cli/src/commands/eval_coding_agent.rs crates/harn-cli/src/commands/tool_mode_parity.rs crates/harn-cli/tests/eval_coding_agent_cli.rs`

Closes #2363