### PR TITLE
Harden typechecker soundness

### DIFF
--- a/conformance/tests/types/generic_abstract_param_return.error
+++ b/conformance/tests/types/generic_abstract_param_return.error
@@ -1,0 +1,1 @@
+return value: expected int, found T

--- a/conformance/tests/types/generic_abstract_param_return.harn
+++ b/conformance/tests/types/generic_abstract_param_return.harn
@@ -1,0 +1,6 @@
+pipeline test(task) {
+  fn bad<T>(x: T) -> int {
+    return x
+  }
+  bad(1)
+}

--- a/conformance/tests/types/generic_abstract_value_return.error
+++ b/conformance/tests/types/generic_abstract_value_return.error
@@ -1,0 +1,1 @@
+return value: expected T, found int

--- a/conformance/tests/types/generic_abstract_value_return.harn
+++ b/conformance/tests/types/generic_abstract_value_return.harn
@@ -1,0 +1,6 @@
+pipeline test(task) {
+  fn bad<T>() -> T {
+    return 1
+  }
+  bad<int>()
+}

--- a/conformance/tests/types/top_level_placeholder_type_mismatch.error
+++ b/conformance/tests/types/top_level_placeholder_type_mismatch.error
@@ -1,0 +1,1 @@
+let binding `y`: expected string, found int

--- a/conformance/tests/types/top_level_placeholder_type_mismatch.harn
+++ b/conformance/tests/types/top_level_placeholder_type_mismatch.harn
@@ -1,0 +1,3 @@
+let x: int = 1
+
+let y: string = x

--- a/conformance/tests/types/typed_fn_bare_return.error
+++ b/conformance/tests/types/typed_fn_bare_return.error
@@ -1,0 +1,1 @@
+return value: expected int, found nil

--- a/conformance/tests/types/typed_fn_bare_return.harn
+++ b/conformance/tests/types/typed_fn_bare_return.harn
@@ -1,0 +1,6 @@
+pipeline test(task) {
+  fn bad() -> int {
+    return
+  }
+  bad()
+}

--- a/conformance/tests/types/typed_fn_missing_return.error
+++ b/conformance/tests/types/typed_fn_missing_return.error
@@ -1,0 +1,1 @@
+function can fall through without returning int

--- a/conformance/tests/types/typed_fn_missing_return.harn
+++ b/conformance/tests/types/typed_fn_missing_return.harn
@@ -1,0 +1,6 @@
+pipeline test(task) {
+  fn bad() -> int {
+    let x = 1
+  }
+  bad()
+}

--- a/conformance/tests/types/typed_fn_nested_match_return_mismatch.error
+++ b/conformance/tests/types/typed_fn_nested_match_return_mismatch.error
@@ -1,0 +1,1 @@
+return value: expected int, found string

--- a/conformance/tests/types/typed_fn_nested_match_return_mismatch.harn
+++ b/conformance/tests/types/typed_fn_nested_match_return_mismatch.harn
@@ -1,0 +1,8 @@
+pipeline test(task) {
+  fn bad(value: string) -> int {
+    match value {
+      _ -> { return "wrong" }
+    }
+  }
+  bad("x")
+}

--- a/conformance/tests/types/typed_pipeline_fallthrough_mismatch.error
+++ b/conformance/tests/types/typed_pipeline_fallthrough_mismatch.error
@@ -1,0 +1,1 @@
+pipeline result: expected int, found nil

--- a/conformance/tests/types/typed_pipeline_fallthrough_mismatch.harn
+++ b/conformance/tests/types/typed_pipeline_fallthrough_mismatch.harn
@@ -1,0 +1,3 @@
+pipeline test(task) -> int {
+  let x = 1
+}

--- a/conformance/tests/types/typed_pipeline_final_expression_mismatch.error
+++ b/conformance/tests/types/typed_pipeline_final_expression_mismatch.error
@@ -1,0 +1,1 @@
+pipeline result: expected int, found string

--- a/conformance/tests/types/typed_pipeline_final_expression_mismatch.harn
+++ b/conformance/tests/types/typed_pipeline_final_expression_mismatch.harn
@@ -1,0 +1,3 @@
+pipeline test(task) -> int {
+  "wrong"
+}

--- a/crates/harn-parser/src/typechecker/exits.rs
+++ b/crates/harn-parser/src/typechecker/exits.rs
@@ -25,6 +25,23 @@ pub fn stmt_definitely_exits(stmt: &SNode) -> bool {
         // returning `match` as unreachable, and to let the type
         // checker treat the tail as `never`.
         Node::MatchExpr { arms, .. } => match_definitely_exits(arms),
+        Node::Block(body)
+        | Node::TryExpr { body }
+        | Node::CostRoute { body, .. }
+        | Node::MutexBlock { body }
+        | Node::DeadlineBlock { body, .. }
+        | Node::Retry { body, .. } => block_definitely_exits(body),
+        Node::TryCatch {
+            body,
+            catch_body,
+            finally_body,
+            ..
+        } => {
+            finally_body
+                .as_ref()
+                .is_some_and(|body| block_definitely_exits(body))
+                || (block_definitely_exits(body) && block_definitely_exits(catch_body))
+        }
         _ => false,
     }
 }

--- a/crates/harn-parser/src/typechecker/inference/decls.rs
+++ b/crates/harn-parser/src/typechecker/inference/decls.rs
@@ -133,6 +133,68 @@ impl TypeChecker {
         }
     }
 
+    pub(in crate::typechecker) fn check_value_returning_body(
+        &mut self,
+        params: &[TypedParam],
+        return_type: &Option<TypeExpr>,
+        body: &[SNode],
+        expected_span: Span,
+        result_label: &str,
+        declaration_label: &str,
+    ) {
+        let mut body_scope = TypeScope::child_of(&self.scope);
+        self.fn_depth += 1;
+        for param in params {
+            let param_type = if param.rest {
+                param
+                    .type_expr
+                    .clone()
+                    .map(|inner| TypeExpr::List(Box::new(inner)))
+            } else {
+                param.type_expr.clone()
+            };
+            let has_annotation = param.type_expr.is_some();
+            body_scope.define_var(&param.name, param_type);
+            if has_annotation {
+                body_scope.mark_annotated(&param.name);
+            }
+            body_scope.clear_nil_widenable(&param.name);
+            if let Some(default) = &param.default_value {
+                self.check_node(default, &mut body_scope);
+            }
+        }
+        self.check_block(body, &mut body_scope);
+        self.fn_depth -= 1;
+
+        if let Some(ret_type) = return_type {
+            let mut ret_scope = body_scope.clone();
+            ret_scope.restore_narrowed_vars();
+            for stmt in body {
+                self.check_return_type(stmt, ret_type, expected_span, &mut ret_scope);
+            }
+            if !self.body_cannot_fall_through(body, &ret_scope) {
+                let actual = self
+                    .infer_block_type(body, &ret_scope)
+                    .unwrap_or_else(|| TypeExpr::Named("nil".into()));
+                if !self.types_compatible(ret_type, &actual, &ret_scope) {
+                    let value_span = body.last().map(|stmt| stmt.span).unwrap_or(expected_span);
+                    self.type_mismatch_at(
+                        Code::ReturnTypeMismatch,
+                        result_label,
+                        ret_type,
+                        &actual,
+                        value_span,
+                        (
+                            Some((expected_span, declaration_label.to_string())),
+                            Some(value_span),
+                        ),
+                        &ret_scope,
+                    );
+                }
+            }
+        }
+    }
+
     fn check_fn_body_inner(
         &mut self,
         type_params: &[TypeParam],
@@ -200,6 +262,69 @@ impl TypeChecker {
             for stmt in body {
                 self.check_return_type(stmt, ret_type, expected_span, &mut ret_scope);
             }
+            if !is_stream
+                && !Self::body_contains_yield(body)
+                && !self.body_cannot_fall_through(body, &ret_scope)
+                && !self.return_type_allows_implicit_nil(ret_type, &ret_scope)
+            {
+                self.error_at(
+                    Code::ReturnTypeMismatch,
+                    format!(
+                        "function can fall through without returning {}",
+                        format_type(ret_type)
+                    ),
+                    expected_span,
+                );
+            }
+        }
+    }
+
+    fn return_type_allows_implicit_nil(&self, expected: &TypeExpr, scope: &TypeScope) -> bool {
+        self.types_compatible(expected, &TypeExpr::Named("nil".into()), scope)
+    }
+
+    fn body_cannot_fall_through(&self, body: &[SNode], scope: &TypeScope) -> bool {
+        body.iter()
+            .any(|stmt| self.stmt_cannot_fall_through(stmt, scope))
+    }
+
+    fn stmt_cannot_fall_through(&self, stmt: &SNode, scope: &TypeScope) -> bool {
+        if Self::block_definitely_exits(std::slice::from_ref(stmt)) {
+            return true;
+        }
+        match &stmt.node {
+            Node::MatchExpr { value, arms } => {
+                self.match_is_exhaustive(value, arms, scope)
+                    && arms.iter().all(|arm| {
+                        let mut arm_scope = scope.child();
+                        let value_type = self.infer_type(value, scope);
+                        self.define_match_pattern_bindings(
+                            &arm.pattern,
+                            value_type.as_ref(),
+                            &mut arm_scope,
+                        );
+                        self.body_cannot_fall_through(&arm.body, &arm_scope)
+                    })
+            }
+            Node::Block(body)
+            | Node::TryExpr { body }
+            | Node::CostRoute { body, .. }
+            | Node::MutexBlock { body }
+            | Node::DeadlineBlock { body, .. }
+            | Node::Retry { body, .. } => self.body_cannot_fall_through(body, scope),
+            Node::TryCatch {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                finally_body
+                    .as_ref()
+                    .is_some_and(|body| self.body_cannot_fall_through(body, scope))
+                    || (self.body_cannot_fall_through(body, scope)
+                        && self.body_cannot_fall_through(catch_body, scope))
+            }
+            _ => matches!(self.infer_type(stmt, scope), Some(TypeExpr::Never)),
         }
     }
 
@@ -253,6 +378,23 @@ impl TypeChecker {
                     }
                 }
             }
+            Node::ReturnStmt { value: None } => {
+                let actual = TypeExpr::Named("nil".into());
+                if !self.types_compatible(expected, &actual, scope) {
+                    self.type_mismatch_at(
+                        Code::ReturnTypeMismatch,
+                        "return value",
+                        expected,
+                        &actual,
+                        snode.span,
+                        (
+                            Some((expected_span, "return type declared here".to_string())),
+                            Some(snode.span),
+                        ),
+                        scope,
+                    );
+                }
+            }
             Node::IfElse {
                 condition,
                 then_body,
@@ -285,6 +427,97 @@ impl TypeChecker {
                     if Self::block_definitely_exits(then_body) {
                         refs.apply_falsy(scope);
                     }
+                }
+            }
+            Node::MatchExpr { value, arms } => {
+                let value_type = self.infer_type(value, scope);
+                for arm in arms {
+                    let mut arm_scope = scope.child();
+                    self.define_match_pattern_bindings(
+                        &arm.pattern,
+                        value_type.as_ref(),
+                        &mut arm_scope,
+                    );
+                    for stmt in &arm.body {
+                        self.check_return_type(stmt, expected, expected_span, &mut arm_scope);
+                    }
+                }
+            }
+            Node::Block(body)
+            | Node::TryExpr { body }
+            | Node::CostRoute { body, .. }
+            | Node::MutexBlock { body }
+            | Node::DeadlineBlock { body, .. }
+            | Node::Retry { body, .. } => {
+                let mut block_scope = scope.child();
+                for stmt in body {
+                    self.check_return_type(stmt, expected, expected_span, &mut block_scope);
+                }
+            }
+            Node::TryCatch {
+                body,
+                error_var,
+                error_type,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                let mut try_scope = scope.child();
+                for stmt in body {
+                    self.check_return_type(stmt, expected, expected_span, &mut try_scope);
+                }
+
+                let mut catch_scope = scope.child();
+                if let Some(var) = error_var {
+                    catch_scope.define_var(var, error_type.clone());
+                    catch_scope.clear_nil_widenable(var);
+                }
+                for stmt in catch_body {
+                    self.check_return_type(stmt, expected, expected_span, &mut catch_scope);
+                }
+
+                if let Some(finally_body) = finally_body {
+                    let mut finally_scope = scope.child();
+                    for stmt in finally_body {
+                        self.check_return_type(stmt, expected, expected_span, &mut finally_scope);
+                    }
+                }
+            }
+            Node::WhileLoop { condition, body } => {
+                let refs = Self::extract_refinements(condition, scope);
+                let mut loop_scope = scope.child();
+                refs.apply_truthy(&mut loop_scope);
+                for stmt in body {
+                    self.check_return_type(stmt, expected, expected_span, &mut loop_scope);
+                }
+            }
+            Node::ForIn {
+                pattern,
+                iterable,
+                body,
+            } => {
+                let mut loop_scope = scope.child();
+                if let crate::ast::BindingPattern::Identifier(variable) = pattern {
+                    let elem_type = self
+                        .infer_type(iterable, scope)
+                        .as_ref()
+                        .and_then(|ty| self.iterable_item_type(ty, scope));
+                    loop_scope.define_var(variable, elem_type);
+                    loop_scope.clear_nil_widenable(variable);
+                }
+                for stmt in body {
+                    self.check_return_type(stmt, expected, expected_span, &mut loop_scope);
+                }
+            }
+            Node::GuardStmt {
+                condition,
+                else_body,
+            } => {
+                let refs = Self::extract_refinements(condition, scope);
+                let mut else_scope = scope.child();
+                refs.apply_falsy(&mut else_scope);
+                for stmt in else_body {
+                    self.check_return_type(stmt, expected, expected_span, &mut else_scope);
                 }
             }
             _ => {}

--- a/crates/harn-parser/src/typechecker/inference/entry.rs
+++ b/crates/harn-parser/src/typechecker/inference/entry.rs
@@ -105,6 +105,30 @@ impl TypeChecker {
                         for stmt in body {
                             self.check_return_type(stmt, ret_type, inner_node.span, &mut ret_scope);
                         }
+                        if !Self::block_definitely_exits(body) {
+                            let actual = self
+                                .infer_block_type(body, &ret_scope)
+                                .unwrap_or_else(|| TypeExpr::Named("nil".into()));
+                            if !self.types_compatible(ret_type, &actual, &ret_scope) {
+                                let value_span =
+                                    body.last().map(|stmt| stmt.span).unwrap_or(inner_node.span);
+                                self.type_mismatch_at(
+                                    Code::ReturnTypeMismatch,
+                                    "pipeline result",
+                                    ret_type,
+                                    &actual,
+                                    value_span,
+                                    (
+                                        Some((
+                                            inner_node.span,
+                                            "pipeline return type declared here".to_string(),
+                                        )),
+                                        Some(value_span),
+                                    ),
+                                    &ret_scope,
+                                );
+                            }
+                        }
                     }
                     self.fn_depth -= 1;
                 }
@@ -166,14 +190,20 @@ impl TypeChecker {
                         vars,
                         mutable_vars,
                         nil_widenable_vars,
+                        schema_bindings,
+                        untyped_sources,
+                        annotated_vars,
                         ..
                     } = scope;
                     let root = Rc::make_mut(&mut self.scope);
                     for (name, ty) in vars {
-                        root.vars.entry(name).or_insert(ty);
+                        root.vars.insert(name, ty);
                     }
                     root.mutable_vars.extend(mutable_vars);
                     root.nil_widenable_vars.extend(nil_widenable_vars);
+                    root.schema_bindings.extend(schema_bindings);
+                    root.untyped_sources.extend(untyped_sources);
+                    root.annotated_vars.extend(annotated_vars);
                 }
             }
         }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -18,6 +18,7 @@ use crate::diagnostic_codes::Code;
 use harn_lexer::{FixEdit, Span};
 
 use super::super::binary_ops::infer_binary_op_type;
+use super::super::schema_inference::schema_type_expr_from_node;
 use super::super::scope::{builtin_return_type, InferredType, TypeScope};
 use super::super::union::simplify_union;
 use super::super::TypeChecker;
@@ -141,7 +142,51 @@ impl TypeChecker {
         }
     }
 
-    fn define_match_pattern_bindings(
+    fn infer_llm_call_result_type(
+        &self,
+        name: &str,
+        args: &[SNode],
+        scope: &TypeScope,
+    ) -> InferredType {
+        let (data_type, data_required) = self.llm_call_schema_data_type(args, scope)?;
+        let mut result = builtin_return_type(name)?;
+        let TypeExpr::Shape(fields) = &mut result else {
+            return Some(result);
+        };
+        if let Some(field) = fields.iter_mut().find(|field| field.name == "data") {
+            field.type_expr = data_type;
+            field.optional = !data_required;
+        }
+        Some(result)
+    }
+
+    fn llm_call_schema_data_type(
+        &self,
+        args: &[SNode],
+        scope: &TypeScope,
+    ) -> Option<(TypeExpr, bool)> {
+        let opts = args.get(2)?;
+        let Node::DictLiteral(entries) = &opts.node else {
+            return None;
+        };
+        let mut data_type = None;
+        let mut data_required = false;
+        for entry in entries {
+            let key = match &entry.key.node {
+                Node::StringLiteral(key) | Node::Identifier(key) => key.as_str(),
+                _ => continue,
+            };
+            if key == "schema" || key == "output_schema" {
+                data_type = schema_type_expr_from_node(&entry.value, scope);
+            } else if key == "output_validation" {
+                data_required =
+                    matches!(&entry.value.node, Node::StringLiteral(value) if value == "error");
+            }
+        }
+        data_type.map(|ty| (ty, data_required))
+    }
+
+    pub(in crate::typechecker) fn define_match_pattern_bindings(
         &self,
         pattern: &SNode,
         value_type: Option<&TypeExpr>,
@@ -210,7 +255,7 @@ impl TypeChecker {
         }
     }
 
-    fn define_enum_pattern_bindings(
+    pub(in crate::typechecker) fn define_enum_pattern_bindings(
         &self,
         enum_name: &str,
         variant: &str,
@@ -428,7 +473,12 @@ impl TypeChecker {
                         return Some(first_type);
                     }
                 }
-                // Generic builtins (llm_call, schema_parse/check/expect):
+                if name == "llm_call" || name == "llm_completion" {
+                    if let Some(result_type) = self.infer_llm_call_result_type(name, args, scope) {
+                        return Some(result_type);
+                    }
+                }
+                // Generic builtins (schema_parse/check/expect):
                 // bind T by walking each arg node against the param
                 // TypeExpr, then apply bindings to the declared return
                 // type. Falls through to `builtin_return_type` when no T

--- a/crates/harn-parser/src/typechecker/inference/flow.rs
+++ b/crates/harn-parser/src/typechecker/inference/flow.rs
@@ -505,6 +505,198 @@ impl TypeChecker {
         block_definitely_exits(stmts)
     }
 
+    pub(in crate::typechecker) fn match_is_exhaustive(
+        &self,
+        value: &SNode,
+        arms: &[MatchArm],
+        scope: &TypeScope,
+    ) -> bool {
+        if arms.iter().any(Self::match_arm_is_unguarded_catch_all) {
+            return true;
+        }
+        if let Some(enum_name) = self.match_enum_name(value, scope) {
+            return self.match_covers_enum_variants(&enum_name, arms, scope);
+        }
+        if let Some(exhaustive) = self.match_covers_tagged_shape_union(value, arms, scope) {
+            return exhaustive;
+        }
+        self.match_covers_union(value, arms, scope).unwrap_or(false)
+    }
+
+    fn match_enum_name(&self, value: &SNode, scope: &TypeScope) -> Option<String> {
+        let ty = match &value.node {
+            Node::PropertyAccess { object, property } if property == "variant" => {
+                self.infer_type(object, scope)?
+            }
+            _ => self.infer_type(value, scope)?,
+        };
+        match self.resolve_alias(&ty, scope) {
+            TypeExpr::Named(name) | TypeExpr::Applied { name, .. }
+                if scope.get_enum(&name).is_some() =>
+            {
+                Some(name)
+            }
+            _ => None,
+        }
+    }
+
+    fn match_arm_is_unguarded_catch_all(arm: &MatchArm) -> bool {
+        arm.guard.is_none()
+            && pattern_alternatives(&arm.pattern)
+                .iter()
+                .any(|leaf| matches!(&leaf.node, Node::Identifier(_)))
+    }
+
+    fn match_covers_enum_variants(
+        &self,
+        enum_name: &str,
+        arms: &[MatchArm],
+        scope: &TypeScope,
+    ) -> bool {
+        let Some(enum_info) = scope.get_enum(enum_name) else {
+            return false;
+        };
+        let variant_names: Vec<&str> = enum_info
+            .variants
+            .iter()
+            .map(|variant| variant.name.as_str())
+            .collect();
+        let mut covered: Vec<String> = Vec::new();
+        for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
+            for leaf in pattern_alternatives(&arm.pattern) {
+                match &leaf.node {
+                    Node::StringLiteral(name) | Node::Identifier(name)
+                        if variant_names.contains(&name.as_str()) =>
+                    {
+                        covered.push(name.clone());
+                    }
+                    Node::EnumConstruct { variant, .. }
+                    | Node::PropertyAccess {
+                        property: variant, ..
+                    }
+                    | Node::MethodCall {
+                        method: variant, ..
+                    } => covered.push(variant.clone()),
+                    Node::Identifier(_) => return true,
+                    _ => {}
+                }
+            }
+        }
+        variant_names
+            .iter()
+            .all(|variant| covered.iter().any(|covered| covered == variant))
+    }
+
+    fn match_covers_tagged_shape_union(
+        &self,
+        value: &SNode,
+        arms: &[MatchArm],
+        scope: &TypeScope,
+    ) -> Option<bool> {
+        let Node::PropertyAccess { object, property } = &value.node else {
+            return None;
+        };
+        let Node::Identifier(obj_var) = &object.node else {
+            return None;
+        };
+        let Some(Some(raw_type)) = scope.get_var(obj_var).cloned() else {
+            return None;
+        };
+        let TypeExpr::Union(members) = self.resolve_alias(&raw_type, scope) else {
+            return None;
+        };
+        let members = resolve_union_shape_members(&members, scope);
+        if discriminant_field(&members).as_deref() != Some(property.as_str()) {
+            return None;
+        }
+
+        let mut covered: Vec<DiscriminantValue> = Vec::new();
+        for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
+            for leaf in pattern_alternatives(&arm.pattern) {
+                match &leaf.node {
+                    Node::StringLiteral(value) => {
+                        covered.push(DiscriminantValue::Str(value.clone()));
+                    }
+                    Node::IntLiteral(value) => covered.push(DiscriminantValue::Int(*value)),
+                    Node::Identifier(_) => return Some(true),
+                    _ => {}
+                }
+            }
+        }
+
+        Some(members.iter().all(|member| {
+            let TypeExpr::Shape(fields) = member else {
+                return true;
+            };
+            let Some(field) = fields.iter().find(|field| field.name == *property) else {
+                return true;
+            };
+            DiscriminantValue::from_type(&field.type_expr)
+                .is_some_and(|value| covered.contains(&value))
+        }))
+    }
+
+    fn match_covers_union(
+        &self,
+        value: &SNode,
+        arms: &[MatchArm],
+        scope: &TypeScope,
+    ) -> Option<bool> {
+        let inferred = self.infer_type(value, scope)?;
+        let TypeExpr::Union(members) = self.resolve_alias(&inferred, scope) else {
+            return None;
+        };
+
+        if members
+            .iter()
+            .all(|member| matches!(member, TypeExpr::LitString(_) | TypeExpr::LitInt(_)))
+        {
+            let mut covered: Vec<DiscriminantValue> = Vec::new();
+            for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
+                for leaf in pattern_alternatives(&arm.pattern) {
+                    match &leaf.node {
+                        Node::StringLiteral(value) => {
+                            covered.push(DiscriminantValue::Str(value.clone()));
+                        }
+                        Node::IntLiteral(value) => covered.push(DiscriminantValue::Int(*value)),
+                        Node::Identifier(_) => return Some(true),
+                        _ => {}
+                    }
+                }
+            }
+            return Some(members.iter().all(|member| {
+                DiscriminantValue::from_type(member).is_some_and(|value| covered.contains(&value))
+            }));
+        }
+
+        if !members
+            .iter()
+            .all(|member| matches!(member, TypeExpr::Named(_)))
+        {
+            return None;
+        }
+
+        let mut covered: Vec<&'static str> = Vec::new();
+        for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
+            for leaf in pattern_alternatives(&arm.pattern) {
+                match &leaf.node {
+                    Node::NilLiteral => covered.push("nil"),
+                    Node::BoolLiteral(_) => covered.push("bool"),
+                    Node::IntLiteral(_) => covered.push("int"),
+                    Node::FloatLiteral(_) => covered.push("float"),
+                    Node::StringLiteral(_) => covered.push("string"),
+                    Node::Identifier(_) => return Some(true),
+                    _ => {}
+                }
+            }
+        }
+
+        Some(members.iter().all(|member| match member {
+            TypeExpr::Named(name) => covered.contains(&name.as_str()),
+            _ => true,
+        }))
+    }
+
     pub(in crate::typechecker) fn check_match_exhaustiveness(
         &mut self,
         value: &SNode,
@@ -512,30 +704,7 @@ impl TypeChecker {
         scope: &TypeScope,
         span: Span,
     ) {
-        // Detect pattern: match <expr>.variant { "VariantA" -> ... }
-        let enum_name = match &value.node {
-            Node::PropertyAccess { object, property } if property == "variant" => {
-                // Infer the type of the object
-                match self.infer_type(object, scope) {
-                    Some(TypeExpr::Named(name)) => {
-                        if scope.get_enum(&name).is_some() {
-                            Some(name)
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
-                }
-            }
-            _ => {
-                // Direct match on an enum value: match <expr> { ... }
-                match self.infer_type(value, scope) {
-                    Some(TypeExpr::Named(name)) if scope.get_enum(&name).is_some() => Some(name),
-                    _ => None,
-                }
-            }
-        };
-
+        let enum_name = self.match_enum_name(value, scope);
         let Some(enum_name) = enum_name else {
             // Two non-enum cases left:
             //   1. `match obj.<tag>` where `obj` is a tagged shape union →
@@ -556,25 +725,23 @@ impl TypeChecker {
         let mut covered: Vec<String> = Vec::new();
         let mut has_wildcard = false;
 
-        for arm in arms {
+        for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
             for leaf in pattern_alternatives(&arm.pattern) {
                 match &leaf.node {
                     // String literal pattern (matching on .variant): "VariantA"
                     Node::StringLiteral(s) => covered.push(s.clone()),
-                    // Identifier pattern acts as a wildcard/catch-all
-                    Node::Identifier(name)
-                        if name == "_"
-                            || !variants
-                                .variants
-                                .iter()
-                                .any(|variant| variant.name == *name) =>
-                    {
-                        has_wildcard = true;
-                    }
                     // Direct enum construct pattern: EnumName.Variant
                     Node::EnumConstruct { variant, .. } => covered.push(variant.clone()),
                     // PropertyAccess pattern: EnumName.Variant (no args)
                     Node::PropertyAccess { property, .. } => covered.push(property.clone()),
+                    // MethodCall pattern: EnumName.Variant(bindings...)
+                    Node::MethodCall {
+                        method: variant, ..
+                    } => covered.push(variant.clone()),
+                    // Identifier patterns bind and catch all remaining values at runtime.
+                    Node::Identifier(_) => {
+                        has_wildcard = true;
+                    }
                     _ => {
                         // Unknown pattern shape — conservatively treat as wildcard
                         has_wildcard = true;
@@ -637,7 +804,7 @@ impl TypeChecker {
 
         let mut has_wildcard = false;
         let mut covered: Vec<DiscriminantValue> = Vec::new();
-        for arm in arms {
+        for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
             for leaf in pattern_alternatives(&arm.pattern) {
                 match &leaf.node {
                     Node::StringLiteral(s) => covered.push(DiscriminantValue::Str(s.clone())),
@@ -715,7 +882,7 @@ impl TypeChecker {
         let mut has_wildcard = false;
         let mut covered_types: Vec<String> = Vec::new();
 
-        for arm in arms {
+        for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
             for leaf in pattern_alternatives(&arm.pattern) {
                 match &leaf.node {
                     // type_of(x) == "string" style patterns are common but hard to detect here
@@ -790,7 +957,7 @@ impl TypeChecker {
     ) {
         let mut has_wildcard = false;
         let mut covered: Vec<DiscriminantValue> = Vec::new();
-        for arm in arms {
+        for arm in arms.iter().filter(|arm| arm.guard.is_none()) {
             for leaf in pattern_alternatives(&arm.pattern) {
                 match &leaf.node {
                     Node::StringLiteral(s) => covered.push(DiscriminantValue::Str(s.clone())),

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -148,7 +148,11 @@ impl TypeChecker {
         }
     }
 
-    fn iterable_item_type(&self, iter_type: &TypeExpr, scope: &TypeScope) -> InferredType {
+    pub(in crate::typechecker) fn iterable_item_type(
+        &self,
+        iter_type: &TypeExpr,
+        scope: &TypeScope,
+    ) -> InferredType {
         let resolved = self.resolve_alias(iter_type, scope);
         let non_nil = without_nil(&resolved)?;
         match self.resolve_alias(&non_nil, scope) {
@@ -703,7 +707,14 @@ impl TypeChecker {
                 scope.define_fn(name, sig);
                 scope.define_var(name, None);
                 scope.clear_nil_widenable(name);
-                self.check_fn_body(&[], params, return_type, body, &[], false, span);
+                self.check_value_returning_body(
+                    params,
+                    return_type,
+                    body,
+                    span,
+                    "tool result",
+                    "tool return type declared here",
+                );
             }
 
             Node::SkillDecl { name, fields, .. } => {

--- a/crates/harn-parser/src/typechecker/inference/subtyping.rs
+++ b/crates/harn-parser/src/typechecker/inference/subtyping.rs
@@ -188,17 +188,6 @@ impl TypeChecker {
         if Self::is_wildcard_type(expected) || Self::is_wildcard_type(actual) {
             return true;
         }
-        // Generic type parameters match anything.
-        if let TypeExpr::Named(name) = expected {
-            if scope.is_generic_type_param(name) {
-                return true;
-            }
-        }
-        if let TypeExpr::Named(name) = actual {
-            if scope.is_generic_type_param(name) {
-                return true;
-            }
-        }
         let expected = self.resolve_alias(expected, scope);
         let actual = self.resolve_alias(actual, scope);
 
@@ -214,6 +203,21 @@ impl TypeChecker {
             return self.types_compatible_at(Polarity::Covariant, &expected, inner, scope);
         }
 
+        // never is the bottom type: assignable to any type.
+        if matches!(actual, TypeExpr::Never) {
+            return true;
+        }
+        // Nothing is assignable to never (except never itself, handled above).
+        if matches!(expected, TypeExpr::Never) {
+            return false;
+        }
+        // `any` is the escape hatch; `unknown` is the safe top.
+        if matches!(&expected, TypeExpr::Named(n) if n == "any" || n == "unknown")
+            || matches!(&actual, TypeExpr::Named(n) if n == "any")
+        {
+            return true;
+        }
+
         // Interface satisfaction: if expected names an interface, check method compatibility.
         if let Some(iface_name) = Self::base_type_name(&expected) {
             if let Some(interface_info) = scope.get_interface(iface_name) {
@@ -224,6 +228,11 @@ impl TypeChecker {
                     }
                 }
                 if let Some(type_name) = Self::base_type_name(&actual) {
+                    if scope.is_generic_type_param(type_name)
+                        && scope.get_where_constraint(type_name) == Some(iface_name)
+                    {
+                        return true;
+                    }
                     return self.satisfies_interface(
                         type_name,
                         iface_name,
@@ -235,19 +244,20 @@ impl TypeChecker {
             }
         }
 
+        // Generic type parameters are abstract, not `any`: a value of
+        // unknown caller-chosen type `T` cannot flow into `int`, and an
+        // `int` cannot manufacture a value for arbitrary `T`. The same
+        // abstract parameter remains compatible with itself, while `any`,
+        // `unknown`, `never`, and interface-bound cases were handled above.
+        let expected_generic =
+            matches!(&expected, TypeExpr::Named(name) if scope.is_generic_type_param(name));
+        let actual_generic =
+            matches!(&actual, TypeExpr::Named(name) if scope.is_generic_type_param(name));
+        if expected_generic || actual_generic {
+            return matches!((&expected, &actual), (TypeExpr::Named(a), TypeExpr::Named(b)) if a == b);
+        }
+
         match (&expected, &actual) {
-            // never is the bottom type: assignable to any type.
-            (_, TypeExpr::Never) => true,
-            // Nothing is assignable to never (except never itself, handled above).
-            (TypeExpr::Never, _) => false,
-            // `any` is the top type (escape hatch): every type flows into `any`,
-            // and `any` flows back out to any concrete type with no narrowing required.
-            (TypeExpr::Named(n), _) if n == "any" => true,
-            (_, TypeExpr::Named(n)) if n == "any" => true,
-            // `unknown` is the safe top: every type flows into `unknown`, but
-            // `unknown` only flows back out to `unknown` itself (or `any`, via the
-            // arm above). Concrete uses require narrowing via `type_of` / `schema_is`.
-            (TypeExpr::Named(n), _) if n == "unknown" => true,
             // Reverse direction: `unknown` is not assignable to anything concrete.
             // The `(_, Named("unknown"))` arm deliberately falls through to `=> false`
             // below, producing a "expected T, got unknown" diagnostic.

--- a/crates/harn-parser/src/typechecker/mod.rs
+++ b/crates/harn-parser/src/typechecker/mod.rs
@@ -238,6 +238,7 @@ impl TypeChecker {
         source: &str,
     ) -> Vec<TypeDiagnostic> {
         self.source = Some(source.to_string());
+        self.strict_types = true;
         self.check_inner(program).0
     }
 

--- a/crates/harn-parser/src/typechecker/schema_inference.rs
+++ b/crates/harn-parser/src/typechecker/schema_inference.rs
@@ -25,6 +25,11 @@ pub(super) fn schema_type_expr_from_node(node: &SNode, scope: &TypeScope) -> Opt
             if let Some(schema) = scope.get_schema_binding(name).cloned().flatten() {
                 return Some(schema);
             }
+            if let Some(Some(TypeExpr::Applied { name, args })) = scope.get_var(name) {
+                if name == "Schema" && args.len() == 1 {
+                    return Some(args[0].clone());
+                }
+            }
             scope.resolve_type(name).cloned()
         }
         Node::DictLiteral(entries) => schema_type_expr_from_dict(entries, scope),

--- a/crates/harn-parser/src/typechecker/tests/exhaustiveness.rs
+++ b/crates/harn-parser/src/typechecker/tests/exhaustiveness.rs
@@ -156,6 +156,82 @@ pipeline t(task) {
 }
 
 #[test]
+fn test_tagged_shape_union_guarded_arm_does_not_cover_variant() {
+    let errs = errors(
+        r#"type Msg = {kind: "ping", ttl: int} | {kind: "pong", latency_ms: int}
+
+pipeline t(task) {
+  fn handle(m: Msg) -> string {
+    match m.kind {
+      "ping" -> { return "ping" }
+      "pong" if false -> { return "pong" }
+    }
+  }
+}"#,
+    );
+    let exh: Vec<_> = errs
+        .iter()
+        .filter(|e| e.contains("Non-exhaustive match on tagged shape union"))
+        .collect();
+    assert_eq!(exh.len(), 1, "got: {errs:?}");
+    assert!(
+        exh[0].contains("\"pong\""),
+        "expected guarded pong to remain missing, got: {}",
+        exh[0]
+    );
+}
+
+#[test]
+fn test_literal_union_guarded_arm_does_not_cover_variant() {
+    let errs = errors(
+        r#"type Verdict = "pass" | "fail"
+
+pipeline t(task) {
+  fn classify(v: Verdict) -> string {
+    match v {
+      "pass" -> { return "ok" }
+      "fail" if false -> { return "no" }
+    }
+  }
+}"#,
+    );
+    let exh: Vec<_> = errs
+        .iter()
+        .filter(|e| e.contains("Non-exhaustive match on literal union"))
+        .collect();
+    assert_eq!(exh.len(), 1, "got: {errs:?}");
+    assert!(
+        exh[0].contains("\"fail\""),
+        "expected guarded fail to remain missing, got: {}",
+        exh[0]
+    );
+}
+
+#[test]
+fn test_named_union_guarded_arm_does_not_cover_type() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn show(x: string | int) -> string {
+    match x {
+      "value" -> { return "string" }
+      1 if false -> { return "int" }
+    }
+  }
+}"#,
+    );
+    let exh: Vec<_> = errs
+        .iter()
+        .filter(|e| e.contains("Non-exhaustive match on union type"))
+        .collect();
+    assert_eq!(exh.len(), 1, "got: {errs:?}");
+    assert!(
+        exh[0].contains("int"),
+        "expected guarded int arm to remain missing, got: {}",
+        exh[0]
+    );
+}
+
+#[test]
 fn test_non_exhaustive_match_wildcard_silences_error() {
     // Wildcard `_` arm escapes the new exhaustiveness error.
     let errs = errors(

--- a/crates/harn-parser/src/typechecker/tests/mod.rs
+++ b/crates/harn-parser/src/typechecker/tests/mod.rs
@@ -18,6 +18,7 @@ mod narrowing;
 mod ownership;
 mod reachability;
 mod repair;
+mod soundness;
 mod strict_types;
 mod typing;
 

--- a/crates/harn-parser/src/typechecker/tests/soundness.rs
+++ b/crates/harn-parser/src/typechecker/tests/soundness.rs
@@ -1,0 +1,381 @@
+//! Regression tests for type-system holes that accepted programs the VM
+//! would later execute with a different value shape than the annotation
+//! promised.
+
+use super::*;
+use crate::Parser;
+use harn_lexer::Lexer;
+
+#[test]
+fn top_level_bindings_replace_forward_placeholders_with_real_types() {
+    let errs = errors(
+        r"
+let x: int = 1
+let y: string = x
+",
+    );
+    assert_eq!(errs.len(), 1, "expected top-level mismatch, got: {errs:?}");
+    assert!(errs[0].contains("expected string, found int"), "{errs:?}");
+}
+
+#[test]
+fn unconstrained_generic_param_cannot_flow_to_concrete_return() {
+    let errs = errors(
+        r"
+fn bad<T>(x: T) -> int {
+  return x
+}
+",
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected generic return mismatch, got: {errs:?}"
+    );
+    assert!(errs[0].contains("expected int, found T"), "{errs:?}");
+}
+
+#[test]
+fn concrete_value_cannot_flow_to_unconstrained_generic_return() {
+    let errs = errors(
+        r"
+fn bad<T>() -> T {
+  return 1
+}
+",
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected generic return mismatch, got: {errs:?}"
+    );
+    assert!(errs[0].contains("expected T, found int"), "{errs:?}");
+}
+
+#[test]
+fn bare_return_rejects_non_nil_return_type() {
+    let errs = errors(
+        r"
+fn bad() -> int {
+  return
+}
+",
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected bare-return mismatch, got: {errs:?}"
+    );
+    assert!(errs[0].contains("expected int, found nil"), "{errs:?}");
+}
+
+#[test]
+fn non_nil_return_type_rejects_fallthrough() {
+    let errs = errors(
+        r"
+fn bad() -> int {
+  let x = 1
+}
+",
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected missing-return error, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("can fall through without returning int"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn partial_return_path_rejects_fallthrough() {
+    let errs = errors(
+        r"
+fn bad(flag: bool) -> int {
+  if flag {
+    return 1
+  }
+}
+",
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected missing-return error, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("can fall through without returning int"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn typed_pipeline_checks_final_expression_type() {
+    let errs = errors(
+        r#"
+pipeline test(task) -> int {
+  "wrong"
+}
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected pipeline result mismatch, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("pipeline result: expected int, found string"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn typed_pipeline_rejects_nil_fallthrough() {
+    let errs = errors(
+        r"
+pipeline test(task) -> int {
+  let x = 1
+}
+",
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected pipeline nil result mismatch, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("pipeline result: expected int, found nil"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn tool_body_final_expression_satisfies_return_type() {
+    let errs = errors(
+        r#"
+pipeline test(task) {
+  tool greet(name: string) -> string {
+    "Hello, " + name
+  }
+}
+"#,
+    );
+    assert!(errs.is_empty(), "unexpected tool result error: {errs:?}");
+}
+
+#[test]
+fn tool_body_final_expression_type_is_checked() {
+    let errs = errors(
+        r#"
+pipeline test(task) {
+  tool bad() -> int {
+    "wrong"
+  }
+}
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected tool result mismatch, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("tool result: expected int, found string"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn return_type_checks_recurse_into_match_arms() {
+    let errs = errors(
+        r#"
+fn bad(value: string) -> int {
+  match value {
+    _ -> { return "wrong" }
+  }
+}
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected match-arm return mismatch, got: {errs:?}"
+    );
+    assert!(errs[0].contains("expected int, found string"), "{errs:?}");
+}
+
+#[test]
+fn return_type_checks_recurse_into_try_expr_body() {
+    let errs = errors(
+        r#"
+fn bad() -> int {
+  try {
+    return "wrong"
+  }
+}
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected try-body return mismatch, got: {errs:?}"
+    );
+    assert!(errs[0].contains("expected int, found string"), "{errs:?}");
+}
+
+#[test]
+fn exhaustive_match_return_arms_satisfy_return_type() {
+    let errs = errors(
+        r#"
+type Verdict = "pass" | "fail"
+
+fn classify(v: Verdict) -> string {
+  match v {
+    "pass" -> { return "ok" }
+    "fail" -> { return "no" }
+  }
+}
+"#,
+    );
+    assert!(
+        errs.is_empty(),
+        "unexpected exhaustive-match error: {errs:?}"
+    );
+}
+
+#[test]
+fn exhaustive_match_return_arms_prevent_later_fallthrough() {
+    let errs = errors(
+        r#"
+type Verdict = "pass" | "fail"
+
+fn classify(v: Verdict) -> string {
+  match v {
+    "pass" -> { return "ok" }
+    "fail" -> { return "no" }
+  }
+  log("unreachable")
+}
+"#,
+    );
+    assert!(
+        errs.is_empty(),
+        "unexpected fallthrough after exhaustive match: {errs:?}"
+    );
+}
+
+#[test]
+fn non_exhaustive_match_return_arms_do_not_hide_fallthrough() {
+    let errs = errors(
+        r#"
+fn classify(v: string) -> int {
+  match v {
+    "one" -> { return 1 }
+  }
+}
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected missing-return error, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("can fall through without returning int"),
+        "{errs:?}"
+    );
+}
+
+#[test]
+fn generic_enum_match_requires_all_variants() {
+    let errs = errors(
+        r"
+fn unwrap_ok<T, E>(result: Result<T, E>) -> T {
+  match result {
+    Result.Ok(value) -> { return value }
+  }
+}
+",
+    );
+    assert!(
+        errs.iter()
+            .any(|err| err.contains("Non-exhaustive match") && err.contains("\"Err\"")),
+        "expected generic enum exhaustiveness error, got: {errs:?}"
+    );
+}
+
+#[test]
+fn never_tail_expression_satisfies_return_type() {
+    let errs = errors(
+        r#"
+fn exhaustive(x: string | int) -> string {
+  if type_of(x) == "string" {
+    return "string"
+  }
+  if type_of(x) == "int" {
+    return "int"
+  }
+  unreachable(x)
+}
+"#,
+    );
+    assert!(errs.is_empty(), "unexpected never-tail error: {errs:?}");
+}
+
+#[test]
+fn schema_typed_llm_call_data_flows_through_generic_wrapper() {
+    let errs = errors(
+        r#"
+type GraderOut = {verdict: "pass" | "fail", summary: string}
+
+fn grade<T>(schema: Schema<T>) -> T {
+  let r = llm_call("Grade this", nil, {output_schema: schema, output_validation: "error"})
+  return r.data
+}
+
+fn use_grade() -> GraderOut {
+  return grade(schema_of(GraderOut))
+}
+"#,
+    );
+    assert!(errs.is_empty(), "unexpected schema wrapper error: {errs:?}");
+}
+
+#[test]
+fn schema_typed_llm_call_data_stays_optional_without_error_validation() {
+    let errs = errors(
+        r#"
+type GraderOut = {verdict: "pass" | "fail", summary: string}
+
+fn grade<T>(schema: Schema<T>) -> T {
+  let r = llm_call("Grade this", nil, {output_schema: schema})
+  return r.data
+}
+"#,
+    );
+    assert!(
+        errs.iter().any(|err| err.contains("expected T, found T?")),
+        "expected optional data mismatch, got: {errs:?}"
+    );
+}
+
+#[test]
+fn check_strict_with_source_enables_strict_mode() {
+    let source = r#"pipeline t(task) {
+  let data = json_parse("{}")
+  log(data.name)
+}"#;
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse().unwrap();
+    let diagnostics = TypeChecker::new().check_strict_with_source(&program, source);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("unvalidated")),
+        "expected strict unvalidated warning, got: {diagnostics:?}"
+    );
+}

--- a/docs/src/cli-argparse-reference.md
+++ b/docs/src/cli-argparse-reference.md
@@ -53,9 +53,10 @@ let spec = parser({
 })
 
 let result = parse(spec, argv)
-if result.err != nil {
+let err = result.err
+if err != nil {
   __io_eprintln(render_help(spec))
-  __io_eprintln("error: " + result.err.hint)
+  __io_eprintln("error: " + err.hint)
   exit(2)
 }
 let parsed = result.ok

--- a/docs/src/cli-extending-in-harn.md
+++ b/docs/src/cli-extending-in-harn.md
@@ -282,9 +282,10 @@ usage block:
 import { parser, parse, render_help } from "std/cli/argparse"
 
 let result = parse(spec, argv)
-if result.err != nil {
+let err = result.err
+if err != nil {
   __io_eprintln(render_help(spec))
-  __io_eprintln("error: " + result.err.hint)
+  __io_eprintln("error: " + err.hint)
   exit(2)
 }
 let parsed = result.ok

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -289,14 +289,16 @@ Thread-safe counters:
 let counter = atomic(0)
 log(atomic_get(counter))         // 0
 
-let c2 = atomic_add(counter, 5)
-log(atomic_get(c2))              // 5
+let before_add = atomic_add(counter, 5)
+log(before_add)                  // 0
+log(atomic_get(counter))         // 5
 
-let c3 = atomic_set(c2, 100)
-log(atomic_get(c3))              // 100
+let before_set = atomic_set(counter, 100)
+log(before_set)                  // 5
+log(atomic_get(counter))         // 100
 ```
 
-Atomic operations return new atomic values (they don't mutate in place).
+Atomic updates mutate the handle and return the previous integer value.
 
 ## Mutex
 

--- a/docs/src/language-basics.md
+++ b/docs/src/language-basics.md
@@ -831,6 +831,8 @@ let s = Status.Pending("waiting")
 match s.variant {
   "Pending" -> { log(s.fields[0]) }
   "Active" -> { log("ok") }
+  "Inactive" -> { log("inactive") }
+  "Failed" -> { log(s.fields[1]) }
 }
 ```
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2600,12 +2600,12 @@ be omitted.
 ### tool declarations
 
 ```harn
-tool read_file(path: string, encoding: string) -> string {
+tool read_text(path: string, encoding: string = "utf-8") -> string {
   description "Read a file from the filesystem"
   read_file(path)
 }
 
-tool search(query: string, file_glob: string = "*.py") -> string {
+tool search_files(query: string, file_glob: string = "*.py") -> string {
   description "Search files matching an optional glob"
   "..."
 }
@@ -3876,6 +3876,10 @@ inside each arm; the same narrowing fires under
 `if obj.<tag> == "value"` / `else`:
 
 ```harn
+type Msg =
+  {kind: "ping", ttl: int} |
+  {kind: "pong", latency_ms: int}
+
 fn handle(m: Msg) -> string {
   match m.kind {
     "ping" -> { return "ttl=" + to_string(m.ttl) }

--- a/docs/src/reading-shape-diagnostics.md
+++ b/docs/src/reading-shape-diagnostics.md
@@ -17,7 +17,7 @@ need to dig into the source to interpret one.
 
 ## Missing field on a shape annotation
 
-```harn
+```harn,ignore
 type User = {name: string, email: string, age: int}
 
 let u: User = {name: "Ada", email: "ada@x", age: 36}

--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -153,6 +153,10 @@ silent empty substitution.
 
 ```harn
 let deploy = skill_find(skills, "deploy")
+guard deploy != nil else {
+  exit(1)
+}
+
 let rendered = skill_render(deploy, ["prod", "us-east-1"])
 // rendered now has $1 and $2 replaced with "prod" and "us-east-1".
 ```

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2598,12 +2598,12 @@ be omitted.
 ### tool declarations
 
 ```harn
-tool read_file(path: string, encoding: string) -> string {
+tool read_text(path: string, encoding: string = "utf-8") -> string {
   description "Read a file from the filesystem"
   read_file(path)
 }
 
-tool search(query: string, file_glob: string = "*.py") -> string {
+tool search_files(query: string, file_glob: string = "*.py") -> string {
   description "Search files matching an optional glob"
   "..."
 }
@@ -3874,6 +3874,10 @@ inside each arm; the same narrowing fires under
 `if obj.<tag> == "value"` / `else`:
 
 ```harn
+type Msg =
+  {kind: "ping", ttl: int} |
+  {kind: "pong", latency_ms: int}
+
 fn handle(m: Msg) -> string {
   match m.kind {
     "ping" -> { return "ttl=" + to_string(m.ttl) }


### PR DESCRIPTION
## Summary
- make generic type parameters abstract instead of wildcard-compatible, while preserving interface-bound generic satisfaction
- enforce declared return contracts for bare returns, fallthrough, nested returns, typed pipelines, and exhaustive final matches
- replace top-level forward placeholders with real promoted binding types
- infer schema-aware LLM result data from `Schema<T>`, keeping data optional unless `output_validation: "error"` is set
- align guarded match-arm exhaustiveness behavior across return-path analysis and diagnostics

## Impact
This intentionally tightens type checking in places where previously accepted programs could return or assign values that violated their annotations. Breaking changes are expected for code that relied on unconstrained generics behaving like `any` or on typed functions/pipelines falling through implicitly.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-type-system cargo test -p harn-parser --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-type-system cargo run --quiet --bin harn -- test conformance --filter types/`
- `CARGO_TARGET_DIR=/tmp/harn-target-type-system cargo run --quiet --bin harn -- test conformance --filter control_flow/match`
- `CARGO_TARGET_DIR=/tmp/harn-target-type-system make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-type-system make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-type-system make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-type-system make test` (before the final parser-only guard diagnostic polish; parser lib tests reran afterward)
- `cargo fmt --check`
- `git diff --check`