### PR TITLE
test: update LSP signature expectations after #2575 typed migration

### DIFF
--- a/changelog.d/2583.fixed.md
+++ b/changelog.d/2583.fixed.md
@@ -1,0 +1,5 @@
+- **LSP signature expectations updated after #2575.** The LSP unit test
+  for runtime-only `provider_capabilities` / `llm_available_providers`
+  builtins was still pinned to the old untyped form. Updated to match
+  the typed sigs published by the `#[harn_builtin]` migration. No
+  user-visible runtime behavior change.

--- a/crates/harn-lsp/src/constants.rs
+++ b/crates/harn-lsp/src/constants.rs
@@ -1051,7 +1051,7 @@ mod tests {
         assert!(is_builtin("provider_capabilities"));
         assert_eq!(
             builtin_signature("provider_capabilities"),
-            Some("provider_capabilities(provider, model?)")
+            Some("provider_capabilities(provider: string, model?: string|nil) -> dict")
         );
         assert!(builtin_doc("provider_capabilities")
             .expect("provider_capabilities doc")
@@ -1060,7 +1060,7 @@ mod tests {
         assert!(is_builtin("llm_available_providers"));
         assert_eq!(
             builtin_signature("llm_available_providers"),
-            Some("llm_available_providers()")
+            Some("llm_available_providers() -> list")
         );
         assert!(builtin_doc("llm_available_providers")
             .expect("llm_available_providers doc")

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -314,7 +314,6 @@ fn linkme_distributed_slice_populates_with_all_builtins() {
     );
     assert_eq!(
         linkme_count, manual_count,
-        "linkme slice and manual aggregator out of sync: linkme={}, manual={}",
-        linkme_count, manual_count
+        "linkme slice and manual aggregator out of sync: linkme={linkme_count}, manual={manual_count}"
     );
 }


### PR DESCRIPTION
## Summary

PR #2575 changed the runtime metadata format for `provider_capabilities` and `llm_available_providers` to include types (e.g. `provider_capabilities(provider: string, model?: string|nil) -> dict`), but the LSP test assertions in `constants.rs` still expected the old untyped signature. This caused the `Rust test` CI job to fail on every PR rebased onto current main.

This PR updates the two assertions in `lsp_registry_includes_runtime_metadata_only_llm_config_builtins` to match the new typed signatures. The companion test for `llm_healthcheck` already passes because that builtin has a curated override in the `BUILTINS` array.

## Test plan
- [x] `cargo test -p harn-lsp --bin harn-lsp constants::tests::` passes locally