### PR TITLE
polish: 4 follow-ups from #2441/#2442/#2443 audit (#2454)

### DIFF
--- a/crates/harn-hostlib/src/code_index/cypher.rs
+++ b/crates/harn-hostlib/src/code_index/cypher.rs
@@ -16,9 +16,11 @@
 //! ```
 //!
 //! Variable-length traversal up to depth 4 is supported via `*1..N` or
-//! the shorthand `*` (defaults to `1..3`). The executor implements
-//! depth-first enumeration with a per-step visited set so cycles can't
-//! infinite-loop.
+//! the shorthand `*` (defaults to `1..3`). When the upper bound is
+//! omitted (e.g. `*1..` or `*2..`), it defaults to the executor depth
+//! cap (4) — matching the usual Cypher "open upper bound = capped by
+//! engine" semantics. The executor implements depth-first enumeration
+//! with a per-step visited set so cycles can't infinite-loop.
 //!
 //! Read-only; no MERGE/CREATE/SET. The result is a flat
 //! [`Vec<CypherRow>`] where each row maps the projected aliases to
@@ -60,6 +62,11 @@ pub const MAX_ROWS: usize = 10_000;
 /// edge syntax (`-[:CALLS]->`) rather than relying on a cartesian
 /// product. Enforced at parse time so the executor never sees one.
 pub const MAX_PATTERNS: usize = 3;
+
+/// Maximum traversal depth for variable-length patterns (`*lo..hi`).
+/// Also used as the implicit upper bound when the high end is omitted
+/// (e.g. `*1..`), matching standard "open upper bound" Cypher semantics.
+const VAR_LENGTH_MAX_DEPTH: u32 = 4;
 
 /// Error variants the parser/executor raise. The host wraps these in
 /// [`crate::error::HostlibError`] before surfacing to scripts. Each
@@ -575,7 +582,11 @@ impl<'a> Parser<'a> {
                     } else {
                         None
                     };
-                    (lo.unwrap_or(1) as u32, hi.unwrap_or(3) as u32)
+                    // `*lo..` with no upper bound: default to the executor
+                    // depth cap so users opt into the maximum traversal
+                    // length without naming it explicitly.
+                    let hi_v = hi.map(|n| n as u32).unwrap_or(VAR_LENGTH_MAX_DEPTH);
+                    (lo.unwrap_or(1) as u32, hi_v)
                 } else {
                     // bare `*`: 1..3
                     let lo_v = lo.unwrap_or(1) as u32;
@@ -965,9 +976,9 @@ fn extend_steps(
     // Pattern arrow direction XOR label inversion = effective direction.
     let forward = step.forward ^ label_reversed;
     let (lo, hi) = step.var_length.unwrap_or((1, 1));
-    if hi > 4 {
+    if hi > VAR_LENGTH_MAX_DEPTH {
         return Err(CypherError::ExecError(format!(
-            "variable-length traversal capped at depth 4 (got `*{lo}..{hi}`)"
+            "variable-length traversal capped at depth {VAR_LENGTH_MAX_DEPTH} (got `*{lo}..{hi}`)"
         )));
     }
     let lo = lo.max(1);
@@ -1299,6 +1310,21 @@ mod tests {
             matches!(&err, CypherError::ExecError(msg) if msg.contains("row budget exceeded")),
             "expected ExecError for row budget, got {err:?}"
         );
+    }
+
+    #[test]
+    fn open_upper_bound_defaults_to_depth_cap() {
+        // `*1..` (no hi) should fall back to VAR_LENGTH_MAX_DEPTH, not 3.
+        let toks = lex("MATCH (a:Function)-[:CALLS*1..]->(b:Function) RETURN a.name AS n").unwrap();
+        let q = parse(&toks).unwrap();
+        let step = &q.matches[0].steps[0];
+        assert_eq!(step.var_length, Some((1, VAR_LENGTH_MAX_DEPTH)));
+
+        // `*2..` likewise.
+        let toks = lex("MATCH (a:Function)-[:CALLS*2..]->(b:Function) RETURN a.name AS n").unwrap();
+        let q = parse(&toks).unwrap();
+        let step = &q.matches[0].steps[0];
+        assert_eq!(step.var_length, Some((2, VAR_LENGTH_MAX_DEPTH)));
     }
 
     #[test]

--- a/crates/harn-hostlib/src/code_index/overlay.rs
+++ b/crates/harn-hostlib/src/code_index/overlay.rs
@@ -19,12 +19,22 @@
 //!   by both manual stage-and-apply tests and a future Git-driven
 //!   change-detector.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::ast::Language;
 
 use super::file_table::FileId;
 use super::symbol_graph::SymbolGraph;
+
+/// Cap on the number of branch overlays kept in memory at once.
+///
+/// Each registered overlay holds a full `materialized` clone of the base
+/// graph (see [`BranchOverlay::materialize`]), so unbounded registration
+/// is a real memory leak for long-running daemons that swap between many
+/// branches. The cap evicts the least-recently-set overlay when this is
+/// exceeded — chosen large enough to comfortably cover typical
+/// stack-of-PRs flows while keeping the bound predictable.
+pub const OVERLAY_CAPACITY: usize = 8;
 
 /// Per-file delta entry kept on an overlay.
 #[derive(Debug, Clone)]
@@ -119,9 +129,18 @@ impl BranchOverlay {
 
 /// Holder for the active overlay (if any). Threaded through the index
 /// state so every Cypher query can opt into the per-branch view.
+///
+/// Overlay storage is bounded by [`OVERLAY_CAPACITY`]; once that many
+/// branches have been registered, [`Self::set`] evicts the
+/// least-recently-set overlay to keep daemon memory predictable. Each
+/// overlay still owns a full base-graph clone (see
+/// [`BranchOverlay::materialize`]), so the cap matters in practice.
 #[derive(Debug, Default, Clone)]
 pub struct OverlayState {
     overlays: BTreeMap<String, BranchOverlay>,
+    /// Insertion order of branch names, used to evict the oldest entry
+    /// when `overlays.len()` would exceed [`OVERLAY_CAPACITY`].
+    insertion_order: VecDeque<String>,
     active: Option<String>,
 }
 
@@ -133,8 +152,26 @@ impl OverlayState {
 
     /// Insert or replace a branch overlay. Activating it is a separate
     /// step ([`Self::activate`]).
+    ///
+    /// When the registry already holds [`OVERLAY_CAPACITY`] distinct
+    /// branches, the oldest one is evicted before insertion. If the
+    /// evicted overlay happens to be currently active, the active slot
+    /// is cleared so we don't leave a dangling pointer.
     pub fn set(&mut self, overlay: BranchOverlay) {
-        self.overlays.insert(overlay.branch.clone(), overlay);
+        let branch = overlay.branch.clone();
+        // Bump branch to "most recent" if it was already present.
+        if self.overlays.contains_key(&branch) {
+            self.insertion_order.retain(|b| b != &branch);
+        } else if self.overlays.len() >= OVERLAY_CAPACITY {
+            if let Some(victim) = self.insertion_order.pop_front() {
+                self.overlays.remove(&victim);
+                if self.active.as_deref() == Some(victim.as_str()) {
+                    self.active = None;
+                }
+            }
+        }
+        self.insertion_order.push_back(branch.clone());
+        self.overlays.insert(branch, overlay);
     }
 
     /// Borrow a stored overlay (if registered).
@@ -247,6 +284,62 @@ mod tests {
         assert!(
             (0.66..1.0).contains(&reuse),
             "expected ~2/3 reuse, got {reuse}"
+        );
+    }
+
+    #[test]
+    fn registry_evicts_oldest_overlay_past_capacity() {
+        let base = base_graph();
+        let mut state = OverlayState::new();
+        // Fill the registry exactly to capacity.
+        for i in 0..OVERLAY_CAPACITY {
+            let mut overlay = BranchOverlay::new(format!("topic/{i}"));
+            overlay.materialize(&base);
+            state.set(overlay);
+        }
+        assert!(state.get("topic/0").is_some());
+        assert_eq!(state.overlays.len(), OVERLAY_CAPACITY);
+
+        // One more — the oldest (topic/0) should be evicted.
+        let mut overflow = BranchOverlay::new("topic/new");
+        overflow.materialize(&base);
+        state.set(overflow);
+        assert_eq!(state.overlays.len(), OVERLAY_CAPACITY);
+        assert!(
+            state.get("topic/0").is_none(),
+            "expected oldest overlay to be evicted"
+        );
+        assert!(state.get("topic/new").is_some());
+
+        // Re-setting an existing branch must not evict anything — it
+        // just refreshes recency.
+        let mut refreshed = BranchOverlay::new("topic/1");
+        refreshed.materialize(&base);
+        state.set(refreshed);
+        assert_eq!(state.overlays.len(), OVERLAY_CAPACITY);
+        assert!(state.get("topic/1").is_some());
+    }
+
+    #[test]
+    fn evicting_active_overlay_clears_active_slot() {
+        let base = base_graph();
+        let mut state = OverlayState::new();
+        for i in 0..OVERLAY_CAPACITY {
+            let mut overlay = BranchOverlay::new(format!("topic/{i}"));
+            overlay.materialize(&base);
+            state.set(overlay);
+        }
+        // Activate the soon-to-be-evicted entry.
+        state.activate(Some("topic/0".into()));
+        assert_eq!(state.active(), Some("topic/0"));
+
+        let mut overflow = BranchOverlay::new("topic/new");
+        overflow.materialize(&base);
+        state.set(overflow);
+        assert_eq!(
+            state.active(),
+            None,
+            "active slot should clear when its overlay is evicted"
         );
     }
 

--- a/crates/harn-vm/src/orchestration/crystallize/trajectory.rs
+++ b/crates/harn-vm/src/orchestration/crystallize/trajectory.rs
@@ -167,6 +167,12 @@ pub struct TrajectoryTap {
     similarity_threshold: f64,
     min_segment_len: usize,
     max_segment_len: usize,
+    /// Caller-supplied replay allowlist. When `None` we fall back to
+    /// [`default_trajectory_allowlist`]; when `Some` the caller-supplied
+    /// value is honored verbatim. This lets richer policies (e.g. extra
+    /// per-receipt id paths) flow through without being silently dropped
+    /// by the trace builder.
+    replay_allowlist: Option<Vec<ReplayAllowlistRule>>,
 }
 
 impl TrajectoryTap {
@@ -177,6 +183,7 @@ impl TrajectoryTap {
             similarity_threshold: DEFAULT_SIMILARITY_THRESHOLD,
             min_segment_len: DEFAULT_MIN_SEGMENT_LEN,
             max_segment_len: DEFAULT_MAX_SEGMENT_LEN,
+            replay_allowlist: None,
         }
     }
 
@@ -193,6 +200,14 @@ impl TrajectoryTap {
     pub fn with_segment_len(mut self, min: usize, max: usize) -> Self {
         self.min_segment_len = min.max(1);
         self.max_segment_len = max.max(self.min_segment_len);
+        self
+    }
+
+    /// Override the replay allowlist applied to traces produced by this
+    /// tap. Pass the full set of rules — the default rules are not
+    /// implicitly merged in.
+    pub fn with_replay_allowlist(mut self, rules: Vec<ReplayAllowlistRule>) -> Self {
+        self.replay_allowlist = Some(rules);
         self
     }
 
@@ -273,6 +288,10 @@ impl TrajectoryTap {
         metadata.insert("turn_count".to_string(), json!(turns.len()));
 
         let payload = serde_json::to_vec(&actions).unwrap_or_default();
+        let replay_allowlist = self
+            .replay_allowlist
+            .clone()
+            .unwrap_or_else(default_trajectory_allowlist);
         CrystallizationTrace {
             version: 1,
             id,
@@ -282,7 +301,7 @@ impl TrajectoryTap {
             started_at,
             finished_at,
             actions,
-            replay_allowlist: default_trajectory_allowlist(),
+            replay_allowlist,
             metadata,
             ..CrystallizationTrace::default()
         }
@@ -777,6 +796,42 @@ mod tests {
         let turns = vec![turn(1, vec![call("git_status", &[("path", json!("."))])])];
         let tap = TrajectoryTap::new("s3");
         assert!(tap.collect(&turns).is_empty());
+    }
+
+    #[test]
+    fn collect_honors_custom_replay_allowlist() {
+        let turns = vec![
+            turn(1, vec![call("git_status", &[("path", json!("."))])]),
+            turn(2, vec![call("git_status", &[("path", json!("."))])]),
+        ];
+        let custom = vec![
+            ReplayAllowlistRule {
+                path: "/effect_receipts/*/timestamp".to_string(),
+                reason: "test override".to_string(),
+                replacement: None,
+            },
+            ReplayAllowlistRule {
+                path: "/custom_field".to_string(),
+                reason: "test override".to_string(),
+                replacement: None,
+            },
+        ];
+        let tap = TrajectoryTap::new("s-allowlist").with_replay_allowlist(custom.clone());
+        let traces = tap.collect(&turns);
+        assert_eq!(traces.len(), 1);
+        assert_eq!(
+            traces[0].replay_allowlist, custom,
+            "custom allowlist should be honored verbatim, not overridden by the default"
+        );
+
+        // Sanity: with no override the default is still used.
+        let default_tap = TrajectoryTap::new("s-default");
+        let default_traces = default_tap.collect(&turns);
+        assert_eq!(default_traces.len(), 1);
+        assert_eq!(
+            default_traces[0].replay_allowlist,
+            default_trajectory_allowlist()
+        );
     }
 
     #[test]

--- a/evals/routing_v2/codegen_eval.harn
+++ b/evals/routing_v2/codegen_eval.harn
@@ -63,6 +63,14 @@ fn or_pricing_usd_per_m(model: string) -> dict {
   if model == "anthropic/claude-opus-4.7" {
     return {input: 5.0, output: 25.0}
   }
+  // Unknown model id — the OpenRouter API has accepted both
+  // `<vendor>/<model>` and `openrouter/<vendor>/<model>` shapes in the
+  // past, and silently zero-pricing a routed candidate distorts the
+  // cell totals beyond recognition. Warn loudly so eval operators can
+  // extend the table rather than burying the discrepancy.
+  __io_println(
+    "warning: unknown model id `" + model + "`; pricing as zero — update or_pricing_usd_per_m",
+  )
   return {input: 0.0, output: 0.0}
 }
 
@@ -92,6 +100,11 @@ fn extract_first_fenced_harn(text: string) -> string {
  * only verifier is `typecheck`. The chain returns immediately because the
  * mock provider is free + deterministic; whatever the verifier emits is the
  * canonical "would the typecheck gate have accepted this" answer.
+ *
+ * The catch arm only swallows known routing-shaped errors (dicts carrying a
+ * `reason` field, or strings mentioning routing/budget/verifier). Any other
+ * exception is printed verbatim so unrelated bugs can't silently inflate the
+ * "escalate" bucket and disguise themselves as low baseline quality.
  */
 fn grade_outcome(code: string) -> string {
   llm_mock_push_scope()
@@ -112,6 +125,19 @@ fn grade_outcome(code: string) -> string {
       "escalate"
     }
   } catch (err) {
+    let err_text = to_string(err)
+    let reason = if type_of(err) == "dict" {
+      to_string(err?.reason ?? "")
+    } else {
+      ""
+    }
+    let is_routing_shape = reason != ""
+      || contains(err_text, "routing")
+      || contains(err_text, "budget")
+      || contains(err_text, "verifier")
+    if !is_routing_shape {
+      __io_println("grade_outcome: unexpected exception (not routing-shaped): " + err_text)
+    }
     "escalate"
   }
   llm_mock_pop_scope()
@@ -245,7 +271,22 @@ fn col_totals(rows: list, key: string) -> dict {
   return {cost_usd: cost, valid: valid}
 }
 
+/**
+ * Sanity check that `grade_outcome` returns "accept" on a code snippet
+ * we know typechecks. If this fires, the verifier-receipt shape upstream
+ * has shifted and every baseline output will silently be classified as
+ * "escalate" — which would make the eval results meaningless.
+ */
+fn smoke_check_grade_outcome() {
+  let outcome = grade_outcome("let answer: int = 42\n")
+  if outcome != "accept" {
+    throw "grade_outcome regression: known-good snippet returned `" + outcome
+      + "` instead of `accept`"
+  }
+}
+
 fn main(harness: Harness) {
+  smoke_check_grade_outcome()
   let skill_body = harness.fs.read_text(SKILL_BODY_PATH)
   let rows = TASKS.map({ task -> run_task_quartet(task, skill_body) })
   let bb = col_totals(rows, "baseline_bare")


### PR DESCRIPTION
## Summary

Four small polish items from the audit pass on the merged correctness PRs #2441/#2442/#2443. Each is independent and gated by a new unit test (or smoke assertion for the eval).

- **Item 1** — `crates/harn-hostlib/src/code_index/cypher.rs`: `*1..` (open upper bound) silently capped at 3, contradicting standard Cypher semantics. Default to `VAR_LENGTH_MAX_DEPTH` (4, same constant the executor enforces) and update the module doc. Unit test: `open_upper_bound_defaults_to_depth_cap`.
- **Item 2** — `crates/harn-hostlib/src/code_index/overlay.rs`: `OverlayState.overlays` was unbounded; each entry holds a full base-graph clone. Add `OVERLAY_CAPACITY` (8) with insertion-order eviction; clear `active` if the evicted overlay was current. Tests: `registry_evicts_oldest_overlay_past_capacity`, `evicting_active_overlay_clears_active_slot`.
- **Item 3** — `crates/harn-vm/src/orchestration/crystallize/trajectory.rs`: `TrajectoryTap::collect` hardcoded `default_trajectory_allowlist()` so caller-supplied richer allowlists were silently dropped. Add `replay_allowlist: Option<Vec<…>>` field plus `with_replay_allowlist(...)` builder; fall back to the default only when `None`. Unit test: `collect_honors_custom_replay_allowlist`.
- **Item 4** — `evals/routing_v2/codegen_eval.harn`: narrow the broad `try { … } catch (err) { "escalate" }` in `grade_outcome` to swallow only routing-shaped errors (dict with `reason`, or string mentioning routing/budget/verifier) — anything else prints a `__io_println` diagnostic and still falls through. `or_pricing_usd_per_m` now warns loudly on unknown model ids instead of silently returning `{0, 0}`. New `smoke_check_grade_outcome()` at the top of `main` throws if a known-good snippet flips to escalate.

No new dependencies; the overlay cap uses a plain `VecDeque<String>` for insertion order rather than pulling in `lru`.

Closes burin-labs/harn#2454.

## Test plan

- [x] `cargo test -p harn-hostlib --lib code_index::cypher` (open-upper-bound + depth-cap tests)
- [x] `cargo test -p harn-hostlib --lib code_index::overlay` (eviction + active-slot tests)
- [x] `cargo test -p harn-vm --lib orchestration::crystallize::trajectory` (custom allowlist)
- [x] `harn check evals/routing_v2/codegen_eval.harn` clean
- [ ] CI status (merge queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)