### PR TITLE
perf(vm): peek Property + DirectCall IC, eliminate last InlineCacheEntry clones

### DIFF
--- a/crates/harn-vm/src/bench_internals.rs
+++ b/crates/harn-vm/src/bench_internals.rs
@@ -277,6 +277,216 @@ impl MethodCacheReadFixture {
     }
 }
 
+/// Bytecode-length presets for the property-cache read microbench. Sweeps
+/// N adjacent `Op::GetProperty` slots, exercising the same cache-read
+/// shape that `execute_get_property` issues on every dispatch.
+pub const PROPERTY_CACHE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
+
+/// Microbench fixture for the property inline-cache read path.
+///
+/// `Chunk::inline_cache_entry` (the pre-optimization path) clones the
+/// wrapping `InlineCacheEntry` enum on every dispatch — a 32-48B memcpy
+/// (the wrapping enum is padded to the largest variant, `DirectCall`)
+/// that the variant-checking `let-else` in `try_cached_property`
+/// destructures and throws away. `Chunk::peek_property_cache` (the new
+/// path) returns just the `Property` payload (`u16 + PropertyCacheTarget`),
+/// skipping the outer enum tag init and the padding-to-largest-variant
+/// memcpy. The accumulator sums the cached `name_idx` so the optimizer
+/// cannot dead-code the loop.
+///
+/// The fixture pre-warms every slot to a unit `PropertyCacheTarget`
+/// (`ListCount`) — the hottest steady state for any property-access
+/// pipeline (`.count` on collections, `.first` / `.last`, etc.).
+pub struct PropertyCacheReadFixture {
+    chunk: Chunk,
+    offsets: Vec<usize>,
+    slots: Vec<usize>,
+}
+
+impl PropertyCacheReadFixture {
+    pub fn new(op_count: usize) -> Self {
+        use crate::chunk::{InlineCacheEntry, PropertyCacheTarget};
+        let mut chunk = Chunk::new();
+        let mut offsets = Vec::with_capacity(op_count);
+        for _ in 0..op_count {
+            offsets.push(chunk.code.len());
+            chunk.emit_u16(Op::GetProperty, 0, 1);
+        }
+        let mut slots = Vec::with_capacity(op_count);
+        for &offset in &offsets {
+            let slot = chunk
+                .inline_cache_slot(offset)
+                .expect("Op::GetProperty registers an inline-cache slot at emit time");
+            chunk.set_inline_cache_entry(
+                slot,
+                InlineCacheEntry::Property {
+                    name_idx: 7,
+                    target: PropertyCacheTarget::ListCount,
+                },
+            );
+            slots.push(slot);
+        }
+        Self {
+            chunk,
+            offsets,
+            slots,
+        }
+    }
+
+    pub fn op_count(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Sweep all slots via the new peek path. Returns the sum of
+    /// observed `name_idx` values so the optimizer cannot dead-code
+    /// the loop.
+    pub fn invoke_peek(&self) -> usize {
+        let mut acc = 0usize;
+        for &slot in &self.slots {
+            if let Some((name_idx, _target)) = self.chunk.peek_property_cache(slot) {
+                acc = acc.wrapping_add(name_idx as usize);
+            }
+        }
+        acc
+    }
+
+    /// Control sweep using the pre-optimization `inline_cache_entry`
+    /// clone path. Same accumulator shape so the criterion bench can
+    /// A/B the two paths inside a single binary.
+    pub fn invoke_clone_control(&self) -> usize {
+        use crate::chunk::InlineCacheEntry;
+        let mut acc = 0usize;
+        for &slot in &self.slots {
+            let entry = self.chunk.inline_cache_entry(slot);
+            if let InlineCacheEntry::Property { name_idx, .. } = entry {
+                acc = acc.wrapping_add(name_idx as usize);
+            }
+        }
+        acc
+    }
+}
+
+/// Bytecode-length presets for the direct-call-state read microbench.
+/// Sweeps N adjacent `Op::Call` slots, exercising the same cache-read
+/// shape that `execute_call_sync` and `execute_call_builtin_sync` issue
+/// on every dispatch.
+pub const DIRECT_CALL_STATE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
+
+/// Microbench fixture for the direct-call inline-cache read path.
+///
+/// `Chunk::inline_cache_entry` (the pre-optimization path) clones the
+/// wrapping `InlineCacheEntry::DirectCall { state: DirectCallState }` on
+/// every dispatch, including the outer enum's tag init and 8 bytes of
+/// padding beyond the inner `DirectCallState`. `Chunk::peek_direct_call_state`
+/// returns just the inner `DirectCallState` (still cloned because it
+/// contains the `Rc<VmClosure>` cached target) — but skipping the outer
+/// wrap saves an enum-padded memcpy plus one branch in
+/// `try_cached_direct_call`'s variant check.
+///
+/// Pre-warms every slot to `Specialized { argc: 1, hits: 1000, misses: 0,
+/// target: Rc<VmClosure> }` — the steady state of any hot
+/// `x.map(predicate)`-style direct-call call site.
+pub struct DirectCallStateReadFixture {
+    chunk: Chunk,
+    offsets: Vec<usize>,
+    slots: Vec<usize>,
+}
+
+impl DirectCallStateReadFixture {
+    pub fn new(op_count: usize) -> Self {
+        use crate::chunk::{DirectCallState, DirectCallTarget, InlineCacheEntry};
+        let target_closure = synthetic_direct_call_closure();
+        let mut chunk = Chunk::new();
+        let mut offsets = Vec::with_capacity(op_count);
+        for _ in 0..op_count {
+            offsets.push(chunk.code.len());
+            chunk.emit_u8(Op::Call, 1, 1);
+        }
+        let mut slots = Vec::with_capacity(op_count);
+        for &offset in &offsets {
+            let slot = chunk
+                .inline_cache_slot(offset)
+                .expect("Op::Call registers an inline-cache slot at emit time");
+            chunk.set_inline_cache_entry(
+                slot,
+                InlineCacheEntry::DirectCall {
+                    state: DirectCallState::Specialized {
+                        argc: 1,
+                        target: DirectCallTarget::Closure(Rc::clone(&target_closure)),
+                        hits: 1_000,
+                        misses: 0,
+                    },
+                },
+            );
+            slots.push(slot);
+        }
+        Self {
+            chunk,
+            offsets,
+            slots,
+        }
+    }
+
+    pub fn op_count(&self) -> usize {
+        self.offsets.len()
+    }
+
+    /// Sweep all slots via the new peek path. Returns the sum of
+    /// observed `argc` values so the optimizer cannot dead-code the
+    /// loop.
+    pub fn invoke_peek(&self) -> usize {
+        use crate::chunk::DirectCallState;
+        let mut acc = 0usize;
+        for &slot in &self.slots {
+            if let Some(DirectCallState::Specialized { argc, .. }) =
+                self.chunk.peek_direct_call_state(slot)
+            {
+                acc = acc.wrapping_add(argc);
+            }
+        }
+        acc
+    }
+
+    /// Control sweep using the pre-optimization `inline_cache_entry`
+    /// clone path. Same accumulator shape.
+    pub fn invoke_clone_control(&self) -> usize {
+        use crate::chunk::{DirectCallState, InlineCacheEntry};
+        let mut acc = 0usize;
+        for &slot in &self.slots {
+            let entry = self.chunk.inline_cache_entry(slot);
+            if let InlineCacheEntry::DirectCall {
+                state: DirectCallState::Specialized { argc, .. },
+            } = entry
+            {
+                acc = acc.wrapping_add(argc);
+            }
+        }
+        acc
+    }
+}
+
+fn synthetic_direct_call_closure() -> Rc<VmClosure> {
+    let func = CompiledFunction {
+        name: "synthetic_direct_call_target".to_string(),
+        type_params: Vec::new(),
+        nominal_type_names: Vec::new(),
+        params: Vec::new(),
+        default_start: None,
+        chunk: Rc::new(Chunk::new()),
+        is_generator: false,
+        is_stream: false,
+        has_rest_param: false,
+        has_runtime_type_checks: false,
+    };
+    Rc::new(VmClosure {
+        func: Rc::new(func),
+        env: VmEnv::new(),
+        source_dir: None,
+        module_functions: None,
+        module_state: None,
+    })
+}
+
 pub struct NonModuleClosureCallFixture {
     capture_count: usize,
     last_capture_name: Option<String>,

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -1157,6 +1157,7 @@ impl Chunk {
         Some(materialized)
     }
 
+    #[cfg(feature = "vm-bench-internals")]
     pub(crate) fn inline_cache_entry(&self, slot: usize) -> InlineCacheEntry {
         self.inline_caches
             .borrow()
@@ -1206,6 +1207,40 @@ impl Chunk {
                 argc,
                 target,
             } => Some((name_idx, argc, target)),
+            _ => None,
+        }
+    }
+
+    /// Property-cache fast path read. Returns the cached `(name_idx, target)`
+    /// pair by value when `slot` holds a `Property` entry, else `None`. The
+    /// outer `InlineCacheEntry` is the worst-case-sized variant (DirectCall
+    /// at ~48 bytes including padding); cloning it just to discard four other
+    /// variants in `try_cached_property`'s variant-check is wasted work. The
+    /// peek returns just the `Property` payload (`u16` + `PropertyCacheTarget`),
+    /// skipping the outer enum tag init and the padding-to-largest-variant
+    /// memcpy. Fires on every `Op::GetProperty` / `Op::GetPropertyOpt`
+    /// dispatch, which is the dominant opcode for any field-read-heavy code.
+    #[inline]
+    pub(crate) fn peek_property_cache(&self, slot: usize) -> Option<(u16, PropertyCacheTarget)> {
+        match self.inline_caches.borrow().get(slot)? {
+            InlineCacheEntry::Property { name_idx, target } => Some((*name_idx, target.clone())),
+            _ => None,
+        }
+    }
+
+    /// Direct-call cache state read. Returns just the inner `DirectCallState`
+    /// by value when `slot` holds a `DirectCall` entry, else `None`. Used by
+    /// both `try_cached_direct_call(_)` (steady-state Specialized hit check)
+    /// and `next_direct_call_entry` (Warmup → Specialized state-machine
+    /// transition). Peeking the inner state directly skips the outer
+    /// `InlineCacheEntry` discriminant check and tag init that the dispatcher
+    /// otherwise pays on every `Op::Call` (closure callee) and the named-fn
+    /// fast path inside `Op::CallBuiltin`. Single peek per dispatch covers
+    /// both the read check and the write-back computation.
+    #[inline]
+    pub(crate) fn peek_direct_call_state(&self, slot: usize) -> Option<DirectCallState> {
+        match self.inline_caches.borrow().get(slot)? {
+            InlineCacheEntry::DirectCall { state } => Some(state.clone()),
             _ => None,
         }
     }
@@ -1680,7 +1715,12 @@ impl Default for Chunk {
 
 #[cfg(test)]
 mod tests {
-    use super::{Chunk, InlineCacheEntry, MethodCacheTarget, Op, PropertyCacheTarget};
+    use std::rc::Rc;
+
+    use super::{
+        Chunk, DirectCallState, DirectCallTarget, InlineCacheEntry, MethodCacheTarget, Op,
+        PropertyCacheTarget,
+    };
     use crate::BuiltinId;
 
     #[test]
@@ -2151,6 +2191,7 @@ mod tests {
         let slot = chunk
             .inline_cache_slot(0)
             .expect("MethodCall registers a slot");
+
         chunk.set_inline_cache_entry(
             slot,
             InlineCacheEntry::Property {
@@ -2177,5 +2218,241 @@ mod tests {
         // silently regresses to the heavy `InlineCacheEntry::clone` path.
         fn assert_copy<T: Copy>() {}
         assert_copy::<super::MethodCacheTarget>();
+    }
+
+    // --- peek_property_cache contract ---
+    //
+    // The peek replaces the per-dispatch `InlineCacheEntry::clone` on the
+    // property-read path (`Op::GetProperty` / `Op::GetPropertyOpt`). It
+    // must return None for unrelated IC variants — silently mis-extracting
+    // a `Method` / `DirectCall` / `AdaptiveBinary` slot as `Property` would
+    // feed garbage into `try_cached_property` (wrong target match, possibly
+    // a panic on the field-name lookup). These tests pin the variant gate.
+
+    #[test]
+    fn peek_property_cache_returns_none_for_empty_slot() {
+        let mut chunk = Chunk::new();
+        chunk.emit_u16(Op::GetProperty, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("GetProperty registers a slot");
+        assert!(chunk.peek_property_cache(slot).is_none());
+    }
+
+    #[test]
+    fn peek_property_cache_returns_pair_after_warmup_for_dict_field() {
+        let mut chunk = Chunk::new();
+        chunk.emit_u16(Op::GetProperty, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("GetProperty registers a slot");
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::Property {
+                name_idx: 11,
+                target: PropertyCacheTarget::DictField(Rc::from("count")),
+            },
+        );
+        let (name_idx, target) = chunk
+            .peek_property_cache(slot)
+            .expect("warmed property slot peek");
+        assert_eq!(name_idx, 11);
+        match target {
+            PropertyCacheTarget::DictField(field) => assert_eq!(field.as_ref(), "count"),
+            other => panic!("expected DictField, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peek_property_cache_returns_pair_for_unit_target() {
+        // Unit targets (eg. ListCount, ListEmpty, PairFirst) carry no Rc,
+        // so the cloned PropertyCacheTarget is a pure scalar move at the
+        // peek boundary. The hottest case in practice.
+        let mut chunk = Chunk::new();
+        chunk.emit_u16(Op::GetProperty, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("GetProperty registers a slot");
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::Property {
+                name_idx: 3,
+                target: PropertyCacheTarget::ListCount,
+            },
+        );
+        let (name_idx, target) = chunk
+            .peek_property_cache(slot)
+            .expect("warmed property slot peek");
+        assert_eq!(name_idx, 3);
+        assert_eq!(target, PropertyCacheTarget::ListCount);
+    }
+
+    #[test]
+    fn peek_property_cache_returns_none_for_non_property_variants() {
+        let mut chunk = Chunk::new();
+        chunk.emit_u16(Op::GetProperty, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("GetProperty registers a slot");
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::Method {
+                name_idx: 0,
+                argc: 0,
+                target: MethodCacheTarget::ListCount,
+            },
+        );
+        assert!(chunk.peek_property_cache(slot).is_none());
+    }
+
+    #[test]
+    fn peek_property_cache_returns_none_for_out_of_bounds_slot() {
+        let chunk = Chunk::new();
+        assert!(chunk.peek_property_cache(0).is_none());
+        assert!(chunk.peek_property_cache(usize::MAX).is_none());
+    }
+
+    // --- peek_direct_call_state contract ---
+    //
+    // Used on both the hot Specialized-hit check path (`try_cached_direct_call`
+    // / `try_cached_named_direct_call`) and the state-machine write-back
+    // (`next_direct_call_entry`). Returning None for the non-DirectCall slot
+    // shapes is critical: a mis-extracted Method/Property/AdaptiveBinary slot
+    // would have the dispatcher attempt a closure call with the wrong argc
+    // or Rc::ptr_eq against an unrelated closure.
+
+    #[test]
+    fn peek_direct_call_state_returns_none_for_empty_slot() {
+        let mut chunk = Chunk::new();
+        chunk.emit_u8(Op::Call, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("Op::Call registers a slot");
+        assert!(chunk.peek_direct_call_state(slot).is_none());
+    }
+
+    #[test]
+    fn peek_direct_call_state_returns_warmup_state() {
+        let mut chunk = Chunk::new();
+        chunk.emit_u8(Op::Call, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("Op::Call registers a slot");
+        let target = synthetic_direct_call_target();
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::DirectCall {
+                state: DirectCallState::Warmup {
+                    argc: 2,
+                    target: target.clone(),
+                    hits: 1,
+                },
+            },
+        );
+        let state = chunk
+            .peek_direct_call_state(slot)
+            .expect("warmed direct-call slot peek");
+        match state {
+            DirectCallState::Warmup {
+                argc,
+                target: peeked_target,
+                hits,
+            } => {
+                assert_eq!(argc, 2);
+                assert_eq!(hits, 1);
+                assert_eq!(peeked_target, target);
+            }
+            other => panic!("expected Warmup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peek_direct_call_state_returns_specialized_state() {
+        let mut chunk = Chunk::new();
+        chunk.emit_u8(Op::Call, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("Op::Call registers a slot");
+        let target = synthetic_direct_call_target();
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::DirectCall {
+                state: DirectCallState::Specialized {
+                    argc: 3,
+                    target: target.clone(),
+                    hits: 100,
+                    misses: 0,
+                },
+            },
+        );
+        let state = chunk
+            .peek_direct_call_state(slot)
+            .expect("warmed direct-call slot peek");
+        match state {
+            DirectCallState::Specialized {
+                argc,
+                target: peeked_target,
+                hits,
+                misses,
+            } => {
+                assert_eq!(argc, 3);
+                assert_eq!(hits, 100);
+                assert_eq!(misses, 0);
+                assert_eq!(peeked_target, target);
+            }
+            other => panic!("expected Specialized, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn peek_direct_call_state_returns_none_for_non_direct_call_variants() {
+        let mut chunk = Chunk::new();
+        chunk.emit_u8(Op::Call, 0, 1);
+        let slot = chunk
+            .inline_cache_slot(0)
+            .expect("Op::Call registers a slot");
+
+        chunk.set_inline_cache_entry(
+            slot,
+            InlineCacheEntry::Property {
+                name_idx: 0,
+                target: PropertyCacheTarget::ListCount,
+            },
+        );
+        assert!(chunk.peek_direct_call_state(slot).is_none());
+    }
+
+    #[test]
+    fn peek_direct_call_state_returns_none_for_out_of_bounds_slot() {
+        let chunk = Chunk::new();
+        assert!(chunk.peek_direct_call_state(0).is_none());
+        assert!(chunk.peek_direct_call_state(usize::MAX).is_none());
+    }
+
+    /// Build a synthetic `DirectCallTarget::Closure` for direct-call peek
+    /// tests. The closure has an empty body — the IC peek only inspects
+    /// the wrapping `Rc`, not the closure internals.
+    fn synthetic_direct_call_target() -> DirectCallTarget {
+        use crate::value::VmClosure;
+        use crate::{CompiledFunction, VmEnv};
+        let func = CompiledFunction {
+            name: "synthetic".to_string(),
+            type_params: Vec::new(),
+            nominal_type_names: Vec::new(),
+            params: Vec::new(),
+            default_start: None,
+            chunk: Rc::new(Chunk::new()),
+            is_generator: false,
+            is_stream: false,
+            has_rest_param: false,
+            has_runtime_type_checks: false,
+        };
+        DirectCallTarget::Closure(Rc::new(VmClosure {
+            func: Rc::new(func),
+            env: VmEnv::new(),
+            source_dir: None,
+            module_functions: None,
+            module_state: None,
+        }))
     }
 }

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -722,18 +722,16 @@ impl super::super::Vm {
     /// leaves `ip` untouched so [`execute_call_async`] can read the operand
     /// exactly once.
     pub(super) fn execute_call_sync(&mut self) -> Option<Result<(), VmError>> {
-        let (argc, cache_slot, cache_entry) = {
+        let (argc, cache_slot, cached_state) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
             let argc = frame.chunk.code[frame.ip] as usize;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cache_entry = cache_slot
-                .map(|slot| frame.chunk.inline_cache_entry(slot))
-                .unwrap_or(InlineCacheEntry::Empty);
-            (argc, cache_slot, cache_entry)
+            let cached_state = cache_slot.and_then(|slot| frame.chunk.peek_direct_call_state(slot));
+            (argc, cache_slot, cached_state)
         };
         let callee_idx = self.stack.len().checked_sub(argc + 1)?;
-        let closure = match self.try_cached_direct_call(&cache_entry, argc, callee_idx) {
+        let closure = match self.try_cached_direct_call(cached_state.as_ref(), argc, callee_idx) {
             Some(closure) => closure,
             None => match self.stack.get(callee_idx)? {
                 VmValue::Closure(c) => Rc::clone(c),
@@ -746,7 +744,7 @@ impl super::super::Vm {
 
         if let Some(slot) = cache_slot {
             let next_entry = Self::next_direct_call_entry(
-                cache_entry,
+                cached_state,
                 argc,
                 DirectCallTarget::Closure(Rc::clone(&closure)),
             );
@@ -767,18 +765,15 @@ impl super::super::Vm {
 
     fn try_cached_direct_call(
         &self,
-        cache: &InlineCacheEntry,
+        cached_state: Option<&DirectCallState>,
         argc: usize,
         callee_idx: usize,
     ) -> Option<Rc<VmClosure>> {
-        let InlineCacheEntry::DirectCall {
-            state:
-                DirectCallState::Specialized {
-                    argc: cached_argc,
-                    target: DirectCallTarget::Closure(cached_closure),
-                    ..
-                },
-        } = cache
+        let DirectCallState::Specialized {
+            argc: cached_argc,
+            target: DirectCallTarget::Closure(cached_closure),
+            ..
+        } = cached_state?
         else {
             return None;
         };
@@ -795,19 +790,16 @@ impl super::super::Vm {
     }
 
     fn next_direct_call_entry(
-        previous: InlineCacheEntry,
+        previous_state: Option<DirectCallState>,
         argc: usize,
         target: DirectCallTarget,
     ) -> InlineCacheEntry {
-        let state = match previous {
-            InlineCacheEntry::DirectCall {
-                state:
-                    DirectCallState::Warmup {
-                        argc: cached_argc,
-                        target: cached_target,
-                        hits,
-                    },
-            } if cached_argc == argc && cached_target == target => {
+        let state = match previous_state {
+            Some(DirectCallState::Warmup {
+                argc: cached_argc,
+                target: cached_target,
+                hits,
+            }) if cached_argc == argc && cached_target == target => {
                 let hits = hits.saturating_add(1);
                 if hits >= DIRECT_CALL_QUICKEN_THRESHOLD {
                     DirectCallState::Specialized {
@@ -820,23 +812,18 @@ impl super::super::Vm {
                     DirectCallState::Warmup { argc, target, hits }
                 }
             }
-            InlineCacheEntry::DirectCall {
-                state:
-                    DirectCallState::Specialized {
-                        argc: cached_argc,
-                        target: cached_target,
-                        hits,
-                        misses,
-                    },
-            } if cached_argc == argc && cached_target == target => DirectCallState::Specialized {
+            Some(DirectCallState::Specialized {
+                argc: cached_argc,
+                target: cached_target,
+                hits,
+                misses,
+            }) if cached_argc == argc && cached_target == target => DirectCallState::Specialized {
                 argc,
                 target,
                 hits: hits.saturating_add(1),
                 misses,
             },
-            InlineCacheEntry::DirectCall {
-                state: DirectCallState::Specialized { misses: 0, .. },
-            } => DirectCallState::Specialized {
+            Some(DirectCallState::Specialized { misses: 0, .. }) => DirectCallState::Specialized {
                 argc,
                 target,
                 hits: 1,
@@ -958,16 +945,14 @@ impl super::super::Vm {
     /// resolves synchronously in the hot case but still pays the
     /// future-state-machine tax.
     pub(super) fn execute_call_builtin_sync(&mut self) -> Option<Result<(), VmError>> {
-        let (name_idx, argc, cache_slot, cache_entry) = {
+        let (name_idx, argc, cache_slot, cached_state) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
             let name_idx = frame.chunk.read_u16(frame.ip + 8) as usize;
             let argc = frame.chunk.code[frame.ip + 10] as usize;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cache_entry = cache_slot
-                .map(|slot| frame.chunk.inline_cache_entry(slot))
-                .unwrap_or(InlineCacheEntry::Empty);
-            (name_idx, argc, cache_slot, cache_entry)
+            let cached_state = cache_slot.and_then(|slot| frame.chunk.peek_direct_call_state(slot));
+            (name_idx, argc, cache_slot, cached_state)
         };
         let frame = self.frames.last().unwrap();
         let name = Self::const_str(&frame.chunk.constants[name_idx]).ok()?;
@@ -980,7 +965,7 @@ impl super::super::Vm {
             return None;
         }
 
-        let closure = match self.try_cached_named_direct_call(&cache_entry, name, argc) {
+        let closure = match self.try_cached_named_direct_call(cached_state.as_ref(), name, argc) {
             Some(closure) => closure,
             None => self.resolve_named_closure(name)?,
         };
@@ -990,7 +975,7 @@ impl super::super::Vm {
 
         if let Some(slot) = cache_slot {
             let next_entry = Self::next_direct_call_entry(
-                cache_entry,
+                cached_state,
                 argc,
                 DirectCallTarget::Closure(Rc::clone(&closure)),
             );
@@ -1006,18 +991,15 @@ impl super::super::Vm {
 
     fn try_cached_named_direct_call(
         &self,
-        cache: &InlineCacheEntry,
+        cached_state: Option<&DirectCallState>,
         name: &str,
         argc: usize,
     ) -> Option<Rc<VmClosure>> {
-        let InlineCacheEntry::DirectCall {
-            state:
-                DirectCallState::Specialized {
-                    argc: cached_argc,
-                    target: DirectCallTarget::Closure(cached_closure),
-                    ..
-                },
-        } = cache
+        let DirectCallState::Specialized {
+            argc: cached_argc,
+            target: DirectCallTarget::Closure(cached_closure),
+            ..
+        } = cached_state?
         else {
             return None;
         };

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -65,17 +65,11 @@ impl super::super::Vm {
     }
 
     fn try_cached_property(
-        cache: &InlineCacheEntry,
+        cache: Option<&(u16, PropertyCacheTarget)>,
         name_idx: u16,
         obj: &VmValue,
     ) -> Option<VmValue> {
-        let InlineCacheEntry::Property {
-            name_idx: cached_name_idx,
-            target,
-        } = cache
-        else {
-            return None;
-        };
+        let (cached_name_idx, target) = cache?;
         if *cached_name_idx != name_idx {
             return None;
         }
@@ -419,22 +413,22 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_get_property(&mut self, optional: bool) -> Result<(), VmError> {
-        let (name_idx, cache_slot, cache_entry) = {
+        let (name_idx, cache_slot, cached_property) = {
             let frame = self.frames.last_mut().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cache_entry = cache_slot
-                .map(|slot| frame.chunk.inline_cache_entry(slot))
-                .unwrap_or(InlineCacheEntry::Empty);
-            (name_idx, cache_slot, cache_entry)
+            let cached_property = cache_slot.and_then(|slot| frame.chunk.peek_property_cache(slot));
+            (name_idx, cache_slot, cached_property)
         };
 
         let obj = self.pop()?;
         if optional && matches!(obj, VmValue::Nil) {
             self.stack.push(VmValue::Nil);
-        } else if let Some(result) = Self::try_cached_property(&cache_entry, name_idx, &obj) {
+        } else if let Some(result) =
+            Self::try_cached_property(cached_property.as_ref(), name_idx, &obj)
+        {
             self.stack.push(result);
         } else {
             let (result, target) = {

--- a/perf/vm/Cargo.toml
+++ b/perf/vm/Cargo.toml
@@ -33,6 +33,16 @@ path = "bench_method_cache_read.rs"
 harness = false
 
 [[bench]]
+name = "bench_property_cache_read"
+path = "bench_property_cache_read.rs"
+harness = false
+
+[[bench]]
+name = "bench_direct_call_state_read"
+path = "bench_direct_call_state_read.rs"
+harness = false
+
+[[bench]]
 name = "bench_vm_fixtures"
 path = "bench_vm_fixtures.rs"
 harness = false

--- a/perf/vm/bench_direct_call_state_read.rs
+++ b/perf/vm/bench_direct_call_state_read.rs
@@ -1,0 +1,52 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm::bench_internals::{DirectCallStateReadFixture, DIRECT_CALL_STATE_READ_COUNTS};
+
+/// Microbench for the direct-call inline-cache read path. Fires on
+/// every `Op::Call` (closure-by-value callee) and the named-fn fast
+/// path inside `Op::CallBuiltin` — i.e. every user-fn invocation in
+/// a Harn program after warmup.
+///
+/// `direct_call_state_read/copy_peek` exercises `peek_direct_call_state`,
+/// returning just the inner `DirectCallState` (still clones because it
+/// holds the `Rc<VmClosure>` cached target, but skips the wrapping
+/// `InlineCacheEntry` discriminant init and padding-to-largest-variant
+/// memcpy). `direct_call_state_read/clone_control` exercises the
+/// pre-optimization `inline_cache_entry` path that cloned the full
+/// `InlineCacheEntry` enum on every dispatch.
+fn bench_direct_call_state_read(c: &mut Criterion) {
+    let fixtures = DIRECT_CALL_STATE_READ_COUNTS
+        .into_iter()
+        .map(DirectCallStateReadFixture::new)
+        .collect::<Vec<_>>();
+
+    let mut optimized = c.benchmark_group("direct_call_state_read/copy_peek");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        optimized.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_peek()));
+            },
+        );
+    }
+    optimized.finish();
+
+    let mut baseline = c.benchmark_group("direct_call_state_read/clone_control");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        baseline.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_clone_control()));
+            },
+        );
+    }
+    baseline.finish();
+}
+
+criterion_group!(benches, bench_direct_call_state_read);
+criterion_main!(benches);

--- a/perf/vm/bench_property_cache_read.rs
+++ b/perf/vm/bench_property_cache_read.rs
@@ -1,0 +1,51 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm::bench_internals::{PropertyCacheReadFixture, PROPERTY_CACHE_READ_COUNTS};
+
+/// Microbench for the property-cache inline-cache read path. Fires on
+/// every `Op::GetProperty` / `Op::GetPropertyOpt` dispatch — the
+/// dominant opcode for any field-read-heavy code (`obj.field`,
+/// `xs.count`, `pair.0`, etc.).
+///
+/// `property_cache_read/copy_peek` exercises `peek_property_cache`,
+/// returning just the `Property` payload (`u16 + PropertyCacheTarget`).
+/// `property_cache_read/clone_control` exercises the pre-optimization
+/// `inline_cache_entry` path that cloned the wrapping `InlineCacheEntry`
+/// enum — a 32-48B memcpy (padded to the largest variant, `DirectCall`)
+/// that `try_cached_property`'s `let-else` destructures and throws away.
+fn bench_property_cache_read(c: &mut Criterion) {
+    let fixtures = PROPERTY_CACHE_READ_COUNTS
+        .into_iter()
+        .map(PropertyCacheReadFixture::new)
+        .collect::<Vec<_>>();
+
+    let mut optimized = c.benchmark_group("property_cache_read/copy_peek");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        optimized.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_peek()));
+            },
+        );
+    }
+    optimized.finish();
+
+    let mut baseline = c.benchmark_group("property_cache_read/clone_control");
+    for fixture in &fixtures {
+        let benchmark = format!("ops_{:03}", fixture.op_count());
+        baseline.bench_with_input(
+            BenchmarkId::from_parameter(benchmark),
+            fixture,
+            |b, fixture| {
+                b.iter(|| black_box(fixture.invoke_clone_control()));
+            },
+        );
+    }
+    baseline.finish();
+}
+
+criterion_group!(benches, bench_property_cache_read);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

**Final piece of the IC-clone-elimination series**:
- #2470 — flat-Vec inline-cache slot index (replaced BTreeMap lookup)
- #2478 — adaptive-binary Copy peek (Add/Sub/Mul/.../GE)
- #2484 — method-cache Copy peek (MethodCall/MethodCallOpt/MethodCallSpread)
- **this PR** — Property + DirectCall peeks

After this lands, `Chunk::inline_cache_entry` no longer fires on any production dispatch path — only the bench-internals control side-by-sides keep the old clone path alive for A/B testing.

## Changes

### `peek_property_cache(slot) -> Option<(u16, PropertyCacheTarget)>`
Used by `Op::GetProperty` / `Op::GetPropertyOpt` dispatchers. The wrapping `InlineCacheEntry` enum is padded to its largest variant (`DirectCall`); cloning it to discard the four non-Property variants was wasted work. The peek skips the outer enum tag init and padding-to-largest memcpy. `PropertyCacheTarget::DictField`/`StructField` still cost one `Rc::clone` (`Rc<str>` field name), but the 10 unit variants (`ListCount`, `ListEmpty`, `PairFirst`, etc.) become pure scalar moves.

### `peek_direct_call_state(slot) -> Option<DirectCallState>`
Used by `Op::Call` (closure callee) and the named-fn fast path inside `Op::CallBuiltin`. Returns the inner `DirectCallState` cloned (still holds the `Rc<VmClosure>` cached target), but skips the outer `InlineCacheEntry::DirectCall` wrap.

The state is read once per dispatch and consumed twice — by `try_cached_direct_call` / `try_cached_named_direct_call` (steady-state Specialized-hit check, by ref) and by `next_direct_call_entry` (Warmup → Specialized state-machine transition, by move). Strictly better: same `Rc::clone` count, no outer-enum tag init or padding-to-largest memcpy. The variant check in the read path collapses from two levels (`InlineCacheEntry::DirectCall { state: DirectCallState::Specialized {...} }`) to one (`DirectCallState::Specialized {...}`).

### Refactored signatures
- `try_cached_property(&InlineCacheEntry, ...)` → `try_cached_property(Option<&(u16, PropertyCacheTarget)>, ...)`
- `try_cached_direct_call(&InlineCacheEntry, ...)` → `try_cached_direct_call(Option<&DirectCallState>, ...)`
- `try_cached_named_direct_call(&InlineCacheEntry, ...)` → `try_cached_named_direct_call(Option<&DirectCallState>, ...)`
- `next_direct_call_entry(InlineCacheEntry, ...)` → `next_direct_call_entry(Option<DirectCallState>, ...)`

Write-back paths unchanged — they still build fresh `InlineCacheEntry::{Property,DirectCall} {...}` from values the caller already has.

## Test plan

- [x] 10 new chunk-level contract tests (5 property + 5 direct-call), covering: empty / Warmup / Specialized states, non-matching variants, out-of-bounds slot, unit-target Property + Rc-bearing DictField Property
- [x] `cargo test -p harn-vm --features vm-bench-internals --lib` — all 2738 tests pass
- [x] `cargo clippy -p harn-vm --features vm-bench-internals --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Bench numbers (`bench_property_cache_read` + `bench_direct_call_state_read`) to be added in commit-message amendment
- [ ] CI: Format / Lint / Rust test / Conformance / Windows
- [ ] Auto-merge once checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)