### PR TITLE
stdlib: add code_librarian library wrapping code_index builtins (#2438)

### DIFF
--- a/conformance/tests/stdlib/code_librarian_surface.expected
+++ b/conformance/tests/stdlib/code_librarian_surface.expected
@@ -1,0 +1,13 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/stdlib/code_librarian_surface.harn
+++ b/conformance/tests/stdlib/code_librarian_surface.harn
@@ -1,0 +1,59 @@
+import "std/code_librarian"
+
+/**
+ * Uses the same minimal Rust corpus as the #2434 graph-surface test
+ * (crates/harn-hostlib/tests/code_index_graph_surface.rs) so canned
+ * Cypher queries land on the same node shapes.
+ */
+fn seed_corpus(root: string) {
+  harness.fs.mkdir(root)
+  harness.fs.mkdir(path_join(root, "src"))
+  harness.fs
+    .write_text(path_join(root, "src/a.rs"), "pub fn alpha() {}\npub fn beta() { alpha(); }\n")
+  harness.fs
+    .write_text(path_join(root, "src/b.rs"), "pub fn gamma() {}\npub fn driver() { gamma(); }\n")
+}
+
+pipeline default() {
+  let root = path_join(
+    harness.fs.temp_dir(),
+    "harn_code_librarian_" + to_string(harness.random.gen_range(100000, 999999)),
+  )
+  seed_corpus(root)
+  let _rebuild = hostlib_code_index_rebuild({root: root})
+  // 1) Cypher pass-through returns rows + overlay nil on base.
+  let cy: LibrarianCypherResult = code_librarian_query("MATCH (f:Function {name: 'alpha'}) RETURN f.path AS path")
+  __io_println(len(cy.rows) == 1 && cy.rows[0].path == "src/a.rs")
+  __io_println(cy.overlay == nil)
+  // 2) outline returns typed symbols + import edges for known files.
+  //    The `symbols` channel uses `outline_get` which is populated by
+  //    language-specific extractors; assert only on the known/path
+  //    shape so the test stays robust to extractor coverage.
+  let outline: LibrarianOutline = code_librarian_outline("src/a.rs")
+  __io_println(outline.known && outline.path == "src/a.rs")
+  __io_println(type_of(outline.symbols) == "list")
+  // 3) outline on an unknown path returns known=false (not a throw).
+  let absent: LibrarianOutline = code_librarian_outline("src/does-not-exist.rs")
+  __io_println(!absent.known && len(absent.symbols) == 0)
+  // 4) who_calls returns the CallSite list for the target symbol.
+  let callers: list<LibrarianCallSite> = code_librarian_who_calls("alpha")
+  __io_println(len(callers) >= 1)
+  __io_println(callers[0].path == "src/a.rs" && callers[0].symbol == "alpha")
+  // 5) what_imports returns a list (empty here — corpus has no imports).
+  let imps: list<LibrarianImport> = code_librarian_what_imports("src/a.rs")
+  __io_println(type_of(imps) == "list")
+  // 6) recent_changes from seq=0 returns a list shape.
+  let changes: list<LibrarianFileChange> = code_librarian_recent_changes(0)
+  __io_println(type_of(changes) == "list")
+  // 7) freshness reports known/not-stale for an indexed file.
+  let fresh: LibrarianFreshness = code_librarian_freshness("src/a.rs")
+  __io_println(fresh.known && !fresh.stale)
+  // 8) freshness on an unknown path reports known=false.
+  let unknown_fresh: LibrarianFreshness = code_librarian_freshness("src/does-not-exist.rs")
+  __io_println(!unknown_fresh.known)
+  // 9) branch_overlay(branch) activates; nil deactivates.
+  let on: LibrarianOverlay = code_librarian_branch_overlay("topic/test")
+  __io_println(on.active == "topic/test")
+  let off: LibrarianOverlay = code_librarian_branch_overlay(nil)
+  __io_println(off.active == nil)
+}

--- a/crates/harn-hostlib/tests/code_librarian_recall.rs
+++ b/crates/harn-hostlib/tests/code_librarian_recall.rs
@@ -1,0 +1,262 @@
+#![recursion_limit = "256"]
+//! End-to-end recall test for `std/code_librarian` against the same
+//! 30-question fixture the #2434 ground-truth recall test uses
+//! (`tests/fixtures/code_index_queries/queries.json` plus the sibling
+//! `corpus/` workspace).
+//!
+//! The library's `code_librarian_query` is meant to be a thin typed
+//! pass-through over `hostlib_code_index_cypher`. This test pins that
+//! contract: the librarian must deliver at least the same aggregate
+//! recall the raw Cypher executor does (≥ 80% per #2434).
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::PathBuf;
+
+use harn_lexer::Lexer;
+use harn_parser::Parser;
+use harn_vm::{register_vm_stdlib, Compiler, Vm, VmValue};
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/code_index_queries")
+}
+
+fn run_harn(source: &str) -> VmValue {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut lexer = Lexer::new(source);
+                let tokens = lexer.tokenize().expect("tokenize");
+                let mut parser = Parser::new(tokens);
+                let program = parser.parse().expect("parse");
+                let chunk = Compiler::new().compile(&program).expect("compile");
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                let _ = harn_hostlib::install_default(&mut vm);
+                vm.execute(&chunk).await.expect("execute")
+            })
+            .await
+    })
+}
+
+fn extract_list(value: &VmValue) -> std::rc::Rc<Vec<VmValue>> {
+    match value {
+        VmValue::List(l) => l.clone(),
+        other => panic!("expected list, got {other:?}"),
+    }
+}
+
+fn extract_dict(value: &VmValue) -> std::rc::Rc<BTreeMap<String, VmValue>> {
+    match value {
+        VmValue::Dict(d) => d.clone(),
+        other => panic!("expected dict, got {other:?}"),
+    }
+}
+
+#[test]
+fn librarian_query_meets_ground_truth_recall() {
+    let corpus = fixture_root().join("corpus");
+    let root_str = corpus.to_string_lossy().replace('\\', "/");
+
+    let qa_text =
+        std::fs::read_to_string(fixture_root().join("queries.json")).expect("read queries.json");
+    let qa: serde_json::Value = serde_json::from_str(&qa_text).expect("parse queries.json");
+    let questions = qa["questions"].as_array().expect("questions array");
+    assert_eq!(
+        questions.len(),
+        30,
+        "fixture must hold exactly 30 questions per the issue"
+    );
+
+    // Render the queries into a Harn source that drives them all through
+    // `code_librarian_query` and returns a list-of-lists of match keys.
+    let mut query_lines = String::new();
+    for q in questions {
+        let cypher = q["cypher"].as_str().unwrap();
+        let match_key = q["match_key"].as_str().unwrap();
+        // Inline-escape; the queries.json values use only single quotes
+        // and no backslashes, so a verbatim drop is safe. Defensive check
+        // catches any future fixture additions that violate this.
+        assert!(
+            !cypher.contains('"') && !cypher.contains('\\'),
+            "cypher contains chars that need escaping: {cypher}"
+        );
+        assert!(
+            !match_key.contains('"') && !match_key.contains('\\'),
+            "match_key contains chars that need escaping: {match_key}"
+        );
+        query_lines.push_str(&format!(
+            "rows = rows + [project(code_librarian_query(\"{cypher}\").rows, \"{match_key}\")]\n"
+        ));
+    }
+    let source = format!(
+        r#"
+import "std/code_librarian"
+
+fn project(rows, key) {{
+  var out = []
+  for row in rows {{
+    let v = row?[key]
+    if v != nil {{
+      out = out + [to_string(v)]
+    }}
+  }}
+  return out
+}}
+
+let _ = hostlib_code_index_rebuild({{ root: "{root_str}" }})
+var rows = []
+{query_lines}
+return rows
+"#
+    );
+
+    let result = run_harn(&source);
+    let rows = extract_list(&result);
+    assert_eq!(rows.len(), questions.len(), "row-set count must match");
+
+    let mut total_expected: usize = 0;
+    let mut total_found: usize = 0;
+    let mut failures: Vec<String> = Vec::new();
+    for (q, row_value) in questions.iter().zip(rows.iter()) {
+        let id = q["id"].as_str().unwrap();
+        let expected: BTreeSet<String> = q["expected"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+
+        let found: HashSet<String> = extract_list(row_value)
+            .iter()
+            .filter_map(|v| match v {
+                VmValue::String(s) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect();
+
+        let hits = expected.iter().filter(|e| found.contains(*e)).count();
+        total_expected += expected.len();
+        total_found += hits;
+        if hits < expected.len() {
+            failures.push(format!(
+                "[{id}] missing {missing}/{exp} (got {found:?}, want {expected:?})",
+                missing = expected.len() - hits,
+                exp = expected.len(),
+            ));
+        }
+    }
+
+    let recall = total_found as f64 / total_expected as f64;
+    if recall < 0.80 {
+        for f in &failures {
+            eprintln!("{f}");
+        }
+        panic!(
+            "code_librarian_query recall = {recall:.3} (found {total_found}/{total_expected}); \
+             expected >= 0.80. failures above."
+        );
+    }
+}
+
+#[test]
+fn librarian_who_calls_returns_call_sites() {
+    // Reuse the same fixture: `fetchUser` is called from
+    // `src/auth.ts` and `src/router.ts` per Q19 in queries.json.
+    let corpus = fixture_root().join("corpus");
+    let root_str = corpus.to_string_lossy().replace('\\', "/");
+    let source = format!(
+        r#"
+import "std/code_librarian"
+let _ = hostlib_code_index_rebuild({{ root: "{root_str}" }})
+let callers = code_librarian_who_calls("fetchUser")
+var paths = []
+for c in callers {{
+  paths = paths + [c.path]
+}}
+var symbols = []
+for c in callers {{
+  symbols = symbols + [c.symbol]
+}}
+return {{
+  count: len(callers),
+  paths: paths,
+  symbols: symbols,
+}}
+"#
+    );
+    let result = run_harn(&source);
+    let d = extract_dict(&result);
+    let count = match d.get("count").unwrap() {
+        VmValue::Int(i) => *i,
+        other => panic!("count: {other:?}"),
+    };
+    assert!(
+        count >= 2,
+        "expected at least two callers for fetchUser, got {count}"
+    );
+    let paths: BTreeSet<String> = extract_list(d.get("paths").unwrap())
+        .iter()
+        .filter_map(|v| match v {
+            VmValue::String(s) => Some(s.to_string()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        paths.contains("src/auth.ts") && paths.contains("src/router.ts"),
+        "expected paths to cover auth.ts + router.ts, got {paths:?}"
+    );
+    let symbols: BTreeSet<String> = extract_list(d.get("symbols").unwrap())
+        .iter()
+        .filter_map(|v| match v {
+            VmValue::String(s) => Some(s.to_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        symbols,
+        BTreeSet::from(["fetchUser".to_string()]),
+        "every call site should report the target symbol"
+    );
+}
+
+#[test]
+fn librarian_freshness_and_overlay_roundtrip() {
+    let corpus = fixture_root().join("corpus");
+    let root_str = corpus.to_string_lossy().replace('\\', "/");
+    let source = format!(
+        r#"
+import "std/code_librarian"
+let _ = hostlib_code_index_rebuild({{ root: "{root_str}" }})
+let fresh = code_librarian_freshness("src/util.ts")
+let unknown = code_librarian_freshness("src/no-such-file.ts")
+let on = code_librarian_branch_overlay("topic/test")
+let off = code_librarian_branch_overlay(nil)
+return {{
+  fresh_known: fresh.known,
+  fresh_stale: fresh.stale,
+  unknown_known: unknown.known,
+  on_active: on.active,
+  off_active: off.active,
+}}
+"#
+    );
+    let result = run_harn(&source);
+    let d = extract_dict(&result);
+    let bool_at = |k: &str| match d.get(k).unwrap() {
+        VmValue::Bool(b) => *b,
+        other => panic!("{k}: {other:?}"),
+    };
+    assert!(bool_at("fresh_known"));
+    assert!(!bool_at("fresh_stale"));
+    assert!(!bool_at("unknown_known"));
+    assert!(matches!(
+        d.get("on_active").unwrap(),
+        VmValue::String(s) if s.as_ref() == "topic/test"
+    ));
+    assert!(matches!(d.get("off_active").unwrap(), VmValue::Nil));
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -118,6 +118,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_graphql.harn"),
     },
     StdlibSource {
+        module: "code_librarian",
+        source: include_str!("stdlib/stdlib_code_librarian.harn"),
+    },
+    StdlibSource {
         module: "schema",
         source: include_str!("stdlib/stdlib_schema.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/stdlib_code_librarian.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_code_librarian.harn
@@ -1,0 +1,227 @@
+/**
+ * std/code_librarian — typed code-graph + Cypher surface for Harn scripts.
+ *
+ * Import: import "std/code_librarian"
+ *
+ * Wraps the `hostlib_code_index_*` builtin family (issue #2434, PR #2441)
+ * behind seven ergonomic functions returning typed records. Consumers call
+ * one library instead of stitching outputs from many primitives.
+ *
+ * The library never rebuilds the index; callers are expected to drive
+ * `hostlib_code_index_rebuild` (or its lifecycle equivalent) themselves.
+ *
+ * Underlying executor docs: docs/src/stdlib/code-librarian.md
+ * A typed Cypher row — keys are projected column names from `RETURN`.
+ */
+type LibrarianRecord = dict
+
+/** Result of a Cypher pass-through: rows plus the active overlay name. */
+type LibrarianCypherResult = {rows: list<LibrarianRecord>, overlay: string?}
+
+/** One symbol entry from the file outline, as returned by outline_get. */
+type LibrarianOutlineSymbol = {
+  name: string,
+  kind: string,
+  start_line: int,
+  end_line: int,
+  signature: string,
+}
+
+/** A file outline plus its declared and reverse import edges. */
+type LibrarianOutline = {
+  path: string,
+  file_id: int,
+  known: bool,
+  symbols: list<LibrarianOutlineSymbol>,
+  imports: list<dict>,
+  importers: list<string>,
+}
+
+/** A single caller site for a target symbol. */
+type LibrarianCallSite = {caller: string?, path: string, symbol: string}
+
+/** A single import edge into a target path. */
+type LibrarianImport = {importer: string, kind: string}
+
+/** One entry from the change log for a recent-changes window. */
+type LibrarianFileChange = {
+  path: string,
+  seq: int,
+  agent_id: int,
+  op: string,
+  hash: string,
+  size: int,
+  timestamp_ms: int,
+}
+
+/** Freshness signal: indexed vs on-disk state for a known or unknown path. */
+type LibrarianFreshness = {
+  path: string,
+  known: bool,
+  stale: bool,
+  indexed_hash: string?,
+  indexed_mtime_ms: int?,
+  disk_hash: string?,
+  disk_mtime_ms: int?,
+}
+
+/** Overlay activation result: branch name (or nil when deactivated) + reuse fraction. */
+type LibrarianOverlay = {active: string?, reuse_fraction: float}
+
+/**
+ * Pass a Cypher query straight through to the typed symbol graph executor.
+ * Returns the row list plus the active overlay name (nil when on base).
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: code_librarian_query("MATCH (f:Function {name: 'main'}) RETURN f.path AS path")
+ */
+pub fn code_librarian_query(cypher: string) -> LibrarianCypherResult {
+  let raw = hostlib_code_index_cypher({query: cypher})
+  return {rows: raw?.rows ?? [], overlay: raw?.overlay}
+}
+
+/**
+ * Outline a file: symbols plus the import edges in and out of it. `depth`
+ * is reserved for future graph-aware traversal (currently 1: the file
+ * itself); values >= 1 still return the immediate outline so the call
+ * shape is stable for richer expansions later.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: code_librarian_outline("src/util.ts")
+ */
+pub fn code_librarian_outline(path: string, depth: int = 1) -> LibrarianOutline {
+  if depth < 1 {
+    throw "code_librarian_outline: depth must be >= 1"
+  }
+  let file_id = hostlib_code_index_path_to_id({path: path})
+  if file_id == nil || file_id == 0 {
+    return {file_id: 0, importers: [], imports: [], known: false, path: path, symbols: []}
+  }
+  let symbols = hostlib_code_index_outline_get({file_id: file_id})
+  let imps = hostlib_code_index_imports_for({path: path})
+  let users = hostlib_code_index_importers_of({module: path})
+  return {
+    file_id: file_id,
+    importers: users?.importers ?? [],
+    imports: imps?.imports ?? [],
+    known: true,
+    path: path,
+    symbols: symbols ?? [],
+  }
+}
+
+/**
+ * Resolve every call site that targets `symbol`, walking up to
+ * `max_hops` chained CALLS edges (currently 1 hop — the direct callers).
+ * Higher hop budgets are reserved for the upcoming transitive query
+ * shape; the return type stays the same.
+ *
+ * Canned query: `MATCH (f:Function {name: $name})<-[:CALLS]-(c:CallSite) RETURN c.path AS path, c.caller AS caller, f.name AS symbol`.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: code_librarian_who_calls("formatDate")
+ */
+pub fn code_librarian_who_calls(symbol: string, max_hops: int = 2) -> list<LibrarianCallSite> {
+  if max_hops < 1 {
+    throw "code_librarian_who_calls: max_hops must be >= 1"
+  }
+  let cypher = "MATCH (f:Function {name: '" + symbol
+    + "'})<-[:CALLS]-(c:CallSite) RETURN c.path AS path, c.caller AS caller, f.name AS symbol"
+  let raw = hostlib_code_index_cypher({query: cypher})
+  let rows = raw?.rows ?? []
+  var out: list<LibrarianCallSite> = []
+  for row in rows {
+    out = out + [{caller: row?.caller, path: row?.path ?? "", symbol: row?.symbol ?? symbol}]
+  }
+  return out
+}
+
+/**
+ * Resolve every file that imports `path`. Combines the direct importers
+ * edge (used by Cypher) with the legacy importers_of view so connectors
+ * that haven't migrated still surface here.
+ *
+ * Canned query: `MATCH (m:Module {path: $path})<-[:IMPORTS]-(s:Module) RETURN s.path AS importer, 'import' AS kind`.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: code_librarian_what_imports("src/util.ts")
+ */
+pub fn code_librarian_what_imports(path: string) -> list<LibrarianImport> {
+  let users = hostlib_code_index_importers_of({module: path})
+  let importers = users?.importers ?? []
+  var out: list<LibrarianImport> = []
+  for item in importers {
+    out = out + [{importer: item, kind: "import"}]
+  }
+  return out
+}
+
+/**
+ * Recent changes since `since_seq` in the version log. The issue spec
+ * names this `recent_changes(window: Duration)`; Harn has no native
+ * Duration primitive yet, so the library accepts the same monotonic
+ * sequence number used by `hostlib_code_index_current_seq` /
+ * `changes_since`. `since_seq = 0` returns every recorded change.
+ *
+ * Pair with `hostlib_code_index_current_seq({})` to checkpoint and
+ * resume.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: code_librarian_recent_changes(0)
+ */
+pub fn code_librarian_recent_changes(since_seq: int = 0) -> list<LibrarianFileChange> {
+  if since_seq < 0 {
+    throw "code_librarian_recent_changes: since_seq must be >= 0"
+  }
+  let raw = hostlib_code_index_changes_since({seq: since_seq})
+  return raw ?? []
+}
+
+/**
+ * Staleness signal for `path`: did the on-disk content drift away from
+ * the indexed snapshot? Wraps `hostlib_code_index_freshness` directly,
+ * preserving the `{known, stale, indexed_hash, disk_hash, ...}` shape.
+ *
+ * @effects: [host, fs]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: code_librarian_freshness("src/util.ts")
+ */
+pub fn code_librarian_freshness(path: string) -> LibrarianFreshness {
+  return hostlib_code_index_freshness({path: path})
+}
+
+/**
+ * Activate a per-branch CDC overlay. If the overlay doesn't exist yet
+ * it's created as an empty pass-through so the base graph serves it
+ * untouched (100% reuse baseline). Passing `branch = nil` deactivates
+ * the active overlay and returns to the base graph.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend, invalid_argument]
+ * @api_stability: experimental
+ * @example: code_librarian_branch_overlay("topic/cypher")
+ */
+pub fn code_librarian_branch_overlay(branch: string?) -> LibrarianOverlay {
+  if branch == nil {
+    return hostlib_code_index_branch_overlay({action: "deactivate"})
+  }
+  return hostlib_code_index_branch_overlay({action: "activate", branch: branch})
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -86,6 +86,7 @@
 - [Observability stdlib](./stdlib/observability.md)
 - [Timing stdlib](./stdlib/timing.md)
 - [GraphQL stdlib](./stdlib/graphql.md)
+- [Code librarian stdlib](./stdlib/code-librarian.md)
 - [OAuth storage stdlib](./stdlib/oauth-storage.md)
 - [Prompt library stdlib](./stdlib/prompt-library.md)
 - [Human in the loop](./hitl.md)

--- a/docs/src/stdlib/code-librarian.md
+++ b/docs/src/stdlib/code-librarian.md
@@ -1,0 +1,90 @@
+# Code librarian stdlib
+
+`import "std/code_librarian"` exposes the typed code-graph + Cypher
+surface that ships behind the `hostlib_code_index_*` builtin family
+(issue [#2434](https://github.com/burin-labs/harn/issues/2434), PR
+[#2441](https://github.com/burin-labs/harn/pull/2441)) as a single
+ergonomic API. Consumers — Burin Code, headless TUI workflows, future
+personas — call one library instead of stitching outputs from many
+primitives.
+
+The library never rebuilds the index on its own. Drive
+`hostlib_code_index_rebuild({root: <path>})` first (or the lifecycle
+equivalent), then talk to the librarian.
+
+## Functions
+
+| Function | Returns | Wraps |
+|---|---|---|
+| `code_librarian_query(cypher)` | `LibrarianCypherResult` | `hostlib_code_index_cypher` |
+| `code_librarian_outline(path, depth = 1)` | `LibrarianOutline` | `path_to_id` + `outline_get` + `imports_for` + `importers_of` |
+| `code_librarian_who_calls(symbol, max_hops = 2)` | `list<LibrarianCallSite>` | `hostlib_code_index_cypher` (canned `<-[:CALLS]-` query) |
+| `code_librarian_what_imports(path)` | `list<LibrarianImport>` | `hostlib_code_index_importers_of` |
+| `code_librarian_recent_changes(since_seq = 0)` | `list<LibrarianFileChange>` | `hostlib_code_index_changes_since` |
+| `code_librarian_freshness(path)` | `LibrarianFreshness` | `hostlib_code_index_freshness` |
+| `code_librarian_branch_overlay(branch)` | `LibrarianOverlay` | `hostlib_code_index_branch_overlay` |
+
+The Cypher executor that backs `code_librarian_query` and
+`code_librarian_who_calls` is documented at
+[`crates/harn-hostlib/src/code_index/cypher.rs`](https://github.com/burin-labs/harn/blob/main/crates/harn-hostlib/src/code_index/cypher.rs).
+Supported clauses: `MATCH`, `WHERE`, `RETURN`, alias projections
+(`RETURN expr AS name`), single-edge and variable-length traversal up
+to depth 4.
+
+## Worked example: who calls this function?
+
+```harn
+import "std/code_librarian"
+
+pipeline default() {
+  let _ = hostlib_code_index_rebuild(
+    {root: "crates/harn-hostlib/tests/fixtures/code_index_queries/corpus"},
+  )
+
+  let callers: list<LibrarianCallSite> = code_librarian_who_calls("fetchUser")
+  __io_println("fetchUser has " + to_string(len(callers)) + " call sites:")
+  for c in callers {
+    __io_println("  " + c.path)
+  }
+}
+```
+
+Running this against the ground-truth corpus prints:
+
+```text
+fetchUser has 2 call sites:
+  src/auth.ts
+  src/router.ts
+```
+
+The full walk-through lives at
+[`examples/code_librarian_explore.harn`](https://github.com/burin-labs/harn/blob/main/examples/code_librarian_explore.harn).
+
+## Defaults and limitations
+
+- `depth` on `code_librarian_outline` is reserved for upcoming graph-aware
+  traversal. Today only the immediate outline is returned regardless of
+  the passed value; the type signature stays stable so consumers don't
+  have to rewrite calls when richer traversal lands.
+- `max_hops` on `code_librarian_who_calls` is reserved for the upcoming
+  transitive `<-[:CALLS*1..N]-` query shape. Today only direct callers
+  are returned.
+- `code_librarian_recent_changes` takes a monotonic version sequence
+  number (`since_seq`) because Harn has no native `Duration` primitive
+  yet. Pair with `hostlib_code_index_current_seq({})` to checkpoint and
+  resume.
+- The library does not rebuild the index; consumers must call
+  `hostlib_code_index_rebuild` before the first query (and after
+  large workspace mutations) themselves.
+
+## See also
+
+- [Typed symbol graph + Cypher executor](https://github.com/burin-labs/harn/pull/2441) —
+  the underlying primitives.
+- [`hostlib_code_index_*` registration test][reg-test] — canonical list of every
+  builtin the library wraps.
+- [Ground-truth recall fixture][recall-fixture] — the 30 Q&A pairs the librarian
+  inherits from #2434.
+
+[reg-test]: https://github.com/burin-labs/harn/blob/main/crates/harn-hostlib/tests/registration.rs
+[recall-fixture]: https://github.com/burin-labs/harn/blob/main/crates/harn-hostlib/tests/fixtures/code_index_queries/queries.json

--- a/examples/code_librarian_explore.harn
+++ b/examples/code_librarian_explore.harn
@@ -1,0 +1,44 @@
+/**
+ * Code librarian — quick exploratory walkthrough of std/code_librarian.
+ *
+ * Run from the repo root with:
+ *   cargo run --bin harn -- run examples/code_librarian_explore.harn
+ *
+ * The example rebuilds the code index over the corpus that ships with
+ * the typed symbol graph fixture (#2434), then exercises every public
+ * function in the library. Before the librarian landed each of these
+ * lines reached for a different `hostlib_code_index_*` builtin —
+ * compare with `crates/harn-hostlib/tests/smoke_harn_script.rs`.
+ */
+import "std/code_librarian"
+
+pipeline default() {
+  let root = "crates/harn-hostlib/tests/fixtures/code_index_queries/corpus"
+  let _rebuild = hostlib_code_index_rebuild({root: root})
+  // 1. Direct Cypher pass-through.
+  let alpha: LibrarianCypherResult = code_librarian_query("MATCH (f:Function {name: 'main'}) RETURN f.path AS path")
+  __io_println("functions named `main`: " + to_string(len(alpha.rows)))
+  // 2. Who calls a hot function?
+  let callers: list<LibrarianCallSite> = code_librarian_who_calls("fetchUser")
+  __io_println("fetchUser callers: " + to_string(len(callers)))
+  for c in callers {
+    __io_println("  " + c.path)
+  }
+  // 3. What imports `src/util.ts`?
+  let imps: list<LibrarianImport> = code_librarian_what_imports("src/util.ts")
+  __io_println("importers of src/util.ts: " + to_string(len(imps)))
+  // 4. Outline a file and read its symbol kinds.
+  let outline: LibrarianOutline = code_librarian_outline("src/util.ts")
+  __io_println("src/util.ts known? " + to_string(outline.known))
+  // 5. Freshness — pristine after rebuild.
+  let fresh: LibrarianFreshness = code_librarian_freshness("src/util.ts")
+  __io_println("src/util.ts stale? " + to_string(fresh.stale))
+  // 6. Change log from the start.
+  let changes: list<LibrarianFileChange> = code_librarian_recent_changes(0)
+  __io_println("recorded changes: " + to_string(len(changes)))
+  // 7. Activate a per-branch overlay, then deactivate.
+  let on: LibrarianOverlay = code_librarian_branch_overlay("topic/explore")
+  __io_println("overlay active: " + on.active ?? "<base>")
+  let off: LibrarianOverlay = code_librarian_branch_overlay(nil)
+  __io_println("overlay active: " + off.active ?? "<base>")
+}


### PR DESCRIPTION
## Summary

Wraps the typed code-graph + Cypher surface from #2434 (PR #2441) behind a single ergonomic Harn library. Seven public functions replace 28+ `hostlib_code_index_*` primitives for downstream consumers (Burin Code, headless TUI workflows, future personas).

Closes burin-labs/harn#2438.

## Exports

- `code_librarian_query(cypher) -> LibrarianCypherResult` — typed Cypher pass-through.
- `code_librarian_outline(path, depth = 1) -> LibrarianOutline` — outline + import edges + reverse importers.
- `code_librarian_who_calls(symbol, max_hops = 2) -> [LibrarianCallSite]` — canned `<-[:CALLS]-` query.
- `code_librarian_what_imports(path) -> [LibrarianImport]` — typed importer edges.
- `code_librarian_recent_changes(since_seq = 0) -> [LibrarianFileChange]` — wraps `changes_since`.
- `code_librarian_freshness(path) -> LibrarianFreshness` — disk vs indexed staleness.
- `code_librarian_branch_overlay(branch) -> LibrarianOverlay` — per-branch CDC overlay; `nil` deactivates.

## Where things landed (and why)

The issue text proposes `lib/code_librarian.harn`, but the repo has no top-level `lib/` and stdlib `.harn` libraries live under `crates/harn-stdlib/src/stdlib/`, registered in `crates/harn-stdlib/src/lib.rs`. Followed that convention:

- Library: `crates/harn-stdlib/src/stdlib/stdlib_code_librarian.harn`, registered as module `code_librarian` → `import "std/code_librarian"`.
- Conformance test: `conformance/tests/stdlib/code_librarian_surface.harn`.
- Rust integration test: `crates/harn-hostlib/tests/code_librarian_recall.rs`.
- Docs: `docs/src/stdlib/code-librarian.md` (added to `docs/src/SUMMARY.md` next to the GraphQL stdlib entry).
- Example consumer: `examples/code_librarian_explore.harn`.

## Fixture reuse

The Rust integration test loads the same 30-question JSON fixture (`crates/harn-hostlib/tests/fixtures/code_index_queries/queries.json`) and corpus that #2434 uses, rebuilds the index, runs each canned Cypher through `code_librarian_query`, and asserts the librarian meets the same >= 80% aggregate recall threshold defined in #2434's acceptance criteria.

## Consumer ported

Searched the repo (`personas/`, `examples/`, `experiments/`, `crates/harn-cli/`) — no existing harn-side consumer of `hostlib_code_index_*` exists yet. Shipped `examples/code_librarian_explore.harn` as the canonical worked example so the seven functions have an in-tree caller; this is what new consumers should crib from. (Burin Code was intentionally not touched — different repo.)

## Acceptance criteria interpretations

- **`librarian.query(...)` naming** — Harn stdlib libraries use snake_case `<prefix>_<verb>` (see `std/git`, `std/json`, `std/graphql`); switched to `code_librarian_query` etc. Records keep the prescribed names (`LibrarianRecord`, `LibrarianOutline`, ...).
- **`Duration` parameter on `recent_changes`** — Harn has no native `Duration` primitive. Used the monotonic version sequence number the underlying `changes_since` already takes (`since_seq: int`). Documented the gap in both the library doc-comment and `docs/src/stdlib/code-librarian.md`.
- **`outline_get` symbols populated** — `outline_get` returns empty for the current corpus because the rebuild path leaves `IndexedFile.symbols` empty (pre-existing limitation surfaced while validating; the Cypher graph is populated independently). The library's `code_librarian_outline` therefore wraps `path_to_id` + `outline_get` + `imports_for` + `importers_of` and returns a `known/path/symbols/imports/importers` shape — when extractors start populating `IndexedFile.symbols`, the same call shape carries through.
- **`who_calls` 80% recall vs Q16-Q22 returning empty** — verified that ~half of the queries.json `<-[:CALLS]-` queries (Q16-Q22 against TypeScript) return zero rows against the current corpus, consistent with #2434's 80% (not 100%) threshold. Tests use `fetchUser` (Q19) which the executor does resolve.

## Test plan

- [ ] `cargo test -p harn-hostlib --test code_librarian_recall` — 3 tests pass (ground-truth recall, who_calls call sites, freshness + overlay roundtrip).
- [ ] `cargo run --bin harn -- test conformance --filter code_librarian_surface` — conformance test passes (13 typed-record assertions).
- [ ] `cargo run --bin harn -- lint conformance/tests/stdlib/code_librarian_surface.harn crates/harn-stdlib/src/stdlib/stdlib_code_librarian.harn examples/code_librarian_explore.harn` — no warnings.
- [ ] `cargo run --bin harn -- fmt --check ...same paths...` — no diffs.
- [ ] `cargo run --bin harn -- run examples/code_librarian_explore.harn` — prints the expected walk-through.
- [ ] `bash scripts/check_docs_snippets.sh` — every `harn` doc snippet still type-checks.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>