### PR TITLE
perf(vm): peek method IC by Copy triple, skip InlineCacheEntry clone

### DIFF
--- a/crates/harn-vm/src/bench_internals.rs
+++ b/crates/harn-vm/src/bench_internals.rs
@@ -181,6 +181,102 @@ impl AdaptiveBinaryCacheReadFixture {
     }
 }
 
+/// Bytecode-length presets for the method-cache read microbench. The
+/// fixture sweeps N adjacent `Op::MethodCall` slots, exercising the
+/// same cache-read shape that `execute_method_call(_sync|_spread)`
+/// issues on every dispatch. N spans a small predicate body
+/// through a deep stdlib pipeline.
+pub const METHOD_CACHE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
+
+/// Microbench fixture for the method inline-cache read path.
+///
+/// `Chunk::inline_cache_entry` (the pre-optimization path) clones the
+/// wrapping `InlineCacheEntry` enum on every dispatch — a 32-48B memcpy
+/// that the variant-checking `let-else` in `try_cached_method`
+/// destructures and throws away. `Chunk::peek_method_cache` (the new
+/// path) returns just the `(name_idx, argc, target)` triple by value
+/// (all three are `Copy` — `u16`, `usize`, `MethodCacheTarget`), so the
+/// read is a single scalar move out of the cache instead of a clone.
+///
+/// The fixture pre-warms every slot to a `Method` entry (the steady
+/// state of a hot pipeline like `xs.contains(...).filter(...).count()`)
+/// so the bench measures the read overhead with no per-iteration state
+/// transitions. The accumulator sums the cached `argc` so the optimizer
+/// cannot dead-code the loop.
+pub struct MethodCacheReadFixture {
+    chunk: Chunk,
+    offsets: Vec<usize>,
+    slots: Vec<usize>,
+}
+
+impl MethodCacheReadFixture {
+    pub fn new(op_count: usize) -> Self {
+        use crate::chunk::{InlineCacheEntry, MethodCacheTarget};
+        let mut chunk = Chunk::new();
+        let mut offsets = Vec::with_capacity(op_count);
+        for _ in 0..op_count {
+            offsets.push(chunk.code.len());
+            chunk.emit_method_call(0, 1, 1);
+        }
+        let mut slots = Vec::with_capacity(op_count);
+        for &offset in &offsets {
+            let slot = chunk
+                .inline_cache_slot(offset)
+                .expect("Op::MethodCall registers an inline-cache slot at emit time");
+            // Pre-warm to a Method entry with `ListContains` — a 1-arg
+            // method-call shape that flows through every method-call
+            // dispatcher (`execute_method_call`, `execute_method_call_sync`,
+            // `execute_method_call_spread`).
+            chunk.set_inline_cache_entry(
+                slot,
+                InlineCacheEntry::Method {
+                    name_idx: 0,
+                    argc: 1,
+                    target: MethodCacheTarget::ListContains,
+                },
+            );
+            slots.push(slot);
+        }
+        Self {
+            chunk,
+            offsets,
+            slots,
+        }
+    }
+
+    pub fn op_count(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Sweep all slots via the new Copy peek path. Returns the sum of
+    /// observed `argc` values so the optimizer cannot dead-code the
+    /// loop.
+    pub fn invoke_peek(&self) -> usize {
+        let mut acc = 0usize;
+        for &slot in &self.slots {
+            if let Some((_name_idx, argc, _target)) = self.chunk.peek_method_cache(slot) {
+                acc = acc.wrapping_add(argc);
+            }
+        }
+        acc
+    }
+
+    /// Control sweep using the pre-optimization `inline_cache_entry`
+    /// clone path. Same accumulator shape so the criterion bench can
+    /// A/B the two paths inside a single binary.
+    pub fn invoke_clone_control(&self) -> usize {
+        use crate::chunk::InlineCacheEntry;
+        let mut acc = 0usize;
+        for &slot in &self.slots {
+            let entry = self.chunk.inline_cache_entry(slot);
+            if let InlineCacheEntry::Method { argc, .. } = entry {
+                acc = acc.wrapping_add(argc);
+            }
+        }
+        acc
+    }
+}
+
 pub struct NonModuleClosureCallFixture {
     capture_count: usize,
     last_capture_name: Option<String>,

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -1187,6 +1187,29 @@ impl Chunk {
         }
     }
 
+    /// Method-cache fast path read. Returns the cached `(name_idx, argc,
+    /// target)` triple by value (all three are `Copy`) when `slot` holds a
+    /// `Method` entry, else `None`. Skips the full `InlineCacheEntry::clone`
+    /// that `inline_cache_entry` performs on every `Op::MethodCall`,
+    /// `Op::MethodCallOpt`, and `Op::MethodCallSpread` dispatch: the
+    /// variant-checking `let-else` in `try_cached_method` destructures and
+    /// throws the wrapping enum away anyway, so reading the payload by `Copy`
+    /// avoids the 32-48B enum memcpy. Method-call dispatch is the second-
+    /// hottest IC-keyed opcode class after the adaptive binary ops, so the
+    /// per-dispatch savings compound across the millions of method calls a
+    /// typical pipeline (`xs.filter(...).map(...).count()`) issues.
+    #[inline]
+    pub(crate) fn peek_method_cache(&self, slot: usize) -> Option<(u16, usize, MethodCacheTarget)> {
+        match self.inline_caches.borrow().get(slot)? {
+            &InlineCacheEntry::Method {
+                name_idx,
+                argc,
+                target,
+            } => Some((name_idx, argc, target)),
+            _ => None,
+        }
+    }
+
     pub(crate) fn set_inline_cache_entry(&self, slot: usize, entry: InlineCacheEntry) {
         if let Some(existing) = self.inline_caches.borrow_mut().get_mut(slot) {
             *existing = entry;
@@ -1657,7 +1680,7 @@ impl Default for Chunk {
 
 #[cfg(test)]
 mod tests {
-    use super::{Chunk, Op};
+    use super::{Chunk, InlineCacheEntry, MethodCacheTarget, Op, PropertyCacheTarget};
     use crate::BuiltinId;
 
     #[test]
@@ -2075,5 +2098,84 @@ mod tests {
         assert_copy::<super::AdaptiveBinaryState>();
         assert_copy::<super::AdaptiveBinaryOp>();
         assert_copy::<super::BinaryShape>();
+    }
+
+    // --- peek_method_cache contract ---
+    //
+    // The peek replaces the per-dispatch `InlineCacheEntry::clone` on the
+    // method-call dispatch sites (`Op::MethodCall`, `Op::MethodCallOpt`,
+    // `Op::MethodCallSpread`). It must return None for unrelated IC variants
+    // — silently mis-extracting a `Property` / `DirectCall` / `AdaptiveBinary`
+    // slot as `Method` would feed garbage into `try_cached_method` and either
+    // spec-mis-fire (wrong target/argc) or skip the cache entirely on a real
+    // hit. These tests pin the variant gate.
+
+    #[test]
+    fn peek_method_cache_returns_none_for_empty_slot() {
+        let mut chunk = Chunk::new();
+        chunk.emit_method_call(0, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("MethodCall registers a slot");
+        assert!(chunk.peek_method_cache(slot).is_none());
+    }
+
+    #[test]
+    fn peek_method_cache_returns_triple_after_warmup() {
+        let mut chunk = Chunk::new();
+        chunk.emit_method_call(7, 2, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("MethodCall registers a slot");
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::Method {
+                name_idx: 7,
+                argc: 2,
+                target: MethodCacheTarget::ListContains,
+            },
+        );
+        let (name_idx, argc, target) = chunk.peek_method_cache(slot).expect("warmed slot peek");
+        assert_eq!(name_idx, 7);
+        assert_eq!(argc, 2);
+        assert_eq!(target, MethodCacheTarget::ListContains);
+    }
+
+    #[test]
+    fn peek_method_cache_returns_none_for_non_method_variants() {
+        // The cache slot may legitimately hold an `AdaptiveBinary`,
+        // `Property`, or `DirectCall` entry. The peek must defensively
+        // refuse non-Method variants regardless.
+        let mut chunk = Chunk::new();
+        chunk.emit_method_call(0, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("MethodCall registers a slot");
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::Property {
+                name_idx: 0,
+                target: PropertyCacheTarget::ListCount,
+            },
+        );
+        assert!(chunk.peek_method_cache(slot).is_none());
+    }
+
+    #[test]
+    fn peek_method_cache_returns_none_for_out_of_bounds_slot() {
+        let chunk = Chunk::new();
+        assert!(chunk.peek_method_cache(0).is_none());
+        assert!(chunk.peek_method_cache(usize::MAX).is_none());
+    }
+
+    #[test]
+    fn peek_method_cache_target_is_copy() {
+        // Compile-time assertion: `MethodCacheTarget: Copy` is the whole
+        // point of this peek path — if a future variant adds a non-Copy
+        // field (eg. an `Rc<str>` for a dynamic method name), the static
+        // check below will fail at compile time before the dispatcher
+        // silently regresses to the heavy `InlineCacheEntry::clone` path.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<super::MethodCacheTarget>();
     }
 }

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -348,21 +348,14 @@ impl super::super::Vm {
     }
 
     fn try_cached_method(
-        cache: &InlineCacheEntry,
+        cache: Option<(u16, usize, MethodCacheTarget)>,
         name_idx: u16,
         argc: usize,
         obj: &VmValue,
         args: &[VmValue],
     ) -> Option<VmValue> {
-        let InlineCacheEntry::Method {
-            name_idx: cached_name_idx,
-            argc: cached_argc,
-            target,
-        } = cache
-        else {
-            return None;
-        };
-        if *cached_name_idx != name_idx || *cached_argc != argc {
+        let (cached_name_idx, cached_argc, target) = cache?;
+        if cached_name_idx != name_idx || cached_argc != argc {
             return None;
         }
 
@@ -1310,7 +1303,7 @@ impl super::super::Vm {
     }
 
     pub(super) async fn execute_method_call(&mut self, optional: bool) -> Result<(), VmError> {
-        let (name_idx, argc, cache_slot, cache_entry) = {
+        let (name_idx, argc, cache_slot, cached_method) = {
             let frame = self.frames.last_mut().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
             let name_idx = frame.chunk.read_u16(frame.ip);
@@ -1318,10 +1311,8 @@ impl super::super::Vm {
             let argc = frame.chunk.code[frame.ip] as usize;
             frame.ip += 1;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cache_entry = cache_slot
-                .map(|slot| frame.chunk.inline_cache_entry(slot))
-                .unwrap_or(InlineCacheEntry::Empty);
-            (name_idx, argc, cache_slot, cache_entry)
+            let cached_method = cache_slot.and_then(|slot| frame.chunk.peek_method_cache(slot));
+            (name_idx, argc, cache_slot, cached_method)
         };
         let args_start = self.stack_arg_start(argc)?;
         let obj_idx = args_start
@@ -1336,7 +1327,7 @@ impl super::super::Vm {
             self.stack.truncate(obj_idx);
             self.stack.push(VmValue::Nil);
         } else if let Some(result) = Self::try_cached_method(
-            &cache_entry,
+            cached_method,
             name_idx,
             argc,
             &obj,
@@ -1383,16 +1374,14 @@ impl super::super::Vm {
         &mut self,
         optional: bool,
     ) -> Option<Result<(), VmError>> {
-        let (name_idx, argc, cache_slot, cache_entry) = {
+        let (name_idx, argc, cache_slot, cached_method) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
             let name_idx = frame.chunk.read_u16(frame.ip);
             let argc = frame.chunk.code[frame.ip + 2] as usize;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cache_entry = cache_slot
-                .map(|slot| frame.chunk.inline_cache_entry(slot))
-                .unwrap_or(InlineCacheEntry::Empty);
-            (name_idx, argc, cache_slot, cache_entry)
+            let cached_method = cache_slot.and_then(|slot| frame.chunk.peek_method_cache(slot));
+            (name_idx, argc, cache_slot, cached_method)
         };
 
         let args_start = match self.stack.len().checked_sub(argc) {
@@ -1415,9 +1404,13 @@ impl super::super::Vm {
             ));
         }
 
-        if let Some(result) =
-            Self::try_cached_method(&cache_entry, name_idx, argc, obj, &self.stack[args_start..])
-        {
+        if let Some(result) = Self::try_cached_method(
+            cached_method,
+            name_idx,
+            argc,
+            obj,
+            &self.stack[args_start..],
+        ) {
             return Some(self.finish_method_call_sync(argc, Ok(result), name_idx, None, None));
         }
 
@@ -1473,16 +1466,14 @@ impl super::super::Vm {
     }
 
     pub(super) async fn execute_method_call_spread(&mut self) -> Result<(), VmError> {
-        let (name_idx, cache_slot, cache_entry) = {
+        let (name_idx, cache_slot, cached_method) = {
             let frame = self.frames.last_mut().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cache_entry = cache_slot
-                .map(|slot| frame.chunk.inline_cache_entry(slot))
-                .unwrap_or(InlineCacheEntry::Empty);
-            (name_idx, cache_slot, cache_entry)
+            let cached_method = cache_slot.and_then(|slot| frame.chunk.peek_method_cache(slot));
+            (name_idx, cache_slot, cached_method)
         };
         let args_val = self.pop()?;
         let obj = self.pop()?;
@@ -1495,7 +1486,7 @@ impl super::super::Vm {
             }
         };
         if let Some(result) =
-            Self::try_cached_method(&cache_entry, name_idx, args.len(), &obj, &args)
+            Self::try_cached_method(cached_method, name_idx, args.len(), &obj, &args)
         {
             self.stack.push(result);
         } else {

--- a/perf/vm/Cargo.toml
+++ b/perf/vm/Cargo.toml
@@ -28,6 +28,11 @@ path = "bench_adaptive_binary_cache_read.rs"
 harness = false
 
 [[bench]]
+name = "bench_method_cache_read"
+path = "bench_method_cache_read.rs"
+harness = false
+
+[[bench]]
 name = "bench_vm_fixtures"
 path = "bench_vm_fixtures.rs"
 harness = false

--- a/perf/vm/bench_method_cache_read.rs
+++ b/perf/vm/bench_method_cache_read.rs
@@ -1,0 +1,58 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm::bench_internals::{MethodCacheReadFixture, METHOD_CACHE_READ_COUNTS};
+
+/// Microbench for the method-cache inline-cache read path. The read
+/// fires on every dispatch of every `Op::MethodCall`, `Op::MethodCallOpt`,
+/// and `Op::MethodCallSpread` — the dominant opcode class for any
+/// chained-collection pipeline (`xs.filter(...).map(...).count()`,
+/// `s.contains(...)`, etc.), which most Harn user code exercises.
+///
+/// `method_cache_read/copy_peek` exercises `peek_method_cache`, which
+/// returns the cached `(name_idx, argc, target)` triple by value — all
+/// three are `Copy` (`u16` / `usize` / `MethodCacheTarget` unit enum).
+/// `method_cache_read/clone_control` exercises the pre-optimization
+/// `inline_cache_entry` path that cloned the wrapping `InlineCacheEntry`
+/// enum on every dispatch — a 32-48B memcpy (largest variant size) that
+/// the variant-checking `let-else` in `try_cached_method` destructures
+/// and throws away.
+///
+/// The N axis (8/32/128/512) approximates a small predicate, a loop
+/// body, and a deep stdlib pipeline. Per-op savings compound across
+/// the millions of method calls a typical pipeline issues.
+fn bench_method_cache_read(c: &mut Criterion) {
+    let fixtures = METHOD_CACHE_READ_COUNTS
+        .into_iter()
+        .map(MethodCacheReadFixture::new)
+        .collect::<Vec<_>>();
+
+    let mut optimized = c.benchmark_group("method_cache_read/copy_peek");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        optimized.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_peek()));
+            },
+        );
+    }
+    optimized.finish();
+
+    let mut baseline = c.benchmark_group("method_cache_read/clone_control");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        baseline.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_clone_control()));
+            },
+        );
+    }
+    baseline.finish();
+}
+
+criterion_group!(benches, bench_method_cache_read);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Generalizes the Copy-peek pattern from #2478 (adaptive-binary IC) to the **method inline-cache** read path, the second-hottest IC-keyed opcode class.

- `Op::MethodCall`, `Op::MethodCallOpt`, `Op::MethodCallSpread` previously cloned the entire `InlineCacheEntry` enum (32–48B memcpy) on every dispatch to read a payload the variant match in `try_cached_method` then destructured and threw away.
- All three fields of the `Method` variant — `name_idx: u16`, `argc: usize`, `target: MethodCacheTarget` (17-variant unit enum) — are already `Copy`. So `Chunk::peek_method_cache(slot) -> Option<(u16, usize, MethodCacheTarget)>` reads the slot under the existing `RefCell` borrow and returns the triple by value, no clone.
- `try_cached_method` now takes the peeked triple. The three dispatcher call sites in `vm/ops/call.rs` use it. Write-back path is unchanged (still builds a fresh `InlineCacheEntry::Method { ... }` from values the caller already has).

Microbench (criterion, `bench_method_cache_read`) A/Bs the Copy peek against the pre-optimization clone path inside a single binary at four bytecode-length presets (8/32/128/512 cacheable ops). Numbers will be added to the commit message once the bench finishes.

## Test plan

- [x] `cargo test -p harn-vm --features vm-bench-internals --lib` — all 2733 tests pass
- [x] `cargo clippy -p harn-vm --features vm-bench-internals --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] 5 chunk-level contract tests pin variant gate + Copy assertion
- [ ] CI: Format / Lint / Rust test / Conformance / Windows
- [ ] Auto-merge once checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)