### PR TITLE
docs: introduce changelog.d/ fragment convention + soft CI gate

### DIFF
--- a/.github/scripts/changelog-fragment-check.sh
+++ b/.github/scripts/changelog-fragment-check.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Changelog fragment gate: PRs that change user-visible code must drop a
+# `changelog.d/<id>.<category>.md` fragment OR edit `CHANGELOG.md`
+# directly, or carry the `no-changelog-needed` label. Mirrors the
+# `.github/scripts/demo-gate.sh` pattern.
+#
+# Inputs (from caller):
+#   BASE_SHA          merge-base or PR base commit (default: origin/main)
+#   HEAD_SHA          PR head commit (default: HEAD)
+#   BYPASS_REASON     non-empty string makes the gate pass with a notice
+#   GATE_ENABLE_TRACE non-empty enables verbose diagnostics on stderr
+#
+# Exit codes:
+#   0 — fragment / changelog present, bypassed, or only ignored paths touched.
+#   1 — user-visible change without an accompanying fragment or CHANGELOG edit.
+#   2 — usage error.
+
+set -euo pipefail
+
+BASE_SHA="${BASE_SHA:-origin/main}"
+HEAD_SHA="${HEAD_SHA:-HEAD}"
+BYPASS_REASON="${BYPASS_REASON:-}"
+GATE_ENABLE_TRACE="${GATE_ENABLE_TRACE:-}"
+
+if [ -n "$BYPASS_REASON" ]; then
+  echo "::notice title=Changelog fragment gate bypassed::$BYPASS_REASON"
+  exit 0
+fi
+
+if ! merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null); then
+  merge_base="$BASE_SHA"
+fi
+[ -n "$GATE_ENABLE_TRACE" ] && echo "[changelog-gate] base=$BASE_SHA head=$HEAD_SHA merge_base=$merge_base" >&2
+
+changed_files=$(git diff --name-only --no-renames "$merge_base" "$HEAD_SHA")
+if [ -z "$changed_files" ]; then
+  echo "::notice title=Changelog fragment gate::no file changes; pass."
+  exit 0
+fi
+
+# A direct CHANGELOG.md edit (operator authored straight into Unreleased)
+# satisfies the gate. This is the existing path and intentionally remains.
+if printf '%s\n' "$changed_files" | grep -qxF "CHANGELOG.md"; then
+  echo "::notice title=Changelog fragment gate::CHANGELOG.md edited directly; pass."
+  exit 0
+fi
+
+# Any new fragment under changelog.d/ satisfies the gate. We accept new
+# fragments OR modifications to existing ones (uncommon but valid when a
+# follow-up commit on the same PR refines the wording).
+fragment_hits=$(printf '%s\n' "$changed_files" \
+  | grep -E '^changelog\.d/[A-Za-z0-9_-]+\.(breaking|added|changed|deprecated|removed|fixed|security)\.md$' \
+  || true)
+if [ -n "$fragment_hits" ]; then
+  count=$(printf '%s\n' "$fragment_hits" | wc -l | tr -d ' ')
+  echo "::notice title=Changelog fragment gate::found $count changelog.d fragment(s); pass."
+  exit 0
+fi
+
+# Determine whether the PR has any "user-visible" surface. The heuristic:
+# any change outside the ignorable-by-default paths counts as user-visible
+# and requires a fragment. This deliberately defaults strict so we don't
+# silently ship runtime changes without notes.
+ignored_pattern='^(\.github/|docs/|spec/|README(\.md)?$|AGENTS\.md$|CLAUDE\.md$|\.gitignore$|\.gitattributes$|\.editorconfig$|\.markdownlint\.yaml$|\.markdownlint-cli2\.yaml$|changelog\.d/(\.gitkeep|README\.md)$|tests?/|conformance/|benchmarks/|evals/|examples/|experiments/|test_fixtures/|perf/|playground/|tree-sitter-harn/|editors/)'
+nontrivial=$(printf '%s\n' "$changed_files" | grep -Ev "$ignored_pattern" || true)
+if [ -z "$nontrivial" ]; then
+  echo "::notice title=Changelog fragment gate::only docs/test/CI paths touched; pass."
+  exit 0
+fi
+
+# Failed gate. Print actionable guidance and the first few files that
+# pushed the gate over the line.
+{
+  echo "::error title=Changelog fragment gate::This PR changes user-visible code but has no \`changelog.d/\` fragment."
+  echo ""
+  echo "To fix this, EITHER:"
+  echo "  1. Add a fragment file: \`changelog.d/<pr-or-issue-num>.<category>.md\`"
+  echo "     where <category> is one of: breaking, added, changed, deprecated, removed, fixed, security."
+  echo "     See \`changelog.d/README.md\` for the format."
+  echo ""
+  echo "  2. Edit \`CHANGELOG.md\` directly under \`## Unreleased\` (legacy path; still accepted)."
+  echo ""
+  echo "  3. Apply the \`no-changelog-needed\` label if this PR genuinely needs no entry"
+  echo "     (typo fixes, internal refactors, dep bumps with no user-visible effect)."
+  echo ""
+  echo "Triggering file(s) (up to 10):"
+  printf '%s\n' "$nontrivial" | head -10 | sed 's/^/  - /'
+} >&2
+exit 1

--- a/.github/workflows/changelog-fragment-check.yml
+++ b/.github/workflows/changelog-fragment-check.yml
@@ -1,0 +1,76 @@
+name: Changelog fragment
+
+# Every PR that changes user-visible code must drop a
+# `changelog.d/<id>.<category>.md` fragment OR edit `CHANGELOG.md`
+# directly. The detection logic lives in
+# `.github/scripts/changelog-fragment-check.sh`; this workflow is the CI
+# wrapper that resolves the diff range, reads PR labels for the
+# `no-changelog-needed` opt-out, and runs the script.
+#
+# Mirrors the `demo-gate.yml` pattern. Not yet wired into `ci.yml`'s
+# required "CI status" job — promote to a required check via the
+# merge-queue ruleset once the false-positive rate has been observed
+# on real PRs.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: changelog-fragment-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  changelog-fragment:
+    name: Changelog fragment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # `git merge-base` between the PR base and head needs full history.
+          fetch-depth: 0
+
+      - name: Resolve gate inputs
+        id: inputs
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "merge_group" ]; then
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Changelog fragment::merge_group event — gate is a no-op pass."
+            exit 0
+          fi
+
+          bypass=""
+          if printf '%s' "$PR_LABELS_JSON" \
+            | jq -e 'any(. == "no-changelog-needed")' > /dev/null; then
+            bypass="PR carries the no-changelog-needed label."
+          fi
+
+          {
+            echo "skip=0"
+            echo "base_sha=$PR_BASE_SHA"
+            echo "head_sha=$PR_HEAD_SHA"
+            echo "bypass_reason=$bypass"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run changelog fragment gate
+        if: steps.inputs.outputs.skip != '1'
+        env:
+          BASE_SHA: ${{ steps.inputs.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.inputs.outputs.head_sha }}
+          BYPASS_REASON: ${{ steps.inputs.outputs.bypass_reason }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/changelog-fragment-check.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,26 @@ lineage, and mutation session audit metadata. Hosts own approval UX, concrete
 file mutations, and undo/redo semantics. For autonomous or background edits,
 prefer worktree-backed execution over ambient cwd state.
 
+## Changelog fragments
+
+- Non-trivial PRs drop a single fragment file: `changelog.d/<id>.<category>.md`.
+  `<id>` is the PR or issue number, `<category>` is one of `breaking`,
+  `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`. The body
+  is the bullet(s) you would have hand-edited under `### Heading` inside
+  `## Unreleased`.
+- See `changelog.d/README.md` for the format and examples.
+- At release time the fragments are assembled into `## Unreleased` and the
+  fragment files are deleted in the same release commit.
+- The `Changelog fragment` GitHub Actions check is the soft gate. PRs that
+  genuinely need no entry (typos, internal refactors, dep bumps with no
+  user-visible effect) carry the `no-changelog-needed` label; the gate
+  treats that as a pass. Direct edits to `CHANGELOG.md` are also accepted
+  (legacy path).
+- Architecture: the assembler and the per-major archive helper live in
+  `harn-bump-fleet/lib/changelog.harn`; release-time invocation lives in
+  `harn-bump-fleet/release_harn.harn::apply_draft_release_notes`. Bump
+  helpers and tests are versioned with the harn-bump-fleet repo, not here.
+
 ## Release
 
 - Open version-bump PR after release content lands:

--- a/changelog.d/.markdownlint-cli2.jsonc
+++ b/changelog.d/.markdownlint-cli2.jsonc
@@ -1,0 +1,13 @@
+{
+  // Fragment files (`<id>.<category>.md`) are bullet snippets that get
+  // concatenated under a `### Category` heading at release time — they
+  // are never standalone documents, so MD041 ("first line is H1") and
+  // MD025 ("single H1") don't apply. README.md in this directory is a
+  // normal document and is not affected (markdownlint-cli2 doesn't have
+  // per-file overrides in a single config; if you author a non-fragment
+  // file here, add its own H1 — the README already has one).
+  "config": {
+    "MD041": false,
+    "MD025": false
+  }
+}

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,94 @@
+# `changelog.d/` — changelog fragments
+
+Each non-trivial PR drops a single markdown file in this directory. At release
+time `release_harn.harn` (in `~/projects/harn-bump-fleet`) reads every fragment,
+groups them by category, folds them into the top `## Unreleased` block in
+`../CHANGELOG.md`, then deletes the fragments in the same release commit.
+
+The pattern is a small adaptation of [towncrier](https://towncrier.readthedocs.io).
+It exists to remove `## Unreleased` as a merge-conflict hot spot. Two PRs that
+both add a bullet to `## Unreleased` will conflict on every line they touch;
+two PRs that each add their own `2491.added.md` / `2492.breaking.md` fragment
+file never touch the same path.
+
+## File format
+
+```text
+changelog.d/<id>.<category>.md
+```
+
+- **`<id>`** — the PR or issue number this fragment describes. Numeric is best
+  (sorts deterministically inside a category); slugs like `migration-2026-05`
+  are accepted too. The id is *not* rendered into the published changelog — it
+  exists solely to make filenames unique.
+- **`<category>`** — one of: `breaking`, `added`, `changed`, `deprecated`,
+  `removed`, `fixed`, `security`. Maps 1:1 to a `### Heading` in the assembled
+  section, emitted in the canonical Keep-a-Changelog order shown above.
+- **`.md`** — must be markdown. Files that don't match the
+  `<id>.<category>.md` shape (including this `README.md` and the
+  `.gitkeep`) are ignored by the assembler.
+
+## Body format
+
+The body is the bullet(s) that would otherwise be hand-typed under
+`### Breaking` / `### Added` / etc. in `CHANGELOG.md`. Do not include the
+`### Heading` line itself — the assembler adds it. Multiple bullets per
+fragment are fine.
+
+Example: `changelog.d/2492.breaking.md`
+
+```markdown
+- **The typechecker now enforces declared generic and return contracts more
+  strictly (#2492).** Generic type parameters are no longer treated as
+  wildcard-compatible values, typed functions and pipelines must satisfy
+  their declared return types across bare returns, fallthrough, nested
+  returns, and exhaustive final matches, and top-level forward
+  placeholders promote to their concrete binding types.
+```
+
+Example: `changelog.d/2493.fixed.md`
+
+```markdown
+- **Unused-variable lint now recognizes `parallel ... with { ... }` option
+  expressions (#2493).** Locals used only in options such as
+  `max_concurrent` are no longer reported as unused.
+```
+
+At release time these become:
+
+```markdown
+## v0.8.46
+
+### Breaking
+
+- **The typechecker now enforces declared generic and return contracts...**
+
+### Fixed
+
+- **Unused-variable lint now recognizes `parallel ... with { ... }`...**
+```
+
+## Authoring guidance
+
+- One fragment per logical change. A PR that ships a feature *and* a related
+  fix is welcome to land two fragments (e.g. `2494.added.md` and
+  `2494.fixed.md`). The two-segment filename naturally supports this.
+- Lead with **bold** project-area framing the way existing `CHANGELOG.md`
+  entries do (e.g. `**Built-in clone, deep_clone, deep_merge.**` …). The
+  assembler preserves your markdown verbatim.
+- Cite the PR or issue number in the body too (`(#2492)`), not just in the
+  filename. Filenames are not rendered into the published changelog;
+  in-body citations are how the reader navigates back to the source.
+- Operator-authored bullets typed directly into `## Unreleased` still work
+  and are preserved at promotion time (they merge with fragment-derived
+  bullets under matching subsections). Fragments are the preferred path
+  precisely because they avoid the merge-conflict surface, but the
+  in-place path is intentionally not removed.
+
+## Bypass
+
+PRs that genuinely do not need a changelog entry (typo fixes, internal
+refactors, CI tweaks, dependency bumps that have no user-visible effect)
+carry the `no-changelog-needed` label. The
+`.github/workflows/changelog-fragment-check.yml` soft gate accepts that
+label as the bypass, mirroring the `no-demo-needed` pattern.

--- a/changelog.d/changelog-fragments.changed.md
+++ b/changelog.d/changelog-fragments.changed.md
@@ -1,0 +1,11 @@
+- **Towncrier-style changelog fragments.** PRs can now drop a single
+  `changelog.d/<id>.<category>.md` file (categories: `breaking`, `added`,
+  `changed`, `deprecated`, `removed`, `fixed`, `security`) instead of
+  hand-editing `## Unreleased`. At release time the bump fleet's
+  `release_harn.harn` assembles the fragments into the Unreleased block
+  (preserving any operator-authored bullets) and stages the fragment files
+  for deletion in the same release commit. Removes `## Unreleased` as a
+  merge-conflict hot spot for parallel PRs. Direct edits to `CHANGELOG.md`
+  remain accepted (legacy path). A soft `Changelog fragment` CI gate flags
+  PRs that change user-visible code without a fragment; the
+  `no-changelog-needed` label bypasses it.


### PR DESCRIPTION
## Summary

Adds a [towncrier](https://towncrier.readthedocs.io)-style fragments directory so PRs that change user-visible code can drop a single \`changelog.d/<id>.<category>.md\` file instead of hand-editing \`## Unreleased\`. Removes the merge-conflict hot spot that \`## Unreleased\` becomes when multiple PRs land in parallel.

- New \`changelog.d/\` directory with \`README.md\` (full format spec + examples), \`.gitkeep\` (persists when empty), and \`.markdownlint-cli2.jsonc\` (disables MD041/MD025 for bullet fragments; README still linted normally).
- Categories follow Keep-a-Changelog: \`breaking\`, \`added\`, \`changed\`, \`deprecated\`, \`removed\`, \`fixed\`, \`security\`.
- New soft \`Changelog fragment\` GitHub Actions check (\`.github/workflows/changelog-fragment-check.yml\` + \`.github/scripts/changelog-fragment-check.sh\`), mirroring the \`demo-gate\` pattern: bypassed by the \`no-changelog-needed\` label and by docs/CI/test-only diffs. Direct edits to \`CHANGELOG.md\` are also accepted (legacy path).
- \`AGENTS.md\` documents the convention.
- Self-applies: drops a dogfood fragment for this change.

The assembler + release-time invocation live in [burin-labs/harn-bump-fleet#108](https://github.com/burin-labs/harn-bump-fleet/pull/108) (companion PR). Once that lands, \`release_harn.harn\` folds any \`changelog.d/\` fragments into \`## Unreleased\` before promotion and stages the fragment files for deletion in the same release commit.

## Why now

\`CHANGELOG.md\` is 10,765 lines across 112 versioned sections (v0.6.0 → v0.8.45). Over the last 2 months it has 746 commits — that's ~12/day. Most of the complexity in \`harn-bump-fleet/lib/changelog.harn\` (\`changelog_promote_pin_time_unreleased\` and \`changelog_repair_post_merge_drift\`, ~300 LOC with 3 fallback strategies each) exists to handle drift in \`## Unreleased\` from parallel PRs. Fragments take that pain off the format entirely.

## Test plan

- [ ] CI passes (incl. the new \`Changelog fragment\` check, which should self-skip because this PR only touches CI/docs paths AND drops a dogfood fragment).
- [ ] After the harn-bump-fleet companion PR lands, the next release run folds any pending fragments correctly.
- [ ] After v0.9.0 cuts, optionally invoke \`changelog_archive_below_version\` to snip v0.6.* / v0.7.* / v0.8.* into \`CHANGELOG-pre-0.9.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)