### PR TITLE
ci: drop duplicate mcp-rc-conformance, split pure-script audit gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,12 @@ jobs:
           cache-bin: false
       - run: make conformance
       - run: make protocol-conformance
-      - run: make mcp-rc-conformance
+      # NOTE: `make mcp-rc-conformance` used to run here as well, but its two
+      # `cargo test -p ... --tests` invocations are a strict subset of
+      # `cargo nextest run --workspace` in the parallel `rust-test` job —
+      # they were paying ~4 min to redo work the workspace test run already
+      # covers. Removed in favor of relying on `rust-test`; kept as a
+      # developer-convenience target in the Makefile for local iteration.
       # Promoted out of `make lint` (in the rust-lint job) so the Linux
       # critical path doesn't pay ~1-2 min to compile harn-cli from scratch
       # just to count `@xfail:` markers. `make conformance` above already
@@ -156,9 +161,10 @@ jobs:
       - run: make fmt-harn
       # Audit gates promoted from release_gate.sh audit so a stale
       # generated artifact (highlight keywords, language-spec mirror,
-      # trigger quickref, provider/connector matrices, docs snippets,
-      # release metadata) fails the
-      # PR instead of waiting until release time.
+      # trigger quickref, provider/connector matrices, docs snippets)
+      # fails the PR instead of waiting until release time. These all
+      # use the already-warm `target/debug/harn` binary built by
+      # `make conformance` above, so they're effectively free here.
       - run: make check-highlight
       - run: make check-language-spec
       - run: make check-trigger-quickref
@@ -168,6 +174,21 @@ jobs:
       - run: make check-trigger-examples
       - run: make check-docs-snippets
       - run: make check-diagnostics-catalog
+
+  audit-scripts:
+    name: Audit scripts
+    # Pure-Python / pure-shell audit gates that do NOT need a Rust toolchain
+    # or a built `target/debug/harn` binary. Split out of `harn-audit` so
+    # they run in parallel with the long Rust build path and provide fast
+    # feedback on docs / metadata / binding drift without waiting on
+    # `make conformance` (~4 min).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history + tags so the changelog retroactive-edit check can
+          # traverse BASE..HEAD and inspect commit trailers.
+          fetch-depth: 0
       # check-bindings runs the published Python and Go protocol bindings
       # against the committed JSON fixture. ubuntu-latest ships python3 and
       # go preinstalled, so no setup action is required.
@@ -365,7 +386,7 @@ jobs:
     name: CI status
     runs-on: ubuntu-latest
     if: always()
-    needs: [fmt, lint-md, rust-lint, rust-test, harn-audit, windows, portal, actions, e2e]
+    needs: [fmt, lint-md, rust-lint, rust-test, harn-audit, audit-scripts, windows, portal, actions, e2e]
     steps:
       - name: Verify required CI jobs
         run: |
@@ -375,6 +396,7 @@ jobs:
             ["Rust lint"]="${{ needs['rust-lint'].result }}"
             ["Rust test"]="${{ needs['rust-test'].result }}"
             ["Harn conformance + audit"]="${{ needs['harn-audit'].result }}"
+            ["Audit scripts"]="${{ needs['audit-scripts'].result }}"
             ["Portal frontend"]="${{ needs.portal.result }}"
             ["GitHub Actions hygiene"]="${{ needs.actions.result }}"
           )

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,14 @@ protocol-conformance:
 #   - tests/legacy_compat.rs    — 2025-11-25 wire compat regression
 #   - tests/artifacts.rs        — published fixtures + recursive $defs
 #   - harn-cli mcp_rc_compat_tests — orchestrator MCP server
+#
+# This target is a developer-convenience entry point for local iteration
+# on the MCP surface — it lets you re-run the focused suite without
+# building the whole workspace. CI does NOT call it: the two `cargo test`
+# invocations below are a strict subset of `cargo nextest run --workspace`
+# in the `rust-test` workflow job, so running it again in `harn-audit`
+# would pay ~4 min of wall-clock to redo work the workspace test run
+# already covers.
 mcp-rc-conformance:
 	@echo "=== MCP RC harness: harn-mcp-rc-compat suite (client / generic_server / legacy_compat / artifacts) ==="
 	HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-mcp-rc-compat --tests


### PR DESCRIPTION
## Summary

The `Harn conformance + audit` job had grown to ~11 min wall-clock per CI run. After investigating step timings on [run 26487870797 / job 77999295819](https://github.com/burin-labs/harn/actions/runs/26487870797/job/77999295819), found two wins:

### (1) Drop `make mcp-rc-conformance` from CI (~4 min saved)

The target ran two `cargo test -p ... --tests` invocations that are a **strict subset** of `cargo nextest run --workspace` in the parallel `rust-test` job. `rust-test` already exercised every test the dropped step did — `harn-audit` was paying ~4 min to redo work the workspace test run already covers.

Kept in the Makefile as a developer-convenience entry point (re-run the focused MCP suite without rebuilding the whole workspace). Only the CI invocation is removed. Added a Makefile comment so future contributors don't add it back to CI by mistake.

### (2) Split pure-script audit gates into a new `audit-scripts` job (~30s saved + fast feedback)

Five pure-Python / pure-shell gates that don't need a Rust toolchain or built `target/debug/harn` were paying ~30s of rust-cache restore + queueing behind `make conformance` (~4 min) for no reason:

- `make check-bindings` (python + go round-trip, ~13s)
- `make lint-test-patterns` (~17s)
- `make lint-diagnostic-codes` (~1s)
- `python3 scripts/verify_release_metadata.py` (~1s)
- `python3 scripts/check_changelog_no_retroactive_edits.py` (~1s)

Moved to a new `audit-scripts` job. Costs one extra runner-minute, buys fast-feedback on docs / metadata / binding drift without waiting on the long Rust build path.

### Expected impact

| | Before | After |
|---|---|---|
| `harn-audit` wall-clock | ~11:03 | ~6:20 |
| `audit-scripts` wall-clock | n/a | ~40s (parallel) |
| **Overall CI critical path** | ~11:03 | **~6:20** |

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] Local smoke of moved targets: `make lint-test-patterns`, `make lint-diagnostic-codes`, `python3 scripts/verify_release_metadata.py`, `make check-bindings` — all pass
- [x] Updated `ci-status` `needs` and `results` table to include `audit-scripts` so the umbrella gate continues to require it
- [ ] CI: should land in ~6 min instead of ~11 min, demonstrating the win on its own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)