### PR TITLE
vm: routing_policy v2 — verifier-signal escalation (#2435)

### DIFF
--- a/conformance/tests/llm_routing/verifier_escalate.expected
+++ b/conformance/tests/llm_routing/verifier_escalate.expected
@@ -1,0 +1,9 @@
+answer: 42
+2
+cheap
+escalate
+lint
+escalate
+frontier
+accept
+1

--- a/conformance/tests/llm_routing/verifier_escalate.harn
+++ b/conformance/tests/llm_routing/verifier_escalate.harn
@@ -1,0 +1,31 @@
+/**
+ * Verifier-signal escalation: the cheap link returns text containing a
+ * forbidden pattern, so the lint verifier escalates to the frontier
+ * link. The frontier candidate passes verification and is returned.
+ */
+pipeline test(task) {
+  llm_mock_clear()
+  llm_mock({text: "answer: TODO finish later", model: "mock", provider: "mock"})
+  llm_mock({text: "answer: 42", model: "mock-strong", provider: "mock"})
+  let policy = routing_policy(
+    {
+      chain: [
+        {provider: "mock", model: "mock", label: "cheap"},
+        {provider: "mock", model: "mock-strong", label: "frontier"},
+      ],
+      escalate_on: [{kind: "lint", forbidden_patterns: ["TODO"], on_fail: "escalate"}],
+      label: "verifier-escalate",
+    },
+  )
+  let result = llm_call("question", nil, {routing: policy})
+  __io_println(result.text)
+  let attempts = result.routing.attempts
+  __io_println(len(attempts))
+  __io_println(attempts[0].label)
+  __io_println(attempts[0].verifier_outcome)
+  __io_println(attempts[0].verifier_signals[0].kind)
+  __io_println(attempts[0].verifier_signals[0].signal)
+  __io_println(attempts[1].label)
+  __io_println(attempts[1].verifier_outcome)
+  __io_println(result.routing.selected)
+}

--- a/conformance/tests/llm_routing/verifier_refine.expected
+++ b/conformance/tests/llm_routing/verifier_refine.expected
@@ -1,0 +1,5 @@
+use match instead
+2
+refine
+accept
+1

--- a/conformance/tests/llm_routing/verifier_refine.harn
+++ b/conformance/tests/llm_routing/verifier_refine.harn
@@ -1,0 +1,25 @@
+/**
+ * Verifier-signal refine: the first attempt has a forbidden pattern,
+ * the lint verifier asks the router to retry the same link with a
+ * tightened prompt. The second attempt is clean and gets returned.
+ * Both attempts must show up on the routing trace.
+ */
+pipeline test(task) {
+  llm_mock_clear()
+  llm_mock({text: "use unwrap() here", model: "mock", provider: "mock"})
+  llm_mock({text: "use match instead", model: "mock", provider: "mock"})
+  let policy = routing_policy(
+    {
+      chain: [{provider: "mock", model: "mock", label: "cheap"}],
+      escalate_on: [{kind: "lint", forbidden_patterns: ["unwrap"], on_fail: "refine"}],
+      label: "verifier-refine",
+    },
+  )
+  let result = llm_call("question", nil, {routing: policy})
+  __io_println(result.text)
+  let attempts = result.routing.attempts
+  __io_println(len(attempts))
+  __io_println(attempts[0].verifier_outcome)
+  __io_println(attempts[1].verifier_outcome)
+  __io_println(result.routing.selected)
+}

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -41,6 +41,7 @@ pub mod reasoning_policy;
 pub(crate) mod reminder_providers;
 mod rerank;
 pub(crate) mod routing;
+pub(crate) mod routing_verifier;
 pub(crate) mod schema_recover;
 pub(crate) mod skill_score;
 mod stream_builtins;

--- a/crates/harn-vm/src/llm/routing.rs
+++ b/crates/harn-vm/src/llm/routing.rs
@@ -19,6 +19,10 @@ use crate::value::{ErrorCategory, VmError, VmValue};
 
 use super::api::{LlmCallOptions, LlmRoutePolicy};
 use super::cost::{calculate_cost_for_provider, peek_total_cost, LlmBudgetEnvelope};
+use super::routing_verifier::{
+    build_refine_nudge, parse_escalate_on, run_verifier, verifiers_summary, Verifier,
+    VerifierSignal,
+};
 
 /// Marker key set by `routing_policy(...)` to distinguish a validated
 /// routing config dict from a stray dict the user happened to pass.
@@ -137,6 +141,16 @@ pub(crate) struct RoutingPolicyConfig {
     pub latency: LatencyRules,
     pub budget: BudgetRules,
     pub observe: ObserveRules,
+    /// Verifier chain that gates frontier-tier escalation. Each
+    /// verifier inspects the candidate's text after a successful
+    /// link; the first non-`accept` signal drives the next decision
+    /// (refine = retry same link with a nudge; escalate = advance).
+    pub escalate_on: Vec<Verifier>,
+    /// Maximum number of refine retries permitted **per link**.
+    /// Refines also count against `failover.max_attempts`, so the
+    /// effective cap is `min(refines_per_link, remaining_attempts)`.
+    /// Defaults to 1.
+    pub max_refines_per_link: usize,
     /// Stable identifier — short label or the full
     /// `routing_policy(chain=N)` summary. Forwarded into tape events so
     /// transcripts can correlate attempts back to the policy that drove
@@ -501,6 +515,17 @@ pub(crate) fn build_routing_policy(config: &BTreeMap<String, VmValue>) -> Result
     let latency = parse_latency(config.get("latency"))?;
     let budget = parse_budget(config.get("budget"))?;
     let observe = parse_observe(config.get("observe"))?;
+    let escalate_on = parse_escalate_on(config.get("escalate_on"))?;
+    let max_refines_per_link = match config.get("max_refines_per_link") {
+        None | Some(VmValue::Nil) => 1usize,
+        Some(VmValue::Int(n)) if *n >= 0 => *n as usize,
+        Some(other) => {
+            return Err(runtime_error(format!(
+                "routing_policy.max_refines_per_link: expected a non-negative integer, got {}",
+                other.type_name()
+            )));
+        }
+    };
     let label_text = parse_label(config, "label")?;
     let label = if label_text.is_empty() {
         format!("routing_policy(chain={})", chain.len())
@@ -521,6 +546,13 @@ pub(crate) fn build_routing_policy(config: &BTreeMap<String, VmValue>) -> Result
     summary.insert("failover".to_string(), failover_value(&failover));
     summary.insert("latency".to_string(), latency_value(&latency));
     summary.insert("observe".to_string(), observe_value(&observe));
+    if !escalate_on.is_empty() {
+        summary.insert("escalate_on".to_string(), verifiers_summary(&escalate_on));
+        summary.insert(
+            "max_refines_per_link".to_string(),
+            VmValue::Int(max_refines_per_link as i64),
+        );
+    }
 
     let parsed = RoutingPolicyConfig {
         chain,
@@ -528,6 +560,8 @@ pub(crate) fn build_routing_policy(config: &BTreeMap<String, VmValue>) -> Result
         latency,
         budget,
         observe,
+        escalate_on,
+        max_refines_per_link,
         label,
     };
     let handle = intern_policy(parsed);
@@ -695,6 +729,46 @@ pub(crate) struct RoutingAttempt {
     pub duration_ms: u64,
     pub cost_usd: Option<f64>,
     pub error: Option<RoutingErrorSnapshot>,
+    /// Per-verifier signals emitted after this attempt's response.
+    /// Empty when the policy has no `escalate_on` chain or the
+    /// attempt failed before verifiers ran.
+    pub verifier_signals: Vec<VerifierSignalRecord>,
+    /// What the verifier chain told the router to do with this
+    /// candidate. `Accept` means the answer was returned;
+    /// `Refine`/`Escalate` mean the router moved on (within the same
+    /// link or to the next link respectively).
+    pub verifier_outcome: Option<VerifierOutcome>,
+}
+
+/// One signal entry in `RoutingAttempt.verifier_signals`. Kept simple
+/// so it survives serialization through `VmValue` dicts without losing
+/// the verifier's name and the human-readable reason.
+#[derive(Clone, Debug)]
+pub(crate) struct VerifierSignalRecord {
+    pub name: String,
+    pub kind: String,
+    pub signal: String,
+    pub reason: Option<String>,
+}
+
+/// Aggregated verdict across the verifier chain for one attempt. Drives
+/// receipt rendering ("escalated because verifier=refine on attempt 1,
+/// escalate on attempt 2").
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum VerifierOutcome {
+    Accept,
+    Refine,
+    Escalate,
+}
+
+impl VerifierOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Accept => "accept",
+            Self::Refine => "refine",
+            Self::Escalate => "escalate",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -984,6 +1058,8 @@ fn check_link_budget(
                 duration_ms: 0,
                 cost_usd: None,
                 error: Some(snapshot),
+                verifier_signals: Vec::new(),
+                verifier_outcome: None,
             });
             Ok(false)
         }
@@ -1047,16 +1123,134 @@ fn pending_attempt_record(
         duration_ms: duration_ms(elapsed),
         cost_usd: None,
         error: None,
+        verifier_signals: Vec::new(),
+        verifier_outcome: None,
     }
+}
+
+/// Extract the text the verifier chain should inspect. Mirrors how
+/// `agent_config::build_llm_call_result` derives the human-visible
+/// answer so the verifier sees the same thing the script will.
+fn candidate_text_for_verifier(result: &super::api::LlmResult) -> String {
+    if !result.text.is_empty() {
+        return result.text.clone();
+    }
+    // Tool-only responses still get a deterministic text payload
+    // verifiers can match against (their JSON serialization), so
+    // `lint`-style pattern rules work on tool-call shape too.
+    if !result.tool_calls.is_empty() {
+        return serde_json::to_string(&result.tool_calls).unwrap_or_default();
+    }
+    String::new()
+}
+
+/// Run the verifier chain over a candidate. Returns the per-verifier
+/// records plus the aggregated outcome. The first non-`accept` signal
+/// dominates: a single `escalate` outranks any later `refine`s, so
+/// callers don't have to redo the precedence reasoning.
+async fn run_verifier_chain(
+    verifiers: &[Verifier],
+    text: &str,
+) -> (Vec<VerifierSignalRecord>, VerifierOutcome, Vec<String>) {
+    if verifiers.is_empty() {
+        return (Vec::new(), VerifierOutcome::Accept, Vec::new());
+    }
+    let mut records = Vec::with_capacity(verifiers.len());
+    let mut outcome = VerifierOutcome::Accept;
+    let mut refine_reasons: Vec<String> = Vec::new();
+    for verifier in verifiers {
+        let signal = run_verifier(verifier, text).await;
+        let signal_label = signal.as_str().to_string();
+        let reason = signal.reason().map(str::to_string);
+        records.push(VerifierSignalRecord {
+            name: verifier.name().to_string(),
+            kind: verifier.kind_label().to_string(),
+            signal: signal_label,
+            reason: reason.clone(),
+        });
+        match signal {
+            VerifierSignal::Accept => {}
+            VerifierSignal::Refine { reason } => {
+                if outcome == VerifierOutcome::Accept {
+                    outcome = VerifierOutcome::Refine;
+                }
+                refine_reasons.push(reason);
+            }
+            VerifierSignal::Escalate { .. } => {
+                outcome = VerifierOutcome::Escalate;
+                // Don't `break` — we still want the full picture for
+                // receipts, but no later refine can downgrade escalate.
+            }
+        }
+    }
+    (records, outcome, refine_reasons)
+}
+
+/// Default `max_attempts` budget when `escalate_on` is configured but
+/// the script didn't set one explicitly. Without this nudge, the
+/// default `chain.len()` would silently disable refine retries (each
+/// link only gets one shot, leaving no slot for a tightened-prompt
+/// retry). Adding `chain.len() * max_refines_per_link` keeps the
+/// "happy path = once per link" semantics intact while making room
+/// for the refine fan-out the verifier chain expects.
+fn implied_max_attempts(policy: &RoutingPolicyConfig) -> usize {
+    let base = policy.chain.len();
+    if policy.escalate_on.is_empty() {
+        base
+    } else {
+        base + base.saturating_mul(policy.max_refines_per_link)
+    }
+}
+
+fn emit_verifier_signal_event(
+    dispatch: &str,
+    policy: &RoutingPolicyConfig,
+    attempt_no: usize,
+    link: &ChainLink,
+    outcome: VerifierOutcome,
+    signals: &[VerifierSignalRecord],
+) {
+    let mut meta = serde_json::Map::new();
+    meta.insert("policy".to_string(), json!(policy.label.clone()));
+    meta.insert("attempt".to_string(), json!(attempt_no));
+    meta.insert("provider".to_string(), json!(link.provider.clone()));
+    meta.insert("model".to_string(), json!(link.model.clone()));
+    meta.insert("link_label".to_string(), json!(link.display_label()));
+    meta.insert("outcome".to_string(), json!(outcome.as_str()));
+    meta.insert(
+        "signals".to_string(),
+        serde_json::Value::Array(
+            signals
+                .iter()
+                .map(|s| {
+                    json!({
+                        "name": s.name,
+                        "kind": s.kind,
+                        "signal": s.signal,
+                        "reason": s.reason,
+                    })
+                })
+                .collect(),
+        ),
+    );
+    emit_routing_event(dispatch, "verifier_signal", meta);
 }
 
 /// Run the chain. Each link is tried in order; failover rules decide
 /// whether to advance after an error. `latency.race_after_ms`, when
 /// set, kicks off the next attempt in parallel and returns whichever
 /// finishes first; the loser is cancelled and recorded as `race_lost`.
+///
+/// When `policy.escalate_on` is non-empty, each successful link's
+/// candidate runs through the verifier chain before being returned:
+/// `accept` returns, `refine` retries the same link with a nudge
+/// (up to `policy.max_refines_per_link` per link), `escalate`
+/// advances to the next link. If the verifier rejects the last link
+/// and no frontier remains, the rejected candidate is returned anyway
+/// — verifiers gate routing, not correctness.
 pub(crate) async fn execute_with_routing(
     policy: &RoutingPolicyConfig,
-    base_opts: LlmCallOptions,
+    mut base_opts: LlmCallOptions,
     bridge: Option<&Rc<crate::bridge::HostBridge>>,
 ) -> Result<(super::api::LlmResult, RoutingTrace), VmError> {
     let dispatch = policy.dispatch_label();
@@ -1066,7 +1260,10 @@ pub(crate) async fn execute_with_routing(
         selected: None,
         session_cost_usd: peek_total_cost(),
     };
-    let max_attempts = policy.failover.max_attempts.unwrap_or(policy.chain.len());
+    let max_attempts = policy
+        .failover
+        .max_attempts
+        .unwrap_or_else(|| implied_max_attempts(policy));
     if max_attempts == 0 {
         return Err(runtime_error(
             "routing_policy.failover.max_attempts: must be >= 1".to_string(),
@@ -1075,6 +1272,14 @@ pub(crate) async fn execute_with_routing(
     let mut last_error: Option<VmError> = None;
     let mut last_snapshot: Option<RoutingErrorSnapshot> = None;
     let mut attempts_used: usize = 0;
+    let original_messages = base_opts.messages.clone();
+    // Per-link refine bookkeeping. Both reset on `idx` advance so a
+    // refine streak from one link doesn't bleed into the next.
+    let mut refines_for_current_link: usize = 0;
+    let mut nudge_reasons_for_current_link: Vec<String> = Vec::new();
+    // Last verifier-rejected candidate, returned as a fallback when
+    // the chain exhausts without an `accept`.
+    let mut last_rejected_candidate: Option<(super::api::LlmResult, usize)> = None;
 
     let mut decision_meta = serde_json::Map::new();
     decision_meta.insert("policy".to_string(), json!(policy.label.clone()));
@@ -1203,9 +1408,34 @@ pub(crate) async fn execute_with_routing(
                     record.status = AttemptStatus::Succeeded;
                     record.cost_usd = Some(project_link_cost_usd(&value));
                 }
+                // Run the verifier chain over the winning candidate.
+                let candidate_text = if policy.escalate_on.is_empty() {
+                    String::new()
+                } else {
+                    candidate_text_for_verifier(&value)
+                };
+                let (signals, outcome, refine_reasons) =
+                    run_verifier_chain(&policy.escalate_on, &candidate_text).await;
+                let outcome_for_attempt = if policy.escalate_on.is_empty() {
+                    None
+                } else {
+                    Some(outcome)
+                };
+                if let Some(record) = attempt_records
+                    .iter_mut()
+                    .find(|rec| matches!(rec.status, AttemptStatus::Succeeded))
+                {
+                    record.verifier_signals = signals.clone();
+                    record.verifier_outcome = outcome_for_attempt;
+                }
+                if !policy.escalate_on.is_empty() {
+                    emit_verifier_signal_event(
+                        &dispatch, policy, attempt_no, &link, outcome, &signals,
+                    );
+                }
                 let starting_len = trace.attempts.len();
                 trace.attempts.extend(attempt_records);
-                trace.selected = trace
+                let success_idx = trace
                     .attempts
                     .iter()
                     .enumerate()
@@ -1216,8 +1446,53 @@ pub(crate) async fn execute_with_routing(
                             && a.model == value.model
                     })
                     .map(|(idx, _)| idx);
-                trace.session_cost_usd = peek_total_cost();
-                return Ok((value, trace));
+
+                match outcome {
+                    VerifierOutcome::Accept => {
+                        trace.selected = success_idx;
+                        trace.session_cost_usd = peek_total_cost();
+                        return Ok((value, trace));
+                    }
+                    VerifierOutcome::Refine
+                        if refines_for_current_link < policy.max_refines_per_link
+                            && attempts_used + consumed < max_attempts =>
+                    {
+                        // Same link, tightened prompt: append the
+                        // cumulative refine nudge to the original
+                        // messages snapshot (re-applying each iteration
+                        // keeps prior bad responses out of context).
+                        nudge_reasons_for_current_link.extend(refine_reasons);
+                        let nudge = build_refine_nudge(&nudge_reasons_for_current_link);
+                        base_opts.messages = original_messages.clone();
+                        if !nudge.is_empty() {
+                            base_opts.messages.push(serde_json::json!({
+                                "role": "user",
+                                "content": nudge,
+                            }));
+                        }
+                        refines_for_current_link += 1;
+                        attempts_used += consumed;
+                        if let Some(idx_v) = success_idx {
+                            last_rejected_candidate = Some((value, idx_v));
+                        }
+                        continue;
+                    }
+                    VerifierOutcome::Refine | VerifierOutcome::Escalate => {
+                        // Either refine budget is exhausted (treat as
+                        // escalate) or verifier escalated outright:
+                        // advance to the next link, reset link-local
+                        // refine state.
+                        refines_for_current_link = 0;
+                        nudge_reasons_for_current_link.clear();
+                        base_opts.messages = original_messages.clone();
+                        attempts_used += consumed;
+                        idx += consumed;
+                        if let Some(idx_v) = success_idx {
+                            last_rejected_candidate = Some((value, idx_v));
+                        }
+                        continue;
+                    }
+                }
             }
             Err(err) => {
                 let (eligible, snapshot) = matches_failover(&policy.failover, &err);
@@ -1238,6 +1513,20 @@ pub(crate) async fn execute_with_routing(
                 idx += consumed;
                 continue;
             }
+        }
+    }
+
+    // Verifier-rejected fallback: if the chain exhausted because the
+    // verifier kept escalating but we never got a transport error,
+    // return the last successful candidate the chain produced rather
+    // than failing the call. The verifier complaint is preserved on
+    // `routing.attempts[*].verifier_outcome` so the caller can still
+    // see why escalation ran out.
+    if last_error.is_none() {
+        if let Some((value, idx)) = last_rejected_candidate {
+            trace.selected = Some(idx);
+            trace.session_cost_usd = peek_total_cost();
+            return Ok((value, trace));
         }
     }
 
@@ -1424,7 +1713,23 @@ pub(crate) fn trace_to_decision(
     for (idx, attempt) in trace.attempts.iter().enumerate() {
         let selected = trace.selected == Some(idx);
         let reason = match attempt.status {
-            AttemptStatus::Succeeded => "selected".to_string(),
+            AttemptStatus::Succeeded => match attempt.verifier_outcome {
+                Some(VerifierOutcome::Refine) => {
+                    if selected {
+                        "selected:verifier_refine_fallback".to_string()
+                    } else {
+                        "verifier:refine".to_string()
+                    }
+                }
+                Some(VerifierOutcome::Escalate) => {
+                    if selected {
+                        "selected:verifier_escalate_fallback".to_string()
+                    } else {
+                        "verifier:escalate".to_string()
+                    }
+                }
+                Some(VerifierOutcome::Accept) | None => "selected".to_string(),
+            },
             AttemptStatus::Failed => attempt
                 .error
                 .as_ref()
@@ -1515,6 +1820,44 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
                     err_dict.insert("status".to_string(), VmValue::Int(status as i64));
                 }
                 dict.insert("error".to_string(), VmValue::Dict(Rc::new(err_dict)));
+            }
+            if let Some(outcome) = attempt.verifier_outcome {
+                dict.insert(
+                    "verifier_outcome".to_string(),
+                    VmValue::String(Rc::from(outcome.as_str())),
+                );
+            }
+            if !attempt.verifier_signals.is_empty() {
+                let signals: Vec<VmValue> = attempt
+                    .verifier_signals
+                    .iter()
+                    .map(|signal| {
+                        let mut sig_dict = BTreeMap::new();
+                        sig_dict.insert(
+                            "name".to_string(),
+                            VmValue::String(Rc::from(signal.name.clone())),
+                        );
+                        sig_dict.insert(
+                            "kind".to_string(),
+                            VmValue::String(Rc::from(signal.kind.clone())),
+                        );
+                        sig_dict.insert(
+                            "signal".to_string(),
+                            VmValue::String(Rc::from(signal.signal.clone())),
+                        );
+                        if let Some(reason) = &signal.reason {
+                            sig_dict.insert(
+                                "reason".to_string(),
+                                VmValue::String(Rc::from(reason.clone())),
+                            );
+                        }
+                        VmValue::Dict(Rc::new(sig_dict))
+                    })
+                    .collect();
+                dict.insert(
+                    "verifier_signals".to_string(),
+                    VmValue::List(Rc::new(signals)),
+                );
             }
             VmValue::Dict(Rc::new(dict))
         })

--- a/crates/harn-vm/src/llm/routing_verifier.rs
+++ b/crates/harn-vm/src/llm/routing_verifier.rs
@@ -1,0 +1,889 @@
+//! Verifier-signal escalation for `routing_policy`.
+//!
+//! A verifier inspects an LLM candidate's text and emits a signal in
+//! `{accept, refine, escalate}`. `RoutingPolicyConfig.escalate_on`
+//! holds an ordered chain of verifiers — the first non-`accept` signal
+//! drives the next routing decision:
+//!
+//! - `accept`: keep the candidate and return it from the chain.
+//! - `refine`: retry the **same** chain link with a tightened prompt;
+//!   the reason text is appended as a corrective user message.
+//! - `escalate`: advance to the next chain link (typically the
+//!   frontier-tier model).
+//!
+//! Verifiers run after a successful provider call and are cheap by
+//! construction — type-check / lint stay in-process via harn-parser;
+//! test-run shells out under a per-verifier timeout.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::time::Duration;
+
+use harn_parser::DiagnosticSeverity;
+use regex::Regex;
+
+use crate::value::{VmError, VmValue};
+
+/// Maximum bytes piped into a `test_run` verifier's stdin. Caps the
+/// host-side blast radius if a model emits a runaway response.
+const TEST_RUN_STDIN_CAP_BYTES: usize = 256 * 1024;
+
+const DEFAULT_TEST_RUN_TIMEOUT_SECS: u64 = 30;
+
+/// What a verifier wants the router to do with this candidate.
+///
+/// Reason text is plumbed back into telemetry, receipts, and the
+/// refine-nudge message so transcripts can show *why* a verifier
+/// rejected an answer rather than just *that* it did.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum VerifierSignal {
+    Accept,
+    Refine { reason: String },
+    Escalate { reason: String },
+}
+
+impl VerifierSignal {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Accept => "accept",
+            Self::Refine { .. } => "refine",
+            Self::Escalate { .. } => "escalate",
+        }
+    }
+
+    pub(crate) fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Accept => None,
+            Self::Refine { reason } | Self::Escalate { reason } => Some(reason.as_str()),
+        }
+    }
+}
+
+/// Whether a verifier's failure mode bumps to the next link
+/// (`Escalate`) or retries the same link with a nudge (`Refine`).
+/// Each verifier kind has a defensible default but scripts can flip
+/// it via `on_fail` in the spec.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FailMode {
+    Escalate,
+    Refine,
+}
+
+impl FailMode {
+    fn parse(value: &str) -> Result<Self, VmError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "escalate" | "" => Ok(Self::Escalate),
+            "refine" => Ok(Self::Refine),
+            other => Err(runtime_error(format!(
+                "routing_policy.escalate_on[*].on_fail: expected \"escalate\" or \"refine\", got {other:?}"
+            ))),
+        }
+    }
+}
+
+/// A parsed verifier ready to dispatch against a candidate. The kinds
+/// are deliberately closed: extending them requires a new variant so
+/// the script-facing spec, telemetry name, and receipt rendering all
+/// stay in lockstep.
+#[derive(Clone, Debug)]
+pub(crate) enum Verifier {
+    TypeCheck {
+        name: String,
+        extract_fenced: bool,
+        on_fail: FailMode,
+    },
+    Lint {
+        name: String,
+        forbidden: Vec<Regex>,
+        forbidden_sources: Vec<String>,
+        required: Vec<Regex>,
+        required_sources: Vec<String>,
+        max_line_length: Option<usize>,
+        on_fail: FailMode,
+    },
+    TestRun {
+        name: String,
+        command: Vec<String>,
+        timeout: Duration,
+        pass_via_stdin: bool,
+        on_fail: FailMode,
+    },
+}
+
+impl Verifier {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::TypeCheck { name, .. } | Self::Lint { name, .. } | Self::TestRun { name, .. } => {
+                name.as_str()
+            }
+        }
+    }
+
+    pub(crate) fn kind_label(&self) -> &'static str {
+        match self {
+            Self::TypeCheck { .. } => "typecheck",
+            Self::Lint { .. } => "lint",
+            Self::TestRun { .. } => "test_run",
+        }
+    }
+}
+
+/// Run a verifier against `candidate_text`. Returns `Accept` when the
+/// verifier passes; otherwise `Refine` or `Escalate` per the verifier's
+/// `on_fail` mode. The async surface is uniform across kinds so the
+/// caller can `await` the chain without branching on kind.
+pub(crate) async fn run_verifier(verifier: &Verifier, candidate_text: &str) -> VerifierSignal {
+    match verifier {
+        Verifier::TypeCheck {
+            extract_fenced,
+            on_fail,
+            ..
+        } => run_typecheck(candidate_text, *extract_fenced, *on_fail),
+        Verifier::Lint {
+            forbidden,
+            forbidden_sources,
+            required,
+            required_sources,
+            max_line_length,
+            on_fail,
+            ..
+        } => run_lint(
+            candidate_text,
+            forbidden,
+            forbidden_sources,
+            required,
+            required_sources,
+            *max_line_length,
+            *on_fail,
+        ),
+        Verifier::TestRun {
+            command,
+            timeout,
+            pass_via_stdin,
+            on_fail,
+            ..
+        } => run_test_command(candidate_text, command, *timeout, *pass_via_stdin, *on_fail).await,
+    }
+}
+
+fn run_typecheck(candidate_text: &str, extract_fenced: bool, on_fail: FailMode) -> VerifierSignal {
+    let source = if extract_fenced {
+        extract_fenced_blocks(candidate_text, &["harn"])
+    } else {
+        candidate_text.to_string()
+    };
+    if source.trim().is_empty() {
+        return signal_for(
+            on_fail,
+            "typecheck: no Harn source found in candidate text".to_string(),
+        );
+    }
+    match harn_parser::check_source(&source) {
+        Err(err) => signal_for(on_fail, format!("typecheck: parse failed: {err}")),
+        Ok((_, diagnostics)) => {
+            let errors: Vec<String> = diagnostics
+                .iter()
+                .filter(|d| d.severity == DiagnosticSeverity::Error)
+                .map(|d| d.message.clone())
+                .collect();
+            if errors.is_empty() {
+                VerifierSignal::Accept
+            } else {
+                signal_for(on_fail, format!("typecheck: {}", errors.join("; ")))
+            }
+        }
+    }
+}
+
+fn run_lint(
+    candidate_text: &str,
+    forbidden: &[Regex],
+    forbidden_sources: &[String],
+    required: &[Regex],
+    required_sources: &[String],
+    max_line_length: Option<usize>,
+    on_fail: FailMode,
+) -> VerifierSignal {
+    let mut issues: Vec<String> = Vec::new();
+    for (idx, re) in forbidden.iter().enumerate() {
+        if re.is_match(candidate_text) {
+            let pattern = forbidden_sources
+                .get(idx)
+                .cloned()
+                .unwrap_or_else(|| re.as_str().to_string());
+            issues.push(format!("forbidden pattern matched: {pattern}"));
+        }
+    }
+    for (idx, re) in required.iter().enumerate() {
+        if !re.is_match(candidate_text) {
+            let pattern = required_sources
+                .get(idx)
+                .cloned()
+                .unwrap_or_else(|| re.as_str().to_string());
+            issues.push(format!("required pattern missing: {pattern}"));
+        }
+    }
+    if let Some(limit) = max_line_length {
+        if let Some((line_no, _)) = candidate_text
+            .lines()
+            .enumerate()
+            .find(|(_, line)| line.chars().count() > limit)
+        {
+            issues.push(format!(
+                "line {} exceeds max_line_length={limit}",
+                line_no + 1
+            ));
+        }
+    }
+    if issues.is_empty() {
+        VerifierSignal::Accept
+    } else {
+        signal_for(on_fail, format!("lint: {}", issues.join("; ")))
+    }
+}
+
+async fn run_test_command(
+    candidate_text: &str,
+    command: &[String],
+    timeout: Duration,
+    pass_via_stdin: bool,
+    on_fail: FailMode,
+) -> VerifierSignal {
+    if command.is_empty() {
+        return signal_for(
+            on_fail,
+            "test_run: command is empty (configure routing_policy.escalate_on[*].command)"
+                .to_string(),
+        );
+    }
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::Command;
+
+    let mut cmd = Command::new(&command[0]);
+    cmd.args(&command[1..]);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    // `wait_with_output` consumes the Child handle, so a timeout that
+    // fires while we're awaiting it would otherwise leak the OS
+    // process. `kill_on_drop` makes the OS reap the child when the
+    // Child handle drops, which happens precisely when the timeout
+    // future is cancelled below.
+    cmd.kill_on_drop(true);
+    if pass_via_stdin {
+        cmd.stdin(std::process::Stdio::piped());
+    } else {
+        cmd.stdin(std::process::Stdio::null());
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(err) => {
+            return signal_for(
+                on_fail,
+                format!("test_run: failed to spawn {command:?}: {err}"),
+            );
+        }
+    };
+
+    if pass_via_stdin {
+        if let Some(mut stdin) = child.stdin.take() {
+            let mut bytes = candidate_text.as_bytes();
+            if bytes.len() > TEST_RUN_STDIN_CAP_BYTES {
+                bytes = &bytes[..TEST_RUN_STDIN_CAP_BYTES];
+            }
+            let _ = stdin.write_all(bytes).await;
+            let _ = stdin.shutdown().await;
+        }
+    }
+
+    let wait = tokio::time::timeout(timeout, child.wait_with_output()).await;
+    match wait {
+        Err(_) => signal_for(
+            on_fail,
+            format!("test_run: timed out after {}s", timeout.as_secs()),
+        ),
+        Ok(Err(err)) => signal_for(on_fail, format!("test_run: wait failed: {err}")),
+        Ok(Ok(output)) => {
+            if output.status.success() {
+                VerifierSignal::Accept
+            } else {
+                let mut tail = String::from_utf8_lossy(&output.stderr).into_owned();
+                if tail.trim().is_empty() {
+                    tail = String::from_utf8_lossy(&output.stdout).into_owned();
+                }
+                let summary = summarize_command_output(&tail);
+                signal_for(
+                    on_fail,
+                    format!(
+                        "test_run: command exited with status {}: {summary}",
+                        output
+                            .status
+                            .code()
+                            .map(|c| c.to_string())
+                            .unwrap_or_else(|| "signal".to_string())
+                    ),
+                )
+            }
+        }
+    }
+}
+
+fn summarize_command_output(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return "(no output)".to_string();
+    }
+    // Last non-empty line is usually the actionable summary
+    // ("error: cannot find ..."). Cap at a sensible width so receipt
+    // payloads stay readable in transcripts.
+    let last = trimmed
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or(trimmed);
+    let mut out: String = last.chars().take(240).collect();
+    if last.chars().count() > 240 {
+        out.push('…');
+    }
+    out
+}
+
+fn signal_for(mode: FailMode, reason: String) -> VerifierSignal {
+    match mode {
+        FailMode::Refine => VerifierSignal::Refine { reason },
+        FailMode::Escalate => VerifierSignal::Escalate { reason },
+    }
+}
+
+/// Extract ```harn / ``` (or other named) fenced blocks. Falls back to
+/// the entire text when no fences match — preserves typecheck coverage
+/// for models that emit bare Harn source.
+fn extract_fenced_blocks(text: &str, langs: &[&str]) -> String {
+    let mut out = String::new();
+    let mut chars = text.char_indices().peekable();
+    while let Some((idx, _)) = chars.next() {
+        if !text[idx..].starts_with("```") {
+            continue;
+        }
+        let after_fence = &text[idx + 3..];
+        let header_end = after_fence.find('\n').unwrap_or(after_fence.len());
+        let lang = after_fence[..header_end].trim();
+        let body_start = idx + 3 + header_end + 1;
+        let Some(rel_end) = text[body_start..].find("```") else {
+            break;
+        };
+        let body_end = body_start + rel_end;
+        if lang.is_empty() || langs.iter().any(|l| lang.eq_ignore_ascii_case(l)) {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(text[body_start..body_end].trim_end_matches('\n'));
+        }
+        // Skip ahead so the outer iterator doesn't try to re-parse the
+        // characters we just consumed.
+        while let Some((next_idx, _)) = chars.peek() {
+            if *next_idx >= body_end + 3 {
+                break;
+            }
+            chars.next();
+        }
+    }
+    if out.is_empty() {
+        text.to_string()
+    } else {
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Refine nudges
+// ---------------------------------------------------------------------------
+
+/// Compose a corrective user message from one or more refine reasons.
+/// Used by the routing executor when retrying the same link.
+pub(crate) fn build_refine_nudge(reasons: &[String]) -> String {
+    if reasons.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from(
+        "The previous response did not pass verification. Please address the following and try again:\n",
+    );
+    for reason in reasons {
+        out.push_str("- ");
+        out.push_str(reason);
+        out.push('\n');
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Config parsing — turn a Harn-side spec into `Vec<Verifier>`
+// ---------------------------------------------------------------------------
+
+fn runtime_error(message: String) -> VmError {
+    VmError::Thrown(VmValue::String(Rc::from(message)))
+}
+
+fn parse_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<String>, VmError> {
+    match dict.get(key) {
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(VmValue::String(s)) => Ok(Some(s.to_string())),
+        Some(other) => Err(runtime_error(format!(
+            "routing_policy.escalate_on[*].{key}: expected a string, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_bool(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<bool>, VmError> {
+    match dict.get(key) {
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(VmValue::Bool(b)) => Ok(Some(*b)),
+        Some(other) => Err(runtime_error(format!(
+            "routing_policy.escalate_on[*].{key}: expected a boolean, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_pos_usize(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<usize>, VmError> {
+    match dict.get(key) {
+        Some(VmValue::Nil) | None => Ok(None),
+        Some(VmValue::Int(n)) if *n >= 0 => Ok(Some(*n as usize)),
+        Some(other) => Err(runtime_error(format!(
+            "routing_policy.escalate_on[*].{key}: expected a non-negative integer, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_regex_list(
+    dict: &BTreeMap<String, VmValue>,
+    key: &str,
+) -> Result<(Vec<Regex>, Vec<String>), VmError> {
+    let value = match dict.get(key) {
+        None | Some(VmValue::Nil) => return Ok((Vec::new(), Vec::new())),
+        Some(v) => v,
+    };
+    let items = match value {
+        VmValue::List(items) => items.clone(),
+        VmValue::String(s) => Rc::new(vec![VmValue::String(s.clone())]),
+        other => {
+            return Err(runtime_error(format!(
+                "routing_policy.escalate_on[*].{key}: expected a list of regex strings, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let mut compiled = Vec::with_capacity(items.len());
+    let mut sources = Vec::with_capacity(items.len());
+    for item in items.iter() {
+        let pattern = match item {
+            VmValue::String(s) => s.to_string(),
+            other => {
+                return Err(runtime_error(format!(
+                    "routing_policy.escalate_on[*].{key}: list entries must be regex strings, got {}",
+                    other.type_name()
+                )));
+            }
+        };
+        let trimmed = pattern.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let re = Regex::new(trimmed).map_err(|err| {
+            runtime_error(format!(
+                "routing_policy.escalate_on[*].{key}: invalid regex {trimmed:?}: {err}"
+            ))
+        })?;
+        compiled.push(re);
+        sources.push(trimmed.to_string());
+    }
+    Ok((compiled, sources))
+}
+
+fn parse_command(value: Option<&VmValue>) -> Result<Vec<String>, VmError> {
+    match value {
+        None | Some(VmValue::Nil) => Ok(Vec::new()),
+        Some(VmValue::String(s)) => {
+            // Split on whitespace for the common simple-command case;
+            // structured args go through the list form.
+            Ok(s.split_whitespace().map(str::to_string).collect())
+        }
+        Some(VmValue::List(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for (idx, item) in items.iter().enumerate() {
+                match item {
+                    VmValue::String(s) => out.push(s.to_string()),
+                    other => {
+                        return Err(runtime_error(format!(
+                            "routing_policy.escalate_on[*].command[{idx}]: expected string, got {}",
+                            other.type_name()
+                        )));
+                    }
+                }
+            }
+            Ok(out)
+        }
+        Some(other) => Err(runtime_error(format!(
+            "routing_policy.escalate_on[*].command: expected string or list, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_on_fail(dict: &BTreeMap<String, VmValue>, default: FailMode) -> Result<FailMode, VmError> {
+    match dict.get("on_fail") {
+        Some(VmValue::Nil) | None => Ok(default),
+        Some(VmValue::String(s)) => FailMode::parse(s),
+        Some(other) => Err(runtime_error(format!(
+            "routing_policy.escalate_on[*].on_fail: expected a string, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_one_verifier(value: &VmValue, idx: usize) -> Result<Verifier, VmError> {
+    let dict = match value {
+        VmValue::Dict(dict) => dict.clone(),
+        VmValue::String(target) => {
+            // Shorthand: "typecheck" / "lint" → all defaults.
+            return shorthand_verifier(target, idx);
+        }
+        other => {
+            return Err(runtime_error(format!(
+                "routing_policy.escalate_on[{idx}]: expected dict or string, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let kind = dict
+        .get("kind")
+        .map(|v| v.display())
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    let name = parse_string(&dict, "name")?.unwrap_or_else(|| match kind.as_str() {
+        "typecheck" | "type_check" | "type-check" => "typecheck".to_string(),
+        "lint" => "lint".to_string(),
+        "test_run" | "testrun" | "test-run" | "test" => "test_run".to_string(),
+        other => other.to_string(),
+    });
+    match kind.as_str() {
+        "typecheck" | "type_check" | "type-check" => {
+            let extract_fenced = parse_bool(&dict, "extract_fenced")?.unwrap_or(true);
+            let on_fail = parse_on_fail(&dict, FailMode::Escalate)?;
+            Ok(Verifier::TypeCheck {
+                name,
+                extract_fenced,
+                on_fail,
+            })
+        }
+        "lint" => {
+            let (forbidden, forbidden_sources) = parse_regex_list(&dict, "forbidden_patterns")?;
+            let (required, required_sources) = parse_regex_list(&dict, "required_patterns")?;
+            let max_line_length = parse_pos_usize(&dict, "max_line_length")?;
+            let on_fail = parse_on_fail(&dict, FailMode::Refine)?;
+            if forbidden.is_empty() && required.is_empty() && max_line_length.is_none() {
+                return Err(runtime_error(format!(
+                    "routing_policy.escalate_on[{idx}]: lint verifier needs at least one of forbidden_patterns, required_patterns, or max_line_length"
+                )));
+            }
+            Ok(Verifier::Lint {
+                name,
+                forbidden,
+                forbidden_sources,
+                required,
+                required_sources,
+                max_line_length,
+                on_fail,
+            })
+        }
+        "test_run" | "testrun" | "test-run" | "test" => {
+            let command = parse_command(dict.get("command"))?;
+            if command.is_empty() {
+                return Err(runtime_error(format!(
+                    "routing_policy.escalate_on[{idx}]: test_run verifier requires a non-empty `command`"
+                )));
+            }
+            let timeout_secs = match dict.get("timeout_secs") {
+                Some(VmValue::Nil) | None => DEFAULT_TEST_RUN_TIMEOUT_SECS,
+                Some(VmValue::Int(n)) if *n > 0 => *n as u64,
+                Some(other) => {
+                    return Err(runtime_error(format!(
+                        "routing_policy.escalate_on[{idx}].timeout_secs: expected a positive integer, got {}",
+                        other.type_name()
+                    )));
+                }
+            };
+            let pass_via_stdin = parse_bool(&dict, "pass_via_stdin")?.unwrap_or(true);
+            let on_fail = parse_on_fail(&dict, FailMode::Escalate)?;
+            Ok(Verifier::TestRun {
+                name,
+                command,
+                timeout: Duration::from_secs(timeout_secs),
+                pass_via_stdin,
+                on_fail,
+            })
+        }
+        "" => Err(runtime_error(format!(
+            "routing_policy.escalate_on[{idx}]: `kind` is required (one of typecheck, lint, test_run)"
+        ))),
+        other => Err(runtime_error(format!(
+            "routing_policy.escalate_on[{idx}]: unknown kind {other:?} (expected typecheck, lint, or test_run)"
+        ))),
+    }
+}
+
+fn shorthand_verifier(kind: &str, idx: usize) -> Result<Verifier, VmError> {
+    let normalized = kind.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "typecheck" | "type_check" | "type-check" => Ok(Verifier::TypeCheck {
+            name: "typecheck".to_string(),
+            extract_fenced: true,
+            on_fail: FailMode::Escalate,
+        }),
+        // Lint and test_run can't take a sensible default: lint needs
+        // at least one pattern or a length cap, test_run needs a
+        // command. Bail loudly so the user fixes their config.
+        "lint" => Err(runtime_error(format!(
+            "routing_policy.escalate_on[{idx}]: shorthand \"lint\" needs at least one of forbidden_patterns, required_patterns, or max_line_length — use a dict spec"
+        ))),
+        "test_run" | "testrun" | "test-run" | "test" => Err(runtime_error(format!(
+            "routing_policy.escalate_on[{idx}]: shorthand \"test_run\" needs a command — use a dict spec"
+        ))),
+        other => Err(runtime_error(format!(
+            "routing_policy.escalate_on[{idx}]: unknown shorthand verifier {other:?}"
+        ))),
+    }
+}
+
+/// Public entry: parse the `escalate_on` field. Empty list / nil →
+/// `Ok(Vec::new())` so the legacy fallback path runs.
+pub(crate) fn parse_escalate_on(value: Option<&VmValue>) -> Result<Vec<Verifier>, VmError> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let items = match value {
+        VmValue::Nil => return Ok(Vec::new()),
+        VmValue::List(items) => items.clone(),
+        VmValue::Dict(_) | VmValue::String(_) => Rc::new(vec![value.clone()]),
+        other => {
+            return Err(runtime_error(format!(
+                "routing_policy.escalate_on: expected a list of verifier specs, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    let mut out = Vec::with_capacity(items.len());
+    for (idx, item) in items.iter().enumerate() {
+        out.push(parse_one_verifier(item, idx)?);
+    }
+    Ok(out)
+}
+
+/// Render verifier specs into a summary `VmValue` for the tagged
+/// `routing_policy(...)` dict — keeps script-side debugging readable
+/// (`policy.escalate_on` mirrors what the parser ingested).
+pub(crate) fn verifiers_summary(verifiers: &[Verifier]) -> VmValue {
+    let items: Vec<VmValue> = verifiers
+        .iter()
+        .map(|v| {
+            let mut dict = BTreeMap::new();
+            dict.insert(
+                "kind".to_string(),
+                VmValue::String(Rc::from(v.kind_label())),
+            );
+            dict.insert(
+                "name".to_string(),
+                VmValue::String(Rc::from(v.name().to_string())),
+            );
+            let on_fail = match v {
+                Verifier::TypeCheck { on_fail, .. }
+                | Verifier::Lint { on_fail, .. }
+                | Verifier::TestRun { on_fail, .. } => *on_fail,
+            };
+            dict.insert(
+                "on_fail".to_string(),
+                VmValue::String(Rc::from(match on_fail {
+                    FailMode::Refine => "refine",
+                    FailMode::Escalate => "escalate",
+                })),
+            );
+            VmValue::Dict(Rc::new(dict))
+        })
+        .collect();
+    VmValue::List(Rc::new(items))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dict(items: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+        items
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn shorthand_typecheck_parses() {
+        let spec = VmValue::List(Rc::new(vec![VmValue::String(Rc::from("typecheck"))]));
+        let verifiers = parse_escalate_on(Some(&spec)).expect("parses");
+        assert_eq!(verifiers.len(), 1);
+        assert!(matches!(verifiers[0], Verifier::TypeCheck { .. }));
+    }
+
+    #[test]
+    fn lint_requires_at_least_one_rule() {
+        let spec = VmValue::List(Rc::new(vec![VmValue::Dict(Rc::new(dict(&[(
+            "kind",
+            VmValue::String(Rc::from("lint")),
+        )])))]));
+        let err = parse_escalate_on(Some(&spec)).unwrap_err();
+        let message = match err {
+            VmError::Thrown(VmValue::String(s)) => s.to_string(),
+            other => panic!("unexpected error: {other:?}"),
+        };
+        assert!(message.contains("at least one"));
+    }
+
+    #[test]
+    fn test_run_requires_command() {
+        let spec = VmValue::List(Rc::new(vec![VmValue::Dict(Rc::new(dict(&[(
+            "kind",
+            VmValue::String(Rc::from("test_run")),
+        )])))]));
+        let err = parse_escalate_on(Some(&spec)).unwrap_err();
+        let message = match err {
+            VmError::Thrown(VmValue::String(s)) => s.to_string(),
+            other => panic!("unexpected error: {other:?}"),
+        };
+        assert!(message.contains("command"));
+    }
+
+    #[test]
+    fn lint_verifier_signals_refine_on_forbidden_pattern() {
+        let verifier = Verifier::Lint {
+            name: "lint".to_string(),
+            forbidden: vec![Regex::new(r"(?i)unwrap\s*\(\s*\)").unwrap()],
+            forbidden_sources: vec!["unwrap()".to_string()],
+            required: Vec::new(),
+            required_sources: Vec::new(),
+            max_line_length: None,
+            on_fail: FailMode::Refine,
+        };
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let signal = rt.block_on(run_verifier(&verifier, "let x = foo.unwrap();"));
+        match signal {
+            VerifierSignal::Refine { reason } => assert!(reason.contains("unwrap")),
+            other => panic!("expected refine, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lint_verifier_accepts_clean_text() {
+        let verifier = Verifier::Lint {
+            name: "lint".to_string(),
+            forbidden: vec![Regex::new(r"\bTODO\b|\bFIXME\b").unwrap()],
+            forbidden_sources: vec!["TODO|FIXME".to_string()],
+            required: Vec::new(),
+            required_sources: Vec::new(),
+            max_line_length: Some(120),
+            on_fail: FailMode::Escalate,
+        };
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let signal = rt.block_on(run_verifier(&verifier, "let x = 1\n"));
+        assert_eq!(signal, VerifierSignal::Accept);
+    }
+
+    #[test]
+    fn typecheck_verifier_accepts_valid_harn() {
+        let verifier = Verifier::TypeCheck {
+            name: "typecheck".to_string(),
+            extract_fenced: false,
+            on_fail: FailMode::Escalate,
+        };
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let signal = rt.block_on(run_verifier(&verifier, "let x = 1\n"));
+        assert_eq!(signal, VerifierSignal::Accept);
+    }
+
+    #[test]
+    fn typecheck_verifier_escalates_on_parse_failure() {
+        let verifier = Verifier::TypeCheck {
+            name: "typecheck".to_string(),
+            extract_fenced: false,
+            on_fail: FailMode::Escalate,
+        };
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let signal = rt.block_on(run_verifier(&verifier, "let x = @@@\n"));
+        assert!(matches!(signal, VerifierSignal::Escalate { .. }));
+    }
+
+    #[test]
+    fn typecheck_extracts_fenced_harn_block() {
+        let verifier = Verifier::TypeCheck {
+            name: "typecheck".to_string(),
+            extract_fenced: true,
+            on_fail: FailMode::Escalate,
+        };
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let candidate = "Here's the fix:\n```harn\nlet x = 1\n```\nDone.";
+        let signal = rt.block_on(run_verifier(&verifier, candidate));
+        assert_eq!(signal, VerifierSignal::Accept);
+    }
+
+    #[test]
+    fn build_refine_nudge_groups_reasons() {
+        let nudge = build_refine_nudge(&[
+            "lint: forbidden pattern matched".to_string(),
+            "typecheck: parse failed".to_string(),
+        ]);
+        assert!(nudge.contains("lint:"));
+        assert!(nudge.contains("typecheck:"));
+        assert!(nudge.contains("did not pass verification"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_run_verifier_accepts_zero_exit() {
+        let verifier = Verifier::TestRun {
+            name: "test_run".to_string(),
+            command: vec!["true".to_string()],
+            timeout: Duration::from_secs(5),
+            pass_via_stdin: false,
+            on_fail: FailMode::Escalate,
+        };
+        let signal = run_verifier(&verifier, "anything").await;
+        assert_eq!(signal, VerifierSignal::Accept);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_run_verifier_escalates_on_nonzero_exit() {
+        let verifier = Verifier::TestRun {
+            name: "test_run".to_string(),
+            command: vec!["false".to_string()],
+            timeout: Duration::from_secs(5),
+            pass_via_stdin: false,
+            on_fail: FailMode::Escalate,
+        };
+        let signal = run_verifier(&verifier, "anything").await;
+        assert!(matches!(signal, VerifierSignal::Escalate { .. }));
+    }
+}

--- a/crates/harn-vm/src/observability/otel.rs
+++ b/crates/harn-vm/src/observability/otel.rs
@@ -139,8 +139,7 @@ impl ObservabilityGuard {
         #[cfg(not(feature = "otel"))]
         if std::env::var("HARN_OTEL_ENDPOINT")
             .ok()
-            .filter(|value| !value.trim().is_empty())
-            .is_some()
+            .is_some_and(|value| !value.trim().is_empty())
         {
             return Err(
                 "HARN_OTEL_ENDPOINT is set, but this build was compiled without the `otel` feature"

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -3544,10 +3544,16 @@ let policy = routing_policy({
     on_exceed: "abort",                               // or "skip" | "warn"
   },
   observe: {emit_event: "billing.routing_decision"},  // optional dispatch label
+  escalate_on: [                                      // optional verifier chain
+    {kind: "typecheck"},                              // parse the candidate as Harn
+    {kind: "lint", forbidden_patterns: ["TODO", "unwrap\\("], on_fail: "refine"},
+    {kind: "test_run", command: ["cargo", "test", "--quiet"], timeout_secs: 60},
+  ],
+  max_refines_per_link: 1,                            // optional, default 1
 })
 
 let result = llm_call("Summarize this PR.", nil, {routing: policy})
-// result.routing = {policy, attempts: [{provider, model, status, duration_ms, cost_usd, error?}], selected, session_cost_usd}
+// result.routing = {policy, attempts: [{provider, model, status, duration_ms, cost_usd, error?, verifier_outcome?, verifier_signals?}], selected, session_cost_usd}
 ```
 
 Semantics:
@@ -3569,11 +3575,34 @@ Semantics:
   pricing in `std/llm/economics`. `on_exceed: "abort"` throws the
   standard budget-exceeded error, `"skip"` advances to the next chain
   link, `"warn"` emits an event and proceeds.
+- **Verifier escalation** (`escalate_on`): each verifier inspects the
+  successful candidate's text. The first non-`accept` signal drives
+  the next decision — `refine` re-runs the **same** link with a
+  tightened prompt (up to `max_refines_per_link` retries; nudge text
+  includes the verifier's reason), `escalate` advances to the next
+  link. If the verifier rejects the last link and no frontier remains,
+  the rejected candidate is returned anyway with
+  `verifier_outcome: "escalate"` on the trace — verifiers gate routing
+  decisions, not correctness. Each `escalate_on` entry is a dict with
+  `kind: "typecheck" | "lint" | "test_run"` plus kind-specific
+  options:
+  - `typecheck`: parses the candidate as Harn (extracting ```harn /
+    ``` fenced blocks by default via `extract_fenced: true`); parse
+    or type errors trigger `on_fail` (default `escalate`).
+  - `lint`: regex-based pattern check with
+    `forbidden_patterns: [...]`, `required_patterns: [...]`, and
+    `max_line_length: N`; any rule violation triggers `on_fail`
+    (default `refine`).
+  - `test_run`: spawns `command: [...]` with the candidate text on
+    stdin (toggle with `pass_via_stdin: false`); non-zero exit
+    triggers `on_fail` (default `escalate`). `timeout_secs` defaults
+    to 30. **Authority lives in the script that builds the policy** —
+    `test_run` shells out under the calling process's permissions.
 - **Tape events**: `<dispatch>.decision`, `<dispatch>.attempt`,
   `<dispatch>.race_started`, `<dispatch>.race_won`,
   `<dispatch>.race_lost`, `<dispatch>.budget_exceeded`,
-  `<dispatch>.exhausted` (default `dispatch = llm.routing`; override via
-  `observe.emit_event`).
+  `<dispatch>.verifier_signal`, `<dispatch>.exhausted` (default
+  `dispatch = llm.routing`; override via `observe.emit_event`).
 - **Replay**: the routing decision rides on the result envelope's
   `routing_decision` block, so transcripts and replay re-attribute each
   attempt to the same chain link without re-resolving.

--- a/docs/src/stdlib/llm-handlers.md
+++ b/docs/src/stdlib/llm-handlers.md
@@ -218,15 +218,31 @@ let policy = routing_policy({
   latency: {race_after_ms: 5000},
   budget:  {per_call_usd: 0.5, on_exceed: "abort"},
   observe: {emit_event: "billing.routing_decision"},
+  escalate_on: [                                       // optional verifier chain
+    {kind: "typecheck"},
+    {kind: "lint", forbidden_patterns: ["TODO"], on_fail: "refine"},
+  ],
 })
 
 let result = llm_call("Summarize this PR.", nil, {routing: policy})
 ```
 
+`escalate_on` makes frontier escalation **conditional on a
+code-quality signal** rather than static routing. Verifiers see the
+candidate's text after a successful link: `accept` keeps it,
+`refine` retries the same link with the verifier's reason appended to
+the prompt (capped by `max_refines_per_link`, default `1`),
+`escalate` advances to the next link. Three built-in kinds —
+`typecheck` (harn-parser), `lint` (regex `forbidden_patterns` /
+`required_patterns` / `max_line_length`), and `test_run` (spawns a
+configurable command with the candidate on stdin) — let scripts gate
+"only call Opus when Devstral's answer doesn't typecheck." See the
+quickref for the full per-kind option list.
+
 Compared to `compose([with_routing, with_retry, with_fallback])`, the
 primitive is replay-deterministic (every attempt rides on the result
 envelope's `routing` block), records its own tape events
-(`<dispatch>.{decision,attempt,race_started,race_won,race_lost,budget_exceeded,exhausted}`),
+(`<dispatch>.{decision,attempt,race_started,race_won,race_lost,budget_exceeded,verifier_signal,exhausted}`),
 and pays for `latency.race_after_ms` racing out-of-the-box. Migrate
 existing chains by replacing the wrapper composition with one
 `routing_policy({...})` call; layer `compose([with_logging,


### PR DESCRIPTION
## Summary

- Adds `escalate_on` to `routing_policy({...})`: a chain of verifiers that inspect each successful candidate's text and emit `{accept, refine, escalate}`. `refine` retries the same chain link with the verifier's reason appended as a corrective user message (capped by `max_refines_per_link`, default 1); `escalate` advances to the next link. Verifier rejection on the last link returns the candidate anyway — verifiers gate **routing decisions**, not correctness.
- Ships three verifier kinds: `typecheck` (harn-parser, extracts \`\`\`harn fenced blocks by default), `lint` (regex `forbidden_patterns` / `required_patterns` / `max_line_length`), and `test_run` (configurable command with `kill_on_drop`, stdin capped at 256 KiB, default 30 s timeout).
- Emits `<dispatch>.verifier_signal` tape events and surfaces per-attempt `verifier_outcome` + `verifier_signals` on `result.routing.attempts[*]` so transcripts attribute escalation to a specific verifier and reason.
- Drive-by: collapse a pre-existing `Option::filter(...).is_some()` to `is_some_and` in `observability/otel.rs` so the lint-floor pre-commit hook stays green on this commit.

## Closes

Closes burin-labs/harn#2435.

Acceptance-criteria status from the issue:

- [x] `Verifier` trait + three implementations (`TypeCheck`, `Lint`, `TestRun`) — implemented as a `Verifier` enum with one dispatcher (`run_verifier`) so the script-facing spec, telemetry name, and receipt rendering stay in lockstep.
- [x] `RoutingPolicyConfig.escalate_on` field accepts a verifier chain.
- [x] Receipt rendering updated to show verifier signals per attempt (`verifier_outcome` + `verifier_signals[*]` on `routing.attempts`).
- [ ] SWE-Bench-Verified 10-issue eval target — deferred. Requires a real-money eval harness with frontier API keys; filing as a follow-up so the runtime primitive can land independently and be exercised against the eval once the harness is in place.

## Test plan

- [x] `cargo test -p harn-vm --lib llm::routing` — 19/19 pass (including 11 new tests covering parser, typecheck, lint, and test_run verifiers).
- [x] `cargo test -p harn-vm --lib` — 2686/2686 pass (no regressions).
- [x] `cargo run --bin harn -- test conformance --filter llm_routing` — 9/9 pass, including the new `verifier_escalate.harn` (lint forbids "TODO" → escalate to frontier link) and `verifier_refine.harn` (lint forbids "unwrap" → refine same link with nudge).
- [x] `cargo run --bin harn -- fmt --check conformance/tests/llm_routing/verifier_*.harn` and `lint` clean.
- [x] Pre-commit + pre-push hooks pass (rust fmt, harn fmt, harn lint, clippy on harn-vm, markdownlint, CI ratchets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)