### PR TITLE
code_index: populate IndexedFile.symbols during rebuild (#2456)

### DIFF
--- a/crates/harn-hostlib/src/code_index/file_table.rs
+++ b/crates/harn-hostlib/src/code_index/file_table.rs
@@ -11,9 +11,10 @@
 /// without invalidating string keys.
 pub type FileId = u32;
 
-/// Outline-style symbol entry. Reserved for AST integration; the code-index
-/// importer leaves `IndexedFile::symbols` empty, but the shape is kept stable
-/// so storage upgrades won't have to re-key.
+/// Outline-style symbol entry. Populated during the index rebuild from
+/// the same tree-sitter parse that backs the typed symbol graph (issue
+/// #2456); files whose extension doesn't map to a known grammar leave
+/// `IndexedFile::symbols` empty.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexedSymbol {
     /// Symbol name (e.g. `"helper"`).
@@ -47,7 +48,9 @@ pub struct IndexedFile {
     pub content_hash: u64,
     /// Last-modified time in milliseconds since the Unix epoch.
     pub mtime_ms: i64,
-    /// Outline symbols supplied by callers that have richer syntax context.
+    /// Outline symbols extracted from the tree-sitter parse driven by
+    /// [`super::IndexState::rebuild_symbol_graph_for`]. Empty for files
+    /// without a recognised grammar.
     pub symbols: Vec<IndexedSymbol>,
     /// Raw import statement strings extracted from the file.
     pub imports: Vec<String>,

--- a/crates/harn-hostlib/src/code_index/state.rs
+++ b/crates/harn-hostlib/src/code_index/state.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::agents::AgentRegistry;
-use super::file_table::{fnv1a64, FileId, IndexedFile};
+use super::file_table::{fnv1a64, FileId, IndexedFile, IndexedSymbol};
 use super::graph::DepGraph;
 use super::imports;
 use super::overlay::OverlayState;
@@ -25,7 +25,7 @@ use super::versions::VersionLog;
 use super::walker::{is_indexable_file, language_for_extension, walk_indexable, MAX_FILE_BYTES};
 use super::words::WordIndex;
 
-use crate::ast::Language as AstLanguage;
+use crate::ast::{Language as AstLanguage, Symbol as AstSymbol};
 
 /// In-memory index for one workspace. Composed from the per-file table,
 /// the trigram + word sub-indexes, the dep graph, the append-only version
@@ -238,7 +238,11 @@ impl IndexState {
     /// graph in [`Self::symbols`]. Cheap to call after a single-file
     /// reindex; the full-rebuild loop calls this once per file. Files
     /// with no recognised tree-sitter grammar (the index also handles
-    /// `.md`, `.json`, …) are skipped silently.
+    /// `.md`, `.json`, …) are skipped silently — `IndexedFile::symbols`
+    /// stays empty for those files. For grammar-recognised files the
+    /// same parse populates `IndexedFile::symbols` so the
+    /// `outline_get` builtin doesn't have to re-parse on every call
+    /// (issue #2456).
     pub(super) fn rebuild_symbol_graph_for(&mut self, id: FileId) {
         let Some(file) = self.files.get(&id).cloned() else {
             return;
@@ -251,8 +255,16 @@ impl IndexState {
         else {
             return;
         };
-        self.symbols
-            .rebuild_file(id, &file.relative_path, language, &source, &file.imports);
+        let outcome =
+            self.symbols
+                .rebuild_file(id, &file.relative_path, language, &source, &file.imports);
+        if let Some(file_mut) = self.files.get_mut(&id) {
+            file_mut.symbols = outcome
+                .symbols
+                .iter()
+                .map(indexed_symbol_from_ast)
+                .collect();
+        }
     }
 
     /// Walk every file's import-resolution table and add the
@@ -341,6 +353,20 @@ impl IndexState {
     /// Restore the `next_id` counter from a serialised snapshot.
     pub(crate) fn set_next_file_id(&mut self, id: FileId) {
         self.next_id = id.max(1);
+    }
+}
+
+/// Map an AST-level [`AstSymbol`] (0-based tree-sitter coordinates) into
+/// the flat [`IndexedSymbol`] (1-based outline coordinates) that the
+/// `outline_get` builtin returns. Pure, used by
+/// [`IndexState::rebuild_symbol_graph_for`].
+fn indexed_symbol_from_ast(sym: &AstSymbol) -> IndexedSymbol {
+    IndexedSymbol {
+        name: sym.name.clone(),
+        kind: sym.kind.as_str().to_string(),
+        start_line: sym.start_row.saturating_add(1),
+        end_line: sym.end_row.saturating_add(1),
+        signature: sym.signature.clone(),
     }
 }
 

--- a/crates/harn-hostlib/src/code_index/symbol_graph.rs
+++ b/crates/harn-hostlib/src/code_index/symbol_graph.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use tree_sitter::{Node as TsNode, Tree};
 
-use crate::ast::{api as ast_api, Language, SymbolKind};
+use crate::ast::{api as ast_api, Language, Symbol, SymbolKind};
 
 use super::file_table::FileId;
 
@@ -160,6 +160,19 @@ pub struct Edge {
     pub kind: EdgeKind,
 }
 
+/// Result of [`SymbolGraph::rebuild_file`]. Exposes the flat symbol list
+/// produced by the tree-sitter parse so callers can populate sibling
+/// indexes (e.g. `IndexedFile::symbols`) without re-parsing.
+#[derive(Debug, Clone, Default)]
+pub struct RebuildOutcome {
+    /// Number of nodes installed for this file, including the Module
+    /// node. Matches the previous `usize` return value.
+    pub node_count: usize,
+    /// Flat symbol list extracted from the parse. Empty when the
+    /// grammar didn't recognise the source.
+    pub symbols: Vec<Symbol>,
+}
+
 /// Typed symbol graph for a single workspace.
 #[derive(Debug, Default, Clone)]
 pub struct SymbolGraph {
@@ -284,7 +297,10 @@ impl SymbolGraph {
 
     /// Replace every node + edge belonging to `file_id` with the freshly
     /// parsed set derived from `source`. Returns the count of nodes
-    /// installed (including the per-file Module node).
+    /// installed (including the per-file Module node) along with the
+    /// flat symbol list that was extracted from the parse — callers
+    /// (notably [`super::IndexState`]) reuse the symbol list to populate
+    /// `IndexedFile::symbols` without re-parsing.
     pub fn rebuild_file(
         &mut self,
         file_id: FileId,
@@ -292,7 +308,7 @@ impl SymbolGraph {
         language: Language,
         source: &str,
         import_strings: &[String],
-    ) -> usize {
+    ) -> RebuildOutcome {
         self.remove_file(file_id);
         let module_id = self.add_module_for_file(file_id, path, &language);
 
@@ -400,7 +416,11 @@ impl SymbolGraph {
             self.add_edge(module_id, target, EdgeKind::Refs);
         }
 
-        self.by_file.get(&file_id).map(Vec::len).unwrap_or_default()
+        let node_count = self.by_file.get(&file_id).map(Vec::len).unwrap_or_default();
+        RebuildOutcome {
+            node_count,
+            symbols,
+        }
     }
 
     /// Resolve every IMPORTS edge whose target is currently an `Import`
@@ -587,8 +607,16 @@ mod tests {
     #[test]
     fn add_and_remove_round_trip() {
         let mut g = SymbolGraph::new();
-        let count = g.rebuild_file(1, "src/a.rs", Language::Rust, "fn foo() {}\n", &[]);
-        assert!(count >= 2, "module + function expected, got {count}");
+        let outcome = g.rebuild_file(1, "src/a.rs", Language::Rust, "fn foo() {}\n", &[]);
+        assert!(
+            outcome.node_count >= 2,
+            "module + function expected, got {}",
+            outcome.node_count
+        );
+        assert!(
+            outcome.symbols.iter().any(|s| s.name == "foo"),
+            "rebuild_file should surface the parsed `foo` symbol"
+        );
         assert!(!g.nodes_named("foo").is_empty());
         g.remove_file(1);
         assert_eq!(g.node_count(), 0);
@@ -599,8 +627,12 @@ mod tests {
     fn rebuild_file_emits_function_module_and_call_nodes() {
         let mut g = SymbolGraph::new();
         let src = "fn alpha() {}\nfn beta() { alpha(); }\n";
-        let count = g.rebuild_file(7, "src/x.rs", Language::Rust, src, &[]);
-        assert!(count >= 3, "expected module + 2 functions, got {count}");
+        let outcome = g.rebuild_file(7, "src/x.rs", Language::Rust, src, &[]);
+        assert!(
+            outcome.node_count >= 3,
+            "expected module + 2 functions, got {}",
+            outcome.node_count
+        );
         let alpha_funcs: Vec<_> = g
             .iter_nodes()
             .filter(|n| n.kind == NodeKind::Function && n.name == "alpha")

--- a/crates/harn-hostlib/tests/code_index_live_state.rs
+++ b/crates/harn-hostlib/tests/code_index_live_state.rs
@@ -501,6 +501,51 @@ fn outline_get_returns_empty_for_unknown_id() {
     assert!(extract_list(&outline).is_empty());
 }
 
+#[test]
+fn outline_get_populates_symbols_after_rebuild() {
+    // Issue #2456: rebuild used to leave `IndexedFile::symbols` empty
+    // even though the typed symbol graph did parse the file. Now the
+    // same parse populates both; `outline_get` must surface the
+    // resulting flat outline.
+    let dir = workspace();
+    let (registry, _) = build();
+    rebuild_in(dir.path(), &registry);
+
+    let util_id = extract_int(&call(
+        &registry,
+        "hostlib_code_index_path_to_id",
+        dict(&[("path", VmValue::String(Rc::from("src/util.ts")))]),
+    ));
+    let outline = call(
+        &registry,
+        "hostlib_code_index_outline_get",
+        dict(&[("file_id", VmValue::Int(util_id))]),
+    );
+    let entries = extract_list(&outline);
+    assert!(
+        !entries.is_empty(),
+        "outline_get should return at least one symbol for src/util.ts after rebuild"
+    );
+    let helper = entries
+        .iter()
+        .find(|v| {
+            let d = extract_dict(v);
+            matches!(d.get("name"), Some(VmValue::String(s)) if s.as_ref() == "helper")
+        })
+        .expect("expected a `helper` symbol in src/util.ts");
+    let helper_dict = extract_dict(helper);
+    let kind = match helper_dict.get("kind") {
+        Some(VmValue::String(s)) => s.to_string(),
+        other => panic!("expected string kind, got {other:?}"),
+    };
+    assert_eq!(kind, "function", "`helper` should be a function symbol");
+    let start_line = extract_int(helper_dict.get("start_line").expect("start_line"));
+    assert!(
+        start_line >= 1,
+        "start_line should be 1-based, got {start_line}"
+    );
+}
+
 // === Change log ===
 
 #[test]


### PR DESCRIPTION
## Summary

The typed symbol graph (#2434, shipped in PR #2441) extracts function /
type / module symbols from a tree-sitter parse on every rebuild, but
never wrote them back to the existing flat `IndexedFile::symbols`
outline that the `hostlib_code_index_outline_get` builtin returns.
Effect: `outline_get(path)` reported an empty outline on every corpus
even though the Cypher graph was fully populated.

## Fix (single-parse path)

- `SymbolGraph::rebuild_file` now returns
  `RebuildOutcome { node_count, symbols }`, exposing the
  `Vec<ast::Symbol>` it already extracted from the tree-sitter parse.
- `IndexState::rebuild_symbol_graph_for` maps those into
  `IndexedSymbol { name, kind, start_line, end_line, signature }`
  (1-based lines to match the wire format) and writes them into
  `IndexedFile::symbols`.
- No extra parse — the same single tree-sitter parse feeds both the
  graph and the flat outline.
- Existing call sites in `overlay.rs` and `cypher.rs` keep working
  because they ignore the return value.

## Tests

- New integration test in `crates/harn-hostlib/tests/code_index_live_state.rs`:
  `outline_get_populates_symbols_after_rebuild` asserts a non-empty
  outline and a `helper` function symbol for `src/util.ts` in the
  shared workspace fixture.
- Tightened the existing `SymbolGraph::rebuild_file` unit tests to
  assert the returned `symbols` list surfaces the expected names.
- The conformance test
  `conformance/tests/stdlib/code_librarian_surface.harn` (added in the
  still-open PR #2455) was intentionally not modified here — that file
  isn't on `main` yet, so tightening it belongs in the #2455 merge.
  Once both land, the librarian wrapper picks up the populated outline
  automatically.

## Test plan

- [x] `cargo test -p harn-hostlib --lib code_index` — 54 / 54 pass
- [x] `cargo test -p harn-hostlib --test code_index_live_state` —
      new test passes alongside the unknown-id case
- [x] `cargo test -p harn-hostlib --test code_index_cypher_recall
      --test code_index_graph_surface --test code_index_scenario` —
      no regressions

Closes burin-labs/harn#2456

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>