### PR TITLE
Support provider-error LLM mock fixtures

### DIFF
--- a/conformance/tests/integration/llm_mock_error_envelope_invalid_kind.error
+++ b/conformance/tests/integration/llm_mock_error_envelope_invalid_kind.error
@@ -1,0 +1,1 @@
+unknown error kind `flaky`

--- a/conformance/tests/integration/llm_mock_error_envelope_invalid_kind.harn
+++ b/conformance/tests/integration/llm_mock_error_envelope_invalid_kind.harn
@@ -1,0 +1,3 @@
+pipeline default(task) {
+  llm_mock({error: {status: 503, kind: "flaky"}})
+}

--- a/conformance/tests/integration/llm_mock_error_envelopes.expected
+++ b/conformance/tests/integration/llm_mock_error_envelopes.expected
@@ -1,0 +1,10 @@
+false
+true
+503
+transient
+upstream_unavailable
+overloaded
+mock
+mock-model
+120
+recovered

--- a/conformance/tests/integration/llm_mock_error_envelopes.harn
+++ b/conformance/tests/integration/llm_mock_error_envelopes.harn
@@ -1,0 +1,27 @@
+pipeline default(task) {
+  llm_mock_clear()
+  llm_mock(
+    {
+      error: {
+        status: 503,
+        kind: "transient",
+        reason: "upstream_unavailable",
+        message: "upstream unavailable",
+        retry_after_ms: 120,
+      },
+    },
+  )
+  llm_mock({text: "recovered", tool_calls: []})
+  let first = llm_call_safe("first", nil, {provider: "mock", model: "mock-model"})
+  __io_println(first.ok)
+  __io_println(first.response == nil)
+  __io_println(first.error.status)
+  __io_println(first.error.kind)
+  __io_println(first.error.reason)
+  __io_println(first.error.category)
+  __io_println(first.error.provider)
+  __io_println(first.error.model)
+  __io_println(first.error.retry_after_ms)
+  let second = llm_call("second", nil, {provider: "mock", model: "mock-model"})
+  __io_println(second.text)
+}

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -596,4 +596,48 @@ pipeline default(task) {
 
         assert!(output.contains("fixture replay"));
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn playground_replays_cli_llm_mock_error_envelopes() {
+        let _guard = crate::tests::common::env_lock::lock_env().lock().await;
+        let temp = tempfile::tempdir().unwrap();
+        let host = temp.path().join("host.harn");
+        let script = temp.path().join("pipeline.harn");
+        let fixtures = temp.path().join("fixtures.jsonl");
+        write_file(&host, "");
+        write_file(
+            &script,
+            r#"
+pipeline default(task) {
+  let first = llm_call_safe("first", nil, {provider: "mock", model: "mock-model"})
+  __io_println(first.ok)
+  __io_println(first.error.status)
+  __io_println(first.error.kind)
+  __io_println(first.error.reason)
+  let second = llm_call("second", nil, {provider: "mock", model: "mock-model"})
+  __io_println(second.text)
+}
+"#,
+        );
+        write_file(
+            &fixtures,
+            r#"{"error":{"status":503,"kind":"transient","reason":"upstream_unavailable"}}
+{"text":"recovered","tool_calls":[]}
+"#,
+        );
+
+        let output = execute_playground(&PlaygroundConfig {
+            host,
+            script,
+            task: String::new(),
+            llm: None,
+            llm_mock_mode: CliLlmMockMode::Replay {
+                fixture_path: fixtures,
+            },
+        })
+        .await
+        .unwrap();
+
+        assert!(output.contains("false\n503\ntransient\nupstream_unavailable\nrecovered"));
+    }
 }

--- a/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
@@ -765,6 +765,7 @@ pub(crate) const LLM_CALL_ERROR: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::new("kind", TY_STRING),
     ShapeFieldDescriptor::new("reason", TY_STRING),
     ShapeFieldDescriptor::new("message", TY_STRING),
+    ShapeFieldDescriptor::optional("status", TY_INT),
     ShapeFieldDescriptor::optional("retry_after_ms", TY_INT),
     ShapeFieldDescriptor::optional("provider", TY_STRING),
     ShapeFieldDescriptor::optional("model", TY_STRING),

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -1237,6 +1237,7 @@ fn test_structured_stdlib_return_shapes_allow_documented_field_access() {
   let ok: bool = safe.ok
   let safe_text: string | nil = safe.response?.text
   let safe_error: string | nil = safe.error?.message
+  let safe_status: int | nil = safe.error?.status
 
   let completion = llm_completion("prefix", "suffix", "system")
   let stop: string | nil = completion.stop_reason

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -20,6 +20,14 @@ impl LlmErrorKind {
             Self::Terminal => "terminal",
         }
     }
+
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "transient" => Some(Self::Transient),
+            "terminal" => Some(Self::Terminal),
+            _ => None,
+        }
+    }
 }
 
 /// Canonical reason within the LLM error taxonomy.

--- a/crates/harn-vm/src/llm/jsonl.rs
+++ b/crates/harn-vm/src/llm/jsonl.rs
@@ -6,8 +6,7 @@
 
 use std::path::Path;
 
-use crate::llm::mock::{LlmMock, MockError};
-use crate::value::ErrorCategory;
+use crate::llm::mock::{self, LlmMock, MockError};
 
 /// Parse a JSONL fixture file into a vector of [`LlmMock`] entries.
 /// Empty lines are skipped; every other line must be a JSON object.
@@ -184,13 +183,36 @@ pub fn serialize_llm_mock(mock: LlmMock) -> Result<String, String> {
         );
     }
     if let Some(error) = mock.error {
-        object.insert(
-            "error".to_string(),
-            serde_json::json!({
-                "category": error.category.as_str(),
-                "message": error.message,
-            }),
+        let mut error_object = serde_json::Map::new();
+        error_object.insert(
+            "category".to_string(),
+            serde_json::Value::String(error.category.as_str().to_string()),
         );
+        if !error.message.is_empty() {
+            error_object.insert(
+                "message".to_string(),
+                serde_json::Value::String(error.message),
+            );
+        }
+        if let Some(status) = error.status {
+            error_object.insert(
+                "status".to_string(),
+                serde_json::Value::Number(status.into()),
+            );
+        }
+        if let Some(kind) = error.kind {
+            error_object.insert("kind".to_string(), serde_json::Value::String(kind));
+        }
+        if let Some(reason) = error.reason {
+            error_object.insert("reason".to_string(), serde_json::Value::String(reason));
+        }
+        if let Some(retry_after_ms) = error.retry_after_ms {
+            error_object.insert(
+                "retry_after_ms".to_string(),
+                serde_json::Value::Number(retry_after_ms.into()),
+            );
+        }
+        object.insert("error".to_string(), serde_json::Value::Object(error_object));
     }
     serde_json::to_string(&serde_json::Value::Object(object))
         .map_err(|error| format!("failed to serialize recorded fixture: {error}"))
@@ -241,21 +263,53 @@ fn parse_llm_mock_error(value: Option<&serde_json::Value>) -> Result<Option<Mock
         return Ok(None);
     }
     let object = value.as_object().ok_or_else(|| {
-        "error must be an object {category, message, retry_after_ms?}".to_string()
+        "error must be an object {category?, message?, status?, kind?, reason?, retry_after_ms?}"
+            .to_string()
     })?;
-    let category_str = object
+    let category = object
         .get("category")
-        .and_then(|value| value.as_str())
-        .ok_or_else(|| "error.category is required".to_string())?;
-    let category = ErrorCategory::parse(category_str);
-    if category.as_str() != category_str {
-        return Err(format!("unknown error category `{category_str}`"));
-    }
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| "error.category must be a string".to_string())
+        })
+        .transpose()?;
     let message = object
         .get("message")
-        .and_then(|value| value.as_str())
-        .unwrap_or_default()
-        .to_string();
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| "error.message must be a string".to_string())
+        })
+        .transpose()?;
+    let status = match object.get("status") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::Number(n)) => match n.as_i64() {
+            Some(v) => Some(mock::validate_mock_error_status(v)?),
+            None => return Err("error.status must be an HTTP status code".to_string()),
+        },
+        Some(_) => return Err("error.status must be an HTTP status code".to_string()),
+    };
+    let kind = object
+        .get("kind")
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| "error.kind must be a string".to_string())
+        })
+        .transpose()?;
+    let reason = object
+        .get("reason")
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| "error.reason must be a string".to_string())
+        })
+        .transpose()?;
     let retry_after_ms = match object.get("retry_after_ms") {
         None | Some(serde_json::Value::Null) => None,
         Some(serde_json::Value::Number(n)) => match n.as_u64() {
@@ -264,11 +318,7 @@ fn parse_llm_mock_error(value: Option<&serde_json::Value>) -> Result<Option<Mock
         },
         Some(_) => return Err("error.retry_after_ms must be a non-negative integer".to_string()),
     };
-    Ok(Some(MockError {
-        category,
-        message,
-        retry_after_ms,
-    }))
+    mock::build_mock_error(category, message, status, kind, reason, retry_after_ms).map(Some)
 }
 
 fn optional_string_field(
@@ -336,6 +386,72 @@ mod tests {
         match result {
             Err(err) => assert!(err.contains("unknown error category"), "{err}"),
             Ok(_) => panic!("expected parse failure for unknown error category"),
+        }
+    }
+
+    #[test]
+    fn parses_explicit_generic_error_category() {
+        let mock = parse_llm_mock_value(&serde_json::json!({
+            "error": { "category": "generic", "message": "x" }
+        }))
+        .expect("parse generic error");
+        let error = mock.error.expect("error");
+        assert_eq!(error.category.as_str(), "generic");
+        assert_eq!(error.message, "x");
+    }
+
+    #[test]
+    fn parses_provider_error_envelope() {
+        let mock = parse_llm_mock_value(&serde_json::json!({
+            "error": {
+                "status": 503,
+                "kind": "transient",
+                "reason": "upstream_unavailable",
+                "message": "upstream unavailable",
+                "retry_after_ms": 250
+            }
+        }))
+        .expect("parse provider envelope");
+        let error = mock.error.expect("error");
+        assert_eq!(error.category.as_str(), "overloaded");
+        assert_eq!(error.status, Some(503));
+        assert_eq!(error.kind.as_deref(), Some("transient"));
+        assert_eq!(error.reason.as_deref(), Some("upstream_unavailable"));
+        assert_eq!(error.retry_after_ms, Some(250));
+    }
+
+    #[test]
+    fn roundtrip_preserves_provider_error_envelope() {
+        let mock = parse_llm_mock_value(&serde_json::json!({
+            "match": "*retry*",
+            "error": {
+                "status": 503,
+                "kind": "transient",
+                "reason": "upstream_unavailable",
+                "retry_after_ms": 250
+            }
+        }))
+        .expect("parse provider envelope");
+        let line = serialize_llm_mock(mock).expect("serialize");
+        let value: serde_json::Value = serde_json::from_str(&line).expect("reparse json");
+        let reparsed = parse_llm_mock_value(&value).expect("reparse mock");
+        let error = reparsed.error.expect("error");
+        assert_eq!(reparsed.match_pattern.as_deref(), Some("*retry*"));
+        assert_eq!(error.category.as_str(), "overloaded");
+        assert_eq!(error.status, Some(503));
+        assert_eq!(error.kind.as_deref(), Some("transient"));
+        assert_eq!(error.reason.as_deref(), Some("upstream_unavailable"));
+        assert_eq!(error.retry_after_ms, Some(250));
+    }
+
+    #[test]
+    fn parse_rejects_unknown_error_kind() {
+        let result = parse_llm_mock_value(&serde_json::json!({
+            "error": { "status": 503, "kind": "maybe" }
+        }));
+        match result {
+            Err(err) => assert!(err.contains("unknown error kind"), "{err}"),
+            Ok(_) => panic!("expected parse failure for unknown error kind"),
         }
     }
 }

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -1,9 +1,10 @@
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
 
 use super::api::{LlmResult, ProviderTelemetry};
 use crate::orchestration::ToolCallRecord;
-use crate::value::{ErrorCategory, VmError};
+use crate::value::{ErrorCategory, VmError, VmValue};
 
 /// LLM replay mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,12 +29,144 @@ enum CliLlmMockMode {
 pub struct MockError {
     pub category: ErrorCategory,
     pub message: String,
-    /// Optional hint echoed into the error message as a synthetic
-    /// `retry-after:` header so the existing `extract_retry_after_ms`
-    /// parser recovers it — matches how real provider errors embed
-    /// the value. Lets tests assert that `e.retry_after_ms` flows
-    /// end-to-end on the thrown dict.
+    pub status: Option<u16>,
+    pub kind: Option<String>,
+    pub reason: Option<String>,
+    /// Optional retry hint. Provider-envelope mocks put this directly
+    /// on the thrown dict; legacy category-only mocks embed it in the
+    /// message so the live-provider parser path still exercises the
+    /// same extraction code.
     pub retry_after_ms: Option<u64>,
+}
+
+impl MockError {
+    fn has_provider_envelope(&self) -> bool {
+        self.status.is_some() || self.kind.is_some() || self.reason.is_some()
+    }
+}
+
+pub(crate) fn build_mock_error(
+    category: Option<String>,
+    message: Option<String>,
+    status: Option<u16>,
+    kind: Option<String>,
+    reason: Option<String>,
+    retry_after_ms: Option<u64>,
+) -> Result<MockError, String> {
+    if retry_after_ms.is_some_and(|ms| ms > i64::MAX as u64) {
+        return Err("error.retry_after_ms must fit in a signed 64-bit integer".to_string());
+    }
+    let kind = match kind {
+        Some(value) if value.trim().is_empty() => None,
+        Some(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            if super::api::LlmErrorKind::parse(&normalized).is_none() {
+                return Err(format!("unknown error kind `{value}`"));
+            }
+            Some(normalized)
+        }
+        None => None,
+    };
+    let reason = reason.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
+    let category_was_provided = category.is_some();
+    let category = match category {
+        Some(value) if value.trim().is_empty() => {
+            return Err("error.category must not be empty".to_string());
+        }
+        Some(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            let category = ErrorCategory::parse(&normalized);
+            if category.as_str() != normalized {
+                return Err(format!("unknown error category `{value}`"));
+            }
+            category
+        }
+        None => infer_mock_error_category(status, kind.as_deref(), reason.as_deref()),
+    };
+    if !category_was_provided && kind.is_none() && status.is_none() && reason.is_none() {
+        return Err(
+            "error.category is required unless error.status, error.kind, or error.reason is set"
+                .to_string(),
+        );
+    }
+    Ok(MockError {
+        category,
+        message: message.unwrap_or_else(|| {
+            default_mock_error_message(status, kind.as_deref(), reason.as_deref())
+        }),
+        status,
+        kind,
+        reason,
+        retry_after_ms,
+    })
+}
+
+pub(crate) fn validate_mock_error_status(status: i64) -> Result<u16, String> {
+    let status = u16::try_from(status)
+        .map_err(|_| "error.status must be an HTTP status code".to_string())?;
+    reqwest::StatusCode::from_u16(status)
+        .map_err(|_| "error.status must be an HTTP status code".to_string())?;
+    Ok(status)
+}
+
+fn infer_mock_error_category(
+    status: Option<u16>,
+    kind: Option<&str>,
+    reason: Option<&str>,
+) -> ErrorCategory {
+    if let Some(status) = status {
+        match status {
+            401 | 403 => return ErrorCategory::Auth,
+            404 | 410 => return ErrorCategory::NotFound,
+            408 | 504 | 522 | 524 => return ErrorCategory::Timeout,
+            429 => return ErrorCategory::RateLimit,
+            503 | 529 => return ErrorCategory::Overloaded,
+            500 | 502 => return ErrorCategory::ServerError,
+            _ => {}
+        }
+    }
+    if let Some(reason) = reason {
+        match reason {
+            "rate_limit" => return ErrorCategory::RateLimit,
+            "timeout" => return ErrorCategory::Timeout,
+            "network_error" | "transient_network" => return ErrorCategory::TransientNetwork,
+            "server_error" | "provider_error" | "provider_5xx" | "upstream_unavailable" => {
+                return ErrorCategory::ServerError;
+            }
+            "auth_failure" => return ErrorCategory::Auth,
+            "model_unavailable" => return ErrorCategory::NotFound,
+            _ => {}
+        }
+    }
+    if kind == Some("transient") {
+        return ErrorCategory::ServerError;
+    }
+    ErrorCategory::Generic
+}
+
+fn default_mock_error_message(
+    status: Option<u16>,
+    kind: Option<&str>,
+    reason: Option<&str>,
+) -> String {
+    match (status, kind, reason) {
+        (Some(status), Some(kind), Some(reason)) => {
+            format!("HTTP {status} mock LLM error ({kind}/{reason})")
+        }
+        (Some(status), _, Some(reason)) => format!("HTTP {status} mock LLM error ({reason})"),
+        (Some(status), _, _) => format!("HTTP {status} mock LLM error"),
+        (None, Some(kind), Some(reason)) => format!("mock LLM error ({kind}/{reason})"),
+        (None, Some(kind), None) => format!("mock LLM error ({kind})"),
+        (None, None, Some(reason)) => format!("mock LLM error ({reason})"),
+        (None, None, None) => String::new(),
+    }
 }
 
 #[derive(Clone)]
@@ -379,27 +512,66 @@ fn apply_mock_prompt_cache(result: &mut LlmResult, cache_key: &str) {
 /// provider path would have raised, so classification, retry, and
 /// `error_category` all behave identically to a real failure.
 fn mock_error_to_vm_error(err: &MockError) -> VmError {
-    // Embed `retry_after_ms` as a synthetic `retry-after:` header on
-    // the message so `agent_observe::extract_retry_after_ms` — the
-    // same parser that handles real HTTP 429s — surfaces the value
-    // on the caller's thrown dict. Keeps the mock path byte-for-byte
-    // compatible with a real rate-limit response.
-    let message = match err.retry_after_ms {
-        Some(ms) => {
-            let secs = (ms as f64 / 1000.0).max(0.0);
-            let sep = if err.message.is_empty() || err.message.ends_with('\n') {
-                ""
-            } else {
-                "\n"
-            };
-            format!("{}{sep}retry-after: {secs}\n", err.message)
+    let message = mock_error_message(err);
+    if err.has_provider_envelope() {
+        let classified = super::api::classify_llm_error(err.category.clone(), &message);
+        let mut dict = BTreeMap::new();
+        dict.insert(
+            "category".to_string(),
+            VmValue::String(Rc::from(err.category.as_str())),
+        );
+        dict.insert(
+            "kind".to_string(),
+            VmValue::String(Rc::from(
+                err.kind
+                    .as_deref()
+                    .unwrap_or_else(|| classified.kind.as_str()),
+            )),
+        );
+        dict.insert(
+            "reason".to_string(),
+            VmValue::String(Rc::from(
+                err.reason
+                    .as_deref()
+                    .unwrap_or_else(|| classified.reason.as_str()),
+            )),
+        );
+        dict.insert("message".to_string(), VmValue::String(Rc::from(message)));
+        if let Some(status) = err.status {
+            dict.insert("status".to_string(), VmValue::Int(i64::from(status)));
         }
-        None => err.message.clone(),
-    };
+        if let Some(retry_after_ms) = err.retry_after_ms {
+            dict.insert(
+                "retry_after_ms".to_string(),
+                VmValue::Int(retry_after_ms as i64),
+            );
+        }
+        return VmError::Thrown(VmValue::Dict(Rc::new(dict)));
+    }
+
     VmError::CategorizedError {
         message,
         category: err.category.clone(),
     }
+}
+
+fn mock_error_message(err: &MockError) -> String {
+    // Embed legacy category-only retry hints into the message so the
+    // same parser that handles live provider headers populates
+    // `retry_after_ms` on the final thrown dict.
+    let Some(ms) = err.retry_after_ms else {
+        return err.message.clone();
+    };
+    if err.has_provider_envelope() {
+        return err.message.clone();
+    }
+    let secs = (ms as f64 / 1000.0).max(0.0);
+    let sep = if err.message.is_empty() || err.message.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    format!("{}{sep}retry-after: {secs}\n", err.message)
 }
 
 /// Try to find and return a matching mock response. Returns

--- a/crates/harn-vm/src/llm/mock_builtins.rs
+++ b/crates/harn-vm/src/llm/mock_builtins.rs
@@ -143,36 +143,30 @@ fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         }
     });
 
-    // Optional error injection: {error: {category, message,
-    // retry_after_ms?}}. When present the mock short-circuits the
-    // provider call and surfaces as `VmError::CategorizedError`,
-    // making it observable via `error_category`, the `llm_call`
-    // thrown dict, and the `llm_call_safe` envelope.
+    // Optional error injection. Category-only mocks surface as
+    // categorized provider failures; provider-envelope mocks also keep
+    // status/kind/reason on the final thrown dict.
     let error = match config.get("error") {
         None | Some(VmValue::Nil) => None,
         Some(VmValue::Dict(err_dict)) => {
-            let category_str = err_dict
-                .get("category")
-                .map(|v| v.display())
-                .unwrap_or_default();
-            if category_str.is_empty() {
-                return Err(VmError::Runtime(
-                    "llm_mock: error.category is required".to_string(),
-                ));
-            }
-            let category = crate::value::ErrorCategory::parse(&category_str);
-            // Reject typos loudly: `parse` falls back to Generic on
-            // unknown input. Let `"generic"` through; anything else
-            // that fell back is a typo.
-            if category.as_str() != category_str {
-                return Err(VmError::Runtime(format!(
-                    "llm_mock: unknown error category `{category_str}`",
-                )));
-            }
-            let message = err_dict
-                .get("message")
-                .map(|v| v.display())
-                .unwrap_or_default();
+            let category = optional_display_field(err_dict, "category");
+            let message = optional_display_field(err_dict, "message");
+            let status = match err_dict.get("status") {
+                None | Some(VmValue::Nil) => None,
+                Some(value) => match value.as_int() {
+                    Some(n) => Some(
+                        mock::validate_mock_error_status(n)
+                            .map_err(|error| VmError::Runtime(format!("llm_mock: {error}")))?,
+                    ),
+                    None => {
+                        return Err(VmError::Runtime(
+                            "llm_mock: error.status must be an HTTP status code".to_string(),
+                        ));
+                    }
+                },
+            };
+            let kind = optional_display_field(err_dict, "kind");
+            let reason = optional_display_field(err_dict, "reason");
             let retry_after_ms = match err_dict.get("retry_after_ms") {
                 None | Some(VmValue::Nil) => None,
                 Some(v) => match v.as_int() {
@@ -184,15 +178,14 @@ fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
                     }
                 },
             };
-            Some(mock::MockError {
-                category,
-                message,
-                retry_after_ms,
-            })
+            Some(
+                mock::build_mock_error(category, message, status, kind, reason, retry_after_ms)
+                    .map_err(|error| VmError::Runtime(format!("llm_mock: {error}")))?,
+            )
         }
         _ => {
             return Err(VmError::Runtime(
-                "llm_mock: error must be a dict {category, message, retry_after_ms?}".to_string(),
+                "llm_mock: error must be a dict {category?, message?, status?, kind?, reason?, retry_after_ms?}".to_string(),
             ));
         }
     };
@@ -216,6 +209,16 @@ fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         error,
     });
     Ok(VmValue::Nil)
+}
+
+fn optional_display_field(
+    dict: &std::collections::BTreeMap<String, VmValue>,
+    key: &str,
+) -> Option<String> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => None,
+        Some(value) => Some(value.display()),
+    }
 }
 
 fn llm_mock_calls_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -3389,7 +3389,7 @@ without string-sniffing:
 try {
   let r = llm_call(user_prompt, nil, opts)
 } catch (e) {
-  // e is {kind, reason, category, message, retry_after_ms?, provider, model}
+  // e is {kind, reason, category, message, status?, retry_after_ms?, provider, model}
   if e.kind == "transient" && e.reason == "rate_limit" {
     sleep(e.retry_after_ms ?? 1000)
     continue
@@ -3447,8 +3447,10 @@ terminal reasons are `"auth_failure"`, `"context_overflow"`,
 `"unknown"`. `llm_call` and `agent_loop` spend their retry budget only
 when `kind == "transient"`.
 
-Pair with `llm_mock({error: {category, message, retry_after_ms?}})` to
-write deterministic tests for either helper's error path:
+Pair with `llm_mock({error: {category, message, retry_after_ms?}})` or
+the provider-envelope form
+`llm_mock({error: {status, kind, reason?, message?, retry_after_ms?}})`
+to write deterministic tests for either helper's error path:
 
 ```harn
 llm_mock({error: {category: "rate_limit", message: "429", retry_after_ms: 2500}})
@@ -3465,6 +3467,13 @@ llm_mock({error: {category: "rate_limit", message: "429"}})
 let r = llm_call_safe("hi", nil, {provider: "mock", llm_retries: 0})
 assert(!r.ok)
 assert(r.error.category == "rate_limit")
+
+llm_mock({error: {status: 503, kind: "transient", reason: "upstream_unavailable"}})
+let recovered = llm_call_safe("hi", nil, {provider: "mock"})
+assert(!recovered.ok)
+assert(recovered.error.status == 503)
+assert(recovered.error.kind == "transient")
+assert(recovered.error.reason == "upstream_unavailable")
 ```
 
 ## Composable LLM callers

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1638,7 +1638,7 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 | Function | Parameters | Returns | Description |
 |---|---|---|---|
 | `llm_call(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Single LLM request. Returns `{text, model, provider, input_tokens, output_tokens, usage, prose, visible_text, blocks, transcript?, tool_calls?, stop_reason?, data?}`. Supports `budget: {max_cost_usd?, max_input_tokens?, max_output_tokens?, total_budget_usd?}` pre-flight checks and throws on transport / rate-limit / budget / schema-validation failures |
-| `llm_call_safe(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Non-throwing envelope around `llm_call`. Returns `{ok: bool, response: llm_call result or nil, error: {category, kind, reason, message, provider?, model?, retry_after_ms?} or nil}`. `error.category` is one of `ErrorCategory`'s canonical strings (`"rate_limit"`, `"timeout"`, `"overloaded"`, `"server_error"`, `"transient_network"`, `"schema_validation"`, `"auth"`, `"not_found"`, `"circuit_open"`, `"budget_exceeded"`, `"tool_error"`, `"tool_rejected"`, `"egress_blocked"`, `"cancelled"`, `"generic"`) |
+| `llm_call_safe(prompt, system?, options?)` | prompt: string, system: string, options: dict | dict | Non-throwing envelope around `llm_call`. Returns `{ok: bool, response: llm_call result or nil, error: {category, kind, reason, message, provider?, model?, status?, retry_after_ms?} or nil}`. `error.category` is one of `ErrorCategory`'s canonical strings (`"rate_limit"`, `"timeout"`, `"overloaded"`, `"server_error"`, `"transient_network"`, `"schema_validation"`, `"auth"`, `"not_found"`, `"circuit_open"`, `"budget_exceeded"`, `"tool_error"`, `"tool_rejected"`, `"egress_blocked"`, `"cancelled"`, `"generic"`) |
 | `llm_stream_call(prompt, system?, options?)` | prompt: string, system: string, options: dict | stream | Streaming LLM request. Returns `Stream<{delta, visible_delta, partial, role, finish_reason}>`; dropping the stream cancels the background request. Uses the same options as `llm_call`; the `stream` option remains the transport toggle |
 | `with_rate_limit(provider, fn, options?)` | provider: string, fn: closure, options: dict | whatever `fn` returns | Acquire a permit from the provider's sliding-window rate limiter, invoke `fn`, and retry with exponential backoff on retryable errors (`rate_limit`, `overloaded`, `transient_network`, `timeout`). Options: `max_retries` (default 5), `backoff_ms` (default 1000, capped at 30s after doubling) |
 | `llm_completion(prefix, suffix?, system?, options?)` | prefix: string, suffix: string, system: string, options: dict | dict | Text completion / fill-in-the-middle request. Returns the same result shape as `llm_call` |
@@ -1701,7 +1701,7 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 | `llm_budget_remaining()` | — | float or nil | Remaining budget (nil if no budget set) |
 | `tiktoken_count_tokens(text, model)` | text: string, model: string | int | Count text with the selected tiktoken encoder for known OpenAI models and labeled Claude/Gemini approximations |
 | `tiktoken_tokenizer_info(model)` | model: string | dict | Return `{model, model_family, source, exact, known_model_family, encoder}` for the encoder or heuristic fallback used by a model ID |
-| `llm_mock(response)` | response: dict | nil | Queue a mock LLM response. Dict supports `text`, `tool_calls`, `blocks`, `logprobs`, `match` (glob), `consume_match` (consume a matched pattern instead of reusing it), `input_tokens`, `output_tokens`, `thinking`, `stop_reason`, `provider`, `model`, `error: {category, message}` (short-circuits the call and surfaces as `VmError::CategorizedError` — useful for testing `llm_call_safe` envelopes and `with_rate_limit` retry loops) |
+| `llm_mock(response)` | response: dict | nil | Queue a mock LLM response. Dict supports `text`, `tool_calls`, `blocks`, `logprobs`, `match` (glob), `consume_match` (consume a matched pattern instead of reusing it), `input_tokens`, `output_tokens`, `thinking`, `stop_reason`, `provider`, `model`, `error: {category, message?, retry_after_ms?}` or provider envelopes `error: {status, kind, reason?, message?, retry_after_ms?}` (short-circuits the call and surfaces the same structured error dict as live provider failures — useful for testing `llm_call_safe` envelopes and retry loops) |
 | `llm_mock_calls()` | — | list | Return list of `{messages, system, tools}` for all calls made to the mock provider |
 | `llm_mock_clear()` | — | nil | Clear all queued mock responses and recorded calls |
 
@@ -1747,6 +1747,7 @@ llm_mock({text: "step 2", match: "*planner*", consume_match: true})
 // `try { ... } catch`, `llm_call_safe`, and `with_rate_limit` all see
 // it the same way they would a live provider failure.
 llm_mock({error: {category: "rate_limit", message: "429 Too Many Requests"}})
+llm_mock({error: {status: 503, kind: "transient", reason: "upstream_unavailable"}})
 
 // Inspect what was sent
 let calls = llm_mock_calls()

--- a/docs/src/llm/llm_call.md
+++ b/docs/src/llm/llm_call.md
@@ -505,6 +505,10 @@ llm_mock({text: "I don't know.", match: "*unknown*"})
 llm_mock({text: "step 1", match: "*planner*", consume_match: true})
 llm_mock({text: "step 2", match: "*planner*", consume_match: true})
 
+// Provider-style error envelopes exercise the same catch/safe-call paths
+// as live provider failures.
+llm_mock({error: {status: 503, kind: "transient", reason: "upstream_unavailable"}})
+
 // Inspect what was sent to the mock provider
 let calls = llm_mock_calls()
 // Each entry: {messages: [...], system: "..." or nil, tools: [...] or nil}

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -223,6 +223,7 @@ infrastructure from a JSONL fixture file:
 {"text":"PLAN: find the middleware module first","model":"fixture-model"}
 {"match":"*hello*","text":"matched","model":"fixture-model"}
 {"match":"*","error":{"category":"rate_limit","message":"fake rate limit"}}
+{"match":"*retry*","error":{"status":503,"kind":"transient","reason":"upstream_unavailable"}}
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

- accept provider-style `error` envelopes in `llm_mock(...)` and JSONL `--llm-mock` fixtures
- validate mock `error.kind` against the LLM error taxonomy and preserve `status`, `kind`, `reason`, and `retry_after_ms` on thrown/safe-call error dicts
- add unit, CLI replay, and conformance coverage for error-then-success fixtures plus invalid-kind rejection
- document provider-error fixtures in the quickref, builtins, LLM call guide, and testing guide

The Burin `install_llm_mock_fixture_text` helper delegates JSONL rows directly to Harn `llm_mock(...)`; `scripts/run-eval.ts` already forwards `--llm-mock` into Harn, so the same fixture format now works through the shared Harn loader path.

Closes #2476

## Verification

- `cargo test -p harn-cli playground_replays_cli_llm_mock_error_envelopes --no-default-features`
- `cargo test -p harn-vm llm::jsonl --no-default-features`
- `cargo test -p harn-parser test_structured_stdlib_return_shapes_allow_documented_field_access`
- `cargo run --quiet --bin harn -- test conformance --filter llm_mock_error`
- `cargo run --quiet --bin harn -- lint conformance/tests/integration/llm_mock_error_envelopes.harn conformance/tests/integration/llm_mock_error_envelope_invalid_kind.harn`
- `cargo run --quiet --bin harn -- fmt --check conformance/tests/integration/llm_mock_error_envelopes.harn conformance/tests/integration/llm_mock_error_envelope_invalid_kind.harn`
- `make check-docs-snippets`
- pre-commit hook
- pre-push hook
