### PR TITLE
Add ACP control arbitration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ condensed series summaries instead of full per-patch history.
   `host_owner`. Harn routes host JSON-RPC requests only to the host owner,
   broadcasts session notifications and presence updates, and rejects read-only
   observer controls with structured role errors.
+- **ACP control arbitration (#2412).** ACP WebSocket permission responses are
+  first-valid-response-wins with idempotent same-actor replays and structured
+  `already_decided` rejects. Session cancel and pending-inject controls now
+  return stable lifecycle outcomes, carry actor metadata, and emit
+  audit-visible `control_outcome` events.
 
 ## v0.8.37
 

--- a/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
@@ -50,6 +50,8 @@ struct AcpWorker {
     clients: Mutex<BTreeMap<String, AcpClient>>,
     host_owner_client_id: Mutex<Option<String>>,
     pending_client_requests: Mutex<BTreeMap<String, String>>,
+    pending_host_requests: Mutex<BTreeMap<String, AcpHostRequest>>,
+    decided_host_requests: Mutex<BTreeMap<String, AcpHostDecision>>,
     sessions: Mutex<BTreeMap<String, AcpSessionSummary>>,
     replay_buffer: Mutex<VecDeque<AcpReplayEvent>>,
     next_event_id: AtomicU64,
@@ -116,13 +118,51 @@ enum AcpAttachError {
 enum AcpClientRequestError {
     Disconnected,
     DuplicateRequestId,
-    Forbidden { method: String, role: AcpAttachRole },
+    UnknownHostRequest {
+        request_id: String,
+    },
+    IdempotentHostDecision {
+        decision: AcpHostDecision,
+    },
+    AlreadyDecided {
+        decision: AcpHostDecision,
+        attempted_actor: AcpControlActor,
+        attempted_payload: JsonValue,
+    },
+    Forbidden {
+        method: String,
+        role: AcpAttachRole,
+    },
 }
 
 enum AcpOutboundRoute {
-    HostRequest,
+    HostRequest { id_key: String, method: String },
     Response(Option<String>),
     Broadcast,
+}
+
+#[derive(Clone, Debug)]
+struct AcpHostRequest {
+    method: String,
+    session_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct AcpControlActor {
+    client_id: String,
+    connection_id: Option<String>,
+    role: AcpAttachRole,
+    source: String,
+}
+
+#[derive(Clone, Debug)]
+struct AcpHostDecision {
+    request_id: String,
+    method: String,
+    session_id: Option<String>,
+    actor: AcpControlActor,
+    payload: JsonValue,
+    decided_at_ms: u128,
 }
 
 struct PersistedAcpReplay {
@@ -152,6 +192,8 @@ impl AcpWebSocketHub {
             clients: Mutex::new(BTreeMap::new()),
             host_owner_client_id: Mutex::new(None),
             pending_client_requests: Mutex::new(BTreeMap::new()),
+            pending_host_requests: Mutex::new(BTreeMap::new()),
+            decided_host_requests: Mutex::new(BTreeMap::new()),
             sessions: Mutex::new(BTreeMap::new()),
             replay_buffer: Mutex::new(VecDeque::new()),
             next_event_id: AtomicU64::new(1),
@@ -456,6 +498,40 @@ impl AcpAttachRole {
     }
 }
 
+impl AcpControlActor {
+    fn to_json(&self) -> JsonValue {
+        let mut value = json!({
+            "clientId": self.client_id,
+            "role": self.role.as_str(),
+            "source": self.source,
+        });
+        if let Some(connection_id) = self.connection_id.as_ref() {
+            value["connectionId"] = json!(connection_id);
+        }
+        value
+    }
+}
+
+impl AcpHostDecision {
+    fn error_data(&self, reason: &str, attempted_actor: Option<&AcpControlActor>) -> JsonValue {
+        let mut data = json!({
+            "reason": reason,
+            "requestId": self.request_id,
+            "method": self.method,
+            "decidedBy": self.actor.to_json(),
+            "decidedAtMs": self.decided_at_ms,
+            "decision": self.payload,
+        });
+        if let Some(session_id) = self.session_id.as_ref() {
+            data["sessionId"] = json!(session_id);
+        }
+        if let Some(actor) = attempted_actor {
+            data["attemptedBy"] = actor.to_json();
+        }
+        data
+    }
+}
+
 impl AcpWorker {
     fn attach(
         &self,
@@ -531,12 +607,88 @@ impl AcpWorker {
         Some((client_id, role))
     }
 
-    fn send_client_request(
+    fn client_actor(&self, client_id: &str, role: AcpAttachRole) -> AcpControlActor {
+        let connection_id = self
+            .clients
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(client_id)
+            .map(|client| client.connection_id.clone());
+        AcpControlActor {
+            client_id: client_id.to_string(),
+            connection_id,
+            role,
+            source: "websocket".to_string(),
+        }
+    }
+
+    fn pending_host_request(&self, id_key: &str) -> Option<AcpHostRequest> {
+        self.pending_host_requests
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(id_key)
+            .cloned()
+    }
+
+    fn annotate_control_actor(&self, value: &mut JsonValue, actor: &AcpControlActor) {
+        let Some(params) = value.get_mut("params") else {
+            return;
+        };
+        let Some(params) = params.as_object_mut() else {
+            return;
+        };
+        let harn = params
+            .entry("_harn".to_string())
+            .or_insert_with(|| json!({}));
+        if let Some(harn) = harn.as_object_mut() {
+            harn.insert("actor".to_string(), actor.to_json());
+            harn.entry("clientId".to_string())
+                .or_insert_with(|| json!(actor.client_id));
+            harn.entry("role".to_string())
+                .or_insert_with(|| json!(actor.role.as_str()));
+            harn.entry("source".to_string())
+                .or_insert_with(|| json!(actor.source));
+            if let Some(connection_id) = actor.connection_id.as_ref() {
+                harn.entry("connectionId".to_string())
+                    .or_insert_with(|| json!(connection_id));
+            }
+        }
+    }
+
+    fn decision_payload(value: &JsonValue) -> JsonValue {
+        if let Some(error) = value.get("error") {
+            json!({"error": error})
+        } else {
+            json!({"result": value.get("result").cloned().unwrap_or(JsonValue::Null)})
+        }
+    }
+
+    async fn append_control_outcome(&self, decision: &AcpHostDecision, status: &str, reason: &str) {
+        let topic_id = decision.session_id.as_deref().unwrap_or(&self.id);
+        append_acp_event(
+            &self.event_log,
+            topic_id,
+            "control_outcome",
+            json!({
+                "request_id": decision.request_id,
+                "method": decision.method,
+                "status": status,
+                "reason": reason,
+                "actor": decision.actor.to_json(),
+                "decision": decision.payload,
+                "decided_at_ms": decision.decided_at_ms,
+            }),
+        )
+        .await;
+    }
+
+    async fn send_client_request(
         &self,
         client_id: &str,
         role: AcpAttachRole,
-        value: JsonValue,
+        mut value: JsonValue,
     ) -> Result<(), AcpClientRequestError> {
+        let actor = self.client_actor(client_id, role);
         if let Some(method) = value.get("method").and_then(JsonValue::as_str) {
             if !role_may_send_method(role, method) {
                 return Err(AcpClientRequestError::Forbidden {
@@ -544,7 +696,78 @@ impl AcpWorker {
                     role,
                 });
             }
-        } else if role != AcpAttachRole::HostOwner {
+            self.annotate_control_actor(&mut value, &actor);
+        } else if let Some(id_key) = jsonrpc_id_key(&value) {
+            if let Some(decision) = self
+                .decided_host_requests
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&id_key)
+                .cloned()
+            {
+                let attempted_payload = Self::decision_payload(&value);
+                if decision.actor.client_id == actor.client_id
+                    && decision.payload == attempted_payload
+                {
+                    return Err(AcpClientRequestError::IdempotentHostDecision { decision });
+                }
+                return Err(AcpClientRequestError::AlreadyDecided {
+                    decision,
+                    attempted_actor: actor,
+                    attempted_payload,
+                });
+            }
+
+            let Some(host_request) = self.pending_host_request(&id_key) else {
+                return Err(AcpClientRequestError::UnknownHostRequest { request_id: id_key });
+            };
+            if role != AcpAttachRole::HostOwner
+                && !(role == AcpAttachRole::Controller
+                    && host_request.method == "session/request_permission")
+            {
+                return Err(AcpClientRequestError::Forbidden {
+                    method: host_request.method,
+                    role,
+                });
+            }
+
+            self.request_tx
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .as_ref()
+                .ok_or(AcpClientRequestError::Disconnected)?
+                .send(value.clone())
+                .map_err(|_| AcpClientRequestError::Disconnected)?;
+
+            self.pending_host_requests
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&id_key);
+            let decision = AcpHostDecision {
+                request_id: id_key.clone(),
+                method: host_request.method,
+                session_id: host_request.session_id,
+                actor,
+                payload: Self::decision_payload(&value),
+                decided_at_ms: unix_epoch_ms(),
+            };
+            {
+                let mut decided = self
+                    .decided_host_requests
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                decided.insert(id_key, decision.clone());
+                while decided.len() > ACP_REPLAY_BUFFER_LIMIT {
+                    let Some(first_key) = decided.keys().next().cloned() else {
+                        break;
+                    };
+                    decided.remove(&first_key);
+                }
+            }
+            self.append_control_outcome(&decision, "accepted", "first_valid_response")
+                .await;
+            return Ok(());
+        } else {
             return Err(AcpClientRequestError::Forbidden {
                 method: "<response>".to_string(),
                 role,
@@ -589,6 +812,14 @@ impl AcpWorker {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .take();
+        self.pending_host_requests
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+        self.decided_host_requests
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
     }
 
     fn is_expired(&self, retention: Duration) -> bool {
@@ -702,6 +933,19 @@ impl AcpWorker {
         )
         .await;
 
+        if let AcpOutboundRoute::HostRequest { id_key, method } = acp_outbound_route(&line) {
+            self.pending_host_requests
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(
+                    id_key,
+                    AcpHostRequest {
+                        method,
+                        session_id: session_id.clone(),
+                    },
+                );
+        }
+
         self.deliver_output(&line, annotated);
     }
 
@@ -775,7 +1019,13 @@ impl AcpWorker {
 
     fn deliver_output(&self, original_line: &str, annotated: String) {
         match acp_outbound_route(original_line) {
-            AcpOutboundRoute::HostRequest => self.send_to_host_owner(annotated),
+            AcpOutboundRoute::HostRequest { method, .. } => {
+                if method == "session/request_permission" {
+                    self.send_to_control_actors(annotated);
+                } else {
+                    self.send_to_host_owner(annotated);
+                }
+            }
             AcpOutboundRoute::Response(id_key) => {
                 let target = id_key.and_then(|id_key| {
                     self.pending_client_requests
@@ -803,6 +1053,25 @@ impl AcpWorker {
             .clone();
         if let Some(client_id) = host_owner {
             let _ = self.send_to_client(&client_id, line);
+        }
+    }
+
+    fn send_to_control_actors(&self, line: String) {
+        let clients: Vec<mpsc::UnboundedSender<String>> = self
+            .clients
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .filter(|client| {
+                matches!(
+                    client.role,
+                    AcpAttachRole::HostOwner | AcpAttachRole::Controller
+                )
+            })
+            .map(|client| client.socket_tx.clone())
+            .collect();
+        for socket_tx in clients {
+            let _ = socket_tx.send(line.clone());
         }
     }
 
@@ -1070,7 +1339,10 @@ async fn run_acp_websocket(socket: WebSocket, state: Arc<AcpWebSocketState>) {
                                 };
                                 let request_id =
                                     value.get("id").cloned().unwrap_or(JsonValue::Null);
-                                match worker.send_client_request(&client_id, client_role, value) {
+                                match worker
+                                    .send_client_request(&client_id, client_role, value)
+                                    .await
+                                {
                                     Ok(()) => {}
                                     Err(AcpClientRequestError::Forbidden { method, role }) => {
                                         send_socket_jsonrpc_error_with_data(
@@ -1083,6 +1355,67 @@ async fn run_acp_websocket(socket: WebSocket, state: Arc<AcpWebSocketState>) {
                                                 "role": role.as_str(),
                                                 "reason": "role_not_authorized",
                                             }),
+                                        );
+                                    }
+                                    Err(AcpClientRequestError::UnknownHostRequest {
+                                        request_id: unknown_request_id,
+                                    }) => {
+                                        send_socket_jsonrpc_error_with_data(
+                                            &socket_tx,
+                                            &request_id,
+                                            -32014,
+                                            "ACP host request is not pending",
+                                            json!({
+                                                "requestId": unknown_request_id,
+                                                "reason": "unknown_request_id",
+                                            }),
+                                        );
+                                    }
+                                    Err(AcpClientRequestError::IdempotentHostDecision {
+                                        decision,
+                                    }) => {
+                                        worker
+                                            .append_control_outcome(
+                                                &decision,
+                                                "idempotent",
+                                                "same_actor_same_decision",
+                                            )
+                                            .await;
+                                        send_socket_jsonrpc_result(
+                                            &socket_tx,
+                                            &request_id,
+                                            json!({
+                                                "status": "already_applied",
+                                                "_meta": {
+                                                    "harn": decision.error_data(
+                                                        "same_actor_same_decision",
+                                                        None,
+                                                    ),
+                                                },
+                                            }),
+                                        );
+                                    }
+                                    Err(AcpClientRequestError::AlreadyDecided {
+                                        decision,
+                                        attempted_actor,
+                                        attempted_payload,
+                                    }) => {
+                                        worker
+                                            .append_control_outcome(
+                                                &decision,
+                                                "rejected",
+                                                "already_decided",
+                                            )
+                                            .await;
+                                        let mut data = decision
+                                            .error_data("already_decided", Some(&attempted_actor));
+                                        data["attemptedDecision"] = attempted_payload;
+                                        send_socket_jsonrpc_error_with_data(
+                                            &socket_tx,
+                                            &request_id,
+                                            -32013,
+                                            "ACP host request already has a decision",
+                                            data,
                                         );
                                     }
                                     Err(AcpClientRequestError::DuplicateRequestId) => {
@@ -1604,12 +1937,15 @@ fn acp_outbound_route(line: &str) -> AcpOutboundRoute {
     let Ok(value) = serde_json::from_str::<JsonValue>(line) else {
         return AcpOutboundRoute::Broadcast;
     };
-    let has_method = value.get("method").and_then(JsonValue::as_str).is_some();
+    let method = value.get("method").and_then(JsonValue::as_str);
     let id_key = jsonrpc_id_key(&value);
-    match (has_method, id_key) {
-        (true, Some(_)) => AcpOutboundRoute::HostRequest,
-        (false, id_key) => AcpOutboundRoute::Response(id_key),
-        (true, None) => AcpOutboundRoute::Broadcast,
+    match (method, id_key) {
+        (Some(method), Some(id_key)) => AcpOutboundRoute::HostRequest {
+            id_key,
+            method: method.to_string(),
+        },
+        (None, id_key) => AcpOutboundRoute::Response(id_key),
+        (Some(_), None) => AcpOutboundRoute::Broadcast,
     }
 }
 
@@ -1624,6 +1960,13 @@ fn jsonrpc_id_key(value: &JsonValue) -> Option<String> {
     value
         .get("id")
         .and_then(|id| serde_json::to_string(id).ok())
+}
+
+fn unix_epoch_ms() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
 }
 
 fn annotate_acp_line(
@@ -1764,4 +2107,185 @@ fn session_id_from_acp_message(line: &str) -> Option<String> {
                 })
                 .map(ToString::to_string)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harn_vm::event_log::{AnyEventLog, MemoryEventLog};
+    use std::collections::{BTreeMap, VecDeque};
+    use std::sync::atomic::AtomicU64;
+    use std::sync::{Arc, Mutex, Weak};
+    use tokio::sync::mpsc;
+
+    type TestWorkerChannels = (
+        Arc<AcpWorker>,
+        mpsc::UnboundedReceiver<JsonValue>,
+        mpsc::UnboundedReceiver<String>,
+        mpsc::UnboundedReceiver<String>,
+        mpsc::UnboundedReceiver<String>,
+    );
+
+    fn test_worker() -> TestWorkerChannels {
+        let (request_tx, request_rx) = mpsc::unbounded_channel();
+        let (owner_tx, owner_rx) = mpsc::unbounded_channel();
+        let (controller_tx, controller_rx) = mpsc::unbounded_channel();
+        let (observer_tx, observer_rx) = mpsc::unbounded_channel();
+        let worker = Arc::new(AcpWorker {
+            id: "worker-test".to_string(),
+            request_tx: Mutex::new(Some(request_tx)),
+            clients: Mutex::new(BTreeMap::from([
+                (
+                    "owner".to_string(),
+                    AcpClient {
+                        connection_id: "owner-conn".to_string(),
+                        role: AcpAttachRole::HostOwner,
+                        socket_tx: owner_tx,
+                    },
+                ),
+                (
+                    "controller".to_string(),
+                    AcpClient {
+                        connection_id: "controller-conn".to_string(),
+                        role: AcpAttachRole::Controller,
+                        socket_tx: controller_tx,
+                    },
+                ),
+                (
+                    "observer".to_string(),
+                    AcpClient {
+                        connection_id: "observer-conn".to_string(),
+                        role: AcpAttachRole::Observer,
+                        socket_tx: observer_tx,
+                    },
+                ),
+            ])),
+            host_owner_client_id: Mutex::new(Some("owner".to_string())),
+            pending_client_requests: Mutex::new(BTreeMap::new()),
+            pending_host_requests: Mutex::new(BTreeMap::new()),
+            decided_host_requests: Mutex::new(BTreeMap::new()),
+            sessions: Mutex::new(BTreeMap::new()),
+            replay_buffer: Mutex::new(VecDeque::new()),
+            next_event_id: AtomicU64::new(1),
+            detached_at: Mutex::new(None),
+            event_log: Arc::new(AnyEventLog::Memory(MemoryEventLog::new(64))),
+            hub: Weak::new(),
+        });
+        (worker, request_rx, owner_rx, controller_rx, observer_rx)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_hub_arbitrates_permission_responses() {
+        let (worker, mut request_rx, mut owner_rx, mut controller_rx, mut observer_rx) =
+            test_worker();
+        worker
+            .handle_output(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 77,
+                    "method": "session/request_permission",
+                    "params": {
+                        "sessionId": "session-1",
+                        "toolCallId": "tool-1",
+                        "toolName": "edit"
+                    },
+                })
+                .to_string(),
+            )
+            .await;
+
+        let owner_request: JsonValue =
+            serde_json::from_str(&owner_rx.recv().await.expect("owner request")).unwrap();
+        let controller_request: JsonValue =
+            serde_json::from_str(&controller_rx.recv().await.expect("controller request")).unwrap();
+        assert_eq!(owner_request["method"], "session/request_permission");
+        assert_eq!(controller_request["method"], "session/request_permission");
+        assert!(observer_rx.try_recv().is_err());
+
+        worker
+            .send_client_request(
+                "controller",
+                AcpAttachRole::Controller,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 77,
+                    "result": {"outcome": "approved"},
+                }),
+            )
+            .await
+            .expect("first controller decision wins");
+        let forwarded = request_rx.recv().await.expect("forwarded response");
+        assert_eq!(forwarded["id"], 77);
+        assert_eq!(forwarded["result"]["outcome"], "approved");
+
+        let duplicate = worker
+            .send_client_request(
+                "controller",
+                AcpAttachRole::Controller,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 77,
+                    "result": {"outcome": "approved"},
+                }),
+            )
+            .await
+            .expect_err("same actor duplicate should be idempotent");
+        assert!(matches!(
+            duplicate,
+            AcpClientRequestError::IdempotentHostDecision { .. }
+        ));
+
+        let conflict = worker
+            .send_client_request(
+                "owner",
+                AcpAttachRole::HostOwner,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 77,
+                    "result": {"outcome": "denied"},
+                }),
+            )
+            .await
+            .expect_err("late conflicting decision should be rejected");
+        match conflict {
+            AcpClientRequestError::AlreadyDecided {
+                decision,
+                attempted_actor,
+                attempted_payload,
+            } => {
+                assert_eq!(decision.actor.client_id, "controller");
+                assert_eq!(attempted_actor.client_id, "owner");
+                assert_eq!(attempted_payload["result"]["outcome"], "denied");
+            }
+            other => panic!("expected AlreadyDecided, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_hub_adds_actor_metadata_to_controller_controls() {
+        let (worker, mut request_rx, _owner_rx, _controller_rx, _observer_rx) = test_worker();
+        worker
+            .send_client_request(
+                "controller",
+                AcpAttachRole::Controller,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 9,
+                    "method": "session/cancel",
+                    "params": {"sessionId": "session-1"},
+                }),
+            )
+            .await
+            .expect("controller cancel forwards");
+        let forwarded = request_rx.recv().await.expect("forwarded cancel");
+        assert_eq!(
+            forwarded["params"]["_harn"]["actor"],
+            json!({
+                "clientId": "controller",
+                "connectionId": "controller-conn",
+                "role": "controller",
+                "source": "websocket",
+            })
+        );
+    }
 }

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -749,6 +749,33 @@ impl AgentEventSink for AcpAgentEventSink {
                     "update": update,
                 }));
             }
+            AgentEvent::ControlOutcome {
+                session_id,
+                control_id,
+                method,
+                outcome,
+                status,
+                actor,
+                target,
+                reason,
+                metadata,
+            } => {
+                let mut payload = serde_json::json!({
+                    "controlId": control_id,
+                    "method": method,
+                    "outcome": outcome,
+                    "status": status,
+                    "actor": actor,
+                    "target": target,
+                });
+                if let Some(reason) = reason {
+                    payload["reason"] = serde_json::Value::String(reason.clone());
+                }
+                if !metadata.is_null() {
+                    payload["metadata"] = metadata.clone();
+                }
+                self.emit_agent_event_ext("control_outcome", session_id, payload);
+            }
             AgentEvent::WorkerUpdate {
                 session_id,
                 worker_id,

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -38,7 +38,7 @@ pub use schema::{
     HARN_TOOL_LIFECYCLE_EXTENSION_FIELDS,
 };
 use sessions::{
-    mark_cancelled_session, preempt_session_interruption, prepare_session_prompt, Session,
+    lookup_session_cancellation, preempt_session_interruption, prepare_session_prompt, Session,
     SessionCancellation, SessionInfo,
 };
 pub use transport::{run_acp_channel_server, run_acp_server};
@@ -70,12 +70,102 @@ use io::send_json_response;
 
 const ACP_AUTH_REQUIRED_CODE: i64 = -32000;
 
+#[derive(Clone)]
+struct InjectControlRecord {
+    owner: serde_json::Value,
+    status: String,
+}
+
 fn session_id_param(params: &serde_json::Value) -> Option<String> {
     params
         .get("sessionId")
         .or_else(|| params.get("session_id"))
         .and_then(|value| value.as_str())
         .map(str::to_string)
+}
+
+fn harn_meta(params: &serde_json::Value) -> Option<&serde_json::Map<String, serde_json::Value>> {
+    params
+        .get("_harn")
+        .and_then(serde_json::Value::as_object)
+        .or_else(|| {
+            params
+                .get("_meta")
+                .and_then(|meta| meta.get("harn"))
+                .and_then(serde_json::Value::as_object)
+        })
+}
+
+fn string_meta_field(
+    meta: &serde_json::Map<String, serde_json::Value>,
+    camel: &str,
+    snake: &str,
+) -> Option<String> {
+    meta.get(camel)
+        .or_else(|| meta.get(snake))
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+
+fn control_actor_from_params(params: &serde_json::Value) -> serde_json::Value {
+    let Some(meta) = harn_meta(params) else {
+        return serde_json::json!({
+            "clientId": "legacy-acp-client",
+            "role": "host_owner",
+            "source": "acp",
+        });
+    };
+    if let Some(actor) = meta.get("actor").and_then(serde_json::Value::as_object) {
+        let mut actor = actor.clone();
+        actor
+            .entry("source".to_string())
+            .or_insert_with(|| serde_json::json!("acp"));
+        actor
+            .entry("role".to_string())
+            .or_insert_with(|| serde_json::json!("host_owner"));
+        actor
+            .entry("clientId".to_string())
+            .or_insert_with(|| serde_json::json!("legacy-acp-client"));
+        return serde_json::Value::Object(actor);
+    }
+
+    let mut actor = serde_json::Map::new();
+    actor.insert(
+        "clientId".to_string(),
+        serde_json::json!(string_meta_field(meta, "clientId", "client_id")
+            .unwrap_or_else(|| "legacy-acp-client".to_string())),
+    );
+    if let Some(connection_id) = string_meta_field(meta, "connectionId", "connection_id") {
+        actor.insert("connectionId".to_string(), serde_json::json!(connection_id));
+    }
+    if let Some(display_name) = string_meta_field(meta, "displayName", "display_name") {
+        actor.insert("displayName".to_string(), serde_json::json!(display_name));
+    }
+    actor.insert(
+        "role".to_string(),
+        serde_json::json!(
+            string_meta_field(meta, "role", "role").unwrap_or_else(|| "host_owner".to_string())
+        ),
+    );
+    actor.insert(
+        "source".to_string(),
+        serde_json::json!(
+            string_meta_field(meta, "source", "source").unwrap_or_else(|| { "acp".to_string() })
+        ),
+    );
+    serde_json::Value::Object(actor)
+}
+
+fn actor_is_host_owner(actor: &serde_json::Value) -> bool {
+    actor
+        .get("role")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|role| role == "host_owner" || role == "hostOwner" || role == "owner")
+}
+
+fn control_id() -> String {
+    format!("ctrl_{}", uuid::Uuid::now_v7().simple())
 }
 
 fn session_list_filter<'a>(
@@ -370,6 +460,9 @@ pub struct AcpServer {
     runtime_configurator: Arc<dyn AcpRuntimeConfigurator>,
     /// Active sessions keyed by session ID.
     sessions: HashMap<String, Session>,
+    /// ACP control-plane ownership for pending injected messages, keyed by
+    /// session id then message id.
+    inject_controls: HashMap<String, BTreeMap<String, InjectControlRecord>>,
     /// Monotonically increasing JSON-RPC request ID for outgoing requests.
     next_id: AtomicU64,
     /// Pending outgoing request waiters, keyed by JSON-RPC id.
@@ -409,6 +502,7 @@ impl AcpServer {
             authenticated_principal: None,
             runtime_configurator: config.runtime_configurator,
             sessions: HashMap::new(),
+            inject_controls: HashMap::new(),
             next_id: AtomicU64::new(1),
             pending: Arc::new(Mutex::new(HashMap::new())),
             session_cancellations: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -572,6 +666,29 @@ impl AcpServer {
         if let Ok(line) = serde_json::to_string(&response) {
             self.write_line(&line);
         }
+    }
+
+    fn emit_control_outcome(
+        &self,
+        session_id: &str,
+        method: &str,
+        outcome: &str,
+        status: &str,
+        actor: serde_json::Value,
+        target: serde_json::Value,
+        reason: Option<&str>,
+    ) {
+        harn_vm::agent_events::emit_event(&harn_vm::agent_events::AgentEvent::ControlOutcome {
+            session_id: session_id.to_string(),
+            control_id: control_id(),
+            method: method.to_string(),
+            outcome: outcome.to_string(),
+            status: status.to_string(),
+            actor,
+            target,
+            reason: reason.map(str::to_string),
+            metadata: serde_json::Value::Null,
+        });
     }
 
     /// Send a JSON-RPC notification (no id, no response expected).
@@ -1336,8 +1453,56 @@ impl AcpServer {
         }
     }
 
-    fn handle_session_cancel(&mut self, params: &serde_json::Value) {
-        mark_cancelled_session(&self.session_cancellations, params);
+    fn handle_session_cancel(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = session_id_param(params) else {
+            if !id.is_null() {
+                self.send_error(id, -32602, "session/cancel requires sessionId");
+            }
+            return;
+        };
+        let Some(cancellation) =
+            lookup_session_cancellation(&self.session_cancellations, &session_id)
+        else {
+            if !id.is_null() {
+                self.send_error(id, -32004, &format!("Session not found: {session_id}"));
+            }
+            return;
+        };
+
+        let actor = control_actor_from_params(params);
+        let newly_cancelled = if cancellation.take_routed_cancel_ack() {
+            true
+        } else {
+            cancellation.cancel()
+        };
+        let status = if newly_cancelled {
+            "cancelled"
+        } else {
+            "already_cancelled"
+        };
+        self.emit_control_outcome(
+            &session_id,
+            "session/cancel",
+            status,
+            "accepted",
+            actor.clone(),
+            serde_json::json!({"sessionId": session_id}),
+            None,
+        );
+        if !id.is_null() {
+            self.send_response(
+                id,
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "status": status,
+                    "_meta": {
+                        "harn": {
+                            "actor": actor,
+                        }
+                    }
+                }),
+            );
+        }
     }
 
     /// Targeted preemption: stop one in-flight tool call without tearing
@@ -1407,6 +1572,7 @@ impl AcpServer {
             .lock()
             .unwrap_or_else(|error| error.into_inner())
             .remove(session_id);
+        self.inject_controls.remove(session_id);
         clear_session_sinks(session_id);
         #[cfg(feature = "hostlib")]
         {
@@ -1425,15 +1591,29 @@ impl AcpServer {
         self.send_response(id, serde_json::json!({}));
     }
 
-    async fn handle_session_inject(&self, id: &serde_json::Value, params: &serde_json::Value) {
+    async fn handle_session_inject(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(session_id) = session_id_param(params) else {
+            self.send_error(id, -32602, "session/inject requires sessionId");
+            return;
+        };
         let Some(inject_state) = self.session_inject_state(id, params, "session/inject", true)
         else {
             return;
         };
+        let actor = control_actor_from_params(params);
         let mode = match bridge_mode_for_session_inject(params) {
             Ok(mode) => mode,
             Err(message) => {
                 self.send_error(id, -32602, &message);
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/inject",
+                    "rejected",
+                    "rejected",
+                    actor,
+                    serde_json::json!({"sessionId": session_id}),
+                    Some("invalid_mode"),
+                );
                 return;
             }
         };
@@ -1442,13 +1622,52 @@ impl AcpServer {
                 Ok(content) => content,
                 Err(message) => {
                     self.send_error(id, -32602, &message);
+                    self.emit_control_outcome(
+                        &session_id,
+                        "session/inject",
+                        "rejected",
+                        "rejected",
+                        actor,
+                        serde_json::json!({"sessionId": session_id}),
+                        Some("invalid_content"),
+                    );
                     return;
                 }
             };
         let message_id = inject_state
             .push_pending_user_message(content, transcript_content, mode)
             .await;
-        self.send_response(id, serde_json::json!({ "messageId": message_id }));
+        self.inject_controls
+            .entry(session_id.clone())
+            .or_default()
+            .insert(
+                message_id.clone(),
+                InjectControlRecord {
+                    owner: actor.clone(),
+                    status: "pending".to_string(),
+                },
+            );
+        self.emit_control_outcome(
+            &session_id,
+            "session/inject",
+            "accepted",
+            "accepted",
+            actor.clone(),
+            serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+            None,
+        );
+        self.send_response(
+            id,
+            serde_json::json!({
+                "messageId": message_id,
+                "status": "accepted",
+                "_meta": {
+                    "harn": {
+                        "actor": actor,
+                    }
+                }
+            }),
+        );
     }
 
     fn clear_active_prompt_transport(&mut self, session_id: &str) {
@@ -1459,10 +1678,14 @@ impl AcpServer {
     }
 
     async fn handle_session_revoke_inject(
-        &self,
+        &mut self,
         id: &serde_json::Value,
         params: &serde_json::Value,
     ) {
+        let Some(session_id) = session_id_param(params) else {
+            self.send_error(id, -32602, "session/revoke_inject requires sessionId");
+            return;
+        };
         let Some(inject_state) =
             self.session_inject_state(id, params, "session/revoke_inject", false)
         else {
@@ -1473,12 +1696,91 @@ impl AcpServer {
         else {
             return;
         };
+        let actor = control_actor_from_params(params);
+        if let Some(owner) = self
+            .inject_controls
+            .get(&session_id)
+            .and_then(|records| records.get(message_id))
+            .map(|record| record.owner.clone())
+        {
+            if owner != actor && !actor_is_host_owner(&actor) {
+                self.send_pending_inject_error_with_data(
+                    id,
+                    message_id,
+                    "not_owner_or_not_authorized",
+                    "pending inject is owned by another ACP actor",
+                    serde_json::json!({
+                        "actor": actor,
+                        "owner": owner,
+                    }),
+                );
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/revoke_inject",
+                    "rejected",
+                    "rejected",
+                    control_actor_from_params(params),
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    Some("not_owner_or_not_authorized"),
+                );
+                return;
+            }
+        }
         match inject_state.revoke_pending_user_message(message_id).await {
-            harn_vm::bridge::PendingUserMessageMutationResult::Mutated
-            | harn_vm::bridge::PendingUserMessageMutationResult::AlreadyRevoked => {
-                self.send_response(id, serde_json::json!({}));
+            harn_vm::bridge::PendingUserMessageMutationResult::Mutated => {
+                if let Some(record) = self
+                    .inject_controls
+                    .get_mut(&session_id)
+                    .and_then(|records| records.get_mut(message_id))
+                {
+                    record.status = "revoked".to_string();
+                }
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/revoke_inject",
+                    "revoked",
+                    "accepted",
+                    actor.clone(),
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    None,
+                );
+                self.send_response(
+                    id,
+                    serde_json::json!({"messageId": message_id, "status": "revoked"}),
+                );
+            }
+            harn_vm::bridge::PendingUserMessageMutationResult::AlreadyRevoked => {
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/revoke_inject",
+                    "already_revoked",
+                    "idempotent",
+                    actor.clone(),
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    None,
+                );
+                self.send_response(
+                    id,
+                    serde_json::json!({"messageId": message_id, "status": "already_revoked"}),
+                );
             }
             harn_vm::bridge::PendingUserMessageMutationResult::AlreadyDelivered => {
+                if let Some(record) = self
+                    .inject_controls
+                    .get_mut(&session_id)
+                    .and_then(|records| records.get_mut(message_id))
+                {
+                    record.status = "delivered".to_string();
+                }
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/revoke_inject",
+                    "already_delivered",
+                    "rejected",
+                    actor,
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    Some("already_delivered"),
+                );
                 self.send_pending_inject_error(
                     id,
                     message_id,
@@ -1487,6 +1789,15 @@ impl AcpServer {
                 );
             }
             harn_vm::bridge::PendingUserMessageMutationResult::UnknownMessageId => {
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/revoke_inject",
+                    "unknown_message_id",
+                    "rejected",
+                    actor,
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    Some("unknown_message_id"),
+                );
                 self.send_pending_inject_error(
                     id,
                     message_id,
@@ -1498,10 +1809,14 @@ impl AcpServer {
     }
 
     async fn handle_session_replace_inject(
-        &self,
+        &mut self,
         id: &serde_json::Value,
         params: &serde_json::Value,
     ) {
+        let Some(session_id) = session_id_param(params) else {
+            self.send_error(id, -32602, "session/replace_inject requires sessionId");
+            return;
+        };
         let Some(inject_state) =
             self.session_inject_state(id, params, "session/replace_inject", false)
         else {
@@ -1512,11 +1827,50 @@ impl AcpServer {
         else {
             return;
         };
+        let actor = control_actor_from_params(params);
+        if let Some(owner) = self
+            .inject_controls
+            .get(&session_id)
+            .and_then(|records| records.get(message_id))
+            .map(|record| record.owner.clone())
+        {
+            if owner != actor && !actor_is_host_owner(&actor) {
+                self.send_pending_inject_error_with_data(
+                    id,
+                    message_id,
+                    "not_owner_or_not_authorized",
+                    "pending inject is owned by another ACP actor",
+                    serde_json::json!({
+                        "actor": actor,
+                        "owner": owner,
+                    }),
+                );
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/replace_inject",
+                    "rejected",
+                    "rejected",
+                    control_actor_from_params(params),
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    Some("not_owner_or_not_authorized"),
+                );
+                return;
+            }
+        }
         let (content, transcript_content) =
             match normalize_session_inject_content("session/replace_inject", params) {
                 Ok(content) => content,
                 Err(message) => {
                     self.send_error(id, -32602, &message);
+                    self.emit_control_outcome(
+                        &session_id,
+                        "session/replace_inject",
+                        "rejected",
+                        "rejected",
+                        actor,
+                        serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                        Some("invalid_content"),
+                    );
                     return;
                 }
             };
@@ -1525,9 +1879,30 @@ impl AcpServer {
             .await
         {
             harn_vm::bridge::PendingUserMessageMutationResult::Mutated => {
-                self.send_response(id, serde_json::json!({ "messageId": message_id }));
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/replace_inject",
+                    "replaced",
+                    "accepted",
+                    actor.clone(),
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    None,
+                );
+                self.send_response(
+                    id,
+                    serde_json::json!({ "messageId": message_id, "status": "replaced" }),
+                );
             }
             harn_vm::bridge::PendingUserMessageMutationResult::AlreadyRevoked => {
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/replace_inject",
+                    "already_revoked",
+                    "rejected",
+                    actor,
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    Some("already_revoked"),
+                );
                 self.send_pending_inject_error(
                     id,
                     message_id,
@@ -1536,6 +1911,22 @@ impl AcpServer {
                 );
             }
             harn_vm::bridge::PendingUserMessageMutationResult::AlreadyDelivered => {
+                if let Some(record) = self
+                    .inject_controls
+                    .get_mut(&session_id)
+                    .and_then(|records| records.get_mut(message_id))
+                {
+                    record.status = "delivered".to_string();
+                }
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/replace_inject",
+                    "already_delivered",
+                    "rejected",
+                    actor,
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    Some("already_delivered"),
+                );
                 self.send_pending_inject_error(
                     id,
                     message_id,
@@ -1544,6 +1935,15 @@ impl AcpServer {
                 );
             }
             harn_vm::bridge::PendingUserMessageMutationResult::UnknownMessageId => {
+                self.emit_control_outcome(
+                    &session_id,
+                    "session/replace_inject",
+                    "unknown_message_id",
+                    "rejected",
+                    actor,
+                    serde_json::json!({"sessionId": session_id, "messageId": message_id}),
+                    Some("unknown_message_id"),
+                );
                 self.send_pending_inject_error(
                     id,
                     message_id,
@@ -1608,15 +2008,32 @@ impl AcpServer {
         reason: &str,
         message: &str,
     ) {
-        self.send_error_with_data(
+        self.send_pending_inject_error_with_data(
             id,
-            -32602,
+            message_id,
+            reason,
             message,
-            serde_json::json!({
-                "reason": reason,
-                "messageId": message_id,
-            }),
+            serde_json::Value::Null,
         );
+    }
+
+    fn send_pending_inject_error_with_data(
+        &self,
+        id: &serde_json::Value,
+        message_id: &str,
+        reason: &str,
+        message: &str,
+        extra: serde_json::Value,
+    ) {
+        let mut data = serde_json::Map::new();
+        data.insert("reason".to_string(), serde_json::json!(reason));
+        data.insert("messageId".to_string(), serde_json::json!(message_id));
+        if let Some(extra) = extra.as_object() {
+            for (key, value) in extra {
+                data.insert(key.clone(), value.clone());
+            }
+        }
+        self.send_error_with_data(id, -32602, message, serde_json::Value::Object(data));
     }
 
     async fn handle_session_remind(&self, id: &serde_json::Value, params: &serde_json::Value) {
@@ -2621,7 +3038,7 @@ impl AcpServer {
                 self.handle_session_prompt(&id, &params).await;
             }
             "session/cancel" => {
-                self.handle_session_cancel(&params);
+                self.handle_session_cancel(&id, &params);
             }
             "session/cancel_tool_call" => {
                 if self.reject_unauthenticated(&id) {

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -57,6 +57,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "composition_error",
     "composition_finish",
     "composition_start",
+    "control_outcome",
     "daemon_watchdog_tripped",
     "feedback_injected",
     "iteration_end",

--- a/crates/harn-serve/src/adapters/acp/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/sessions.rs
@@ -11,6 +11,7 @@ pub(super) struct SessionInfo {
 pub(super) struct SessionCancellation {
     pub(super) cancelled: Arc<AtomicBool>,
     pub(super) notify: Arc<Notify>,
+    routed_cancel_ack_pending: Arc<AtomicBool>,
     /// Set by the transport reader after it resets cancellation for a
     /// prompt, so the prompt handler does not erase a cancel notification
     /// that arrived while the prompt was queued.
@@ -22,19 +23,33 @@ impl Default for SessionCancellation {
         Self {
             cancelled: Arc::new(AtomicBool::new(false)),
             notify: Arc::new(Notify::new()),
+            routed_cancel_ack_pending: Arc::new(AtomicBool::new(false)),
             prepared_prompt: Arc::new(AtomicBool::new(false)),
         }
     }
 }
 
 impl SessionCancellation {
-    pub(super) fn cancel(&self) {
-        self.cancelled.store(true, Ordering::SeqCst);
+    pub(super) fn cancel(&self) -> bool {
+        let already_cancelled = self.cancelled.swap(true, Ordering::SeqCst);
         self.notify.notify_waiters();
+        !already_cancelled
+    }
+
+    pub(super) fn cancel_for_routed_request(&self) {
+        if self.cancel() {
+            self.routed_cancel_ack_pending.store(true, Ordering::SeqCst);
+        }
+    }
+
+    pub(super) fn take_routed_cancel_ack(&self) -> bool {
+        self.routed_cancel_ack_pending.swap(false, Ordering::SeqCst)
     }
 
     pub(super) fn reset(&self) {
         self.cancelled.store(false, Ordering::SeqCst);
+        self.routed_cancel_ack_pending
+            .store(false, Ordering::SeqCst);
     }
 
     pub(super) fn prepare_prompt(&self) {
@@ -88,6 +103,24 @@ pub(super) fn mark_cancelled_session(
     true
 }
 
+pub(super) fn mark_cancelled_session_for_routed_request(
+    cancellations: &Arc<std::sync::Mutex<HashMap<String, SessionCancellation>>>,
+    params: &serde_json::Value,
+) -> bool {
+    let Some(session_id) = params
+        .get("sessionId")
+        .or_else(|| params.get("session_id"))
+        .and_then(|value| value.as_str())
+    else {
+        return false;
+    };
+    let Some(cancellation) = lookup_session_cancellation(cancellations, session_id) else {
+        return false;
+    };
+    cancellation.cancel_for_routed_request();
+    true
+}
+
 pub(super) fn lookup_session_cancellation(
     cancellations: &Arc<std::sync::Mutex<HashMap<String, SessionCancellation>>>,
     session_id: &str,
@@ -107,8 +140,13 @@ pub(super) fn preempt_session_interruption(
     let params = msg.get("params").unwrap_or(&serde_json::Value::Null);
     match method {
         Some("session/cancel") => {
-            mark_cancelled_session(cancellations, params);
-            msg.get("id").is_none()
+            if msg.get("id").is_some() {
+                mark_cancelled_session_for_routed_request(cancellations, params);
+                false
+            } else {
+                mark_cancelled_session(cancellations, params);
+                true
+            }
         }
         Some("session/truncate" | "session/close" | "session/stop") => {
             mark_cancelled_session(cancellations, params);

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -456,6 +456,53 @@ async fn session_inject_requires_active_prompt_bridge() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn session_cancel_is_idempotent_and_actor_attributed() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": "."},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+
+    for (id, expected) in [(2, "cancelled"), (3, "already_cancelled")] {
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "session/cancel",
+                "params": {
+                    "sessionId": session_id,
+                    "_harn": {
+                        "actor": {
+                            "clientId": "controller-a",
+                            "connectionId": "conn-a",
+                            "role": "controller",
+                            "source": "ide"
+                        }
+                    }
+                },
+            }))
+            .await;
+        let response = recv_json(&mut rx).await;
+        assert_eq!(response["result"]["status"], expected);
+        assert_eq!(
+            response["result"]["_meta"]["harn"]["actor"]["clientId"],
+            "controller-a"
+        );
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn session_prompt_compile_error_clears_active_inject_bridge() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
@@ -572,21 +619,30 @@ async fn session_inject_revoke_and_replace_pending_messages() {
         .await;
     let replace = recv_json(&mut rx).await;
     assert_eq!(replace["result"]["messageId"], first_id);
+    assert_eq!(replace["result"]["status"], "replaced");
 
     for id in [5, 6] {
         server
             .handle_incoming_message(serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "method": "session/revoke_inject",
-                "params": {
-                    "sessionId": session_id,
-                    "messageId": second_id,
-                },
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": "session/revoke_inject",
+                    "params": {
+                        "sessionId": session_id,
+                        "messageId": second_id,
+                    },
             }))
             .await;
         let revoke = recv_json(&mut rx).await;
-        assert_eq!(revoke["result"], serde_json::json!({}));
+        assert_eq!(revoke["result"]["messageId"], second_id);
+        assert_eq!(
+            revoke["result"]["status"],
+            if id == 5 {
+                "revoked"
+            } else {
+                "already_revoked"
+            }
+        );
     }
 
     let delivered = bridge
@@ -655,6 +711,7 @@ async fn session_inject_state_survives_prompt_bridge_replacement() {
         .await;
     let replace = recv_json(&mut rx).await;
     assert_eq!(replace["result"]["messageId"], message_id);
+    assert_eq!(replace["result"]["status"], "replaced");
 
     let replacement_bridge = Rc::new(
         harn_vm::bridge::HostBridge::from_parts_with_writer_cancel_notify_and_injection_state(
@@ -749,6 +806,79 @@ async fn session_inject_reports_unknown_and_already_delivered_ids() {
     assert_eq!(
         already_delivered["error"]["data"]["reason"],
         "already_delivered"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn session_inject_rejects_cross_actor_mutation() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {"cwd": "."},
+        }))
+        .await;
+    let created = recv_json(&mut rx).await;
+    let session_id = created["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+    attach_test_host_bridge(&mut server, &session_id);
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/inject",
+            "params": {
+                "sessionId": session_id,
+                "mode": "queue",
+                "content": "owned pending message",
+                "_harn": {
+                    "actor": {
+                        "clientId": "controller-a",
+                        "role": "controller",
+                        "source": "ide"
+                    }
+                }
+            },
+        }))
+        .await;
+    let accepted = recv_json(&mut rx).await;
+    let message_id = accepted["result"]["messageId"].as_str().unwrap();
+    assert_eq!(accepted["result"]["status"], "accepted");
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/replace_inject",
+            "params": {
+                "sessionId": session_id,
+                "messageId": message_id,
+                "content": "stolen edit",
+                "_harn": {
+                    "actor": {
+                        "clientId": "controller-b",
+                        "role": "controller",
+                        "source": "ide"
+                    }
+                }
+            },
+        }))
+        .await;
+    let rejected = recv_json(&mut rx).await;
+    assert_eq!(
+        rejected["error"]["data"]["reason"],
+        "not_owner_or_not_authorized"
+    );
+    assert_eq!(
+        rejected["error"]["data"]["owner"]["clientId"],
+        "controller-a"
     );
 }
 

--- a/crates/harn-vm/src/agent_events.rs
+++ b/crates/harn-vm/src/agent_events.rs
@@ -673,6 +673,22 @@ pub enum AgentEvent {
         pending_count: usize,
         total_bytes: u64,
     },
+    /// ACP control-plane arbitration outcome. Emitted for accepted,
+    /// idempotent, and rejected controls so replay/audit consumers can show
+    /// who acted and why a late or unauthorized action lost.
+    ControlOutcome {
+        session_id: String,
+        control_id: String,
+        method: String,
+        outcome: String,
+        status: String,
+        actor: serde_json::Value,
+        target: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+        metadata: serde_json::Value,
+    },
     /// Lifecycle update for a delegated/background worker. Carries the
     /// canonical typed `event` variant alongside the worker's current
     /// `status` string and the structured `metadata` payload that
@@ -913,6 +929,7 @@ impl AgentEvent {
             | Self::Handoff { session_id, .. }
             | Self::FsWatch { session_id, .. }
             | Self::StagedWritesPending { session_id, .. }
+            | Self::ControlOutcome { session_id, .. }
             | Self::WorkerUpdate { session_id, .. }
             | Self::HitlRequested { session_id, .. }
             | Self::HitlResolved { session_id, .. }

--- a/docs/src/acp/websocket.md
+++ b/docs/src/acp/websocket.md
@@ -158,8 +158,10 @@ metadata is available. `liveState` is one of:
 - `controller` clients may send bounded session controls such as
   `session/cancel`, `session/inject`, `session/revoke_inject`,
   `session/replace_inject`, `session/truncate`, `session/remind`,
-  `session/set_mode`, and `session/set_config_option`. Host requests are still
-  delivered only to the `host_owner`.
+  `session/set_mode`, and `session/set_config_option`. General host requests
+  are still delivered only to the `host_owner`; `session/request_permission`
+  is also delivered to controllers so an attached control surface can answer
+  approval prompts.
 
 Legacy clients that omit a role request `host_owner`, preserving the old
 single-host behavior. To attach a read-only client, pass the role through
@@ -229,6 +231,21 @@ Read-only control attempts fail with a structured JSON-RPC error:
   }
 }
 ```
+
+Permission decisions are deterministic when multiple control-capable clients
+race on the same `session/request_permission` request:
+
+- the first valid response wins and is forwarded to the running ACP worker;
+- the same response from the same actor/request id is idempotent and returns
+  `status: "already_applied"`;
+- conflicting late responses fail with `code: -32013` and `data.reason:
+  "already_decided"`, including `decidedBy`, `decidedAtMs`, and the attempted
+  actor.
+
+Forwarded controls carry `_harn.actor` with `clientId`, `connectionId`, `role`,
+and `source: "websocket"`. ACP adapter audit/replay emits matching
+`_harn/agentEvent` frames with `kind: "control_outcome"` for accepted,
+idempotent, and rejected outcomes.
 
 Retained workers expire after 5 minutes by default. `HARN_ACP_WS_RETAIN_SECS`
 can tune that window for controlled deployments and tests. After expiry, or

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -506,12 +506,16 @@ Payload:
 On the ACP adapter surface, hosts can wake the daemon by sending a pending
 user-message inject. `session/inject` accepts `{sessionId, mode, content}`
 where `content` is a string or ACP content-block array, then responds
-immediately with an agent-owned `messageId`. Harn later delivers the same id
-as `session/update` with `sessionUpdate: "user_message"`. `mode: "steer"` maps
-to the next safe operation boundary, and `mode: "queue"` maps to
-end-of-interaction delivery. Pending injects can be revoked with
-`session/revoke_inject` or edited in place with `session/replace_inject` before
-delivery.
+immediately with `status: "accepted"` and an agent-owned `messageId`. Harn
+later delivers the same id as `session/update` with `sessionUpdate:
+"user_message"`. `mode: "steer"` maps to the next safe operation boundary, and
+`mode: "queue"` maps to end-of-interaction delivery. Pending injects can be
+revoked with `session/revoke_inject` or edited in place with
+`session/replace_inject` before delivery; successful mutation responses return
+`status: "revoked"`, `"already_revoked"`, or `"replaced"`. Races return
+structured error data with `reason: "already_delivered"`,
+`"already_revoked"`, `"unknown_message_id"`, or
+`"not_owner_or_not_authorized"`.
 
 To inject ambient context without pretending it is a user message, send
 `session/remind`:

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -77,6 +77,7 @@ public enum HarnProtocolConstants {
         "composition_error",
         "composition_finish",
         "composition_start",
+        "control_outcome",
         "daemon_watchdog_tripped",
         "feedback_injected",
         "iteration_end",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -155,6 +155,7 @@ var HarnAgentEventKinds = []HarnAgentEventKind{
 	"composition_error",
 	"composition_finish",
 	"composition_start",
+	"control_outcome",
 	"daemon_watchdog_tripped",
 	"feedback_injected",
 	"iteration_end",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -119,6 +119,7 @@ export const HARN_AGENT_EVENT_KINDS = [
   "composition_error",
   "composition_finish",
   "composition_start",
+  "control_outcome",
   "daemon_watchdog_tripped",
   "feedback_injected",
   "iteration_end",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -82,6 +82,7 @@
       "composition_error",
       "composition_finish",
       "composition_start",
+      "control_outcome",
       "daemon_watchdog_tripped",
       "feedback_injected",
       "iteration_end",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -207,6 +207,7 @@ HARN_AGENT_EVENT_KINDS: tuple = (
     "composition_error",
     "composition_finish",
     "composition_start",
+    "control_outcome",
     "daemon_watchdog_tripped",
     "feedback_injected",
     "iteration_end",


### PR DESCRIPTION
## Summary
- arbitrate ACP permission responses with first-valid-response-wins semantics and idempotent replay handling
- add actor attribution for controller controls plus cancel/inject lifecycle outcome events
- tighten inject revoke/replace ownership, lifecycle errors, docs, and changelog notes

Closes #2412

## Verification
- cargo fmt --check
- git diff --check
- npx markdownlint-cli2 docs/src/acp/websocket.md docs/src/bridge-protocol.md CHANGELOG.md
- CARGO_TARGET_DIR=/tmp/harn-target-2412 cargo clippy -p harn-vm -p harn-serve -p harn-cli --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harn-target-2412 cargo test -p harn-serve session_inject -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-2412 cargo test -p harn-serve session_cancel_is_idempotent_and_actor_attributed -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-2412 cargo test -p harn-cli acp_hub_ -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-2412 cargo test -p harn-cli acp_websocket -- --nocapture
- pre-push hook targeted checks