### PR TITLE
Add agent loop budget rails

### DIFF
--- a/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
+++ b/conformance/protocols/fixtures/acp/agent_event_ext_notifications.valid.json
@@ -290,8 +290,22 @@
       "jsonrpc": "2.0",
       "method": "_harn/agentEvent",
       "params": {
+        "budgetKind": "max_iterations",
+        "costUsd": 0.12,
         "kind": "budget_exhausted",
         "maxIterations": 8,
+        "sessionId": "session-1",
+        "wallClockMs": 1500
+      }
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "_harn/agentEvent",
+      "params": {
+        "breakerKind": "consecutive_failures",
+        "consecutiveCount": 3,
+        "kind": "budget_circuit_breaker",
+        "pausedForMs": 2000,
         "sessionId": "session-1"
       }
     },

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -78,12 +78,14 @@
             "sessionId": { "type": "string", "minLength": 1 },
             "kind": {
               "enum": [
+                "budget_circuit_breaker",
                 "budget_exhausted",
                 "composition_child_call",
                 "composition_child_result",
                 "composition_error",
                 "composition_finish",
                 "composition_start",
+                "control_outcome",
                 "daemon_watchdog_tripped",
                 "feedback_injected",
                 "iteration_end",
@@ -92,9 +94,10 @@
                 "loop_control_decision",
                 "loop_stuck",
                 "progress_reported",
+                "scope_classifier_verdict",
                 "session_closed",
-                "step_judge_decision",
                 "structural_validator_decision",
+                "step_judge_decision",
                 "tool_call_audit",
                 "tool_format_override",
                 "typed_checkpoint"

--- a/conformance/tests/agents/agent_loop_budget_rails.expected
+++ b/conformance/tests/agents/agent_loop_budget_rails.expected
@@ -1,0 +1,16 @@
+wall_status=budget_exhausted
+wall_reason=wall_clock
+wall_kind=wall_clock
+wall_event_elapsed=true
+wall_iteration_elapsed=true
+cost_status=budget_exhausted
+cost_reason=total_cost
+cost_kind=total_cost
+cost_event_positive=true
+cost_iteration_positive=true
+circuit_status=budget_exhausted
+circuit_reason=circuit_breaker
+circuit_count=2
+circuit_pause=2500
+circuit_budget_kind=consecutive_failures
+circuit_clock=2500

--- a/conformance/tests/agents/agent_loop_budget_rails.harn
+++ b/conformance/tests/agents/agent_loop_budget_rails.harn
@@ -1,0 +1,124 @@
+import { agent_capture_events } from "std/agent/events"
+
+fn first_event(events, event_type) {
+  for event in events {
+    if event.type == event_type {
+      return event
+    }
+  }
+  return nil
+}
+
+fn wall_clock_case() {
+  mock_time(0)
+  let caller = { _call ->
+    advance_time(1500)
+    return {
+      ok: true,
+      value: {text: "still working", provider: "mock", model: "mock", input_tokens: 0, output_tokens: 0},
+    }
+  }
+  let session = "budget-wall-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "work",
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        llm_caller: caller,
+        loop_until_done: true,
+        done_sentinel: "DONE",
+        max_nudges: 5,
+        iteration_budget: {mode: "fixed", max: 5, wall_clock_ms: 1000},
+      },
+    ) },
+  )
+  let budget_event = first_event(captured.events, "budget_exhausted")
+  let iteration_event = first_event(captured.events, "iteration_end")
+  __io_println("wall_status=" + captured.result.status)
+  __io_println("wall_reason=" + captured.result.stop_reason)
+  __io_println("wall_kind=" + budget_event.kind)
+  __io_println("wall_event_elapsed=" + to_string(budget_event.wall_clock_ms >= 1000))
+  __io_println(
+    "wall_iteration_elapsed=" + to_string(iteration_event.iteration_info.wall_clock_ms >= 1000),
+  )
+  unmock_time()
+}
+
+fn total_cost_case() {
+  let caller = { _call -> return {
+    ok: true,
+    value: {
+      text: "still working",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      input_tokens: 100000,
+      output_tokens: 100000,
+    },
+  } }
+  let session = "budget-cost-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "work",
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        llm_caller: caller,
+        loop_until_done: true,
+        done_sentinel: "DONE",
+        max_nudges: 5,
+        iteration_budget: {mode: "fixed", max: 5, total_cost_usd: 0.000001},
+      },
+    ) },
+  )
+  let budget_event = first_event(captured.events, "budget_exhausted")
+  let iteration_event = first_event(captured.events, "iteration_end")
+  __io_println("cost_status=" + captured.result.status)
+  __io_println("cost_reason=" + captured.result.stop_reason)
+  __io_println("cost_kind=" + budget_event.kind)
+  __io_println("cost_event_positive=" + to_string(budget_event.cost_usd > 0.0))
+  __io_println("cost_iteration_positive=" + to_string(iteration_event.iteration_info.cost_usd > 0.0))
+}
+
+fn circuit_case() {
+  mock_time(0)
+  let caller = { _call -> return {
+    ok: false,
+    status: "provider_error",
+    stop_reason: "provider_error",
+    error: {status: 503, message: "provider unavailable"},
+  } }
+  let session = "budget-circuit-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "retry",
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        llm_caller: caller,
+        iteration_budget: {mode: "fixed", max: 5, consecutive_failures: {max: 2, paused_for_ms: 2500}},
+      },
+    ) },
+  )
+  let breaker = first_event(captured.events, "budget_circuit_breaker")
+  let budget_event = first_event(captured.events, "budget_exhausted")
+  __io_println("circuit_status=" + captured.result.status)
+  __io_println("circuit_reason=" + captured.result.stop_reason)
+  __io_println("circuit_count=" + to_string(breaker.consecutive_count))
+  __io_println("circuit_pause=" + to_string(breaker.paused_for_ms))
+  __io_println("circuit_budget_kind=" + budget_event.kind)
+  __io_println("circuit_clock=" + to_string(harness.clock.now_ms()))
+  unmock_time()
+}
+
+pipeline default() {
+  wall_clock_case()
+  total_cost_case()
+  circuit_case()
+}

--- a/conformance/tests/agents/task_plan_budget_workflow_execute.expected
+++ b/conformance/tests/agents/task_plan_budget_workflow_execute.expected
@@ -1,0 +1,5 @@
+completed
+failed
+budget_exhausted
+failed
+true

--- a/conformance/tests/agents/task_plan_budget_workflow_execute.harn
+++ b/conformance/tests/agents/task_plan_budget_workflow_execute.harn
@@ -1,0 +1,37 @@
+import { task_plan_compile } from "std/agent/task_plan"
+
+pipeline main() {
+  llm_mock_clear()
+  llm_mock(
+    {
+      text: "still working",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      input_tokens: 100000,
+      output_tokens: 100000,
+    },
+  )
+  let plan = {
+    schema_version: "1",
+    objective: "Budgeted workflow",
+    entry: "work",
+    nodes: {
+      work: {
+        kind: "agent_loop",
+        purpose: "Run budgeted loop",
+        prompt: "Spend one modeled call",
+        model: {provider: "mock", model: "gpt-4o-mini"},
+        agent_loop: {done_sentinel: "DONE"},
+      },
+    },
+    budgets: {total_cost_usd: 0.000001},
+  }
+  let compiled = task_plan_compile(plan)
+  let result = workflow_execute("Budgeted workflow", compiled.workflow, [], {max_steps: 1})
+  let stage = result.run.stages[0]
+  __io_println(result.status)
+  __io_println(stage.status)
+  __io_println(stage.outcome)
+  __io_println(stage.branch)
+  __io_println(stage.metadata.model_policy.iteration_budget.total_cost_usd == 0.000001)
+}

--- a/conformance/tests/agents/task_plan_validate_and_compile.expected
+++ b/conformance/tests/agents/task_plan_validate_and_compile.expected
@@ -3,10 +3,16 @@ true
 3
 3
 32
+30000
 true
 discover
 stage
 agent
+30000
+true
+2
+rate_limit
+500
 verify
 cargo test -p auth
 agent_loop

--- a/conformance/tests/agents/task_plan_validate_and_compile.harn
+++ b/conformance/tests/agents/task_plan_validate_and_compile.harn
@@ -23,6 +23,11 @@ pipeline main() {
       verify: {kind: "verify", verify: {command: "cargo test -p auth", expect_status: 0}},
     },
     edges: [{from: "discover", to: "implement"}, {from: "implement", to: "verify"}],
+    budgets: {
+      wall_clock_ms: 30000,
+      total_cost_usd: 0.25,
+      consecutive_failures: {max: 2, kinds: ["rate_limit"], paused_for_ms: 500},
+    },
     capabilities: {tools: ["read", "edit", "grep"], side_effect_level: "writes_files"},
     verification: {primary: "verify"},
     promotion_policy: {shadow_runs_required: 3, human_review_required: true},
@@ -33,11 +38,18 @@ pipeline main() {
   __io_println(report.graph_stats.node_count)
   __io_println(report.graph_stats.reachable_count)
   __io_println(report.budget_summary.max_nodes)
+  __io_println(report.budget_summary.wall_clock_ms)
   let compiled = task_plan_compile(plan)
   __io_println(compiled.ok)
   __io_println(compiled.workflow.entry)
   __io_println(compiled.workflow.nodes.implement.kind)
   __io_println(compiled.workflow.nodes.implement.mode)
+  let loop_budget = compiled.workflow.nodes.implement.model_policy.iteration_budget
+  __io_println(loop_budget.wall_clock_ms)
+  __io_println(loop_budget.total_cost_usd > 0.0)
+  __io_println(loop_budget.consecutive_failures.max)
+  __io_println(loop_budget.consecutive_failures.kinds[0])
+  __io_println(loop_budget.consecutive_failures.paused_for_ms)
   __io_println(compiled.workflow.nodes.verify.kind)
   __io_println(compiled.workflow.nodes.verify.verify.command)
   __io_println(compiled.workflow.nodes.implement.metadata.task_plan_kind)

--- a/conformance/tests/on_budget_replan.expected
+++ b/conformance/tests/on_budget_replan.expected
@@ -1,0 +1,6 @@
+strategy=replan
+branched_at=1
+reminders=1
+body=Previous loop hit `wall_clock` at iteration 2. Restart from checkpoint with a different approach.
+body_clean=true
+namespace=true

--- a/conformance/tests/on_budget_replan.harn
+++ b/conformance/tests/on_budget_replan.harn
@@ -1,0 +1,32 @@
+import { OnBudget, replan } from "std/lifecycle/on_budget"
+
+fn reminder_has_no_command_terms(body) {
+  let lowered = lowercase(body)
+  return !contains(lowered, "cargo")
+    && !contains(lowered, "swift")
+    && !contains(lowered, "pytest")
+    && !contains(lowered, "jest")
+    && !contains(lowered, "gradle")
+    && !contains(lowered, "dotnet")
+    && !contains(lowered, "rspec")
+    && !contains(lowered, "go test")
+    && !contains(lowered, "tsc")
+    && !contains(lowered, "rustc")
+}
+
+pipeline default() {
+  let src = agent_session_open("on-budget-replan-source")
+  agent_session_inject(src, {role: "user", content: "seed"})
+  agent_session_inject(src, {role: "assistant", content: "branch"})
+  let result = replan(harness, {session_id: src, iteration: 2, last_good_iteration: 1, kind: "wall_clock"})
+  let snapshot = agent_session_snapshot(result.session_id)
+  let reminders = transcript_events_by_kind(snapshot, "system_reminder")
+  let body = reminders[0].reminder.body
+  let ns = OnBudget()
+  __io_println("strategy=" + result.strategy)
+  __io_println("branched_at=" + to_string(snapshot.branched_at_event_index))
+  __io_println("reminders=" + to_string(len(reminders)))
+  __io_println("body=" + body)
+  __io_println("body_clean=" + to_string(reminder_has_no_command_terms(body)))
+  __io_println("namespace=" + to_string(ns.replan != nil))
+}

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1162,11 +1162,44 @@ impl AgentEventSink for AcpAgentEventSink {
             AgentEvent::BudgetExhausted {
                 session_id,
                 max_iterations,
+                kind,
+                cost_usd,
+                wall_clock_ms,
             } => {
+                let mut payload = serde_json::Map::new();
+                payload.insert(
+                    "maxIterations".to_string(),
+                    serde_json::json!(max_iterations),
+                );
+                if let Some(kind) = kind {
+                    payload.insert("budgetKind".to_string(), serde_json::json!(kind));
+                }
+                if let Some(cost_usd) = cost_usd {
+                    payload.insert("costUsd".to_string(), serde_json::json!(cost_usd));
+                }
+                if let Some(wall_clock_ms) = wall_clock_ms {
+                    payload.insert("wallClockMs".to_string(), serde_json::json!(wall_clock_ms));
+                }
                 self.emit_agent_event_ext(
                     "budget_exhausted",
                     session_id,
-                    serde_json::json!({"maxIterations": max_iterations}),
+                    serde_json::Value::Object(payload),
+                );
+            }
+            AgentEvent::BudgetCircuitBreaker {
+                session_id,
+                kind,
+                consecutive_count,
+                paused_for_ms,
+            } => {
+                self.emit_agent_event_ext(
+                    "budget_circuit_breaker",
+                    session_id,
+                    serde_json::json!({
+                        "breakerKind": kind,
+                        "consecutiveCount": consecutive_count,
+                        "pausedForMs": paused_for_ms,
+                    }),
                 );
             }
             AgentEvent::LoopStuck {

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -459,6 +459,15 @@ fn agent_event_ext_fixture_events() -> Vec<AgentEvent> {
         AgentEvent::BudgetExhausted {
             session_id: "session-1".to_string(),
             max_iterations: 8,
+            kind: Some("max_iterations".to_string()),
+            cost_usd: Some(0.12),
+            wall_clock_ms: Some(1_500),
+        },
+        AgentEvent::BudgetCircuitBreaker {
+            session_id: "session-1".to_string(),
+            kind: "consecutive_failures".to_string(),
+            consecutive_count: 3,
+            paused_for_ms: 2_000,
         },
         AgentEvent::LoopStuck {
             session_id: "session-1".to_string(),
@@ -1683,6 +1692,15 @@ fn internal_agent_events_never_emit_session_updates() {
     sink.handle_event(&AgentEvent::BudgetExhausted {
         session_id: "session-1".to_string(),
         max_iterations: 3,
+        kind: None,
+        cost_usd: None,
+        wall_clock_ms: None,
+    });
+    sink.handle_event(&AgentEvent::BudgetCircuitBreaker {
+        session_id: "session-1".to_string(),
+        kind: "consecutive_failures".to_string(),
+        consecutive_count: 2,
+        paused_for_ms: 0,
     });
     sink.handle_event(&AgentEvent::IterationEnd {
         session_id: "session-1".to_string(),
@@ -1723,7 +1741,7 @@ fn internal_agent_events_never_emit_session_updates() {
         );
     }
     assert_eq!(
-        count, 6,
+        count, 7,
         "expected one ExtNotification per fed AgentEvent, got {count}"
     );
 }

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -52,6 +52,7 @@ pub const HARN_AGENT_EVENT_METHOD: &str = "_harn/agentEvent";
 /// "unknown kind, ignore." Keep it sorted for diff-friendliness and
 /// keep it in lockstep with the match arm in `events.rs`.
 pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
+    "budget_circuit_breaker",
     "budget_exhausted",
     "composition_child_call",
     "composition_child_result",

--- a/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
+++ b/crates/harn-serve/tests/fixtures/acp/agent_event_ext_notifications.json
@@ -285,8 +285,22 @@
     "jsonrpc": "2.0",
     "method": "_harn/agentEvent",
     "params": {
+      "budgetKind": "max_iterations",
+      "costUsd": 0.12,
       "kind": "budget_exhausted",
       "maxIterations": 8,
+      "sessionId": "session-1",
+      "wallClockMs": 1500
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "_harn/agentEvent",
+    "params": {
+      "breakerKind": "consecutive_failures",
+      "consecutiveCount": 3,
+      "kind": "budget_circuit_breaker",
+      "pausedForMs": 2000,
       "sessionId": "session-1"
     }
   },

--- a/crates/harn-stdlib/src/stdlib/agent/control.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/control.harn
@@ -16,6 +16,9 @@ type AgentLoopBudget = {
   max: int,
   extend_by: int,
   expose_decisions: bool,
+  wall_clock_ms: int?,
+  total_cost_usd: float?,
+  consecutive_failures: dict?,
 }
 
 type AgentLoopBudgetDecision = {
@@ -61,6 +64,12 @@ fn __agent_loop_state(args) -> AgentLoopState {
       max: args.budget_max,
       remaining: remaining,
       extension_count: args.extensions_used,
+      wall_clock_ms: args.wall_clock_ms ?? 0,
+      wall_clock_limit_ms: args.wall_clock_limit_ms,
+      cost_usd: args.cost_usd ?? 0.0,
+      total_cost_limit_usd: args.total_cost_limit_usd,
+      consecutive_failures: args.consecutive_failures ?? 0,
+      consecutive_failure_limit: args.consecutive_failure_limit,
     },
     turn: {
       tool_call_count: args.turn_tool_count,
@@ -236,6 +245,12 @@ pub fn agent_loop_snapshot_state(args) -> AgentLoopState {
       current_limit: args.current_limit,
       budget_max: args.budget_max,
       extensions_used: args.extensions_used,
+      wall_clock_ms: args.wall_clock_ms,
+      wall_clock_limit_ms: args.wall_clock_limit_ms,
+      cost_usd: args.cost_usd,
+      total_cost_limit_usd: args.total_cost_limit_usd,
+      consecutive_failures: args.consecutive_failures,
+      consecutive_failure_limit: args.consecutive_failure_limit,
       turn_tool_count: tool_count,
       turn_successful: turn_successful,
       turn_rejected: args.turn_rejected,

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -46,6 +46,7 @@ import {
   agent_session_record_assistant,
   agent_session_record_tool_results,
   agent_session_record_usage,
+  agent_session_totals,
 } from "std/agent/state"
 import { agent_step_judge } from "std/agent/step_judge"
 import {
@@ -973,7 +974,7 @@ fn __next_text_only_count(tool_count, consecutive_text_only) {
  * the transcript JSONL. Empty/missing fields are dropped so the event
  * stays small for providers that don't report telemetry.
  */
-fn __iteration_info_payload(llm_result, tool_count, visible_text) {
+fn __iteration_info_payload(llm_result, tool_count, visible_text, aggregates = nil) {
   let telemetry = llm_result?.provider_telemetry ?? {}
   let thinking = llm_result?.thinking ?? ""
   let thinking_chars = if type_of(thinking) == "string" {
@@ -981,6 +982,7 @@ fn __iteration_info_payload(llm_result, tool_count, visible_text) {
   } else {
     0
   }
+  let extra = aggregates ?? {}
   return {
     tool_count: tool_count,
     text: visible_text,
@@ -991,6 +993,156 @@ fn __iteration_info_payload(llm_result, tool_count, visible_text) {
     output_tokens: llm_result?.output_tokens ?? 0,
     thinking_chars: thinking_chars,
   }
+    + extra
+}
+
+fn __agent_loop_elapsed_ms(start_ms) {
+  let elapsed = now_ms() - start_ms
+  if elapsed < 0 {
+    return 0
+  }
+  return elapsed
+}
+
+fn __agent_loop_cost_usd(totals) {
+  let value = to_float(totals?.cost_usd ?? 0.0)
+  if value == nil {
+    return 0.0
+  }
+  return value
+}
+
+fn __agent_loop_budget_aggregates(session_id, totals, loop_start_ms) {
+  let resolved_totals = totals ?? agent_session_totals(session_id)
+  return {
+    cost_usd: __agent_loop_cost_usd(resolved_totals),
+    wall_clock_ms: __agent_loop_elapsed_ms(loop_start_ms),
+  }
+}
+
+fn __agent_loop_iteration_info(
+  session_id,
+  llm_result,
+  tool_count,
+  visible_text,
+  totals,
+  loop_start_ms,
+) {
+  return __iteration_info_payload(
+    llm_result,
+    tool_count,
+    visible_text,
+    __agent_loop_budget_aggregates(session_id, totals, loop_start_ms),
+  )
+}
+
+fn __agent_loop_budget_exhaustion(
+  session_id,
+  budget,
+  iteration,
+  totals,
+  loop_start_ms,
+  max_iterations,
+) {
+  let aggregates = __agent_loop_budget_aggregates(session_id, totals, loop_start_ms)
+  if budget?.wall_clock_ms != nil && aggregates.wall_clock_ms >= budget.wall_clock_ms {
+    return aggregates
+      + {exhausted: true, kind: "wall_clock", iteration: iteration, max_iterations: max_iterations}
+  }
+  if budget?.total_cost_usd != nil && aggregates.cost_usd >= budget.total_cost_usd {
+    return aggregates
+      + {exhausted: true, kind: "total_cost", iteration: iteration, max_iterations: max_iterations}
+  }
+  return aggregates + {exhausted: false, kind: "", iteration: iteration, max_iterations: max_iterations}
+}
+
+fn __agent_loop_emit_budget_exhausted(session_id, exhaustion) {
+  agent_emit_event(
+    session_id,
+    "budget_exhausted",
+    {
+      kind: exhaustion?.kind ?? "budget_exhausted",
+      max_iterations: exhaustion?.max_iterations ?? 0,
+      iteration: exhaustion?.iteration ?? 0,
+      cost_usd: exhaustion?.cost_usd ?? 0.0,
+      wall_clock_ms: exhaustion?.wall_clock_ms ?? 0,
+    },
+  )
+}
+
+fn __agent_loop_record_budget_stop(decisions, iteration, current_max, reason) {
+  return decisions
+    .push(
+    {
+      iteration: iteration,
+      action: "stop",
+      old_limit: current_max,
+      new_limit: current_max,
+      reason: reason,
+      status: "budget_exhausted",
+    },
+  )
+}
+
+fn __agent_loop_state_budget_fields(
+  session_id,
+  totals,
+  loop_start_ms,
+  budget,
+  consecutive_failure_count,
+) {
+  let aggregates = __agent_loop_budget_aggregates(session_id, totals, loop_start_ms)
+  let failure_config = __agent_loop_consecutive_failure_config(budget)
+  return {
+    wall_clock_ms: aggregates.wall_clock_ms,
+    wall_clock_limit_ms: budget?.wall_clock_ms,
+    cost_usd: aggregates.cost_usd,
+    total_cost_limit_usd: budget?.total_cost_usd,
+    consecutive_failures: consecutive_failure_count,
+    consecutive_failure_limit: failure_config?.max,
+  }
+}
+
+fn __agent_loop_failure_matches_kind(error, wanted) {
+  let category = to_string(error?.category ?? "")
+  let reason = to_string(error?.reason ?? "")
+  let kind = to_string(error?.kind ?? "")
+  let status = to_int(error?.status ?? error?.status_code ?? 0) ?? 0
+  if wanted == "transient" {
+    return kind == "transient" || category == "transient_network" || category == "timeout"
+      || reason == "timeout"
+  }
+  if wanted == "rate_limit" {
+    return kind == "rate_limit" || category == "rate_limit" || category == "rate_limited"
+      || reason == "rate_limit"
+      || status == 429
+  }
+  if wanted == "provider_5xx" {
+    return kind == "provider_5xx" || category == "server_error" || category == "overloaded"
+      || reason == "server_error"
+      || (status >= 500 && status < 600)
+  }
+  return category == wanted || reason == wanted || kind == wanted
+}
+
+fn __agent_loop_consecutive_failure_config(budget) {
+  let config = budget?.consecutive_failures
+  if type_of(config) != "dict" {
+    return nil
+  }
+  return config
+}
+
+fn __agent_loop_tracks_failure(error, config) {
+  if config == nil {
+    return false
+  }
+  for kind in config?.kinds ?? ["transient", "rate_limit", "provider_5xx"] {
+    if __agent_loop_failure_matches_kind(error, kind) {
+      return true
+    }
+  }
+  return false
 }
 
 fn __agent_loop_finalize_failed(session, iteration) {
@@ -1510,8 +1662,27 @@ fn __agent_loop_run(message, session, initial_opts) {
     var current_max = budget.initial
     var extensions_used = 0
     var budget_decisions = []
+    var consecutive_failure_count = 0
+    var budget_exhausted_emitted = false
     var last_tool_count = 0
+    let loop_start_ms = now_ms()
     while iteration < current_max {
+      let boundary_exhaustion = __agent_loop_budget_exhaustion(
+        session.session_id,
+        budget,
+        iteration,
+        nil,
+        loop_start_ms,
+        current_max,
+      )
+      if boundary_exhaustion.exhausted {
+        __agent_loop_emit_budget_exhausted(session.session_id, boundary_exhaustion)
+        budget_exhausted_emitted = true
+        budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, boundary_exhaustion.kind)
+        final_status = "budget_exhausted"
+        stop_reason = boundary_exhaustion.kind
+        break
+      }
       let checkpoint = __agent_loop_suspend_checkpoint(session, iteration)
       if checkpoint != nil {
         __drain_audit_flushes(audit_background_tasks)
@@ -1574,12 +1745,58 @@ fn __agent_loop_run(message, session, initial_opts) {
       }
       let call = __invoke_llm(message, turn_system, llm_opts)
       if !call.ok {
+        let failure_config = __agent_loop_consecutive_failure_config(budget)
+        if __agent_loop_tracks_failure(call?.error, failure_config) {
+          iteration = iteration + 1
+          consecutive_failure_count = consecutive_failure_count + 1
+          let failure_aggregates = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
+          agent_emit_event(
+            session.session_id,
+            "iteration_end",
+            {
+              iteration: iteration_index + 1,
+              iteration_info: failure_aggregates
+                + {
+                dispatch_skipped: true,
+                skip_reason: "provider_failure",
+                provider_error: call?.error ?? {},
+                consecutive_failures: consecutive_failure_count,
+              },
+            },
+          )
+          if consecutive_failure_count >= failure_config.max {
+            let paused_for_ms = failure_config?.paused_for_ms ?? 0
+            agent_emit_event(
+              session.session_id,
+              "budget_circuit_breaker",
+              {
+                kind: "consecutive_failures",
+                consecutive_count: consecutive_failure_count,
+                paused_for_ms: paused_for_ms,
+              },
+            )
+            if paused_for_ms > 0 {
+              sleep_ms(paused_for_ms)
+            }
+            let exhaustion = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
+              + {exhausted: true, kind: "consecutive_failures", iteration: iteration, max_iterations: current_max}
+            __agent_loop_emit_budget_exhausted(session.session_id, exhaustion)
+            budget_exhausted_emitted = true
+            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, exhaustion.kind)
+            final_status = "budget_exhausted"
+            stop_reason = "circuit_breaker"
+            terminal_error = call?.error
+            break
+          }
+          continue
+        }
         final_status = call.status
         stop_reason = call?.stop_reason ?? call.status
         terminal_error = call?.error
         break
       }
       let llm_result = call.value
+      consecutive_failure_count = 0
       iteration = iteration + 1
       let raw_text = llm_result?.text ?? ""
       let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools)
@@ -1614,7 +1831,14 @@ fn __agent_loop_run(message, session, initial_opts) {
           "iteration_end",
           {
             iteration: iteration_index + 1,
-            iteration_info: __iteration_info_payload(llm_result, len(tool_calls), visible_text),
+            iteration_info: __agent_loop_iteration_info(
+              session.session_id,
+              llm_result,
+              len(tool_calls),
+              visible_text,
+              _totals,
+              loop_start_ms,
+            ),
           },
         )
         final_status = "suspended"
@@ -1657,12 +1881,20 @@ fn __agent_loop_run(message, session, initial_opts) {
         if feedback != "" {
           agent_session_inject_feedback(session.session_id, "structural_validator", feedback)
         }
+        let structural_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
         agent_emit_event(
           session.session_id,
           "iteration_end",
           {
             iteration: iteration_index + 1,
-            iteration_info: __iteration_info_payload(llm_result, 0, visible_text)
+            iteration_info: __agent_loop_iteration_info(
+              session.session_id,
+              llm_result,
+              0,
+              visible_text,
+              structural_totals,
+              loop_start_ms,
+            )
               + {
               dispatch_skipped: true,
               skip_reason: "structural_validator_revise",
@@ -1671,6 +1903,27 @@ fn __agent_loop_run(message, session, initial_opts) {
             },
           },
         )
+        let structural_exhaustion = __agent_loop_budget_exhaustion(
+          session.session_id,
+          budget,
+          iteration,
+          structural_totals,
+          loop_start_ms,
+          current_max,
+        )
+        if structural_exhaustion.exhausted {
+          __agent_loop_emit_budget_exhausted(session.session_id, structural_exhaustion)
+          budget_exhausted_emitted = true
+          budget_decisions = __agent_loop_record_budget_stop(
+            budget_decisions,
+            iteration,
+            current_max,
+            structural_exhaustion.kind,
+          )
+          final_status = "budget_exhausted"
+          stop_reason = structural_exhaustion.kind
+          break
+        }
         continue
       } else if !(structural_verdict?.skipped ?? false) {
         structural_validator_attempts = 0
@@ -1692,16 +1945,39 @@ fn __agent_loop_run(message, session, initial_opts) {
             )
           }
         } else {
-          agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+          let stall_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
           let tool_count = len(tool_calls)
           agent_emit_event(
             session.session_id,
             "iteration_end",
             {
               iteration: iteration_index + 1,
-              iteration_info: __iteration_info_payload(llm_result, tool_count, visible_text),
+              iteration_info: __agent_loop_iteration_info(
+                session.session_id,
+                llm_result,
+                tool_count,
+                visible_text,
+                stall_totals,
+                loop_start_ms,
+              ),
             },
           )
+          let stall_exhaustion = __agent_loop_budget_exhaustion(
+            session.session_id,
+            budget,
+            iteration,
+            stall_totals,
+            loop_start_ms,
+            current_max,
+          )
+          if stall_exhaustion.exhausted {
+            __agent_loop_emit_budget_exhausted(session.session_id, stall_exhaustion)
+            budget_exhausted_emitted = true
+            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, stall_exhaustion.kind)
+            final_status = "budget_exhausted"
+            stop_reason = stall_exhaustion.kind
+            break
+          }
           let stalled_done_checkpoint = __agent_loop_checkpoint(session.session_id, "iteration_end", {iteration: iteration_index + 1})
           if stalled_done_checkpoint.delivered > 0 {
             continue
@@ -1732,12 +2008,20 @@ fn __agent_loop_run(message, session, initial_opts) {
           if critique != "" {
             agent_session_inject_feedback(session.session_id, "step_judge", critique)
           }
+          let step_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
           agent_emit_event(
             session.session_id,
             "iteration_end",
             {
               iteration: iteration_index + 1,
-              iteration_info: __iteration_info_payload(llm_result, 0, visible_text)
+              iteration_info: __agent_loop_iteration_info(
+                session.session_id,
+                llm_result,
+                0,
+                visible_text,
+                step_totals,
+                loop_start_ms,
+              )
                 + {
                 dispatch_skipped: true,
                 skip_reason: "step_judge_revise",
@@ -1746,6 +2030,22 @@ fn __agent_loop_run(message, session, initial_opts) {
               },
             },
           )
+          let step_exhaustion = __agent_loop_budget_exhaustion(
+            session.session_id,
+            budget,
+            iteration,
+            step_totals,
+            loop_start_ms,
+            current_max,
+          )
+          if step_exhaustion.exhausted {
+            __agent_loop_emit_budget_exhausted(session.session_id, step_exhaustion)
+            budget_exhausted_emitted = true
+            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, step_exhaustion.kind)
+            final_status = "budget_exhausted"
+            stop_reason = step_exhaustion.kind
+            break
+          }
           continue
         } else if !(step_verdict?.skipped ?? false) {
           step_judge_attempts = 0
@@ -1760,10 +2060,33 @@ fn __agent_loop_run(message, session, initial_opts) {
           "iteration_end",
           {
             iteration: iteration_index + 1,
-            iteration_info: __iteration_info_payload(llm_result, tool_count_skipped, visible_text)
+            iteration_info: __agent_loop_iteration_info(
+              session.session_id,
+              llm_result,
+              tool_count_skipped,
+              visible_text,
+              totals_skipped,
+              loop_start_ms,
+            )
               + {dispatch_skipped: true, skip_reason: "interrupt_immediate"},
           },
         )
+        let skipped_exhaustion = __agent_loop_budget_exhaustion(
+          session.session_id,
+          budget,
+          iteration,
+          totals_skipped,
+          loop_start_ms,
+          current_max,
+        )
+        if skipped_exhaustion.exhausted {
+          __agent_loop_emit_budget_exhausted(session.session_id, skipped_exhaustion)
+          budget_exhausted_emitted = true
+          budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, skipped_exhaustion.kind)
+          final_status = "budget_exhausted"
+          stop_reason = skipped_exhaustion.kind
+          break
+        }
         if agent_budget_post_call_blocked(totals_skipped, turn_opts) {
           final_status = "budget_exhausted"
           break
@@ -1789,11 +2112,34 @@ fn __agent_loop_run(message, session, initial_opts) {
         "iteration_end",
         {
           iteration: iteration_index + 1,
-          iteration_info: __iteration_info_payload(llm_result, tool_count, visible_text),
+          iteration_info: __agent_loop_iteration_info(
+            session.session_id,
+            llm_result,
+            tool_count,
+            visible_text,
+            totals,
+            loop_start_ms,
+          ),
         },
       )
       let post_dispatch_checkpoint = __agent_loop_checkpoint(session.session_id, "post_tool_dispatch", {iteration: iteration_index + 1})
       let bridge_step_delivered = post_dispatch_checkpoint.delivered
+      let exhaustion = __agent_loop_budget_exhaustion(
+        session.session_id,
+        budget,
+        iteration,
+        totals,
+        loop_start_ms,
+        current_max,
+      )
+      if exhaustion.exhausted {
+        __agent_loop_emit_budget_exhausted(session.session_id, exhaustion)
+        budget_exhausted_emitted = true
+        budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, exhaustion.kind)
+        final_status = "budget_exhausted"
+        stop_reason = exhaustion.kind
+        break
+      }
       if agent_budget_post_call_blocked(totals, turn_opts) {
         final_status = "budget_exhausted"
         break
@@ -1826,7 +2172,14 @@ fn __agent_loop_run(message, session, initial_opts) {
           missing_required_tools: missing_required_for_loop,
           completion_proposed: false,
           verdict: nil,
-        },
+        }
+          + __agent_loop_state_budget_fields(
+          session.session_id,
+          totals,
+          loop_start_ms,
+          budget,
+          consecutive_failure_count,
+        ),
       )
       let post_turn_opts = turn_opts
         + {
@@ -1900,7 +2253,14 @@ fn __agent_loop_run(message, session, initial_opts) {
           missing_required_tools: missing_required_for_loop,
           completion_proposed: outcome.kind == "break",
           verdict: verdict_record,
-        },
+        }
+          + __agent_loop_state_budget_fields(
+          session.session_id,
+          totals,
+          loop_start_ms,
+          budget,
+          consecutive_failure_count,
+        ),
       )
       let command = agent_loop_control_invoke(opts, budget, loop_state)
       let applied = agent_loop_apply_command(
@@ -1925,6 +2285,18 @@ fn __agent_loop_run(message, session, initial_opts) {
     }
     if final_status == "" && iteration >= current_max && stop_reason == nil {
       final_status = "budget_exhausted"
+    }
+    if final_status == "budget_exhausted" && !budget_exhausted_emitted {
+      let terminal_exhaustion = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
+        + {
+        exhausted: true,
+        kind: stop_reason ?? "max_iterations",
+        iteration: iteration,
+        max_iterations: current_max,
+      }
+      __agent_loop_emit_budget_exhausted(session.session_id, terminal_exhaustion)
+      budget_exhausted_emitted = true
+      budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, terminal_exhaustion.kind)
     }
     if opts?.daemon && final_status != "" {
       agent_daemon_snapshot(session, opts, final_status, iteration)

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -514,6 +514,70 @@ fn __positive_int_budget_field(value, fallback, label) {
   return value
 }
 
+fn __nonnegative_int_budget_field(value, fallback, label) {
+  if value == nil {
+    return fallback
+  }
+  if type_of(value) != "int" {
+    throw "agent_loop: `" + label + "` must be a non-negative integer; got " + type_of(value)
+  }
+  if value < 0 {
+    throw "agent_loop: `" + label + "` must be a non-negative integer; got " + to_string(value)
+  }
+  return value
+}
+
+fn __positive_float_budget_field(value, fallback, label) {
+  if value == nil {
+    return fallback
+  }
+  let kind = type_of(value)
+  if kind != "float" && kind != "int" {
+    throw "agent_loop: `" + label + "` must be a positive number; got " + kind
+  }
+  let parsed = to_float(value)
+  if parsed <= 0.0 {
+    throw "agent_loop: `" + label + "` must be a positive number; got " + to_string(value)
+  }
+  return parsed
+}
+
+fn __normalize_consecutive_failure_budget(value) {
+  if value == nil {
+    return nil
+  }
+  if type_of(value) != "dict" {
+    throw "agent_loop: `iteration_budget.consecutive_failures` must be a dict or nil; got "
+      + type_of(value)
+  }
+  if value?.max == nil {
+    throw "agent_loop: `iteration_budget.consecutive_failures.max` is required"
+  }
+  let max_count = __positive_int_budget_field(value?.max, nil, "iteration_budget.consecutive_failures.max")
+  let kinds = value?.kinds ?? ["transient", "rate_limit", "provider_5xx"]
+  if type_of(kinds) != "list" {
+    throw "agent_loop: `iteration_budget.consecutive_failures.kinds` must be a list of strings; got "
+      + type_of(kinds)
+  }
+  if len(kinds) == 0 {
+    throw "agent_loop: `iteration_budget.consecutive_failures.kinds` must not be empty"
+  }
+  for kind in kinds {
+    if type_of(kind) != "string" || kind == "" {
+      throw "agent_loop: `iteration_budget.consecutive_failures.kinds` must contain non-empty strings"
+    }
+  }
+  return {
+    max: max_count,
+    kinds: kinds,
+    paused_for_ms: __nonnegative_int_budget_field(
+      value?.paused_for_ms,
+      0,
+      "iteration_budget.consecutive_failures.paused_for_ms",
+    ),
+  }
+}
+
 fn __validate_loop_control(value) {
   if value == nil {
     return
@@ -824,6 +888,9 @@ fn __normalize_iteration_budget(opts) {
     max: max_cap,
     extend_by: extend_by,
     expose_decisions: expose_decisions,
+    wall_clock_ms: __positive_int_budget_field(user_budget?.wall_clock_ms, nil, "iteration_budget.wall_clock_ms"),
+    total_cost_usd: __positive_float_budget_field(user_budget?.total_cost_usd, nil, "iteration_budget.total_cost_usd"),
+    consecutive_failures: __normalize_consecutive_failure_budget(user_budget?.consecutive_failures),
   }
 }
 

--- a/crates/harn-stdlib/src/stdlib/agent/task_plan.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/task_plan.harn
@@ -179,6 +179,19 @@ pub fn task_plan_schema() {
           max_tool_calls: schema_field(schema_int(), false),
           max_model_calls: schema_field(schema_int(), false),
           max_steps: schema_field(schema_int(), false),
+          wall_clock_ms: schema_field(schema_int(), false),
+          total_cost_usd: schema_field(schema_float(), false),
+          consecutive_failures: schema_field(
+            schema_object(
+              {
+                max: schema_field(schema_int(), false),
+                kinds: schema_field(schema_list(schema_string()), false),
+                paused_for_ms: schema_field(schema_int(), false),
+              },
+              {additional_properties: schema_any()},
+            ),
+            false,
+          ),
         },
       ),
       capabilities: __task_plan_optional_dict(
@@ -388,10 +401,8 @@ fn __task_plan_write_kinds_in_use(plan) {
   return seen
 }
 
-fn __task_plan_validate_budgets(plan, report) {
+fn __task_plan_validate_node_count_budget(node_count, merged, report) {
   var out = report
-  let merged = __TASK_PLAN_DEFAULT_BUDGETS + plan?.budgets ?? {}
-  let node_count = len(__task_plan_collect_node_ids(plan))
   if node_count > merged.max_nodes {
     out = __task_plan_push_error(
       out,
@@ -403,7 +414,11 @@ fn __task_plan_validate_budgets(plan, report) {
         + to_string(merged.max_nodes),
     )
   }
-  let write_kinds_seen = __task_plan_write_kinds_in_use(plan)
+  return out
+}
+
+fn __task_plan_validate_write_capability_budget(plan, write_kinds_seen, report) {
+  var out = report
   let caps = plan?.capabilities ?? {}
   let cap_tools = caps?.tools ?? []
   let allow_writes = contains(cap_tools, "edit")
@@ -420,6 +435,109 @@ fn __task_plan_validate_budgets(plan, report) {
         + ") but capabilities.tools does not list `edit` or `run` and side_effect_level is not `writes_files`/`runs_commands`",
     )
   }
+  return out
+}
+
+fn __task_plan_validate_scalar_loop_budgets(explicit, report) {
+  var out = report
+  if explicit?.wall_clock_ms != nil
+    && (type_of(explicit.wall_clock_ms) != "int" || explicit.wall_clock_ms < 1) {
+    out = __task_plan_push_error(
+      out,
+      "budget_wall_clock_ms",
+      "budgets.wall_clock_ms",
+      "budgets.wall_clock_ms must be a positive integer",
+    )
+  }
+  let total_cost_kind = type_of(explicit?.total_cost_usd)
+  if explicit?.total_cost_usd != nil
+    && ((total_cost_kind != "float" && total_cost_kind != "int")
+    || to_float(explicit.total_cost_usd) <= 0.0) {
+    out = __task_plan_push_error(
+      out,
+      "budget_total_cost_usd",
+      "budgets.total_cost_usd",
+      "budgets.total_cost_usd must be positive",
+    )
+  }
+  return out
+}
+
+fn __task_plan_failure_kinds(failures) {
+  if type_of(failures) == "dict" {
+    return failures?.kinds ?? ["transient", "rate_limit", "provider_5xx"]
+  }
+  return ["transient", "rate_limit", "provider_5xx"]
+}
+
+fn __task_plan_validate_failure_kind_items(kinds, report) {
+  var out = report
+  if type_of(kinds) != "list" || len(kinds) == 0 {
+    return __task_plan_push_error(
+      out,
+      "budget_consecutive_failures_kinds",
+      "budgets.consecutive_failures.kinds",
+      "budgets.consecutive_failures.kinds must not be empty",
+    )
+  }
+  for kind in kinds {
+    if type_of(kind) != "string" || kind == "" {
+      out = __task_plan_push_error(
+        out,
+        "budget_consecutive_failures_kind",
+        "budgets.consecutive_failures.kinds",
+        "budgets.consecutive_failures.kinds must contain non-empty strings",
+      )
+    }
+  }
+  return out
+}
+
+fn __task_plan_validate_consecutive_failure_budget(explicit, report) {
+  var out = report
+  let failures = explicit?.consecutive_failures
+  if failures == nil {
+    return out
+  }
+  if type_of(failures) != "dict" {
+    return __task_plan_push_error(
+      out,
+      "budget_consecutive_failures",
+      "budgets.consecutive_failures",
+      "budgets.consecutive_failures must be an object",
+    )
+  }
+  if failures?.max == nil || type_of(failures.max) != "int" || failures.max < 1 {
+    out = __task_plan_push_error(
+      out,
+      "budget_consecutive_failures_max",
+      "budgets.consecutive_failures.max",
+      "budgets.consecutive_failures.max must be a positive integer",
+    )
+  }
+  out = __task_plan_validate_failure_kind_items(__task_plan_failure_kinds(failures), out)
+  if failures?.paused_for_ms != nil
+    && (type_of(failures.paused_for_ms) != "int" || failures.paused_for_ms < 0) {
+    out = __task_plan_push_error(
+      out,
+      "budget_consecutive_failures_pause",
+      "budgets.consecutive_failures.paused_for_ms",
+      "budgets.consecutive_failures.paused_for_ms must be non-negative",
+    )
+  }
+  return out
+}
+
+fn __task_plan_validate_budgets(plan, report) {
+  var out = report
+  let explicit = plan?.budgets ?? {}
+  let merged = __TASK_PLAN_DEFAULT_BUDGETS + explicit
+  let node_count = len(__task_plan_collect_node_ids(plan))
+  let write_kinds_seen = __task_plan_write_kinds_in_use(plan)
+  out = __task_plan_validate_node_count_budget(node_count, merged, out)
+  out = __task_plan_validate_write_capability_budget(plan, write_kinds_seen, out)
+  out = __task_plan_validate_scalar_loop_budgets(explicit, out)
+  out = __task_plan_validate_consecutive_failure_budget(explicit, out)
   return out + {budget_summary: merged + {node_count: node_count, write_kinds: write_kinds_seen}}
 }
 
@@ -581,7 +699,44 @@ fn __task_plan_workflow_mode(node) {
   return "llm"
 }
 
-fn __task_plan_model_policy(node) {
+fn __task_plan_loop_budget_policy(plan) {
+  let budgets = plan?.budgets ?? {}
+  var policy = {}
+  if budgets?.wall_clock_ms != nil {
+    policy = policy + {wall_clock_ms: budgets.wall_clock_ms}
+  }
+  if budgets?.total_cost_usd != nil {
+    policy = policy + {total_cost_usd: budgets.total_cost_usd}
+  }
+  if budgets?.consecutive_failures != nil {
+    policy = policy + {consecutive_failures: budgets.consecutive_failures}
+  }
+  return policy
+}
+
+fn __task_plan_merge_iteration_budget(model_policy, budget_policy) {
+  if len(budget_policy) == 0 {
+    return model_policy
+  }
+  let raw = model_policy?.iteration_budget
+  let existing = if type_of(raw) == "dict" {
+    raw
+  } else if raw != nil {
+    {mode: raw}
+  } else {
+    {}
+  }
+  return model_policy + {iteration_budget: existing + budget_policy}
+}
+
+fn __task_plan_mode_budget_policy(mode, budget_policy) {
+  if mode == "agent" || mode == "llm" {
+    return budget_policy
+  }
+  return {}
+}
+
+fn __task_plan_model_policy(node, budget_policy) {
   let model = node?.model ?? {}
   var policy = {}
   if model?.provider != nil {
@@ -599,7 +754,7 @@ fn __task_plan_model_policy(node) {
   if model?.max_tokens != nil {
     policy = policy + {max_tokens: model.max_tokens}
   }
-  return policy
+  return __task_plan_merge_iteration_budget(policy, budget_policy)
 }
 
 fn __task_plan_capability_policy(node) {
@@ -684,9 +839,9 @@ fn __task_plan_kind_fields(node) {
   return {}
 }
 
-fn __task_plan_compile_node(node_id, node) {
+fn __task_plan_compile_node(node_id, node, budget_policy) {
   let mode = __task_plan_workflow_mode(node)
-  let model_policy = __task_plan_model_policy(node)
+  let model_policy = __task_plan_model_policy(node, __task_plan_mode_budget_policy(mode, budget_policy))
   let capability_policy = __task_plan_capability_policy(node)
   let base_meta = {task_plan_kind: node?.kind, task_plan_purpose: node?.purpose ?? ""}
     + node?.metadata ?? {}
@@ -716,8 +871,9 @@ fn __task_plan_compile_node(node_id, node) {
 
 fn __task_plan_compile_nodes(plan) {
   var compiled = {}
+  let budget_policy = __task_plan_loop_budget_policy(plan)
   for entry in plan?.nodes ?? {} {
-    compiled = compiled + {[entry.key]: __task_plan_compile_node(entry.key, entry.value)}
+    compiled = compiled + {[entry.key]: __task_plan_compile_node(entry.key, entry.value, budget_policy)}
   }
   return compiled
 }

--- a/crates/harn-stdlib/src/stdlib/lifecycle/on_budget.harn
+++ b/crates/harn-stdlib/src/stdlib/lifecycle/on_budget.harn
@@ -4,7 +4,7 @@
  * The runtime fires the `OnBudgetThreshold` lifecycle event whenever an
  * agent loop / pipeline crosses a configured budget threshold (cents,
  * tokens, thinking-tokens, etc.). Users register a handler closure to
- * decide what happens next. This module ships three canonical
+ * decide what happens next. This module ships four canonical
  * strategies so the common cases stay one-liners:
  *
  *   * `OnBudget.terminate` — hard stop. Emits a `budget_exceeded` audit
@@ -20,8 +20,11 @@
  *     `budget_warning` system_reminder so the agent's next turn sees
  *     the overrun, and returns `budget_state` unchanged so combinator
  *     chains see a passthrough.
+ *   * `OnBudget.replan` — forks the current session at the last known
+ *     good iteration, injects a generic replan reminder, and resumes
+ *     the fork when the budget snapshot carries a task.
  *
- * All three follow the `(harness, budget_state) -> result` shape, which
+ * All four follow the `(harness, budget_state) -> result` shape, which
  * is identical to the `(harness, return_value) -> return_value` contract
  * the rest of the lifecycle layer uses. That means every callback in
  * this module composes freely with `std/lifecycle/combinators`:
@@ -178,6 +181,105 @@ pub fn warn_and_continue(harness, budget_state) {
   return budget_state
 }
 
+fn __on_budget_int(value, fallback) {
+  let parsed = to_int(value ?? fallback)
+  if parsed == nil || parsed < 0 {
+    return fallback
+  }
+  return parsed
+}
+
+fn __on_budget_session_id(snapshot) {
+  let nested = snapshot?.session?.id
+  let direct = snapshot?.session_id
+  let current = agent_session_current_id()
+  let session_id = direct ?? nested ?? current ?? ""
+  return to_string(session_id)
+}
+
+fn __on_budget_replan_keep_first(src, snapshot, iteration) {
+  var keep_first = __on_budget_int(snapshot?.last_good_iteration, iteration)
+  let source = agent_session_snapshot(src) ?? {}
+  let max_events = len(source.messages ?? [])
+  if keep_first > max_events {
+    keep_first = max_events
+  }
+  return keep_first
+}
+
+fn __on_budget_replan_reminder(kind, iteration) {
+  return "Previous loop hit `" + kind + "` at iteration " + to_string(iteration)
+    + ". Restart from checkpoint with a different approach."
+}
+
+/**
+ * Replan budget strategy. Forks the active source session at
+ * `last_good_iteration`, injects a generic reminder describing the
+ * exhausted budget kind, and resumes the fork when `budget_state`
+ * carries `{task|message, system?, options?}`. Without a task it returns
+ * the fork envelope after injection, which lets orchestration code
+ * decide when to schedule the retry.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: ["budget_replan_missing_session"]
+ * @api_stability: experimental
+ * @example: register_persona_hook("*", "OnBudgetThreshold", OnBudget.replan)
+ */
+pub fn replan(harness, budget_state) {
+  __on_budget_emit_audit(harness, "budget_replan", "replan", budget_state)
+  let snapshot = __on_budget_snapshot(budget_state)
+  let src = __on_budget_session_id(snapshot)
+  if src == "" {
+    throw {
+      category: "budget_exceeded",
+      kind: "terminal",
+      reason: "budget_replan_missing_session",
+      strategy: "replan",
+      budget_state: snapshot,
+      message: "OnBudget.replan requires a source session",
+    }
+  }
+  let iteration = __on_budget_int(snapshot?.iteration ?? snapshot?.n, 0)
+  let keep_first = __on_budget_replan_keep_first(src, snapshot, iteration)
+  let dst = snapshot?.dst_session_id
+  let forked = if dst != nil {
+    agent_session_fork_at(src, keep_first, to_string(dst))
+  } else {
+    agent_session_fork_at(src, keep_first)
+  }
+  let budget_kind = to_string(snapshot?.budget_kind ?? snapshot?.kind ?? "budget")
+  let reminder_body = __on_budget_replan_reminder(budget_kind, iteration)
+  agent_session_inject(
+    forked,
+    transcript_reminder_event(
+      {
+        body: reminder_body,
+        tags: ["on_budget", "replan"],
+        dedupe_key: "on_budget.replan:" + forked,
+        ttl_turns: 1,
+      },
+    ),
+  )
+  let task = snapshot?.task ?? snapshot?.message
+  let base_options = snapshot?.options ?? {}
+  let result = if task != nil {
+    agent_loop(task, snapshot?.system, base_options + {session_id: forked})
+  } else {
+    nil
+  }
+  return {
+    status: "replanned",
+    strategy: "replan",
+    session_id: forked,
+    source_session_id: src,
+    iteration: iteration,
+    last_good_iteration: keep_first,
+    reminder: reminder_body,
+    result: result,
+  }
+}
+
 /**
  * `OnBudget()` returns the named-strategy namespace as a dict so
  * callers can use dotted access (e.g. `OnBudget.terminate`) after a
@@ -193,5 +295,10 @@ pub fn warn_and_continue(harness, budget_state) {
  * @example: let OnBudget = OnBudget()
  */
 pub fn OnBudget() {
-  return {terminate: terminate, graceful_exit: graceful_exit, warn_and_continue: warn_and_continue}
+  return {
+    terminate: terminate,
+    graceful_exit: graceful_exit,
+    warn_and_continue: warn_and_continue,
+    replan: replan,
+  }
 }

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -271,6 +271,21 @@ pub enum AgentEvent {
     BudgetExhausted {
         session_id: String,
         max_iterations: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        kind: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cost_usd: Option<f64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wall_clock_ms: Option<u64>,
+    },
+    /// Emitted when a loop-level budget circuit breaker trips after N
+    /// consecutive retryable failures. `paused_for_ms` is the mock-time-aware
+    /// backoff already honored before the terminal budget event.
+    BudgetCircuitBreaker {
+        session_id: String,
+        kind: String,
+        consecutive_count: usize,
+        paused_for_ms: u64,
     },
     /// Emitted when the loop breaks because consecutive text-only turns
     /// hit `max_nudges`. Parity with `BudgetExhausted` / `IterationEnd` for
@@ -655,6 +670,7 @@ impl AgentEvent {
             | Self::TypedCheckpoint { session_id, .. }
             | Self::FeedbackInjected { session_id, .. }
             | Self::BudgetExhausted { session_id, .. }
+            | Self::BudgetCircuitBreaker { session_id, .. }
             | Self::LoopStuck { session_id, .. }
             | Self::DaemonWatchdogTripped { session_id, .. }
             | Self::SkillActivated { session_id, .. }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1391,6 +1391,8 @@ async fn host_agent_emit_event(args: Vec<VmValue>) -> Result<VmValue, VmError> {
             | "agent_loop_stall_warning"
             | "tool_format_override"
             | "tool_call_audit"
+            | "budget_exhausted"
+            | "budget_circuit_breaker"
             | "loop_checkpoint"
     ) {
         let role = if matches!(
@@ -1425,6 +1427,22 @@ fn build_agent_event(
             .and_then(|m| m.get(key))
             .and_then(|v| v.as_u64())
             .unwrap_or(0) as usize
+    };
+    let get_u64 = |key: &str| -> u64 {
+        payload_obj
+            .and_then(|m| m.get(key))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+    };
+    let get_opt_u64 = |key: &str| -> Option<u64> {
+        payload_obj
+            .and_then(|m| m.get(key))
+            .and_then(|v| v.as_u64())
+    };
+    let get_opt_f64 = |key: &str| -> Option<f64> {
+        payload_obj
+            .and_then(|m| m.get(key))
+            .and_then(|v| v.as_f64())
     };
     let get_string = |key: &str| -> String {
         payload_obj
@@ -1569,6 +1587,19 @@ fn build_agent_event(
                 .and_then(|m| m.get("metadata"))
                 .cloned()
                 .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new())),
+        }),
+        "budget_exhausted" => Ok(AgentEvent::BudgetExhausted {
+            session_id: session_id.to_string(),
+            max_iterations: get_usize("max_iterations"),
+            kind: get_opt_string("kind"),
+            cost_usd: get_opt_f64("cost_usd"),
+            wall_clock_ms: get_opt_u64("wall_clock_ms"),
+        }),
+        "budget_circuit_breaker" => Ok(AgentEvent::BudgetCircuitBreaker {
+            session_id: session_id.to_string(),
+            kind: get_string("kind"),
+            consecutive_count: get_usize("consecutive_count"),
+            paused_for_ms: get_u64("paused_for_ms"),
         }),
         "tool_search_query" => Ok(AgentEvent::ToolSearchQuery {
             session_id: session_id.to_string(),

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -72,6 +72,7 @@ public enum HarnProtocolConstants {
         "worker_update",
     ]
     public static let harnAgentEventKinds: [String] = [
+        "budget_circuit_breaker",
         "budget_exhausted",
         "composition_child_call",
         "composition_child_result",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -153,6 +153,7 @@ type HarnAgentEventKind = string
 
 // HarnAgentEventKinds enumerates every wire value Harn currently emits for HarnAgentEventKind.
 var HarnAgentEventKinds = []HarnAgentEventKind{
+	"budget_circuit_breaker",
 	"budget_exhausted",
 	"composition_child_call",
 	"composition_child_result",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -119,6 +119,7 @@ export type HarnACPSessionUpdateExtension = (typeof HARN_ACP_SESSION_UPDATE_EXTE
 
 export const HARN_AGENT_EVENT_METHOD = "_harn/agentEvent"
 export const HARN_AGENT_EVENT_KINDS = [
+  "budget_circuit_breaker",
   "budget_exhausted",
   "composition_child_call",
   "composition_child_result",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -78,6 +78,7 @@
       }
     },
     "harnAgentEventKinds": [
+      "budget_circuit_breaker",
       "budget_exhausted",
       "composition_child_call",
       "composition_child_result",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -205,6 +205,7 @@ HARN_ACP_SESSION_UPDATE_EXTENSIONS: tuple = (
     "worker_update",
 )
 HARN_AGENT_EVENT_KINDS: tuple = (
+    "budget_circuit_breaker",
     "budget_exhausted",
     "composition_child_call",
     "composition_child_result",

--- a/spec/protocol-artifacts/schemas/acp-session-update.schema.json
+++ b/spec/protocol-artifacts/schemas/acp-session-update.schema.json
@@ -78,12 +78,14 @@
             "sessionId": { "type": "string", "minLength": 1 },
             "kind": {
               "enum": [
+                "budget_circuit_breaker",
                 "budget_exhausted",
                 "composition_child_call",
                 "composition_child_result",
                 "composition_error",
                 "composition_finish",
                 "composition_start",
+                "control_outcome",
                 "daemon_watchdog_tripped",
                 "feedback_injected",
                 "iteration_end",
@@ -92,9 +94,10 @@
                 "loop_control_decision",
                 "loop_stuck",
                 "progress_reported",
+                "scope_classifier_verdict",
                 "session_closed",
-                "step_judge_decision",
                 "structural_validator_decision",
+                "step_judge_decision",
                 "tool_call_audit",
                 "tool_format_override",
                 "typed_checkpoint"


### PR DESCRIPTION
Closes #2471.

## Summary
- extend AgentLoopBudget with wall-clock, total-cost, and consecutive-failure circuit breaker rails
- carry running wall-clock/cost aggregates through iteration and budget events, including ACP protocol artifacts
- add OnBudget.replan with session fork/reminder injection and task-plan budget lowering/execution coverage

## Verification
- cargo run --quiet --bin harn -- test conformance --filter budget
- cargo run --quiet --bin harn -- test conformance --filter task_plan_validate_and_compile
- cargo run --quiet --bin harn -- fmt --check <touched harn files>
- cargo fmt --check
- make check-protocol-artifacts
- cargo test -p harn-vm agent_events -- --nocapture
- cargo test -p harn-serve adapters::acp::events::tests -- --nocapture
- make lint-test-patterns
- make test
