### PR TITLE
docs: cookbook chapter 'Precise edits with AST tools' + agent-loop pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,17 @@ lineage, and mutation session audit metadata. Hosts own approval UX, concrete
 file mutations, and undo/redo semantics. For autonomous or background edits,
 prefer worktree-backed execution over ambient cwd state.
 
+## Editing source
+
+Mutate source files through `std/edit` rather than freeform text patches:
+`edit_apply_node` to replace a node, `edit_insert_at_anchor` to add a
+sibling/child, `edit_rename_symbol` for cross-file renames, `edit_dry_run`
+to preview a multi-op plan, and `edit_safe_text_patch` only when the
+language has no tree-sitter grammar or the change is purely textual. The
+decision tree (and a `system_reminder` snippet that nudges agent loops the
+same way) lives in
+[Precise edits with AST tools](docs/src/cookbook.md#precise-edits-with-ast-tools).
+
 ## Changelog fragments
 
 - Non-trivial PRs drop a single fragment file: `changelog.d/<id>.<category>.md`.

--- a/changelog.d/2511.added.md
+++ b/changelog.d/2511.added.md
@@ -1,0 +1,17 @@
+- **Cookbook chapter "Precise edits with AST tools" + agent-loop pattern recipe.**
+  Wraps the five `std/edit` primitives (`edit_apply_node`,
+  `edit_insert_at_anchor`, `edit_rename_symbol`, `edit_dry_run`,
+  `edit_safe_text_patch`) into a Diataxis "How to X" chapter under
+  [`docs/src/cookbook.md`](docs/src/cookbook.md). Adds the
+  shape → primitive decision table, a "How to rename a symbol
+  cross-file" recipe, a "When AST tools won't work" fallback section,
+  and a "How to nudge an agent toward AST tools" recipe that lifts the
+  canonical edit-strategy `system_reminder` body and `inject_reminder`
+  wiring so other agent loops can adopt the same default. Cross-linked
+  from [`docs/src/llm/agent_loop.md`](docs/src/llm/agent_loop.md) and
+  the repo [`AGENTS.md`](AGENTS.md). Demonstrated end-to-end in the
+  [fixer persona](personas/fixer/lib/remediation_plan.harn): a pure
+  `plan_for_atoms` mapper that turns remediation atom shapes into
+  `edit_dry_run`-shaped plan ops, with 7 deterministic tests under
+  [`personas/fixer/tests/`](personas/fixer/tests/). Lands the docs
+  child of the AST-precise edit primitive epic (#2497).

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -200,6 +200,26 @@ pipeline default(task) {
 
 ## Precise edits with AST tools
 
+Agent-authored source mutations are easiest to keep correct when they speak
+the language of the tree, not the language of the diff. `std/edit` ships
+five primitives covering the common reaches. Pick by the **shape** of the
+change first; let the language-support table tie-break:
+
+| Shape | Reach for | Falls back to |
+|---|---|---|
+| Replace an existing node (function body, call expression, declaration) | [`edit_apply_node`](#how-to-rewrite-a-function-body-via-a-tree-sitter-query) | `edit_safe_text_patch` when the language has no grammar |
+| Add a sibling or child next to a node (new test, new import, new arm) | [`edit_insert_at_anchor`](#how-to-add-a-new-test-to-a-rust-mod) | `edit_safe_text_patch` |
+| Rename an identifier across the workspace | [`edit_rename_symbol`](#how-to-rename-a-symbol-across-the-workspace) | `edit_safe_text_patch` only when the language is out-of-batch |
+| Preview a multi-step plan before committing | [`edit_dry_run`](#how-to-preview-a-multi-step-edit-plan-and-approve) | (composes with all of the above) |
+| Anything else, or text-shaped change with collision risk | [`edit_safe_text_patch`](#how-to-apply-a-multi-hunk-text-patch-atomically) | — (this *is* the fallback) |
+
+The decision is the same one a human editor makes: structural changes
+through the AST, textual changes through the patch. A `system_reminder`
+that lifts this table into the agent's next-turn prompt — see
+[How to nudge an agent toward AST tools](#how-to-nudge-an-agent-toward-ast-tools)
+— is the smallest change that durably shifts a coding agent away from
+freeform text patches.
+
 ### How to rewrite a function body via a tree-sitter query
 
 `edit_apply_node` from [`std/edit`](./stdlib/edit.md) replaces AST nodes
@@ -465,6 +485,141 @@ Plan ops share a transient staged-fs session, so the second op sees
 the first op's pending write. That means several ops touching the
 same file collapse to one cumulative diff, which is the form a
 reviewer (human or LLM) actually wants.
+
+### How to rename a symbol across the workspace
+
+`edit_rename_symbol` resolves an identifier through the typed symbol
+graph from [`std/code_librarian`](./stdlib/code-librarian.md) and rewrites
+every identifier-context occurrence — never comments, never string
+literals, never partial-name matches — across every file in scope. It
+short-circuits with `result == "conflict"` if `new_name` already exists
+as an identifier in any file the rename would touch, so the workspace
+can't end up with two identically named definitions in the same scope.
+
+```harn,ignore
+import { edit_rename_symbol } from "std/edit"
+
+pipeline default(task) {
+  let result = edit_rename_symbol({
+    symbol_ref: {name: "Widget", path: "src/lib.rs", kind: "Type"},
+    new_name: "Gadget",
+    scope: "workspace",
+    dry_run: true,
+  })
+
+  if result.result != "applied" {
+    log("rename refused: ${result.result} — ${result.details ?? \"\"}")
+    return
+  }
+  for file in result.touched_files {
+    log("${file.path}: ${len(file.edits)} edit(s)")
+  }
+}
+```
+
+Drop `dry_run` to actually rewrite the files; pair the call with a
+`session_id` for full staged-fs atomicity across the rename plus any
+sibling writes. Supported languages on the first batch: Rust,
+TypeScript/TSX, JavaScript/JSX, Python, Swift, Go.
+
+For the full result shape (`touched_files[*].edits[*]` with byte and
+`(row, col)` spans, plus `conflicts[*]` shadow sites), see the deeper
+[Rename a symbol across the workspace](./cookbooks/rename-symbol.md)
+cookbook.
+
+### When AST tools won't work
+
+The AST primitives all require a tree-sitter grammar for the file's
+language. They return `result == "unsupported_language"` instead of
+silently mangling bytes. The supported set is intentionally
+narrower than what `tree-sitter` can parse — the host vendors only
+grammars that have been smoke-tested against the edit primitives.
+
+Reach for `edit_safe_text_patch` (or the lower-level
+`edit_apply_old_new_patch`) when:
+
+- the file's language is not in the supported batch (printable list
+  lives next to each primitive in [`std/edit`](./stdlib/edit.md));
+- the change is purely textual — `LICENSE` headers, `CHANGELOG.md`
+  entries, embedded SQL inside a string literal — and writing a
+  tree-sitter query would mean writing one that matches a comment or
+  string node anyway;
+- the agent reasoned in terms of literal lines and the model already
+  has the exact pre-image bytes in the prompt;
+- a sibling agent might be rewriting the same file concurrently and
+  you need a deterministic `stale_base` outcome rather than a tree
+  re-parse failure.
+
+`edit_safe_text_patch` is the safe-by-default text fallback: it
+hash-checks the pre-image against `expected_hash`, composes all hunks
+against the same staged-fs overlay, and either commits the post-image
+atomically or returns a single rejection result that the caller can
+react to.
+
+```harn,ignore
+import { edit_safe_text_patch } from "std/edit"
+
+pipeline default(task) {
+  let snapshot = hostlib_fs_read_text({path: "CHANGELOG.md"})
+  let result = edit_safe_text_patch({
+    path: "CHANGELOG.md",
+    expected_hash: snapshot.sha256,
+    hunks: [
+      {old_text: "## Unreleased\n", new_text: "## Unreleased\n\n- Fixed onboarding race.\n"},
+    ],
+  })
+  log(result.result)
+}
+```
+
+The progression — try the AST primitive first, drop to
+`edit_safe_text_patch` on `unsupported_language`, give up and ask the
+operator only when the patch also rejects — keeps the agent on the
+narrowest tool that can finish the job.
+
+### How to nudge an agent toward AST tools
+
+The point of these primitives is only realised when the agent *reaches*
+for them. The smallest change that durably moves a coding agent away
+from freeform text patches is one `system_reminder` lifted into the
+prompt for every coding-agent loop. Reminders are typed, ephemeral
+transcript injections with TTL and dedupe — see
+[System reminders](./system-reminders.md) for the lifecycle — so the
+snippet survives the next turn but does not bloat the durable transcript.
+
+The canonical body and producer wiring:
+
+```harn,ignore
+let edit_strategy_reminder = """
+Prefer the AST-precise primitives in std/edit when modifying source:
+- edit_apply_node for replacing a node (function body, call, decl).
+- edit_insert_at_anchor for adding a sibling/child (test, import, arm).
+- edit_rename_symbol for cross-file identifier renames.
+- edit_dry_run to preview a multi-op plan before committing.
+Fall back to edit_safe_text_patch only when the language has no
+tree-sitter grammar or the change is purely textual.
+"""
+
+let injected = transcript.inject_reminder(transcript(), {
+  body: edit_strategy_reminder,
+  tags: ["edit_strategy"],
+  dedupe_key: "edit_strategy:prefer_ast",
+  ttl_turns: 4,
+  preserve_on_compact: true,
+  propagate: "all",
+  role_hint: "developer",
+})
+```
+
+`propagate: "all"` lets sub-agents inherit the same guidance, and
+`preserve_on_compact: true` keeps it visible across the next compaction
+boundary. The `dedupe_key` makes the reminder safe to re-inject on
+every iteration (e.g. from a session_start hook) — the lifecycle
+collapses duplicates automatically.
+
+Lift the same body into a host-side reminder by sending an ACP
+`session/remind` notification with the same payload; see
+[System reminders > From a host bridge](./system-reminders.md#from-a-host-bridge).
 
 ## MCP servers
 

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -701,6 +701,17 @@ agent_loop(task, system, {
 policy hook used by stall diagnostics so completion checks happen on a signal
 rather than a fixed "are you done?" prompt.
 
+## Editing source from inside an agent loop
+
+Agent loops that mutate code should reach for the AST-precise primitives in
+[`std/edit`](../stdlib/edit.md) before freeform text patches. The cookbook
+chapter [Precise edits with AST tools](../cookbook.md#precise-edits-with-ast-tools)
+walks through the decision tree (replace → `edit_apply_node`, add →
+`edit_insert_at_anchor`, rename → `edit_rename_symbol`, preview →
+`edit_dry_run`, text fallback → `edit_safe_text_patch`) and ships a
+`system_reminder` snippet you can lift into `agent_loop`'s session-start
+hook so the model carries the same decision tree into every coding turn.
+
 ## Daemon stdlib wrappers
 
 When you want a first-class daemon handle instead of wiring `agent_loop`

--- a/personas/fixer/README.md
+++ b/personas/fixer/README.md
@@ -9,9 +9,24 @@ The v0 workflow is intentionally declarative. Runtime hosts provide the actual
 event envelope, signing keys, and approval UX while `harn-vm` owns deterministic
 follow-up slice construction.
 
+## Edit strategy
+
+Fixer's mutation half routes through the AST-precise primitives in
+[`std/edit`](../../docs/src/stdlib/edit.md): `edit_apply_node` for node
+replacement, `edit_insert_at_anchor` for sibling/child inserts,
+`edit_rename_symbol` for cross-file identifier renames, `edit_dry_run` to
+preview a multi-op plan, and `edit_safe_text_patch` as the text fallback
+when the language has no tree-sitter grammar or the change is purely
+textual. `lib/remediation_plan.harn` maps each incoming remediation atom
+to the narrowest primitive that fits its shape; the decision tree and
+the agent-loop `system_reminder` snippet that propagates the same
+preference live in
+[Precise edits with AST tools](../../docs/src/cookbook.md#precise-edits-with-ast-tools).
+
 Validate locally:
 
 ```bash
 harn persona --manifest personas/fixer/harn.toml inspect fixer --json
 harn check personas/fixer/manifest.harn
+harn test personas/fixer/tests/
 ```

--- a/personas/fixer/lib/remediation_plan.harn
+++ b/personas/fixer/lib/remediation_plan.harn
@@ -1,0 +1,85 @@
+// Map Flow remediation atoms to std/edit plan ops.
+//
+// Fixer consumes inert remediation suggestions and proposes a follow-up
+// slice. The mutation half of that work routes through std/edit's
+// AST-precise primitives so the resulting atoms preserve language
+// structure rather than relying on freeform text patches. Each atom kind
+// picks the narrowest primitive that fits its shape; only text-shaped
+// remediations and unsupported-language atoms drop to safe_text_patch.
+//
+// Pure shape translation. No I/O. Easy to test from
+// `tests/remediation_plan_test.harn`.
+//
+// Reference: docs/src/cookbook.md#precise-edits-with-ast-tools.
+/**
+ * plan_for_atoms(atoms) -> {plan, fallbacks}.
+ *
+ * `atoms` is a list of remediation atom dicts in the shape:
+ *
+ *   { kind: "rewrite_node" | "insert_at_anchor" | "rename_symbol" | "text",
+ *     path?: string, query?: string, replacement?: string, position?: string,
+ *     content?: string, symbol_ref?: dict, new_name?: string, scope?: string,
+ *     old_text?: string, new_text?: string,
+ *     language_supports_ast?: bool }
+ *
+ * Returns `{plan, fallbacks}` where `plan` is an `edit_dry_run`-shaped
+ * list of plan ops and `fallbacks` lists atoms that could not be mapped
+ * to a structural op (and the reason why).
+ */
+pub fn plan_for_atoms(atoms) {
+  let input = atoms ?? []
+  var plan = []
+  var fallbacks = []
+  for atom in input {
+    let entry = _op_for_atom(atom)
+    if entry?.op != nil {
+      plan = plan + [entry.op]
+    } else {
+      fallbacks = fallbacks + [entry?.fallback]
+    }
+  }
+  return {plan: plan, fallbacks: fallbacks}
+}
+
+fn _op_for_atom(atom) {
+  let kind = atom?.kind ?? ""
+  let supports_ast = atom?.language_supports_ast ?? true
+  if kind == "rewrite_node" && supports_ast {
+    return {
+      op: {
+        op: "apply_node",
+        path: atom.path,
+        query: atom.query,
+        replacement: atom.replacement,
+        select: atom?.select ?? "unique",
+      },
+    }
+  }
+  if kind == "insert_at_anchor" && supports_ast {
+    return {
+      op: {
+        op: "insert_at_anchor",
+        path: atom.path,
+        query: atom.query,
+        position: atom?.position ?? "after",
+        content: atom.content,
+      },
+    }
+  }
+  if kind == "rename_symbol" && supports_ast {
+    // edit_dry_run delegates rename to the standalone primitive so the
+    // per-file metadata survives — fixer mirrors that contract.
+    return {op: nil, fallback: {atom: atom, reason: "rename_symbol_uses_standalone_primitive"}}
+  }
+  if kind == "text" || !supports_ast {
+    return {
+      op: {
+        op: "safe_text_patch",
+        path: atom.path,
+        old_text: atom?.old_text ?? "",
+        new_text: atom?.new_text ?? "",
+      },
+    }
+  }
+  return {op: nil, fallback: {atom: atom, reason: "unknown_remediation_atom_kind"}}
+}

--- a/personas/fixer/manifest.harn
+++ b/personas/fixer/manifest.harn
@@ -1,3 +1,5 @@
+import { plan_for_atoms } from "lib/remediation_plan"
+
 fn fixer_manifest() {
   return {
     name: "fixer",
@@ -10,14 +12,53 @@ fn fixer_manifest() {
       "Materialize each suggested atom as a Fixer-signed atom.",
       "Use the original author's principal co-signature when the host can obtain it.",
       "Propose a follow-up slice containing the blocked slice atoms and remediation atoms.",
+      "Map every remediation atom to an std/edit AST primitive (apply_node, insert_at_anchor, rename_symbol); only drop to safe_text_patch when the language is unsupported or the change is text-shaped.",
       "Record a receipt so the fix is auditable as its own shipping event.",
     ],
     required_capabilities: ["git.get_diff", "project.scan", "runtime.approved_plan", "runtime.dry_run", "runtime.record_run"],
+    edit_strategy: {
+      prefer: ["edit_apply_node", "edit_insert_at_anchor", "edit_rename_symbol"],
+      preview: "edit_dry_run",
+      fallback: "edit_safe_text_patch",
+    },
   }
+}
+
+// Mirrors docs/src/cookbook.md#precise-edits-with-ast-tools.
+/**
+ * remediation_plan_for_demo() turns a small bundled atom set into the
+ * `edit_dry_run`-shaped plan the persona would hand to the host. Kept
+ * deterministic so `harn run personas/fixer/manifest.harn` produces
+ * stable JSON for smoke runs and embedders inspecting the persona.
+ */
+pub fn remediation_plan_for_demo() {
+  let atoms = [
+    {
+      kind: "rewrite_node",
+      path: "src/lib.rs",
+      query: "(function_item name: (identifier) @name (#eq? @name \"greet\") body: (block) @target)",
+      replacement: "{ format!(\"hi {name}!\") }",
+    },
+    {
+      kind: "insert_at_anchor",
+      path: "src/lib.rs",
+      query: "(mod_item name: (identifier) @name (#eq? @name \"tests\") body: (declaration_list) @anchor)",
+      position: "last_child",
+      content: "#[test]\nfn covers_remediation() {}",
+    },
+    {
+      kind: "text",
+      path: "CHANGELOG.md",
+      old_text: "## Unreleased\n",
+      new_text: "## Unreleased\n\n- Fixed onboarding race.\n",
+    },
+  ]
+  return plan_for_atoms(atoms)
 }
 
 pipeline run(task) {
   let manifest = fixer_manifest()
-  __io_println(json_stringify(manifest))
-  return manifest
+  let demo = remediation_plan_for_demo()
+  __io_println(json_stringify({manifest: manifest, demo_plan: demo}))
+  return {manifest: manifest, demo_plan: demo}
 }

--- a/personas/fixer/tests/remediation_plan_test.harn
+++ b/personas/fixer/tests/remediation_plan_test.harn
@@ -1,0 +1,93 @@
+// Run: harn test personas/fixer/tests/remediation_plan_test.harn
+import { plan_for_atoms } from "../lib/remediation_plan"
+
+pipeline test_rewrite_node_atom_picks_apply_node(task) {
+  let atoms = [
+    {
+      kind: "rewrite_node",
+      path: "src/lib.rs",
+      query: "(function_item body: (block) @target)",
+      replacement: "{ unimplemented!() }",
+    },
+  ]
+  let result = plan_for_atoms(atoms)
+  assert_eq(len(result.plan), 1)
+  assert_eq(result.plan[0].op, "apply_node")
+  assert_eq(result.plan[0].path, "src/lib.rs")
+  assert_eq(result.plan[0].select, "unique")
+  assert_eq(len(result.fallbacks), 0)
+}
+
+pipeline test_insert_at_anchor_atom_picks_insert_at_anchor(task) {
+  let atoms = [
+    {
+      kind: "insert_at_anchor",
+      path: "src/lib.rs",
+      query: "(mod_item name: (identifier) @name (#eq? @name \"tests\") body: (declaration_list) @anchor)",
+      position: "last_child",
+      content: "#[test]\nfn added() {}",
+    },
+  ]
+  let result = plan_for_atoms(atoms)
+  assert_eq(len(result.plan), 1)
+  assert_eq(result.plan[0].op, "insert_at_anchor")
+  assert_eq(result.plan[0].position, "last_child")
+}
+
+pipeline test_rename_symbol_atom_falls_back_to_standalone_primitive(task) {
+  let atoms = [
+    {
+      kind: "rename_symbol",
+      symbol_ref: {name: "Widget", path: "src/lib.rs", kind: "Type"},
+      new_name: "Gadget",
+      scope: "workspace",
+    },
+  ]
+  let result = plan_for_atoms(atoms)
+  assert_eq(len(result.plan), 0)
+  assert_eq(len(result.fallbacks), 1)
+  assert_eq(result.fallbacks[0].reason, "rename_symbol_uses_standalone_primitive")
+}
+
+pipeline test_text_atom_drops_to_safe_text_patch(task) {
+  let atoms = [
+    {
+      kind: "text",
+      path: "CHANGELOG.md",
+      old_text: "## Unreleased\n",
+      new_text: "## Unreleased\n\n- Fixed onboarding race.\n",
+    },
+  ]
+  let result = plan_for_atoms(atoms)
+  assert_eq(len(result.plan), 1)
+  assert_eq(result.plan[0].op, "safe_text_patch")
+}
+
+pipeline test_unsupported_language_drops_to_safe_text_patch(task) {
+  let atoms = [
+    {
+      kind: "rewrite_node",
+      path: "weird.zigzag",
+      query: "(any) @target",
+      replacement: "stub",
+      language_supports_ast: false,
+    },
+  ]
+  let result = plan_for_atoms(atoms)
+  assert_eq(len(result.plan), 1)
+  assert_eq(result.plan[0].op, "safe_text_patch")
+}
+
+pipeline test_unknown_kind_reports_fallback(task) {
+  let atoms = [{kind: "mystery", path: "x"}]
+  let result = plan_for_atoms(atoms)
+  assert_eq(len(result.plan), 0)
+  assert_eq(len(result.fallbacks), 1)
+  assert_eq(result.fallbacks[0].reason, "unknown_remediation_atom_kind")
+}
+
+pipeline test_empty_input_yields_empty_plan(task) {
+  let result = plan_for_atoms([])
+  assert_eq(len(result.plan), 0)
+  assert_eq(len(result.fallbacks), 0)
+}


### PR DESCRIPTION
## Summary

Wraps the five `std/edit` primitives (`edit_apply_node`, `edit_insert_at_anchor`, `edit_rename_symbol`, `edit_dry_run`, `edit_safe_text_patch`) into a single Diataxis "How to X" chapter so the agent loop reaches for the right structural primitive by default and only drops to text patches when the language has no tree-sitter grammar or the change is purely textual.

Lands the docs child of the AST-precise edit primitive epic ([#2497](https://github.com/burin-labs/harn/issues/2497)). Closes [#2511](https://github.com/burin-labs/harn/issues/2511).

## What's in

- **[docs/src/cookbook.md](docs/src/cookbook.md)**: shape → primitive decision table at the top of the chapter; new "How to rename a symbol cross-file" recipe (links to the deeper `cookbooks/rename-symbol.md`); new "When AST tools won't work" fallback section with explicit criteria; new "How to nudge an agent toward AST tools" recipe carrying the canonical edit-strategy reminder body and `transcript.inject_reminder` wiring (lifted from [#1815](https://github.com/burin-labs/harn/issues/1815)).
- **[docs/src/llm/agent_loop.md](docs/src/llm/agent_loop.md)** + **[AGENTS.md](AGENTS.md)**: cross-link callouts pointing at the cookbook chapter so coding-agent authors discover the primitives where they already look.
- **personas/fixer**: `lib/remediation_plan.harn` maps each remediation atom to the narrowest `std/edit` primitive; `manifest.harn` declares the `edit_strategy` preference (AST first, `safe_text_patch` fallback) and emits a deterministic demo plan; 7-test shape suite under `tests/remediation_plan_test.harn`.
- **[changelog.d/2511.added.md](changelog.d/2511.added.md)**.

## Acceptance checklist (from #2511)

- [x] "How to safely rewrite a function body" → `edit_apply_node` (kept from [#2541](https://github.com/burin-labs/harn/pull/2541))
- [x] "How to add a new test/import/case" → `edit_insert_at_anchor` (kept from #2541)
- [x] "How to rename a symbol cross-file" → `edit_rename_symbol` (added)
- [x] "How to preview a multi-step edit plan" → `edit_dry_run` (kept from #2541)
- [x] "When AST tools won't work" → fallback to `safe_text_patch` (added)
- [x] Agent-loop `system_reminder` snippet lifted from #1815 (added)
- [x] Linked from `agent_loop.md` and the CLAUDE.md template (AGENTS.md is canonical; `CLAUDE.md` redirects there)
- [x] Demonstrated in a persona (`personas/fixer`)

## Test plan

- [x] `cargo run --bin harn -- check / lint / fmt`: clean across the touched Harn files
- [x] `harn test personas/fixer/tests/`: 7/7 pass
- [x] `make check-docs-snippets`: 610 checked, 0 failed
- [x] `cargo test -p harn-cli persona_manifest_flag_loads_fixer_persona`: ok
- [x] `markdownlint-cli2` on the touched markdown: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)