### PR TITLE
ci: publish-release self-heals when tag-push run misses publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -72,7 +72,20 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-release
+  # Scope by ref so a tag-push run does not contend with concurrent
+  # main-push runs from the same release commit (or vice versa). Without
+  # the ref scope a queued tag-push run could sit behind a long main-push
+  # detect-drift and be silently skipped if the GHA queue policy decides
+  # the queued run is stale — see harn#2547 for the v0.8.47 incident
+  # where the tag-push run was cancelled before reaching the publish
+  # step. Different `group` values run concurrently; crates.io
+  # publication is already idempotent (release_ship.sh skips
+  # already-published crates), and the tag-push and main-push paths can
+  # only ever publish the same version once anyway (the tag-push branch
+  # publishes from the pinned tag commit; the main-push branch only
+  # publishes when Cargo.toml is *ahead* of the latest tag, which by
+  # definition is a different version).
+  group: publish-release-${{ github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -149,18 +162,25 @@ jobs:
             echo "::notice::Cargo.toml=$CARGO_VERSION is behind latest tag $LATEST_TAG → publish job will skip."
           else
             DRIFT=false
-            # No drift on push-to-main: tag was already published by the
-            # tag-push trigger of this workflow (or by the build-release-
-            # binaries.yml tag trigger for the binaries). Confirm the
-            # release artifact actually shipped — a clear "already
-            # published" notice reads better than an unexplained
-            # "Publish release: skipped" job in the run UI.
+            # No version drift on push-to-main: tag was already published
+            # by the tag-push trigger of this workflow (or by the
+            # build-release-binaries.yml tag trigger for the binaries).
+            # Self-heal when that prior tag-push run didn't actually
+            # land everything (e.g. cancelled by concurrency policy as
+            # in the v0.8.47 incident, or the App-token publish step
+            # errored). If the GitHub release for $LATEST_TAG has fewer
+            # than the expected assets, force DRIFT=true so the publish
+            # job re-fires. release_ship.sh's per-crate publish is
+            # already idempotent — it skips crates already on crates.io
+            # — so re-running is a no-op for crates that landed and a
+            # recovery for those that didn't.
             if [[ "$EVENT_NAME" == "push" ]]; then
               ASSET_COUNT="$(gh release view "$LATEST_TAG" --json assets --jq '.assets | length' 2>/dev/null || echo 0)"
               if (( ASSET_COUNT >= 5 )); then
                 echo "::notice::$LATEST_TAG already published — $ASSET_COUNT assets on https://github.com/$GITHUB_REPOSITORY/releases/tag/$LATEST_TAG. Publish job will skip; this is the intended behavior under tag-first publishing."
               else
-                echo "::warning::$LATEST_TAG only has $ASSET_COUNT release assets (expected ≥5). The tag-push trigger of build-release-binaries.yml may have failed — re-fire it manually if so."
+                DRIFT=true
+                echo "::warning::$LATEST_TAG only has $ASSET_COUNT release assets (expected ≥5). Treating as drift and re-publishing from $LATEST_TAG to recover; release_ship.sh's per-crate publish is idempotent."
               fi
             else
               echo "::notice::Cargo.toml=$CARGO_VERSION matches latest tag $LATEST_TAG → no-op."
@@ -170,6 +190,16 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" && "$DRIFT" == "false" && -n "$LATEST_TAG" ]]; then
             PUBLISH_REF="$LATEST_TAG"
             echo "::notice::Manual recovery has no tag drift; publishing from existing tag $LATEST_TAG instead of current main."
+          fi
+          # Self-heal recovery on push-to-main: when DRIFT was forced
+          # true above because the tag exists but the release is
+          # missing assets, the workspace at main may have advanced
+          # past the release commit. Pin the publish to the tag so
+          # crates.io content stays tied to the tagged commit, even if
+          # main moved.
+          if [[ "$EVENT_NAME" == "push" && "$REF_TYPE" == "branch" && "$DRIFT" == "true" && "$CARGO_VERSION" == "$LATEST_VERSION" && -n "$LATEST_TAG" ]]; then
+            PUBLISH_REF="$LATEST_TAG"
+            echo "::notice::Self-heal recovery: publishing from existing tag $LATEST_TAG instead of current main so the release content stays tied to the tagged commit."
           fi
           {
             echo "drift=$DRIFT"

--- a/changelog.d/publish-release-drift-self-heal.fixed.md
+++ b/changelog.d/publish-release-drift-self-heal.fixed.md
@@ -1,0 +1,19 @@
+- **`publish-release.yml` self-heals when tag-push run misses publish.**
+  Two failures observed during the v0.8.47 cut: the tag-push run of
+  `publish-release.yml` was cancelled by the shared `publish-release`
+  concurrency group (the simultaneous main-push run for the same SHA
+  was still queued), and the subsequent main-push runs all no-op'd
+  because `Cargo.toml` already matched the latest tag. Two fixes:
+  - Concurrency group now scopes by `github.ref_name` so tag-push
+    and main-push runs of the same release commit can run in
+    parallel without contending. Different versions (the only case
+    where main-push would actually publish) are already in different
+    groups; same-version contention is the only thing the old
+    unscoped group prevented, which is exactly the case crates.io
+    publish-skip already makes idempotent.
+  - Drift detection now treats "tag exists but GitHub release has
+    fewer than 5 assets" as drift, forcing the publish job to re-fire
+    from the existing tag (`PUBLISH_REF` pinned to `$LATEST_TAG`).
+    `release_ship.sh --finalize` skips already-published crates, so
+    the recovery is a no-op for crates that landed and a real
+    recovery for any that didn't.


### PR DESCRIPTION
## Summary

Two layered fixes for the v0.8.47 release-flow incident where the
\`publish-release.yml\` tag-push run was cancelled by concurrency
contention with the simultaneous main-push run for the same SHA, and
the subsequent main-push runs all no-op'd because Cargo.toml already
matched the latest tag — leaving the crates.io publication entirely
to whichever release operator happened to run \`release_ship.sh
--finalize\` locally as a fallback. Under the bump-fleet flow that's
exactly what's supposed to happen automatically.

## What broke for v0.8.47

- 03:35:15Z — main-push for SHA b30f50e1 fired publish-release. Detect-drift saw \`Cargo.toml=0.8.47, latest_tag=v0.8.47\` (the prepare step already pushed the tag). \`DRIFT=false\` → publish job skipped.
- 03:36:45Z — tag-push for v0.8.47 fired publish-release. \`detect-drift\` set \`DRIFT=true\` (tag branch). But the run got cancelled before reaching the publish step. Likely cause: the unscoped \`concurrency: { group: publish-release, cancel-in-progress: false }\` group queued the tag-push behind the already-running main-push, and GHA's queue policy cancelled the queued run.
- Subsequent main-push runs (03:37 … 04:01) all hit no-drift and skipped.

Net result: crates.io eventually got v0.8.47 only because a release operator ran \`release_ship.sh --finalize\` locally. The GHA workflow looked green throughout despite never having published anything.

## Fixes

### 1. Scope the concurrency group by ref

\`group: publish-release\` → \`group: publish-release-\${{ github.ref_name }}\`.

Tag-push (\`refs/tags/vX.Y.Z\`) and main-push (\`main\`) now use distinct
groups and never contend. Different versions can't conflict on
crates.io; same-version contention is exactly the case
\`cargo publish\` (via \`release_ship.sh\`) already makes idempotent
(per-crate already-published is skipped).

### 2. Treat \"tag exists but release missing\" as drift

In \`detect-drift\`, when \`Cargo.toml == latest_tag\` AND we're on a
push event AND the GitHub release for \`\$LATEST_TAG\` has < 5 assets,
force \`DRIFT=true\` and pin \`PUBLISH_REF=\$LATEST_TAG\` so the publish
job re-fires from the tagged commit (not whatever has since landed
on main). \`release_ship.sh --finalize\` is idempotent — already-on-
crates.io crates are skipped — so this is a safe recovery for an
incomplete prior tag-push run.

Both fixes layered: (1) prevents the cancellation in the first
place; (2) recovers if (1) somehow still fails (e.g. App-token
fetch error, transient runner outage). Together they remove the
silent \"release shipped via local --finalize fallback\" mode that
hid in the workflow.

## Test plan

- [x] \`actionlint\` clean on the modified YAML (verified via the pre-commit hooks)
- [ ] Land + observe the v0.8.48 cut to confirm tag-push run runs to completion
- [ ] Verify a \`gh release delete v0.8.47 --yes && gh workflow run publish-release.yml\` recovery path lands the release page (manual smoke when convenient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)