### PR TITLE
Fix unused-variable lint for parallel options

### DIFF
--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -988,9 +988,13 @@ impl<'a> Linter<'a> {
                 expr,
                 body,
                 variable,
+                options,
                 ..
             } => {
                 self.lint_node(expr);
+                for (_, value) in options {
+                    self.lint_node(value);
+                }
                 self.push_scope();
                 if let Some(v) = variable {
                     if let Some(scope) = self.scopes.last_mut() {

--- a/crates/harn-lint/src/tests/unused.rs
+++ b/crates/harn-lint/src/tests/unused.rs
@@ -112,6 +112,23 @@ log(add(1, 2))
 }
 
 #[test]
+fn test_parallel_options_mark_variables_used() {
+    let diags = lint_source(
+        r"
+pipeline default(task) {
+let concurrency = 2
+let results = parallel each [1, 2] with { max_concurrent: concurrency } { n -> n }
+log(results)
+}
+",
+    );
+    assert!(
+        !has_rule(&diags, "unused-variable"),
+        "parallel options should mark referenced variables used: {diags:?}"
+    );
+}
+
+#[test]
 fn test_multiple_rules() {
     let diags = lint_source(
         r#"


### PR DESCRIPTION
## Summary
- traverse parallel option expressions in the unused-variable linter
- add a regression where max_concurrent is the only use of a local variable

## Why
Burin's Harn 0.8.44 migration exposed a false HARN-LNT-014 warning for variables used in parallel with { max_concurrent: ... }. The parser and other lint visitors already walk these option expressions; this brings unused-variable analysis in line with them.

## Validation
- cargo fmt -p harn-lint --check
- CARGO_TARGET_DIR=/tmp/harn-lint-parallel-options-target cargo test -p harn-lint test_parallel_options_mark_variables_used
- CARGO_TARGET_DIR=/tmp/harn-lint-parallel-options-target cargo test -p harn-lint unused
- CARGO_TARGET_DIR=/tmp/harn-lint-parallel-options-target cargo test -p harn-lint
- CARGO_TARGET_DIR=/tmp/harn-lint-parallel-options-target cargo run --quiet --bin harn -- lint /Users/ksinder/projects/burin-code-worktrees/harn-env-migration/Sources/BurinCore/Resources/pipelines/infra/librarian-refresh.harn
- pre-commit changed-package clippy hook
- pre-push targeted local checks