### PR TITLE
Polish session replay CLI completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ condensed series summaries instead of full per-patch history.
 
 ### Added
 
+- **`harn replay` can read sessions directly from `events.sqlite`
+  (#2474).** `harn replay --session-id <id> --events-db <path>`
+  reconstructs a replayable run record from the session's
+  sanitized `observability.agent_events` stream, and `--runs N`
+  compares allowlist-normalized event material across repeated replay
+  reads.
 - **Agent-loop tool-surface narrowing (#2473).** `agent_loop` now narrows
   model-visible tools between turns after a rolling five-turn inactivity
   window. The `tool_surface_narrowing` option accepts `enabled`,

--- a/crates/harn-cli/src/commands/replay.rs
+++ b/crates/harn-cli/src/commands/replay.rs
@@ -262,6 +262,9 @@ fn run_human(source: ReplaySource, runs: usize) -> i32 {
     }
     if runs > 1 {
         let determinism = determinism_summary(&source, &executions);
+        let fixture_failed = executions
+            .iter()
+            .any(|execution| !execution.report.fixture.pass);
         println!(
             "Determinism: {} (compared {} run(s))",
             if determinism.pass { "PASS" } else { "FAIL" },
@@ -270,7 +273,7 @@ fn run_human(source: ReplaySource, runs: usize) -> i32 {
         for failure in determinism.failures {
             println!("  {failure}");
         }
-        return i32::from(!determinism.pass);
+        return i32::from(fixture_failed || !determinism.pass);
     }
     i32::from(!executions[0].report.fixture.pass)
 }
@@ -529,6 +532,9 @@ fn print_report_human(report: &ReplayReport) {
         "Embedded replay fixture: {}",
         if report.fixture.pass { "PASS" } else { "FAIL" }
     );
+    for failure in &report.fixture.failures {
+        println!("  failure: {failure}");
+    }
     for transition in &report.transitions {
         println!(
             "transition {} -> {} ({})",

--- a/crates/harn-cli/tests/replay_session_cli.rs
+++ b/crates/harn-cli/tests/replay_session_cli.rs
@@ -37,6 +37,35 @@ fn unique_normalized_runs(parsed: &serde_json::Value) -> BTreeSet<String> {
         .collect()
 }
 
+fn write_failing_run_record(path: &std::path::Path) {
+    let run = json!({
+        "_type": "run_record",
+        "id": "run-failing-fixture",
+        "workflow_id": "replay-fixture-exit",
+        "workflow_name": "Replay fixture exit",
+        "task": "Exercise human replay exit handling",
+        "status": "failed",
+        "started_at": "2026-05-26T00:00:00.000Z",
+        "finished_at": "2026-05-26T00:00:01.000Z",
+        "replay_fixture": {
+            "_type": "replay_fixture",
+            "id": "fixture-expects-completed",
+            "source_run_id": "run-failing-fixture",
+            "workflow_id": "replay-fixture-exit",
+            "workflow_name": "Replay fixture exit",
+            "created_at": "2026-05-26T00:00:01.000Z",
+            "eval_kind": "replay",
+            "expected_status": "completed",
+            "stage_assertions": []
+        }
+    });
+    std::fs::write(
+        path,
+        serde_json::to_vec_pretty(&run).expect("serialize failing run record"),
+    )
+    .expect("write failing run record");
+}
+
 fn append_agent_event(
     log: &SqliteEventLog,
     topic: &Topic,
@@ -185,6 +214,23 @@ fn replay_session_id_errors_when_session_absent() {
         .as_str()
         .unwrap_or("")
         .contains("session-missing"));
+}
+
+#[test]
+fn replay_human_runs_fail_when_embedded_fixture_fails() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let run_record = temp.path().join("run.json");
+    write_failing_run_record(&run_record);
+
+    let out = Command::new(binary_path())
+        .args(["replay", run_record.to_str().unwrap(), "--runs", "2"])
+        .output()
+        .expect("spawn harn replay --runs");
+    assert!(!out.status.success(), "expected replay fixture failure");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Embedded replay fixture: FAIL"));
+    assert!(stdout.contains("run status mismatch"));
+    assert!(stdout.contains("Determinism: PASS"));
 }
 
 #[test]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1428,11 +1428,20 @@ harn runs inspect .harn-runs/<run>.json --compare baseline.json
 
 ## harn replay
 
-Replay a persisted workflow run record from saved output.
+Replay a persisted workflow run record from saved output, a replay-oracle
+fixture, or an agent session stored in the SQLite EventLog.
 
 ```bash
 harn replay .harn-runs/<run>.json
+harn replay --fixture conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json --runs 3 --json
+harn replay --session-id <id> --events-db .harn/events.sqlite --runs 3 --json
 ```
+
+`--session-id` reads the `observability.agent_events.<sanitized-id>` topic
+from `--events-db` in append order, reconstructs a replayable run record,
+and feeds it through the same replay summary path as run-record input.
+When `--runs N` is greater than one, JSON output includes per-run reports
+plus an allowlist-normalized determinism summary.
 
 ## harn eval
 


### PR DESCRIPTION
## Summary
- make human-mode `harn replay --runs N` fail when any embedded replay fixture fails, matching JSON mode success criteria
- print embedded fixture failure details in human replay output
- document `--session-id`, `--events-db`, and multi-run replay output in the CLI reference and changelog

## Verification
- `cargo fmt --all --check`
- `cargo test -p harn-cli --test replay_session_cli`
- `cargo test -p harn-cli test_parses_replay_sources_and_runs`
- `/var/folders/1h/v3ltwjgn6h79_77xhvgxwgm80000gn/T/harn-target/85f3-harn/debug/harn replay --fixture conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json --runs 3 --json | jq -c .runs[] | (del(.[] | .event_id, .occurred_at_ms)) | sort -u | wc -l` => `1`
- `make check-docs-snippets`
- `make lint-test-patterns`
- `npx markdownlint-cli2 CHANGELOG.md docs/src/cli-reference.md`
- pre-commit hook
- pre-push hook

Closes #2474