### PR TITLE
fmt-harn: own root-level stdlib/personas/tests Harn fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,12 @@ lint-harn:
 FMT_HARN_SKIP := semicolon_statements.harn semicolon_if_else_invalid.harn semicolon_try_catch_invalid.harn semicolon_empty_statement_invalid.harn
 EXPERIMENT_HARN_CHECK := experiments/burin-mini/host.harn experiments/burin-mini/lib/common.harn experiments/burin-mini/lib/profiles.harn
 STDLIB_HARN_DIR := crates/harn-stdlib/src/stdlib
+# Extra repo-root directories that contain user-facing .harn fixtures
+# but were historically outside the fmt-harn gate. Keeping them in the
+# gate avoids the "I edited persona X and pre-commit reformatted three
+# unrelated files" surprise from accumulated drift.
+EXTRA_HARN_DIRS := stdlib personas tests examples evals
+
 fmt-harn-fix:
 	@echo "=== Formatting Harn files ==="
 	@find $(STDLIB_HARN_DIR) -name '*.harn' -print0 \
@@ -221,6 +227,8 @@ fmt-harn-fix:
 		| xargs -0 cargo run --quiet --bin harn -- fmt
 	@find scripts -name '*.harn' -print0 \
 		| xargs -0 cargo run --quiet --bin harn -- fmt
+	@find $(EXTRA_HARN_DIRS) -type f -name '*.harn' -print0 2>/dev/null \
+		| xargs -0 -r cargo run --quiet --bin harn -- fmt
 	@echo "    Harn formatting OK."
 
 fmt-harn:
@@ -235,6 +243,8 @@ fmt-harn:
 		| xargs -0 cargo run --quiet --bin harn -- fmt --check
 	@find crates/harn-cli/assets/demo -name '*.harn' -print0 \
 		| xargs -0 cargo run --quiet --bin harn -- fmt --check
+	@find $(EXTRA_HARN_DIRS) -type f -name '*.harn' -print0 2>/dev/null \
+		| xargs -0 -r cargo run --quiet --bin harn -- fmt --check
 	@echo "    Harn formatting OK."
 
 # Run the @test pipelines that cover scripts/*.harn against pure-logic

--- a/personas/merge_captain/lib/checkpoint_store.harn
+++ b/personas/merge_captain/lib/checkpoint_store.harn
@@ -90,9 +90,7 @@ pub fn list_all_checkpoints(handle) {
       }
     },
   )
-    .filter(
-    { env -> env != nil },
-  )
+    .filter({ env -> env != nil })
 }
 
 /** Drop a checkpoint (e.g. for a merged or closed PR we no longer track). */

--- a/personas/merge_captain/lib/prompt_pack.harn
+++ b/personas/merge_captain/lib/prompt_pack.harn
@@ -472,22 +472,16 @@ fn _checkpoint_validator(id, context, extra_validator) {
         if !extra {
           errors = errors + ["custom validator returned false"]
         }
-      } else {
-        if type_of(extra) == "dict" {
-          if !(extra?.ok ?? false) {
-            let extra_errors = extra?.errors ?? extra?.validation_errors
-              ?? [extra?.message ?? "custom validator rejected output"]
-            errors = errors + extra_errors
-          }
-        } else {
-          if type_of(extra) == "list" {
-            errors = errors + extra.map({ item -> to_string(item) })
-          } else {
-            if type_of(extra) == "string" && trim(extra) != "" {
-              errors = errors + [extra]
-            }
-          }
+      } else if type_of(extra) == "dict" {
+        if !(extra?.ok ?? false) {
+          let extra_errors = extra?.errors ?? extra?.validation_errors
+            ?? [extra?.message ?? "custom validator rejected output"]
+          errors = errors + extra_errors
         }
+      } else if type_of(extra) == "list" {
+        errors = errors + extra.map({ item -> to_string(item) })
+      } else if type_of(extra) == "string" && trim(extra) != "" {
+        errors = errors + [extra]
       }
     }
     return {ok: len(errors) == 0, errors: errors}

--- a/personas/merge_captain/lib/scheduler.harn
+++ b/personas/merge_captain/lib/scheduler.harn
@@ -312,9 +312,7 @@ pub fn reconcile_disappeared(args) {
   let observed_numbers = args.observed_numbers
   var receipts = []
   let stale = list_all_checkpoints(checkpoint_handle)
-    .filter(
-    { env -> env.repo == policy.repo && !observed_numbers.contains(env.number) },
-  )
+    .filter({ env -> env.repo == policy.repo && !observed_numbers.contains(env.number) })
   for env in stale {
     let detail = get_pr_details(adapter, env.repo, env.number)
     let final_obs = if detail != nil {

--- a/personas/merge_captain/tests/scheduler_test.harn
+++ b/personas/merge_captain/tests/scheduler_test.harn
@@ -61,7 +61,7 @@ fn _open_handle(suffix) {
 }
 
 pipeline test_sweep_classifies_clean_pr(task) {
-  let snapshot = _snapshot([_pr(1, {})], {["1"]: _ok_check()})
+  let snapshot = _snapshot([_pr(1, {})], {"1": _ok_check()})
   let adapter = fixture_adapter(snapshot)
   let handle = _open_handle("classify-clean")
   let summary = sweep(
@@ -79,7 +79,7 @@ pipeline test_sweep_classifies_clean_pr(task) {
 }
 
 pipeline test_sweep_persists_checkpoints(task) {
-  let snapshot = _snapshot([_pr(1, {behind_by: 2, mergeable_state: "behind"})], {["1"]: _ok_check()})
+  let snapshot = _snapshot([_pr(1, {behind_by: 2, mergeable_state: "behind"})], {"1": _ok_check()})
   let adapter = fixture_adapter(snapshot)
   let handle = _open_handle("persist")
   sweep(
@@ -99,8 +99,8 @@ pipeline test_sweep_persists_checkpoints(task) {
 
 pipeline test_resume_picks_up_new_pr(task) {
   let policy = _policy_for(_default_repo(), true)
-  let snapshot1 = _snapshot([_pr(1, {})], {["1"]: _ok_check()})
-  let snapshot2 = _snapshot([_pr(1, {}), _pr(2, {})], {["1"]: _ok_check(), ["2"]: _ok_check()})
+  let snapshot1 = _snapshot([_pr(1, {})], {"1": _ok_check()})
+  let snapshot2 = _snapshot([_pr(1, {}), _pr(2, {})], {"1": _ok_check(), "2": _ok_check()})
   let handle = _open_handle("resume-add")
   // First sweep tracks PR 1 only.
   sweep(
@@ -130,7 +130,7 @@ pipeline test_resume_picks_up_new_pr(task) {
 
 pipeline test_disappeared_pr_gets_terminal_receipt(task) {
   let policy = _policy_for(_default_repo(), true)
-  let snapshot1 = _snapshot([_pr(1, {})], {["1"]: _ok_check()})
+  let snapshot1 = _snapshot([_pr(1, {})], {"1": _ok_check()})
   let snapshot2 = _snapshot([], {})
   let handle = _open_handle("disappear")
   sweep(
@@ -168,7 +168,7 @@ pipeline test_failing_ci_with_local_verify_runs_dry(task) {
       local_verification: [{name: "tests", command: "true"}],
     },
   )
-  let snapshot = _snapshot([_pr(1, {})], {["1"]: _fail_check()})
+  let snapshot = _snapshot([_pr(1, {})], {"1": _fail_check()})
   let handle = _open_handle("local-verify")
   let summary = sweep(
     {
@@ -225,7 +225,7 @@ pipeline test_repair_worker_dispatch_attaches_run_to_receipt(task) {
       },
     },
   )
-  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {"1": _fail_check()})
   let handle = _open_handle("repair-worker-attach")
   let summary = sweep(
     {
@@ -271,7 +271,7 @@ pipeline test_repair_worker_blocked_when_human_required(task) {
       repair_worker: {enabled: true, handles_kinds: ["ci_failure"], require_human_for: ["semantic_repair"]},
     },
   )
-  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {"1": _fail_check()})
   let handle = _open_handle("repair-worker-blocked")
   var executor_calls = 0
   let executor = { _bundle, _options ->
@@ -307,7 +307,7 @@ pipeline test_repair_worker_disabled_falls_back_to_local_verify(task) {
       local_verification: [{name: "tests", command: "true"}],
     },
   )
-  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {"1": _fail_check()})
   let handle = _open_handle("repair-worker-disabled")
   let summary = sweep(
     {
@@ -339,7 +339,7 @@ pipeline test_repair_worker_validators_fail_writes_outside_scope(task) {
       },
     },
   )
-  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {["1"]: _fail_check()})
+  let snapshot = _snapshot([_pr(1, {head_ref: "feat-1"})], {"1": _fail_check()})
   let handle = _open_handle("repair-worker-violations")
   let bad_output = _ok_repair_output() + {files_changed: [{path: "secrets/key.pem", action: "created"}]}
   let summary = sweep(

--- a/personas/review_captain/lib/receipt.harn
+++ b/personas/review_captain/lib/receipt.harn
@@ -21,12 +21,10 @@ pub fn build_review_receipt(args) {
   let blocking = _has_blocking(combined_findings)
   let verdict = if blocking {
     "blocking"
+  } else if len(combined_findings) > 0 || len(missing_tests) > 0 || len(risky_hits) > 0 {
+    "needs_follow_up"
   } else {
-    if len(combined_findings) > 0 || len(missing_tests) > 0 || len(risky_hits) > 0 {
-      "needs_follow_up"
-    } else {
-      "approve"
-    }
+    "approve"
   }
   let summary = _summary(combined_findings, llm_summary, blocking, missing_tests, risky_hits)
   return {

--- a/stdlib/collections.harn
+++ b/stdlib/collections.harn
@@ -1,24 +1,38 @@
-// std/collections — Collection utilities.
-
-// Remove entries from a dict where the value is nil, empty string, or "null" string.
+/**
+ * std/collections — Collection utilities.
+ * Remove entries from a dict where the value is nil, empty string, or "null" string.
+ */
 pub fn filter_nil(d) {
-  return d.filter({ v ->
-    if v == nil { return false }
-    if v == "" { return false }
-    if v == "null" { return false }
-    return true
-  })
+  return d
+    .filter(
+    { v ->
+      if v == nil {
+        return false
+      }
+      if v == "" {
+        return false
+      }
+      if v == "null" {
+        return false
+      }
+      return true
+    },
+  )
 }
 
-// Check if a store key is stale (older than max_age_seconds).
-// Uses store_get/store_set convention: timestamps stored as key + "_ts".
+/**
+ * Check if a store key is stale (older than max_age_seconds).
+ * Uses store_get/store_set convention: timestamps stored as key + "_ts".
+ */
 pub fn store_stale(key, max_age_seconds) {
   let ts = store_get(key + "_ts")
-  if ts == nil { return true }
-  return (timestamp() - ts) > max_age_seconds
+  if ts == nil {
+    return true
+  }
+  return timestamp() - ts > max_age_seconds
 }
 
-// Refresh a store key's timestamp to now.
+/** Refresh a store key's timestamp to now. */
 pub fn store_refresh(key) {
   store_set(key + "_ts", timestamp())
 }

--- a/stdlib/graphql.harn
+++ b/stdlib/graphql.harn
@@ -99,10 +99,7 @@ pub fn graphql_introspection_query() {
 
 /** graphql_auth_headers. */
 pub fn graphql_auth_headers(auth = nil, extra_headers = nil) {
-  var headers = {
-    ["Content-Type"]: "application/json",
-    Accept: "application/graphql-response+json, application/json",
-  }
+  var headers = {"Content-Type": "application/json", Accept: "application/graphql-response+json, application/json"}
   if auth != nil {
     if type_of(auth) == "string" {
       headers = merge(headers, {Authorization: "Bearer " + auth})

--- a/stdlib/json.harn
+++ b/stdlib/json.harn
@@ -1,49 +1,31 @@
 // std/json — JSON utility patterns
 //
 // Import with: import "std/json"
-
 /** Pretty-print a value as indented JSON (2-space indent). */
-fn pretty(value) {
+pub fn pretty(value) {
   return json_stringify(value)
 }
 
 /** Safely parse JSON, returning nil on failure instead of throwing. */
-fn safe_parse(text) {
+pub fn safe_parse(text) {
   try {
     return json_parse(text)
-  } catch e {
+  } catch (e) {
     return nil
   }
 }
 
 /** Merge two dicts (shallow). Keys in b override keys in a. */
-fn merge(a, b) {
-  var result = a
-  for entry in b {
-    result = {..result, [entry.key]: entry.value}
-  }
-  return result
+pub fn merge(a, b) {
+  return __dict_merge(a ?? {}, b ?? {})
 }
 
 /** Pick specific keys from a dict. */
-fn pick(data, keys) {
-  var result = {}
-  for k in keys {
-    if data[k] != nil {
-      result = {..result, [k]: data[k]}
-    }
-  }
-  return result
+pub fn pick(data, keys) {
+  return __dict_pick(data ?? {}, keys ?? [])
 }
 
 /** Omit specific keys from a dict. */
-fn omit(data, keys) {
-  let exclude = set(keys)
-  var result = {}
-  for entry in data {
-    if !set_contains(exclude, entry.key) {
-      result = {..result, [entry.key]: entry.value}
-    }
-  }
-  return result
+pub fn omit(data, keys) {
+  return __dict_omit(data ?? {}, keys ?? [])
 }

--- a/stdlib/math.harn
+++ b/stdlib/math.harn
@@ -1,7 +1,8 @@
-// std/math — Extended math utilities
-//
-// Import with: import "std/math"
-
+/**
+ * std/math — Extended math utilities
+ *
+ * Import with: import "std/math"
+ */
 fn _is_number(value) {
   let t = type_of(value)
   return t == "int" || t == "float"
@@ -144,11 +145,7 @@ fn _rank_items(items, score_fn = nil, descending = false) {
   var ranked = []
   var idx = 0
   while idx < len(items) {
-    let entry = {
-      index: idx,
-      item: items[idx],
-      score: _score_item(items[idx], score_fn)
-    }
+    let entry = {index: idx, item: items[idx], score: _score_item(items[idx], score_fn)}
     ranked = _insert_ranked(ranked, entry, descending)
     idx = idx + 1
   }
@@ -238,7 +235,6 @@ fn _recompute_centroids(points, assignments, k, dims, errors) {
     counts = counts.push(0)
     idx = idx + 1
   }
-
   idx = 0
   while idx < len(points) {
     let cluster = assignments[idx]
@@ -252,7 +248,6 @@ fn _recompute_centroids(points, assignments, k, dims, errors) {
     }
     idx = idx + 1
   }
-
   var centroids = []
   idx = 0
   while idx < k {
@@ -270,14 +265,17 @@ fn _recompute_centroids(points, assignments, k, dims, errors) {
     }
     idx = idx + 1
   }
-
   return {centroids: centroids, counts: counts}
 }
 
 /** Clamp a value between min and max. */
 fn clamp(value, lo, hi) {
-  if value < lo { return lo }
-  if value > hi { return hi }
+  if value < lo {
+    return lo
+  }
+  if value > hi {
+    return hi
+  }
   return value
 }
 
@@ -311,7 +309,9 @@ fn sum(items) {
 /** Average of a list of numbers. */
 fn avg(items) {
   _require_numeric_list(items)
-  if len(items) == 0 { return 0 }
+  if len(items) == 0 {
+    return 0
+  }
   return sum(items) / (len(items) * 1.0)
 }
 
@@ -336,7 +336,9 @@ fn percentile(items, p) {
   let sorted = _require_non_empty_numeric_list(items).sort()
   _require_number(p, "percentile")
   require p >= 0 && p <= 100, "percentile must be between 0 and 100"
-  if len(sorted) == 1 { return sorted[0] }
+  if len(sorted) == 1 {
+    return sorted[0]
+  }
   let n = len(sorted)
   let h = 1 + (n - 1) * (p / 100.0)
   let lower = floor(h)
@@ -373,7 +375,11 @@ fn variance(items, sample = false) {
     let delta = x - mu
     total = total + delta * delta
   }
-  let denom = if sample { len(xs) - 1 } else { len(xs) }
+  let denom = if sample {
+    len(xs) - 1
+  } else {
+    len(xs)
+  }
   return total / denom
 }
 
@@ -472,7 +478,11 @@ fn normal_cdf(x, mu = 0, sigma = 1) {
   _require_number(mu, "mean")
   _require_positive_number(sigma, "stddev")
   let z = (x - mu) / sigma
-  let sign = if z < 0 { -1 } else { 1 }
+  let sign = if z < 0 {
+    -1
+  } else {
+    1
+  }
   let az = abs(z) / sqrt(2)
   let t = 1 / (1 + 0.3275911 * az)
   let a1 = 0.254829592
@@ -480,7 +490,7 @@ fn normal_cdf(x, mu = 0, sigma = 1) {
   let a3 = 1.421413741
   let a4 = -1.453152027
   let a5 = 1.061405429
-  let erf = sign * (1 - (((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * exp(-az * az)))
+  let erf = sign * (1 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * exp(-az * az))
   return 0.5 * (1 + erf)
 }
 
@@ -489,7 +499,6 @@ fn normal_quantile(prob, mu = 0, sigma = 1) {
   let p = _require_probability(prob)
   _require_number(mu, "mean")
   _require_positive_number(sigma, "stddev")
-
   let a1 = -39.69683028665376
   let a2 = 220.9460984245205
   let a3 = -275.9285104469687
@@ -513,26 +522,24 @@ fn normal_quantile(prob, mu = 0, sigma = 1) {
   let d4 = 3.754408661907416
   let plow = 0.02425
   let phigh = 1 - plow
-
   var x = 0.0
   if p < plow {
     let q = sqrt(-2 * ln(p))
-    let num = (((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6)
-    let den = ((((d1 * q + d2) * q + d3) * q + d4) * q + 1)
+    let num = ((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6
+    let den = (((d1 * q + d2) * q + d3) * q + d4) * q + 1
     x = num / den
   } else if p <= phigh {
     let q = p - 0.5
     let r = q * q
     let num = (((((a1 * r + a2) * r + a3) * r + a4) * r + a5) * r + a6) * q
-    let den = (((((b1 * r + b2) * r + b3) * r + b4) * r + b5) * r + 1)
+    let den = ((((b1 * r + b2) * r + b3) * r + b4) * r + b5) * r + 1
     x = num / den
   } else {
     let q = sqrt(-2 * ln(1 - p))
-    let num = (((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6)
-    let den = ((((d1 * q + d2) * q + d3) * q + d4) * q + 1)
+    let num = ((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6
+    let den = (((d1 * q + d2) * q + d3) * q + d4) * q + 1
     x = -(num / den)
   }
-
   return mu + sigma * x
 }
 
@@ -616,7 +623,11 @@ fn covariance(xs, ys, sample = false) {
     total = total + (xs[idx] - mu_x) * (ys[idx] - mu_y)
     idx = idx + 1
   }
-  let denom = if sample { len(xs) - 1 } else { len(xs) }
+  let denom = if sample {
+    len(xs) - 1
+  } else {
+    len(xs)
+  }
   return total / denom
 }
 
@@ -667,21 +678,18 @@ fn kmeans(points, k, options = nil) {
   _require_non_negative_int(k, "k")
   require k >= 1, "k must be at least 1"
   require k <= len(points), "k must not exceed the number of points"
-
   let max_iterations = if options != nil && options.max_iterations != nil {
     options.max_iterations
   } else {
     100
   }
   _require_positive_int(max_iterations, "max_iterations")
-
   var centroids = _init_kmeans_centroids(points, k)
   var assignments = []
   var counts = []
   var iterations = 0
   var converged = false
   var inertia = 0.0
-
   while iterations < max_iterations {
     let assigned = _assign_points(points, centroids)
     let next_assignments = assigned.assignments
@@ -697,7 +705,6 @@ fn kmeans(points, k, options = nil) {
     }
     assignments = next_assignments
   }
-
   if !converged {
     let assigned = _assign_points(points, centroids)
     assignments = assigned.assignments
@@ -713,13 +720,12 @@ fn kmeans(points, k, options = nil) {
     }
     counts = final_counts
   }
-
   return {
     centroids: centroids,
     assignments: assignments,
     counts: counts,
     iterations: iterations,
     converged: converged,
-    inertia: inertia
+    inertia: inertia,
   }
 }

--- a/stdlib/path.harn
+++ b/stdlib/path.harn
@@ -1,7 +1,6 @@
 // std/path — Path manipulation utilities
 //
 // Import with: import "std/path"
-
 /** Get the file extension without the dot. */
 fn ext(path) {
   let e = extname(path)
@@ -15,7 +14,9 @@ fn ext(path) {
 fn stem(path) {
   let base = basename(path)
   let dot = base.index_of(".")
-  if dot < 0 { return base }
+  if dot < 0 {
+    return base
+  }
   return base.substring(0, dot)
 }
 
@@ -42,19 +43,25 @@ fn workspace_normalize(path, workspace_root = nil) {
 /** List files in a directory recursively (one level). */
 fn list_files(dir) {
   let entries = list_dir(dir)
-  return entries.filter({ name ->
-    let full = path_join(dir, name)
-    let info = stat(full)
-    return info.is_file
-  })
+  return entries
+    .filter(
+    { name ->
+      let full = path_join(dir, name)
+      let info = stat(full)
+      return info.is_file
+    },
+  )
 }
 
 /** List subdirectories. */
 fn list_dirs(dir) {
   let entries = list_dir(dir)
-  return entries.filter({ name ->
-    let full = path_join(dir, name)
-    let info = stat(full)
-    return info.is_dir
-  })
+  return entries
+    .filter(
+    { name ->
+      let full = path_join(dir, name)
+      let info = stat(full)
+      return info.is_dir
+    },
+  )
 }

--- a/stdlib/prompt_library.harn
+++ b/stdlib/prompt_library.harn
@@ -373,24 +373,24 @@ pub fn prompt_fragment(id, body, config = nil) {
   }
   return filter_nil(
     {
-    id: id,
-    title: config?.title ?? id,
-    tags: config?.tags ?? [],
-    token_budget: config?.token_budget ?? __estimate_tokens_text(body),
-    cache_ttl: config?.cache_ttl ?? "5m",
-    cache_control: config?.cache_control ?? {type: "ephemeral"},
-    body: body,
-    path: config?.path,
-    source_path: config?.source_path,
-    provenance: provenance,
-    status: status,
-    tenant_id: config?.tenant_id,
-    score: config?.score,
-    members: config?.members,
-    support: config?.support,
-    tokens_saved: config?.tokens_saved,
-    monthly_savings_usd: config?.monthly_savings_usd,
-  },
+      id: id,
+      title: config?.title ?? id,
+      tags: config?.tags ?? [],
+      token_budget: config?.token_budget ?? __estimate_tokens_text(body),
+      cache_ttl: config?.cache_ttl ?? "5m",
+      cache_control: config?.cache_control ?? {type: "ephemeral"},
+      body: body,
+      path: config?.path,
+      source_path: config?.source_path,
+      provenance: provenance,
+      status: status,
+      tenant_id: config?.tenant_id,
+      score: config?.score,
+      members: config?.members,
+      support: config?.support,
+      tokens_saved: config?.tokens_saved,
+      monthly_savings_usd: config?.monthly_savings_usd,
+    },
   )
 }
 
@@ -525,15 +525,15 @@ pub fn prompt_library_hotspots(conversations, options = nil) {
       records = records
         .push(
         {
-        id: __conversation_id(conversation, index),
-        tenant_id: if type_of(conversation) == "dict" {
-        conversation?.tenant_id
-      } else {
-        nil
-      },
-        snippet: snippet,
-        embedding: __conversation_embedding(conversation, snippet),
-      },
+          id: __conversation_id(conversation, index),
+          tenant_id: if type_of(conversation) == "dict" {
+            conversation?.tenant_id
+          } else {
+            nil
+          },
+          snippet: snippet,
+          embedding: __conversation_embedding(conversation, snippet),
+        },
       )
       points = points.push(records[-1].embedding)
     }
@@ -573,22 +573,22 @@ pub fn prompt_library_hotspots(conversations, options = nil) {
           proposals = proposals
             .push(
             prompt_fragment(
-            id,
-            prefix.text,
-            {
-            title: "K-means hotspot " + to_string(cluster_id),
-            tags: options?.tags ?? ["hotspot"],
-            token_budget: prefix.tokens,
-            provenance: "kmeans",
-            tenant_id: tenant,
-            status: "pending_review",
-            score: chosen.silhouette,
-            members: members_by_cluster[cluster_id],
-            support: prefix.support,
-            tokens_saved: tokens_saved,
-            monthly_savings_usd: monthly,
-          },
-          ),
+              id,
+              prefix.text,
+              {
+                title: "K-means hotspot " + to_string(cluster_id),
+                tags: options?.tags ?? ["hotspot"],
+                token_budget: prefix.tokens,
+                provenance: "kmeans",
+                tenant_id: tenant,
+                status: "pending_review",
+                score: chosen.silhouette,
+                members: members_by_cluster[cluster_id],
+                support: prefix.support,
+                tokens_saved: tokens_saved,
+                monthly_savings_usd: monthly,
+              },
+            ),
           )
         }
       }
@@ -608,17 +608,17 @@ pub fn prompt_library_review_queue(library, filters = nil) {
     queue = queue
       .push(
       {
-      id: fragment.id,
-      title: fragment.title,
-      tenant_id: fragment?.tenant_id,
-      text: fragment.body,
-      token_budget: fragment?.token_budget,
-      support: fragment?.support,
-      members: fragment?.members ?? [],
-      tokens_saved: fragment?.tokens_saved ?? 0,
-      monthly_savings_usd: fragment?.monthly_savings_usd ?? 0.0,
-      status: fragment.status,
-    },
+        id: fragment.id,
+        title: fragment.title,
+        tenant_id: fragment?.tenant_id,
+        text: fragment.body,
+        token_budget: fragment?.token_budget,
+        support: fragment?.support,
+        members: fragment?.members ?? [],
+        tokens_saved: fragment?.tokens_saved ?? 0,
+        monthly_savings_usd: fragment?.monthly_savings_usd ?? 0.0,
+        status: fragment.status,
+      },
     )
   }
   return queue

--- a/stdlib/schema.harn
+++ b/stdlib/schema.harn
@@ -1,7 +1,8 @@
-// std/schema — ergonomic schema builders and typed-value helpers
-//
-// Import with: import "std/schema"
-
+/**
+ * std/schema — ergonomic schema builders and typed-value helpers
+ *
+ * Import with: import "std/schema"
+ */
 pub fn schema_any() {
   return {type: "any"}
 }
@@ -67,7 +68,6 @@ pub fn schema_field(schema, required = true) {
 pub fn schema_object(fields, options = nil) {
   var properties = {}
   var required = []
-
   for entry in fields {
     let raw_schema = entry.value
     let is_required = raw_schema.required == nil || raw_schema.required
@@ -77,7 +77,6 @@ pub fn schema_object(fields, options = nil) {
       required = required + [entry.key]
     }
   }
-
   var out = {type: "dict", properties: properties}
   if len(required) > 0 {
     out = out + {required: required}

--- a/stdlib/text.harn
+++ b/stdlib/text.harn
@@ -1,39 +1,59 @@
-// std/text — Text processing utilities for LLM output and code analysis.
-
-// Extract file paths from text.
-// Splits on newlines, skips comment lines, extracts path-like words,
-// validates extensions, and deduplicates.
+/**
+ * std/text — Text processing utilities for LLM output and code analysis.
+ * Extract file paths from text.
+ * Splits on newlines, skips comment lines, extracts path-like words,
+ * validates extensions, and deduplicates.
+ */
 pub fn extract_paths(text) {
   let lines = split(text, "\n")
-    .filter({ line ->
+    .filter(
+    { line ->
       let t = trim(line)
       return contains(t, "/")
         && !starts_with(t, "//")
         && !starts_with(t, "#")
-    })
+    },
+  )
   var seen = []
-  return lines.flat_map({ line ->
-    return split(trim(line), " ").map({ word ->
-      var clean = regex_replace("^[\"'`,;:()\\[\\]{}><]+|[\"'`,;:()\\[\\]{}><]+$", "", trim(word))
-      while ends_with(clean, ".") || ends_with(clean, ",") || ends_with(clean, ":") || ends_with(clean, ";") {
-        clean = substring(clean, 0, len(clean) - 1)
+  return lines
+    .flat_map(
+    { line -> return split(trim(line), " ")
+      .map(
+      { word ->
+        var clean = regex_replace("^[\"'`,;:()\\[\\]{}><]+|[\"'`,;:()\\[\\]{}><]+$", "", trim(word))
+        while ends_with(clean, ".") || ends_with(clean, ",") || ends_with(clean, ":")
+          || ends_with(clean, ";") {
+          clean = substring(clean, 0, len(clean) - 1)
+        }
+        return clean
+      },
+    )
+      .filter(
+      { clean ->
+        if !contains(clean, "/") && !contains(clean, ".") {
+          return false
+        }
+        let ext = extname(clean)
+        return ext != "" && len(ext) <= 11
+      },
+    ) },
+  )
+    .filter(
+    { p ->
+      if seen.contains(p) {
+        return false
       }
-      return clean
-    }).filter({ clean ->
-      if !contains(clean, "/") && !contains(clean, ".") { return false }
-      let ext = extname(clean)
-      return ext != "" && len(ext) <= 11
-    })
-  }).filter({ p ->
-    if seen.contains(p) { return false }
-    seen = seen + [p]
-    return true
-  }).sort()
+      seen = seen + [p]
+      return true
+    },
+  ).sort()
 }
 
-// Parse fenced code blocks from LLM response text.
-// Returns list of {type: "code"|"call", lang: string|nil, code: string}.
-// State machine — not easily expressed as pure map/filter.
+/**
+ * Parse fenced code blocks from LLM response text.
+ * Returns list of {type: "code"|"call", lang: string|nil, code: string}.
+ * State machine — not easily expressed as pure map/filter.
+ */
 pub fn parse_cells(response) {
   let lines = split(response, "\n")
   var cells = []
@@ -41,7 +61,6 @@ pub fn parse_cells(response) {
   var block_type = "code"
   var block_lang = nil
   var current_lines = []
-
   var trimmed = ""
   var lang_part = ""
   for line in lines {
@@ -76,22 +95,27 @@ pub fn parse_cells(response) {
   return cells
 }
 
-// Filter parsed cells to keep test-relevant ones.
-// Keeps type="code" cells and type="call" cells containing "write_file".
-// If target_file is provided, only write_file calls mentioning that file are kept.
+/**
+ * Filter parsed cells to keep test-relevant ones.
+ * Keeps type="code" cells and type="call" cells containing "write_file".
+ * If target_file is provided, only write_file calls mentioning that file are kept.
+ */
 pub fn filter_test_cells(cells, target_file) {
-  return cells.filter({ cell ->
-    if cell.type == "call" && contains(cell.code, "write_file") {
-      if target_file != nil {
-        return contains(cell.code, target_file)
+  return cells
+    .filter(
+    { cell ->
+      if cell.type == "call" && contains(cell.code, "write_file") {
+        if target_file != nil {
+          return contains(cell.code, target_file)
+        }
+        return true
       }
-      return true
-    }
-    return cell.type == "code"
-  })
+      return cell.type == "code"
+    },
+  )
 }
 
-// Keep first n and last n lines of text, with an omission marker in between.
+/** Keep first n and last n lines of text, with an omission marker in between. */
 pub fn truncate_head_tail(text, n) {
   let lines = split(text, "\n")
   if len(lines) <= n * 2 {
@@ -99,12 +123,16 @@ pub fn truncate_head_tail(text, n) {
   }
   let skipped = len(lines) - n * 2
   return join(lines[:n], "\n")
-    + "\n... (" + to_string(skipped) + " lines omitted) ...\n"
+    + "\n... ("
+    + to_string(skipped)
+    + " lines omitted) ...\n"
     + join(lines[-n:], "\n")
 }
 
-// Check if compiler/build output contains compile error indicators.
-// Matches Python errors and generic patterns (case-sensitive, matching burin-code behavior).
+/**
+ * Check if compiler/build output contains compile error indicators.
+ * Matches Python errors and generic patterns (case-sensitive, matching burin-code behavior).
+ */
 pub fn detect_compile_error(output) {
   return contains(output, "SyntaxError")
     || contains(output, "IndentationError")
@@ -114,8 +142,10 @@ pub fn detect_compile_error(output) {
     || contains(output, "cannot find")
 }
 
-// Check if test output contains both got/actual AND want/expected indicators.
-// Returns true only if BOTH sides are present.
+/**
+ * Check if test output contains both got/actual AND want/expected indicators.
+ * Returns true only if BOTH sides are present.
+ */
 pub fn has_got_want(output) {
   let has_got = contains(output, "got:")
     || contains(output, "Got:")
@@ -128,16 +158,19 @@ pub fn has_got_want(output) {
   return has_got && has_want
 }
 
-// Extract error-relevant lines from test output.
-// Filters for lines containing error keywords, returns first 20 joined with newlines.
+/**
+ * Extract error-relevant lines from test output.
+ * Filters for lines containing error keywords, returns first 20 joined with newlines.
+ */
 pub fn format_test_errors(output) {
-  let error_lines = split(output, "\n").filter({ line ->
-    return contains(line, "FAIL")
+  let error_lines = split(output, "\n")
+    .filter(
+    { line -> return contains(line, "FAIL")
       || contains(line, "Error")
       || contains(line, "error")
       || contains(line, "AssertionError")
-      || contains(line, "assert")
-  })
+      || contains(line, "assert") },
+  )
   if len(error_lines) > 20 {
     return join(error_lines[:20], "\n")
   }

--- a/stdlib/vision.harn
+++ b/stdlib/vision.harn
@@ -1,13 +1,9 @@
-// std/vision — deterministic OCR helpers built on the runtime's vision builtins.
-//
-// Import with: import "std/vision"
-
-type VisionBox = {
-  left: int,
-  top: int,
-  width: int,
-  height: int,
-}
+/**
+ * std/vision — deterministic OCR helpers built on the runtime's vision builtins.
+ *
+ * Import with: import "std/vision"
+ */
+type VisionBox = {left: int, top: int, width: int, height: int}
 
 type VisionToken = {
   page: int,
@@ -19,7 +15,7 @@ type VisionToken = {
   normalized: string,
   char_start: int,
   char_end: int,
-  confidence: float | nil,
+  confidence: float?,
   bbox: VisionBox,
 }
 
@@ -33,7 +29,7 @@ type VisionLine = {
   token_count: int,
   char_start: int,
   char_end: int,
-  confidence: float | nil,
+  confidence: float?,
   bbox: VisionBox,
 }
 
@@ -47,14 +43,14 @@ type VisionBlock = {
   line_count: int,
   char_start: int,
   char_end: int,
-  confidence: float | nil,
+  confidence: float?,
   bbox: VisionBox,
 }
 
 type VisionSource = {
   kind: string,
-  path: string | nil,
-  name: string | nil,
+  path: string?,
+  name: string?,
   mime_type: string,
   byte_len: int,
   sha256: string,

--- a/tests/bridge/test_combined.harn
+++ b/tests/bridge/test_combined.harn
@@ -2,13 +2,10 @@ pipeline default(task) {
   // Test multiple bridge calls in sequence
   let file_content = read_file("README.md")
   log("File: ${file_content}")
-
   let llm_response = llm_call("Summarize this", "Be brief")
   log("LLM: ${llm_response}")
-
   let host_result = host_call("get_repo_map", {})
   log("Host: ${host_result}")
-
   progress("done", "All bridge calls completed")
   log("Success")
 }


### PR DESCRIPTION
## Summary

Repo-root `.harn` fixtures under `stdlib/`, `personas/`, `tests/bridge/`, `examples/`, and `evals/` were never inside `make fmt-harn`'s scope, which meant 14 files accumulated formatting drift dating back to v0.2.9. This PR brings them into the gate and applies the backlog so the next person to touch any of them doesn't get surprised by a 200-line reformat-only diff in their PR.

- Apply `harn fmt` to the 14 drifted files (pure formatting, no semantic edits).
- Make [`stdlib/json.harn`](stdlib/json.harn) parse again: it had been using `var result = a` + `{..result, [k]: v}` (neither valid Harn since at least v0.4.7) and silently shipped broken. Rewrite to mirror the canonical `crates/harn-stdlib/src/stdlib/stdlib_json.harn` (uses the `__dict_merge` / `__dict_pick` / `__dict_omit` builtins) and mark the helpers `pub` so the unused-fn lint stays quiet.
- Add `EXTRA_HARN_DIRS := stdlib personas tests examples evals` and thread it through both `fmt-harn` and `fmt-harn-fix` so future drift in any of those trees fails the CI / `make all` gate. Pre-commit already lints staged files only — this just closes the "no one notices for years" hole at the full-repo level.

CI's `Harn conformance + audit` job invokes `make fmt-harn`, so the broader coverage rides in for free; no workflow changes needed.

## Test plan

- [x] `make fmt-harn` clean (was failing on the 14 files + the malformed `stdlib/json.harn` before).
- [x] `cargo run --bin harn -- lint stdlib/ personas/ tests/bridge/ examples/ tests/smoke/` clean.
- [x] `cargo check -p harn-vm` clean.
- [x] Pre-commit + pre-push hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)