### PR TITLE
Prefer catalog model providers over local fast path

### DIFF
--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -137,6 +137,55 @@ mod tests {
     }
 
     #[test]
+    fn catalog_model_entry_beats_local_base_url_fast_path() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_base = std::env::var("LOCAL_LLM_BASE_URL").ok();
+        let prev_local_model = std::env::var("LOCAL_LLM_MODEL").ok();
+        let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
+        let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
+
+        unsafe {
+            std::env::set_var("LOCAL_LLM_BASE_URL", "http://127.0.0.1:11434");
+            std::env::remove_var("LOCAL_LLM_MODEL");
+            std::env::remove_var("HARN_LLM_PROVIDER");
+            std::env::remove_var("HARN_LLM_MODEL");
+        }
+        reset_provider_key_cache();
+
+        let catalog_model = Some(BTreeMap::from([(
+            "model".to_string(),
+            VmValue::String(Rc::from("qwen-3-coder-480b")),
+        )]));
+        assert_eq!(vm_resolve_provider(&catalog_model), "cerebras");
+
+        let local_model = Some(BTreeMap::from([(
+            "model".to_string(),
+            VmValue::String(Rc::from("my-custom-local-tag")),
+        )]));
+        assert_eq!(vm_resolve_provider(&local_model), "local");
+
+        unsafe {
+            match prev_base {
+                Some(value) => std::env::set_var("LOCAL_LLM_BASE_URL", value),
+                None => std::env::remove_var("LOCAL_LLM_BASE_URL"),
+            }
+            match prev_local_model {
+                Some(value) => std::env::set_var("LOCAL_LLM_MODEL", value),
+                None => std::env::remove_var("LOCAL_LLM_MODEL"),
+            }
+            match prev_harn_provider {
+                Some(value) => std::env::set_var("HARN_LLM_PROVIDER", value),
+                None => std::env::remove_var("HARN_LLM_PROVIDER"),
+            }
+            match prev_harn_model {
+                Some(value) => std::env::set_var("HARN_LLM_MODEL", value),
+                None => std::env::remove_var("HARN_LLM_MODEL"),
+            }
+        }
+        reset_provider_key_cache();
+    }
+
+    #[test]
     fn vm_messages_to_json_preserves_tool_message_fields() {
         let message = VmValue::Dict(Rc::new(BTreeMap::from([
             ("role".to_string(), VmValue::String(Rc::from("tool"))),

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -273,19 +273,32 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
     if let Ok(p) = std::env::var("HARN_LLM_PROVIDER") {
         return p;
     }
+    let explicit_model = options
+        .as_ref()
+        .and_then(|o| o.get("model"))
+        .map(|v| v.display());
+    if let Some(model) = explicit_model.as_deref() {
+        let (_, catalog_provider) = llm_config::resolve_model(model);
+        if let Some(provider) = catalog_provider {
+            return provider;
+        }
+        let normalized = llm_config::normalize_model_id(model);
+        if let Some(entry) = llm_config::model_catalog_entry(model)
+            .or_else(|| llm_config::model_catalog_entry(&normalized))
+        {
+            return entry.provider;
+        }
+    }
+
     // First-class local OpenAI-compatible server support.
     if std::env::var("LOCAL_LLM_BASE_URL").is_ok()
-        && (options.as_ref().and_then(|o| o.get("model")).is_some()
+        && (explicit_model.is_some()
             || std::env::var("HARN_LLM_MODEL").is_ok()
             || std::env::var("LOCAL_LLM_MODEL").is_ok())
     {
         return "local".to_string();
     }
-    if let Some(m) = options
-        .as_ref()
-        .and_then(|o| o.get("model"))
-        .map(|v| v.display())
-    {
+    if let Some(m) = explicit_model {
         return infer_provider_from_model_selector(&m, true);
     }
     if let Some(tier) = options


### PR DESCRIPTION
## Summary
- prefer explicit alias/catalog model providers before the LOCAL_LLM_BASE_URL fallback
- keep unknown explicit model ids routed to local when LOCAL_LLM_BASE_URL is set
- add a regression test for qwen-3-coder-480b resolving to Cerebras despite a local base URL

## Verification
- cargo test -p harn-vm catalog_model_entry_beats_local_base_url_fast_path --lib -- --nocapture
- git diff --check
- pre-commit hooks
- pre-push hooks