### PR TITLE
[A.2] harn-serve: tenant_id propagation (DispatchCtx + AuthRequest + EventLog + .harn ambient)

### DIFF
--- a/changelog.d/2499.added.md
+++ b/changelog.d/2499.added.md
@@ -1,0 +1,17 @@
+- **`tenant_id` propagation through `harn-serve`.** `AuthRequest`,
+  `AuthenticatedPrincipal`, `OAuthClaims`, `ApiKeyEntry`, `HmacAuthConfig`,
+  `OAuth21AuthConfig`, and `CallRequest` now carry an optional
+  `TenantId`. `DispatchCore` resolves it (request override → principal →
+  none), installs a `harn_vm::enter_tenant` scope for the dispatched
+  callable, records it as a trust-graph metadata field, and surfaces it
+  as a `tenant_id` span attribute on `harn_serve.dispatch`.
+- **`harness.tenant.id()` ambient.** New `HarnessTenant` sub-handle
+  (typechecked, dispatched through `HarnessKind::Tenant`) returns the
+  active tenant id string and raises a typed `ErrorCategory::Auth`
+  runtime error when no tenant is bound. `harness.tenant.try_id()`
+  returns `nil` instead for branchable callers.
+- **DispatchCore auto-injects the `harness` capability handle.**
+  Exported `pub fn foo(harness: Harness, ...)` now receives the runtime
+  handle without the caller having to encode one through `CallArguments`
+  — closes a pre-existing gap where dispatched scripts could not reach
+  any `harness.*` surface.

--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -709,6 +709,7 @@ fn script_http_auth_request(
         body,
         headers: script_normalized_headers(headers),
         validated_oauth: None,
+        tenant_id: None,
     }
 }
 
@@ -834,6 +835,7 @@ fn build_auth_policy(api_keys: &[String], hmac_secret: Option<&String>) -> AuthP
             provider: "harn-serve".to_string(),
             timestamp_window: Duration::seconds(300),
             granted_scopes: BTreeSet::new(),
+            tenant_id: None,
         }));
     }
     AuthPolicy { methods }

--- a/crates/harn-parser/src/harness_methods.rs
+++ b/crates/harn-parser/src/harness_methods.rs
@@ -124,6 +124,14 @@ pub fn harness_llm_ambient(method: &str) -> Option<&'static str> {
     }
 }
 
+pub fn harness_tenant_ambient(method: &str) -> Option<&'static str> {
+    match method {
+        "id" => Some("harness_tenant_id"),
+        "try_id" => Some("harness_tenant_try_id"),
+        _ => None,
+    }
+}
+
 pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'static str> {
     match sub_handle {
         "stdio" => harness_stdio_ambient(method),
@@ -137,6 +145,7 @@ pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'st
         "crypto" => harness_crypto_ambient(method),
         "system" => harness_system_ambient(method),
         "llm" => harness_llm_ambient(method),
+        "tenant" => harness_tenant_ambient(method),
         _ => None,
     }
 }
@@ -154,6 +163,7 @@ pub fn harness_type_sub_handle(type_name: &str) -> Option<&'static str> {
         "HarnessCrypto" => Some("crypto"),
         "HarnessSystem" => Some("system"),
         "HarnessLlm" => Some("llm"),
+        "HarnessTenant" => Some("tenant"),
         _ => None,
     }
 }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -948,6 +948,7 @@ impl TypeChecker {
                 "crypto" => Some(TypeExpr::Named("HarnessCrypto".into())),
                 "system" => Some(TypeExpr::Named("HarnessSystem".into())),
                 "llm" => Some(TypeExpr::Named("HarnessLlm".into())),
+                "tenant" => Some(TypeExpr::Named("HarnessTenant".into())),
                 _ if optional => Some(TypeExpr::Named("nil".into())),
                 _ => None,
             },

--- a/crates/harn-serve/src/adapters/a2a/schema.rs
+++ b/crates/harn-serve/src/adapters/a2a/schema.rs
@@ -1088,6 +1088,7 @@ pub(super) fn http_auth_request(
         body,
         headers: normalized_headers(headers),
         validated_oauth: None,
+        tenant_id: None,
     }
 }
 

--- a/crates/harn-serve/src/adapters/a2a/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tasks.rs
@@ -118,6 +118,7 @@ impl A2aServer {
                 cancel_token: Some(task.cancel_token.clone()),
                 agent_session_id: Some(session_id.clone()),
                 progress: None,
+                tenant_id: None,
             })
             .await;
 

--- a/crates/harn-serve/src/adapters/a2a/tests/protocol.rs
+++ b/crates/harn-serve/src/adapters/a2a/tests/protocol.rs
@@ -767,6 +767,7 @@ fn auth_request_with_bearer(token: &str) -> AuthRequest {
             format!("Bearer {token}"),
         )]),
         validated_oauth: None,
+        tenant_id: None,
     }
 }
 

--- a/crates/harn-serve/src/adapters/acp/auth.rs
+++ b/crates/harn-serve/src/adapters/acp/auth.rs
@@ -64,6 +64,7 @@ pub(super) fn acp_auth_request_for_method(
             .unwrap_or_default(),
         headers: harn_auth_headers(meta),
         validated_oauth: None,
+        tenant_id: None,
     };
 
     match method {

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -1940,6 +1940,7 @@ async fn authorize(
         body: body.to_vec(),
         headers: headers_to_map(headers),
         validated_oauth: None,
+        tenant_id: None,
     };
     match state.auth_policy.authorize(&request).await {
         AuthorizationDecision::Authorized(_) => Ok(()),

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -326,6 +326,7 @@ impl McpServer {
                 body: line.into_bytes(),
                 headers: BTreeMap::new(),
                 validated_oauth: None,
+                tenant_id: None,
             };
             self.clone()
                 .handle_stdio_message(request, session.clone(), auth, tx.clone())

--- a/crates/harn-serve/src/adapters/mcp/auth.rs
+++ b/crates/harn-serve/src/adapters/mcp/auth.rs
@@ -13,6 +13,7 @@ pub(super) fn http_auth_request(
         body,
         headers: normalized_headers(headers),
         validated_oauth: None,
+        tenant_id: None,
     }
 }
 

--- a/crates/harn-serve/src/adapters/mcp/schema.rs
+++ b/crates/harn-serve/src/adapters/mcp/schema.rs
@@ -35,6 +35,7 @@ pub(super) fn build_call_request(
         cancel_token: Some(cancel_token),
         agent_session_id: None,
         progress,
+        tenant_id: None,
     })
 }
 

--- a/crates/harn-serve/src/auth.rs
+++ b/crates/harn-serve/src/auth.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use harn_vm::connectors::ConnectorError;
 use harn_vm::event_log::MemoryEventLog;
-use harn_vm::ProviderId;
+use harn_vm::{ProviderId, TenantId};
 use subtle::ConstantTimeEq;
 use time::{Duration, OffsetDateTime};
 
@@ -13,6 +13,13 @@ pub struct AuthenticatedPrincipal {
     /// Scopes the credential carries. Compared against the per-route
     /// `required_scopes` passed to `AuthPolicy::authorize_with_scopes`.
     pub granted_scopes: BTreeSet<String>,
+    /// Tenant the credential is bound to. Populated by API-key /
+    /// HMAC / OAuth verification when the configured method ties the
+    /// credential to a specific `TenantId`; `None` means the
+    /// credential is tenant-agnostic (e.g. an open-permissions key, or
+    /// an admin/system bearer). Threaded through `DispatchCtx` into
+    /// the `.harn` callee as `harness.tenant.id()`.
+    pub tenant_id: Option<TenantId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -21,6 +28,12 @@ pub struct OAuthClaims {
     pub issuer: String,
     pub audience: Option<String>,
     pub scopes: BTreeSet<String>,
+    /// Tenant claim the transport extracted from the verified JWT
+    /// (typically `tenant_id`, `tid`, or a custom claim configured per
+    /// deployment). When the auth policy's `OAuth21AuthConfig` does not
+    /// pick a specific claim name, this is the trusted fallback the
+    /// transport itself believes refers to the tenant.
+    pub tenant_id: Option<TenantId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -30,6 +43,14 @@ pub struct AuthRequest {
     pub body: Vec<u8>,
     pub headers: BTreeMap<String, String>,
     pub validated_oauth: Option<OAuthClaims>,
+    /// Tenant the transport resolved ahead of authentication (e.g. a
+    /// cloud gateway that looks up the API key in its own store and
+    /// hands `harn-serve` the result). When set, it wins over whatever
+    /// the configured auth method would resolve, so the same
+    /// `AuthPolicy` works for both first-party API key configs and
+    /// transports that own tenant resolution. `None` means defer to
+    /// the auth method.
+    pub tenant_id: Option<TenantId>,
 }
 
 impl AuthRequest {
@@ -68,6 +89,11 @@ fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option
 pub struct ApiKeyEntry {
     pub key: String,
     pub scopes: BTreeSet<String>,
+    /// Tenant the key is bound to. When set, every authenticated
+    /// dispatch under this key carries the tenant into `DispatchCtx`
+    /// and the `harness.tenant` ambient. `None` means a tenant-agnostic
+    /// key — useful for single-tenant deployments and integration tests.
+    pub tenant_id: Option<TenantId>,
 }
 
 impl ApiKeyEntry {
@@ -75,7 +101,15 @@ impl ApiKeyEntry {
         Self {
             key: key.into(),
             scopes: scopes.into_iter().collect(),
+            tenant_id: None,
         }
+    }
+
+    /// Bind this key to a tenant. Chainable so callers can construct
+    /// the entry in one expression: `ApiKeyEntry::new("k", scopes).with_tenant("acme")`.
+    pub fn with_tenant(mut self, tenant: impl Into<String>) -> Self {
+        self.tenant_id = Some(TenantId::new(tenant));
+        self
     }
 }
 
@@ -102,6 +136,11 @@ pub struct HmacAuthConfig {
     pub timestamp_window: Duration,
     /// Scopes any caller authenticated via this shared secret carries.
     pub granted_scopes: BTreeSet<String>,
+    /// Tenant any caller authenticated via this shared secret is bound
+    /// to. `None` leaves the dispatch tenant-agnostic — appropriate for
+    /// single-tenant deployments or callers that resolve tenancy out of
+    /// band (e.g. from the canonical request body).
+    pub tenant_id: Option<TenantId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -113,6 +152,12 @@ pub struct OAuth21AuthConfig {
     /// can pin a baseline (e.g. `harn:invoke`) without repeating it on every
     /// route mount.
     pub required_scopes: BTreeSet<String>,
+    /// Tenant fallback when the verified JWT did not carry a
+    /// `tenant_id` claim (or the transport did not extract one).
+    /// Useful for single-tenant OAuth deployments where every token is
+    /// implicitly bound to the same tenant. The transport-supplied
+    /// `OAuthClaims.tenant_id` still wins when present.
+    pub tenant_id: Option<TenantId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -183,11 +228,12 @@ impl AuthPolicy {
         request: &AuthRequest,
         required: &BTreeSet<String>,
     ) -> AuthorizationDecision {
-        let principal = if self.methods.is_empty() {
+        let mut principal = if self.methods.is_empty() {
             AuthenticatedPrincipal {
                 subject: "anonymous".to_string(),
                 scheme: "none".to_string(),
                 granted_scopes: BTreeSet::new(),
+                tenant_id: None,
             }
         } else {
             let mut failures = Vec::new();
@@ -206,6 +252,15 @@ impl AuthPolicy {
                 None => return AuthorizationDecision::Rejected(failures.join("; ")),
             }
         };
+
+        // Transports that resolve tenancy themselves (e.g. an upstream
+        // cloud gateway that owns the API-key → tenant lookup) hand the
+        // result in via `AuthRequest.tenant_id`. That override wins so
+        // operators can swap auth methods without rewiring how the
+        // tenant is sourced.
+        if let Some(override_tenant) = request.tenant_id.clone() {
+            principal.tenant_id = Some(override_tenant);
+        }
 
         if !required.is_subset(&principal.granted_scopes) {
             return AuthorizationDecision::MissingScope {
@@ -313,6 +368,7 @@ async fn authorize_method(
                     subject: "api-key".to_string(),
                     scheme: "api_key".to_string(),
                     granted_scopes: entry.scopes.clone(),
+                    tenant_id: entry.tenant_id.clone(),
                 }),
                 None => Err("invalid API key".to_string()),
             }
@@ -336,6 +392,7 @@ async fn authorize_method(
                 subject: "hmac".to_string(),
                 scheme: "hmac".to_string(),
                 granted_scopes: config.granted_scopes.clone(),
+                tenant_id: config.tenant_id.clone(),
             })
         }
         AuthMethodConfig::OAuth21(config) => {
@@ -361,6 +418,14 @@ async fn authorize_method(
                 subject: claims.subject.clone(),
                 scheme: "oauth21".to_string(),
                 granted_scopes: claims.scopes.clone(),
+                // Token-borne claim wins, with the policy-level
+                // fallback (`OAuth21AuthConfig.tenant_id`) covering
+                // single-tenant deployments where every token implicitly
+                // belongs to the same tenant.
+                tenant_id: claims
+                    .tenant_id
+                    .clone()
+                    .or_else(|| config.tenant_id.clone()),
             })
         }
     }
@@ -424,6 +489,7 @@ mod tests {
                     provider: "harn-serve".to_string(),
                     timestamp_window: Duration::seconds(60),
                     granted_scopes: BTreeSet::new(),
+                    tenant_id: None,
                 }),
                 AuthMethodConfig::ApiKey(ApiKeyAuthConfig::single("second")),
             ],
@@ -458,6 +524,7 @@ mod tests {
                 provider: "harn-serve".to_string(),
                 timestamp_window: Duration::seconds(60),
                 granted_scopes: BTreeSet::new(),
+                tenant_id: None,
             })],
         };
         let request = AuthRequest {
@@ -466,6 +533,7 @@ mod tests {
             body: body.to_vec(),
             headers: BTreeMap::from([("authorization".to_string(), authorization)]),
             validated_oauth: None,
+            tenant_id: None,
         };
 
         let decision = policy.authorize(&request).await;
@@ -479,6 +547,7 @@ mod tests {
                 issuer: "https://issuer.example".to_string(),
                 audience: Some("harn-serve".to_string()),
                 required_scopes: scopes(&["invoke"]),
+                tenant_id: None,
             })],
         };
         let request = AuthRequest {
@@ -487,6 +556,7 @@ mod tests {
                 issuer: "https://issuer.example".to_string(),
                 audience: Some("harn-serve".to_string()),
                 scopes: scopes(&["invoke", "read"]),
+                tenant_id: None,
             }),
             ..AuthRequest::default()
         };
@@ -498,6 +568,7 @@ mod tests {
                 subject: "alice".to_string(),
                 scheme: "oauth21".to_string(),
                 granted_scopes: scopes(&["invoke", "read"]),
+                tenant_id: None,
             })
         );
     }
@@ -509,6 +580,7 @@ mod tests {
                 issuer: "https://issuer.example".to_string(),
                 audience: Some("harn-serve".to_string()),
                 required_scopes: BTreeSet::new(),
+                tenant_id: None,
             })],
         };
         let request = AuthRequest {
@@ -517,6 +589,7 @@ mod tests {
                 issuer: "https://issuer.example".to_string(),
                 audience: None,
                 scopes: BTreeSet::new(),
+                tenant_id: None,
             }),
             ..AuthRequest::default()
         };
@@ -644,6 +717,7 @@ mod tests {
                 provider: "harn-serve".to_string(),
                 timestamp_window: Duration::seconds(60),
                 granted_scopes: scopes(&["personas:read"]),
+                tenant_id: None,
             })],
         };
         let request = AuthRequest {
@@ -652,6 +726,7 @@ mod tests {
             body: body.to_vec(),
             headers: BTreeMap::from([("authorization".to_string(), authorization)]),
             validated_oauth: None,
+            tenant_id: None,
         };
 
         let decision = policy
@@ -661,6 +736,100 @@ mod tests {
             panic!("expected Authorized");
         };
         assert_eq!(principal.granted_scopes, scopes(&["personas:read"]));
+    }
+
+    #[tokio::test]
+    async fn api_key_with_tenant_carries_tenant_into_principal() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::ApiKey(ApiKeyAuthConfig {
+                keys: vec![ApiKeyEntry::new("tenant-key", []).with_tenant("acme")],
+            })],
+        };
+        let request = AuthRequest {
+            headers: BTreeMap::from([(
+                "authorization".to_string(),
+                "Bearer tenant-key".to_string(),
+            )]),
+            ..AuthRequest::default()
+        };
+
+        let AuthorizationDecision::Authorized(principal) = policy.authorize(&request).await else {
+            panic!("expected Authorized");
+        };
+        assert_eq!(principal.tenant_id, Some(TenantId::new("acme")));
+    }
+
+    #[tokio::test]
+    async fn request_tenant_override_wins_over_method_tenant() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::ApiKey(ApiKeyAuthConfig {
+                keys: vec![ApiKeyEntry::new("key", []).with_tenant("baseline")],
+            })],
+        };
+        let request = AuthRequest {
+            headers: BTreeMap::from([("authorization".to_string(), "Bearer key".to_string())]),
+            tenant_id: Some(TenantId::new("override")),
+            ..AuthRequest::default()
+        };
+
+        let AuthorizationDecision::Authorized(principal) = policy.authorize(&request).await else {
+            panic!("expected Authorized");
+        };
+        assert_eq!(principal.tenant_id, Some(TenantId::new("override")));
+    }
+
+    #[tokio::test]
+    async fn oauth_claims_tenant_wins_over_policy_fallback() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::OAuth21(OAuth21AuthConfig {
+                issuer: "https://issuer.example".to_string(),
+                audience: None,
+                required_scopes: BTreeSet::new(),
+                tenant_id: Some(TenantId::new("policy-default")),
+            })],
+        };
+        let request = AuthRequest {
+            validated_oauth: Some(OAuthClaims {
+                subject: "alice".to_string(),
+                issuer: "https://issuer.example".to_string(),
+                audience: None,
+                scopes: BTreeSet::new(),
+                tenant_id: Some(TenantId::new("token-bound")),
+            }),
+            ..AuthRequest::default()
+        };
+
+        let AuthorizationDecision::Authorized(principal) = policy.authorize(&request).await else {
+            panic!("expected Authorized");
+        };
+        assert_eq!(principal.tenant_id, Some(TenantId::new("token-bound")));
+    }
+
+    #[tokio::test]
+    async fn oauth_policy_fallback_tenant_used_when_claims_have_none() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::OAuth21(OAuth21AuthConfig {
+                issuer: "https://issuer.example".to_string(),
+                audience: None,
+                required_scopes: BTreeSet::new(),
+                tenant_id: Some(TenantId::new("policy-default")),
+            })],
+        };
+        let request = AuthRequest {
+            validated_oauth: Some(OAuthClaims {
+                subject: "alice".to_string(),
+                issuer: "https://issuer.example".to_string(),
+                audience: None,
+                scopes: BTreeSet::new(),
+                tenant_id: None,
+            }),
+            ..AuthRequest::default()
+        };
+
+        let AuthorizationDecision::Authorized(principal) = policy.authorize(&request).await else {
+            panic!("expected Authorized");
+        };
+        assert_eq!(principal.tenant_id, Some(TenantId::new("policy-default")));
     }
 
     #[tokio::test]

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -12,7 +12,7 @@ use harn_vm::event_log::{
 use harn_vm::llm::vm_value_to_json;
 use harn_vm::mcp_progress::ProgressContext;
 use harn_vm::trust_graph::{append_trust_record, AutonomyTier, TrustOutcome, TrustRecord};
-use harn_vm::{TraceId, Vm, VmValue};
+use harn_vm::{TenantId, TraceId, Vm, VmValue};
 use tokio::task::LocalSet;
 use tracing::Instrument;
 
@@ -75,6 +75,13 @@ pub struct CallRequest {
     /// the MCP transport adapter populates this today; other adapters
     /// leave it `None` and the builtin is a no-op.
     pub progress: Option<ProgressContext>,
+    /// Tenant the adapter wants this dispatch to run under, overriding
+    /// whatever `AuthPolicy` resolves from the credential. Set this
+    /// when the transport already owns tenant resolution (e.g. an
+    /// upstream cloud gateway that mapped the API key to a tenant in
+    /// its own store before forwarding the call). When `None`, the
+    /// tenant is sourced from the authenticated principal.
+    pub tenant_id: Option<TenantId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -165,7 +172,7 @@ impl DispatchCore {
         self.event_log.clone()
     }
 
-    pub async fn dispatch(&self, request: CallRequest) -> Result<CallResponse, DispatchError> {
+    pub async fn dispatch(&self, mut request: CallRequest) -> Result<CallResponse, DispatchError> {
         let trace_id = request.trace_id.clone().unwrap_or_default();
         let function_scopes = self
             .catalog
@@ -178,7 +185,16 @@ impl DispatchCore {
             .authorize_with_scopes(&request.auth, &function_scopes)
             .await;
         match authorization {
-            AuthorizationDecision::Authorized(_) => {}
+            AuthorizationDecision::Authorized(principal) => {
+                // Adapter-supplied tenants override; otherwise the
+                // authenticated principal's tenant wins. Resolving here
+                // (not later inside `invoke_*`) keeps trust records and
+                // span attributes consistent with the value the .harn
+                // callee actually sees.
+                if request.tenant_id.is_none() {
+                    request.tenant_id = principal.tenant_id;
+                }
+            }
             AuthorizationDecision::Rejected(message) => {
                 self.record_trust(
                     &request,
@@ -228,6 +244,12 @@ impl DispatchCore {
             }
         }
 
+        // tenant_id is a low-cardinality routing key (one entry per
+        // tenant), not PII — safe to record as a span attribute so
+        // exporters can filter traces by tenant. `Empty` until populated
+        // so the absent case isn't recorded as the literal string
+        // `"None"`. Recorded once after the span opens, mirroring how
+        // OTEL bindings expect span attributes to be set.
         let span = tracing::info_span!(
             target: "harn.serve",
             "harn_serve.dispatch",
@@ -235,7 +257,11 @@ impl DispatchCore {
             function = %request.function,
             caller = %request.caller,
             trace_id = %trace_id.0,
+            tenant_id = tracing::field::Empty,
         );
+        if let Some(tenant) = request.tenant_id.as_ref() {
+            span.record("tenant_id", tenant.0.as_str());
+        }
         let _ = harn_vm::observability::otel::set_span_parent(
             &span,
             &trace_id,
@@ -337,6 +363,7 @@ impl DispatchCore {
         let agent_session_id = request.agent_session_id.clone();
         let progress = request.progress.clone();
 
+        let tenant_id = request.tenant_id.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -345,6 +372,7 @@ impl DispatchCore {
                     harn_vm::agent_sessions::open_or_create(Some(session_id.to_string()));
                     harn_vm::agent_sessions::enter_current_session(session_id.to_string())
                 });
+                let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -354,6 +382,7 @@ impl DispatchCore {
                 vm.set_source_info(&script_path.display().to_string(), &source);
                 vm.set_source_dir(store_base);
                 vm.install_cancel_token(cancel_token);
+                vm.set_harness(harn_vm::Harness::real());
                 self.config.vm_configurator.configure(&mut vm)?;
 
                 let exports = vm
@@ -367,7 +396,7 @@ impl DispatchCore {
                         script_path.display()
                     )));
                 };
-                let args = build_vm_args(&request.arguments, function)?;
+                let args = build_vm_args(&request.arguments, function, &vm)?;
                 let result = vm.call_closure_pub(closure, &args).await;
 
                 match result {
@@ -416,6 +445,7 @@ impl DispatchCore {
         let agent_session_id = request.agent_session_id.clone();
         let progress = request.progress.clone();
 
+        let tenant_id = request.tenant_id.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -424,6 +454,7 @@ impl DispatchCore {
                     harn_vm::agent_sessions::open_or_create(Some(session_id.to_string()));
                     harn_vm::agent_sessions::enter_current_session(session_id.to_string())
                 });
+                let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -433,6 +464,7 @@ impl DispatchCore {
                 vm.set_source_info(&script_path.display().to_string(), &source);
                 vm.set_source_dir(store_base);
                 vm.install_cancel_token(cancel_token);
+                vm.set_harness(harn_vm::Harness::real());
                 self.config.vm_configurator.configure(&mut vm)?;
                 for (name, value) in globals {
                     vm.set_global(&name, value);
@@ -482,6 +514,11 @@ impl DispatchCore {
         record
             .metadata
             .insert("function".to_string(), serde_json::json!(request.function));
+        if let Some(tenant) = request.tenant_id.as_ref() {
+            record
+                .metadata
+                .insert("tenant_id".to_string(), serde_json::json!(tenant.0));
+        }
         if let Some(error) = error {
             record
                 .metadata
@@ -499,13 +536,39 @@ impl DispatchCore {
 fn build_vm_args(
     arguments: &CallArguments,
     function: &crate::ExportedFunction,
+    vm: &Vm,
 ) -> Result<Vec<VmValue>, DispatchError> {
-    match arguments {
-        CallArguments::Positional(values) => Ok(values.iter().map(json_to_vm_value).collect()),
+    let mut params = function.params.as_slice();
+    let mut prefix = Vec::new();
+    // Exported `pub fn foo(harness: Harness, ...)` opts the function
+    // into the runtime-supplied capability handle the same way
+    // top-level `fn main(harness: Harness)` does. The dispatch surface
+    // hands JSON in, so the host fills the slot from
+    // `vm.set_harness(...)` instead of asking the caller to encode a
+    // Harness through CallArguments. Only the first positional slot
+    // qualifies (matches the language convention).
+    if first_param_is_harness(function) {
+        let harness = vm
+            .global("harness")
+            .ok_or_else(|| {
+                DispatchError::Execution(
+                    "Harness handle not installed; DispatchCore must call vm.set_harness() before invoking exported functions that take a harness param"
+                        .to_string(),
+                )
+            })?
+            .clone();
+        prefix.push(harness);
+        params = &params[1..];
+    }
+
+    let rest = match arguments {
+        CallArguments::Positional(values) => {
+            values.iter().map(json_to_vm_value).collect::<Vec<_>>()
+        }
         CallArguments::Named(values) => {
             let mut args = Vec::new();
             let mut saw_gap = false;
-            for param in &function.params {
+            for param in params {
                 let value = values.get(&param.name);
                 match value {
                     Some(value) => {
@@ -528,9 +591,24 @@ fn build_vm_args(
                     }
                 }
             }
-            Ok(trim_trailing_defaults(args))
+            trim_trailing_defaults(args)
         }
-    }
+    };
+
+    prefix.extend(rest);
+    Ok(prefix)
+}
+
+/// `true` when the first exported param is the canonical `harness`
+/// capability handle slot. Type annotation is optional (most pubs use
+/// untyped `harness` in stdlib) so we only check the name; the
+/// typechecker still enforces the `Harness` type in declared signatures.
+fn first_param_is_harness(function: &crate::ExportedFunction) -> bool {
+    function
+        .params
+        .first()
+        .map(|param| param.name == "harness")
+        .unwrap_or(false)
 }
 
 fn build_pipeline_globals(
@@ -641,6 +719,7 @@ pub fn greet(name: string) -> string {
                 cancel_token: None,
                 agent_session_id: None,
                 progress: None,
+                tenant_id: None,
             })
             .await
             .expect("dispatch");
@@ -681,6 +760,7 @@ pipeline default(task) {
                 cancel_token: None,
                 agent_session_id: None,
                 progress: None,
+                tenant_id: None,
             })
             .await
             .expect("dispatch");
@@ -738,6 +818,7 @@ pub fn greet(name: string) -> string {
                 cancel_token: None,
                 agent_session_id: None,
                 progress: None,
+                tenant_id: None,
             })
             .await
             .expect("dispatch");
@@ -774,6 +855,7 @@ pub fn inspect(upload: string) -> string {
             cancel_token: None,
             agent_session_id: None,
             progress: None,
+            tenant_id: None,
         };
 
         let first = core
@@ -825,6 +907,7 @@ pub fn greet(name: string) -> string {
                 cancel_token: None,
                 agent_session_id: None,
                 progress: None,
+                tenant_id: None,
             })
             .await
             .expect("dispatch");
@@ -873,10 +956,179 @@ pub fn spin() -> string {
                 cancel_token: Some(cancel_token),
                 agent_session_id: None,
                 progress: None,
+                tenant_id: None,
             })
             .await
             .expect("dispatch");
 
         assert_eq!(response.value, serde_json::json!("stopped"));
+    }
+
+    /// `.harn` callees see the tenant the host bound via
+    /// `AuthPolicy` — the `ApiKeyEntry` was configured with a tenant,
+    /// the principal carries it forward, and `DispatchCore::dispatch`
+    /// installs the [`harn_vm::enter_tenant`] guard so the script's
+    /// `harness.tenant.id()` returns the same id end-to-end.
+    #[tokio::test]
+    async fn dispatch_threads_api_key_tenant_into_harness_and_trust_record() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r"
+pub fn whoami(harness: Harness) -> string {
+  return harness.tenant.id()
+}
+",
+        )
+        .expect("write script");
+
+        let mut config = DispatchCoreConfig::for_script(&script);
+        config.auth_policy = crate::auth::AuthPolicy {
+            methods: vec![crate::auth::AuthMethodConfig::ApiKey(
+                crate::auth::ApiKeyAuthConfig {
+                    keys: vec![
+                        crate::auth::ApiKeyEntry::new("alice-key", []).with_tenant("acme-corp")
+                    ],
+                },
+            )],
+        };
+        let core = DispatchCore::new(config).expect("core");
+
+        let response = core
+            .dispatch(CallRequest {
+                adapter: "mcp".to_string(),
+                function: "whoami".to_string(),
+                arguments: CallArguments::Positional(Vec::new()),
+                auth: AuthRequest {
+                    headers: BTreeMap::from([(
+                        "authorization".to_string(),
+                        "Bearer alice-key".to_string(),
+                    )]),
+                    ..AuthRequest::default()
+                },
+                caller: "tester".to_string(),
+                replay_key: Some("tenant-whoami".to_string()),
+                trace_id: None,
+                parent_span_id: None,
+                metadata: BTreeMap::new(),
+                cancel_token: None,
+                agent_session_id: None,
+                progress: None,
+                tenant_id: None,
+            })
+            .await
+            .expect("dispatch");
+
+        assert_eq!(response.value, serde_json::json!("acme-corp"));
+
+        let records =
+            harn_vm::query_trust_records(&core.event_log, &harn_vm::TrustQueryFilters::default())
+                .await
+                .expect("records");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].metadata["tenant_id"], "acme-corp");
+    }
+
+    /// `harness.tenant.id()` raises a typed runtime error (categorized
+    /// as `auth`) when the dispatch was not bound to a tenant. The
+    /// dispatch surface then maps it through the standard `Execution`
+    /// error envelope so callers see the canonical message.
+    #[tokio::test]
+    async fn dispatch_missing_tenant_raises_typed_runtime_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r"
+pub fn whoami(harness: Harness) -> string {
+  return harness.tenant.id()
+}
+",
+        )
+        .expect("write script");
+
+        let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+        let error = core
+            .dispatch(CallRequest {
+                adapter: "mcp".to_string(),
+                function: "whoami".to_string(),
+                arguments: CallArguments::Positional(Vec::new()),
+                auth: AuthRequest::default(),
+                caller: "tester".to_string(),
+                replay_key: Some("missing-tenant".to_string()),
+                trace_id: None,
+                parent_span_id: None,
+                metadata: BTreeMap::new(),
+                cancel_token: None,
+                agent_session_id: None,
+                progress: None,
+                tenant_id: None,
+            })
+            .await
+            .expect_err("missing tenant should error");
+
+        let message = error.message();
+        assert!(
+            message.contains("harness.tenant.id()"),
+            "expected typed tenant error, got: {message}"
+        );
+    }
+
+    /// `CallRequest.tenant_id` overrides the principal-supplied tenant
+    /// — covers the case where an upstream gateway already resolved
+    /// tenancy out-of-band and hands the answer to harn-serve.
+    #[tokio::test]
+    async fn dispatch_request_tenant_overrides_principal_tenant() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            r"
+pub fn whoami(harness: Harness) -> string {
+  return harness.tenant.id()
+}
+",
+        )
+        .expect("write script");
+
+        let mut config = DispatchCoreConfig::for_script(&script);
+        config.auth_policy = crate::auth::AuthPolicy {
+            methods: vec![crate::auth::AuthMethodConfig::ApiKey(
+                crate::auth::ApiKeyAuthConfig {
+                    keys: vec![
+                        crate::auth::ApiKeyEntry::new("key", []).with_tenant("principal-tenant")
+                    ],
+                },
+            )],
+        };
+        let core = DispatchCore::new(config).expect("core");
+
+        let response = core
+            .dispatch(CallRequest {
+                adapter: "mcp".to_string(),
+                function: "whoami".to_string(),
+                arguments: CallArguments::Positional(Vec::new()),
+                auth: AuthRequest {
+                    headers: BTreeMap::from([(
+                        "authorization".to_string(),
+                        "Bearer key".to_string(),
+                    )]),
+                    ..AuthRequest::default()
+                },
+                caller: "tester".to_string(),
+                replay_key: Some("override-tenant".to_string()),
+                trace_id: None,
+                parent_span_id: None,
+                metadata: BTreeMap::new(),
+                cancel_token: None,
+                agent_session_id: None,
+                progress: None,
+                tenant_id: Some(harn_vm::TenantId::new("override-tenant")),
+            })
+            .await
+            .expect("dispatch");
+
+        assert_eq!(response.value, serde_json::json!("override-tenant"));
     }
 }

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -45,6 +45,10 @@ pub enum HarnessKind {
     Crypto,
     System,
     Llm,
+    /// Tenant sub-handle exposing the ambient `TenantId` (if any) that
+    /// the dispatching host bound to this call. See
+    /// [`crate::harness_tenant`].
+    Tenant,
 }
 
 impl HarnessKind {
@@ -65,6 +69,7 @@ impl HarnessKind {
             HarnessKind::Crypto => "HarnessCrypto",
             HarnessKind::System => "HarnessSystem",
             HarnessKind::Llm => "HarnessLlm",
+            HarnessKind::Tenant => "HarnessTenant",
         }
     }
 
@@ -84,6 +89,7 @@ impl HarnessKind {
             HarnessKind::Crypto => Some("crypto"),
             HarnessKind::System => Some("system"),
             HarnessKind::Llm => Some("llm"),
+            HarnessKind::Tenant => Some("tenant"),
         }
     }
 
@@ -101,6 +107,7 @@ impl HarnessKind {
             "crypto" => Some(HarnessKind::Crypto),
             "system" => Some(HarnessKind::System),
             "llm" => Some(HarnessKind::Llm),
+            "tenant" => Some(HarnessKind::Tenant),
             _ => None,
         }
     }
@@ -118,6 +125,7 @@ impl HarnessKind {
         HarnessKind::Crypto,
         HarnessKind::System,
         HarnessKind::Llm,
+        HarnessKind::Tenant,
     ];
 
     /// Every kind a Harn-script type annotation may reference.
@@ -134,6 +142,7 @@ impl HarnessKind {
         HarnessKind::Crypto,
         HarnessKind::System,
         HarnessKind::Llm,
+        HarnessKind::Tenant,
     ];
 }
 
@@ -661,6 +670,13 @@ impl Harness {
         }
     }
 
+    /// Field access for `harness.tenant`.
+    pub fn tenant(&self) -> HarnessTenant {
+        HarnessTenant {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
     /// Lower this handle into the `VmValue::Harness` payload.
     pub fn into_vm_value(self) -> crate::value::VmValue {
         crate::value::VmValue::harness(VmHarness {
@@ -765,6 +781,16 @@ pub struct HarnessLlm {
     inner: Arc<HarnessInner>,
 }
 
+/// tenant sub-handle: `id`, `try_id`. Surfaces the ambient `TenantId`
+/// bound by the dispatching host (see [`crate::harness_tenant`]). No
+/// host state — the methods consult a thread-local stack — but the
+/// handle still rides the shared `Arc<HarnessInner>` so null/mock-mode
+/// gating in [`crate::vm::methods::harness`] applies uniformly.
+#[derive(Debug, Clone)]
+pub struct HarnessTenant {
+    inner: Arc<HarnessInner>,
+}
+
 macro_rules! sub_handle_inner {
     ($($ty:ty),* $(,)?) => {
         $(
@@ -788,6 +814,7 @@ sub_handle_inner!(
     HarnessCrypto,
     HarnessSystem,
     HarnessLlm,
+    HarnessTenant,
 );
 
 impl HarnessClock {
@@ -985,6 +1012,7 @@ mod tests {
             r#"fn main(harness: Harness) { harness.crypto.sha256("") }"#,
             r"fn main(harness: Harness) { harness.system.cpu() }",
             r"fn main(harness: Harness) { harness.llm.catalog() }",
+            r"fn main(harness: Harness) { harness.tenant.id() }",
         ] {
             let error = run_harness_source(source, harness.clone()).expect_err("call denied");
             assert!(
@@ -1012,6 +1040,7 @@ mod tests {
                 (HarnessKind::Crypto, "sha256"),
                 (HarnessKind::System, "cpu"),
                 (HarnessKind::Llm, "catalog"),
+                (HarnessKind::Tenant, "id"),
             ]
         );
         assert_eq!(events[0].args, vec!["blocked"]);

--- a/crates/harn-vm/src/harness_tenant.rs
+++ b/crates/harn-vm/src/harness_tenant.rs
@@ -1,0 +1,85 @@
+//! Ambient tenant scope threaded into `.harn` callees by hosts that
+//! resolve a tenant before dispatch (today: `harn-serve` via
+//! `AuthenticatedPrincipal::tenant_id`; future: in-process orchestrators
+//! that already hold a `TenantId`).
+//!
+//! Exposed to scripts as the `harness.tenant` sub-handle:
+//!
+//! ```harn
+//! let tenant_id = harness.tenant.id()
+//! ```
+//!
+//! `id()` returns the active tenant id string or raises a typed
+//! [`ErrorCategory::Auth`] runtime error when the host did not bind a
+//! tenant. `try_id()` returns `nil` instead so callers can branch on
+//! tenancy without try/catch.
+//!
+//! The scope is stack-shaped (push/pop via [`enter_tenant`]) so nested
+//! dispatches (a callee that re-enters the dispatcher under a different
+//! tenant) restore the outer tenant on return.
+
+use std::cell::RefCell;
+
+use crate::TenantId;
+
+thread_local! {
+    static ACTIVE_TENANT_STACK: RefCell<Vec<TenantId>> = const { RefCell::new(Vec::new()) };
+}
+
+/// RAII guard returned by [`enter_tenant`]. Popping the stack on drop
+/// keeps the ambient scope balanced even when the dispatched callable
+/// panics or returns an error.
+#[must_use = "dropping the guard immediately pops the tenant scope"]
+pub struct TenantScopeGuard {
+    _private: (),
+}
+
+impl Drop for TenantScopeGuard {
+    fn drop(&mut self) {
+        ACTIVE_TENANT_STACK.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+/// Push `tenant` onto the ambient stack for the lifetime of the
+/// returned guard. The innermost entry wins for [`current_tenant_id`].
+pub fn enter_tenant(tenant: TenantId) -> TenantScopeGuard {
+    ACTIVE_TENANT_STACK.with(|stack| stack.borrow_mut().push(tenant));
+    TenantScopeGuard { _private: () }
+}
+
+/// Currently-active tenant id, or `None` when the host did not bind
+/// one. The innermost [`enter_tenant`] scope wins.
+pub fn current_tenant_id() -> Option<TenantId> {
+    ACTIVE_TENANT_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+/// Standard message raised by `harness.tenant.id()` when no tenant is
+/// bound. Lives here (and not inline at the call site) so adapters and
+/// tests can assert against one canonical string.
+pub const MISSING_TENANT_MESSAGE: &str =
+    "harness.tenant.id(): no tenant bound to this dispatch — the host did not authenticate a tenant-scoped principal";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_returns_none_when_nothing_pushed() {
+        assert_eq!(current_tenant_id(), None);
+    }
+
+    #[test]
+    fn guard_pops_on_drop_and_inner_scope_shadows_outer() {
+        let outer = enter_tenant(TenantId::new("outer"));
+        assert_eq!(current_tenant_id(), Some(TenantId::new("outer")));
+        {
+            let _inner = enter_tenant(TenantId::new("inner"));
+            assert_eq!(current_tenant_id(), Some(TenantId::new("inner")));
+        }
+        assert_eq!(current_tenant_id(), Some(TenantId::new("outer")));
+        drop(outer);
+        assert_eq!(current_tenant_id(), None);
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -32,6 +32,7 @@ pub mod harness;
 pub(crate) mod harness_crypto;
 pub mod harness_net;
 pub mod harness_system;
+pub mod harness_tenant;
 mod http;
 pub mod jsonrpc;
 pub mod llm;
@@ -148,12 +149,15 @@ pub use corrections::{
 pub use harness::{
     DenyEvent, Harness, HarnessCall, HarnessClock, HarnessCrypto, HarnessEnv, HarnessFs,
     HarnessKind, HarnessLlm, HarnessNet, HarnessProcess, HarnessRandom, HarnessStdio,
-    HarnessSystem, HarnessTerm, MockAwareClock, MockHarnessBuilder, VmHarness,
+    HarnessSystem, HarnessTenant, HarnessTerm, MockAwareClock, MockHarnessBuilder, VmHarness,
 };
 pub use harness_net::{
     bypass_enabled as net_policy_bypass_enabled, NetMatcher, NetPolicy, NetPolicyAudit,
     NetPolicyDecision, NetPolicyDefault, NetPolicyRule, OnViolation, HARN_NET_POLICY_BYPASS_ENV,
     NET_POLICY_AUDIT_TOPIC,
+};
+pub use harness_tenant::{
+    current_tenant_id, enter_tenant, TenantScopeGuard, MISSING_TENANT_MESSAGE,
 };
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;

--- a/crates/harn-vm/src/runtime_context.rs
+++ b/crates/harn-vm/src/runtime_context.rs
@@ -283,7 +283,16 @@ pub(crate) fn runtime_context_value(vm: &crate::vm::Vm) -> VmValue {
         insert_string(&mut values, "trigger_id", None);
         insert_string(&mut values, "trigger_event_id", None);
         insert_string(&mut values, "binding_key", None);
-        insert_string(&mut values, "tenant_id", None);
+        // Outside a trigger dispatch, fall back to the ambient
+        // `enter_tenant` scope hosts install (today: harn-serve binds
+        // it from the authenticated principal). Keeps
+        // `runtime_context.tenant_id` consistent across trigger and
+        // non-trigger code paths.
+        insert_string(
+            &mut values,
+            "tenant_id",
+            crate::harness_tenant::current_tenant_id().map(|tenant| tenant.0),
+        );
         insert_string(&mut values, "provider", None);
         insert_string(
             &mut values,

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -87,6 +87,7 @@ impl crate::vm::Vm {
             HarnessKind::Process => self.call_harness_process_method(handle, method, args),
             HarnessKind::Crypto => self.call_harness_crypto_method(handle, method, args),
             HarnessKind::Llm => self.call_harness_llm_method(handle, method),
+            HarnessKind::Tenant => self.call_harness_tenant_method(handle, method, args),
         }
     }
 
@@ -263,6 +264,32 @@ impl crate::vm::Vm {
         match method {
             "catalog" => Ok(crate::llm::config_builtins::llm_catalog_value()),
             "providers" => Ok(crate::llm::config_builtins::llm_provider_status_value()),
+            _ => Err(method_unsupported(handle, method)),
+        }
+    }
+
+    fn call_harness_tenant_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        if !args.is_empty() {
+            return Err(VmError::TypeError(format!(
+                "HarnessTenant.{method} takes no arguments"
+            )));
+        }
+        match method {
+            "id" => match crate::harness_tenant::current_tenant_id() {
+                Some(tenant) => Ok(vm_string(tenant.0)),
+                None => Err(VmError::CategorizedError {
+                    message: crate::harness_tenant::MISSING_TENANT_MESSAGE.to_string(),
+                    category: ErrorCategory::Auth,
+                }),
+            },
+            "try_id" => Ok(crate::harness_tenant::current_tenant_id()
+                .map(|tenant| vm_string(tenant.0))
+                .unwrap_or(VmValue::Nil)),
             _ => Err(method_unsupported(handle, method)),
         }
     }
@@ -857,6 +884,13 @@ impl crate::vm::Vm {
                 Ok(crate::stdlib::json_to_vm_value(&json))
             }
             HarnessKind::Llm => self.call_harness_llm_method(handle, method),
+            HarnessKind::Tenant => {
+                // Mock mode shares the same ambient stack as real mode
+                // so conformance fixtures can drive `enter_tenant(...)`
+                // and assert `harness.tenant.id()` returns the pushed
+                // id. No mock-only state is needed.
+                self.call_harness_tenant_method(handle, method, args)
+            }
         }
     }
 }

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -795,6 +795,15 @@ impl Vm {
         Rc::make_mut(&mut self.globals).insert(name.to_string(), value);
     }
 
+    /// Read a previously-installed global (the value `set_global` /
+    /// `set_harness` recorded). Returns `None` for unknown names.
+    /// Hosts use this to look up runtime-installed capability handles
+    /// (e.g. the `harness` slot) without having to track them
+    /// separately.
+    pub fn global(&self, name: &str) -> Option<&VmValue> {
+        self.globals.get(name)
+    }
+
     /// Install the script's `Harness` capability handle as the `harness`
     /// global so the auto-call emitted by `Compiler::compile()` (for
     /// `fn main(harness: Harness)` entrypoints) can read it. Hosts that


### PR DESCRIPTION
## Summary
- Threads `TenantId` end-to-end through `harn-serve`: `AuthRequest` → `AuthenticatedPrincipal` → `DispatchCore` → `.harn` callee ambient → `EventLog` trust record → telemetry span attribute.
- New `harness.tenant.id()` / `harness.tenant.try_id()` ambient sub-handle (`HarnessKind::Tenant`). Missing tenant raises a typed `ErrorCategory::Auth` runtime error with a canonical message.
- `DispatchCore` now auto-installs the `Harness` capability handle and auto-injects it for exported `pub fn foo(harness: Harness, ...)` callees — closes a pre-existing gap where dispatched scripts could not reach any `harness.*` surface at all.

## Architecture
- Tenant resolution order in `DispatchCore::dispatch`: explicit `CallRequest.tenant_id` override → `AuthenticatedPrincipal.tenant_id` (from `AuthPolicy`) → none. The resolved value is stamped into the trust record (`metadata["tenant_id"]`) and the `harn_serve.dispatch` span (`tenant_id` field), and pushed onto the `harn_vm::harness_tenant` thread-local stack for the lifetime of the script execution.
- `AuthRequest.tenant_id` lets transports that already resolved tenancy (e.g. an upstream cloud gateway that maps API keys → tenants in its own store) hand the answer to `harn-serve` without re-running the lookup.
- `OAuthClaims.tenant_id` (transport-extracted JWT claim) wins over the policy-level `OAuth21AuthConfig.tenant_id` fallback (single-tenant deployments). `ApiKeyEntry` / `HmacAuthConfig` bind a tenant per credential config.
- `runtime_context.tenant_id` outside a trigger dispatch now falls back to `harness_tenant::current_tenant_id()` so serve-mode and trigger-mode see the same tenant key.

## Out of scope
- Cross-tenant queries / admin tools (deferred per issue).
- Tenant-creation lifecycle (lives in `harn-cloud-admin`).
- Postgres-hostlib `tenant_scoped: true` parameter injection (A.C3 ticket).

## Test plan
- [x] `cargo test -p harn-serve --lib` — 223 pass, includes new `dispatch_threads_api_key_tenant_into_harness_and_trust_record`, `dispatch_missing_tenant_raises_typed_runtime_error`, `dispatch_request_tenant_overrides_principal_tenant`, plus 4 new auth-policy unit tests covering ApiKey/OAuth-claims/OAuth-policy/AuthRequest-override paths.
- [x] `cargo test -p harn-vm --lib harness` — 48 pass, includes new `harness_tenant::tests::guard_pops_on_drop_and_inner_scope_shadows_outer`.
- [x] `cargo test --workspace --lib` — 4930 pass, 0 fail.
- [x] `cargo clippy -p harn-vm -p harn-serve -p harn-parser -p harn-cli --all-targets -- -D warnings`.

Closes burin-labs/harn#2499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)