### PR TITLE
perf(vm): peek adaptive-binary IC by Copy state, skip InlineCacheEntry clone

### DIFF
--- a/crates/harn-vm/src/bench_internals.rs
+++ b/crates/harn-vm/src/bench_internals.rs
@@ -74,6 +74,113 @@ impl InlineCacheSlotLookupFixture {
     }
 }
 
+/// Bytecode-length presets for the adaptive-binary-cache read microbench.
+/// The fixture walks N adjacent `Op::Add` slots, exercising the same
+/// cache-read shape that `execute_adaptive_binary` issues on every
+/// dispatch. The interesting axis is "how many cacheable ops per sweep"
+/// — that's what the dispatch loop pays per iteration of a tight
+/// arithmetic body.
+pub const ADAPTIVE_BINARY_CACHE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
+
+/// Microbench fixture for the adaptive-binary inline-cache read path.
+///
+/// `Chunk::inline_cache_entry` (the pre-optimization path) clones the
+/// wrapping `InlineCacheEntry` enum on every dispatch — a 24-32B memcpy
+/// that the variant-checking match in `try_specialized_binary`
+/// destructures and throws away. `Chunk::peek_adaptive_binary_cache`
+/// (the new path) returns just the `(AdaptiveBinaryOp,
+/// AdaptiveBinaryState)` pair by value (both `Copy`), so the read is a
+/// single scalar move instead of a clone.
+///
+/// The fixture pre-warms every slot to the Specialized state (the steady
+/// state of a hot loop) so the bench measures the read overhead with no
+/// per-iteration state transitions. The accumulator sums the cached
+/// `hits` counter so the optimizer cannot dead-code the loop.
+pub struct AdaptiveBinaryCacheReadFixture {
+    chunk: Chunk,
+    offsets: Vec<usize>,
+    slots: Vec<usize>,
+}
+
+impl AdaptiveBinaryCacheReadFixture {
+    pub fn new(op_count: usize) -> Self {
+        use crate::chunk::{AdaptiveBinaryOp, AdaptiveBinaryState, BinaryShape, InlineCacheEntry};
+        let mut chunk = Chunk::new();
+        let mut offsets = Vec::with_capacity(op_count);
+        for _ in 0..op_count {
+            offsets.push(chunk.code.len());
+            chunk.emit(Op::Add, 1);
+        }
+        let mut slots = Vec::with_capacity(op_count);
+        for &offset in &offsets {
+            let slot = chunk
+                .inline_cache_slot(offset)
+                .expect("Op::Add registers an inline-cache slot at emit time");
+            // Pre-warm to Specialized{Int}, which is the steady state of a
+            // hot loop after `ADAPTIVE_QUICKEN_THRESHOLD` Int-Int Adds.
+            // That's the case that exercises the IC read on every dispatch.
+            chunk.set_inline_cache_entry(
+                slot,
+                InlineCacheEntry::AdaptiveBinary {
+                    op: AdaptiveBinaryOp::Add,
+                    state: AdaptiveBinaryState::Specialized {
+                        shape: BinaryShape::Int,
+                        hits: 1_000,
+                        misses: 0,
+                    },
+                },
+            );
+            slots.push(slot);
+        }
+        Self {
+            chunk,
+            offsets,
+            slots,
+        }
+    }
+
+    pub fn op_count(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Sweep all slots via the new Copy peek path. Returns the sum of
+    /// observed `hits` counters so the optimizer cannot dead-code the
+    /// loop.
+    pub fn invoke_peek(&self) -> u64 {
+        use crate::chunk::AdaptiveBinaryState;
+        let mut acc = 0u64;
+        for &slot in &self.slots {
+            if let Some((_op, state)) = self.chunk.peek_adaptive_binary_cache(slot) {
+                let hits = match state {
+                    AdaptiveBinaryState::Specialized { hits, .. } => hits,
+                    AdaptiveBinaryState::Warmup { hits, .. } => hits as u64,
+                };
+                acc = acc.wrapping_add(hits);
+            }
+        }
+        acc
+    }
+
+    /// Control sweep using the pre-optimization `inline_cache_entry`
+    /// clone path. Same accumulator shape so the criterion bench can
+    /// A/B the two paths inside a single binary.
+    pub fn invoke_clone_control(&self) -> u64 {
+        use crate::chunk::{AdaptiveBinaryState, InlineCacheEntry};
+        let mut acc = 0u64;
+        for &slot in &self.slots {
+            let entry = self.chunk.inline_cache_entry(slot);
+            if let InlineCacheEntry::AdaptiveBinary { state, .. } = entry {
+                let hits = match state {
+                    AdaptiveBinaryState::Specialized { hits, .. } => hits,
+                    AdaptiveBinaryState::Warmup { hits, .. } => hits as u64,
+                };
+                acc = acc.wrapping_add(hits);
+            }
+        }
+        acc
+    }
+}
+
 pub struct NonModuleClosureCallFixture {
     capture_count: usize,
     last_capture_name: Option<String>,

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -436,7 +436,15 @@ pub(crate) enum AdaptiveBinaryOp {
     GreaterEqual,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Adaptive-binary IC state. All fields are scalar `Copy` (shape is a
+/// `Copy` enum, hit/miss counters are integers), so the struct as a whole
+/// is `Copy`. This lets `execute_adaptive_binary` extract the cached state
+/// by value for the specialization check without cloning the wrapping
+/// `InlineCacheEntry` on every dispatch — the previous shape held
+/// `Clone-only` state via the outer enum and forced a 24-32B memcpy on
+/// every Add/Sub/Mul/Div/Mod/Eq/Neq/Less/Greater/LessEq/GreaterEq op,
+/// which is the hottest opcode class in the dispatch loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AdaptiveBinaryState {
     Warmup {
         shape: BinaryShape,
@@ -1155,6 +1163,28 @@ impl Chunk {
             .get(slot)
             .cloned()
             .unwrap_or(InlineCacheEntry::Empty)
+    }
+
+    /// Adaptive-binary fast path read. Returns the cached
+    /// `(op, state)` pair by value (both `Copy`) when slot holds an
+    /// `AdaptiveBinary` entry, else `None`. Skips the
+    /// `InlineCacheEntry::clone` that `inline_cache_entry` performs:
+    /// since `AdaptiveBinaryState: Copy`, the read does a single
+    /// scalar move out of the cache instead of a 24-32B memcpy of the
+    /// wrapping enum (which the variant-checking match destructures
+    /// and throws away anyway). Fires on every Add/Sub/Mul/Div/Mod/Eq/
+    /// Neq/Less/Greater/LessEq/GreaterEq dispatch, so the per-op
+    /// savings compound across the millions of dispatches a typical
+    /// loop body issues.
+    #[inline]
+    pub(crate) fn peek_adaptive_binary_cache(
+        &self,
+        slot: usize,
+    ) -> Option<(AdaptiveBinaryOp, AdaptiveBinaryState)> {
+        match self.inline_caches.borrow().get(slot)? {
+            &InlineCacheEntry::AdaptiveBinary { op, state } => Some((op, state)),
+            _ => None,
+        }
     }
 
     pub(crate) fn set_inline_cache_entry(&self, slot: usize, entry: InlineCacheEntry) {
@@ -1952,5 +1982,98 @@ mod tests {
             let from_index = chunk.inline_cache_slot(offset);
             assert_eq!(from_index, from_map, "parity broken at offset {offset}");
         }
+    }
+
+    // --- peek_adaptive_binary_cache contract ---
+    //
+    // The peek replaces the per-dispatch `InlineCacheEntry::clone` on the
+    // hottest opcode class (Add / Sub / Mul / Div / Mod / Eq / Neq /
+    // Less / Greater / LessEq / GreaterEq). It must return None for
+    // unrelated IC variants — silently mis-extracting a `Property` /
+    // `DirectCall` / `Method` slot as `AdaptiveBinary` would feed
+    // garbage into `try_specialized_binary` and either spec-mis-fire or
+    // crash. These tests pin the variant gate.
+
+    #[test]
+    fn peek_adaptive_binary_returns_none_for_empty_slot() {
+        let mut chunk = Chunk::new();
+        chunk.emit(Op::Add, 1);
+        let slot = chunk.inline_cache_slot(0).expect("Add registers a slot");
+        // Default state of a freshly-emitted slot is Empty.
+        assert!(chunk.peek_adaptive_binary_cache(slot).is_none());
+    }
+
+    #[test]
+    fn peek_adaptive_binary_returns_op_and_state_after_warmup() {
+        use super::{AdaptiveBinaryOp, AdaptiveBinaryState, BinaryShape, InlineCacheEntry};
+        let mut chunk = Chunk::new();
+        chunk.emit(Op::Add, 1);
+        let slot = chunk.inline_cache_slot(0).expect("Add registers a slot");
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::AdaptiveBinary {
+                op: AdaptiveBinaryOp::Add,
+                state: AdaptiveBinaryState::Warmup {
+                    shape: BinaryShape::Int,
+                    hits: 2,
+                },
+            },
+        );
+        let (op, state) = chunk
+            .peek_adaptive_binary_cache(slot)
+            .expect("warmed slot peek");
+        assert_eq!(op, AdaptiveBinaryOp::Add);
+        assert!(matches!(
+            state,
+            AdaptiveBinaryState::Warmup {
+                shape: BinaryShape::Int,
+                hits: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn peek_adaptive_binary_returns_none_for_non_binary_variants() {
+        // The cache slot may legitimately hold a `Property`, `Method`,
+        // or `DirectCall` entry (eg. a Property slot at the offset
+        // sequence happens to alias an Add slot during a code rewrite —
+        // currently this cannot happen, but the peek must defensively
+        // refuse non-AdaptiveBinary variants regardless).
+        use super::{InlineCacheEntry, PropertyCacheTarget};
+        let mut chunk = Chunk::new();
+        chunk.emit(Op::Add, 1);
+        let slot = chunk.inline_cache_slot(0).expect("Add registers a slot");
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::Property {
+                name_idx: 0,
+                target: PropertyCacheTarget::ListCount,
+            },
+        );
+        assert!(chunk.peek_adaptive_binary_cache(slot).is_none());
+    }
+
+    #[test]
+    fn peek_adaptive_binary_returns_none_for_out_of_bounds_slot() {
+        // Defensive: `execute_adaptive_binary` filters its `slot`
+        // through `inline_cache_slot` first, but
+        // `peek_adaptive_binary_cache` should still return None for an
+        // unmapped slot rather than panicking.
+        let chunk = Chunk::new();
+        assert!(chunk.peek_adaptive_binary_cache(0).is_none());
+        assert!(chunk.peek_adaptive_binary_cache(usize::MAX).is_none());
+    }
+
+    #[test]
+    fn peek_adaptive_binary_state_is_copy() {
+        // Compile-time assertion: `AdaptiveBinaryState: Copy` is the
+        // whole point of this optimization — if a future variant adds
+        // a non-Copy field, the static check below will fail at compile
+        // time before the dispatcher silently regresses to the heavy
+        // `InlineCacheEntry::clone` path.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<super::AdaptiveBinaryState>();
+        assert_copy::<super::AdaptiveBinaryOp>();
+        assert_copy::<super::BinaryShape>();
     }
 }

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -57,34 +57,55 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_adaptive_binary(&mut self, op: AdaptiveBinaryOp) -> Result<(), VmError> {
-        let (cache_slot, cache_entry) = {
+        // Read the cache slot index from the flat side-table (O(1) `Vec`
+        // index after #2470) and, if a slot exists, peek the cached
+        // `AdaptiveBinaryState` by value. The peek avoids cloning the
+        // wrapping `InlineCacheEntry` enum — that clone used to fire on
+        // every dispatch of every binary op, paying a 24-32B memcpy
+        // that the variant-checking match would just throw away. Since
+        // `AdaptiveBinaryState: Copy`, the read here is a single scalar
+        // move (`u8`/`u64` fields, all stack-resident).
+        let (cache_slot, cached_state) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cache_entry = cache_slot
-                .map(|slot| frame.chunk.inline_cache_entry(slot))
-                .unwrap_or(InlineCacheEntry::Empty);
-            (cache_slot, cache_entry)
+            let cached_state = cache_slot
+                .and_then(|slot| frame.chunk.peek_adaptive_binary_cache(slot))
+                .filter(|(cached_op, _)| *cached_op == op)
+                .map(|(_, state)| state);
+            (cache_slot, cached_state)
         };
 
         let b = self.pop()?;
         let a = self.pop()?;
         let shape = BinaryShape::for_values(op, &a, &b);
 
-        let result = if let Some((result, next_entry)) =
-            Self::try_specialized_binary(op, &cache_entry, &a, &b)
+        let result = if let Some((result, next_state)) =
+            Self::try_specialized_binary(op, cached_state, &a, &b)
         {
             if let Some(slot) = cache_slot {
                 let frame = self.frames.last().unwrap();
-                frame.chunk.set_inline_cache_entry(slot, next_entry);
+                frame.chunk.set_inline_cache_entry(
+                    slot,
+                    InlineCacheEntry::AdaptiveBinary {
+                        op,
+                        state: next_state,
+                    },
+                );
             }
             result
         } else {
             let result = Self::generic_binary_result(self, op, a, b)?;
             if let (Some(slot), Some(shape)) = (cache_slot, shape) {
-                let next_entry = Self::next_adaptive_binary_entry(op, cache_entry, shape);
+                let next_state = Self::next_adaptive_binary_state(cached_state, shape);
                 let frame = self.frames.last().unwrap();
-                frame.chunk.set_inline_cache_entry(slot, next_entry);
+                frame.chunk.set_inline_cache_entry(
+                    slot,
+                    InlineCacheEntry::AdaptiveBinary {
+                        op,
+                        state: next_state,
+                    },
+                );
             }
             result
         };
@@ -93,55 +114,55 @@ impl super::super::Vm {
         Ok(())
     }
 
+    /// Adaptive-binary specialization fast path. Takes the peeked
+    /// `Copy` `AdaptiveBinaryState` (already filtered for the current
+    /// op by [`execute_adaptive_binary`]) instead of `&InlineCacheEntry`,
+    /// so the helper no longer destructures the outer enum on every
+    /// dispatch. Returns `(result, next_state)` on a hit; the caller
+    /// is responsible for wrapping `next_state` into `InlineCacheEntry`
+    /// before writing it back through `set_inline_cache_entry`.
     fn try_specialized_binary(
         op: AdaptiveBinaryOp,
-        cache: &InlineCacheEntry,
+        cached_state: Option<AdaptiveBinaryState>,
         a: &VmValue,
         b: &VmValue,
-    ) -> Option<(VmValue, InlineCacheEntry)> {
-        let InlineCacheEntry::AdaptiveBinary {
-            op: cached_op,
-            state:
-                AdaptiveBinaryState::Specialized {
-                    shape,
-                    hits,
-                    misses,
-                },
-        } = cache
+    ) -> Option<(VmValue, AdaptiveBinaryState)> {
+        let AdaptiveBinaryState::Specialized {
+            shape,
+            hits,
+            misses,
+        } = cached_state?
         else {
             return None;
         };
-        if *cached_op != op || Some(*shape) != BinaryShape::for_values(op, a, b) {
+        if Some(shape) != BinaryShape::for_values(op, a, b) {
             return None;
         }
-        let result = Self::specialized_binary_result(op, *shape, a, b)?;
+        let result = Self::specialized_binary_result(op, shape, a, b)?;
         Some((
             result,
-            InlineCacheEntry::AdaptiveBinary {
-                op,
-                state: AdaptiveBinaryState::Specialized {
-                    shape: *shape,
-                    hits: hits.saturating_add(1),
-                    misses: *misses,
-                },
+            AdaptiveBinaryState::Specialized {
+                shape,
+                hits: hits.saturating_add(1),
+                misses,
             },
         ))
     }
 
-    fn next_adaptive_binary_entry(
-        op: AdaptiveBinaryOp,
-        previous: InlineCacheEntry,
+    /// Compute the next adaptive-binary cache state from the peeked
+    /// previous state and the freshly-observed `shape`. Operates on
+    /// `Copy` state directly — the helper no longer needs to take the
+    /// wrapping `InlineCacheEntry` by value (which used to force the
+    /// caller to clone the enum on the miss path too).
+    fn next_adaptive_binary_state(
+        previous: Option<AdaptiveBinaryState>,
         shape: BinaryShape,
-    ) -> InlineCacheEntry {
-        let state = match previous {
-            InlineCacheEntry::AdaptiveBinary {
-                op: cached_op,
-                state:
-                    AdaptiveBinaryState::Warmup {
-                        shape: cached,
-                        hits,
-                    },
-            } if cached_op == op && cached == shape => {
+    ) -> AdaptiveBinaryState {
+        match previous {
+            Some(AdaptiveBinaryState::Warmup {
+                shape: cached,
+                hits,
+            }) if cached == shape => {
                 let hits = hits.saturating_add(1);
                 if hits >= ADAPTIVE_QUICKEN_THRESHOLD {
                     AdaptiveBinaryState::Specialized {
@@ -153,30 +174,24 @@ impl super::super::Vm {
                     AdaptiveBinaryState::Warmup { shape, hits }
                 }
             }
-            InlineCacheEntry::AdaptiveBinary {
-                op: cached_op,
-                state:
-                    AdaptiveBinaryState::Specialized {
-                        shape: cached,
-                        hits,
-                        misses,
-                    },
-            } if cached_op == op && cached == shape => AdaptiveBinaryState::Specialized {
+            Some(AdaptiveBinaryState::Specialized {
+                shape: cached,
+                hits,
+                misses,
+            }) if cached == shape => AdaptiveBinaryState::Specialized {
                 shape,
                 hits: hits.saturating_add(1),
                 misses,
             },
-            InlineCacheEntry::AdaptiveBinary {
-                op: cached_op,
-                state: AdaptiveBinaryState::Specialized { misses: 0, .. },
-            } if cached_op == op => AdaptiveBinaryState::Specialized {
-                shape,
-                hits: 1,
-                misses: 1,
-            },
+            Some(AdaptiveBinaryState::Specialized { misses: 0, .. }) => {
+                AdaptiveBinaryState::Specialized {
+                    shape,
+                    hits: 1,
+                    misses: 1,
+                }
+            }
             _ => AdaptiveBinaryState::Warmup { shape, hits: 1 },
-        };
-        InlineCacheEntry::AdaptiveBinary { op, state }
+        }
     }
 
     fn generic_binary_result(

--- a/perf/vm/Cargo.toml
+++ b/perf/vm/Cargo.toml
@@ -23,6 +23,11 @@ path = "bench_inline_cache_slot.rs"
 harness = false
 
 [[bench]]
+name = "bench_adaptive_binary_cache_read"
+path = "bench_adaptive_binary_cache_read.rs"
+harness = false
+
+[[bench]]
 name = "bench_vm_fixtures"
 path = "bench_vm_fixtures.rs"
 harness = false

--- a/perf/vm/bench_adaptive_binary_cache_read.rs
+++ b/perf/vm/bench_adaptive_binary_cache_read.rs
@@ -1,0 +1,55 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm::bench_internals::{AdaptiveBinaryCacheReadFixture, ADAPTIVE_BINARY_CACHE_READ_COUNTS};
+
+/// Microbench for the adaptive-binary inline-cache read path. The read
+/// fires on every dispatch of every adaptive binary op (Add / Sub /
+/// Mul / Div / Mod / Eq / Neq / Less / Greater / LessEq / GreaterEq) —
+/// the hottest opcode class in the VM dispatch loop.
+///
+/// `inline_cache_slot/copy_peek` exercises `peek_adaptive_binary_cache`,
+/// which returns the cached `(op, state)` pair by value (both `Copy`).
+/// `inline_cache_slot/clone_control` exercises the pre-optimization
+/// `inline_cache_entry` path that cloned the wrapping `InlineCacheEntry`
+/// enum on every dispatch — a 24-32B memcpy that the variant-checking
+/// match destructures and throws away.
+///
+/// The N axis (8/32/128/512) approximates a small predicate, a loop
+/// body, and a deep stdlib fn body. Per-op savings compound across
+/// the millions of dispatches a typical loop body issues.
+fn bench_adaptive_binary_cache_read(c: &mut Criterion) {
+    let fixtures = ADAPTIVE_BINARY_CACHE_READ_COUNTS
+        .into_iter()
+        .map(AdaptiveBinaryCacheReadFixture::new)
+        .collect::<Vec<_>>();
+
+    let mut optimized = c.benchmark_group("adaptive_binary_cache_read/copy_peek");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        optimized.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_peek()));
+            },
+        );
+    }
+    optimized.finish();
+
+    let mut baseline = c.benchmark_group("adaptive_binary_cache_read/clone_control");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        baseline.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_clone_control()));
+            },
+        );
+    }
+    baseline.finish();
+}
+
+criterion_group!(benches, bench_adaptive_binary_cache_read);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

`execute_adaptive_binary` fires on every dispatch of every Add / Sub / Mul / Div / Mod / Eq / Neq / Less / Greater / LessEq / GreaterEq — the hottest opcode class in the VM dispatch loop. Before this change, the cache read went through `Chunk::inline_cache_entry`, which cloned the wrapping `InlineCacheEntry` enum on every dispatch (a 24-32B memcpy) that `try_specialized_binary`'s variant-checking match destructured and threw away.

The clone was *forced* because the outer enum has non-Copy variants (`DirectCall` carries `Rc<VmClosure>`, `Property::DictField` / `StructField` carry `Rc<str>`) — but the AdaptiveBinary path never touches those.

This PR:

1. Makes `AdaptiveBinaryState` derive `Copy` (all fields are already scalar: `BinaryShape: Copy`, `u8` / `u64` counters).
2. Adds `Chunk::peek_adaptive_binary_cache(slot) -> Option<(AdaptiveBinaryOp, AdaptiveBinaryState)>` which extracts just the `(op, state)` pair *by value* when the slot holds an `AdaptiveBinary` entry. The `RefCell` borrow lives only for the peek; the returned pair is a tiny `Copy` value that the dispatcher then flows through the helpers without ever materializing the wrapping enum.
3. Drops `try_specialized_binary` / `next_adaptive_binary_entry`'s `&InlineCacheEntry` / `previous: InlineCacheEntry` parameters in favor of the `Copy` state directly — eliminating the match-and-discard boilerplate that the outer-enum shape required.

## Bench (criterion, M5 Pro, release, A/B in one binary)

| Cacheable ops | copy_peek | clone_control | speedup |
|---------------|-----------|---------------|---------|
| 8             |  10.63 ns |  23.54 ns     | **2.22×** |
| 32            |  44.10 ns |  81.27 ns     | **1.84×** |
| 128           | 142.39 ns | 288.62 ns     | **2.03×** |
| 512           | 743.93 ns | 941.80 ns     | **1.27×** |

(`adaptive_binary_cache_read/{copy_peek,clone_control}` criterion groups in the new `bench_adaptive_binary_cache_read.rs`)

Per-op savings stabilize at ~1 ns/dispatch — exactly the cost of the 24-32B memcpy the clone path was paying. That fires on every adaptive binary op, so the savings compound across the millions of dispatches a typical loop body issues.

The 512-op case shows compressed speedup (1.27×) because at that scale both paths start hitting the same Vec<u32> cache-line traffic — the constant per-op overhead is what matters for the real dispatcher.

## Tests

- 5 new `chunk.rs::tests` pin the contract:
  - `peek_adaptive_binary_returns_none_for_empty_slot`
  - `peek_adaptive_binary_returns_op_and_state_after_warmup`
  - `peek_adaptive_binary_returns_none_for_non_binary_variants` — silently mis-extracting a `Property` / `Method` / `DirectCall` slot as `AdaptiveBinary` would feed garbage into the dispatcher
  - `peek_adaptive_binary_returns_none_for_out_of_bounds_slot` (defensive, no panic)
  - `peek_adaptive_binary_state_is_copy` — **compile-time** assertion. If a future variant of `AdaptiveBinaryState` / `AdaptiveBinaryOp` / `BinaryShape` adds a non-Copy field, the test fails to build, catching the silent regression to the heavy clone path before it ships.
- Full `harn-vm` suite (2719 in-crate tests + integration) is green.

## Test plan

- [x] `cargo test -p harn-vm --lib chunk::tests::peek` — 5 new pass
- [x] `cargo test -p harn-vm` — full suite green
- [x] `cargo bench -p harn-vm-perf --bench bench_adaptive_binary_cache_read` — A/B numbers above
- [ ] CI (merge queue gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)