### PR TITLE
typechecker: preserve current shape fields across schema_is narrowing

### DIFF
--- a/changelog.d/shape-intersect-preserves-current-fields.fixed.md
+++ b/changelog.d/shape-intersect-preserves-current-fields.fixed.md
@@ -1,0 +1,9 @@
+- **Typechecker: `schema_is(x, S)` on a shape value no longer drops fields the
+  variable was already known to have.** When `x` was typed as a shape, the
+  truthy branch previously narrowed to the schema's shape verbatim, discarding
+  every field the existing annotation declared — so e.g. `if schema_is(x, {b:
+  string}) { x.a }` on `x: {a: int, b: string}` falsely reported `a` missing.
+  Width subtyping says the value still has those fields after the check, so the
+  intersection now keeps the current shape's fields, intersects overlapping
+  field types, and appends schema-only required fields that the matched check
+  proves are present.

--- a/crates/harn-parser/src/typechecker/tests/narrowing.rs
+++ b/crates/harn-parser/src/typechecker/tests/narrowing.rs
@@ -640,3 +640,45 @@ fn test_match_or_pattern_on_literal_union_narrows_to_sub_union() {
     );
     assert!(errs.is_empty(), "got: {errs:?}");
 }
+
+#[test]
+fn test_schema_is_shape_narrowing_preserves_current_fields() {
+    // `schema_is(x, S)` confirms that `x` matches `S` — it adds
+    // information, it does not remove it. Width subtyping says a value
+    // typed `{a: int, b: string}` already has both fields, so the
+    // truthy branch must still permit `x.a` after narrowing against a
+    // schema that only mentions `b`.
+    let errs = errors(
+        r#"type Tag = {b: string}
+
+pipeline t(task) {
+  fn check(x: {a: int, b: string}) {
+    if schema_is(x, Tag) {
+      let _a: int = x.a
+      let _b: string = x.b
+    }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_schema_is_shape_narrowing_adds_schema_only_required_field() {
+    // A schema-only required field is confirmed present by the
+    // matched check, so the truthy branch should expose it alongside
+    // the existing fields.
+    let errs = errors(
+        r#"type WithTag = {kind: string}
+
+pipeline t(task) {
+  fn check(x: {a: int}) {
+    if schema_is(x, WithTag) {
+      let _a: int = x.a
+      let _kind: string = x.kind
+    }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}

--- a/crates/harn-parser/src/typechecker/tests/narrowing.rs
+++ b/crates/harn-parser/src/typechecker/tests/narrowing.rs
@@ -649,7 +649,7 @@ fn test_schema_is_shape_narrowing_preserves_current_fields() {
     // truthy branch must still permit `x.a` after narrowing against a
     // schema that only mentions `b`.
     let errs = errors(
-        r#"type Tag = {b: string}
+        r"type Tag = {b: string}
 
 pipeline t(task) {
   fn check(x: {a: int, b: string}) {
@@ -658,7 +658,7 @@ pipeline t(task) {
       let _b: string = x.b
     }
   }
-}"#,
+}",
     );
     assert!(errs.is_empty(), "got: {errs:?}");
 }
@@ -669,7 +669,7 @@ fn test_schema_is_shape_narrowing_adds_schema_only_required_field() {
     // matched check, so the truthy branch should expose it alongside
     // the existing fields.
     let errs = errors(
-        r#"type WithTag = {kind: string}
+        r"type WithTag = {kind: string}
 
 pipeline t(task) {
   fn check(x: {a: int}) {
@@ -678,7 +678,7 @@ pipeline t(task) {
       let _kind: string = x.kind
     }
   }
-}"#,
+}",
     );
     assert!(errs.is_empty(), "got: {errs:?}");
 }

--- a/crates/harn-parser/src/typechecker/union.rs
+++ b/crates/harn-parser/src/typechecker/union.rs
@@ -213,7 +213,45 @@ pub(super) fn intersect_types(current: &TypeExpr, schema_type: &TypeExpr) -> Opt
         (TypeExpr::DictType(key, value), TypeExpr::Named(name)) if name == "dict" => {
             Some(TypeExpr::DictType(key.clone(), value.clone()))
         }
-        (TypeExpr::Shape(_), TypeExpr::Shape(fields)) => Some(TypeExpr::Shape(fields.clone())),
+        (TypeExpr::Shape(current_fields), TypeExpr::Shape(schema_fields)) => {
+            // Width subtyping: a value typed `current` already has every
+            // field in `current_fields`; `schema_is(x, S)` only confirms
+            // the value matches `schema_fields` (it adds information, it
+            // does not remove it). Returning just `schema_fields` would
+            // drop the fields we already knew about. Merge instead:
+            //   - keep every field in `current_fields`
+            //   - intersect overlapping field types (the value satisfies
+            //     both annotations)
+            //   - mark overlapping fields required when either side
+            //     required them (the post-check value definitely has the
+            //     field if either annotation says so)
+            //   - append schema-only required fields (the check confirmed
+            //     they are present); skip schema-only optional fields
+            //     (the check tells us nothing new about them).
+            let mut merged: Vec<ShapeField> = Vec::with_capacity(current_fields.len());
+            for field in current_fields {
+                if let Some(schema_field) = schema_fields.iter().find(|f| f.name == field.name) {
+                    let intersected = intersect_types(&field.type_expr, &schema_field.type_expr)?;
+                    merged.push(ShapeField {
+                        name: field.name.clone(),
+                        type_expr: intersected,
+                        optional: field.optional && schema_field.optional,
+                    });
+                } else {
+                    merged.push(field.clone());
+                }
+            }
+            for schema_field in schema_fields {
+                if schema_field.optional {
+                    continue;
+                }
+                if merged.iter().any(|f| f.name == schema_field.name) {
+                    continue;
+                }
+                merged.push(schema_field.clone());
+            }
+            Some(TypeExpr::Shape(merged))
+        }
         (TypeExpr::List(current_inner), TypeExpr::List(schema_inner)) => {
             intersect_types(current_inner, schema_inner)
                 .map(|inner| TypeExpr::List(Box::new(inner)))


### PR DESCRIPTION
## Summary

- Fix unsound shape-intersection in `intersect_types` (`crates/harn-parser/src/typechecker/union.rs`): when both `current` and `schema_type` were `Shape`s, the truthy branch of `schema_is(x, S)` was narrowed to the schema's shape verbatim, dropping every field the variable's existing annotation declared.
- Merge the two shapes instead: keep current's fields, intersect overlapping field types, mark a field required when either side required it, and append schema-only required fields the matched check proves are present.
- Two new narrowing tests in `tests/narrowing.rs` cover both directions (preserve existing field, append schema-required field).

### Repro (was failing on `main`)

```harn
type Tag = {b: string}

pipeline t(task) {
  fn check(x: {a: int, b: string}) {
    if schema_is(x, Tag) {
      let _a: int = x.a   // error: field `a` does not exist on shape `{b: string}`
    }
  }
}
```

Width subtyping says `x` already has `a` and `b`. `schema_is` adds information about a value, it never removes it, so the truthy branch must still expose `a`.

## Test plan

- [x] `cargo test -p harn-parser --lib typechecker::` — 277 typechecker tests pass.
- [x] `cargo test -p harn-parser --lib` — 377 parser tests pass.
- [x] `cargo check --workspace` clean.
- [x] New `test_schema_is_shape_narrowing_preserves_current_fields` + `test_schema_is_shape_narrowing_adds_schema_only_required_field` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)