### PR TITLE
Remove stale Cerebras qwen-3-coder-480b catalog entry

### DIFF
--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -949,13 +949,6 @@ context_window = 131072
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.85, output_per_mtok = 1.20 }
 
-[models."qwen-3-coder-480b"]
-name = "Qwen3 Coder 480B (Cerebras)"
-provider = "cerebras"
-context_window = 131072
-capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 2.00, output_per_mtok = 2.00 }
-
 # Open-router Qwen3.5 9B (kept for the `small` tier alias).
 
 [models."Qwen/Qwen3.5-9B"]

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1143,7 +1143,7 @@ mod tests {
             std::env::remove_var("HARN_DEFAULT_PROVIDER");
         }
 
-        for model in ["gpt-oss-120b", "llama-3.3-70b", "qwen-3-coder-480b"] {
+        for model in ["gpt-oss-120b", "llama-3.3-70b"] {
             assert_eq!(
                 infer_provider(model),
                 "cerebras",

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -134,7 +134,6 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `anthropic` | `claude-sonnet-4-7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `cerebras` | `gpt-oss-120b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `cerebras` | `llama-3.3-70b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
-| `cerebras` | `qwen-3-coder-480b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `llamacpp` | `qwen3.6-35b-a3b` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -1811,62 +1811,6 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
-      "id": "qwen-3-coder-480b",
-      "name": "Qwen3 Coder 480B (Cerebras)",
-      "provider": "cerebras",
-      "aliases": [],
-      "context_window": 131072,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "tool_support": {
-        "native": true,
-        "text": true,
-        "preferred_format": "native",
-        "parity": "unknown",
-        "tool_search": []
-      },
-      "structured_output": "native",
-      "format_preferences": {
-        "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": true,
-        "structured_output_mode": "native_json",
-        "supports_assistant_prefill": false,
-        "prefers_role_developer": false,
-        "prefers_xml_tools": false,
-        "thinking_block_style": "none"
-      },
-      "reasoning": {
-        "modes": [],
-        "effort_supported": false,
-        "none_supported": false,
-        "interleaved_supported": false,
-        "preserve_thinking": false
-      },
-      "prompt_cache": false,
-      "pricing": {
-        "input_per_mtok": 2.0,
-        "output_per_mtok": 2.0,
-        "cache_read_per_mtok": null,
-        "cache_write_per_mtok": null
-      },
-      "deprecation": {
-        "status": "active"
-      },
-      "availability": "serverless",
-      "quality_tags": [],
-      "capability_tags": [
-        "streaming",
-        "tools",
-        "structured_output"
-      ]
-    },
-    {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
       "provider": "gemini",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -1693,62 +1693,6 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
-      "id": "qwen-3-coder-480b",
-      "name": "Qwen3 Coder 480B (Cerebras)",
-      "provider": "cerebras",
-      "aliases": [],
-      "context_window": 131072,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "tool_support": {
-        "native": true,
-        "text": true,
-        "preferred_format": "native",
-        "parity": "unknown",
-        "tool_search": []
-      },
-      "structured_output": "native",
-      "format_preferences": {
-        "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": true,
-        "structured_output_mode": "native_json",
-        "supports_assistant_prefill": false,
-        "prefers_role_developer": false,
-        "prefers_xml_tools": false,
-        "thinking_block_style": "none"
-      },
-      "reasoning": {
-        "modes": [],
-        "effort_supported": false,
-        "none_supported": false,
-        "interleaved_supported": false,
-        "preserve_thinking": false
-      },
-      "prompt_cache": false,
-      "pricing": {
-        "input_per_mtok": 2.0,
-        "output_per_mtok": 2.0,
-        "cache_read_per_mtok": null,
-        "cache_write_per_mtok": null
-      },
-      "deprecation": {
-        "status": "active"
-      },
-      "availability": "serverless",
-      "quality_tags": [],
-      "capability_tags": [
-        "streaming",
-        "tools",
-        "structured_output"
-      ]
-    },
-    {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
       "provider": "gemini",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -1537,62 +1537,6 @@
       ]
     },
     {
-      "id": "qwen-3-coder-480b",
-      "name": "Qwen3 Coder 480B (Cerebras)",
-      "provider": "cerebras",
-      "aliases": [],
-      "context_window": 131072,
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      },
-      "tool_support": {
-        "native": true,
-        "text": true,
-        "preferred_format": "native",
-        "parity": "unknown",
-        "tool_search": []
-      },
-      "structured_output": "native",
-      "format_preferences": {
-        "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": true,
-        "structured_output_mode": "native_json",
-        "supports_assistant_prefill": false,
-        "prefers_role_developer": false,
-        "prefers_xml_tools": false,
-        "thinking_block_style": "none"
-      },
-      "reasoning": {
-        "modes": [],
-        "effort_supported": false,
-        "none_supported": false,
-        "interleaved_supported": false,
-        "preserve_thinking": false
-      },
-      "prompt_cache": false,
-      "pricing": {
-        "input_per_mtok": 2.0,
-        "output_per_mtok": 2.0,
-        "cache_read_per_mtok": null,
-        "cache_write_per_mtok": null
-      },
-      "deprecation": {
-        "status": "active"
-      },
-      "availability": "serverless",
-      "quality_tags": [],
-      "capability_tags": [
-        "streaming",
-        "tools",
-        "structured_output"
-      ]
-    },
-    {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
       "provider": "gemini",


### PR DESCRIPTION
## Summary
- remove the stale `qwen-3-coder-480b` Cerebras catalog entry from the embedded provider catalog
- tighten the VM catalog-resolution regression test so it only covers still-served Cerebras model ids
- regenerate the checked-in provider-catalog artifacts consumed by downstream hosts

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2400 cargo test -p harn-vm test_direct_catalog_model_id_resolves_to_catalog_provider -- --nocapture`
- `cargo run --quiet --bin harn -- providers validate --check-artifacts`

Closes #2400
