### PR TITLE
builtins: phase 7 — pool + workflow/compact DSL migrations

### DIFF
--- a/changelog.d/2554.removed.md
+++ b/changelog.d/2554.removed.md
@@ -1,0 +1,17 @@
+- **Pool + workflow/compact migrated to `#[harn_builtin]`** (phase 7).
+  `crates/harn-vm/src/stdlib/pool/mod.rs` (8 builtins: `__pool_create` /
+  `__pool_get` / `__pool_list` / `__pool_size` / `__pool_snapshot` /
+  `__pool_simulate_restart` / `__pool_submit` (async) / `__pool_wait`
+  (async)) cut over off the legacy `BuiltinGroup` DSL onto annotated
+  free fns; all marked `runtime_only = true` to match the pre-migration
+  intent (host helpers exposed via `RUNTIME_ONLY_EXCEPTIONS` rather than
+  user-facing parser sigs).
+
+  `crates/harn-vm/src/stdlib/workflow/compact.rs` (4 builtins:
+  `select_artifacts_adaptive` / `estimate_tokens` / `microcompact` /
+  `transcript_auto_compact` (async)) migrated. The remaining ~30
+  workflow primitives (hooks / host / inspect) keep the DSL for now —
+  follow-up will land them as the cutover continues.
+
+  Net effect: `stdlib::registration` retains 3 callers (workflow/register.rs
+  for the hooks/host/inspect primitives; everything else is `#[harn_builtin]`).

--- a/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
@@ -689,14 +689,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         TY_LIST,
     ),
     BuiltinSignature::simple(
-        "transcript_auto_compact",
-        &[
-            Param::new("messages", TY_LIST),
-            Param::optional("options", TY_DICT),
-        ],
-        TY_LIST,
-    ),
-    BuiltinSignature::simple(
         "transcript_compact",
         &[
             Param::new("transcript", TY_MESSAGES_OR_TRANSCRIPT),

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -307,11 +307,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     ),
     BuiltinSignature::simple("e", &[], TY_FLOAT),
     BuiltinSignature::simple(
-        "estimate_tokens",
-        &[Param::new("messages", TY_LIST)],
-        TY_INT,
-    ),
-    BuiltinSignature::simple(
         "emit_channel",
         &[
             Param::new("name", TY_STRING),
@@ -357,7 +352,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         TY_LIST,
     ),
     BuiltinSignature::variadic("metrics_inc", &[Param::new("args", TY_ANY)], TY_ANY),
-    BuiltinSignature::variadic("microcompact", &[Param::new("args", TY_ANY)], TY_STRING),
     BuiltinSignature::variadic(
         "monitor_wait_for_native",
         &[Param::new("args", TY_ANY)],

--- a/crates/harn-parser/src/builtin_signatures/signatures/workflow.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/workflow.rs
@@ -30,17 +30,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     ),
     // handoff_effects(source, ceiling?) -> typed effect set computed from a
     // child agent's entrypoint Harn source,
-    // select_artifacts_adaptive(artifacts, policy?) -> list of selected
-    // artifacts after dedup, microcompaction, and policy-driven
-    // selection.
-    BuiltinSignature::simple(
-        "select_artifacts_adaptive",
-        &[
-            Param::optional("artifacts", Ty::Union(&[TY_LIST, TY_NIL])),
-            Param::optional("policy", TY_DICT_OR_NIL),
-        ],
-        TY_LIST,
-    ),
     // workflow_clone(workflow) -> cloned workflow graph dict.
     BuiltinSignature::simple(
         "workflow_clone",

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -363,6 +363,7 @@ pub fn all_builtin_defs() -> &'static [&'static macros::VmBuiltinDef] {
         out.extend_from_slice(waitpoints::MODULE_BUILTINS);
         out.extend_from_slice(web::MODULE_BUILTINS);
         out.extend_from_slice(workflow_messages::MODULE_BUILTINS);
+        out.extend_from_slice(agents::workflow::MODULE_BUILTINS);
         out.extend_from_slice(xml::MODULE_BUILTINS);
         out
     })

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -334,6 +334,7 @@ pub fn all_builtin_defs() -> &'static [&'static macros::VmBuiltinDef] {
         out.extend_from_slice(observability::MODULE_BUILTINS);
         out.extend_from_slice(path::MODULE_BUILTINS);
         out.extend_from_slice(path_scope_guard::MODULE_BUILTINS);
+        out.extend_from_slice(pool::MODULE_BUILTINS);
         out.extend_from_slice(postgres::MODULE_BUILTINS);
         out.extend_from_slice(process::MODULE_BUILTINS);
         out.extend_from_slice(project::MODULE_BUILTINS);

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -1198,7 +1198,7 @@ fn pool_get_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
 }
 
 /// List every pool registered in the local pool registry.
-#[harn_builtin(sig = "__pool_list() -> list", category = "pool")]
+#[harn_builtin(sig = "__pool_list() -> list", category = "pool", runtime_only = true)]
 fn pool_list_sync(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let mut entries: Vec<Rc<RefCell<PoolEntry>>> =
         POOLS.with(|pools| pools.borrow().values().cloned().collect());
@@ -1212,7 +1212,11 @@ fn pool_list_sync(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
 }
 
 /// Return active + queued task count for a pool.
-#[harn_builtin(sig = "__pool_size(pool: dict) -> int", category = "pool")]
+#[harn_builtin(
+    sig = "__pool_size(pool: string|dict) -> int",
+    category = "pool",
+    runtime_only = true
+)]
 fn pool_size_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let pool_id = pool_id_from_value(
         args.first()
@@ -1232,14 +1236,22 @@ fn pool_size_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
 /// simulate "kill process → restart" without actually forking a new
 /// process. Returns `nil`.
 /// Drop the in-process pool registry; pipeline-scope pools reload from disk on next pool_create.
-#[harn_builtin(sig = "__pool_simulate_restart() -> nil", category = "pool")]
+#[harn_builtin(
+    sig = "__pool_simulate_restart() -> nil",
+    category = "pool",
+    runtime_only = true
+)]
 fn pool_reload_sync(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     reset_pool_state();
     Ok(VmValue::Nil)
 }
 
 /// Return the full pool snapshot for inspection.
-#[harn_builtin(sig = "__pool_snapshot(pool: dict) -> dict", category = "pool")]
+#[harn_builtin(
+    sig = "__pool_snapshot(pool: string|dict) -> dict",
+    category = "pool",
+    runtime_only = true
+)]
 fn pool_snapshot_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let pool_id = pool_id_from_value(
         args.first().ok_or_else(|| {
@@ -1254,7 +1266,7 @@ fn pool_snapshot_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
 
 /// Submit a closure to a pool; spawns when a slot is free, otherwise queues.
 #[harn_builtin(
-    sig = "__pool_submit(pool: dict, closure: closure, options?: dict|nil) -> dict",
+    sig = "__pool_submit(pool: string|dict, closure: closure, options?: dict|nil) -> dict",
     kind = "async",
     category = "pool",
     runtime_only = true
@@ -2335,7 +2347,7 @@ fn finalize_task(
 
 /// Block until one or more pool task handles reach a terminal state.
 #[harn_builtin(
-    sig = "__pool_wait(handle_or_handles: dict|list) -> dict",
+    sig = "__pool_wait(handle_or_handles: string|dict|list) -> dict",
     kind = "async",
     category = "pool",
     runtime_only = true

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -28,11 +28,9 @@ use crate::event_log::{
     active_event_log, install_memory_for_current_thread, EventLog, LogEvent, Topic,
 };
 use crate::runtime_limits::RuntimeLimits;
-use crate::stdlib::registration::{
-    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
-};
+use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmClosure, VmError, VmValue};
-use crate::vm::{Vm, VmBuiltinArity};
+use crate::vm::Vm;
 use harn_parser::diagnostic_codes::Code;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -1045,6 +1043,12 @@ fn ordered_pool_config(opts: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmV
     config
 }
 
+/// Create a named agent pool and register it in the local pool registry.
+#[harn_builtin(
+    sig = "__pool_create(options?: dict|nil) -> dict",
+    category = "pool",
+    runtime_only = true
+)]
 fn pool_create_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let opts = parse_options(args.first(), "pool_create")?;
     let name = parse_name(&opts).unwrap_or_else(|| format!("pool_{}", uuid::Uuid::now_v7()));
@@ -1165,6 +1169,12 @@ fn parse_durable_dir(opts: &BTreeMap<String, VmValue>) -> Result<Option<String>,
     }
 }
 
+/// Look up a pool by name or id; returns nil when missing.
+#[harn_builtin(
+    sig = "__pool_get(name_or_id: string|dict) -> dict|nil",
+    category = "pool",
+    runtime_only = true
+)]
 fn pool_get_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let key = args
         .first()
@@ -1187,6 +1197,8 @@ fn pool_get_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
     Ok(snapshot)
 }
 
+/// List every pool registered in the local pool registry.
+#[harn_builtin(sig = "__pool_list() -> list", category = "pool")]
 fn pool_list_sync(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let mut entries: Vec<Rc<RefCell<PoolEntry>>> =
         POOLS.with(|pools| pools.borrow().values().cloned().collect());
@@ -1199,6 +1211,8 @@ fn pool_list_sync(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     )))
 }
 
+/// Return active + queued task count for a pool.
+#[harn_builtin(sig = "__pool_size(pool: dict) -> int", category = "pool")]
 fn pool_size_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let pool_id = pool_id_from_value(
         args.first()
@@ -1217,11 +1231,15 @@ fn pool_size_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
 /// from the on-disk JSONL artifact. Conformance fixtures use this to
 /// simulate "kill process → restart" without actually forking a new
 /// process. Returns `nil`.
+/// Drop the in-process pool registry; pipeline-scope pools reload from disk on next pool_create.
+#[harn_builtin(sig = "__pool_simulate_restart() -> nil", category = "pool")]
 fn pool_reload_sync(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     reset_pool_state();
     Ok(VmValue::Nil)
 }
 
+/// Return the full pool snapshot for inspection.
+#[harn_builtin(sig = "__pool_snapshot(pool: dict) -> dict", category = "pool")]
 fn pool_snapshot_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let pool_id = pool_id_from_value(
         args.first().ok_or_else(|| {
@@ -1234,6 +1252,13 @@ fn pool_snapshot_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
     Ok(snapshot)
 }
 
+/// Submit a closure to a pool; spawns when a slot is free, otherwise queues.
+#[harn_builtin(
+    sig = "__pool_submit(pool: dict, closure: closure, options?: dict|nil) -> dict",
+    kind = "async",
+    category = "pool",
+    runtime_only = true
+)]
 async fn pool_submit_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let pool_id = pool_id_from_value(
         args.first()
@@ -2308,6 +2333,13 @@ fn finalize_task(
     wake_space_waiters(pool);
 }
 
+/// Block until one or more pool task handles reach a terminal state.
+#[harn_builtin(
+    sig = "__pool_wait(handle_or_handles: dict|list) -> dict",
+    kind = "async",
+    category = "pool",
+    runtime_only = true
+)]
 async fn pool_wait_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let target = args
         .first()
@@ -2351,51 +2383,21 @@ async fn wait_single_task(value: &VmValue) -> Result<VmValue, VmError> {
     Ok(snapshot)
 }
 
-const POOL_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
-    SyncBuiltin::new("__pool_create", pool_create_sync)
-        .signature("__pool_create(options?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .doc("Create a named agent pool and register it in the local pool registry."),
-    SyncBuiltin::new("__pool_get", pool_get_sync)
-        .signature("__pool_get(name_or_id)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Look up a pool by name or id; returns nil when missing."),
-    SyncBuiltin::new("__pool_list", pool_list_sync)
-        .signature("__pool_list()")
-        .arity(VmBuiltinArity::Exact(0))
-        .doc("List every pool registered in the local pool registry."),
-    SyncBuiltin::new("__pool_size", pool_size_sync)
-        .signature("__pool_size(pool)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Return active + queued task count for a pool."),
-    SyncBuiltin::new("__pool_snapshot", pool_snapshot_sync)
-        .signature("__pool_snapshot(pool)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Return the full pool snapshot for inspection."),
-    SyncBuiltin::new("__pool_simulate_restart", pool_reload_sync)
-        .signature("__pool_simulate_restart()")
-        .arity(VmBuiltinArity::Exact(0))
-        .doc("Drop the in-process pool registry; pipeline-scope pools reload from disk on next pool_create."),
+pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
+    &POOL_CREATE_SYNC_DEF,
+    &POOL_GET_SYNC_DEF,
+    &POOL_LIST_SYNC_DEF,
+    &POOL_SIZE_SYNC_DEF,
+    &POOL_SNAPSHOT_SYNC_DEF,
+    &POOL_RELOAD_SYNC_DEF,
+    &POOL_SUBMIT_BUILTIN_DEF,
+    &POOL_WAIT_BUILTIN_DEF,
 ];
-
-const POOL_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    async_builtin!("__pool_submit", pool_submit_builtin)
-        .signature("__pool_submit(pool, closure, options?)")
-        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .doc("Submit a closure to a pool; spawns when a slot is free, otherwise queues."),
-    async_builtin!("__pool_wait", pool_wait_builtin)
-        .signature("__pool_wait(handle_or_handles)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Block until one or more pool task handles reach a terminal state."),
-];
-
-const POOL_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
-    .category("pool")
-    .sync(POOL_SYNC_PRIMITIVES)
-    .async_(POOL_ASYNC_PRIMITIVES);
 
 pub(crate) fn register_pool_builtins(vm: &mut Vm) {
-    register_builtin_group(vm, POOL_PRIMITIVES);
+    for def in MODULE_BUILTINS {
+        vm.register_builtin_def(def);
+    }
 }
 
 /// Drop all in-process pool registry state. Called from

--- a/crates/harn-vm/src/stdlib/workflow/compact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/compact.rs
@@ -3,11 +3,17 @@
 use std::rc::Rc;
 
 use crate::orchestration::ArtifactRecord;
+use crate::stdlib::macros::harn_builtin;
 use crate::value::{VmError, VmValue};
 
 use super::super::{parse_artifact_list, parse_context_policy};
 use super::convert::to_vm;
 
+/// Select workflow artifacts according to a context policy.
+#[harn_builtin(
+    sig = "select_artifacts_adaptive(artifacts?: list|nil, policy?: dict|nil) -> list",
+    category = "workflow.host"
+)]
 pub(super) fn select_artifacts_adaptive_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -20,6 +26,11 @@ pub(super) fn select_artifacts_adaptive_builtin(
     to_vm(&selected)
 }
 
+/// Estimate tokens for a list of message objects.
+#[harn_builtin(
+    sig = "estimate_tokens(messages?: list) -> int",
+    category = "workflow.host"
+)]
 pub(super) fn estimate_tokens_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -39,6 +50,11 @@ pub(super) fn estimate_tokens_builtin(
     Ok(VmValue::Int(tokens as i64))
 }
 
+/// Compact long tool output with the host microcompaction primitive.
+#[harn_builtin(
+    sig = "microcompact(text: string, max_chars?: int) -> string",
+    category = "workflow.host"
+)]
 pub(super) fn microcompact_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -65,6 +81,12 @@ fn non_negative_usize(value: &VmValue, builtin: &str, key: &str) -> Result<usize
     }
 }
 
+/// Apply the workflow/agent transcript auto-compaction primitive to a message list.
+#[harn_builtin(
+    sig = "transcript_auto_compact(messages: list, options?: dict|nil) -> list",
+    kind = "async",
+    category = "workflow.host"
+)]
 pub(super) async fn transcript_auto_compact_builtin(
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/stdlib/workflow/mod.rs
+++ b/crates/harn-vm/src/stdlib/workflow/mod.rs
@@ -16,7 +16,7 @@ mod usage;
 
 pub(in crate::stdlib) use self::artifact::load_run_tree;
 pub(in crate::stdlib) use self::convert::workflow_graph_to_vm;
-pub(crate) use self::register::register_workflow_builtins;
+pub(crate) use self::register::{register_workflow_builtins, MODULE_BUILTINS};
 
 #[cfg(test)]
 mod tests;

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -1,12 +1,16 @@
 //! Top-level workflow executor and builtin registration.
 
 use crate::stdlib::harn_entry::register_harn_entrypoint_category;
+use crate::stdlib::macros::VmBuiltinDef;
 use crate::stdlib::registration::{
     async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
 };
 use crate::vm::{Vm, VmBuiltinArity};
 
-use super::compact::*;
+use super::compact::{
+    ESTIMATE_TOKENS_BUILTIN_DEF, MICROCOMPACT_BUILTIN_DEF, SELECT_ARTIFACTS_ADAPTIVE_BUILTIN_DEF,
+    TRANSCRIPT_AUTO_COMPACT_BUILTIN_DEF,
+};
 use super::hooks::*;
 use super::host::*;
 use super::inspect::*;
@@ -152,21 +156,6 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
         .doc("Queue a `FileEdited` notification; hooks fire on the next agent-loop boundary."),
     SyncBuiltin::new(
-        "select_artifacts_adaptive",
-        select_artifacts_adaptive_builtin,
-    )
-    .signature("select_artifacts_adaptive(artifacts?, policy?)")
-    .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-    .doc("Select workflow artifacts according to a context policy."),
-    SyncBuiltin::new("estimate_tokens", estimate_tokens_builtin)
-        .signature("estimate_tokens(messages?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .doc("Estimate tokens for a list of message objects."),
-    SyncBuiltin::new("microcompact", microcompact_builtin)
-        .signature("microcompact(text, max_chars?)")
-        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .doc("Compact long tool output with the host microcompaction primitive."),
-    SyncBuiltin::new(
         HOST_WORKFLOW_PREPARE_RUN_BUILTIN,
         host_workflow_prepare_run_builtin,
     )
@@ -232,10 +221,6 @@ const WORKFLOW_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
     .signature("__host_workflow_map_finalize(strategy, total_items, completed, failures, produced)")
     .arity(VmBuiltinArity::Exact(5))
     .doc("Finalize a Harn-owned workflow map stage after branch settlement."),
-    async_builtin!("transcript_auto_compact", transcript_auto_compact_builtin)
-        .signature("transcript_auto_compact(messages, options?)")
-        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .doc("Apply the workflow/agent transcript auto-compaction primitive to a message list."),
     async_builtin!("__host_fire_session_hook", fire_session_hook_builtin)
         .signature("__host_fire_session_hook(event, payload?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
@@ -251,7 +236,17 @@ const WORKFLOW_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
     .sync(WORKFLOW_SYNC_PRIMITIVES)
     .async_(WORKFLOW_ASYNC_PRIMITIVES);
 
+pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
+    &SELECT_ARTIFACTS_ADAPTIVE_BUILTIN_DEF,
+    &ESTIMATE_TOKENS_BUILTIN_DEF,
+    &MICROCOMPACT_BUILTIN_DEF,
+    &TRANSCRIPT_AUTO_COMPACT_BUILTIN_DEF,
+];
+
 pub(crate) fn register_workflow_builtins(vm: &mut Vm) {
     register_builtin_group(vm, WORKFLOW_PRIMITIVES);
+    for def in MODULE_BUILTINS {
+        vm.register_builtin_def(def);
+    }
     register_harn_entrypoint_category(vm, WORKFLOW_STDLIB_ENTRYPOINT_CATEGORY);
 }


### PR DESCRIPTION
## Summary

Phase 7 continues the `BuiltinGroup` → `#[harn_builtin]` cutover:

- **pool/mod.rs** (8 builtins, all `runtime_only=true` since they're host-helper `__pool_*` primitives)
- **workflow/compact.rs** (4 builtins: `select_artifacts_adaptive`, `estimate_tokens`, `microcompact`, `transcript_auto_compact` async)

Deletes the matching `BuiltinSignature` literals from `workflow.rs`, `stdlib.rs`, `agents.rs`. After this lands, only `workflow/register.rs` (its hooks/host/inspect sub-files) keeps the legacy DSL; once those migrate, `stdlib::registration` can be deleted outright.

## Test plan
- [x] `cargo check -p harn-vm`
- [x] `cargo test -p harn-vm --test builtin_registry_alignment` (4 green)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)