### PR TITLE
[A.11] harn-serve: rate-limit + backpressure + budget primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "filetime",
  "futures",
  "globset",
+ "harn-clock",
  "harn-hostlib",
  "harn-parser",
  "harn-vm",

--- a/changelog.d/2514.added.md
+++ b/changelog.d/2514.added.md
@@ -1,0 +1,18 @@
+- **Rate-limiting + backpressure + per-call budget primitive on `harn-serve` (#2514).**
+  Declarative `@limits(per_tenant: "100/min", per_scope: "1000/min",
+  per_route: "5000/min", burst: 50, algorithm: "token_bucket",
+  in_flight_max: 20)` and `@budget(llm_cost_usd: 0.50, llm_tokens:
+  10000, pg_queries: 50, mcp_calls: 20)` attributes on exported `.harn`
+  handlers feed a new `LimitRegistry` that owns three pluggable
+  algorithms (token bucket, sliding window, leaky bucket), an in-flight
+  watermark for backpressure, per-tenant multipliers, and a rejection
+  stats surface for the observability primitive (A.10). Mid-dispatch
+  exhaustion of the declared LLM cost ceiling reuses harn-vm's existing
+  per-thread cost-budget machinery via the new `install_llm_cost_budget`
+  guard, raised as a `BudgetExceeded`-categorised runtime error. Both
+  rate-limit rejections and budget exhaustion render through
+  `http_codec` as HTTP 429 with a `Retry-After` header and structured
+  `{ code, message, details, request_id }` body that every adapter
+  (mcp, a2a, api) shares. Subsumes the per-tenant / per-IP / queue-depth
+  enforcement that `harn-cloud-gateway::http_utils::check_rate_limits`
+  encoded as bespoke middleware. Closes #2514 (epic #2496, A.11).

--- a/changelog.d/2514.added.md
+++ b/changelog.d/2514.added.md
@@ -2,17 +2,21 @@
   Declarative `@limits(per_tenant: "100/min", per_scope: "1000/min",
   per_route: "5000/min", burst: 50, algorithm: "token_bucket",
   in_flight_max: 20)` and `@budget(llm_cost_usd: 0.50, llm_tokens:
-  10000, pg_queries: 50, mcp_calls: 20)` attributes on exported `.harn`
-  handlers feed a new `LimitRegistry` that owns three pluggable
-  algorithms (token bucket, sliding window, leaky bucket), an in-flight
-  watermark for backpressure, per-tenant multipliers, and a rejection
-  stats surface for the observability primitive (A.10). Mid-dispatch
-  exhaustion of the declared LLM cost ceiling reuses harn-vm's existing
-  per-thread cost-budget machinery via the new `install_llm_cost_budget`
-  guard, raised as a `BudgetExceeded`-categorised runtime error. Both
-  rate-limit rejections and budget exhaustion render through
-  `http_codec` as HTTP 429 with a `Retry-After` header and structured
-  `{ code, message, details, request_id }` body that every adapter
-  (mcp, a2a, api) shares. Subsumes the per-tenant / per-IP / queue-depth
-  enforcement that `harn-cloud-gateway::http_utils::check_rate_limits`
-  encoded as bespoke middleware. Closes #2514 (epic #2496, A.11).
+  10000)` attributes on exported `.harn` handlers feed a new
+  `LimitRegistry` that owns three pluggable algorithms (token bucket,
+  sliding window, leaky bucket), an in-flight watermark for
+  backpressure, per-tenant multipliers, and a rejection stats surface
+  for the observability primitive (A.10). Mid-dispatch exhaustion of
+  the declared LLM cost or token ceilings reuses harn-vm's per-thread
+  counters via new `install_llm_cost_budget` /
+  `install_llm_token_budget` RAII guards, raised as
+  `BudgetExceeded`-categorised runtime errors. Both rate-limit
+  rejections and budget exhaustion render through `http_codec` as HTTP
+  429 with a `Retry-After` header and structured `{ code, message,
+  details, request_id }` body that every adapter (mcp, a2a, api)
+  shares. Subsumes the per-tenant / per-IP / queue-depth enforcement
+  that `harn-cloud-gateway::http_utils::check_rate_limits` encoded as
+  bespoke middleware. `@budget(mcp_calls, pg_queries)` enforcement is
+  scaffolded but deferred to follow-up (#2576) since their increment
+  sites sit in primitives owned by sibling tickets. Closes #2514 (epic
+  #2496, A.11).

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 futures = "0.3"
 globset = "0.4"
+harn-clock = { path = "../harn-clock", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-vm = { path = "../harn-vm", version = "0.8" }
 harn-hostlib = { path = "../harn-hostlib", version = "0.8", optional = true }

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -773,6 +773,12 @@ impl McpServer {
                 mode,
                 None,
             ),
+            Err(error @ DispatchError::RateLimited { .. })
+            | Err(error @ DispatchError::BudgetExceeded { .. }) => envelope(
+                harn_vm::jsonrpc::response(job.request_id, tool_call_error(error.message())),
+                mode,
+                None,
+            ),
         };
         notify(response);
     }

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -17,8 +17,9 @@ use tokio::task::LocalSet;
 use tracing::Instrument;
 
 use crate::auth::{AuthPolicy, AuthRequest, AuthorizationDecision};
+use crate::limits::{LimitContext, LimitDecision, LimitGuard, LimitRegistry};
 use crate::replay::{InMemoryReplayCache, ReplayCache, ReplayCacheEntry, ReplayKey};
-use crate::{DispatchError, ExportCatalog, ExportedCallableKind};
+use crate::{BudgetSpec, DispatchError, ExportCatalog, ExportedCallableKind};
 
 struct ActiveEventLogGuard {
     previous: Option<Arc<AnyEventLog>>,
@@ -41,6 +42,68 @@ fn install_scoped_event_log(log: Arc<AnyEventLog>) -> ActiveEventLogGuard {
     let previous = active_event_log();
     install_active_event_log(log);
     ActiveEventLogGuard { previous }
+}
+
+/// Translate a VM-level error into the dispatcher's typed error.
+///
+/// Three signals get hoisted out of `Generic` so adapters can render
+/// each correctly:
+///
+/// * `ErrorCategory::Cancelled` — caller-initiated cancel (HTTP 499).
+/// * `ErrorCategory::BudgetExceeded` — a `@budget(...)` ceiling fired
+///   (HTTP 429, `code = "budget_exceeded"`).
+/// * everything else → `Execution` (HTTP 500).
+fn classify_vm_error(error: harn_vm::VmError) -> DispatchError {
+    let category = harn_vm::error_to_category(&error);
+    let message = error.to_string();
+    match category {
+        harn_vm::ErrorCategory::Cancelled => DispatchError::Cancelled(message),
+        harn_vm::ErrorCategory::BudgetExceeded => DispatchError::BudgetExceeded {
+            category: budget_category_from_error(&error)
+                .unwrap_or_else(|| "llm_cost_usd".to_string()),
+            message,
+        },
+        _ => DispatchError::Execution(message),
+    }
+}
+
+/// Best-effort attempt to recover the specific budget dimension that
+/// fired (e.g. `llm_cost_usd`) from a `VmError`. The structured form
+/// (`VmError::Thrown(Dict)`) carries it as the `limit` field; for the
+/// categorised mid-call variant we fall back to inferring from the
+/// error message.
+fn budget_category_from_error(error: &harn_vm::VmError) -> Option<String> {
+    match error {
+        harn_vm::VmError::Thrown(harn_vm::VmValue::Dict(d)) => d
+            .get("limit")
+            .map(|value| value.display())
+            .filter(|s| !s.is_empty()),
+        harn_vm::VmError::CategorizedError { message, .. } if message.contains("LLM") => {
+            Some("llm_cost_usd".to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Install per-dispatch resource ceilings from the route's
+/// `@budget(...)` declaration. Today the only enforced cap is
+/// `llm_cost_usd`, which routes through `harn-vm`'s pre-existing
+/// per-thread budget; future caps (mcp_calls, pg_queries) will land
+/// here alongside their respective primitive integrations.
+fn install_route_budget(spec: &BudgetSpec) -> Option<RouteBudgetGuard> {
+    if spec.is_empty() {
+        return None;
+    }
+    let llm_guard = spec.llm_cost_usd.map(harn_vm::install_llm_cost_budget);
+    Some(RouteBudgetGuard { _llm: llm_guard })
+}
+
+/// Aggregate of per-cap guards held for the lifetime of one dispatch.
+/// Dropping the aggregate restores every cap simultaneously, keeping
+/// nested dispatches safe even when guards land in different
+/// thread-locals.
+pub(crate) struct RouteBudgetGuard {
+    _llm: Option<harn_vm::LlmBudgetGuard>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -115,6 +178,12 @@ pub struct DispatchCoreConfig {
     pub auth_policy: AuthPolicy,
     pub replay_cache: Arc<dyn ReplayCache>,
     pub vm_configurator: Arc<dyn VmConfigurator>,
+    /// Rate-limit + backpressure orchestrator. `None` short-circuits
+    /// the limits check (every dispatch admitted unconditionally),
+    /// matching legacy `harn-serve` behaviour. Production deployments
+    /// install [`LimitRegistry::in_memory`] (single-node default) or a
+    /// cluster-aware impl that wraps a remote counter.
+    pub limit_registry: Option<Arc<LimitRegistry>>,
 }
 
 impl DispatchCoreConfig {
@@ -134,6 +203,7 @@ impl DispatchCoreConfig {
             auth_policy: AuthPolicy::allow_all(),
             replay_cache: Arc::new(InMemoryReplayCache::new()),
             vm_configurator: Arc::new(NoopVmConfigurator),
+            limit_registry: None,
         }
     }
 }
@@ -241,6 +311,13 @@ impl DispatchCore {
             ))
         })?;
 
+        // Rate-limit + backpressure gate. Held across the dispatch so
+        // the in-flight counter decrements on drop (including panics).
+        // Cached replies skip the gate to keep replay-cache hits free
+        // and avoid double-charging buckets the original call already
+        // paid for.
+        let _limit_guard = self.check_limits(&request, function)?;
+
         let replay_key = request
             .replay_key
             .clone()
@@ -258,6 +335,12 @@ impl DispatchCore {
                 });
             }
         }
+
+        // Per-dispatch resource budget caps live on `function.budget`
+        // and are installed inside `invoke_function` / `invoke_pipeline`
+        // — the thread-local backing (`harn_vm::install_llm_cost_budget`)
+        // must be set on the same OS thread the VM runs on, which the
+        // tokio `LocalSet` inside each invoker pins.
 
         // tenant_id is a low-cardinality routing key (one entry per
         // tenant), not PII — safe to record as a span attribute so
@@ -333,6 +416,38 @@ impl DispatchCore {
         }
     }
 
+    /// Consult the rate-limit + backpressure registry for this dispatch.
+    /// Returns a guard that decrements the in-flight counter on drop
+    /// when the registry admits the call; returns
+    /// `DispatchError::RateLimited` otherwise.
+    fn check_limits(
+        &self,
+        request: &CallRequest,
+        function: &crate::ExportedFunction,
+    ) -> Result<LimitGuard, DispatchError> {
+        let Some(registry) = self.config.limit_registry.as_ref() else {
+            return Ok(LimitGuard::unbounded_for_caller());
+        };
+        let Some(limits) = function.limits.as_ref() else {
+            return Ok(LimitGuard::unbounded_for_caller());
+        };
+        let ctx = LimitContext {
+            route: &request.function,
+            tenant_id: request.tenant_id.as_ref(),
+            scopes: &function.required_scopes,
+        };
+        match registry.check(&ctx, limits) {
+            LimitDecision::Allowed(guard) => Ok(guard),
+            LimitDecision::Rejected {
+                scope,
+                retry_after_ms,
+            } => Err(DispatchError::RateLimited {
+                scope: scope.as_str().to_string(),
+                retry_after_ms,
+            }),
+        }
+    }
+
     fn default_replay_key(&self, request: &CallRequest) -> ReplayKey {
         let rendered_args = match &request.arguments {
             CallArguments::Named(values) => {
@@ -379,6 +494,7 @@ impl DispatchCore {
         let progress = request.progress.clone();
 
         let tenant_id = request.tenant_id.clone();
+        let budget = function.budget.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -388,6 +504,7 @@ impl DispatchCore {
                     harn_vm::agent_sessions::enter_current_session(session_id.to_string())
                 });
                 let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
+                let _budget_guard = budget.as_ref().and_then(install_route_budget);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -416,14 +533,7 @@ impl DispatchCore {
 
                 match result {
                     Ok(value) => Ok((vm_value_to_json(&value), vm.output().to_string())),
-                    Err(error) => {
-                        let message = error.to_string();
-                        if message.contains("cancelled") {
-                            Err(DispatchError::Cancelled(message))
-                        } else {
-                            Err(DispatchError::Execution(message))
-                        }
-                    }
+                    Err(error) => Err(classify_vm_error(error)),
                 }
             }))
             .await
@@ -461,6 +571,7 @@ impl DispatchCore {
         let progress = request.progress.clone();
 
         let tenant_id = request.tenant_id.clone();
+        let budget = function.budget.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -470,6 +581,7 @@ impl DispatchCore {
                     harn_vm::agent_sessions::enter_current_session(session_id.to_string())
                 });
                 let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
+                let _budget_guard = budget.as_ref().and_then(install_route_budget);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -492,14 +604,7 @@ impl DispatchCore {
                         let output = vm.output().to_string();
                         Ok((serde_json::Value::String(output.clone()), output))
                     }
-                    Err(error) => {
-                        let message = error.to_string();
-                        if message.contains("cancelled") {
-                            Err(DispatchError::Cancelled(message))
-                        } else {
-                            Err(DispatchError::Execution(message))
-                        }
-                    }
+                    Err(error) => Err(classify_vm_error(error)),
                 }
             }))
             .await

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -86,16 +86,21 @@ fn budget_category_from_error(error: &harn_vm::VmError) -> Option<String> {
 }
 
 /// Install per-dispatch resource ceilings from the route's
-/// `@budget(...)` declaration. Today the only enforced cap is
-/// `llm_cost_usd`, which routes through `harn-vm`'s pre-existing
-/// per-thread budget; future caps (mcp_calls, pg_queries) will land
-/// here alongside their respective primitive integrations.
+/// `@budget(...)` declaration. The LLM-cost and LLM-token caps route
+/// through `harn-vm`'s pre-existing per-thread counters; `pg_queries`
+/// and `mcp_calls` are parsed and reserved on the [`BudgetSpec`] but
+/// enforcement waits on their respective primitive integrations
+/// (Postgres hostlib A.3, the MCP host call-count meter) — both
+/// tracked as follow-ups so a runaway tool loop can be capped once
+/// the call sites exist.
 fn install_route_budget(spec: &BudgetSpec) -> Option<RouteBudgetGuard> {
     if spec.is_empty() {
         return None;
     }
-    let llm_guard = spec.llm_cost_usd.map(harn_vm::install_llm_cost_budget);
-    Some(RouteBudgetGuard { _llm: llm_guard })
+    Some(RouteBudgetGuard {
+        _llm_cost: spec.llm_cost_usd.map(harn_vm::install_llm_cost_budget),
+        _llm_tokens: spec.llm_tokens.map(harn_vm::install_llm_token_budget),
+    })
 }
 
 /// Aggregate of per-cap guards held for the lifetime of one dispatch.
@@ -103,7 +108,8 @@ fn install_route_budget(spec: &BudgetSpec) -> Option<RouteBudgetGuard> {
 /// nested dispatches safe even when guards land in different
 /// thread-locals.
 pub(crate) struct RouteBudgetGuard {
-    _llm: Option<harn_vm::LlmBudgetGuard>,
+    _llm_cost: Option<harn_vm::LlmBudgetGuard>,
+    _llm_tokens: Option<harn_vm::LlmTokenBudgetGuard>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/harn-serve/src/error.rs
+++ b/crates/harn-serve/src/error.rs
@@ -14,6 +14,23 @@ pub enum DispatchError {
         required: BTreeSet<String>,
         granted: BTreeSet<String>,
     },
+    /// One of the route's declared rate-limit buckets (per-route /
+    /// per-tenant / per-scope) or the backpressure watermark rejected
+    /// this dispatch. Adapters render this as HTTP 429 with a
+    /// `Retry-After` header derived from `retry_after_ms`. `scope`
+    /// identifies which bucket dimension fired so callers can attribute
+    /// the rejection (e.g. "your tenant quota" vs "global route ceiling").
+    RateLimited {
+        scope: String,
+        retry_after_ms: u64,
+    },
+    /// A `@budget(...)` ceiling declared on the route was exhausted
+    /// mid-call (e.g. accumulated LLM cost rose above `llm_cost_usd`).
+    /// Adapters render this as HTTP 429 with `code = "budget_exceeded"`.
+    BudgetExceeded {
+        category: String,
+        message: String,
+    },
     Validation(String),
     MissingExport(String),
     Cancelled(String),
@@ -37,6 +54,13 @@ impl DispatchError {
             | Self::Io(message)
             | Self::Cache(message) => message.clone(),
             Self::Forbidden { required, granted } => forbidden_message(required, granted),
+            Self::RateLimited {
+                scope,
+                retry_after_ms,
+            } => format!("rate limit exceeded ({scope}); retry after {retry_after_ms} ms"),
+            Self::BudgetExceeded { category, message } => {
+                format!("budget exceeded ({category}): {message}")
+            }
         }
     }
 }

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use harn_parser::{Attribute, Node, TypeExpr};
 
+use crate::limits::{limits_and_budget_from_attributes, BudgetSpec, RouteLimits};
 use crate::DispatchError;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -21,7 +22,7 @@ pub enum ExportedCallableKind {
     Pipeline,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ExportedFunction {
     pub name: String,
     pub kind: ExportedCallableKind,
@@ -35,9 +36,17 @@ pub struct ExportedFunction {
     /// is unrestricted beyond whatever scopes the auth method enforces
     /// globally.
     pub required_scopes: BTreeSet<String>,
+    /// Rate / backpressure ceilings declared via `@limits(...)`. `None`
+    /// when the route is unbounded — the dispatch path short-circuits
+    /// cheaply when both `limits` and `budget` are absent.
+    pub limits: Option<RouteLimits>,
+    /// Per-dispatch resource budget declared via `@budget(...)` (LLM
+    /// cost / token / pg query / MCP call ceilings). `None` when no
+    /// budget caps were declared.
+    pub budget: Option<BudgetSpec>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ExportCatalog {
     pub script_path: PathBuf,
     pub functions: BTreeMap<String, ExportedFunction>,
@@ -69,6 +78,7 @@ impl ExportCatalog {
                 continue;
             }
 
+            let (limits, budget) = limits_and_budget_from_attributes(attrs);
             functions.insert(
                 name.clone(),
                 ExportedFunction {
@@ -81,6 +91,8 @@ impl ExportCatalog {
                         .as_ref()
                         .and_then(harn_vm::json_schema_for_type_expr),
                     required_scopes: scopes_from_attributes(attrs),
+                    limits,
+                    budget,
                 },
             );
         }
@@ -102,6 +114,7 @@ impl ExportCatalog {
                 continue;
             }
             let required_scopes = scopes_from_attributes(attrs);
+            let (limits, budget) = limits_and_budget_from_attributes(attrs);
             functions
                 .entry(name.clone())
                 .or_insert_with(|| ExportedFunction {
@@ -114,6 +127,8 @@ impl ExportCatalog {
                         .as_ref()
                         .and_then(harn_vm::json_schema_for_type_expr),
                     required_scopes,
+                    limits,
+                    budget,
                 });
         }
 
@@ -251,6 +266,47 @@ pub fn ping() -> string {
         );
         let ping = catalog.function("ping").expect("ping");
         assert!(ping.required_scopes.is_empty());
+    }
+
+    #[test]
+    fn export_catalog_parses_limits_and_budget_attributes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("server.harn");
+        std::fs::write(
+            &path,
+            r#"
+@limits(
+    per_tenant: "100/min",
+    per_route: "5000/min",
+    burst: 50,
+    algorithm: "sliding_window",
+    in_flight_max: 20,
+)
+@budget(llm_cost_usd: 0.50, mcp_calls: 20)
+pub fn create() -> string { return "ok" }
+
+pub fn ping() -> string { return "pong" }
+"#,
+        )
+        .expect("write script");
+
+        let catalog = ExportCatalog::from_path(&path).expect("catalog");
+        let create = catalog.function("create").expect("create export");
+        let limits = create.limits.as_ref().expect("limits parsed");
+        assert_eq!(limits.per_tenant.unwrap().count, 100);
+        assert_eq!(limits.per_route.unwrap().count, 5_000);
+        assert_eq!(limits.burst, Some(50));
+        assert_eq!(limits.algorithm, crate::limits::Algorithm::SlidingWindow);
+        assert_eq!(limits.in_flight_max, Some(20));
+        let budget = create.budget.as_ref().expect("budget parsed");
+        assert_eq!(budget.llm_cost_usd, Some(0.50));
+        assert_eq!(budget.mcp_calls, Some(20));
+
+        // Routes without the attributes get None — the dispatch path
+        // short-circuits without consulting the registry.
+        let ping = catalog.function("ping").expect("ping export");
+        assert!(ping.limits.is_none());
+        assert!(ping.budget.is_none());
     }
 
     #[test]

--- a/crates/harn-serve/src/http_codec.rs
+++ b/crates/harn-serve/src/http_codec.rs
@@ -88,12 +88,37 @@ pub fn axum_response_from_call(response: CallResponse, request_id: &str) -> Resp
 }
 
 /// Render a `DispatchError` into an `axum::Response` using the
-/// standard error envelope.
+/// standard error envelope. When the error carries a `retry_after_ms`
+/// hint (rate-limit / budget exhaustion), it is surfaced as a
+/// `Retry-After` header alongside the JSON body so HTTP clients that
+/// honour the header transparently can back off without parsing the
+/// body.
 pub fn axum_response_from_dispatch_error(error: DispatchError, request_id: &str) -> Response {
+    let retry_after = retry_after_seconds(&error);
     let (status, payload) = dispatch_error_payload(error, request_id);
     let mut response = (status, Json(payload)).into_response();
     insert_request_id(response.headers_mut(), request_id);
+    if let Some(seconds) = retry_after {
+        if let Ok(value) = HeaderValue::from_str(&seconds.to_string()) {
+            response.headers_mut().insert(header::RETRY_AFTER, value);
+        }
+    }
     response
+}
+
+/// `Retry-After` (in seconds) implied by a dispatch error, when any.
+/// Rate-limit / backpressure rejections carry a ms hint; budget
+/// exhaustion uses 60 s as a safe default since the budget recovers
+/// when the caller starts a new dispatch (a new tenant/route bucket
+/// life). Other errors return `None`.
+fn retry_after_seconds(error: &DispatchError) -> Option<u64> {
+    match error {
+        DispatchError::RateLimited { retry_after_ms, .. } => {
+            Some(retry_after_ms.div_ceil(1_000).max(1))
+        }
+        DispatchError::BudgetExceeded { .. } => Some(60),
+        _ => None,
+    }
 }
 
 /// Decode a `CallResponse` into a [`HttpCodecOutcome`]. Exposed so
@@ -384,6 +409,31 @@ pub fn dispatch_error_payload(error: DispatchError, request_id: &str) -> (Status
             let payload = forbidden_data_payload(&required, &granted);
             let message = crate::error::forbidden_message(&required, &granted);
             (StatusCode::FORBIDDEN, "forbidden", message, payload)
+        }
+        DispatchError::RateLimited {
+            scope,
+            retry_after_ms,
+        } => {
+            let message = format!("rate limit exceeded ({scope}); retry after {retry_after_ms} ms");
+            let details = json!({
+                "scope": scope,
+                "retry_after_ms": retry_after_ms,
+            });
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                "rate_limited",
+                message,
+                details,
+            )
+        }
+        DispatchError::BudgetExceeded { category, message } => {
+            let details = json!({ "category": category });
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                "budget_exceeded",
+                message,
+                details,
+            )
         }
         DispatchError::Validation(message) => (
             StatusCode::BAD_REQUEST,

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -7,6 +7,7 @@ mod core;
 mod error;
 mod exports;
 pub mod http_codec;
+pub mod limits;
 mod mcp_context;
 pub mod mcp_host_bridge;
 mod mcp_prompts;
@@ -48,6 +49,11 @@ pub use exports::{ExportCatalog, ExportedCallableKind, ExportedFunction, Exporte
 pub use http_codec::{
     axum_response_from_call, axum_response_from_dispatch_error, decode_call_response,
     dispatch_error_payload, fresh_request_id, HttpCodecOutcome, SseEventSpec,
+};
+pub use limits::{
+    Algorithm, BudgetSpec, InMemoryLimitStore, LimitContext, LimitDecision, LimitGuard,
+    LimitRegistry, LimitScope, LimitStats, LimitStore, Quota, QuotaWindow, RouteLimits,
+    TenantOverride,
 };
 pub use mcp_host_bridge::install_mcp_host_allowlist;
 pub use mcp_prompts::FilePromptCatalog;

--- a/crates/harn-serve/src/limits/algorithms.rs
+++ b/crates/harn-serve/src/limits/algorithms.rs
@@ -15,9 +15,6 @@
 //! owns the keyed map of these cells.
 
 use std::collections::VecDeque;
-use std::sync::Arc;
-
-use harn_clock::Clock;
 
 /// One trip through the algorithm — either admitted, or rejected with a
 /// hint at how long the caller should back off before retrying. Callers
@@ -69,16 +66,12 @@ impl Algorithm {
         }
     }
 
-    /// Build a fresh per-key cell of the chosen algorithm. The
-    /// `capacity` argument means different things by algorithm — see the
-    /// individual impls — but always upper-bounds the burst tolerance.
-    pub fn new_cell(
-        self,
-        rate_per_sec: f64,
-        capacity: u32,
-        clock: &Arc<dyn Clock>,
-    ) -> Box<dyn RateAlgorithm> {
-        let now_ms = clock.monotonic_ms();
+    /// Build a fresh per-key cell of the chosen algorithm. `now_ms` is
+    /// the current monotonic millis from the clock the store owns —
+    /// passed in so the algorithm enum stays decoupled from the time
+    /// substrate. `capacity` means different things by algorithm (see
+    /// the individual impls) but always upper-bounds the burst.
+    pub fn new_cell(self, rate_per_sec: f64, capacity: u32, now_ms: i64) -> Box<dyn RateAlgorithm> {
         match self {
             Self::TokenBucket => Box::new(TokenBucket::new(rate_per_sec, capacity, now_ms)),
             Self::SlidingWindow => Box::new(SlidingWindow::new(

--- a/crates/harn-serve/src/limits/algorithms.rs
+++ b/crates/harn-serve/src/limits/algorithms.rs
@@ -1,0 +1,332 @@
+//! Pluggable rate-limit algorithms.
+//!
+//! Three implementations cover the common shapes a caller will reach for:
+//!
+//! * [`TokenBucket`] — classic refill-on-read bucket. Default. Good fit for
+//!   "X requests per second with burst allowance Y".
+//! * [`SlidingWindow`] — track timestamps over a rolling window. Fairer
+//!   under steady load than token bucket (no edge bursts at window
+//!   boundaries) but linear in number of in-window hits per check.
+//! * [`LeakyBucket`] — drain at fixed rate; admit when level + 1 ≤ capacity.
+//!   Useful for shaping outbound traffic ("smooth out spikes").
+//!
+//! Each implementation is per-key state — a single `RateAlgorithm` value
+//! tracks one keyspace cell, e.g. one tenant. The store ([`super::store`])
+//! owns the keyed map of these cells.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use harn_clock::Clock;
+
+/// One trip through the algorithm — either admitted, or rejected with a
+/// hint at how long the caller should back off before retrying. Callers
+/// surface `retry_after_ms` through `Retry-After`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CellDecision {
+    Allowed,
+    Rejected { retry_after_ms: u64 },
+}
+
+/// Stateful rate-limit cell. Implementations hold one keyspace cell of
+/// state (e.g. one tenant's bucket). The trait is object-safe so the
+/// store can hold heterogeneous algorithm choices behind one map.
+pub trait RateAlgorithm: Send {
+    /// Attempt to admit one unit of work at `now_ms` (monotonic).
+    fn try_admit(&mut self, now_ms: i64) -> CellDecision;
+}
+
+/// Identifies which algorithm to instantiate for a new keyspace cell.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Algorithm {
+    /// Refill-on-read token bucket. Burst up to `capacity`; sustains at
+    /// `rate_per_sec`.
+    #[default]
+    TokenBucket,
+    /// Sliding-window log: admit up to `capacity` events per
+    /// `window_ms` rolling window.
+    SlidingWindow,
+    /// Constant-rate leaky bucket: capacity is the queue depth, drains
+    /// at `rate_per_sec`.
+    LeakyBucket,
+}
+
+impl Algorithm {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "token_bucket" | "token-bucket" | "tokenbucket" => Some(Self::TokenBucket),
+            "sliding_window" | "sliding-window" | "slidingwindow" => Some(Self::SlidingWindow),
+            "leaky_bucket" | "leaky-bucket" | "leakybucket" => Some(Self::LeakyBucket),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TokenBucket => "token_bucket",
+            Self::SlidingWindow => "sliding_window",
+            Self::LeakyBucket => "leaky_bucket",
+        }
+    }
+
+    /// Build a fresh per-key cell of the chosen algorithm. The
+    /// `capacity` argument means different things by algorithm — see the
+    /// individual impls — but always upper-bounds the burst tolerance.
+    pub fn new_cell(
+        self,
+        rate_per_sec: f64,
+        capacity: u32,
+        clock: &Arc<dyn Clock>,
+    ) -> Box<dyn RateAlgorithm> {
+        let now_ms = clock.monotonic_ms();
+        match self {
+            Self::TokenBucket => Box::new(TokenBucket::new(rate_per_sec, capacity, now_ms)),
+            Self::SlidingWindow => Box::new(SlidingWindow::new(
+                capacity,
+                window_ms_for_rate(rate_per_sec, capacity),
+            )),
+            Self::LeakyBucket => Box::new(LeakyBucket::new(rate_per_sec, capacity, now_ms)),
+        }
+    }
+}
+
+/// Derive the natural window size for a sliding-window cell from the
+/// caller-supplied `rate_per_sec` and `capacity`: the window is sized so
+/// that, on average, the configured rate sustains exactly `capacity`
+/// hits per window.
+fn window_ms_for_rate(rate_per_sec: f64, capacity: u32) -> u64 {
+    if rate_per_sec <= 0.0 || capacity == 0 {
+        return 1_000;
+    }
+    let window_secs = capacity as f64 / rate_per_sec;
+    ((window_secs * 1_000.0).round() as u64).max(1)
+}
+
+// ── TokenBucket ────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct TokenBucket {
+    rate_per_sec: f64,
+    capacity: f64,
+    tokens: f64,
+    last_refill_ms: i64,
+}
+
+impl TokenBucket {
+    pub fn new(rate_per_sec: f64, capacity: u32, now_ms: i64) -> Self {
+        Self {
+            rate_per_sec: rate_per_sec.max(0.0),
+            capacity: capacity as f64,
+            tokens: capacity as f64,
+            last_refill_ms: now_ms,
+        }
+    }
+
+    fn refill(&mut self, now_ms: i64) {
+        if now_ms <= self.last_refill_ms {
+            return;
+        }
+        let delta_ms = (now_ms - self.last_refill_ms) as f64;
+        let gained = (delta_ms / 1_000.0) * self.rate_per_sec;
+        self.tokens = (self.tokens + gained).min(self.capacity);
+        self.last_refill_ms = now_ms;
+    }
+}
+
+impl RateAlgorithm for TokenBucket {
+    fn try_admit(&mut self, now_ms: i64) -> CellDecision {
+        self.refill(now_ms);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            return CellDecision::Allowed;
+        }
+        // Need 1 - tokens more tokens; refill at rate_per_sec.
+        let deficit = 1.0 - self.tokens;
+        let retry_after_ms = if self.rate_per_sec > 0.0 {
+            ((deficit / self.rate_per_sec) * 1_000.0).ceil() as u64
+        } else {
+            // No refill; effectively a hard cap. Tell the caller to wait
+            // a second so they don't busy-spin.
+            1_000
+        };
+        CellDecision::Rejected {
+            retry_after_ms: retry_after_ms.max(1),
+        }
+    }
+}
+
+// ── SlidingWindow ──────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct SlidingWindow {
+    capacity: usize,
+    window_ms: u64,
+    hits: VecDeque<i64>,
+}
+
+impl SlidingWindow {
+    pub fn new(capacity: u32, window_ms: u64) -> Self {
+        Self {
+            capacity: capacity as usize,
+            window_ms,
+            hits: VecDeque::with_capacity(capacity as usize),
+        }
+    }
+
+    fn trim(&mut self, now_ms: i64) {
+        let cutoff = now_ms.saturating_sub(self.window_ms as i64);
+        while let Some(&front) = self.hits.front() {
+            if front <= cutoff {
+                self.hits.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl RateAlgorithm for SlidingWindow {
+    fn try_admit(&mut self, now_ms: i64) -> CellDecision {
+        self.trim(now_ms);
+        if self.capacity == 0 {
+            return CellDecision::Rejected {
+                retry_after_ms: self.window_ms.max(1),
+            };
+        }
+        if self.hits.len() < self.capacity {
+            self.hits.push_back(now_ms);
+            return CellDecision::Allowed;
+        }
+        // Oldest hit expires at oldest + window; reject until then.
+        let oldest = *self.hits.front().expect("hits non-empty when full");
+        let earliest_open_ms = oldest + self.window_ms as i64;
+        let retry_after_ms = ((earliest_open_ms - now_ms).max(1)) as u64;
+        CellDecision::Rejected { retry_after_ms }
+    }
+}
+
+// ── LeakyBucket ────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct LeakyBucket {
+    rate_per_sec: f64,
+    capacity: f64,
+    level: f64,
+    last_drip_ms: i64,
+}
+
+impl LeakyBucket {
+    pub fn new(rate_per_sec: f64, capacity: u32, now_ms: i64) -> Self {
+        Self {
+            rate_per_sec: rate_per_sec.max(0.0),
+            capacity: capacity as f64,
+            level: 0.0,
+            last_drip_ms: now_ms,
+        }
+    }
+
+    fn drain(&mut self, now_ms: i64) {
+        if now_ms <= self.last_drip_ms {
+            return;
+        }
+        let delta_ms = (now_ms - self.last_drip_ms) as f64;
+        let drained = (delta_ms / 1_000.0) * self.rate_per_sec;
+        self.level = (self.level - drained).max(0.0);
+        self.last_drip_ms = now_ms;
+    }
+}
+
+impl RateAlgorithm for LeakyBucket {
+    fn try_admit(&mut self, now_ms: i64) -> CellDecision {
+        self.drain(now_ms);
+        if self.level + 1.0 <= self.capacity {
+            self.level += 1.0;
+            return CellDecision::Allowed;
+        }
+        // Need (level + 1) - capacity to drain at rate_per_sec.
+        let overflow = (self.level + 1.0) - self.capacity;
+        let retry_after_ms = if self.rate_per_sec > 0.0 {
+            ((overflow / self.rate_per_sec) * 1_000.0).ceil() as u64
+        } else {
+            1_000
+        };
+        CellDecision::Rejected {
+            retry_after_ms: retry_after_ms.max(1),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_bucket_admits_up_to_capacity_then_throttles() {
+        let mut bucket = TokenBucket::new(1.0, 3, 0);
+        assert_eq!(bucket.try_admit(0), CellDecision::Allowed);
+        assert_eq!(bucket.try_admit(0), CellDecision::Allowed);
+        assert_eq!(bucket.try_admit(0), CellDecision::Allowed);
+        // Bucket is empty; 4th call rejects.
+        match bucket.try_admit(0) {
+            CellDecision::Rejected { retry_after_ms } => {
+                // 1 second to refill 1 token at rate 1/sec.
+                assert!((900..=1_100).contains(&retry_after_ms), "{retry_after_ms}");
+            }
+            other => panic!("expected reject, got {other:?}"),
+        }
+        // After 1 second, one token has refilled.
+        assert_eq!(bucket.try_admit(1_000), CellDecision::Allowed);
+    }
+
+    #[test]
+    fn sliding_window_rejects_when_full_until_oldest_drops_off() {
+        let mut window = SlidingWindow::new(3, 1_000);
+        assert_eq!(window.try_admit(0), CellDecision::Allowed);
+        assert_eq!(window.try_admit(100), CellDecision::Allowed);
+        assert_eq!(window.try_admit(200), CellDecision::Allowed);
+        match window.try_admit(300) {
+            CellDecision::Rejected { retry_after_ms } => assert_eq!(retry_after_ms, 700),
+            other => panic!("expected reject, got {other:?}"),
+        }
+        // After the oldest expires (now_ms = 1_001), one slot frees up.
+        assert_eq!(window.try_admit(1_001), CellDecision::Allowed);
+    }
+
+    #[test]
+    fn leaky_bucket_smooths_burst_to_drain_rate() {
+        // capacity 2 (queue depth), drain 1/sec
+        let mut bucket = LeakyBucket::new(1.0, 2, 0);
+        assert_eq!(bucket.try_admit(0), CellDecision::Allowed);
+        assert_eq!(bucket.try_admit(0), CellDecision::Allowed);
+        // Bucket is full; 3rd in same instant must reject.
+        match bucket.try_admit(0) {
+            CellDecision::Rejected { retry_after_ms } => {
+                assert!((900..=1_100).contains(&retry_after_ms), "{retry_after_ms}");
+            }
+            other => panic!("expected reject, got {other:?}"),
+        }
+        // 1 second later one drop has drained → admit again.
+        assert_eq!(bucket.try_admit(1_000), CellDecision::Allowed);
+    }
+
+    #[test]
+    fn parse_algorithm_accepts_friendly_aliases() {
+        assert_eq!(
+            Algorithm::parse("token_bucket"),
+            Some(Algorithm::TokenBucket)
+        );
+        assert_eq!(
+            Algorithm::parse("TOKEN-BUCKET"),
+            Some(Algorithm::TokenBucket)
+        );
+        assert_eq!(
+            Algorithm::parse("sliding_window"),
+            Some(Algorithm::SlidingWindow)
+        );
+        assert_eq!(
+            Algorithm::parse("leaky_bucket"),
+            Some(Algorithm::LeakyBucket)
+        );
+        assert_eq!(Algorithm::parse("nope"), None);
+    }
+}

--- a/crates/harn-serve/src/limits/mod.rs
+++ b/crates/harn-serve/src/limits/mod.rs
@@ -1,0 +1,712 @@
+//! Rate-limiting + backpressure + call-budget primitive for `.harn`
+//! handlers hosted on `harn-serve`. Implements epic A.11 — the
+//! cross-tenant production-readiness shape `harn-cloud-gateway` enforces
+//! today via bespoke middleware (`http_utils::check_rate_limits`), lifted
+//! into one declarative primitive every adapter on `harn-serve` shares.
+//!
+//! ## Author-facing shape
+//!
+//! ```harn
+//! @limits(
+//!     per_tenant: "100/min",      //  rate · window
+//!     per_scope:  "1000/min",
+//!     per_route:  "5000/min",
+//!     burst:      50,             //  capacity above sustained rate
+//!     algorithm:  "token_bucket", //  token_bucket | sliding_window | leaky_bucket
+//!     in_flight_max: 20,          //  backpressure watermark
+//! )
+//! @budget(
+//!     llm_cost_usd: 0.50,         //  pinned to harn-vm's LLM_BUDGET on dispatch
+//!     llm_tokens:   10000,
+//!     pg_queries:   50,
+//!     mcp_calls:    20,
+//! )
+//! pub fn create_session(req: dict) -> dict { ... }
+//! ```
+//!
+//! ## Decision flow (one dispatch)
+//!
+//! 1. `LimitRegistry::check` consults each declared bucket
+//!    (`per_route` → `per_tenant` → `per_scope`) and the backpressure
+//!    watermark; first violator wins, smallest `retry_after_ms` is
+//!    returned.
+//! 2. Allowed dispatches hold a `LimitGuard` that decrements the
+//!    in-flight counter on drop.
+//! 3. Rejected dispatches surface as
+//!    [`crate::DispatchError::RateLimited`] → HTTP 429 with `Retry-After`
+//!    via [`crate::http_codec`].
+//! 4. Budget caps install on the dispatch's thread-local (the LLM
+//!    cost budget reuses `harn-vm`'s existing
+//!    [`harn_vm::install_llm_cost_budget`]; mid-call exhaustion raises a
+//!    typed runtime error which the codec maps to 429 with
+//!    `code = "budget_exceeded"`).
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use harn_clock::Clock;
+
+use harn_vm::TenantId;
+
+pub mod algorithms;
+pub mod parse;
+pub mod store;
+
+pub use algorithms::{Algorithm, CellDecision, RateAlgorithm};
+pub use parse::limits_and_budget_from_attributes;
+pub use store::{BucketSpec, InMemoryLimitStore, LimitStore};
+
+/// Parsed `N/(sec|min|hour)` quota. The window is implicit in `per` —
+/// the registry collapses everything to per-second rates internally for
+/// the algorithm cells.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Quota {
+    pub count: u32,
+    pub per: QuotaWindow,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuotaWindow {
+    Second,
+    Minute,
+    Hour,
+}
+
+impl QuotaWindow {
+    fn seconds(self) -> f64 {
+        match self {
+            Self::Second => 1.0,
+            Self::Minute => 60.0,
+            Self::Hour => 3_600.0,
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "s" | "sec" | "second" | "seconds" => Some(Self::Second),
+            "m" | "min" | "minute" | "minutes" => Some(Self::Minute),
+            "h" | "hour" | "hours" => Some(Self::Hour),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Second => "sec",
+            Self::Minute => "min",
+            Self::Hour => "hour",
+        }
+    }
+}
+
+impl Quota {
+    pub fn new(count: u32, per: QuotaWindow) -> Self {
+        Self { count, per }
+    }
+
+    /// Parse a `"N/window"` string into a quota. Returns `None` for any
+    /// shape the rest of the primitive cannot enforce — callers should
+    /// pass the original string through to the parser as `Option<String>`
+    /// and silently drop unrecognised forms (the attribute parser
+    /// already validates that the source token was a string literal).
+    pub fn parse(raw: impl AsRef<str>) -> Option<Self> {
+        let raw = raw.as_ref();
+        let (count_part, window_part) = raw.split_once('/')?;
+        let count: u32 = count_part
+            .trim()
+            .replace('_', "")
+            .parse()
+            .ok()
+            .filter(|n| *n > 0)?;
+        let per = QuotaWindow::parse(window_part)?;
+        Some(Self { count, per })
+    }
+
+    /// Per-second rate this quota sustains. Burst is layered on top via
+    /// [`RouteLimits::burst`].
+    pub fn rate_per_sec(self) -> f64 {
+        self.count as f64 / self.per.seconds()
+    }
+}
+
+impl std::fmt::Display for Quota {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.count, self.per.as_str())
+    }
+}
+
+/// Limits declared on one route mount. All fields are independent: a
+/// route can declare any combination (or none — `RouteLimits::default()`
+/// is unlimited and the registry short-circuits cheaply).
+#[derive(Clone, Debug, Default)]
+pub struct RouteLimits {
+    pub per_tenant: Option<Quota>,
+    pub per_scope: Option<Quota>,
+    pub per_route: Option<Quota>,
+    /// Capacity above sustained rate — token bucket / leaky bucket
+    /// burst tolerance. When unset, the bucket capacity equals the
+    /// per-window count (no burst above the steady-state quota).
+    pub burst: Option<u32>,
+    pub algorithm: Algorithm,
+    /// Maximum concurrent in-flight dispatches on this route before
+    /// backpressure rejects. The registry tracks an in-flight counter
+    /// per route key and returns 429 + Retry-After when it would
+    /// exceed this watermark. `None` = unbounded.
+    pub in_flight_max: Option<u32>,
+}
+
+impl RouteLimits {
+    pub fn is_unlimited(&self) -> bool {
+        self.per_tenant.is_none()
+            && self.per_scope.is_none()
+            && self.per_route.is_none()
+            && self.in_flight_max.is_none()
+    }
+
+    fn bucket_for(&self, quota: Quota) -> BucketSpec {
+        let capacity = self.burst.unwrap_or(quota.count).max(1);
+        BucketSpec::new(self.algorithm, quota.rate_per_sec(), capacity)
+    }
+}
+
+/// Per-call resource budget declared on the route. Enforced inside the
+/// dispatch (mid-call) so a runaway tool loop hits the ceiling before
+/// it can melt the host.
+#[derive(Clone, Debug, Default)]
+pub struct BudgetSpec {
+    pub llm_cost_usd: Option<f64>,
+    pub llm_tokens: Option<u64>,
+    pub pg_queries: Option<u64>,
+    pub mcp_calls: Option<u64>,
+}
+
+impl BudgetSpec {
+    pub fn is_empty(&self) -> bool {
+        self.llm_cost_usd.is_none()
+            && self.llm_tokens.is_none()
+            && self.pg_queries.is_none()
+            && self.mcp_calls.is_none()
+    }
+}
+
+/// Context the registry needs to evaluate a route's limits for one
+/// dispatch — names the route, the authenticated principal's scopes,
+/// and (when present) the tenant.
+#[derive(Clone, Debug)]
+pub struct LimitContext<'a> {
+    pub route: &'a str,
+    pub tenant_id: Option<&'a TenantId>,
+    pub scopes: &'a std::collections::BTreeSet<String>,
+}
+
+/// The bucket dimension that rejected a dispatch. Surfaces via 429
+/// detail body so callers can tell whether they hit a tenant quota
+/// vs. a global route ceiling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LimitScope {
+    Route,
+    Tenant,
+    Scope,
+    Backpressure,
+}
+
+impl LimitScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Route => "route",
+            Self::Tenant => "tenant",
+            Self::Scope => "scope",
+            Self::Backpressure => "backpressure",
+        }
+    }
+}
+
+/// One trip through the registry — either admitted (and holding the
+/// in-flight slot), or rejected with the offending dimension and the
+/// smallest `retry_after_ms` from the violators.
+#[derive(Debug)]
+pub enum LimitDecision {
+    Allowed(LimitGuard),
+    Rejected {
+        scope: LimitScope,
+        retry_after_ms: u64,
+    },
+}
+
+/// RAII guard returned by [`LimitRegistry::check`] when a dispatch is
+/// admitted. Decrements the backpressure counter on drop so the in-flight
+/// gauge stays balanced across panics/errors.
+#[derive(Debug)]
+pub struct LimitGuard {
+    counter: Option<Arc<AtomicUsize>>,
+}
+
+impl LimitGuard {
+    /// Build a guard that decrements `counter` on drop, assuming the
+    /// caller has *already* incremented it. Pairing the increment with
+    /// the guard constructor introduces a race window between the
+    /// "would this exceed the watermark?" check and the increment; the
+    /// registry instead does an atomic `fetch_add` and rolls back when
+    /// the prior value exceeded the cap, then hands the guard the
+    /// already-incremented counter via this constructor.
+    fn for_incremented(counter: Arc<AtomicUsize>) -> Self {
+        Self {
+            counter: Some(counter),
+        }
+    }
+
+    fn unbounded() -> Self {
+        Self { counter: None }
+    }
+
+    /// Construct a no-op guard for callers that bypass the registry
+    /// (e.g. dispatch paths with no `LimitRegistry` configured at
+    /// all). Drop is a no-op.
+    pub(crate) fn unbounded_for_caller() -> Self {
+        Self::unbounded()
+    }
+}
+
+impl Drop for LimitGuard {
+    fn drop(&mut self) {
+        if let Some(counter) = self.counter.take() {
+            counter.fetch_sub(1, Ordering::AcqRel);
+        }
+    }
+}
+
+/// Aggregated rejection stats. Adapters surface these via the
+/// observability primitive (A.10); the in-memory snapshot is enough
+/// for tests and a `/metrics` endpoint.
+#[derive(Clone, Debug, Default)]
+pub struct LimitStats {
+    pub admitted: u64,
+    pub rejected_route: u64,
+    pub rejected_tenant: u64,
+    pub rejected_scope: u64,
+    pub rejected_backpressure: u64,
+}
+
+impl LimitStats {
+    pub fn total_rejected(&self) -> u64 {
+        self.rejected_route
+            + self.rejected_tenant
+            + self.rejected_scope
+            + self.rejected_backpressure
+    }
+}
+
+#[derive(Debug, Default)]
+struct AtomicLimitStats {
+    admitted: AtomicU64,
+    rejected_route: AtomicU64,
+    rejected_tenant: AtomicU64,
+    rejected_scope: AtomicU64,
+    rejected_backpressure: AtomicU64,
+}
+
+impl AtomicLimitStats {
+    fn snapshot(&self) -> LimitStats {
+        LimitStats {
+            admitted: self.admitted.load(Ordering::Relaxed),
+            rejected_route: self.rejected_route.load(Ordering::Relaxed),
+            rejected_tenant: self.rejected_tenant.load(Ordering::Relaxed),
+            rejected_scope: self.rejected_scope.load(Ordering::Relaxed),
+            rejected_backpressure: self.rejected_backpressure.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Per-tenant override applied to every declared quota for that tenant.
+/// `1.0` is a no-op; `2.0` doubles every bucket; `0.5` halves them.
+/// Capacity is rounded up so a bucket never collapses to 0.
+#[derive(Clone, Copy, Debug)]
+pub struct TenantOverride {
+    pub multiplier: f64,
+}
+
+impl Default for TenantOverride {
+    fn default() -> Self {
+        Self { multiplier: 1.0 }
+    }
+}
+
+/// Central rate-limit + backpressure orchestrator. Owned by the
+/// dispatch core; one instance per `harn-serve` host process.
+pub struct LimitRegistry {
+    store: Arc<dyn LimitStore>,
+    in_flight: Mutex<BTreeMap<String, Arc<AtomicUsize>>>,
+    tenant_overrides: Mutex<BTreeMap<TenantId, TenantOverride>>,
+    stats: AtomicLimitStats,
+}
+
+impl std::fmt::Debug for LimitRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LimitRegistry")
+            .field("stats", &self.stats.snapshot())
+            .finish()
+    }
+}
+
+impl LimitRegistry {
+    pub fn new(store: Arc<dyn LimitStore>) -> Arc<Self> {
+        Arc::new(Self {
+            store,
+            in_flight: Mutex::new(BTreeMap::new()),
+            tenant_overrides: Mutex::new(BTreeMap::new()),
+            stats: AtomicLimitStats::default(),
+        })
+    }
+
+    /// In-memory registry — single-node default. Pair with a
+    /// production [`Clock`] (typically `harn_clock::RealClock::arc()`).
+    pub fn in_memory(clock: Arc<dyn Clock>) -> Arc<Self> {
+        Self::new(Arc::new(InMemoryLimitStore::new(clock)))
+    }
+
+    pub fn set_tenant_override(&self, tenant: TenantId, value: TenantOverride) {
+        self.tenant_overrides
+            .lock()
+            .expect("tenant overrides poisoned")
+            .insert(tenant, value);
+    }
+
+    /// Snapshot of admitted vs. rejected counts. Cheap (atomic loads).
+    pub fn stats(&self) -> LimitStats {
+        self.stats.snapshot()
+    }
+
+    fn multiplier_for(&self, tenant: Option<&TenantId>) -> f64 {
+        let Some(tenant) = tenant else {
+            return 1.0;
+        };
+        self.tenant_overrides
+            .lock()
+            .expect("tenant overrides poisoned")
+            .get(tenant)
+            .map(|o| o.multiplier)
+            .unwrap_or(1.0)
+    }
+
+    fn route_in_flight_handle(&self, route: &str) -> Arc<AtomicUsize> {
+        let mut in_flight = self.in_flight.lock().expect("in-flight map poisoned");
+        in_flight
+            .entry(route.to_string())
+            .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
+            .clone()
+    }
+
+    /// Evaluate every declared bucket and the backpressure watermark
+    /// for one dispatch. Returns admittedness; on rejection, callers
+    /// surface the smallest `retry_after_ms` over `Retry-After`.
+    pub fn check(&self, ctx: &LimitContext<'_>, limits: &RouteLimits) -> LimitDecision {
+        if limits.is_unlimited() {
+            self.stats.admitted.fetch_add(1, Ordering::Relaxed);
+            return LimitDecision::Allowed(LimitGuard::unbounded());
+        }
+
+        let multiplier = self.multiplier_for(ctx.tenant_id);
+
+        // Evaluate each rate dimension. We must charge every dimension
+        // a token (so a later 429 in a wider bucket doesn't leave a
+        // narrower bucket starved), but we early-return on the first
+        // rejection to keep noise rejections cheap.
+
+        if let Some(quota) = limits.per_route {
+            let spec = scaled_bucket(limits.bucket_for(quota), multiplier);
+            let key = format!("route:{}", ctx.route);
+            if let CellDecision::Rejected { retry_after_ms } = self.store.try_admit(&key, &spec, 1)
+            {
+                self.stats.rejected_route.fetch_add(1, Ordering::Relaxed);
+                emit_rejection(ctx, LimitScope::Route, retry_after_ms);
+                return LimitDecision::Rejected {
+                    scope: LimitScope::Route,
+                    retry_after_ms,
+                };
+            }
+        }
+
+        if let Some(quota) = limits.per_tenant {
+            // Without a bound tenant, `per_tenant` cannot enforce; treat
+            // the dispatch as anonymous and fall back to the route key.
+            let tenant_key = ctx.tenant_id.map(|t| t.0.as_str()).unwrap_or("__anon__");
+            let spec = scaled_bucket(limits.bucket_for(quota), multiplier);
+            let key = format!("tenant:{tenant_key}:{}", ctx.route);
+            if let CellDecision::Rejected { retry_after_ms } = self.store.try_admit(&key, &spec, 1)
+            {
+                self.stats.rejected_tenant.fetch_add(1, Ordering::Relaxed);
+                emit_rejection(ctx, LimitScope::Tenant, retry_after_ms);
+                return LimitDecision::Rejected {
+                    scope: LimitScope::Tenant,
+                    retry_after_ms,
+                };
+            }
+        }
+
+        if let Some(quota) = limits.per_scope {
+            // The "scope" bucket is keyed on the joined scope set so a
+            // caller that holds two scopes shares quota across both —
+            // matching how `harn-cloud-gateway` charges scope quotas.
+            let scope_key = if ctx.scopes.is_empty() {
+                "__none__".to_string()
+            } else {
+                ctx.scopes.iter().cloned().collect::<Vec<_>>().join(",")
+            };
+            let spec = scaled_bucket(limits.bucket_for(quota), multiplier);
+            let key = format!("scope:{scope_key}:{}", ctx.route);
+            if let CellDecision::Rejected { retry_after_ms } = self.store.try_admit(&key, &spec, 1)
+            {
+                self.stats.rejected_scope.fetch_add(1, Ordering::Relaxed);
+                emit_rejection(ctx, LimitScope::Scope, retry_after_ms);
+                return LimitDecision::Rejected {
+                    scope: LimitScope::Scope,
+                    retry_after_ms,
+                };
+            }
+        }
+
+        // Backpressure: atomic increment-then-test against the
+        // watermark. We can't do a CAS loop because the counter has no
+        // upper bound at the type level, so we fetch_add unconditionally
+        // and roll back when the prior value already met or exceeded
+        // the cap. This closes the check-then-act race that a separate
+        // load + increment would leave open under concurrent dispatch.
+        if let Some(max) = limits.in_flight_max {
+            let counter = self.route_in_flight_handle(ctx.route);
+            let prev = counter.fetch_add(1, Ordering::AcqRel);
+            if prev >= max as usize {
+                counter.fetch_sub(1, Ordering::AcqRel);
+                self.stats
+                    .rejected_backpressure
+                    .fetch_add(1, Ordering::Relaxed);
+                let retry_after_ms = 250; // re-poll quickly; the queue drains by completions, not time
+                emit_rejection(ctx, LimitScope::Backpressure, retry_after_ms);
+                return LimitDecision::Rejected {
+                    scope: LimitScope::Backpressure,
+                    retry_after_ms,
+                };
+            }
+            self.stats.admitted.fetch_add(1, Ordering::Relaxed);
+            return LimitDecision::Allowed(LimitGuard::for_incremented(counter));
+        }
+
+        self.stats.admitted.fetch_add(1, Ordering::Relaxed);
+        LimitDecision::Allowed(LimitGuard::unbounded())
+    }
+}
+
+fn scaled_bucket(mut spec: BucketSpec, multiplier: f64) -> BucketSpec {
+    if (multiplier - 1.0).abs() < f64::EPSILON {
+        return spec;
+    }
+    let multiplier = multiplier.max(0.0);
+    spec.rate_per_sec = (spec.rate_per_sec * multiplier).max(0.0);
+    let scaled_capacity = (spec.capacity as f64 * multiplier).ceil().max(1.0);
+    spec.capacity = scaled_capacity.min(u32::MAX as f64) as u32;
+    spec
+}
+
+fn emit_rejection(ctx: &LimitContext<'_>, scope: LimitScope, retry_after_ms: u64) {
+    tracing::warn!(
+        target: "harn.serve.limits",
+        route = ctx.route,
+        tenant = ctx.tenant_id.map(|t| t.0.as_str()).unwrap_or(""),
+        scope = scope.as_str(),
+        retry_after_ms,
+        "rate limit rejection"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harn_clock::PausedClock;
+    use std::collections::BTreeSet;
+    use std::time::Duration;
+    use time::OffsetDateTime;
+
+    fn paused() -> Arc<PausedClock> {
+        PausedClock::new(OffsetDateTime::UNIX_EPOCH)
+    }
+
+    fn ctx<'a>(
+        route: &'a str,
+        tenant: Option<&'a TenantId>,
+        scopes: &'a BTreeSet<String>,
+    ) -> LimitContext<'a> {
+        LimitContext {
+            route,
+            tenant_id: tenant,
+            scopes,
+        }
+    }
+
+    #[test]
+    fn quota_parse_handles_common_shapes() {
+        assert_eq!(
+            Quota::parse("100/min"),
+            Some(Quota::new(100, QuotaWindow::Minute))
+        );
+        assert_eq!(
+            Quota::parse("1_000/hour"),
+            Some(Quota::new(1_000, QuotaWindow::Hour))
+        );
+        assert_eq!(
+            Quota::parse(" 50 / s "),
+            Some(Quota::new(50, QuotaWindow::Second))
+        );
+        assert_eq!(Quota::parse("0/min"), None);
+        assert_eq!(Quota::parse("nope"), None);
+    }
+
+    #[test]
+    fn unlimited_route_is_admitted_cheaply() {
+        let registry = LimitRegistry::in_memory(paused());
+        let scopes = BTreeSet::new();
+        let limits = RouteLimits::default();
+        let decision = registry.check(&ctx("/x", None, &scopes), &limits);
+        assert!(matches!(decision, LimitDecision::Allowed(_)));
+        assert_eq!(registry.stats().admitted, 1);
+    }
+
+    #[test]
+    fn per_tenant_quota_isolates_tenants() {
+        let registry = LimitRegistry::in_memory(paused());
+        let scopes = BTreeSet::new();
+        let tenant_a = TenantId::new("a");
+        let tenant_b = TenantId::new("b");
+        let limits = RouteLimits {
+            per_tenant: Some(Quota::new(1, QuotaWindow::Second)),
+            burst: Some(2),
+            ..RouteLimits::default()
+        };
+
+        // Tenant A burns its burst of 2.
+        assert!(matches!(
+            registry.check(&ctx("/r", Some(&tenant_a), &scopes), &limits),
+            LimitDecision::Allowed(_)
+        ));
+        assert!(matches!(
+            registry.check(&ctx("/r", Some(&tenant_a), &scopes), &limits),
+            LimitDecision::Allowed(_)
+        ));
+        // 3rd hits the tenant quota.
+        let rejected = registry.check(&ctx("/r", Some(&tenant_a), &scopes), &limits);
+        let LimitDecision::Rejected { scope, .. } = rejected else {
+            panic!("expected rejection, got {rejected:?}");
+        };
+        assert_eq!(scope, LimitScope::Tenant);
+
+        // Tenant B is unaffected — distinct bucket.
+        assert!(matches!(
+            registry.check(&ctx("/r", Some(&tenant_b), &scopes), &limits),
+            LimitDecision::Allowed(_)
+        ));
+    }
+
+    #[test]
+    fn backpressure_rejects_when_watermark_reached() {
+        let registry = LimitRegistry::in_memory(paused());
+        let scopes = BTreeSet::new();
+        let limits = RouteLimits {
+            in_flight_max: Some(2),
+            ..RouteLimits::default()
+        };
+
+        let _g1 = match registry.check(&ctx("/r", None, &scopes), &limits) {
+            LimitDecision::Allowed(g) => g,
+            other => panic!("{other:?}"),
+        };
+        let _g2 = match registry.check(&ctx("/r", None, &scopes), &limits) {
+            LimitDecision::Allowed(g) => g,
+            other => panic!("{other:?}"),
+        };
+        let rejected = registry.check(&ctx("/r", None, &scopes), &limits);
+        match rejected {
+            LimitDecision::Rejected {
+                scope,
+                retry_after_ms,
+            } => {
+                assert_eq!(scope, LimitScope::Backpressure);
+                assert!(retry_after_ms > 0);
+            }
+            other => panic!("expected rejection, got {other:?}"),
+        }
+
+        // Drop g2 → slot frees up.
+        drop(_g2);
+        assert!(matches!(
+            registry.check(&ctx("/r", None, &scopes), &limits),
+            LimitDecision::Allowed(_)
+        ));
+    }
+
+    #[test]
+    fn tenant_override_widens_bucket() {
+        let registry = LimitRegistry::in_memory(paused());
+        let scopes = BTreeSet::new();
+        let tenant = TenantId::new("vip");
+        registry.set_tenant_override(tenant.clone(), TenantOverride { multiplier: 4.0 });
+
+        let limits = RouteLimits {
+            per_tenant: Some(Quota::new(1, QuotaWindow::Second)),
+            burst: Some(1),
+            ..RouteLimits::default()
+        };
+
+        // Multiplier 4 → effective burst 4. Burn through 4 admissions.
+        for _ in 0..4 {
+            assert!(matches!(
+                registry.check(&ctx("/r", Some(&tenant), &scopes), &limits),
+                LimitDecision::Allowed(_)
+            ));
+        }
+        // 5th rejects.
+        assert!(matches!(
+            registry.check(&ctx("/r", Some(&tenant), &scopes), &limits),
+            LimitDecision::Rejected { .. }
+        ));
+    }
+
+    #[test]
+    fn ten_x_burst_settles_to_steady_rate_after_window() {
+        // Acceptance scenario distilled: a burst of 10× the steady rate
+        // should drain to exactly the rate by the time the window
+        // rolls. We model it as 1/sec rate, burst 1 — fire 10 → 1
+        // admitted, 9 rejected; advance 10s → 10 more admitted (one
+        // per second of refill); next reject again.
+        let clock = paused();
+        let registry = LimitRegistry::in_memory(clock.clone());
+        let scopes = BTreeSet::new();
+        let limits = RouteLimits {
+            per_route: Some(Quota::new(1, QuotaWindow::Second)),
+            burst: Some(1),
+            ..RouteLimits::default()
+        };
+
+        let mut admitted_burst = 0;
+        for _ in 0..10 {
+            if let LimitDecision::Allowed(_) = registry.check(&ctx("/r", None, &scopes), &limits) {
+                admitted_burst += 1;
+            }
+        }
+        assert_eq!(admitted_burst, 1, "burst should exhaust capacity");
+
+        // Advance 10 seconds → 10 refilled tokens become 1 (capacity 1).
+        // Actually each second yields 1 admit; loop one admit per advance.
+        let mut admitted_steady = 0;
+        for _ in 0..10 {
+            clock.advance(Duration::from_secs(1));
+            if let LimitDecision::Allowed(_) = registry.check(&ctx("/r", None, &scopes), &limits) {
+                admitted_steady += 1;
+            }
+        }
+        assert_eq!(admitted_steady, 10);
+
+        // Stats: 1 burst + 10 steady = 11 admitted, 9 rejected.
+        let stats = registry.stats();
+        assert_eq!(stats.admitted, 11);
+        assert_eq!(stats.total_rejected(), 9);
+    }
+}

--- a/crates/harn-serve/src/limits/mod.rs
+++ b/crates/harn-serve/src/limits/mod.rs
@@ -390,11 +390,54 @@ impl LimitRegistry {
     }
 
     fn route_in_flight_handle(&self, route: &str) -> Arc<AtomicUsize> {
+        // Fast path: lookup with the borrowed `&str` to skip the
+        // allocation when the route is already known. Falls through to
+        // an owned-key insertion when it isn't, which only happens
+        // once per route over the process lifetime.
         let mut in_flight = self.in_flight.lock().expect("in-flight map poisoned");
-        in_flight
-            .entry(route.to_string())
-            .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
-            .clone()
+        if let Some(handle) = in_flight.get(route) {
+            return handle.clone();
+        }
+        let counter = Arc::new(AtomicUsize::new(0));
+        in_flight.insert(route.to_string(), counter.clone());
+        counter
+    }
+
+    /// Bump a stats counter by scope, used by both successful-admit
+    /// and rejection paths so the per-scope rejection counters stay
+    /// in lockstep with the [`LimitScope`] enum (adding a new scope
+    /// only requires extending this match + the struct).
+    fn record_rejection(&self, scope: LimitScope) {
+        let counter = match scope {
+            LimitScope::Route => &self.stats.rejected_route,
+            LimitScope::Tenant => &self.stats.rejected_tenant,
+            LimitScope::Scope => &self.stats.rejected_scope,
+            LimitScope::Backpressure => &self.stats.rejected_backpressure,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Try one rate dimension against the underlying store. Returns
+    /// `Some(retry_after_ms)` on rejection (registry has already
+    /// counted the rejection and emitted telemetry); `None` on
+    /// admission. Centralises the "build spec, try_admit, emit
+    /// rejection" plumbing the three rate dimensions all share.
+    fn admit_rate_dimension(
+        &self,
+        ctx: &LimitContext<'_>,
+        scope: LimitScope,
+        quota: Quota,
+        limits: &RouteLimits,
+        multiplier: f64,
+        key: &str,
+    ) -> Option<u64> {
+        let spec = scaled_bucket(limits.bucket_for(quota), multiplier);
+        let CellDecision::Rejected { retry_after_ms } = self.store.try_admit(key, &spec, 1) else {
+            return None;
+        };
+        self.record_rejection(scope);
+        emit_rejection(ctx, scope, retry_after_ms);
+        Some(retry_after_ms)
     }
 
     /// Evaluate every declared bucket and the backpressure watermark
@@ -414,12 +457,10 @@ impl LimitRegistry {
         // rejection to keep noise rejections cheap.
 
         if let Some(quota) = limits.per_route {
-            let spec = scaled_bucket(limits.bucket_for(quota), multiplier);
             let key = format!("route:{}", ctx.route);
-            if let CellDecision::Rejected { retry_after_ms } = self.store.try_admit(&key, &spec, 1)
+            if let Some(retry_after_ms) =
+                self.admit_rate_dimension(ctx, LimitScope::Route, quota, limits, multiplier, &key)
             {
-                self.stats.rejected_route.fetch_add(1, Ordering::Relaxed);
-                emit_rejection(ctx, LimitScope::Route, retry_after_ms);
                 return LimitDecision::Rejected {
                     scope: LimitScope::Route,
                     retry_after_ms,
@@ -428,15 +469,16 @@ impl LimitRegistry {
         }
 
         if let Some(quota) = limits.per_tenant {
-            // Without a bound tenant, `per_tenant` cannot enforce; treat
-            // the dispatch as anonymous and fall back to the route key.
+            // Without a bound tenant the per_tenant bucket is meaningless,
+            // but rejecting "no tenant" outright would surprise dev/test
+            // callers who haven't wired authentication yet — instead fold
+            // anonymous traffic into a shared `__anon__` bucket so the
+            // ceiling still bounds runaway clients.
             let tenant_key = ctx.tenant_id.map(|t| t.0.as_str()).unwrap_or("__anon__");
-            let spec = scaled_bucket(limits.bucket_for(quota), multiplier);
             let key = format!("tenant:{tenant_key}:{}", ctx.route);
-            if let CellDecision::Rejected { retry_after_ms } = self.store.try_admit(&key, &spec, 1)
+            if let Some(retry_after_ms) =
+                self.admit_rate_dimension(ctx, LimitScope::Tenant, quota, limits, multiplier, &key)
             {
-                self.stats.rejected_tenant.fetch_add(1, Ordering::Relaxed);
-                emit_rejection(ctx, LimitScope::Tenant, retry_after_ms);
                 return LimitDecision::Rejected {
                     scope: LimitScope::Tenant,
                     retry_after_ms,
@@ -445,20 +487,12 @@ impl LimitRegistry {
         }
 
         if let Some(quota) = limits.per_scope {
-            // The "scope" bucket is keyed on the joined scope set so a
-            // caller that holds two scopes shares quota across both —
-            // matching how `harn-cloud-gateway` charges scope quotas.
-            let scope_key = if ctx.scopes.is_empty() {
-                "__none__".to_string()
-            } else {
-                ctx.scopes.iter().cloned().collect::<Vec<_>>().join(",")
-            };
-            let spec = scaled_bucket(limits.bucket_for(quota), multiplier);
-            let key = format!("scope:{scope_key}:{}", ctx.route);
-            if let CellDecision::Rejected { retry_after_ms } = self.store.try_admit(&key, &spec, 1)
+            // Joined-scope keying matches `harn-cloud-gateway` semantics:
+            // callers that present the same scope set share quota.
+            let key = format!("scope:{}:{}", scope_key(ctx.scopes), ctx.route);
+            if let Some(retry_after_ms) =
+                self.admit_rate_dimension(ctx, LimitScope::Scope, quota, limits, multiplier, &key)
             {
-                self.stats.rejected_scope.fetch_add(1, Ordering::Relaxed);
-                emit_rejection(ctx, LimitScope::Scope, retry_after_ms);
                 return LimitDecision::Rejected {
                     scope: LimitScope::Scope,
                     retry_after_ms,
@@ -477,10 +511,8 @@ impl LimitRegistry {
             let prev = counter.fetch_add(1, Ordering::AcqRel);
             if prev >= max as usize {
                 counter.fetch_sub(1, Ordering::AcqRel);
-                self.stats
-                    .rejected_backpressure
-                    .fetch_add(1, Ordering::Relaxed);
-                let retry_after_ms = 250; // re-poll quickly; the queue drains by completions, not time
+                let retry_after_ms = BACKPRESSURE_RETRY_AFTER_MS;
+                self.record_rejection(LimitScope::Backpressure);
                 emit_rejection(ctx, LimitScope::Backpressure, retry_after_ms);
                 return LimitDecision::Rejected {
                     scope: LimitScope::Backpressure,
@@ -494,6 +526,24 @@ impl LimitRegistry {
         self.stats.admitted.fetch_add(1, Ordering::Relaxed);
         LimitDecision::Allowed(LimitGuard::unbounded())
     }
+}
+
+/// Backpressure rejections drain by *completions*, not by clock — the
+/// caller's hint is a short poll interval, not a quota window.
+const BACKPRESSURE_RETRY_AFTER_MS: u64 = 250;
+
+fn scope_key(scopes: &std::collections::BTreeSet<String>) -> String {
+    if scopes.is_empty() {
+        return "__none__".to_string();
+    }
+    let mut out = String::new();
+    for scope in scopes {
+        if !out.is_empty() {
+            out.push(',');
+        }
+        out.push_str(scope);
+    }
+    out
 }
 
 fn scaled_bucket(mut spec: BucketSpec, multiplier: f64) -> BucketSpec {

--- a/crates/harn-serve/src/limits/parse.rs
+++ b/crates/harn-serve/src/limits/parse.rs
@@ -1,0 +1,156 @@
+//! Parse `@limits(...)` and `@budget(...)` attribute literals into the
+//! typed [`RouteLimits`] / [`BudgetSpec`] structs the rest of the
+//! primitive consumes.
+//!
+//! Acceptable forms:
+//!
+//! ```harn
+//! @limits(
+//!     per_tenant: "100/min",
+//!     per_scope:  "1000/min",
+//!     per_route:  "5000/min",
+//!     burst:      50,
+//!     algorithm:  "token_bucket",
+//!     in_flight_max: 20,
+//! )
+//! @budget(
+//!     llm_cost_usd: 0.50,
+//!     pg_queries:   50,
+//!     mcp_calls:    20,
+//! )
+//! ```
+//!
+//! Parsing is tolerant: unknown keys are ignored (forward-compat with
+//! richer specs landed later); missing keys leave the field unset.
+//! Quota strings accept `N/sec`, `N/min`, `N/hour` (or `s`/`m`/`h`).
+
+use std::collections::BTreeSet;
+
+use harn_parser::{Attribute, Node};
+
+use super::{Algorithm, BudgetSpec, Quota, RouteLimits};
+
+/// Collect both `@limits(...)` and `@budget(...)` declarations from a
+/// declaration's attribute list. Each attribute kind may appear at most
+/// once; multiple occurrences merge by taking the last-write-wins.
+pub fn limits_and_budget_from_attributes(
+    attrs: &[Attribute],
+) -> (Option<RouteLimits>, Option<BudgetSpec>) {
+    let mut limits: Option<RouteLimits> = None;
+    let mut budget: Option<BudgetSpec> = None;
+
+    for attr in attrs {
+        match attr.name.as_str() {
+            "limits" => limits = Some(parse_limits(attr, limits.take())),
+            "budget" => budget = Some(parse_budget(attr, budget.take())),
+            _ => continue,
+        }
+    }
+    (limits, budget)
+}
+
+fn parse_limits(attr: &Attribute, base: Option<RouteLimits>) -> RouteLimits {
+    let mut limits = base.unwrap_or_default();
+    for arg in &attr.args {
+        let Some(key) = arg.name.as_deref() else {
+            continue;
+        };
+        match key {
+            "per_tenant" => {
+                if let Some(quota) = string_value(arg).and_then(Quota::parse) {
+                    limits.per_tenant = Some(quota);
+                }
+            }
+            "per_scope" => {
+                if let Some(quota) = string_value(arg).and_then(Quota::parse) {
+                    limits.per_scope = Some(quota);
+                }
+            }
+            "per_route" => {
+                if let Some(quota) = string_value(arg).and_then(Quota::parse) {
+                    limits.per_route = Some(quota);
+                }
+            }
+            "burst" => {
+                if let Some(value) = int_value(arg) {
+                    limits.burst = Some(value.max(1) as u32);
+                }
+            }
+            "algorithm" => {
+                if let Some(algo) = string_value(arg).as_deref().and_then(Algorithm::parse) {
+                    limits.algorithm = algo;
+                }
+            }
+            "in_flight_max" => {
+                if let Some(value) = int_value(arg) {
+                    limits.in_flight_max = Some(value.max(1) as u32);
+                }
+            }
+            _ => continue,
+        }
+    }
+    limits
+}
+
+fn parse_budget(attr: &Attribute, base: Option<BudgetSpec>) -> BudgetSpec {
+    let mut budget = base.unwrap_or_default();
+    for arg in &attr.args {
+        let Some(key) = arg.name.as_deref() else {
+            continue;
+        };
+        match key {
+            "llm_cost_usd" => {
+                if let Some(value) = float_value(arg) {
+                    budget.llm_cost_usd = Some(value.max(0.0));
+                }
+            }
+            "llm_tokens" => {
+                if let Some(value) = int_value(arg) {
+                    budget.llm_tokens = Some(value.max(0) as u64);
+                }
+            }
+            "pg_queries" => {
+                if let Some(value) = int_value(arg) {
+                    budget.pg_queries = Some(value.max(0) as u64);
+                }
+            }
+            "mcp_calls" => {
+                if let Some(value) = int_value(arg) {
+                    budget.mcp_calls = Some(value.max(0) as u64);
+                }
+            }
+            _ => continue,
+        }
+    }
+    budget
+}
+
+fn string_value(arg: &harn_parser::AttributeArg) -> Option<String> {
+    match &arg.value.node {
+        Node::StringLiteral(s) | Node::RawStringLiteral(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+fn int_value(arg: &harn_parser::AttributeArg) -> Option<i64> {
+    match &arg.value.node {
+        Node::IntLiteral(n) => Some(*n),
+        Node::FloatLiteral(f) if f.is_finite() && f.fract() == 0.0 => Some(*f as i64),
+        _ => None,
+    }
+}
+
+fn float_value(arg: &harn_parser::AttributeArg) -> Option<f64> {
+    match &arg.value.node {
+        Node::FloatLiteral(f) => Some(*f),
+        Node::IntLiteral(n) => Some(*n as f64),
+        _ => None,
+    }
+}
+
+/// Forward-declared in [`super::ExportedFunctionLimits`] / consumed by
+/// `exports.rs`. Centralised here so attribute parsing tests can
+/// validate the wiring without pulling the export catalog into scope.
+pub fn collect_scope_set(scopes: &BTreeSet<String>) -> Vec<String> {
+    scopes.iter().cloned().collect()
+}

--- a/crates/harn-serve/src/limits/store.rs
+++ b/crates/harn-serve/src/limits/store.rs
@@ -1,0 +1,166 @@
+//! Keyspace storage for rate-limit cells.
+//!
+//! The store sits between the [`super::LimitRegistry`] and the underlying
+//! [`super::RateAlgorithm`] cells: it owns the keyed map and clones a
+//! fresh cell on demand using the route's algorithm choice. The
+//! in-memory implementation is the only one that ships with the
+//! primitive today — the trait exists so a Redis-backed counter can
+//! land later without a wire-API churn.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use harn_clock::Clock;
+
+use super::algorithms::{Algorithm, CellDecision, RateAlgorithm};
+
+/// One bucket dimension on a route (per-tenant, per-scope, per-route).
+/// Stored with the rate / capacity so the store can lazily instantiate
+/// the right algorithm on first access.
+#[derive(Clone, Debug)]
+pub struct BucketSpec {
+    pub algorithm: Algorithm,
+    pub rate_per_sec: f64,
+    pub capacity: u32,
+}
+
+impl BucketSpec {
+    pub fn new(algorithm: Algorithm, rate_per_sec: f64, capacity: u32) -> Self {
+        Self {
+            algorithm,
+            rate_per_sec: rate_per_sec.max(0.0),
+            capacity: capacity.max(1),
+        }
+    }
+}
+
+/// Storage trait. Implementations own the keyed-cell map and the
+/// algorithm instantiation; callers (the registry) ask "would this key
+/// admit one unit of work now?" and surface the answer.
+///
+/// Implementations must be safe to call concurrently — the in-memory
+/// impl uses a mutex per cell-keyspace; a future Redis impl would push
+/// the atomicity into the server.
+pub trait LimitStore: Send + Sync {
+    /// Attempt to admit `cost` units of work against `key`. The cell is
+    /// created on first access using `spec`. `cost` is unused today
+    /// (callers always pass 1) but reserved so a future variant can
+    /// charge an LLM call its token count up front.
+    fn try_admit(&self, key: &str, spec: &BucketSpec, cost: u32) -> CellDecision;
+}
+
+/// Single-node in-memory store. Each cell is a boxed
+/// [`RateAlgorithm`] guarded by a per-cell mutex (so concurrent
+/// dispatches against the *same* bucket serialise on the bucket, not
+/// the whole map).
+/// Shared, mutex-protected handle to one keyspace cell. The double
+/// indirection (`Arc<Mutex<…>>`) lets the store hand out a clone of the
+/// cell handle without holding the outer map mutex during the per-cell
+/// check, so concurrent dispatches against distinct keys never
+/// contend on the map.
+type SharedCell = Arc<Mutex<Box<dyn RateAlgorithm>>>;
+
+pub struct InMemoryLimitStore {
+    clock: Arc<dyn Clock>,
+    cells: Mutex<HashMap<String, SharedCell>>,
+}
+
+impl std::fmt::Debug for InMemoryLimitStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.cells.lock().map(|map| map.len()).unwrap_or(0);
+        f.debug_struct("InMemoryLimitStore")
+            .field("cells", &len)
+            .finish()
+    }
+}
+
+impl InMemoryLimitStore {
+    pub fn new(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            clock,
+            cells: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Cell count — testing aid for cache pressure regressions.
+    pub fn cell_count(&self) -> usize {
+        self.cells.lock().expect("limit cells poisoned").len()
+    }
+
+    fn cell_handle(&self, key: &str, spec: &BucketSpec) -> SharedCell {
+        let mut cells = self.cells.lock().expect("limit cells poisoned");
+        cells
+            .entry(key.to_string())
+            .or_insert_with(|| {
+                let cell = spec
+                    .algorithm
+                    .new_cell(spec.rate_per_sec, spec.capacity, &self.clock);
+                Arc::new(Mutex::new(cell))
+            })
+            .clone()
+    }
+}
+
+impl LimitStore for InMemoryLimitStore {
+    fn try_admit(&self, key: &str, spec: &BucketSpec, _cost: u32) -> CellDecision {
+        let handle = self.cell_handle(key, spec);
+        let now_ms = self.clock.monotonic_ms();
+        let mut cell = handle.lock().expect("limit cell poisoned");
+        cell.try_admit(now_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    use harn_clock::PausedClock;
+    use time::OffsetDateTime;
+
+    fn clock() -> Arc<PausedClock> {
+        PausedClock::new(OffsetDateTime::UNIX_EPOCH)
+    }
+
+    #[test]
+    fn in_memory_store_admits_burst_then_rejects() {
+        let store = InMemoryLimitStore::new(clock());
+        let spec = BucketSpec::new(Algorithm::TokenBucket, 1.0, 3);
+
+        for _ in 0..3 {
+            assert!(matches!(
+                store.try_admit("t:a", &spec, 1),
+                CellDecision::Allowed
+            ));
+        }
+        let rejected = store.try_admit("t:a", &spec, 1);
+        assert!(matches!(rejected, CellDecision::Rejected { .. }));
+
+        // Distinct key has its own cell.
+        assert!(matches!(
+            store.try_admit("t:b", &spec, 1),
+            CellDecision::Allowed
+        ));
+    }
+
+    #[test]
+    fn in_memory_store_recovers_after_clock_advance() {
+        let clock = clock();
+        let store = InMemoryLimitStore::new(clock.clone());
+        let spec = BucketSpec::new(Algorithm::TokenBucket, 1.0, 1);
+
+        assert!(matches!(
+            store.try_admit("t:a", &spec, 1),
+            CellDecision::Allowed
+        ));
+        assert!(matches!(
+            store.try_admit("t:a", &spec, 1),
+            CellDecision::Rejected { .. }
+        ));
+        clock.advance(Duration::from_secs(1));
+        assert!(matches!(
+            store.try_admit("t:a", &spec, 1),
+            CellDecision::Allowed
+        ));
+    }
+}

--- a/crates/harn-serve/src/limits/store.rs
+++ b/crates/harn-serve/src/limits/store.rs
@@ -87,24 +87,27 @@ impl InMemoryLimitStore {
         self.cells.lock().expect("limit cells poisoned").len()
     }
 
-    fn cell_handle(&self, key: &str, spec: &BucketSpec) -> SharedCell {
+    fn cell_handle(&self, key: &str, spec: &BucketSpec, now_ms: i64) -> SharedCell {
+        // Fast path: borrowed lookup avoids the `to_string()` alloc on
+        // every dispatch against an already-known key. The slow path
+        // only fires the first time a route/tenant/scope appears.
         let mut cells = self.cells.lock().expect("limit cells poisoned");
-        cells
-            .entry(key.to_string())
-            .or_insert_with(|| {
-                let cell = spec
-                    .algorithm
-                    .new_cell(spec.rate_per_sec, spec.capacity, &self.clock);
-                Arc::new(Mutex::new(cell))
-            })
-            .clone()
+        if let Some(handle) = cells.get(key) {
+            return handle.clone();
+        }
+        let cell = spec
+            .algorithm
+            .new_cell(spec.rate_per_sec, spec.capacity, now_ms);
+        let handle = Arc::new(Mutex::new(cell));
+        cells.insert(key.to_string(), handle.clone());
+        handle
     }
 }
 
 impl LimitStore for InMemoryLimitStore {
     fn try_admit(&self, key: &str, spec: &BucketSpec, _cost: u32) -> CellDecision {
-        let handle = self.cell_handle(key, spec);
         let now_ms = self.clock.monotonic_ms();
+        let handle = self.cell_handle(key, spec, now_ms);
         let mut cell = handle.lock().expect("limit cell poisoned");
         cell.try_admit(now_ms)
     }

--- a/crates/harn-serve/tests/limits_loadgen.rs
+++ b/crates/harn-serve/tests/limits_loadgen.rs
@@ -213,31 +213,41 @@ pub fn slow() -> string {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn backpressure_concurrent_overflow_rejects_above_watermark() {
-    // Drive the registry directly with parallel `check` calls so the
-    // overflow trips deterministically — `core.dispatch` can't hold
-    // its guard open across our async boundary without slow .harn
-    // I/O. The registry's atomic fetch_add / rollback closes the
-    // race; here we verify the math holds under contention.
+    // Drive 32 parallel `check` calls into an in_flight_max=3 registry
+    // and use a `Notify` to hold every admitted task at the same
+    // suspension point — that way the watermark is *known* full when
+    // the remaining tasks make their attempt, regardless of how the
+    // runtime schedules them. Proves the atomic fetch_add + rollback
+    // closes the check-then-act race even under contention.
     use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::Arc as StdArc;
 
     use harn_serve::{LimitContext, LimitDecision, LimitScope, RouteLimits};
+    use tokio::sync::Notify;
+
+    const MAX: u32 = 3;
+    const TOTAL: usize = 32;
 
     let registry = LimitRegistry::in_memory(paused_clock());
     let limits = RouteLimits {
-        in_flight_max: Some(3),
+        in_flight_max: Some(MAX),
         ..RouteLimits::default()
     };
     let admitted = StdArc::new(AtomicUsize::new(0));
     let rejected = StdArc::new(AtomicUsize::new(0));
+    // All admitted tasks suspend on this until the main thread
+    // releases them — guaranteeing the bucket is full when the
+    // remaining (TOTAL - MAX) tasks make their attempt.
+    let release = StdArc::new(Notify::new());
 
     let mut handles = Vec::new();
-    for _ in 0..32 {
+    for _ in 0..TOTAL {
         let registry = registry.clone();
         let limits = limits.clone();
         let admitted = admitted.clone();
         let rejected = rejected.clone();
+        let release = release.clone();
         handles.push(tokio::spawn(async move {
             let scopes = BTreeSet::new();
             let ctx = LimitContext {
@@ -247,17 +257,15 @@ async fn backpressure_concurrent_overflow_rejects_above_watermark() {
             };
             match registry.check(&ctx, &limits) {
                 LimitDecision::Allowed(guard) => {
-                    admitted.fetch_add(1, AtomicOrdering::Relaxed);
-                    // Hold the guard briefly so concurrent attempts
-                    // observe a full bucket.
-                    tokio::task::yield_now().await;
+                    admitted.fetch_add(1, AtomicOrdering::AcqRel);
+                    release.notified().await;
                     drop(guard);
                 }
                 LimitDecision::Rejected {
                     scope: LimitScope::Backpressure,
                     ..
                 } => {
-                    rejected.fetch_add(1, AtomicOrdering::Relaxed);
+                    rejected.fetch_add(1, AtomicOrdering::AcqRel);
                 }
                 LimitDecision::Rejected { scope, .. } => {
                     panic!("expected backpressure rejection, got {scope:?}");
@@ -265,17 +273,35 @@ async fn backpressure_concurrent_overflow_rejects_above_watermark() {
             }
         }));
     }
+
+    // Wait until exactly MAX tasks have admitted (and `TOTAL - MAX`
+    // rejected). Poll on the atomic counters with a short backoff —
+    // capped at 5 s so a hung test fails fast on CI rather than
+    // timing out the whole job.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let a = admitted.load(AtomicOrdering::Acquire);
+        let r = rejected.load(AtomicOrdering::Acquire);
+        if a == MAX as usize && r == TOTAL - MAX as usize {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out: admitted={a}, rejected={r} (want {MAX} and {})",
+            TOTAL - MAX as usize
+        );
+        tokio::task::yield_now().await;
+    }
+
+    // Release the admitted tasks so they drop their guards and join.
+    release.notify_waiters();
     for h in handles {
         h.await.expect("task joined");
     }
-    let admitted = admitted.load(AtomicOrdering::Relaxed);
-    let rejected = rejected.load(AtomicOrdering::Relaxed);
-    assert_eq!(admitted + rejected, 32);
-    // We can't assert exact splits (scheduler-dependent) but the
-    // critical invariant is that the in-flight count never overshot
-    // the cap: any rejection means the race was correctly closed.
-    assert!(rejected > 0, "expected at least one backpressure rejection");
-    assert!(admitted > 0, "expected at least one admission");
+
+    let stats = registry.stats();
+    assert_eq!(stats.admitted as usize, MAX as usize);
+    assert_eq!(stats.rejected_backpressure as usize, TOTAL - MAX as usize);
 }
 
 #[tokio::test]

--- a/crates/harn-serve/tests/limits_loadgen.rs
+++ b/crates/harn-serve/tests/limits_loadgen.rs
@@ -35,7 +35,7 @@ fn synth_request(function: &str) -> CallRequest {
         // Unique replay key per call so the cache never short-circuits
         // the limit check — the spec runs each call through the full
         // gate.
-        replay_key: Some(format!("loadgen-{}-{}", function, uuid_short())),
+        replay_key: Some(format!("loadgen-{function}-{}", uuid_short())),
         trace_id: None,
         parent_span_id: None,
         metadata: BTreeMap::new(),
@@ -177,7 +177,13 @@ pub fn ping() -> string {
 }
 
 #[tokio::test]
-async fn backpressure_high_watermark_rejects_concurrent_overflow() {
+async fn backpressure_sequential_dispatches_never_exceed_watermark() {
+    // Strictly-sequential dispatches under `in_flight_max` should
+    // never reject: each guard drops on `await` completion before the
+    // next call arrives. The companion `LimitRegistry`-level
+    // concurrency test (limits::tests::backpressure_rejects_when_…)
+    // exercises overlapping in-flight slots without needing a slow
+    // .harn body.
     let dir = TempDir::new().expect("tempdir");
     let path = write_script(
         &dir,
@@ -189,23 +195,13 @@ pub fn slow() -> string {
 "#,
     );
 
-    let clock = paused_clock();
-    let registry = LimitRegistry::in_memory(clock);
-    let core = Arc::new(
-        DispatchCore::new(DispatchCoreConfig {
-            limit_registry: Some(registry.clone()),
-            ..DispatchCoreConfig::for_script(&path)
-        })
-        .expect("dispatch core"),
-    );
+    let registry = LimitRegistry::in_memory(paused_clock());
+    let core = DispatchCore::new(DispatchCoreConfig {
+        limit_registry: Some(registry.clone()),
+        ..DispatchCoreConfig::for_script(&path)
+    })
+    .expect("dispatch core");
 
-    // Pin two slots open by holding the dispatch futures' returned
-    // bodies — we can't easily block inside .harn from a test without
-    // a channel, so instead exercise the in-flight counter directly
-    // through repeated calls and watch the stats. Even though each
-    // dispatch finishes before the next starts in this single-task
-    // test, the in-flight max=2 ceiling should never reject a strictly
-    // sequential call.
     for _ in 0..5 {
         core.dispatch(synth_request("slow"))
             .await
@@ -213,6 +209,73 @@ pub fn slow() -> string {
     }
     assert_eq!(registry.stats().admitted, 5);
     assert_eq!(registry.stats().rejected_backpressure, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn backpressure_concurrent_overflow_rejects_above_watermark() {
+    // Drive the registry directly with parallel `check` calls so the
+    // overflow trips deterministically — `core.dispatch` can't hold
+    // its guard open across our async boundary without slow .harn
+    // I/O. The registry's atomic fetch_add / rollback closes the
+    // race; here we verify the math holds under contention.
+    use std::collections::BTreeSet;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Arc as StdArc;
+
+    use harn_serve::{LimitContext, LimitDecision, LimitScope, RouteLimits};
+
+    let registry = LimitRegistry::in_memory(paused_clock());
+    let limits = RouteLimits {
+        in_flight_max: Some(3),
+        ..RouteLimits::default()
+    };
+    let admitted = StdArc::new(AtomicUsize::new(0));
+    let rejected = StdArc::new(AtomicUsize::new(0));
+
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let registry = registry.clone();
+        let limits = limits.clone();
+        let admitted = admitted.clone();
+        let rejected = rejected.clone();
+        handles.push(tokio::spawn(async move {
+            let scopes = BTreeSet::new();
+            let ctx = LimitContext {
+                route: "/r",
+                tenant_id: None,
+                scopes: &scopes,
+            };
+            match registry.check(&ctx, &limits) {
+                LimitDecision::Allowed(guard) => {
+                    admitted.fetch_add(1, AtomicOrdering::Relaxed);
+                    // Hold the guard briefly so concurrent attempts
+                    // observe a full bucket.
+                    tokio::task::yield_now().await;
+                    drop(guard);
+                }
+                LimitDecision::Rejected {
+                    scope: LimitScope::Backpressure,
+                    ..
+                } => {
+                    rejected.fetch_add(1, AtomicOrdering::Relaxed);
+                }
+                LimitDecision::Rejected { scope, .. } => {
+                    panic!("expected backpressure rejection, got {scope:?}");
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.await.expect("task joined");
+    }
+    let admitted = admitted.load(AtomicOrdering::Relaxed);
+    let rejected = rejected.load(AtomicOrdering::Relaxed);
+    assert_eq!(admitted + rejected, 32);
+    // We can't assert exact splits (scheduler-dependent) but the
+    // critical invariant is that the in-flight count never overshot
+    // the cap: any rejection means the race was correctly closed.
+    assert!(rejected > 0, "expected at least one backpressure rejection");
+    assert!(admitted > 0, "expected at least one admission");
 }
 
 #[tokio::test]

--- a/crates/harn-serve/tests/limits_loadgen.rs
+++ b/crates/harn-serve/tests/limits_loadgen.rs
@@ -1,0 +1,292 @@
+//! Synthetic load test for the A.11 rate-limit + backpressure
+//! primitive: drive 10× the steady rate through `DispatchCore` and
+//! confirm the registry settles to the configured ceiling, rejections
+//! map cleanly to HTTP 429 with a sane `Retry-After`, and the
+//! per-bucket stats are accurate.
+//!
+//! The test uses `PausedClock` so we can advance virtual time without
+//! sleeping, keeping the loadgen fast and free of wall-clock flake.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::http::{header, StatusCode};
+use harn_clock::PausedClock;
+use harn_serve::{
+    axum_response_from_dispatch_error, fresh_request_id, AuthPolicy, CallArguments, CallRequest,
+    DispatchCore, DispatchCoreConfig, DispatchError, LimitRegistry,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+use time::OffsetDateTime;
+
+fn paused_clock() -> Arc<PausedClock> {
+    PausedClock::new(OffsetDateTime::UNIX_EPOCH)
+}
+
+fn synth_request(function: &str) -> CallRequest {
+    CallRequest {
+        adapter: "test".into(),
+        function: function.into(),
+        arguments: CallArguments::Positional(Vec::new()),
+        auth: Default::default(),
+        caller: "test".into(),
+        // Unique replay key per call so the cache never short-circuits
+        // the limit check — the spec runs each call through the full
+        // gate.
+        replay_key: Some(format!("loadgen-{}-{}", function, uuid_short())),
+        trace_id: None,
+        parent_span_id: None,
+        metadata: BTreeMap::new(),
+        cancel_token: None,
+        agent_session_id: None,
+        progress: None,
+        tenant_id: None,
+    }
+}
+
+fn uuid_short() -> String {
+    uuid::Uuid::now_v7().simple().to_string()
+}
+
+fn write_script(dir: &TempDir, source: &str) -> std::path::PathBuf {
+    let path = dir.path().join("handler.harn");
+    std::fs::write(&path, source).expect("write script");
+    path
+}
+
+#[tokio::test]
+async fn loadgen_10x_burst_settles_to_steady_rate_with_correct_retry_after() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_script(
+        &dir,
+        r#"
+@limits(per_route: "1/sec", burst: 1)
+pub fn ping() -> string {
+  return "pong"
+}
+"#,
+    );
+
+    let clock = paused_clock();
+    let registry = LimitRegistry::in_memory(clock.clone());
+    let core = DispatchCore::new(DispatchCoreConfig {
+        limit_registry: Some(registry.clone()),
+        ..DispatchCoreConfig::for_script(&path)
+    })
+    .expect("dispatch core");
+
+    // Phase 1 — 10× burst at t=0. Only the burst capacity (1) should be
+    // admitted; the rest must reject with `Retry-After ≤ 1 sec`.
+    let mut admitted = 0u32;
+    let mut last_retry_after_ms: u64 = 0;
+    for _ in 0..10 {
+        match core.dispatch(synth_request("ping")).await {
+            Ok(_) => admitted += 1,
+            Err(DispatchError::RateLimited { retry_after_ms, .. }) => {
+                last_retry_after_ms = retry_after_ms;
+            }
+            Err(other) => panic!("unexpected dispatch error: {other:?}"),
+        }
+    }
+    assert_eq!(admitted, 1, "burst should saturate at capacity 1");
+    assert!(
+        last_retry_after_ms > 0 && last_retry_after_ms <= 1_500,
+        "retry-after should be ≤ window; got {last_retry_after_ms} ms"
+    );
+
+    // Phase 2 — drain at the steady rate (1/sec) by stepping virtual
+    // time. After advancing 1 second per attempt, every call admits.
+    let mut steady_admits = 0u32;
+    for _ in 0..10 {
+        clock.advance(Duration::from_secs(1));
+        if core.dispatch(synth_request("ping")).await.is_ok() {
+            steady_admits += 1;
+        }
+    }
+    assert_eq!(steady_admits, 10, "rate should sustain exactly 1/sec");
+
+    // Registry stats must reflect the same counts.
+    let stats = registry.stats();
+    assert_eq!(stats.admitted, 11);
+    assert_eq!(stats.total_rejected(), 9);
+    assert_eq!(stats.rejected_route, 9);
+}
+
+#[tokio::test]
+async fn rate_limit_renders_429_with_retry_after_header_via_codec() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_script(
+        &dir,
+        r#"
+@limits(per_route: "1/sec", burst: 1)
+pub fn ping() -> string {
+  return "pong"
+}
+"#,
+    );
+
+    let clock = paused_clock();
+    let registry = LimitRegistry::in_memory(clock.clone());
+    let core = DispatchCore::new(DispatchCoreConfig {
+        limit_registry: Some(registry),
+        ..DispatchCoreConfig::for_script(&path)
+    })
+    .expect("dispatch core");
+
+    // First call burns the burst.
+    core.dispatch(synth_request("ping"))
+        .await
+        .expect("first call admits");
+
+    // Second call rejects with `RateLimited`; render through the codec
+    // and verify the 429 + Retry-After + structured body shape that
+    // adapters (mcp, a2a, api) all share.
+    let err = core
+        .dispatch(synth_request("ping"))
+        .await
+        .expect_err("second call rejects");
+
+    let request_id = fresh_request_id();
+    let response = axum_response_from_dispatch_error(err, &request_id);
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let retry_after = response
+        .headers()
+        .get(header::RETRY_AFTER)
+        .expect("Retry-After header present");
+    let retry_after_secs: u64 = retry_after
+        .to_str()
+        .expect("utf-8")
+        .parse()
+        .expect("integer seconds");
+    assert!(
+        (1..=2).contains(&retry_after_secs),
+        "Retry-After should be 1 sec for a 1/sec quota; got {retry_after_secs}"
+    );
+
+    // Body must carry the canonical envelope shape that A.4 standardised.
+    let bytes = axum::body::to_bytes(response.into_body(), 4_096)
+        .await
+        .expect("body bytes");
+    let body: Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(body["code"], "rate_limited");
+    assert_eq!(body["request_id"], request_id);
+    assert_eq!(body["details"]["scope"], "route");
+    assert!(body["details"]["retry_after_ms"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn backpressure_high_watermark_rejects_concurrent_overflow() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_script(
+        &dir,
+        r#"
+@limits(in_flight_max: 2)
+pub fn slow() -> string {
+  return "ok"
+}
+"#,
+    );
+
+    let clock = paused_clock();
+    let registry = LimitRegistry::in_memory(clock);
+    let core = Arc::new(
+        DispatchCore::new(DispatchCoreConfig {
+            limit_registry: Some(registry.clone()),
+            ..DispatchCoreConfig::for_script(&path)
+        })
+        .expect("dispatch core"),
+    );
+
+    // Pin two slots open by holding the dispatch futures' returned
+    // bodies — we can't easily block inside .harn from a test without
+    // a channel, so instead exercise the in-flight counter directly
+    // through repeated calls and watch the stats. Even though each
+    // dispatch finishes before the next starts in this single-task
+    // test, the in-flight max=2 ceiling should never reject a strictly
+    // sequential call.
+    for _ in 0..5 {
+        core.dispatch(synth_request("slow"))
+            .await
+            .expect("sequential dispatch should succeed under in_flight_max=2");
+    }
+    assert_eq!(registry.stats().admitted, 5);
+    assert_eq!(registry.stats().rejected_backpressure, 0);
+}
+
+#[tokio::test]
+async fn unlimited_route_skips_registry_and_admits_unconditionally() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_script(
+        &dir,
+        r#"
+pub fn ping() -> string {
+  return "pong"
+}
+"#,
+    );
+
+    let clock = paused_clock();
+    let registry = LimitRegistry::in_memory(clock);
+    let core = DispatchCore::new(DispatchCoreConfig {
+        limit_registry: Some(registry.clone()),
+        ..DispatchCoreConfig::for_script(&path)
+    })
+    .expect("dispatch core");
+
+    for _ in 0..50 {
+        core.dispatch(synth_request("ping")).await.expect("admit");
+    }
+    // No `@limits` attribute ⇒ the dispatch short-circuits the registry
+    // entirely (cheap path), so stats stay at zero. This is the
+    // intended optimisation: routes that opt out of limits pay no
+    // bookkeeping cost. Production deployments that want a baseline
+    // for every endpoint can declare a permissive `@limits(per_route:
+    // "1000000/sec")` to keep stats flowing.
+    assert_eq!(registry.stats().admitted, 0);
+    assert_eq!(registry.stats().total_rejected(), 0);
+}
+
+#[tokio::test]
+async fn budget_exhaustion_renders_429_with_budget_exceeded_code() {
+    // The `@budget(llm_cost_usd: 0.0001)` declaration installs an
+    // ultra-tight LLM cost ceiling at dispatch start. Since the test
+    // handler doesn't actually call an LLM, we exercise the budget
+    // pathway directly by calling `llm_budget(0.0)` — which would
+    // normally be the script's own preferred way of setting the budget
+    // — and then projecting a cost via `__internal_simulate` would be
+    // overkill. Instead we test the wiring end-to-end by simulating
+    // the categorised error mapping path: an exhausted LLM budget
+    // raises `ErrorCategory::BudgetExceeded`, which the dispatcher
+    // maps to `DispatchError::BudgetExceeded`, which the codec
+    // surfaces as HTTP 429 + `code = "budget_exceeded"`.
+    use harn_serve::axum_response_from_dispatch_error;
+
+    let err = DispatchError::BudgetExceeded {
+        category: "llm_cost_usd".to_string(),
+        message: "LLM budget exceeded: spent $0.0010 of $0.0001 budget".to_string(),
+    };
+    let request_id = fresh_request_id();
+    let response = axum_response_from_dispatch_error(err, &request_id);
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let retry_after = response
+        .headers()
+        .get(header::RETRY_AFTER)
+        .expect("budget exhaustion ships a Retry-After hint");
+    assert_eq!(retry_after.to_str().unwrap(), "60");
+    let bytes = axum::body::to_bytes(response.into_body(), 4_096)
+        .await
+        .expect("body bytes");
+    let body: Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(body["code"], "budget_exceeded");
+    assert_eq!(body["details"]["category"], "llm_cost_usd");
+}
+
+/// Suppress an `AuthPolicy` warning that would otherwise complain when
+/// these tests run in a workspace that lints unused crate items.
+#[allow(dead_code)]
+fn _ensure_auth_policy_in_scope() -> AuthPolicy {
+    AuthPolicy::allow_all()
+}

--- a/crates/harn-serve/tests/limits_loadgen.rs
+++ b/crates/harn-serve/tests/limits_loadgen.rs
@@ -275,23 +275,31 @@ async fn backpressure_concurrent_overflow_rejects_above_watermark() {
     }
 
     // Wait until exactly MAX tasks have admitted (and `TOTAL - MAX`
-    // rejected). Poll on the atomic counters with a short backoff —
-    // capped at 5 s so a hung test fails fast on CI rather than
-    // timing out the whole job.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        let a = admitted.load(AtomicOrdering::Acquire);
-        let r = rejected.load(AtomicOrdering::Acquire);
-        if a == MAX as usize && r == TOTAL - MAX as usize {
-            break;
+    // rejected). Wrapping the poll in `tokio::time::timeout` keeps a
+    // hung test from stalling the whole CI job, and avoids the
+    // wall-clock-deadline pattern the audit rejects.
+    let admitted_wait = admitted.clone();
+    let rejected_wait = rejected.clone();
+    tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+        loop {
+            let a = admitted_wait.load(AtomicOrdering::Acquire);
+            let r = rejected_wait.load(AtomicOrdering::Acquire);
+            if a == MAX as usize && r == TOTAL - MAX as usize {
+                return;
+            }
+            tokio::task::yield_now().await;
         }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "timed out: admitted={a}, rejected={r} (want {MAX} and {})",
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "timed out: admitted={}, rejected={} (want {} and {})",
+            admitted.load(AtomicOrdering::Acquire),
+            rejected.load(AtomicOrdering::Acquire),
+            MAX,
             TOTAL - MAX as usize
-        );
-        tokio::task::yield_now().await;
-    }
+        )
+    });
 
     // Release the admitted tasks so they drop their guards and join.
     release.notify_waiters();

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -164,7 +164,8 @@ pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;
 pub use llm::trigger_predicate::TriggerPredicateBudget;
 pub use llm::{
-    current_agent_session_id, install_llm_cost_budget, register_session_end_hook, LlmBudgetGuard,
+    current_agent_session_id, install_llm_cost_budget, install_llm_token_budget,
+    register_session_end_hook, LlmBudgetGuard, LlmTokenBudgetGuard,
 };
 pub use mcp::{connect_mcp_server_from_json, connect_mcp_server_from_spec, register_mcp_builtins};
 pub use mcp_card::{fetch_server_card, load_server_card_from_path, CardError};

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -163,7 +163,9 @@ pub use harness_tenant::{
 pub use http::{register_http_builtins, reset_http_state};
 pub use llm::register_llm_builtins;
 pub use llm::trigger_predicate::TriggerPredicateBudget;
-pub use llm::{current_agent_session_id, register_session_end_hook};
+pub use llm::{
+    current_agent_session_id, install_llm_cost_budget, register_session_end_hook, LlmBudgetGuard,
+};
 pub use mcp::{connect_mcp_server_from_json, connect_mcp_server_from_spec, register_mcp_builtins};
 pub use mcp_card::{fetch_server_card, load_server_card_from_path, CardError};
 pub use mcp_host::{

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -8,12 +8,16 @@ use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 thread_local! {
     static LLM_BUDGET: RefCell<Option<f64>> = const { RefCell::new(None) };
     static LLM_ACCUMULATED_COST: RefCell<f64> = const { RefCell::new(0.0) };
+    static LLM_TOKEN_BUDGET: RefCell<Option<u64>> = const { RefCell::new(None) };
+    static LLM_ACCUMULATED_TOKENS: RefCell<u64> = const { RefCell::new(0) };
 }
 
 /// Reset thread-local cost state. Call between test runs to avoid leaking.
 pub(crate) fn reset_cost_state() {
     LLM_BUDGET.with(|b| *b.borrow_mut() = None);
     LLM_ACCUMULATED_COST.with(|a| *a.borrow_mut() = 0.0);
+    LLM_TOKEN_BUDGET.with(|b| *b.borrow_mut() = None);
+    LLM_ACCUMULATED_TOKENS.with(|a| *a.borrow_mut() = 0);
 }
 
 pub fn peek_total_cost() -> f64 {
@@ -52,6 +56,42 @@ pub fn install_llm_cost_budget(max_cost_usd: f64) -> LlmBudgetGuard {
         previous_budget,
         previous_accumulated,
     }
+}
+
+/// RAII guard for [`install_llm_token_budget`]. Pairs the dispatch-level
+/// token cap with the cost-cap guard so `@budget(llm_tokens, llm_cost_usd)`
+/// both restore on drop.
+#[must_use = "dropping the guard immediately restores the prior LLM token budget"]
+pub struct LlmTokenBudgetGuard {
+    previous_budget: Option<u64>,
+    previous_accumulated: u64,
+}
+
+impl Drop for LlmTokenBudgetGuard {
+    fn drop(&mut self) {
+        LLM_TOKEN_BUDGET.with(|b| *b.borrow_mut() = self.previous_budget);
+        LLM_ACCUMULATED_TOKENS.with(|a| *a.borrow_mut() = self.previous_accumulated);
+    }
+}
+
+/// Pin the per-dispatch LLM token ceiling (input + output combined) at
+/// `max_tokens` for the lifetime of the returned guard. Sourced from
+/// `@budget(llm_tokens: …)` on `.harn` handlers in `harn-serve`. Like
+/// the cost-cap variant, mid-stream exhaustion raises a
+/// `BudgetExceeded`-categorised error that adapters render as HTTP 429.
+pub fn install_llm_token_budget(max_tokens: u64) -> LlmTokenBudgetGuard {
+    let previous_budget = LLM_TOKEN_BUDGET.with(|b| *b.borrow());
+    let previous_accumulated = LLM_ACCUMULATED_TOKENS.with(|a| *a.borrow());
+    LLM_TOKEN_BUDGET.with(|b| *b.borrow_mut() = Some(max_tokens));
+    LLM_ACCUMULATED_TOKENS.with(|a| *a.borrow_mut() = 0);
+    LlmTokenBudgetGuard {
+        previous_budget,
+        previous_accumulated,
+    }
+}
+
+pub fn peek_total_tokens() -> u64 {
+    LLM_ACCUMULATED_TOKENS.with(|acc| *acc.borrow())
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -523,6 +563,25 @@ pub(crate) fn accumulate_cost_for_provider(
     // the per-call cost is zero — token-only step budgets need the
     // count regardless of pricing.
     crate::step_runtime::record_step_llm_usage(model, input_tokens, output_tokens, cost)?;
+    let total_tokens = input_tokens.max(0) as u64 + output_tokens.max(0) as u64;
+    if total_tokens > 0 {
+        LLM_ACCUMULATED_TOKENS.with(|acc| {
+            let mut slot = acc.borrow_mut();
+            *slot = slot.saturating_add(total_tokens);
+        });
+        LLM_TOKEN_BUDGET.with(|budget| {
+            if let Some(max) = *budget.borrow() {
+                let total = LLM_ACCUMULATED_TOKENS.with(|acc| *acc.borrow());
+                if total > max {
+                    return Err(categorized_error(
+                        format!("LLM token budget exceeded: spent {total} of {max} tokens"),
+                        ErrorCategory::BudgetExceeded,
+                    ));
+                }
+            }
+            Ok(())
+        })?;
+    }
     if cost == 0.0 {
         return Ok(());
     }
@@ -1144,5 +1203,53 @@ mod tests {
         assert!((cache_hit_ratio(1000, 250, 0) - 0.25).abs() < f64::EPSILON);
         assert!((cache_hit_ratio(100, 900, 0) - 0.9).abs() < f64::EPSILON);
         assert_eq!(cache_hit_ratio(0, 0, 0), 0.0);
+    }
+
+    #[test]
+    fn token_budget_guard_restores_prior_state_on_drop() {
+        let _guard_outer = crate::llm::env_lock().lock().unwrap();
+        reset_cost_state();
+
+        let outer = install_llm_token_budget(100);
+        assert_eq!(peek_total_tokens(), 0);
+        // Simulate accumulation by writing the thread-local directly.
+        LLM_ACCUMULATED_TOKENS.with(|a| *a.borrow_mut() = 50);
+
+        // Nested guard wipes accumulation and installs a tighter cap.
+        {
+            let _inner = install_llm_token_budget(10);
+            assert_eq!(peek_total_tokens(), 0);
+            LLM_ACCUMULATED_TOKENS.with(|a| *a.borrow_mut() = 5);
+        }
+
+        // Outer scope restored on inner drop.
+        assert_eq!(peek_total_tokens(), 50);
+        drop(outer);
+        assert_eq!(peek_total_tokens(), 0);
+
+        reset_cost_state();
+    }
+
+    #[test]
+    fn token_budget_raises_categorized_error_when_exhausted() {
+        let _guard_outer = crate::llm::env_lock().lock().unwrap();
+        reset_cost_state();
+        let _budget = install_llm_token_budget(10);
+
+        // First call within budget — admits.
+        let first = accumulate_cost_for_provider("anthropic", "claude-sonnet-4-20250514", 5, 0);
+        assert!(first.is_ok());
+
+        // Second call pushes over — raises BudgetExceeded.
+        let second = accumulate_cost_for_provider("anthropic", "claude-sonnet-4-20250514", 8, 0);
+        match second {
+            Err(VmError::CategorizedError { category, message }) => {
+                assert_eq!(category, ErrorCategory::BudgetExceeded);
+                assert!(message.contains("token budget"), "got: {message}");
+            }
+            other => panic!("expected BudgetExceeded, got {other:?}"),
+        }
+
+        reset_cost_state();
     }
 }

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-use crate::value::{VmError, VmValue};
+use crate::value::{categorized_error, ErrorCategory, VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
 thread_local! {
@@ -18,6 +18,40 @@ pub(crate) fn reset_cost_state() {
 
 pub fn peek_total_cost() -> f64 {
     LLM_ACCUMULATED_COST.with(|acc| *acc.borrow())
+}
+
+/// RAII guard installed by [`install_llm_cost_budget`]. Restores the
+/// prior ceiling (and accumulated total) on drop so nested dispatches
+/// (a handler that re-enters the dispatcher) cannot leak a tighter
+/// budget into the outer scope, or a wider one back into a finished
+/// inner scope.
+#[must_use = "dropping the guard immediately restores the prior LLM cost budget"]
+pub struct LlmBudgetGuard {
+    previous_budget: Option<f64>,
+    previous_accumulated: f64,
+}
+
+impl Drop for LlmBudgetGuard {
+    fn drop(&mut self) {
+        LLM_BUDGET.with(|b| *b.borrow_mut() = self.previous_budget);
+        LLM_ACCUMULATED_COST.with(|a| *a.borrow_mut() = self.previous_accumulated);
+    }
+}
+
+/// Pin the per-call LLM cost ceiling at `max_cost_usd` for the lifetime
+/// of the returned guard. Sourced from `@budget(llm_cost_usd = …)` on
+/// `.harn` handlers in `harn-serve`; mid-call exhaustion raises a
+/// `BudgetExceeded`-categorised error which adapter codecs render as
+/// HTTP 429.
+pub fn install_llm_cost_budget(max_cost_usd: f64) -> LlmBudgetGuard {
+    let previous_budget = LLM_BUDGET.with(|b| b.borrow().to_owned());
+    let previous_accumulated = LLM_ACCUMULATED_COST.with(|a| *a.borrow());
+    LLM_BUDGET.with(|b| *b.borrow_mut() = Some(max_cost_usd.max(0.0)));
+    LLM_ACCUMULATED_COST.with(|a| *a.borrow_mut() = 0.0);
+    LlmBudgetGuard {
+        previous_budget,
+        previous_accumulated,
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -499,9 +533,10 @@ pub(crate) fn accumulate_cost_for_provider(
         if let Some(max) = *budget.borrow() {
             let total = LLM_ACCUMULATED_COST.with(|acc| *acc.borrow());
             if total > max {
-                return Err(VmError::Thrown(VmValue::String(Rc::from(format!(
-                    "LLM budget exceeded: spent ${total:.4} of ${max:.4} budget"
-                )))));
+                return Err(categorized_error(
+                    format!("LLM budget exceeded: spent ${total:.4} of ${max:.4} budget"),
+                    ErrorCategory::BudgetExceeded,
+                ));
             }
         }
         Ok(())

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -243,7 +243,9 @@ pub(crate) use self::call::{
     structured_output_errors, structured_safe_envelope_err, structured_safe_envelope_ok,
     SchemaLoopOutcome,
 };
-pub use self::cost::{calculate_cost_for_provider, peek_total_cost};
+pub use self::cost::{
+    calculate_cost_for_provider, install_llm_cost_budget, peek_total_cost, LlmBudgetGuard,
+};
 pub use self::healthcheck::{
     build_healthcheck_url, run_provider_healthcheck, run_provider_healthcheck_with_options,
     ProviderHealthcheckOptions, ProviderHealthcheckResult,

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -244,7 +244,8 @@ pub(crate) use self::call::{
     SchemaLoopOutcome,
 };
 pub use self::cost::{
-    calculate_cost_for_provider, install_llm_cost_budget, peek_total_cost, LlmBudgetGuard,
+    calculate_cost_for_provider, install_llm_cost_budget, install_llm_token_budget,
+    peek_total_cost, peek_total_tokens, LlmBudgetGuard, LlmTokenBudgetGuard,
 };
 pub use self::healthcheck::{
     build_healthcheck_url, run_provider_healthcheck, run_provider_healthcheck_with_options,


### PR DESCRIPTION
## Summary

- New `crates/harn-serve/src/limits/` module: three pluggable rate-limit algorithms (token bucket / sliding window / leaky bucket), backpressure in-flight watermark, per-tenant multipliers, in-memory store with trait-based extension point for a future cluster-aware backend, atomic rejection stats.
- `@limits(per_tenant: "100/min", per_scope: "1000/min", per_route: "5000/min", burst: 50, algorithm: "token_bucket", in_flight_max: 20)` and `@budget(llm_cost_usd: 0.50, llm_tokens: 10000, pg_queries: 50, mcp_calls: 20)` attribute parsing on exported `.harn` handlers, surfaced on `ExportedFunction.{limits, budget}`.
- `DispatchCore` consults the registry between auth and invoke; on rejection returns new `DispatchError::RateLimited { scope, retry_after_ms }`. Mid-call LLM cost or token exhaustion via the new `harn_vm::install_llm_cost_budget` / `install_llm_token_budget` guards is categorised as `ErrorCategory::BudgetExceeded` and mapped to `DispatchError::BudgetExceeded { category, message }`.
- `http_codec::axum_response_from_dispatch_error` renders both as HTTP 429 with `Retry-After` header + canonical `{ code, message, request_id, details }` body — every adapter (mcp, a2a, api) shares the rendering for free. MCP JSON-RPC adapter gets dedicated arms for the new variants.

## Acceptance against #2514

- [x] Declarative `@limits` + `@budget`
- [x] Token bucket + sliding window + leaky bucket (pluggable via `algorithm:` arg)
- [x] Burst capacity above sustained rate
- [x] Per-tenant / per-scope / per-route dimensions
- [x] Backpressure watermark (`in_flight_max`) with race-free atomic fetch_add + rollback
- [x] Mid-call LLM-cost + LLM-token budget exhaustion → typed runtime error → 429 with `code: "budget_exceeded"`
- [x] 429 + `Retry-After` header through `http_codec`
- [x] Tenant-aware multiplier override via `LimitRegistry::set_tenant_override`
- [x] Single-node memory default; `LimitStore` trait reserved for a future Redis-backed counter
- [x] Tracing rejection emit on `target = "harn.serve.limits"` + per-bucket atomic stats (`LimitStats`) for A.10
- [x] Integration test: 10× burst settles to steady rate; rejections carry valid `Retry-After`
- [ ] **Deferred** to follow-up: `@budget(mcp_calls, pg_queries)` enforcement — both need their respective primitive integrations (MCP call-count meter; A.3 Postgres hostlib). Tracked at #2576.

## Adversarial review (round 2)

- DRY: extracted `admit_rate_dimension` so all three rate buckets share one "build spec, try_admit, bump stats, emit telemetry" path. New scopes drop in by extending the `LimitScope` enum + `record_rejection` match.
- Leaky abstraction: `Algorithm::new_cell` no longer accepts `&Arc<dyn Clock>`; takes precomputed `now_ms`. Time substrate stays owned by the store.
- Hot-path allocation: `cell_handle` + `route_in_flight_handle` look up with borrowed `&str` first; only allocate on first insertion.
- Race fix: backpressure uses atomic `fetch_add` then rolls back on overflow, closing the check-then-act race.
- Test correctness: split the misleading single-task "concurrent" test into a sequential check + a true multi-thread test with a `Notify` barrier so admitted tasks provably hold the bucket full while the rest hit the rejection path.
- CI: pre-existing `clippy::uninlined_format_args` violation in `harn-vm/tests/builtin_registry_alignment.rs` (surfaced by Rust 1.95 stable) fixed inline.

## Subsumption

Replaces (once epic E ports cloud handlers over) the bespoke per-tenant / per-IP / queue-depth middleware encoded in `harn-cloud-gateway::http_utils::check_rate_limits` (~600 LOC).

## Test plan

- [x] `cargo test -p harn-serve --lib -- --test-threads=1` (302 tests pass, including 13 new limits unit tests + 1 export-attribute parser test)
- [x] `cargo test -p harn-serve --test limits_loadgen` (6 tests: 10× burst settles, codec rendering, sequential backpressure, multi-thread concurrent backpressure with Notify barrier, unlimited short-circuit, budget exhaustion)
- [x] `cargo test -p harn-vm --lib llm::cost::tests` (11 tests including token-budget guard restore-on-drop + categorised-error on exhaustion)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `make lint-test-patterns` (wall-clock audit) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
