### PR TITLE
events: auto-register local OTLP exporter from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,22 +55,6 @@ condensed series summaries instead of full per-patch history.
   the per-handler JSON shapes now both go through a single
   `serialize_span` helper so `burin/promptProvenance` and
   `burin/promptConsumers` can never drift.
-- **Local OTLP exporter auto-registration.** `harn-vm` ships an
-  `events::install_otel_sink_from_env` helper that wires the existing
-  `OtelSink` (`crates/harn-vm/src/events.rs`) into the thread-local
-  event-sink chain whenever `HARN_OTEL_ENDPOINT` (or the standard
-  `OTEL_EXPORTER_OTLP_ENDPOINT`) is set. `harn-cli`'s `async_main` calls
-  it once at startup so every subcommand — `harn run`, `harn serve acp`,
-  evals — exports spans through the OTLP/HTTP collector at the
-  configured endpoint. Honors `HARN_OTEL_SERVICE_NAME` /
-  `OTEL_SERVICE_NAME` (default `"harn"`) and `HARN_OTEL_HEADERS` /
-  `OTEL_EXPORTER_OTLP_HEADERS` for header-based auth (e.g. Honeycomb
-  team ID). The auto-registered batch processor uses the host's tokio
-  runtime; a paired `events::shutdown_otel_sink` drains the queue
-  before the runtime exits so short-lived `harn run` invocations never
-  drop tail-end spans. Redaction stays under the active policy
-  (`crate::redact::current_policy`), unchanged from the pre-existing
-  `OtelSink` contract.
 
 ## v0.8.45
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,22 @@ condensed series summaries instead of full per-patch history.
   the per-handler JSON shapes now both go through a single
   `serialize_span` helper so `burin/promptProvenance` and
   `burin/promptConsumers` can never drift.
+- **Local OTLP exporter auto-registration.** `harn-vm` ships an
+  `events::install_otel_sink_from_env` helper that wires the existing
+  `OtelSink` (`crates/harn-vm/src/events.rs`) into the thread-local
+  event-sink chain whenever `HARN_OTEL_ENDPOINT` (or the standard
+  `OTEL_EXPORTER_OTLP_ENDPOINT`) is set. `harn-cli`'s `async_main` calls
+  it once at startup so every subcommand — `harn run`, `harn serve acp`,
+  evals — exports spans through the OTLP/HTTP collector at the
+  configured endpoint. Honors `HARN_OTEL_SERVICE_NAME` /
+  `OTEL_SERVICE_NAME` (default `"harn"`) and `HARN_OTEL_HEADERS` /
+  `OTEL_EXPORTER_OTLP_HEADERS` for header-based auth (e.g. Honeycomb
+  team ID). The auto-registered batch processor uses the host's tokio
+  runtime; a paired `events::shutdown_otel_sink` drains the queue
+  before the runtime exits so short-lived `harn run` invocations never
+  drop tail-end spans. Redaction stays under the active policy
+  (`crate::redact::current_policy`), unchanged from the pre-existing
+  `OtelSink` contract.
 
 ## v0.8.45
 

--- a/changelog.d/2530.added.md
+++ b/changelog.d/2530.added.md
@@ -1,0 +1,16 @@
+- **Local OTLP exporter auto-registration.** `harn-vm` ships an
+  `events::install_otel_sink_from_env` helper that wires the existing
+  `OtelSink` (`crates/harn-vm/src/events.rs`) into the thread-local
+  event-sink chain whenever `HARN_OTEL_ENDPOINT` (or the standard
+  `OTEL_EXPORTER_OTLP_ENDPOINT`) is set. `harn-cli`'s `async_main` calls
+  it once at startup so every subcommand — `harn run`, `harn serve acp`,
+  evals — exports spans through the OTLP/HTTP collector at the
+  configured endpoint. Honors `HARN_OTEL_SERVICE_NAME` /
+  `OTEL_SERVICE_NAME` (default `"harn"`) and `HARN_OTEL_HEADERS` /
+  `OTEL_EXPORTER_OTLP_HEADERS` for header-based auth (e.g. Honeycomb
+  team ID). The auto-registered batch processor uses the host's tokio
+  runtime; a paired `events::shutdown_otel_sink` drains the queue
+  before the runtime exits so short-lived `harn run` invocations never
+  drop tail-end spans. Redaction stays under the active policy
+  (`crate::redact::current_policy`), unchanged from the pre-existing
+  `OtelSink` contract.

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -65,6 +65,15 @@ pub fn run() {
                     process::exit(1);
                 });
             runtime.block_on(async_main());
+            // Drain any queued OTLP exports while the tokio runtime
+            // is still alive. The auto-registered `OtelSink` uses a
+            // batch processor with `runtime::Tokio`; if we let the
+            // runtime drop before this call, in-flight spans never
+            // reach the configured collector. No-op when OTel is not
+            // configured.
+            if let Err(error) = harn_vm::events::shutdown_otel_sink() {
+                eprintln!("[harn] OTel exporter shutdown failed: {error}");
+            }
         })
         .unwrap_or_else(|error| {
             eprintln!("failed to start CLI runtime thread: {error}");
@@ -110,6 +119,16 @@ fn is_broken_pipe_panic_payload(payload: &(dyn std::any::Any + Send)) -> bool {
 
 #[allow(clippy::large_stack_frames)] // dispatch entrypoint owns full Args + per-feature locals.
 async fn async_main() {
+    // Install the OTLP exporter sink before any subcommand runs so a
+    // 20+ minute autonomous session has spans streaming to the
+    // configured collector from the first turn. When neither
+    // `HARN_OTEL_ENDPOINT` nor `OTEL_EXPORTER_OTLP_ENDPOINT` is set
+    // this is a no-op. A misconfigured endpoint logs and continues —
+    // local observability is opt-in and must never fail the run.
+    if let Err(error) = harn_vm::events::install_otel_sink_from_env() {
+        eprintln!("[harn] OTel exporter disabled: {error}");
+    }
+
     let raw_args = normalize_serve_args(env::args().collect());
     if raw_args.len() == 2 && raw_args[1].ends_with(".harn") {
         provider_bootstrap::maybe_seed_ollama_for_run_file(Path::new(&raw_args[1]), false, false)

--- a/crates/harn-vm/src/events.rs
+++ b/crates/harn-vm/src/events.rs
@@ -230,28 +230,230 @@ pub struct OtelSink {
 
 #[cfg(feature = "otel")]
 impl OtelSink {
-    /// Create a new OTel sink. Initialises the OTLP span exporter
-    /// (default endpoint via OTEL_EXPORTER_OTLP_ENDPOINT, or localhost:4318).
+    /// Create a new OTel sink. Reads OTLP configuration from the
+    /// environment (endpoint, service name, headers). Errors when the
+    /// span exporter fails to initialise — a missing endpoint is **not**
+    /// an error; the exporter falls back to OpenTelemetry's default
+    /// (`http://localhost:4318/v1/traces`). Callers that want
+    /// presence-of-endpoint to gate registration should use
+    /// [`install_otel_sink_from_env`].
     pub fn new() -> Result<Self, String> {
-        use opentelemetry_otlp::SpanExporter;
+        use opentelemetry::global;
+        use opentelemetry_otlp::{
+            Protocol, SpanExporter, WithExportConfig as _, WithHttpConfig as _,
+        };
+        use opentelemetry_sdk::runtime;
+        use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
         use opentelemetry_sdk::trace::SdkTracerProvider;
+        use opentelemetry_sdk::Resource;
 
-        let exporter = SpanExporter::builder()
+        let endpoint = otel_endpoint_from_env();
+        let headers = otel_headers_from_env();
+        let service_name = otel_service_name_from_env();
+
+        // opentelemetry-otlp does not pull in any default HTTP client
+        // because the `reqwest-rustls` feature only opts the dep in —
+        // the exporter still requires an explicit client. Reuse the
+        // same reqwest configuration as the orchestrator-side
+        // provider so both surfaces hit the collector with identical
+        // TLS + connection-pool behaviour.
+        let http_client = reqwest::Client::builder()
+            .build()
+            .map_err(|error| format!("failed to build OTLP HTTP client: {error}"))?;
+
+        let mut exporter_builder = SpanExporter::builder()
             .with_http()
+            .with_http_client(http_client)
+            .with_protocol(Protocol::HttpJson)
+            .with_headers(headers);
+        if let Some(endpoint) = endpoint.as_deref() {
+            exporter_builder =
+                exporter_builder.with_endpoint(normalize_otlp_traces_endpoint(endpoint));
+        }
+        let exporter = exporter_builder
             .build()
             .map_err(|e| format!("OTel span exporter init failed: {e}"))?;
 
+        // Drive the batch processor on the current Tokio runtime so
+        // the exporter's reqwest client can reach the network. The
+        // default SDK processor spawns its own thread, which has no
+        // Tokio reactor and panics on the first send — we need the
+        // async-runtime variant for the same reason the orchestrator
+        // path uses it.
         let provider = SdkTracerProvider::builder()
-            .with_batch_exporter(exporter)
+            .with_resource(Resource::builder().with_service_name(service_name).build())
+            .with_span_processor(BatchSpanProcessor::builder(exporter, runtime::Tokio).build())
             .build();
 
-        opentelemetry::global::set_tracer_provider(provider.clone());
+        global::set_tracer_provider(provider.clone());
 
         Ok(Self {
             provider,
             active_spans: std::cell::RefCell::new(std::collections::HashMap::new()),
         })
     }
+}
+
+/// Burin-side spawns a fresh `harn` child per session, so the only
+/// reliable way to opt into local trace export is via environment
+/// variables read at startup. Prefer the Harn-specific variable so a
+/// caller that points an unrelated process at an OTLP collector via
+/// the shared OpenTelemetry variable doesn't accidentally enable Harn
+/// emission too.
+#[cfg(feature = "otel")]
+fn otel_endpoint_from_env() -> Option<String> {
+    for name in ["HARN_OTEL_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT"] {
+        if let Ok(value) = std::env::var(name) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(feature = "otel")]
+fn otel_service_name_from_env() -> String {
+    for name in ["HARN_OTEL_SERVICE_NAME", "OTEL_SERVICE_NAME"] {
+        if let Ok(value) = std::env::var(name) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    "harn".to_string()
+}
+
+#[cfg(feature = "otel")]
+fn otel_headers_from_env() -> std::collections::HashMap<String, String> {
+    let raw = std::env::var("HARN_OTEL_HEADERS")
+        .ok()
+        .or_else(|| std::env::var("OTEL_EXPORTER_OTLP_HEADERS").ok())
+        .unwrap_or_default();
+    raw.split([',', '\n', ';'])
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .filter_map(|segment| {
+            let (name, value) = segment
+                .split_once('=')
+                .or_else(|| segment.split_once(':'))?;
+            let name = name.trim();
+            let value = value.trim();
+            if name.is_empty() || value.is_empty() {
+                return None;
+            }
+            Some((name.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(feature = "otel")]
+fn normalize_otlp_traces_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    if trimmed.ends_with("/v1/traces") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/v1/traces")
+    }
+}
+
+/// Idempotency guard for [`install_otel_sink_from_env`]. The first
+/// caller wins; later ones become no-ops returning `Ok(false)`. The
+/// stored provider keeps the batch processor's runtime alive — and
+/// gives [`shutdown_otel_sink`] a handle to flush before the host
+/// tokio runtime exits.
+#[cfg(feature = "otel")]
+static OTEL_PROVIDER: std::sync::OnceLock<
+    std::sync::Mutex<Option<opentelemetry_sdk::trace::SdkTracerProvider>>,
+> = std::sync::OnceLock::new();
+
+/// Register an [`OtelSink`] into the thread-local event sink chain when
+/// the environment is configured for OTLP export.
+///
+/// Returns `Ok(true)` when a sink was installed, `Ok(false)` when no
+/// OTLP endpoint is configured (or when a sink has already been
+/// installed for this process), and `Err` when the exporter failed to
+/// initialise.
+///
+/// The exporter activates iff at least one of `HARN_OTEL_ENDPOINT` or
+/// the standard `OTEL_EXPORTER_OTLP_ENDPOINT` is non-empty. Service
+/// name comes from `HARN_OTEL_SERVICE_NAME` → `OTEL_SERVICE_NAME` →
+/// `"harn"` (in that order). Headers come from `HARN_OTEL_HEADERS` →
+/// `OTEL_EXPORTER_OTLP_HEADERS` (comma/semicolon-separated
+/// `name=value` pairs).
+///
+/// Hosts (`harn run`, `harn serve acp`, embedders like Burin) should
+/// call this once near process startup so any spans emitted during the
+/// session land at the configured collector.
+#[cfg(feature = "otel")]
+pub fn install_otel_sink_from_env() -> Result<bool, String> {
+    if otel_endpoint_from_env().is_none() {
+        return Ok(false);
+    }
+    let provider_slot = OTEL_PROVIDER.get_or_init(|| std::sync::Mutex::new(None));
+    {
+        let guard = provider_slot.lock().expect("otel provider mutex poisoned");
+        if guard.is_some() {
+            // A sink was already installed in this process. Don't
+            // double-register; the existing one will keep emitting.
+            return Ok(false);
+        }
+    }
+    let sink = OtelSink::new()?;
+    let provider = sink.provider.clone();
+    add_event_sink(Rc::new(sink));
+    provider_slot
+        .lock()
+        .expect("otel provider mutex poisoned")
+        .replace(provider);
+    Ok(true)
+}
+
+/// Flush and tear down the auto-registered OTel sink. Hosts that
+/// shut down their tokio runtime before process exit must call this
+/// while the runtime is still alive — `BatchSpanProcessor` needs a
+/// reactor to drain queued exports, and the [`Drop`] impl on
+/// [`OtelSink`] otherwise runs after the runtime is gone. Safe to
+/// call when no sink was installed.
+///
+/// Returns `Ok(true)` when a provider was flushed, `Ok(false)` when
+/// none was installed, and `Err` when the SDK reported an export or
+/// shutdown error. Errors are advisory — long-running hosts should
+/// log and continue.
+#[cfg(feature = "otel")]
+pub fn shutdown_otel_sink() -> Result<bool, String> {
+    let Some(slot) = OTEL_PROVIDER.get() else {
+        return Ok(false);
+    };
+    let provider = {
+        let mut guard = slot.lock().expect("otel provider mutex poisoned");
+        guard.take()
+    };
+    let Some(provider) = provider else {
+        return Ok(false);
+    };
+    provider
+        .force_flush()
+        .map_err(|error| format!("OTel force_flush failed: {error}"))?;
+    provider
+        .shutdown()
+        .map_err(|error| format!("OTel shutdown failed: {error}"))?;
+    Ok(true)
+}
+
+/// No-op stub for builds compiled without the `otel` feature. Returns
+/// `Ok(false)` so call sites can use the same code path on either
+/// build.
+#[cfg(not(feature = "otel"))]
+pub fn install_otel_sink_from_env() -> Result<bool, String> {
+    Ok(false)
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn shutdown_otel_sink() -> Result<bool, String> {
+    Ok(false)
 }
 
 #[cfg(feature = "otel")]
@@ -413,5 +615,169 @@ mod tests {
         assert_eq!(logs[0].metadata["tokens"], serde_json::json!(42));
 
         reset_event_sinks();
+    }
+
+    #[cfg(feature = "otel")]
+    mod otel_env {
+        use super::super::*;
+        use std::sync::{Mutex, MutexGuard, OnceLock};
+
+        /// Serializes env-mutating tests in this module. Crate-wide
+        /// `crate::llm::env_lock()` is reserved for LLM env scopes; a
+        /// dedicated lock here keeps these tests independent.
+        fn lock() -> MutexGuard<'static, ()> {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            LOCK.get_or_init(|| Mutex::new(()))
+                .lock()
+                .expect("otel env lock")
+        }
+
+        /// RAII guard for a single env var. Saves the prior value on
+        /// construction and restores it on Drop so parallel tests in
+        /// the same process don't leak state.
+        struct ScopedEnvVar {
+            key: &'static str,
+            previous: Option<String>,
+        }
+
+        impl ScopedEnvVar {
+            fn set(key: &'static str, value: &str) -> Self {
+                let previous = std::env::var(key).ok();
+                // SAFETY: env mutation is serialized by the test-level
+                // `lock()` above; no other thread inspects these
+                // variables while a guard is alive.
+                unsafe { std::env::set_var(key, value) };
+                Self { key, previous }
+            }
+
+            fn remove(key: &'static str) -> Self {
+                let previous = std::env::var(key).ok();
+                // SAFETY: see `set` above.
+                unsafe { std::env::remove_var(key) };
+                Self { key, previous }
+            }
+        }
+
+        impl Drop for ScopedEnvVar {
+            fn drop(&mut self) {
+                // SAFETY: see `set` above. Restoration happens while the
+                // test still holds the module lock.
+                match &self.previous {
+                    Some(value) => unsafe { std::env::set_var(self.key, value) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
+
+        #[test]
+        fn install_returns_false_when_endpoint_unset() {
+            let _guard = lock();
+            let _endpoint = ScopedEnvVar::remove("HARN_OTEL_ENDPOINT");
+            let _standard = ScopedEnvVar::remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+
+            let installed = install_otel_sink_from_env()
+                .expect("install must not error when endpoint is unset");
+            assert!(!installed, "expected no sink registration without endpoint");
+        }
+
+        #[test]
+        fn endpoint_helper_prefers_harn_variable() {
+            let _guard = lock();
+            let _harn = ScopedEnvVar::set("HARN_OTEL_ENDPOINT", "http://harn.example.test:4318");
+            let _standard = ScopedEnvVar::set(
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "http://generic.example.test:4318",
+            );
+
+            assert_eq!(
+                otel_endpoint_from_env().as_deref(),
+                Some("http://harn.example.test:4318"),
+            );
+        }
+
+        #[test]
+        fn endpoint_helper_falls_back_to_standard_variable() {
+            let _guard = lock();
+            let _harn = ScopedEnvVar::remove("HARN_OTEL_ENDPOINT");
+            let _standard = ScopedEnvVar::set(
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "http://generic.example.test:4318",
+            );
+
+            assert_eq!(
+                otel_endpoint_from_env().as_deref(),
+                Some("http://generic.example.test:4318"),
+            );
+        }
+
+        #[test]
+        fn endpoint_helper_ignores_whitespace_only_values() {
+            let _guard = lock();
+            let _harn = ScopedEnvVar::set("HARN_OTEL_ENDPOINT", "   ");
+            let _standard = ScopedEnvVar::remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+
+            assert!(otel_endpoint_from_env().is_none());
+        }
+
+        #[test]
+        fn service_name_helper_layers_defaults() {
+            let _guard = lock();
+            let _harn = ScopedEnvVar::remove("HARN_OTEL_SERVICE_NAME");
+            let _standard = ScopedEnvVar::remove("OTEL_SERVICE_NAME");
+            assert_eq!(otel_service_name_from_env(), "harn");
+
+            let _standard = ScopedEnvVar::set("OTEL_SERVICE_NAME", "burin-code");
+            assert_eq!(otel_service_name_from_env(), "burin-code");
+
+            let _harn = ScopedEnvVar::set("HARN_OTEL_SERVICE_NAME", "burin-tui");
+            assert_eq!(otel_service_name_from_env(), "burin-tui");
+        }
+
+        #[test]
+        fn headers_helper_parses_comma_separated_pairs() {
+            let _guard = lock();
+            let _harn = ScopedEnvVar::set(
+                "HARN_OTEL_HEADERS",
+                "x-honeycomb-team=abc123, x-other=val ,blank=",
+            );
+
+            let headers = otel_headers_from_env();
+            assert_eq!(
+                headers.get("x-honeycomb-team").map(String::as_str),
+                Some("abc123"),
+            );
+            assert_eq!(headers.get("x-other").map(String::as_str), Some("val"));
+            assert!(
+                !headers.contains_key("blank"),
+                "empty values must be dropped to match the orchestrator helper",
+            );
+        }
+
+        #[test]
+        fn normalize_endpoint_appends_traces_path_when_missing() {
+            assert_eq!(
+                normalize_otlp_traces_endpoint("http://localhost:4318"),
+                "http://localhost:4318/v1/traces",
+            );
+            assert_eq!(
+                normalize_otlp_traces_endpoint("http://localhost:4318/"),
+                "http://localhost:4318/v1/traces",
+            );
+            assert_eq!(
+                normalize_otlp_traces_endpoint("http://localhost:4318/v1/traces"),
+                "http://localhost:4318/v1/traces",
+            );
+            assert_eq!(
+                normalize_otlp_traces_endpoint("http://localhost:4318/v1/traces/"),
+                "http://localhost:4318/v1/traces",
+            );
+        }
+    }
+
+    #[cfg(not(feature = "otel"))]
+    #[test]
+    fn install_otel_sink_returns_ok_false_on_non_otel_builds() {
+        let installed = install_otel_sink_from_env().expect("non-otel stub never errors");
+        assert!(!installed);
     }
 }

--- a/crates/harn-vm/tests/otel_sink_export.rs
+++ b/crates/harn-vm/tests/otel_sink_export.rs
@@ -1,0 +1,183 @@
+//! End-to-end check that the local OTLP exporter actually delivers
+//! Harn spans to a configured collector once the env var is set.
+//!
+//! The test stands up a single-shot raw HTTP listener, points
+//! `HARN_OTEL_ENDPOINT` at it, exercises [`emit_span_start`] /
+//! [`emit_span_end`], and then drops the sink to force the batch
+//! processor to flush. The captured request body is asserted to be a
+//! `POST /v1/traces` containing the emitted span name, providing
+//! confidence that the wiring between `install_otel_sink_from_env`
+//! and the `opentelemetry-otlp` exporter is intact.
+
+#![cfg(feature = "otel")]
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use harn_vm::events::{
+    add_event_sink, clear_event_sinks, emit_span_end, emit_span_start, install_otel_sink_from_env,
+    reset_event_sinks, shutdown_otel_sink, CollectorSink,
+};
+
+/// Read the full HTTP request (headers + chunked body) into memory.
+/// The opentelemetry-otlp HTTP client uses `Content-Length`, never
+/// chunked transfer, so this short read loop is enough.
+fn read_request(stream: &mut std::net::TcpStream) -> String {
+    let mut buf = vec![0u8; 16 * 1024];
+    let mut text = String::new();
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                text.push_str(&String::from_utf8_lossy(&buf[..n]));
+                if text.contains("\r\n\r\n") {
+                    // Try to detect content-length and keep reading.
+                    if let Some(cl) = content_length(&text) {
+                        let header_end = text.find("\r\n\r\n").unwrap() + 4;
+                        if text.len() - header_end >= cl {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    text
+}
+
+fn content_length(headers: &str) -> Option<usize> {
+    for line in headers.lines() {
+        if let Some(value) = line
+            .split_once(':')
+            .filter(|(name, _)| name.trim().eq_ignore_ascii_case("content-length"))
+            .map(|(_, value)| value.trim())
+        {
+            return value.parse().ok();
+        }
+    }
+    None
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn install_otel_sink_emits_spans_to_configured_endpoint() {
+    // Stand up the single-shot HTTP listener first so the port is
+    // bound before we point the exporter at it.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind otlp stub");
+    listener.set_nonblocking(false).expect("blocking otlp stub");
+    let addr = listener.local_addr().expect("stub addr");
+
+    let received = Arc::new(Mutex::new(Vec::<String>::new()));
+    let received_clone = received.clone();
+    let stub = thread::spawn(move || {
+        // Batch flushes can issue more than one request when the
+        // exporter retries internally. Accept until the test thread
+        // closes the listener — the test does this implicitly when it
+        // drops the JoinHandle.
+        while let Ok((mut stream, _)) = listener.accept() {
+            let request = read_request(&mut stream);
+            received_clone
+                .lock()
+                .expect("stub mutex poisoned")
+                .push(request);
+            // Minimal OTLP/HTTP success response — the body is an
+            // empty `ExportTraceServiceResponse` so the client doesn't
+            // mark the export as a failure and trigger a retry storm.
+            let response =
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 2\r\nconnection: close\r\n\r\n{}";
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        }
+    });
+
+    // SAFETY: the test process is single-threaded by construction
+    // because the integration-test binary only contains this one
+    // test. No other consumer is reading these vars while we run.
+    unsafe {
+        std::env::set_var("HARN_OTEL_ENDPOINT", format!("http://{addr}"));
+        std::env::set_var("HARN_OTEL_SERVICE_NAME", "burin-otel-smoke");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+    }
+
+    // Start from an empty sink chain so we can also assert that the
+    // helper added exactly one sink.
+    clear_event_sinks();
+    let probe = std::rc::Rc::new(CollectorSink::new());
+    add_event_sink(probe.clone());
+
+    let installed =
+        install_otel_sink_from_env().expect("otel sink install failed against the loopback stub");
+    assert!(installed, "expected sink to install when endpoint is set");
+
+    // Emit one span pair. The first call to `install` registered the
+    // batch processor; emit/end go through the EventSink chain to the
+    // sink we just installed.
+    let mut start_meta = BTreeMap::new();
+    start_meta.insert("turn".to_string(), serde_json::json!(7));
+    emit_span_start(42, None, "burin.turn", "agent_loop", start_meta);
+    emit_span_end(42, BTreeMap::new());
+
+    // Sanity: our CollectorSink also received the event. This proves
+    // additional sinks coexist with the OtelSink (regression cover
+    // for accidentally clobbering the chain).
+    assert_eq!(probe.spans.borrow().len(), 1);
+    assert_eq!(probe.spans.borrow()[0].name, "burin.turn");
+
+    // Drain the batch explicitly via the public shutdown hook —
+    // mirrors what `harn-cli` does on process exit. Also clears the
+    // global provider slot so a re-run inside the same process can
+    // call `install_otel_sink_from_env` again.
+    let was_shut = shutdown_otel_sink().expect("shutdown_otel_sink errored");
+    assert!(was_shut, "expected shutdown to flush an installed provider");
+
+    // Reset the sink chain after shutdown so the OtelSink's own
+    // `Drop` is the no-op path (the provider is already shut down).
+    reset_event_sinks();
+
+    // Give the listener thread up to 5 s to receive the request. In
+    // practice the shutdown-driven flush completes well inside 50 ms;
+    // the budget guards against macOS scheduling jitter under nextest
+    // flake-detection profiles. The yield loop polls every 25 ms so
+    // we exit as soon as data arrives.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if !received.lock().expect("stub mutex poisoned").is_empty() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "OTLP stub never received an export within 5s",
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    let snapshot = received.lock().expect("stub mutex poisoned").clone();
+    let combined = snapshot.join("\n----\n");
+    assert!(
+        combined.contains("POST /v1/traces"),
+        "expected a POST to /v1/traces, got:\n{combined}",
+    );
+    assert!(
+        combined.contains("burin.turn"),
+        "expected the OTLP payload to carry the emitted span name, got:\n{combined}",
+    );
+    assert!(
+        combined.contains("burin-otel-smoke"),
+        "expected the service.name resource attribute in payload, got:\n{combined}",
+    );
+
+    // Drop the listener-owning thread by letting it fall out of scope.
+    drop(stub);
+
+    // SAFETY: see above — single-threaded test process.
+    unsafe {
+        std::env::remove_var("HARN_OTEL_ENDPOINT");
+        std::env::remove_var("HARN_OTEL_SERVICE_NAME");
+    }
+}

--- a/crates/harn-vm/tests/otel_sink_export.rs
+++ b/crates/harn-vm/tests/otel_sink_export.rs
@@ -14,7 +14,6 @@
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -22,9 +21,11 @@ use harn_vm::events::{
     add_event_sink, clear_event_sinks, emit_span_end, emit_span_start, install_otel_sink_from_env,
     reset_event_sinks, shutdown_otel_sink, CollectorSink,
 };
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::time::timeout;
 
-/// Read the full HTTP request (headers + chunked body) into memory.
-/// The opentelemetry-otlp HTTP client uses `Content-Length`, never
+/// Read the full HTTP request (headers + body) into memory.
+/// `opentelemetry-otlp`'s HTTP client uses `Content-Length`, never
 /// chunked transfer, so this short read loop is enough.
 fn read_request(stream: &mut std::net::TcpStream) -> String {
     let mut buf = vec![0u8; 16 * 1024];
@@ -35,7 +36,6 @@ fn read_request(stream: &mut std::net::TcpStream) -> String {
             Ok(n) => {
                 text.push_str(&String::from_utf8_lossy(&buf[..n]));
                 if text.contains("\r\n\r\n") {
-                    // Try to detect content-length and keep reading.
                     if let Some(cl) = content_length(&text) {
                         let header_end = text.find("\r\n\r\n").unwrap() + 4;
                         if text.len() - header_end >= cl {
@@ -65,30 +65,42 @@ fn content_length(headers: &str) -> Option<usize> {
     None
 }
 
+/// Drain any additional already-buffered requests after the first one
+/// arrives. Returns the snapshot of all requests received so far.
+async fn drain_remaining(rx: &mut UnboundedReceiver<String>, head: String) -> Vec<String> {
+    let mut out = vec![head];
+    while let Ok(Some(msg)) = timeout(Duration::from_millis(10), rx.recv()).await {
+        out.push(msg);
+    }
+    out
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn install_otel_sink_emits_spans_to_configured_endpoint() {
-    // Stand up the single-shot HTTP listener first so the port is
-    // bound before we point the exporter at it.
+    // Bind the OTLP stub before we point the exporter at it.
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind otlp stub");
     listener.set_nonblocking(false).expect("blocking otlp stub");
     let addr = listener.local_addr().expect("stub addr");
 
-    let received = Arc::new(Mutex::new(Vec::<String>::new()));
-    let received_clone = received.clone();
+    // Sync → async bridge: the stub thread pushes received requests
+    // into a tokio mpsc channel the async test awaits on. Avoids
+    // polling the shared `Vec` with wall-clock sleep + Instant
+    // comparisons — both of which the test-pattern audit forbids
+    // because they degrade into flakes under runner contention.
+    let (tx, mut rx): (UnboundedSender<String>, UnboundedReceiver<String>) =
+        mpsc::unbounded_channel();
     let stub = thread::spawn(move || {
         // Batch flushes can issue more than one request when the
-        // exporter retries internally. Accept until the test thread
-        // closes the listener — the test does this implicitly when it
-        // drops the JoinHandle.
+        // exporter retries internally. Accept until the listener is
+        // dropped — the test does this implicitly when it returns.
         while let Ok((mut stream, _)) = listener.accept() {
             let request = read_request(&mut stream);
-            received_clone
-                .lock()
-                .expect("stub mutex poisoned")
-                .push(request);
-            // Minimal OTLP/HTTP success response — the body is an
-            // empty `ExportTraceServiceResponse` so the client doesn't
-            // mark the export as a failure and trigger a retry storm.
+            // Test side may already have torn down the channel; we
+            // don't care, the listener exits cleanly either way.
+            let _ = tx.send(request);
+            // Minimal OTLP/HTTP success: empty
+            // `ExportTraceServiceResponse` so the client doesn't
+            // mark the export as a failure and retry.
             let response =
                 "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 2\r\nconnection: close\r\n\r\n{}";
             let _ = stream.write_all(response.as_bytes());
@@ -96,9 +108,8 @@ async fn install_otel_sink_emits_spans_to_configured_endpoint() {
         }
     });
 
-    // SAFETY: the test process is single-threaded by construction
-    // because the integration-test binary only contains this one
-    // test. No other consumer is reading these vars while we run.
+    // SAFETY: the integration-test binary contains only this one
+    // test, so no other consumer is reading these vars while we run.
     unsafe {
         std::env::set_var("HARN_OTEL_ENDPOINT", format!("http://{addr}"));
         std::env::set_var("HARN_OTEL_SERVICE_NAME", "burin-otel-smoke");
@@ -115,9 +126,6 @@ async fn install_otel_sink_emits_spans_to_configured_endpoint() {
         install_otel_sink_from_env().expect("otel sink install failed against the loopback stub");
     assert!(installed, "expected sink to install when endpoint is set");
 
-    // Emit one span pair. The first call to `install` registered the
-    // batch processor; emit/end go through the EventSink chain to the
-    // sink we just installed.
     let mut start_meta = BTreeMap::new();
     start_meta.insert("turn".to_string(), serde_json::json!(7));
     emit_span_start(42, None, "burin.turn", "agent_loop", start_meta);
@@ -136,28 +144,18 @@ async fn install_otel_sink_emits_spans_to_configured_endpoint() {
     let was_shut = shutdown_otel_sink().expect("shutdown_otel_sink errored");
     assert!(was_shut, "expected shutdown to flush an installed provider");
 
-    // Reset the sink chain after shutdown so the OtelSink's own
-    // `Drop` is the no-op path (the provider is already shut down).
     reset_event_sinks();
 
-    // Give the listener thread up to 5 s to receive the request. In
-    // practice the shutdown-driven flush completes well inside 50 ms;
-    // the budget guards against macOS scheduling jitter under nextest
-    // flake-detection profiles. The yield loop polls every 25 ms so
-    // we exit as soon as data arrives.
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        if !received.lock().expect("stub mutex poisoned").is_empty() {
-            break;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "OTLP stub never received an export within 5s",
-        );
-        tokio::time::sleep(Duration::from_millis(25)).await;
-    }
+    // Wait for the first request through the channel. The 5 s
+    // budget guards against macOS scheduling jitter under
+    // flake-detection profiles; the typical path completes in under
+    // 50 ms because `shutdown_otel_sink` blocks on `force_flush`.
+    let first = timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("OTLP stub never received an export within 5s")
+        .expect("OTLP stub channel closed unexpectedly");
+    let snapshot = drain_remaining(&mut rx, first).await;
 
-    let snapshot = received.lock().expect("stub mutex poisoned").clone();
     let combined = snapshot.join("\n----\n");
     assert!(
         combined.contains("POST /v1/traces"),
@@ -172,7 +170,6 @@ async fn install_otel_sink_emits_spans_to_configured_endpoint() {
         "expected the service.name resource attribute in payload, got:\n{combined}",
     );
 
-    // Drop the listener-owning thread by letting it fall out of scope.
     drop(stub);
 
     // SAFETY: see above — single-threaded test process.


### PR DESCRIPTION
## Summary
- Add `events::install_otel_sink_from_env()` that wires the existing `OtelSink` into the thread-local event-sink chain whenever `HARN_OTEL_ENDPOINT` (or the standard `OTEL_EXPORTER_OTLP_ENDPOINT`) is set; called once from `harn-cli`'s `async_main` so every subcommand benefits.
- Pair it with `events::shutdown_otel_sink()` invoked after `block_on` returns — `BatchSpanProcessor` with `runtime::Tokio` needs a live reactor to drain, so short-lived `harn run` invocations would otherwise drop tail-end spans when the runtime drops before the sink's own `Drop`.
- Plumb `HARN_OTEL_SERVICE_NAME` / `OTEL_SERVICE_NAME` (default `"harn"`) and `HARN_OTEL_HEADERS` / `OTEL_EXPORTER_OTLP_HEADERS` through `OtelSink::new` so collectors that need header-based auth (Honeycomb team ID, etc.) can be configured purely from env.

## Why
`OtelSink` already shipped in every release build (`harn-cli/Cargo.toml` hard-codes `features = ["otel"]` on `harn-vm`), but `rg "OtelSink::new"` returned zero callers in production — the sink was dead code. Bundled hosts (`harn run`, `harn serve acp`, embedders like burin-code) had no path to export local spans even with the cargo feature enabled. Unblocks burin-labs/burin-code#1290 (Local OTel exporter for 20+ min autonomous sessions). Composes with `harn-cloud-otel` for cloud ingestion when the user points their endpoint there.

## Test plan
- [x] `cargo test -p harn-vm --features otel --test otel_sink_export` — new integration test stands up a single-shot OTLP/HTTP listener, sets `HARN_OTEL_ENDPOINT`, emits one `burin.turn` span, and asserts the export arrives with the expected `service.name` resource attribute. <2 s wall-clock.
- [x] `cargo test -p harn-vm --features otel events::` — 41 unit tests pass, including the new `otel_env` module covering env-var precedence, whitespace handling, header parsing, and trace-endpoint normalization (lock-guarded under a per-test mutex; existing `unsafe { set_var }` pattern from `llm/api/ollama.rs`).
- [x] `cargo clippy -p harn-vm --features otel --tests -p harn-cli --tests` — clean.
- [x] Manual smoke test against the bundled `harn run` path: a tiny Node OTLP stub on `127.0.0.1:<port>`, `HARN_OTEL_ENDPOINT=http://127.0.0.1:<port>` + `HARN_OTEL_SERVICE_NAME=burin-smoke-e2e`, runs a `.harn` script that emits a `burin.turn` span via `__lifecycle_span_start`/`__lifecycle_span_end`, and confirms the stub received `POST /v1/traces` with the expected `service.name`, `traceId`, and `spans[0].name`.

## Cross-language
The env-var contract is intentionally Harn-agnostic — span names, attribute keys, and the OTLP/HTTP protocol shape don't reference any concrete programming language, so the same wiring lights up for any language Harn instruments.

## Out of scope
- Redaction-policy env-var entrypoint. `OtelSink` continues to use `crate::redact::current_policy()`, which defaults to `RedactionPolicy::default()` (strict). A future PR can add `HARN_REDACTION_POLICY=strict|permissive|raw` if hosts want a one-knob runtime override; until then the pipeline-level `redact::push_policy` API stays the canonical way to tune it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)