### PR TITLE
Anchor A-08: Cache-stable rendering for workspace-anchor reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ condensed series summaries instead of full per-patch history.
   loops do not spend their last turn on a veto that cannot be regenerated.
   The skip is emitted as a `step_judge_decision` event with `skipped: true`
   and `reason: "low_iteration_budget"`.
+- **Workspace anchors now stay out of stored session prompts (#2224).**
+  Agent sessions now render the active workspace anchor through a canonical
+  `workspace_anchor` reminder provider instead of relying on callers to splice
+  workspace/project fields into persisted system prompt text. Re-anchoring
+  updates the next reminder body while leaving `agent_session_system_prompt(id)`
+  byte-stable. Debug builds now assert `HARN-CACHE-001` if a caller records a
+  session system prompt containing `{{workspace_*}}` or `{{project_*}}`
+  template tokens.
 
 ### Added
 

--- a/conformance/tests/agents/agent_workspace_anchor_cache_contract.expected
+++ b/conformance/tests/agents/agent_workspace_anchor_cache_contract.expected
@@ -1,0 +1,14 @@
+true
+2
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/agents/agent_workspace_anchor_cache_contract.harn
+++ b/conformance/tests/agents/agent_workspace_anchor_cache_contract.harn
@@ -1,0 +1,58 @@
+pipeline default() {
+  llm_mock_clear()
+  llm_mock({text: "first ##DONE##", input_tokens: 1, output_tokens: 1, model: "o3"})
+  llm_mock({text: "second ##DONE##", input_tokens: 1, output_tokens: 1, model: "o3"})
+  let session_id = "workspace-anchor-cache-" + uuid()
+  let _ = agent_session_open(
+    session_id,
+    {workspace_anchor: {primary: "/workspace/a", anchored_at: "2026-05-24T00:00:00Z"}},
+  )
+  let first = agent_loop(
+    "first",
+    "Base system.",
+    {provider: "mock", model: "o3", session_id: session_id, max_iterations: 1},
+  )
+  let changed = agent_session_set_workspace_anchor(
+    session_id,
+    {
+      primary: "/workspace/b",
+      additional_roots: [{path: "/workspace/c", mount_mode: "read_only", mounted_at: "2026-05-24T00:00:01Z"}],
+      anchored_at: "2026-05-24T00:00:02Z",
+    },
+  )
+  let second = agent_loop(
+    "second",
+    nil,
+    {provider: "mock", model: "o3", session_id: session_id, max_iterations: 1},
+  )
+  let calls = llm_mock_calls()
+  let first_reminders = transcript_events_by_kind(first.transcript, "system_reminder")
+  let second_reminders = transcript_events_by_kind(second.transcript, "system_reminder")
+  let first_body = first_reminders[len(first_reminders) - 1].reminder.body
+  let second_body = second_reminders[len(second_reminders) - 1].reminder.body
+  __io_println(changed)
+  __io_println(len(calls))
+  __io_println(calls[0].system == calls[1].system)
+  __io_println(
+    agent_session_system_prompt(session_id)
+      == first.transcript.metadata.system_prompt.content,
+  )
+  __io_println(calls[0].messages[0].role == "developer")
+  __io_println(contains(calls[0].messages[0].content, "<workspace-anchor>"))
+  __io_println(contains(calls[0].messages[0].content, "primary: /workspace/a"))
+  __io_println(contains(calls[1].messages[0].content, "primary: /workspace/b"))
+  __io_println(
+    contains(
+      calls[1].messages[0].content,
+      "/workspace/c (mount_mode: read_only, mounted_at: 2026-05-24T00:00:01Z)",
+    ),
+  )
+  __io_println(!contains(calls[1].system, "/workspace/a"))
+  __io_println(!contains(calls[1].system, "/workspace/b"))
+  __io_println(
+    first.transcript.metadata.system_prompt.sha256
+      == second.transcript.metadata.system_prompt.sha256,
+  )
+  __io_println(contains(first_body, "primary: /workspace/a"))
+  __io_println(contains(second_body, "primary: /workspace/b"))
+}

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -40,6 +40,7 @@ pub const DEFAULT_TRANSCRIPT_MESSAGE_CAP: usize = 4096;
 /// Default cap on retained transcript audit events per session. Events
 /// include message-derived entries plus orchestration lifecycle records.
 pub const DEFAULT_TRANSCRIPT_EVENT_CAP: usize = 32768;
+const CACHE_STABLE_SYSTEM_PROMPT_DIAGNOSTIC: &str = "HARN-CACHE-001";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TranscriptBudgetRecovery {
@@ -1882,6 +1883,7 @@ pub fn record_system_prompt(id: &str, system_prompt: &str) -> Result<(), String>
     if system_prompt.is_empty() {
         return Ok(());
     }
+    assert_cache_stable_system_prompt(system_prompt);
     SESSIONS.with(|s| {
         let mut map = s.borrow_mut();
         let Some(state) = map.get_mut(id) else {
@@ -1925,6 +1927,33 @@ pub fn system_prompt(id: &str) -> Option<String> {
             .and_then(|state| state.system_prompt.clone())
     })
 }
+
+fn forbidden_workspace_prompt_token(system_prompt: &str) -> Option<&'static str> {
+    let mut remaining = system_prompt;
+    while let Some(index) = remaining.find("{{") {
+        let candidate = remaining[index + 2..].trim_start();
+        if candidate.starts_with("workspace_") {
+            return Some("workspace_");
+        }
+        if candidate.starts_with("project_") {
+            return Some("project_");
+        }
+        remaining = candidate;
+    }
+    None
+}
+
+#[cfg(debug_assertions)]
+fn assert_cache_stable_system_prompt(system_prompt: &str) {
+    if let Some(prefix) = forbidden_workspace_prompt_token(system_prompt) {
+        panic!(
+            "{CACHE_STABLE_SYSTEM_PROMPT_DIAGNOSTIC}: session system prompts must not interpolate `{{{{{prefix}...` tokens; move workspace/project context into the workspace-anchor reminder"
+        );
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn assert_cache_stable_system_prompt(_system_prompt: &str) {}
 
 /// Pin (or clear, with `None`) a model selector on a session. Returns
 /// `Ok(true)` when the value actually changed so callers can decide

--- a/crates/harn-vm/src/agent_sessions_tests.rs
+++ b/crates/harn-vm/src/agent_sessions_tests.rs
@@ -233,6 +233,18 @@ fn records_system_prompt_as_metadata_event_without_message() {
     assert_eq!(event_count_by_kind(&id, "system_prompt"), 1);
 }
 
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "HARN-CACHE-001")]
+fn debug_build_rejects_workspace_prompt_template_tokens() {
+    reset_session_store();
+    let id = open_or_create(Some("system-prompt-cache-contract".into()));
+    let _ = record_system_prompt(
+        &id,
+        "Never bake {{ project_root }} into the session prompt.",
+    );
+}
+
 #[test]
 fn pinned_model_round_trips_through_session_state_and_snapshot() {
     reset_session_store();

--- a/crates/harn-vm/src/llm/reminder_providers.rs
+++ b/crates/harn-vm/src/llm/reminder_providers.rs
@@ -18,6 +18,7 @@ const TOOL_OUTPUT_TRUNCATED_ID: &str = "tool_output_truncated";
 const POST_COMPACT_RECAP_ID: &str = "post_compact_recap";
 const RESUME_CONTINUITY_ID: &str = "resume_continuity";
 const PROJECT_FACTS_ID: &str = "project_facts";
+const WORKSPACE_ANCHOR_ID: &str = "workspace_anchor";
 
 const TOKEN_PRESSURE_EVENTS: &[HookEvent] = &[HookEvent::OnBudgetThreshold];
 const IDLE_NUDGE_EVENTS: &[HookEvent] = &[HookEvent::SessionIdle];
@@ -25,6 +26,8 @@ const TOOL_OUTPUT_TRUNCATED_EVENTS: &[HookEvent] = &[HookEvent::PostToolUse];
 const POST_COMPACT_RECAP_EVENTS: &[HookEvent] = &[HookEvent::PostCompact];
 const RESUME_CONTINUITY_EVENTS: &[HookEvent] = &[HookEvent::WorkerResumed];
 const PROJECT_FACTS_EVENTS: &[HookEvent] = &[HookEvent::SessionStart, HookEvent::OnBudgetThreshold];
+const WORKSPACE_ANCHOR_EVENTS: &[HookEvent] =
+    &[HookEvent::SessionStart, HookEvent::OnBudgetThreshold];
 
 const PROJECT_FACTS_DEFAULT_NAMESPACE: &str = "project/facts";
 const PROJECT_FACTS_DEFAULT_MAX: i64 = 5;
@@ -67,6 +70,7 @@ struct ToolOutputTruncatedProvider;
 struct PostCompactRecapProvider;
 struct ResumeContinuityProvider;
 struct ProjectFactsProvider;
+struct WorkspaceAnchorProvider;
 
 impl ReminderProvider for TokenPressureProvider {
     fn id(&self) -> &'static str {
@@ -348,6 +352,55 @@ impl ReminderProvider for ProjectFactsProvider {
     }
 }
 
+impl ReminderProvider for WorkspaceAnchorProvider {
+    fn id(&self) -> &'static str {
+        WORKSPACE_ANCHOR_ID
+    }
+
+    fn subscribes_to(&self) -> &'static [HookEvent] {
+        WORKSPACE_ANCHOR_EVENTS
+    }
+
+    fn evaluate(&self, ctx: &ProviderContext) -> Option<ReminderSpec> {
+        let anchor = crate::agent_sessions::workspace_anchor(&ctx.session_id)?;
+        let mut reminder = provider_reminder(
+            format_workspace_anchor_body(&anchor),
+            WORKSPACE_ANCHOR_ID,
+            ctx,
+        );
+        reminder.tags = vec![WORKSPACE_ANCHOR_ID.to_string()];
+        reminder.dedupe_key = Some(WORKSPACE_ANCHOR_ID.to_string());
+        reminder.ttl_turns = Some(1);
+        reminder.preserve_on_compact = false;
+        reminder.propagate = ReminderPropagate::Session;
+        reminder.role_hint = ReminderRoleHint::System;
+        Some(reminder)
+    }
+}
+
+fn format_workspace_anchor_body(anchor: &crate::workspace_anchor::WorkspaceAnchor) -> String {
+    let mut body = format!(
+        "<workspace-anchor>\nprimary: {}",
+        anchor.primary.to_string_lossy()
+    );
+    if anchor.additional_roots.is_empty() {
+        body.push_str("\nadditional_roots: []");
+    } else {
+        body.push_str("\nadditional_roots:");
+        for root in &anchor.additional_roots {
+            body.push_str("\n  - ");
+            body.push_str(&root.path.to_string_lossy());
+            body.push_str(" (mount_mode: ");
+            body.push_str(root.mount_mode.as_str());
+            body.push_str(", mounted_at: ");
+            body.push_str(&root.mounted_at);
+            body.push(')');
+        }
+    }
+    body.push_str("\n</workspace-anchor>");
+    body
+}
+
 pub fn parse_provider_event(name: &str) -> Result<HookEvent, String> {
     match name.trim() {
         "PostToolUse" | "post_tool_use" => Ok(HookEvent::PostToolUse),
@@ -449,7 +502,7 @@ pub async fn evaluate_and_inject(
     }))
 }
 
-fn canonical_providers() -> [&'static dyn ReminderProvider; 6] {
+fn canonical_providers() -> [&'static dyn ReminderProvider; 7] {
     [
         &TokenPressureProvider,
         &IdleNudgeProvider,
@@ -457,6 +510,7 @@ fn canonical_providers() -> [&'static dyn ReminderProvider; 6] {
         &PostCompactRecapProvider,
         &ResumeContinuityProvider,
         &ProjectFactsProvider,
+        &WorkspaceAnchorProvider,
     ]
 }
 
@@ -523,7 +577,7 @@ fn enabled_provider_ids(
     enabled
 }
 
-fn canonical_provider_ids() -> [&'static str; 6] {
+fn canonical_provider_ids() -> [&'static str; 7] {
     [
         TOKEN_PRESSURE_ID,
         IDLE_NUDGE_ID,
@@ -531,6 +585,7 @@ fn canonical_provider_ids() -> [&'static str; 6] {
         POST_COMPACT_RECAP_ID,
         RESUME_CONTINUITY_ID,
         PROJECT_FACTS_ID,
+        WORKSPACE_ANCHOR_ID,
     ]
 }
 
@@ -1065,5 +1120,43 @@ mod tests {
         let payload_mid = json!({"tokens_used": 80, "context_window": 100});
         let mid = ctx(HookEvent::OnBudgetThreshold, payload_mid, JsonValue::Null);
         assert!(!under_budget_pressure(&mid, Some(&custom_ratio)));
+    }
+
+    #[test]
+    fn workspace_anchor_provider_formats_primary_and_mounted_roots() {
+        crate::agent_sessions::reset_session_store();
+        let session_id =
+            crate::agent_sessions::open_or_create(Some("workspace-anchor-reminder".into()));
+        crate::agent_sessions::set_workspace_anchor(
+            &session_id,
+            Some(crate::workspace_anchor::WorkspaceAnchor {
+                primary: std::path::PathBuf::from("/workspace/main"),
+                additional_roots: vec![crate::workspace_anchor::MountedRoot {
+                    path: std::path::PathBuf::from("/workspace/lib"),
+                    mount_mode: crate::workspace_anchor::MountMode::Extend,
+                    mounted_at: "2026-05-24T00:00:01Z".to_string(),
+                }],
+                anchored_at: "2026-05-24T00:00:00Z".to_string(),
+            }),
+        )
+        .expect("set anchor");
+        let ctx = ProviderContext {
+            event: HookEvent::SessionStart,
+            session_id,
+            payload: json!({}),
+            options: JsonValue::Null,
+        };
+
+        let reminder = WorkspaceAnchorProvider
+            .evaluate(&ctx)
+            .expect("workspace reminder");
+
+        assert_eq!(reminder.dedupe_key.as_deref(), Some("workspace_anchor"));
+        assert_eq!(reminder.ttl_turns, Some(1));
+        assert!(reminder.body.contains("<workspace-anchor>"));
+        assert!(reminder.body.contains("primary: /workspace/main"));
+        assert!(reminder
+            .body
+            .contains("/workspace/lib (mount_mode: extend, mounted_at: 2026-05-24T00:00:01Z)"));
     }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -106,6 +106,7 @@
   - [Merge Captain](./personas/merge-captain.md)
 - [Skill provenance](./skill-provenance.md)
 - [Sessions](./sessions.md)
+- [Workspace anchor cache contract](./agents/cache_contract.md)
 - [Session bundles](./session-bundles.md)
 - [Agent state](./agent-state.md)
 - [Agent lifecycle: suspend, resume, self-park](./agent-lifecycle.md)

--- a/docs/src/agents/cache_contract.md
+++ b/docs/src/agents/cache_contract.md
@@ -1,0 +1,33 @@
+# Workspace Anchor Cache Contract
+
+The session `workspace_anchor` is transient turn context, not durable system
+prompt content.
+
+The contract is:
+
+- `SessionState::system_prompt` must stay free of `{{workspace_*}}` and
+  `{{project_*}}` template tokens.
+- active workspace state is rendered through the canonical `workspace_anchor`
+  reminder provider instead
+- downstream callers that still assemble `pipeline_input` or system prompt text
+  by hand must keep workspace/project fields out of the persisted session
+  prompt surface
+
+The canonical reminder body is:
+
+```text
+<workspace-anchor>
+primary: /Users/me/projects/X
+additional_roots:
+  - /Users/me/projects/Y (mount_mode: read_only, mounted_at: 2026-05-23T10:15:00Z)
+</workspace-anchor>
+```
+
+That reminder is injected on `SessionStart` and refreshed after each turn via
+the `OnBudgetThreshold` provider pass. Re-anchoring therefore updates the next
+turn's reminder payload without rewriting the stored session prompt.
+
+In debug builds, Harn asserts this contract when it records a session system
+prompt. If the prompt text contains `{{workspace_*}}` or `{{project_*}}`, the
+runtime panics with `HARN-CACHE-001` so the offending caller can move that data
+into reminder space instead.


### PR DESCRIPTION
Closes #2224

## Summary
- add a canonical `workspace_anchor` reminder provider that renders workspace anchor state as a trailing reminder instead of baking it into the stored session prompt
- reject debug-build session prompt recordings that still interpolate `{{workspace_*}}` or `{{project_*}}` tokens with `HARN-CACHE-001`
- document the cache contract and cover it with focused VM tests plus a conformance case that re-anchors across turns

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2224 cargo test -p harn-vm debug_build_rejects_workspace_prompt_template_tokens -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2224 cargo test -p harn-vm workspace_anchor_provider_formats_primary_and_mounted_roots -- --nocapture`
- `/tmp/harn-target-2224/debug/harn fmt --check conformance/tests/agents/agent_workspace_anchor_cache_contract.harn`
- `/tmp/harn-target-2224/debug/harn lint conformance/tests/agents/agent_workspace_anchor_cache_contract.harn`
- `/tmp/harn-target-2224/debug/harn test conformance --filter agent_workspace_anchor_cache_contract`
- `cargo fmt --all --check`