### PR TITLE
Polish MCP RC implementation: unify shared types and apply envelope uniformly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
           cache-bin: false
       - run: make conformance
       - run: make protocol-conformance
+      - run: make mcp-rc-conformance
       # Promoted out of `make lint` (in the rust-lint job) so the Linux
       # critical path doesn't pay ~1-2 min to compile harn-cli from scratch
       # just to count `@xfail:` markers. `make conformance` above already

--- a/crates/harn-cli/src/commands/mcp/mcp_rc_compat_tests.rs
+++ b/crates/harn-cli/src/commands/mcp/mcp_rc_compat_tests.rs
@@ -94,6 +94,25 @@ async fn orchestrator_modern_tools_list_carries_rc_envelope_and_cache_hint() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn orchestrator_modern_non_list_methods_carry_result_type_envelope() {
+    let _guard = lock_harn_state();
+    let (service, _temp) = fresh_service().await;
+    let mut session = ConnectionState::default();
+    for method in ["ping", "tasks/list"] {
+        let request = rc_request(1, method, json!({}), "harn-rc-compat-client");
+        let response = service.handle_request(&mut session, request).await;
+        let result = response
+            .get("result")
+            .unwrap_or_else(|| panic!("{method} should return result, got {response:?}"));
+        assert_eq!(
+            result["resultType"],
+            json!("complete"),
+            "{method} modern response must carry RC envelope"
+        );
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn orchestrator_unsupported_meta_version_returns_minus_32004() {
     let _guard = lock_harn_state();
     let (service, _temp) = fresh_service().await;

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -25,7 +25,7 @@ pub(crate) mod serve;
 const DEFAULT_REDIRECT_URI: &str = "http://127.0.0.1:9783/oauth/callback";
 const KEYRING_SERVICE: &str = "dev.harn.mcp";
 const TOKEN_REFRESH_SKEW_SECS: i64 = 60;
-const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+use harn_vm::mcp_protocol::PROTOCOL_VERSION as MCP_PROTOCOL_VERSION;
 
 #[derive(Clone)]
 pub(crate) struct ResolvedMcpServer {

--- a/crates/harn-cli/src/commands/mcp/serve/http.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/http.rs
@@ -669,13 +669,7 @@ fn validate_protocol_header(headers: &HeaderMap) -> Result<(), Box<Response>> {
     else {
         return Ok(());
     };
-    // Accept the stable production version, the prior `2025-03-26`
-    // shipping version (still in the wild), and the RC profile both
-    // sides opt into per request.
-    if value == MCP_PROTOCOL_VERSION
-        || value == "2025-03-26"
-        || value == mcp_protocol::DRAFT_PROTOCOL_VERSION
-    {
+    if mcp_protocol::is_supported_protocol_version(value) {
         Ok(())
     } else {
         Err(Box::new(StatusCode::BAD_REQUEST.into_response()))

--- a/crates/harn-cli/src/commands/mcp/serve/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/mod.rs
@@ -57,9 +57,10 @@ mod serve_tests;
 #[path = "../mcp_rc_compat_tests.rs"]
 mod mcp_rc_compat_tests;
 
-pub(super) const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
-pub(super) const MCP_SESSION_HEADER: &str = "mcp-session-id";
-pub(super) const MCP_PROTOCOL_HEADER: &str = "mcp-protocol-version";
+pub(super) use harn_vm::mcp_protocol::{
+    MCP_SESSION_HEADER_LEGACY as MCP_SESSION_HEADER, PROTOCOL_VERSION as MCP_PROTOCOL_VERSION,
+    RC_HEADER_PROTOCOL_VERSION as MCP_PROTOCOL_HEADER,
+};
 pub(super) const DEPRECATION_HEADER: &str = "deprecation";
 pub(super) const ACTION_GRAPH_TOPIC: &str = "observability.action_graph";
 pub(super) const TRIGGER_EVENTS_TOPIC: &str = "triggers.events";

--- a/crates/harn-cli/src/commands/mcp/serve/protocol.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/protocol.rs
@@ -1,8 +1,9 @@
 use serde_json::{json, Value as JsonValue};
 
 use harn_vm::mcp_protocol::{
-    self, apply_rc_result_envelope, enforce_request_protocol_version, parse_request_metadata,
-    server_discover_result, McpCacheHint, McpProtocolMode,
+    self, apply_rc_result_envelope, enforce_request_protocol_version,
+    is_supported_protocol_version, parse_request_metadata, server_discover_result, McpCacheHint,
+    McpProtocolMode,
 };
 
 use super::types::{ConnectionState, McpOrchestratorService};
@@ -77,56 +78,35 @@ impl McpOrchestratorService {
             return response;
         }
 
-        match method {
-            "initialized" => JsonValue::Null,
+        let response = match method {
+            "initialized" => return JsonValue::Null,
             "ping" => harn_vm::jsonrpc::response(id, json!({})),
             mcp_protocol::METHOD_LOGGING_SET_LEVEL => {
                 self.handle_logging_set_level(id, session, &params)
             }
-            "tools/list" => apply_envelope(self.handle_tools_list(id, &params), mode, list_hint()),
-            "tools/call" => apply_envelope(
-                self.handle_tools_call(id, session, &params).await,
-                mode,
-                None,
-            ),
+            "tools/list" => self.handle_tools_list(id, &params),
+            "tools/call" => self.handle_tools_call(id, session, &params).await,
             mcp_protocol::METHOD_TASKS_GET => self.handle_tasks_get(id, session, &params),
             mcp_protocol::METHOD_TASKS_RESULT => {
                 self.handle_tasks_result(id, session, &params).await
             }
             mcp_protocol::METHOD_TASKS_LIST => self.handle_tasks_list(id, session, &params),
             mcp_protocol::METHOD_TASKS_CANCEL => self.handle_tasks_cancel(id, session, &params),
-            "resources/list" => apply_envelope(
-                self.handle_resources_list(id, &params).await,
-                mode,
-                list_hint(),
-            ),
-            "resources/read" => apply_envelope(
-                self.handle_resources_read(id, &params).await,
-                mode,
-                read_hint(),
-            ),
+            "resources/list" => self.handle_resources_list(id, &params).await,
+            "resources/read" => self.handle_resources_read(id, &params).await,
             "resources/subscribe" => self.handle_resources_subscribe(id, session, &params).await,
             "resources/unsubscribe" => self.handle_resources_unsubscribe(id, session, &params),
-            "resources/templates/list" => apply_envelope(
-                self.handle_resource_templates_list(id, &params),
-                mode,
-                list_hint(),
-            ),
-            "prompts/list" => {
-                apply_envelope(self.handle_prompts_list(id, &params), mode, list_hint())
-            }
-            "prompts/get" => apply_envelope(self.handle_prompts_get(id, &params), mode, None),
+            "resources/templates/list" => self.handle_resource_templates_list(id, &params),
+            "prompts/list" => self.handle_prompts_list(id, &params),
+            "prompts/get" => self.handle_prompts_get(id, &params),
             mcp_protocol::METHOD_COMPLETION_COMPLETE => {
                 self.handle_completion_complete(id, &params).await
-            }
-            _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
-                mcp_protocol::unsupported_latest_spec_method_response(id, method)
-                    .expect("checked unsupported MCP method")
             }
             _ => {
                 harn_vm::jsonrpc::error_response(id, -32601, &format!("Method not found: {method}"))
             }
-        }
+        };
+        apply_envelope(response, mode, cache_hint_for_method(method))
     }
 
     pub(super) fn handle_server_discover(&self, id: JsonValue) -> JsonValue {
@@ -155,11 +135,16 @@ impl McpOrchestratorService {
             .and_then(JsonValue::as_str)
             .unwrap_or("unknown");
         session.client_identity = format!("{client_name}/{client_version}");
-        session.protocol_version = params
+        // Echo the version the client asked for when we support it,
+        // falling back to the stable default. Unknown versions silently
+        // negotiate down rather than failing initialize — the RC's
+        // `-32004` path is reserved for explicit `_meta` negotiation.
+        let advertised_version = params
             .get("protocolVersion")
             .and_then(JsonValue::as_str)
-            .unwrap_or(MCP_PROTOCOL_VERSION)
-            .to_string();
+            .filter(|version| is_supported_protocol_version(version))
+            .unwrap_or(MCP_PROTOCOL_VERSION);
+        session.protocol_version = advertised_version.to_string();
 
         if super::http::initialize_api_key(params).is_some() {
             eprintln!(
@@ -179,18 +164,15 @@ impl McpOrchestratorService {
         session.initialized = true;
         session.protocol_mode = McpProtocolMode::Legacy;
 
-        let mut result = json!({
-            "protocolVersion": MCP_PROTOCOL_VERSION,
-            "capabilities": orchestrator_capabilities(),
-            "serverInfo": orchestrator_server_info(),
-            "instructions": "Expose Harn trigger and orchestrator controls over MCP."
-        });
-        // Legacy initialize never carries `resultType`, so this leaves
-        // the existing wire bytes unchanged. The branch keeps the path
-        // symmetric in case a Modern client routes through here for
-        // backwards-compat probing.
-        apply_rc_result_envelope(&mut result, session.protocol_mode, None);
-        harn_vm::jsonrpc::response(id, result)
+        harn_vm::jsonrpc::response(
+            id,
+            json!({
+                "protocolVersion": advertised_version,
+                "capabilities": orchestrator_capabilities(),
+                "serverInfo": orchestrator_server_info(),
+                "instructions": "Expose Harn trigger and orchestrator controls over MCP.",
+            }),
+        )
     }
 
     pub(super) fn handle_prompts_list(&self, id: JsonValue, params: &JsonValue) -> JsonValue {
@@ -429,20 +411,27 @@ pub(super) fn orchestrator_server_info() -> JsonValue {
     })
 }
 
-fn list_hint() -> Option<&'static McpCacheHint> {
+/// Map a JSON-RPC method to its conservative cache hint. Read/list
+/// methods get a TTL; everything else is `None`, which still routes
+/// through [`apply_envelope`] so Modern clients see `resultType`.
+pub(super) fn cache_hint_for_method(method: &str) -> Option<&'static McpCacheHint> {
     const LIST: McpCacheHint = McpCacheHint::list_default();
-    Some(&LIST)
-}
-
-fn read_hint() -> Option<&'static McpCacheHint> {
     const READ: McpCacheHint = McpCacheHint::read_default();
-    Some(&READ)
+    match method {
+        "tools/list"
+        | "resources/list"
+        | "resources/templates/list"
+        | "prompts/list"
+        | mcp_protocol::METHOD_TASKS_LIST => Some(&LIST),
+        "resources/read" => Some(&READ),
+        _ => None,
+    }
 }
 
 /// Stamp the RC `resultType`/cache-hint envelope onto a handler's
 /// response in one place. Error responses pass through untouched —
 /// the RC envelope only applies to `result` bodies.
-fn apply_envelope(
+pub(super) fn apply_envelope(
     mut response: JsonValue,
     mode: McpProtocolMode,
     hint: Option<&'static McpCacheHint>,

--- a/crates/harn-cli/src/commands/mcp/serve_tests.rs
+++ b/crates/harn-cli/src/commands/mcp/serve_tests.rs
@@ -428,30 +428,6 @@ async fn audit_events_emit_log_notifications_with_logger_and_level() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn latest_spec_gap_methods_return_explicit_json_rpc_errors() {
-    let _guard = lock_harn_state();
-    let temp = TempDir::new().unwrap();
-    write_fixture(&temp);
-    let service = McpOrchestratorService::new(&fixture_args(&temp)).unwrap();
-    let mut session = init_session(&service).await;
-
-    for method in mcp_protocol::UNSUPPORTED_LATEST_SPEC_METHODS
-        .iter()
-        .map(|entry| entry.method)
-    {
-        let response = service
-            .handle_request(
-                &mut session,
-                harn_vm::jsonrpc::request(99, method, json!({})),
-            )
-            .await;
-        assert_eq!(response["error"]["code"], json!(-32601), "{method}");
-        assert_eq!(response["error"]["data"]["method"], json!(method));
-        assert_eq!(response["error"]["data"]["status"], json!("unsupported"));
-    }
-}
-
-#[tokio::test(flavor = "current_thread")]
 async fn resource_template_and_empty_prompt_lists_roundtrip() {
     let _guard = lock_harn_state();
     let temp = TempDir::new().unwrap();

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -478,63 +478,30 @@ impl McpServer {
             return ImmediateResult::Response(response);
         }
 
-        match method {
-            "notifications/initialized" | "initialized" => ImmediateResult::Accepted,
-            "ping" => ImmediateResult::Response(harn_vm::jsonrpc::response(id, json!({}))),
-            "logging/setLevel" => {
-                ImmediateResult::Response(harn_vm::jsonrpc::response(id, json!({})))
-            }
-            "tools/list" => ImmediateResult::Response(envelope(
-                harn_vm::jsonrpc::response(id, self.tools_list_result(&params)),
-                mode,
-                Some(McpCacheHint::list_default()),
-            )),
+        let response = match method {
+            "notifications/initialized" | "initialized" => return ImmediateResult::Accepted,
+            "ping" => harn_vm::jsonrpc::response(id, json!({})),
+            "logging/setLevel" => harn_vm::jsonrpc::response(id, json!({})),
+            "tools/list" => harn_vm::jsonrpc::response(id, self.tools_list_result(&params)),
             "tools/call" => match self.prepare_stream_job(id, params, session, connection, auth) {
-                Ok(job) => ImmediateResult::Stream(Box::new(job)),
-                Err(response) => ImmediateResult::Response(response),
+                Ok(job) => return ImmediateResult::Stream(Box::new(job)),
+                Err(response) => return ImmediateResult::Response(response),
             },
-            "resources/list" => ImmediateResult::Response(envelope(
-                harn_vm::jsonrpc::response(id, self.resources_list_result(&params)),
-                mode,
-                Some(McpCacheHint::list_default()),
-            )),
-            "resources/read" => ImmediateResult::Response(envelope(
-                self.handle_resources_read(id, &params),
-                mode,
-                Some(McpCacheHint::read_default()),
-            )),
-            "resources/templates/list" => ImmediateResult::Response(envelope(
-                harn_vm::jsonrpc::response(id, self.resources_templates_list_result(&params)),
-                mode,
-                Some(McpCacheHint::list_default()),
-            )),
-            "prompts/list" => ImmediateResult::Response(envelope(
-                harn_vm::jsonrpc::response(id, self.prompts_list_result(&params)),
-                mode,
-                Some(McpCacheHint::list_default()),
-            )),
-            "prompts/get" => ImmediateResult::Response(envelope(
-                self.handle_prompts_get(id, &params),
-                mode,
-                None,
-            )),
-            mcp_protocol::METHOD_COMPLETION_COMPLETE => ImmediateResult::Response(envelope(
-                self.handle_completion_complete(id, &params),
-                mode,
-                None,
-            )),
-            _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
-                ImmediateResult::Response(
-                    mcp_protocol::unsupported_latest_spec_method_response(id, method)
-                        .expect("checked unsupported MCP method"),
-                )
+            "resources/list" => harn_vm::jsonrpc::response(id, self.resources_list_result(&params)),
+            "resources/read" => self.handle_resources_read(id, &params),
+            "resources/templates/list" => {
+                harn_vm::jsonrpc::response(id, self.resources_templates_list_result(&params))
             }
-            _ => ImmediateResult::Response(harn_vm::jsonrpc::error_response(
-                id,
-                -32601,
-                &format!("Method not found: {method}"),
-            )),
-        }
+            "prompts/list" => harn_vm::jsonrpc::response(id, self.prompts_list_result(&params)),
+            "prompts/get" => self.handle_prompts_get(id, &params),
+            mcp_protocol::METHOD_COMPLETION_COMPLETE => {
+                self.handle_completion_complete(id, &params)
+            }
+            _ => {
+                harn_vm::jsonrpc::error_response(id, -32601, &format!("Method not found: {method}"))
+            }
+        };
+        ImmediateResult::Response(envelope(response, mode, cache_hint_for_method(method)))
     }
 
     fn handle_initialize(
@@ -944,12 +911,29 @@ impl McpServer {
 fn envelope(
     mut response: JsonValue,
     mode: McpProtocolMode,
-    cache: Option<McpCacheHint>,
+    cache: Option<&'static McpCacheHint>,
 ) -> JsonValue {
     if let Some(result) = response.get_mut("result") {
-        apply_rc_result_envelope(result, mode, cache.as_ref());
+        apply_rc_result_envelope(result, mode, cache);
     }
     response
+}
+
+/// Map a JSON-RPC method to its conservative cache hint. Read/list
+/// methods get a TTL; everything else is `None`, which still routes
+/// through [`envelope`] so Modern clients see `resultType`.
+fn cache_hint_for_method(method: &str) -> Option<&'static McpCacheHint> {
+    const LIST: McpCacheHint = McpCacheHint::list_default();
+    const READ: McpCacheHint = McpCacheHint::read_default();
+    match method {
+        "tools/list"
+        | "resources/list"
+        | "resources/templates/list"
+        | "prompts/list"
+        | mcp_protocol::METHOD_TASKS_LIST => Some(&LIST),
+        "resources/read" => Some(&READ),
+        _ => None,
+    }
 }
 
 fn requires_protocol_auth(method: &str) -> bool {

--- a/crates/harn-serve/src/adapters/mcp/auth.rs
+++ b/crates/harn-serve/src/adapters/mcp/auth.rs
@@ -131,11 +131,7 @@ pub(super) fn validate_protocol_header(headers: &HeaderMap) -> Result<(), Box<Re
     else {
         return Ok(());
     };
-    // Accept the stable version, the RC profile, and the prior stable
-    // (`2025-03-26`) for clients still in the lifecycle's compatibility
-    // window. Anything else is a hard 400 so a fuzzed or wrong-product
-    // header never falls through.
-    if value == "2025-03-26" || mcp_protocol::is_supported_protocol_version(value) {
+    if mcp_protocol::is_supported_protocol_version(value) {
         Ok(())
     } else {
         Err(Box::new(StatusCode::BAD_REQUEST.into_response()))

--- a/crates/harn-serve/src/adapters/mcp/tests.rs
+++ b/crates/harn-serve/src/adapters/mcp/tests.rs
@@ -396,54 +396,6 @@ async fn mcp_response(server: &McpServer, request: JsonValue, session: SharedSes
 }
 
 #[tokio::test]
-async fn latest_spec_gap_methods_return_explicit_json_rpc_errors() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let script = dir.path().join("server.harn");
-    std::fs::write(
-        &script,
-        r#"
-pub fn greet(name: string) -> string {
-  return name
-}
-"#,
-    )
-    .expect("write script");
-    let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
-    let server = McpServer::new(McpServerConfig::new(core));
-    let session = SharedSession::new();
-    let _ = server.handle_initialize(
-        json!(1),
-        &session,
-        &json!({
-            "protocolVersion": MCP_PROTOCOL_VERSION,
-            "clientInfo": {"name": "test", "version": "1"}
-        }),
-    );
-
-    for method in harn_vm::mcp_protocol::UNSUPPORTED_LATEST_SPEC_METHODS
-        .iter()
-        .map(|entry| entry.method)
-    {
-        let response = match server
-            .process_message(
-                harn_vm::jsonrpc::request(2, method, json!({})),
-                session.clone(),
-                AuthRequest::default(),
-            )
-            .await
-        {
-            ImmediateResult::Response(response) => response,
-            ImmediateResult::Accepted | ImmediateResult::Stream(_) => {
-                panic!("expected error response for {method}")
-            }
-        };
-        assert_eq!(response["error"]["code"], json!(-32601), "{method}");
-        assert_eq!(response["error"]["data"]["method"], json!(method));
-        assert_eq!(response["error"]["data"]["status"], json!("unsupported"));
-    }
-}
-
-#[tokio::test]
 async fn tool_call_rejects_task_augmentation() {
     let dir = tempfile::tempdir().expect("tempdir");
     let script = dir.path().join("server.harn");

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -159,10 +159,7 @@ pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;
 pub use llm::trigger_predicate::TriggerPredicateBudget;
 pub use llm::{current_agent_session_id, register_session_end_hook};
-pub use mcp::{
-    connect_mcp_server, connect_mcp_server_from_json, connect_mcp_server_from_spec,
-    register_mcp_builtins,
-};
+pub use mcp::{connect_mcp_server_from_json, connect_mcp_server_from_spec, register_mcp_builtins};
 pub use mcp_card::{fetch_server_card, load_server_card_from_path, CardError};
 pub use mcp_registry::{
     active_handle as mcp_active_handle, ensure_active as mcp_ensure_active,

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -20,7 +20,9 @@ use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
 use crate::mcp_protocol::{
-    DRAFT_PROTOCOL_VERSION, PROTOCOL_VERSION, RC_META_KEY_CLIENT_CAPABILITIES,
+    cache_hints_to_json, rc_name_header_value, McpCacheHint, McpProtocolMode,
+    DRAFT_PROTOCOL_VERSION, MCP_SESSION_HEADER_LEGACY, PROTOCOL_VERSION, RC_HEADER_METHOD,
+    RC_HEADER_NAME, RC_HEADER_PROTOCOL_VERSION, RC_META_KEY_CLIENT_CAPABILITIES,
     RC_META_KEY_CLIENT_INFO, RC_META_KEY_PROTOCOL_VERSION, RESULT_TYPE_INPUT_REQUIRED,
     UNSUPPORTED_PROTOCOL_VERSION_CODE,
 };
@@ -91,18 +93,6 @@ struct HttpMcpClientInner {
     proxy_server_name: Option<String>,
     get_stream_task: Option<tokio::task::JoinHandle<()>>,
     tool_headers: BTreeMap<String, Vec<McpToolHeader>>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum McpProtocolMode {
-    Legacy,
-    Modern,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct McpCacheHint {
-    ttl_ms: Option<u64>,
-    cache_scope: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -287,7 +277,7 @@ impl VmMcpClientHandle {
     }
 
     async fn record_cache_hint(&self, method: &str, result: &serde_json::Value) {
-        let Some(hint) = parse_cache_hint(result) else {
+        let Some(hint) = McpCacheHint::from_result(result) else {
             return;
         };
         self.cache_hints
@@ -635,7 +625,7 @@ async fn send_http_request(
         let status = response.status().as_u16();
         let headers = response.headers().clone();
         if let Some(protocol_version) = headers
-            .get("MCP-Protocol-Version")
+            .get(RC_HEADER_PROTOCOL_VERSION)
             .and_then(|v| v.to_str().ok())
         {
             inner.protocol_version = protocol_version.to_string();
@@ -886,20 +876,22 @@ fn apply_http_headers(
     params: Option<&serde_json::Value>,
     tool_headers: &BTreeMap<String, Vec<McpToolHeader>>,
 ) -> reqwest::RequestBuilder {
-    request = request.header("MCP-Protocol-Version", protocol_version);
+    request = request.header(RC_HEADER_PROTOCOL_VERSION, protocol_version);
     if let Some(token) = auth_token {
         request = request.header("Authorization", format!("Bearer {token}"));
     }
     if protocol_mode == McpProtocolMode::Legacy {
         if let Some(session_id) = session_id {
-            request = request.header("MCP-Session-Id", session_id);
+            request = request.header(MCP_SESSION_HEADER_LEGACY, session_id);
         }
     }
     if protocol_mode == McpProtocolMode::Modern {
         if let Some(method) = method {
-            request = request.header("Mcp-Method", method);
-            if let Some(name) = mcp_standard_name_header(method, params) {
-                request = request.header("Mcp-Name", name);
+            request = request.header(RC_HEADER_METHOD, method);
+            if let Some(params) = params {
+                if let Some(name) = rc_name_header_value(method, params) {
+                    request = request.header(RC_HEADER_NAME, name);
+                }
             }
             if method == "tools/call" {
                 request = apply_mcp_tool_parameter_headers(request, params, tool_headers);
@@ -913,21 +905,6 @@ fn legacy_session_id(inner: &HttpMcpClientInner) -> Option<&str> {
     (inner.protocol_mode == McpProtocolMode::Legacy)
         .then_some(inner.session_id.as_deref())
         .flatten()
-}
-
-fn mcp_standard_name_header(method: &str, params: Option<&serde_json::Value>) -> Option<String> {
-    let params = params?;
-    match method {
-        "tools/call" | "prompts/get" => params
-            .get("name")
-            .and_then(|value| value.as_str())
-            .map(str::to_string),
-        "resources/read" => params
-            .get("uri")
-            .and_then(|value| value.as_str())
-            .map(str::to_string),
-        _ => None,
-    }
 }
 
 fn apply_mcp_tool_parameter_headers(
@@ -993,7 +970,7 @@ async fn reinitialize_http_client(inner: &mut HttpMcpClientInner) -> Result<(), 
     .await?;
     if let Some(protocol_version) = initialize
         .headers()
-        .get("MCP-Protocol-Version")
+        .get(RC_HEADER_PROTOCOL_VERSION)
         .and_then(|v| v.to_str().ok())
     {
         inner.protocol_version = protocol_version.to_string();
@@ -1001,7 +978,7 @@ async fn reinitialize_http_client(inner: &mut HttpMcpClientInner) -> Result<(), 
     if inner.protocol_mode == McpProtocolMode::Legacy {
         if let Some(session_id) = initialize
             .headers()
-            .get("MCP-Session-Id")
+            .get(MCP_SESSION_HEADER_LEGACY)
             .and_then(|v| v.to_str().ok())
         {
             inner.session_id = Some(session_id.to_string());
@@ -1027,7 +1004,7 @@ async fn reinitialize_http_client(inner: &mut HttpMcpClientInner) -> Result<(), 
     let status = response.status().as_u16();
     if let Some(protocol_version) = response
         .headers()
-        .get("MCP-Protocol-Version")
+        .get(RC_HEADER_PROTOCOL_VERSION)
         .and_then(|v| v.to_str().ok())
     {
         inner.protocol_version = protocol_version.to_string();
@@ -1035,7 +1012,7 @@ async fn reinitialize_http_client(inner: &mut HttpMcpClientInner) -> Result<(), 
     if inner.protocol_mode == McpProtocolMode::Legacy {
         if let Some(session_id) = response
             .headers()
-            .get("MCP-Session-Id")
+            .get(MCP_SESSION_HEADER_LEGACY)
             .and_then(|v| v.to_str().ok())
         {
             inner.session_id = Some(session_id.to_string());
@@ -1155,14 +1132,11 @@ fn jsonrpc_error_to_vm_error(error: &serde_json::Value) -> VmError {
 fn client_request_rejection(msg: &serde_json::Value) -> Option<serde_json::Value> {
     let request_id = msg.get("id")?.clone();
     let method = msg.get("method").and_then(|value| value.as_str())?;
-    crate::mcp_protocol::unsupported_latest_spec_method_response(request_id.clone(), method)
-        .or_else(|| {
-            Some(crate::jsonrpc::error_response(
-                request_id,
-                -32601,
-                &format!("Method not found: {method}"),
-            ))
-        })
+    Some(crate::jsonrpc::error_response(
+        request_id,
+        -32601,
+        &format!("Method not found: {method}"),
+    ))
 }
 
 fn harn_roots_list_response(id: serde_json::Value) -> serde_json::Value {
@@ -1593,40 +1567,6 @@ fn is_method_not_found_response(msg: &serde_json::Value) -> bool {
         == Some(-32601)
 }
 
-fn parse_cache_hint(result: &serde_json::Value) -> Option<McpCacheHint> {
-    let ttl_ms = result.get("ttlMs").and_then(|value| value.as_u64());
-    let cache_scope = result
-        .get("cacheScope")
-        .and_then(|value| value.as_str())
-        .filter(|value| matches!(*value, "public" | "private"))
-        .map(str::to_string);
-    if ttl_ms.is_none() && cache_scope.is_none() {
-        return None;
-    }
-    Some(McpCacheHint {
-        ttl_ms,
-        cache_scope,
-    })
-}
-
-fn cache_hints_json(hints: &BTreeMap<String, McpCacheHint>) -> serde_json::Value {
-    let mut object = serde_json::Map::new();
-    for (method, hint) in hints {
-        let mut entry = serde_json::Map::new();
-        if let Some(ttl_ms) = hint.ttl_ms {
-            entry.insert("ttlMs".to_string(), serde_json::json!(ttl_ms));
-        }
-        if let Some(cache_scope) = hint.cache_scope.as_ref() {
-            entry.insert(
-                "cacheScope".to_string(),
-                serde_json::Value::String(cache_scope.clone()),
-            );
-        }
-        object.insert(method.clone(), serde_json::Value::Object(entry));
-    }
-    serde_json::Value::Object(object)
-}
-
 fn extract_tool_headers(tool: &serde_json::Value) -> Result<Vec<McpToolHeader>, String> {
     let Some(properties) = tool
         .get("inputSchema")
@@ -1998,23 +1938,6 @@ async fn resolve_input_required_result(
     }))
 }
 
-pub async fn connect_mcp_server(
-    name: &str,
-    command: &str,
-    args: &[String],
-) -> Result<VmMcpClientHandle, VmError> {
-    let mut handle = mcp_connect_stdio_impl(
-        command,
-        args,
-        &BTreeMap::new(),
-        McpProtocolMode::Legacy,
-        PROTOCOL_VERSION.to_string(),
-    )
-    .await?;
-    handle.name = name.to_string();
-    Ok(handle)
-}
-
 pub async fn connect_mcp_server_from_spec(
     spec: &McpServerSpec,
 ) -> Result<VmMcpClientHandle, VmError> {
@@ -2319,7 +2242,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         if !cache_hints.is_empty() {
             info.insert(
                 "cache_hints".to_string(),
-                json_to_vm_value(&cache_hints_json(&cache_hints)),
+                json_to_vm_value(&cache_hints_to_json(cache_hints.iter())),
             );
         }
         Ok(VmValue::Dict(Rc::new(info)))
@@ -2738,7 +2661,7 @@ print(json.dumps({
                     handle.cache_hints.lock().await.get("tools/list"),
                     Some(&McpCacheHint {
                         ttl_ms: Some(300_000),
-                        cache_scope: Some("public".to_string()),
+                        scope: Some("public"),
                     })
                 );
 

--- a/crates/harn-vm/src/mcp_protocol.rs
+++ b/crates/harn-vm/src/mcp_protocol.rs
@@ -35,6 +35,9 @@ pub const RC_META_KEY_CLIENT_CAPABILITIES: &str = "io.modelcontextprotocol/clien
 pub const RC_HEADER_PROTOCOL_VERSION: &str = "mcp-protocol-version";
 pub const RC_HEADER_METHOD: &str = "mcp-method";
 pub const RC_HEADER_NAME: &str = "mcp-name";
+/// Legacy HTTP session header that pre-RC clients and servers carry. The
+/// RC modern profile is stateless and never emits this header.
+pub const MCP_SESSION_HEADER_LEGACY: &str = "mcp-session-id";
 
 /// `resultType` discriminants exposed to RC clients on every response
 /// result body. Legacy clients never see this field, which preserves the
@@ -66,31 +69,6 @@ pub struct McpListPage {
     pub end: usize,
     pub next_cursor: Option<String>,
 }
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct UnsupportedMcpMethod {
-    pub method: &'static str,
-    pub feature: &'static str,
-    pub role: &'static str,
-    pub reason: &'static str,
-}
-
-pub const UNSUPPORTED_LATEST_SPEC_METHODS: &[UnsupportedMcpMethod] = &[
-    // `sampling/createMessage` (client) is supported — handled in
-    // `mcp::handle_inbound_client_request` via
-    // `mcp_sampling::dispatch_inbound_sampling`, which routes the
-    // request through the host bridge's `("mcp", "sample")` operation
-    // and on to Harn's `llm_call`. Intentionally omitted from this
-    // gap list.
-    //
-    // `elicitation/create` is supported on both roles — handled in
-    // `mcp::stdio_call`/`mcp::http_call` (client) and via `mcp_elicit(...)`
-    // (server). It is intentionally omitted from this gap list.
-    //
-    // `roots/list` is supported when Harn acts as an MCP client and answers
-    // inbound server-to-client root discovery requests. It is intentionally
-    // omitted from this gap list.
-];
 
 pub const MCP_COMPLETION_MAX_VALUES: usize = 100;
 
@@ -398,6 +376,53 @@ impl McpCacheHint {
             scope: None,
         }
     }
+
+    /// Extract a cache hint from an RC result body. Returns `None` when
+    /// neither `ttlMs` nor a recognized `cacheScope` is present; unknown
+    /// scopes are silently dropped so we stay forward-compatible.
+    pub fn from_result(result: &JsonValue) -> Option<Self> {
+        let ttl_ms = result.get("ttlMs").and_then(JsonValue::as_u64);
+        let scope = result
+            .get("cacheScope")
+            .and_then(JsonValue::as_str)
+            .and_then(Self::canonical_scope);
+        if ttl_ms.is_none() && scope.is_none() {
+            return None;
+        }
+        Some(Self { ttl_ms, scope })
+    }
+
+    fn canonical_scope(value: &str) -> Option<&'static str> {
+        match value {
+            "public" => Some("public"),
+            "private" => Some("private"),
+            _ => None,
+        }
+    }
+
+    pub fn to_json_object(&self) -> serde_json::Map<String, JsonValue> {
+        let mut entry = serde_json::Map::new();
+        if let Some(ttl_ms) = self.ttl_ms {
+            entry.insert("ttlMs".to_string(), json!(ttl_ms));
+        }
+        if let Some(scope) = self.scope {
+            entry.insert("cacheScope".to_string(), JsonValue::String(scope.into()));
+        }
+        entry
+    }
+}
+
+/// Build a JSON object mapping method names to their recorded RC cache
+/// hints. Empty input yields an empty object.
+pub fn cache_hints_to_json<'a, I>(hints: I) -> JsonValue
+where
+    I: IntoIterator<Item = (&'a String, &'a McpCacheHint)>,
+{
+    let mut object = serde_json::Map::new();
+    for (method, hint) in hints {
+        object.insert(method.clone(), JsonValue::Object(hint.to_json_object()));
+    }
+    JsonValue::Object(object)
 }
 
 /// Build the canonical `server/discover` result both server surfaces
@@ -420,26 +445,6 @@ pub fn server_discover_result(
         result["instructions"] = JsonValue::String(instructions.to_string());
     }
     result
-}
-
-pub fn unsupported_latest_spec_method(method: &str) -> Option<&'static UnsupportedMcpMethod> {
-    UNSUPPORTED_LATEST_SPEC_METHODS
-        .iter()
-        .find(|entry| entry.method == method)
-}
-
-pub fn unsupported_latest_spec_method_response(
-    id: impl Into<JsonValue>,
-    method: &str,
-) -> Option<JsonValue> {
-    unsupported_latest_spec_method(method).map(|entry| {
-        crate::jsonrpc::error_response_with_data(
-            id,
-            -32601,
-            &format!("Unsupported MCP method: {method}"),
-            unsupported_method_data(entry),
-        )
-    })
 }
 
 pub fn unsupported_client_bound_method_response(
@@ -692,18 +697,6 @@ pub fn mcp_list_page(
     })
 }
 
-fn unsupported_method_data(entry: &UnsupportedMcpMethod) -> JsonValue {
-    json!({
-        "type": "mcp.unsupportedFeature",
-        "protocolVersion": PROTOCOL_VERSION,
-        "method": entry.method,
-        "feature": entry.feature,
-        "role": entry.role,
-        "status": "unsupported",
-        "reason": entry.reason,
-    })
-}
-
 fn parse_mcp_list_cursor(params: &JsonValue, method: &str) -> Result<usize, String> {
     let Some(cursor) = params.get("cursor") else {
         return Ok(0);
@@ -726,8 +719,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn completion_complete_is_no_longer_in_the_unsupported_gap_list() {
-        assert!(unsupported_latest_spec_method(METHOD_COMPLETION_COMPLETE).is_none());
+    fn completion_payload_dedupes_and_ranks_prefix_matches() {
         let response = completion_result(
             json!(1),
             vec![
@@ -744,37 +736,6 @@ mod tests {
         );
         assert_eq!(response["result"]["completion"]["total"], json!(2));
         assert_eq!(response["result"]["completion"]["hasMore"], json!(false));
-    }
-
-    #[test]
-    fn elicitation_create_is_no_longer_in_the_unsupported_gap_list() {
-        // Removed from `UNSUPPORTED_LATEST_SPEC_METHODS` once we
-        // implemented bidirectional elicitation (issue #875). Lookup
-        // therefore returns `None` and callers route the method
-        // through the elicitation bus (server) or the host bridge
-        // (client) instead of the auto-rejection path.
-        assert!(unsupported_latest_spec_method("elicitation/create").is_none());
-    }
-
-    #[test]
-    fn roots_list_is_no_longer_in_the_unsupported_gap_list() {
-        assert!(unsupported_latest_spec_method(METHOD_ROOTS_LIST).is_none());
-    }
-
-    #[test]
-    fn resource_subscriptions_are_no_longer_in_the_unsupported_gap_list() {
-        assert!(unsupported_latest_spec_method("resources/subscribe").is_none());
-        assert!(unsupported_latest_spec_method("resources/unsubscribe").is_none());
-    }
-
-    #[test]
-    fn sampling_create_message_is_no_longer_in_the_unsupported_gap_list() {
-        // Removed from `UNSUPPORTED_LATEST_SPEC_METHODS` once we
-        // implemented inbound server-to-client sampling (issue #874).
-        // Lookup therefore returns `None` and callers route the method
-        // through `mcp_sampling::dispatch_inbound_sampling` on the
-        // client side instead of the auto-rejection path.
-        assert!(unsupported_latest_spec_method("sampling/createMessage").is_none());
     }
 
     #[test]

--- a/crates/harn-vm/src/mcp_server/server.rs
+++ b/crates/harn-vm/src/mcp_server/server.rs
@@ -9,8 +9,9 @@ use crate::mcp_progress::{
     is_valid_progress_token, scope_context, ProgressBus, ProgressContext,
 };
 use crate::mcp_protocol::{
-    self, apply_rc_result_envelope, enforce_request_protocol_version, parse_request_metadata,
-    server_discover_result, McpCacheHint, McpProtocolMode,
+    self, apply_rc_result_envelope, enforce_request_protocol_version,
+    is_supported_protocol_version, parse_request_metadata, server_discover_result, McpCacheHint,
+    McpProtocolMode, McpRequestMetadata,
 };
 use crate::stdlib::json_to_vm_value;
 use crate::value::VmError;
@@ -181,31 +182,27 @@ impl McpServer {
             return Some(response);
         }
 
-        Some(match method {
+        let response = match method {
             mcp_protocol::METHOD_SERVER_DISCOVER => self.handle_server_discover(&id),
-            "initialize" => self.handle_initialize(&id),
+            "initialize" => self.handle_initialize(&id, &params, &metadata),
             "ping" => crate::jsonrpc::response(id.clone(), serde_json::json!({})),
             "logging/setLevel" => self.handle_logging_set_level(&id, &params),
             "harn.hitl.respond" => self.handle_hitl_respond(&id, &params).await,
-            "tools/list" => self.handle_tools_list(&id, &params, mode),
-            "tools/call" => self.handle_tools_call(&id, &params, vm, mode).await,
+            "tools/list" => self.handle_tools_list(&id, &params),
+            "tools/call" => self.handle_tools_call(&id, &params, vm).await,
             mcp_protocol::METHOD_TASKS_GET => self.handle_task_lookup(&id, &params),
             mcp_protocol::METHOD_TASKS_RESULT => self.handle_task_lookup(&id, &params),
             mcp_protocol::METHOD_TASKS_LIST => self.handle_tasks_list(&id, &params),
             mcp_protocol::METHOD_TASKS_CANCEL => self.handle_task_lookup(&id, &params),
-            "resources/list" => self.handle_resources_list(&id, &params, mode),
-            "resources/read" => self.handle_resources_read(&id, &params, vm, mode).await,
+            "resources/list" => self.handle_resources_list(&id, &params),
+            "resources/read" => self.handle_resources_read(&id, &params, vm).await,
             "resources/subscribe" => self.handle_resources_subscribe(&id, &params),
             "resources/unsubscribe" => self.handle_resources_unsubscribe(&id, &params),
-            "resources/templates/list" => self.handle_resource_templates_list(&id, &params, mode),
-            "prompts/list" => self.handle_prompts_list(&id, &params, mode),
-            "prompts/get" => self.handle_prompts_get(&id, &params, vm, mode).await,
+            "resources/templates/list" => self.handle_resource_templates_list(&id, &params),
+            "prompts/list" => self.handle_prompts_list(&id, &params),
+            "prompts/get" => self.handle_prompts_get(&id, &params, vm).await,
             mcp_protocol::METHOD_COMPLETION_COMPLETE => {
                 self.handle_completion_complete(&id, &params, vm).await
-            }
-            _ if mcp_protocol::unsupported_latest_spec_method(method).is_some() => {
-                mcp_protocol::unsupported_latest_spec_method_response(id.clone(), method)
-                    .expect("checked unsupported MCP method")
             }
             _ => serde_json::json!({
                 "jsonrpc": "2.0",
@@ -215,7 +212,12 @@ impl McpServer {
                     "message": format!("Method not found: {method}")
                 }
             }),
-        })
+        };
+        Some(apply_envelope(
+            response,
+            mode,
+            cache_hint_for_method(method),
+        ))
     }
 
     fn server_capabilities(&self) -> serde_json::Map<String, serde_json::Value> {
@@ -262,14 +264,32 @@ impl McpServer {
         crate::jsonrpc::response(id.clone(), result)
     }
 
-    fn handle_initialize(&self, id: &serde_json::Value) -> serde_json::Value {
-        let capabilities = self.server_capabilities();
+    fn handle_initialize(
+        &self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+        metadata: &McpRequestMetadata,
+    ) -> serde_json::Value {
+        // Echo the version the client asked for when we support it,
+        // falling back to the stable default otherwise. Modern clients
+        // can also pin their target through RC `_meta.protocolVersion`,
+        // which `enforce_request_protocol_version` validated upstream.
+        let requested = metadata
+            .protocol_version
+            .as_deref()
+            .or_else(|| {
+                params
+                    .get("protocolVersion")
+                    .and_then(serde_json::Value::as_str)
+            })
+            .filter(|version| is_supported_protocol_version(version))
+            .unwrap_or(PROTOCOL_VERSION);
         serde_json::json!({
             "jsonrpc": "2.0",
             "id": id,
             "result": {
-                "protocolVersion": PROTOCOL_VERSION,
-                "capabilities": capabilities,
+                "protocolVersion": requested,
+                "capabilities": self.server_capabilities(),
                 "serverInfo": self.server_info_value(),
             }
         })
@@ -279,7 +299,6 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
-        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let page = match mcp_protocol::mcp_list_page(params, self.tools.len(), "tools/list") {
             Ok(page) => page,
@@ -315,7 +334,6 @@ impl McpServer {
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
-        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -329,7 +347,6 @@ impl McpServer {
         id: &serde_json::Value,
         params: &serde_json::Value,
         vm: &mut Vm,
-        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
         if mcp_protocol::requests_task_augmentation(params) {
@@ -362,15 +379,13 @@ impl McpServer {
         if let Err(message) =
             crate::mcp_file_upload::validate_file_inputs_for_call(&arguments, &tool.input_schema)
         {
-            let mut call_result = serde_json::json!({
-                "content": [{ "type": "text", "text": message }],
-                "isError": true
-            });
-            apply_rc_result_envelope(&mut call_result, mode, None);
             return serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": id,
-                "result": call_result,
+                "result": {
+                    "content": [{ "type": "text", "text": message }],
+                    "isError": true,
+                },
             });
         }
         let args_vm = json_to_vm_value(&arguments);
@@ -408,25 +423,20 @@ impl McpServer {
                     };
                     call_result["structuredContent"] = structured;
                 }
-                apply_rc_result_envelope(&mut call_result, mode, None);
                 serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": id,
                     "result": call_result
                 })
             }
-            Err(e) => {
-                let mut call_result = serde_json::json!({
+            Err(e) => serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
                     "content": [{ "type": "text", "text": format!("{e}") }],
-                    "isError": true
-                });
-                apply_rc_result_envelope(&mut call_result, mode, None);
-                serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "result": call_result,
-                })
-            }
+                    "isError": true,
+                },
+            }),
         }
     }
 
@@ -502,7 +512,6 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
-        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let mut all_resources = Vec::with_capacity(self.resources.len() + 1);
         if self.server_card.is_some() {
@@ -538,7 +547,6 @@ impl McpServer {
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
-        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -552,7 +560,6 @@ impl McpServer {
         id: &serde_json::Value,
         params: &serde_json::Value,
         vm: &mut Vm,
-        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let uri = params.get("uri").and_then(|u| u.as_str()).unwrap_or("");
 
@@ -566,12 +573,10 @@ impl McpServer {
                     "text": serde_json::to_string(card).unwrap_or_else(|_| "{}".to_string()),
                     "mimeType": "application/json",
                 });
-                let mut result = serde_json::json!({ "contents": [content] });
-                apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::read_default()));
                 return serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": result
+                    "result": { "contents": [content] }
                 });
             }
         }
@@ -582,12 +587,10 @@ impl McpServer {
             if let Some(ref mime) = resource.mime_type {
                 content["mimeType"] = serde_json::json!(mime);
             }
-            let mut result = serde_json::json!({ "contents": [content] });
-            apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::read_default()));
             return serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": id,
-                "result": result
+                "result": { "contents": [content] }
             });
         }
 
@@ -604,16 +607,10 @@ impl McpServer {
                         if let Some(ref mime) = tmpl.mime_type {
                             content["mimeType"] = serde_json::json!(mime);
                         }
-                        let mut result = serde_json::json!({ "contents": [content] });
-                        apply_rc_result_envelope(
-                            &mut result,
-                            mode,
-                            Some(&McpCacheHint::read_default()),
-                        );
                         serde_json::json!({
                             "jsonrpc": "2.0",
                             "id": id,
-                            "result": result
+                            "result": { "contents": [content] }
                         })
                     }
                     Err(e) => serde_json::json!({
@@ -671,7 +668,6 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
-        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let page = match mcp_protocol::mcp_list_page(
             params,
@@ -703,7 +699,6 @@ impl McpServer {
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
-        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -716,7 +711,6 @@ impl McpServer {
         &self,
         id: &serde_json::Value,
         params: &serde_json::Value,
-        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let page = match mcp_protocol::mcp_list_page(params, self.prompts.len(), "prompts/list") {
             Ok(page) => page,
@@ -754,7 +748,6 @@ impl McpServer {
         if let Some(next_cursor) = page.next_cursor {
             result["nextCursor"] = serde_json::json!(next_cursor);
         }
-        apply_rc_result_envelope(&mut result, mode, Some(&McpCacheHint::list_default()));
 
         serde_json::json!({
             "jsonrpc": "2.0",
@@ -781,7 +774,6 @@ impl McpServer {
         id: &serde_json::Value,
         params: &serde_json::Value,
         vm: &mut Vm,
-        mode: McpProtocolMode,
     ) -> serde_json::Value {
         let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
 
@@ -807,12 +799,10 @@ impl McpServer {
         match result {
             Ok(value) => {
                 let messages = prompt_value_to_messages(&value);
-                let mut result = serde_json::json!({ "messages": messages });
-                apply_rc_result_envelope(&mut result, mode, None);
                 serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": result
+                    "result": { "messages": messages }
                 })
             }
             Err(e) => serde_json::json!({
@@ -944,6 +934,36 @@ impl McpServer {
             };
         crate::mcp_protocol::completion_result(id.clone(), candidates, value)
     }
+}
+
+/// Map a JSON-RPC method to its conservative cache hint. Read/list
+/// methods get a TTL; everything else is `None`, which still routes
+/// through [`apply_envelope`] so Modern clients see `resultType`.
+fn cache_hint_for_method(method: &str) -> Option<&'static McpCacheHint> {
+    const LIST: McpCacheHint = McpCacheHint::list_default();
+    const READ: McpCacheHint = McpCacheHint::read_default();
+    match method {
+        "tools/list"
+        | "resources/list"
+        | "resources/templates/list"
+        | "prompts/list"
+        | mcp_protocol::METHOD_TASKS_LIST => Some(&LIST),
+        "resources/read" => Some(&READ),
+        _ => None,
+    }
+}
+
+/// Stamp the RC `resultType`/cache-hint envelope onto a handler's
+/// response in one place. Error responses pass through untouched.
+fn apply_envelope(
+    mut response: serde_json::Value,
+    mode: McpProtocolMode,
+    hint: Option<&'static McpCacheHint>,
+) -> serde_json::Value {
+    if let Some(result) = response.get_mut("result") {
+        apply_rc_result_envelope(result, mode, hint);
+    }
+    response
 }
 
 fn completion_argument_name(params: &serde_json::Value) -> Result<&str, String> {

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -264,40 +264,6 @@ fn test_annotations_empty_returns_none() {
 }
 
 #[tokio::test]
-async fn server_latest_spec_gap_methods_return_explicit_json_rpc_errors() {
-    let server = McpServer::new(
-        "test".to_string(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-    );
-    let mut vm = crate::Vm::new();
-
-    for method in crate::mcp_protocol::UNSUPPORTED_LATEST_SPEC_METHODS
-        .iter()
-        .map(|entry| entry.method)
-    {
-        let response = server
-            .handle_json_rpc(
-                crate::jsonrpc::request(1, method, serde_json::json!({})),
-                &mut vm,
-            )
-            .await
-            .expect("response");
-        assert_eq!(response["error"]["code"], serde_json::json!(-32601));
-        assert_eq!(
-            response["error"]["data"]["method"],
-            serde_json::json!(method)
-        );
-        assert_eq!(
-            response["error"]["data"]["status"],
-            serde_json::json!("unsupported")
-        );
-    }
-}
-
-#[tokio::test]
 async fn server_advertises_resource_list_changed_capability() {
     let server = McpServer::new(
         "test".to_string(),
@@ -745,6 +711,78 @@ async fn server_modern_tools_list_emits_result_type_and_cache_hint() {
     );
     assert!(legacy["result"].get("ttlMs").is_none());
     assert!(legacy["result"].get("cacheScope").is_none());
+}
+
+#[tokio::test]
+async fn server_modern_non_list_methods_carry_result_type_envelope() {
+    let server = McpServer::new(
+        "rc-test".to_string(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+    for method in [
+        "ping",
+        "logging/setLevel",
+        crate::mcp_protocol::METHOD_TASKS_LIST,
+    ] {
+        let params = rc_metadata_params(serde_json::json!({"level": "warning"}));
+        let response = server
+            .handle_json_rpc(crate::jsonrpc::request(1, method, params), &mut vm)
+            .await
+            .expect("response");
+        let result = response
+            .get("result")
+            .unwrap_or_else(|| panic!("{method} should return result, got {response:?}"));
+        assert_eq!(
+            result["resultType"],
+            serde_json::json!(crate::mcp_protocol::RESULT_TYPE_COMPLETE),
+            "{method} modern response must carry RC envelope"
+        );
+    }
+}
+
+#[tokio::test]
+async fn server_initialize_echoes_client_requested_protocol_version() {
+    let server = McpServer::new(
+        "rc-test".to_string(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    let mut vm = crate::Vm::new();
+    let response = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                1,
+                "initialize",
+                serde_json::json!({"protocolVersion": "2025-11-25"}),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert_eq!(response["result"]["protocolVersion"], "2025-11-25");
+
+    let response = server
+        .handle_json_rpc(
+            crate::jsonrpc::request(
+                2,
+                "initialize",
+                serde_json::json!({"protocolVersion": "2099-12-31"}),
+            ),
+            &mut vm,
+        )
+        .await
+        .expect("response");
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        crate::mcp_protocol::PROTOCOL_VERSION,
+        "unsupported version must negotiate down to the stable default"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #2182. Polish pass after the MCP RC compatibility epic (#2183-#2187) shipped in five PRs. A fresh-eyes audit found shared types being shadowed, RC envelopes being inlined per-handler (with several handlers silently missing them on Modern responses), and a handful of dead helpers leftover.

Net: **-149 LOC** across 15 files, with new regression tests pinning behavior.

### Shared types: stop shadowing `mcp_protocol`
- `harn-vm/src/mcp.rs` had its own private `McpProtocolMode` and `McpCacheHint` (the latter with `Option<String>` scope vs. the shared `Option<&'static str>`) plus parallel `parse_cache_hint` / `cache_hints_json` / `mcp_standard_name_header` helpers. All deleted in favor of the canonical `mcp_protocol` versions.
- Promoted `McpCacheHint::from_result` and `cache_hints_to_json` into `mcp_protocol` so any future consumer reaches for them first.

### Header / version constants: single source of truth
- `harn-cli/src/commands/mcp/mod.rs`, `harn-cli/src/commands/mcp/serve/mod.rs`, and raw `"MCP-Protocol-Version"`/`"MCP-Session-Id"` literals across `mcp.rs` now consume `RC_HEADER_PROTOCOL_VERSION`, `RC_HEADER_NAME`, `RC_HEADER_METHOD`, and the new `MCP_SESSION_HEADER_LEGACY` from `mcp_protocol`. No more parallel `"2025-11-25"` constants drifting independently.

### Uniform RC envelope application
Three dispatchers (generic server, orchestrator, `harn-serve` adapter) each previously inlined `apply_rc_result_envelope(...)` inside individual handlers. Side-effect: `ping`, `tasks/list`, `logging/setLevel`, `completion/complete`, `resources/subscribe`, etc. shipped bare results to Modern clients (no `resultType: "complete"`).

Now each dispatcher's match returns the raw response and a single `apply_envelope(response, mode, cache_hint_for_method(method))` runs at the bottom, driven by a per-method classifier. Two new regression tests lock in the behavior (`server_modern_non_list_methods_carry_result_type_envelope` and `orchestrator_modern_non_list_methods_carry_result_type_envelope`).

### Correctness: `initialize` must echo client's requested version
Generic server's `handle_initialize` previously ignored `params` and always echoed `PROTOCOL_VERSION`. Now it parses the client's `protocolVersion` (and the RC `_meta.protocolVersion`), echoes it back when supported, and falls back to the stable default only when the requested version is unknown. The orchestrator's path got the same treatment. New test `server_initialize_echoes_client_requested_protocol_version` covers both branches.

### HTTP/dispatcher alignment
Two `validate_protocol_header` implementations (orchestrator's `serve/http.rs` and `harn-serve`'s `adapters/mcp/auth.rs`) special-cased `2025-03-26` even though the dispatchers' `supported_protocol_versions()` doesn't list it — a soft-fail window where the HTTP layer would accept a request the dispatcher couldn't service. Both now delegate to `is_supported_protocol_version` exclusively.

### Dead code removal
- `UNSUPPORTED_LATEST_SPEC_METHODS` slice has been empty since elicitation, sampling, roots/list, and resource subscriptions shipped. The `_ if unsupported_latest_spec_method(...).is_some() =>` arms in five dispatchers were dead code. Removed slice, helpers, and the stale "is_no_longer_in" gap-list tests.
- `connect_mcp_server(name, command, args)` was a public Legacy-pinned wrapper with no callers anywhere in the org. Removed; downstream code uses `connect_mcp_server_from_spec` / `connect_mcp_server_from_json` which already honor the spec's protocol mode.

### CI
`make mcp-rc-conformance` existed as a Makefile target but was never invoked. Wired into the `harn-audit` job alongside `make conformance` and `make protocol-conformance` so any regression in the published RC fixture matrix fails the PR rather than waiting for someone to notice locally.

## Test plan

- [x] `cargo test -p harn-vm --lib mcp_server` (28 pass, including 2 new)
- [x] `cargo test -p harn-vm --lib mcp` (135 pass)
- [x] `cargo test -p harn-cli --lib mcp_rc_compat_tests` (6 pass, including 1 new)
- [x] `cargo test -p harn-cli --lib serve_tests` (32 pass)
- [x] `cargo test -p harn-serve --lib adapters::mcp` (11 pass)
- [x] `cargo test -p harn-mcp-rc-compat` (full RC compat harness)
- [x] `cargo check --workspace --tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)