### PR TITLE
harn-serve: serialize mcp_host_bridge tests to fix parallel flake

### DIFF
--- a/changelog.d/mcp-host-bridge-test-mutex.fixed.md
+++ b/changelog.d/mcp-host-bridge-test-mutex.fixed.md
@@ -1,0 +1,9 @@
+- **`harn-serve`: serialize `mcp_host_bridge` tests that mutate the
+  process-global MCP host guard.** `install_with_none_clears_guard` and
+  `tool_filter_only_admits_listed_tools` both call
+  `mcp_host::reset_for_tests()` and then install an allowlist via
+  `set_allowlist`. Under `cargo test -p harn-serve --lib` (~309 tests,
+  parallel), a neighbour could race the install→assert window and flip
+  the global guard mid-test, producing a ~50% flake rate. Both tests now
+  take a poison-tolerant `static Mutex<()>` for their duration, pinning
+  the global to one test at a time.

--- a/crates/harn-serve/src/mcp_host_bridge.rs
+++ b/crates/harn-serve/src/mcp_host_bridge.rs
@@ -46,6 +46,22 @@ mod tests {
     use super::*;
     use crate::auth::{AuthPolicy, McpAllowlist, McpAllowlistTools};
     use harn_vm::mcp_host;
+    use std::sync::{Mutex, MutexGuard};
+
+    // Serializes the tests below: they mutate the process-global MCP host
+    // guard via `set_allowlist` / `reset_for_tests`, so when `cargo test`
+    // runs the suite in parallel a neighbour can race the install→assert
+    // window. Holding this lock for the duration of each test pins the
+    // global state to one test at a time.
+    static MCP_HOST_GUARD: Mutex<()> = Mutex::new(());
+
+    fn lock_mcp_host() -> MutexGuard<'static, ()> {
+        // Recover from a poisoned lock — a panic in one of these tests
+        // shouldn't cascade-fail the rest of the file.
+        MCP_HOST_GUARD
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     fn policy_with(allowlist: Option<McpAllowlist>) -> AuthPolicy {
         AuthPolicy {
@@ -56,6 +72,7 @@ mod tests {
 
     #[test]
     fn install_with_none_clears_guard() {
+        let _serial = lock_mcp_host();
         mcp_host::reset_for_tests();
         install_mcp_host_allowlist(&policy_with(None));
         // No guard installed → spawn should not be denied by it. We
@@ -84,6 +101,7 @@ mod tests {
 
     #[test]
     fn tool_filter_only_admits_listed_tools() {
+        let _serial = lock_mcp_host();
         mcp_host::reset_for_tests();
         let mut allowlist = McpAllowlist::deny_all();
         let mut tools = std::collections::BTreeSet::new();


### PR DESCRIPTION
## Summary

The two tests in `crates/harn-serve/src/mcp_host_bridge.rs::tests` mutate
the process-global MCP host guard via `set_allowlist` / `reset_for_tests`.
Under `cargo test -p harn-serve --lib` (~309 tests, parallel) a neighbour
could race the install→assert window and flip the guard mid-test,
producing a ~50% flake rate.

Both tests now take a poison-tolerant `static Mutex<()>` for their full
duration, pinning the global to one test at a time. The tests are
already deterministic on their own; the only fix needed was mutual
exclusion. `serial_test` isn't in the workspace, so the fix is a plain
`std::sync::Mutex<()>` with `unwrap_or_else(|p| p.into_inner())` so one
test panicking doesn't cascade-fail the rest of the file.

## Test plan

- [x] `cargo test -p harn-serve --lib` ×10 — was ~50% flake, now 10/10 green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)