### PR TITLE
Add ACP attach discovery metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ condensed series summaries instead of full per-patch history.
   - `sub_agent_run` accepts an `anchor` option. The runtime rejects a child
     anchor that escapes the parent's anchor + mounted roots and applies the
     anchor to the child session on spawn.
+- **ACP attach discovery by workspace anchor (#2413).** `session/list` now
+  accepts workspace-anchor, cwd, and live-state filters, returns attach metadata
+  for live, detached-retained, and replay-only sessions, and `session/load`
+  reports replay-only state after retained WebSocket workers expire.
 
 ## v0.8.37
 

--- a/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
@@ -49,12 +49,22 @@ struct AcpWorker {
     request_tx: Mutex<Option<mpsc::UnboundedSender<JsonValue>>>,
     socket_tx: Mutex<Option<mpsc::UnboundedSender<String>>>,
     active_connection_id: Mutex<Option<String>>,
-    sessions: Mutex<BTreeSet<String>>,
+    sessions: Mutex<BTreeMap<String, AcpSessionSummary>>,
     replay_buffer: Mutex<VecDeque<AcpReplayEvent>>,
     next_event_id: AtomicU64,
     detached_at: Mutex<Option<Instant>>,
     event_log: Arc<AnyEventLog>,
     hub: Weak<AcpWebSocketHub>,
+}
+
+#[derive(Clone, Debug)]
+struct AcpSessionSummary {
+    session_id: String,
+    cwd: Option<String>,
+    title: Option<String>,
+    meta: serde_json::Map<String, JsonValue>,
+    workspace_anchor: Option<JsonValue>,
+    last_event_id: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -68,6 +78,11 @@ struct AcpReplayEvent {
 enum AcpAttachError {
     NotFound,
     AlreadyAttached,
+}
+
+struct PersistedAcpReplay {
+    summary: Option<AcpSessionSummary>,
+    replayed: Vec<JsonValue>,
 }
 
 impl AcpWebSocketHub {
@@ -91,7 +106,7 @@ impl AcpWebSocketHub {
             request_tx: Mutex::new(Some(to_acp_tx)),
             socket_tx: Mutex::new(None),
             active_connection_id: Mutex::new(None),
-            sessions: Mutex::new(BTreeSet::new()),
+            sessions: Mutex::new(BTreeMap::new()),
             replay_buffer: Mutex::new(VecDeque::new()),
             next_event_id: AtomicU64::new(1),
             detached_at: Mutex::new(None),
@@ -136,12 +151,13 @@ impl AcpWebSocketHub {
         Ok(worker)
     }
 
-    fn register_session(&self, session_id: String, worker: &Arc<AcpWorker>) {
-        worker
-            .sessions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(session_id.clone());
+    fn register_session(
+        &self,
+        session_id: String,
+        worker: &Arc<AcpWorker>,
+        summary: Option<AcpSessionSummary>,
+    ) {
+        worker.merge_session_summary(session_id.clone(), summary);
         let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
         state
             .workers_by_session
@@ -246,6 +262,112 @@ impl AcpWebSocketHub {
                 .is_some()
         })
     }
+
+    async fn discover_sessions(&self, params: &JsonValue) -> Vec<JsonValue> {
+        let mut summaries: BTreeMap<String, JsonValue> = BTreeMap::new();
+        let workers: Vec<Arc<AcpWorker>> = self
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .workers_by_session
+            .values()
+            .cloned()
+            .collect();
+        for worker in workers {
+            let live_state = worker.live_state();
+            let attachable_roles = worker.attachable_roles();
+            for summary in worker.session_summaries() {
+                if acp_session_summary_matches(&summary, live_state, params) {
+                    summaries.insert(
+                        summary.session_id.clone(),
+                        summary.to_json(live_state, &attachable_roles),
+                    );
+                }
+            }
+        }
+
+        for summary in persisted_acp_session_summaries(&self.event_log).await {
+            if summaries.contains_key(&summary.session_id) {
+                continue;
+            }
+            if acp_session_summary_matches(&summary, "expired_replay_only", params) {
+                summaries.insert(
+                    summary.session_id.clone(),
+                    summary.to_json("expired_replay_only", &[]),
+                );
+            }
+        }
+
+        summaries.into_values().collect()
+    }
+}
+
+impl AcpSessionSummary {
+    fn new(session_id: String) -> Self {
+        Self {
+            session_id,
+            cwd: None,
+            title: None,
+            meta: serde_json::Map::new(),
+            workspace_anchor: None,
+            last_event_id: None,
+        }
+    }
+
+    fn merge(&mut self, other: AcpSessionSummary) {
+        if other.cwd.is_some() {
+            self.cwd = other.cwd;
+        }
+        if other.title.is_some() {
+            self.title = other.title;
+        }
+        if other.workspace_anchor.is_some() {
+            self.workspace_anchor = other.workspace_anchor;
+        }
+        if other.last_event_id.is_some() {
+            self.last_event_id = other.last_event_id;
+        }
+        for (key, value) in other.meta {
+            self.meta.insert(key, value);
+        }
+    }
+
+    fn to_json(&self, live_state: &str, attachable_roles: &[&str]) -> JsonValue {
+        let mut item = json!({
+            "sessionId": self.session_id,
+            "liveState": live_state,
+            "attachableRoles": attachable_roles,
+        });
+        if let Some(cwd) = self.cwd.as_ref() {
+            item["cwd"] = json!(cwd);
+        }
+        if let Some(title) = self.title.as_ref() {
+            item["title"] = json!(title);
+        }
+        if let Some(workspace_anchor) = self.workspace_anchor.as_ref() {
+            item["workspaceAnchor"] = workspace_anchor.clone();
+        }
+        if let Some(last_event_id) = self.last_event_id {
+            item["lastEventId"] = json!(last_event_id);
+        }
+
+        let mut meta = self.meta.clone();
+        let mut harn_meta = match meta.remove("harn") {
+            Some(JsonValue::Object(map)) => map,
+            _ => serde_json::Map::new(),
+        };
+        harn_meta.insert("liveState".to_string(), json!(live_state));
+        harn_meta.insert("attachableRoles".to_string(), json!(attachable_roles));
+        if let Some(workspace_anchor) = self.workspace_anchor.as_ref() {
+            harn_meta.insert("workspaceAnchor".to_string(), workspace_anchor.clone());
+        }
+        if let Some(last_event_id) = self.last_event_id {
+            harn_meta.insert("lastEventId".to_string(), json!(last_event_id));
+        }
+        meta.insert("harn".to_string(), JsonValue::Object(harn_meta));
+        item["_meta"] = JsonValue::Object(meta);
+        item
+    }
 }
 
 impl AcpWorker {
@@ -319,23 +441,74 @@ impl AcpWorker {
         self.sessions
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .iter()
+            .keys()
             .cloned()
             .collect()
     }
 
-    async fn handle_output(self: &Arc<Self>, line: String) {
-        let session_id = session_id_from_acp_message(&line).or_else(|| {
-            let sessions = self.session_ids();
-            (sessions.len() == 1).then(|| sessions[0].clone())
-        });
-        if let Some(session_id) = session_id.clone() {
-            if let Some(hub) = self.hub.upgrade() {
-                hub.register_session(session_id, self);
-            }
+    fn session_summaries(&self) -> Vec<AcpSessionSummary> {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    fn merge_session_summary(&self, session_id: String, summary: Option<AcpSessionSummary>) {
+        let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = sessions
+            .entry(session_id.clone())
+            .or_insert_with(|| AcpSessionSummary::new(session_id));
+        if let Some(summary) = summary {
+            entry.merge(summary);
         }
+    }
+
+    fn live_state(&self) -> &'static str {
+        if self
+            .active_connection_id
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_some()
+        {
+            "live"
+        } else {
+            "detached_retained"
+        }
+    }
+
+    fn attachable_roles(&self) -> Vec<&'static str> {
+        if self.live_state() == "detached_retained" {
+            vec!["host_owner"]
+        } else {
+            Vec::new()
+        }
+    }
+
+    async fn handle_output(self: &Arc<Self>, line: String) {
+        let mut summaries = acp_session_summaries_from_message(&line);
+        let session_id = summaries
+            .first()
+            .map(|summary| summary.session_id.clone())
+            .or_else(|| session_id_from_acp_message(&line))
+            .or_else(|| {
+                let sessions = self.session_ids();
+                (sessions.len() == 1).then(|| sessions[0].clone())
+            });
 
         let event_id = self.next_event_id.fetch_add(1, Ordering::SeqCst);
+        if summaries.is_empty() {
+            if let Some(session_id) = session_id.clone() {
+                summaries.push(AcpSessionSummary::new(session_id));
+            }
+        }
+        if let Some(hub) = self.hub.upgrade() {
+            for mut summary in summaries {
+                summary.last_event_id = Some(event_id);
+                hub.register_session(summary.session_id.clone(), self, Some(summary));
+            }
+        }
         let annotated = annotate_acp_line(&line, event_id, session_id.as_deref(), false);
         {
             let mut replay_buffer = self.replay_buffer.lock().unwrap_or_else(|e| e.into_inner());
@@ -490,6 +663,20 @@ async fn run_acp_websocket(socket: WebSocket, state: Arc<AcpWebSocketState>) {
                         .await;
                         match serde_json::from_str::<JsonValue>(&line) {
                             Ok(value) => {
+                                if is_session_list_request(&value) {
+                                    let sessions = state
+                                        .hub
+                                        .discover_sessions(
+                                            value.get("params").unwrap_or(&JsonValue::Null),
+                                        )
+                                        .await;
+                                    send_socket_jsonrpc_result(
+                                        &socket_tx,
+                                        value.get("id").unwrap_or(&JsonValue::Null),
+                                        json!({"sessions": sessions}),
+                                    );
+                                    continue;
+                                }
                                 if let Some(load_session_id) = session_load_session_id(&value) {
                                     match state.hub.attach(
                                         &load_session_id,
@@ -511,7 +698,7 @@ async fn run_acp_websocket(socket: WebSocket, state: Arc<AcpWebSocketState>) {
                                             continue;
                                         }
                                         Err(AcpAttachError::NotFound) => {
-                                            replay_persisted_acp_events(
+                                            let replay = replay_persisted_acp_events(
                                                 &state.event_log,
                                                 &load_session_id,
                                                 last_acked_event_id(&value),
@@ -519,12 +706,28 @@ async fn run_acp_websocket(socket: WebSocket, state: Arc<AcpWebSocketState>) {
                                             )
                                             .await;
                                             if worker.is_none() {
-                                                send_socket_jsonrpc_error(
-                                                    &socket_tx,
-                                                    value.get("id").unwrap_or(&JsonValue::Null),
-                                                    -32004,
-                                                    &format!("Session not found: {load_session_id}"),
-                                                );
+                                                if let Some(summary) = replay.summary {
+                                                    send_socket_jsonrpc_result(
+                                                        &socket_tx,
+                                                        value
+                                                            .get("id")
+                                                            .unwrap_or(&JsonValue::Null),
+                                                        json!({
+                                                            "session": summary
+                                                                .to_json("expired_replay_only", &[]),
+                                                            "replayed": replay.replayed,
+                                                        }),
+                                                    );
+                                                } else {
+                                                    send_socket_jsonrpc_error(
+                                                        &socket_tx,
+                                                        value
+                                                            .get("id")
+                                                            .unwrap_or(&JsonValue::Null),
+                                                        -32004,
+                                                        &format!("Session not found: {load_session_id}"),
+                                                    );
+                                                }
                                                 continue;
                                             }
                                         }
@@ -651,16 +854,24 @@ async fn replay_persisted_acp_events(
     session_id: &str,
     last_acked_event_id: u64,
     socket_tx: &mpsc::UnboundedSender<String>,
-) {
+) -> PersistedAcpReplay {
     let Ok(topic) = Topic::new(format!("{ACP_TOPIC_PREFIX}.{session_id}")) else {
-        return;
+        return PersistedAcpReplay {
+            summary: None,
+            replayed: Vec::new(),
+        };
     };
     let Ok(events) = event_log
         .read_range(&topic, None, ACP_REPLAY_BUFFER_LIMIT)
         .await
     else {
-        return;
+        return PersistedAcpReplay {
+            summary: None,
+            replayed: Vec::new(),
+        };
     };
+    let mut summary: Option<AcpSessionSummary> = None;
+    let mut replayed = Vec::new();
     for (_, event) in events {
         if event.kind != "message_sent" {
             continue;
@@ -672,15 +883,67 @@ async fn replay_persisted_acp_events(
         else {
             continue;
         };
+        if let Some(event_summary) =
+            acp_session_summary_from_log_payload(session_id, &event.payload)
+        {
+            match summary.as_mut() {
+                Some(summary) => summary.merge(event_summary),
+                None => summary = Some(event_summary),
+            }
+        }
         if acp_event_id <= last_acked_event_id {
             continue;
         }
         let Some(line) = event.payload.get("line").and_then(JsonValue::as_str) else {
             continue;
         };
-        let replayed = annotate_acp_line(line, acp_event_id, Some(session_id), true);
-        let _ = socket_tx.send(replayed);
+        let replayed_line = annotate_acp_line(line, acp_event_id, Some(session_id), true);
+        let _ = socket_tx.send(replayed_line);
+        replayed.push(json!({"eventId": acp_event_id}));
     }
+    PersistedAcpReplay { summary, replayed }
+}
+
+async fn persisted_acp_session_summaries(event_log: &Arc<AnyEventLog>) -> Vec<AcpSessionSummary> {
+    let Ok(topics) = event_log.topics().await else {
+        return Vec::new();
+    };
+    let mut summaries = Vec::new();
+    for topic in topics {
+        let Some(session_id) = topic.as_str().strip_prefix(&format!("{ACP_TOPIC_PREFIX}.")) else {
+            continue;
+        };
+        let Ok(events) = event_log
+            .read_range(&topic, None, ACP_REPLAY_BUFFER_LIMIT)
+            .await
+        else {
+            continue;
+        };
+        let mut summary: Option<AcpSessionSummary> = None;
+        for (_, event) in events {
+            if event.kind != "message_sent"
+                || event
+                    .payload
+                    .get("acp_event_id")
+                    .and_then(JsonValue::as_u64)
+                    .is_none()
+            {
+                continue;
+            }
+            if let Some(event_summary) =
+                acp_session_summary_from_log_payload(session_id, &event.payload)
+            {
+                match summary.as_mut() {
+                    Some(summary) => summary.merge(event_summary),
+                    None => summary = Some(event_summary),
+                }
+            }
+        }
+        if let Some(summary) = summary {
+            summaries.push(summary);
+        }
+    }
+    summaries
 }
 
 fn acp_replay_log_payload(line: &str, acp_event_id: u64, session_id: Option<&str>) -> JsonValue {
@@ -719,6 +982,213 @@ fn acp_message_log_payload(line: &str, session_id: Option<&str>) -> JsonValue {
             "session_id": session_id,
         }),
     }
+}
+
+fn acp_session_summary_from_log_payload(
+    topic_session_id: &str,
+    payload: &JsonValue,
+) -> Option<AcpSessionSummary> {
+    let last_event_id = payload.get("acp_event_id").and_then(JsonValue::as_u64);
+    let mut summary = payload
+        .get("line")
+        .and_then(JsonValue::as_str)
+        .and_then(|line| {
+            let mut summaries = acp_session_summaries_from_message(line);
+            summaries
+                .iter()
+                .position(|summary| summary.session_id == topic_session_id)
+                .map(|index| summaries.remove(index))
+                .or_else(|| summaries.into_iter().next())
+        })
+        .unwrap_or_else(|| AcpSessionSummary::new(topic_session_id.to_string()));
+    summary.last_event_id = last_event_id;
+    Some(summary)
+}
+
+fn acp_session_summaries_from_message(line: &str) -> Vec<AcpSessionSummary> {
+    let Ok(value) = serde_json::from_str::<JsonValue>(line) else {
+        return Vec::new();
+    };
+    let mut summaries = BTreeMap::<String, AcpSessionSummary>::new();
+    if let Some(session) = value.get("result").and_then(|result| result.get("session")) {
+        if let Some(summary) = acp_session_summary_from_session_value(session) {
+            summaries.insert(summary.session_id.clone(), summary);
+        }
+    }
+    if let Some(items) = value
+        .get("result")
+        .and_then(|result| result.get("sessions"))
+        .and_then(JsonValue::as_array)
+    {
+        for item in items {
+            if let Some(summary) = acp_session_summary_from_session_value(item) {
+                summaries
+                    .entry(summary.session_id.clone())
+                    .and_modify(|existing| existing.merge(summary.clone()))
+                    .or_insert(summary);
+            }
+        }
+    }
+    if let Some(summary) = acp_session_summary_from_result_value(&value) {
+        summaries
+            .entry(summary.session_id.clone())
+            .and_modify(|existing| existing.merge(summary.clone()))
+            .or_insert(summary);
+    }
+    if let Some(session_id) = session_id_from_acp_message(line) {
+        summaries
+            .entry(session_id.clone())
+            .or_insert_with(|| AcpSessionSummary::new(session_id));
+    }
+    summaries.into_values().collect()
+}
+
+fn acp_session_summary_from_result_value(value: &JsonValue) -> Option<AcpSessionSummary> {
+    let result = value.get("result")?;
+    let session_id = result
+        .get("sessionId")
+        .or_else(|| result.get("session_id"))
+        .and_then(JsonValue::as_str)?;
+    let mut summary = AcpSessionSummary::new(session_id.to_string());
+    summary.cwd = result
+        .get("cwd")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    summary.workspace_anchor = workspace_anchor_json(result);
+    summary.last_event_id = result
+        .get("lastEventId")
+        .or_else(|| result.get("last_event_id"))
+        .and_then(JsonValue::as_u64);
+    Some(summary)
+}
+
+fn acp_session_summary_from_session_value(session: &JsonValue) -> Option<AcpSessionSummary> {
+    let session_id = session
+        .get("sessionId")
+        .or_else(|| session.get("session_id"))
+        .and_then(JsonValue::as_str)?;
+    let mut summary = AcpSessionSummary::new(session_id.to_string());
+    summary.cwd = session
+        .get("cwd")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    summary.title = session
+        .get("title")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
+    summary.meta = session
+        .get("_meta")
+        .and_then(JsonValue::as_object)
+        .cloned()
+        .unwrap_or_default();
+    summary.workspace_anchor = workspace_anchor_json(session);
+    summary.last_event_id = session
+        .get("lastEventId")
+        .or_else(|| session.get("last_event_id"))
+        .and_then(JsonValue::as_u64)
+        .or_else(|| {
+            session
+                .get("_meta")
+                .and_then(|meta| meta.get("harn"))
+                .and_then(|harn| {
+                    harn.get("lastEventId")
+                        .or_else(|| harn.get("last_event_id"))
+                        .and_then(JsonValue::as_u64)
+                })
+        });
+    Some(summary)
+}
+
+fn workspace_anchor_json(value: &JsonValue) -> Option<JsonValue> {
+    value
+        .get("workspaceAnchor")
+        .or_else(|| value.get("workspace_anchor"))
+        .cloned()
+        .or_else(|| {
+            value
+                .get("_meta")
+                .and_then(|meta| meta.get("harn"))
+                .and_then(|harn| {
+                    harn.get("workspaceAnchor")
+                        .or_else(|| harn.get("workspace_anchor"))
+                })
+                .cloned()
+        })
+}
+
+fn is_session_list_request(value: &JsonValue) -> bool {
+    value.get("method").and_then(JsonValue::as_str) == Some("session/list")
+}
+
+fn acp_session_summary_matches(
+    summary: &AcpSessionSummary,
+    live_state: &str,
+    params: &JsonValue,
+) -> bool {
+    if let Some(cwd) = acp_session_filter_value(params, "cwd", "cwd").and_then(JsonValue::as_str) {
+        if summary.cwd.as_deref() != Some(cwd) {
+            return false;
+        }
+    }
+    if let Some(states) = acp_session_state_filter(params) {
+        if !states.iter().any(|state| state == live_state) {
+            return false;
+        }
+    }
+    if let Some(filter) = acp_session_filter_value(params, "workspaceAnchor", "workspace_anchor") {
+        let Some(anchor) = summary.workspace_anchor.as_ref() else {
+            return false;
+        };
+        if let Some(primary) = filter.as_str() {
+            return anchor
+                .get("primary")
+                .and_then(JsonValue::as_str)
+                .is_some_and(|value| value == primary);
+        }
+        if let Some(primary) = filter.get("primary").and_then(JsonValue::as_str) {
+            return anchor
+                .get("primary")
+                .and_then(JsonValue::as_str)
+                .is_some_and(|value| value == primary);
+        }
+        return anchor == filter;
+    }
+    true
+}
+
+fn acp_session_state_filter(params: &JsonValue) -> Option<Vec<String>> {
+    let value = acp_session_filter_value(params, "liveState", "live_state")
+        .or_else(|| acp_session_filter_value(params, "state", "state"))?;
+    if let Some(raw) = value.as_str() {
+        return Some(vec![raw.to_string()]);
+    }
+    value.as_array().map(|items| {
+        items
+            .iter()
+            .filter_map(|item| item.as_str().map(str::to_string))
+            .collect()
+    })
+}
+
+fn acp_session_filter_value<'a>(
+    params: &'a JsonValue,
+    camel: &str,
+    snake: &str,
+) -> Option<&'a JsonValue> {
+    params
+        .get(camel)
+        .or_else(|| params.get(snake))
+        .or_else(|| {
+            params
+                .get("filter")
+                .and_then(|filter| filter.get(camel).or_else(|| filter.get(snake)))
+        })
+        .or_else(|| {
+            params
+                .get("_meta")
+                .and_then(|meta| meta.get("harn"))
+                .and_then(|harn| harn.get(camel).or_else(|| harn.get(snake)))
+        })
 }
 
 fn annotate_acp_line(
@@ -778,6 +1248,17 @@ fn send_socket_jsonrpc_error(
     message: &str,
 ) {
     let response = harn_vm::jsonrpc::error_response(id.clone(), code, message);
+    if let Ok(line) = serde_json::to_string(&response) {
+        let _ = socket_tx.send(line);
+    }
+}
+
+fn send_socket_jsonrpc_result(
+    socket_tx: &mpsc::UnboundedSender<String>,
+    id: &JsonValue,
+    result: JsonValue,
+) {
+    let response = harn_vm::jsonrpc::response(id.clone(), result);
     if let Ok(line) = serde_json::to_string(&response) {
         let _ = socket_tx.send(line);
     }

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -523,6 +523,78 @@ async fn acp_websocket_parallel_clients_get_distinct_sessions_and_can_load_activ
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn acp_websocket_session_list_discovers_live_and_detached_sessions_by_cwd() {
+    let _guard = lock_harn_state();
+    reset_active_event_log();
+
+    let dir = tempdir().expect("tempdir");
+    let cwd = dir.path().display().to_string();
+    let (listener, _log, _dir) = start_acp_test_listener_with_env(
+        ListenerRuntimeEnv::for_test().with_api_key("ws-test-key"),
+    )
+    .await;
+    let (mut owner, _) =
+        tokio_tungstenite::connect_async(authorized_acp_request(listener.local_addr()))
+            .await
+            .expect("owner connect");
+    let created = acp_request(&mut owner, 1, "session/new", json!({"cwd": cwd.clone()})).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    let (mut observer, _) =
+        tokio_tungstenite::connect_async(authorized_acp_request(listener.local_addr()))
+            .await
+            .expect("observer connect");
+    let listed = acp_request(
+        &mut observer,
+        2,
+        "session/list",
+        json!({"cwd": cwd.clone()}),
+    )
+    .await;
+    assert_eq!(
+        listed["result"]["sessions"][0]["sessionId"],
+        json!(session_id)
+    );
+    assert_eq!(listed["result"]["sessions"][0]["liveState"], json!("live"));
+    assert_eq!(
+        listed["result"]["sessions"][0]["attachableRoles"],
+        json!([])
+    );
+
+    owner.close(None).await.expect("close owner");
+    drop(owner);
+    wait_for_acp_session_detached(&listener, &session_id).await;
+
+    let detached = acp_request(
+        &mut observer,
+        3,
+        "session/list",
+        json!({
+            "cwd": cwd,
+            "liveState": "detached_retained",
+        }),
+    )
+    .await;
+    assert_eq!(
+        detached["result"]["sessions"][0]["sessionId"],
+        json!(session_id)
+    );
+    assert_eq!(
+        detached["result"]["sessions"][0]["attachableRoles"],
+        json!(["host_owner"])
+    );
+
+    listener
+        .shutdown(Duration::from_secs(5))
+        .await
+        .expect("shutdown listener");
+    reset_active_event_log();
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn acp_websocket_rejects_duplicate_attach_to_live_session() {
     let _guard = lock_harn_state();
     reset_active_event_log();
@@ -697,17 +769,21 @@ async fn acp_websocket_replays_serialized_events_after_worker_expiry() {
     .await;
 
     let mut saw_persisted_replay = false;
-    let mut saw_expired_session_error = false;
+    let mut saw_expired_session_load = false;
     tokio::time::timeout(Duration::from_secs(10), async {
-        while !(saw_persisted_replay && saw_expired_session_error) {
+        while !(saw_persisted_replay && saw_expired_session_load) {
             let message = next_acp_text(&mut reconnected).await;
             if message["_harn"]["replayed"] == json!(true) {
                 assert_eq!(message["result"]["sessionId"], json!(session_id));
                 saw_persisted_replay = true;
             }
             if message.get("id").and_then(JsonValue::as_u64) == Some(4) {
-                assert_eq!(message["error"]["code"], json!(-32004));
-                saw_expired_session_error = true;
+                assert_eq!(
+                    message["result"]["session"]["liveState"],
+                    json!("expired_replay_only")
+                );
+                assert_eq!(message["result"]["session"]["attachableRoles"], json!([]));
+                saw_expired_session_load = true;
             }
         }
     })

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -78,6 +78,74 @@ fn session_id_param(params: &serde_json::Value) -> Option<String> {
         .map(str::to_string)
 }
 
+fn session_list_filter<'a>(
+    params: &'a serde_json::Value,
+    camel: &str,
+    snake: &str,
+) -> Option<&'a serde_json::Value> {
+    params
+        .get(camel)
+        .or_else(|| params.get(snake))
+        .or_else(|| {
+            params
+                .get("filter")
+                .and_then(|filter| filter.get(camel).or_else(|| filter.get(snake)))
+        })
+        .or_else(|| {
+            params
+                .get("_meta")
+                .and_then(|meta| meta.get("harn"))
+                .and_then(|harn| harn.get(camel).or_else(|| harn.get(snake)))
+        })
+}
+
+fn session_workspace_anchor_filter(params: &serde_json::Value) -> Option<&serde_json::Value> {
+    session_list_filter(params, "workspaceAnchor", "workspace_anchor")
+}
+
+fn session_cwd_filter(params: &serde_json::Value) -> Option<&str> {
+    session_list_filter(params, "cwd", "cwd").and_then(serde_json::Value::as_str)
+}
+
+fn session_live_state_filter(params: &serde_json::Value) -> Option<Vec<String>> {
+    let value = session_list_filter(params, "liveState", "live_state")
+        .or_else(|| session_list_filter(params, "state", "state"))?;
+    if let Some(raw) = value.as_str() {
+        return Some(vec![raw.to_string()]);
+    }
+    value.as_array().map(|items| {
+        items
+            .iter()
+            .filter_map(|item| item.as_str().map(str::to_string))
+            .collect()
+    })
+}
+
+fn workspace_anchor_filter_matches(
+    anchor: Option<&harn_vm::workspace_anchor::WorkspaceAnchor>,
+    filter: Option<&serde_json::Value>,
+) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+    let Some(anchor) = anchor else {
+        return false;
+    };
+    if let Some(raw) = filter.as_str() {
+        return anchor.primary.to_string_lossy() == raw;
+    }
+    if let Some(primary) = filter.get("primary").and_then(serde_json::Value::as_str) {
+        return anchor.primary.to_string_lossy() == primary;
+    }
+    harn_vm::workspace_anchor::WorkspaceAnchor::from_json(filter).is_ok_and(|expected| {
+        expected.primary == anchor.primary && expected.additional_roots == anchor.additional_roots
+    })
+}
+
+fn live_state_filter_matches(live_state: &str, filter: Option<&[String]>) -> bool {
+    filter.is_none_or(|states| states.iter().any(|state| state == live_state))
+}
+
 fn bridge_mode_for_session_inject(params: &serde_json::Value) -> Result<&'static str, String> {
     match params.get("mode").and_then(|value| value.as_str()) {
         // ACP `session/inject.mode = "queue"` is the audit/trail variant —
@@ -702,11 +770,15 @@ impl AcpServer {
 
         let session_id = self.next_session_id();
         self.insert_session(session_id.clone(), cwd, SessionInfo::default());
+        let session = self
+            .session_item_json(&session_id, "live", None)
+            .unwrap_or_else(|| serde_json::json!({"sessionId": session_id}));
 
         self.send_response(
             id,
             serde_json::json!({
                 "sessionId": session_id,
+                "session": session,
                 "modes": modes::session_mode_state(modes::DEFAULT_MODE_ID),
                 "configOptions": modes::config_options_state(
                     modes::DEFAULT_MODE_ID,
@@ -1605,23 +1677,12 @@ impl AcpServer {
         }
     }
 
-    fn handle_session_list(&self, id: &serde_json::Value) {
+    fn handle_session_list(&self, id: &serde_json::Value, params: &serde_json::Value) {
         let sessions: Vec<serde_json::Value> = self
             .sessions
             .iter()
-            .map(|(sid, session)| {
-                let mut item = serde_json::json!({
-                    "sessionId": sid,
-                    "cwd": session.cwd,
-                });
-                if let Some(title) = &session.info.title {
-                    item["title"] = serde_json::json!(title);
-                }
-                if !session.info.meta.is_empty() {
-                    item["_meta"] = serde_json::Value::Object(session.info.meta.clone());
-                }
-                item
-            })
+            .filter(|(sid, session)| self.session_matches_list_filters(sid, session, params))
+            .filter_map(|(sid, _)| self.session_item_json(sid, "live", None))
             .collect();
         self.send_response(id, serde_json::json!({"sessions": sessions}));
     }
@@ -1773,17 +1834,7 @@ impl AcpServer {
 
     fn session_restore_result(&self, session_id: &str) -> Option<serde_json::Value> {
         let session = self.sessions.get(session_id)?;
-        let mut session_value = serde_json::json!({
-            "sessionId": session_id,
-            "cwd": session.cwd.display().to_string(),
-        });
-        if let Some(title) = session.info.title.as_ref() {
-            session_value["title"] = serde_json::json!(title);
-        }
-        if !session.info.meta.is_empty() {
-            session_value["_meta"] = serde_json::Value::Object(session.info.meta.clone());
-        }
-
+        let session_value = self.session_item_json(session_id, "live", None)?;
         Some(serde_json::json!({
             "session": session_value,
             "modes": modes::session_mode_state(&session.current_mode_id),
@@ -1793,6 +1844,89 @@ impl AcpServer {
                 self.pinned_reasoning_policy(session_id).as_deref(),
             ),
         }))
+    }
+
+    fn session_item_json(
+        &self,
+        session_id: &str,
+        live_state: &str,
+        last_event_id: Option<u64>,
+    ) -> Option<serde_json::Value> {
+        let session = self.sessions.get(session_id)?;
+        let workspace_anchor = harn_vm::agent_sessions::workspace_anchor(session_id);
+        let snapshot = harn_vm::agent_sessions::snapshot(session_id)
+            .map(|value| harn_vm::llm::vm_value_to_json(&value))
+            .unwrap_or(serde_json::Value::Null);
+        let active_prompt = session.host_bridge.is_some();
+        let attachable_roles = serde_json::json!(["host_owner"]);
+        let mut item = serde_json::json!({
+            "sessionId": session_id,
+            "cwd": session.cwd.display().to_string(),
+            "liveState": live_state,
+            "attachableRoles": attachable_roles,
+            "currentModeId": session.current_mode_id,
+            "activePrompt": active_prompt,
+        });
+        if let Some(created_at) = snapshot.get("created_at").cloned() {
+            item["createdAt"] = created_at;
+        }
+        if let Some(last_event_id) = last_event_id {
+            item["lastEventId"] = serde_json::json!(last_event_id);
+        }
+        if let Some(title) = session.info.title.as_ref() {
+            item["title"] = serde_json::json!(title);
+        }
+        if let Some(anchor) = workspace_anchor.as_ref() {
+            item["workspaceAnchor"] = anchor.to_json();
+        }
+
+        let mut meta = session.info.meta.clone();
+        let mut harn_meta = match meta.remove("harn") {
+            Some(serde_json::Value::Object(map)) => map,
+            _ => serde_json::Map::new(),
+        };
+        harn_meta.insert("liveState".to_string(), serde_json::json!(live_state));
+        harn_meta.insert(
+            "attachableRoles".to_string(),
+            item["attachableRoles"].clone(),
+        );
+        harn_meta.insert(
+            "currentModeId".to_string(),
+            serde_json::json!(session.current_mode_id),
+        );
+        harn_meta.insert("activePrompt".to_string(), serde_json::json!(active_prompt));
+        if let Some(last_event_id) = last_event_id {
+            harn_meta.insert("lastEventId".to_string(), serde_json::json!(last_event_id));
+        }
+        if let Some(anchor) = workspace_anchor {
+            harn_meta.insert("workspaceAnchor".to_string(), anchor.to_json());
+        }
+        meta.insert("harn".to_string(), serde_json::Value::Object(harn_meta));
+        item["_meta"] = serde_json::Value::Object(meta);
+        Some(item)
+    }
+
+    fn session_matches_list_filters(
+        &self,
+        session_id: &str,
+        session: &Session,
+        params: &serde_json::Value,
+    ) -> bool {
+        if let Some(cwd) = session_cwd_filter(params) {
+            if session.cwd.to_string_lossy() != cwd {
+                return false;
+            }
+        }
+        let live_state = "live";
+        let state_filter = session_live_state_filter(params);
+        if !live_state_filter_matches(live_state, state_filter.as_deref()) {
+            return false;
+        }
+        let workspace_anchor = harn_vm::agent_sessions::workspace_anchor(session_id);
+        workspace_anchor_filter_matches(
+            workspace_anchor.as_ref(),
+            session_workspace_anchor_filter(params),
+        )
     }
 
     fn restored_session_id<'a>(
@@ -2581,7 +2715,7 @@ impl AcpServer {
                 if self.reject_unauthenticated(&id) {
                     return;
                 }
-                self.handle_session_list(&id);
+                self.handle_session_list(&id, &params);
             }
             _ => {
                 if !id.is_null() {

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -286,6 +286,136 @@ async fn acp_server_handles_session_flow_and_prompt_updates() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn acp_session_list_filters_by_workspace_anchor_and_cwd() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let primary = dir.path().join("project");
+            let sibling = dir.path().join("project-tools");
+            std::fs::create_dir_all(&primary).expect("primary dir");
+            std::fs::create_dir_all(&sibling).expect("sibling dir");
+
+            let (request_tx, request_rx) = mpsc::unbounded_channel();
+            let (response_tx, mut response_rx) = mpsc::unbounded_channel();
+            let server = tokio::task::spawn_local(super::run_acp_channel_server(
+                AcpServerConfig::new(None),
+                request_rx,
+                response_tx,
+            ));
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "session/new",
+                    "params": {"cwd": primary.display().to_string()},
+                }))
+                .expect("send first session/new");
+            let first = recv_json(&mut response_rx).await;
+            let first_id = first["result"]["sessionId"]
+                .as_str()
+                .expect("first session id")
+                .to_string();
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "session/new",
+                    "params": {"cwd": sibling.display().to_string()},
+                }))
+                .expect("send second session/new");
+            let second = recv_json(&mut response_rx).await;
+            let second_id = second["result"]["sessionId"]
+                .as_str()
+                .expect("second session id")
+                .to_string();
+
+            harn_vm::agent_sessions::set_workspace_anchor(
+                &first_id,
+                Some(harn_vm::workspace_anchor::WorkspaceAnchor {
+                    primary: primary.clone(),
+                    additional_roots: Vec::new(),
+                    anchored_at: "2026-05-25T00:00:00Z".to_string(),
+                }),
+            )
+            .expect("set first anchor");
+            harn_vm::agent_sessions::set_workspace_anchor(
+                &second_id,
+                Some(harn_vm::workspace_anchor::WorkspaceAnchor {
+                    primary: sibling.clone(),
+                    additional_roots: Vec::new(),
+                    anchored_at: "2026-05-25T00:00:00Z".to_string(),
+                }),
+            )
+            .expect("set second anchor");
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "session/list",
+                    "params": {
+                        "workspaceAnchor": {"primary": primary.display().to_string()},
+                    },
+                }))
+                .expect("send anchored session/list");
+            let anchored = recv_json(&mut response_rx).await;
+            assert_eq!(
+                anchored["result"]["sessions"]
+                    .as_array()
+                    .expect("anchored sessions")
+                    .len(),
+                1
+            );
+            assert_eq!(
+                anchored["result"]["sessions"][0]["sessionId"],
+                serde_json::json!(first_id)
+            );
+            assert_eq!(
+                anchored["result"]["sessions"][0]["workspaceAnchor"]["primary"],
+                serde_json::json!(primary.display().to_string())
+            );
+            assert_eq!(
+                anchored["result"]["sessions"][0]["_meta"]["harn"]["liveState"],
+                serde_json::json!("live")
+            );
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "session/list",
+                    "params": {"cwd": sibling.display().to_string()},
+                }))
+                .expect("send cwd session/list");
+            let by_cwd = recv_json(&mut response_rx).await;
+            assert_eq!(
+                by_cwd["result"]["sessions"][0]["sessionId"],
+                serde_json::json!(second_id)
+            );
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "session/load",
+                    "params": {"sessionId": first_id},
+                }))
+                .expect("send session/load");
+            let loaded = recv_json(&mut response_rx).await;
+            assert_eq!(
+                loaded["result"]["session"]["_meta"]["harn"]["workspaceAnchor"]["primary"],
+                serde_json::json!(primary.display().to_string())
+            );
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn acp_session_truncate_mutates_current_session_and_notifies_client() {
     let local = tokio::task::LocalSet::new();
     local

--- a/docs/src/acp/websocket.md
+++ b/docs/src/acp/websocket.md
@@ -125,7 +125,31 @@ event id:
 ```
 
 Clients should persist the highest `_harn.eventId` they have durably processed.
-On reconnect, call `session/load` with that cursor:
+Before reconnecting a specific session, clients can discover attachable sessions
+with `session/list`. Harn accepts `workspaceAnchor` as the preferred project key
+and `cwd` as a compatibility fallback:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "session/list",
+  "params": {
+    "workspaceAnchor": { "primary": "/workspace/harn" },
+    "liveState": ["live", "detached_retained"]
+  }
+}
+```
+
+Each result includes `sessionId`, `cwd` when known, `workspaceAnchor` when the
+session has one, `liveState`, `attachableRoles`, and `lastEventId` when replay
+metadata is available. `liveState` is one of:
+
+- `live`: a retained worker is still running.
+- `detached_retained`: a retained worker is waiting for a host owner reconnect.
+- `expired_replay_only`: only serialized audit/replay frames remain.
+
+On reconnect, call `session/load` with the selected session id and cursor:
 
 ```json
 {
@@ -151,7 +175,8 @@ can tune that window for controlled deployments and tests. After expiry, or
 after an orchestrator process restart, Harn can still replay serialized outbound
 frames from the EventLog topic `acp.session.<session-id>`, but it cannot resume
 an in-flight VM stack that was waiting inside the expired process. In that case
-the host should treat replay as recovery/audit state and start a new prompt.
+`session/load` returns `liveState: "expired_replay_only"` and the host should
+treat replay as recovery/audit state before starting a new prompt.
 
 ## Example
 


### PR DESCRIPTION
## Summary
- add ACP session discovery metadata for live, detached-retained, and expired replay-only sessions
- support `session/list` filtering by `workspaceAnchor`, cwd/current directory fallback, and `liveState`
- make `session/load` return replay-only session metadata after worker expiry instead of a generic not-found
- document the WebSocket discovery response and attach lifecycle metadata

Closes #2413

## Verification
- `cargo fmt`
- `git diff --check`
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-2413 cargo test -p harn-serve acp_session_list_filters_by_workspace_anchor_and_cwd -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2413 cargo test -p harn-cli acp_websocket_session_list_discovers_live_and_detached_sessions_by_cwd -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2413 cargo test -p harn-cli acp_websocket_replays_serialized_events_after_worker_expiry -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2413 cargo test -p harn-cli acp_websocket -- --nocapture`
- pre-commit hook
- pre-push hook with `CARGO_TARGET_DIR=/tmp/harn-target-2413-push`
