### PR TITLE
Add session-id replay from events sqlite

### DIFF
--- a/crates/harn-cli/src/cli/runs.rs
+++ b/crates/harn-cli/src/cli/runs.rs
@@ -23,8 +23,25 @@ pub(crate) struct RunsInspectArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct ReplayArgs {
-    /// Path to the run record JSON file.
-    pub path: String,
+    /// Path to the run record JSON file. Kept for compatibility with older `harn replay <path>` usage.
+    #[arg(
+        value_name = "PATH",
+        required_unless_present_any = ["fixture", "session_id"],
+        conflicts_with_all = ["fixture", "session_id"]
+    )]
+    pub path: Option<String>,
+    /// Path to a run record or replay-oracle fixture.
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["path", "session_id"])]
+    pub fixture: Option<String>,
+    /// Reconstruct replay input from the agent-session events in `--events-db`.
+    #[arg(long, requires = "events_db", conflicts_with_all = ["path", "fixture"])]
+    pub session_id: Option<String>,
+    /// SQLite EventLog database to read for `--session-id`.
+    #[arg(long, value_name = "PATH", requires = "session_id")]
+    pub events_db: Option<String>,
+    /// Number of replay reads to compare for deterministic output.
+    #[arg(long, default_value_t = 1)]
+    pub runs: usize,
     /// Emit a structured `JsonEnvelope` replay summary instead of human-readable output.
     /// See `docs/src/cli-json-contract.md` for the envelope shape.
     #[arg(long)]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -867,6 +867,53 @@ fn test_parses_runs_inspect_compare() {
 }
 
 #[test]
+fn test_parses_replay_sources_and_runs() {
+    let cli = Cli::parse_from(["harn", "replay", "run.json", "--json"]);
+    let Command::Replay(replay) = cli.command.unwrap() else {
+        panic!("expected replay command");
+    };
+    assert_eq!(replay.path.as_deref(), Some("run.json"));
+    assert!(replay.fixture.is_none());
+    assert!(replay.session_id.is_none());
+    assert_eq!(replay.runs, 1);
+    assert!(replay.json);
+
+    let cli = Cli::parse_from([
+        "harn",
+        "replay",
+        "--fixture",
+        "trace.json",
+        "--runs",
+        "3",
+        "--json",
+    ]);
+    let Command::Replay(replay) = cli.command.unwrap() else {
+        panic!("expected replay command");
+    };
+    assert!(replay.path.is_none());
+    assert_eq!(replay.fixture.as_deref(), Some("trace.json"));
+    assert_eq!(replay.runs, 3);
+    assert!(replay.json);
+
+    let cli = Cli::parse_from([
+        "harn",
+        "replay",
+        "--session-id",
+        "session-123",
+        "--events-db",
+        ".harn/events.sqlite",
+        "--runs",
+        "2",
+    ]);
+    let Command::Replay(replay) = cli.command.unwrap() else {
+        panic!("expected replay command");
+    };
+    assert_eq!(replay.session_id.as_deref(), Some("session-123"));
+    assert_eq!(replay.events_db.as_deref(), Some(".harn/events.sqlite"));
+    assert_eq!(replay.runs, 2);
+}
+
+#[test]
 fn test_parses_session_bundle_commands() {
     let cli = Cli::parse_from([
         "harn",

--- a/crates/harn-cli/src/commands/replay.rs
+++ b/crates/harn-cli/src/commands/replay.rs
@@ -1,9 +1,16 @@
 //! `harn replay` JSON output. See `docs/src/cli-json-contract.md`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use harn_vm::event_log::{AnyEventLog, SqliteEventLog};
+use harn_vm::orchestration::{
+    load_agent_session_replay_events_from_log, ReplayAllowlistRule, ReplayDivergence,
+    ReplayExpectation, ReplayOracleTrace, ReplayTraceRun,
+};
 use serde::Serialize;
+use serde_json::{json, Value as JsonValue};
 
+use crate::cli::ReplayArgs;
 use crate::json_envelope::{self, JsonEnvelope};
 
 pub(crate) const REPLAY_SCHEMA_VERSION: u32 = 1;
@@ -50,22 +57,390 @@ pub(crate) struct ReplayFixtureResult {
     pub stage_count: usize,
 }
 
-pub(crate) fn run_json(path: &str) -> i32 {
-    let run = match load_run_record(Path::new(path)) {
-        Ok(run) => run,
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReplayRunsEnvelope {
+    #[serde(rename = "schemaVersion")]
+    pub schema_version: u32,
+    pub ok: bool,
+    pub source: ReplaySourceSummary,
+    pub reports: Vec<ReplayReport>,
+    pub runs: Vec<Vec<JsonValue>>,
+    pub determinism: ReplayDeterminismSummary,
+    pub error: Option<json_envelope::JsonError>,
+    pub warnings: Vec<json_envelope::JsonWarning>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReplaySourceSummary {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_db: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReplayDeterminismSummary {
+    pub pass: bool,
+    pub compared_runs: usize,
+    pub allowlist: Vec<ReplayAllowlistRule>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub divergence: Option<ReplayDivergence>,
+    pub failures: Vec<String>,
+}
+
+struct ReplayExecution {
+    report: ReplayReport,
+    trace_run: ReplayTraceRun,
+    event_sequence: Vec<JsonValue>,
+}
+
+enum ReplaySource {
+    RunRecord {
+        path: PathBuf,
+    },
+    ReplayTrace {
+        path: PathBuf,
+        trace: Box<ReplayOracleTrace>,
+    },
+    Session {
+        session_id: String,
+        events_db: PathBuf,
+    },
+}
+
+impl ReplaySource {
+    fn summary(&self) -> ReplaySourceSummary {
+        match self {
+            Self::RunRecord { path } => ReplaySourceSummary {
+                kind: "run_record".to_string(),
+                path: Some(path.to_string_lossy().into_owned()),
+                session_id: None,
+                events_db: None,
+            },
+            Self::ReplayTrace { path, .. } => ReplaySourceSummary {
+                kind: "replay_trace".to_string(),
+                path: Some(path.to_string_lossy().into_owned()),
+                session_id: None,
+                events_db: None,
+            },
+            Self::Session {
+                session_id,
+                events_db,
+            } => ReplaySourceSummary {
+                kind: "event_log_session".to_string(),
+                path: None,
+                session_id: Some(session_id.clone()),
+                events_db: Some(events_db.to_string_lossy().into_owned()),
+            },
+        }
+    }
+
+    fn allowlist(&self) -> Vec<ReplayAllowlistRule> {
+        match self {
+            Self::ReplayTrace { trace, .. } => trace.allowlist.clone(),
+            Self::RunRecord { .. } | Self::Session { .. } => default_replay_allowlist(),
+        }
+    }
+
+    fn load_error_code(&self) -> &'static str {
+        match self {
+            Self::RunRecord { .. } => "run_record_load_failed",
+            Self::ReplayTrace { .. } => "replay_fixture_load_failed",
+            Self::Session { .. } => "replay_load_failed",
+        }
+    }
+}
+
+pub(crate) fn run(args: ReplayArgs) -> i32 {
+    if args.runs == 0 {
+        if args.json {
+            print_json_error("invalid_runs", "--runs must be at least 1");
+        } else {
+            eprintln!("error: --runs must be at least 1");
+        }
+        return 1;
+    }
+
+    let source = match resolve_source(&args) {
+        Ok(source) => source,
         Err(error) => {
-            let envelope: JsonEnvelope<ReplayReport> =
-                JsonEnvelope::err(REPLAY_SCHEMA_VERSION, "run_record_load_failed", error);
-            println!("{}", json_envelope::to_string_pretty(&envelope));
+            if args.json {
+                print_json_error("replay_source_invalid", error);
+            } else {
+                eprintln!("error: {error}");
+            }
             return 1;
         }
     };
 
+    if args.json {
+        run_json(source, args.runs)
+    } else {
+        run_human(source, args.runs)
+    }
+}
+
+fn run_json(source: ReplaySource, runs: usize) -> i32 {
+    let executions = match execute_runs(&source, runs) {
+        Ok(executions) => executions,
+        Err(error) => {
+            print_json_error(source.load_error_code(), error);
+            return 1;
+        }
+    };
+
+    if runs == 1 {
+        let execution = executions
+            .into_iter()
+            .next()
+            .expect("execute_runs returns one execution for runs=1");
+        let envelope = envelope_for_report(execution.report);
+        let exit = i32::from(!envelope.ok);
+        println!("{}", json_envelope::to_string_pretty(&envelope));
+        return exit;
+    }
+
+    let determinism = determinism_summary(&source, &executions);
+    let reports = executions
+        .iter()
+        .map(|execution| execution.report.clone())
+        .collect::<Vec<_>>();
+    let runs = executions
+        .iter()
+        .map(|execution| execution.event_sequence.clone())
+        .collect::<Vec<_>>();
+    let fixture_failed = reports.iter().any(|report| !report.fixture.pass);
+    let ok = !fixture_failed && determinism.pass;
+    let error = if ok {
+        None
+    } else {
+        Some(json_envelope::JsonError {
+            code: if fixture_failed {
+                "replay_fixture_failed".to_string()
+            } else {
+                "replay_determinism_failed".to_string()
+            },
+            message: if fixture_failed {
+                "one or more replay fixtures did not pass".to_string()
+            } else {
+                "allowlist-stripped replay runs diverged".to_string()
+            },
+            details: serde_json::Value::Null,
+        })
+    };
+    let payload = ReplayRunsEnvelope {
+        schema_version: REPLAY_SCHEMA_VERSION,
+        ok,
+        source: source.summary(),
+        reports,
+        runs,
+        determinism,
+        error,
+        warnings: Vec::new(),
+    };
+    let exit = i32::from(!payload.ok);
+    println!("{}", to_string_pretty(&payload));
+    exit
+}
+
+fn run_human(source: ReplaySource, runs: usize) -> i32 {
+    let executions = match execute_runs(&source, runs) {
+        Ok(executions) => executions,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    for (index, execution) in executions.iter().enumerate() {
+        if runs > 1 {
+            println!("Replay run {}:", index + 1);
+        }
+        print_report_human(&execution.report);
+    }
+    if runs > 1 {
+        let determinism = determinism_summary(&source, &executions);
+        println!(
+            "Determinism: {} (compared {} run(s))",
+            if determinism.pass { "PASS" } else { "FAIL" },
+            determinism.compared_runs
+        );
+        for failure in determinism.failures {
+            println!("  {failure}");
+        }
+        return i32::from(!determinism.pass);
+    }
+    i32::from(!executions[0].report.fixture.pass)
+}
+
+fn resolve_source(args: &ReplayArgs) -> Result<ReplaySource, String> {
+    if let Some(session_id) = &args.session_id {
+        let events_db = args
+            .events_db
+            .as_ref()
+            .ok_or_else(|| "--events-db is required with --session-id".to_string())?;
+        return Ok(ReplaySource::Session {
+            session_id: session_id.clone(),
+            events_db: PathBuf::from(events_db),
+        });
+    }
+    if let Some(fixture) = &args.fixture {
+        return resolve_fixture_source(Path::new(fixture));
+    }
+    if let Some(path) = &args.path {
+        return Ok(ReplaySource::RunRecord {
+            path: PathBuf::from(path),
+        });
+    }
+    Err("one of <PATH>, --fixture, or --session-id must be provided".to_string())
+}
+
+fn resolve_fixture_source(path: &Path) -> Result<ReplaySource, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read fixture {}: {error}", path.display()))?;
+    let value: JsonValue = serde_json::from_str(&raw)
+        .map_err(|error| format!("failed to parse fixture {}: {error}", path.display()))?;
+    if value
+        .get("schema_version")
+        .and_then(JsonValue::as_str)
+        .is_some_and(|schema| schema == harn_vm::REPLAY_TRACE_SCHEMA_VERSION)
+    {
+        let trace = serde_json::from_value::<ReplayOracleTrace>(value)
+            .map_err(|error| format!("failed to parse replay trace {}: {error}", path.display()))?;
+        return Ok(ReplaySource::ReplayTrace {
+            path: path.to_path_buf(),
+            trace: Box::new(trace),
+        });
+    }
+    Ok(ReplaySource::RunRecord {
+        path: path.to_path_buf(),
+    })
+}
+
+fn execute_runs(source: &ReplaySource, runs: usize) -> Result<Vec<ReplayExecution>, String> {
+    (0..runs).map(|index| execute_once(source, index)).collect()
+}
+
+fn execute_once(source: &ReplaySource, index: usize) -> Result<ReplayExecution, String> {
+    match source {
+        ReplaySource::RunRecord { path } => execute_run_record(path),
+        ReplaySource::ReplayTrace { trace, .. } => execute_replay_trace(trace, index),
+        ReplaySource::Session {
+            session_id,
+            events_db,
+        } => execute_session_replay(session_id, events_db),
+    }
+}
+
+fn execute_run_record(path: &Path) -> Result<ReplayExecution, String> {
+    let run = harn_vm::orchestration::load_run_record(path)
+        .map_err(|error| format!("failed to load run record {}: {error}", path.display()))?;
+    let report = replay_report_from_run(&run);
+    let raw_events = event_sequence_from_report(&report);
+    let trace_run = ReplayTraceRun {
+        run_id: report.run_id.clone(),
+        event_log_entries: raw_events,
+        ..ReplayTraceRun::default()
+    };
+    let event_sequence = canonical_event_sequence(&trace_run, &default_replay_allowlist())?;
+    Ok(ReplayExecution {
+        report,
+        trace_run,
+        event_sequence,
+    })
+}
+
+fn execute_session_replay(session_id: &str, events_db: &Path) -> Result<ReplayExecution, String> {
+    let log = AnyEventLog::Sqlite(
+        SqliteEventLog::open_read_only(events_db.to_path_buf(), 1).map_err(|error| {
+            format!(
+                "failed to open events db {} read-only: {error}",
+                events_db.display()
+            )
+        })?,
+    );
+    let events =
+        futures::executor::block_on(load_agent_session_replay_events_from_log(&log, session_id))
+            .map_err(|error| format!("failed to read session events: {error}"))?;
+    if events.is_empty() {
+        return Err(format!(
+            "event log {} does not contain events for session_id {session_id:?}",
+            events_db.display()
+        ));
+    }
+    let run =
+        harn_vm::session_bundle::import_run_record_from_agent_session_events(session_id, &events)
+            .map_err(|error| {
+            format!("failed to reconstruct run record from session events: {error}")
+        })?;
+    let report = replay_report_from_run(&run);
+    let raw_events = events
+        .iter()
+        .map(|entry| {
+            let event = serde_json::to_value(&entry.event).unwrap_or(JsonValue::Null);
+            json!({
+                "event_id": entry.event_id,
+                "topic": format!(
+                    "observability.agent_events.{}",
+                    harn_vm::event_log::sanitize_topic_component(session_id)
+                ),
+                "kind": entry.kind,
+                "occurred_at_ms": entry.occurred_at_ms,
+                "payload": {
+                    "session_id": session_id,
+                    "event": event,
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+    let trace_run = ReplayTraceRun {
+        run_id: report.run_id.clone(),
+        event_log_entries: raw_events,
+        ..ReplayTraceRun::default()
+    };
+    let event_sequence = canonical_event_sequence(&trace_run, &default_replay_allowlist())?;
+    Ok(ReplayExecution {
+        report,
+        trace_run,
+        event_sequence,
+    })
+}
+
+fn execute_replay_trace(
+    trace: &ReplayOracleTrace,
+    index: usize,
+) -> Result<ReplayExecution, String> {
+    let trace_run = if index.is_multiple_of(2) {
+        trace.first_run.clone()
+    } else {
+        trace.second_run.clone()
+    };
+    let fixture = trace_fixture_result(trace, &trace_run)?;
+    let report = ReplayReport {
+        run_id: trace_run.run_id.clone(),
+        status: if fixture.pass { "completed" } else { "failed" }.to_string(),
+        stage_count: 0,
+        stages: Vec::new(),
+        transitions: Vec::new(),
+        transcript_event_count: trace_run.event_log_entries.len(),
+        fixture,
+    };
+    let event_sequence = canonical_event_sequence(&trace_run, &trace.allowlist)?;
+    Ok(ReplayExecution {
+        report,
+        trace_run,
+        event_sequence,
+    })
+}
+
+fn replay_report_from_run(run: &harn_vm::orchestration::RunRecord) -> ReplayReport {
     let fixture = run
         .replay_fixture
         .clone()
-        .unwrap_or_else(|| harn_vm::orchestration::replay_fixture_from_run(&run));
-    let report = harn_vm::orchestration::evaluate_run_against_fixture(&run, &fixture);
+        .unwrap_or_else(|| harn_vm::orchestration::replay_fixture_from_run(run));
+    let report = harn_vm::orchestration::evaluate_run_against_fixture(run, &fixture);
 
     let stages: Vec<ReplayStage> = run
         .stages
@@ -96,7 +471,7 @@ pub(crate) fn run_json(path: &str) -> i32 {
         .map(|v| v.len())
         .unwrap_or(0);
 
-    let payload = ReplayReport {
+    ReplayReport {
         run_id: run.id.clone(),
         status: run.status.clone(),
         stage_count: run.stages.len(),
@@ -108,9 +483,11 @@ pub(crate) fn run_json(path: &str) -> i32 {
             failures: report.failures.clone(),
             stage_count: report.stage_count,
         },
-    };
+    }
+}
 
-    let envelope = if payload.fixture.pass {
+fn envelope_for_report(payload: ReplayReport) -> JsonEnvelope<ReplayReport> {
+    if payload.fixture.pass {
         JsonEnvelope::ok(REPLAY_SCHEMA_VERSION, payload)
     } else {
         JsonEnvelope {
@@ -124,15 +501,242 @@ pub(crate) fn run_json(path: &str) -> i32 {
             }),
             warnings: Vec::new(),
         }
-    };
-    let exit = i32::from(!envelope.ok);
-    println!("{}", json_envelope::to_string_pretty(&envelope));
-    exit
+    }
 }
 
-fn load_run_record(path: &Path) -> Result<harn_vm::orchestration::RunRecord, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
-    serde_json::from_str(&raw)
-        .map_err(|error| format!("failed to parse run record {}: {error}", path.display()))
+fn print_report_human(report: &ReplayReport) {
+    println!("Replay: {}", report.run_id);
+    for stage in &report.stages {
+        println!(
+            "[{}] status={} outcome={} branch={}",
+            stage.node_id,
+            stage.status,
+            stage.outcome,
+            stage.branch.clone().unwrap_or_else(|| "-".to_string())
+        );
+        if let Some(text) = &stage.visible_text {
+            println!("  visible: {text}");
+        }
+        if let Some(verification) = &stage.verification {
+            println!("  verification: {verification}");
+        }
+    }
+    println!(
+        "Transcript events persisted: {}",
+        report.transcript_event_count
+    );
+    println!(
+        "Embedded replay fixture: {}",
+        if report.fixture.pass { "PASS" } else { "FAIL" }
+    );
+    for transition in &report.transitions {
+        println!(
+            "transition {} -> {} ({})",
+            transition
+                .from_node_id
+                .clone()
+                .unwrap_or_else(|| "start".to_string()),
+            transition.to_node_id,
+            transition
+                .branch
+                .clone()
+                .unwrap_or_else(|| "default".to_string())
+        );
+    }
+}
+
+fn trace_fixture_result(
+    trace: &ReplayOracleTrace,
+    trace_run: &ReplayTraceRun,
+) -> Result<ReplayFixtureResult, String> {
+    let oracle = ReplayOracleTrace {
+        name: format!("{} replay fixture", trace.name),
+        expect: ReplayExpectation::Match,
+        protocol_fixture_refs: trace.protocol_fixture_refs.clone(),
+        allowlist: trace.allowlist.clone(),
+        first_run: trace.first_run.clone(),
+        second_run: trace_run.clone(),
+        ..ReplayOracleTrace::default()
+    };
+    let report = harn_vm::run_replay_oracle_trace(&oracle)
+        .map_err(|error| format!("failed to evaluate replay trace: {error}"))?;
+    let failures = report
+        .divergence
+        .as_ref()
+        .map(|divergence| vec![divergence.message.clone()])
+        .unwrap_or_default();
+    Ok(ReplayFixtureResult {
+        pass: report.passed,
+        failures,
+        stage_count: 0,
+    })
+}
+
+fn determinism_summary(
+    source: &ReplaySource,
+    executions: &[ReplayExecution],
+) -> ReplayDeterminismSummary {
+    let allowlist = source.allowlist();
+    if executions.len() <= 1 {
+        return ReplayDeterminismSummary {
+            pass: true,
+            compared_runs: executions.len(),
+            allowlist,
+            divergence: None,
+            failures: Vec::new(),
+        };
+    }
+
+    let baseline = executions[0].trace_run.clone();
+    for (index, execution) in executions.iter().enumerate().skip(1) {
+        let trace = ReplayOracleTrace {
+            name: format!("harn replay run {} determinism", index + 1),
+            expect: ReplayExpectation::Match,
+            allowlist: allowlist.clone(),
+            first_run: baseline.clone(),
+            second_run: execution.trace_run.clone(),
+            ..ReplayOracleTrace::default()
+        };
+        match harn_vm::run_replay_oracle_trace(&trace) {
+            Ok(report) if report.passed => {}
+            Ok(report) => {
+                let failure = report
+                    .divergence
+                    .as_ref()
+                    .map(|divergence| divergence.message.clone())
+                    .unwrap_or_else(|| format!("run {} diverged", index + 1));
+                return ReplayDeterminismSummary {
+                    pass: false,
+                    compared_runs: executions.len(),
+                    allowlist,
+                    divergence: report.divergence,
+                    failures: vec![failure],
+                };
+            }
+            Err(error) => {
+                return ReplayDeterminismSummary {
+                    pass: false,
+                    compared_runs: executions.len(),
+                    allowlist,
+                    divergence: None,
+                    failures: vec![error.to_string()],
+                };
+            }
+        }
+    }
+
+    ReplayDeterminismSummary {
+        pass: true,
+        compared_runs: executions.len(),
+        allowlist,
+        divergence: None,
+        failures: Vec::new(),
+    }
+}
+
+fn default_replay_allowlist() -> Vec<ReplayAllowlistRule> {
+    vec![
+        ReplayAllowlistRule {
+            path: "/run_id".to_string(),
+            reason: "run ids are allocated per replay execution".to_string(),
+            replacement: None,
+        },
+        ReplayAllowlistRule {
+            path: "/event_log_entries/*/event_id".to_string(),
+            reason: "EventLog offsets are backend-local".to_string(),
+            replacement: None,
+        },
+        ReplayAllowlistRule {
+            path: "/event_log_entries/*/occurred_at_ms".to_string(),
+            reason: "append timestamps are wall-clock observations".to_string(),
+            replacement: None,
+        },
+    ]
+}
+
+fn event_sequence_from_report(report: &ReplayReport) -> Vec<JsonValue> {
+    let mut events = Vec::new();
+    for (index, stage) in report.stages.iter().enumerate() {
+        events.push(json!({
+            "event_id": index + 1,
+            "occurred_at_ms": 0,
+            "kind": "replay_stage",
+            "payload": stage,
+        }));
+    }
+    for (index, transition) in report.transitions.iter().enumerate() {
+        events.push(json!({
+            "event_id": report.stages.len() + index + 1,
+            "occurred_at_ms": 0,
+            "kind": "replay_transition",
+            "payload": transition,
+        }));
+    }
+    if events.is_empty() {
+        events.push(json!({
+            "event_id": 1,
+            "occurred_at_ms": 0,
+            "kind": "replay_report",
+            "payload": report,
+        }));
+    }
+    events
+}
+
+fn canonical_event_sequence(
+    run: &ReplayTraceRun,
+    allowlist: &[ReplayAllowlistRule],
+) -> Result<Vec<JsonValue>, String> {
+    let canonical = harn_vm::canonicalize_run(run, allowlist)
+        .map_err(|error| format!("failed to apply replay allowlist: {error}"))?;
+    Ok(flatten_trace_run_value(&canonical))
+}
+
+fn flatten_trace_run_value(run: &JsonValue) -> Vec<JsonValue> {
+    let mut events = Vec::new();
+    for section in [
+        "event_log_entries",
+        "trigger_firings",
+        "llm_interactions",
+        "protocol_interactions",
+        "approval_interactions",
+        "effect_receipts",
+        "persona_runtime_states",
+        "agent_transcript_deltas",
+        "final_artifacts",
+        "policy_decisions",
+        "channel_receipts",
+        "lifecycle_receipts",
+    ] {
+        if let Some(values) = run.get(section).and_then(JsonValue::as_array) {
+            append_trace_section(&mut events, section, values);
+        }
+    }
+    events
+}
+
+fn append_trace_section(events: &mut Vec<JsonValue>, section: &str, values: &[JsonValue]) {
+    for value in values {
+        let mut value = value.clone();
+        if let JsonValue::Object(map) = &mut value {
+            map.entry("replay_section".to_string())
+                .or_insert_with(|| JsonValue::String(section.to_string()));
+            events.push(value);
+        } else {
+            events.push(json!({
+                "replay_section": section,
+                "value": value,
+            }));
+        }
+    }
+}
+
+fn print_json_error(code: &str, message: impl Into<String>) {
+    let envelope: JsonEnvelope<JsonValue> =
+        JsonEnvelope::err(REPLAY_SCHEMA_VERSION, code, message.into());
+    println!("{}", json_envelope::to_string_pretty(&envelope));
+}
+
+fn to_string_pretty<T: Serialize>(value: &T) -> String {
+    serde_json::to_string_pretty(value).expect("replay JSON payload serializes")
 }

--- a/crates/harn-cli/src/json_envelope.rs
+++ b/crates/harn-cli/src/json_envelope.rs
@@ -293,7 +293,7 @@ pub fn catalog() -> Vec<SchemaEntry> {
             command: "replay",
             schema_version: crate::commands::replay::REPLAY_SCHEMA_VERSION,
             description:
-                "Replay summary: per-stage status/outcome/branch plus the embedded replay-fixture verdict.",
+                "Replay summary: per-stage status/outcome/branch, embedded fixture verdicts, and multi-run determinism.",
             schema_json: None,
         },
         SchemaEntry {

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1122,13 +1122,9 @@ async fn async_main() {
         },
         Command::Session(args) => commands::session::run(args),
         Command::Replay(args) => {
-            if args.json {
-                let exit = commands::replay::run_json(&args.path);
-                if exit != 0 {
-                    process::exit(exit);
-                }
-            } else {
-                replay_run_record(&args.path);
+            let exit = commands::replay::run(args);
+            if exit != 0 {
+                process::exit(exit);
             }
         }
         Command::Eval(args) => match args.command {
@@ -2197,58 +2193,6 @@ fn inspect_run_record(path: &str, compare: Option<&str>) {
     if let Some(compare_path) = compare {
         let baseline = load_run_record_or_exit(Path::new(compare_path));
         print_run_diff(&harn_vm::orchestration::diff_run_records(&baseline, &run));
-    }
-}
-
-fn replay_run_record(path: &str) {
-    let run = load_run_record_or_exit(Path::new(path));
-    println!("Replay: {}", run.id);
-    for stage in &run.stages {
-        println!(
-            "[{}] status={} outcome={} branch={}",
-            stage.node_id,
-            stage.status,
-            stage.outcome,
-            stage.branch.clone().unwrap_or_else(|| "-".to_string())
-        );
-        if let Some(text) = &stage.visible_text {
-            println!("  visible: {text}");
-        }
-        if let Some(verification) = &stage.verification {
-            println!("  verification: {verification}");
-        }
-    }
-    if let Some(transcript) = &run.transcript {
-        println!(
-            "Transcript events persisted: {}",
-            transcript["events"]
-                .as_array()
-                .map(|v| v.len())
-                .unwrap_or(0)
-        );
-    }
-    let fixture = run
-        .replay_fixture
-        .clone()
-        .unwrap_or_else(|| harn_vm::orchestration::replay_fixture_from_run(&run));
-    let report = harn_vm::orchestration::evaluate_run_against_fixture(&run, &fixture);
-    println!(
-        "Embedded replay fixture: {}",
-        if report.pass { "PASS" } else { "FAIL" }
-    );
-    for transition in &run.transitions {
-        println!(
-            "transition {} -> {} ({})",
-            transition
-                .from_node_id
-                .clone()
-                .unwrap_or_else(|| "start".to_string()),
-            transition.to_node_id,
-            transition
-                .branch
-                .clone()
-                .unwrap_or_else(|| "default".to_string())
-        );
     }
 }
 

--- a/crates/harn-cli/tests/replay_session_cli.rs
+++ b/crates/harn-cli/tests/replay_session_cli.rs
@@ -1,0 +1,217 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::Command;
+
+use harn_vm::event_log::{EventLog, LogEvent, SqliteEventLog, Topic};
+use serde_json::json;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|error| {
+        panic!("stdout is not JSON: {error}\nstdout:\n{stdout}");
+    })
+}
+
+fn normalized_run_json(run: &serde_json::Value) -> String {
+    let mut run = run.clone();
+    if let Some(events) = run.as_array_mut() {
+        for event in events {
+            if let Some(object) = event.as_object_mut() {
+                object.remove("event_id");
+                object.remove("occurred_at_ms");
+            }
+        }
+    }
+    serde_json::to_string(&run).expect("serialize normalized run")
+}
+
+fn unique_normalized_runs(parsed: &serde_json::Value) -> BTreeSet<String> {
+    parsed["runs"]
+        .as_array()
+        .expect("runs should be an array")
+        .iter()
+        .map(normalized_run_json)
+        .collect()
+}
+
+fn append_agent_event(
+    log: &SqliteEventLog,
+    topic: &Topic,
+    session_id: &str,
+    occurred_at_ms: i64,
+    event: serde_json::Value,
+) {
+    let kind = event
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .expect("agent event type")
+        .to_string();
+    let mut headers = BTreeMap::new();
+    headers.insert("session_id".to_string(), session_id.to_string());
+    let record = LogEvent {
+        kind,
+        payload: json!({
+            "index_hint": occurred_at_ms,
+            "session_id": session_id,
+            "event": event,
+        }),
+        headers,
+        occurred_at_ms,
+    };
+    futures::executor::block_on(log.append(topic, record)).expect("append event");
+}
+
+fn seed_session_db(path: &std::path::Path, session_id: &str) {
+    let log = SqliteEventLog::open(path.to_path_buf(), 16).expect("open sqlite event log");
+    let topic = Topic::new(format!(
+        "observability.agent_events.{}",
+        harn_vm::event_log::sanitize_topic_component(session_id)
+    ))
+    .expect("topic");
+    append_agent_event(
+        &log,
+        &topic,
+        session_id,
+        1_770_000_000_000,
+        json!({
+            "type": "user_message",
+            "session_id": session_id,
+            "message_id": "msg_1",
+            "content": [{"type": "text", "text": "Replay this session"}],
+        }),
+    );
+    append_agent_event(
+        &log,
+        &topic,
+        session_id,
+        1_770_000_000_100,
+        json!({
+            "type": "iteration_start",
+            "session_id": session_id,
+            "iteration": 1,
+            "provider": "mock",
+            "model": "mock-model",
+        }),
+    );
+    append_agent_event(
+        &log,
+        &topic,
+        session_id,
+        1_770_000_000_200,
+        json!({
+            "type": "agent_message_chunk",
+            "session_id": session_id,
+            "content": "done",
+        }),
+    );
+    append_agent_event(
+        &log,
+        &topic,
+        session_id,
+        1_770_000_000_300,
+        json!({
+            "type": "session_closed",
+            "session_id": session_id,
+            "reason": "test complete",
+            "status": "completed",
+            "metadata": {},
+        }),
+    );
+    futures::executor::block_on(log.flush()).expect("flush event log");
+}
+
+#[test]
+fn replay_session_id_reads_events_db_and_compares_runs() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-2474";
+    seed_session_db(&db, session_id);
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--runs",
+            "3",
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --session-id");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = stdout_json(&out);
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["source"]["kind"], "event_log_session");
+    assert_eq!(parsed["reports"].as_array().unwrap().len(), 3);
+    assert_eq!(parsed["runs"].as_array().unwrap().len(), 3);
+    assert_eq!(parsed["runs"][0].as_array().unwrap().len(), 4);
+    assert_eq!(parsed["determinism"]["pass"], true);
+    assert_eq!(parsed["reports"][0]["run_id"], session_id);
+    assert_eq!(parsed["reports"][0]["transcript_event_count"], 4);
+    assert_eq!(unique_normalized_runs(&parsed).len(), 1);
+}
+
+#[test]
+fn replay_session_id_errors_when_session_absent() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    seed_session_db(&db, "session-present");
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            "session-missing",
+            "--events-db",
+            db.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --session-id");
+    assert!(!out.status.success(), "expected missing session to fail");
+    let parsed = stdout_json(&out);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "replay_load_failed");
+    assert!(parsed["error"]["message"]
+        .as_str()
+        .unwrap_or("")
+        .contains("session-missing"));
+}
+
+#[test]
+fn replay_fixture_runs_use_oracle_allowlist() {
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json");
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--fixture",
+            fixture.to_str().unwrap(),
+            "--runs",
+            "3",
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --fixture --runs");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = stdout_json(&out);
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["source"]["kind"], "replay_trace");
+    assert_eq!(parsed["reports"].as_array().unwrap().len(), 3);
+    assert_eq!(parsed["runs"].as_array().unwrap().len(), 3);
+    assert_eq!(parsed["determinism"]["pass"], true);
+    assert_eq!(unique_normalized_runs(&parsed).len(), 1);
+}

--- a/crates/harn-vm/src/event_log/sqlite.rs
+++ b/crates/harn-vm/src/event_log/sqlite.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 
 use super::util::{
     event_id_to_sqlite_i64, now_ms, prepare_event_after, sqlite_i64_to_event_id,
@@ -77,6 +77,22 @@ impl SqliteEventLog {
                 );",
             )
             .map_err(|error| LogError::Sqlite(format!("event log schema error: {error}")))?;
+        Ok(Self {
+            path,
+            connection: Mutex::new(connection),
+            broadcasts: BroadcastMap::default(),
+            queue_depth: queue_depth.max(1),
+        })
+    }
+
+    pub fn open_read_only(path: PathBuf, queue_depth: usize) -> Result<Self, LogError> {
+        let connection = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|error| {
+                LogError::Sqlite(format!("event log read-only open error: {error}"))
+            })?;
+        connection
+            .busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(|error| LogError::Sqlite(format!("event log busy-timeout error: {error}")))?;
         Ok(Self {
             path,
             connection: Mutex::new(connection),

--- a/crates/harn-vm/src/orchestration/records/mod.rs
+++ b/crates/harn-vm/src/orchestration/records/mod.rs
@@ -19,8 +19,8 @@ pub use eval_pack::{
     normalize_eval_pack_manifest_value, normalize_eval_suite_manifest, replay_fixture_from_run,
 };
 pub use persistence::{
-    load_agent_session_replay_events, load_run_record, normalize_run_record, save_run_record,
-    AgentSessionReplayEvent,
+    load_agent_session_replay_events, load_agent_session_replay_events_from_log, load_run_record,
+    normalize_run_record, save_run_record, AgentSessionReplayEvent,
 };
 pub use types::{
     tool_fixture_hash, ClarifyingQuestionEvalSpec, CompactionEventRecord, DaemonEventKindRecord,

--- a/crates/harn-vm/src/orchestration/records/persistence.rs
+++ b/crates/harn-vm/src/orchestration/records/persistence.rs
@@ -114,6 +114,8 @@ pub(super) fn read_topic_records(
 #[derive(Clone, Debug)]
 pub struct AgentSessionReplayEvent {
     pub event_id: EventId,
+    pub kind: String,
+    pub occurred_at_ms: i64,
     pub event: AgentEvent,
 }
 
@@ -123,6 +125,13 @@ pub async fn load_agent_session_replay_events(
     let Some(log) = active_event_log() else {
         return Ok(Vec::new());
     };
+    load_agent_session_replay_events_from_log(log.as_ref(), session_id).await
+}
+
+pub async fn load_agent_session_replay_events_from_log(
+    log: &AnyEventLog,
+    session_id: &str,
+) -> Result<Vec<AgentSessionReplayEvent>, VmError> {
     let topic = Topic::new(format!(
         "observability.agent_events.{}",
         sanitize_topic_component(session_id)
@@ -153,7 +162,12 @@ pub async fn load_agent_session_replay_events(
                 ))
             })?;
             if event.session_id() == session_id {
-                events.push(AgentSessionReplayEvent { event_id, event });
+                events.push(AgentSessionReplayEvent {
+                    event_id,
+                    kind: record.kind,
+                    occurred_at_ms: record.occurred_at_ms,
+                    event,
+                });
             }
         }
         if batch_len < 1024 {

--- a/crates/harn-vm/src/session_bundle.rs
+++ b/crates/harn-vm/src/session_bundle.rs
@@ -10,12 +10,15 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
 
+use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 
+use crate::agent_events::AgentEvent;
+use crate::event_log::sanitize_topic_component;
 use crate::orchestration::{
-    new_id, now_rfc3339, ReplayFixture, RunCheckpointRecord, RunHitlQuestionRecord, RunRecord,
-    RunTraceSpanRecord, RunTransitionRecord, ToolCallRecord,
+    new_id, now_rfc3339, AgentSessionReplayEvent, ReplayFixture, RunCheckpointRecord,
+    RunHitlQuestionRecord, RunRecord, RunTraceSpanRecord, RunTransitionRecord, ToolCallRecord,
 };
 use crate::redact::{RedactionPolicy, REDACTED_PLACEHOLDER};
 use crate::workspace_anchor::{anchor_from_transcript_metadata_json, MountedRoot, WorkspaceAnchor};
@@ -339,6 +342,7 @@ pub enum SessionBundleError {
     InvalidType { path: String, expected: String },
     UnsafeSecretMarker { path: String, excerpt: String },
     MissingRunRecord,
+    MissingSessionEvents { session_id: String },
 }
 
 impl fmt::Display for SessionBundleError {
@@ -361,6 +365,10 @@ impl fmt::Display for SessionBundleError {
                 "session bundle contains an unsafe unredacted secret marker at {path}: {excerpt}"
             ),
             Self::MissingRunRecord => write!(f, "session bundle does not include an importable run record"),
+            Self::MissingSessionEvents { session_id } => write!(
+                f,
+                "event log does not contain replayable events for session_id {session_id:?}"
+            ),
         }
     }
 }
@@ -552,6 +560,234 @@ pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, Sess
         }));
     }
     Err(SessionBundleError::MissingRunRecord)
+}
+
+pub fn session_bundle_from_agent_session_events(
+    session_id: &str,
+    events: &[AgentSessionReplayEvent],
+) -> Result<SessionBundle, SessionBundleError> {
+    if events.is_empty() {
+        return Err(SessionBundleError::MissingSessionEvents {
+            session_id: session_id.to_string(),
+        });
+    }
+
+    let stable_id = sanitize_topic_component(session_id);
+    let started_at = rfc3339_from_epoch_ms(events[0].occurred_at_ms);
+    let finished_at = events.iter().rev().find_map(|entry| match &entry.event {
+        AgentEvent::SessionClosed { .. } => Some(rfc3339_from_epoch_ms(entry.occurred_at_ms)),
+        _ => None,
+    });
+    let status = events
+        .iter()
+        .rev()
+        .find_map(|entry| match &entry.event {
+            AgentEvent::SessionClosed { status, .. } if !status.is_empty() => Some(status.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| "completed".to_string());
+    let run_id = session_id.to_string();
+    let workflow_id = "agent_session".to_string();
+    let created_at = finished_at.clone().unwrap_or_else(|| started_at.clone());
+    let transcript_events = transcript_events_from_agent_session(events)?;
+    let transcript_messages = transcript_messages_from_agent_session(events);
+    let mut transcript_metadata = BTreeMap::new();
+    transcript_metadata.insert("session_id".to_string(), json!(session_id));
+    transcript_metadata.insert(
+        "source".to_string(),
+        json!("events.sqlite observability.agent_events topic"),
+    );
+
+    let replay_fixture = ReplayFixture {
+        type_name: "replay_fixture".to_string(),
+        id: format!("fixture_from_session_{stable_id}"),
+        source_run_id: run_id.clone(),
+        workflow_id: workflow_id.clone(),
+        workflow_name: Some(format!("Agent session {session_id}")),
+        created_at: created_at.clone(),
+        eval_kind: Some("replay".to_string()),
+        expected_status: status.clone(),
+        ..ReplayFixture::default()
+    };
+
+    Ok(SessionBundle {
+        bundle_id: format!("bundle_from_session_{stable_id}"),
+        created_at,
+        producer: BundleProducer {
+            name: "harn".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            schema_id: SESSION_BUNDLE_SCHEMA_ID.to_string(),
+        },
+        source: BundleSource {
+            kind: "event_log_session".to_string(),
+            run_record_id: run_id,
+            workflow_id,
+            workflow_name: Some(format!("Agent session {session_id}")),
+            task: task_from_agent_session(events)
+                .unwrap_or_else(|| format!("Agent session {session_id}")),
+            status,
+            started_at,
+            finished_at,
+            ..BundleSource::default()
+        },
+        runtime: BundleRuntime {
+            harn_version: env!("CARGO_PKG_VERSION").to_string(),
+            ..BundleRuntime::default()
+        },
+        transcript: BundleTranscript {
+            sections: vec![BundleTranscriptSection {
+                id: "agent_events".to_string(),
+                label: "Agent event log".to_string(),
+                scope: "session".to_string(),
+                location: format!(
+                    "observability.agent_events.{}",
+                    sanitize_topic_component(session_id)
+                ),
+                summary: None,
+                messages: transcript_messages,
+                events: transcript_events,
+                assets: Vec::new(),
+                metadata: transcript_metadata,
+            }],
+        },
+        permissions: permissions_from_agent_session(events),
+        replay: BundleReplay {
+            replay_fixture: Some(replay_fixture),
+            event_log_pointers: vec![BundleEventLogPointer {
+                kind: "agent_events".to_string(),
+                topic: Some(format!(
+                    "observability.agent_events.{}",
+                    sanitize_topic_component(session_id)
+                )),
+                path: None,
+                location: "events.sqlite".to_string(),
+                available: true,
+            }],
+            deterministic_events: deterministic_events_from_agent_session(events)?,
+            ..BundleReplay::default()
+        },
+        ..SessionBundle::default()
+    })
+}
+
+pub fn import_run_record_from_agent_session_events(
+    session_id: &str,
+    events: &[AgentSessionReplayEvent],
+) -> Result<RunRecord, SessionBundleError> {
+    let bundle = session_bundle_from_agent_session_events(session_id, events)?;
+    let run_record = import_run_record_value(&bundle)?;
+    serde_json::from_value(run_record)
+        .map_err(|error| SessionBundleError::Decode(error.to_string()))
+}
+
+fn transcript_events_from_agent_session(
+    events: &[AgentSessionReplayEvent],
+) -> Result<Vec<JsonValue>, SessionBundleError> {
+    events
+        .iter()
+        .map(|entry| {
+            let event = serde_json::to_value(&entry.event)
+                .map_err(|error| SessionBundleError::Encode(error.to_string()))?;
+            Ok(json!({
+                "event_id": entry.event_id,
+                "kind": entry.kind,
+                "occurred_at_ms": entry.occurred_at_ms,
+                "event": event,
+            }))
+        })
+        .collect()
+}
+
+fn transcript_messages_from_agent_session(events: &[AgentSessionReplayEvent]) -> Vec<JsonValue> {
+    events
+        .iter()
+        .filter_map(|entry| match &entry.event {
+            AgentEvent::UserMessage { content, .. } => Some(json!({
+                "role": "user",
+                "content": content,
+            })),
+            AgentEvent::AgentMessageChunk { content, .. } if !content.is_empty() => Some(json!({
+                "role": "assistant",
+                "content": content,
+            })),
+            _ => None,
+        })
+        .collect()
+}
+
+fn permissions_from_agent_session(events: &[AgentSessionReplayEvent]) -> Vec<BundlePermission> {
+    let mut permissions = Vec::new();
+    for entry in events {
+        if let AgentEvent::HitlRequested {
+            request_id,
+            kind,
+            payload,
+            ..
+        } = &entry.event
+        {
+            permissions.push(BundlePermission {
+                kind: "hitl_question".to_string(),
+                source: "agent_events".to_string(),
+                request_id: Some(request_id.clone()),
+                agent: None,
+                payload: json!({
+                    "kind": kind,
+                    "payload": payload,
+                    "event_id": entry.event_id,
+                    "occurred_at_ms": entry.occurred_at_ms,
+                }),
+            });
+        }
+    }
+    permissions
+}
+
+fn deterministic_events_from_agent_session(
+    events: &[AgentSessionReplayEvent],
+) -> Result<Vec<BundleJsonEntry>, SessionBundleError> {
+    transcript_events_from_agent_session(events).map(|entries| {
+        entries
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| BundleJsonEntry {
+                source: "events.sqlite.agent_events".to_string(),
+                index,
+                value,
+            })
+            .collect()
+    })
+}
+
+fn task_from_agent_session(events: &[AgentSessionReplayEvent]) -> Option<String> {
+    events.iter().find_map(|entry| match &entry.event {
+        AgentEvent::UserMessage { content, .. } => user_message_text(content),
+        _ => None,
+    })
+}
+
+fn user_message_text(content: &[JsonValue]) -> Option<String> {
+    let parts = content
+        .iter()
+        .filter_map(|value| {
+            value
+                .get("text")
+                .and_then(JsonValue::as_str)
+                .or_else(|| value.as_str())
+                .map(str::to_string)
+        })
+        .filter(|text| !text.trim().is_empty())
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
+}
+
+fn rfc3339_from_epoch_ms(ms: i64) -> String {
+    DateTime::<Utc>::from_timestamp_millis(ms)
+        .unwrap_or_else(|| DateTime::<Utc>::from_timestamp(0, 0).expect("unix epoch is valid"))
+        .to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
 fn raw_bundle_from_run(

--- a/docs/src/cli-json-contract.md
+++ b/docs/src/cli-json-contract.md
@@ -155,10 +155,22 @@ of whether they invoked `check` or `lint`.
 ### `harn replay --json`
 
 Loads a persisted run record and emits a structured per-stage summary
-plus the embedded replay-fixture verdict. `ok: false` with
-`error.code: "replay_fixture_failed"` indicates the fixture did not
-pass; the same envelope still includes the full `data` payload so
-callers can diff.
+plus the embedded replay-fixture verdict. `harn replay --fixture <path>`
+accepts either a run record or a `harn.orchestration.replay_trace.v1`
+fixture. `harn replay --session-id <id> --events-db <path>` reconstructs
+the same replayable run-record shape from the SQLite EventLog
+`observability.agent_events.<id>` topic.
+
+The default `--runs 1` response keeps the original single `ReplayReport`
+payload. When `--runs N` is greater than one, the response keeps
+`schemaVersion`, `ok`, `error`, and `warnings` at the top level and also
+emits top-level `reports`, `runs`, and `determinism` fields. `reports`
+contains one `ReplayReport` per replay read, `runs` contains the
+allowlist-normalized event sequences, and `determinism` reports the
+allowlist-stripped replay comparison. `ok: false` with `error.code:
+"replay_fixture_failed"` indicates at least one fixture verdict failed;
+`error.code: "replay_determinism_failed"` indicates the per-run event
+material diverged after applying the replay allowlist.
 
 ### `harn run --emit-summary-json`
 


### PR DESCRIPTION
## Summary
- add `harn replay --session-id <id> --events-db <path>` using a read-only SQLite EventLog and session-bundle RunRecord reconstruction
- add `--runs N` multi-run replay output with top-level normalized `runs`, per-run reports, and determinism summary
- preserve existing single-run replay JSON behavior and document the new replay JSON shape

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2474 cargo test -p harn-cli test_parses_replay_sources_and_runs`
- `CARGO_TARGET_DIR=/tmp/harn-target-2474 cargo test -p harn-cli --test replay_session_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-2474 cargo test -p harn-cli --test lint_replay_version_upgrade_json_cli replay_json`
- `CARGO_TARGET_DIR=/tmp/harn-target-2474 cargo test -p harn-vm session_bundle`
- `/tmp/harn-target-2474/debug/harn replay --fixture conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json --runs 3 --json | jq -c '.runs[] | (del(.[] | .event_id, .occurred_at_ms))' | sort -u | wc -l` => `1`\n- pre-commit hook: rustfmt, prompt-prose lint, clippy for changed packages, markdownlint\n- pre-push hook: targeted local checks, markdownlint\n\nCloses #2474