### PR TITLE
builtins: doc + Display + drift-test follow-ups to #[harn_builtin] cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,8 +130,8 @@ polling loops, `SystemTime::now()`, or short `recv_timeout` calls to tests. Use
 - Register new stdlib builtins with `#[harn_builtin]` (see
   [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-stdlib-builtin)). The legacy
   `SyncBuiltin` / `AsyncBuiltin` / `BuiltinGroup` / `register_builtin_group`
-  DSL in `crates/harn-vm/src/stdlib/registration.rs` is deprecated and only
-  survives for a handful of captured-state files; do not extend it.
+  DSL was removed in PR #2575; every builtin now flows through
+  `#[harn_builtin]` + the workspace-global `ALL_BUILTIN_DEFS` linkme slice.
 - Public CLI, builtin, or host-capability changes need user-facing docs and
   help text.
 - Prompt-template syntax changes also require

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,9 +179,7 @@ The detection logic lives in
 flags additions to:
 
 - **Stdlib builtins** — `crates/harn-vm/src/stdlib/**/*.rs`: a new
-  `#[harn_builtin]` annotation, or (in the few remaining unmigrated
-  modules) a new `vm.register_builtin(...)`, `SyncBuiltin::new(...)`,
-  `async_builtin!(...)`, or `register_builtin_group(...)` call. See
+  `#[harn_builtin]` annotation. See
   [Adding a stdlib builtin](#adding-a-stdlib-builtin) for the canonical
   proc-macro pattern.
 - **Host capabilities** — `crates/harn-vm/src/stdlib/host.rs` (a new
@@ -366,25 +364,17 @@ Prefer `#[harn_builtin(parser_only = true)]` in the VM crate for new
 parser-only entries; only touch the parser-side shadow when you're
 adding a name the VM stdlib genuinely doesn't expose.
 
-### Deprecated registration DSL
+### Captured-state pattern (for builtins that need per-VM handles)
 
-`crates/harn-vm/src/stdlib/registration.rs` (`SyncBuiltin`,
-`AsyncBuiltin`, `BuiltinGroup`, `register_builtin_group`,
-`async_builtin!`) is deprecated. It survives only for a small set of
-captured-state files that depend on closure-captured `Rc`/`Arc` handles
-that the proc-macro doesn't yet model. Do not extend it. New builtins
-must use `#[harn_builtin]`; the unmigrated holdouts will move once the
-captured-state shape lands a proc-macro-friendly equivalent.
-
-### Looking ahead
-
-Today every migrated module hand-rolls its `MODULE_BUILTINS` slice and
-`stdlib::all_builtin_defs()` lists each module by name. A planned
-follow-up will collapse those per-module slices into a single
-workspace-global slice via `linkme::distributed_slice`, so the macro
-expansion will register itself automatically and the central
-concatenation in `stdlib.rs` will go away. Until that lands, keep
-appending to `MODULE_BUILTINS` and `all_builtin_defs()` as above.
+A few builtins need access to per-VM state (`MetadataState`,
+`CheckpointState`, `pool` registry, etc.) that closures used to capture
+directly. The proc-macro shape is a free fn, so those modules use a
+`thread_local!` cell installed by the module's `register_<module>_builtins`
+function and read inside the macro-emitted handler via
+`with_state(fn_name, |state| { ... })`. See `crates/harn-vm/src/checkpoint.rs`
+and `crates/harn-vm/src/metadata.rs` for canonical examples. The Harn VM
+runs single-threaded per execution, so this matches the old
+`Rc<RefCell<State>>` semantics 1:1.
 
 ## Adding conformance tests
 

--- a/changelog.d/proc-macro-followups.changed.md
+++ b/changelog.d/proc-macro-followups.changed.md
@@ -1,0 +1,30 @@
+- **Docs + Display + drift test follow-ups to the `#[harn_builtin]`
+  cutover.** Three small polish wins on the registry shipped in PR #2575:
+  - **Doc sweep.** AGENTS.md, CONTRIBUTING.md, and module-level docstrings
+    in `crates/harn-vm/src/stdlib.rs`, `crates/harn-vm/src/stdlib/macros.rs`,
+    and `crates/harn-builtin-macros/src/lib.rs` no longer claim the legacy
+    `SyncBuiltin` / `BuiltinGroup` / `register_builtin_group` DSL still
+    survives — it was deleted, and the docs now reflect that. The
+    "Looking ahead" linkme section in CONTRIBUTING.md is replaced with
+    a "Captured-state pattern" note that points readers at the
+    `thread_local!`-backed examples in `crates/harn-vm/src/checkpoint.rs`
+    and `crates/harn-vm/src/metadata.rs`.
+  - **`Display` for `BuiltinSignature` and `Ty`.** Renders a parsed
+    sig back into the `#[harn_builtin]` `sig = "..."` grammar — recovers
+    the `T?` and `number` sugars (the sig parser desugars both into
+    unions). Lets downstream tools (LSP hover, `harn explain`, error
+    formatting) emit a canonical form regardless of how the macro author
+    typed the original sig string.
+  - **Round-trip drift test.** New
+    `crates/harn-vm/tests/builtin_signature_text_drift.rs` walks
+    `ALL_BUILTIN_DEFS`, renders each parsed `BuiltinSignature` through
+    `Display`, canonicalizes both sides (whitespace squash + sugar
+    normalization), and asserts no drift. Catches future parser tweaks
+    that would silently change how `a | b | c` associates or how
+    `...rest` is parsed.
+
+  Larger follow-ups filed as separate issues for later evaluation:
+  #2584 (collapse VM opcode dispatch tables via `#[harn_opcode]`),
+  #2585 (collapse `HookEvent` enum/parse/render), #2586 (measure +
+  decide whether the `deferred_builtin` registration path is dead
+  weight post-linkme).

--- a/crates/harn-builtin-macros/src/lib.rs
+++ b/crates/harn-builtin-macros/src/lib.rs
@@ -2,13 +2,14 @@
 //!
 //! Annotates a Rust function that implements one builtin and emits both a
 //! runtime registration entry and a parser `BuiltinSignature` from a single
-//! declaration. This is the canonical way to register stdlib builtins — see
-//! `CONTRIBUTING.md` ("Adding a stdlib builtin") for the wire-up checklist
-//! and `crates/harn-vm/src/stdlib/bytes.rs`, `runtime_scope.rs`, and
-//! `strings.rs` for sync, async, and `aliases = [...]` examples respectively.
-//! The legacy `SyncBuiltin` / `AsyncBuiltin` / `register_builtin_group` DSL
-//! in `harn-vm/src/stdlib/registration.rs` is deprecated and must not be
-//! extended.
+//! declaration. This is the only supported way to register stdlib builtins —
+//! see `CONTRIBUTING.md` ("Adding a stdlib builtin") for the wire-up
+//! checklist and `crates/harn-vm/src/stdlib/bytes.rs`, `runtime_scope.rs`,
+//! and `strings.rs` for sync, async, and `aliases = [...]` examples
+//! respectively. The macro contributes each emitted `VmBuiltinDef` to the
+//! workspace-global `ALL_BUILTIN_DEFS` linkme distributed slice, so simply
+//! annotating a fn (in a module already pulled into `harn-vm`) is enough to
+//! make it land in the registry — no per-module aggregation edits required.
 
 extern crate proc_macro;
 

--- a/crates/harn-builtin-meta/src/lib.rs
+++ b/crates/harn-builtin-meta/src/lib.rs
@@ -136,6 +136,81 @@ impl Ty {
     }
 }
 
+impl core::fmt::Display for Ty {
+    /// Render a parsed [`Ty`] back into the `#[harn_builtin]` sig grammar.
+    /// Round-trip target: parsing the output through the proc-macro's
+    /// sig parser yields a structurally-equal [`Ty`] (modulo whitespace and
+    /// canonical operator spacing). See the drift test in
+    /// `crates/harn-vm/tests/builtin_signature_text_drift.rs`.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Ty::Named(s) | Ty::Generic(s) => f.write_str(s),
+            Ty::Any => f.write_str("any"),
+            Ty::Never => f.write_str("never"),
+            Ty::Optional(inner) => write!(f, "{inner}?"),
+            Ty::Apply(name, args) => {
+                f.write_str(name)?;
+                f.write_str("<")?;
+                for (i, a) in args.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{a}")?;
+                }
+                f.write_str(">")
+            }
+            Ty::Union(parts) => {
+                // Recover sig-grammar sugar so output round-trips through
+                // the proc-macro sig parser (which desugars `T?` and
+                // `number` into unions).
+                if let [inner, Ty::Named("nil")] = parts {
+                    if !matches!(inner, Ty::Named("nil")) {
+                        return write!(f, "{inner}?");
+                    }
+                }
+                if let [Ty::Named("int"), Ty::Named("float")] = parts {
+                    return f.write_str("number");
+                }
+                for (i, p) in parts.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(" | ")?;
+                    }
+                    write!(f, "{p}")?;
+                }
+                Ok(())
+            }
+            Ty::Fn(params, ret) => {
+                f.write_str("(")?;
+                for (i, p) in params.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{p}")?;
+                }
+                write!(f, ") -> {ret}")
+            }
+            Ty::Shape(fields) => {
+                f.write_str("{")?;
+                for (i, fld) in fields.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    let name = fld.name;
+                    let ty = &fld.ty;
+                    write!(f, "{name}: {ty}")?;
+                    if fld.optional {
+                        f.write_str("?")?;
+                    }
+                }
+                f.write_str("}")
+            }
+            Ty::SchemaOf(t) => write!(f, "Schema<{t}>"),
+            Ty::LitInt(n) => write!(f, "{n}"),
+            Ty::LitString(s) => write!(f, "\"{s}\""),
+        }
+    }
+}
+
 impl BuiltinSignature {
     /// Non-generic, fixed-arity builtin: no type parameters, no rest, no
     /// where-clause bounds. Covers ~70% of the registry; lets each call
@@ -215,6 +290,53 @@ impl BuiltinSignature {
     }
 }
 
+impl core::fmt::Display for BuiltinSignature {
+    /// Render a parsed [`BuiltinSignature`] back into the `#[harn_builtin]`
+    /// `sig = "..."` grammar. Used by the drift test and by tooling that
+    /// wants a canonical string form of the signature regardless of how it
+    /// was originally typed.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if !self.type_params.is_empty() {
+            f.write_str("<")?;
+            for (i, tp) in self.type_params.iter().enumerate() {
+                if i > 0 {
+                    f.write_str(", ")?;
+                }
+                f.write_str(tp)?;
+            }
+            if !self.where_clauses.is_empty() {
+                f.write_str(" where ")?;
+                for (i, (tp, iface)) in self.where_clauses.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, "{tp}: {iface}")?;
+                }
+            }
+            f.write_str("> ")?;
+        }
+        f.write_str(self.name)?;
+        f.write_str("(")?;
+        let last_idx = self.params.len().saturating_sub(1);
+        for (i, p) in self.params.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            if self.has_rest && i == last_idx {
+                f.write_str("...")?;
+            }
+            f.write_str(p.name)?;
+            if p.optional {
+                f.write_str("?")?;
+            }
+            let ty = &p.ty;
+            write!(f, ": {ty}")?;
+        }
+        let ret = &self.returns;
+        write!(f, ") -> {ret}")
+    }
+}
+
 /// Public view of one builtin used by `harn-lint` and other crates that need
 /// just identifier + return-type hints (no parameter types).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -252,3 +374,94 @@ pub const TY_DICT_OR_NIL: Ty = Ty::Union(&[TY_DICT, TY_NIL]);
 pub const TY_BYTES_OR_NIL: Ty = Ty::Union(&[TY_BYTES, TY_NIL]);
 /// `int | float`.
 pub const TY_NUMBER: Ty = Ty::Union(&[TY_INT, TY_FLOAT]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const APPLY_ARGS: &[Ty] = &[TY_DICT];
+    const FN_PARAMS: &[Ty] = &[TY_INT, TY_STRING];
+    const SHAPE_FIELDS: &[ShapeFieldDescriptor] = &[
+        ShapeFieldDescriptor::new("name", TY_STRING),
+        ShapeFieldDescriptor::optional("age", TY_INT),
+    ];
+
+    #[test]
+    fn ty_display_atomic_and_compound() {
+        assert_eq!(format!("{TY_INT}"), "int");
+        assert_eq!(format!("{TY_ANY}"), "any");
+        assert_eq!(format!("{TY_NEVER}"), "never");
+        // `T | nil` round-trips as `T?` (the sig grammar's optional sugar
+        // is desugared into a 2-element union, not `Ty::Optional`).
+        assert_eq!(format!("{TY_STRING_OR_NIL}"), "string?");
+        let opt_int = Ty::Optional(&TY_INT);
+        assert_eq!(format!("{opt_int}"), "int?");
+        // `int | float` round-trips as `number` (the predeclared shorthand).
+        assert_eq!(format!("{TY_NUMBER}"), "number");
+        let list_dict = Ty::Apply("list", APPLY_ARGS);
+        assert_eq!(format!("{list_dict}"), "list<dict>");
+        let lit_int = Ty::LitInt(42);
+        assert_eq!(format!("{lit_int}"), "42");
+        let lit_str = Ty::LitString("pass");
+        assert_eq!(format!("{lit_str}"), "\"pass\"");
+        let schema_t = Ty::SchemaOf("T");
+        assert_eq!(format!("{schema_t}"), "Schema<T>");
+        let fn_ty = Ty::Fn(FN_PARAMS, &TY_BOOL);
+        assert_eq!(format!("{fn_ty}"), "(int, string) -> bool");
+        let shape = Ty::Shape(SHAPE_FIELDS);
+        assert_eq!(format!("{shape}"), "{name: string, age: int?}");
+    }
+
+    const BASIC_PARAMS: &[Param] = &[Param::new("a", TY_DICT), Param::new("b", TY_DICT)];
+    const REST_PARAMS: &[Param] = &[Param::new("prefix", TY_STRING), Param::new("args", TY_ANY)];
+    const OPT_PARAMS: &[Param] = &[
+        Param::new("receipt", TY_DICT),
+        Param::optional("candidate", TY_ANY),
+    ];
+    const GENERIC_PARAMS: &[Param] = &[Param::new("schema", Ty::SchemaOf("T"))];
+
+    #[test]
+    fn signature_display_basic() {
+        let sig = BuiltinSignature::simple("deep_merge", BASIC_PARAMS, TY_DICT);
+        assert_eq!(format!("{sig}"), "deep_merge(a: dict, b: dict) -> dict");
+    }
+
+    #[test]
+    fn signature_display_with_optional_and_rest() {
+        let sig = BuiltinSignature {
+            name: "io_println",
+            params: REST_PARAMS,
+            returns: TY_NIL,
+            type_params: &[],
+            has_rest: true,
+            where_clauses: &[],
+        };
+        assert_eq!(
+            format!("{sig}"),
+            "io_println(prefix: string, ...args: any) -> nil"
+        );
+
+        let opt_sig =
+            BuiltinSignature::simple("lifecycle_replay_resume_input", OPT_PARAMS, TY_DICT);
+        assert_eq!(
+            format!("{opt_sig}"),
+            "lifecycle_replay_resume_input(receipt: dict, candidate?: any) -> dict"
+        );
+    }
+
+    #[test]
+    fn signature_display_with_generics_and_where() {
+        let sig = BuiltinSignature {
+            name: "schema_parse",
+            params: GENERIC_PARAMS,
+            returns: Ty::Generic("T"),
+            type_params: &["T"],
+            has_rest: false,
+            where_clauses: &[("T", "Decode")],
+        };
+        assert_eq!(
+            format!("{sig}"),
+            "<T where T: Decode> schema_parse(schema: Schema<T>) -> T"
+        );
+    }
+}

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -1,17 +1,17 @@
 //! Standard library builtins for the Harn VM.
 //!
-//! New builtins are declared with the `#[harn_builtin]` proc-macro
+//! Every builtin is declared with the `#[harn_builtin]` proc-macro
 //! (`crate::stdlib::macros::harn_builtin`). Each annotation emits a sibling
 //! `static <FN>_DEF: VmBuiltinDef` carrying the signature, aliases, handler,
-//! and metadata; modules collect those into a `MODULE_BUILTINS: &[&VmBuiltinDef]`
-//! slice and expose a `register_<module>_builtins(vm)` that iterates it.
-//! `all_builtin_defs()` below concatenates every module's slice (alphabetical
-//! by module) and `register_vm_stdlib` installs the resulting signatures into
-//! the parser registry.
+//! and metadata, and registers it into the workspace-global
+//! [`macros::ALL_BUILTIN_DEFS`] distributed slice at link time. The CLI / LSP /
+//! lint / serve / dap binaries call [`force_link`] to defeat rlib dead-code
+//! stripping (linkme issue #36) so every static lands in the slice. Modules
+//! still expose a `register_<module>_builtins(vm)` helper for ordered eager
+//! registration (e.g. so `clock::timestamp` can override `process::timestamp`).
+//! `register_vm_stdlib` calls those helpers in order and then installs the
+//! aggregated signatures into the parser registry.
 //!
-//! The legacy DSL under [`registration`] (`SyncBuiltin`, `AsyncBuiltin`,
-//! `BuiltinGroup`, `register_builtin_group`) is deprecated and retained only
-//! for a small set of unmigrated callers. New code MUST use `#[harn_builtin]`.
 //! See `CONTRIBUTING.md` ("Adding a stdlib builtin") for the full template.
 
 pub mod macros;

--- a/crates/harn-vm/src/stdlib/macros.rs
+++ b/crates/harn-vm/src/stdlib/macros.rs
@@ -55,10 +55,9 @@ pub enum VmBuiltinHandler {
 pub type VmBuiltinDef = BuiltinDef<VmBuiltinHandler>;
 
 /// Eager-registration helper: install every entry (name + aliases) on `vm`
-/// using the macro-emitted handler. The replacement for the legacy
-/// `register_builtin_group(vm, BuiltinGroup::new().sync(...))` shape —
-/// post-migration call sites just iterate a `&[&VmBuiltinDef]` slice and
-/// call this once per entry.
+/// using the macro-emitted handler. Each module's `register_*_builtins(vm)`
+/// calls this with its `MODULE_BUILTINS` slice so the call ordering between
+/// modules stays deterministic (e.g. `clock` overrides `process::timestamp`).
 pub fn register_builtin_defs(vm: &mut crate::vm::Vm, defs: &'static [&'static VmBuiltinDef]) {
     for def in defs {
         vm.register_builtin_def(def);
@@ -68,7 +67,7 @@ pub fn register_builtin_defs(vm: &mut crate::vm::Vm, defs: &'static [&'static Vm
 /// Deferred-registration helper: register names + aliases as deferred
 /// builtins on `vm`. The first time any of them dispatches, `registrar`
 /// runs (typically installs the LLM stack), which re-registers the real
-/// impls. Replaces `register_deferred_builtin_group` from the legacy DSL.
+/// impls.
 pub fn register_deferred_builtin_defs(
     vm: &mut crate::vm::Vm,
     defs: &[&'static VmBuiltinDef],

--- a/crates/harn-vm/tests/builtin_signature_text_drift.rs
+++ b/crates/harn-vm/tests/builtin_signature_text_drift.rs
@@ -1,0 +1,143 @@
+//! Drift test between each builtin's raw `sig = "..."` text and the
+//! [`BuiltinSignature`] that `#[harn_builtin]` parsed it into.
+//!
+//! The proc-macro stores both representations on every `VmBuiltinDef`:
+//!
+//! * `signature_text` — the literal string the human typed.
+//! * `sig` (a parsed `BuiltinSignature` struct) — the AST the typechecker
+//!   actually consumes.
+//!
+//! If these ever disagree structurally (e.g. a future parser tweak silently
+//! changes how `a | b | c` associates, or `...rest` loses its `has_rest`
+//! bit, or shape fields get reordered), tooling that surfaces
+//! `signature_text` to the user would show one thing while the typechecker
+//! enforces another. This test catches that by rendering the parsed
+//! `BuiltinSignature` back through its `Display` impl and comparing — after
+//! canonicalization — against the raw text.
+//!
+//! Canonicalization handles documented sugar (the sig parser desugars these
+//! into the same `Ty` shape, so `Display` picks one canonical rendering):
+//! * Whitespace differences (`a:dict` vs `a: dict`) — squashed.
+//! * `T?` and `T|nil` — normalized to `T?` (Display's choice).
+//! * `int|float` and `number` — normalized to `number`.
+
+use harn_builtin_meta::BuiltinSignature;
+
+/// Recognized type-name first chars in canonicalization. Sig type names are
+/// always lowercase identifiers (`dict`, `string`, …) plus the
+/// uppercase-leading `Schema` and user generic params.
+fn is_typename_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_typename_cont(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// True when the previous byte indicates a type position in the squashed sig
+/// stream: after `:` (param/field type), `<` (apply arg), `>` (after `->`),
+/// `|` (union continuation), `(` / `,` (fn-type params).
+fn at_type_pos(prev: u8) -> bool {
+    matches!(prev, b':' | b'<' | b'>' | b'|' | b'(' | b',')
+}
+
+/// Normalize a sig string so equivalent grammatical forms compare equal:
+/// strip whitespace, then rewrite `T|nil` → `T?` and `int|float` → `number`
+/// in type positions.
+fn canonical(s: &str) -> String {
+    let squashed: String = s.chars().filter(|c| !c.is_whitespace()).collect();
+    let bytes = squashed.as_bytes();
+    let mut out = String::with_capacity(squashed.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let prev = if i == 0 { b'\0' } else { bytes[i - 1] };
+        if at_type_pos(prev) && is_typename_start(bytes[i]) {
+            let start = i;
+            while i < bytes.len() && is_typename_cont(bytes[i]) {
+                i += 1;
+            }
+            let name = &squashed[start..i];
+            // `int|float` (when not part of a wider union) → `number`.
+            if name == "int"
+                && squashed[i..].starts_with("|float")
+                && bytes
+                    .get(i + 6)
+                    .map(|c| matches!(*c, b',' | b')' | b'>' | b'}' | b'\0'))
+                    .unwrap_or(true)
+            {
+                out.push_str("number");
+                i += 6;
+                continue;
+            }
+            // `T|nil` (when not part of a wider union) → `T?`.
+            if squashed[i..].starts_with("|nil") {
+                let after = i + 4;
+                let terminates = bytes
+                    .get(after)
+                    .map(|c| matches!(*c, b',' | b')' | b'>' | b'}'))
+                    .unwrap_or(true);
+                if terminates && name != "nil" {
+                    out.push_str(name);
+                    out.push('?');
+                    i = after;
+                    continue;
+                }
+            }
+            out.push_str(name);
+            continue;
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+#[test]
+fn every_builtin_signature_text_round_trips_through_display() {
+    let mut mismatches: Vec<String> = Vec::new();
+
+    for def in harn_vm::stdlib::macros::ALL_BUILTIN_DEFS.iter() {
+        let Some(raw_text) = def.signature_text else {
+            // `runtime_only = true` / `parser_only = true` builtins legitimately
+            // omit the text; nothing to compare.
+            continue;
+        };
+
+        let rendered = format!("{}", &def.sig as &BuiltinSignature);
+        if canonical(raw_text) != canonical(&rendered) {
+            mismatches.push(format!(
+                "builtin {:?}:\n  raw:      {}\n  rendered: {}\n  raw(canon):      {}\n  rendered(canon): {}",
+                def.sig.name,
+                raw_text,
+                rendered,
+                canonical(raw_text),
+                canonical(&rendered),
+            ));
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "signature_text drifted from BuiltinSignature for {} builtin(s):\n\n{}",
+        mismatches.len(),
+        mismatches.join("\n\n")
+    );
+}
+
+#[test]
+fn signature_text_present_for_user_visible_builtins() {
+    // Sanity: most non-runtime-only entries should have populated text.
+    // This isn't a strict contract (some categories deliberately suppress
+    // it), but a near-total absence would indicate the macro stopped
+    // forwarding the literal.
+    let total = harn_vm::stdlib::macros::ALL_BUILTIN_DEFS.len();
+    let with_text = harn_vm::stdlib::macros::ALL_BUILTIN_DEFS
+        .iter()
+        .filter(|d| d.signature_text.is_some())
+        .count();
+    assert!(
+        with_text * 2 > total,
+        "fewer than half of builtins have signature_text populated ({with_text}/{total}); \
+         the proc-macro may have stopped forwarding `sig = \"...\"` to signature_text"
+    );
+}


### PR DESCRIPTION
## Summary

Three small polish wins on top of [PR #2575](https://github.com/burin-labs/harn/pull/2575) — the final landing of the `#[harn_builtin]` proc-macro cutover. All five items came from a retrospective sweep of the registry surface after PR #2575 merged. The two biggest follow-up candidates (opcode and HookEvent macros) and a measurement-driven decision (deferred path) are filed as separate issues for later evaluation rather than bundled here.

### What changed

1. **Doc sweep.** `AGENTS.md`, `CONTRIBUTING.md`, and module-level docstrings in `crates/harn-vm/src/stdlib.rs`, `crates/harn-vm/src/stdlib/macros.rs`, and `crates/harn-builtin-macros/src/lib.rs` still claimed the legacy `SyncBuiltin` / `BuiltinGroup` / `register_builtin_group` DSL survived for some captured-state holdouts. It was deleted in PR #2575. The docs now reflect that, and `CONTRIBUTING.md`'s stale "Looking ahead" linkme section is replaced with a "Captured-state pattern" note pointing readers at the `thread_local!`-backed examples in `crates/harn-vm/src/checkpoint.rs` and `crates/harn-vm/src/metadata.rs`.

2. **`Display` for `BuiltinSignature` and `Ty`.** New impl in `harn-builtin-meta` renders a parsed signature back into the `#[harn_builtin]` `sig = "..."` grammar — including recovering the `T?` and `number` sugars (the sig parser desugars both into `Union(&[T, nil])` and `Union(&[int, float])`, so `Display` picks the sugar form as canonical). Lets LSP hover, `harn explain`, and error formatting emit a canonical type string regardless of how the macro author typed the original `sig = \"...\"`.

3. **Round-trip drift test.** New `crates/harn-vm/tests/builtin_signature_text_drift.rs` walks `ALL_BUILTIN_DEFS`, renders each parsed `BuiltinSignature` through `Display`, canonicalizes both sides (whitespace squash + sugar normalization for `T|nil` ↔ `T?` and `int|float` ↔ `number`), and asserts no drift. Catches future parser tweaks that would silently change how `a | b | c` associates or how `...rest` is parsed.

### Follow-ups filed (not in scope here)

- **#2584** — Collapse VM opcode dispatch tables via `#[harn_opcode]`. Highest-ROI extension of the proc-macro pattern: `enum Op` has ~84 variants across **three** mandatory dispatch tables (sync, async, disasm). Substantial refactor, deserves its own epic.
- **#2585** — Collapse `HookEvent` enum/parse/render. Same pattern, smaller scale (~35 variants), should follow opcodes.
- **#2586** — Measure + decide whether the `deferred_builtin` registration path is dead weight now that linkme aggregates metadata eagerly. Likely deletable, but measure first.

## Test plan

- [x] `cargo test -p harn-builtin-meta` — 4 Display unit tests pass
- [x] `cargo test -p harn-vm --test builtin_signature_text_drift` — drift test passes on all current builtins after canonicalization
- [x] `cargo test -p harn-vm --test builtin_registry_alignment` — existing alignment tests still pass
- [x] `cargo test -p harn-vm --test orchestration_cutover` — no regression
- [x] `cargo build --workspace` — clean build
- [x] `cargo clippy -p harn-builtin-meta -p harn-vm` — clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)