### PR TITLE
Fix llm_call routing when LOCAL_LLM_BASE_URL is set

### DIFF
--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -137,6 +137,68 @@ mod tests {
     }
 
     #[test]
+    fn catalog_known_model_beats_local_base_url_fast_path() {
+        // Regression: when LOCAL_LLM_BASE_URL is set (e.g. an Ollama
+        // server running on the dev box), an explicit `model:` option
+        // that names a catalog-known cross-provider alias must route
+        // to the catalog provider, not silently fall into the
+        // `local` fast-path. Otherwise a call like
+        // `llm_call(..., {model: "anthropic/claude-sonnet-4-6"})`
+        // ends up at the local Ollama endpoint and returns a 404
+        // `model_unavailable`.
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let prev_base = std::env::var("LOCAL_LLM_BASE_URL").ok();
+        let prev_local_model = std::env::var("LOCAL_LLM_MODEL").ok();
+        let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
+        let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
+
+        unsafe {
+            std::env::set_var("LOCAL_LLM_BASE_URL", "http://127.0.0.1:11434");
+            std::env::remove_var("LOCAL_LLM_MODEL");
+            std::env::remove_var("HARN_LLM_PROVIDER");
+            std::env::remove_var("HARN_LLM_MODEL");
+        }
+        reset_provider_key_cache();
+
+        // `anthropic/claude-sonnet-4-6` is a catalog alias that resolves
+        // to the openrouter provider. With LOCAL_LLM_BASE_URL set the
+        // pre-fix code would have returned "local".
+        let opts = Some(BTreeMap::from([(
+            "model".to_string(),
+            VmValue::String(Rc::from("anthropic/claude-sonnet-4-6")),
+        )]));
+        assert_eq!(vm_resolve_provider(&opts), "openrouter");
+
+        // An unknown id with no catalog hit still falls into "local"
+        // so users with a custom local server keep working.
+        let opts_unknown = Some(BTreeMap::from([(
+            "model".to_string(),
+            VmValue::String(Rc::from("my-custom-local-tag")),
+        )]));
+        assert_eq!(vm_resolve_provider(&opts_unknown), "local");
+
+        unsafe {
+            match prev_base {
+                Some(value) => std::env::set_var("LOCAL_LLM_BASE_URL", value),
+                None => std::env::remove_var("LOCAL_LLM_BASE_URL"),
+            }
+            match prev_local_model {
+                Some(value) => std::env::set_var("LOCAL_LLM_MODEL", value),
+                None => std::env::remove_var("LOCAL_LLM_MODEL"),
+            }
+            match prev_harn_provider {
+                Some(value) => std::env::set_var("HARN_LLM_PROVIDER", value),
+                None => std::env::remove_var("HARN_LLM_PROVIDER"),
+            }
+            match prev_harn_model {
+                Some(value) => std::env::set_var("HARN_LLM_MODEL", value),
+                None => std::env::remove_var("HARN_LLM_MODEL"),
+            }
+        }
+        reset_provider_key_cache();
+    }
+
+    #[test]
     fn vm_messages_to_json_preserves_tool_message_fields() {
         let message = VmValue::Dict(Rc::new(BTreeMap::from([
             ("role".to_string(), VmValue::String(Rc::from("tool"))),

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -273,19 +273,43 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
     if let Ok(p) = std::env::var("HARN_LLM_PROVIDER") {
         return p;
     }
-    // First-class local OpenAI-compatible server support.
+    // When an explicit `model:` option is set, prefer a catalog-known
+    // provider over the LOCAL_LLM_BASE_URL fast-path. Without this,
+    // a user with `LOCAL_LLM_BASE_URL` pointing at Ollama silently
+    // routes every catalog-known model
+    // (e.g. `anthropic/claude-sonnet-4-6` → openrouter,
+    // `qwen-3-coder-480b` → cerebras) to their local server and
+    // gets a `model_unavailable` 404 instead of the real provider.
+    let explicit_model = options
+        .as_ref()
+        .and_then(|o| o.get("model"))
+        .map(|v| v.display());
+    if let Some(ref m) = explicit_model {
+        use crate::llm::provider::ProviderInferenceSource;
+        // 1. Direct `[aliases]` match wins immediately.
+        let (_resolved, alias_provider) = llm_config::resolve_model(m);
+        if let Some(provider) = alias_provider {
+            return provider;
+        }
+        // 2. `[models]` table + `[[inference_rules]]` matches are also
+        //    authoritative. Only a DefaultFallback (nothing matched)
+        //    falls through to the local fast-path below.
+        let inference = llm_config::infer_provider_detail(m);
+        if inference.source != ProviderInferenceSource::DefaultFallback {
+            return inference.provider;
+        }
+    }
+    // First-class local OpenAI-compatible server support: only kicks in
+    // when the model isn't catalog-known, so unknown ids still route to
+    // the local server.
     if std::env::var("LOCAL_LLM_BASE_URL").is_ok()
-        && (options.as_ref().and_then(|o| o.get("model")).is_some()
+        && (explicit_model.is_some()
             || std::env::var("HARN_LLM_MODEL").is_ok()
             || std::env::var("LOCAL_LLM_MODEL").is_ok())
     {
         return "local".to_string();
     }
-    if let Some(m) = options
-        .as_ref()
-        .and_then(|o| o.get("model"))
-        .map(|v| v.display())
-    {
+    if let Some(m) = explicit_model {
         return infer_provider_from_model_selector(&m, true);
     }
     if let Some(tier) = options


### PR DESCRIPTION
## Summary

`vm_resolve_provider` short-circuited to the `local` provider any time `LOCAL_LLM_BASE_URL` was present in the environment **and** an explicit `model:` option was passed — even when the model id was a catalog-known alias for a different provider. With Ollama running locally this routed `llm_call(..., {model: \"anthropic/claude-sonnet-4-6\"})` to the local endpoint and surfaced a `model_unavailable` 404 instead of dispatching through OpenRouter.

The fix tries the catalog first (alias table, `[models]` entries, inference rules) and only falls back to the local fast-path when nothing in the catalog matches. Unknown ids (e.g. user-named local fine-tunes) still reach the local OpenAI-compatible server.

Discovered while running the three-strategy follow-up eval for #2196 against multiple providers — every non-Ollama model returned a routing error because the dev box had `LOCAL_LLM_BASE_URL=http://localhost:11434` set.

## Behaviour matrix (after fix)

| Scenario | Provider returned |
|---|---|
| `{model: \"anthropic/claude-sonnet-4-6\"}` + `LOCAL_LLM_BASE_URL` set | `openrouter` (catalog hit, was `local`) |
| `{model: \"qwen-3-coder-480b\"}` + `LOCAL_LLM_BASE_URL` set | `cerebras` (catalog hit, was `local`) |
| `{model: \"my-custom-local-tag\"}` + `LOCAL_LLM_BASE_URL` set | `local` (unchanged) |
| `LOCAL_LLM_MODEL=...` + `LOCAL_LLM_BASE_URL` set, no `model:` option | `local` (unchanged) |
| Explicit `provider:` option or `HARN_LLM_PROVIDER` env | unchanged (highest priority) |

## Test plan

- [x] `cargo test --release -p harn-vm --lib 'helpers::tests::'` — 12/12 pass, including:
  - new `catalog_known_model_beats_local_base_url_fast_path` regression test (covers both the catalog hit and the unknown-id fallthrough)
  - existing `local_provider_is_selected_when_local_base_url_and_model_are_set` (no regression)
- [x] Manual reproduction: re-ran `examples/task_plan/compare_strategies.harn --model=anthropic/claude-sonnet-4-6` with `LOCAL_LLM_BASE_URL` set; routes correctly to openrouter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)