### PR TITLE
[CLI-SH-22b] Emit run phase and rusage JSON

### DIFF
--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -114,6 +114,48 @@ pub(crate) struct RunArgs {
         conflicts_with = "summary_file"
     )]
     pub summary_fd: Option<i32>,
+    /// Emit one terminal run-phase JSON object as a single NDJSON line.
+    /// Defaults to stderr; use --phase-file or --phase-fd to keep the
+    /// phase report separate from the script's own stderr.
+    #[arg(long = "emit-phase-json", action = clap::ArgAction::SetTrue)]
+    pub emit_phase_json: bool,
+    /// Write --emit-phase-json output to this file instead of stderr.
+    #[arg(
+        long = "phase-file",
+        value_name = "PATH",
+        requires = "emit_phase_json",
+        conflicts_with = "phase_fd"
+    )]
+    pub phase_file: Option<PathBuf>,
+    /// Write --emit-phase-json output to this already-open file descriptor.
+    #[arg(
+        long = "phase-fd",
+        value_name = "FD",
+        requires = "emit_phase_json",
+        conflicts_with = "phase_file"
+    )]
+    pub phase_fd: Option<i32>,
+    /// Emit one terminal run-rusage JSON object as a single NDJSON line.
+    /// Defaults to stderr; use --rusage-file or --rusage-fd to keep the
+    /// CPU sample separate from the script's own stderr.
+    #[arg(long = "emit-rusage-json", action = clap::ArgAction::SetTrue)]
+    pub emit_rusage_json: bool,
+    /// Write --emit-rusage-json output to this file instead of stderr.
+    #[arg(
+        long = "rusage-file",
+        value_name = "PATH",
+        requires = "emit_rusage_json",
+        conflicts_with = "rusage_fd"
+    )]
+    pub rusage_file: Option<PathBuf>,
+    /// Write --emit-rusage-json output to this already-open file descriptor.
+    #[arg(
+        long = "rusage-fd",
+        value_name = "FD",
+        requires = "emit_rusage_json",
+        conflicts_with = "rusage_file"
+    )]
+    pub rusage_fd: Option<i32>,
     /// Path to the .harn file to execute.
     pub file: Option<String>,
     /// Positional arguments passed to the pipeline as the global `argv`

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -318,6 +318,34 @@ fn test_parses_run_summary_flags() {
 }
 
 #[test]
+fn test_parses_run_phase_and_rusage_flags() {
+    let cli = Cli::parse_from([
+        "harn",
+        "run",
+        "--emit-phase-json",
+        "--phase-file",
+        "phases.jsonl",
+        "--emit-rusage-json",
+        "--rusage-fd",
+        "4",
+        "main.harn",
+    ]);
+
+    let Command::Run(args) = cli.command.unwrap() else {
+        panic!("expected run command");
+    };
+    assert!(args.emit_phase_json);
+    assert_eq!(
+        args.phase_file.as_deref(),
+        Some(std::path::Path::new("phases.jsonl"))
+    );
+    assert_eq!(args.phase_fd, None);
+    assert!(args.emit_rusage_json);
+    assert_eq!(args.rusage_file, None);
+    assert_eq!(args.rusage_fd, Some(4));
+}
+
+#[test]
 fn test_parses_eval_tool_calls_args() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -12,7 +12,7 @@ use harn_vm::event_log::EventLog;
 use serde::Serialize;
 
 use crate::commands::mcp::{self, AuthResolution};
-use crate::commands::time::RunTiming;
+use crate::commands::time::{self, PhaseRecord, RunTiming};
 use crate::package;
 use crate::parse_source_file;
 use crate::skill_loader::{
@@ -38,11 +38,27 @@ pub struct RunJsonOptions {
 /// Post-run summary configuration for `harn run --emit-summary-json`.
 #[derive(Clone, Debug)]
 pub struct RunSummaryOptions {
-    pub sink: RunSummarySink,
+    pub sink: RunJsonSink,
 }
 
 #[derive(Clone, Debug)]
-pub enum RunSummarySink {
+pub struct RunPhaseOptions {
+    pub sink: RunJsonSink,
+}
+
+#[derive(Clone, Debug)]
+pub struct RunRusageOptions {
+    pub sink: RunJsonSink,
+}
+
+#[derive(Clone, Debug)]
+pub struct RunJsonSink {
+    pub target: RunJsonSinkTarget,
+    pub fd_flag: &'static str,
+}
+
+#[derive(Clone, Debug)]
+pub enum RunJsonSinkTarget {
     /// Append the summary to the captured stderr buffer so it remains
     /// terminal after all diagnostics that `run_file_with_skill_dirs`
     /// flushes on return.
@@ -72,19 +88,58 @@ struct RunSummaryLlm {
 }
 
 pub const RUN_SUMMARY_SCHEMA_VERSION: u32 = 1;
+pub const RUN_PHASE_SCHEMA_VERSION: u32 = 1;
+pub const RUN_RUSAGE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize)]
+struct RunPhaseEvent {
+    schema_version: u32,
+    event: &'static str,
+    phases: Vec<PhaseRecord>,
+}
+
+#[derive(Serialize)]
+struct RunRusageEvent {
+    schema_version: u32,
+    event: &'static str,
+    cpu_ms: u64,
+}
 
 pub(crate) fn run_summary_options_from_args(
     args: &crate::cli::RunArgs,
 ) -> Option<RunSummaryOptions> {
     args.emit_summary_json.then(|| RunSummaryOptions {
-        sink: if let Some(path) = args.summary_file.clone() {
-            RunSummarySink::File(path)
-        } else if let Some(fd) = args.summary_fd {
-            RunSummarySink::Fd(fd)
-        } else {
-            RunSummarySink::Stderr
-        },
+        sink: build_run_json_sink(args.summary_file.clone(), args.summary_fd, "--summary-fd"),
     })
+}
+
+pub(crate) fn run_phase_options_from_args(args: &crate::cli::RunArgs) -> Option<RunPhaseOptions> {
+    args.emit_phase_json.then(|| RunPhaseOptions {
+        sink: build_run_json_sink(args.phase_file.clone(), args.phase_fd, "--phase-fd"),
+    })
+}
+
+pub(crate) fn run_rusage_options_from_args(args: &crate::cli::RunArgs) -> Option<RunRusageOptions> {
+    args.emit_rusage_json.then(|| RunRusageOptions {
+        sink: build_run_json_sink(args.rusage_file.clone(), args.rusage_fd, "--rusage-fd"),
+    })
+}
+
+fn build_run_json_sink(
+    file: Option<PathBuf>,
+    fd: Option<i32>,
+    fd_flag: &'static str,
+) -> RunJsonSink {
+    RunJsonSink {
+        target: if let Some(path) = file {
+            RunJsonSinkTarget::File(path)
+        } else if let Some(fd) = fd {
+            RunJsonSinkTarget::Fd(fd)
+        } else {
+            RunJsonSinkTarget::Stderr
+        },
+        fd_flag,
+    }
 }
 
 pub(crate) enum RunFileMcpServeMode {
@@ -554,6 +609,8 @@ struct ExecuteRunInputs<'a> {
     interrupt_tokens: Option<RunInterruptTokens>,
     json: Option<(RunJsonOptions, Box<dyn io::Write + Send>)>,
     summary: Option<RunSummaryOptions>,
+    phase: Option<RunPhaseOptions>,
+    rusage: Option<RunRusageOptions>,
     timing: Option<&'a mut RunTiming>,
     harnpack: HarnpackRunOptions,
 }
@@ -633,6 +690,8 @@ pub(crate) async fn run_file(
         RunSandboxOptions::default(),
         None,
         None,
+        None,
+        None,
         HarnpackRunOptions::default(),
     )
     .await;
@@ -664,6 +723,8 @@ pub(crate) async fn run_file_with_skill_dirs(
     sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
     summary: Option<RunSummaryOptions>,
+    phase: Option<RunPhaseOptions>,
+    rusage: Option<RunRusageOptions>,
     harnpack: HarnpackRunOptions,
 ) {
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
@@ -685,6 +746,8 @@ pub(crate) async fn run_file_with_skill_dirs(
         interrupt_tokens: Some(interrupt_tokens.clone()),
         json: json_with_stdout,
         summary,
+        phase,
+        rusage,
         timing: None,
         harnpack,
     })
@@ -721,6 +784,8 @@ pub(crate) async fn run_resume_with_skill_dirs(
     sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
     summary: Option<RunSummaryOptions>,
+    phase: Option<RunPhaseOptions>,
+    rusage: Option<RunRusageOptions>,
 ) {
     let source = r#"import { resume_agent, wait_agent } from "std/agent/workers"
 
@@ -759,6 +824,8 @@ pipeline main(task) {
         sandbox,
         json,
         summary,
+        phase,
+        rusage,
         HarnpackRunOptions::default(),
     )
     .await;
@@ -1103,6 +1170,8 @@ async fn execute_run_with_harnpack_and_sandbox_options(
         interrupt_tokens: None,
         json: None,
         summary: None,
+        phase: None,
+        rusage: None,
         timing: None,
         harnpack,
     })
@@ -1140,6 +1209,8 @@ pub async fn execute_run_json(
         interrupt_tokens: None,
         json: Some((options, out)),
         summary: None,
+        phase: None,
+        rusage: None,
         timing: None,
         harnpack: HarnpackRunOptions::default(),
     })
@@ -1168,6 +1239,8 @@ pub(crate) async fn execute_run_with_timing(
         interrupt_tokens: None,
         json: None,
         summary: None,
+        phase: None,
+        rusage: None,
         timing,
         harnpack: HarnpackRunOptions::default(),
     })
@@ -1191,10 +1264,19 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         interrupt_tokens,
         json,
         summary,
-        mut timing,
+        phase,
+        rusage,
+        timing,
         harnpack,
     } = inputs;
     let run_started = Instant::now();
+    let cpu_started_ms = rusage.as_ref().map(|_| time::cpu_ms());
+    let mut owned_timing = if timing.is_none() && (phase.is_some() || rusage.is_some()) {
+        Some(RunTiming::default())
+    } else {
+        None
+    };
+    let mut timing = timing.or(owned_timing.as_mut());
 
     // `--json` installs an in-process sink that diverts every
     // observable VM event (stdout, stderr, transcript, tool, hook,
@@ -1219,6 +1301,8 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
                     stderr,
                     json_session,
                     summary.as_ref(),
+                    phase.as_ref(),
+                    rusage.as_ref(),
                     run_started,
                     err,
                 );
@@ -1236,7 +1320,10 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
                 stderr,
                 json_session,
                 summary.as_ref(),
+                phase.as_ref(),
+                rusage.as_ref(),
                 run_started,
+                cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start)),
                 &outcome,
             );
         }
@@ -1255,8 +1342,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             stderr,
             json_session,
             summary.as_ref(),
+            phase.as_ref(),
+            rusage.as_ref(),
             run_started,
             None,
+            timing.as_deref(),
+            0,
+            cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start)),
             "compile_error",
             message,
         );
@@ -1271,7 +1363,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     if trace || summary.is_some() {
         harn_vm::llm::enable_tracing();
     }
-    if profile.is_enabled() {
+    if profile.is_enabled() || phase.is_some() {
         harn_vm::tracing::set_tracing_enabled(true);
     }
     if let Err(error) = install_cli_llm_mock_mode(&llm_mock_mode) {
@@ -1281,8 +1373,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             stderr,
             json_session,
             summary.as_ref(),
+            phase.as_ref(),
+            rusage.as_ref(),
             run_started,
             None,
+            timing.as_deref(),
+            0,
+            cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start)),
             "llm_mock_install",
             error,
         );
@@ -1388,8 +1485,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             stderr,
             json_session,
             summary.as_ref(),
+            phase.as_ref(),
+            rusage.as_ref(),
             run_started,
             None,
+            timing.as_deref(),
+            0,
+            cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start)),
             "manifest_triggers",
             error.to_string(),
         );
@@ -1403,8 +1505,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             stderr,
             json_session,
             summary.as_ref(),
+            phase.as_ref(),
+            rusage.as_ref(),
             run_started,
             None,
+            timing.as_deref(),
+            0,
+            cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start)),
             "manifest_hooks",
             error.to_string(),
         );
@@ -1439,8 +1546,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             stderr,
             json_session,
             summary.as_ref(),
+            phase.as_ref(),
+            rusage.as_ref(),
             run_started,
             profile_rollup.as_ref(),
+            timing.as_deref(),
+            harn_vm::tracing::peek_spans().len() as u64,
+            cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start)),
             "llm_mock_record",
             error,
         );
@@ -1480,8 +1592,13 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
                 stderr,
                 json_session,
                 summary.as_ref(),
+                phase.as_ref(),
+                rusage.as_ref(),
                 run_started,
                 profile_rollup.as_ref(),
+                timing.as_deref(),
+                harn_vm::tracing::peek_spans().len() as u64,
+                cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start)),
                 "attestation",
                 error.to_string(),
             );
@@ -1492,6 +1609,8 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
     match execution {
         Ok((output, return_value)) => {
             stdout.push_str(output);
+            let main_events = harn_vm::tracing::peek_spans().len() as u64;
+            let cpu_ms_total = cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start));
             let profile_rollup = if profile.is_enabled() {
                 Some(harn_vm::profile::build(&harn_vm::tracing::peek_spans()))
             } else {
@@ -1511,38 +1630,45 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
             if exit_code != 0 {
                 stderr.push_str(&render_return_value_error(&return_value));
             }
-            let summary_emission = emit_run_summary_for_exit(
+            let aux_emission = emit_run_aux_for_exit(
                 summary.as_ref(),
+                phase.as_ref(),
+                rusage.as_ref(),
                 run_started,
                 exit_code,
                 profile_rollup.as_ref(),
                 summary_llm,
+                timing.as_deref(),
+                main_events,
+                cpu_ms_total,
                 json_session.is_some(),
                 &mut stderr,
             );
             if let Some(session) = json_session {
-                if let Some(error) = summary_emission.error {
+                if let Some(error) = aux_emission.error {
                     let mut outcome = session.finalize_error(
-                        "summary",
-                        format!("failed to emit run summary: {error}"),
+                        "run_aux",
+                        format!("failed to emit auxiliary run JSON: {error}"),
                         1,
                     );
-                    outcome.stderr = summary_emission.stderr;
+                    outcome.stderr = aux_emission.stderr;
                     return outcome;
                 }
                 let value = harn_vm::llm::vm_value_to_json(&return_value);
-                let mut outcome = session.finalize_result(value, summary_emission.exit_code);
-                outcome.stderr = summary_emission.stderr;
+                let mut outcome = session.finalize_result(value, aux_emission.exit_code);
+                outcome.stderr = aux_emission.stderr;
                 return outcome;
             }
             RunOutcome {
                 stdout,
                 stderr,
-                exit_code: summary_emission.exit_code,
+                exit_code: aux_emission.exit_code,
             }
         }
         Err(rendered_error) => {
             stderr.push_str(&rendered_error);
+            let main_events = harn_vm::tracing::peek_spans().len() as u64;
+            let cpu_ms_total = cpu_started_ms.map(|start| time::cpu_ms().saturating_sub(start));
             let profile_rollup = if profile.is_enabled() {
                 Some(harn_vm::profile::build(&harn_vm::tracing::peek_spans()))
             } else {
@@ -1555,25 +1681,30 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
                     stderr.push_str(&format!("warning: failed to write profile: {error}\n"));
                 }
             }
-            let summary_emission = emit_run_summary_for_exit(
+            let aux_emission = emit_run_aux_for_exit(
                 summary.as_ref(),
+                phase.as_ref(),
+                rusage.as_ref(),
                 run_started,
                 1,
                 profile_rollup.as_ref(),
                 None,
+                timing.as_deref(),
+                main_events,
+                cpu_ms_total,
                 json_session.is_some(),
                 &mut stderr,
             );
             if let Some(session) = json_session {
                 let mut outcome =
-                    session.finalize_error("runtime", rendered_error, summary_emission.exit_code);
-                outcome.stderr = summary_emission.stderr;
+                    session.finalize_error("runtime", rendered_error, aux_emission.exit_code);
+                outcome.stderr = aux_emission.stderr;
                 return outcome;
             }
             RunOutcome {
                 stdout,
                 stderr,
-                exit_code: summary_emission.exit_code,
+                exit_code: aux_emission.exit_code,
             }
         }
     }
@@ -1629,68 +1760,125 @@ fn run_summary_llm_snapshot() -> RunSummaryLlm {
     }
 }
 
-struct RunSummaryEmission {
+struct RunAuxEmission {
     stderr: String,
     exit_code: i32,
     error: Option<String>,
 }
 
-fn emit_run_summary_for_exit(
-    options: Option<&RunSummaryOptions>,
+#[allow(clippy::too_many_arguments)]
+fn emit_run_aux_for_exit(
+    summary: Option<&RunSummaryOptions>,
+    phase: Option<&RunPhaseOptions>,
+    rusage: Option<&RunRusageOptions>,
     started: Instant,
     exit_code: i32,
     profile: Option<&harn_vm::profile::RunProfile>,
     llm: Option<RunSummaryLlm>,
+    timing: Option<&RunTiming>,
+    main_events: u64,
+    cpu_ms_total: Option<u64>,
     json_mode: bool,
     stderr: &mut String,
-) -> RunSummaryEmission {
-    let mut summary_stderr = String::new();
+) -> RunAuxEmission {
+    let mut aux_stderr = String::new();
     let mut final_exit_code = exit_code;
-    let mut summary_error = None;
+    let mut aux_error = None;
+    let aux_target = if json_mode { &mut aux_stderr } else { stderr };
+    let default_timing = RunTiming::default();
+    let timing = timing.unwrap_or(&default_timing);
 
-    if let Some(options) = options {
+    if let Some(options) = summary {
         let llm = llm.unwrap_or_else(run_summary_llm_snapshot);
         let summary = build_run_summary(started, exit_code, profile, llm);
-        let summary_target = if json_mode {
-            &mut summary_stderr
-        } else {
-            stderr
+        if let Err(error) = emit_raw_json_line(&options.sink, &summary, "run summary", aux_target) {
+            record_aux_error(
+                &mut final_exit_code,
+                &mut aux_error,
+                aux_target,
+                "run summary",
+                error,
+            );
+        }
+    }
+    if let Some(options) = phase {
+        let phase_event = RunPhaseEvent {
+            schema_version: RUN_PHASE_SCHEMA_VERSION,
+            event: "run_phase",
+            phases: time::build_phase_records(timing, main_events),
         };
-        if let Err(error) = emit_run_summary(options, &summary, summary_target) {
-            summary_target.push_str(&format!("error: failed to emit run summary: {error}\n"));
-            if final_exit_code == 0 {
-                final_exit_code = 1;
-                summary_error = Some(error);
-            }
+        if let Err(error) = emit_raw_json_line(&options.sink, &phase_event, "run phase", aux_target)
+        {
+            record_aux_error(
+                &mut final_exit_code,
+                &mut aux_error,
+                aux_target,
+                "run phase",
+                error,
+            );
+        }
+    }
+    if let Some(options) = rusage {
+        let rusage_event = RunRusageEvent {
+            schema_version: RUN_RUSAGE_SCHEMA_VERSION,
+            event: "run_rusage",
+            cpu_ms: cpu_ms_total.unwrap_or(0),
+        };
+        if let Err(error) =
+            emit_raw_json_line(&options.sink, &rusage_event, "run rusage", aux_target)
+        {
+            record_aux_error(
+                &mut final_exit_code,
+                &mut aux_error,
+                aux_target,
+                "run rusage",
+                error,
+            );
         }
     }
 
-    RunSummaryEmission {
-        stderr: summary_stderr,
+    RunAuxEmission {
+        stderr: aux_stderr,
         exit_code: final_exit_code,
-        error: summary_error,
+        error: aux_error,
     }
 }
 
-fn emit_run_summary(
-    options: &RunSummaryOptions,
-    summary: &RunSummary<'_>,
+fn record_aux_error(
+    final_exit_code: &mut i32,
+    aux_error: &mut Option<String>,
+    stderr: &mut String,
+    label: &str,
+    error: String,
+) {
+    stderr.push_str(&format!("error: failed to emit {label}: {error}\n"));
+    if *final_exit_code == 0 {
+        *final_exit_code = 1;
+    }
+    if aux_error.is_none() {
+        *aux_error = Some(error);
+    }
+}
+
+fn emit_raw_json_line(
+    sink: &RunJsonSink,
+    value: &impl Serialize,
+    label: &str,
     stderr: &mut String,
 ) -> Result<(), String> {
-    let line = serde_json::to_string(summary)
-        .map_err(|error| format!("serialize run summary: {error}"))?
-        + "\n";
-    match &options.sink {
-        RunSummarySink::Stderr => {
+    let line =
+        serde_json::to_string(value).map_err(|error| format!("serialize {label}: {error}"))? + "\n";
+    match &sink.target {
+        RunJsonSinkTarget::Stderr => {
             stderr.push_str(&line);
             Ok(())
         }
-        RunSummarySink::File(path) => write_run_summary_file(path, &line),
-        RunSummarySink::Fd(fd) => write_run_summary_fd(*fd, &line),
+        RunJsonSinkTarget::File(path) => write_raw_json_file(path, &line),
+        RunJsonSinkTarget::Fd(fd) => write_raw_json_fd(*fd, &line, sink.fd_flag),
     }
 }
 
-fn write_run_summary_file(path: &Path, line: &str) -> Result<(), String> {
+fn write_raw_json_file(path: &Path, line: &str) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             fs::create_dir_all(parent)
@@ -1701,29 +1889,29 @@ fn write_run_summary_file(path: &Path, line: &str) -> Result<(), String> {
 }
 
 #[cfg(unix)]
-fn write_run_summary_fd(fd: i32, line: &str) -> Result<(), String> {
+fn write_raw_json_fd(fd: i32, line: &str, flag: &str) -> Result<(), String> {
     use std::fs::File;
     use std::os::unix::io::FromRawFd;
 
     if fd < 0 {
-        return Err(format!("invalid --summary-fd {fd}: must be non-negative"));
+        return Err(format!("invalid {flag} {fd}: must be non-negative"));
     }
     let duped = unsafe { libc::dup(fd) };
     if duped < 0 {
         return Err(format!(
-            "duplicate --summary-fd {fd}: {}",
+            "duplicate {flag} {fd}: {}",
             io::Error::last_os_error()
         ));
     }
     let mut file = unsafe { File::from_raw_fd(duped) };
     file.write_all(line.as_bytes())
         .and_then(|_| file.flush())
-        .map_err(|error| format!("write --summary-fd {fd}: {error}"))
+        .map_err(|error| format!("write {flag} {fd}: {error}"))
 }
 
 #[cfg(not(unix))]
-fn write_run_summary_fd(_fd: i32, _line: &str) -> Result<(), String> {
-    Err("--summary-fd is only supported on Unix platforms".to_string())
+fn write_raw_json_fd(_fd: i32, _line: &str, flag: &str) -> Result<(), String> {
+    Err(format!("{flag} is only supported on Unix platforms"))
 }
 
 async fn append_run_provenance_event(
@@ -1902,29 +2090,39 @@ fn finalize_run_error(
     mut stderr: String,
     json_session: Option<JsonRunSession>,
     summary: Option<&RunSummaryOptions>,
+    phase: Option<&RunPhaseOptions>,
+    rusage: Option<&RunRusageOptions>,
     started: Instant,
     profile: Option<&harn_vm::profile::RunProfile>,
+    timing: Option<&RunTiming>,
+    main_events: u64,
+    cpu_ms_total: Option<u64>,
     code: impl Into<String>,
     message: impl Into<String>,
 ) -> RunOutcome {
-    let summary_emission = emit_run_summary_for_exit(
+    let aux_emission = emit_run_aux_for_exit(
         summary,
+        phase,
+        rusage,
         started,
         1,
         profile,
         None,
+        timing,
+        main_events,
+        cpu_ms_total,
         json_session.is_some(),
         &mut stderr,
     );
     if let Some(session) = json_session {
-        let mut outcome = session.finalize_error(code, message, summary_emission.exit_code);
-        outcome.stderr = summary_emission.stderr;
+        let mut outcome = session.finalize_error(code, message, aux_emission.exit_code);
+        outcome.stderr = aux_emission.stderr;
         return outcome;
     }
     RunOutcome {
         stdout,
         stderr,
-        exit_code: summary_emission.exit_code,
+        exit_code: aux_emission.exit_code,
     }
 }
 
@@ -1936,6 +2134,8 @@ fn finalize_harnpack_error(
     mut stderr: String,
     json_session: Option<JsonRunSession>,
     summary: Option<&RunSummaryOptions>,
+    phase: Option<&RunPhaseOptions>,
+    rusage: Option<&RunRusageOptions>,
     started: Instant,
     err: HarnpackError,
 ) -> RunOutcome {
@@ -1947,7 +2147,12 @@ fn finalize_harnpack_error(
         stderr,
         json_session,
         summary,
+        phase,
+        rusage,
         started,
+        None,
+        None,
+        0,
         None,
         code,
         message,
@@ -1962,7 +2167,10 @@ fn finalize_harnpack_dry_run(
     mut stderr: String,
     json_session: Option<JsonRunSession>,
     summary_options: Option<&RunSummaryOptions>,
+    phase_options: Option<&RunPhaseOptions>,
+    rusage_options: Option<&RunRusageOptions>,
     started: Instant,
+    cpu_ms_total: Option<u64>,
     prepared: &PreparedHarnpack,
 ) -> RunOutcome {
     let summary = format!(
@@ -1970,23 +2178,28 @@ fn finalize_harnpack_dry_run(
         prepared.bundle_hash, prepared.signature_verified, prepared.cache_hit
     );
     stderr.push_str(&summary);
-    let summary_emission = emit_run_summary_for_exit(
+    let aux_emission = emit_run_aux_for_exit(
         summary_options,
+        phase_options,
+        rusage_options,
         started,
         0,
         None,
         None,
+        None,
+        0,
+        cpu_ms_total,
         json_session.is_some(),
         &mut stderr,
     );
     if let Some(session) = json_session {
-        if let Some(error) = summary_emission.error {
+        if let Some(error) = aux_emission.error {
             let mut outcome = session.finalize_error(
-                "summary",
-                format!("failed to emit run summary: {error}"),
+                "run_aux",
+                format!("failed to emit auxiliary run JSON: {error}"),
                 1,
             );
-            outcome.stderr = summary_emission.stderr;
+            outcome.stderr = aux_emission.stderr;
             return outcome;
         }
         let value = serde_json::json!({
@@ -1996,14 +2209,14 @@ fn finalize_harnpack_dry_run(
             "cache_hit": prepared.cache_hit,
             "dry_run_verify": true,
         });
-        let mut outcome = session.finalize_result(value, summary_emission.exit_code);
-        outcome.stderr = summary_emission.stderr;
+        let mut outcome = session.finalize_result(value, aux_emission.exit_code);
+        outcome.stderr = aux_emission.stderr;
         return outcome;
     }
     RunOutcome {
         stdout: String::new(),
         stderr,
-        exit_code: summary_emission.exit_code,
+        exit_code: aux_emission.exit_code,
     }
 }
 

--- a/crates/harn-cli/src/commands/run.rs
+++ b/crates/harn-cli/src/commands/run.rs
@@ -51,6 +51,13 @@ pub struct RunRusageOptions {
     pub sink: RunJsonSink,
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct RunAuxOptions {
+    pub summary: Option<RunSummaryOptions>,
+    pub phase: Option<RunPhaseOptions>,
+    pub rusage: Option<RunRusageOptions>,
+}
+
 #[derive(Clone, Debug)]
 pub struct RunJsonSink {
     pub target: RunJsonSinkTarget,
@@ -111,6 +118,14 @@ pub(crate) fn run_summary_options_from_args(
     args.emit_summary_json.then(|| RunSummaryOptions {
         sink: build_run_json_sink(args.summary_file.clone(), args.summary_fd, "--summary-fd"),
     })
+}
+
+pub(crate) fn run_aux_options_from_args(args: &crate::cli::RunArgs) -> RunAuxOptions {
+    RunAuxOptions {
+        summary: run_summary_options_from_args(args),
+        phase: run_phase_options_from_args(args),
+        rusage: run_rusage_options_from_args(args),
+    }
 }
 
 pub(crate) fn run_phase_options_from_args(args: &crate::cli::RunArgs) -> Option<RunPhaseOptions> {
@@ -608,9 +623,7 @@ struct ExecuteRunInputs<'a> {
     sandbox: RunSandboxOptions,
     interrupt_tokens: Option<RunInterruptTokens>,
     json: Option<(RunJsonOptions, Box<dyn io::Write + Send>)>,
-    summary: Option<RunSummaryOptions>,
-    phase: Option<RunPhaseOptions>,
-    rusage: Option<RunRusageOptions>,
+    aux: RunAuxOptions,
     timing: Option<&'a mut RunTiming>,
     harnpack: HarnpackRunOptions,
 }
@@ -689,9 +702,7 @@ pub(crate) async fn run_file(
         profile,
         RunSandboxOptions::default(),
         None,
-        None,
-        None,
-        None,
+        RunAuxOptions::default(),
         HarnpackRunOptions::default(),
     )
     .await;
@@ -722,9 +733,7 @@ pub(crate) async fn run_file_with_skill_dirs(
     profile: RunProfileOptions,
     sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
-    summary: Option<RunSummaryOptions>,
-    phase: Option<RunPhaseOptions>,
-    rusage: Option<RunRusageOptions>,
+    aux: RunAuxOptions,
     harnpack: HarnpackRunOptions,
 ) {
     // Graceful shutdown: flush run records before exit on SIGINT/SIGTERM.
@@ -745,9 +754,7 @@ pub(crate) async fn run_file_with_skill_dirs(
         sandbox,
         interrupt_tokens: Some(interrupt_tokens.clone()),
         json: json_with_stdout,
-        summary,
-        phase,
-        rusage,
+        aux,
         timing: None,
         harnpack,
     })
@@ -783,9 +790,7 @@ pub(crate) async fn run_resume_with_skill_dirs(
     profile: RunProfileOptions,
     sandbox: RunSandboxOptions,
     json: Option<RunJsonOptions>,
-    summary: Option<RunSummaryOptions>,
-    phase: Option<RunPhaseOptions>,
-    rusage: Option<RunRusageOptions>,
+    aux: RunAuxOptions,
 ) {
     let source = r#"import { resume_agent, wait_agent } from "std/agent/workers"
 
@@ -823,9 +828,7 @@ pipeline main(task) {
         profile,
         sandbox,
         json,
-        summary,
-        phase,
-        rusage,
+        aux,
         HarnpackRunOptions::default(),
     )
     .await;
@@ -1169,9 +1172,7 @@ async fn execute_run_with_harnpack_and_sandbox_options(
         sandbox,
         interrupt_tokens: None,
         json: None,
-        summary: None,
-        phase: None,
-        rusage: None,
+        aux: RunAuxOptions::default(),
         timing: None,
         harnpack,
     })
@@ -1208,9 +1209,7 @@ pub async fn execute_run_json(
         sandbox: RunSandboxOptions::default(),
         interrupt_tokens: None,
         json: Some((options, out)),
-        summary: None,
-        phase: None,
-        rusage: None,
+        aux: RunAuxOptions::default(),
         timing: None,
         harnpack: HarnpackRunOptions::default(),
     })
@@ -1238,9 +1237,7 @@ pub(crate) async fn execute_run_with_timing(
         sandbox,
         interrupt_tokens: None,
         json: None,
-        summary: None,
-        phase: None,
-        rusage: None,
+        aux: RunAuxOptions::default(),
         timing,
         harnpack: HarnpackRunOptions::default(),
     })
@@ -1263,12 +1260,15 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         sandbox,
         interrupt_tokens,
         json,
-        summary,
-        phase,
-        rusage,
+        aux,
         timing,
         harnpack,
     } = inputs;
+    let RunAuxOptions {
+        summary,
+        phase,
+        rusage,
+    } = aux;
     let run_started = Instant::now();
     let cpu_started_ms = rusage.as_ref().map(|_| time::cpu_ms());
     let mut owned_timing = if timing.is_none() && (phase.is_some() || rusage.is_some()) {

--- a/crates/harn-cli/src/commands/time.rs
+++ b/crates/harn-cli/src/commands/time.rs
@@ -216,54 +216,8 @@ pub(crate) async fn run(args: TimeRunArgs) {
         })
         .collect();
 
-    let main_events = spans.len() as u64;
-
     let cache_hit = timing.cache_hit;
-    let phases = vec![
-        PhaseRecord {
-            name: "parse".into(),
-            duration_ms: timing.parse.as_millis() as u64,
-            input_bytes: if cache_hit {
-                None
-            } else {
-                Some(timing.input_bytes)
-            },
-            cache: None,
-            events: None,
-        },
-        PhaseRecord {
-            name: "typecheck".into(),
-            duration_ms: timing.typecheck.as_millis() as u64,
-            input_bytes: None,
-            cache: None,
-            events: None,
-        },
-        PhaseRecord {
-            name: "bytecode_compile".into(),
-            duration_ms: timing.bytecode_compile.as_millis() as u64,
-            input_bytes: None,
-            cache: Some(if cache_hit {
-                "hit".into()
-            } else {
-                "miss".into()
-            }),
-            events: None,
-        },
-        PhaseRecord {
-            name: "run_setup".into(),
-            duration_ms: timing.run_setup.as_millis() as u64,
-            input_bytes: None,
-            cache: None,
-            events: None,
-        },
-        PhaseRecord {
-            name: "run_main".into(),
-            duration_ms: timing.run_main.as_millis() as u64,
-            input_bytes: None,
-            cache: None,
-            events: Some(main_events),
-        },
-    ];
+    let phases = build_phase_records(&timing, spans.len() as u64);
 
     let report = TimingReport {
         command: "run".into(),
@@ -363,7 +317,7 @@ fn format_ms(ms: u64) -> String {
 /// milliseconds. Falls back to `0` on platforms where `getrusage` is
 /// unavailable so the field is always present in the envelope.
 #[cfg(unix)]
-fn cpu_ms() -> u64 {
+pub(crate) fn cpu_ms() -> u64 {
     use std::mem::MaybeUninit;
     // SAFETY: `getrusage` writes a fully-initialized `rusage` on success;
     // we treat the value as live only after the syscall reports OK.
@@ -380,7 +334,7 @@ fn cpu_ms() -> u64 {
 }
 
 #[cfg(not(unix))]
-fn cpu_ms() -> u64 {
+pub(crate) fn cpu_ms() -> u64 {
     0
 }
 
@@ -393,6 +347,55 @@ fn duration_ms(secs: libc::time_t, micros: libc::suseconds_t) -> u64 {
     let secs_ms = i128::from(secs).saturating_mul(1000);
     let micros_ms = i128::from(micros) / 1000;
     secs_ms.saturating_add(micros_ms).max(0) as u64
+}
+
+pub(crate) fn build_phase_records(timing: &RunTiming, main_events: u64) -> Vec<PhaseRecord> {
+    let cache_hit = timing.cache_hit;
+    vec![
+        PhaseRecord {
+            name: "parse".into(),
+            duration_ms: timing.parse.as_millis() as u64,
+            input_bytes: if cache_hit {
+                None
+            } else {
+                Some(timing.input_bytes)
+            },
+            cache: None,
+            events: None,
+        },
+        PhaseRecord {
+            name: "typecheck".into(),
+            duration_ms: timing.typecheck.as_millis() as u64,
+            input_bytes: None,
+            cache: None,
+            events: None,
+        },
+        PhaseRecord {
+            name: "bytecode_compile".into(),
+            duration_ms: timing.bytecode_compile.as_millis() as u64,
+            input_bytes: None,
+            cache: Some(if cache_hit {
+                "hit".into()
+            } else {
+                "miss".into()
+            }),
+            events: None,
+        },
+        PhaseRecord {
+            name: "run_setup".into(),
+            duration_ms: timing.run_setup.as_millis() as u64,
+            input_bytes: None,
+            cache: None,
+            events: None,
+        },
+        PhaseRecord {
+            name: "run_main".into(),
+            duration_ms: timing.run_main.as_millis() as u64,
+            input_bytes: None,
+            cache: None,
+            events: Some(main_events),
+        },
+    ]
 }
 
 #[cfg(test)]

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -229,9 +229,7 @@ async fn async_main() {
             let json_options = args
                 .json
                 .then_some(commands::run::RunJsonOptions { quiet: args.quiet });
-            let summary_options = commands::run::run_summary_options_from_args(&args);
-            let phase_options = commands::run::run_phase_options_from_args(&args);
-            let rusage_options = commands::run::run_rusage_options_from_args(&args);
+            let aux_options = commands::run::run_aux_options_from_args(&args);
             let harnpack_options = commands::run::harnpack::HarnpackRunOptions {
                 allow_unsigned: args.allow_unsigned,
                 dry_run_verify: args.dry_run_verify,
@@ -249,9 +247,7 @@ async fn async_main() {
                     profile_options,
                     sandbox_options.clone(),
                     json_options,
-                    summary_options,
-                    phase_options,
-                    rusage_options,
+                    aux_options,
                 )
                 .await;
                 return;
@@ -286,9 +282,7 @@ async fn async_main() {
                             profile_options.clone(),
                             sandbox_options.clone(),
                             json_options.clone(),
-                            summary_options.clone(),
-                            phase_options.clone(),
-                            rusage_options.clone(),
+                            aux_options.clone(),
                             harnpack_options.clone(),
                         )
                         .await;
@@ -310,9 +304,7 @@ async fn async_main() {
                             profile_options,
                             sandbox_options,
                             json_options,
-                            summary_options,
-                            phase_options,
-                            rusage_options,
+                            aux_options,
                             harnpack_options,
                         )
                         .await

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -230,6 +230,8 @@ async fn async_main() {
                 .json
                 .then_some(commands::run::RunJsonOptions { quiet: args.quiet });
             let summary_options = commands::run::run_summary_options_from_args(&args);
+            let phase_options = commands::run::run_phase_options_from_args(&args);
+            let rusage_options = commands::run::run_rusage_options_from_args(&args);
             let harnpack_options = commands::run::harnpack::HarnpackRunOptions {
                 allow_unsigned: args.allow_unsigned,
                 dry_run_verify: args.dry_run_verify,
@@ -248,6 +250,8 @@ async fn async_main() {
                     sandbox_options.clone(),
                     json_options,
                     summary_options,
+                    phase_options,
+                    rusage_options,
                 )
                 .await;
                 return;
@@ -283,6 +287,8 @@ async fn async_main() {
                             sandbox_options.clone(),
                             json_options.clone(),
                             summary_options.clone(),
+                            phase_options.clone(),
+                            rusage_options.clone(),
                             harnpack_options.clone(),
                         )
                         .await;
@@ -305,6 +311,8 @@ async fn async_main() {
                             sandbox_options,
                             json_options,
                             summary_options,
+                            phase_options,
+                            rusage_options,
                             harnpack_options,
                         )
                         .await

--- a/crates/harn-cli/tests/run_json_cli.rs
+++ b/crates/harn-cli/tests/run_json_cli.rs
@@ -6,7 +6,10 @@
 
 use std::process::Command;
 
-use harn_cli::commands::run::{json_events::RUN_JSON_SCHEMA_VERSION, RUN_SUMMARY_SCHEMA_VERSION};
+use harn_cli::commands::run::{
+    json_events::RUN_JSON_SCHEMA_VERSION, RUN_PHASE_SCHEMA_VERSION, RUN_RUSAGE_SCHEMA_VERSION,
+    RUN_SUMMARY_SCHEMA_VERSION,
+};
 use harn_cli::tests::common::json_envelope::assert_envelope;
 use serde_json::Value;
 
@@ -40,6 +43,17 @@ fn last_json_line(bytes: &[u8]) -> Value {
         .unwrap_or_else(|| panic!("expected at least one stderr line, got: {text:?}"));
     serde_json::from_str(line).unwrap_or_else(|error| {
         panic!("last stderr line is not valid JSON ({error}): {line}\nfull stderr:\n{text}")
+    })
+}
+
+fn read_json_file(path: &std::path::Path) -> Value {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    serde_json::from_str(text.trim()).unwrap_or_else(|error| {
+        panic!(
+            "file is not valid JSON ({error}): {}\n{text}",
+            path.display()
+        )
     })
 }
 
@@ -425,6 +439,215 @@ pipeline main(_) {
     );
     assert_eq!(summary["event"], "run_summary");
     assert_eq!(summary["exit_code"].as_i64(), Some(1));
+}
+
+#[test]
+fn run_emit_phase_json_defaults_to_terminal_stderr_with_fixed_phase_shape() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let cache_dir = tempfile::TempDir::new().expect("cache dir");
+    let script = write_script(
+        tmp.path(),
+        "phase_stderr.harn",
+        r#"
+pipeline main(_) {
+    __io_println("phase")
+}
+"#,
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--emit-phase-json")
+        .arg(&script)
+        .env("HARN_CACHE_DIR", cache_dir.path())
+        .env("HARN_BYTECODE_CACHE", "1")
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --emit-phase-json");
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "phase\n");
+
+    let phase = last_json_line(&output.stderr);
+    assert_eq!(
+        phase["schema_version"].as_u64(),
+        Some(u64::from(RUN_PHASE_SCHEMA_VERSION))
+    );
+    assert_eq!(phase["event"], "run_phase");
+    let phases = phase["phases"].as_array().expect("phase rows");
+    assert_eq!(phases.len(), 5, "{phase}");
+    let names: Vec<&str> = phases
+        .iter()
+        .map(|row| row["name"].as_str().expect("phase name"))
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "parse",
+            "typecheck",
+            "bytecode_compile",
+            "run_setup",
+            "run_main"
+        ]
+    );
+    assert_eq!(phases[2]["cache"], "miss");
+    assert!(phases[4]["events"].as_u64().is_some(), "{phase}");
+}
+
+#[test]
+fn run_emit_phase_and_rusage_file_sinks_keep_run_json_stdout_clean() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let cache_dir = tempfile::TempDir::new().expect("cache dir");
+    let script = write_script(
+        tmp.path(),
+        "phase_file.harn",
+        r#"
+pipeline main(_) {
+    __io_println("hello")
+}
+"#,
+    );
+    let phase_path = tmp.path().join("run-phase.jsonl");
+    let rusage_path = tmp.path().join("run-rusage.jsonl");
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--json")
+        .arg("--emit-phase-json")
+        .arg("--phase-file")
+        .arg(&phase_path)
+        .arg("--emit-rusage-json")
+        .arg("--rusage-file")
+        .arg(&rusage_path)
+        .arg(&script)
+        .env("HARN_CACHE_DIR", cache_dir.path())
+        .env("HARN_BYTECODE_CACHE", "1")
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --json --emit-phase-json --emit-rusage-json");
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "file sinks should keep stderr clean: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let lines = parse_ndjson(&output.stdout);
+    assert_eq!(lines.last().unwrap()["data"]["event_type"], "result");
+    assert!(
+        lines.iter().all(|line| {
+            !matches!(
+                line["data"]["event_type"].as_str(),
+                Some("run_phase" | "run_rusage")
+            )
+        }),
+        "aux JSON must not be mixed into --json stdout: {lines:?}"
+    );
+
+    let phase = read_json_file(&phase_path);
+    assert_eq!(phase["event"], "run_phase");
+    assert_eq!(
+        phase["schema_version"].as_u64(),
+        Some(u64::from(RUN_PHASE_SCHEMA_VERSION))
+    );
+    assert_eq!(phase["phases"].as_array().expect("phases").len(), 5);
+
+    let rusage = read_json_file(&rusage_path);
+    assert_eq!(rusage["event"], "run_rusage");
+    assert_eq!(
+        rusage["schema_version"].as_u64(),
+        Some(u64::from(RUN_RUSAGE_SCHEMA_VERSION))
+    );
+    assert!(rusage["cpu_ms"].as_u64().is_some(), "{rusage}");
+}
+
+#[cfg(unix)]
+#[test]
+fn run_emit_rusage_json_fd_sink_writes_inherited_descriptor() {
+    use std::os::fd::AsRawFd;
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(
+        tmp.path(),
+        "rusage_fd.harn",
+        r#"
+pipeline main(_) {
+    __io_println("fd")
+}
+"#,
+    );
+    let rusage_path = tmp.path().join("rusage-fd.jsonl");
+    let rusage_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(true)
+        .open(&rusage_path)
+        .expect("open rusage fd");
+    let fd = rusage_file.as_raw_fd();
+
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    assert!(
+        flags >= 0,
+        "fcntl(F_GETFD): {}",
+        std::io::Error::last_os_error()
+    );
+    let clear_result = unsafe { libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
+    assert!(
+        clear_result >= 0,
+        "fcntl(F_SETFD clear CLOEXEC): {}",
+        std::io::Error::last_os_error()
+    );
+
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg("--emit-rusage-json")
+        .arg("--rusage-fd")
+        .arg(fd.to_string())
+        .arg(&script)
+        .env("HARN_EVENT_LOG_BACKEND", "memory")
+        .output()
+        .expect("spawn harn run --rusage-fd");
+
+    let restore_result = unsafe { libc::fcntl(fd, libc::F_SETFD, flags) };
+    assert!(
+        restore_result >= 0,
+        "fcntl(F_SETFD restore): {}",
+        std::io::Error::last_os_error()
+    );
+    drop(rusage_file);
+
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "fd\n");
+    assert!(
+        output.stderr.is_empty(),
+        "--rusage-fd should keep stderr clean: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let rusage = read_json_file(&rusage_path);
+    assert_eq!(rusage["event"], "run_rusage");
+    assert_eq!(
+        rusage["schema_version"].as_u64(),
+        Some(u64::from(RUN_RUSAGE_SCHEMA_VERSION))
+    );
+    assert!(rusage["cpu_ms"].as_u64().is_some(), "{rusage}");
 }
 
 #[test]

--- a/docs/src/cli-json-contract.md
+++ b/docs/src/cli-json-contract.md
@@ -54,11 +54,11 @@ per line) rather than a single document. Today this set is `harn run
 --json` and `harn dev --watch --json`. Each line still carries
 `schemaVersion`; consumers can `jq -c` over the stream.
 
-`harn run --emit-summary-json` is intentionally separate from this
-envelope stream. It emits one raw NDJSON object to stderr by default
-or to `--summary-file` / `--summary-fd` when supplied, so wrappers can
-read aggregate metrics without changing the `harn run --json` stdout
-contract.
+`harn run --emit-summary-json`, `--emit-phase-json`, and
+`--emit-rusage-json` are intentionally separate from this envelope
+stream. Each emits one raw NDJSON object to stderr by default or to a
+dedicated file/fd sink when supplied, so wrappers can read auxiliary
+run metadata without changing the `harn run --json` stdout contract.
 
 ## Supported commands
 
@@ -77,6 +77,8 @@ versions.
 | `harn tokens --json`           | Lexer token stream with source lexemes                   |
 | `harn run --json`              | Streaming NDJSON event log (stdout/stderr/tool/result)   |
 | `harn run --emit-summary-json` | One terminal raw NDJSON summary object on stderr/file/fd  |
+| `harn run --emit-phase-json`   | One terminal raw NDJSON phase object on stderr/file/fd    |
+| `harn run --emit-rusage-json`  | One terminal raw NDJSON CPU sample on stderr/file/fd      |
 | `harn replay --json`           | Per-stage replay summary + embedded fixture verdict      |
 | `harn test conformance --json` | Conformance results with xfail accounting                |
 | `harn graph --json`            | Static module graph: symbols, imports, capabilities      |
@@ -194,6 +196,51 @@ Unix file descriptor.
 The LLM counters are enabled by the summary flag itself, so callers do
 not need to add `--trace` to receive `llm.call_count`, token totals,
 LLM time, and accumulated cost.
+
+### `harn run --emit-phase-json`
+
+The phase sink is also a raw NDJSON line. It preserves the same
+five-row phase contract as `harn time run --json`, but routes it to a
+separate sink so a parent wrapper can spawn `harn run` and recover
+parse/typecheck/compile/setup/main timing without parsing stdout.
+`--phase-file <path>` overwrites the file with the one-line phase
+object; `--phase-fd <fd>` writes the same line to an already-open Unix
+file descriptor.
+
+```json
+{
+  "schema_version": 1,
+  "event": "run_phase",
+  "phases": [
+    { "name": "parse", "duration_ms": 12, "input_bytes": 4096 },
+    { "name": "typecheck", "duration_ms": 80 },
+    { "name": "bytecode_compile", "duration_ms": 35, "cache": "miss" },
+    { "name": "run_setup", "duration_ms": 8 },
+    { "name": "run_main", "duration_ms": 1200, "events": 14 }
+  ]
+}
+```
+
+The phase order is fixed: `parse`, `typecheck`, `bytecode_compile`,
+`run_setup`, `run_main`. Cache hits keep all five rows and switch the
+`bytecode_compile` row to `"cache": "hit"` while leaving `parse` and
+`typecheck` at `duration_ms: 0`.
+
+### `harn run --emit-rusage-json`
+
+The rusage sink is a raw NDJSON line carrying the process CPU sample
+needed by subprocess wrappers that cannot call `getrusage` in-process.
+`--rusage-file <path>` overwrites the file with the one-line object;
+`--rusage-fd <fd>` writes the same line to an already-open Unix file
+descriptor.
+
+```json
+{
+  "schema_version": 1,
+  "event": "run_rusage",
+  "cpu_ms": 320
+}
+```
 
 ## Compatibility
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -49,6 +49,12 @@ harn run --resume .harn/workers/worker_...json
 | `--emit-summary-json` | Emit one terminal `run_summary` JSON object as a single NDJSON line; defaults to stderr |
 | `--summary-file <path>` | Write `--emit-summary-json` output to a file instead of stderr |
 | `--summary-fd <fd>` | Write `--emit-summary-json` output to an already-open Unix file descriptor |
+| `--emit-phase-json` | Emit one terminal `run_phase` JSON object as a single NDJSON line; defaults to stderr |
+| `--phase-file <path>` | Write `--emit-phase-json` output to a file instead of stderr |
+| `--phase-fd <fd>` | Write `--emit-phase-json` output to an already-open Unix file descriptor |
+| `--emit-rusage-json` | Emit one terminal `run_rusage` JSON object as a single NDJSON line; defaults to stderr |
+| `--rusage-file <path>` | Write `--emit-rusage-json` output to a file instead of stderr |
+| `--rusage-fd <fd>` | Write `--emit-rusage-json` output to an already-open Unix file descriptor |
 | `--allow-unsigned` | When running a `.harnpack`, accept bundles that carry no Ed25519 signature (local-dev override) |
 | `--dry-run-verify` | When running a `.harnpack`, verify the signature and replay into the cache without executing the entrypoint |
 
@@ -121,6 +127,53 @@ Shape (`schema_version: 1`):
 `profile` is present only when the run enables profiling with
 `--profile` or `--profile-json`. The LLM metrics are collected whenever
 summary JSON is requested, even without `--trace`.
+
+### Post-run phase JSON
+
+`harn run --emit-phase-json <file>` emits one raw JSON object after
+the run finishes. This uses the same fixed five-phase contract as
+`harn time run --json`, but keeps the data on a separate sink so a
+wrapper can spawn `harn run` and recover parse/typecheck/compile/setup
+timings without changing stdout. Use `--phase-file <path>` or
+`--phase-fd <fd>` to isolate the line from stderr.
+
+Shape (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "event": "run_phase",
+  "phases": [
+    { "name": "parse", "duration_ms": 12, "input_bytes": 4096 },
+    { "name": "typecheck", "duration_ms": 80 },
+    { "name": "bytecode_compile", "duration_ms": 35, "cache": "miss" },
+    { "name": "run_setup", "duration_ms": 8 },
+    { "name": "run_main", "duration_ms": 1200, "events": 14 }
+  ]
+}
+```
+
+The phase array is always in this order: `parse`, `typecheck`,
+`bytecode_compile`, `run_setup`, `run_main`. On a bytecode-cache hit,
+`parse` and `typecheck` stay present with `duration_ms: 0`, and the
+`bytecode_compile` row flips to `"cache": "hit"`.
+
+### Post-run rusage JSON
+
+`harn run --emit-rusage-json <file>` emits one raw JSON object after
+the run finishes containing the total `getrusage(RUSAGE_SELF)` CPU time
+sample for the process during that run. Use `--rusage-file <path>` or
+`--rusage-fd <fd>` to isolate the line from stderr.
+
+Shape (`schema_version: 1`):
+
+```json
+{
+  "schema_version": 1,
+  "event": "run_rusage",
+  "cpu_ms": 320
+}
+```
 
 You can also run a file directly without the `run` subcommand:
 


### PR DESCRIPTION
## Summary
- add `harn run` phase and rusage auxiliary JSON sinks using the existing summary-style flag pattern
- reuse the `harn time run` phase builder so the emitted `run_phase` payload keeps the fixed five-phase contract
- document the new raw JSON sinks and cover stderr/file/fd behavior in CLI and integration tests

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2350 cargo test -p harn-cli --lib test_parses_run_phase_and_rusage_flags -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2350 cargo test -p harn-cli --test run_json_cli -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2350 cargo test -p harn-cli --test time_cli -- --nocapture`
- `cargo fmt --check --all`

Closes #2350
