### PR TITLE
Fix three correctness bugs from a sweep

### DIFF
--- a/crates/harn-cli/src/commands/orchestrator/listener/routes/ingest.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/routes/ingest.rs
@@ -865,7 +865,7 @@ pub(super) fn current_unix_ms() -> i64 {
 }
 
 fn unix_ms(timestamp: OffsetDateTime) -> i64 {
-    (timestamp.unix_timestamp_nanos() / 1_000_000) as i64
+    harn_vm::clock::offset_datetime_to_ms(timestamp)
 }
 
 fn duration_between_ms(later_ms: i64, earlier_ms: i64) -> Duration {

--- a/crates/harn-clock/src/lib.rs
+++ b/crates/harn-clock/src/lib.rs
@@ -44,11 +44,16 @@ pub trait Clock: Send + Sync + fmt::Debug {
     async fn sleep_until_utc(&self, deadline: OffsetDateTime);
 }
 
+/// Convert an `OffsetDateTime` to Unix epoch milliseconds. The division
+/// happens in `i128` so timestamps past April 2262 — where nanoseconds
+/// exceed `i64::MAX` — don't silently corrupt when cast.
+pub fn offset_datetime_to_ms(ts: OffsetDateTime) -> i64 {
+    (ts.unix_timestamp_nanos() / 1_000_000) as i64
+}
+
 /// Convenience: current wall-clock millis since UNIX_EPOCH.
 pub fn now_wall_ms(clock: &dyn Clock) -> i64 {
-    let ts = clock.now_utc();
-    let nanos = ts.unix_timestamp_nanos();
-    (nanos / 1_000_000) as i64
+    offset_datetime_to_ms(clock.now_utc())
 }
 
 // ── Real clock ─────────────────────────────────────────────────────────────────

--- a/crates/harn-vm/src/channels.rs
+++ b/crates/harn-vm/src/channels.rs
@@ -775,7 +775,7 @@ fn signed_timestamp(
     emitted_by: &str,
 ) -> SignedTimestamp {
     let at = crate::clock_mock::now_utc();
-    let at_ms = (at.unix_timestamp_nanos() / 1_000_000) as i64;
+    let at_ms = harn_clock::offset_datetime_to_ms(at);
     let at_text = at.format(&Rfc3339).unwrap_or_else(|_| at.to_string());
     let material = format!(
         "harn.channel.timestamp.v1\nat_ms={at_ms}\nid={event_id}\nname={}\nscope={}\nscope_id={}\nemitted_by={emitted_by}\n",
@@ -821,7 +821,7 @@ fn signed_match_timestamp(
     trigger_id: &str,
 ) -> SignedTimestamp {
     let at = crate::clock_mock::now_utc();
-    let at_ms = (at.unix_timestamp_nanos() / 1_000_000) as i64;
+    let at_ms = harn_clock::offset_datetime_to_ms(at);
     let at_text = at.format(&Rfc3339).unwrap_or_else(|_| at.to_string());
     let material = format!(
         "harn.channel.match_timestamp.v1\nat_ms={at_ms}\nevent_id={event_id}\ntrigger_id={trigger_id}\nname={}\nscope={}\nscope_id={}\n",
@@ -1898,7 +1898,7 @@ async fn fire_channel_match(
         match_span.set_metadata("batch", summary.clone());
     }
     let span_id = crate::tracing::current_span_id().unwrap_or(0);
-    let matched_at_ms = crate::clock_mock::now_utc().unix_timestamp_nanos() as i64 / 1_000_000;
+    let matched_at_ms = harn_clock::offset_datetime_to_ms(crate::clock_mock::now_utc());
     let matched_in_session_id = crate::agent_sessions::current_session_id()
         .or_else(|| event.tenant_id.as_ref().map(|t| t.0.clone()));
     emit_channel_match_transcript(

--- a/crates/harn-vm/src/connectors/cron/scheduler.rs
+++ b/crates/harn-vm/src/connectors/cron/scheduler.rs
@@ -32,7 +32,11 @@ impl CronSchedule {
         after: OffsetDateTime,
     ) -> Result<OffsetDateTime, ConnectorError> {
         let mut cursor = self.to_local(after);
-        let last_local = None;
+        // DST fall-back makes the same `naive_local` happen twice across two
+        // UTC offsets; mirror `due_ticks_between` and skip a candidate that
+        // shares its wall-clock minute with `after` so the caller does not
+        // observe a fresh tick at a time they have already seen.
+        let last_local = cursor.naive_local();
         loop {
             let candidate = self
                 .cron
@@ -46,8 +50,7 @@ impl CronSchedule {
             {
                 continue;
             }
-            let candidate_local = candidate.naive_local();
-            if last_local == Some(candidate_local) {
+            if candidate.naive_local() == last_local {
                 continue;
             }
             return chrono_to_offset(candidate).map_err(schedule_error);

--- a/crates/harn-vm/src/connectors/cron/tests.rs
+++ b/crates/harn-vm/src/connectors/cron/tests.rs
@@ -111,6 +111,18 @@ fn fallback_hour_fires_only_once() {
 }
 
 #[test]
+fn next_tick_after_fallback_skips_duplicate_wall_clock_hour() {
+    // After firing at the first 01:00 EDT during fall-back, the scheduler
+    // must not return the second 01:00 EST as the next tick — that wall
+    // clock minute already fired. Roll forward to the next day instead.
+    let schedule = CronSchedule::parse("0 1 * * *", "America/New_York".parse().unwrap()).unwrap();
+    let next = schedule
+        .next_tick_after(parse("2026-11-01T05:00:00Z"))
+        .unwrap();
+    assert_eq!(next, parse("2026-11-02T06:00:00Z"));
+}
+
+#[test]
 fn spring_forward_gap_does_not_fire_missing_hour() {
     let schedule = CronSchedule::parse("0 2 * * *", "America/New_York".parse().unwrap()).unwrap();
     let due = schedule

--- a/crates/harn-vm/src/llm/tools/parse/bare.rs
+++ b/crates/harn-vm/src/llm/tools/parse/bare.rs
@@ -168,46 +168,13 @@ pub(crate) fn parse_bare_calls_in_body(
                         let object_arg_start = has_object_literal_arg_start(text, k + name_len + 1);
                         if known.contains(name_str) {
                             if !object_arg_start {
-                                if bytes.get(k + name_len) == Some(&b'{') {
-                                    let name = name_str.to_string();
-                                    match parse_object_literal_from(&text[k + name_len..], &name) {
-                                        Ok((arguments, consumed)) => {
-                                            calls.push(serde_json::json!({
-                                                "id": format!("tc_{}", calls.len()),
-                                                "name": name,
-                                                "arguments": arguments,
-                                            }));
-                                            let mut end = k + name_len + consumed;
-                                            while end < bytes.len()
-                                                && (bytes[end] == b' ' || bytes[end] == b'\t')
-                                            {
-                                                end += 1;
-                                            }
-                                            if end < bytes.len() && bytes[end] == b'>' {
-                                                end += 1;
-                                            }
-                                            call_ranges.push((j, end));
-                                            i = end;
-                                            at_line_start =
-                                                bytes.get(i.saturating_sub(1)) == Some(&b'\n');
-                                            continue;
-                                        }
-                                        Err(msg) => {
-                                            errors.push(msg);
-                                            i = k + name_len + 1;
-                                            at_line_start = false;
-                                            continue;
-                                        }
-                                    }
-                                } else {
-                                    errors.push(format!(
-                                        "Tool '{}' must be called with an object literal argument like {}({{ ... }}).",
-                                        name_str, name_str
-                                    ));
-                                    i = k + name_len + 1;
-                                    at_line_start = false;
-                                    continue;
-                                }
+                                errors.push(format!(
+                                    "Tool '{}' must be called with an object literal argument like {}({{ ... }}).",
+                                    name_str, name_str
+                                ));
+                                i = k + name_len + 1;
+                                at_line_start = false;
+                                continue;
                             }
                             let name = name_str.to_string();
                             match parse_ts_call_from(&text[k..], name.clone()) {

--- a/crates/harn-vm/src/orchestration/lifecycle_receipts.rs
+++ b/crates/harn-vm/src/orchestration/lifecycle_receipts.rs
@@ -106,7 +106,7 @@ impl SignedLifecycleTimestamp {
     /// `at_ms` rewritten on disk fails verification.
     pub fn now_for(kind: &str, subject_id: &str, initiator_id: &str) -> Self {
         let at = crate::clock_mock::now_utc();
-        let at_ms = (at.unix_timestamp_nanos() / 1_000_000) as i64;
+        let at_ms = harn_clock::offset_datetime_to_ms(at);
         let at_text = at.format(&Rfc3339).unwrap_or_else(|_| at.to_string());
         let signature = sign_timestamp_material(kind, at_ms, subject_id, initiator_id);
         Self {

--- a/crates/harn-vm/src/personas.rs
+++ b/crates/harn-vm/src/personas.rs
@@ -2005,7 +2005,7 @@ fn next_cron_ms(schedule: &str, after_ms: i64) -> Result<i64, String> {
 }
 
 pub fn now_ms() -> i64 {
-    OffsetDateTime::now_utc().unix_timestamp_nanos() as i64 / 1_000_000
+    harn_clock::offset_datetime_to_ms(OffsetDateTime::now_utc())
 }
 
 fn offset_datetime_from_ms(ms: i64) -> OffsetDateTime {
@@ -2022,7 +2022,7 @@ pub fn format_ms(ms: i64) -> String {
 pub fn parse_rfc3339_ms(value: &str) -> Result<i64, String> {
     let ts = OffsetDateTime::parse(value, &Rfc3339)
         .map_err(|error| format!("invalid RFC3339 timestamp '{value}': {error}"))?;
-    Ok(ts.unix_timestamp_nanos() as i64 / 1_000_000)
+    Ok(harn_clock::offset_datetime_to_ms(ts))
 }
 
 fn runtime_topic() -> Result<Topic, String> {
@@ -2064,6 +2064,19 @@ mod tests {
 
     fn log() -> Arc<AnyEventLog> {
         Arc::new(AnyEventLog::Memory(MemoryEventLog::new(64)))
+    }
+
+    #[test]
+    fn parse_rfc3339_ms_round_trips_post_2262_dates() {
+        // Year 2300 sits beyond `i64` nanoseconds (~April 2262). Casting
+        // `unix_timestamp_nanos()` to `i64` *before* dividing by 1_000_000
+        // would truncate and yield a negative value; dividing first keeps
+        // the conversion exact.
+        let raw = "2300-01-01T00:00:00Z";
+        let ms = parse_rfc3339_ms(raw).expect("parse 2300-01-01");
+        assert!(ms > 0, "expected positive ms for {raw}, got {ms}");
+        let round_tripped = parse_rfc3339_ms(&format_ms(ms)).expect("re-parse formatted ms");
+        assert_eq!(ms, round_tripped, "ms should round-trip through format_ms");
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/triggers/dispatcher/util.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/util.rs
@@ -225,7 +225,7 @@ pub(super) fn current_unix_ms() -> i64 {
 }
 
 pub(super) fn unix_ms(timestamp: time::OffsetDateTime) -> i64 {
-    (timestamp.unix_timestamp_nanos() / 1_000_000) as i64
+    harn_clock::offset_datetime_to_ms(timestamp)
 }
 
 pub(super) fn accepted_at_ms(
@@ -364,7 +364,7 @@ pub(super) fn next_budget_reset_rfc3339(binding: &TriggerBinding) -> String {
 }
 
 pub(super) fn now_unix_ms() -> i64 {
-    (crate::triggers::test_util::clock::now_utc().unix_timestamp_nanos() / 1_000_000) as i64
+    harn_clock::offset_datetime_to_ms(crate::triggers::test_util::clock::now_utc())
 }
 
 pub(super) fn cancelled_dispatch_outcome(

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -1584,7 +1584,7 @@ impl TriggerRegistry {
         id: &str,
         as_of: OffsetDateTime,
     ) -> Result<u32, TriggerRegistryError> {
-        let cutoff_ms = (as_of.unix_timestamp_nanos() / 1_000_000) as i64;
+        let cutoff_ms = harn_clock::offset_datetime_to_ms(as_of);
         let mut active_version = None;
         for record in self.lifecycle_records_for(id) {
             if record.occurred_at_ms > cutoff_ms {

--- a/crates/harn-vm/src/triggers/test_util/clock.rs
+++ b/crates/harn-vm/src/triggers/test_util/clock.rs
@@ -93,7 +93,7 @@ impl MockClock {
 
     /// Wall clock in millis since `UNIX_EPOCH`.
     pub fn now_wall_ms(&self) -> i64 {
-        self.now_utc().unix_timestamp_nanos() as i64 / 1_000_000
+        harn_clock::offset_datetime_to_ms(self.now_utc())
     }
 
     /// Monotonic millis since this clock was created.
@@ -184,7 +184,7 @@ pub fn now_utc() -> OffsetDateTime {
 }
 
 pub fn now_ms() -> i64 {
-    now_utc().unix_timestamp_nanos() as i64 / 1_000_000
+    harn_clock::offset_datetime_to_ms(now_utc())
 }
 
 pub fn instant_now() -> ClockInstant {


### PR DESCRIPTION
## Summary

A sweep for unambiguous correctness bugs turned up three independent defects and a DRY opportunity worth bundling.

- **i128 → i64 truncation before division in millisecond conversion.** Five call sites used the pattern `ts.unix_timestamp_nanos() as i64 / 1_000_000`, which truncates to `i64` *before* dividing. For any timestamp past April 2262 (where nanoseconds exceed `i64::MAX`) the result is silently wrong. `parse_rfc3339_ms` accepts user-supplied RFC3339 strings, so this is reachable today by passing e.g. `"2300-01-01T00:00:00Z"`. Centralized the conversion in `harn_clock::offset_datetime_to_ms` and routed the five offenders **and** four already-correct cousins through it so the pattern can't drift back. New regression test in `personas.rs` round-trips `"2300-01-01T00:00:00Z"`.
- **`CronSchedule::next_tick_after` had a dead DST-fallback dedup.** The function declared `let last_local = None;` and never reassigned, so the `if last_local == Some(candidate_local)` check below it was unreachable. The intent (copied from the working sibling `due_ticks_between`) was to skip the duplicate wall-clock minute that DST fall-back produces. After firing at the first 01:00 EDT on a fall-back day the scheduler would return the second 01:00 EST as a fresh tick — a duplicate the caller already saw. Seeded `last_local` from `cursor` so it actually does the comparison. New regression test `next_tick_after_fallback_skips_duplicate_wall_clock_hour` in `crates/harn-vm/src/connectors/cron/tests.rs`.
- **`parse_bare_calls_in_body` had a dead branch.** [PR #1644](https://github.com/burin-labs/harn/pull/1644) added an `if bytes.get(k + name_len) == Some(&b'{')` block inside an outer `if bytes.get(k + name_len) == Some(&b'(')` — those two conditions are mutually exclusive, so the new branch never ran. Removed the dead path; the surviving error-emit path is the original (and unchanged) behavior. Existing `rejects_legacy_named_argument_call_form` test covers it.

## Test plan

- [x] `cargo test -p harn-vm --lib` (2673 passed)
- [x] `cargo test -p harn-clock --lib` (6 passed)
- [x] `cargo clippy -p harn-vm -p harn-clock -p harn-cli --lib --no-deps` clean
- [x] Pre-commit + pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)