### PR TITLE
builtins: phase 8 — workflow inspect/host/compact DSL migrations

### DIFF
--- a/changelog.d/2556.removed.md
+++ b/changelog.d/2556.removed.md
@@ -1,0 +1,25 @@
+- **Workflow inspect + host + compact migrated to `#[harn_builtin]`** (phase 8).
+  27 builtins move off the legacy `BuiltinGroup`/`SyncBuiltin`/`async_builtin!`
+  DSL onto annotated free fns colocated with their implementations:
+
+  - `crates/harn-vm/src/stdlib/workflow/inspect.rs` (14 builtins:
+    `workflow_graph` / `workflow_validate` / `workflow_inspect` /
+    `workflow_policy_report` / `workflow_clone` / `workflow_insert_node` /
+    `workflow_replace_node` / `workflow_rewire` /
+    `workflow_set_{model,context,auto_compact,output_visibility}_policy` /
+    `workflow_diff` / `workflow_commit`).
+  - `crates/harn-vm/src/stdlib/workflow/host.rs` (9 builtins: all
+    `__host_workflow_*` primitives, `runtime_only = true`).
+  - `crates/harn-vm/src/stdlib/workflow/compact.rs` (4 builtins:
+    `select_artifacts_adaptive` / `estimate_tokens` / `microcompact` /
+    `transcript_auto_compact` async).
+
+  `register_workflow_builtins` keeps the `BuiltinGroup` shim for
+  `hooks.rs` (~15 builtins) while iterating a new `MODULE_BUILTINS`
+  slice for the migrated set. Once `hooks.rs` finishes,
+  `crate::stdlib::registration` can be deleted outright.
+
+  Deletes the matching `BuiltinSignature` literals from
+  `workflow.rs`, `stdlib.rs`, `agents.rs` plus the dead-code
+  `HOST_WORKFLOW_*_BUILTIN` constants that only powered the DSL
+  signature strings.

--- a/crates/harn-parser/src/builtin_signatures/signatures/workflow.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/workflow.rs
@@ -12,7 +12,7 @@
 
 use super::{
     BuiltinSignature, Param, Ty, TY_ANY, TY_CLOSURE, TY_DICT, TY_DICT_OR_NIL, TY_LIST, TY_NIL,
-    TY_STRING, TY_STRING_OR_NIL,
+    TY_STRING,
 };
 
 /// `dict | Schema<any>` — schema aliases type-check as `Schema<T>` but
@@ -28,29 +28,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         &[Param::new("options", TY_DICT)],
         TY_DICT,
     ),
-    // handoff_effects(source, ceiling?) -> typed effect set computed from a
-    // child agent's entrypoint Harn source,
-    // workflow_clone(workflow) -> cloned workflow graph dict.
-    BuiltinSignature::simple(
-        "workflow_clone",
-        &[Param::new("workflow", TY_DICT)],
-        TY_DICT,
-    ),
-    // workflow_commit(workflow, reason?) -> committed graph dict.
-    BuiltinSignature::simple(
-        "workflow_commit",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::optional("reason", TY_STRING_OR_NIL),
-        ],
-        TY_DICT,
-    ),
-    // workflow_diff(left, right) -> `{changed, left, right}` dict.
-    BuiltinSignature::simple(
-        "workflow_diff",
-        &[Param::new("left", TY_DICT), Param::new("right", TY_DICT)],
-        TY_DICT,
-    ),
     // workflow_execute(task, workflow, artifacts?, options?) — async;
     // runs the workflow and returns `{status, run, artifacts,
     // transcript, path}`.
@@ -64,108 +41,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         ],
         TY_DICT,
     ),
-    // workflow_graph(workflow?) -> normalized graph dict.
-    BuiltinSignature::simple(
-        "workflow_graph",
-        &[Param::optional("workflow", TY_DICT_OR_NIL)],
-        TY_DICT,
-    ),
-    // workflow_insert_node(workflow, node, edge?) -> updated graph dict.
-    BuiltinSignature::simple(
-        "workflow_insert_node",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::new("node", TY_DICT),
-            Param::optional("edge", TY_DICT_OR_NIL),
-        ],
-        TY_DICT,
-    ),
-    // workflow_inspect(workflow, ceiling?) -> `{graph, validation,
-    // node_count, edge_count}` dict.
-    BuiltinSignature::simple(
-        "workflow_inspect",
-        &[
-            Param::optional("workflow", TY_DICT_OR_NIL),
-            Param::optional("ceiling", TY_DICT_OR_NIL),
-        ],
-        TY_DICT,
-    ),
-    // workflow_policy_report(workflow, ceiling?) -> per-node policy
-    // report dict.
-    BuiltinSignature::simple(
-        "workflow_policy_report",
-        &[
-            Param::optional("workflow", TY_DICT_OR_NIL),
-            Param::optional("ceiling", TY_DICT_OR_NIL),
-        ],
-        TY_DICT,
-    ),
-    // workflow_replace_node(workflow, node_id, node) -> updated graph
-    // dict.
-    BuiltinSignature::simple(
-        "workflow_replace_node",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::new("node_id", TY_STRING),
-            Param::new("node", TY_DICT),
-        ],
-        TY_DICT,
-    ),
-    // workflow_rewire(workflow, from, to, branch?) -> updated graph dict.
-    BuiltinSignature::simple(
-        "workflow_rewire",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::new("from", TY_STRING),
-            Param::new("to", TY_STRING),
-            Param::optional("branch", TY_STRING_OR_NIL),
-        ],
-        TY_DICT,
-    ),
-    // workflow_set_auto_compact(workflow, node_id, policy) -> updated
-    // graph dict.
-    BuiltinSignature::simple(
-        "workflow_set_auto_compact",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::new("node_id", TY_STRING),
-            Param::new("policy", TY_DICT),
-        ],
-        TY_DICT,
-    ),
-    // workflow_set_context_policy(workflow, node_id, policy) -> updated
-    // graph dict.
-    BuiltinSignature::simple(
-        "workflow_set_context_policy",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::new("node_id", TY_STRING),
-            Param::new("policy", TY_DICT),
-        ],
-        TY_DICT,
-    ),
-    // workflow_set_model_policy(workflow, node_id, policy) -> updated
-    // graph dict.
-    BuiltinSignature::simple(
-        "workflow_set_model_policy",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::new("node_id", TY_STRING),
-            Param::new("policy", TY_DICT),
-        ],
-        TY_DICT,
-    ),
-    // workflow_set_output_visibility(workflow, node_id, visibility) ->
-    // updated graph dict. `visibility` is `string | nil`.
-    BuiltinSignature::simple(
-        "workflow_set_output_visibility",
-        &[
-            Param::new("workflow", TY_DICT),
-            Param::new("node_id", TY_STRING),
-            Param::new("visibility", TY_STRING_OR_NIL),
-        ],
-        TY_DICT,
-    ),
     BuiltinSignature::simple(
         "workflow_typed_output_checkpoint",
         &[
@@ -174,16 +49,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::new("schema", TY_SCHEMA_VALUE),
             Param::optional("options", TY_DICT_OR_NIL),
             Param::optional("validator", Ty::Union(&[TY_CLOSURE, TY_NIL])),
-        ],
-        TY_DICT,
-    ),
-    // workflow_validate(workflow?, ceiling?) -> validation report dict
-    // (`{valid, errors, warnings, ...}`).
-    BuiltinSignature::simple(
-        "workflow_validate",
-        &[
-            Param::optional("workflow", TY_DICT_OR_NIL),
-            Param::optional("ceiling", TY_DICT_OR_NIL),
         ],
         TY_DICT,
     ),

--- a/crates/harn-vm/src/stdlib/workflow/host.rs
+++ b/crates/harn-vm/src/stdlib/workflow/host.rs
@@ -4,9 +4,17 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use crate::orchestration::{normalize_workflow_value, ArtifactRecord, WorkflowEdge};
+use crate::stdlib::macros::harn_builtin;
 use crate::value::{VmError, VmValue};
 
 use super::super::parse_artifact_list;
+
+// Builtin-name string constants — referenced inside fn bodies for
+// error formatting. Only the ones that appear in error paths remain.
+const HOST_WORKFLOW_MAP_PLAN_BUILTIN: &str = "__host_workflow_map_plan";
+const HOST_WORKFLOW_MAP_BRANCH_ARTIFACT_BUILTIN: &str = "__host_workflow_map_branch_artifact";
+const HOST_WORKFLOW_MAP_EXECUTE_BRANCH_BUILTIN: &str = "__host_workflow_map_execute_branch";
+const HOST_WORKFLOW_MAP_FINALIZE_BUILTIN: &str = "__host_workflow_map_finalize";
 
 use super::artifact::artifact_from_value;
 use super::convert::to_vm;
@@ -22,19 +30,12 @@ use super::state::{
     record_workflow_transitions, remove_workflow_state, workflow_control_to_vm,
 };
 
-pub(super) const HOST_WORKFLOW_PREPARE_RUN_BUILTIN: &str = "__host_workflow_prepare_run";
-pub(super) const HOST_WORKFLOW_STAGE_PREPARE_BUILTIN: &str = "__host_workflow_stage_prepare";
-pub(super) const HOST_WORKFLOW_STAGE_COMPLETE_BUILTIN: &str = "__host_workflow_stage_complete";
-pub(super) const HOST_WORKFLOW_RECORD_TRANSITIONS_BUILTIN: &str =
-    "__host_workflow_record_transitions";
-pub(super) const HOST_WORKFLOW_FINALIZE_RUN_BUILTIN: &str = "__host_workflow_finalize_run";
-pub(super) const HOST_WORKFLOW_MAP_PLAN_BUILTIN: &str = "__host_workflow_map_plan";
-pub(super) const HOST_WORKFLOW_MAP_BRANCH_ARTIFACT_BUILTIN: &str =
-    "__host_workflow_map_branch_artifact";
-pub(super) const HOST_WORKFLOW_MAP_EXECUTE_BRANCH_BUILTIN: &str =
-    "__host_workflow_map_execute_branch";
-pub(super) const HOST_WORKFLOW_MAP_FINALIZE_BUILTIN: &str = "__host_workflow_map_finalize";
-
+/// Prepare low-level workflow run state for the Harn stdlib workflow executor.
+#[harn_builtin(
+    sig = "__host_workflow_prepare_run(task: string, graph: dict, artifacts?: list|nil, options?: dict|nil) -> dict",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) fn host_workflow_prepare_run_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -55,6 +56,13 @@ pub(super) fn host_workflow_prepare_run_builtin(
     Ok(control)
 }
 
+/// Prepare one low-level workflow stage and install its execution scope.
+#[harn_builtin(
+    sig = "__host_workflow_stage_prepare(state_id: string, node_id: string, ready_nodes: list, options?: dict|nil) -> dict",
+    kind = "async",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) async fn host_workflow_stage_prepare_builtin(
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
@@ -75,6 +83,13 @@ pub(super) async fn host_workflow_stage_prepare_builtin(
     Ok(plan)
 }
 
+/// Complete one prepared low-level workflow stage and tear down its execution scope.
+#[harn_builtin(
+    sig = "__host_workflow_stage_complete(state_id: string, node_id: string, llm_result: any) -> dict",
+    kind = "async",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) async fn host_workflow_stage_complete_builtin(
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
@@ -104,6 +119,12 @@ pub(super) async fn host_workflow_stage_complete_builtin(
     Ok(VmValue::Dict(Rc::new(dict)))
 }
 
+/// Record workflow stage transitions and checkpoint low-level run state.
+#[harn_builtin(
+    sig = "__host_workflow_record_transitions(state_id: string, ready_nodes: list, stage: dict, edges: list) -> dict",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) fn host_workflow_record_transitions_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -134,6 +155,12 @@ pub(super) fn host_workflow_record_transitions_builtin(
     Ok(control)
 }
 
+/// Finalize low-level workflow run state and persist the final checkpoint.
+#[harn_builtin(
+    sig = "__host_workflow_finalize_run(state_id: string, ready_nodes: list) -> dict",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) fn host_workflow_finalize_run_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -145,6 +172,13 @@ pub(super) fn host_workflow_finalize_run_builtin(
     finalize_workflow_state(state)
 }
 
+/// Return the host-normalized execution plan for a workflow map stage.
+#[harn_builtin(
+    sig = "__host_workflow_map_plan(node: dict, artifacts: list) -> dict",
+    kind = "async",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) async fn host_workflow_map_plan_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let node: crate::orchestration::WorkflowNode =
         parse_json_arg(args.first(), HOST_WORKFLOW_MAP_PLAN_BUILTIN)?;
@@ -153,6 +187,12 @@ pub(super) async fn host_workflow_map_plan_builtin(args: Vec<VmValue>) -> Result
     to_vm(&plan)
 }
 
+/// Build the synthesized input artifact for one Harn-owned workflow map branch.
+#[harn_builtin(
+    sig = "__host_workflow_map_branch_artifact(node_id: string, item: any, lineage: dict) -> dict",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) fn host_workflow_map_branch_artifact_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -172,6 +212,13 @@ pub(super) fn host_workflow_map_branch_artifact_builtin(
     to_vm(&map_branch_artifact(&node_id, &item, &lineage).normalize())
 }
 
+/// Execute one workflow map branch while Harn owns branch scheduling.
+#[harn_builtin(
+    sig = "__host_workflow_map_execute_branch(node_id: string, plan: dict, item: any, branch_artifact: dict, options?: dict|nil) -> dict",
+    kind = "async",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) async fn host_workflow_map_execute_branch_builtin(
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
@@ -260,6 +307,13 @@ pub(super) async fn host_workflow_map_execute_branch_builtin(
     to_vm(&branch)
 }
 
+/// Finalize a Harn-owned workflow map stage after branch settlement.
+#[harn_builtin(
+    sig = "__host_workflow_map_finalize(strategy: string, total_items: int, completed: list, failures: list, produced: list) -> dict",
+    kind = "async",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) async fn host_workflow_map_finalize_builtin(
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/stdlib/workflow/inspect.rs
+++ b/crates/harn-vm/src/stdlib/workflow/inspect.rs
@@ -6,11 +6,17 @@ use std::rc::Rc;
 use crate::orchestration::{
     append_audit_entry, builtin_ceiling, normalize_workflow_value, validate_workflow, WorkflowEdge,
 };
+use crate::stdlib::macros::harn_builtin;
 use crate::value::{VmError, VmValue};
 
 use super::convert::{to_vm, workflow_graph_to_vm};
 use super::policy::{normalize_policy, set_node_policy};
 
+/// Normalize a workflow value and return the canonical workflow graph dict.
+#[harn_builtin(
+    sig = "workflow_graph(input?: dict|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_graph_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -23,6 +29,11 @@ pub(super) fn workflow_graph_builtin(
     workflow_graph_to_vm(&graph)
 }
 
+/// Validate a workflow graph against a capability policy ceiling.
+#[harn_builtin(
+    sig = "workflow_validate(input?: dict|nil, ceiling?: dict|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_validate_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -39,6 +50,11 @@ pub(super) fn workflow_validate_builtin(
     ))
 }
 
+/// Return normalized workflow graph shape and validation details.
+#[harn_builtin(
+    sig = "workflow_inspect(input?: dict|nil, ceiling?: dict|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_inspect_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -59,6 +75,11 @@ pub(super) fn workflow_inspect_builtin(
     }))
 }
 
+/// Report workflow and node policies against an effective ceiling.
+#[harn_builtin(
+    sig = "workflow_policy_report(graph: dict, ceiling?: dict|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_policy_report_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -84,6 +105,11 @@ pub(super) fn workflow_policy_report_builtin(
     }))
 }
 
+/// Clone a workflow graph and append audit metadata.
+#[harn_builtin(
+    sig = "workflow_clone(graph: dict) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_clone_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -99,6 +125,11 @@ pub(super) fn workflow_clone_builtin(
     workflow_graph_to_vm(&graph)
 }
 
+/// Insert a node and optional edge into a workflow graph.
+#[harn_builtin(
+    sig = "workflow_insert_node(graph: dict, node: dict, edge?: dict|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_insert_node_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -140,6 +171,11 @@ pub(super) fn workflow_insert_node_builtin(
     workflow_graph_to_vm(&graph)
 }
 
+/// Replace one node in a workflow graph.
+#[harn_builtin(
+    sig = "workflow_replace_node(graph: dict, node_id: string, node: dict) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_replace_node_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -169,6 +205,11 @@ pub(super) fn workflow_replace_node_builtin(
     workflow_graph_to_vm(&graph)
 }
 
+/// Replace outgoing edge wiring for one workflow graph node.
+#[harn_builtin(
+    sig = "workflow_rewire(graph: dict, from: string, to: string, branch?: string|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_rewire_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -199,6 +240,11 @@ pub(super) fn workflow_rewire_builtin(
     workflow_graph_to_vm(&graph)
 }
 
+/// Set one node's model policy.
+#[harn_builtin(
+    sig = "workflow_set_model_policy(graph: dict, node_id: string, policy: dict) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_set_model_policy_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -210,6 +256,11 @@ pub(super) fn workflow_set_model_policy_builtin(
     })
 }
 
+/// Set one node's context policy.
+#[harn_builtin(
+    sig = "workflow_set_context_policy(graph: dict, node_id: string, policy: dict) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_set_context_policy_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -221,6 +272,11 @@ pub(super) fn workflow_set_context_policy_builtin(
     })
 }
 
+/// Set one node's auto-compaction policy.
+#[harn_builtin(
+    sig = "workflow_set_auto_compact(graph: dict, node_id: string, policy: dict) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_set_auto_compact_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -232,6 +288,11 @@ pub(super) fn workflow_set_auto_compact_builtin(
     })
 }
 
+/// Set one node's output visibility policy.
+#[harn_builtin(
+    sig = "workflow_set_output_visibility(graph: dict, node_id: string, visibility: string|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_set_output_visibility_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -250,6 +311,11 @@ pub(super) fn workflow_set_output_visibility_builtin(
     })
 }
 
+/// Compare two workflow graph values for canonical JSON changes.
+#[harn_builtin(
+    sig = "workflow_diff(left: dict, right: dict) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_diff_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -271,6 +337,11 @@ pub(super) fn workflow_diff_builtin(
     }))
 }
 
+/// Validate and commit workflow graph audit metadata.
+#[harn_builtin(
+    sig = "workflow_commit(graph: dict, reason?: string|nil) -> dict",
+    category = "workflow.host"
+)]
 pub(super) fn workflow_commit_builtin(
     args: &[VmValue],
     _out: &mut String,

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -12,80 +12,25 @@ use super::compact::{
     TRANSCRIPT_AUTO_COMPACT_BUILTIN_DEF,
 };
 use super::hooks::*;
-use super::host::*;
-use super::inspect::*;
+use super::host::{
+    HOST_WORKFLOW_FINALIZE_RUN_BUILTIN_DEF, HOST_WORKFLOW_MAP_BRANCH_ARTIFACT_BUILTIN_DEF,
+    HOST_WORKFLOW_MAP_EXECUTE_BRANCH_BUILTIN_DEF, HOST_WORKFLOW_MAP_FINALIZE_BUILTIN_DEF,
+    HOST_WORKFLOW_MAP_PLAN_BUILTIN_DEF, HOST_WORKFLOW_PREPARE_RUN_BUILTIN_DEF,
+    HOST_WORKFLOW_RECORD_TRANSITIONS_BUILTIN_DEF, HOST_WORKFLOW_STAGE_COMPLETE_BUILTIN_DEF,
+    HOST_WORKFLOW_STAGE_PREPARE_BUILTIN_DEF,
+};
+use super::inspect::{
+    WORKFLOW_CLONE_BUILTIN_DEF, WORKFLOW_COMMIT_BUILTIN_DEF, WORKFLOW_DIFF_BUILTIN_DEF,
+    WORKFLOW_GRAPH_BUILTIN_DEF, WORKFLOW_INSERT_NODE_BUILTIN_DEF, WORKFLOW_INSPECT_BUILTIN_DEF,
+    WORKFLOW_POLICY_REPORT_BUILTIN_DEF, WORKFLOW_REPLACE_NODE_BUILTIN_DEF,
+    WORKFLOW_REWIRE_BUILTIN_DEF, WORKFLOW_SET_AUTO_COMPACT_BUILTIN_DEF,
+    WORKFLOW_SET_CONTEXT_POLICY_BUILTIN_DEF, WORKFLOW_SET_MODEL_POLICY_BUILTIN_DEF,
+    WORKFLOW_SET_OUTPUT_VISIBILITY_BUILTIN_DEF, WORKFLOW_VALIDATE_BUILTIN_DEF,
+};
 
 const WORKFLOW_STDLIB_ENTRYPOINT_CATEGORY: &str = "workflow.stdlib";
 
 const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
-    SyncBuiltin::new("workflow_graph", workflow_graph_builtin)
-        .signature("workflow_graph(input?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .doc("Normalize a workflow value and return the canonical workflow graph dict."),
-    SyncBuiltin::new("workflow_validate", workflow_validate_builtin)
-        .signature("workflow_validate(input?, ceiling?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-        .doc("Validate a workflow graph against a capability policy ceiling."),
-    SyncBuiltin::new("workflow_inspect", workflow_inspect_builtin)
-        .signature("workflow_inspect(input?, ceiling?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 2 })
-        .doc("Return normalized workflow graph shape and validation details."),
-    SyncBuiltin::new("workflow_policy_report", workflow_policy_report_builtin)
-        .signature("workflow_policy_report(graph, ceiling?)")
-        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .doc("Report workflow and node policies against an effective ceiling."),
-    SyncBuiltin::new("workflow_clone", workflow_clone_builtin)
-        .signature("workflow_clone(graph)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Clone a workflow graph and append audit metadata."),
-    SyncBuiltin::new("workflow_insert_node", workflow_insert_node_builtin)
-        .signature("workflow_insert_node(graph, node, edge?)")
-        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .doc("Insert a node and optional edge into a workflow graph."),
-    SyncBuiltin::new("workflow_replace_node", workflow_replace_node_builtin)
-        .signature("workflow_replace_node(graph, node_id, node)")
-        .arity(VmBuiltinArity::Exact(3))
-        .doc("Replace one node in a workflow graph."),
-    SyncBuiltin::new("workflow_rewire", workflow_rewire_builtin)
-        .signature("workflow_rewire(graph, from, to, branch?)")
-        .arity(VmBuiltinArity::Range { min: 3, max: 4 })
-        .doc("Replace outgoing edge wiring for one workflow graph node."),
-    SyncBuiltin::new(
-        "workflow_set_model_policy",
-        workflow_set_model_policy_builtin,
-    )
-    .signature("workflow_set_model_policy(graph, node_id, policy)")
-    .arity(VmBuiltinArity::Exact(3))
-    .doc("Set one node's model policy."),
-    SyncBuiltin::new(
-        "workflow_set_context_policy",
-        workflow_set_context_policy_builtin,
-    )
-    .signature("workflow_set_context_policy(graph, node_id, policy)")
-    .arity(VmBuiltinArity::Exact(3))
-    .doc("Set one node's context policy."),
-    SyncBuiltin::new(
-        "workflow_set_auto_compact",
-        workflow_set_auto_compact_builtin,
-    )
-    .signature("workflow_set_auto_compact(graph, node_id, policy)")
-    .arity(VmBuiltinArity::Exact(3))
-    .doc("Set one node's auto-compaction policy."),
-    SyncBuiltin::new(
-        "workflow_set_output_visibility",
-        workflow_set_output_visibility_builtin,
-    )
-    .signature("workflow_set_output_visibility(graph, node_id, visibility)")
-    .arity(VmBuiltinArity::Exact(3))
-    .doc("Set one node's output visibility policy."),
-    SyncBuiltin::new("workflow_diff", workflow_diff_builtin)
-        .signature("workflow_diff(left, right)")
-        .arity(VmBuiltinArity::Exact(2))
-        .doc("Compare two workflow graph values for canonical JSON changes."),
-    SyncBuiltin::new("workflow_commit", workflow_commit_builtin)
-        .signature("workflow_commit(graph, reason?)")
-        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .doc("Validate and commit workflow graph audit metadata."),
     SyncBuiltin::new("register_tool_hook", register_tool_hook_builtin)
         .signature("register_tool_hook(config?)")
         .arity(VmBuiltinArity::Range { min: 0, max: 1 })
@@ -155,72 +100,9 @@ const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
         .signature("notify_file_edited(path, metadata?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
         .doc("Queue a `FileEdited` notification; hooks fire on the next agent-loop boundary."),
-    SyncBuiltin::new(
-        HOST_WORKFLOW_PREPARE_RUN_BUILTIN,
-        host_workflow_prepare_run_builtin,
-    )
-    .signature("__host_workflow_prepare_run(task, graph, artifacts?, options?)")
-    .arity(VmBuiltinArity::Range { min: 2, max: 4 })
-    .doc("Prepare low-level workflow run state for the Harn stdlib workflow executor."),
-    SyncBuiltin::new(
-        HOST_WORKFLOW_RECORD_TRANSITIONS_BUILTIN,
-        host_workflow_record_transitions_builtin,
-    )
-    .signature("__host_workflow_record_transitions(state_id, ready_nodes, stage, edges)")
-    .arity(VmBuiltinArity::Exact(4))
-    .doc("Record workflow stage transitions and checkpoint low-level run state."),
-    SyncBuiltin::new(
-        HOST_WORKFLOW_FINALIZE_RUN_BUILTIN,
-        host_workflow_finalize_run_builtin,
-    )
-    .signature("__host_workflow_finalize_run(state_id, ready_nodes)")
-    .arity(VmBuiltinArity::Exact(2))
-    .doc("Finalize low-level workflow run state and persist the final checkpoint."),
-    SyncBuiltin::new(
-        HOST_WORKFLOW_MAP_BRANCH_ARTIFACT_BUILTIN,
-        host_workflow_map_branch_artifact_builtin,
-    )
-    .signature("__host_workflow_map_branch_artifact(node_id, item, lineage)")
-    .arity(VmBuiltinArity::Exact(3))
-    .doc("Build the synthesized input artifact for one Harn-owned workflow map branch."),
 ];
 
 const WORKFLOW_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    async_builtin!(
-        HOST_WORKFLOW_STAGE_PREPARE_BUILTIN,
-        host_workflow_stage_prepare_builtin
-    )
-    .signature("__host_workflow_stage_prepare(state_id, node_id, ready_nodes, options?)")
-    .arity(VmBuiltinArity::Range { min: 3, max: 4 })
-    .doc("Prepare one low-level workflow stage and install its execution scope."),
-    async_builtin!(
-        HOST_WORKFLOW_STAGE_COMPLETE_BUILTIN,
-        host_workflow_stage_complete_builtin
-    )
-    .signature("__host_workflow_stage_complete(state_id, node_id, llm_result)")
-    .arity(VmBuiltinArity::Exact(3))
-    .doc("Complete one prepared low-level workflow stage and tear down its execution scope."),
-    async_builtin!(
-        HOST_WORKFLOW_MAP_PLAN_BUILTIN,
-        host_workflow_map_plan_builtin
-    )
-    .signature("__host_workflow_map_plan(node, artifacts)")
-    .arity(VmBuiltinArity::Exact(2))
-    .doc("Return the host-normalized execution plan for a workflow map stage."),
-    async_builtin!(
-        HOST_WORKFLOW_MAP_EXECUTE_BRANCH_BUILTIN,
-        host_workflow_map_execute_branch_builtin
-    )
-    .signature("__host_workflow_map_execute_branch(node_id, plan, item, branch_artifact, options?)")
-    .arity(VmBuiltinArity::Range { min: 4, max: 5 })
-    .doc("Execute one workflow map branch while Harn owns branch scheduling."),
-    async_builtin!(
-        HOST_WORKFLOW_MAP_FINALIZE_BUILTIN,
-        host_workflow_map_finalize_builtin
-    )
-    .signature("__host_workflow_map_finalize(strategy, total_items, completed, failures, produced)")
-    .arity(VmBuiltinArity::Exact(5))
-    .doc("Finalize a Harn-owned workflow map stage after branch settlement."),
     async_builtin!("__host_fire_session_hook", fire_session_hook_builtin)
         .signature("__host_fire_session_hook(event, payload?)")
         .arity(VmBuiltinArity::Range { min: 1, max: 2 })
@@ -237,10 +119,36 @@ const WORKFLOW_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
     .async_(WORKFLOW_ASYNC_PRIMITIVES);
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
+    // compact (already migrated to #[harn_builtin] in stdlib/workflow/compact.rs)
     &SELECT_ARTIFACTS_ADAPTIVE_BUILTIN_DEF,
     &ESTIMATE_TOKENS_BUILTIN_DEF,
     &MICROCOMPACT_BUILTIN_DEF,
     &TRANSCRIPT_AUTO_COMPACT_BUILTIN_DEF,
+    // inspect (graph-shape builders + structural manipulation)
+    &WORKFLOW_GRAPH_BUILTIN_DEF,
+    &WORKFLOW_VALIDATE_BUILTIN_DEF,
+    &WORKFLOW_INSPECT_BUILTIN_DEF,
+    &WORKFLOW_POLICY_REPORT_BUILTIN_DEF,
+    &WORKFLOW_CLONE_BUILTIN_DEF,
+    &WORKFLOW_INSERT_NODE_BUILTIN_DEF,
+    &WORKFLOW_REPLACE_NODE_BUILTIN_DEF,
+    &WORKFLOW_REWIRE_BUILTIN_DEF,
+    &WORKFLOW_SET_MODEL_POLICY_BUILTIN_DEF,
+    &WORKFLOW_SET_CONTEXT_POLICY_BUILTIN_DEF,
+    &WORKFLOW_SET_AUTO_COMPACT_BUILTIN_DEF,
+    &WORKFLOW_SET_OUTPUT_VISIBILITY_BUILTIN_DEF,
+    &WORKFLOW_DIFF_BUILTIN_DEF,
+    &WORKFLOW_COMMIT_BUILTIN_DEF,
+    // host (low-level workflow runtime helpers, all runtime_only)
+    &HOST_WORKFLOW_PREPARE_RUN_BUILTIN_DEF,
+    &HOST_WORKFLOW_RECORD_TRANSITIONS_BUILTIN_DEF,
+    &HOST_WORKFLOW_FINALIZE_RUN_BUILTIN_DEF,
+    &HOST_WORKFLOW_MAP_BRANCH_ARTIFACT_BUILTIN_DEF,
+    &HOST_WORKFLOW_STAGE_PREPARE_BUILTIN_DEF,
+    &HOST_WORKFLOW_STAGE_COMPLETE_BUILTIN_DEF,
+    &HOST_WORKFLOW_MAP_PLAN_BUILTIN_DEF,
+    &HOST_WORKFLOW_MAP_EXECUTE_BRANCH_BUILTIN_DEF,
+    &HOST_WORKFLOW_MAP_FINALIZE_BUILTIN_DEF,
 ];
 
 pub(crate) fn register_workflow_builtins(vm: &mut Vm) {


### PR DESCRIPTION
## Summary

Phase 8 continues the `BuiltinGroup` → `#[harn_builtin]` cutover with the 27 workflow primitives in `inspect.rs` + `host.rs` + `compact.rs`. After this lands, only `hooks.rs` (~15 builtins) keeps the legacy DSL — once that migrates too, `stdlib::registration` can be deleted outright and the linkme final ship is the remaining capstone.

## Files migrated

- `workflow/inspect.rs` (14 builtins): all `workflow_*` graph manipulators
- `workflow/host.rs` (9 builtins): `__host_workflow_*` runtime helpers (`runtime_only=true`)
- `workflow/compact.rs` (4 builtins): `select_artifacts_adaptive` / `estimate_tokens` / `microcompact` / `transcript_auto_compact` (async)

`register_workflow_builtins` keeps the `BuiltinGroup` for `hooks.rs` while iterating a new `MODULE_BUILTINS` slice for the migrated set. Wires that slice into `stdlib::all_builtin_defs()` and deletes the matching `BuiltinSignature` literals from `workflow.rs`, `stdlib.rs`, `agents.rs` plus the dead-code `HOST_WORKFLOW_*_BUILTIN` constants that only powered the DSL signature strings.

## Test plan
- [x] `cargo check -p harn-vm` (clean, no warnings)
- [x] `cargo test -p harn-vm --test builtin_registry_alignment` (4 green)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)