### PR TITLE
Fix redaction, duration, and package path bugs

### DIFF
--- a/crates/harn-cli/src/cli/util.rs
+++ b/crates/harn-cli/src/cli/util.rs
@@ -91,14 +91,51 @@ pub(crate) fn parse_duration_arg(raw: &str) -> Result<StdDuration, String> {
     match unit {
         "ms" => Ok(StdDuration::from_millis(value)),
         "s" => Ok(StdDuration::from_secs(value)),
-        "m" => Ok(StdDuration::from_secs(value.saturating_mul(60))),
-        "h" => Ok(StdDuration::from_secs(value.saturating_mul(60 * 60))),
-        "d" => Ok(StdDuration::from_secs(value.saturating_mul(60 * 60 * 24))),
-        "w" => Ok(StdDuration::from_secs(
-            value.saturating_mul(60 * 60 * 24 * 7),
-        )),
+        "m" => Ok(StdDuration::from_secs(checked_duration_product(
+            raw, value, 60,
+        )?)),
+        "h" => Ok(StdDuration::from_secs(checked_duration_product(
+            raw,
+            value,
+            60 * 60,
+        )?)),
+        "d" => Ok(StdDuration::from_secs(checked_duration_product(
+            raw,
+            value,
+            60 * 60 * 24,
+        )?)),
+        "w" => Ok(StdDuration::from_secs(checked_duration_product(
+            raw,
+            value,
+            60 * 60 * 24 * 7,
+        )?)),
         _ => Err(format!(
             "unsupported duration unit '{unit}'; expected ms, s, m, h, d, or w"
         )),
+    }
+}
+
+fn checked_duration_product(raw: &str, value: u64, multiplier: u64) -> Result<u64, String> {
+    value
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("duration '{raw}' is too large"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_arg_rejects_unit_overflow() {
+        let err = parse_duration_arg("18446744073709551615w").unwrap_err();
+        assert!(err.contains("too large"), "{err}");
+    }
+
+    #[test]
+    fn parse_duration_arg_accepts_large_millisecond_value() {
+        assert_eq!(
+            parse_duration_arg("18446744073709551615ms").unwrap(),
+            StdDuration::from_millis(u64::MAX)
+        );
     }
 }

--- a/crates/harn-cli/src/package/package_ops.rs
+++ b/crates/harn-cli/src/package/package_ops.rs
@@ -2131,6 +2131,7 @@ pub(crate) fn safe_package_relative_path(
     let rel = PathBuf::from(rel_path);
     if rel.is_absolute()
         || has_windows_rooted_or_drive_relative_prefix(rel_path)
+        || has_windows_separator_escape(rel_path)
         || rel.components().any(|component| {
             matches!(
                 component,
@@ -2150,6 +2151,18 @@ fn has_windows_rooted_or_drive_relative_prefix(path: &str) -> bool {
     let bytes = normalized.as_bytes();
     normalized.starts_with('/')
         || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+}
+
+fn has_windows_separator_escape(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    Path::new(&normalized).components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::ParentDir
+                | std::path::Component::Prefix(_)
+                | std::path::Component::RootDir
+        )
+    })
 }
 
 pub(crate) fn extract_api_symbols(source: &str) -> Vec<PackageApiSymbol> {
@@ -2911,6 +2924,9 @@ rev = "feedface"
             r"C:\repo\secret.harn",
             "C:secret.harn",
             r"\\server\share\secret.harn",
+            r"..\secret.harn",
+            r"lib\..\secret.harn",
+            r"lib/..\secret.harn",
         ] {
             assert!(
                 safe_package_relative_path(tmp.path(), rel_path).is_err(),

--- a/crates/harn-cli/src/package/validation.rs
+++ b/crates/harn-cli/src/package/validation.rs
@@ -494,7 +494,9 @@ pub(crate) fn parse_duration_millis(raw: &str) -> Result<u64, PackageError> {
             return Err(format!("invalid duration unit in '{raw}'; expected ms, s, m, or h").into())
         }
     };
-    Ok(amount.saturating_mul(multiplier))
+    amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("duration '{raw}' is too large").into())
 }
 
 pub(crate) fn validate_static_trigger_config(
@@ -1288,4 +1290,23 @@ pub(crate) fn is_predicate_return_type(ty: &harn_parser::TypeExpr) -> bool {
                 && args.len() == 2
                 && args.first().is_some_and(is_bool_type)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_millis_rejects_unit_overflow() {
+        let err = parse_duration_millis("18446744073709551615h").unwrap_err();
+        assert!(err.to_string().contains("too large"), "{err}");
+    }
+
+    #[test]
+    fn parse_duration_millis_accepts_large_plain_milliseconds() {
+        assert_eq!(
+            parse_duration_millis("18446744073709551615").unwrap(),
+            u64::MAX
+        );
+    }
 }

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -2478,8 +2478,18 @@ mod tests {
         body: serde_json::Value,
     }
 
+    // The loopback HTTP tests start background GET streams against in-process
+    // mock servers. Keep those stream lifetimes isolated under the parallel
+    // Rust test harness so one test cannot consume another test's scarce local
+    // networking resources while it is still shutting down.
+    async fn http_mcp_test_guard() -> tokio::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().await
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn http_get_stream_dispatches_inbound_elicitation_response() {
+        let _guard = http_mcp_test_guard().await;
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (base_url, mut responses) = spawn_eliciting_http_mcp_server().await;
@@ -2640,6 +2650,7 @@ print(json.dumps({
 
     #[tokio::test(flavor = "current_thread")]
     async fn modern_http_sends_stateless_metadata_headers_and_schema_headers() {
+        let _guard = http_mcp_test_guard().await;
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (base_url, mut requests) = spawn_modern_http_mcp_server().await;
@@ -2694,6 +2705,7 @@ print(json.dumps({
 
     #[tokio::test(flavor = "current_thread")]
     async fn modern_http_discovery_falls_back_to_legacy_initialize_when_endpoint_is_not_modern() {
+        let _guard = http_mcp_test_guard().await;
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (base_url, mut requests) = spawn_legacy_http_fallback_server().await;
@@ -2728,6 +2740,7 @@ print(json.dumps({
 
     #[tokio::test(flavor = "current_thread")]
     async fn modern_input_required_result_dispatches_and_retries() {
+        let _guard = http_mcp_test_guard().await;
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (base_url, mut requests) = spawn_modern_http_mcp_server().await;
@@ -2904,23 +2917,20 @@ llm_mock_clear()
                 let Ok((mut stream, _)) = listener.accept().await else {
                     break;
                 };
-                let request_tx = request_tx.clone();
-                tokio::spawn(async move {
-                    let Ok((_request_line, headers, body)) = read_http_request(&mut stream).await
-                    else {
-                        return;
-                    };
-                    let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
-                        return;
-                    };
-                    let _ = request_tx.send(RecordedHttpRequest {
-                        headers: headers.clone(),
-                        body: request.clone(),
-                    });
-                    let method = request.get("method").and_then(|value| value.as_str());
-                    let response = modern_http_response(&request, method);
-                    let _ = write_http_json(&mut stream, "200 OK", &[], response).await;
+                let Ok((_request_line, headers, body)) = read_http_request(&mut stream).await
+                else {
+                    continue;
+                };
+                let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
+                    continue;
+                };
+                let _ = request_tx.send(RecordedHttpRequest {
+                    headers: headers.clone(),
+                    body: request.clone(),
                 });
+                let method = request.get("method").and_then(|value| value.as_str());
+                let response = modern_http_response(&request, method);
+                let _ = write_http_json(&mut stream, "200 OK", &[], response).await;
             }
         });
 
@@ -2938,54 +2948,50 @@ llm_mock_clear()
                 let Ok((mut stream, _)) = listener.accept().await else {
                     break;
                 };
-                let request_tx = request_tx.clone();
-                tokio::spawn(async move {
-                    let Ok((request_line, headers, body)) = read_http_request(&mut stream).await
-                    else {
-                        return;
-                    };
-                    if request_line.starts_with("GET ") {
-                        let _ = write_http_empty(&mut stream, "404 Not Found").await;
-                        return;
-                    }
-                    let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
-                        return;
-                    };
-                    let method = request.get("method").and_then(|value| value.as_str());
-                    let _ = request_tx.send(RecordedHttpRequest {
-                        headers: headers.clone(),
-                        body: request.clone(),
-                    });
-                    match method {
-                        Some("server/discover") => {
-                            let _ = write_http_empty(&mut stream, "400 Bad Request").await;
-                        }
-                        Some("initialize") => {
-                            let response = serde_json::json!({
-                                "jsonrpc": "2.0",
-                                "id": request["id"].clone(),
-                                "result": {
-                                    "protocolVersion": PROTOCOL_VERSION,
-                                    "capabilities": {"tools": {}},
-                                    "serverInfo": {"name": "legacy-http", "version": "1.0.0"}
-                                }
-                            });
-                            let _ = write_http_json(
-                                &mut stream,
-                                "200 OK",
-                                &[("MCP-Session-Id", "legacy-session")],
-                                response,
-                            )
-                            .await;
-                        }
-                        Some("notifications/initialized") => {
-                            let _ = write_http_empty(&mut stream, "202 Accepted").await;
-                        }
-                        _ => {
-                            let _ = write_http_empty(&mut stream, "404 Not Found").await;
-                        }
-                    }
+                let Ok((request_line, headers, body)) = read_http_request(&mut stream).await else {
+                    continue;
+                };
+                if request_line.starts_with("GET ") {
+                    let _ = write_http_empty(&mut stream, "404 Not Found").await;
+                    continue;
+                }
+                let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
+                    continue;
+                };
+                let method = request.get("method").and_then(|value| value.as_str());
+                let _ = request_tx.send(RecordedHttpRequest {
+                    headers: headers.clone(),
+                    body: request.clone(),
                 });
+                match method {
+                    Some("server/discover") => {
+                        let _ = write_http_empty(&mut stream, "400 Bad Request").await;
+                    }
+                    Some("initialize") => {
+                        let response = serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "id": request["id"].clone(),
+                            "result": {
+                                "protocolVersion": PROTOCOL_VERSION,
+                                "capabilities": {"tools": {}},
+                                "serverInfo": {"name": "legacy-http", "version": "1.0.0"}
+                            }
+                        });
+                        let _ = write_http_json(
+                            &mut stream,
+                            "200 OK",
+                            &[("MCP-Session-Id", "legacy-session")],
+                            response,
+                        )
+                        .await;
+                    }
+                    Some("notifications/initialized") => {
+                        let _ = write_http_empty(&mut stream, "202 Accepted").await;
+                    }
+                    _ => {
+                        let _ = write_http_empty(&mut stream, "404 Not Found").await;
+                    }
+                }
             }
         });
 
@@ -3119,10 +3125,7 @@ llm_mock_clear()
                 let Ok((stream, _)) = listener.accept().await else {
                     break;
                 };
-                let response_tx = response_tx.clone();
-                tokio::spawn(async move {
-                    let _ = handle_mock_http_mcp_connection(stream, response_tx).await;
-                });
+                let _ = handle_mock_http_mcp_connection(stream, response_tx.clone()).await;
             }
         });
 
@@ -3140,17 +3143,14 @@ llm_mock_clear()
                 let Ok((mut stream, _)) = listener.accept().await else {
                     break;
                 };
-                let request_tx = request_tx.clone();
-                tokio::spawn(async move {
-                    let Ok((_request_line, _headers, body)) = read_http_request(&mut stream).await
-                    else {
-                        return;
-                    };
-                    if let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) {
-                        let _ = request_tx.send(request);
-                    }
-                    let _ = write_http_empty(&mut stream, "202 Accepted").await;
-                });
+                let Ok((_request_line, _headers, body)) = read_http_request(&mut stream).await
+                else {
+                    continue;
+                };
+                if let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) {
+                    let _ = request_tx.send(request);
+                }
+                let _ = write_http_empty(&mut stream, "202 Accepted").await;
             }
         });
 
@@ -3167,6 +3167,7 @@ llm_mock_clear()
                 "HTTP/1.1 200 OK\r\n",
                 "content-type: text/event-stream\r\n",
                 "cache-control: no-cache\r\n",
+                "connection: close\r\n",
                 "\r\n",
                 "id: prime\r\n",
                 "data: \r\n",
@@ -3177,6 +3178,7 @@ llm_mock_clear()
                 "\r\n"
             );
             stream.write_all(response.as_bytes()).await?;
+            stream.flush().await?;
             return Ok(());
         }
 
@@ -3310,7 +3312,7 @@ llm_mock_clear()
     ) -> Result<(), std::io::Error> {
         let body = serde_json::to_string(&body).unwrap();
         let mut response = format!(
-            "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n",
+            "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n",
             body.len()
         );
         for (name, value) in headers {
@@ -3321,12 +3323,15 @@ llm_mock_clear()
         }
         response.push_str("\r\n");
         response.push_str(&body);
-        stream.write_all(response.as_bytes()).await
+        stream.write_all(response.as_bytes()).await?;
+        stream.flush().await
     }
 
     async fn write_http_empty(stream: &mut TcpStream, status: &str) -> Result<(), std::io::Error> {
-        let response = format!("HTTP/1.1 {status}\r\ncontent-length: 0\r\n\r\n");
-        stream.write_all(response.as_bytes()).await
+        let response =
+            format!("HTTP/1.1 {status}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n");
+        stream.write_all(response.as_bytes()).await?;
+        stream.flush().await
     }
 
     #[test]
@@ -3481,6 +3486,7 @@ llm_mock_clear()
 
     #[tokio::test(flavor = "current_thread")]
     async fn roots_list_changed_notification_is_sent_once_per_snapshot() {
+        let _guard = http_mcp_test_guard().await;
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (base_url, mut requests) = spawn_recording_http_mcp_server().await;

--- a/crates/harn-vm/src/redact/mod.rs
+++ b/crates/harn-vm/src/redact/mod.rs
@@ -349,17 +349,12 @@ fn default_safe_headers() -> BTreeSet<String> {
         "request-id".to_string(),
         "user-agent".to_string(),
         "x-a2a-delivery".to_string(),
-        "x-a2a-signature".to_string(),
         "x-correlation-id".to_string(),
         "x-github-delivery".to_string(),
         "x-github-event".to_string(),
         "x-github-hook-id".to_string(),
-        "x-hub-signature-256".to_string(),
-        "x-linear-signature".to_string(),
-        "x-notion-signature".to_string(),
         "x-request-id".to_string(),
         "x-slack-request-timestamp".to_string(),
-        "x-slack-signature".to_string(),
     ])
 }
 
@@ -368,20 +363,21 @@ fn default_deny_header_substrings() -> BTreeSet<String> {
         "authorization".to_string(),
         "cookie".to_string(),
         "secret".to_string(),
+        "signature".to_string(),
         "token".to_string(),
         "key".to_string(),
     ])
 }
 
 fn is_default_sensitive_url_param(lower: &str) -> bool {
+    let compact = compact_secret_name(lower);
     matches!(
-        lower,
-        "api_key"
-            | "apikey"
-            | "access_token"
-            | "refresh_token"
-            | "id_token"
-            | "client_secret"
+        compact.as_str(),
+        "apikey"
+            | "accesstoken"
+            | "refreshtoken"
+            | "idtoken"
+            | "clientsecret"
             | "password"
             | "secret"
             | "token"
@@ -389,41 +385,46 @@ fn is_default_sensitive_url_param(lower: &str) -> bool {
             | "bearer"
             | "sig"
             | "signature"
-    ) || lower.ends_with("_token")
-        || lower.ends_with("_secret")
-        || lower.ends_with("_password")
+    ) || compact.ends_with("token")
+        || compact.ends_with("secret")
+        || compact.ends_with("password")
 }
 
 fn is_default_sensitive_field(lower: &str) -> bool {
+    let compact = compact_secret_name(lower);
     matches!(
-        lower,
+        compact.as_str(),
         "authorization"
-            | "proxy-authorization"
+            | "proxyauthorization"
             | "cookie"
-            | "set-cookie"
-            | "api_key"
+            | "setcookie"
             | "apikey"
-            | "api-key"
-            | "x-amz-security-token"
-            | "x-api-key"
-            | "x-auth-token"
-            | "x-csrf-token"
-            | "x-xsrf-token"
-            | "access_token"
-            | "refresh_token"
-            | "id_token"
-            | "bearer_token"
-            | "client_secret"
-            | "secret"
+            | "xamzsecuritytoken"
+            | "xapikey"
+            | "xauthtoken"
+            | "xcsrftoken"
+            | "xxsrftoken"
+            | "accesstoken"
+            | "refreshtoken"
+            | "idtoken"
+            | "bearertoken"
+            | "clientsecret"
             | "password"
+            | "secret"
             | "passwd"
-            | "private_key"
-            | "session_token"
-    ) || lower.ends_with("_token")
-        || lower.ends_with("_secret")
-        || lower.ends_with("_password")
-        || lower.ends_with("_apikey")
-        || lower.ends_with("_api_key")
+            | "privatekey"
+            | "sessiontoken"
+    ) || compact.ends_with("token")
+        || compact.ends_with("secret")
+        || compact.ends_with("password")
+        || compact.ends_with("apikey")
+}
+
+fn compact_secret_name(lower: &str) -> String {
+    lower
+        .chars()
+        .filter(|ch| *ch != '_' && *ch != '-')
+        .collect()
 }
 
 thread_local! {
@@ -500,6 +501,10 @@ mod tests {
             ("Cookie".to_string(), "session=abc".to_string()),
             ("Content-Type".to_string(), "application/json".to_string()),
             ("X-Webhook-Token".to_string(), "tok-xyz".to_string()),
+            (
+                "X-Slack-Signature".to_string(),
+                "v0=abcdef123456".to_string(),
+            ),
             ("User-Agent".to_string(), "Harn/1.0".to_string()),
             ("X-GitHub-Delivery".to_string(), "delivery-123".to_string()),
         ])
@@ -516,6 +521,10 @@ mod tests {
         assert_eq!(redacted.get("Cookie").unwrap(), REDACTED_HEADER_VALUE);
         assert_eq!(
             redacted.get("X-Webhook-Token").unwrap(),
+            REDACTED_HEADER_VALUE
+        );
+        assert_eq!(
+            redacted.get("X-Slack-Signature").unwrap(),
             REDACTED_HEADER_VALUE
         );
         assert_eq!(redacted.get("User-Agent").unwrap(), "Harn/1.0");
@@ -547,9 +556,11 @@ mod tests {
     #[test]
     fn redact_url_strips_userinfo_and_sensitive_query_params() {
         let policy = RedactionPolicy::default();
-        let redacted =
-            policy.redact_url("https://user:pw@api.example.com/v1?api_key=abcdef&page=2");
+        let redacted = policy.redact_url(
+            "https://user:pw@api.example.com/v1?api_key=abcdef&clientSecret=hidden&page=2",
+        );
         assert!(redacted.contains("api_key=%5Bredacted%5D"));
+        assert!(redacted.contains("clientSecret=%5Bredacted%5D"));
         assert!(redacted.contains("page=2"));
         assert!(!redacted.contains("user:pw@"));
     }
@@ -571,9 +582,10 @@ mod tests {
                 "x-trace-id": "trace_1",
             },
             "list": [
-                { "auth_token": "tok_secret", "name": "alice" },
+                { "auth_token": "tok_secret", "accessToken": "camel", "name": "alice" },
                 { "name": "bob" },
             ],
+            "clientSecret": "camel-secret",
             "free_form": "Bearer ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD",
             "url": "https://api.example.com/v1?api_key=hideme",
         });
@@ -585,7 +597,9 @@ mod tests {
         );
         assert_eq!(value["headers"]["x-trace-id"], "trace_1");
         assert_eq!(value["list"][0]["auth_token"], REDACTED_PLACEHOLDER);
+        assert_eq!(value["list"][0]["accessToken"], REDACTED_PLACEHOLDER);
         assert_eq!(value["list"][0]["name"], "alice");
+        assert_eq!(value["clientSecret"], REDACTED_PLACEHOLDER);
         let free_form = value["free_form"].as_str().unwrap();
         // Free-form pattern matches now produce the OA-06 named
         // placeholder `<redacted:<pattern>:<len>>` so audit logs can


### PR DESCRIPTION
## Summary
- redact webhook signature headers and compact secret-field variants like `clientSecret` / `accessToken`
- reject overflowing duration units instead of silently saturating them
- reject Windows-style package path traversal and make MCP loopback HTTP tests deterministic under the parallel harness

## Verification
- `cargo fmt --check && git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-7f7d-three-bugs cargo test -p harn-vm --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-7f7d-three-bugs cargo test -p harn-cli --lib`
- pre-commit changed-package clippy
- pre-push targeted local checks

MCP test behavior was checked against the streamable HTTP spec shape: server-to-client GET streams are optional, JSON-RPC responses/notifications can be acknowledged with 202-style empty responses, and session headers remain explicit.