### PR TITLE
builtins: phase 5 — DSL holdouts (path_scope_guard + tui)

### DIFF
--- a/changelog.d/2551.removed.md
+++ b/changelog.d/2551.removed.md
@@ -1,0 +1,12 @@
+- **DSL holdouts migrated to `#[harn_builtin]`** (phase 5).
+  `crates/harn-vm/src/stdlib/path_scope_guard.rs` (2 builtins:
+  `register_path_scope_guard` / `clear_path_scope_guard`) and
+  `crates/harn-vm/src/stdlib/tui.rs` (3 builtins: `__tui_page` /
+  `__tui_clear` / `__tui_terminal_width`) cut over to annotated free
+  fns. Removes the matching `BuiltinSignature` literals from
+  `crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs`
+  plus the now-unused `PAGER_OPTIONS` shape from `shapes.rs`.
+
+  Three legacy-DSL modules remain (`workflow_messages` / `pool/mod.rs` /
+  `workflow/register.rs`) before `stdlib::registration` can be deleted
+  outright.

--- a/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/shapes.rs
@@ -578,16 +578,6 @@ pub(crate) const READ_LINE_OPTIONS: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::optional("raw", TY_BOOL),
 ]);
 
-/// Options dict for `__tui_page` (the runtime backing `std/tui::page`).
-/// Mirrors `parse_page_options` in `crates/harn-vm/src/stdlib/tui.rs`.
-pub(crate) const PAGER_OPTIONS: Ty = Ty::Shape(&[
-    ShapeFieldDescriptor::new("body", TY_STRING),
-    ShapeFieldDescriptor::optional("title", TY_STRING),
-    ShapeFieldDescriptor::optional("footer", TY_STRING),
-    ShapeFieldDescriptor::optional("format", TY_STRING),
-    ShapeFieldDescriptor::optional("no_pager", TY_BOOL),
-]);
-
 /// Options dict for `signal_install` / cooperative signal handler primitives.
 pub(crate) const SIGNAL_HANDLER_OPTIONS: Ty = Ty::Shape(&[
     ShapeFieldDescriptor::optional("once", TY_BOOL),

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -302,7 +302,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         TY_NIL,
     ),
     BuiltinSignature::simple("circuit_reset", &[Param::new("name", TY_STRING)], TY_NIL),
-    BuiltinSignature::simple("clear_path_scope_guard", &[], TY_NIL),
     BuiltinSignature::simple("clear_tool_hooks", &[], TY_NIL),
     BuiltinSignature::simple("clear_persona_hooks", &[], TY_NIL),
     BuiltinSignature::simple("clear_session_hooks", &[], TY_NIL),
@@ -613,11 +612,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature::simple(
         "register_checkpoint_hook",
         &[Param::new("kinds", TY_ANY), Param::new("handler", TY_ANY)],
-        TY_NIL,
-    ),
-    BuiltinSignature::simple(
-        "register_path_scope_guard",
-        &[Param::optional("opts", TY_DICT_OR_NIL)],
         TY_NIL,
     ),
     BuiltinSignature::simple(

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -1,8 +1,7 @@
 //! Core stdlib builtin signatures that are not in the higher-level namespaces.
 
 use super::shapes::{
-    DAEMON_CONFIG, DAEMON_SUMMARY, IO_RESULT_ENVELOPE, PAGER_OPTIONS, READ_LINE_OPTIONS,
-    SIGNAL_HANDLER_OPTIONS,
+    DAEMON_CONFIG, DAEMON_SUMMARY, IO_RESULT_ENVELOPE, READ_LINE_OPTIONS, SIGNAL_HANDLER_OPTIONS,
 };
 use super::{
     BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_BYTES, TY_CLOSURE, TY_DICT, TY_DICT_OR_NIL,
@@ -163,17 +162,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         "__signal_raise",
         &[Param::optional("signal", TY_STRING)],
         TY_NIL,
-    ),
-    BuiltinSignature::simple("__tui_clear", &[], TY_NIL),
-    BuiltinSignature::simple(
-        "__tui_page",
-        &[Param::new("options", PAGER_OPTIONS)],
-        TY_DICT,
-    ),
-    BuiltinSignature::simple(
-        "__tui_terminal_width",
-        &[Param::optional("default_width", TY_INT)],
-        TY_INT,
     ),
     BuiltinSignature::simple(
         "append_file",

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -313,6 +313,7 @@ pub fn all_builtin_defs() -> &'static [&'static macros::VmBuiltinDef] {
         out.extend_from_slice(oauth_storage::MODULE_BUILTINS);
         out.extend_from_slice(observability::MODULE_BUILTINS);
         out.extend_from_slice(path::MODULE_BUILTINS);
+        out.extend_from_slice(path_scope_guard::MODULE_BUILTINS);
         out.extend_from_slice(postgres::MODULE_BUILTINS);
         out.extend_from_slice(process::MODULE_BUILTINS);
         out.extend_from_slice(project::MODULE_BUILTINS);

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -334,6 +334,7 @@ pub fn all_builtin_defs() -> &'static [&'static macros::VmBuiltinDef] {
         out.extend_from_slice(tools::MODULE_BUILTINS);
         out.extend_from_slice(tracing::MODULE_BUILTINS);
         out.extend_from_slice(triggers_stdlib::MODULE_BUILTINS);
+        out.extend_from_slice(tui::MODULE_BUILTINS);
         out.extend_from_slice(types::MODULE_BUILTINS);
         out.extend_from_slice(url_parse::MODULE_BUILTINS);
         out.extend_from_slice(waitpoint::MODULE_BUILTINS);

--- a/crates/harn-vm/src/stdlib/path_scope_guard.rs
+++ b/crates/harn-vm/src/stdlib/path_scope_guard.rs
@@ -15,9 +15,9 @@ use crate::llm::helpers::{ReminderPropagate, ReminderRoleHint, ReminderSource, S
 use crate::orchestration::{
     set_singleton_pre_tool_hook, PreToolAction, PreToolHookFn, ReminderSpec,
 };
-use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
+use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
-use crate::vm::{Vm, VmBuiltinArity};
+use crate::vm::Vm;
 use crate::workspace_anchor::MountMode;
 
 const DEFAULT_ARG_KEYS: &[&str] = &[
@@ -36,39 +36,28 @@ const DEFAULT_ARG_KEYS: &[&str] = &[
 pub const PATH_SCOPE_VIOLATION_PREFIX: &str = "[path_scope_violation] ";
 
 pub fn register_path_scope_guard_builtins(vm: &mut Vm) {
-    register_builtin_group(vm, BUILTINS);
+    for def in MODULE_BUILTINS {
+        vm.register_builtin_def(def);
+    }
 }
 
-const BUILTINS: BuiltinGroup<'static> = BuiltinGroup::new()
-    .category("agent.path_scope_guard")
-    .sync(&[
-        SyncBuiltin::new(
-            "register_path_scope_guard",
-            register_path_scope_guard_builtin,
-        )
-        .signature("register_path_scope_guard(opts?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .doc(
-            "Install a PreToolUse hook that denies (or emits a `<scope-alert>` \
-             reminder for) tool calls whose path-shaped args point outside the \
-             session's workspace anchor (#2221). `opts` may set `arg_keys` \
-             (default: path/destination/source/file/filepath/file_path/target), \
-             `on_violation` (\"deny\" or \"reminder\"; default \"deny\"), and \
-             `mount_modes` (which mounted-root modes count as in-scope; default \
-             the session's writable mounts: extend + sandboxed). Returns nil. \
-             Pairs with the `<scope-alert>` reminder body for the model-facing \
-             handoff hint (#2222).",
-        ),
-        SyncBuiltin::new("clear_path_scope_guard", clear_path_scope_guard_builtin)
-            .signature("clear_path_scope_guard()")
-            .arity(VmBuiltinArity::Exact(0))
-            .doc("Remove the active path_scope_guard registration."),
-    ]);
+pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] =
+    &[&REGISTER_PATH_SCOPE_GUARD_DEF, &CLEAR_PATH_SCOPE_GUARD_DEF];
 
-fn register_path_scope_guard_builtin(
-    args: &[VmValue],
-    _out: &mut String,
-) -> Result<VmValue, VmError> {
+/// Install a PreToolUse hook that denies (or emits a `<scope-alert>`
+/// reminder for) tool calls whose path-shaped args point outside the
+/// session's workspace anchor (#2221). `opts` may set `arg_keys`
+/// (default: path/destination/source/file/filepath/file_path/target),
+/// `on_violation` ("deny" or "reminder"; default "deny"), and
+/// `mount_modes` (which mounted-root modes count as in-scope; default
+/// the session's writable mounts: extend + sandboxed). Returns nil.
+/// Pairs with the `<scope-alert>` reminder body for the model-facing
+/// handoff hint (#2222).
+#[harn_builtin(
+    sig = "register_path_scope_guard(opts?: dict|nil) -> nil",
+    category = "agent.path_scope_guard"
+)]
+fn register_path_scope_guard(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let opts = match args.first() {
         None | Some(VmValue::Nil) => BTreeMap::new(),
         Some(VmValue::Dict(map)) => map.as_ref().clone(),
@@ -129,10 +118,12 @@ fn register_path_scope_guard_builtin(
     Ok(VmValue::Nil)
 }
 
-fn clear_path_scope_guard_builtin(
-    _args: &[VmValue],
-    _out: &mut String,
-) -> Result<VmValue, VmError> {
+/// Remove the active path_scope_guard registration.
+#[harn_builtin(
+    sig = "clear_path_scope_guard() -> nil",
+    category = "agent.path_scope_guard"
+)]
+fn clear_path_scope_guard(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     set_singleton_pre_tool_hook(None);
     Ok(VmValue::Nil)
 }

--- a/crates/harn-vm/src/stdlib/tui.rs
+++ b/crates/harn-vm/src/stdlib/tui.rs
@@ -5,32 +5,16 @@ use std::io::{ErrorKind, Write};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 
-use crate::stdlib::registration::{register_builtin_group, BuiltinGroup, SyncBuiltin};
+use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
-use crate::vm::{Vm, VmBuiltinArity};
+use crate::vm::Vm;
 
 const CLEAR_SEQUENCE: &str = "\x1b[2J\x1b[H";
 const DEFAULT_TERMINAL_WIDTH: usize = 80;
 const DEFAULT_RULE_CHAR: &str = "─";
 
-const TUI_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
-    SyncBuiltin::new("__tui_page", tui_page_builtin)
-        .signature("__tui_page(options)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Render a text or markdown page through a pager when appropriate."),
-    SyncBuiltin::new("__tui_clear", tui_clear_builtin)
-        .signature("__tui_clear()")
-        .arity(VmBuiltinArity::Exact(0))
-        .doc("Write the ANSI clear-screen sequence to stdout."),
-    SyncBuiltin::new("__tui_terminal_width", tui_terminal_width_builtin)
-        .signature("__tui_terminal_width(default_width?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .doc("Return the current terminal width or the supplied default."),
-];
-
-const TUI_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
-    .category("tui")
-    .sync(TUI_SYNC_PRIMITIVES);
+pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] =
+    &[&__TUI_PAGE_DEF, &__TUI_CLEAR_DEF, &__TUI_TERMINAL_WIDTH_DEF];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PageOptions {
@@ -48,10 +32,14 @@ enum PageFormat {
 }
 
 pub(crate) fn register_tui_builtins(vm: &mut Vm) {
-    register_builtin_group(vm, TUI_PRIMITIVES);
+    for def in MODULE_BUILTINS {
+        vm.register_builtin_def(def);
+    }
 }
 
-fn tui_page_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+/// Render a text or markdown page through a pager when appropriate.
+#[harn_builtin(sig = "__tui_page(options: dict) -> dict", category = "tui")]
+fn __tui_page(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
     let options = parse_page_options(args)?;
     let content = render_page_content(&options);
 
@@ -70,12 +58,19 @@ fn tui_page_builtin(args: &[VmValue], out: &mut String) -> Result<VmValue, VmErr
     }
 }
 
-fn tui_clear_builtin(_args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
+/// Write the ANSI clear-screen sequence to stdout.
+#[harn_builtin(sig = "__tui_clear() -> nil", category = "tui")]
+fn __tui_clear(_args: &[VmValue], out: &mut String) -> Result<VmValue, VmError> {
     super::io::write_stdout(out, CLEAR_SEQUENCE);
     Ok(VmValue::Nil)
 }
 
-fn tui_terminal_width_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+/// Return the current terminal width or the supplied default.
+#[harn_builtin(
+    sig = "__tui_terminal_width(default_width?: int) -> int",
+    category = "tui"
+)]
+fn __tui_terminal_width(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let default = args
         .first()
         .and_then(VmValue::as_int)


### PR DESCRIPTION
## Summary

Phase 5 follow-up. Migrates two of the four `BuiltinGroup`/`SyncBuiltin` holdouts off the legacy DSL onto `#[harn_builtin]`:

- **`path_scope_guard.rs`** (2 builtins): straight DSL → macro swap, no captured state.
- **`tui.rs`** (3 builtins): `__tui_page` / `__tui_clear` / `__tui_terminal_width`, plus deletion of the redundant `PAGER_OPTIONS` shape literal (was only a parser hint, not a runtime guard).

Two larger DSL files remain (`workflow_messages.rs` 896 LOC + 13 sites, `pool/mod.rs` 2512 LOC + 9 sites). Once those land, `crates/harn-vm/src/stdlib/registration.rs` can be deleted outright and the `linkme::distributed_slice` final ship becomes the only remaining capstone.

## Test plan
- [x] `cargo check -p harn-vm`
- [x] `cargo test -p harn-vm --test builtin_registry_alignment` (4 green)
- [ ] CI conformance + parser tests (let the queue run them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)