### PR TITLE
vm: collapse opcode dispatch tables via define_opcodes! proc-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-opcode-macros"
+version = "0.8.47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "harn-orchestration-perf"
 version = "0.0.0"
 dependencies = [
@@ -2568,6 +2577,7 @@ dependencies = [
  "harn-ir",
  "harn-lexer",
  "harn-modules",
+ "harn-opcode-macros",
  "harn-parser",
  "harn-stdlib",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/harn-builtin-meta",
     "crates/harn-builtin-registry",
     "crates/harn-builtin-macros",
+    "crates/harn-opcode-macros",
     "crates/harn-clock",
     "crates/harn-lexer",
     "crates/harn-parser",

--- a/changelog.d/2584.changed.md
+++ b/changelog.d/2584.changed.md
@@ -1,0 +1,10 @@
+**vm:** collapsed the VM's three hand-maintained opcode dispatch tables
+(`execute_op_sync`, `execute_op_async`, `Chunk::disassemble`) and the
+classification helpers (`op_reads_outer_name`, `is_adaptive_binary_op`)
+into a single declarative table driven by a new `define_opcodes!`
+proc-macro. Adding or renaming an opcode is now a one-line edit; coverage
+drift across the previously hand-maintained matches is gone. Surfaced two
+pre-existing disasm bugs as part of the migration — `Op::CheckType` and
+`Op::GetArgc` now render properly instead of `UNKNOWN(0x..)`, and
+`Op::MethodCallSpread` reads its name-index operand at the correct
+offset.

--- a/crates/harn-opcode-macros/Cargo.toml
+++ b/crates/harn-opcode-macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "harn-opcode-macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "define_opcodes! proc-macro: emits the VM Op enum, sync/async dispatch, disassembly, and classification helpers from a single declarative table."
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }
+quote = "1"
+proc-macro2 = "1"
+
+[lints]
+workspace = true

--- a/crates/harn-opcode-macros/src/lib.rs
+++ b/crates/harn-opcode-macros/src/lib.rs
@@ -1,0 +1,343 @@
+//! `define_opcodes!` function-like proc-macro.
+//!
+//! Single source of truth for the VM's opcode set. One invocation in
+//! `harn-vm/src/chunk.rs` emits the `Op` enum, the byte-to-variant mapping,
+//! the sync and async dispatch tables, the disassembly renderer, and the
+//! classification helpers (`op_reads_outer_name`, `is_adaptive_binary_op`).
+//! Adding or renaming an opcode is a one-line edit; coverage drift across
+//! the previously hand-maintained tables is now impossible.
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{braced, bracketed, parenthesized, parse_macro_input, Expr, Ident, LitStr, Token};
+
+/// Parse a single opcode entry. Syntax:
+///
+/// ```ignore
+/// VariantName {
+///     <kind>(<expr>[, <expr>]),
+///     disasm: <helper>("<LABEL>"),
+///     flags: [<flag>, ...]   // optional
+/// };
+/// ```
+///
+/// where `<kind>` is one of:
+/// - `sync(expr)` — `expr: Result<(), VmError>`
+/// - `sync_void(expr)` — `expr: ()`, wrapped to `Ok(())`
+/// - `sync_return(expr)` — `expr: VmError`, wrapped to `return Some(Err(expr))`
+/// - `split(sync_expr, async_expr)` — sync path returns `Option<Result>`,
+///   async path returns `Result<(), VmError>`
+/// - `async_op(expr)` — `expr: Result<(), VmError>`, only dispatched in async
+///   table; sync table emits `return None`. Named `async_op` instead of
+///   `async` to avoid the reserved-keyword friction even though `syn` would
+///   tolerate the raw identifier.
+struct OpcodeEntry {
+    variant: Ident,
+    dispatch: Dispatch,
+    disasm: Disasm,
+    flags: Vec<Ident>,
+}
+
+enum Dispatch {
+    Sync(Expr),
+    SyncVoid(Expr),
+    SyncReturn(Expr),
+    Split { sync: Expr, async_: Expr },
+    Async(Expr),
+}
+
+struct Disasm {
+    helper: Ident,
+    label: LitStr,
+}
+
+impl Parse for OpcodeEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let variant: Ident = input.parse()?;
+        let body;
+        braced!(body in input);
+
+        let kind: Ident = body.parse()?;
+        let kind_args;
+        parenthesized!(kind_args in body);
+
+        let dispatch = match kind.to_string().as_str() {
+            "sync" => {
+                let expr: Expr = kind_args.parse()?;
+                Dispatch::Sync(expr)
+            }
+            "sync_void" => {
+                let expr: Expr = kind_args.parse()?;
+                Dispatch::SyncVoid(expr)
+            }
+            "sync_return" => {
+                let expr: Expr = kind_args.parse()?;
+                Dispatch::SyncReturn(expr)
+            }
+            "split" => {
+                let sync: Expr = kind_args.parse()?;
+                kind_args.parse::<Token![,]>()?;
+                let async_: Expr = kind_args.parse()?;
+                Dispatch::Split { sync, async_ }
+            }
+            "async_op" => {
+                let expr: Expr = kind_args.parse()?;
+                Dispatch::Async(expr)
+            }
+            other => {
+                return Err(syn::Error::new(
+                    kind.span(),
+                    format!(
+                        "unknown opcode kind `{other}` — expected one of: \
+                         sync, sync_void, sync_return, split, async_op"
+                    ),
+                ));
+            }
+        };
+
+        body.parse::<Token![,]>()?;
+        let disasm_kw: Ident = body.parse()?;
+        if disasm_kw != "disasm" {
+            return Err(syn::Error::new(
+                disasm_kw.span(),
+                "expected `disasm:` after dispatch kind",
+            ));
+        }
+        body.parse::<Token![:]>()?;
+        let helper: Ident = body.parse()?;
+        let helper_args;
+        parenthesized!(helper_args in body);
+        let label: LitStr = helper_args.parse()?;
+        let disasm = Disasm { helper, label };
+
+        let mut flags = Vec::new();
+        if body.peek(Token![,]) {
+            body.parse::<Token![,]>()?;
+            if !body.is_empty() {
+                let flags_kw: Ident = body.parse()?;
+                if flags_kw != "flags" {
+                    return Err(syn::Error::new(
+                        flags_kw.span(),
+                        "expected `flags: [...]` after `disasm`",
+                    ));
+                }
+                body.parse::<Token![:]>()?;
+                let flags_inner;
+                bracketed!(flags_inner in body);
+                let parsed: Punctuated<Ident, Token![,]> =
+                    Punctuated::parse_terminated(&flags_inner)?;
+                flags = parsed.into_iter().collect();
+            }
+        }
+
+        Ok(Self {
+            variant,
+            dispatch,
+            disasm,
+            flags,
+        })
+    }
+}
+
+struct Opcodes {
+    entries: Vec<OpcodeEntry>,
+}
+
+impl Parse for Opcodes {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut entries = Vec::new();
+        while !input.is_empty() {
+            let entry: OpcodeEntry = input.parse()?;
+            input.parse::<Token![;]>()?;
+            entries.push(entry);
+        }
+        Ok(Self { entries })
+    }
+}
+
+/// Emit the VM opcode definitions from a centralized declarative table.
+///
+/// See the crate-level doc for syntax. Generated outputs:
+/// - `pub enum Op { ... }` (`#[repr(u8)]`, `Debug + Clone + Copy + Eq`)
+/// - `impl Op { const ALL: &[Self]; const COUNT: usize; fn from_byte(...) -> Option<Self> }`
+/// - `impl crate::vm::Vm { fn execute_op_sync(...); async fn execute_op_async(...) }`
+/// - `impl crate::chunk::Chunk { fn disassemble_op(...) }`
+/// - One free `pub(crate) fn <flag>(op: Op) -> bool` per declared flag.
+///   The well-known flags `reads_outer_name` and `adaptive_binary` map
+///   to `op_reads_outer_name` and `is_adaptive_binary_op` respectively
+///   so existing call sites need no renames.
+#[proc_macro]
+pub fn define_opcodes(input: TokenStream) -> TokenStream {
+    let opcodes = parse_macro_input!(input as Opcodes);
+    match expand(&opcodes) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand(opcodes: &Opcodes) -> syn::Result<TokenStream2> {
+    if opcodes.entries.is_empty() {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "define_opcodes! requires at least one opcode entry",
+        ));
+    }
+
+    let variants = opcodes.entries.iter().map(|e| &e.variant);
+    let all_variants: Vec<_> = opcodes.entries.iter().map(|e| &e.variant).collect();
+
+    // Sync dispatch arms.
+    let sync_arms = opcodes.entries.iter().map(|e| {
+        let v = &e.variant;
+        match &e.dispatch {
+            Dispatch::Sync(expr) => quote!(Op::#v => #expr,),
+            Dispatch::SyncVoid(expr) => quote!(Op::#v => { #expr; Ok(()) },),
+            Dispatch::SyncReturn(expr) => quote!(Op::#v => return ::core::option::Option::Some(::core::result::Result::Err(#expr)),),
+            Dispatch::Split { sync, .. } => quote!(Op::#v => return #sync,),
+            Dispatch::Async(_) => quote!(Op::#v => return ::core::option::Option::None,),
+        }
+    });
+
+    // Async dispatch arms — only `async` and `split` kinds appear here.
+    // Sync-only opcodes hit a debug_assert!-guarded panic to flag any
+    // out-of-sync caller (the hot loop never calls execute_op_async for
+    // a sync opcode because execute_op_sync returns Some(...) for them).
+    let async_arms = opcodes.entries.iter().filter_map(|e| {
+        let v = &e.variant;
+        match &e.dispatch {
+            Dispatch::Async(expr) => Some(quote!(Op::#v => #expr,)),
+            Dispatch::Split { async_, .. } => Some(quote!(Op::#v => #async_,)),
+            _ => None,
+        }
+    });
+
+    // Disasm arms — call the per-opcode helper with the label.
+    // Helpers live in `crate::chunk` as `pub(crate) fn disasm_<helper>(...)`
+    // and take `(&Chunk, &mut usize, &str)`. Fully-qualifying the path
+    // means this dispatch table can be emitted into any module without
+    // forcing a `use crate::chunk::*` at the call site.
+    let disasm_arms = opcodes.entries.iter().map(|e| {
+        let v = &e.variant;
+        let helper = format_ident!("disasm_{}", e.disasm.helper);
+        let label = &e.disasm.label;
+        quote!(Op::#v => crate::chunk::#helper(self, ip, #label),)
+    });
+
+    // Flag-derived classification helpers. Collect the set of distinct
+    // flag names declared across all entries so each generated predicate
+    // has a contributor list and zero-cost `matches!` macro expansion.
+    let mut flag_groups: std::collections::BTreeMap<String, Vec<&Ident>> =
+        std::collections::BTreeMap::new();
+    for entry in &opcodes.entries {
+        for flag in &entry.flags {
+            flag_groups
+                .entry(flag.to_string())
+                .or_default()
+                .push(&entry.variant);
+        }
+    }
+
+    // Each flag becomes a free `fn` at module scope, named for the flag.
+    // Hand-rolled mapping ties into the existing call sites (chunk.rs,
+    // arithmetic.rs) so the macro replaces the predicate definitions
+    // without forcing every caller to switch namespaces.
+    let flag_fns = flag_groups.iter().map(|(name, variants)| {
+        let fn_ident = match name.as_str() {
+            "reads_outer_name" => format_ident!("op_reads_outer_name"),
+            "adaptive_binary" => format_ident!("is_adaptive_binary_op"),
+            other => format_ident!("op_has_flag_{}", other),
+        };
+        quote!(
+            #[inline]
+            pub(crate) fn #fn_ident(op: Op) -> bool {
+                matches!(op, #(Op::#variants)|*)
+            }
+        )
+    });
+
+    let opcode_count = all_variants.len();
+
+    let out = quote! {
+        /// Bytecode opcodes for the Harn VM. Defined by
+        /// `define_opcodes!`; the `u8` representation is the on-disk
+        /// bytecode encoding.
+        #[derive(::core::fmt::Debug, ::core::clone::Clone, ::core::marker::Copy, ::core::cmp::PartialEq, ::core::cmp::Eq)]
+        #[repr(u8)]
+        pub enum Op {
+            #(#variants),*
+        }
+
+        impl Op {
+            /// Every opcode in declaration order. The index is the
+            /// canonical `u8` representation; `from_byte` is the
+            /// inverse mapping.
+            pub(crate) const ALL: &'static [Self] = &[#(Op::#all_variants),*];
+
+            /// Number of declared opcodes (== `ALL.len()`).
+            pub(crate) const COUNT: usize = #opcode_count;
+
+            #[inline]
+            pub(crate) fn from_byte(byte: u8) -> ::core::option::Option<Self> {
+                Self::ALL.get(byte as usize).copied()
+            }
+        }
+
+        impl crate::vm::Vm {
+            /// Sync dispatch table. Returns `Some(Ok(()))` / `Some(Err(_))`
+            /// when the opcode completed synchronously and `None` when
+            /// the caller must fall through to [`Self::execute_op_async`].
+            /// See the per-arm comments in `define_opcodes!` for what
+            /// each variant does on dispatch.
+            pub(super) fn execute_op_sync(&mut self, op: Op) -> ::core::option::Option<::core::result::Result<(), crate::value::VmError>> {
+                let result: ::core::result::Result<(), crate::value::VmError> = match op {
+                    #(#sync_arms)*
+                };
+                ::core::option::Option::Some(result)
+            }
+
+            /// Async dispatch table. The caller must have observed `None`
+            /// from [`Self::execute_op_sync`] for this opcode; reaching the
+            /// catch-all is a coverage bug between the two halves.
+            pub(super) async fn execute_op_async(&mut self, op: Op) -> ::core::result::Result<(), crate::value::VmError> {
+                match op {
+                    #(#async_arms)*
+                    sync_op => {
+                        debug_assert!(
+                            false,
+                            "execute_op_async called with sync opcode {sync_op:?} \
+                             — define_opcodes! kept the two halves aligned"
+                        );
+                        ::core::result::Result::Err(crate::value::VmError::Runtime(format!(
+                            "internal VM dispatch error: {sync_op:?} is not an async opcode"
+                        )))
+                    }
+                }
+            }
+        }
+
+        impl crate::chunk::Chunk {
+            /// Render a single opcode at `ip` (positioned immediately
+            /// after the opcode byte) into a human-readable disassembly
+            /// line. Each helper advances `ip` past the operand bytes
+            /// it consumes. Delegated from
+            /// [`crate::chunk::Chunk::disassemble`].
+            #[allow(clippy::too_many_lines)]
+            pub(crate) fn disassemble_op(&self, op: Op, ip: &mut usize, out: &mut String) {
+                let line = match op {
+                    #(#disasm_arms)*
+                };
+                out.push_str(&line);
+                out.push('\n');
+            }
+        }
+
+        #(#flag_fns)*
+    };
+
+    Ok(out)
+}

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -31,6 +31,7 @@ testbench-wasi = ["dep:wasmtime", "dep:wasmtime-wasi", "dep:wat", "dep:tempfile"
 harn-builtin-meta = { path = "../harn-builtin-meta", version = "0.8" }
 harn-builtin-registry = { path = "../harn-builtin-registry", version = "0.8" }
 harn-builtin-macros = { path = "../harn-builtin-macros", version = "0.8" }
+harn-opcode-macros = { path = "../harn-opcode-macros", version = "0.8" }
 linkme = "0.3"
 harn-clock = { path = "../harn-clock", version = "0.8" }
 harn-ir = { path = "../harn-ir", version = "0.8" }

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -17,368 +17,14 @@ use crate::runtime_guards::RuntimeParamGuard;
 /// out of the addressable slot range.
 pub(crate) const NO_INLINE_CACHE_SLOT: u32 = u32::MAX;
 
-/// Bytecode opcodes for the Harn VM.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum Op {
-    /// Push a constant from the constant pool onto the stack.
-    Constant, // arg: u16 constant index
-    /// Push nil onto the stack.
-    Nil,
-    /// Push true onto the stack.
-    True,
-    /// Push false onto the stack.
-    False,
-
-    // --- Variable operations ---
-    /// Get a variable by name (from constant pool).
-    GetVar, // arg: u16 constant index (name)
-    /// Define a new immutable variable. Pops value from stack.
-    DefLet, // arg: u16 constant index (name)
-    /// Define a new mutable variable. Pops value from stack.
-    DefVar, // arg: u16 constant index (name)
-    /// Assign to an existing mutable variable. Pops value from stack.
-    SetVar, // arg: u16 constant index (name)
-    /// Push a new lexical scope onto the environment stack.
-    PushScope,
-    /// Pop the current lexical scope from the environment stack.
-    PopScope,
-
-    // --- Arithmetic ---
-    Add,
-    Sub,
-    Mul,
-    Div,
-    Mod,
-    Pow,
-    Negate,
-
-    // --- Comparison ---
-    Equal,
-    NotEqual,
-    Less,
-    Greater,
-    LessEqual,
-    GreaterEqual,
-
-    // --- Logical ---
-    Not,
-
-    // --- Control flow ---
-    /// Jump unconditionally. arg: u16 offset.
-    Jump,
-    /// Jump if top of stack is falsy. Does not pop. arg: u16 offset.
-    JumpIfFalse,
-    /// Jump if top of stack is truthy. Does not pop. arg: u16 offset.
-    JumpIfTrue,
-    /// Pop top of stack (discard).
-    Pop,
-
-    // --- Functions ---
-    /// Call a function/builtin. arg: u8 = arg count. Name is on stack below args.
-    Call,
-    /// Tail call: like Call, but replaces the current frame instead of pushing
-    /// a new one. Used for `return f(x)` to enable tail call optimization.
-    /// For builtins, behaves like a regular Call (no frame to replace).
-    TailCall,
-    /// Return from current function. Pops return value.
-    Return,
-    /// Create a closure. arg: u16 = chunk index in function table.
-    Closure,
-
-    // --- Collections ---
-    /// Build a list. arg: u16 = element count. Elements are on stack.
-    BuildList,
-    /// Build a dict. arg: u16 = entry count. Key-value pairs on stack.
-    BuildDict,
-    /// Subscript access: stack has [object, index]. Pushes result.
-    Subscript,
-    /// Optional subscript (`obj?[index]`). Like `Subscript` but pushes nil
-    /// instead of indexing when the object is nil.
-    SubscriptOpt,
-    /// Slice access: stack has [object, start_or_nil, end_or_nil]. Pushes sublist/substring.
-    Slice,
-
-    // --- Object operations ---
-    /// Property access. arg: u16 = constant index (property name).
-    GetProperty,
-    /// Optional property access (?.). Like GetProperty but returns nil
-    /// instead of erroring when the object is nil. arg: u16 = constant index.
-    GetPropertyOpt,
-    /// Property assignment. arg: u16 = constant index (property name).
-    /// Stack: [value] → assigns to the named variable's property.
-    SetProperty,
-    /// Subscript assignment. arg: u16 = constant index (variable name).
-    /// Stack: [index, value] → assigns to variable[index] = value.
-    SetSubscript,
-    /// Method call. arg1: u16 = constant index (method name), arg2: u8 = arg count.
-    MethodCall,
-    /// Optional method call (?.). Like MethodCall but returns nil if the
-    /// receiver is nil instead of dispatching. arg1: u16, arg2: u8.
-    MethodCallOpt,
-
-    // --- String ---
-    /// String concatenation of N parts. arg: u16 = part count.
-    Concat,
-
-    // --- Iteration ---
-    /// Set up a for-in loop. Expects iterable on stack. Pushes iterator state.
-    IterInit,
-    /// Advance iterator. If exhausted, jumps. arg: u16 = jump offset.
-    /// Pushes next value and the variable name is set via DefVar before the loop.
-    IterNext,
-
-    // --- Pipe ---
-    /// Pipe: pops [value, callable], invokes callable(value).
-    Pipe,
-
-    // --- Error handling ---
-    /// Pop value, raise as error.
-    Throw,
-    /// Push exception handler. arg: u16 = offset to catch handler.
-    TryCatchSetup,
-    /// Remove top exception handler (end of try body).
-    PopHandler,
-
-    // --- Concurrency ---
-    /// Execute closure N times sequentially, push results as list.
-    /// Stack: count, closure → result_list
-    Parallel,
-    /// Execute closure for each item in list, push results as list.
-    /// Stack: list, closure → result_list
-    ParallelMap,
-    /// Execute closure for each item in list, push a stream that emits in completion order.
-    /// Stack: list, closure → stream
-    ParallelMapStream,
-    /// Like ParallelMap but wraps each result in Result.Ok/Err, never fails.
-    /// Stack: list, closure → {results: [Result], succeeded: int, failed: int}
-    ParallelSettle,
-    /// Store closure for deferred execution, push TaskHandle.
-    /// Stack: closure → TaskHandle
-    Spawn,
-    /// Acquire a process-local mutex for the current lexical scope.
-    /// arg: u16 constant index (key string).
-    SyncMutexEnter,
-
-    // --- Imports ---
-    /// Import a file. arg: u16 = constant index (path string).
-    Import,
-    /// Selective import. arg1: u16 = path string, arg2: u16 = names list constant.
-    SelectiveImport,
-
-    // --- Deadline ---
-    /// Pop duration value, push deadline onto internal deadline stack.
-    DeadlineSetup,
-    /// Pop deadline from internal deadline stack.
-    DeadlineEnd,
-
-    // --- Enum ---
-    /// Build an enum variant value.
-    /// arg1: u16 = constant index (enum name), arg2: u16 = constant index (variant name),
-    /// arg3: u16 = field count. Fields are on stack.
-    BuildEnum,
-
-    // --- Match ---
-    /// Match an enum pattern. Checks enum_name + variant on the top of stack (dup'd match value).
-    /// arg1: u16 = constant index (enum name), arg2: u16 = constant index (variant name).
-    /// If match succeeds, pushes true; else pushes false.
-    MatchEnum,
-
-    // --- Loop control ---
-    /// Pop the top iterator from the iterator stack (cleanup on break from for-in).
-    PopIterator,
-
-    // --- Defaults ---
-    /// Push the number of arguments passed to the current function call.
-    GetArgc,
-
-    // --- Type checking ---
-    /// Runtime type check on a variable.
-    /// arg1: u16 = constant index (variable name),
-    /// arg2: u16 = constant index (expected type name).
-    /// Throws a TypeError if the variable's type doesn't match.
-    CheckType,
-
-    // --- Result try operator ---
-    /// Try-unwrap: if top is Result.Ok(v), replace with v. If Result.Err(e), return it.
-    TryUnwrap,
-    /// Wrap top of stack in Result.Ok unless it is already a Result.
-    TryWrapOk,
-
-    // --- Spread call ---
-    /// Call with spread arguments. Stack: [callee, args_list] -> result.
-    CallSpread,
-    /// Direct builtin call. Followed by u64 builtin ID, u16 name constant, u8 arg count.
-    /// Runtime still checks closure shadowing before using the ID.
-    CallBuiltin,
-    /// Direct builtin spread call. Followed by u64 builtin ID and u16 name constant.
-    /// Stack: [args_list] -> result.
-    CallBuiltinSpread,
-    /// Method call with spread arguments. Stack: [object, args_list] -> result.
-    /// Followed by 2 bytes for method name constant index.
-    MethodCallSpread,
-
-    // --- Misc ---
-    /// Duplicate top of stack.
-    Dup,
-    /// Swap top two stack values.
-    Swap,
-    /// Membership test: stack has [item, collection]. Pushes bool.
-    /// Works for lists (item in list), dicts (key in dict), strings (substr in string), and sets.
-    Contains,
-
-    // --- Typed arithmetic/comparison fast paths ---
-    AddInt,
-    SubInt,
-    MulInt,
-    DivInt,
-    ModInt,
-    AddFloat,
-    SubFloat,
-    MulFloat,
-    DivFloat,
-    ModFloat,
-    EqualInt,
-    NotEqualInt,
-    LessInt,
-    GreaterInt,
-    LessEqualInt,
-    GreaterEqualInt,
-    EqualFloat,
-    NotEqualFloat,
-    LessFloat,
-    GreaterFloat,
-    LessEqualFloat,
-    GreaterEqualFloat,
-    EqualBool,
-    NotEqualBool,
-    EqualString,
-    NotEqualString,
-
-    /// Yield a value from a generator. Pops value, sends through channel, suspends.
-    Yield,
-
-    // --- Slot-indexed locals ---
-    /// Get a frame-local slot. arg: u16 slot index.
-    GetLocalSlot,
-    /// Define or initialize a frame-local slot. Pops value from stack.
-    DefLocalSlot,
-    /// Assign an existing frame-local slot. Pops value from stack.
-    SetLocalSlot,
-}
-
-impl Op {
-    pub(crate) const ALL: &'static [Self] = &[
-        Op::Constant,
-        Op::Nil,
-        Op::True,
-        Op::False,
-        Op::GetVar,
-        Op::DefLet,
-        Op::DefVar,
-        Op::SetVar,
-        Op::PushScope,
-        Op::PopScope,
-        Op::Add,
-        Op::Sub,
-        Op::Mul,
-        Op::Div,
-        Op::Mod,
-        Op::Pow,
-        Op::Negate,
-        Op::Equal,
-        Op::NotEqual,
-        Op::Less,
-        Op::Greater,
-        Op::LessEqual,
-        Op::GreaterEqual,
-        Op::Not,
-        Op::Jump,
-        Op::JumpIfFalse,
-        Op::JumpIfTrue,
-        Op::Pop,
-        Op::Call,
-        Op::TailCall,
-        Op::Return,
-        Op::Closure,
-        Op::BuildList,
-        Op::BuildDict,
-        Op::Subscript,
-        Op::SubscriptOpt,
-        Op::Slice,
-        Op::GetProperty,
-        Op::GetPropertyOpt,
-        Op::SetProperty,
-        Op::SetSubscript,
-        Op::MethodCall,
-        Op::MethodCallOpt,
-        Op::Concat,
-        Op::IterInit,
-        Op::IterNext,
-        Op::Pipe,
-        Op::Throw,
-        Op::TryCatchSetup,
-        Op::PopHandler,
-        Op::Parallel,
-        Op::ParallelMap,
-        Op::ParallelMapStream,
-        Op::ParallelSettle,
-        Op::Spawn,
-        Op::SyncMutexEnter,
-        Op::Import,
-        Op::SelectiveImport,
-        Op::DeadlineSetup,
-        Op::DeadlineEnd,
-        Op::BuildEnum,
-        Op::MatchEnum,
-        Op::PopIterator,
-        Op::GetArgc,
-        Op::CheckType,
-        Op::TryUnwrap,
-        Op::TryWrapOk,
-        Op::CallSpread,
-        Op::CallBuiltin,
-        Op::CallBuiltinSpread,
-        Op::MethodCallSpread,
-        Op::Dup,
-        Op::Swap,
-        Op::Contains,
-        Op::AddInt,
-        Op::SubInt,
-        Op::MulInt,
-        Op::DivInt,
-        Op::ModInt,
-        Op::AddFloat,
-        Op::SubFloat,
-        Op::MulFloat,
-        Op::DivFloat,
-        Op::ModFloat,
-        Op::EqualInt,
-        Op::NotEqualInt,
-        Op::LessInt,
-        Op::GreaterInt,
-        Op::LessEqualInt,
-        Op::GreaterEqualInt,
-        Op::EqualFloat,
-        Op::NotEqualFloat,
-        Op::LessFloat,
-        Op::GreaterFloat,
-        Op::LessEqualFloat,
-        Op::GreaterEqualFloat,
-        Op::EqualBool,
-        Op::NotEqualBool,
-        Op::EqualString,
-        Op::NotEqualString,
-        Op::Yield,
-        Op::GetLocalSlot,
-        Op::DefLocalSlot,
-        Op::SetLocalSlot,
-    ];
-
-    pub(crate) fn from_byte(byte: u8) -> Option<Self> {
-        Self::ALL.get(byte as usize).copied()
-    }
-}
+/// Bytecode opcodes for the Harn VM. The enum, the byte-to-variant
+/// mapping, the sync and async dispatch tables, the disassembly
+/// renderer, and the per-opcode classification helpers are all emitted
+/// by `harn_opcode_macros::define_opcodes!` in [`crate::vm::ops`].
+/// Re-exported here so callers that import `crate::chunk::Op` need no
+/// awareness of the macro layout.
+pub use crate::vm::ops::Op;
+pub(crate) use crate::vm::ops::{is_adaptive_binary_op, op_reads_outer_name};
 
 /// A constant value in the constant pool.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -877,34 +523,6 @@ impl Chunk {
         }
     }
 
-    /// Opcodes that perform a runtime env-based name lookup or
-    /// assignment. Emitting any of these marks the chunk as needing the
-    /// caller-scope late-bind walk in [`Vm::closure_call_env`].
-    ///
-    /// `Op::Call` / `Op::TailCall` / `Op::Pipe` make the list because
-    /// the compiler emits `Op::Constant("name") + Op::TailCall` for
-    /// `return fn_name(...)` (see `compile_return` in
-    /// `compiler/statements.rs`) — the callee is materialized on the
-    /// stack as a String and resolved through
-    /// [`Vm::resolve_named_closure`] at dispatch time, which is exactly
-    /// the path the walk feeds. Excluding them would silently break
-    /// mutual recursion across a tail-call boundary.
-    #[inline]
-    pub(crate) fn op_reads_outer_name(op: Op) -> bool {
-        matches!(
-            op,
-            Op::GetVar
-                | Op::SetVar
-                | Op::CallBuiltin
-                | Op::CallBuiltinSpread
-                | Op::CallSpread
-                | Op::Call
-                | Op::TailCall
-                | Op::Pipe
-                | Op::CheckType
-        )
-    }
-
     /// Set the current column for subsequent emit calls.
     pub fn set_column(&mut self, col: u32) {
         self.current_col = col;
@@ -932,7 +550,7 @@ impl Chunk {
         if is_adaptive_binary_op(op) {
             self.register_inline_cache(op_offset);
         }
-        if Self::op_reads_outer_name(op) {
+        if op_reads_outer_name(op) {
             self.references_outer_names = true;
         }
     }
@@ -956,7 +574,7 @@ impl Chunk {
         ) {
             self.register_inline_cache(op_offset);
         }
-        if Self::op_reads_outer_name(op) {
+        if op_reads_outer_name(op) {
             self.references_outer_names = true;
         }
     }
@@ -974,7 +592,7 @@ impl Chunk {
         if matches!(op, Op::Call) {
             self.register_inline_cache(op_offset);
         }
-        if Self::op_reads_outer_name(op) {
+        if op_reads_outer_name(op) {
             self.references_outer_names = true;
         }
     }
@@ -1344,367 +962,160 @@ impl Chunk {
         ])
     }
 
-    /// Disassemble for debugging.
+    /// Disassemble the chunk for debugging. The per-opcode rendering is
+    /// macro-generated alongside the dispatch tables in
+    /// `crate::vm::ops` — see [`Self::disassemble_op`].
     pub fn disassemble(&self, name: &str) -> String {
         let mut out = format!("== {name} ==\n");
         let mut ip = 0;
         while ip < self.code.len() {
-            let op = self.code[ip];
+            let op_byte = self.code[ip];
             let line = self.lines.get(ip).copied().unwrap_or(0);
             out.push_str(&format!("{ip:04} [{line:>4}] "));
             ip += 1;
 
-            match op {
-                x if x == Op::Constant as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    let val = &self.constants[idx as usize];
-                    out.push_str(&format!("CONSTANT {idx:>4} ({val})\n"));
-                }
-                x if x == Op::Nil as u8 => out.push_str("NIL\n"),
-                x if x == Op::True as u8 => out.push_str("TRUE\n"),
-                x if x == Op::False as u8 => out.push_str("FALSE\n"),
-                x if x == Op::GetVar as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "GET_VAR {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::DefLet as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "DEF_LET {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::DefVar as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "DEF_VAR {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::SetVar as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "SET_VAR {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::GetLocalSlot as u8 => {
-                    let slot = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("GET_LOCAL_SLOT {slot:>4}"));
-                    if let Some(info) = self.local_slots.get(slot as usize) {
-                        out.push_str(&format!(" ({})", info.name));
-                    }
-                    out.push('\n');
-                }
-                x if x == Op::DefLocalSlot as u8 => {
-                    let slot = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("DEF_LOCAL_SLOT {slot:>4}"));
-                    if let Some(info) = self.local_slots.get(slot as usize) {
-                        out.push_str(&format!(" ({})", info.name));
-                    }
-                    out.push('\n');
-                }
-                x if x == Op::SetLocalSlot as u8 => {
-                    let slot = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("SET_LOCAL_SLOT {slot:>4}"));
-                    if let Some(info) = self.local_slots.get(slot as usize) {
-                        out.push_str(&format!(" ({})", info.name));
-                    }
-                    out.push('\n');
-                }
-                x if x == Op::PushScope as u8 => out.push_str("PUSH_SCOPE\n"),
-                x if x == Op::PopScope as u8 => out.push_str("POP_SCOPE\n"),
-                x if x == Op::Add as u8 => out.push_str("ADD\n"),
-                x if x == Op::Sub as u8 => out.push_str("SUB\n"),
-                x if x == Op::Mul as u8 => out.push_str("MUL\n"),
-                x if x == Op::Div as u8 => out.push_str("DIV\n"),
-                x if x == Op::Mod as u8 => out.push_str("MOD\n"),
-                x if x == Op::Pow as u8 => out.push_str("POW\n"),
-                x if x == Op::Negate as u8 => out.push_str("NEGATE\n"),
-                x if x == Op::Equal as u8 => out.push_str("EQUAL\n"),
-                x if x == Op::NotEqual as u8 => out.push_str("NOT_EQUAL\n"),
-                x if x == Op::Less as u8 => out.push_str("LESS\n"),
-                x if x == Op::Greater as u8 => out.push_str("GREATER\n"),
-                x if x == Op::LessEqual as u8 => out.push_str("LESS_EQUAL\n"),
-                x if x == Op::GreaterEqual as u8 => out.push_str("GREATER_EQUAL\n"),
-                x if x == Op::Contains as u8 => out.push_str("CONTAINS\n"),
-                x if x == Op::Not as u8 => out.push_str("NOT\n"),
-                x if x == Op::Jump as u8 => {
-                    let target = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("JUMP {target:>4}\n"));
-                }
-                x if x == Op::JumpIfFalse as u8 => {
-                    let target = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("JUMP_IF_FALSE {target:>4}\n"));
-                }
-                x if x == Op::JumpIfTrue as u8 => {
-                    let target = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("JUMP_IF_TRUE {target:>4}\n"));
-                }
-                x if x == Op::Pop as u8 => out.push_str("POP\n"),
-                x if x == Op::Call as u8 => {
-                    let argc = self.code[ip];
-                    ip += 1;
-                    out.push_str(&format!("CALL {argc:>4}\n"));
-                }
-                x if x == Op::TailCall as u8 => {
-                    let argc = self.code[ip];
-                    ip += 1;
-                    out.push_str(&format!("TAIL_CALL {argc:>4}\n"));
-                }
-                x if x == Op::Return as u8 => out.push_str("RETURN\n"),
-                x if x == Op::Closure as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("CLOSURE {idx:>4}\n"));
-                }
-                x if x == Op::BuildList as u8 => {
-                    let count = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("BUILD_LIST {count:>4}\n"));
-                }
-                x if x == Op::BuildDict as u8 => {
-                    let count = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("BUILD_DICT {count:>4}\n"));
-                }
-                x if x == Op::Subscript as u8 => out.push_str("SUBSCRIPT\n"),
-                x if x == Op::SubscriptOpt as u8 => out.push_str("SUBSCRIPT_OPT\n"),
-                x if x == Op::Slice as u8 => out.push_str("SLICE\n"),
-                x if x == Op::GetProperty as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "GET_PROPERTY {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::GetPropertyOpt as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "GET_PROPERTY_OPT {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::SetProperty as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "SET_PROPERTY {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::SetSubscript as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "SET_SUBSCRIPT {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::MethodCall as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    let argc = self.code[ip];
-                    ip += 1;
-                    out.push_str(&format!(
-                        "METHOD_CALL {:>4} ({}) argc={}\n",
-                        idx, self.constants[idx as usize], argc
-                    ));
-                }
-                x if x == Op::MethodCallOpt as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    let argc = self.code[ip];
-                    ip += 1;
-                    out.push_str(&format!(
-                        "METHOD_CALL_OPT {:>4} ({}) argc={}\n",
-                        idx, self.constants[idx as usize], argc
-                    ));
-                }
-                x if x == Op::Concat as u8 => {
-                    let count = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("CONCAT {count:>4}\n"));
-                }
-                x if x == Op::IterInit as u8 => out.push_str("ITER_INIT\n"),
-                x if x == Op::IterNext as u8 => {
-                    let target = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("ITER_NEXT {target:>4}\n"));
-                }
-                x if x == Op::Throw as u8 => out.push_str("THROW\n"),
-                x if x == Op::TryCatchSetup as u8 => {
-                    let target = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!("TRY_CATCH_SETUP {target:>4}\n"));
-                }
-                x if x == Op::PopHandler as u8 => out.push_str("POP_HANDLER\n"),
-                x if x == Op::Pipe as u8 => out.push_str("PIPE\n"),
-                x if x == Op::Parallel as u8 => out.push_str("PARALLEL\n"),
-                x if x == Op::ParallelMap as u8 => out.push_str("PARALLEL_MAP\n"),
-                x if x == Op::ParallelMapStream as u8 => out.push_str("PARALLEL_MAP_STREAM\n"),
-                x if x == Op::ParallelSettle as u8 => out.push_str("PARALLEL_SETTLE\n"),
-                x if x == Op::Spawn as u8 => out.push_str("SPAWN\n"),
-                x if x == Op::Import as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "IMPORT {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::SelectiveImport as u8 => {
-                    let path_idx = self.read_u16(ip);
-                    ip += 2;
-                    let names_idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "SELECTIVE_IMPORT {:>4} ({}) names: {:>4} ({})\n",
-                        path_idx,
-                        self.constants[path_idx as usize],
-                        names_idx,
-                        self.constants[names_idx as usize]
-                    ));
-                }
-                x if x == Op::SyncMutexEnter as u8 => {
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "SYNC_MUTEX_ENTER {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::DeadlineSetup as u8 => out.push_str("DEADLINE_SETUP\n"),
-                x if x == Op::DeadlineEnd as u8 => out.push_str("DEADLINE_END\n"),
-                x if x == Op::BuildEnum as u8 => {
-                    let enum_idx = self.read_u16(ip);
-                    ip += 2;
-                    let variant_idx = self.read_u16(ip);
-                    ip += 2;
-                    let field_count = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "BUILD_ENUM {:>4} ({}) {:>4} ({}) fields={}\n",
-                        enum_idx,
-                        self.constants[enum_idx as usize],
-                        variant_idx,
-                        self.constants[variant_idx as usize],
-                        field_count
-                    ));
-                }
-                x if x == Op::MatchEnum as u8 => {
-                    let enum_idx = self.read_u16(ip);
-                    ip += 2;
-                    let variant_idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "MATCH_ENUM {:>4} ({}) {:>4} ({})\n",
-                        enum_idx,
-                        self.constants[enum_idx as usize],
-                        variant_idx,
-                        self.constants[variant_idx as usize]
-                    ));
-                }
-                x if x == Op::PopIterator as u8 => out.push_str("POP_ITERATOR\n"),
-                x if x == Op::TryUnwrap as u8 => out.push_str("TRY_UNWRAP\n"),
-                x if x == Op::TryWrapOk as u8 => out.push_str("TRY_WRAP_OK\n"),
-                x if x == Op::CallSpread as u8 => out.push_str("CALL_SPREAD\n"),
-                x if x == Op::CallBuiltin as u8 => {
-                    let id = self.read_u64(ip);
-                    ip += 8;
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    let argc = self.code[ip];
-                    ip += 1;
-                    out.push_str(&format!(
-                        "CALL_BUILTIN {id:#018x} {:>4} ({}) argc={}\n",
-                        idx, self.constants[idx as usize], argc
-                    ));
-                }
-                x if x == Op::CallBuiltinSpread as u8 => {
-                    let id = self.read_u64(ip);
-                    ip += 8;
-                    let idx = self.read_u16(ip);
-                    ip += 2;
-                    out.push_str(&format!(
-                        "CALL_BUILTIN_SPREAD {id:#018x} {:>4} ({})\n",
-                        idx, self.constants[idx as usize]
-                    ));
-                }
-                x if x == Op::MethodCallSpread as u8 => {
-                    let idx = self.read_u16(ip + 1);
-                    ip += 2;
-                    out.push_str(&format!("METHOD_CALL_SPREAD {idx}\n"));
-                }
-                x if x == Op::Dup as u8 => out.push_str("DUP\n"),
-                x if x == Op::Swap as u8 => out.push_str("SWAP\n"),
-                x if x == Op::AddInt as u8 => out.push_str("ADD_INT\n"),
-                x if x == Op::SubInt as u8 => out.push_str("SUB_INT\n"),
-                x if x == Op::MulInt as u8 => out.push_str("MUL_INT\n"),
-                x if x == Op::DivInt as u8 => out.push_str("DIV_INT\n"),
-                x if x == Op::ModInt as u8 => out.push_str("MOD_INT\n"),
-                x if x == Op::AddFloat as u8 => out.push_str("ADD_FLOAT\n"),
-                x if x == Op::SubFloat as u8 => out.push_str("SUB_FLOAT\n"),
-                x if x == Op::MulFloat as u8 => out.push_str("MUL_FLOAT\n"),
-                x if x == Op::DivFloat as u8 => out.push_str("DIV_FLOAT\n"),
-                x if x == Op::ModFloat as u8 => out.push_str("MOD_FLOAT\n"),
-                x if x == Op::EqualInt as u8 => out.push_str("EQUAL_INT\n"),
-                x if x == Op::NotEqualInt as u8 => out.push_str("NOT_EQUAL_INT\n"),
-                x if x == Op::LessInt as u8 => out.push_str("LESS_INT\n"),
-                x if x == Op::GreaterInt as u8 => out.push_str("GREATER_INT\n"),
-                x if x == Op::LessEqualInt as u8 => out.push_str("LESS_EQUAL_INT\n"),
-                x if x == Op::GreaterEqualInt as u8 => out.push_str("GREATER_EQUAL_INT\n"),
-                x if x == Op::EqualFloat as u8 => out.push_str("EQUAL_FLOAT\n"),
-                x if x == Op::NotEqualFloat as u8 => out.push_str("NOT_EQUAL_FLOAT\n"),
-                x if x == Op::LessFloat as u8 => out.push_str("LESS_FLOAT\n"),
-                x if x == Op::GreaterFloat as u8 => out.push_str("GREATER_FLOAT\n"),
-                x if x == Op::LessEqualFloat as u8 => out.push_str("LESS_EQUAL_FLOAT\n"),
-                x if x == Op::GreaterEqualFloat as u8 => out.push_str("GREATER_EQUAL_FLOAT\n"),
-                x if x == Op::EqualBool as u8 => out.push_str("EQUAL_BOOL\n"),
-                x if x == Op::NotEqualBool as u8 => out.push_str("NOT_EQUAL_BOOL\n"),
-                x if x == Op::EqualString as u8 => out.push_str("EQUAL_STRING\n"),
-                x if x == Op::NotEqualString as u8 => out.push_str("NOT_EQUAL_STRING\n"),
-                x if x == Op::Yield as u8 => out.push_str("YIELD\n"),
-                _ => {
-                    out.push_str(&format!("UNKNOWN(0x{op:02x})\n"));
-                }
+            if let Some(op) = Op::from_byte(op_byte) {
+                self.disassemble_op(op, &mut ip, &mut out);
+            } else {
+                out.push_str(&format!("UNKNOWN(0x{op_byte:02x})\n"));
             }
         }
         out
     }
 }
 
-fn is_adaptive_binary_op(op: Op) -> bool {
-    matches!(
-        op,
-        Op::Add
-            | Op::Sub
-            | Op::Mul
-            | Op::Div
-            | Op::Mod
-            | Op::Equal
-            | Op::NotEqual
-            | Op::Less
-            | Op::Greater
-            | Op::LessEqual
-            | Op::GreaterEqual
+/// Disassembly helpers consumed by the macro-generated
+/// [`Chunk::disassemble_op`]. Each helper takes the current code position
+/// (already advanced past the opcode byte), advances it over the operand
+/// bytes the opcode carries, and renders one human-readable line without
+/// a trailing newline (the dispatcher appends it).
+///
+/// Defining one helper per operand layout — and not one per opcode —
+/// keeps adding an opcode a one-line edit in the `define_opcodes!` table
+/// rather than a paired edit here. New layouts live with the helpers;
+/// new opcodes live with the dispatch.
+pub(crate) fn disasm_bare(_chunk: &Chunk, _ip: &mut usize, label: &str) -> String {
+    label.to_string()
+}
+
+pub(crate) fn disasm_u8(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let arg = chunk.code[*ip];
+    *ip += 1;
+    format!("{label} {arg:>4}")
+}
+
+pub(crate) fn disasm_u16(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let arg = chunk.read_u16(*ip);
+    *ip += 2;
+    format!("{label} {arg:>4}")
+}
+
+pub(crate) fn disasm_const_pool_u16(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let idx = chunk.read_u16(*ip);
+    *ip += 2;
+    format!("{label} {idx:>4} ({})", chunk.constants[idx as usize])
+}
+
+pub(crate) fn disasm_local_slot_u16(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let slot = chunk.read_u16(*ip);
+    *ip += 2;
+    let mut out = format!("{label} {slot:>4}");
+    if let Some(info) = chunk.local_slots.get(slot as usize) {
+        out.push_str(&format!(" ({})", info.name));
+    }
+    out
+}
+
+pub(crate) fn disasm_method_call(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let idx = chunk.read_u16(*ip);
+    *ip += 2;
+    let argc = chunk.code[*ip];
+    *ip += 1;
+    format!(
+        "{label} {idx:>4} ({}) argc={argc}",
+        chunk.constants[idx as usize]
     )
+}
+
+pub(crate) fn disasm_match_enum(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let enum_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    let var_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    format!(
+        "{label} {enum_idx:>4} ({}) {var_idx:>4} ({})",
+        chunk.constants[enum_idx as usize], chunk.constants[var_idx as usize],
+    )
+}
+
+pub(crate) fn disasm_build_enum(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let enum_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    let var_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    let field_count = chunk.read_u16(*ip);
+    *ip += 2;
+    format!(
+        "{label} {enum_idx:>4} ({}) {var_idx:>4} ({}) fields={field_count}",
+        chunk.constants[enum_idx as usize], chunk.constants[var_idx as usize],
+    )
+}
+
+pub(crate) fn disasm_selective_import(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let path_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    let names_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    format!(
+        "{label} {path_idx:>4} ({}) names: {names_idx:>4} ({})",
+        chunk.constants[path_idx as usize], chunk.constants[names_idx as usize],
+    )
+}
+
+pub(crate) fn disasm_check_type(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let var_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    let type_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    format!(
+        "{label} {var_idx:>4} ({}) -> {type_idx:>4} ({})",
+        chunk.constants[var_idx as usize], chunk.constants[type_idx as usize],
+    )
+}
+
+pub(crate) fn disasm_call_builtin(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let id = chunk.read_u64(*ip);
+    *ip += 8;
+    let idx = chunk.read_u16(*ip);
+    *ip += 2;
+    let argc = chunk.code[*ip];
+    *ip += 1;
+    format!(
+        "{label} {id:#018x} {idx:>4} ({}) argc={argc}",
+        chunk.constants[idx as usize],
+    )
+}
+
+pub(crate) fn disasm_call_builtin_spread(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let id = chunk.read_u64(*ip);
+    *ip += 8;
+    let idx = chunk.read_u16(*ip);
+    *ip += 2;
+    format!(
+        "{label} {id:#018x} {idx:>4} ({})",
+        chunk.constants[idx as usize],
+    )
+}
+
+pub(crate) fn disasm_method_call_spread(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    // emit_u16(Op::MethodCallSpread, name_idx, ...) writes opcode + 2
+    // bytes of u16 name_idx, so the operand is read at *ip with the
+    // usual `read_u16`. The previous hand-written disasm read at
+    // `ip + 1`, which displayed the wrong constant index — silently
+    // corrupting any disassembly that hit a `MethodCallSpread` opcode.
+    let idx = chunk.read_u16(*ip);
+    *ip += 2;
+    format!("{label} {idx:>4} ({})", chunk.constants[idx as usize])
 }
 
 impl Default for Chunk {
@@ -1730,6 +1141,38 @@ mod tests {
             assert_eq!(Op::from_byte(byte as u8), Some(op));
         }
         assert_eq!(Op::from_byte(Op::ALL.len() as u8), None);
+        assert_eq!(Op::COUNT, Op::ALL.len());
+    }
+
+    #[test]
+    fn disassemble_covers_every_opcode_variant() {
+        // The macro-generated `disassemble_op` match is exhaustive on
+        // `Op`, so this is a compile-time guarantee. The runtime check
+        // pins that no helper falls through to `UNKNOWN(...)` for a
+        // valid opcode byte — catching any future macro refactor that
+        // silently drops a helper arm. Each opcode is exercised in
+        // isolation against a hand-built chunk so the test logic does
+        // not depend on operand sizes (and so a single short opcode
+        // does not bleed into reading trailing padding as a follow-on
+        // opcode in the chunk-level loop).
+        for op in Op::ALL.iter().copied() {
+            let mut chunk = Chunk::new();
+            chunk.add_constant(super::Constant::String("__probe__".to_string()));
+            // Pad to the worst-case operand width (CallBuiltin: u64 +
+            // u16 + u8 = 11 bytes) so any helper has well-formed bytes
+            // to consume regardless of its layout.
+            for _ in 0..16 {
+                chunk.code.push(0);
+            }
+            let mut ip: usize = 0;
+            let mut out = String::new();
+            chunk.disassemble_op(op, &mut ip, &mut out);
+            assert!(
+                !out.contains("UNKNOWN"),
+                "disasm emitted UNKNOWN for {op:?}: {out}",
+            );
+            assert!(!out.is_empty(), "disasm produced no output for {op:?}");
+        }
     }
 
     // --- references_outer_names tracking ---

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -9,7 +9,7 @@ mod interrupts;
 pub mod iter;
 mod methods;
 mod modules;
-mod ops;
+pub(crate) mod ops;
 mod scope;
 mod state;
 

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -1,3 +1,23 @@
+//! VM opcode dispatch.
+//!
+//! The `Op` enum, the byte-to-variant mapping, the sync and async
+//! dispatch tables, the disassembly renderer, and the per-opcode
+//! classification helpers (`op_reads_outer_name`, `is_adaptive_binary_op`)
+//! are all emitted by `harn_opcode_macros::define_opcodes!` from the
+//! single declarative table below. Adding or renaming an opcode is now a
+//! one-line edit instead of paired edits to four hand-maintained match
+//! tables — see issue #2584 for the migration that collapsed them.
+//!
+//! Each entry follows the shape
+//!
+//! ```ignore
+//! VariantName { <kind>(<expr>...), disasm: <helper>("<LABEL>") [, flags: [...]] };
+//! ```
+//!
+//! where `<kind>` selects the dispatch shape (`sync`, `sync_void`,
+//! `sync_return`, `split`, `async_op`) and the `<helper>` resolves to a
+//! `disasm_<helper>` free fn in `crate::chunk`.
+
 mod arithmetic;
 mod call;
 mod collections;
@@ -11,245 +31,169 @@ mod misc;
 mod parallel;
 mod stack;
 
-use crate::chunk::Op;
 use crate::value::{VmError, VmValue};
 
+harn_opcode_macros::define_opcodes! {
+    // === Constants & nil ===
+    Constant { sync(self.execute_constant()), disasm: const_pool_u16("CONSTANT") };
+    Nil { sync_void(self.execute_nil()), disasm: bare("NIL") };
+    True { sync_void(self.execute_true()), disasm: bare("TRUE") };
+    False { sync_void(self.execute_false()), disasm: bare("FALSE") };
+
+    // === Variables ===
+    GetVar { sync(self.execute_get_var()), disasm: const_pool_u16("GET_VAR"), flags: [reads_outer_name] };
+    DefLet { sync(self.execute_def_let()), disasm: const_pool_u16("DEF_LET") };
+    DefVar { sync(self.execute_def_var()), disasm: const_pool_u16("DEF_VAR") };
+    SetVar { sync(self.execute_set_var()), disasm: const_pool_u16("SET_VAR"), flags: [reads_outer_name] };
+    PushScope { sync_void(self.execute_push_scope()), disasm: bare("PUSH_SCOPE") };
+    PopScope { sync_void(self.execute_pop_scope()), disasm: bare("POP_SCOPE") };
+
+    // === Generic arithmetic (adaptive binary IC) ===
+    Add { sync(self.execute_add()), disasm: bare("ADD"), flags: [adaptive_binary] };
+    Sub { sync(self.execute_sub()), disasm: bare("SUB"), flags: [adaptive_binary] };
+    Mul { sync(self.execute_mul()), disasm: bare("MUL"), flags: [adaptive_binary] };
+    Div { sync(self.execute_div()), disasm: bare("DIV"), flags: [adaptive_binary] };
+    Mod { sync(self.execute_mod()), disasm: bare("MOD"), flags: [adaptive_binary] };
+    Pow { sync(self.execute_pow()), disasm: bare("POW") };
+    Negate { sync(self.execute_negate()), disasm: bare("NEGATE") };
+
+    // === Generic comparison (adaptive binary IC) ===
+    Equal { sync(self.execute_equal()), disasm: bare("EQUAL"), flags: [adaptive_binary] };
+    NotEqual { sync(self.execute_not_equal()), disasm: bare("NOT_EQUAL"), flags: [adaptive_binary] };
+    Less { sync(self.execute_less()), disasm: bare("LESS"), flags: [adaptive_binary] };
+    Greater { sync(self.execute_greater()), disasm: bare("GREATER"), flags: [adaptive_binary] };
+    LessEqual { sync(self.execute_less_equal()), disasm: bare("LESS_EQUAL"), flags: [adaptive_binary] };
+    GreaterEqual { sync(self.execute_greater_equal()), disasm: bare("GREATER_EQUAL"), flags: [adaptive_binary] };
+
+    // === Logical ===
+    Not { sync(self.execute_not()), disasm: bare("NOT") };
+
+    // === Control flow ===
+    Jump { sync_void(self.execute_jump()), disasm: u16("JUMP") };
+    JumpIfFalse { sync(self.execute_jump_if_false()), disasm: u16("JUMP_IF_FALSE") };
+    JumpIfTrue { sync(self.execute_jump_if_true()), disasm: u16("JUMP_IF_TRUE") };
+    Pop { sync(self.execute_pop()), disasm: bare("POP") };
+
+    // === Functions ===
+    Call { split(self.execute_call_sync(), self.execute_call_async().await), disasm: u8("CALL"), flags: [reads_outer_name] };
+    TailCall { split(self.execute_tail_call_sync(), self.execute_tail_call_async().await), disasm: u8("TAIL_CALL"), flags: [reads_outer_name] };
+    Return { sync_return(self.execute_return()), disasm: bare("RETURN") };
+    Closure { sync_void(self.execute_closure()), disasm: u16("CLOSURE") };
+
+    // === Collections ===
+    BuildList { sync_void(self.execute_build_list()), disasm: u16("BUILD_LIST") };
+    BuildDict { sync_void(self.execute_build_dict()), disasm: u16("BUILD_DICT") };
+    Subscript { sync(self.execute_subscript(false)), disasm: bare("SUBSCRIPT") };
+    SubscriptOpt { sync(self.execute_subscript(true)), disasm: bare("SUBSCRIPT_OPT") };
+    Slice { sync(self.execute_slice()), disasm: bare("SLICE") };
+
+    // === Object operations ===
+    GetProperty { sync(self.execute_get_property(false)), disasm: const_pool_u16("GET_PROPERTY") };
+    GetPropertyOpt { sync(self.execute_get_property(true)), disasm: const_pool_u16("GET_PROPERTY_OPT") };
+    SetProperty { sync(self.execute_set_property()), disasm: const_pool_u16("SET_PROPERTY") };
+    SetSubscript { sync(self.execute_set_subscript()), disasm: const_pool_u16("SET_SUBSCRIPT") };
+    MethodCall { split(self.execute_method_call_sync(false), self.execute_method_call(false).await), disasm: method_call("METHOD_CALL") };
+    MethodCallOpt { split(self.execute_method_call_sync(true), self.execute_method_call(true).await), disasm: method_call("METHOD_CALL_OPT") };
+
+    // === Strings ===
+    Concat { sync_void(self.execute_concat()), disasm: u16("CONCAT") };
+
+    // === Iteration ===
+    IterInit { sync(self.execute_iter_init()), disasm: bare("ITER_INIT") };
+    IterNext { split(self.execute_iter_next_sync(), self.execute_iter_next_async().await), disasm: u16("ITER_NEXT") };
+
+    // === Pipe (async) ===
+    Pipe { async_op(self.execute_pipe().await), disasm: bare("PIPE"), flags: [reads_outer_name] };
+
+    // === Error handling ===
+    Throw { sync(self.execute_throw()), disasm: bare("THROW") };
+    TryCatchSetup { sync_void(self.execute_try_catch_setup()), disasm: u16("TRY_CATCH_SETUP") };
+    PopHandler { sync_void(self.execute_pop_handler()), disasm: bare("POP_HANDLER") };
+
+    // === Concurrency ===
+    Parallel { async_op(self.execute_parallel().await), disasm: bare("PARALLEL") };
+    ParallelMap { async_op(self.execute_parallel_map().await), disasm: bare("PARALLEL_MAP") };
+    ParallelMapStream { async_op(self.execute_parallel_map_stream().await), disasm: bare("PARALLEL_MAP_STREAM") };
+    ParallelSettle { async_op(self.execute_parallel_settle().await), disasm: bare("PARALLEL_SETTLE") };
+    Spawn { sync(self.execute_spawn()), disasm: bare("SPAWN") };
+    SyncMutexEnter { async_op(self.execute_sync_mutex_enter().await), disasm: const_pool_u16("SYNC_MUTEX_ENTER") };
+
+    // === Imports (async) ===
+    Import { async_op(self.execute_import_op().await), disasm: const_pool_u16("IMPORT") };
+    SelectiveImport { async_op(self.execute_selective_import().await), disasm: selective_import("SELECTIVE_IMPORT") };
+
+    // === Deadline ===
+    DeadlineSetup { sync(self.execute_deadline_setup()), disasm: bare("DEADLINE_SETUP") };
+    DeadlineEnd { sync_void(self.execute_deadline_end()), disasm: bare("DEADLINE_END") };
+
+    // === Enum ===
+    BuildEnum { sync(self.execute_build_enum()), disasm: build_enum("BUILD_ENUM") };
+    MatchEnum { sync(self.execute_match_enum()), disasm: match_enum("MATCH_ENUM") };
+
+    // === Loop control ===
+    PopIterator { sync_void(self.execute_pop_iterator()), disasm: bare("POP_ITERATOR") };
+
+    // === Defaults ===
+    GetArgc { sync_void(self.execute_get_argc()), disasm: bare("GET_ARGC") };
+
+    // === Type checking ===
+    CheckType { sync(self.execute_check_type()), disasm: check_type("CHECK_TYPE"), flags: [reads_outer_name] };
+
+    // === Result try operator ===
+    TryUnwrap { sync(self.execute_try_unwrap()), disasm: bare("TRY_UNWRAP") };
+    TryWrapOk { sync(self.execute_try_wrap_ok()), disasm: bare("TRY_WRAP_OK") };
+
+    // === Spread calls ===
+    CallSpread { async_op(self.execute_call_spread().await), disasm: bare("CALL_SPREAD"), flags: [reads_outer_name] };
+    CallBuiltin { split(self.execute_call_builtin_sync(), self.execute_call_builtin_async().await), disasm: call_builtin("CALL_BUILTIN"), flags: [reads_outer_name] };
+    CallBuiltinSpread { async_op(self.execute_call_builtin_spread().await), disasm: call_builtin_spread("CALL_BUILTIN_SPREAD"), flags: [reads_outer_name] };
+    MethodCallSpread { async_op(self.execute_method_call_spread().await), disasm: method_call_spread("METHOD_CALL_SPREAD") };
+
+    // === Misc ===
+    Dup { sync(self.execute_dup()), disasm: bare("DUP") };
+    Swap { sync_void(self.execute_swap()), disasm: bare("SWAP") };
+    Contains { sync(self.execute_contains()), disasm: bare("CONTAINS") };
+
+    // === Typed arithmetic fast paths ===
+    AddInt { sync(self.execute_add_int()), disasm: bare("ADD_INT") };
+    SubInt { sync(self.execute_sub_int()), disasm: bare("SUB_INT") };
+    MulInt { sync(self.execute_mul_int()), disasm: bare("MUL_INT") };
+    DivInt { sync(self.execute_div_int()), disasm: bare("DIV_INT") };
+    ModInt { sync(self.execute_mod_int()), disasm: bare("MOD_INT") };
+    AddFloat { sync(self.execute_add_float()), disasm: bare("ADD_FLOAT") };
+    SubFloat { sync(self.execute_sub_float()), disasm: bare("SUB_FLOAT") };
+    MulFloat { sync(self.execute_mul_float()), disasm: bare("MUL_FLOAT") };
+    DivFloat { sync(self.execute_div_float()), disasm: bare("DIV_FLOAT") };
+    ModFloat { sync(self.execute_mod_float()), disasm: bare("MOD_FLOAT") };
+
+    // === Typed comparison fast paths ===
+    EqualInt { sync(self.execute_equal_int()), disasm: bare("EQUAL_INT") };
+    NotEqualInt { sync(self.execute_not_equal_int()), disasm: bare("NOT_EQUAL_INT") };
+    LessInt { sync(self.execute_less_int()), disasm: bare("LESS_INT") };
+    GreaterInt { sync(self.execute_greater_int()), disasm: bare("GREATER_INT") };
+    LessEqualInt { sync(self.execute_less_equal_int()), disasm: bare("LESS_EQUAL_INT") };
+    GreaterEqualInt { sync(self.execute_greater_equal_int()), disasm: bare("GREATER_EQUAL_INT") };
+    EqualFloat { sync(self.execute_equal_float()), disasm: bare("EQUAL_FLOAT") };
+    NotEqualFloat { sync(self.execute_not_equal_float()), disasm: bare("NOT_EQUAL_FLOAT") };
+    LessFloat { sync(self.execute_less_float()), disasm: bare("LESS_FLOAT") };
+    GreaterFloat { sync(self.execute_greater_float()), disasm: bare("GREATER_FLOAT") };
+    LessEqualFloat { sync(self.execute_less_equal_float()), disasm: bare("LESS_EQUAL_FLOAT") };
+    GreaterEqualFloat { sync(self.execute_greater_equal_float()), disasm: bare("GREATER_EQUAL_FLOAT") };
+    EqualBool { sync(self.execute_equal_bool()), disasm: bare("EQUAL_BOOL") };
+    NotEqualBool { sync(self.execute_not_equal_bool()), disasm: bare("NOT_EQUAL_BOOL") };
+    EqualString { sync(self.execute_equal_string()), disasm: bare("EQUAL_STRING") };
+    NotEqualString { sync(self.execute_not_equal_string()), disasm: bare("NOT_EQUAL_STRING") };
+
+    // === Generators (async) ===
+    Yield { async_op(self.execute_yield().await), disasm: bare("YIELD") };
+
+    // === Slot-indexed locals ===
+    GetLocalSlot { sync(self.execute_get_local_slot()), disasm: local_slot_u16("GET_LOCAL_SLOT") };
+    DefLocalSlot { sync(self.execute_def_local_slot()), disasm: local_slot_u16("DEF_LOCAL_SLOT") };
+    SetLocalSlot { sync(self.execute_set_local_slot()), disasm: local_slot_u16("SET_LOCAL_SLOT") };
+}
+
 impl super::Vm {
-    /// Execute a single opcode in a non-`async` context.
-    ///
-    /// Returns `Some(result)` for sync opcodes (the vast majority — arithmetic,
-    /// comparison, jumps, slot ops, etc.) and `None` for opcodes that must
-    /// `.await` (calls, method dispatch, iter-next, pipe, parallel families,
-    /// imports, yield). The interpreter's hot loop tries this first to skip
-    /// the per-iteration future-state-machine overhead that the unified async
-    /// dispatcher used to pay on every opcode.
-    ///
-    /// Coverage parity with [`execute_op_async`] is enforced by the
-    /// exhaustive match: a newly added opcode forces a `match` update and the
-    /// fall-through arm classifies it as sync-vs-async explicitly.
-    pub(super) fn execute_op_sync(&mut self, op: Op) -> Option<Result<(), VmError>> {
-        let result: Result<(), VmError> = match op {
-            Op::Constant => self.execute_constant(),
-            Op::Nil => {
-                self.execute_nil();
-                Ok(())
-            }
-            Op::True => {
-                self.execute_true();
-                Ok(())
-            }
-            Op::False => {
-                self.execute_false();
-                Ok(())
-            }
-            Op::GetVar => self.execute_get_var(),
-            Op::DefLet => self.execute_def_let(),
-            Op::DefVar => self.execute_def_var(),
-            Op::SetVar => self.execute_set_var(),
-            Op::GetLocalSlot => self.execute_get_local_slot(),
-            Op::DefLocalSlot => self.execute_def_local_slot(),
-            Op::SetLocalSlot => self.execute_set_local_slot(),
-            Op::PushScope => {
-                self.execute_push_scope();
-                Ok(())
-            }
-            Op::PopScope => {
-                self.execute_pop_scope();
-                Ok(())
-            }
-            Op::Add => self.execute_add(),
-            Op::Sub => self.execute_sub(),
-            Op::Mul => self.execute_mul(),
-            Op::Div => self.execute_div(),
-            Op::Mod => self.execute_mod(),
-            Op::Pow => self.execute_pow(),
-            Op::Negate => self.execute_negate(),
-            Op::Equal => self.execute_equal(),
-            Op::NotEqual => self.execute_not_equal(),
-            Op::Less => self.execute_less(),
-            Op::Greater => self.execute_greater(),
-            Op::LessEqual => self.execute_less_equal(),
-            Op::GreaterEqual => self.execute_greater_equal(),
-            Op::Not => self.execute_not(),
-            Op::Jump => {
-                self.execute_jump();
-                Ok(())
-            }
-            Op::JumpIfFalse => self.execute_jump_if_false(),
-            Op::JumpIfTrue => self.execute_jump_if_true(),
-            Op::Pop => self.execute_pop(),
-            Op::Return => return Some(Err(self.execute_return())),
-            Op::Closure => {
-                self.execute_closure();
-                Ok(())
-            }
-            Op::BuildList => {
-                self.execute_build_list();
-                Ok(())
-            }
-            Op::BuildDict => {
-                self.execute_build_dict();
-                Ok(())
-            }
-            Op::Subscript => self.execute_subscript(false),
-            Op::SubscriptOpt => self.execute_subscript(true),
-            Op::Slice => self.execute_slice(),
-            Op::GetProperty => self.execute_get_property(false),
-            Op::GetPropertyOpt => self.execute_get_property(true),
-            Op::SetProperty => self.execute_set_property(),
-            Op::SetSubscript => self.execute_set_subscript(),
-            Op::Concat => {
-                self.execute_concat();
-                Ok(())
-            }
-            Op::IterInit => self.execute_iter_init(),
-            // IterNext is a split opcode: the sync fast path handles
-            // Vec/Dict/Range/empty iterators inline; if it returns `None`
-            // we hand off to `execute_op_async` for Channel/Generator/
-            // Stream/VmIter without having touched `ip`.
-            Op::IterNext => return self.execute_iter_next_sync(),
-            // Call is split: the sync fast path handles non-generator
-            // user closures with no `@step` definition attached. Other
-            // callee variants (string, builtin ref, etc.) return `None`
-            // and fall through to `execute_call_async` without touching
-            // `ip`.
-            Op::Call => return self.execute_call_sync(),
-            // CallBuiltin is the opcode `f(x)` compiles to and the
-            // actual hot dispatch for user closures. The sync fast path
-            // peeks the name from the inline operand, skips
-            // runtime-construct names (`await`/`cancel`/...), generators,
-            // and `@step`-decorated functions, then pushes the closure
-            // frame inline. Builtins and the listed escape hatches fall
-            // through to `execute_call_builtin_async` with `ip` untouched.
-            Op::CallBuiltin => return self.execute_call_builtin_sync(),
-            // TailCall is split: the sync fast path handles the
-            // steady-state user-closure tail call inline (TCO frame
-            // reuse). Tracked-function frames/callees, generators, and
-            // string/builtin-ref callees return `None` and fall through
-            // to `execute_tail_call_async`.
-            Op::TailCall => return self.execute_tail_call_sync(),
-            // MethodCall is split: optional-nil receivers, inline-cache
-            // hits, and receiver methods that are known to be synchronous
-            // complete here. Callback-taking collection methods and host
-            // capability methods fall through with `ip` untouched.
-            Op::MethodCall => return self.execute_method_call_sync(false),
-            Op::MethodCallOpt => return self.execute_method_call_sync(true),
-            Op::Throw => self.execute_throw(),
-            Op::TryCatchSetup => {
-                self.execute_try_catch_setup();
-                Ok(())
-            }
-            Op::PopHandler => {
-                self.execute_pop_handler();
-                Ok(())
-            }
-            Op::Spawn => self.execute_spawn(),
-            Op::DeadlineSetup => self.execute_deadline_setup(),
-            Op::DeadlineEnd => {
-                self.execute_deadline_end();
-                Ok(())
-            }
-            Op::BuildEnum => self.execute_build_enum(),
-            Op::MatchEnum => self.execute_match_enum(),
-            Op::PopIterator => {
-                self.execute_pop_iterator();
-                Ok(())
-            }
-            Op::GetArgc => {
-                self.execute_get_argc();
-                Ok(())
-            }
-            Op::CheckType => self.execute_check_type(),
-            Op::TryUnwrap => self.execute_try_unwrap(),
-            Op::TryWrapOk => self.execute_try_wrap_ok(),
-            Op::Dup => self.execute_dup(),
-            Op::Swap => {
-                self.execute_swap();
-                Ok(())
-            }
-            Op::Contains => self.execute_contains(),
-            Op::AddInt => self.execute_add_int(),
-            Op::SubInt => self.execute_sub_int(),
-            Op::MulInt => self.execute_mul_int(),
-            Op::DivInt => self.execute_div_int(),
-            Op::ModInt => self.execute_mod_int(),
-            Op::AddFloat => self.execute_add_float(),
-            Op::SubFloat => self.execute_sub_float(),
-            Op::MulFloat => self.execute_mul_float(),
-            Op::DivFloat => self.execute_div_float(),
-            Op::ModFloat => self.execute_mod_float(),
-            Op::EqualInt => self.execute_equal_int(),
-            Op::NotEqualInt => self.execute_not_equal_int(),
-            Op::LessInt => self.execute_less_int(),
-            Op::GreaterInt => self.execute_greater_int(),
-            Op::LessEqualInt => self.execute_less_equal_int(),
-            Op::GreaterEqualInt => self.execute_greater_equal_int(),
-            Op::EqualFloat => self.execute_equal_float(),
-            Op::NotEqualFloat => self.execute_not_equal_float(),
-            Op::LessFloat => self.execute_less_float(),
-            Op::GreaterFloat => self.execute_greater_float(),
-            Op::LessEqualFloat => self.execute_less_equal_float(),
-            Op::GreaterEqualFloat => self.execute_greater_equal_float(),
-            Op::EqualBool => self.execute_equal_bool(),
-            Op::NotEqualBool => self.execute_not_equal_bool(),
-            Op::EqualString => self.execute_equal_string(),
-            Op::NotEqualString => self.execute_not_equal_string(),
-            // Async-dispatched opcodes: caller must fall through to
-            // `execute_op_async`. Keeping these in a single explicit arm
-            // keeps the sync/async classification visible alongside the
-            // sync dispatch table.
-            Op::CallBuiltinSpread
-            | Op::Pipe
-            | Op::Parallel
-            | Op::ParallelMap
-            | Op::ParallelMapStream
-            | Op::ParallelSettle
-            | Op::SyncMutexEnter
-            | Op::Import
-            | Op::SelectiveImport
-            | Op::CallSpread
-            | Op::MethodCallSpread
-            | Op::Yield => return None,
-        };
-        Some(result)
-    }
-
-    /// Execute a single async opcode. The caller must have already verified
-    /// that [`execute_op_sync`] returned `None` for this opcode; reaching the
-    /// catch-all is a coverage bug between the two dispatch tables.
-    pub(super) async fn execute_op_async(&mut self, op: Op) -> Result<(), VmError> {
-        match op {
-            Op::Call => self.execute_call_async().await,
-            Op::CallBuiltin => self.execute_call_builtin_async().await,
-            Op::CallBuiltinSpread => self.execute_call_builtin_spread().await,
-            Op::TailCall => self.execute_tail_call_async().await,
-            Op::MethodCall => self.execute_method_call(false).await,
-            Op::MethodCallOpt => self.execute_method_call(true).await,
-            Op::IterNext => self.execute_iter_next_async().await,
-            Op::Pipe => self.execute_pipe().await,
-            Op::Parallel => self.execute_parallel().await,
-            Op::ParallelMap => self.execute_parallel_map().await,
-            Op::ParallelMapStream => self.execute_parallel_map_stream().await,
-            Op::ParallelSettle => self.execute_parallel_settle().await,
-            Op::SyncMutexEnter => self.execute_sync_mutex_enter().await,
-            Op::Import => self.execute_import_op().await,
-            Op::SelectiveImport => self.execute_selective_import().await,
-            Op::CallSpread => self.execute_call_spread().await,
-            Op::MethodCallSpread => self.execute_method_call_spread().await,
-            Op::Yield => self.execute_yield().await,
-            sync_op => {
-                debug_assert!(
-                    false,
-                    "execute_op_async called with sync opcode {sync_op:?} — \
-                     dispatch tables in execute_op_sync / execute_op_async are out of sync"
-                );
-                Err(VmError::Runtime(format!(
-                    "internal VM dispatch error: {sync_op:?} is not an async opcode"
-                )))
-            }
-        }
-    }
-
     /// Execute a single opcode. Used by the scope-interrupt wrapper that
     /// drives cancellable / deadlined execution; the hot interpreter loop
     /// in `run_chunk_ref` bypasses this and calls `execute_op_sync` /


### PR DESCRIPTION
## Summary

The VM's opcode set drove **four hand-maintained match tables** that all had to stay in lockstep:

1. `enum Op` + `Op::ALL` (104 variants × twice, once in the enum and once in the byte-order array)
2. `Vm::execute_op_sync` — sync dispatch (~104 arms)
3. `Vm::execute_op_async` — async dispatch (18 arms)
4. `Chunk::disassemble`'s inner match — ~73 arms
5. Plus the classifier helpers `Chunk::op_reads_outer_name` and `is_adaptive_binary_op`

Drift between them compiled fine but silently broke runtime or disassembly. As proof: `Op::CheckType` and `Op::GetArgc` had been falling through to the `UNKNOWN(0x..)` disasm arm, and `Op::MethodCallSpread` read its name-index operand at the wrong offset.

This PR introduces a new `harn-opcode-macros` proc-macro crate with a `define_opcodes!` function-like macro. One declarative table in `crates/harn-vm/src/vm/ops/mod.rs` is now the single source of truth. The macro emits the enum, the byte mapping, both dispatch tables, the disassembly renderer, and the classification helpers.

Adding or renaming an opcode is now a **one-line edit**. The hot dispatch loop still uses `match Op { ... }` (preserving the jump-table codegen the hottest opcodes rely on) — the macro just authors the arms.

Design notes:

- Each opcode entry has a `kind` (`sync` / `sync_void` / `sync_return` / `split` / `async_op`), a `disasm` helper, and optional `flags`.
- Flag-derived classifiers (`op_reads_outer_name`, `is_adaptive_binary_op`) are emitted as free `fn`s with names that match the existing call sites — no caller renames needed.
- Disasm helpers live in `crate::chunk` as `pub(crate) fn disasm_*` to keep close to the `Chunk` accessors they use.
- A new `Op::COUNT` constant is exposed for any future `[T; Op::COUNT]` lookup tables.

Bug fixes surfaced by the migration:

- `Op::CheckType` and `Op::GetArgc` now render in disassembly instead of `UNKNOWN(0x..)`.
- `Op::MethodCallSpread`'s disasm reads its u16 name-index at the correct offset.

A new `disassemble_covers_every_opcode_variant` test pins disasm coverage forward.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy -p harn-vm -p harn-opcode-macros --all-targets -- -D warnings`
- [x] `cargo test -p harn-vm --lib` — 2823 pass, 1 pre-existing flaky failure (`harness::tests::mock_harness_rejects_wrong_argument_types`) confirmed on main
- [x] `cargo test -p harn-vm --lib bytecode_cache` — round-trip serialization tests all green (byte stability preserved)
- [x] `cargo bench -p harn-vm --bench vm_adaptive_inline_cache --no-run` — benches build

Closes burin-labs/harn#2584

🤖 Generated with [Claude Code](https://claude.com/claude-code)