### PR TITLE
test: de-flake orchestrator_worker_claim_expiry_requeue under heavy load

### DIFF
--- a/changelog.d/orchestrator-worker-claim-expiry-flake.fixed.md
+++ b/changelog.d/orchestrator-worker-claim-expiry-flake.fixed.md
@@ -1,0 +1,13 @@
+- **`orchestrator_worker_claim_expiry_requeue` conformance test
+  de-flaked under load.** The original `sleep(120ms)` after the failing
+  drain assumed the first subprocess's 25ms heartbeat (TTL/2 with
+  TTL=50ms) would have stopped by the time the second drain spawned.
+  Under heavy parallel cargo load on the same host the second `harn`
+  process could cold-start and call `claim_next` while the last
+  heartbeat was still alive, see zero ready jobs, and trip the
+  reclaim assertion. Replaced with a poll-with-budget loop that
+  re-runs `drain` (idempotent — a no-op drain returns
+  `drained:0` without consuming state) at 50ms intervals up to 5s
+  until `drained == 1 && acked == 1 && deferred == 0`. Same code
+  shape as `wait_for_readyz` in
+  `orchestrator_recover_stranded_envelopes.harn`.

--- a/conformance/tests/scenarios/orchestrator_worker_claim_expiry_requeue.harn
+++ b/conformance/tests/scenarios/orchestrator_worker_claim_expiry_requeue.harn
@@ -87,8 +87,8 @@ pipeline default(task) {
   // state — so retrying until the reclaim lands is safe. Budget is
   // generous enough to absorb GHA-runner stalls without making the
   // happy path slower than the original wait.
-  var second = null
-  var second_data = null
+  var second = nil
+  var second_data = nil
   let claim_reclaim_deadline = harness.clock.now_ms() + 5000
   while harness.clock.now_ms() < claim_reclaim_deadline {
     second = exec(

--- a/conformance/tests/scenarios/orchestrator_worker_claim_expiry_requeue.harn
+++ b/conformance/tests/scenarios/orchestrator_worker_claim_expiry_requeue.harn
@@ -77,22 +77,44 @@ pipeline default(task) {
       && first_data.responses[0].outcome?.status == "dlq"
       && first_data.responses[0].outcome?.error != nil,
   )
-  sleep(120ms)
-  let second = exec(
-    harn_bin,
-    "orchestrator",
-    "queue",
-    "--config",
-    path_join(ok_consumer_dir, "harn.toml"),
-    "--state-dir",
-    state_dir,
-    "drain",
-    "triage",
-    "--consumer-id",
-    "consumer-b",
-    "--json",
-  )
-  let second_data = json_parse(second.stdout)
+  // Poll the second drain until the expired claim is reclaimed. A bare
+  // `sleep(120ms)` was the original wait, but under heavy parallel
+  // cargo load the second subprocess can cold-start and call
+  // `claim_next` while the first drain's last 25ms heartbeat is still
+  // alive (TTL = 50ms, heartbeat = TTL/2), so the second drain saw
+  // zero ready jobs and the assertions tripped. Re-running `drain` is
+  // idempotent — a no-op drain returns `drained:0` without consuming
+  // state — so retrying until the reclaim lands is safe. Budget is
+  // generous enough to absorb GHA-runner stalls without making the
+  // happy path slower than the original wait.
+  var second = null
+  var second_data = null
+  let claim_reclaim_deadline = harness.clock.now_ms() + 5000
+  while harness.clock.now_ms() < claim_reclaim_deadline {
+    second = exec(
+      harn_bin,
+      "orchestrator",
+      "queue",
+      "--config",
+      path_join(ok_consumer_dir, "harn.toml"),
+      "--state-dir",
+      state_dir,
+      "drain",
+      "triage",
+      "--consumer-id",
+      "consumer-b",
+      "--json",
+    )
+    if second.success {
+      let parsed = json_parse(second.stdout)
+      if parsed.drained == 1 && parsed.acked == 1 && parsed.deferred == 0 {
+        second_data = parsed
+        break
+      }
+      second_data = parsed
+    }
+    sleep(50ms)
+  }
   __io_println(
     second.success && second_data.drained == 1 && second_data.acked == 1
       && second_data.deferred == 0,


### PR DESCRIPTION
## Summary

Replaces the bare \`sleep(120ms)\` between the failing-handler drain
and the healthy-handler drain in
\`orchestrator_worker_claim_expiry_requeue.harn\` with a
poll-with-budget loop. Re-runs \`harn orchestrator queue drain\` at
50ms intervals up to 5s until the reclaim lands.

## Why

The original sleep assumed the first subprocess's 25ms heartbeat
(TTL/2 with TTL=50ms) would have stopped by the time the second
drain spawned. Under heavy parallel cargo load on the same host
(e.g. multiple worktrees building, or a release_ship.sh audit
piggybacking on a busy machine) the second \`harn\` process can
cold-start and call \`claim_next\` while the last heartbeat is still
alive — claim expiry = \`last_renewal_ms + 50ms\`, expiry-strip at
\`crates/harn-vm/src/triggers/worker_queue.rs:458-465\`. The drain
then sees zero ready jobs and the reclaim assertion trips.

The retry is safe: re-invoking \`drain\` against a still-claimed job
returns \`drained:0\` without consuming state, so the loop only
\"observes\" the reclaim — it doesn't fight for it. Same code shape as
\`wait_for_readyz\` in \`orchestrator_recover_stranded_envelopes.harn\`.

Encountered during the \`release_ship.sh\` audit pre-flight for v0.8.47.

## Test plan

- [x] \`harn fmt --check\` clean on the modified file
- [ ] Local: run the test sequentially with no cargo background load → still passes (regression check)
- [ ] Local: run the test concurrently with 3 other \`cargo build\` invocations → no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)