### PR TITLE
conformance: tighten code_librarian outline assertion after #2458

### DIFF
--- a/conformance/tests/stdlib/code_librarian_surface.harn
+++ b/conformance/tests/stdlib/code_librarian_surface.harn
@@ -26,12 +26,12 @@ pipeline default() {
   __io_println(len(cy.rows) == 1 && cy.rows[0].path == "src/a.rs")
   __io_println(cy.overlay == nil)
   // 2) outline returns typed symbols + import edges for known files.
-  //    The `symbols` channel uses `outline_get` which is populated by
-  //    language-specific extractors; assert only on the known/path
-  //    shape so the test stays robust to extractor coverage.
+  //    Since #2458, the symbol-graph rebuild also populates the flat
+  //    `IndexedFile.symbols` list that `outline_get` returns, so the
+  //    corpus's two `pub fn`s show up here.
   let outline: LibrarianOutline = code_librarian_outline("src/a.rs")
   __io_println(outline.known && outline.path == "src/a.rs")
-  __io_println(type_of(outline.symbols) == "list")
+  __io_println(len(outline.symbols) >= 2)
   // 3) outline on an unknown path returns known=false (not a throw).
   let absent: LibrarianOutline = code_librarian_outline("src/does-not-exist.rs")
   __io_println(!absent.known && len(absent.symbols) == 0)


### PR DESCRIPTION
## Summary

Follow-up to PR #2458 ("populate IndexedFile.symbols during rebuild"). The conformance fixture added by PR #2455 ("code_librarian library") deliberately kept its outline assertion loose (`type_of(outline.symbols) == "list"`) because #2458 hadn't landed yet. Now that it has, tighten the assertion to verify the symbols are actually populated — the seed corpus has two `pub fn`s in `src/a.rs`, so `len(outline.symbols) >= 2`.

Also refreshes the now-stale comment that pointed at extractor coverage as the reason for the loose check.

## Test plan

- [x] `make conformance` clean (pre-commit hook runs Harn fmt + lint)
- [x] `.expected` unchanged (we replaced one `true` assertion with another `true` assertion)