### PR TITLE
[B.4 polish] edit_safe_text_patch: correctness + telemetry + DRY pass

### DIFF
--- a/changelog.d/2548-polish.changed.md
+++ b/changelog.d/2548-polish.changed.md
@@ -1,0 +1,53 @@
+- **`edit_safe_text_patch`: polish + correctness pass.** Follow-up to
+  the #2509 / #2542 landing fixes several issues caught in adversarial
+  review:
+  - **H2**: `create_parents: false` is now honored on the direct-disk
+    path — previously `atomic_write`'s unconditional `create_dir_all`
+    silently created the parent. The disk path now pre-checks the
+    parent and returns a structured error with the right remediation
+    hint when the directory is missing.
+  - **H3**: latent precedence bug in the `hunk_conflict` error message
+    fixed — `+ outcome?.error_code ?? "no_match"` parses as
+    `(... + outcome?.error_code) ?? "no_match"` so the fallback never
+    fires. Parenthesized + hoisted to a `let hunk_error_code` so the
+    same value flows into both the top-level `failed_hunk_error_code`
+    and the per-error `hunk_error_code`.
+  - **M1**: new `AgentEvent::SafeTextPatchResult` carrying
+    `{session_id, path, result, hunks_count, bytes_written,
+    failed_hunk_index?}` fires from every terminal return path
+    (applied / no_op / stale_base / hunk_conflict). Hosts subscribe to
+    stream-aggregate stale-base / hunk-conflict rates and average
+    hunks-per-patch without polling. The ACP adapter translates the
+    event into a `progress` extension with
+    `_meta.harn.kind = "safe_text_patch_result"`. New
+    `hostlib_fs_emit_safe_text_patch_result` builtin routes the event
+    from the Harn wrapper; silently no-ops outside a session.
+  - **M3**: dropped a redundant SHA-256 pass on the commit path —
+    `__edit_sha256(working)` was computed even though the hostlib
+    commit echoes the same digest. Now only computed on the dry-run
+    and hunk-conflict paths where the commit isn't called.
+  - **M5/M6**: dropped redundant `result.changed` (it always equalled
+    `result == "applied"`). Aligned `dry_run` semantics with
+    `edit_apply_node` — `applied: true` now means "matcher succeeded"
+    regardless of whether bytes were written, and a new top-level
+    `result.dry_run` boolean disambiguates.
+  - **L1/L2**: small DRY win — new `hash_label(&[u8]) -> String`
+    helper collapses 4 copies of the `format!("sha256:{}", hex::...)`
+    pattern.
+  - **L3**: schemas tightened — `expected_hash` / `current_hash` /
+    `before_sha256` / `after_sha256` now carry the
+    `^sha256:[0-9a-f]{64}$` regex pattern via a shared `$defs/sha256Label`
+    schema reference. `expected_hash` is now required in the response
+    (was nullable but always emitted).
+  - **L5**: dropped dead `failed_hunk_message` field — the error list
+    already carries the same string under `errors[0].hunk_message`.
+  - **L6/L7**: docs gain a bounded `stale_base` retry loop example
+    and a dry-run → apply workflow example mirroring how
+    `edit_apply_node` documents the same flag.
+  - **Tests**: added integration coverage for non-UTF8 read
+    rejection, ~1.5 MB content roundtrip, `create_parents: false`
+    rejection, and the new agent-event wiring.
+
+  H1 (sandbox-gating of the un-gated `fs/*` and `ast/*` edit
+  primitives) is filed as #2548 — cross-cutting concern with sibling
+  primitives out of scope here.

--- a/conformance/tests/stdlib/edit_safe_text_patch.expected
+++ b/conformance/tests/stdlib/edit_safe_text_patch.expected
@@ -14,9 +14,14 @@ true
 true
 hunk_conflict
 1
+no_match
+true
 1
 true
 applied
+true
+true
+0
 true
 true
 applied

--- a/conformance/tests/stdlib/edit_safe_text_patch.harn
+++ b/conformance/tests/stdlib/edit_safe_text_patch.harn
@@ -73,6 +73,8 @@ pipeline default() {
   )
   __io_println(conflict_result.result)
   __io_println(conflict_result.failed_hunk_index)
+  __io_println(conflict_result.failed_hunk_error_code)
+  __io_println(contains(conflict_result.errors[0].message, "hunk 1 rejected: no_match"))
   __io_println(conflict_result.telemetry.hunk_conflict)
   __io_println(harness.fs.read_text(conflict_path) == conflict_before)
   // 4) Dry run renders the post-image into `preview` without touching disk.
@@ -88,6 +90,9 @@ pipeline default() {
     },
   )
   __io_println(preview_result.result)
+  __io_println(preview_result.applied)
+  __io_println(preview_result.dry_run)
+  __io_println(preview_result.bytes_written)
   __io_println(contains(preview_result.preview, "ALPHA"))
   __io_println(harness.fs.read_text(preview_path) == preview_before)
   // 5) Optional `expected_hash` — when omitted the call still applies and

--- a/crates/harn-hostlib/schemas/fs/emit_safe_text_patch_result.request.json
+++ b/crates/harn-hostlib/schemas/fs/emit_safe_text_patch_result.request.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/emit_safe_text_patch_result.request.json",
+  "title": "fs.emit_safe_text_patch_result request",
+  "description": "Emit a per-call `SafeTextPatchResult` agent event so hosts can roll up stale-base / hunk-conflict rates and average hunks-per-patch without scraping result dicts out of pipeline logs. Called by `std/edit`'s `edit_safe_text_patch` at every terminal return path (applied / no_op / stale_base / hunk_conflict). Silently no-ops when no session is active.",
+  "type": "object",
+  "properties": {
+    "path": { "type": "string", "minLength": 1 },
+    "result": {
+      "type": "string",
+      "enum": ["applied", "no_op", "stale_base", "hunk_conflict"]
+    },
+    "hunks_count": { "type": "integer", "minimum": 0, "default": 0 },
+    "bytes_written": { "type": "integer", "minimum": 0, "default": 0 },
+    "failed_hunk_index": { "type": ["integer", "null"], "minimum": 0 },
+    "session_id": { "type": ["string", "null"] }
+  },
+  "required": ["path", "result"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/fs/emit_safe_text_patch_result.response.json
+++ b/crates/harn-hostlib/schemas/fs/emit_safe_text_patch_result.response.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/fs/emit_safe_text_patch_result.response.json",
+  "title": "fs.emit_safe_text_patch_result response",
+  "type": "boolean",
+  "description": "`true` when the event was routed to an active session; `false` when no session is active and the call was a no-op."
+}

--- a/crates/harn-hostlib/schemas/fs/read_text.response.json
+++ b/crates/harn-hostlib/schemas/fs/read_text.response.json
@@ -11,6 +11,7 @@
     },
     "sha256": {
       "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
       "description": "`sha256:HEX` of the bytes read. Pair this with `fs.safe_text_patch` as `expected_hash`."
     },
     "size": { "type": "integer", "minimum": 0 },

--- a/crates/harn-hostlib/schemas/fs/safe_text_patch.request.json
+++ b/crates/harn-hostlib/schemas/fs/safe_text_patch.request.json
@@ -3,6 +3,12 @@
   "$id": "https://harnlang.com/schemas/hostlib/fs/safe_text_patch.request.json",
   "title": "fs.safe_text_patch request",
   "description": "Atomic compare-and-swap text write. Reads the current bytes at `path` through the staged-fs overlay (when a session is active) and writes `content` only when the observed `sha256:HEX` matches `expected_hash`. Hosts use this to commit multi-hunk agent edits without losing concurrent writes from sibling agents.",
+  "$defs": {
+    "sha256Label": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
   "type": "object",
   "properties": {
     "path": { "type": "string", "minLength": 1 },
@@ -11,7 +17,7 @@
       "description": "Final post-image bytes (UTF-8). Multi-hunk callers compose the post-image in memory and submit it here."
     },
     "expected_hash": {
-      "type": ["string", "null"],
+      "oneOf": [{ "$ref": "#/$defs/sha256Label" }, { "type": "null" }],
       "description": "`sha256:HEX` snapshot the caller observed. When omitted the call skips the stale-base check and behaves as an unconditional write (still atomic through the staged-fs overlay)."
     },
     "session_id": {

--- a/crates/harn-hostlib/schemas/fs/safe_text_patch.response.json
+++ b/crates/harn-hostlib/schemas/fs/safe_text_patch.response.json
@@ -2,6 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/hostlib/fs/safe_text_patch.response.json",
   "title": "fs.safe_text_patch response",
+  "$defs": {
+    "sha256Label": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
   "type": "object",
   "properties": {
     "path": { "type": "string" },
@@ -13,12 +19,14 @@
     "applied": { "type": "boolean" },
     "stale_base": { "type": "boolean" },
     "current_hash": {
-      "type": "string",
+      "allOf": [{ "$ref": "#/$defs/sha256Label" }],
       "description": "`sha256:HEX` of the observed pre-image. Echoed even on `stale_base` so the caller can re-read and retry without an extra hop."
     },
-    "before_sha256": { "type": "string" },
-    "after_sha256": { "type": "string" },
-    "expected_hash": { "type": ["string", "null"] },
+    "before_sha256": { "$ref": "#/$defs/sha256Label" },
+    "after_sha256": { "$ref": "#/$defs/sha256Label" },
+    "expected_hash": {
+      "oneOf": [{ "$ref": "#/$defs/sha256Label" }, { "type": "null" }]
+    },
     "created": { "type": "boolean" },
     "bytes_written": { "type": "integer", "minimum": 0 }
   },
@@ -30,6 +38,7 @@
     "current_hash",
     "before_sha256",
     "after_sha256",
+    "expected_hash",
     "created",
     "bytes_written"
   ],

--- a/crates/harn-hostlib/src/fs.rs
+++ b/crates/harn-hostlib/src/fs.rs
@@ -21,8 +21,8 @@ use sha2::{Digest, Sha256};
 use crate::error::HostlibError;
 use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
 use crate::tools::args::{
-    build_dict, dict_arg, optional_bool, optional_string, optional_string_list, require_string,
-    str_value,
+    build_dict, dict_arg, optional_bool, optional_int, optional_string, optional_string_list,
+    require_string, str_value,
 };
 
 const SET_MODE_BUILTIN: &str = "hostlib_fs_set_mode";
@@ -31,6 +31,7 @@ const COMMIT_BUILTIN: &str = "hostlib_fs_commit_staged";
 const DISCARD_BUILTIN: &str = "hostlib_fs_discard_staged";
 const SAFE_TEXT_PATCH_BUILTIN: &str = "hostlib_fs_safe_text_patch";
 const READ_TEXT_BUILTIN: &str = "hostlib_fs_read_text";
+const EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN: &str = "hostlib_fs_emit_safe_text_patch_result";
 
 const MANIFEST_VERSION: u32 = 1;
 const STATE_REL: &[&str] = &[".harn", "state", "staged"];
@@ -71,6 +72,12 @@ impl HostlibCapability for FsCapability {
             safe_text_patch_builtin,
         );
         register(registry, READ_TEXT_BUILTIN, "read_text", read_text_builtin);
+        register(
+            registry,
+            EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN,
+            "emit_safe_text_patch_result",
+            emit_safe_text_patch_result_builtin,
+        );
     }
 }
 
@@ -561,6 +568,13 @@ impl SafeTextPatchResult {
     }
 }
 
+/// Format `bytes` as the `sha256:HEX` label used in `before_sha256` /
+/// `after_sha256` / `current_hash` / `expected_hash` everywhere in the
+/// safe-text-patch surface.
+fn hash_label(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+}
+
 /// Atomic compare-and-swap-style text write.
 ///
 /// Reads the current bytes at `path` through the staged-fs overlay (when a
@@ -591,7 +605,7 @@ pub fn safe_text_patch(
     overwrite: bool,
 ) -> Result<SafeTextPatchOutcome, HostlibError> {
     let new_bytes = content.as_bytes();
-    let after_hash = format!("sha256:{}", hex::encode(Sha256::digest(new_bytes)));
+    let after_hash = hash_label(new_bytes);
 
     if let Some(outcome) = safe_text_patch_staged(
         path,
@@ -665,7 +679,7 @@ fn safe_text_patch_staged(
             }
         },
     };
-    let current_hash = format!("sha256:{}", hex::encode(Sha256::digest(&existing_bytes)));
+    let current_hash = hash_label(&existing_bytes);
 
     if let Some(expected) = expected_hash {
         if expected != current_hash {
@@ -757,7 +771,7 @@ fn safe_text_patch_disk(
             });
         }
     };
-    let current_hash = format!("sha256:{}", hex::encode(Sha256::digest(&existing_bytes)));
+    let current_hash = hash_label(&existing_bytes);
 
     if let Some(expected) = expected_hash {
         if expected != current_hash {
@@ -786,18 +800,21 @@ fn safe_text_patch_disk(
             message: format!("`{}` exists and overwrite=false", path.display()),
         });
     }
-
-    crate::fs_snapshot::auto_capture_for_write(SAFE_TEXT_PATCH_BUILTIN, path);
-    if create_parents {
+    if !create_parents {
         if let Some(parent) = path.parent() {
-            if !parent.as_os_str().is_empty() {
-                stdfs::create_dir_all(parent).map_err(|err| HostlibError::Backend {
+            if !parent.as_os_str().is_empty() && !parent.is_dir() {
+                return Err(HostlibError::Backend {
                     builtin: SAFE_TEXT_PATCH_BUILTIN,
-                    message: format!("mkdir `{}`: {err}", parent.display()),
-                })?;
+                    message: format!(
+                        "parent directory for `{}` does not exist (pass create_parents=true to mkdir)",
+                        path.display()
+                    ),
+                });
             }
         }
     }
+
+    crate::fs_snapshot::auto_capture_for_write(SAFE_TEXT_PATCH_BUILTIN, path);
     atomic_write(path, new_bytes).map_err(|err| HostlibError::Backend {
         builtin: SAFE_TEXT_PATCH_BUILTIN,
         message: format!("write `{}`: {err}", path.display()),
@@ -849,7 +866,7 @@ fn read_text_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let path = Path::new(&path_str);
 
     let (bytes, existed) = read_existing(READ_TEXT_BUILTIN, path, session_id.as_deref())?;
-    let hash = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
+    let hash = hash_label(&bytes);
     let content = match std::str::from_utf8(&bytes) {
         Ok(s) => s.to_string(),
         Err(err) => {
@@ -914,6 +931,51 @@ fn safe_text_patch_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         ),
     ];
     Ok(build_dict(entries))
+}
+
+fn emit_safe_text_patch_result_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN, args)?;
+    let dict = raw.as_ref();
+
+    let path = require_string(EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN, dict, "path")?;
+    let result = require_string(EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN, dict, "result")?;
+    let hunks_count = optional_int(EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN, dict, "hunks_count", 0)?;
+    let bytes_written = optional_int(
+        EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN,
+        dict,
+        "bytes_written",
+        0,
+    )?;
+    let failed_hunk_index = match dict.get("failed_hunk_index") {
+        None | Some(VmValue::Nil) => None,
+        Some(VmValue::Int(n)) if *n >= 0 => Some(*n as usize),
+        Some(other) => {
+            return Err(HostlibError::InvalidParameter {
+                builtin: EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN,
+                param: "failed_hunk_index",
+                message: format!("expected non-negative integer, got {}", other.type_name()),
+            });
+        }
+    };
+    let session_id = optional_string(EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN, dict, "session_id")?
+        .or_else(harn_vm::agent_sessions::current_session_id);
+
+    if let Some(session_id) = session_id.filter(|s| !s.trim().is_empty()) {
+        harn_vm::agent_events::emit_event(&AgentEvent::SafeTextPatchResult {
+            session_id,
+            path,
+            result,
+            hunks_count: hunks_count.max(0) as usize,
+            bytes_written: bytes_written.max(0) as u64,
+            failed_hunk_index,
+        });
+        Ok(VmValue::Bool(true))
+    } else {
+        // Silently no-op when no session is active — telemetry without a
+        // session has nowhere to route. Caller can opt in by always
+        // passing session_id explicitly.
+        Ok(VmValue::Bool(false))
+    }
 }
 
 fn set_mode_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -658,6 +658,18 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
     ),
     (
         "fs",
+        "emit_safe_text_patch_result",
+        SchemaKind::Request,
+        include_str!("../schemas/fs/emit_safe_text_patch_result.request.json"),
+    ),
+    (
+        "fs",
+        "emit_safe_text_patch_result",
+        SchemaKind::Response,
+        include_str!("../schemas/fs/emit_safe_text_patch_result.response.json"),
+    ),
+    (
+        "fs",
         "snapshot",
         SchemaKind::Request,
         include_str!("../schemas/fs/snapshot.request.json"),

--- a/crates/harn-hostlib/tests/fs_staging.rs
+++ b/crates/harn-hostlib/tests/fs_staging.rs
@@ -639,7 +639,7 @@ fn safe_text_patch_disk_rejects_missing_parent_when_create_parents_false() {
 fn read_text_rejects_non_utf8_with_clear_diagnostic() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("blob.bin");
-    fs::write(&file, &[0xffu8, 0xfe, 0xfd]).unwrap();
+    fs::write(&file, [0xffu8, 0xfe, 0xfd]).unwrap();
     let reg = registry();
 
     let err = (reg.find("hostlib_fs_read_text").unwrap().handler)(&dict_arg(&[(

--- a/crates/harn-hostlib/tests/fs_staging.rs
+++ b/crates/harn-hostlib/tests/fs_staging.rs
@@ -609,3 +609,132 @@ fn safe_text_patch_serializes_concurrent_staged_commits() {
     assert_eq!(applied, 1, "exactly one writer must commit");
     assert_eq!(stale_base, 1, "the other must observe stale_base");
 }
+
+#[test]
+fn safe_text_patch_disk_rejects_missing_parent_when_create_parents_false() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("missing-parent").join("file.txt");
+    let reg = registry();
+    let empty_hash = sha256_of(b"");
+
+    let err = (reg.find("hostlib_fs_safe_text_patch").unwrap().handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&nested))),
+        ("content", vm_string("never written\n")),
+        ("expected_hash", vm_string(&empty_hash)),
+        ("create_parents", VmValue::Bool(false)),
+    ]))
+    .expect_err("must reject when parent directory does not exist");
+    let message = format!("{err:?}");
+    assert!(
+        message.contains("parent directory") && message.contains("create_parents=true"),
+        "error must explain the cause and the fix: {message}"
+    );
+    assert!(
+        !nested.exists() && !nested.parent().unwrap().exists(),
+        "must not have written the file or created the parent directory"
+    );
+}
+
+#[test]
+fn read_text_rejects_non_utf8_with_clear_diagnostic() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("blob.bin");
+    fs::write(&file, &[0xffu8, 0xfe, 0xfd]).unwrap();
+    let reg = registry();
+
+    let err = (reg.find("hostlib_fs_read_text").unwrap().handler)(&dict_arg(&[(
+        "path",
+        vm_string(&path_str(&file)),
+    )]))
+    .expect_err("must reject non-UTF8 input");
+    let message = format!("{err:?}");
+    assert!(
+        message.contains("UTF-8"),
+        "error must mention UTF-8 as the cause: {message}"
+    );
+}
+
+#[test]
+fn safe_text_patch_round_trips_large_payload() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("large.txt");
+    // ~1.5 MB — enough to verify the read + hash + write loop does not
+    // truncate or hash a sliced view of the bytes.
+    let payload = "abcdefghij".repeat(150_000);
+    fs::write(&file, &payload).unwrap();
+    let reg = registry();
+    let pre_hash = sha256_of(payload.as_bytes());
+
+    let new_payload = "xyzwvutsrq".repeat(150_000);
+    let response = (reg.find("hostlib_fs_safe_text_patch").unwrap().handler)(&dict_arg(&[
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string(&new_payload)),
+        ("expected_hash", vm_string(&pre_hash)),
+    ]))
+    .unwrap();
+    assert_eq!(dict_str(&response, "result"), "applied");
+    assert_eq!(
+        dict_int(&response, "bytes_written") as usize,
+        new_payload.len()
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), new_payload);
+}
+
+#[test]
+fn emit_safe_text_patch_result_routes_to_active_session() {
+    use harn_vm::agent_events::{
+        register_wildcard_sink, unregister_wildcard_sink, AgentEvent, AgentEventSink,
+    };
+    use std::sync::{Arc, Mutex};
+
+    struct Capture {
+        events: Mutex<Vec<AgentEvent>>,
+    }
+    impl AgentEventSink for Capture {
+        fn handle_event(&self, event: &AgentEvent) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let sink = Arc::new(Capture {
+        events: Mutex::new(Vec::new()),
+    });
+    let handle = register_wildcard_sink(sink.clone());
+
+    let reg = registry();
+    let session = unique_session("emit-event");
+    let _guard = harn_vm::agent_sessions::enter_current_session(session.clone());
+
+    let response = (reg
+        .find("hostlib_fs_emit_safe_text_patch_result")
+        .unwrap()
+        .handler)(&dict_arg(&[
+        ("path", vm_string("/tmp/never-written.txt")),
+        ("result", vm_string("stale_base")),
+        ("hunks_count", VmValue::Int(3)),
+        ("bytes_written", VmValue::Int(0)),
+    ]))
+    .unwrap();
+    assert!(matches!(response, VmValue::Bool(true)));
+
+    let events = sink.events.lock().unwrap();
+    let event = events
+        .iter()
+        .find_map(|e| match e {
+            AgentEvent::SafeTextPatchResult {
+                session_id: sid,
+                path,
+                result,
+                hunks_count,
+                ..
+            } if sid == &session => Some((path.clone(), result.clone(), *hunks_count)),
+            _ => None,
+        })
+        .expect("event must route to the active session");
+    drop(events);
+    assert_eq!(event.0, "/tmp/never-written.txt");
+    assert_eq!(event.1, "stale_base");
+    assert_eq!(event.2, 3);
+
+    unregister_wildcard_sink(handle);
+}

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -177,6 +177,7 @@ fn fs_capability_registers_documented_methods() {
             "hostlib_fs_discard_staged",
             "hostlib_fs_safe_text_patch",
             "hostlib_fs_read_text",
+            "hostlib_fs_emit_safe_text_patch_result",
         ]
     );
     let expected_missing: &[(&str, &str)] = &[
@@ -186,6 +187,7 @@ fn fs_capability_registers_documented_methods() {
         ("hostlib_fs_discard_staged", "session_id"),
         ("hostlib_fs_safe_text_patch", "path"),
         ("hostlib_fs_read_text", "path"),
+        ("hostlib_fs_emit_safe_text_patch_result", "path"),
     ];
     for (name, expected_param) in expected_missing {
         let entry = registry.find(name).expect("registered");

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -782,6 +782,51 @@ impl AgentEventSink for AcpAgentEventSink {
                     "update": update,
                 }));
             }
+            AgentEvent::SafeTextPatchResult {
+                session_id,
+                path,
+                result,
+                hunks_count,
+                bytes_written,
+                failed_hunk_index,
+            } => {
+                let mut update = super::bridge::progress_update(
+                    "safe_text_patch",
+                    &format!("safe_text_patch: {result}"),
+                    None,
+                    None,
+                    None,
+                );
+                let mut harn_meta = serde_json::Map::new();
+                harn_meta.insert(
+                    "kind".to_string(),
+                    serde_json::Value::String("safe_text_patch_result".to_string()),
+                );
+                harn_meta.insert("path".to_string(), serde_json::Value::String(path.clone()));
+                harn_meta.insert(
+                    "result".to_string(),
+                    serde_json::Value::String(result.clone()),
+                );
+                harn_meta.insert(
+                    "hunksCount".to_string(),
+                    serde_json::Value::from(*hunks_count as u64),
+                );
+                harn_meta.insert(
+                    "bytesWritten".to_string(),
+                    serde_json::Value::from(*bytes_written),
+                );
+                if let Some(idx) = failed_hunk_index {
+                    harn_meta.insert(
+                        "failedHunkIndex".to_string(),
+                        serde_json::Value::from(*idx as u64),
+                    );
+                }
+                merge_harn_meta(&mut update, harn_meta);
+                self.write_notification(serde_json::json!({
+                    "sessionId": session_id,
+                    "update": update,
+                }));
+            }
             AgentEvent::ControlOutcome {
                 session_id,
                 control_id,

--- a/crates/harn-stdlib/src/stdlib/stdlib_edit.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_edit.harn
@@ -1067,12 +1067,24 @@ fn __edit_safe_patch_telemetry(result, hunks_count, failed_hunk_index) {
 fn __edit_safe_patch_result(ctx, fields = nil) {
   let extra = fields ?? {}
   let result = extra?.result ?? ctx.result
+  let matched = result == "applied" || result == "no_op"
   let failed_idx = extra?.failed_hunk_index
+  let bytes_written = extra?.bytes_written ?? 0
+  hostlib_fs_emit_safe_text_patch_result(
+    {
+      session_id: ctx.session_id,
+      path: ctx.path,
+      result: result,
+      hunks_count: ctx.hunks_count,
+      bytes_written: bytes_written,
+      failed_hunk_index: failed_idx,
+    },
+  )
   let base = {
-    ok: result == "applied" || result == "no_op",
+    ok: matched,
     result: result,
-    applied: false,
-    changed: false,
+    applied: matched,
+    dry_run: ctx.dry_run ?? false,
     path: ctx.path,
     before_sha256: ctx.before_hash,
     after_sha256: ctx.before_hash,
@@ -1082,9 +1094,8 @@ fn __edit_safe_patch_result(ctx, fields = nil) {
     hunk_results: extra?.hunk_results ?? [],
     failed_hunk_index: failed_idx,
     failed_hunk_error_code: extra?.failed_hunk_error_code,
-    failed_hunk_message: extra?.failed_hunk_message,
     stale_base: result == "stale_base",
-    bytes_written: 0,
+    bytes_written: bytes_written,
     created: false,
     preview: nil,
     errors: [],
@@ -1131,13 +1142,16 @@ fn __edit_safe_patch_result(ctx, fields = nil) {
  *
  * ## Result
  *
- * Returns `{ok, result, applied, changed, path, before_sha256,
+ * Returns `{ok, result, applied, dry_run, path, before_sha256,
  * after_sha256, current_hash, expected_hash, hunks_count,
- * hunk_results, failed_hunk_index?, stale_base, bytes_written,
- * preview?, telemetry, provenance}`. `result` is one of `applied`,
- * `no_op`, `stale_base`, `hunk_conflict`. `telemetry` carries
- * per-call counters hosts roll up into stale-base / hunk-conflict
- * rates and average hunks-per-patch.
+ * hunk_results, failed_hunk_index?, failed_hunk_error_code?,
+ * stale_base, bytes_written, created, preview?, errors, warnings,
+ * telemetry, provenance}`. `result` is one of `applied`, `no_op`,
+ * `stale_base`, `hunk_conflict`; `applied: true` means the matcher
+ * succeeded (mirrors `edit_apply_node`'s convention — `dry_run: true`
+ * keeps `applied` true while skipping the on-disk write). `telemetry`
+ * carries per-call counters hosts roll up into stale-base /
+ * hunk-conflict rates and average hunks-per-patch.
  *
  * @effects: [host, fs]
  * @allocation: heap
@@ -1158,10 +1172,12 @@ pub fn edit_safe_text_patch(params) {
   let current_hash = read_response?.sha256 ?? __edit_sha256(current_content)
   let ctx = {
     path: path,
+    session_id: session_id,
     before_hash: current_hash,
     current_hash: current_hash,
     expected_hash: expected_hash,
     hunks_count: len(hunks),
+    dry_run: dry_run,
     result: "applied",
     options: opts,
   }
@@ -1190,6 +1206,7 @@ pub fn edit_safe_text_patch(params) {
     let outcome = edit_apply_old_new_patch(working, hunk?.old_text, hunk?.new_text, hunk_opts)
     hunk_results = hunk_results + [outcome]
     if !outcome.ok {
+      let hunk_error_code = outcome?.error_code ?? "no_match"
       return __edit_safe_patch_result(
         ctx,
         {
@@ -1197,14 +1214,13 @@ pub fn edit_safe_text_patch(params) {
           after_sha256: __edit_sha256(working),
           hunk_results: hunk_results,
           failed_hunk_index: idx,
-          failed_hunk_error_code: outcome?.error_code,
-          failed_hunk_message: outcome?.message,
+          failed_hunk_error_code: hunk_error_code,
           errors: [
             {
               code: "hunk_conflict",
-              message: "hunk " + to_string(idx) + " rejected: " + outcome?.error_code ?? "no_match",
+              message: "hunk " + to_string(idx) + " rejected: " + hunk_error_code,
               hunk_index: idx,
-              hunk_error_code: outcome?.error_code,
+              hunk_error_code: hunk_error_code,
               hunk_message: outcome?.message,
             },
           ],
@@ -1214,8 +1230,8 @@ pub fn edit_safe_text_patch(params) {
     working = outcome.patched
     idx = idx + 1
   }
-  let after_hash = __edit_sha256(working)
   if dry_run {
+    let after_hash = __edit_sha256(working)
     let result_kind = if current_content == working {
       "no_op"
     } else {
@@ -1223,13 +1239,7 @@ pub fn edit_safe_text_patch(params) {
     }
     return __edit_safe_patch_result(
       ctx,
-      {
-        result: result_kind,
-        after_sha256: after_hash,
-        hunk_results: hunk_results,
-        changed: current_content != working,
-        preview: working,
-      },
+      {result: result_kind, after_sha256: after_hash, hunk_results: hunk_results, preview: working},
     )
   }
   let commit = hostlib_fs_safe_text_patch(
@@ -1244,12 +1254,13 @@ pub fn edit_safe_text_patch(params) {
   )
   let commit_result = commit?.result ?? "applied"
   let committed_hash = commit?.current_hash ?? current_hash
+  let committed_after = commit?.after_sha256 ?? current_hash
   if commit_result == "stale_base" {
     return __edit_safe_patch_result(
       ctx.merge({current_hash: committed_hash}),
       {
         result: "stale_base",
-        after_sha256: after_hash,
+        after_sha256: committed_after,
         hunk_results: hunk_results,
         errors: [
           {
@@ -1266,10 +1277,8 @@ pub fn edit_safe_text_patch(params) {
     ctx.merge({current_hash: committed_hash}),
     {
       result: commit_result,
-      after_sha256: commit?.after_sha256 ?? after_hash,
+      after_sha256: committed_after,
       hunk_results: hunk_results,
-      applied: commit?.applied ?? false,
-      changed: commit_result == "applied",
       bytes_written: commit?.bytes_written ?? 0,
       created: commit?.created ?? false,
     },

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -426,6 +426,20 @@ pub enum AgentEvent {
         pending_count: usize,
         total_bytes: u64,
     },
+    /// Per-call outcome of `hostlib_fs_safe_text_patch`. Hosts subscribe to
+    /// this to roll up stale-base / hunk-conflict rates and average
+    /// hunks-per-patch without scraping result dicts out of pipeline logs.
+    /// Fired from both the staged-overlay and direct-disk code paths so
+    /// the rollup is comprehensive.
+    SafeTextPatchResult {
+        session_id: String,
+        path: String,
+        result: String,
+        hunks_count: usize,
+        bytes_written: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        failed_hunk_index: Option<usize>,
+    },
     /// ACP control-plane arbitration outcome. Emitted for accepted,
     /// idempotent, and rejected controls so replay/audit consumers can show
     /// who acted and why a late or unauthorized action lost.
@@ -685,6 +699,7 @@ impl AgentEvent {
             | Self::Handoff { session_id, .. }
             | Self::FsWatch { session_id, .. }
             | Self::StagedWritesPending { session_id, .. }
+            | Self::SafeTextPatchResult { session_id, .. }
             | Self::ControlOutcome { session_id, .. }
             | Self::WorkerUpdate { session_id, .. }
             | Self::HitlRequested { session_id, .. }

--- a/docs/src/stdlib/edit.md
+++ b/docs/src/stdlib/edit.md
@@ -350,7 +350,7 @@ Backed by the `hostlib_fs_safe_text_patch` builtin (issue
 | `session_id` | no | Hostlib session whose staged-fs overlay should intercept the read and the write. |
 | `match_options` | no | Default `edit_apply_old_new_patch` options merged into every hunk. |
 | `dry_run` | no | When `true` the post-image is rendered into `preview` but no bytes are written. |
-| `create_parents` | no, default `true` | Create missing parent directories on write. |
+| `create_parents` | no, default `true` | Create missing parent directories on write. When `false`, a missing parent is a hard error (the call does **not** silently fall back to creating it). |
 | `overwrite` | no, default `true` | Allow replacing existing files. |
 
 ### Result
@@ -366,7 +366,14 @@ Every result carries `before_sha256` / `after_sha256` / `current_hash`,
 the per-hunk `hunk_results`, a `telemetry` envelope (`applied`,
 `stale_base`, `hunk_conflict`, `no_op` counters plus `hunks`), and a
 `provenance` envelope so hosts can roll up stale-base / hunk-conflict
-rates and average hunks-per-patch without re-parsing logs.
+rates and average hunks-per-patch without re-parsing logs. The same
+counters fire through the `SafeTextPatchResult` agent event so hosts
+that subscribe to the event stream see every terminal outcome without
+polling.
+
+`applied` is `true` whenever the hunk matcher succeeded — including
+when `dry_run: true` skipped the on-disk write. Distinguish the two
+via the `dry_run` field on the result, mirroring `edit_apply_node`.
 
 ### Worked example: two hunks under stale-base guarding
 
@@ -438,6 +445,76 @@ pipeline default() {
     },
   )
   __io_println(winner.result)                 // "applied"
+}
+```
+
+### Bounded retry loop on `stale_base`
+
+The natural pattern for hot paths: re-snapshot and re-apply against the
+overlay's actual hash, up to a small cap. Past the cap, surface the
+conflict to the caller rather than spinning forever.
+
+```harn,ignore
+import { edit_safe_text_patch } from "std/edit"
+
+fn rewrite(path, hunks, session_id) {
+  var attempt = 0
+  let max_attempts = 3
+  while attempt < max_attempts {
+    let snapshot = hostlib_fs_read_text({path: path, session_id: session_id})
+    let result = edit_safe_text_patch(
+      {
+        path: path,
+        expected_hash: snapshot.sha256,
+        hunks: hunks,
+        session_id: session_id,
+      },
+    )
+    if result.result != "stale_base" {
+      return result
+    }
+    attempt = attempt + 1
+  }
+  return {result: "stale_base_exhausted", attempts: max_attempts}
+}
+```
+
+### Preview an edit before writing
+
+`dry_run: true` runs the matcher and returns the post-image in
+`preview` without touching the file. `applied: true` plus
+`dry_run: true` together mean "the matcher succeeded but we did not
+write" — same convention as `edit_apply_node`.
+
+```harn,ignore
+import { edit_safe_text_patch } from "std/edit"
+
+pipeline default() {
+  let path = "src/lib.rs"
+  let snapshot = hostlib_fs_read_text({path: path})
+  let preview = edit_safe_text_patch(
+    {
+      path: path,
+      expected_hash: snapshot.sha256,
+      hunks: [{old_text: "return 1", new_text: "return 11"}],
+      dry_run: true,
+    },
+  )
+  __io_println(preview.applied)               // true (matcher succeeded)
+  __io_println(preview.dry_run)               // true (no write happened)
+  __io_println(preview.bytes_written)         // 0
+  // The file on disk is unchanged. `preview.preview` carries the
+  // post-image the real apply would produce — show it in a diff UI,
+  // gate on user approval, then re-run with `dry_run: false`.
+  if user_approves(preview.preview) {
+    edit_safe_text_patch(
+      {
+        path: path,
+        expected_hash: snapshot.sha256,
+        hunks: [{old_text: "return 1", new_text: "return 11"}],
+      },
+    )
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #2542 acting on findings from a post-merge adversarial review
of the safe_text_patch primitive. Fixes two latent correctness bugs, adds
the missing telemetry surface, tightens the public API shape to match
`edit_apply_node`, and lands the supporting tests + docs.

- **Correctness**
  - **H2** `create_parents: false` is now honored on the direct-disk
    path — previously `atomic_write`'s unconditional `create_dir_all`
    silently created the parent regardless of the flag. Disk path now
    pre-checks and returns a structured error with the right remediation
    hint when the parent is missing.
  - **H3** Latent `+ / ??` precedence bug in the hunk_conflict error
    message fixed — fallback was unreachable, parenthesized + hoisted to
    a `let hunk_error_code`.
- **Telemetry**
  - **M1** New `AgentEvent::SafeTextPatchResult` fires from every
    terminal return path (applied / no_op / stale_base / hunk_conflict)
    so hosts can stream-aggregate rates without polling. ACP adapter
    translates it to a `progress` extension with
    `_meta.harn.kind = "safe_text_patch_result"`. Backed by a new
    `hostlib_fs_emit_safe_text_patch_result` builtin.
- **API cleanup**
  - **M3** Stopped recomputing the post-image hash on the commit path —
    the hostlib commit response now drives `after_sha256` everywhere
    except the dry-run and hunk_conflict branches that can't avoid it.
  - **M5/M6** Dropped redundant `result.changed` (it always equalled
    `result == "applied"`); aligned `dry_run` semantics with
    `edit_apply_node` — `applied: true` now means matcher succeeded,
    new top-level `result.dry_run` disambiguates.
  - **L5** Dropped dead `result.failed_hunk_message` (the same string
    is already in `errors[0].hunk_message`).
- **DRY / schemas**
  - **L1/L2** New `hash_label(&[u8]) -> String` collapses 4 copies of
    the `format!("sha256:{}", hex::encode(Sha256::digest(...)))` pattern.
  - **L3** All hash fields carry the `^sha256:[0-9a-f]{64}$` regex via a
    shared `$defs/sha256Label` schema reference. `expected_hash` is now
    required in the response (was nullable but always emitted).
- **Docs**
  - **L6/L7** Added a bounded `stale_base` retry-loop example and a
    dry-run → apply workflow example; updated the `create_parents`
    parameter table entry to call out the new fail-fast semantics.

H1 (sandbox-gating of the un-gated `fs/*` and `ast/*` edit primitives)
is filed as #2548 — cross-cutting concern with sibling helpers
(`edit_apply_node`, `edit_insert_at_anchor`), explicitly out of scope.

## Test plan

- [x] `cargo test -p harn-hostlib --test fs_staging` — 18 tests
  (4 new: `safe_text_patch_disk_rejects_missing_parent_when_create_parents_false`,
  `read_text_rejects_non_utf8_with_clear_diagnostic`,
  `safe_text_patch_round_trips_large_payload`,
  `emit_safe_text_patch_result_routes_to_active_session`).
- [x] `cargo test -p harn-hostlib --tests` — full hostlib suite, all
  green.
- [x] `cargo clippy -p harn-hostlib -p harn-vm -p harn-serve` clean.
- [x] `harn test conformance tests/stdlib` — 265 / 265 pass, including
  the updated `edit_safe_text_patch.harn` with new assertions for
  `failed_hunk_error_code`, the parenthesized error message, and the
  new `dry_run` / `applied` / `bytes_written` shape.
- [x] `make check-docs-snippets` — 610 / 610 pass.
- [x] `make lint-md` — 0 errors.
- [x] `harn lint` + `harn fmt --check` clean on the updated Harn file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)