### PR TITLE
evals/routing_v2: empirical demo + per-attempt token receipts

### DIFF
--- a/conformance/tests/llm_routing/verifier_escalate.expected
+++ b/conformance/tests/llm_routing/verifier_escalate.expected
@@ -7,3 +7,5 @@ escalate
 frontier
 accept
 1
+true
+true

--- a/conformance/tests/llm_routing/verifier_escalate.harn
+++ b/conformance/tests/llm_routing/verifier_escalate.harn
@@ -28,4 +28,8 @@ pipeline test(task) {
   __io_println(attempts[1].label)
   __io_println(attempts[1].verifier_outcome)
   __io_println(result.routing.selected)
+  // Per-attempt token counts now ride on the trace so downstream graders
+  // can re-cost against alternate pricing tables.
+  __io_println(to_string(attempts[0].input_tokens > 0))
+  __io_println(to_string(attempts[1].output_tokens > 0))
 }

--- a/crates/harn-vm/src/llm/routing.rs
+++ b/crates/harn-vm/src/llm/routing.rs
@@ -728,6 +728,14 @@ pub(crate) struct RoutingAttempt {
     pub status: AttemptStatus,
     pub duration_ms: u64,
     pub cost_usd: Option<f64>,
+    /// Token counts attributed to this attempt's provider call. Mirrors
+    /// the winning `LlmResult.input_tokens` / `output_tokens` so
+    /// downstream graders can re-compute spend against alternate
+    /// pricing tables (e.g. OpenRouter, which isn't in the catalog).
+    /// `None` when the attempt was skipped, race-lost, or budget-aborted
+    /// before the provider returned a payload.
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
     pub error: Option<RoutingErrorSnapshot>,
     /// Per-verifier signals emitted after this attempt's response.
     /// Empty when the policy has no `escalate_on` chain or the
@@ -1057,6 +1065,8 @@ fn check_link_budget(
                 status: AttemptStatus::Skipped,
                 duration_ms: 0,
                 cost_usd: None,
+                input_tokens: None,
+                output_tokens: None,
                 error: Some(snapshot),
                 verifier_signals: Vec::new(),
                 verifier_outcome: None,
@@ -1122,6 +1132,8 @@ fn pending_attempt_record(
         status: AttemptStatus::Failed,
         duration_ms: duration_ms(elapsed),
         cost_usd: None,
+        input_tokens: None,
+        output_tokens: None,
         error: None,
         verifier_signals: Vec::new(),
         verifier_outcome: None,
@@ -1407,6 +1419,8 @@ pub(crate) async fn execute_with_routing(
                 {
                     record.status = AttemptStatus::Succeeded;
                     record.cost_usd = Some(project_link_cost_usd(&value));
+                    record.input_tokens = Some(value.input_tokens);
+                    record.output_tokens = Some(value.output_tokens);
                 }
                 // Run the verifier chain over the winning candidate.
                 let candidate_text = if policy.escalate_on.is_empty() {
@@ -1587,6 +1601,8 @@ async fn run_race(
             if let Ok(ref v) = res {
                 record.status = AttemptStatus::Succeeded;
                 record.cost_usd = Some(project_link_cost_usd(v));
+                record.input_tokens = Some(v.input_tokens);
+                record.output_tokens = Some(v.output_tokens);
             }
             (res, vec![record])
         }
@@ -1628,6 +1644,8 @@ async fn run_race(
                     if let Ok(ref v) = res {
                         primary_record.status = AttemptStatus::Succeeded;
                         primary_record.cost_usd = Some(project_link_cost_usd(v));
+                        primary_record.input_tokens = Some(v.input_tokens);
+                        primary_record.output_tokens = Some(v.output_tokens);
                     }
                     let mut backup_record = pending_attempt_record(
                         backup_attempt_no,
@@ -1657,6 +1675,8 @@ async fn run_race(
                     if let Ok(ref v) = res {
                         backup_record.status = AttemptStatus::Succeeded;
                         backup_record.cost_usd = Some(project_link_cost_usd(v));
+                        backup_record.input_tokens = Some(v.input_tokens);
+                        backup_record.output_tokens = Some(v.output_tokens);
                     }
                     let mut primary_record = pending_attempt_record(
                         primary_attempt_no,
@@ -1805,6 +1825,12 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
             );
             if let Some(cost) = attempt.cost_usd {
                 dict.insert("cost_usd".to_string(), VmValue::Float(cost));
+            }
+            if let Some(tokens) = attempt.input_tokens {
+                dict.insert("input_tokens".to_string(), VmValue::Int(tokens));
+            }
+            if let Some(tokens) = attempt.output_tokens {
+                dict.insert("output_tokens".to_string(), VmValue::Int(tokens));
             }
             if let Some(error) = &attempt.error {
                 let mut err_dict = BTreeMap::new();

--- a/evals/routing_v2/README.md
+++ b/evals/routing_v2/README.md
@@ -1,0 +1,115 @@
+# routing_policy v2 — verifier-signal escalation eval
+
+This directory hosts a small empirical demo for the verifier-signal
+escalation feature shipped in [#2435][issue] / [#2440][pr].
+
+The original issue's acceptance criterion #3 called for a SWE-Bench-Verified
+10-issue eval that's deferred pending the Docker / Python harness work. This
+script is the smaller, "does the wiring actually fire end-to-end with real
+API spend?" demo that was budget-approved for a single session.
+
+[issue]: https://github.com/burin-labs/harn/issues/2435
+[pr]: https://github.com/burin-labs/harn/pull/2440
+
+## What the script does
+
+[`codegen_eval.harn`](codegen_eval.harn) runs the same five Harn-codegen
+prompts through two strategies side by side:
+
+| Strategy | Chain | Verifier |
+|---|---|---|
+| `baseline` | `mistralai/devstral-small` only | none |
+| `routed`   | `mistralai/devstral-small → anthropic/claude-opus-4.7` | `typecheck` (harn-parser) |
+
+The verifier extracts the first ```` ```harn ```` fenced block from each
+candidate, runs `harn_parser::check_source` on it, and emits `accept` or
+`escalate`. When `routed` escalates, the chain advances to the frontier link;
+when the frontier also fails, the rejected candidate is returned (per the
+"verifiers gate routing, not correctness" semantics).
+
+To grade the baseline output with the **same** harn-parser the verifier uses,
+the script pushes each candidate as a mock-LLM response into a one-link
+`mock:mock` routing_policy with the typecheck verifier, then reads the
+verifier outcome off the receipt. That keeps the validity column anchored to
+the parser, not a regex heuristic, with no extra API spend.
+
+## Running it
+
+```bash
+# Source the OpenRouter key (the script reads $OPENROUTER_API_KEY).
+set -a; . /path/to/.env; set +a
+
+cargo run --quiet --bin harn -- run evals/routing_v2/codegen_eval.harn
+```
+
+The `routing_policy.budget` block caps spend at `per_call_usd: 0.50`,
+`session_usd: 2.50`. A full 5-task run costs **about one cent** at current
+OpenRouter rates (Devstral $0.10/$0.30 per M, Opus $5/$25 per M).
+
+## Sample results
+
+Four independent runs collected during initial validation (LLM outputs are
+non-deterministic, so individual task verdicts shift run-to-run):
+
+| Run | baseline valid | routed valid | baseline $ | routed $ | escalations |
+|---|---|---|---|---|---|
+| 1 | 3/5 | 4/5 | $0.000087 | $0.007990 | 2/5 |
+| 2 | 3/5 | 4/5 | $0.000087 | $0.007840 | 2/5 |
+| 3 | 3/5 | 4/5 | $0.000087 | $0.007640 | 2/5 |
+| 4 | 3/5 | 3/5 | $0.000087 | $0.006037 | 2/5 |
+
+A representative full JSON dump (run #4) is checked in at
+[`sample_run.json`](sample_run.json). Notice that each attempt now carries
+its own `input_tokens` / `output_tokens` alongside `cost_usd` — added in
+this PR so downstream graders (this eval included) can attribute spend
+against arbitrary pricing tables, not just the runtime catalog.
+
+### Per-task narrative
+
+| Task | What happened (typical) |
+|---|---|
+| `fib` | Devstral emits Python-style `function fib(n: int) -> int:` (colon-block, `function` keyword). Verifier flags at 1:5–1:10. Opus *usually* produces canonical `fn fib(n: int) -> int { ... }` and passes; in run #4 Opus instead reached for Rust-style `let mut a: int = 0` and the verifier flagged that too. **Routing kept escalating but the chain exhausted, so the receipt records both rejections and returns Opus's candidate — strictly more diagnostics than a single-tier call would have surfaced.** |
+| `trivial_let` | Both models emit `let answer: int = 42`. Verifier accepts. No escalation, no cost overhead. |
+| `sum_list` | Both models produce parseable Harn `fn sum_list`. Verifier accepts. No escalation. (The bodies are semantically sketchy — neither model handles Harn's by-value mutation rules — but that's beyond the typecheck verifier's reach.) |
+| `is_even_pipeline` | Devstral **and** Opus reliably both emit `pipeline check(task: int) {...}` — `pipeline` parameters don't accept type annotations like `fn` does. Verifier flags both at 1:20. Routing exhausts the chain and returns the frontier candidate; receipt shows `verifier_outcome: escalate` on both attempts so a downstream pass can react. |
+| `fix_typo` | Both models correct `funtion` → `fn`. Verifier accepts. No escalation. |
+
+## Key learnings
+
+1. **The wiring works end-to-end on real APIs.** Verifier signals fire, the
+   chain advances, refine-vs-escalate semantics behave as specified, and
+   per-attempt `verifier_outcome` + `verifier_signals` ride through to the
+   result envelope unchanged.
+2. **Cost overhead is real but absolute spend is tiny.** Routed is ~90× more
+   expensive than the bare cheap-tier baseline on this suite, but the total
+   for five tasks is still under one cent. With a higher base rate of
+   verifier-passing answers (most production prompts), the ratio collapses
+   toward 1×.
+3. **The "both attempts fail" path is more useful than it looks.** Even when
+   the chain exhausts, the verifier reasons recorded on `routing.attempts`
+   give the caller actionable diagnostics ("parse failed at 1:20"). That's a
+   strictly better failure mode than the pre-#2435 status quo of "the model
+   said this and we didn't notice it was wrong."
+
+## What is intentionally not here
+
+- **Full SWE-Bench-Verified harness.** Issue #2435's AC #3 stays open. That
+  needs a Docker / pytest / dataset-download pipeline that's an independent
+  project.
+- **Refine retries.** `max_refines_per_link: 0` keeps the wiring readable for
+  this demo; flipping it to 1+ adds another exercise dimension we can run
+  once a refine-aware fixture set exists.
+- **Multi-verifier chains.** Only `typecheck` is exercised here. `lint` and
+  `test_run` are tested in the unit suite (`crates/harn-vm/src/llm/routing_verifier.rs`)
+  but the eval doesn't currently stress them.
+
+## Drive-by harness improvement
+
+Building this eval surfaced a real receipt gap: `RoutingAttempt` carried
+`cost_usd` but no per-attempt token counts, so any attribution against an
+alternate pricing table (OpenRouter, in this case — the runtime catalog
+covers native providers only) had to fall back to attributing all spend to
+the final winning attempt. This PR also adds `input_tokens` and
+`output_tokens` to the receipt on every successful attempt, which the eval
+now uses to cost the cheap-tier link precisely even when the chain
+escalates past it.

--- a/evals/routing_v2/codegen_eval.harn
+++ b/evals/routing_v2/codegen_eval.harn
@@ -1,0 +1,263 @@
+// Multi-task routing_policy v2 eval.
+//
+// Same task list, two strategies side by side:
+//   • baseline: always devstral-small
+//   • routed:   devstral → opus, escalate when the typecheck verifier
+//               fails to parse the extracted Harn block
+//
+// Each task is a different "Devstral can / can't handle Harn-specific
+// syntax" probe so we can see when the verifier escalates vs accepts.
+//
+// Cost is computed from per-call tokens against a hard-coded
+// OpenRouter rate table (Devstral $0.10/$0.30 per M, Opus $5/$25 per M).
+let CHEAP_MODEL = {provider: "openrouter", model: "mistralai/devstral-small"}
+
+let FRONTIER_MODEL = {provider: "openrouter", model: "anthropic/claude-opus-4.7"}
+
+let MAX_TOKENS = 500
+
+let TASKS = [
+  {
+    id: "fib",
+    prompt: "Write a Harn function `fib(n: int) -> int` that returns the n-th Fibonacci number. "
+      + "Definition: fib(0)=0, fib(1)=1, fib(n)=fib(n-1)+fib(n-2). "
+      + "Output ONLY the function definition wrapped in a ```harn fenced code block.",
+  },
+  {
+    id: "trivial_let",
+    prompt: "Output exactly this Harn snippet inside a ```harn fenced code block:\n"
+      + "let answer: int = 42\n"
+      + "No prose, no extra code.",
+  },
+  {
+    id: "sum_list",
+    prompt: "Write a Harn function `sum_list(items: list) -> int` that returns the sum of all integers "
+      + "in the list. Use a `for` loop. Harn uses `fn` for functions, `let` for bindings, and braces "
+      + "for blocks (not Python-style colons or `def`). Output ONLY the function in a ```harn code block.",
+  },
+  {
+    id: "is_even_pipeline",
+    prompt: "Write a Harn pipeline named `check` that takes one parameter `task` of type int, and prints "
+      + "'even' if task is divisible by 2, else 'odd'. Use `pipeline check(task: int) { ... }`. Use "
+      + "`__io_println(\"even\")` for printing. Output ONLY the pipeline definition in a ```harn block.",
+  },
+  {
+    id: "fix_typo",
+    prompt: "The following Harn snippet has a typo — `funtion` should be `fn`. Output the corrected "
+      + "snippet inside a ```harn code block:\n"
+      + "funtion greet(name: string) {\n  __io_println(\"hello \" + name)\n}",
+  },
+]
+
+fn or_pricing_usd_per_m(model: string) -> dict {
+  if model == "mistralai/devstral-small" {
+    return {input: 0.1, output: 0.3}
+  }
+  if model == "anthropic/claude-opus-4.7" {
+    return {input: 5.0, output: 25.0}
+  }
+  return {input: 0.0, output: 0.0}
+}
+
+fn cost_for_tokens(model: string, input_tokens: int, output_tokens: int) -> float {
+  let p = or_pricing_usd_per_m(model)
+  return to_float(input_tokens) / 1000000.0 * to_float(p.input)
+    + to_float(output_tokens) / 1000000.0 * to_float(p.output)
+}
+
+fn extract_first_fenced_harn(text: string) -> string {
+  let after_open = split(text, "```harn")
+  if len(after_open) < 2 {
+    return ""
+  }
+  let body_and_after = after_open[1]
+  let before_close = split(body_and_after, "```")
+  if len(before_close) < 1 {
+    return ""
+  }
+  return trim(before_close[0])
+}
+
+/**
+ * Grade a candidate using the SAME verifier the routing_policy uses.
+ *
+ * We push the code as a mock-LLM response into a 1-link routing_policy
+ * whose only verifier is `typecheck`; the chain returns immediately
+ * because the mock provider is free + deterministic. Whatever the
+ * verifier emits is the canonical "would the typecheck gate have
+ * accepted this" answer.
+ */
+fn grade_outcome(code: string) -> string {
+  llm_mock_push_scope()
+  llm_mock({text: code, model: "mock", provider: "mock"})
+  let policy = routing_policy(
+    {
+      chain: [{provider: "mock", model: "mock"}],
+      escalate_on: [{kind: "typecheck", extract_fenced: false, on_fail: "escalate"}],
+      label: "typecheck-grader",
+    },
+  )
+  let outcome = try {
+    let validation = llm_call("validate", nil, {routing: policy, max_tokens: 1})
+    let attempts = validation.routing.attempts
+    if len(attempts) > 0 {
+      attempts[0]?.verifier_outcome ?? "escalate"
+    } else {
+      "escalate"
+    }
+  } catch (err) {
+    "escalate"
+  }
+  llm_mock_pop_scope()
+  return outcome
+}
+
+fn typechecks(code: string) -> bool {
+  if trim(code) == "" {
+    return false
+  }
+  return grade_outcome(code) == "accept"
+}
+
+fn run_one_baseline(task: dict) -> dict {
+  let result = llm_call(
+    task.prompt,
+    nil,
+    {
+      provider: CHEAP_MODEL.provider,
+      model: CHEAP_MODEL.model,
+      max_tokens: MAX_TOKENS,
+      budget: {max_cost_usd: 0.2},
+    },
+  )
+  let code = extract_first_fenced_harn(result.text)
+  return {
+    task_id: task.id,
+    strategy: "baseline",
+    cost_usd: cost_for_tokens(CHEAP_MODEL.model, result.input_tokens, result.output_tokens),
+    input_tokens: result.input_tokens,
+    output_tokens: result.output_tokens,
+    code: code,
+    looks_valid: typechecks(code),
+  }
+}
+
+fn attempt_cost(attempt: dict) -> float {
+  // Each successful attempt now carries `input_tokens` / `output_tokens`
+  // on the trace, so we can attribute spend precisely against the
+  // hard-coded OpenRouter rate table (the runtime's catalog cost_usd
+  // is native-providers-only and would report 0 here).
+  let input = to_int(attempt?.input_tokens ?? 0)
+  let output = to_int(attempt?.output_tokens ?? 0)
+  return cost_for_tokens(attempt.model, input, output)
+}
+
+fn run_one_routed(task: dict) -> dict {
+  let policy = routing_policy(
+    {
+      chain: [
+        {provider: CHEAP_MODEL.provider, model: CHEAP_MODEL.model, label: "cheap"},
+        {provider: FRONTIER_MODEL.provider, model: FRONTIER_MODEL.model, label: "frontier"},
+      ],
+      escalate_on: [{kind: "typecheck", extract_fenced: true, on_fail: "escalate"}],
+      budget: {per_call_usd: 0.5, session_usd: 2.5, on_exceed: "abort"},
+      max_refines_per_link: 0,
+      label: "routing-v2",
+    },
+  )
+  let result = llm_call(task.prompt, nil, {routing: policy, max_tokens: MAX_TOKENS})
+  let code = extract_first_fenced_harn(result.text)
+  let attempts = result.routing.attempts
+  let selected = result.routing.selected ?? 0
+  let final_model = attempts[selected].model
+  let total_cost = attempts.map({ a -> attempt_cost(a) }).reduce(0.0, { acc, x -> acc + x })
+  let escalated = len(attempts) > 1
+  return {
+    task_id: task.id,
+    strategy: "routed",
+    cost_usd: total_cost,
+    escalated: escalated,
+    attempts: attempts,
+    selected: selected,
+    final_model: final_model,
+    code: code,
+    looks_valid: typechecks(code),
+  }
+}
+
+fn run_task_pair(task: dict) -> dict {
+  __io_println("=== task " + task.id + " ===")
+  let b = run_one_baseline(task)
+  let r = run_one_routed(task)
+  __io_println("  baseline cost=" + to_string(b.cost_usd) + " valid=" + to_string(b.looks_valid))
+  __io_println(
+    "  routed   cost=" + to_string(r.cost_usd) + " valid=" + to_string(r.looks_valid)
+      + " escalated="
+      + to_string(r.escalated),
+  )
+  return {baseline: b, routed: r}
+}
+
+fn main(_harness: Harness) {
+  let rows = TASKS.map({ task -> run_task_pair(task) })
+  let baseline_total = rows
+    .map({ row -> to_float(row.baseline.cost_usd) })
+    .reduce(0.0, { acc, x -> acc + x })
+  let routed_total = rows
+    .map({ row -> to_float(row.routed.cost_usd) })
+    .reduce(0.0, { acc, x -> acc + x })
+  let baseline_valid = rows
+    .map(
+    { row ->
+      if row.baseline.looks_valid {
+        1
+      } else {
+        0
+      }
+    },
+  )
+    .reduce(0, { acc, x -> acc + x })
+  let routed_valid = rows
+    .map(
+    { row ->
+      if row.routed.looks_valid {
+        1
+      } else {
+        0
+      }
+    },
+  )
+    .reduce(0, { acc, x -> acc + x })
+  let escalations = rows
+    .map(
+    { row ->
+      if row.routed.escalated {
+        1
+      } else {
+        0
+      }
+    },
+  )
+    .reduce(0, { acc, x -> acc + x })
+  __io_println("=========================================")
+  __io_println("baseline total cost: " + to_string(baseline_total))
+  __io_println("routed   total cost: " + to_string(routed_total))
+  __io_println("baseline valid: " + to_string(baseline_valid) + "/" + to_string(len(TASKS)))
+  __io_println("routed   valid: " + to_string(routed_valid) + "/" + to_string(len(TASKS)))
+  __io_println("escalations: " + to_string(escalations) + "/" + to_string(len(TASKS)))
+  __io_println(
+    json_stringify_pretty(
+      {
+        summary: {
+          baseline_total_cost_usd: baseline_total,
+          routed_total_cost_usd: routed_total,
+          baseline_valid: baseline_valid,
+          routed_valid: routed_valid,
+          escalations: escalations,
+          n_tasks: len(TASKS),
+        },
+        rows: rows,
+      },
+    ),
+  )
+}

--- a/evals/routing_v2/sample_run.json
+++ b/evals/routing_v2/sample_run.json
@@ -1,0 +1,265 @@
+{
+  "rows": [
+    {
+      "baseline": {
+        "code": "def fib(n: int) -> int:\n    if n == 0:\n        return 0\n    elif n == 1:\n        return 1\n    else:\n        return fib(n-1) + fib(n-2)",
+        "cost_usd": 0.0000234,
+        "input_tokens": 69,
+        "looks_valid": false,
+        "output_tokens": 55,
+        "strategy": "baseline",
+        "task_id": "fib"
+      },
+      "routed": {
+        "attempts": [
+          {
+            "cost_usd": 0.001032,
+            "duration_ms": 677,
+            "index": 1,
+            "input_tokens": 69,
+            "label": "cheap",
+            "model": "mistralai/devstral-small",
+            "output_tokens": 55,
+            "provider": "openrouter",
+            "status": "succeeded",
+            "verifier_outcome": "escalate",
+            "verifier_signals": [
+              {
+                "kind": "typecheck",
+                "name": "typecheck",
+                "reason": "typecheck: parse failed: Expected top-level item separator (`;` or newline), got id(fib) at 1:5",
+                "signal": "escalate"
+              }
+            ]
+          },
+          {
+            "cost_usd": 0.002241,
+            "duration_ms": 2472,
+            "index": 2,
+            "input_tokens": 112,
+            "label": "frontier",
+            "model": "anthropic/claude-opus-4.7",
+            "output_tokens": 127,
+            "provider": "openrouter",
+            "status": "succeeded",
+            "verifier_outcome": "escalate",
+            "verifier_signals": [
+              {
+                "kind": "typecheck",
+                "name": "typecheck",
+                "reason": "typecheck: parse failed: Expected =, got id(a) at 5:13",
+                "signal": "escalate"
+              }
+            ]
+          }
+        ],
+        "code": "fn fib(n: int) -> int {\n    if n < 2 {\n        return n;\n    }\n    let mut a: int = 0;\n    let mut b: int = 1;\n    let mut i: int = 2;\n    while i <= n {\n        let c: int = a + b;\n        a = b;\n        b = c;\n        i = i + 1;\n    }\n    return b;\n}",
+        "cost_usd": 0.0037583999999999994,
+        "escalated": true,
+        "final_model": "anthropic/claude-opus-4.7",
+        "looks_valid": false,
+        "selected": 1,
+        "strategy": "routed",
+        "task_id": "fib"
+      }
+    },
+    {
+      "baseline": {
+        "code": "let answer: int = 42",
+        "cost_usd": 8e-6,
+        "input_tokens": 35,
+        "looks_valid": true,
+        "output_tokens": 15,
+        "strategy": "baseline",
+        "task_id": "trivial_let"
+      },
+      "routed": {
+        "attempts": [
+          {
+            "cost_usd": 0.00032999999999999994,
+            "duration_ms": 360,
+            "index": 1,
+            "input_tokens": 35,
+            "label": "cheap",
+            "model": "mistralai/devstral-small",
+            "output_tokens": 15,
+            "provider": "openrouter",
+            "status": "succeeded",
+            "verifier_outcome": "accept",
+            "verifier_signals": [
+              {
+                "kind": "typecheck",
+                "name": "typecheck",
+                "signal": "accept"
+              }
+            ]
+          }
+        ],
+        "code": "let answer: int = 42",
+        "cost_usd": 8e-6,
+        "escalated": false,
+        "final_model": "mistralai/devstral-small",
+        "looks_valid": true,
+        "selected": 0,
+        "strategy": "routed",
+        "task_id": "trivial_let"
+      }
+    },
+    {
+      "baseline": {
+        "code": "fn sum_list(items: list) -> int {\n    let sum = 0\n    for item in items {\n        sum = sum + item\n    }\n    return sum\n}",
+        "cost_usd": 0.0000205,
+        "input_tokens": 76,
+        "looks_valid": true,
+        "output_tokens": 43,
+        "strategy": "baseline",
+        "task_id": "sum_list"
+      },
+      "routed": {
+        "attempts": [
+          {
+            "cost_usd": 0.000873,
+            "duration_ms": 741,
+            "index": 1,
+            "input_tokens": 76,
+            "label": "cheap",
+            "model": "mistralai/devstral-small",
+            "output_tokens": 43,
+            "provider": "openrouter",
+            "status": "succeeded",
+            "verifier_outcome": "accept",
+            "verifier_signals": [
+              {
+                "kind": "typecheck",
+                "name": "typecheck",
+                "signal": "accept"
+              }
+            ]
+          }
+        ],
+        "code": "fn sum_list(items: list) -> int {\n  let sum = 0\n  for item in items {\n    sum = sum + item\n  }\n  return sum\n}",
+        "cost_usd": 0.0000205,
+        "escalated": false,
+        "final_model": "mistralai/devstral-small",
+        "looks_valid": true,
+        "selected": 0,
+        "strategy": "routed",
+        "task_id": "sum_list"
+      }
+    },
+    {
+      "baseline": {
+        "code": "pipeline check(task: int) {\n    if (task % 2 == 0) {\n        __io_println(\"even\")\n    } else {\n        __io_println(\"odd\")\n    }\n}",
+        "cost_usd": 0.0000224,
+        "input_tokens": 77,
+        "looks_valid": false,
+        "output_tokens": 49,
+        "strategy": "baseline",
+        "task_id": "is_even_pipeline"
+      },
+      "routed": {
+        "attempts": [
+          {
+            "cost_usd": 0.000966,
+            "duration_ms": 607,
+            "index": 1,
+            "input_tokens": 77,
+            "label": "cheap",
+            "model": "mistralai/devstral-small",
+            "output_tokens": 49,
+            "provider": "openrouter",
+            "status": "succeeded",
+            "verifier_outcome": "escalate",
+            "verifier_signals": [
+              {
+                "kind": "typecheck",
+                "name": "typecheck",
+                "reason": "typecheck: parse failed: Expected parameter name, got : at 1:20",
+                "signal": "escalate"
+              }
+            ]
+          },
+          {
+            "cost_usd": 0.0013289999999999999,
+            "duration_ms": 1712,
+            "index": 2,
+            "input_tokens": 118,
+            "label": "frontier",
+            "model": "anthropic/claude-opus-4.7",
+            "output_tokens": 65,
+            "provider": "openrouter",
+            "status": "succeeded",
+            "verifier_outcome": "escalate",
+            "verifier_signals": [
+              {
+                "kind": "typecheck",
+                "name": "typecheck",
+                "reason": "typecheck: parse failed: Expected parameter name, got : at 1:20",
+                "signal": "escalate"
+              }
+            ]
+          }
+        ],
+        "code": "pipeline check(task: int) {\n    if (task % 2 == 0) {\n        __io_println(\"even\");\n    } else {\n        __io_println(\"odd\");\n    }\n}",
+        "cost_usd": 0.0022374,
+        "escalated": true,
+        "final_model": "anthropic/claude-opus-4.7",
+        "looks_valid": false,
+        "selected": 1,
+        "strategy": "routed",
+        "task_id": "is_even_pipeline"
+      }
+    },
+    {
+      "baseline": {
+        "code": "fn greet(name: string) {\n  __io_println(\"hello \" + name)\n}",
+        "cost_usd": 0.000013000000000000001,
+        "input_tokens": 55,
+        "looks_valid": true,
+        "output_tokens": 25,
+        "strategy": "baseline",
+        "task_id": "fix_typo"
+      },
+      "routed": {
+        "attempts": [
+          {
+            "cost_usd": 0.00054,
+            "duration_ms": 370,
+            "index": 1,
+            "input_tokens": 55,
+            "label": "cheap",
+            "model": "mistralai/devstral-small",
+            "output_tokens": 25,
+            "provider": "openrouter",
+            "status": "succeeded",
+            "verifier_outcome": "accept",
+            "verifier_signals": [
+              {
+                "kind": "typecheck",
+                "name": "typecheck",
+                "signal": "accept"
+              }
+            ]
+          }
+        ],
+        "code": "fn greet(name: string) {\n  __io_println(\"hello \" + name)\n}",
+        "cost_usd": 0.000013000000000000001,
+        "escalated": false,
+        "final_model": "mistralai/devstral-small",
+        "looks_valid": true,
+        "selected": 0,
+        "strategy": "routed",
+        "task_id": "fix_typo"
+      }
+    }
+  ],
+  "summary": {
+    "baseline_total_cost_usd": 0.00008730000000000001,
+    "baseline_valid": 3,
+    "escalations": 2,
+    "n_tasks": 5,
+    "routed_total_cost_usd": 0.0060373,
+    "routed_valid": 3
+  }
+}
+


### PR DESCRIPTION
## Summary

- Adds [`evals/routing_v2/codegen_eval.harn`](evals/routing_v2/codegen_eval.harn): runs five Harn-codegen prompts side-by-side through a bare-cheap-tier baseline and a Devstral→Opus chain whose `typecheck` verifier escalates on harn-parser failures. Validity is graded with the **same** verifier (a mock-LLM-backed one-link routing_policy), so the eval's pass/fail column matches what the runtime gate would have said.
- Adds [`evals/routing_v2/README.md`](evals/routing_v2/README.md): methodology, four reproduced runs, per-task narrative, and what's explicitly deferred (full SWE-Bench-Verified harness still on the table for #2435 AC #3).
- **Drive-by harness fix**: `RoutingAttempt` now carries per-attempt `input_tokens` / `output_tokens` (populated on the normal success path and both arms of the race path) and surfaces them through `trace_to_vm_attempts`. Without this, anyone re-costing against a non-catalog pricing table (OpenRouter, in this case) had to attribute all spend to the final winning attempt; with it, the eval can compute precise per-attempt OpenRouter spend even when the chain escalates past the cheap tier.

## Empirical results

Four reproduced runs (~\$0.03 total spend across all four):

| Run | baseline valid | routed valid | baseline \$ | routed \$ | escalations |
|---|---|---|---|---|---|
| 1 | 3/5 | 4/5 | \$0.000087 | \$0.007990 | 2/5 |
| 2 | 3/5 | 4/5 | \$0.000087 | \$0.007840 | 2/5 |
| 3 | 3/5 | 4/5 | \$0.000087 | \$0.007640 | 2/5 |
| 4 | 3/5 | 3/5 | \$0.000087 | \$0.006037 | 2/5 |

Devstral reliably emits Python-style `function fib(n: int) -> int:` on the fib task; the verifier catches it at 1:5–1:10 and the chain escalates. Opus *usually* fixes it but occasionally reaches for Rust-style `let mut a: int = 0` instead — in those cases the verifier flags both, the chain exhausts, and the receipt records both rejections (strictly more diagnostics than a single-tier call). The pipeline-typed-params task fails reliably on both tiers (genuine ambiguity in the prompt vs. Harn's pipeline syntax); the receipt makes the failure visible rather than silent. The three easy tasks complete on Devstral and the chain returns immediately with zero overhead.

## Refs

Closes the deferred AC #4 from [burin-labs/harn#2435](https://github.com/burin-labs/harn/issues/2435) ("Receipt rendering updated to show verifier signals per attempt") in the sense of *empirical validation*. AC #3 (SWE-Bench-Verified 10-issue eval) stays deferred — it needs a Docker / pytest / dataset-download pipeline that's an independent project.

## Test plan

- [x] `cargo check -p harn-vm` clean
- [x] `cargo test -p harn-vm --lib llm::routing` — 19/19 pass (existing tests still pass with the new fields)
- [x] `cargo run --bin harn -- test conformance --filter llm_routing` — 9/9 pass, including the updated `verifier_escalate.harn` asserting the new token fields are non-zero
- [x] `cargo clippy -p harn-vm --lib --all-targets -- -D warnings` clean
- [x] `cargo run --bin harn -- fmt --check evals/routing_v2/codegen_eval.harn` and `lint` clean
- [x] Pre-commit + pre-push hooks pass
- [x] Eval driver runs end-to-end against real OpenRouter spend (four times, ~\$0.03 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)