### PR TITLE
builtins: phase 6 — workflow_messages.rs DSL migration

### DIFF
--- a/changelog.d/2553.removed.md
+++ b/changelog.d/2553.removed.md
@@ -1,0 +1,16 @@
+- **`workflow_messages.rs` migrated to `#[harn_builtin]`** (phase 6).
+  11 mailbox primitives — `workflow.signal` / `workflow.query` /
+  `workflow.update` (async) / `workflow.publish_query` /
+  `workflow.receive` / `workflow.respond_update` / `workflow.pause` /
+  `workflow.resume` / `workflow.status` / `workflow.continue_as_new`
+  plus the top-level `continue_as_new` alias — cut over from the
+  legacy `BuiltinGroup`/`SyncBuiltin`/`async_builtin!` DSL onto
+  annotated free fns. The macro sig parser handles dotted builtin
+  names (`workflow.signal`), so no `BuiltinRef` shim changes were
+  needed. Deletes the corresponding `BuiltinSignature` literals from
+  `workflow.rs` plus the now-unused `TY_WORKFLOW_TARGET` helper.
+
+  Remaining DSL holdouts: `crates/harn-vm/src/stdlib/workflow/register.rs`
+  (workflow executor primitives across 4 sibling modules) and
+  `crates/harn-vm/src/stdlib/pool/mod.rs`. Both block deletion of the
+  `stdlib::registration` module.

--- a/crates/harn-parser/src/builtin_signatures/signatures/workflow.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/workflow.rs
@@ -15,11 +15,6 @@ use super::{
     TY_STRING, TY_STRING_OR_NIL,
 };
 
-/// `string | dict` — accepted shapes for workflow targets in the
-/// `workflow.*` mailbox primitives. Either a workflow id string or a
-/// `{workflow_id, base_dir?}` dict.
-const TY_WORKFLOW_TARGET: Ty = Ty::Union(&[TY_STRING, TY_DICT]);
-
 /// `dict | Schema<any>` — schema aliases type-check as `Schema<T>` but
 /// compile down to JSON-Schema dictionaries at runtime.
 const TY_SCHEMA_VALUE: Ty = Ty::Union(&[TY_DICT, Ty::Apply("Schema", &[TY_ANY])]);
@@ -31,13 +26,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature::simple(
         "assemble_context",
         &[Param::new("options", TY_DICT)],
-        TY_DICT,
-    ),
-    // continue_as_new(target) — bump the workflow generation, clear
-    // pending responses, and return updated status.
-    BuiltinSignature::simple(
-        "continue_as_new",
-        &[Param::new("target", TY_WORKFLOW_TARGET)],
         TY_DICT,
     ),
     // handoff_effects(source, ceiling?) -> typed effect set computed from a
@@ -52,89 +40,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::optional("policy", TY_DICT_OR_NIL),
         ],
         TY_LIST,
-    ),
-    // workflow.continue_as_new(target) -> updated status dict.
-    BuiltinSignature::simple(
-        "workflow.continue_as_new",
-        &[Param::new("target", TY_WORKFLOW_TARGET)],
-        TY_DICT,
-    ),
-    // workflow.pause(target) -> updated status dict.
-    BuiltinSignature::simple(
-        "workflow.pause",
-        &[Param::new("target", TY_WORKFLOW_TARGET)],
-        TY_DICT,
-    ),
-    // workflow.publish_query(target, name, value) -> publish-summary
-    // dict.
-    BuiltinSignature::simple(
-        "workflow.publish_query",
-        &[
-            Param::new("target", TY_WORKFLOW_TARGET),
-            Param::new("name", TY_STRING),
-            Param::new("value", TY_ANY),
-        ],
-        TY_DICT,
-    ),
-    // workflow.query(target, name) -> stored query value (any).
-    BuiltinSignature::simple(
-        "workflow.query",
-        &[
-            Param::new("target", TY_WORKFLOW_TARGET),
-            Param::new("name", TY_STRING),
-        ],
-        TY_ANY,
-    ),
-    // workflow.receive(target) -> next message dict | nil.
-    BuiltinSignature::simple(
-        "workflow.receive",
-        &[Param::new("target", TY_WORKFLOW_TARGET)],
-        TY_DICT_OR_NIL,
-    ),
-    // workflow.respond_update(target, request_id, value, name?).
-    BuiltinSignature::simple(
-        "workflow.respond_update",
-        &[
-            Param::new("target", TY_WORKFLOW_TARGET),
-            Param::new("request_id", TY_STRING),
-            Param::new("value", TY_ANY),
-            Param::optional("name", TY_STRING_OR_NIL),
-        ],
-        TY_DICT,
-    ),
-    // workflow.resume(target) -> updated status dict.
-    BuiltinSignature::simple(
-        "workflow.resume",
-        &[Param::new("target", TY_WORKFLOW_TARGET)],
-        TY_DICT,
-    ),
-    // workflow.signal(target, name, payload?) -> enqueue summary dict.
-    BuiltinSignature::simple(
-        "workflow.signal",
-        &[
-            Param::new("target", TY_WORKFLOW_TARGET),
-            Param::new("name", TY_STRING),
-            Param::optional("payload", TY_ANY),
-        ],
-        TY_DICT,
-    ),
-    // workflow.status(target) -> status dict.
-    BuiltinSignature::simple(
-        "workflow.status",
-        &[Param::new("target", TY_WORKFLOW_TARGET)],
-        TY_DICT,
-    ),
-    // workflow.update(target, name, payload?, options?) — async; returns
-    // the update response value (caller-defined shape, hence `any`).
-    BuiltinSignature::simple(
-        "workflow.update",
-        &[
-            Param::new("target", TY_WORKFLOW_TARGET),
-            Param::new("name", TY_STRING),
-            Param::optional("payload", TY_ANY),
-            Param::optional("options", TY_DICT_OR_NIL),
-        ],
-        TY_ANY,
     ),
     // workflow_clone(workflow) -> cloned workflow graph dict.
     BuiltinSignature::simple(

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -338,6 +338,7 @@ pub fn all_builtin_defs() -> &'static [&'static macros::VmBuiltinDef] {
         out.extend_from_slice(waitpoint::MODULE_BUILTINS);
         out.extend_from_slice(waitpoints::MODULE_BUILTINS);
         out.extend_from_slice(web::MODULE_BUILTINS);
+        out.extend_from_slice(workflow_messages::MODULE_BUILTINS);
         out.extend_from_slice(xml::MODULE_BUILTINS);
         out
     })

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -5,69 +5,27 @@ use std::time::Duration as StdDuration;
 
 use serde::{Deserialize, Serialize};
 
+use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::stdlib::process::runtime_root_base;
-use crate::stdlib::registration::{
-    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
-};
 use crate::value::{VmError, VmValue};
-use crate::vm::{Vm, VmBuiltinArity};
+use crate::vm::Vm;
 
 const DEFAULT_UPDATE_TIMEOUT_MS: u64 = 30_000;
 const UPDATE_POLL_INTERVAL_MS: u64 = 25;
 
-const WORKFLOW_MESSAGE_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
-    SyncBuiltin::new("workflow.signal", workflow_signal_builtin)
-        .signature("workflow.signal(target, name, payload?)")
-        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .doc("Enqueue a workflow signal message."),
-    SyncBuiltin::new("workflow.query", workflow_query_builtin)
-        .signature("workflow.query(target, name)")
-        .arity(VmBuiltinArity::Exact(2))
-        .doc("Read the latest published workflow query value."),
-    SyncBuiltin::new("workflow.publish_query", workflow_publish_query_builtin)
-        .signature("workflow.publish_query(target, name, value?)")
-        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .doc("Publish a workflow query value."),
-    SyncBuiltin::new("workflow.receive", workflow_receive_builtin)
-        .signature("workflow.receive(target)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Receive the next workflow mailbox message."),
-    SyncBuiltin::new("workflow.respond_update", workflow_respond_update_builtin)
-        .signature("workflow.respond_update(target, request_id, value?, name?)")
-        .arity(VmBuiltinArity::Range { min: 2, max: 4 })
-        .doc("Respond to a pending workflow update request."),
-    SyncBuiltin::new("workflow.pause", workflow_pause_builtin)
-        .signature("workflow.pause(target)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Pause a workflow mailbox."),
-    SyncBuiltin::new("workflow.resume", workflow_resume_builtin)
-        .signature("workflow.resume(target)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Resume a workflow mailbox."),
-    SyncBuiltin::new("workflow.status", workflow_status_builtin)
-        .signature("workflow.status(target)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Return workflow mailbox status."),
-    SyncBuiltin::new("workflow.continue_as_new", workflow_continue_as_new_builtin)
-        .signature("workflow.continue_as_new(target)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Advance a workflow mailbox generation."),
-    SyncBuiltin::new("continue_as_new", continue_as_new_builtin)
-        .signature("continue_as_new(target)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Advance a workflow mailbox generation."),
+pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
+    &WORKFLOW_SIGNAL_BUILTIN_DEF,
+    &WORKFLOW_QUERY_BUILTIN_DEF,
+    &WORKFLOW_PUBLISH_QUERY_BUILTIN_DEF,
+    &WORKFLOW_RECEIVE_BUILTIN_DEF,
+    &WORKFLOW_RESPOND_UPDATE_BUILTIN_DEF,
+    &WORKFLOW_PAUSE_BUILTIN_DEF,
+    &WORKFLOW_RESUME_BUILTIN_DEF,
+    &WORKFLOW_STATUS_BUILTIN_DEF,
+    &WORKFLOW_CONTINUE_AS_NEW_BUILTIN_DEF,
+    &CONTINUE_AS_NEW_BUILTIN_DEF,
+    &WORKFLOW_UPDATE_BUILTIN_DEF,
 ];
-
-const WORKFLOW_MESSAGE_ASYNC_PRIMITIVES: &[AsyncBuiltin] =
-    &[async_builtin!("workflow.update", workflow_update_builtin)
-        .signature("workflow.update(target, name, payload?, options?)")
-        .arity(VmBuiltinArity::Range { min: 2, max: 4 })
-        .doc("Enqueue a workflow update and wait for a response.")];
-
-const WORKFLOW_MESSAGE_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
-    .category("workflow.messages")
-    .sync(WORKFLOW_MESSAGE_SYNC_PRIMITIVES)
-    .async_(WORKFLOW_MESSAGE_ASYNC_PRIMITIVES);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WorkflowMessageRecord {
@@ -575,9 +533,16 @@ pub(crate) fn register_workflow_message_builtins(vm: &mut Vm) {
         ]))),
     );
 
-    register_builtin_group(vm, WORKFLOW_MESSAGE_PRIMITIVES);
+    for def in MODULE_BUILTINS {
+        vm.register_builtin_def(def);
+    }
 }
 
+/// Enqueue a workflow signal message.
+#[harn_builtin(
+    sig = "workflow.signal(target: string|dict, name: string, payload?: any) -> dict",
+    category = "workflow.messages"
+)]
 fn workflow_signal_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.signal")?;
     let name = args
@@ -594,6 +559,11 @@ fn workflow_signal_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
     Ok(crate::stdlib::json_to_vm_value(&result))
 }
 
+/// Read the latest published workflow query value.
+#[harn_builtin(
+    sig = "workflow.query(target: string|dict, name: string) -> any",
+    category = "workflow.messages"
+)]
 fn workflow_query_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.query")?;
     let name = args
@@ -611,6 +581,12 @@ fn workflow_query_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
     ))
 }
 
+/// Enqueue a workflow update and wait for a response.
+#[harn_builtin(
+    sig = "workflow.update(target: string|dict, name: string, payload?: any, options?: dict|nil) -> any",
+    kind = "async",
+    category = "workflow.messages"
+)]
 async fn workflow_update_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.update")?;
     let name = args
@@ -641,6 +617,11 @@ async fn workflow_update_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError>
     Ok(crate::stdlib::json_to_vm_value(&result))
 }
 
+/// Publish a workflow query value.
+#[harn_builtin(
+    sig = "workflow.publish_query(target: string|dict, name: string, value?: any) -> dict",
+    category = "workflow.messages"
+)]
 fn workflow_publish_query_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.publish_query")?;
     let name = args
@@ -658,6 +639,11 @@ fn workflow_publish_query_builtin(args: &[VmValue], _out: &mut String) -> Result
     Ok(crate::stdlib::json_to_vm_value(&result))
 }
 
+/// Receive the next workflow mailbox message.
+#[harn_builtin(
+    sig = "workflow.receive(target: string|dict) -> dict|nil",
+    category = "workflow.messages"
+)]
 fn workflow_receive_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.receive")?;
     let Some(message) = receive_message(&target).map_err(VmError::Runtime)? else {
@@ -674,6 +660,11 @@ fn workflow_receive_builtin(args: &[VmValue], _out: &mut String) -> Result<VmVal
     })))
 }
 
+/// Respond to a pending workflow update request.
+#[harn_builtin(
+    sig = "workflow.respond_update(target: string|dict, request_id: string, value?: any, name?: string|nil) -> dict",
+    category = "workflow.messages"
+)]
 fn workflow_respond_update_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -705,6 +696,11 @@ fn workflow_respond_update_builtin(
     Ok(crate::stdlib::json_to_vm_value(&result))
 }
 
+/// Pause a workflow mailbox.
+#[harn_builtin(
+    sig = "workflow.pause(target: string|dict) -> dict",
+    category = "workflow.messages"
+)]
 fn workflow_pause_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.pause")?;
     let result =
@@ -712,6 +708,11 @@ fn workflow_pause_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
     Ok(crate::stdlib::json_to_vm_value(&result))
 }
 
+/// Resume a workflow mailbox.
+#[harn_builtin(
+    sig = "workflow.resume(target: string|dict) -> dict",
+    category = "workflow.messages"
+)]
 fn workflow_resume_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.resume")?;
     let result = workflow_resume_for_base(&target.base_dir, &target.workflow_id)
@@ -719,6 +720,11 @@ fn workflow_resume_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
     Ok(crate::stdlib::json_to_vm_value(&result))
 }
 
+/// Return workflow mailbox status.
+#[harn_builtin(
+    sig = "workflow.status(target: string|dict) -> dict",
+    category = "workflow.messages"
+)]
 fn workflow_status_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.status")?;
     let state = load_state(&target).map_err(VmError::Runtime)?;
@@ -727,6 +733,11 @@ fn workflow_status_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
     )))
 }
 
+/// Advance a workflow mailbox generation.
+#[harn_builtin(
+    sig = "workflow.continue_as_new(target: string|dict) -> dict",
+    category = "workflow.messages"
+)]
 fn workflow_continue_as_new_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -734,6 +745,11 @@ fn workflow_continue_as_new_builtin(
     continue_as_new_for_label(args, "workflow.continue_as_new")
 }
 
+/// Advance a workflow mailbox generation (top-level alias).
+#[harn_builtin(
+    sig = "continue_as_new(target: string|dict) -> dict",
+    category = "workflow.messages"
+)]
 fn continue_as_new_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     continue_as_new_for_label(args, "continue_as_new")
 }


### PR DESCRIPTION
## Summary

Phase 6: migrates `crates/harn-vm/src/stdlib/workflow_messages.rs` (11 builtins, 10 sync + 1 async) off the legacy `BuiltinGroup` DSL onto `#[harn_builtin]`.

Covered: `workflow.signal` / `workflow.query` / `workflow.update` (async) / `workflow.publish_query` / `workflow.receive` / `workflow.respond_update` / `workflow.pause` / `workflow.resume` / `workflow.status` / `workflow.continue_as_new` + the top-level `continue_as_new` alias.

The macro sig parser handles dotted names already (`workflow.signal` etc.), so no shim required. Deletes the matching `BuiltinSignature` literals plus the now-unused `TY_WORKFLOW_TARGET` helper from `workflow.rs`.

Remaining DSL holdouts before `stdlib::registration` can be deleted:
- `crates/harn-vm/src/stdlib/workflow/register.rs` (workflow executor primitives across 4 sibling modules — bigger surface area)
- `crates/harn-vm/src/stdlib/pool/mod.rs` (2512 LOC, likely per-pool captured state)

## Test plan
- [x] `cargo check -p harn-vm`
- [x] `cargo test -p harn-vm --test builtin_registry_alignment` (4 green)
- [x] `cargo test -p harn-vm --lib workflow_messages` (6 green)
- [ ] CI conformance + parser tests (let the queue run them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)