### PR TITLE
test: inline format args in builtin_registry_alignment (CI unblocker)

### DIFF
--- a/changelog.d/2573.changed.md
+++ b/changelog.d/2573.changed.md
@@ -1,0 +1,5 @@
+- **CI lint unblocker (#2573).** Inlined the `linkme_distributed_slice_populates_with_all_builtins`
+  test's `format!` arguments so it satisfies Rust 1.95's `clippy::uninlined_format_args`
+  under `-Dwarnings`. The previous positional form (`"...={}, ...={}", a, b`) was the only
+  diff between local and CI lint outcomes, so every open PR was red on Rust lint until this
+  fix landed.

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -314,7 +314,6 @@ fn linkme_distributed_slice_populates_with_all_builtins() {
     );
     assert_eq!(
         linkme_count, manual_count,
-        "linkme slice and manual aggregator out of sync: linkme={}, manual={}",
-        linkme_count, manual_count
+        "linkme slice and manual aggregator out of sync: linkme={linkme_count}, manual={manual_count}"
     );
 }


### PR DESCRIPTION
## Summary

The new `linkme_distributed_slice_populates_with_all_builtins` test (introduced in #2567 / 860dae9b) uses positional `assert_eq!(.., "...={}, ...={}", a, b)` formatting. Rust 1.95's clippy promoted `uninlined_format_args` into the pedantic group with bite, and CI runs Rust lint with `-Dwarnings`, so every PR that touches anything is currently red on Rust lint.

This one-line fix inlines `{linkme_count}` / `{manual_count}` into the format string. Verified locally with `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets --no-deps` — clean.

Filing as its own tiny PR so it lands fast and unblocks every other in-flight PR (notably [#2571](https://github.com/burin-labs/harn/pull/2571), which is also red on the same lint).

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo clippy -p harn-vm --tests --no-deps` clean
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets --no-deps` clean
- [x] No behavior change — pure formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)