### PR TITLE
Unify budget transcript compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ condensed series summaries instead of full per-patch history.
   (cerebras, dashscope, huggingface, minimax, mlx, tgi, vllm, zai)
   and pointed the inline comment at the runtime list so future
   drift is visible at the call site.
+- **Budget-pressure compaction now uses the orchestration compaction ladder
+  (#2472).** Session transcript budget enforcement now delegates through the
+  shared lifecycle path with `reason: "budget_pressure"`, tries the default LLM
+  summary strategy, and falls back to deterministic truncation within the
+  configured session budget when summarization is unavailable. Ordinary
+  threshold compactions now persist and publish `reason: "threshold"` so live
+  events and transcript metadata distinguish the trigger.
 
 ## v0.8.43
 

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -535,6 +535,7 @@ impl AgentEventSink for AcpAgentEventSink {
             AgentEvent::TranscriptCompacted {
                 session_id,
                 mode,
+                reason,
                 strategy,
                 archived_messages,
                 estimated_tokens_before,
@@ -549,6 +550,10 @@ impl AgentEventSink for AcpAgentEventSink {
                 });
                 let mut harn_meta = serde_json::Map::new();
                 harn_meta.insert("mode".to_string(), serde_json::Value::String(mode.clone()));
+                harn_meta.insert(
+                    "reason".to_string(),
+                    serde_json::Value::String(reason.clone()),
+                );
                 harn_meta.insert(
                     "strategy".to_string(),
                     serde_json::Value::String(strategy.clone()),

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -167,6 +167,7 @@ fn extension_fixture_events() -> Vec<AgentEvent> {
         AgentEvent::TranscriptCompacted {
             session_id: "session-1".to_string(),
             mode: "auto".to_string(),
+            reason: "threshold".to_string(),
             strategy: "summary".to_string(),
             archived_messages: 3,
             estimated_tokens_before: 100,
@@ -910,6 +911,7 @@ async fn forwarded_agent_events_serialize_as_session_updates() {
         AgentEvent::TranscriptCompacted {
             session_id: "session-1".to_string(),
             mode: "auto".to_string(),
+            reason: "threshold".to_string(),
             strategy: "summary".to_string(),
             archived_messages: 3,
             estimated_tokens_before: 100,

--- a/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
+++ b/crates/harn-serve/tests/fixtures/acp/session_update_extensions.json
@@ -110,6 +110,7 @@
             "instructionMode": "extend",
             "instructionSource": "host",
             "mode": "auto",
+            "reason": "threshold",
             "snapshotAssetId": "asset-1",
             "strategy": "summary"
           }

--- a/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
@@ -405,6 +405,7 @@ pub fn agent_autocompact_if_needed(session, opts) {
   let policy_fields = __compaction_policy_event_fields(policy)
   let pre_payload = {
     session: {id: session.session_id},
+    reason: "threshold",
     strategy: if policy_label != "" {
       policy_label
     } else {
@@ -431,6 +432,7 @@ pub fn agent_autocompact_if_needed(session, opts) {
     __host_agent_session_replace_messages(session.session_id, compacted, summary)
     let metadata = {
       mode: "auto",
+      reason: "threshold",
       strategy: if policy_label != "" {
         policy_label
       } else {

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -341,6 +341,7 @@ pub enum AgentEvent {
     TranscriptCompacted {
         session_id: String,
         mode: String,
+        reason: String,
         strategy: String,
         archived_messages: usize,
         estimated_tokens_before: usize,

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -1102,20 +1102,16 @@ fn append_event_to_transcript(transcript: VmValue, event: VmValue) -> VmValue {
     VmValue::Dict(Rc::new(next))
 }
 
-fn summary_message_vm(summary: &str) -> VmValue {
-    crate::stdlib::json_to_vm_value(&summary_message_json(summary))
-}
-
 fn tail_message_capacity(
     policy: &SessionTranscriptBudgetPolicy,
     reserve_audit_event: bool,
 ) -> usize {
-    let event_capacity = if reserve_audit_event {
-        policy.max_events.saturating_sub(1)
-    } else {
-        policy.max_events
-    };
+    let event_capacity = tail_event_capacity(policy, usize::from(reserve_audit_event));
     policy.max_messages.min(event_capacity)
+}
+
+fn tail_event_capacity(policy: &SessionTranscriptBudgetPolicy, reserved_events: usize) -> usize {
+    policy.max_events.saturating_sub(reserved_events)
 }
 
 fn trim_transcript_for_budget(
@@ -1140,47 +1136,106 @@ fn trim_transcript_for_budget(
     VmValue::Dict(Rc::new(next))
 }
 
+struct BudgetCompactionLiveEvent {
+    policy: crate::orchestration::CompactionPolicy,
+    policy_strategy: String,
+    metrics: crate::orchestration::TranscriptCompactedEventMetrics,
+}
+
+struct BudgetCompactionResult {
+    transcript: VmValue,
+    live_event: Option<BudgetCompactionLiveEvent>,
+}
+
 fn compact_transcript_for_budget(
     transcript: &VmValue,
     policy: &SessionTranscriptBudgetPolicy,
     keep_last: usize,
-    reason: &str,
-) -> VmValue {
+    session_id: &str,
+) -> BudgetCompactionResult {
     let dict = transcript.as_dict().cloned().unwrap_or_else(BTreeMap::new);
     let messages = transcript_messages_from_dict(&dict);
-    let message_capacity = tail_message_capacity(policy, true);
-    let mut retained = Vec::new();
-    let mut summary = None;
+    let message_capacity = policy.max_messages.min(tail_event_capacity(policy, 2));
+    // Auto-compaction may widen a suffix to start on a clean user-turn boundary,
+    // so reserve one extra slot beyond the summary when sizing for hard caps.
+    let tail_keep = keep_last.min(message_capacity.saturating_sub(2));
+    let mut config = crate::orchestration::AutoCompactConfig {
+        token_threshold: 0,
+        keep_last: tail_keep,
+        compact_strategy: crate::orchestration::CompactStrategy::Llm,
+        hard_limit_strategy: crate::orchestration::CompactStrategy::Truncate,
+        fallback_strategy: Some(crate::orchestration::CompactStrategy::Truncate),
+        policy_strategy: crate::orchestration::compact_strategy_name(
+            &crate::orchestration::CompactStrategy::Llm,
+        )
+        .to_string(),
+        ..Default::default()
+    };
 
-    if messages.len() > message_capacity {
-        if message_capacity > 0 {
-            let tail_keep = keep_last.min(message_capacity.saturating_sub(1));
-            let archived = messages.len().saturating_sub(tail_keep);
-            let summary_text = format!(
-                "[auto-compacted {archived} older message(s) under transcript budget]\nSession transcript exceeded the {reason} budget; retained the most recent {tail_keep} message(s)."
-            );
-            retained.push(summary_message_vm(&summary_text));
-            retained.extend(messages.into_iter().skip(archived).take(tail_keep));
-            summary = Some(summary_text);
-        }
-    } else {
-        retained = messages;
+    let mut json_messages = messages
+        .iter()
+        .map(crate::llm::helpers::vm_value_to_json)
+        .collect::<Vec<_>>();
+    let lifecycle =
+        crate::orchestration::CompactLifecycle::new(crate::orchestration::CompactMode::Auto)
+            .with_session_id(Some(session_id))
+            .with_trigger(crate::orchestration::CompactionTrigger::BudgetPressure)
+            .with_hook_dispatch(false)
+            .with_evaluate_providers(false);
+    let llm_opts = crate::llm::extract_llm_options(&[
+        VmValue::String(Rc::from("")),
+        VmValue::Nil,
+        VmValue::Nil,
+    ])
+    .ok();
+    let outcome = futures::executor::block_on(crate::orchestration::run_compaction_lifecycle(
+        &mut json_messages,
+        &mut config,
+        llm_opts.as_ref(),
+        lifecycle,
+    ))
+    .ok()
+    .flatten();
+
+    let retained = json_messages
+        .iter()
+        .map(crate::stdlib::json_to_vm_value)
+        .collect::<Vec<_>>();
+    let mut events = crate::llm::helpers::transcript_events_from_messages(&retained);
+    let summary = outcome.as_ref().map(|outcome| outcome.summary.clone());
+    let mut live_event = None;
+    if let Some(outcome) = outcome {
+        events.push(crate::llm::helpers::transcript_event(
+            "compaction",
+            "system",
+            "internal",
+            "",
+            Some(outcome.event_metadata.clone()),
+        ));
+        live_event = Some(BudgetCompactionLiveEvent {
+            policy: config.policy.clone(),
+            policy_strategy: outcome.policy_strategy,
+            metrics: crate::orchestration::TranscriptCompactedEventMetrics {
+                archived_messages: outcome.archived_messages,
+                estimated_tokens_before: outcome.estimated_tokens_before,
+                estimated_tokens_after: outcome.estimated_tokens_after,
+                snapshot_asset_id: outcome.snapshot_asset_id,
+            },
+        });
     }
 
     let mut next = dict;
-    next.insert(
-        "events".to_string(),
-        VmValue::List(Rc::new(
-            crate::llm::helpers::transcript_events_from_messages(&retained),
-        )),
-    );
+    next.insert("events".to_string(), VmValue::List(Rc::new(events)));
     next.insert("messages".to_string(), VmValue::List(Rc::new(retained)));
     if let Some(summary) = summary {
         next.insert("summary".to_string(), VmValue::String(Rc::from(summary)));
     } else {
         next.remove("summary");
     }
-    VmValue::Dict(Rc::new(next))
+    BudgetCompactionResult {
+        transcript: VmValue::Dict(Rc::new(next)),
+        live_event,
+    }
 }
 
 fn recovered_transcript_with_audit(
@@ -1288,9 +1343,10 @@ fn apply_transcript_with_budget(
             Ok(())
         }
         TranscriptBudgetRecovery::Compact { keep_last } => {
-            let recovered = compact_transcript_for_budget(&candidate, &policy, keep_last, reason);
+            let compacted =
+                compact_transcript_for_budget(&candidate, &policy, keep_last, &state.id);
             let (with_audit, audit, usage_after) = recovered_transcript_with_audit(
-                recovered,
+                compacted.transcript,
                 "compacted",
                 source,
                 reason,
@@ -1319,6 +1375,18 @@ fn apply_transcript_with_budget(
             }
             state.last_transcript_budget_action = Some(audit);
             state.transcript = with_audit;
+            if let Some(event) = compacted.live_event {
+                crate::orchestration::emit_transcript_compacted_event_sync(
+                    &state.id,
+                    crate::orchestration::CompactMode::Auto,
+                    crate::orchestration::CompactionTrigger::BudgetPressure
+                        .as_str()
+                        .to_string(),
+                    &event.policy,
+                    event.policy_strategy,
+                    event.metrics,
+                );
+            }
             Ok(())
         }
     }

--- a/crates/harn-vm/src/agent_sessions_tests.rs
+++ b/crates/harn-vm/src/agent_sessions_tests.rs
@@ -52,6 +52,19 @@ fn event_count_by_kind(id: &str, expected_kind: &str) -> usize {
         .unwrap_or(0)
 }
 
+fn events_by_kind_json(id: &str, expected_kind: &str) -> Vec<serde_json::Value> {
+    snapshot(id)
+        .map(|snapshot| crate::llm::helpers::vm_value_to_json(&snapshot))
+        .and_then(|snapshot| snapshot.get("events").cloned())
+        .and_then(|events| events.as_array().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|event| {
+            event.get("kind").and_then(serde_json::Value::as_str) == Some(expected_kind)
+        })
+        .collect()
+}
+
 fn event_count(id: &str) -> usize {
     snapshot(id)
         .and_then(|snapshot| snapshot.as_dict().cloned())
@@ -69,6 +82,29 @@ fn budget_metadata(id: &str) -> serde_json::Value {
         .and_then(|value| value.get("metadata").cloned())
         .and_then(|metadata| metadata.get("transcript_budget").cloned())
         .expect("transcript budget metadata")
+}
+
+struct CliLlmMockGuard;
+
+impl Drop for CliLlmMockGuard {
+    fn drop(&mut self) {
+        crate::llm::clear_cli_llm_mock_mode();
+    }
+}
+
+fn install_cli_llm_mock(value: serde_json::Value) -> CliLlmMockGuard {
+    let mock = crate::llm::parse_llm_mock_value(&value).expect("valid llm mock");
+    crate::llm::install_cli_llm_mocks(vec![mock]);
+    CliLlmMockGuard
+}
+
+fn install_budget_fallback_mock() -> CliLlmMockGuard {
+    install_cli_llm_mock(serde_json::json!({
+        "error": {
+            "category": "server_error",
+            "message": "summarizer unavailable"
+        }
+    }))
 }
 
 fn simple_event(kind: &str) -> VmValue {
@@ -132,6 +168,7 @@ fn transcript_budget_rejects_event_count_growth() {
 #[test]
 fn transcript_budget_compaction_recovers_and_preserves_prompt_state() {
     reset_session_store();
+    let _mock = install_budget_fallback_mock();
     set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::compact(3, 4, 1));
     let id = open_or_create(Some("budget-compact-recover".into()));
 
@@ -148,7 +185,14 @@ fn transcript_budget_compaction_recovers_and_preserves_prompt_state() {
     let summary = snapshot_json["summary"]
         .as_str()
         .expect("budget compaction summary");
-    assert!(summary.contains("auto-compacted 3 older message(s)"));
+    assert!(summary.contains("auto-compacted"));
+    assert!(summary.contains("via truncate strategy"));
+    let compaction_events = events_by_kind_json(&id, "compaction");
+    assert_eq!(compaction_events.len(), 1);
+    let compaction_payload = &compaction_events[0]["metadata"];
+    assert_eq!(compaction_payload["reason"], "budget_pressure");
+    assert_eq!(compaction_payload["strategy"], "llm");
+    assert_eq!(compaction_payload["engine_strategy"], "truncate");
     let metadata = budget_metadata(&id);
     assert_eq!(metadata["last_action"]["action"], "compacted");
     assert_eq!(metadata["last_action"]["reason"], "message_count");
@@ -168,8 +212,65 @@ fn transcript_budget_compaction_recovers_and_preserves_prompt_state() {
 }
 
 #[test]
+fn transcript_budget_compaction_uses_llm_summary_when_available() {
+    reset_all_sinks();
+    reset_session_store();
+    let _mock = install_cli_llm_mock(serde_json::json!({
+        "text": "<canned budget summary>"
+    }));
+    set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::compact(3, 5, 1));
+    let id = open_or_create(Some("budget-compact-llm".into()));
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    register_sink(&id, Arc::new(CapturingSink(captured.clone())));
+
+    inject_message(&id, make_msg("user", "one")).unwrap();
+    inject_message(&id, make_msg("assistant", "two")).unwrap();
+    inject_message(&id, make_msg("user", "three")).unwrap();
+    inject_message(&id, make_msg("assistant", "four")).unwrap();
+
+    assert!(message_count(&id) <= 3);
+    assert!(event_count(&id) <= 5);
+    let snapshot = snapshot(&id).expect("session snapshot");
+    let snapshot_json = crate::llm::helpers::vm_value_to_json(&snapshot);
+    let summary = snapshot_json["summary"]
+        .as_str()
+        .expect("budget compaction summary");
+    assert!(summary.contains("<canned budget summary>"));
+
+    let compaction_events = events_by_kind_json(&id, "compaction");
+    assert_eq!(compaction_events.len(), 1);
+    let compaction_payload = &compaction_events[0]["metadata"];
+    assert_eq!(compaction_payload["reason"], "budget_pressure");
+    assert_eq!(compaction_payload["strategy"], "llm");
+    assert_eq!(compaction_payload["engine_strategy"], "llm");
+
+    let events = captured.lock().expect("capture sink poisoned");
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        AgentEvent::TranscriptCompacted {
+            session_id,
+            mode,
+            reason,
+            strategy,
+            ..
+        } => {
+            assert_eq!(session_id, &id);
+            assert_eq!(mode, "auto");
+            assert_eq!(reason, "budget_pressure");
+            assert_eq!(strategy, "llm");
+        }
+        event => panic!("expected TranscriptCompacted event, got {event:?}"),
+    }
+
+    reset_all_sinks();
+    reset_default_transcript_budget_policy();
+    reset_session_store();
+}
+
+#[test]
 fn fork_preserves_transcript_budget_metadata() {
     reset_session_store();
+    let _mock = install_budget_fallback_mock();
     set_default_transcript_budget_policy(SessionTranscriptBudgetPolicy::compact(3, 4, 1));
     let parent = open_or_create(Some("budget-fork-parent".into()));
     inject_message(&parent, make_msg("user", "one")).unwrap();

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1755,6 +1755,11 @@ fn host_agent_record_compaction_builtin(
         .and_then(serde_json::Value::as_str)
         .unwrap_or("auto")
         .to_string();
+    let reason = payload_json
+        .get("reason")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("threshold")
+        .to_string();
     let strategy = payload_json
         .get("strategy")
         .or_else(|| payload_json.get("engine_strategy"))
@@ -1798,6 +1803,7 @@ fn host_agent_record_compaction_builtin(
     crate::llm::emit_live_agent_event_sync(&crate::agent_events::AgentEvent::TranscriptCompacted {
         session_id,
         mode,
+        reason,
         strategy,
         archived_messages,
         estimated_tokens_before,

--- a/crates/harn-vm/src/orchestration/compact_lifecycle.rs
+++ b/crates/harn-vm/src/orchestration/compact_lifecycle.rs
@@ -41,7 +41,7 @@ use crate::llm::helpers::{
 use crate::value::{VmError, VmValue};
 
 use super::{
-    auto_compact_messages, compact_strategy_name, compaction_policy_metadata_fields,
+    auto_compact_messages_with_result, compact_strategy_name, compaction_policy_metadata_fields,
     estimate_message_tokens, parse_compact_strategy, run_lifecycle_hooks,
     run_lifecycle_hooks_with_control, AutoCompactConfig, CompactStrategy, CompactionPolicy,
     HookControl, HookEvent,
@@ -99,12 +99,34 @@ impl CompactMode {
     }
 }
 
+/// Identifies why compaction fired. This is separate from [`CompactMode`]:
+/// mode describes the caller surface, while trigger explains the pressure
+/// that made the caller compact.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompactionTrigger {
+    Manual,
+    Threshold,
+    BudgetPressure,
+}
+
+impl CompactionTrigger {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::Threshold => "threshold",
+            Self::BudgetPressure => "budget_pressure",
+        }
+    }
+}
+
 /// Per-call inputs that travel with a compaction request through the
 /// lifecycle. Stored as references to keep allocations down on the hot path.
 pub struct CompactLifecycle<'a> {
     pub session_id: Option<&'a str>,
     pub transcript_id: Option<&'a str>,
     pub mode: CompactMode,
+    pub trigger: CompactionTrigger,
+    pub fire_hooks: bool,
     /// Reminder events from the source transcript that should pass through
     /// the `preserve_on_compact` / `ttl_turns` / `dedupe_key` lifecycle
     /// before being re-attached to the compacted transcript.
@@ -129,10 +151,20 @@ pub struct CompactLifecycle<'a> {
 
 impl<'a> CompactLifecycle<'a> {
     pub fn new(mode: CompactMode) -> Self {
+        let trigger = match mode {
+            CompactMode::Manual | CompactMode::Host | CompactMode::ResumeDigest => {
+                CompactionTrigger::Manual
+            }
+            CompactMode::Auto | CompactMode::Workflow | CompactMode::Worker => {
+                CompactionTrigger::Threshold
+            }
+        };
         Self {
             session_id: None,
             transcript_id: None,
             mode,
+            trigger,
+            fire_hooks: mode.fires_hooks(),
             reminder_events: Vec::new(),
             summary_override: None,
             provider_options: JsonValue::Object(serde_json::Map::new()),
@@ -148,6 +180,16 @@ impl<'a> CompactLifecycle<'a> {
 
     pub fn with_transcript_id(mut self, transcript_id: Option<&'a str>) -> Self {
         self.transcript_id = transcript_id;
+        self
+    }
+
+    pub fn with_trigger(mut self, trigger: CompactionTrigger) -> Self {
+        self.trigger = trigger;
+        self
+    }
+
+    pub fn with_hook_dispatch(mut self, fire_hooks: bool) -> Self {
+        self.fire_hooks = fire_hooks;
         self
     }
 
@@ -202,6 +244,14 @@ pub struct CompactionOutcome {
     pub event_metadata: JsonValue,
 }
 
+#[derive(Clone, Debug)]
+pub struct TranscriptCompactedEventMetrics {
+    pub archived_messages: usize,
+    pub estimated_tokens_before: usize,
+    pub estimated_tokens_after: usize,
+    pub snapshot_asset_id: Option<String>,
+}
+
 /// Reminder-lifecycle bookkeeping produced before the compaction runs and
 /// consumed by both the persisted transcript and the AgentEvent payload.
 #[derive(Debug, Default)]
@@ -234,13 +284,13 @@ pub struct ReminderDedupeRecord {
 }
 
 /// Run a transcript compaction through the canonical lifecycle. The
-/// `messages` vec is mutated in place by [`auto_compact_messages`]; on a
+/// `messages` vec is mutated in place by [`auto_compact_messages_with_result`]; on a
 /// `Ok(None)` return it is left untouched so callers that always write
 /// messages back (e.g. `transcript_auto_compact()`) can do so unconditionally.
 ///
 /// `Ok(None)` means no compaction happened — either the messages were
 /// already under threshold, a PreCompact hook returned `Block`, or
-/// `auto_compact_messages` itself decided there was nothing to do.
+/// `auto_compact_messages_with_result` itself decided there was nothing to do.
 pub(crate) async fn run_compaction_lifecycle(
     messages: &mut Vec<JsonValue>,
     config: &mut AutoCompactConfig,
@@ -254,7 +304,7 @@ pub(crate) async fn run_compaction_lifecycle(
     let estimated_tokens_before = estimate_message_tokens(messages);
     let original_message_count = messages.len();
 
-    let fires_hooks = lifecycle.mode.fires_hooks();
+    let fires_hooks = lifecycle.fire_hooks;
 
     if fires_hooks {
         let pre_payload = build_hook_payload(
@@ -276,9 +326,13 @@ pub(crate) async fn run_compaction_lifecycle(
     let reminder_report = compact_reminder_events(reminder_events);
     config.custom_compactor_reminders = reminder_report.custom_reminders.clone();
 
-    let Some(raw_summary) = auto_compact_messages(messages, config, llm_opts).await? else {
+    let Some(compact_result) =
+        auto_compact_messages_with_result(messages, config, llm_opts).await?
+    else {
         return Ok(None);
     };
+    let engine_strategy = compact_result.strategy;
+    let raw_summary = compact_result.summary;
     let summary = lifecycle.summary_override.clone().unwrap_or(raw_summary);
 
     if fires_hooks {
@@ -294,22 +348,27 @@ pub(crate) async fn run_compaction_lifecycle(
         build_snapshot_asset(
             transcript,
             config,
+            &engine_strategy,
             archived_messages,
             estimated_tokens_before,
             estimated_tokens_after,
         )
     });
     let snapshot_asset_id = snapshot_asset.as_ref().map(snapshot_asset_id_of);
+    let event_metrics = TranscriptCompactedEventMetrics {
+        archived_messages,
+        estimated_tokens_before,
+        estimated_tokens_after,
+        snapshot_asset_id: snapshot_asset_id.clone(),
+    };
 
     let event_metadata = build_event_metadata(
         &lifecycle,
         config,
-        archived_messages,
-        estimated_tokens_before,
-        estimated_tokens_after,
-        snapshot_asset_id.as_deref(),
+        &event_metrics,
         &reminder_report,
         &summary,
+        &engine_strategy,
     );
 
     if fires_hooks {
@@ -334,11 +393,9 @@ pub(crate) async fn run_compaction_lifecycle(
             emit_transcript_compacted_event(
                 session_id,
                 lifecycle.mode,
+                lifecycle.trigger.as_str(),
                 config,
-                archived_messages,
-                estimated_tokens_before,
-                estimated_tokens_after,
-                snapshot_asset_id.as_deref(),
+                event_metrics.clone(),
             )
             .await;
             if lifecycle.evaluate_providers {
@@ -361,7 +418,7 @@ pub(crate) async fn run_compaction_lifecycle(
         reminder_report,
         snapshot_asset,
         snapshot_asset_id,
-        strategy: config.compact_strategy.clone(),
+        strategy: engine_strategy,
         policy_strategy: config.policy_strategy.clone(),
         event_metadata,
     }))
@@ -374,20 +431,19 @@ pub(crate) async fn run_compaction_lifecycle(
 pub async fn emit_transcript_compacted_event(
     session_id: &str,
     mode: CompactMode,
+    reason: &str,
     config: &AutoCompactConfig,
-    archived_messages: usize,
-    estimated_tokens_before: usize,
-    estimated_tokens_after: usize,
-    snapshot_asset_id: Option<&str>,
+    metrics: TranscriptCompactedEventMetrics,
 ) {
     crate::llm::emit_live_agent_event(&AgentEvent::TranscriptCompacted {
         session_id: session_id.to_string(),
         mode: mode.as_str().to_string(),
+        reason: reason.to_string(),
         strategy: config.policy_strategy.clone(),
-        archived_messages,
-        estimated_tokens_before,
-        estimated_tokens_after,
-        snapshot_asset_id: snapshot_asset_id.map(str::to_string),
+        archived_messages: metrics.archived_messages,
+        estimated_tokens_before: metrics.estimated_tokens_before,
+        estimated_tokens_after: metrics.estimated_tokens_after,
+        snapshot_asset_id: metrics.snapshot_asset_id,
         instruction_mode: Some(config.policy.instruction_mode().to_string()),
         instruction_source: config.policy.instruction_source().map(str::to_string),
         compaction_policy: config.policy.metadata_json(),
@@ -401,21 +457,20 @@ pub async fn emit_transcript_compacted_event(
 pub fn emit_transcript_compacted_event_sync(
     session_id: &str,
     mode: CompactMode,
+    reason: String,
     policy: &CompactionPolicy,
     policy_strategy: String,
-    archived_messages: usize,
-    estimated_tokens_before: usize,
-    estimated_tokens_after: usize,
-    snapshot_asset_id: Option<String>,
+    metrics: TranscriptCompactedEventMetrics,
 ) {
     crate::llm::emit_live_agent_event_sync(&AgentEvent::TranscriptCompacted {
         session_id: session_id.to_string(),
         mode: mode.as_str().to_string(),
+        reason,
         strategy: policy_strategy,
-        archived_messages,
-        estimated_tokens_before,
-        estimated_tokens_after,
-        snapshot_asset_id,
+        archived_messages: metrics.archived_messages,
+        estimated_tokens_before: metrics.estimated_tokens_before,
+        estimated_tokens_after: metrics.estimated_tokens_after,
+        snapshot_asset_id: metrics.snapshot_asset_id,
         instruction_mode: Some(policy.instruction_mode().to_string()),
         instruction_source: policy.instruction_source().map(str::to_string),
         compaction_policy: policy.metadata_json(),
@@ -457,6 +512,7 @@ fn build_hook_payload(
         "session": {"id": session_id},
         "session_id": session_id,
         "mode": lifecycle.mode.as_str(),
+        "reason": lifecycle.trigger.as_str(),
         "strategy": strategy,
         "engine_strategy": strategy,
         "keep_last": config.keep_last,
@@ -571,24 +627,23 @@ fn apply_pre_modify_overrides(
 fn build_event_metadata(
     lifecycle: &CompactLifecycle<'_>,
     config: &AutoCompactConfig,
-    archived_messages: usize,
-    estimated_tokens_before: usize,
-    estimated_tokens_after: usize,
-    snapshot_asset_id: Option<&str>,
+    metrics: &TranscriptCompactedEventMetrics,
     reminder_report: &ReminderCompactReport,
     summary: &str,
+    engine_strategy: &CompactStrategy,
 ) -> JsonValue {
     let mut metadata = serde_json::json!({
         "mode": lifecycle.mode.as_str(),
+        "reason": lifecycle.trigger.as_str(),
         "strategy": config.policy_strategy,
-        "engine_strategy": compact_strategy_name(&config.compact_strategy),
+        "engine_strategy": compact_strategy_name(engine_strategy),
         "keep_last": config.keep_last,
         "target_tokens": (config.token_threshold > 0).then_some(config.token_threshold),
-        "archived_messages": archived_messages,
-        "estimated_tokens_before": estimated_tokens_before,
-        "estimated_tokens_after": estimated_tokens_after,
+        "archived_messages": metrics.archived_messages,
+        "estimated_tokens_before": metrics.estimated_tokens_before,
+        "estimated_tokens_after": metrics.estimated_tokens_after,
         "new_summary_len": summary.len(),
-        "snapshot_asset_id": snapshot_asset_id,
+        "snapshot_asset_id": metrics.snapshot_asset_id.as_deref(),
         "reminders_decremented": reminder_report.decremented_count,
         "reminders_expired": reminder_report.expired.len(),
         "reminders_deduped": reminder_report.deduped.len(),
@@ -789,6 +844,7 @@ fn emit_reminder_lifecycle_records(transcript_id: Option<&str>, report: &Reminde
 fn build_snapshot_asset(
     transcript: &VmValue,
     config: &AutoCompactConfig,
+    engine_strategy: &CompactStrategy,
     archived_messages: usize,
     estimated_tokens_before: usize,
     estimated_tokens_after: usize,
@@ -796,7 +852,7 @@ fn build_snapshot_asset(
     let mut asset_metadata = BTreeMap::from([
         (
             "strategy".to_string(),
-            VmValue::String(Rc::from(compact_strategy_name(&config.compact_strategy))),
+            VmValue::String(Rc::from(compact_strategy_name(engine_strategy))),
         ),
         (
             "archived_messages".to_string(),

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -469,6 +469,10 @@ pub struct AutoCompactConfig {
     /// broader than the engine strategy, e.g. `hybrid` lowers to LLM
     /// summarization plus truncate fallback.
     pub policy_strategy: String,
+    /// Strategy to try when the primary strategy fails. Budget-pressure
+    /// compaction uses this to keep the session within its hard cap even when
+    /// an LLM summarizer is unavailable.
+    pub fallback_strategy: Option<CompactStrategy>,
     /// Host/user-supplied instructions that guide compaction without
     /// becoming part of the compacted transcript unless `scope` explicitly
     /// asks for model-visible policy text.
@@ -491,6 +495,7 @@ impl Default for AutoCompactConfig {
             compress_callback: None,
             summarize_prompt: None,
             policy_strategy: compact_strategy_name(&CompactStrategy::ObservationMask).to_string(),
+            fallback_strategy: None,
             policy: CompactionPolicy::default(),
         }
     }
@@ -985,6 +990,7 @@ async fn invoke_mask_callback(
         .collect())
 }
 
+#[derive(Clone, Copy)]
 struct CompactionStrategyInputs<'a> {
     strategy: &'a CompactStrategy,
     old_messages: &'a [serde_json::Value],
@@ -1056,12 +1062,39 @@ async fn apply_compaction_strategy(input: CompactionStrategyInputs<'_>) -> Resul
     }
 }
 
+async fn apply_compaction_strategy_with_fallback(
+    input: CompactionStrategyInputs<'_>,
+    fallback_strategy: Option<&CompactStrategy>,
+) -> Result<(String, CompactStrategy), VmError> {
+    match apply_compaction_strategy(input).await {
+        Ok(summary) => Ok((summary, input.strategy.clone())),
+        Err(primary_error) => {
+            let Some(fallback) = fallback_strategy.filter(|fallback| *fallback != input.strategy)
+            else {
+                return Err(primary_error);
+            };
+            let fallback_input = CompactionStrategyInputs {
+                strategy: fallback,
+                ..input
+            };
+            apply_compaction_strategy(fallback_input)
+                .await
+                .map(|summary| (summary, fallback.clone()))
+        }
+    }
+}
+
+pub(crate) struct AutoCompactResult {
+    pub summary: String,
+    pub strategy: CompactStrategy,
+}
+
 /// Auto-compact a message list in place using two-tier compaction.
-pub(crate) async fn auto_compact_messages(
+pub(crate) async fn auto_compact_messages_with_result(
     messages: &mut Vec<serde_json::Value>,
     config: &AutoCompactConfig,
     llm_opts: Option<&crate::llm::api::LlmCallOptions>,
-) -> Result<Option<String>, VmError> {
+) -> Result<Option<AutoCompactResult>, VmError> {
     if config.token_threshold > 0 && estimate_message_tokens(messages) <= config.token_threshold {
         return Ok(None);
     }
@@ -1107,17 +1140,20 @@ pub(crate) async fn auto_compact_messages(
     let old_messages: Vec<_> = messages.drain(compact_start..split_at).collect();
     let archived_count = old_messages.len();
 
-    let mut summary = apply_compaction_strategy(CompactionStrategyInputs {
-        strategy: &config.compact_strategy,
-        old_messages: &old_messages,
-        archived_count,
-        llm_opts,
-        custom_compactor: config.custom_compactor.as_ref(),
-        custom_compactor_reminders: &config.custom_compactor_reminders,
-        mask_callback: config.mask_callback.as_ref(),
-        summarize_prompt: config.summarize_prompt.as_deref(),
-        policy: &config.policy,
-    })
+    let (mut summary, mut strategy) = apply_compaction_strategy_with_fallback(
+        CompactionStrategyInputs {
+            strategy: &config.compact_strategy,
+            old_messages: &old_messages,
+            archived_count,
+            llm_opts,
+            custom_compactor: config.custom_compactor.as_ref(),
+            custom_compactor_reminders: &config.custom_compactor_reminders,
+            mask_callback: config.mask_callback.as_ref(),
+            summarize_prompt: config.summarize_prompt.as_deref(),
+            policy: &config.policy,
+        },
+        config.fallback_strategy.as_ref(),
+    )
     .await?;
 
     if let Some(hard_limit) = config.hard_limit_tokens {
@@ -1130,18 +1166,24 @@ pub(crate) async fn auto_compact_messages(
                 "role": "user",
                 "content": summary,
             })];
-            summary = apply_compaction_strategy(CompactionStrategyInputs {
-                strategy: &config.hard_limit_strategy,
-                old_messages: &tier1_as_messages,
-                archived_count,
-                llm_opts,
-                custom_compactor: config.custom_compactor.as_ref(),
-                custom_compactor_reminders: &config.custom_compactor_reminders,
-                mask_callback: None,
-                summarize_prompt: config.summarize_prompt.as_deref(),
-                policy: &config.policy,
-            })
-            .await?;
+            let (hard_limit_summary, hard_limit_strategy) =
+                apply_compaction_strategy_with_fallback(
+                    CompactionStrategyInputs {
+                        strategy: &config.hard_limit_strategy,
+                        old_messages: &tier1_as_messages,
+                        archived_count,
+                        llm_opts,
+                        custom_compactor: config.custom_compactor.as_ref(),
+                        custom_compactor_reminders: &config.custom_compactor_reminders,
+                        mask_callback: None,
+                        summarize_prompt: config.summarize_prompt.as_deref(),
+                        policy: &config.policy,
+                    },
+                    config.fallback_strategy.as_ref(),
+                )
+                .await?;
+            summary = hard_limit_summary;
+            strategy = hard_limit_strategy;
         }
     }
 
@@ -1154,7 +1196,21 @@ pub(crate) async fn auto_compact_messages(
             "content": summary,
         }),
     );
-    Ok(Some(summary))
+    Ok(Some(AutoCompactResult { summary, strategy }))
+}
+
+/// Auto-compact a message list in place using two-tier compaction.
+#[cfg(test)]
+pub(crate) async fn auto_compact_messages(
+    messages: &mut Vec<serde_json::Value>,
+    config: &AutoCompactConfig,
+    llm_opts: Option<&crate::llm::api::LlmCallOptions>,
+) -> Result<Option<String>, VmError> {
+    Ok(
+        auto_compact_messages_with_result(messages, config, llm_opts)
+            .await?
+            .map(|result| result.summary),
+    )
 }
 
 fn apply_model_visible_policy(mut summary: String, policy: &CompactionPolicy) -> String {

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -105,7 +105,7 @@ that route on it keep working unchanged. Concretely:
 | `log`                  | `level`, `message`, `fields`                                                                                                           |
 | `fs_watch`             | `subscriptionId`, `events`                                                                                                             |
 | `worker_update`        | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit`                               |
-| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` |
+| `transcript_compacted` | `mode`, `reason`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` |
 | `handoff`              | `handoffId`, `artifactId`, `handoff`                                                                                                   |
 | `skill_activated`      | `skillName`, `iteration`, `reason`                                                                                                     |
 | `skill_deactivated`    | `skillName`, `iteration`                                                                                                               |

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -350,10 +350,10 @@ Available strategies:
 | `"hybrid"` | Summarize older messages, keep the latest suffix, and use truncate as the hard-limit fallback |
 
 Compaction emits `TranscriptCompacted` live events and transcript
-`compaction` events with `strategy`, `engine_strategy`,
+`compaction` events with `reason`, `strategy`, `engine_strategy`,
 `estimated_tokens_before`, `estimated_tokens_after`, `instruction_mode`,
 `instruction_source`, and `compaction_policy`, so replay tools can verify which
-policy and host/user instruction lane ran.
+trigger, policy, and host/user instruction lane ran.
 
 Hosts can attach first-class compaction instructions without building custom
 prompt concatenation. The typed `CompactionPolicy` shape accepts

--- a/docs/src/spec/harn-extensions/v1.md
+++ b/docs/src/spec/harn-extensions/v1.md
@@ -104,7 +104,7 @@ Harn extension session updates keep the `sessionUpdate` discriminator at
 | `log` | `level`, `message`, `fields` | Stable v1 |
 | `fs_watch` | `subscriptionId`, `events` | Stable v1 |
 | `worker_update` | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit` | Stable v1 |
-| `transcript_compacted` | `mode`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` | Stable v1 |
+| `transcript_compacted` | `mode`, `reason`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` | Stable v1 |
 | `handoff` | `handoffId`, `artifactId`, `handoff` | Stable v1 |
 | `skill_activated` | `skillName`, `iteration`, `reason` | Stable v1 |
 | `skill_deactivated` | `skillName`, `iteration` | Stable v1 |


### PR DESCRIPTION
## Summary
- route session budget compaction through the shared orchestration lifecycle with `BudgetPressure` metadata
- distinguish `threshold` and `budget_pressure` compaction reasons in transcript and ACP events
- add LLM-summary and truncate-fallback budget compaction coverage with canned mocks

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2472 cargo test -p harn-vm transcript_budget -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2472 cargo test -p harn-serve adapters::acp::events::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2472 cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-target-2472 cargo check -p harn-serve`
- `harn fmt --check crates/harn-stdlib/src/stdlib/agent/autocompact.harn`
- `harn check crates/harn-stdlib/src/stdlib/agent/autocompact.harn`
- `harn lint crates/harn-stdlib/src/stdlib/agent/autocompact.harn`
- `cargo fmt --check`
- `make lint-test-patterns`
- pre-commit hook
- pre-push hook

Closes #2472