### PR TITLE
typechecker: intersect_types iter/owned arms + symmetry cleanup

### DIFF
--- a/changelog.d/intersect-types-iter-owned.fixed.md
+++ b/changelog.d/intersect-types-iter-owned.fixed.md
@@ -1,0 +1,19 @@
+- **Typechecker: `intersect_types` now handles `iter<T>` and `owned<T>`.**
+  Both kinds had no entry in the intersection table, so any `schema_is(x,
+  S)` whose static `x` happened to be an `iter` or `owned` value silently
+  dropped the relevant union member and left `x` un-narrowed in the
+  truthy branch. `iter<T>` now intersects with `Named("iter")` and with
+  another `iter<T>` the same way `list<T>` does. `owned<T>` is
+  transparent at the equality boundary but the annotation survives the
+  intersection — `owned<channel> ∩ channel = owned<channel>` — so the
+  HARN-OWN-005 leak lint keeps tracking the narrowed binding.
+
+- **Typechecker cleanup: collapse `Named ↔ parameterised` arms in
+  `intersect_types`.** Each `(Named, T) / (T, Named)` pair produces the
+  same intersection regardless of operand order, so the 12 individual
+  arms (`Shape`, `DictType`, `List`, `Iter`, `Generator`, `Stream`, plus
+  `unknown`/`any`) now share a single OR-pattern per kind. The width-
+  subtyping merge for `Shape ∩ Shape` and the Union-distributes-over-
+  intersection logic both move into named helpers (`intersect_shapes`,
+  `intersect_union_with`) so the top-level match reads as a kind table
+  without lossy duplication.

--- a/crates/harn-parser/src/typechecker/tests/narrowing.rs
+++ b/crates/harn-parser/src/typechecker/tests/narrowing.rs
@@ -682,3 +682,46 @@ pipeline t(task) {
     );
     assert!(errs.is_empty(), "got: {errs:?}");
 }
+
+#[test]
+fn test_schema_is_narrows_iter_union() {
+    // `iter<T>` had no entry in `intersect_types`, so narrowing an
+    // `iter<int> | string` union via `schema_is(x, iter<int>)` used to
+    // drop both members and leave `x` un-narrowed. Verify the truthy
+    // branch now exposes the iter element type so a typed bind succeeds.
+    let errs = errors(
+        r"type IterInt = iter<int>
+pipeline t(task) {
+  fn check(x: iter<int> | string) {
+    if schema_is(x, IterInt) {
+      let _i: iter<int> = x
+    }
+  }
+}",
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_schema_is_narrows_owned_union_and_preserves_marker() {
+    // Two regressions in one fixture. (1) `owned<T>` had no entry in
+    // `intersect_types`, so a `owned<channel> | nil` union narrowed via
+    // `schema_is(x, channel)` used to drop the owned member entirely and
+    // leave the binding un-narrowed. (2) The intersection must preserve
+    // the ownership annotation so the HARN-OWN-005 leak lint keeps
+    // tracking the binding — the truthy branch's `let _c: owned<channel>
+    // = x` only typechecks if the narrowed type is `owned<channel>`, not
+    // a stripped `channel`.
+    let errs = errors(
+        r"type Ch = channel
+pipeline t(task) {
+  fn check(x: owned<channel> | nil) {
+    if schema_is(x, Ch) {
+      let _c: owned<channel> = x
+      drop(_c)
+    }
+  }
+}",
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}

--- a/crates/harn-parser/src/typechecker/union.rs
+++ b/crates/harn-parser/src/typechecker/union.rs
@@ -131,13 +131,101 @@ pub(super) fn extract_type_of_var(node: &SNode) -> Option<String> {
     None
 }
 
+/// Width subtyping for `Shape ∩ Shape`. Pulled out of `intersect_types`
+/// so the arm body in the big match stays short and the merge invariant
+/// reads top-down. See `intersect_types` for why we merge instead of
+/// returning the schema's fields verbatim.
+fn intersect_shapes(
+    current_fields: &[ShapeField],
+    schema_fields: &[ShapeField],
+) -> Option<TypeExpr> {
+    // Width subtyping: a value typed `current` already has every field
+    // in `current_fields`; `schema_is(x, S)` only confirms the value
+    // matches `schema_fields` (it adds information, it does not remove
+    // it). Returning just `schema_fields` would drop the fields we
+    // already knew about. Merge instead:
+    //   - keep every field in `current_fields`
+    //   - intersect overlapping field types (the value satisfies both
+    //     annotations)
+    //   - mark overlapping fields required when either side required
+    //     them (the post-check value definitely has the field if either
+    //     annotation says so)
+    //   - append schema-only required fields (the check confirmed they
+    //     are present); skip schema-only optional fields (the check
+    //     tells us nothing new about them).
+    let mut merged: Vec<ShapeField> = Vec::with_capacity(current_fields.len());
+    for field in current_fields {
+        if let Some(schema_field) = schema_fields.iter().find(|f| f.name == field.name) {
+            let intersected = intersect_types(&field.type_expr, &schema_field.type_expr)?;
+            merged.push(ShapeField {
+                name: field.name.clone(),
+                type_expr: intersected,
+                optional: field.optional && schema_field.optional,
+            });
+        } else {
+            merged.push(field.clone());
+        }
+    }
+    for schema_field in schema_fields {
+        if schema_field.optional {
+            continue;
+        }
+        if merged.iter().any(|f| f.name == schema_field.name) {
+            continue;
+        }
+        merged.push(schema_field.clone());
+    }
+    Some(TypeExpr::Shape(merged))
+}
+
+/// Distribute an intersection over a union: keep the members that overlap
+/// the other side, dropping the empty intersections. Used by both halves
+/// of the `(Union, _) / (_, Union)` symmetry — `flip` controls which side
+/// `member` lands on in the recursive call so the operation stays
+/// commutative without forcing equal-by-construction operands.
+fn intersect_union_with(members: &[TypeExpr], other: &TypeExpr, flip: bool) -> Option<TypeExpr> {
+    let kept = members
+        .iter()
+        .filter_map(|member| {
+            if flip {
+                intersect_types(other, member)
+            } else {
+                intersect_types(member, other)
+            }
+        })
+        .collect::<Vec<_>>();
+    match kept.len() {
+        0 => None,
+        1 => kept.into_iter().next(),
+        _ => Some(TypeExpr::Union(kept)),
+    }
+}
+
 pub(super) fn intersect_types(current: &TypeExpr, schema_type: &TypeExpr) -> Option<TypeExpr> {
+    // `owned<T>` is transparent to the underlying handle type at the
+    // type-equality boundary (the ownership marker only drives the
+    // HARN-OWN-005 leak lint, not value shape). Strip the marker before
+    // descending so `intersect_types(owned<channel>, channel)` succeeds
+    // the same way `intersect_types(channel, channel)` would — then
+    // re-wrap if EITHER side carried it, since the intersection of a
+    // marked-and-unmarked pair is the more specific (marked) form.
+    match (current, schema_type) {
+        (TypeExpr::Owned(c), TypeExpr::Owned(s)) => {
+            return intersect_types(c, s).map(|t| TypeExpr::Owned(Box::new(t)));
+        }
+        (TypeExpr::Owned(inner), other) | (other, TypeExpr::Owned(inner)) => {
+            return intersect_types(inner, other).map(|t| TypeExpr::Owned(Box::new(t)));
+        }
+        _ => {}
+    }
+
     match (current, schema_type) {
         // Literal intersections: two equal literals keep the literal.
         (TypeExpr::LitString(a), TypeExpr::LitString(b)) if a == b => {
             Some(TypeExpr::LitString(a.clone()))
         }
         (TypeExpr::LitInt(a), TypeExpr::LitInt(b)) if a == b => Some(TypeExpr::LitInt(*a)),
+
         // Intersecting a literal with its base type keeps the literal.
         (TypeExpr::LitString(s), TypeExpr::Named(n))
         | (TypeExpr::Named(n), TypeExpr::LitString(s))
@@ -150,128 +238,80 @@ pub(super) fn intersect_types(current: &TypeExpr, schema_type: &TypeExpr) -> Opt
         {
             Some(TypeExpr::LitInt(*v))
         }
-        (TypeExpr::Union(members), other) => {
-            let kept = members
-                .iter()
-                .filter_map(|member| intersect_types(member, other))
-                .collect::<Vec<_>>();
-            match kept.len() {
-                0 => None,
-                1 => kept.into_iter().next(),
-                _ => Some(TypeExpr::Union(kept)),
-            }
-        }
-        (other, TypeExpr::Union(members)) => {
-            let kept = members
-                .iter()
-                .filter_map(|member| intersect_types(other, member))
-                .collect::<Vec<_>>();
-            match kept.len() {
-                0 => None,
-                1 => kept.into_iter().next(),
-                _ => Some(TypeExpr::Union(kept)),
-            }
-        }
+
+        // Union distributes over the other side; the `flip` argument
+        // preserves the original operand order so commutativity is
+        // observed without aliasing the helper's recursive calls.
+        (TypeExpr::Union(members), other) => intersect_union_with(members, other, false),
+        (other, TypeExpr::Union(members)) => intersect_union_with(members, other, true),
+
         (TypeExpr::Named(left), TypeExpr::Named(right)) if left == right => {
             Some(TypeExpr::Named(left.clone()))
         }
-        (TypeExpr::Named(name), TypeExpr::Shape(fields)) if name == "dict" => {
+
+        // Named-as-runtime-kind ↔ parameterised constructor. Each pair is
+        // symmetric — the same `Some(parameterised.clone())` result
+        // regardless of operand order — so collapse the two arms into one
+        // OR-pattern. The kind table mirrors `member_matches_runtime_kind`
+        // and `VmValue::type_name`; keep them aligned if either changes.
+        (TypeExpr::Named(name), TypeExpr::Shape(fields))
+        | (TypeExpr::Shape(fields), TypeExpr::Named(name))
+            if name == "dict" =>
+        {
             Some(TypeExpr::Shape(fields.clone()))
         }
-        (TypeExpr::Shape(fields), TypeExpr::Named(name)) if name == "dict" => {
-            Some(TypeExpr::Shape(fields.clone()))
+        (TypeExpr::Named(name), TypeExpr::DictType(key, value))
+        | (TypeExpr::DictType(key, value), TypeExpr::Named(name))
+            if name == "dict" =>
+        {
+            Some(TypeExpr::DictType(key.clone(), value.clone()))
         }
-        (TypeExpr::Named(name), TypeExpr::List(inner)) if name == "list" => {
+        (TypeExpr::Named(name), TypeExpr::List(inner))
+        | (TypeExpr::List(inner), TypeExpr::Named(name))
+            if name == "list" =>
+        {
             Some(TypeExpr::List(inner.clone()))
         }
-        (TypeExpr::List(inner), TypeExpr::Named(name)) if name == "list" => {
-            Some(TypeExpr::List(inner.clone()))
+        (TypeExpr::Named(name), TypeExpr::Iter(inner))
+        | (TypeExpr::Iter(inner), TypeExpr::Named(name))
+            if name == "iter" =>
+        {
+            Some(TypeExpr::Iter(inner.clone()))
         }
         (TypeExpr::Named(name), TypeExpr::Generator(inner))
-            if name == "generator" || name == "Generator" =>
-        {
-            Some(TypeExpr::Generator(inner.clone()))
-        }
-        (TypeExpr::Generator(inner), TypeExpr::Named(name))
+        | (TypeExpr::Generator(inner), TypeExpr::Named(name))
             if name == "generator" || name == "Generator" =>
         {
             Some(TypeExpr::Generator(inner.clone()))
         }
         (TypeExpr::Named(name), TypeExpr::Stream(inner))
+        | (TypeExpr::Stream(inner), TypeExpr::Named(name))
             if name == "stream" || name == "Stream" =>
         {
             Some(TypeExpr::Stream(inner.clone()))
         }
-        (TypeExpr::Stream(inner), TypeExpr::Named(name))
-            if name == "stream" || name == "Stream" =>
-        {
-            Some(TypeExpr::Stream(inner.clone()))
+
+        // Parameterised ∩ Parameterised: keep the kind, intersect the
+        // payload. `intersect_shapes` carries the width-subtyping merge.
+        (TypeExpr::Shape(c), TypeExpr::Shape(s)) => intersect_shapes(c, s),
+        (TypeExpr::List(c), TypeExpr::List(s)) => {
+            intersect_types(c, s).map(|i| TypeExpr::List(Box::new(i)))
         }
-        (TypeExpr::Named(name), TypeExpr::DictType(key, value)) if name == "dict" => {
-            Some(TypeExpr::DictType(key.clone(), value.clone()))
+        (TypeExpr::Iter(c), TypeExpr::Iter(s)) => {
+            intersect_types(c, s).map(|i| TypeExpr::Iter(Box::new(i)))
         }
-        (TypeExpr::DictType(key, value), TypeExpr::Named(name)) if name == "dict" => {
-            Some(TypeExpr::DictType(key.clone(), value.clone()))
+        (TypeExpr::Generator(c), TypeExpr::Generator(s)) => {
+            intersect_types(c, s).map(|i| TypeExpr::Generator(Box::new(i)))
         }
-        (TypeExpr::Shape(current_fields), TypeExpr::Shape(schema_fields)) => {
-            // Width subtyping: a value typed `current` already has every
-            // field in `current_fields`; `schema_is(x, S)` only confirms
-            // the value matches `schema_fields` (it adds information, it
-            // does not remove it). Returning just `schema_fields` would
-            // drop the fields we already knew about. Merge instead:
-            //   - keep every field in `current_fields`
-            //   - intersect overlapping field types (the value satisfies
-            //     both annotations)
-            //   - mark overlapping fields required when either side
-            //     required them (the post-check value definitely has the
-            //     field if either annotation says so)
-            //   - append schema-only required fields (the check confirmed
-            //     they are present); skip schema-only optional fields
-            //     (the check tells us nothing new about them).
-            let mut merged: Vec<ShapeField> = Vec::with_capacity(current_fields.len());
-            for field in current_fields {
-                if let Some(schema_field) = schema_fields.iter().find(|f| f.name == field.name) {
-                    let intersected = intersect_types(&field.type_expr, &schema_field.type_expr)?;
-                    merged.push(ShapeField {
-                        name: field.name.clone(),
-                        type_expr: intersected,
-                        optional: field.optional && schema_field.optional,
-                    });
-                } else {
-                    merged.push(field.clone());
-                }
-            }
-            for schema_field in schema_fields {
-                if schema_field.optional {
-                    continue;
-                }
-                if merged.iter().any(|f| f.name == schema_field.name) {
-                    continue;
-                }
-                merged.push(schema_field.clone());
-            }
-            Some(TypeExpr::Shape(merged))
+        (TypeExpr::Stream(c), TypeExpr::Stream(s)) => {
+            intersect_types(c, s).map(|i| TypeExpr::Stream(Box::new(i)))
         }
-        (TypeExpr::List(current_inner), TypeExpr::List(schema_inner)) => {
-            intersect_types(current_inner, schema_inner)
-                .map(|inner| TypeExpr::List(Box::new(inner)))
-        }
-        (TypeExpr::Generator(current_inner), TypeExpr::Generator(schema_inner)) => {
-            intersect_types(current_inner, schema_inner)
-                .map(|inner| TypeExpr::Generator(Box::new(inner)))
-        }
-        (TypeExpr::Stream(current_inner), TypeExpr::Stream(schema_inner)) => {
-            intersect_types(current_inner, schema_inner)
-                .map(|inner| TypeExpr::Stream(Box::new(inner)))
-        }
-        (
-            TypeExpr::DictType(current_key, current_value),
-            TypeExpr::DictType(schema_key, schema_value),
-        ) => {
-            let key = intersect_types(current_key, schema_key)?;
-            let value = intersect_types(current_value, schema_value)?;
+        (TypeExpr::DictType(ck, cv), TypeExpr::DictType(sk, sv)) => {
+            let key = intersect_types(ck, sk)?;
+            let value = intersect_types(cv, sv)?;
             Some(TypeExpr::DictType(Box::new(key), Box::new(value)))
         }
+
         // `unknown` and `any` are top types in the value-narrowing
         // direction — a successful `schema_is(x, S)` proves `x` matches
         // `S`, so the truthy branch can narrow to `S` regardless of how
@@ -279,12 +319,12 @@ pub(super) fn intersect_types(current: &TypeExpr, schema_type: &TypeExpr) -> Opt
         // `let x: unknown = …` stays `unknown` after `schema_is` (the
         // refinement set is empty), and field access on the narrowed
         // value triggers spurious "property access on unknown" warnings.
-        (TypeExpr::Named(name), other) if matches!(name.as_str(), "unknown" | "any") => {
+        (TypeExpr::Named(name), other) | (other, TypeExpr::Named(name))
+            if matches!(name.as_str(), "unknown" | "any") =>
+        {
             Some(other.clone())
         }
-        (current, TypeExpr::Named(name)) if matches!(name.as_str(), "unknown" | "any") => {
-            Some(current.clone())
-        }
+
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Adversarial re-read of `intersect_types` after shipping the shape-narrowing fix (#2544) and vacuous-condition lint (#2546) surfaced two silent-data-loss arms plus a duplicated-pair pattern that had built up across earlier additions to the table.

**Bug fixes:**

- `iter<T>` had no entry in `intersect_types`. An `iter<int> | string` value narrowed via `schema_is(x, iter<int>)` dropped both members in the Union arm and left `x` un-narrowed. Added `Named("iter") ↔ Iter` and `Iter ∩ Iter` arms parallel to the existing `list / generator / stream` ones.
- `owned<T>` had no entry. `intersect_types(owned<channel>, channel)` fell to `None` even though `owned` is documented as transparent at the equality boundary. Strip + re-wrap the marker at the top of the function — the intersection of a marked-and-unmarked pair returns the more specific (marked) form, so the HARN-OWN-005 leak lint keeps tracking the narrowed binding.

**DRY:**

- Every `(Named, T) | (T, Named)` pair (six kinds — Shape, DictType, List, Iter, Generator, Stream, plus `unknown`/`any`) now uses a single OR-pattern arm. Each pair was structurally identical and the duplication had been growing.
- Width-subtyping merge for `Shape ∩ Shape` moves into `intersect_shapes`; Union distribution moves into `intersect_union_with(flip)`. The top-level match now reads as a kind table without lossy duplication.

## Test plan

- [x] `cargo test -p harn-parser --lib` — all 380 tests pass (378 pre-existing + 2 new).
- [x] `cargo clippy -p harn-parser --tests --all-features -- -D warnings` — clean.
- [x] `test_schema_is_narrows_iter_union` — fails without the new Iter arm (union narrowing drops both members), passes with it.
- [x] `test_schema_is_narrows_owned_union_and_preserves_marker` — fails without the new Owned strip-and-rewrap (intersection returns None), passes with it.
- [x] Refactor is semantically equivalent for every case the table already covered, verified by every existing schema_is / is_type / type_of / nil-narrowing test continuing to pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)