### PR TITLE
Fix three audit findings from #2441/#2442 (literal alias collisions, trace drop, cypher budget)

### DIFF
--- a/crates/harn-hostlib/schemas/code_index/cypher.request.json
+++ b/crates/harn-hostlib/schemas/code_index/cypher.request.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/code_index/cypher.request.json",
   "title": "code_index.cypher request",
-  "description": "Run a read-only Cypher query against the workspace typed symbol graph. Supported subset: MATCH, WHERE, RETURN with typed nodes (Function|Type|Module|Import|CallSite|Macro), typed edges (CALLS|REFS|IMPORTS|CONTAINS|OVERRIDES with `_BY` inverses), variable-length hops up to depth 4 (`*1..N`), and AND/OR/NOT predicates. The query observes the per-branch overlay if one is active (see `branch_overlay`).",
+  "description": "Run a read-only Cypher query against the workspace typed symbol graph. Supported subset: MATCH, WHERE, RETURN with typed nodes (Function|Type|Module|Import|CallSite|Macro), typed edges (CALLS|REFS|IMPORTS|CONTAINS|OVERRIDES with `_BY` inverses), variable-length hops up to depth 4 (`*1..N`), and AND/OR/NOT predicates. The query observes the per-branch overlay if one is active (see `branch_overlay`). Execution is bounded: the executor materializes at most 10,000 rows (intermediate bindings and projected rows alike) and accepts at most 3 comma-separated MATCH patterns — exceeding either budget surfaces a parse or exec error instead of running unboundedly.",
   "type": "object",
   "properties": {
     "query": {

--- a/crates/harn-hostlib/src/code_index/cypher.rs
+++ b/crates/harn-hostlib/src/code_index/cypher.rs
@@ -23,6 +23,19 @@
 //! Read-only; no MERGE/CREATE/SET. The result is a flat
 //! [`Vec<CypherRow>`] where each row maps the projected aliases to
 //! [`CypherValue`]s.
+//!
+//! Execution is bounded by two budgets enforced inside [`exec`] and
+//! [`parse`]:
+//! * [`MAX_ROWS`] — maximum number of intermediate bindings *and*
+//!   projected rows. The executor returns [`CypherError::ExecError`] as
+//!   soon as it tries to push past the cap, so a degenerate
+//!   `MATCH (a),(b),(c) RETURN ...` query cannot lock the symbol-graph
+//!   index for arbitrarily long.
+//! * [`MAX_PATTERNS`] — maximum number of comma-separated disjoint
+//!   patterns in one query. Beyond this, the parser raises
+//!   [`CypherError::ParseError`]; richer joins should use the edge
+//!   syntax (`-[:CALLS]->`) which is bounded by [`MAX_ROWS`] but does
+//!   not multiply pattern counts.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
@@ -31,6 +44,22 @@ use std::rc::Rc;
 use harn_vm::VmValue;
 
 use super::symbol_graph::{EdgeKind, NodeId, NodeKind, SymbolGraph};
+
+/// Hard upper bound on the number of rows the executor will materialize
+/// before raising [`CypherError::ExecError`]. A query like
+/// `MATCH (a),(b),(c),(d) RETURN ...` over a workspace symbol graph can
+/// produce N⁴ rows in the worst case; without a cap a single Cypher call
+/// can lock the host's symbol-graph index for many seconds. This budget
+/// matches the schema description (`code_index/cypher.request.json`).
+pub const MAX_ROWS: usize = 10_000;
+
+/// Hard upper bound on the number of comma-separated `MATCH` patterns in
+/// one query. Each additional pattern multiplies the row count, so we
+/// refuse to even start enumerating beyond three disjoint patterns —
+/// scripts that need a richer join should chain patterns through the
+/// edge syntax (`-[:CALLS]->`) rather than relying on a cartesian
+/// product. Enforced at parse time so the executor never sees one.
+pub const MAX_PATTERNS: usize = 3;
 
 /// Error variants the parser/executor raise. The host wraps these in
 /// [`crate::error::HostlibError`] before surfacing to scripts. Each
@@ -397,7 +426,15 @@ enum Literal {
 #[derive(Debug, Clone)]
 struct Projection {
     operand: Operand,
+    /// Final alias used in the projected row. Empty during parsing
+    /// when no explicit `AS` clause was supplied; filled in after the
+    /// query is fully parsed by [`resolve_projection_aliases`].
     alias: String,
+    /// `true` if the user supplied an `AS <name>` clause for this
+    /// projection. Used to disambiguate default-alias collisions
+    /// (e.g. `RETURN 1, 2` would otherwise project two `value` keys
+    /// into the same `BTreeMap`).
+    explicit_alias: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -467,6 +504,14 @@ impl<'a> Parser<'a> {
         while matches!(self.peek(), Some(Token::Comma)) {
             self.advance();
             matches.push(self.parse_pattern()?);
+            if matches.len() > MAX_PATTERNS {
+                return Err(CypherError::ParseError(format!(
+                    "too many disjoint MATCH patterns (got {}, cap is {}); \
+                     join through edge syntax (`-[:KIND]->`) instead of a cartesian product",
+                    matches.len(),
+                    MAX_PATTERNS
+                )));
+            }
         }
         let where_clause = if self.match_keyword("WHERE") {
             Some(self.parse_expr()?)
@@ -479,6 +524,7 @@ impl<'a> Parser<'a> {
             self.advance();
             projections.push(self.parse_projection()?);
         }
+        resolve_projection_aliases(&mut projections)?;
         Ok(Query {
             matches,
             where_clause,
@@ -729,7 +775,7 @@ impl<'a> Parser<'a> {
         let operand = self.parse_operand()?;
         let alias = if self.match_keyword("AS") {
             match self.advance() {
-                Some(Token::Ident(s)) => s.clone(),
+                Some(Token::Ident(s)) => Some(s.clone()),
                 other => {
                     return Err(CypherError::ParseError(format!(
                         "expected alias after AS, got {other:?}"
@@ -737,9 +783,14 @@ impl<'a> Parser<'a> {
                 }
             }
         } else {
-            default_alias(&operand)
+            None
         };
-        Ok(Projection { operand, alias })
+        let explicit_alias = alias.is_some();
+        Ok(Projection {
+            operand,
+            alias: alias.unwrap_or_default(),
+            explicit_alias,
+        })
     }
 }
 
@@ -755,6 +806,59 @@ fn default_alias(operand: &Operand) -> String {
         } => format!("{var}.{p}"),
         Operand::Literal(_) => "value".to_string(),
     }
+}
+
+/// Assign default aliases to every projection that didn't get an
+/// explicit `AS <name>`. Default aliases for literal operands all start
+/// as `"value"`, so without deduplication a query like `RETURN 1, 2`
+/// would silently overwrite the first column. We resolve the collision
+/// deterministically by suffixing the second, third, … occurrence with
+/// `_2`, `_3`, … For non-literal default aliases (`var` or
+/// `var.property`) we leave names unchanged because they are already
+/// disambiguated by the underlying path. If a default-derived alias
+/// collides with an explicit alias, the default is suffixed; an
+/// explicit alias colliding with another explicit alias raises a
+/// `ParseError::ParseError` because that is a user authoring mistake.
+fn resolve_projection_aliases(projections: &mut [Projection]) -> Result<(), CypherError> {
+    use std::collections::HashSet;
+
+    // First pass: collect explicit aliases and detect duplicates among them.
+    let mut seen: HashSet<String> = HashSet::new();
+    for proj in projections.iter() {
+        if proj.explicit_alias && !seen.insert(proj.alias.clone()) {
+            return Err(CypherError::ParseError(format!(
+                "duplicate alias `{}` in RETURN clause",
+                proj.alias
+            )));
+        }
+    }
+
+    // Second pass: fill in default aliases with collision-suffixing.
+    let mut literal_count: usize = 0;
+    for proj in projections.iter_mut() {
+        if proj.explicit_alias {
+            continue;
+        }
+        let base = default_alias(&proj.operand);
+        let is_literal_default = matches!(proj.operand, Operand::Literal(_));
+        let mut candidate = base.clone();
+        if is_literal_default {
+            literal_count += 1;
+            if literal_count >= 2 {
+                candidate = format!("{base}_{literal_count}");
+            }
+        }
+        // Guard against any other accidental collision (default path
+        // alias clashing with an explicit alias or another default).
+        let mut bump: usize = 2;
+        while seen.contains(&candidate) {
+            candidate = format!("{base}_{bump}");
+            bump += 1;
+        }
+        seen.insert(candidate.clone());
+        proj.alias = candidate;
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -773,6 +877,17 @@ fn exec(query: &Query, graph: &SymbolGraph) -> Result<Vec<CypherRow>, CypherErro
                     merged.insert(k, v);
                 }
                 new_rows.push(merged);
+                // Pre-projection budget: a cartesian explosion can
+                // balloon `new_rows` long before we ever start
+                // building projected rows, so we cap intermediate
+                // bindings too.
+                if new_rows.len() > MAX_ROWS {
+                    return Err(CypherError::ExecError(format!(
+                        "row budget exceeded ({} > {}); narrow the MATCH or add a WHERE clause",
+                        new_rows.len(),
+                        MAX_ROWS
+                    )));
+                }
             }
         }
         all_rows = new_rows;
@@ -791,6 +906,16 @@ fn exec(query: &Query, graph: &SymbolGraph) -> Result<Vec<CypherRow>, CypherErro
             row.insert(proj.alias.clone(), v);
         }
         out.push(row);
+        // Post-WHERE budget: even if intermediate bindings stayed
+        // under the cap, a permissive projection on a wide graph can
+        // still hand back too many rows.
+        if out.len() > MAX_ROWS {
+            return Err(CypherError::ExecError(format!(
+                "row budget exceeded ({} > {}); narrow the MATCH or add a WHERE clause",
+                out.len(),
+                MAX_ROWS
+            )));
+        }
     }
     Ok(out)
 }
@@ -1108,6 +1233,71 @@ mod tests {
         assert_eq!(
             rows[0].get("path"),
             Some(&CypherValue::String("src/a.rs".into()))
+        );
+    }
+
+    #[test]
+    fn literal_default_aliases_do_not_collide() {
+        // `RETURN 1, 2, 3` previously projected all three literals under
+        // the same `"value"` key, silently overwriting earlier columns.
+        // The deduplicator suffixes the 2nd/3rd literals as `value_2`
+        // / `value_3` so every literal makes it into the row.
+        let g = fixture();
+        let rows = execute("MATCH (f:Function {name: 'start'}) RETURN 1, 2, 3", &g).unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.get("value"), Some(&CypherValue::Int(1)));
+        assert_eq!(row.get("value_2"), Some(&CypherValue::Int(2)));
+        assert_eq!(row.get("value_3"), Some(&CypherValue::Int(3)));
+    }
+
+    #[test]
+    fn duplicate_explicit_aliases_are_rejected() {
+        let g = fixture();
+        let err = execute("MATCH (f:Function) RETURN f.name AS n, f.path AS n", &g).unwrap_err();
+        assert!(
+            matches!(err, CypherError::ParseError(_)),
+            "expected ParseError for duplicate explicit alias, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_too_many_disjoint_patterns() {
+        // Four disjoint patterns is one more than `MAX_PATTERNS`; the
+        // parser refuses before the executor ever sees the cartesian
+        // explosion.
+        let g = fixture();
+        let err = execute(
+            "MATCH (a:Function),(b:Function),(c:Function),(d:Function) RETURN a.name",
+            &g,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(&err, CypherError::ParseError(msg) if msg.contains("too many disjoint MATCH patterns")),
+            "expected ParseError for too many patterns, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn enforces_row_budget_on_cartesian_explosion() {
+        // Build a synthetic graph with enough Function nodes that even
+        // a three-pattern cartesian product blows the row budget.
+        // 25 * 25 * 25 = 15,625 > MAX_ROWS (10,000).
+        let mut g = SymbolGraph::new();
+        let mut source = String::new();
+        for i in 0..25 {
+            source.push_str(&format!("fn f{i}() {{}}\n"));
+        }
+        g.rebuild_file(1, "src/big.rs", Language::Rust, &source, &[]);
+
+        let err = execute(
+            "MATCH (a:Function),(b:Function),(c:Function) RETURN a.name AS n",
+            &g,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(&err, CypherError::ExecError(msg) if msg.contains("row budget exceeded")),
+            "expected ExecError for row budget, got {err:?}"
         );
     }
 

--- a/crates/harn-vm/src/orchestration/crystallize/trajectory.rs
+++ b/crates/harn-vm/src/orchestration/crystallize/trajectory.rs
@@ -557,9 +557,13 @@ fn verify_trajectory_candidate_with_tolerance(
 /// surface.
 ///
 /// Returns `Ok(None)` when no segments cleared `min_segment_len`. When
-/// only a single segment is produced, falls back to
-/// [`synthesize_candidate_from_trace`] so a one-session trajectory
-/// still yields a candidate.
+/// fewer than `min_examples` segments are produced, falls back to
+/// [`synthesize_candidate_from_trace`] using the first trace so a
+/// short trajectory still yields a candidate. Any additional segments
+/// not picked up by synthesis are still returned in
+/// [`TrajectoryIngestResult::traces`] so callers / verifiers / bundle
+/// builders can see them, and a `tracing::warn!` is emitted listing the
+/// ids of the traces the synthesis path did not consume.
 pub fn ingest_agent_loop_trajectory(
     tap: &TrajectoryTap,
     turns: &[AgentTurnRecord],
@@ -571,10 +575,28 @@ pub fn ingest_agent_loop_trajectory(
     }
     let needs_synthesis = traces.len() < options.min_examples.max(2);
     let (mut artifacts, trace_pool) = if needs_synthesis {
-        let trace = traces.into_iter().next().expect("non-empty by check above");
-        let artifacts =
-            synthesize_candidate_from_trace(trace.clone(), options, Vec::new(), None, None)?;
-        (artifacts, vec![trace])
+        // Synthesis builds a single-trace candidate, but we must not
+        // silently discard the other traces — they still belong to
+        // the result so the bundle pipeline, verifier, and any
+        // downstream auditor can observe the full ingested set.
+        let trace_pool = traces.clone();
+        let mut iter = traces.into_iter();
+        let primary = iter.next().expect("non-empty by check above");
+        let dropped_from_synthesis: Vec<String> = iter.map(|t| t.id).collect();
+        if !dropped_from_synthesis.is_empty() {
+            tracing::warn!(
+                target: "harn_vm::crystallize::trajectory",
+                primary_trace_id = %primary.id,
+                dropped_trace_ids = ?dropped_from_synthesis,
+                min_examples = options.min_examples,
+                segment_count = trace_pool.len(),
+                "trajectory synthesis kept only the first trace; \
+                 remaining traces are surfaced via TrajectoryIngestResult.traces \
+                 but are not part of the synthesized candidate"
+            );
+        }
+        let artifacts = synthesize_candidate_from_trace(primary, options, Vec::new(), None, None)?;
+        (artifacts, trace_pool)
     } else {
         let trace_pool = traces.clone();
         let artifacts = crystallize_traces(traces, options)?;

--- a/crates/harn-vm/tests/trajectory_tap.rs
+++ b/crates/harn-vm/tests/trajectory_tap.rs
@@ -232,6 +232,89 @@ fn verifier_rejects_candidate_when_trace_diverges() {
             .any(|reason| reason.contains("trajectory verifier"))));
 }
 
+/// Build a synthetic agent turn with a single tool call whose name is
+/// driven by `tool` so consecutive turns with different `tool` values
+/// land in different signature groups (and therefore different
+/// trajectory segments).
+fn distinct_tool_turn(iteration: usize, tool: &str) -> AgentTurnRecord {
+    AgentTurnRecord {
+        iteration,
+        session_id: "synthesis_drop_session".to_string(),
+        success: true,
+        tool_calls: vec![merge_captain_call(
+            iteration,
+            tool,
+            &[("repo", json!("burin-labs/harn"))],
+        )],
+        provider: Some("openrouter".to_string()),
+        model: Some("anthropic/claude-haiku".to_string()),
+        input_tokens: 100,
+        output_tokens: 50,
+        duration_ms: Some(200),
+        assistant_text: Some(format!("ran {tool}")),
+        ..AgentTurnRecord::default()
+    }
+}
+
+#[test]
+fn synthesis_branch_surfaces_all_traces_to_caller() {
+    // Bug 2 regression: when `tap.collect()` returns multiple segments
+    // but the count falls below `min_examples.max(2)`, the synthesis
+    // branch used to `.into_iter().next()` and silently drop the rest
+    // of the traces. The fix keeps every collected trace in
+    // `TrajectoryIngestResult::traces` (and emits a `tracing::warn!`
+    // for the dropped-from-synthesis ids).
+    //
+    // We construct three turn-pairs with distinct tool-call signatures
+    // so the TrajectoryTap splits them into three separate segments,
+    // then set `min_examples = 5` to force the synthesis fallback.
+    let turns = vec![
+        distinct_tool_turn(1, "list_open_prs"),
+        distinct_tool_turn(2, "list_open_prs"),
+        distinct_tool_turn(3, "check_ci_status"),
+        distinct_tool_turn(4, "check_ci_status"),
+        distinct_tool_turn(5, "label_pr"),
+        distinct_tool_turn(6, "label_pr"),
+    ];
+    let tap = TrajectoryTap::new("synthesis_drop_session").with_similarity_threshold(1.0);
+    let collected = tap.collect(&turns);
+    assert!(
+        collected.len() >= 3,
+        "fixture should split into at least 3 segments, got {}",
+        collected.len()
+    );
+    let collected_ids: Vec<String> = collected.iter().map(|t| t.id.clone()).collect();
+
+    let result = ingest_agent_loop_trajectory(
+        &tap,
+        &turns,
+        CrystallizeOptions {
+            min_examples: 5,
+            workflow_name: Some("synthesis_drop_workflow".to_string()),
+            ..CrystallizeOptions::default()
+        },
+    )
+    .expect("ingest")
+    .expect("at least one trace");
+
+    // Pre-fix code returned only the first trace here. Post-fix, every
+    // segment the tap surfaced must appear in the result.
+    assert_eq!(
+        result.traces.len(),
+        collected.len(),
+        "all collected traces should be surfaced to the caller; \
+         got {:?}, expected {:?}",
+        result.traces.iter().map(|t| &t.id).collect::<Vec<_>>(),
+        collected_ids,
+    );
+    for id in &collected_ids {
+        assert!(
+            result.traces.iter().any(|t| &t.id == id),
+            "trace id `{id}` missing from result.traces (would have been silently dropped)"
+        );
+    }
+}
+
 #[test]
 fn failed_turn_splits_segment_into_two_candidates() {
     // A failed turn between two successful runs must not appear in any


### PR DESCRIPTION
## Summary

Three focused correctness fixes from an audit pass over PRs #2441 / #2442. Each finding is fenced by a regression test that fails on the pre-fix code.

### 1. Silent literal-alias collisions in Cypher `RETURN`
`crates/harn-hostlib/src/code_index/cypher.rs` — `default_alias` hardcoded `"value"` for every `Operand::Literal`. A query like `RETURN 1, 2, 3` projected three rows into the same `BTreeMap` key, silently dropping every literal but the last. Default literal aliases are now deduplicated as `value`, `value_2`, `value_3`, … and duplicate *explicit* aliases (`f.name AS n, f.path AS n`) raise a `CypherError::ParseError` instead of overwriting silently. A new `Projection::explicit_alias` flag drives the post-parse `resolve_projection_aliases` pass.

### 2. Silent trace loss in trajectory crystallization
`crates/harn-vm/src/orchestration/crystallize/trajectory.rs` — `ingest_agent_loop_trajectory` synthesis branch did `.into_iter().next()` on the collected traces and silently dropped every trace after the first whenever the segment count was below `min_examples.max(2)`. With `min_examples = 5` and 4 collected segments, three trajectory segments vanished without diagnostic. Synthesis still consumes only the first trace (that is the function contract — `synthesize_candidate_from_trace` is single-trace by design), but all collected traces now ride through to `TrajectoryIngestResult.traces` so the bundle / verifier / downstream auditor can observe the full ingested set, and the dropped ids are reported via `tracing::warn!`.

### 3. No exec budget on the Cypher executor
`crates/harn-hostlib/src/code_index/cypher.rs` + `crates/harn-hostlib/schemas/code_index/cypher.request.json` — only a 4-deep variable-length cap existed; a query like `MATCH (a),(b),(c),(d) RETURN ...` could trigger N⁴ cartesian enumeration over the workspace symbol graph and lock the index for many seconds. Added a `MAX_ROWS = 10_000` budget enforced inside `exec` on both intermediate bindings *and* projected rows (short-circuits with `CypherError::ExecError` once the cap is crossed) and a parse-time `MAX_PATTERNS = 3` cap that rejects degenerate disjoint-pattern joins with `CypherError::ParseError`. Both caps are surfaced in the request-schema description.

## Audit source

Audit pass over the changes landed in #2441 / #2442. No `Closes` footer — these aren't tracking issues; the PR is self-describing.

## Test plan
- [x] Bug 1: `code_index::cypher::tests::literal_default_aliases_do_not_collide` asserts `RETURN 1, 2, 3` projects three distinct keys (`value`, `value_2`, `value_3`).
- [x] Bug 1: `code_index::cypher::tests::duplicate_explicit_aliases_are_rejected` asserts duplicate `AS` aliases raise `ParseError`.
- [x] Bug 2: `tests/trajectory_tap.rs::synthesis_branch_surfaces_all_traces_to_caller` builds 3 distinct-signature segments with `min_examples = 5` and asserts every collected trace appears in `result.traces` (pre-fix: only 1 of 3 surfaced).
- [x] Bug 3: `code_index::cypher::tests::enforces_row_budget_on_cartesian_explosion` builds a 25-Function graph and asserts `MATCH (a),(b),(c) RETURN a.name` short-circuits with `ExecError` ("row budget exceeded").
- [x] Bug 3: `code_index::cypher::tests::rejects_too_many_disjoint_patterns` asserts 4 disjoint patterns raise `ParseError` before the executor ever runs.
- [x] `cargo clippy -p harn-hostlib -p harn-vm --lib --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)