### PR TITLE
Fix structural validator lifecycle-only tool handling

### DIFF
--- a/conformance/tests/agents/agent_loop_structural_validator.expected
+++ b/conformance/tests/agents/agent_loop_structural_validator.expected
@@ -32,3 +32,5 @@ true
 true
 true
 true
+true
+true

--- a/conformance/tests/agents/agent_loop_structural_validator.harn
+++ b/conformance/tests/agents/agent_loop_structural_validator.harn
@@ -155,6 +155,26 @@ pipeline default() {
   __io_println(post_write_non_empty.result.status == "done")
   __io_println(len(post_write_non_empty_decisions) == 0)
   llm_mock_clear()
+  llm_mock({text: "The PATCH_HINT is:\n\n```python\ndef add(a, b): return a + b\n```"})
+  let lifecycle_only_session = "structural-validator-lifecycle-only-" + uuid()
+  let lifecycle_only = agent_capture_events(
+    lifecycle_only_session,
+    fn() { return agent_loop(
+      "No tools are available. State the smallest code change.",
+      nil,
+      {
+        provider: "mock",
+        tool_format: "text",
+        max_iterations: 1,
+        session_id: lifecycle_only_session,
+        structural_validator: with_structural_validator(),
+      },
+    ) },
+  )
+  let lifecycle_only_decisions = events_of(lifecycle_only.events, "structural_validator_decision")
+  __io_println(lifecycle_only.result.status == "done")
+  __io_println(len(lifecycle_only_decisions) == 0)
+  llm_mock_clear()
   llm_mock({text: malformed_tool_text})
   let malformed_session = "structural-validator-malformed-" + uuid()
   let malformed = agent_capture_events(

--- a/crates/harn-cli/assets/evals/coding_agent_suite.harn
+++ b/crates/harn-cli/assets/evals/coding_agent_suite.harn
@@ -732,9 +732,12 @@ fn __verify_read_only_audit(harness: Harness, root: string, result) {
 
 fn __verify_no_tool_diagnosis(result) {
   let final_text = __final_text(result)
+  let normalized = lowercase(final_text)
+  let describes_change = contains(final_text, "return a + b")
+    || (contains(normalized, "subtraction") && contains(normalized, "addition"))
   let success = __tool_call_count(result) == 0
     && contains(final_text, "PATCH_HINT")
-    && contains(final_text, "return a + b")
+    && describes_change
   return __command_verification(
     success,
     if success {

--- a/crates/harn-stdlib/src/stdlib/llm/structural_validator.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/structural_validator.harn
@@ -202,7 +202,20 @@ fn __sv_tool_annotations(entry) {
   return {}
 }
 
+fn __sv_annotation_enabled(value) -> bool {
+  return type_of(value) == "bool" && value
+}
+
+fn __sv_tool_entry_is_structural(entry) -> bool {
+  let annotations = __sv_tool_annotations(entry)
+  return __sv_annotation_enabled(annotations?.structural)
+    || __sv_annotation_enabled(annotations?.agent_lifecycle)
+}
+
 fn __sv_tool_entry_has_write_capability(entry) -> bool {
+  if __sv_tool_entry_is_structural(entry) {
+    return false
+  }
   let annotations = __sv_tool_annotations(entry)
   let side_effect_level = lowercase(__sv_string(annotations?.side_effect_level ?? annotations?.sideEffectLevel))
   if side_effect_level == "none" || side_effect_level == "read_only" {
@@ -225,6 +238,16 @@ fn __sv_workspace_has_write_capability(payload) -> bool {
   let entries = __sv_list(tools?.tools)
   for entry in entries {
     if type_of(entry) == "dict" && __sv_tool_entry_has_write_capability(entry) {
+      return true
+    }
+  }
+  return false
+}
+
+fn __sv_has_non_structural_tools(payload) -> bool {
+  let tools = __sv_dict(payload?.tools)
+  for entry in __sv_list(tools?.tools) {
+    if type_of(entry) == "dict" && !__sv_tool_entry_is_structural(entry) {
       return true
     }
   }
@@ -327,12 +350,13 @@ fn __sv_join_messages(values) -> string {
 
 fn __sv_tool_calls_well_formed(payload) {
   let is_text_tool_format = lowercase(__sv_string(payload?.tool_format)) == "text"
-  let parse_errors = if is_text_tool_format {
+  let should_enforce_text_protocol = is_text_tool_format && __sv_has_non_structural_tools(payload)
+  let parse_errors = if should_enforce_text_protocol {
     __sv_string_list(payload?.tool_parse_errors)
   } else {
     []
   }
-  let protocol_violations = if is_text_tool_format {
+  let protocol_violations = if should_enforce_text_protocol {
     __sv_string_list(payload?.protocol_violations)
   } else {
     []


### PR DESCRIPTION
## Summary

- treat structural / agent-lifecycle tools as non-writable for structural-validator write-required checks
- skip text-protocol parse enforcement when the only exposed tools are structural lifecycle tools, so prompt-only no-tool turns can answer in prose
- loosen the no-tool coding-agent verifier to accept the intended semantic diagnosis (`subtraction` -> `addition`) when the response still includes `PATCH_HINT` and makes zero tool calls

## Transcript findings acted on

- The no-tool JSONL transcripts showed `agent_await_resumption` being counted as a writable tool, which produced `non_empty_when_writes_expected` feedback even though no task tools were available.
- Gemini Flash Lite correctly diagnosed the no-tool fixture as replacing subtraction with addition, but the verifier required the exact code string `return a + b`; the verifier now accepts that semantically equivalent answer.
- A focused no-tool rerun after the fix passed for GPT-4o mini, Gemini Flash Lite, DeepSeek V3.2, and Devstral Small. Qwen Coder Next still attempted a tool call despite no tools; Qwen Coder 30B omitted `PATCH_HINT`.

## Verification

- repo pre-commit hook
- repo pre-push hook
- `CARGO_TARGET_DIR=/tmp/harn-target-2368-polish cargo build --bin harn`
- `HARN_LLM_CALLS_DISABLED=1 /tmp/harn-target-2368-polish/debug/harn test conformance --filter agent_loop_structural_validator`
- `HARN_LLM_CALLS_DISABLED=1 /tmp/harn-target-2368-polish/debug/harn eval coding-agent --model mock:mock --tool-format text --fixture no-tool-diagnosis --max-runs 1 --output /tmp/harn-2368-notool-mock-followup-rebased --json`
- `CARGO_TARGET_DIR=/tmp/harn-target-2368-polish HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-cli --test eval_coding_agent_cli -- --nocapture`
- `make lint-test-patterns`

Follow-up to #2368.
