### PR TITLE
[codex] Optimize VM string and name hot paths

### DIFF
--- a/crates/harn-vm/src/compiler/closures.rs
+++ b/crates/harn-vm/src/compiler/closures.rs
@@ -104,22 +104,18 @@ impl Compiler {
         let fn_idx = self.chunk.functions.len();
         self.chunk.functions.push(Rc::new(func));
 
-        let define_name = self
-            .chunk
-            .add_constant(Constant::String("tool_define".into()));
+        let define_name = self.string_constant("tool_define");
         self.chunk.emit_u16(Op::Constant, define_name, self.line);
 
-        let reg_name = self
-            .chunk
-            .add_constant(Constant::String("tool_registry".into()));
+        let reg_name = self.string_constant("tool_registry");
         self.chunk.emit_u16(Op::Constant, reg_name, self.line);
         self.chunk.emit_u8(Op::Call, 0, self.line);
 
-        let tool_name_idx = self.chunk.add_constant(Constant::String(name.to_string()));
+        let tool_name_idx = self.string_constant(name);
         self.chunk.emit_u16(Op::Constant, tool_name_idx, self.line);
 
         let desc = description.as_deref().unwrap_or("");
-        let desc_idx = self.chunk.add_constant(Constant::String(desc.to_string()));
+        let desc_idx = self.string_constant(desc);
         self.chunk.emit_u16(Op::Constant, desc_idx, self.line);
 
         // Build parameters dict using the same schema lowering as
@@ -127,7 +123,7 @@ impl Compiler {
         // unions, item schemas, defaults, and dict value schemas.
         let mut param_count: u16 = 0;
         for p in params {
-            let pn_idx = self.chunk.add_constant(Constant::String(p.name.clone()));
+            let pn_idx = self.string_constant(&p.name);
             self.chunk.emit_u16(Op::Constant, pn_idx, self.line);
 
             let base_schema = p
@@ -162,7 +158,7 @@ impl Compiler {
             self.emit_vm_value_literal(&VmValue::Dict(Rc::new(param_schema)));
 
             if let Some(default_value) = p.default_value.as_ref() {
-                let default_key = self.chunk.add_constant(Constant::String("default".into()));
+                let default_key = self.string_constant("default");
                 self.chunk.emit_u16(Op::Constant, default_key, self.line);
                 self.compile_node(default_value)?;
                 self.chunk.emit_u16(Op::BuildDict, 1, self.line);
@@ -173,13 +169,11 @@ impl Compiler {
         }
         self.chunk.emit_u16(Op::BuildDict, param_count, self.line);
 
-        let params_key = self
-            .chunk
-            .add_constant(Constant::String("parameters".into()));
+        let params_key = self.string_constant("parameters");
         self.chunk.emit_u16(Op::Constant, params_key, self.line);
         self.chunk.emit(Op::Swap, self.line);
 
-        let handler_key = self.chunk.add_constant(Constant::String("handler".into()));
+        let handler_key = self.string_constant("handler");
         self.chunk.emit_u16(Op::Constant, handler_key, self.line);
         self.chunk.emit_u16(Op::Closure, fn_idx as u16, self.line);
 
@@ -198,7 +192,7 @@ impl Compiler {
                         line: self.line,
                     }
                 })?;
-            let returns_key = self.chunk.add_constant(Constant::String("returns".into()));
+            let returns_key = self.string_constant("returns");
             self.chunk.emit_u16(Op::Constant, returns_key, self.line);
             self.emit_vm_value_literal(&return_type);
             config_entries += 1;
@@ -225,26 +219,22 @@ impl Compiler {
         fields: &[(String, SNode)],
     ) -> Result<(), CompileError> {
         // Push skill_define
-        let define_idx = self
-            .chunk
-            .add_constant(Constant::String("skill_define".into()));
+        let define_idx = self.string_constant("skill_define");
         self.chunk.emit_u16(Op::Constant, define_idx, self.line);
 
         // Push skill_registry()
-        let reg_idx = self
-            .chunk
-            .add_constant(Constant::String("skill_registry".into()));
+        let reg_idx = self.string_constant("skill_registry");
         self.chunk.emit_u16(Op::Constant, reg_idx, self.line);
         self.chunk.emit_u8(Op::Call, 0, self.line);
 
         // Push skill name
-        let name_const = self.chunk.add_constant(Constant::String(name.to_string()));
+        let name_const = self.string_constant(name);
         self.chunk.emit_u16(Op::Constant, name_const, self.line);
 
         // Build config dict from fields.
         let mut field_count: u16 = 0;
         for (key, value) in fields {
-            let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+            let key_idx = self.string_constant(key);
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             self.compile_node(value)?;
             field_count += 1;
@@ -283,9 +273,7 @@ impl Compiler {
             }
             for field_name in visible_fields {
                 self.emit_get_binding(binding_name);
-                let field_idx = self
-                    .chunk
-                    .add_constant(Constant::String(field_name.clone()));
+                let field_idx = self.string_constant(&field_name);
                 self.chunk.emit_u16(Op::GetProperty, field_idx, self.line);
                 self.emit_define_binding(&field_name, false);
             }
@@ -315,32 +303,28 @@ impl Compiler {
         pack_id: &str,
         fields: &[(String, SNode)],
     ) -> Result<(), CompileError> {
-        let manifest_idx = self
-            .chunk
-            .add_constant(Constant::String("eval_pack_manifest".into()));
+        let manifest_idx = self.string_constant("eval_pack_manifest");
         self.chunk.emit_u16(Op::Constant, manifest_idx, self.line);
 
         let has_id = fields.iter().any(|(key, _)| key == "id");
         let has_version = fields.iter().any(|(key, _)| key == "version");
         let mut entry_count = fields.len() as u16;
         if !has_version {
-            let key_idx = self.chunk.add_constant(Constant::String("version".into()));
+            let key_idx = self.string_constant("version");
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             let value_idx = self.chunk.add_constant(Constant::Int(1));
             self.chunk.emit_u16(Op::Constant, value_idx, self.line);
             entry_count += 1;
         }
         if !has_id {
-            let key_idx = self.chunk.add_constant(Constant::String("id".into()));
+            let key_idx = self.string_constant("id");
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
-            let value_idx = self
-                .chunk
-                .add_constant(Constant::String(pack_id.to_string()));
+            let value_idx = self.string_constant(pack_id);
             self.chunk.emit_u16(Op::Constant, value_idx, self.line);
             entry_count += 1;
         }
         for (key, value) in fields {
-            let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+            let key_idx = self.string_constant(key);
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             self.compile_node(value)?;
         }

--- a/crates/harn-vm/src/compiler/concurrency.rs
+++ b/crates/harn-vm/src/compiler/concurrency.rs
@@ -136,9 +136,7 @@ impl Compiler {
             "__select_list"
         };
 
-        let name_idx = self
-            .chunk
-            .add_constant(Constant::String(builtin_name.into()));
+        let name_idx = self.string_constant(builtin_name);
         self.chunk.emit_u16(Op::Constant, name_idx, self.line);
 
         for case in cases {
@@ -162,7 +160,7 @@ impl Compiler {
 
         for (i, case) in cases.iter().enumerate() {
             self.emit_get_binding(&result_name);
-            let idx_prop = self.chunk.add_constant(Constant::String("index".into()));
+            let idx_prop = self.string_constant("index");
             self.chunk.emit_u16(Op::GetProperty, idx_prop, self.line);
             let case_i = self.chunk.add_constant(Constant::Int(i as i64));
             self.chunk.emit_u16(Op::Constant, case_i, self.line);
@@ -172,7 +170,7 @@ impl Compiler {
             self.begin_scope();
 
             self.emit_get_binding(&result_name);
-            let val_prop = self.chunk.add_constant(Constant::String("value".into()));
+            let val_prop = self.string_constant("value");
             self.chunk.emit_u16(Op::GetProperty, val_prop, self.line);
             self.emit_define_binding(&case.variable, false);
 

--- a/crates/harn-vm/src/compiler/decls.rs
+++ b/crates/harn-vm/src/compiler/decls.rs
@@ -17,12 +17,8 @@ impl Compiler {
         for arg in args {
             self.compile_node(arg)?;
         }
-        let enum_idx = self
-            .chunk
-            .add_constant(Constant::String(enum_name.to_string()));
-        let var_idx = self
-            .chunk
-            .add_constant(Constant::String(variant.to_string()));
+        let enum_idx = self.string_constant(enum_name);
+        let var_idx = self.string_constant(variant);
         // BuildEnum operands: enum_name_idx, variant_idx, field_count.
         self.chunk.emit_u16(Op::BuildEnum, enum_idx, self.line);
         let hi = (var_idx >> 8) as u8;
@@ -51,12 +47,8 @@ impl Compiler {
         fields: &[DictEntry],
     ) -> Result<(), CompileError> {
         // Route through `__make_struct` so impl dispatch sees a StructInstance.
-        let make_idx = self
-            .chunk
-            .add_constant(Constant::String("__make_struct".to_string()));
-        let struct_name_idx = self
-            .chunk
-            .add_constant(Constant::String(struct_name.to_string()));
+        let make_idx = self.string_constant("__make_struct");
+        let struct_name_idx = self.string_constant(struct_name);
         self.chunk.emit_u16(Op::Constant, make_idx, self.line);
         self.chunk
             .emit_u16(Op::Constant, struct_name_idx, self.line);
@@ -92,7 +84,7 @@ impl Compiler {
                 ..
             } = &method_sn.node
             {
-                let key_idx = self.chunk.add_constant(Constant::String(name.clone()));
+                let key_idx = self.string_constant(name);
                 self.chunk.emit_u16(Op::Constant, key_idx, self.line);
 
                 let mut fn_compiler = self.nested_body();
@@ -154,15 +146,11 @@ impl Compiler {
         fn_compiler.declare_param_slots(&params);
         fn_compiler.emit_default_preamble(&params)?;
 
-        let make_idx = fn_compiler
-            .chunk
-            .add_constant(Constant::String("__make_struct".into()));
+        let make_idx = fn_compiler.string_constant("__make_struct");
         fn_compiler
             .chunk
             .emit_u16(Op::Constant, make_idx, self.line);
-        let sname_idx = fn_compiler
-            .chunk
-            .add_constant(Constant::String(name.to_string()));
+        let sname_idx = fn_compiler.string_constant(name);
         fn_compiler
             .chunk
             .emit_u16(Op::Constant, sname_idx, self.line);
@@ -196,7 +184,7 @@ impl Compiler {
 
     pub(super) fn emit_string_list(&mut self, values: &[String]) {
         for value in values {
-            let idx = self.chunk.add_constant(Constant::String(value.clone()));
+            let idx = self.string_constant(value);
             self.chunk.emit_u16(Op::Constant, idx, self.line);
         }
         self.chunk
@@ -260,24 +248,22 @@ impl Compiler {
         attr: &harn_parser::Attribute,
         fn_name: &str,
     ) -> Result<(), CompileError> {
-        let define_idx = self
-            .chunk
-            .add_constant(Constant::String("__register_persona".into()));
+        let define_idx = self.string_constant("__register_persona");
         self.chunk.emit_u16(Op::Constant, define_idx, self.line);
 
-        let fn_const = self.chunk.add_constant(Constant::String(fn_name.into()));
+        let fn_const = self.string_constant(fn_name);
         self.chunk.emit_u16(Op::Constant, fn_const, self.line);
 
         let mut entries: u16 = 0;
         if let Some(name) = attr.named_arg("name") {
-            let key_idx = self.chunk.add_constant(Constant::String("name".into()));
+            let key_idx = self.string_constant("name");
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             self.compile_attribute_value(name)?;
             entries += 1;
         }
         if let Some(stages) = attr.named_arg("stages") {
             if matches!(stages.node, Node::ListLiteral(_)) {
-                let key_idx = self.chunk.add_constant(Constant::String("stages".into()));
+                let key_idx = self.string_constant("stages");
                 self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                 self.compile_attribute_value(stages)?;
                 entries += 1;
@@ -302,13 +288,11 @@ impl Compiler {
         fn_name: &str,
     ) -> Result<(), CompileError> {
         // Push the builtin name.
-        let define_idx = self
-            .chunk
-            .add_constant(Constant::String("__register_step".into()));
+        let define_idx = self.string_constant("__register_step");
         self.chunk.emit_u16(Op::Constant, define_idx, self.line);
 
         // Arg 0: function name (the registry key).
-        let fn_const = self.chunk.add_constant(Constant::String(fn_name.into()));
+        let fn_const = self.string_constant(fn_name);
         self.chunk.emit_u16(Op::Constant, fn_const, self.line);
 
         // Arg 1: metadata dict — emit only the fields the step
@@ -322,7 +306,7 @@ impl Compiler {
             if !META_KEYS.contains(&key.as_str()) {
                 continue;
             }
-            let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+            let key_idx = self.string_constant(key);
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             self.compile_attribute_value(&arg.value)?;
             entries += 1;
@@ -333,7 +317,7 @@ impl Compiler {
         // the dict literal through verbatim.
         if let Some(budget) = attr.named_arg("budget") {
             if matches!(budget.node, Node::DictLiteral(_)) {
-                let key_idx = self.chunk.add_constant(Constant::String("budget".into()));
+                let key_idx = self.string_constant("budget");
                 self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                 self.compile_attribute_value(budget)?;
                 entries += 1;
@@ -365,28 +349,24 @@ impl Compiler {
             .unwrap_or_else(|| fn_name.to_string());
 
         // Push tool_define
-        let define_idx = self
-            .chunk
-            .add_constant(Constant::String("tool_define".into()));
+        let define_idx = self.string_constant("tool_define");
         self.chunk.emit_u16(Op::Constant, define_idx, self.line);
 
         // Push tool_registry()
-        let reg_idx = self
-            .chunk
-            .add_constant(Constant::String("tool_registry".into()));
+        let reg_idx = self.string_constant("tool_registry");
         self.chunk.emit_u16(Op::Constant, reg_idx, self.line);
         self.chunk.emit_u8(Op::Call, 0, self.line);
 
         // Push tool name
-        let name_const = self.chunk.add_constant(Constant::String(tool_name));
+        let name_const = self.owned_string_constant(tool_name);
         self.chunk.emit_u16(Op::Constant, name_const, self.line);
 
         // Push empty description
-        let desc_const = self.chunk.add_constant(Constant::String(String::new()));
+        let desc_const = self.string_constant("");
         self.chunk.emit_u16(Op::Constant, desc_const, self.line);
 
         // Build config dict: { handler: <fn>, annotations: {...} }
-        let handler_key = self.chunk.add_constant(Constant::String("handler".into()));
+        let handler_key = self.string_constant("handler");
         self.chunk.emit_u16(Op::Constant, handler_key, self.line);
         self.emit_get_binding(fn_name);
 
@@ -399,14 +379,12 @@ impl Compiler {
             if key == "name" {
                 continue;
             }
-            let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+            let key_idx = self.string_constant(key);
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             self.compile_attribute_value(&arg.value)?;
             ann_count += 1;
         }
-        let ann_key_idx = self
-            .chunk
-            .add_constant(Constant::String("annotations".into()));
+        let ann_key_idx = self.string_constant("annotations");
         self.chunk.emit_u16(Op::Constant, ann_key_idx, self.line);
         self.chunk.emit_u16(Op::BuildDict, ann_count, self.line);
 
@@ -441,20 +419,16 @@ impl Compiler {
             .unwrap_or_else(|| fn_name.to_string());
 
         // Push skill_define
-        let define_idx = self
-            .chunk
-            .add_constant(Constant::String("skill_define".into()));
+        let define_idx = self.string_constant("skill_define");
         self.chunk.emit_u16(Op::Constant, define_idx, self.line);
 
         // Push skill_registry()
-        let reg_idx = self
-            .chunk
-            .add_constant(Constant::String("skill_registry".into()));
+        let reg_idx = self.string_constant("skill_registry");
         self.chunk.emit_u16(Op::Constant, reg_idx, self.line);
         self.chunk.emit_u8(Op::Call, 0, self.line);
 
         // Push skill name
-        let name_const = self.chunk.add_constant(Constant::String(skill_name));
+        let name_const = self.owned_string_constant(skill_name);
         self.chunk.emit_u16(Op::Constant, name_const, self.line);
 
         // Build config dict: every named attr arg (except `name`) + on_activate.
@@ -466,16 +440,14 @@ impl Compiler {
             if key == "name" {
                 continue;
             }
-            let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+            let key_idx = self.string_constant(key);
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             self.compile_attribute_value(&arg.value)?;
             entries += 1;
         }
 
         // on_activate: <fn_name>
-        let activate_key = self
-            .chunk
-            .add_constant(Constant::String("on_activate".into()));
+        let activate_key = self.string_constant("on_activate");
         self.chunk.emit_u16(Op::Constant, activate_key, self.line);
         self.emit_get_binding(fn_name);
         entries += 1;
@@ -492,7 +464,7 @@ impl Compiler {
     pub(super) fn compile_attribute_value(&mut self, node: &SNode) -> Result<(), CompileError> {
         match &node.node {
             Node::StringLiteral(s) | Node::RawStringLiteral(s) => {
-                let idx = self.chunk.add_constant(Constant::String(s.clone()));
+                let idx = self.string_constant(s);
                 self.chunk.emit_u16(Op::Constant, idx, self.line);
             }
             Node::IntLiteral(i) => {
@@ -515,7 +487,7 @@ impl Compiler {
                 // should behave the same as `kind: "edit"`). This mirrors
                 // common attribute-DSL ergonomics. The parser also folds
                 // dotted sentinels like `github.pr_opened` into this node.
-                let idx = self.chunk.add_constant(Constant::String(name.clone()));
+                let idx = self.string_constant(name);
                 self.chunk.emit_u16(Op::Constant, idx, self.line);
             }
             Node::ListLiteral(items) => {
@@ -539,9 +511,7 @@ impl Compiler {
                     .map(attribute_value_repr)
                     .collect::<Result<Vec<_>, _>>()?
                     .join(", ");
-                let idx = self
-                    .chunk
-                    .add_constant(Constant::String(format!("{name}({rendered_args})")));
+                let idx = self.owned_string_constant(format!("{name}({rendered_args})"));
                 self.chunk.emit_u16(Op::Constant, idx, self.line);
             }
             _ => {

--- a/crates/harn-vm/src/compiler/error_handling.rs
+++ b/crates/harn-vm/src/compiler/error_handling.rs
@@ -39,7 +39,7 @@ impl Compiler {
         }
         self.handler_depth += 1;
         let catch_jump = self.chunk.emit_jump(Op::TryCatchSetup, self.line);
-        let empty_type = self.chunk.add_constant(Constant::String(String::new()));
+        let empty_type = self.string_constant("");
         self.emit_type_name_extra(empty_type);
 
         self.compile_node(operand)?;
@@ -81,16 +81,16 @@ impl Compiler {
         // Extract the type name for typed catch (e.g., "AppError")
         let type_name = error_type.as_ref().and_then(|te| {
             if let harn_parser::TypeExpr::Named(name) = te {
-                Some(name.clone())
+                Some(name.as_str())
             } else {
                 None
             }
         });
 
-        let type_name_idx = if let Some(ref tn) = type_name {
-            self.chunk.add_constant(Constant::String(tn.clone()))
+        let type_name_idx = if let Some(tn) = type_name {
+            self.string_constant(tn)
         } else {
-            self.chunk.add_constant(Constant::String(String::new()))
+            self.string_constant("")
         };
 
         let has_catch = !catch_body.is_empty() || error_var.is_some();
@@ -133,7 +133,7 @@ impl Compiler {
             // rethrow (finally already fired via the body's throw).
             self.handler_depth += 1;
             let rethrow_jump = self.chunk.emit_jump(Op::TryCatchSetup, self.line);
-            let empty_type = self.chunk.add_constant(Constant::String(String::new()));
+            let empty_type = self.string_constant("");
             self.emit_type_name_extra(empty_type);
 
             self.compile_try_body(catch_body)?;
@@ -162,7 +162,7 @@ impl Compiler {
 
             self.handler_depth += 1;
             let error_jump = self.chunk.emit_jump(Op::TryCatchSetup, self.line);
-            let empty_type = self.chunk.add_constant(Constant::String(String::new()));
+            let empty_type = self.string_constant("");
             self.emit_type_name_extra(empty_type);
 
             self.compile_try_body(body)?;
@@ -213,7 +213,7 @@ impl Compiler {
         // `try { body }` returns Result.Ok(value) or Result.Err(error).
         self.handler_depth += 1;
         let catch_jump = self.chunk.emit_jump(Op::TryCatchSetup, self.line);
-        let empty_type = self.chunk.add_constant(Constant::String(String::new()));
+        let empty_type = self.string_constant("");
         self.emit_type_name_extra(empty_type);
 
         self.compile_try_body(body)?;
@@ -230,7 +230,7 @@ impl Compiler {
         // Error path: wrap in Result.Err.
         self.chunk.patch_jump(catch_jump);
 
-        let err_idx = self.chunk.add_constant(Constant::String("Err".to_string()));
+        let err_idx = self.string_constant("Err");
         self.chunk.emit_u16(Op::Constant, err_idx, self.line);
         self.chunk.emit(Op::Swap, self.line);
         self.chunk.emit_u8(Op::Call, 1, self.line);
@@ -257,7 +257,7 @@ impl Compiler {
 
         let catch_jump = self.chunk.emit_jump(Op::TryCatchSetup, self.line);
         // Empty type name → untyped catch.
-        let empty_type = self.chunk.add_constant(Constant::String(String::new()));
+        let empty_type = self.string_constant("");
         let hi = (empty_type >> 8) as u8;
         let lo = empty_type as u8;
         self.chunk.code.push(hi);

--- a/crates/harn-vm/src/compiler/expressions.rs
+++ b/crates/harn-vm/src/compiler/expressions.rs
@@ -1,7 +1,7 @@
 use harn_lexer::StringSegment;
 use harn_parser::{DictEntry, Node, SNode, TypedParam};
 
-use crate::chunk::{Constant, Op};
+use crate::chunk::Op;
 use crate::BuiltinId;
 
 use super::error::CompileError;
@@ -10,7 +10,7 @@ use super::Compiler;
 
 impl Compiler {
     pub(super) fn emit_named_call(&mut self, name: &str, arg_count: usize) {
-        let name_idx = self.chunk.add_constant(Constant::String(name.to_string()));
+        let name_idx = self.string_constant(name);
         self.chunk.emit_call_builtin(
             BuiltinId::from_name(name),
             name_idx,
@@ -20,7 +20,7 @@ impl Compiler {
     }
 
     pub(super) fn emit_named_call_spread(&mut self, name: &str) {
-        let name_idx = self.chunk.add_constant(Constant::String(name.to_string()));
+        let name_idx = self.string_constant(name);
         self.chunk
             .emit_call_builtin_spread(BuiltinId::from_name(name), name_idx, self.line);
     }
@@ -225,10 +225,8 @@ impl Compiler {
                 for arg in args {
                     self.compile_node(arg)?;
                 }
-                let enum_idx = self.chunk.add_constant(Constant::String(name.clone()));
-                let var_idx = self
-                    .chunk
-                    .add_constant(Constant::String(method.to_string()));
+                let enum_idx = self.string_constant(name);
+                let var_idx = self.string_constant(method);
                 self.chunk.emit_u16(Op::BuildEnum, enum_idx, self.line);
                 let hi = (var_idx >> 8) as u8;
                 let lo = var_idx as u8;
@@ -252,9 +250,7 @@ impl Compiler {
         }
         let has_spread = args.iter().any(|a| matches!(&a.node, Node::Spread(_)));
         self.compile_node(object)?;
-        let name_idx = self
-            .chunk
-            .add_constant(Constant::String(method.to_string()));
+        let name_idx = self.string_constant(method);
         if has_spread {
             self.chunk.emit_u16(Op::BuildList, 0, self.line);
             let mut pending = 0u16;
@@ -267,9 +263,7 @@ impl Compiler {
                     }
                     self.compile_node(inner)?;
                     self.chunk.emit(Op::Dup, self.line);
-                    let assert_idx = self
-                        .chunk
-                        .add_constant(Constant::String("__assert_list".into()));
+                    let assert_idx = self.string_constant("__assert_list");
                     self.chunk.emit_u16(Op::Constant, assert_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     self.chunk.emit_u8(Op::Call, 1, self.line);
@@ -304,10 +298,8 @@ impl Compiler {
         // Bare `EnumName.Variant` desugars to a zero-field BuildEnum.
         if let Node::Identifier(name) = &object.node {
             if self.enum_names.contains(name) {
-                let enum_idx = self.chunk.add_constant(Constant::String(name.clone()));
-                let var_idx = self
-                    .chunk
-                    .add_constant(Constant::String(property.to_string()));
+                let enum_idx = self.string_constant(name);
+                let var_idx = self.string_constant(property);
                 self.chunk.emit_u16(Op::BuildEnum, enum_idx, self.line);
                 let hi = (var_idx >> 8) as u8;
                 let lo = var_idx as u8;
@@ -327,9 +319,7 @@ impl Compiler {
             }
         }
         self.compile_node(object)?;
-        let idx = self
-            .chunk
-            .add_constant(Constant::String(property.to_string()));
+        let idx = self.string_constant(property);
         self.chunk.emit_u16(Op::GetProperty, idx, self.line);
         Ok(())
     }
@@ -355,9 +345,7 @@ impl Compiler {
                     }
                     self.compile_node(inner)?;
                     self.chunk.emit(Op::Dup, self.line);
-                    let assert_idx = self
-                        .chunk
-                        .add_constant(Constant::String("__assert_list".into()));
+                    let assert_idx = self.string_constant("__assert_list");
                     self.chunk.emit_u16(Op::Constant, assert_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     self.chunk.emit_u8(Op::Call, 1, self.line);
@@ -418,9 +406,7 @@ impl Compiler {
                     }
                     self.compile_node(inner)?;
                     self.chunk.emit(Op::Dup, self.line);
-                    let assert_idx = self
-                        .chunk
-                        .add_constant(Constant::String("__assert_dict".into()));
+                    let assert_idx = self.string_constant("__assert_dict");
                     self.chunk.emit_u16(Op::Constant, assert_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     self.chunk.emit_u8(Op::Call, 1, self.line);
@@ -448,7 +434,7 @@ impl Compiler {
         for seg in segments {
             match seg {
                 StringSegment::Literal(s) => {
-                    let idx = self.chunk.add_constant(Constant::String(s.clone()));
+                    let idx = self.string_constant(s);
                     self.chunk.emit_u16(Op::Constant, idx, self.line);
                     part_count += 1;
                 }
@@ -459,16 +445,14 @@ impl Compiler {
                         let mut parser = harn_parser::Parser::new(tokens);
                         if let Ok(snode) = parser.parse_single_expression() {
                             self.compile_node(&snode)?;
-                            let to_str = self
-                                .chunk
-                                .add_constant(Constant::String("to_string".into()));
+                            let to_str = self.string_constant("to_string");
                             self.chunk.emit_u16(Op::Constant, to_str, self.line);
                             self.chunk.emit(Op::Swap, self.line);
                             self.chunk.emit_u8(Op::Call, 1, self.line);
                             part_count += 1;
                         } else {
                             // Fallback: treat as literal.
-                            let idx = self.chunk.add_constant(Constant::String(expr_str.clone()));
+                            let idx = self.string_constant(expr_str);
                             self.chunk.emit_u16(Op::Constant, idx, self.line);
                             part_count += 1;
                         }

--- a/crates/harn-vm/src/compiler/hitl.rs
+++ b/crates/harn-vm/src/compiler/hitl.rs
@@ -165,9 +165,7 @@ impl Compiler {
             // the value, alternating: BuildDict consumes them as
             // pairs. This mirrors `compile_dict_literal` for the
             // non-spread path.
-            let key_idx = self
-                .chunk
-                .add_constant(crate::chunk::Constant::String((*key).to_string()));
+            let key_idx = self.string_constant(key);
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             self.compile_node(value)?;
         }

--- a/crates/harn-vm/src/compiler/mod.rs
+++ b/crates/harn-vm/src/compiler/mod.rs
@@ -142,6 +142,9 @@ pub struct Compiler {
     /// from the parser's diagnostic type checker so compile-only callers keep
     /// working without a required type-check pass.
     type_scopes: Vec<std::collections::HashMap<String, TypeExpr>>,
+    /// Current-chunk string constant index. This avoids repeatedly scanning the
+    /// constant pool while compiling name-heavy scripts.
+    string_constants: std::collections::HashMap<String, u16>,
     /// Lexical variable slots for the current compiled frame. The compiler
     /// only consults this for names declared inside the current function-like
     /// body; all unresolved names stay on the existing dynamic/name path.
@@ -179,7 +182,7 @@ impl Compiler {
                 self.chunk.emit_u16(Op::Constant, idx, self.line);
             }
             Node::StringLiteral(s) | Node::RawStringLiteral(s) => {
-                let idx = self.chunk.add_constant(Constant::String(s.clone()));
+                let idx = self.string_constant(s);
                 self.chunk.emit_u16(Op::Constant, idx, self.line);
             }
             Node::BoolLiteral(true) => self.chunk.emit(Op::True, self.line),
@@ -290,7 +293,7 @@ impl Compiler {
                 for arg in args {
                     self.compile_node(arg)?;
                 }
-                let name_idx = self.chunk.add_constant(Constant::String(method.clone()));
+                let name_idx = self.string_constant(method);
                 self.chunk
                     .emit_method_call_opt(name_idx, args.len() as u8, self.line);
             }
@@ -299,7 +302,7 @@ impl Compiler {
             }
             Node::OptionalPropertyAccess { object, property } => {
                 self.compile_node(object)?;
-                let idx = self.chunk.add_constant(Constant::String(property.clone()));
+                let idx = self.string_constant(property);
                 self.chunk.emit_u16(Op::GetPropertyOpt, idx, self.line);
             }
             Node::SubscriptAccess { object, index } => {
@@ -408,9 +411,7 @@ impl Compiler {
                 end,
                 inclusive,
             } => {
-                let name_idx = self
-                    .chunk
-                    .add_constant(Constant::String("__range__".to_string()));
+                let name_idx = self.string_constant("__range__");
                 self.chunk.emit_u16(Op::Constant, name_idx, self.line);
                 self.compile_node(start)?;
                 self.compile_node(end)?;
@@ -434,9 +435,7 @@ impl Compiler {
                 if let Some(message) = message {
                     self.compile_node(message)?;
                 } else {
-                    let idx = self
-                        .chunk
-                        .add_constant(Constant::String("require condition failed".to_string()));
+                    let idx = self.string_constant("require condition failed");
                     self.chunk.emit_u16(Op::Constant, idx, self.line);
                 }
                 self.chunk.emit(Op::Throw, self.line);
@@ -455,9 +454,7 @@ impl Compiler {
             Node::MutexBlock { body } => {
                 self.begin_scope();
                 let finally_floor = self.finally_bodies.len();
-                let key_idx = self
-                    .chunk
-                    .add_constant(Constant::String("__default__".to_string()));
+                let key_idx = self.string_constant("__default__");
                 self.chunk.emit_u16(Op::SyncMutexEnter, key_idx, self.line);
                 for sn in body {
                     self.compile_node(sn)?;
@@ -501,13 +498,13 @@ impl Compiler {
                 self.compile_struct_construct(struct_name, fields)?;
             }
             Node::ImportDecl { path, .. } => {
-                let idx = self.chunk.add_constant(Constant::String(path.clone()));
+                let idx = self.string_constant(path);
                 self.chunk.emit_u16(Op::Import, idx, self.line);
             }
             Node::SelectiveImport { names, path, .. } => {
-                let path_idx = self.chunk.add_constant(Constant::String(path.clone()));
+                let path_idx = self.string_constant(path);
                 let names_str = names.join(",");
-                let names_idx = self.chunk.add_constant(Constant::String(names_str));
+                let names_idx = self.owned_string_constant(names_str);
                 self.chunk
                     .emit_u16(Op::SelectiveImport, path_idx, self.line);
                 let hi = (names_idx >> 8) as u8;

--- a/crates/harn-vm/src/compiler/patterns.rs
+++ b/crates/harn-vm/src/compiler/patterns.rs
@@ -29,9 +29,7 @@ impl Compiler {
             BindingPattern::Dict(fields) => {
                 // Runtime `__assert_dict(value)` type check on the RHS.
                 self.chunk.emit(Op::Dup, self.line);
-                let assert_idx = self
-                    .chunk
-                    .add_constant(Constant::String("__assert_dict".into()));
+                let assert_idx = self.string_constant("__assert_dict");
                 self.chunk.emit_u16(Op::Constant, assert_idx, self.line);
                 self.chunk.emit(Op::Swap, self.line);
                 self.chunk.emit_u8(Op::Call, 1, self.line);
@@ -42,7 +40,7 @@ impl Compiler {
 
                 for field in &non_rest {
                     self.chunk.emit(Op::Dup, self.line);
-                    let key_idx = self.chunk.add_constant(Constant::String(field.key.clone()));
+                    let key_idx = self.string_constant(&field.key);
                     self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                     self.chunk.emit(Op::Subscript, self.line);
                     if let Some(default_expr) = &field.default_value {
@@ -65,13 +63,11 @@ impl Compiler {
 
                 if let Some(rest) = rest_field {
                     // `__dict_rest(dict, [keys_to_exclude])`.
-                    let fn_idx = self
-                        .chunk
-                        .add_constant(Constant::String("__dict_rest".into()));
+                    let fn_idx = self.string_constant("__dict_rest");
                     self.chunk.emit_u16(Op::Constant, fn_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     for field in &non_rest {
-                        let key_idx = self.chunk.add_constant(Constant::String(field.key.clone()));
+                        let key_idx = self.string_constant(&field.key);
                         self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                     }
                     self.chunk
@@ -85,16 +81,12 @@ impl Compiler {
             }
             BindingPattern::Pair(first_name, second_name) => {
                 self.chunk.emit(Op::Dup, self.line);
-                let first_key_idx = self
-                    .chunk
-                    .add_constant(Constant::String("first".to_string()));
+                let first_key_idx = self.string_constant("first");
                 self.chunk
                     .emit_u16(Op::GetProperty, first_key_idx, self.line);
                 self.emit_binding_target(first_name, is_mutable);
 
-                let second_key_idx = self
-                    .chunk
-                    .add_constant(Constant::String("second".to_string()));
+                let second_key_idx = self.string_constant("second");
                 self.chunk
                     .emit_u16(Op::GetProperty, second_key_idx, self.line);
                 self.emit_binding_target(second_name, is_mutable);
@@ -103,9 +95,7 @@ impl Compiler {
             BindingPattern::List(elements) => {
                 // Runtime `__assert_list(value)` type check on the RHS.
                 self.chunk.emit(Op::Dup, self.line);
-                let assert_idx = self
-                    .chunk
-                    .add_constant(Constant::String("__assert_list".into()));
+                let assert_idx = self.string_constant("__assert_list");
                 self.chunk.emit_u16(Op::Constant, assert_idx, self.line);
                 self.chunk.emit(Op::Swap, self.line);
                 self.chunk.emit_u8(Op::Call, 1, self.line);
@@ -192,8 +182,8 @@ impl Compiler {
                     args: pat_args,
                 } => {
                     self.chunk.emit(Op::Dup, self.line);
-                    let en_idx = self.chunk.add_constant(Constant::String(enum_name.clone()));
-                    let vn_idx = self.chunk.add_constant(Constant::String(variant.clone()));
+                    let en_idx = self.string_constant(enum_name);
+                    let vn_idx = self.string_constant(variant);
                     self.chunk.emit_u16(Op::MatchEnum, en_idx, self.line);
                     let hi = (vn_idx >> 8) as u8;
                     let lo = vn_idx as u8;
@@ -212,9 +202,7 @@ impl Compiler {
                     for (i, pat_arg) in pat_args.iter().enumerate() {
                         if let Node::Identifier(binding_name) = &pat_arg.node {
                             self.chunk.emit(Op::Dup, self.line);
-                            let fields_idx = self
-                                .chunk
-                                .add_constant(Constant::String("fields".to_string()));
+                            let fields_idx = self.string_constant("fields");
                             self.chunk.emit_u16(Op::GetProperty, fields_idx, self.line);
                             let idx_const = self.chunk.add_constant(Constant::Int(i as i64));
                             self.chunk.emit_u16(Op::Constant, idx_const, self.line);
@@ -248,13 +236,13 @@ impl Compiler {
                 Node::PropertyAccess { object, property } if matches!(&object.node, Node::Identifier(n) if self.enum_names.contains(n)) =>
                 {
                     let enum_name = if let Node::Identifier(n) = &object.node {
-                        n.clone()
+                        n.as_str()
                     } else {
                         unreachable!()
                     };
                     self.chunk.emit(Op::Dup, self.line);
-                    let en_idx = self.chunk.add_constant(Constant::String(enum_name));
-                    let vn_idx = self.chunk.add_constant(Constant::String(property.clone()));
+                    let en_idx = self.string_constant(enum_name);
+                    let vn_idx = self.string_constant(property);
                     self.chunk.emit_u16(Op::MatchEnum, en_idx, self.line);
                     let hi = (vn_idx >> 8) as u8;
                     let lo = vn_idx as u8;
@@ -296,13 +284,13 @@ impl Compiler {
                     args: pat_args,
                 } if matches!(&object.node, Node::Identifier(n) if self.enum_names.contains(n)) => {
                     let enum_name = if let Node::Identifier(n) = &object.node {
-                        n.clone()
+                        n.as_str()
                     } else {
                         unreachable!()
                     };
                     self.chunk.emit(Op::Dup, self.line);
-                    let en_idx = self.chunk.add_constant(Constant::String(enum_name));
-                    let vn_idx = self.chunk.add_constant(Constant::String(method.clone()));
+                    let en_idx = self.string_constant(enum_name);
+                    let vn_idx = self.string_constant(method);
                     self.chunk.emit_u16(Op::MatchEnum, en_idx, self.line);
                     let hi = (vn_idx >> 8) as u8;
                     let lo = vn_idx as u8;
@@ -319,9 +307,7 @@ impl Compiler {
                     for (i, pat_arg) in pat_args.iter().enumerate() {
                         if let Node::Identifier(binding_name) = &pat_arg.node {
                             self.chunk.emit(Op::Dup, self.line);
-                            let fields_idx = self
-                                .chunk
-                                .add_constant(Constant::String("fields".to_string()));
+                            let fields_idx = self.string_constant("fields");
                             self.chunk.emit_u16(Op::GetProperty, fields_idx, self.line);
                             let idx_const = self.chunk.add_constant(Constant::Int(i as i64));
                             self.chunk.emit_u16(Op::Constant, idx_const, self.line);
@@ -382,11 +368,11 @@ impl Compiler {
                         .all(|e| matches!(&e.key.node, Node::StringLiteral(_))) =>
                 {
                     self.chunk.emit(Op::Dup, self.line);
-                    let typeof_idx = self.chunk.add_constant(Constant::String("type_of".into()));
+                    let typeof_idx = self.string_constant("type_of");
                     self.chunk.emit_u16(Op::Constant, typeof_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     self.chunk.emit_u8(Op::Call, 1, self.line);
-                    let dict_str = self.chunk.add_constant(Constant::String("dict".into()));
+                    let dict_str = self.string_constant("dict");
                     self.chunk.emit_u16(Op::Constant, dict_str, self.line);
                     self.chunk.emit(Op::Equal, self.line);
                     let skip_type = self.chunk.emit_jump(Op::JumpIfFalse, self.line);
@@ -404,8 +390,7 @@ impl Compiler {
                                 | Node::BoolLiteral(_)
                                 | Node::NilLiteral => {
                                     self.chunk.emit(Op::Dup, self.line);
-                                    let key_idx =
-                                        self.chunk.add_constant(Constant::String(key.clone()));
+                                    let key_idx = self.string_constant(key);
                                     self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                                     self.chunk.emit(Op::Subscript, self.line);
                                     self.compile_node(&entry.value)?;
@@ -420,8 +405,7 @@ impl Compiler {
                                 _ => {
                                     // Complex expression constraint: dict[key] == expr.
                                     self.chunk.emit(Op::Dup, self.line);
-                                    let key_idx =
-                                        self.chunk.add_constant(Constant::String(key.clone()));
+                                    let key_idx = self.string_constant(key);
                                     self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                                     self.chunk.emit(Op::Subscript, self.line);
                                     self.compile_node(&entry.value)?;
@@ -436,7 +420,7 @@ impl Compiler {
 
                     for (key, binding) in &bindings {
                         self.chunk.emit(Op::Dup, self.line);
-                        let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+                        let key_idx = self.string_constant(key);
                         self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                         self.chunk.emit(Op::Subscript, self.line);
                         self.emit_binding_target(binding, false);
@@ -478,18 +462,18 @@ impl Compiler {
                 // List pattern: [literal, binding, ...]
                 Node::ListLiteral(elements) => {
                     self.chunk.emit(Op::Dup, self.line);
-                    let typeof_idx = self.chunk.add_constant(Constant::String("type_of".into()));
+                    let typeof_idx = self.string_constant("type_of");
                     self.chunk.emit_u16(Op::Constant, typeof_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     self.chunk.emit_u8(Op::Call, 1, self.line);
-                    let list_str = self.chunk.add_constant(Constant::String("list".into()));
+                    let list_str = self.string_constant("list");
                     self.chunk.emit_u16(Op::Constant, list_str, self.line);
                     self.chunk.emit(Op::Equal, self.line);
                     let skip_type = self.chunk.emit_jump(Op::JumpIfFalse, self.line);
                     self.chunk.emit(Op::Pop, self.line);
 
                     self.chunk.emit(Op::Dup, self.line);
-                    let len_idx = self.chunk.add_constant(Constant::String("len".into()));
+                    let len_idx = self.string_constant("len");
                     self.chunk.emit_u16(Op::Constant, len_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     self.chunk.emit_u8(Op::Call, 1, self.line);
@@ -655,9 +639,7 @@ impl Compiler {
                 }
             }
         }
-        let msg_idx = self.chunk.add_constant(Constant::String(
-            "No match arm matched the value".to_string(),
-        ));
+        let msg_idx = self.string_constant("No match arm matched the value");
         self.chunk.emit(Op::Pop, self.line);
         self.chunk.emit_u16(Op::Constant, msg_idx, self.line);
         self.chunk.emit(Op::Throw, self.line);

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -31,6 +31,7 @@ impl Compiler {
             scope_depth: 0,
             type_aliases: std::collections::HashMap::new(),
             type_scopes: vec![std::collections::HashMap::new()],
+            string_constants: std::collections::HashMap::new(),
             local_scopes: vec![std::collections::HashMap::new()],
             module_level: true,
         }
@@ -59,6 +60,25 @@ impl Compiler {
         names.sort();
         names.dedup();
         names
+    }
+
+    pub(super) fn string_constant(&mut self, value: &str) -> u16 {
+        if let Some(idx) = self.string_constants.get(value) {
+            return *idx;
+        }
+        let owned = value.to_string();
+        let idx = self.chunk.add_constant(Constant::String(owned.clone()));
+        self.string_constants.insert(owned, idx);
+        idx
+    }
+
+    pub(super) fn owned_string_constant(&mut self, value: String) -> u16 {
+        if let Some(idx) = self.string_constants.get(value.as_str()) {
+            return *idx;
+        }
+        let idx = self.chunk.add_constant(Constant::String(value.clone()));
+        self.string_constants.insert(value, idx);
+        idx
     }
 
     /// Populate `type_aliases` from a program's top-level `type T = ...`
@@ -229,7 +249,7 @@ impl Compiler {
             // global. The typechecker rejects every other signature with
             // HARN-NAM-101 so we don't need to re-validate the shape here.
             if Self::has_top_level_fn_main(program) {
-                let harness_name = self.chunk.add_constant(Constant::String("harness".into()));
+                let harness_name = self.string_constant("harness");
                 self.chunk.emit_u16(Op::GetVar, harness_name, self.line);
                 self.emit_named_call("main", 1);
                 pipeline_emits_value = true;
@@ -369,19 +389,15 @@ impl Compiler {
 
                 if let harn_parser::TypeExpr::Named(name) = &check_type {
                     if let Some(methods) = self.interface_methods.get(name).cloned() {
-                        let fn_idx = self
-                            .chunk
-                            .add_constant(Constant::String("__assert_interface".into()));
+                        let fn_idx = self.string_constant("__assert_interface");
                         self.chunk.emit_u16(Op::Constant, fn_idx, self.line);
                         self.emit_get_binding(&param.name);
-                        let name_idx = self
-                            .chunk
-                            .add_constant(Constant::String(param.name.clone()));
+                        let name_idx = self.string_constant(&param.name);
                         self.chunk.emit_u16(Op::Constant, name_idx, self.line);
-                        let iface_idx = self.chunk.add_constant(Constant::String(name.clone()));
+                        let iface_idx = self.string_constant(name);
                         self.chunk.emit_u16(Op::Constant, iface_idx, self.line);
                         let methods_str = methods.join(",");
-                        let methods_idx = self.chunk.add_constant(Constant::String(methods_str));
+                        let methods_idx = self.owned_string_constant(methods_str);
                         self.chunk.emit_u16(Op::Constant, methods_idx, self.line);
                         self.chunk.emit_u8(Op::Call, 4, self.line);
                         self.chunk.emit(Op::Pop, self.line);
@@ -420,14 +436,10 @@ impl Compiler {
     }
 
     fn emit_schema_assert_call(&mut self, param: &TypedParam, schema: &VmValue) {
-        let fn_idx = self
-            .chunk
-            .add_constant(Constant::String("__assert_schema".into()));
+        let fn_idx = self.string_constant("__assert_schema");
         self.chunk.emit_u16(Op::Constant, fn_idx, self.line);
         self.emit_get_binding(&param.name);
-        let name_idx = self
-            .chunk
-            .add_constant(Constant::String(param.name.clone()));
+        let name_idx = self.string_constant(&param.name);
         self.chunk.emit_u16(Op::Constant, name_idx, self.line);
         self.emit_vm_value_literal(schema);
         self.chunk.emit_u8(Op::Call, 3, self.line);
@@ -577,7 +589,7 @@ impl Compiler {
     pub(super) fn emit_vm_value_literal(&mut self, value: &VmValue) {
         match value {
             VmValue::String(text) => {
-                let idx = self.chunk.add_constant(Constant::String(text.to_string()));
+                let idx = self.string_constant(text);
                 self.chunk.emit_u16(Op::Constant, idx, self.line);
             }
             VmValue::Int(number) => {
@@ -602,7 +614,7 @@ impl Compiler {
             }
             VmValue::Dict(entries) => {
                 for (key, item) in entries.iter() {
-                    let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+                    let key_idx = self.string_constant(key);
                     self.chunk.emit_u16(Op::Constant, key_idx, self.line);
                     self.emit_vm_value_literal(item);
                 }
@@ -769,7 +781,7 @@ impl Compiler {
             self.chunk
                 .emit_u16(Op::GetLocalSlot, binding.slot, self.line);
         } else {
-            let idx = self.chunk.add_constant(Constant::String(name.to_string()));
+            let idx = self.string_constant(name);
             self.chunk.emit_u16(Op::GetVar, idx, self.line);
         }
     }
@@ -778,7 +790,7 @@ impl Compiler {
         if let Some(slot) = self.define_local_slot(name, mutable) {
             self.chunk.emit_u16(Op::DefLocalSlot, slot, self.line);
         } else {
-            let idx = self.chunk.add_constant(Constant::String(name.to_string()));
+            let idx = self.string_constant(name);
             let op = if mutable { Op::DefVar } else { Op::DefLet };
             self.chunk.emit_u16(op, idx, self.line);
         }
@@ -799,7 +811,7 @@ impl Compiler {
             self.chunk
                 .emit_u16(Op::SetLocalSlot, binding.slot, self.line);
         } else {
-            let idx = self.chunk.add_constant(Constant::String(name.to_string()));
+            let idx = self.string_constant(name);
             self.chunk.emit_u16(Op::SetVar, idx, self.line);
         }
     }

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -1,6 +1,6 @@
 use harn_parser::{Node, SNode};
 
-use crate::chunk::{Constant, Op};
+use crate::chunk::Op;
 
 use super::error::CompileError;
 use super::pipe::contains_pipe_placeholder;
@@ -43,8 +43,8 @@ impl Compiler {
             }
         } else if let Node::PropertyAccess { object, property } = &target.node {
             if let Some(var_name) = self.root_var_name(object) {
-                let var_idx = self.chunk.add_constant(Constant::String(var_name.clone()));
-                let prop_idx = self.chunk.add_constant(Constant::String(property.clone()));
+                let var_idx = self.string_constant(&var_name);
+                let prop_idx = self.string_constant(property);
                 if let Some(op) = op {
                     self.compile_node(target)?;
                     self.compile_node(value)?;
@@ -66,7 +66,7 @@ impl Compiler {
             }
         } else if let Node::SubscriptAccess { object, index } = &target.node {
             if let Some(var_name) = self.root_var_name(object) {
-                let var_idx = self.chunk.add_constant(Constant::String(var_name.clone()));
+                let var_idx = self.string_constant(&var_name);
                 if let Some(op) = op {
                     self.compile_node(target)?;
                     self.compile_node(value)?;
@@ -216,7 +216,7 @@ impl Compiler {
             // No pending finally — use tail-call optimization when possible.
             if let Some(val) = value {
                 if let Node::FunctionCall { name, args, .. } = &val.node {
-                    let name_idx = self.chunk.add_constant(Constant::String(name.clone()));
+                    let name_idx = self.string_constant(name);
                     self.chunk.emit_u16(Op::Constant, name_idx, self.line);
                     for arg in args {
                         self.compile_node(arg)?;
@@ -248,22 +248,18 @@ impl Compiler {
         options: &[(String, SNode)],
         body: &[SNode],
     ) -> Result<(), CompileError> {
-        let route_idx = self
-            .chunk
-            .add_constant(Constant::String("__cost_route".to_string()));
+        let route_idx = self.string_constant("__cost_route");
         self.chunk.emit_u16(Op::Constant, route_idx, self.line);
 
         for (key, value) in options {
-            let key_idx = self.chunk.add_constant(Constant::String(key.clone()));
+            let key_idx = self.string_constant(key);
             self.chunk.emit_u16(Op::Constant, key_idx, self.line);
             if matches!(
                 key.as_str(),
                 "fallback_strategy" | "strategy" | "quality" | "min_quality"
             ) {
                 if let Node::Identifier(identifier) = &value.node {
-                    let value_idx = self
-                        .chunk
-                        .add_constant(Constant::String(identifier.clone()));
+                    let value_idx = self.string_constant(identifier);
                     self.chunk.emit_u16(Op::Constant, value_idx, self.line);
                     continue;
                 }

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -25,6 +25,14 @@ fn disasm_opcodes(disasm: &str) -> Vec<&str> {
         .collect()
 }
 
+fn string_constant_count(chunk: &Chunk, value: &str) -> usize {
+    chunk
+        .constants
+        .iter()
+        .filter(|constant| matches!(constant, Constant::String(text) if text == value))
+        .count()
+}
+
 #[test]
 fn test_compile_arithmetic() {
     let chunk = compile_source_with_options(
@@ -154,6 +162,42 @@ fn test_optimizer_folds_literal_collections_and_strings() {
         .contains(&Constant::String("haha".to_string())));
     assert!(!opcodes.contains(&"ADD"));
     assert!(!opcodes.contains(&"MUL"));
+}
+
+#[test]
+fn test_compiler_reuses_string_constants_within_chunk() {
+    let chunk = compile_source(
+        r#"pipeline test(task) {
+  log("same")
+  log("same")
+  let row = {status: "same"}
+  log(row.status)
+}"#,
+    );
+
+    assert_eq!(string_constant_count(&chunk, "same"), 1);
+    assert_eq!(string_constant_count(&chunk, "status"), 1);
+}
+
+#[test]
+fn test_compiler_reuses_string_constants_per_nested_chunk() {
+    let chunk = compile_source(
+        r#"fn inner() {
+  log("nested")
+  log("nested")
+}
+
+pipeline test(task) {
+  inner()
+}"#,
+    );
+    let function = chunk
+        .functions
+        .iter()
+        .find(|function| function.name == "inner")
+        .expect("inner function should compile");
+
+    assert_eq!(string_constant_count(&function.chunk, "nested"), 1);
 }
 
 #[test]

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -332,17 +332,13 @@ impl VmValue {
         }
     }
 
-    pub fn struct_instance_with_property(
-        &self,
-        field_name: String,
-        value: VmValue,
-    ) -> Option<Self> {
+    pub fn struct_instance_with_property(&self, field_name: &str, value: VmValue) -> Option<Self> {
         let VmValue::StructInstance { layout, fields } = self else {
             return None;
         };
 
         let mut new_fields = fields.as_ref().clone();
-        let layout = match layout.field_index(&field_name) {
+        let layout = match layout.field_index(field_name) {
             Some(index) => {
                 if index >= new_fields.len() {
                     new_fields.resize(index + 1, None);
@@ -351,7 +347,7 @@ impl VmValue {
                 Rc::clone(layout)
             }
             None => {
-                let new_layout = Rc::new(layout.with_appended_field(field_name));
+                let new_layout = Rc::new(layout.with_appended_field(field_name.to_string()));
                 new_fields.push(Some(value));
                 new_layout
             }

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -174,12 +174,10 @@ impl Vm {
         };
 
         if let Some(handler) = self.exception_handlers.pop() {
-            if !handler.error_type.is_empty() {
+            if let Some(error_type) = handler.error_type.as_deref() {
                 // Typed catch: only match when the thrown enum's type equals the declared type.
                 let matches = match &thrown_value {
-                    VmValue::EnumVariant(enum_variant) => {
-                        enum_variant.has_enum_name(&handler.error_type)
-                    }
+                    VmValue::EnumVariant(enum_variant) => enum_variant.has_enum_name(error_type),
                     _ => false,
                 };
                 if !matches {

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1041,26 +1041,32 @@ impl super::super::Vm {
     /// Async path for `Op::CallBuiltin`. Arguments stay on the VM stack
     /// until the selected callee shape requires owned arguments.
     pub(super) async fn execute_call_builtin_async(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
-        frame.ip += 8;
-        let name_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let argc = frame.chunk.code[frame.ip] as usize;
-        frame.ip += 1;
-        let name = Self::const_string(&frame.chunk.constants[name_idx])?;
+        let (chunk, id, name_idx, argc) = {
+            let frame = self.frames.last_mut().unwrap();
+            let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
+            frame.ip += 8;
+            let name_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let argc = frame.chunk.code[frame.ip] as usize;
+            frame.ip += 1;
+            (Rc::clone(&frame.chunk), id, name_idx, argc)
+        };
+        let name = Self::const_str(&chunk.constants[name_idx])?;
         let args_start = self.stack_arg_start(argc)?;
-        self.call_named_value_from_stack_args(&name, args_start, args_start, Some(id))
+        self.call_named_value_from_stack_args(name, args_start, args_start, Some(id))
             .await
     }
 
     pub(super) async fn execute_call_builtin_spread(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
-        frame.ip += 8;
-        let name_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let name = Self::const_string(&frame.chunk.constants[name_idx])?;
+        let (chunk, id, name_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let id = BuiltinId::from_raw(frame.chunk.read_u64(frame.ip));
+            frame.ip += 8;
+            let name_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), id, name_idx)
+        };
+        let name = Self::const_str(&chunk.constants[name_idx])?;
         let args_val = self.pop()?;
         let args = match args_val {
             VmValue::List(items) => (*items).clone(),
@@ -1070,7 +1076,7 @@ impl super::super::Vm {
                 ))
             }
         };
-        self.call_named_value(&name, args, Some(id)).await
+        self.call_named_value(name, args, Some(id)).await
     }
 
     /// Tail-call optimization body: validate arguments directly on the VM
@@ -1339,20 +1345,21 @@ impl super::super::Vm {
             self.stack.truncate(obj_idx);
             self.stack.push(result);
         } else {
-            let method = {
+            let chunk = {
                 let frame = self.frames.last().unwrap();
-                Self::const_string(&frame.chunk.constants[name_idx as usize])?
+                Rc::clone(&frame.chunk)
             };
-            let cache_target = Self::method_cache_target(&obj, &method, argc);
+            let method = Self::const_str(&chunk.constants[name_idx as usize])?;
+            let cache_target = Self::method_cache_target(&obj, method, argc);
             let result = if let Some(result) =
-                Self::call_method_sync(&obj, &method, &self.stack[args_start..])
+                Self::call_method_sync(&obj, method, &self.stack[args_start..])
             {
                 self.stack.truncate(obj_idx);
                 result?
             } else {
                 let args = self.take_stack_args_from(args_start)?;
                 self.stack.truncate(obj_idx);
-                self.call_method_async(obj, &method, &args).await?
+                self.call_method_async(obj, method, &args).await?
             };
             if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
                 let frame = self.frames.last().unwrap();
@@ -1492,15 +1499,16 @@ impl super::super::Vm {
         {
             self.stack.push(result);
         } else {
-            let method = {
+            let chunk = {
                 let frame = self.frames.last().unwrap();
-                Self::const_string(&frame.chunk.constants[name_idx as usize])?
+                Rc::clone(&frame.chunk)
             };
-            let cache_target = Self::method_cache_target(&obj, &method, args.len());
-            let result = if let Some(result) = Self::call_method_sync(&obj, &method, &args) {
+            let method = Self::const_str(&chunk.constants[name_idx as usize])?;
+            let cache_target = Self::method_cache_target(&obj, method, args.len());
+            let result = if let Some(result) = Self::call_method_sync(&obj, method, &args) {
                 result?
             } else {
-                self.call_method_async(obj, &method, &args).await?
+                self.call_method_async(obj, method, &args).await?
             };
             if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
                 let frame = self.frames.last().unwrap();

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -5,6 +5,18 @@ use crate::chunk::{InlineCacheEntry, PropertyCacheTarget};
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
+    fn concat_display_values(parts: &[VmValue]) -> String {
+        let all_strings_len = parts.iter().try_fold(0usize, |len, part| match part {
+            VmValue::String(text) => Some(len + text.len()),
+            _ => None,
+        });
+        let mut result = String::with_capacity(all_strings_len.unwrap_or(0));
+        for part in parts {
+            part.write_display(&mut result);
+        }
+        result
+    }
+
     fn char_to_value(ch: char) -> VmValue {
         let mut buffer = [0; 4];
         VmValue::String(Rc::from(ch.encode_utf8(&mut buffer)))
@@ -446,28 +458,31 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_set_property(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let prop_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let var_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let prop_name = Self::const_string(&frame.chunk.constants[prop_idx])?;
-        let var_name = Self::const_string(&frame.chunk.constants[var_idx])?;
+        let (chunk, prop_idx, var_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let prop_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let var_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), prop_idx, var_idx)
+        };
+        let prop_name = Self::const_str(&chunk.constants[prop_idx])?;
+        let var_name = Self::const_str(&chunk.constants[var_idx])?;
         let new_value = self.pop()?;
         if let Some(obj) = self
-            .active_local_slot_value(&var_name)
-            .or_else(|| self.env.get(&var_name))
+            .active_local_slot_value(var_name)
+            .or_else(|| self.env.get(var_name))
         {
             let assign_value = |vm: &mut Self, value: VmValue| -> Result<(), VmError> {
-                if !vm.assign_active_local_slot(&var_name, value.clone(), false)? {
-                    vm.env.assign(&var_name, value)?;
+                if !vm.assign_active_local_slot(var_name, value.clone(), false)? {
+                    vm.env.assign(var_name, value)?;
                 }
                 Ok(())
             };
             match obj {
                 VmValue::Dict(map) => {
                     let mut new_map = (*map).clone();
-                    new_map.insert(prop_name, new_value);
+                    new_map.insert(prop_name.to_string(), new_value);
                     assign_value(self, VmValue::Dict(Rc::new(new_map)))?;
                 }
                 VmValue::StructInstance { .. } => {
@@ -488,10 +503,13 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_set_subscript(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let var_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let var_name = Self::const_string(&frame.chunk.constants[var_idx])?;
+        let (chunk, var_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let var_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), var_idx)
+        };
+        let var_name = Self::const_str(&chunk.constants[var_idx])?;
         let index = self.pop()?;
         let new_value = self.pop()?;
 
@@ -500,10 +518,10 @@ impl super::super::Vm {
         // defensive `VmValue::clone` + collection clone the env-fallback
         // path has to pay, which is the per-iteration cost behind builder
         // loops like `out[k] = v` and `aliases[id] = …`.
-        if let Some(slot_idx) = self.active_local_slot_index(&var_name) {
+        if let Some(slot_idx) = self.active_local_slot_index(var_name) {
             let frame = self.frames.last_mut().unwrap();
             if !frame.chunk.local_slots[slot_idx].mutable {
-                return Err(VmError::ImmutableAssignment(var_name));
+                return Err(VmError::ImmutableAssignment(var_name.to_string()));
             }
             let slot = &mut frame.local_slots[slot_idx];
             match &mut slot.value {
@@ -539,7 +557,7 @@ impl super::super::Vm {
         // declared in an outer scope). The env path still has to rebind
         // because `env.get` returns by value, but `Rc::try_unwrap` keeps
         // the no-other-references case allocation-free.
-        if let Some(obj) = self.env.get(&var_name) {
+        if let Some(obj) = self.env.get(var_name) {
             match obj {
                 VmValue::List(items) => {
                     if let Some(i) = index.as_int() {
@@ -559,15 +577,14 @@ impl super::super::Vm {
                         }
                         new_items[idx] = new_value;
                         self.env
-                            .assign(&var_name, VmValue::List(Rc::new(new_items)))?;
+                            .assign(var_name, VmValue::List(Rc::new(new_items)))?;
                     }
                 }
                 VmValue::Dict(map) => {
                     let key = index.display();
                     let mut new_map = Rc::try_unwrap(map).unwrap_or_else(|map| (*map).clone());
                     new_map.insert(key, new_value);
-                    self.env
-                        .assign(&var_name, VmValue::Dict(Rc::new(new_map)))?;
+                    self.env.assign(var_name, VmValue::Dict(Rc::new(new_map)))?;
                 }
                 _ => {}
             }
@@ -579,21 +596,29 @@ impl super::super::Vm {
         let frame = self.frames.last_mut().unwrap();
         let count = frame.chunk.read_u16(frame.ip) as usize;
         frame.ip += 2;
-        let parts = self.stack.split_off(self.stack.len().saturating_sub(count));
-        let result: String = parts.iter().map(|p| p.display()).collect();
+        let start = self.stack.len().saturating_sub(count);
+        let result = Self::concat_display_values(&self.stack[start..]);
+        self.stack.truncate(start);
         self.stack.push(VmValue::String(Rc::from(result)));
     }
 
     pub(super) fn execute_build_enum(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let field_count = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let enum_name = Self::const_string(&frame.chunk.constants[enum_idx])?;
-        let variant = Self::const_string(&frame.chunk.constants[variant_idx])?;
+        let (chunk, enum_idx, variant_idx, field_count) = {
+            let frame = self.frames.last_mut().unwrap();
+            let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let field_count = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), enum_idx, variant_idx, field_count)
+        };
+        let enum_name = chunk
+            .constant_string_rc(enum_idx)
+            .ok_or_else(|| VmError::TypeError("expected string constant".into()))?;
+        let variant = chunk
+            .constant_string_rc(variant_idx)
+            .ok_or_else(|| VmError::TypeError("expected string constant".into()))?;
         let fields = self
             .stack
             .split_off(self.stack.len().saturating_sub(field_count));
@@ -603,18 +628,19 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_match_enum(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let enum_name = Self::const_string(&frame.chunk.constants[enum_idx])?;
-        let variant_name = Self::const_string(&frame.chunk.constants[variant_idx])?;
+        let (chunk, enum_idx, variant_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let enum_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let variant_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), enum_idx, variant_idx)
+        };
+        let enum_name = Self::const_str(&chunk.constants[enum_idx])?;
+        let variant_name = Self::const_str(&chunk.constants[variant_idx])?;
         let val = self.pop()?;
         let matches = match &val {
-            VmValue::EnumVariant(enum_variant) => {
-                enum_variant.is_variant(&enum_name, &variant_name)
-            }
+            VmValue::EnumVariant(enum_variant) => enum_variant.is_variant(enum_name, variant_name),
             _ => false,
         };
         self.stack.push(val);

--- a/crates/harn-vm/src/vm/ops/exception.rs
+++ b/crates/harn-vm/src/vm/ops/exception.rs
@@ -1,4 +1,3 @@
-use crate::chunk::Constant;
 use crate::value::{VmError, VmValue};
 
 use super::super::ExceptionHandler;
@@ -15,10 +14,10 @@ impl super::super::Vm {
         frame.ip += 2;
         let type_idx = frame.chunk.read_u16(frame.ip) as usize;
         frame.ip += 2;
-        let error_type = match &frame.chunk.constants[type_idx] {
-            Constant::String(s) => s.clone(),
-            _ => String::new(),
-        };
+        let error_type = frame
+            .chunk
+            .constant_string_rc(type_idx)
+            .filter(|name| !name.is_empty());
         self.exception_handlers.push(ExceptionHandler {
             catch_ip: catch_offset,
             stack_depth: self.stack.len(),

--- a/crates/harn-vm/src/vm/ops/imports.rs
+++ b/crates/harn-vm/src/vm/ops/imports.rs
@@ -1,23 +1,31 @@
+use std::rc::Rc;
+
 use crate::value::VmError;
 
 impl super::super::Vm {
     pub(super) async fn execute_import_op(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let path_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let import_path = Self::const_string(&frame.chunk.constants[path_idx])?;
-        self.execute_import(&import_path, None).await
+        let (chunk, path_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let path_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), path_idx)
+        };
+        let import_path = Self::const_str(&chunk.constants[path_idx])?;
+        self.execute_import(import_path, None).await
     }
 
     pub(super) async fn execute_selective_import(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let path_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let names_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let import_path = Self::const_string(&frame.chunk.constants[path_idx])?;
-        let names_str = Self::const_string(&frame.chunk.constants[names_idx])?;
+        let (chunk, path_idx, names_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let path_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let names_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), path_idx, names_idx)
+        };
+        let import_path = Self::const_str(&chunk.constants[path_idx])?;
+        let names_str = Self::const_str(&chunk.constants[names_idx])?;
         let names: Vec<String> = names_str.split(',').map(|s| s.to_string()).collect();
-        self.execute_import(&import_path, Some(&names)).await
+        self.execute_import(import_path, Some(&names)).await
     }
 }

--- a/crates/harn-vm/src/vm/ops/misc.rs
+++ b/crates/harn-vm/src/vm/ops/misc.rs
@@ -1,22 +1,18 @@
-use crate::chunk::Constant;
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
     pub(super) fn execute_check_type(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let var_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let type_idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let var_name = match &frame.chunk.constants[var_idx] {
-            Constant::String(s) => s.clone(),
-            _ => return Err(VmError::TypeError("expected string constant".into())),
+        let (chunk, var_idx, type_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let var_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let type_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (std::rc::Rc::clone(&frame.chunk), var_idx, type_idx)
         };
-        let expected_type = match &frame.chunk.constants[type_idx] {
-            Constant::String(s) => s.clone(),
-            _ => return Err(VmError::TypeError("expected string constant".into())),
-        };
-        if let Some(val) = self.env.get(&var_name) {
+        let var_name = Self::const_str(&chunk.constants[var_idx])?;
+        let expected_type = Self::const_str(&chunk.constants[type_idx])?;
+        if let Some(val) = self.env.get(var_name) {
             let actual_type = val.type_name();
             let compatible = actual_type == expected_type
                 || (expected_type == "float" && actual_type == "int")

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -386,15 +386,16 @@ impl super::super::Vm {
     }
 
     pub(super) async fn execute_sync_mutex_enter(&mut self) -> Result<(), VmError> {
-        let key = {
+        let (chunk, idx) = {
             let frame = self.frames.last_mut().unwrap();
             let idx = frame.chunk.read_u16(frame.ip) as usize;
             frame.ip += 2;
-            Self::const_string(&frame.chunk.constants[idx])?
+            (Rc::clone(&frame.chunk), idx)
         };
+        let key = Self::const_str(&chunk.constants[idx])?;
         let permit = self
             .sync_runtime
-            .acquire("mutex", &key, 1, 1, None, self.cancel_token.clone())
+            .acquire("mutex", key, 1, 1, None, self.cancel_token.clone())
             .await?
             .ok_or_else(|| VmError::Runtime(format!("mutex '{key}' timed out")))?;
         self.held_sync_guards

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -1,9 +1,15 @@
 use std::rc::Rc;
 
-use crate::chunk::Constant;
+use crate::chunk::{Chunk, Constant};
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
+    fn constant_name_rc(chunk: &Chunk, idx: usize, fallback: &str) -> Rc<str> {
+        chunk
+            .constant_string_rc(idx)
+            .unwrap_or_else(|| Rc::from(fallback))
+    }
+
     pub(super) fn execute_constant(&mut self) -> Result<(), VmError> {
         let frame = self.frames.last_mut().unwrap();
         let idx = frame.chunk.read_u16(frame.ip) as usize;
@@ -43,46 +49,48 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_get_var(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let name = match &frame.chunk.constants[idx] {
-            Constant::String(s) => s.clone(),
-            _ => return Err(VmError::TypeError("expected string constant".into())),
+        let (chunk, idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), idx)
         };
-        if let Some(val) = self.active_local_slot_value(&name) {
+        let name = Self::const_str(&chunk.constants[idx])?;
+        if let Some(val) = self.active_local_slot_value(name) {
             self.stack.push(val);
-        } else if let Some(val) = self.env.get(&name) {
+        } else if let Some(val) = self.env.get(name) {
             self.stack.push(val);
         } else if let Some(val) = self
             .frames
             .last()
             .and_then(|f| f.module_state.as_ref())
-            .and_then(|ms| ms.borrow().get(&name))
+            .and_then(|ms| ms.borrow().get(name))
         {
             // Module-level var from the closure's originating module.
             self.stack.push(val);
-        } else if let Some(val) = self.globals.get(&name) {
+        } else if let Some(val) = self.globals.get(name) {
             self.stack.push(val.clone());
-        } else if let Some(id) = self.registered_builtin_id(&name) {
+        } else if let Some(id) = self.registered_builtin_id(name) {
             // Allow bare builtin references so they can be passed as callbacks.
             self.stack.push(VmValue::BuiltinRefId {
                 id,
-                name: Rc::from(name.as_str()),
+                name: Self::constant_name_rc(&chunk, idx, name),
             });
-        } else if self.builtins.contains_key(&name) || self.async_builtins.contains_key(&name) {
+        } else if self.builtins.contains_key(name) || self.async_builtins.contains_key(name) {
             // Collided IDs cannot use the direct index, but remain valid callbacks.
-            self.stack
-                .push(VmValue::BuiltinRef(Rc::from(name.as_str())));
-        } else if self.ensure_deferred_builtin(&name) {
-            if let Some(id) = self.registered_builtin_id(&name) {
+            self.stack.push(VmValue::BuiltinRef(Self::constant_name_rc(
+                &chunk, idx, name,
+            )));
+        } else if self.ensure_deferred_builtin(name) {
+            if let Some(id) = self.registered_builtin_id(name) {
                 self.stack.push(VmValue::BuiltinRefId {
                     id,
-                    name: Rc::from(name.as_str()),
+                    name: Self::constant_name_rc(&chunk, idx, name),
                 });
             } else {
-                self.stack
-                    .push(VmValue::BuiltinRef(Rc::from(name.as_str())));
+                self.stack.push(VmValue::BuiltinRef(Self::constant_name_rc(
+                    &chunk, idx, name,
+                )));
             }
         } else {
             let mut all_vars = self.visible_variables();
@@ -95,35 +103,41 @@ impl super::super::Vm {
             candidates.extend(self.async_builtins.keys().cloned());
             candidates.extend(self.deferred_builtin_registrars.keys().cloned());
             if let Some(suggestion) =
-                crate::value::closest_match(&name, candidates.iter().map(|s| s.as_str()))
+                crate::value::closest_match(name, candidates.iter().map(|s| s.as_str()))
             {
                 return Err(VmError::Runtime(format!(
                     "Undefined variable: {name} (did you mean `{suggestion}`?)"
                 )));
             }
-            return Err(VmError::UndefinedVariable(name));
+            return Err(VmError::UndefinedVariable(name.to_string()));
         }
         Ok(())
     }
 
     pub(super) fn execute_def_let(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let name = Self::const_string(&frame.chunk.constants[idx])?;
+        let (chunk, idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), idx)
+        };
+        let name = Self::const_str(&chunk.constants[idx])?;
         let val = self.pop()?;
         self.sync_current_frame_locals_to_env();
-        self.env.define(&name, val, false)
+        self.env.define(name, val, false)
     }
 
     pub(super) fn execute_def_var(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let name = Self::const_string(&frame.chunk.constants[idx])?;
+        let (chunk, idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), idx)
+        };
+        let name = Self::const_str(&chunk.constants[idx])?;
         let val = self.pop()?;
         self.sync_current_frame_locals_to_env();
-        self.env.define(&name, val, true)
+        self.env.define(name, val, true)
     }
 
     pub(super) fn execute_push_scope(&mut self) {
@@ -214,32 +228,35 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_set_var(&mut self) -> Result<(), VmError> {
-        let frame = self.frames.last_mut().unwrap();
-        let idx = frame.chunk.read_u16(frame.ip) as usize;
-        frame.ip += 2;
-        let name = Self::const_string(&frame.chunk.constants[idx])?;
+        let (chunk, idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Rc::clone(&frame.chunk), idx)
+        };
+        let name = Self::const_str(&chunk.constants[idx])?;
         let val = self.pop()?;
         // Local scope wins; otherwise route to the closure's shared
         // module_state. Fall through to env.assign only when neither
         // has it, so UndefinedVariable / ImmutableAssignment surface.
-        if self.assign_active_local_slot(&name, val.clone(), false)? {
+        if self.assign_active_local_slot(name, val.clone(), false)? {
             // Slot locals are the active binding for compiler-resolved names.
-        } else if self.env.get(&name).is_some() {
-            self.env.assign(&name, val)?;
+        } else if self.env.get(name).is_some() {
+            self.env.assign(name, val)?;
         } else if let Some(ms) = self
             .frames
             .last()
             .and_then(|f| f.module_state.as_ref())
             .cloned()
         {
-            if ms.borrow().get(&name).is_some() {
-                ms.borrow_mut().assign(&name, val)?;
+            if ms.borrow().get(name).is_some() {
+                ms.borrow_mut().assign(name, val)?;
             } else {
                 // Neither has it: let env.assign produce the diagnostic.
-                self.env.assign(&name, val)?;
+                self.env.assign(name, val)?;
             }
         } else {
-            self.env.assign(&name, val)?;
+            self.env.assign(name, val)?;
         }
         Ok(())
     }

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -91,8 +91,8 @@ pub(crate) struct ExceptionHandler {
     pub(crate) stack_depth: usize,
     pub(crate) frame_depth: usize,
     pub(crate) env_scope_depth: usize,
-    /// If non-empty, this catch only handles errors whose enum_name matches.
-    pub(crate) error_type: String,
+    /// When present, this catch only handles errors whose enum_name matches.
+    pub(crate) error_type: Option<Rc<str>>,
 }
 
 /// Iterator state for for-in loops.
@@ -821,13 +821,6 @@ impl Vm {
 
     pub(crate) fn peek(&self) -> Result<&VmValue, VmError> {
         self.stack.last().ok_or(VmError::StackUnderflow)
-    }
-
-    pub(crate) fn const_string(c: &Constant) -> Result<String, VmError> {
-        match c {
-            Constant::String(s) => Ok(s.clone()),
-            _ => Err(VmError::TypeError("expected string constant".into())),
-        }
     }
 
     pub(crate) fn const_str(c: &Constant) -> Result<&str, VmError> {

--- a/perf/vm/README.md
+++ b/perf/vm/README.md
@@ -28,6 +28,13 @@ To compare against the checked-in local baseline:
 full suite passes. The comparison column uses the baseline table's
 `mean_avg_ms` value.
 
+For runs where the VM loop timing needs the CLI's span rollup too, ask the
+runner to persist `harn bench --profile-json` output beside the table:
+
+```bash
+./scripts/bench_vm.sh --iterations 20 --profile-json-dir /tmp/harn-vm-profiles
+```
+
 The Criterion VM clone-on-call probe is separate from the fixture runner:
 
 ```bash
@@ -101,6 +108,8 @@ The microbench suite covers focused VM hot paths:
 - method inline-cache hits for list/string/dict/set helpers
 - list callback dispatch through `.filter` and `.map`
 - std/collections dict helper builtins
+- many-part string interpolation and builtin-reference lookup
+- compiler string-constant reuse on name-heavy generated scripts
 - bytecode-cache freeze/serialize and adjacent-artifact load paths
 
 Each Criterion benchmark emits one JSON object per allocation probe on stderr:

--- a/perf/vm/bench_vm_hot_paths.rs
+++ b/perf/vm/bench_vm_hot_paths.rs
@@ -63,6 +63,21 @@ impl VmHotPathFixture {
     }
 }
 
+struct CompilerHotPathFixture {
+    name: &'static str,
+    source: String,
+}
+
+impl CompilerHotPathFixture {
+    fn new(name: &'static str, source: String) -> Self {
+        Self { name, source }
+    }
+
+    fn compile(&self) {
+        black_box(harn_vm::compile_source(&self.source).expect("compiler fixture should compile"));
+    }
+}
+
 struct BytecodeCacheFixture {
     source: String,
     source_path: PathBuf,
@@ -312,7 +327,66 @@ pipeline default(task) {
 "#,
             runtime,
         ),
+        VmHotPathFixture::new(
+            "string_interpolation_many_parts",
+            r#"
+pipeline default(task) {
+  let a = "alpha"
+  let b = "beta"
+  let c = "gamma"
+  let d = "delta"
+  var i = 0
+  var total = 0
+  while i < 2500 {
+    let text = "${a}:${b}:${c}:${d}:${a}:${b}:${c}:${d}"
+    total = total + len(text)
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
+            "builtin_reference_lookup",
+            r#"
+pipeline default(task) {
+  let input = ["a", "bb", "ccc", "dddd"]
+  var i = 0
+  var total = 0
+  while i < 1500 {
+    let counts = input.map(len)
+    total = total + counts[0] + counts[1] + counts[2] + counts[3]
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
     ]
+}
+
+fn compiler_fixtures() -> Vec<CompilerHotPathFixture> {
+    let mut repeated_constants = String::from("pipeline default(task) {\n  var total = 0\n");
+    for i in 0..400 {
+        repeated_constants.push_str(&format!(
+            "  let row{i} = {{status: \"open\", repo: \"harn\", kind: \"issue\", label: \"perf\"}}\n"
+        ));
+        repeated_constants.push_str(&format!(
+            "  total = total + len(row{i}.status) + len(row{i}.repo) + len(row{i}.kind) + len(row{i}.label)\n"
+        ));
+    }
+    repeated_constants.push_str("  if total < 0 { log(\"unreachable\") }\n}\n");
+
+    vec![CompilerHotPathFixture::new(
+        "repeated_string_constants",
+        repeated_constants,
+    )]
 }
 
 fn timed_vm_runs(runtime: &Runtime, fixture: &VmHotPathFixture, iterations: u64) -> Duration {
@@ -321,6 +395,16 @@ fn timed_vm_runs(runtime: &Runtime, fixture: &VmHotPathFixture, iterations: u64)
         let vm = fixture.setup_vm();
         let started = Instant::now();
         fixture.execute(runtime, vm);
+        total += started.elapsed();
+    }
+    total
+}
+
+fn timed_compiler_runs(fixture: &CompilerHotPathFixture, iterations: u64) -> Duration {
+    let mut total = Duration::ZERO;
+    for _ in 0..iterations {
+        let started = Instant::now();
+        fixture.compile();
         total += started.elapsed();
     }
     total
@@ -345,6 +429,31 @@ fn bench_vm_hot_paths(c: &mut Criterion) {
             fixture,
             |b, fixture| {
                 b.iter_custom(|iterations| timed_vm_runs(&runtime, black_box(fixture), iterations));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_compiler_hot_paths(c: &mut Criterion) {
+    let filters = criterion_filters();
+    let fixtures = compiler_fixtures();
+    let mut group = c.benchmark_group("compiler_hot_paths");
+    for fixture in &fixtures {
+        if matches_criterion_filter(&filters, "compiler_hot_paths", fixture.name) {
+            let stats = allocation_stats_per_iteration(ALLOCATION_SAMPLES, || fixture.compile());
+            emit_allocation_jsonl(
+                "compiler_hot_paths",
+                fixture.name,
+                ALLOCATION_SAMPLES,
+                stats,
+            );
+        }
+        group.bench_with_input(
+            BenchmarkId::from_parameter(fixture.name),
+            fixture,
+            |b, fixture| {
+                b.iter_custom(|iterations| timed_compiler_runs(black_box(fixture), iterations));
             },
         );
     }
@@ -389,6 +498,6 @@ fn bench_bytecode_cache(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_vm_hot_paths, bench_bytecode_cache
+    targets = bench_vm_hot_paths, bench_compiler_hot_paths, bench_bytecode_cache
 }
 criterion_main!(benches);

--- a/scripts/bench_vm.sh
+++ b/scripts/bench_vm.sh
@@ -9,11 +9,13 @@ build_release=1
 harn_bin="${HARN_BIN:-}"
 mode="loop"
 startup_runs="${HARN_BENCH_STARTUP_RUNS:-5}"
+profile_json_dir="${HARN_BENCH_PROFILE_JSON_DIR:-}"
 
 usage() {
   cat <<'EOF'
 Usage: scripts/bench_vm.sh [--iterations N] [--baseline FILE] [--no-build]
                            [--cold-start | --warm-start] [--startup-runs N]
+                           [--profile-json-dir DIR]
 
 Runs the deterministic VM microbenchmark fixture set with the release harn
 binary and prints one row per benchmark.
@@ -33,6 +35,9 @@ Options:
   -n, --iterations N    `harn bench` iterations per fixture (default: 20)
   --startup-runs N      cold/warm-start measurement runs per fixture
                         (default: 5)
+  --profile-json-dir DIR
+                        In loop mode, also write `harn bench --profile-json`
+                        rollups to DIR/<fixture>.json
   --baseline FILE       Markdown baseline table to compare average wall time
   --no-build            Skip cargo build --release --bin harn
   -h, --help            Show this help
@@ -42,6 +47,8 @@ Environment:
   HARN_BENCH_ITERATIONS     Default iteration count for loop mode
   HARN_BENCH_STARTUP_RUNS   Default per-fixture runs for cold/warm modes
   HARN_BENCH_FIXTURES_DIR   Override fixture directory
+  HARN_BENCH_PROFILE_JSON_DIR
+                            Default --profile-json-dir
   CARGO_TARGET_DIR          Cargo target directory for release builds
 EOF
 }
@@ -84,6 +91,14 @@ while [[ $# -gt 0 ]]; do
       startup_runs="${2:-}"
       shift 2
       ;;
+    --profile-json-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --profile-json-dir requires a value" >&2
+        exit 2
+      fi
+      profile_json_dir="${2:-}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -114,6 +129,10 @@ fi
 if [[ ! -d "$fixtures_dir" ]]; then
   echo "error: fixture directory not found: $fixtures_dir" >&2
   exit 2
+fi
+
+if [[ -n "$profile_json_dir" ]]; then
+  mkdir -p "$profile_json_dir"
 fi
 
 if [[ "$build_release" -eq 1 ]]; then
@@ -227,7 +246,11 @@ if [[ "$mode" == "loop" ]]; then
   status=0
   for fixture in "${fixtures[@]}"; do
     benchmark="$(basename "$fixture" .harn)"
-    output="$("$harn_bin" bench "$fixture" --iterations "$iterations")" || status=$?
+    bench_args=(bench "$fixture" --iterations "$iterations")
+    if [[ -n "$profile_json_dir" ]]; then
+      bench_args+=(--profile-json "$profile_json_dir/$benchmark.json")
+    fi
+    output="$("$harn_bin" "${bench_args[@]}")" || status=$?
     if [[ "$status" -ne 0 ]]; then
       printf "%s\n" "$output" >&2
       exit "$status"


### PR DESCRIPTION
## Summary
- dedupe compiler-emitted string constants per bytecode chunk through a shared helper
- avoid repeated string/name allocations in VM name operands, builtin references, enum construction, typed catches, imports, and method fallback paths
- optimize string concatenation/interpolation by writing stack values into one pre-sized buffer instead of allocating intermediate display strings
- add focused Criterion probes for many-part interpolation, builtin-reference lookup, and compiler repeated string constants
- document `scripts/bench_vm.sh --profile-json-dir` so VM fixture runs can persist existing CLI `harn bench --profile-json` rollups

## Validation
- pre-commit hook: rustfmt, changed-package clippy for `harn-vm`, markdownlint
- pre-push hook: targeted local checks, markdownlint
- `cargo fmt --check`
- `bash -n scripts/bench_vm.sh`
- `CARGO_TARGET_DIR=/tmp/harn-vm-string-name-opt-check cargo check -p harn-vm -p harn-cli`
- `CARGO_TARGET_DIR=/tmp/harn-vm-string-name-opt-check cargo test -p harn-vm --lib` (2667 passed)
- `CARGO_TARGET_DIR=/tmp/harn-vm-string-name-opt-check cargo check -p harn-vm-perf --benches`
- `./scripts/bench_vm_micro.sh --target-dir /tmp/harn-vm-string-name-opt-bench string_interpolation_many_parts`
- `./scripts/bench_vm_micro.sh --target-dir /tmp/harn-vm-string-name-opt-bench builtin_reference_lookup`
- `./scripts/bench_vm_micro.sh --target-dir /tmp/harn-vm-string-name-opt-bench repeated_string_constants`

## Perf smoke
Focused Criterion reruns against the warmed local bench target reported improvements versus the previous stored measurements:
- `vm_hot_paths/string_interpolation_many_parts`: 5.17-5.29 ms, ~42% faster
- `vm_hot_paths/builtin_reference_lookup`: 2.13-2.16 ms, ~22% faster
- `compiler_hot_paths/repeated_string_constants`: 6.88-7.15 ms, ~16% faster

The bench profile emitted existing dead-code warnings in `agent_sessions.rs`; no new warnings from this patch.
