### PR TITLE
builtins: phase 9 — workflow/hooks.rs (last stdlib DSL holdout)

### DIFF
--- a/changelog.d/2557.removed.md
+++ b/changelog.d/2557.removed.md
@@ -1,0 +1,27 @@
+- **`workflow/hooks.rs` migrated to `#[harn_builtin]`** (phase 9, the last
+  `register_builtin_group` DSL holdout in stdlib). 15 builtins move off
+  the legacy DSL onto annotated free fns colocated with their
+  implementations:
+
+  - `register_tool_hook` / `clear_tool_hooks`
+  - `register_persona_hook` / `register_step_hook` / `clear_persona_hooks`
+  - `register_session_hook` / `clear_session_hooks`
+  - `register_checkpoint_hook`
+  - `register_reminder_provider` / `clear_reminder_providers`
+  - `pipeline_on_finish` / `pipeline_lifecycle_audit_log_take` /
+    `pipeline_lifecycle_audit_log_snapshot`
+  - `__host_settlement_agent_active` / `notify_file_edited`
+  - `__host_fire_session_hook` (async) / `__host_drain_file_edits` (async)
+
+  `workflow/register.rs` is now a thin slice + dispatcher: no more
+  `SyncBuiltin` / `AsyncBuiltin` / `register_builtin_group` calls — just
+  a `MODULE_BUILTINS: &[&VmBuiltinDef]` slice referencing the DEFs
+  emitted by `#[harn_builtin]` annotations across `compact.rs` /
+  `hooks.rs` / `host.rs` / `inspect.rs`. Deletes the matching
+  `BuiltinSignature` literals from `stdlib.rs`.
+
+  After this lands, the only remaining `stdlib::registration` consumers
+  are the `crates/harn-vm/src/llm/*.rs` modules (~37 kLOC, host-side
+  LLM internals — outside the user-facing stdlib surface). Migrating
+  those + deleting the registration module + the `linkme` capstone are
+  tracked as the remaining follow-ups.

--- a/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/stdlib.rs
@@ -221,10 +221,6 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         TY_NIL,
     ),
     BuiltinSignature::simple("circuit_reset", &[Param::new("name", TY_STRING)], TY_NIL),
-    BuiltinSignature::simple("clear_tool_hooks", &[], TY_NIL),
-    BuiltinSignature::simple("clear_persona_hooks", &[], TY_NIL),
-    BuiltinSignature::simple("clear_session_hooks", &[], TY_NIL),
-    BuiltinSignature::simple("clear_reminder_providers", &[], TY_NIL),
     BuiltinSignature::simple(
         "close_channel",
         &[Param::new("channel", Ty::Named("channel"))],
@@ -375,51 +371,8 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
     BuiltinSignature::variadic("pg_query_one", &[Param::new("args", TY_ANY)], TY_ANY),
     BuiltinSignature::variadic("pg_transaction", &[Param::new("args", TY_ANY)], TY_ANY),
     BuiltinSignature::variadic("pi", &[Param::new("args", TY_ANY)], TY_FLOAT),
-    BuiltinSignature::simple("pipeline_lifecycle_audit_log_snapshot", &[], TY_LIST),
-    BuiltinSignature::simple("pipeline_lifecycle_audit_log_take", &[], TY_LIST),
-    BuiltinSignature::simple(
-        "pipeline_on_finish",
-        &[Param::new("callback", TY_ANY)],
-        TY_NIL,
-    ),
     BuiltinSignature::variadic("receive", &[Param::new("args", TY_ANY)], TY_ANY),
     BuiltinSignature::variadic("request_approval", &[Param::new("args", TY_ANY)], TY_DICT),
-    BuiltinSignature::variadic("register_tool_hook", &[Param::new("args", TY_ANY)], TY_NIL),
-    BuiltinSignature::simple(
-        "register_persona_hook",
-        &[
-            Param::new("persona_pattern", TY_STRING),
-            Param::new("event", TY_STRING),
-            Param::new("handler", TY_ANY),
-        ],
-        TY_NIL,
-    ),
-    BuiltinSignature::simple(
-        "register_step_hook",
-        &[
-            Param::new("persona_pattern", TY_STRING),
-            Param::new("step_name", TY_STRING),
-            Param::new("event", TY_STRING),
-            Param::new("handler", TY_ANY),
-        ],
-        TY_NIL,
-    ),
-    BuiltinSignature::variadic(
-        "register_session_hook",
-        &[Param::new("args", TY_ANY)],
-        TY_NIL,
-    ),
-    BuiltinSignature::simple(
-        "register_checkpoint_hook",
-        &[Param::new("kinds", TY_ANY), Param::new("handler", TY_ANY)],
-        TY_NIL,
-    ),
-    BuiltinSignature::simple(
-        "register_reminder_provider",
-        &[Param::new("config", TY_DICT)],
-        TY_NIL,
-    ),
-    BuiltinSignature::variadic("notify_file_edited", &[Param::new("args", TY_ANY)], TY_NIL),
     BuiltinSignature::variadic("runtime_context", &[Param::new("args", TY_ANY)], TY_DICT),
     BuiltinSignature::variadic(
         "runtime_context_clear",

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -3,10 +3,16 @@
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
+use crate::stdlib::macros::harn_builtin;
 use crate::value::{VmError, VmValue};
 
 pub(super) type PostHookFn = Rc<dyn Fn(&str, &str) -> crate::orchestration::PostToolAction>;
 
+/// Register low-level pre/post tool hooks for workflow execution.
+#[harn_builtin(
+    sig = "register_tool_hook(config?: dict|nil) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn register_tool_hook_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -97,6 +103,8 @@ pub(super) fn register_tool_hook_builtin(
     Ok(VmValue::Nil)
 }
 
+/// Clear registered low-level workflow tool hooks.
+#[harn_builtin(sig = "clear_tool_hooks() -> nil", category = "workflow.host")]
 pub(super) fn clear_tool_hooks_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -155,6 +163,11 @@ pub(super) fn required_hook_closure(
     }
 }
 
+/// Register a persona lifecycle hook for matching persona names.
+#[harn_builtin(
+    sig = "register_persona_hook(persona_pattern: string, event: string, handler: closure) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn register_persona_hook_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -173,6 +186,11 @@ pub(super) fn register_persona_hook_builtin(
     Ok(VmValue::Nil)
 }
 
+/// Register a persona step lifecycle hook for one named step.
+#[harn_builtin(
+    sig = "register_step_hook(persona_pattern: string, step_name: string, event: string, handler: closure) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn register_step_hook_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -201,6 +219,8 @@ pub(super) fn register_step_hook_builtin(
     Ok(VmValue::Nil)
 }
 
+/// Clear registered persona and step lifecycle hooks.
+#[harn_builtin(sig = "clear_persona_hooks() -> nil", category = "workflow.host")]
 pub(super) fn clear_persona_hooks_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -209,6 +229,11 @@ pub(super) fn clear_persona_hooks_builtin(
     Ok(VmValue::Nil)
 }
 
+/// Register a session-level lifecycle hook.
+#[harn_builtin(
+    sig = "register_session_hook(event: string, pattern_or_handler: string|closure, handler?: closure) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn register_session_hook_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -236,6 +261,8 @@ pub(super) fn register_session_hook_builtin(
     Ok(VmValue::Nil)
 }
 
+/// Clear registered session-level lifecycle hooks.
+#[harn_builtin(sig = "clear_session_hooks() -> nil", category = "workflow.host")]
 pub(super) fn clear_session_hooks_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -250,6 +277,11 @@ pub(super) fn clear_session_hooks_builtin(
 /// or the wildcard `"*"` / `nil` to subscribe to every seam. The handler
 /// receives the `LoopCheckpoint` payload `{session_id, iteration, kind,
 /// delivered, inbox_delivered, dispatch_skipped}`.
+/// Register a hook covering one or more agent-loop checkpoint seams.
+#[harn_builtin(
+    sig = "register_checkpoint_hook(kinds: string|list|nil, handler: closure) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn register_checkpoint_hook_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -394,6 +426,11 @@ fn reminder_provider_event_list(
     }
 }
 
+/// Register a system-reminder provider closure for agent lifecycle events.
+#[harn_builtin(
+    sig = "register_reminder_provider(config: dict) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn register_reminder_provider_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -444,6 +481,8 @@ pub(super) fn register_reminder_provider_builtin(
     Ok(VmValue::Nil)
 }
 
+/// Clear registered user-defined system-reminder providers.
+#[harn_builtin(sig = "clear_reminder_providers() -> nil", category = "workflow.host")]
 pub(super) fn clear_reminder_providers_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -456,6 +495,11 @@ pub(super) fn clear_reminder_providers_builtin(
 /// declared steps complete (signature `fn(harness, return_value)`). Last-
 /// write-wins; the callback's return value replaces the pipeline's return
 /// value when the lifecycle runs.
+/// Register a callback invoked after the pipeline's declared steps complete.
+#[harn_builtin(
+    sig = "pipeline_on_finish(callback: closure) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn pipeline_on_finish_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -469,6 +513,11 @@ pub(super) fn pipeline_on_finish_builtin(
 /// and clear the log. Surfaces the lifecycle audit channel to Harn so
 /// conformance fixtures, replay oracles, and presets can introspect what
 /// drain/abandon/handoff_to recorded without depending on Rust internals.
+/// Return and clear every entry recorded via harness.emit_audit during this pipeline run.
+#[harn_builtin(
+    sig = "pipeline_lifecycle_audit_log_take() -> list",
+    category = "workflow.host"
+)]
 pub(super) fn pipeline_lifecycle_audit_log_take_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -480,6 +529,11 @@ pub(super) fn pipeline_lifecycle_audit_log_take_builtin(
 
 /// Non-destructive variant: read entries without consuming them. Used by
 /// presets that want to peek without disturbing the replay log.
+/// Return every entry recorded via harness.emit_audit without clearing the log.
+#[harn_builtin(
+    sig = "pipeline_lifecycle_audit_log_snapshot() -> list",
+    category = "workflow.host"
+)]
 pub(super) fn pipeline_lifecycle_audit_log_snapshot_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -495,6 +549,12 @@ pub(super) fn pipeline_lifecycle_audit_log_snapshot_builtin(
 /// on while the loop runs and back off when it exits. Lifecycle hooks
 /// fired from within the loop (e.g. `OnDrainDecision`) observe this as
 /// true.
+/// Return true while the settlement-agent drain loop is running on this thread.
+#[harn_builtin(
+    sig = "__host_settlement_agent_active() -> bool",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) fn settlement_agent_active_builtin(
     _args: &[VmValue],
     _out: &mut String,
@@ -510,6 +570,13 @@ pub(super) fn settlement_agent_active_builtin(
 ///
 /// Returns a dict shaped like:
 ///   { control: "allow" | "block" | "decision", reason?, decision? }
+/// Fire a session-level lifecycle hook and return its control flow.
+#[harn_builtin(
+    sig = "__host_fire_session_hook(event: string, payload?: dict|nil) -> dict",
+    kind = "async",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) async fn fire_session_hook_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let event_name = args
         .first()
@@ -569,6 +636,11 @@ pub(super) async fn fire_session_hook_builtin(args: Vec<VmValue>) -> Result<VmVa
 /// that a file was edited. Records a `file_edited` advisory event on
 /// the active transcript so replay tooling can see it, and queues VM
 /// closure handlers for the next async-builtin boundary.
+/// Queue a `FileEdited` notification; hooks fire on the next agent-loop boundary.
+#[harn_builtin(
+    sig = "notify_file_edited(path: string, metadata?: dict|nil) -> nil",
+    category = "workflow.host"
+)]
 pub(super) fn notify_file_edited_builtin(
     args: &[VmValue],
     _out: &mut String,
@@ -589,6 +661,13 @@ pub(super) fn notify_file_edited_builtin(
 /// notifications recorded since the last drain. Returns the list of
 /// drained paths so callers (the agent loop) can record them on the
 /// transcript or pass them to follow-up tools.
+/// Drain the FileEdited queue, fire matching hooks, return the drained paths.
+#[harn_builtin(
+    sig = "__host_drain_file_edits(session_id?: string|nil) -> list",
+    kind = "async",
+    category = "workflow.host",
+    runtime_only = true
+)]
 pub(super) async fn drain_file_edits_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let session_id = args.first().map(VmValue::display).unwrap_or_default();
     let drained = crate::orchestration::drain_file_edits();

--- a/crates/harn-vm/src/stdlib/workflow/register.rs
+++ b/crates/harn-vm/src/stdlib/workflow/register.rs
@@ -2,16 +2,23 @@
 
 use crate::stdlib::harn_entry::register_harn_entrypoint_category;
 use crate::stdlib::macros::VmBuiltinDef;
-use crate::stdlib::registration::{
-    async_builtin, register_builtin_group, AsyncBuiltin, BuiltinGroup, SyncBuiltin,
-};
-use crate::vm::{Vm, VmBuiltinArity};
+use crate::vm::Vm;
 
 use super::compact::{
     ESTIMATE_TOKENS_BUILTIN_DEF, MICROCOMPACT_BUILTIN_DEF, SELECT_ARTIFACTS_ADAPTIVE_BUILTIN_DEF,
     TRANSCRIPT_AUTO_COMPACT_BUILTIN_DEF,
 };
-use super::hooks::*;
+use super::hooks::{
+    CLEAR_PERSONA_HOOKS_BUILTIN_DEF, CLEAR_REMINDER_PROVIDERS_BUILTIN_DEF,
+    CLEAR_SESSION_HOOKS_BUILTIN_DEF, CLEAR_TOOL_HOOKS_BUILTIN_DEF, DRAIN_FILE_EDITS_BUILTIN_DEF,
+    FIRE_SESSION_HOOK_BUILTIN_DEF, NOTIFY_FILE_EDITED_BUILTIN_DEF,
+    PIPELINE_LIFECYCLE_AUDIT_LOG_SNAPSHOT_BUILTIN_DEF,
+    PIPELINE_LIFECYCLE_AUDIT_LOG_TAKE_BUILTIN_DEF, PIPELINE_ON_FINISH_BUILTIN_DEF,
+    REGISTER_CHECKPOINT_HOOK_BUILTIN_DEF, REGISTER_PERSONA_HOOK_BUILTIN_DEF,
+    REGISTER_REMINDER_PROVIDER_BUILTIN_DEF, REGISTER_SESSION_HOOK_BUILTIN_DEF,
+    REGISTER_STEP_HOOK_BUILTIN_DEF, REGISTER_TOOL_HOOK_BUILTIN_DEF,
+    SETTLEMENT_AGENT_ACTIVE_BUILTIN_DEF,
+};
 use super::host::{
     HOST_WORKFLOW_FINALIZE_RUN_BUILTIN_DEF, HOST_WORKFLOW_MAP_BRANCH_ARTIFACT_BUILTIN_DEF,
     HOST_WORKFLOW_MAP_EXECUTE_BRANCH_BUILTIN_DEF, HOST_WORKFLOW_MAP_FINALIZE_BUILTIN_DEF,
@@ -30,101 +37,13 @@ use super::inspect::{
 
 const WORKFLOW_STDLIB_ENTRYPOINT_CATEGORY: &str = "workflow.stdlib";
 
-const WORKFLOW_SYNC_PRIMITIVES: &[SyncBuiltin] = &[
-    SyncBuiltin::new("register_tool_hook", register_tool_hook_builtin)
-        .signature("register_tool_hook(config?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .doc("Register low-level pre/post tool hooks for workflow execution."),
-    SyncBuiltin::new("clear_tool_hooks", clear_tool_hooks_builtin)
-        .signature("clear_tool_hooks()")
-        .arity(VmBuiltinArity::Exact(0))
-        .doc("Clear registered low-level workflow tool hooks."),
-    SyncBuiltin::new("register_persona_hook", register_persona_hook_builtin)
-        .signature("register_persona_hook(persona_pattern, event, handler)")
-        .arity(VmBuiltinArity::Exact(3))
-        .doc("Register a persona lifecycle hook for matching persona names."),
-    SyncBuiltin::new("register_step_hook", register_step_hook_builtin)
-        .signature("register_step_hook(persona_pattern, step_name, event, handler)")
-        .arity(VmBuiltinArity::Exact(4))
-        .doc("Register a persona step lifecycle hook for one named step."),
-    SyncBuiltin::new("clear_persona_hooks", clear_persona_hooks_builtin)
-        .signature("clear_persona_hooks()")
-        .arity(VmBuiltinArity::Exact(0))
-        .doc("Clear registered persona and step lifecycle hooks."),
-    SyncBuiltin::new("register_session_hook", register_session_hook_builtin)
-        .signature("register_session_hook(event, pattern?, handler)")
-        .arity(VmBuiltinArity::Range { min: 2, max: 3 })
-        .doc("Register a session-level lifecycle hook (session_start, session_end, user_prompt_submit, pre_compact, post_compact, post_turn, permission_asked, permission_replied, file_edited, session_error, session_idle, loop_checkpoint)."),
-    SyncBuiltin::new("clear_session_hooks", clear_session_hooks_builtin)
-        .signature("clear_session_hooks()")
-        .arity(VmBuiltinArity::Exact(0))
-        .doc("Clear registered session-level lifecycle hooks."),
-    SyncBuiltin::new("register_checkpoint_hook", register_checkpoint_hook_builtin)
-        .signature("register_checkpoint_hook(kinds, handler)")
-        .arity(VmBuiltinArity::Exact(2))
-        .doc("Register a hook covering one or more agent-loop checkpoint seams. `kinds` is a list of seam names (iteration_start, pre_tool_dispatch, post_tool_dispatch, iteration_end, pre_compact, post_compact, daemon_idle_pre, daemon_idle_post, loop_exit), a single name, or `*` / nil for every seam."),
-    SyncBuiltin::new("register_reminder_provider", register_reminder_provider_builtin)
-        .signature("register_reminder_provider(config)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Register a system-reminder provider closure for agent lifecycle events."),
-    SyncBuiltin::new("clear_reminder_providers", clear_reminder_providers_builtin)
-        .signature("clear_reminder_providers()")
-        .arity(VmBuiltinArity::Exact(0))
-        .doc("Clear registered user-defined system-reminder providers."),
-    SyncBuiltin::new("pipeline_on_finish", pipeline_on_finish_builtin)
-        .signature("pipeline_on_finish(callback)")
-        .arity(VmBuiltinArity::Exact(1))
-        .doc("Register a callback invoked after the pipeline's declared steps complete. Signature: fn(harness, return_value). Last-write-wins; the callback's return replaces the pipeline's return value."),
-    SyncBuiltin::new(
-        "pipeline_lifecycle_audit_log_take",
-        pipeline_lifecycle_audit_log_take_builtin,
-    )
-    .signature("pipeline_lifecycle_audit_log_take()")
-    .arity(VmBuiltinArity::Exact(0))
-    .doc("Return and clear every entry recorded via harness.emit_audit during this pipeline run."),
-    SyncBuiltin::new(
-        "pipeline_lifecycle_audit_log_snapshot",
-        pipeline_lifecycle_audit_log_snapshot_builtin,
-    )
-    .signature("pipeline_lifecycle_audit_log_snapshot()")
-    .arity(VmBuiltinArity::Exact(0))
-    .doc("Return every entry recorded via harness.emit_audit without clearing the log."),
-    SyncBuiltin::new(
-        "__host_settlement_agent_active",
-        settlement_agent_active_builtin,
-    )
-    .signature("__host_settlement_agent_active()")
-    .arity(VmBuiltinArity::Exact(0))
-    .doc("Return true while the settlement-agent drain loop (#1856) is running on this thread; false otherwise."),
-    SyncBuiltin::new("notify_file_edited", notify_file_edited_builtin)
-        .signature("notify_file_edited(path, metadata?)")
-        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .doc("Queue a `FileEdited` notification; hooks fire on the next agent-loop boundary."),
-];
-
-const WORKFLOW_ASYNC_PRIMITIVES: &[AsyncBuiltin] = &[
-    async_builtin!("__host_fire_session_hook", fire_session_hook_builtin)
-        .signature("__host_fire_session_hook(event, payload?)")
-        .arity(VmBuiltinArity::Range { min: 1, max: 2 })
-        .doc("Fire a session-level lifecycle hook and return its control flow."),
-    async_builtin!("__host_drain_file_edits", drain_file_edits_builtin)
-        .signature("__host_drain_file_edits(session_id?)")
-        .arity(VmBuiltinArity::Range { min: 0, max: 1 })
-        .doc("Drain the FileEdited queue, fire matching hooks, return the drained paths."),
-];
-
-const WORKFLOW_PRIMITIVES: BuiltinGroup<'static> = BuiltinGroup::new()
-    .category("workflow.host")
-    .sync(WORKFLOW_SYNC_PRIMITIVES)
-    .async_(WORKFLOW_ASYNC_PRIMITIVES);
-
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
-    // compact (already migrated to #[harn_builtin] in stdlib/workflow/compact.rs)
+    // compact (token estimation, microcompaction, transcript auto-compact).
     &SELECT_ARTIFACTS_ADAPTIVE_BUILTIN_DEF,
     &ESTIMATE_TOKENS_BUILTIN_DEF,
     &MICROCOMPACT_BUILTIN_DEF,
     &TRANSCRIPT_AUTO_COMPACT_BUILTIN_DEF,
-    // inspect (graph-shape builders + structural manipulation)
+    // inspect (graph-shape builders + structural manipulation).
     &WORKFLOW_GRAPH_BUILTIN_DEF,
     &WORKFLOW_VALIDATE_BUILTIN_DEF,
     &WORKFLOW_INSPECT_BUILTIN_DEF,
@@ -139,7 +58,7 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     &WORKFLOW_SET_OUTPUT_VISIBILITY_BUILTIN_DEF,
     &WORKFLOW_DIFF_BUILTIN_DEF,
     &WORKFLOW_COMMIT_BUILTIN_DEF,
-    // host (low-level workflow runtime helpers, all runtime_only)
+    // host (low-level workflow runtime helpers, all runtime_only).
     &HOST_WORKFLOW_PREPARE_RUN_BUILTIN_DEF,
     &HOST_WORKFLOW_RECORD_TRANSITIONS_BUILTIN_DEF,
     &HOST_WORKFLOW_FINALIZE_RUN_BUILTIN_DEF,
@@ -149,10 +68,27 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     &HOST_WORKFLOW_MAP_PLAN_BUILTIN_DEF,
     &HOST_WORKFLOW_MAP_EXECUTE_BRANCH_BUILTIN_DEF,
     &HOST_WORKFLOW_MAP_FINALIZE_BUILTIN_DEF,
+    // hooks (tool / persona / step / session / checkpoint lifecycle).
+    &REGISTER_TOOL_HOOK_BUILTIN_DEF,
+    &CLEAR_TOOL_HOOKS_BUILTIN_DEF,
+    &REGISTER_PERSONA_HOOK_BUILTIN_DEF,
+    &REGISTER_STEP_HOOK_BUILTIN_DEF,
+    &CLEAR_PERSONA_HOOKS_BUILTIN_DEF,
+    &REGISTER_SESSION_HOOK_BUILTIN_DEF,
+    &CLEAR_SESSION_HOOKS_BUILTIN_DEF,
+    &REGISTER_CHECKPOINT_HOOK_BUILTIN_DEF,
+    &REGISTER_REMINDER_PROVIDER_BUILTIN_DEF,
+    &CLEAR_REMINDER_PROVIDERS_BUILTIN_DEF,
+    &PIPELINE_ON_FINISH_BUILTIN_DEF,
+    &PIPELINE_LIFECYCLE_AUDIT_LOG_TAKE_BUILTIN_DEF,
+    &PIPELINE_LIFECYCLE_AUDIT_LOG_SNAPSHOT_BUILTIN_DEF,
+    &SETTLEMENT_AGENT_ACTIVE_BUILTIN_DEF,
+    &NOTIFY_FILE_EDITED_BUILTIN_DEF,
+    &FIRE_SESSION_HOOK_BUILTIN_DEF,
+    &DRAIN_FILE_EDITS_BUILTIN_DEF,
 ];
 
 pub(crate) fn register_workflow_builtins(vm: &mut Vm) {
-    register_builtin_group(vm, WORKFLOW_PRIMITIVES);
     for def in MODULE_BUILTINS {
         vm.register_builtin_def(def);
     }


### PR DESCRIPTION
## Summary

Phase 9: migrates `crates/harn-vm/src/stdlib/workflow/hooks.rs` (15 builtins, 13 sync + 2 async) off the legacy `BuiltinGroup`/`SyncBuiltin`/`async_builtin!` DSL onto `#[harn_builtin]` annotations.

This is the **last DSL holdout in stdlib**. After this lands, `workflow/register.rs` is a pure `MODULE_BUILTINS: &[&VmBuiltinDef]` slice + a tiny `register_workflow_builtins` dispatcher — no more `SyncBuiltin` / `AsyncBuiltin` / `register_builtin_group` calls anywhere in `crates/harn-vm/src/stdlib/`. The cutover for the user-facing stdlib surface is **complete**.

## Builtins migrated

- `register_tool_hook` / `clear_tool_hooks`
- `register_persona_hook` / `register_step_hook` / `clear_persona_hooks`
- `register_session_hook` / `clear_session_hooks`
- `register_checkpoint_hook`
- `register_reminder_provider` / `clear_reminder_providers`
- `pipeline_on_finish` / `pipeline_lifecycle_audit_log_{take,snapshot}`
- `__host_settlement_agent_active` (runtime_only) / `notify_file_edited`
- `__host_fire_session_hook` (async, runtime_only) / `__host_drain_file_edits` (async, runtime_only)

## Remaining follow-ups (out of scope here)

- `crates/harn-vm/src/llm/*.rs` still consumes `stdlib::registration` — host-side LLM internals (~37 kLOC), not part of the user-facing stdlib. Once those migrate, the `stdlib::registration` module can be deleted.
- `linkme::distributed_slice` capstone (per `/tmp/linkme-migration-plan.md`) to eliminate the hand-maintained `MODULE_BUILTINS` slices and the giant `out.extend_from_slice(...)` aggregator.

## Test plan
- [x] `cargo check -p harn-vm`
- [x] `cargo test -p harn-vm --test builtin_registry_alignment` (4 green)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)