### PR TITLE
Avoid TODO marker in crystallized fuzzy steps

### DIFF
--- a/crates/harn-vm/src/orchestration/crystallize/codegen.rs
+++ b/crates/harn-vm/src/orchestration/crystallize/codegen.rs
@@ -79,7 +79,7 @@ pub fn generate_harn_code(candidate: &WorkflowCandidate) -> String {
         if step.segment == SegmentKind::Fuzzy {
             writeln!(
                 out,
-                "  // TODO: fuzzy segment still needs LLM/reviewer handling before deterministic promotion."
+                "  // review_required: fuzzy segment still needs LLM/reviewer handling before deterministic promotion."
             )
             .unwrap();
             writeln!(

--- a/crates/harn-vm/src/orchestration/crystallize_tests.rs
+++ b/crates/harn-vm/src/orchestration/crystallize_tests.rs
@@ -292,7 +292,9 @@ fn preserves_remaining_fuzzy_segment() {
         .iter()
         .any(|step| step.segment == SegmentKind::Fuzzy));
     assert!(candidate.savings.remaining_model_calls > 0);
-    assert!(artifacts.harn_code.contains("TODO: fuzzy segment"));
+    assert!(artifacts
+        .harn_code
+        .contains("review_required: fuzzy segment"));
 }
 
 #[test]

--- a/docs/src/workflow-crystallization.md
+++ b/docs/src/workflow-crystallization.md
@@ -107,7 +107,7 @@ harn crystallize \
 
 The generated workflow is a reviewable skeleton. It contains explicit
 parameters, capability comments, side-effect comments, approval boundaries, and
-TODO comments for fuzzy segments that still require a model or reviewer.
+`review_required` comments for fuzzy segments that still require a model or reviewer.
 `--shadow-from` may be passed more than once. These directories are not used for
 mining; they are future/holdout traces that must match before promotion
 metadata can report the candidate as ready.


### PR DESCRIPTION
## Summary

- Replace the generated `// TODO:` fuzzy-segment marker with `// review_required:` so crystallized workflow skeletons do not look like unfinished source debt.
- Update the fuzzy-segment unit expectation and workflow-crystallization docs to match the explicit review marker.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-crystallize-review-marker-target cargo test -p harn-vm --lib preserves_remaining_fuzzy_segment`
- `cargo fmt --check`
- pre-commit hook: Rust format, prompt-prose lint, changed-package clippy, markdown lint
- pre-push hook: targeted local checks and markdown lint
