### PR TITLE
[codex] Polish tool parity eval evidence

### DIFF
--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -1,7 +1,7 @@
-//! `harn eval coding-agent` — empirical preset/provider benchmark for a
+//! `harn eval coding-agent` - empirical preset/provider benchmark for a
 //! small coding-agent fixture suite.
 //!
-//! ## .harn dispatch (W7 partial port — see harn#2307)
+//! ## Dispatch boundary
 //!
 //! The **matrix execution pipeline** (fixture resolution, model
 //! discovery, per-cell `execute_run` invocation, Ollama snapshot/
@@ -9,8 +9,8 @@
 //! generation, baseline diff) stays in Rust. Every cell drives the
 //! embedded `coding_agent_suite.harn` driver through `execute_run`,
 //! which itself reaches into VM internals (`commands::run`,
-//! `harn_vm::llm`, `commands::local::runtime`) that aren't reachable
-//! from script-land today — the same constraint that shaped W5 / W6.
+//! `harn_vm::llm`, `commands::local::runtime`) that are not exposed as
+//! script capabilities.
 //!
 //! The **rendering layer** (the `summary.md` body, the `followups.md`
 //! body, the one-line human stdout summary, the `--json` pretty form)
@@ -30,8 +30,8 @@
 //! check, and hosted ingestion — all of which depend on the serde
 //! struct-field byte order.
 //!
-//! `HARN_CLI_IMPL=rust` keeps the legacy direct-render path for the
-//! parity-snapshot harness (#2299) until the C1 ratchet (#2314) lands.
+//! `HARN_CLI_IMPL=rust` keeps the direct-render path available for
+//! parity snapshot coverage.
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ffi::OsString;
@@ -85,9 +85,8 @@ const CODING_AGENT_MODE_ENV: &str = "HARN_EVAL_CODING_AGENT_MODE";
 /// production; in tests it serialises the dispatch window only —
 /// matrix execution still parallelises freely.
 ///
-/// Mirrors the pattern W5's `eval_prompt.rs` and W6's `eval_context.rs`
-/// / `eval_tool_calls.rs` use (see harn#2305 / #2306) so the cross-
-/// script env-var hand-off stays consistent across the eval cluster.
+/// Matches the other eval render shims so the cross-script env-var handoff
+/// stays consistent across the eval cluster.
 static DISPATCH_RENDER_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 const CODING_AGENT_SUITE_HARN: &str = include_str!("../../assets/evals/coding_agent_suite.harn");
@@ -1446,12 +1445,17 @@ fn build_parity_by_pair(comparisons: &[FormatComparison]) -> Vec<ToolModeParityP
 }
 
 fn parity_fixture_input(comparison: &FormatComparison) -> Option<ToolModeParityFixtureInput> {
+    let native_verdict = comparison.native_status.clone()?;
+    let text_verdict = comparison.text_status.clone()?;
+    if native_verdict == "skipped" || text_verdict == "skipped" {
+        return None;
+    }
     Some(ToolModeParityFixtureInput {
         provider: comparison.selector.provider.clone(),
         model: comparison.selector.model.clone(),
         fixture_id: comparison.fixture_id.clone(),
-        native_verdict: comparison.native_status.clone()?,
-        text_verdict: comparison.text_status.clone()?,
+        native_verdict,
+        text_verdict,
         native_passed: comparison.native_passed?,
         text_passed: comparison.text_passed?,
         agreement: comparison.equivalent?,

--- a/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent_tests.rs
@@ -1,5 +1,45 @@
 use super::*;
 
+fn format_comparison_for_test(
+    fixture_id: &str,
+    native_status: &str,
+    text_status: &str,
+) -> FormatComparison {
+    let native_passed = native_status == "passed";
+    let text_passed = text_status == "passed";
+    FormatComparison {
+        fixture_id: fixture_id.to_string(),
+        selector: ModelSelector {
+            selector: "openrouter:qwen/qwen3-coder".to_string(),
+            provider: "openrouter".to_string(),
+            model: "qwen/qwen3-coder".to_string(),
+        },
+        native_run_id: Some(format!("{fixture_id}-native")),
+        text_run_id: Some(format!("{fixture_id}-text")),
+        native_evidence_path: Some(format!("out/{fixture_id}/native/transcript_events.jsonl")),
+        text_evidence_path: Some(format!("out/{fixture_id}/text/transcript_events.jsonl")),
+        native_status: Some(native_status.to_string()),
+        text_status: Some(text_status.to_string()),
+        native_passed: Some(native_passed),
+        text_passed: Some(text_passed),
+        native_tool_call_count: Some(0),
+        text_tool_call_count: Some(0),
+        native_rejected_tool_call_count: Some(0),
+        text_rejected_tool_call_count: Some(0),
+        verifier_match: Some(native_passed == text_passed),
+        tool_sequence_match: Some(true),
+        rejected_tool_call_delta_text_minus_native: Some(0),
+        token_delta_text_minus_native: Some(0),
+        iteration_delta_text_minus_native: Some(0),
+        equivalent: Some(native_status == text_status && native_passed == text_passed),
+        divergence_reasons: Vec::new(),
+        evidence_paths: vec![
+            format!("out/{fixture_id}/native/transcript_events.jsonl"),
+            format!("out/{fixture_id}/text/transcript_events.jsonl"),
+        ],
+    }
+}
+
 #[test]
 fn dotenv_parser_strips_export_and_quotes_without_leaking_values() {
     let parsed = parse_env_line("export TOGETHER_API_KEY=\"secret\"")
@@ -295,6 +335,22 @@ fn write_json_artifacts_emits_tool_mode_parity_overlay() {
         .join("python-add__openrouter_qwen_qwen3-coder")
         .join("parity.json")
         .exists());
+}
+
+#[test]
+fn parity_overlay_excludes_skipped_comparisons() {
+    let summaries = build_parity_by_pair(&[
+        format_comparison_for_test("python-add", "skipped", "skipped"),
+        format_comparison_for_test("cli-help-flag", "failed", "passed"),
+    ]);
+
+    assert_eq!(summaries.len(), 1);
+    let summary = &summaries[0];
+    assert_eq!(summary.sample_size, 1);
+    assert_eq!(summary.native.total_runs, 1);
+    assert_eq!(summary.text.total_runs, 1);
+    assert_eq!(summary.text.passed_runs, 1);
+    assert_eq!(summary.divergence_counts.text_only_pass, 1);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/try_cmd.rs
+++ b/crates/harn-cli/src/commands/try_cmd.rs
@@ -1,11 +1,9 @@
-//! `harn try "<prompt>"` — dispatches to the embedded
-//! `cli/try.harn` script (see harn#2302 / W2). The shim is
-//! intentionally tiny because all the agent_loop wiring lives in
-//! the .harn impl now.
+//! `harn try "<prompt>"` dispatches to the embedded `cli/try.harn`
+//! script. The shim stays intentionally tiny because agent-loop option
+//! wiring belongs in the script.
 //!
-//! `HARN_CLI_IMPL=rust` is reserved for the parity-snapshot harness
-//! to keep both impls comparable until the harn impl is the default
-//! everywhere (see C1 ratchet, #2314).
+//! `HARN_CLI_IMPL=rust` keeps the legacy path available for parity
+//! snapshot coverage.
 
 use harn_vm::llm_config;
 

--- a/crates/harn-cli/src/commands/try_cmd_legacy.rs
+++ b/crates/harn-cli/src/commands/try_cmd_legacy.rs
@@ -1,9 +1,7 @@
 use crate::cli::TryArgs;
 
-/// Legacy synth-into-tempfile-then-`execute_run` path, retained so the
-/// parity-snapshot harness can pin the new dispatch against it. The
-/// C1 ratchet (#2314) removes this once the .harn impl is the
-/// production default everywhere.
+/// Host-side synth-into-tempfile-then-`execute_run` fallback retained for
+/// parity snapshot coverage.
 pub(super) async fn run(args: TryArgs, provider: &str, model: &str) {
     use std::collections::HashSet;
     use std::fs;

--- a/crates/harn-stdlib/src/stdlib/cli/try.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/try.harn
@@ -1,12 +1,9 @@
 import { agent_first_tool_format_override_warning_text } from "std/agent/options"
 
 /**
- * `harn try "<prompt>"` ported to .harn — see harn#2302 (W2).
- *
- * Zero-config agent_loop convenience wrapper. The legacy Rust handler
- * synthesized this exact script into a temp file and shelled out
- * through `execute_run`; this port collapses that round-trip by
- * embedding the script directly.
+ * Zero-config `agent_loop` convenience wrapper for `harn try "<prompt>"`.
+ * The Rust dispatch shim passes resolved CLI options through environment
+ * variables so this script owns the agent-loop behavior.
  *
  * Inputs (from the dispatch shim in crates/harn-cli/src/commands/try_cmd.rs):
  *   argv[0]            — prompt text


### PR DESCRIPTION
## Summary

- Exclude skipped native/text coding-agent comparisons from tool-mode parity evidence so credential or availability skips cannot produce empirical parity overlay rows.
- Add regression coverage for the skipped-comparison case and keep the existing overlay artifact smoke path covered.
- Clean stale implementation-ticket comments in touched eval/try files while preserving behavior.

## Why

Most of #2358 has already landed through the child PRs. This final polish pass closes an audit gap in the eval feedback loop: a skipped comparison is not model behavior evidence and should not feed `tool_mode_parity_overlay.toml`.

## Validation

- `cargo test -p harn-cli --lib parity_overlay_excludes_skipped_comparisons`
- `cargo test -p harn-cli --lib write_json_artifacts_emits_tool_mode_parity_overlay`
- `cargo test -p harn-cli --lib tool_format_override_warning_line_extracts_first_match`
- `cargo test -p harn-vm --lib every_catalogued_chat_model_has_explicit_tool_capabilities`
- `cargo test -p harn-cli --test eval_coding_agent_cli mock_matrix_writes_artifacts_for_native_and_text_tools`
- `cargo test -p harn-cli --test eval_coding_agent_cli coding_agent_suite_records_tool_format_override_transcript_event`
- `cargo test -p harn-cli --test try_dispatch try_dispatch_surfaces_tool_format_override_warning`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/cli/try.harn`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/cli/try.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/cli/try.harn`
- `cargo run --quiet --bin harn -- provider capabilities audit`
- `make check-provider-matrix`
- pre-commit hook
- pre-push hook

Closes #2358
Closes #2360
Closes #2361
