### PR TITLE
ci: narrow Rust-on-Windows path filter to actually-Rust files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,17 +195,37 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
+          # The `windows` job is a Rust compile-break + smoke gate. It only
+          # cares about inputs that affect the Windows Rust build:
+          #   - .rs / build.rs source under crates/
+          #   - Cargo manifest changes (per-crate + workspace)
+          #   - Workspace-level cargo/toolchain config
+          #   - Makefile / scripts that occasionally affect how cargo is invoked
+          #   - This workflow itself (changes to the windows job definition)
+          #
+          # Notably NOT included:
+          #   - crates/**/*.harn        — pure runtime stdlib data; harn-cli's
+          #                               build.rs skips reading them on Windows
+          #                               (see `if cfg!(target_os = "windows")`)
+          #   - conformance/**          — pure .harn test fixtures, never read
+          #                               at compile time
+          #   - crates/**/*.md, *.json  — docs / test fixtures
+          #   - .github/workflows/!ci.yml — sibling workflows don't gate this job
+          #
+          # The `windows-nightly.yml` cron is the cross-platform safety net for
+          # everything not covered here.
           filters: |
             windows:
-              - 'crates/**'
-              - 'conformance/**'
+              - 'crates/**/*.rs'
+              - 'crates/**/Cargo.toml'
+              - 'crates/**/build.rs'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.cargo/**'
               - 'rust-toolchain.toml'
               - 'Makefile'
               - 'scripts/**'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
 
   windows:
     name: Rust on Windows (build + smoke test)


### PR DESCRIPTION
## Summary

Follow-up to #2488 — narrows the path filter that gates the `Rust on Windows (build + smoke test)` job so it stops firing on changes that cannot affect the Windows Rust build.

After #2488 lands and `harn-audit` drops to ~6:20, the Windows job (~11 min) becomes the sole long pole in the CI critical path. Most of the time it triggers on changes that fundamentally cannot break it — pure stdlib `.harn` files, conformance fixtures, sibling workflow tweaks.

## Why the current filter over-triggers

The existing filter:

```yaml
windows:
  - 'crates/**'        # ← too broad — pulls in .harn, .json, .md
  - 'conformance/**'   # ← pure .harn test cases, never compiled
  - '.github/workflows/**'  # ← every workflow, not just ci.yml
  - ...
```

`crates/harn-cli/build.rs` explicitly skips reading `.harn` files on Windows (`if cfg!(target_os = "windows") { write_table(&table_path, &[]); return; }`), so a .harn edit cannot affect Windows compile. Same logic for `conformance/**` (runtime test inputs, never compiled into the binary).

## The narrowed filter

```yaml
windows:
  - 'crates/**/*.rs'
  - 'crates/**/Cargo.toml'
  - 'crates/**/build.rs'
  - 'Cargo.toml'
  - 'Cargo.lock'
  - '.cargo/**'
  - 'rust-toolchain.toml'
  - 'Makefile'
  - 'scripts/**'
  - '.github/workflows/ci.yml'
```

Kept conservatively:
- `Makefile`, `scripts/**` — occasionally affect cargo invocation
- `ci.yml` — changes to the windows job itself must re-run

Excluded:
- `crates/**/*.harn`, `crates/**/*.json`, `crates/**/*.md`
- `conformance/**`
- `.github/workflows/*.yml` other than `ci.yml`

## Risk

Low. `windows-nightly.yml` (cron at 07:00 UTC) continues to run the full workspace test surface on Windows and would catch anything this filter misses within ~24 hours. The per-PR job is the pre-merge gate; nightly is the trailing safety net.

## Estimated impact

~15–25% of PRs that currently trigger Windows would now skip it entirely:
- Pure stdlib edits (`crates/harn-cli/src/embedded/stdlib/*.harn`)
- Conformance test additions
- Sibling workflow tweaks (e.g., changes to `build-release-binaries.yml`, `e2e.yml`)
- Docs-only changes inside `crates/**/*.md`

Saves ~11 min wall-clock on each of those.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] Filter syntax verified against `dorny/paths-filter` glob conventions
- [ ] CI: This PR touches `.github/workflows/ci.yml`, so the new filter selects ITSELF — Windows will run. Expected; that's the "this workflow itself" exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)