### PR TITLE
Fix release build dead-code warnings

### DIFF
--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -43,6 +43,7 @@ pub const DEFAULT_TRANSCRIPT_MESSAGE_CAP: usize = 4096;
 /// Default cap on retained transcript audit events per session. Events
 /// include message-derived entries plus orchestration lifecycle records.
 pub const DEFAULT_TRANSCRIPT_EVENT_CAP: usize = 32768;
+#[cfg(debug_assertions)]
 const CACHE_STABLE_SYSTEM_PROMPT_DIAGNOSTIC: &str = "HARN-CACHE-001";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1939,6 +1940,7 @@ pub fn system_prompt(id: &str) -> Option<String> {
     })
 }
 
+#[cfg(debug_assertions)]
 fn forbidden_workspace_prompt_token(system_prompt: &str) -> Option<&'static str> {
     let mut remaining = system_prompt;
     while let Some(index) = remaining.find("{{") {


### PR DESCRIPTION
## Summary
- Gate the cache-stable system-prompt diagnostic constant and helper behind `debug_assertions`, matching the assertion function that uses them.
- Unblocks release tag builds that run with `RUSTFLAGS=-D warnings`.

## Verification
- `CARGO_TARGET_DIR="$PWD/.target-release-check" CARGO_INCREMENTAL=0 RUSTFLAGS="-D warnings" CARGO_PROFILE_RELEASE_LTO=thin cargo build --release -p harn-cli --bin harn`
- pre-commit changed-package clippy hook
- pre-push targeted local checks