### PR TITLE
[A.12 streaming] harn-serve: per-part multipart + chunked body channels (#2515)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "axum",
  "axum-server",
  "base64",
+ "bytes",
  "ed25519-dalek",
  "filetime",
  "futures",

--- a/changelog.d/2515-streaming.added.md
+++ b/changelog.d/2515-streaming.added.md
@@ -1,0 +1,21 @@
+- **A.12 streaming uploads for `harn-serve` (#2515).** Two new
+  Rust-level primitives let adapter handlers process large inbound
+  bodies without buffering the whole payload, closing the streaming
+  gap the buffered `harn_vm::stdlib::multipart::multipart_parse` left
+  open. `harn_serve::MultipartStream::start(multipart, config)` walks
+  `axum::extract::Multipart` field-by-field and yields each
+  `MultipartField { name, filename, content_type, bytes }` with a
+  bounded inner bytes channel — fields stream straight into hashers,
+  disk, or forwarded requests with a per-field byte cap. Companion
+  `harn_serve::RequestBodyChannel::start(body, config)` exposes
+  `Body::into_data_stream()` as a `mpsc` receiver for
+  `Transfer-Encoding: chunked` consumers. A new
+  `crates/harn-serve/tests/streaming_conformance.rs` proves both
+  primitives walk a 50 MiB payload while the peak in-flight chunk
+  stays bounded to the wire-shaped size (≤4× the source chunk for
+  multipart, ≤2× for raw body), so the 50 MiB allocation cliff that
+  `multipart_parse` would hit on the same upload is avoided. The
+  `.harn` channel bridge for `http.multipart(req)` and
+  `req.body_channel()` builtins lands together with the future `.harn`
+  HTTP handler host (the same hosting pivot blocking the `WsSession`
+  bridge per `#1870`).

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["multipart", "ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 base64 = "0.22"
+bytes = "1"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 futures = "0.3"
 globset = "0.4"

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -16,6 +16,7 @@ pub mod permissions;
 mod protocol_fixture_tests;
 mod replay;
 pub mod sessions;
+pub mod streaming;
 pub mod tls;
 pub mod transport;
 pub mod ws;
@@ -71,6 +72,11 @@ pub use sessions::{
     SessionMeta, SessionSigner, SessionStatus, SessionStore, SharedArchiveSink, SharedSessionStore,
     Snapshot, SnapshotId, SqliteSessionStore, StoreError, StoreHooks, StoreResult, StoredEvent,
     SweepReport, Tombstone, TruncateResult, VerifyFailure, VerifyReport,
+};
+pub use streaming::{
+    BodyChannelConfig, MultipartField, MultipartStream, MultipartStreamConfig, RequestBodyChannel,
+    StreamError, DEFAULT_BODY_CHANNEL_CAPACITY, DEFAULT_FIELD_BYTES_CAPACITY,
+    DEFAULT_MAX_FIELD_BYTES, DEFAULT_MULTIPART_OUTER_CAPACITY,
 };
 pub use tls::{bind_listener, HstsConfig, HttpTlsConfig};
 pub use transport::{

--- a/crates/harn-serve/src/streaming.rs
+++ b/crates/harn-serve/src/streaming.rs
@@ -1,0 +1,553 @@
+//! Streaming request-body primitives for `harn-serve` adapters.
+//!
+//! [`harn_vm::stdlib::multipart::multipart_parse`] buffers the entire
+//! request body into memory before yielding fields. That's fine for the
+//! small forms (1-100 KB) the cloud gateway sees on the auth + admin
+//! surfaces, but it OOMs on the file-upload routes: a 200 MB part
+//! allocates a 200 MB `Vec<u8>` *plus* a 200 MB hop into the parsed-out
+//! field value.
+//!
+//! This module exposes the same building blocks axum itself uses —
+//! [`axum::extract::Multipart`] for per-part streaming, and
+//! [`axum::body::Body::into_data_stream`] for raw chunked-body reads —
+//! adapted into channel-shaped APIs so a future `.harn` HTTP handler
+//! host can pump them through [`harn_vm::value::VmChannelHandle`]
+//! exactly like the LLM streaming builtins (`crates/harn-vm/src/llm/
+//! stream_builtins.rs`) do today.
+//!
+//! Two primitives:
+//!
+//! * [`MultipartStream`] — wraps `axum::extract::Multipart`. The outer
+//!   channel yields one [`MultipartField`] per form field; each field
+//!   carries its own *inner* bytes channel that streams the field body
+//!   in `Bytes` chunks. The producer is single-threaded and walks
+//!   fields sequentially, so the consumer **must** drain field N's
+//!   bytes channel before reading field N+1 — otherwise the producer
+//!   blocks on the inner send and the outer channel stalls.
+//! * [`RequestBodyChannel`] — wraps `Body::into_data_stream()`. The
+//!   channel yields `Bytes` chunks as they arrive on the wire. Use this
+//!   for `Transfer-Encoding: chunked` uploads where the handler wants
+//!   to stream straight into a hasher / disk / forwarded request
+//!   without materialising the body.
+//!
+//! Both primitives are reachable from Rust today via the test-only
+//! routes wired in `crates/harn-serve/tests/streaming_conformance.rs`.
+//! The `.harn` channel bridge — i.e. exposing these as
+//! `http.multipart(req) -> Stream<Part>` and `req.body_channel() ->
+//! Channel<bytes>` builtins — belongs in the future `.harn` HTTP
+//! handler host (the same place [`crate::ws::WsSession`] will land
+//! its channel bridge per the `#1870` plan). This module's docs and
+//! the conformance test stand in for that bridge until the host
+//! lands; the producer task shape is already what the bridge will
+//! drive.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::Multipart;
+use bytes::Bytes;
+use futures::StreamExt;
+use tokio::sync::mpsc;
+
+/// Default buffer depth for the outer multipart channel (the one that
+/// hands out [`MultipartField`] records). Two slots is enough — at any
+/// moment the producer is either parsing the next field header or
+/// streaming the current field's body, so a deep buffer just delays
+/// backpressure without enabling more work in flight.
+pub const DEFAULT_MULTIPART_OUTER_CAPACITY: usize = 2;
+
+/// Default buffer depth for a per-field inner bytes channel. Each slot
+/// holds whatever chunk `multer` decided to emit (typically 8 KB), so
+/// 16 slots cap the per-field in-flight buffer at ~128 KB — small
+/// enough that a thousand concurrent uploads stay under a few hundred
+/// megabytes even before route-level limits kick in.
+pub const DEFAULT_FIELD_BYTES_CAPACITY: usize = 16;
+
+/// Default buffer depth for [`RequestBodyChannel`]. Same reasoning as
+/// the per-field channel: each slot holds one wire-level chunk, and 16
+/// slots is enough to keep the producer ahead of a moderate consumer
+/// without pinning megabytes per connection.
+pub const DEFAULT_BODY_CHANNEL_CAPACITY: usize = 16;
+
+/// Hard cap on per-field bytes. When a field's accumulated body would
+/// exceed this, the producer emits [`StreamError::FieldTooLarge`] on the
+/// inner channel and drops the rest of the field. The outer channel
+/// continues with the next field — the limit is per-field, not
+/// per-request, so a malicious payload can't slip a multi-gigabyte
+/// chunk through.
+///
+/// Defaults to 256 MiB. Set this via [`MultipartStreamConfig::max_field_bytes`]
+/// when wiring the producer for a specific route.
+pub const DEFAULT_MAX_FIELD_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Per-route configuration for [`MultipartStream::start`].
+#[derive(Clone, Debug)]
+pub struct MultipartStreamConfig {
+    /// Outer-channel buffer depth — controls how many fields can be
+    /// queued ahead of the consumer. Defaults to
+    /// [`DEFAULT_MULTIPART_OUTER_CAPACITY`].
+    pub outer_capacity: usize,
+    /// Per-field inner-channel buffer depth — controls how many wire
+    /// chunks can be queued per field. Defaults to
+    /// [`DEFAULT_FIELD_BYTES_CAPACITY`].
+    pub field_bytes_capacity: usize,
+    /// Hard per-field byte cap. Defaults to
+    /// [`DEFAULT_MAX_FIELD_BYTES`].
+    pub max_field_bytes: u64,
+}
+
+impl Default for MultipartStreamConfig {
+    fn default() -> Self {
+        Self {
+            outer_capacity: DEFAULT_MULTIPART_OUTER_CAPACITY,
+            field_bytes_capacity: DEFAULT_FIELD_BYTES_CAPACITY,
+            max_field_bytes: DEFAULT_MAX_FIELD_BYTES,
+        }
+    }
+}
+
+/// Configuration for [`RequestBodyChannel::start`].
+#[derive(Clone, Debug)]
+pub struct BodyChannelConfig {
+    /// Buffer depth for the body channel. Defaults to
+    /// [`DEFAULT_BODY_CHANNEL_CAPACITY`].
+    pub capacity: usize,
+}
+
+impl Default for BodyChannelConfig {
+    fn default() -> Self {
+        Self {
+            capacity: DEFAULT_BODY_CHANNEL_CAPACITY,
+        }
+    }
+}
+
+/// Per-field metadata + a bytes channel for the field body.
+///
+/// Records of this shape are what a future `http.multipart(req)`
+/// `.harn` builtin will yield onto its channel. The handler reads
+/// metadata from the named fields and drains [`MultipartField::bytes`]
+/// to consume the body.
+#[derive(Debug)]
+pub struct MultipartField {
+    /// The `name=` parameter from the part's `Content-Disposition`.
+    /// Required by RFC 7578; the producer surfaces a
+    /// [`StreamError::MissingFieldName`] before reaching the consumer
+    /// when it's absent.
+    pub name: String,
+    /// The `filename=` parameter from `Content-Disposition`, when
+    /// present. Absent for ordinary text fields.
+    pub filename: Option<String>,
+    /// The part's `Content-Type` header, when present. The producer
+    /// passes this through verbatim; it does not validate or default.
+    pub content_type: Option<String>,
+    /// Channel yielding the field body in wire-arrival chunks. Drops
+    /// on `Ok(None)` when the field is fully consumed; an
+    /// [`Err`](StreamError) terminates the field and is followed by
+    /// the channel closing.
+    pub bytes: mpsc::Receiver<Result<Bytes, StreamError>>,
+}
+
+/// A streaming multipart parser handed to a route handler.
+///
+/// Build one with [`MultipartStream::start`]; consume by repeatedly
+/// `await`-ing [`MultipartStream::next_field`]. Returning `Ok(None)`
+/// signals the body is fully consumed; an [`Err`](StreamError)
+/// terminates the stream and is followed by the channel closing.
+pub struct MultipartStream {
+    receiver: mpsc::Receiver<Result<MultipartField, StreamError>>,
+}
+
+impl MultipartStream {
+    /// Start the producer task and return a handle the route handler
+    /// can drain. The task is spawned via `tokio::spawn`; cancelling
+    /// it from the consumer side is implicit — dropping the handle
+    /// closes the outer channel, which the producer notices on its
+    /// next send and uses to abort the parse.
+    pub fn start(multipart: Multipart, config: MultipartStreamConfig) -> Self {
+        let (outer_tx, outer_rx) = mpsc::channel(config.outer_capacity.max(1));
+        tokio::spawn(drive_multipart(multipart, outer_tx, config));
+        Self { receiver: outer_rx }
+    }
+
+    /// Receive the next field. Returns `Ok(None)` when the body is
+    /// fully consumed.
+    pub async fn next_field(&mut self) -> Result<Option<MultipartField>, StreamError> {
+        match self.receiver.recv().await {
+            Some(Ok(field)) => Ok(Some(field)),
+            Some(Err(error)) => Err(error),
+            None => Ok(None),
+        }
+    }
+}
+
+/// A streaming raw request body handed to a route handler.
+///
+/// Build one with [`RequestBodyChannel::start`]; drain via
+/// [`RequestBodyChannel::recv`]. The producer drives
+/// `Body::into_data_stream()` and pushes each emitted [`Bytes`] chunk
+/// onto the channel. Trailers (uncommon in practice but legal on
+/// `Transfer-Encoding: chunked`) are discarded — they would need a
+/// separate side-channel to surface, which no current adapter needs.
+pub struct RequestBodyChannel {
+    receiver: mpsc::Receiver<Result<Bytes, StreamError>>,
+}
+
+impl RequestBodyChannel {
+    /// Start the producer task and return a handle the route handler
+    /// can drain. Dropping the handle closes the channel, which aborts
+    /// the producer on its next send (analogous to
+    /// [`MultipartStream::start`]).
+    pub fn start(body: Body, config: BodyChannelConfig) -> Self {
+        let (tx, rx) = mpsc::channel(config.capacity.max(1));
+        tokio::spawn(drive_body(body, tx));
+        Self { receiver: rx }
+    }
+
+    /// Receive the next chunk. Returns `Ok(None)` when the body is
+    /// fully consumed.
+    pub async fn recv(&mut self) -> Result<Option<Bytes>, StreamError> {
+        match self.receiver.recv().await {
+            Some(Ok(bytes)) => Ok(Some(bytes)),
+            Some(Err(error)) => Err(error),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Errors surfaced on either the outer multipart channel or any inner
+/// per-field channel.
+#[derive(Debug, Clone)]
+pub enum StreamError {
+    /// The multipart parser hit a wire-level error. Wraps the message
+    /// reported by `multer`. Most commonly: malformed boundary,
+    /// truncated body, or `Content-Type` missing the boundary.
+    Multipart(String),
+    /// The body stream (chunked or otherwise) hit a transport error.
+    /// Wraps the message reported by hyper / axum. Most commonly: peer
+    /// reset, timeout, or a length-prefixed body that ran short.
+    Body(String),
+    /// A multipart part was missing the required `name=` parameter on
+    /// its `Content-Disposition` header. RFC 7578 requires it; we
+    /// surface this as a structured error rather than skipping the
+    /// part silently.
+    MissingFieldName,
+    /// A field's accumulated body exceeded
+    /// [`MultipartStreamConfig::max_field_bytes`]. The producer emits
+    /// this on the inner channel, then drops the rest of the field.
+    /// The outer channel continues with the next field.
+    FieldTooLarge {
+        /// The field's `name=` value, when it had one.
+        field: Option<String>,
+        /// The configured limit that was exceeded.
+        limit: u64,
+    },
+}
+
+impl std::fmt::Display for StreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Multipart(message) => write!(f, "multipart parse error: {message}"),
+            Self::Body(message) => write!(f, "body stream error: {message}"),
+            Self::MissingFieldName => write!(
+                f,
+                "multipart part is missing the required name= Content-Disposition param"
+            ),
+            Self::FieldTooLarge { field, limit } => match field {
+                Some(name) => write!(
+                    f,
+                    "multipart field `{name}` exceeded max_field_bytes ({limit})"
+                ),
+                None => write!(f, "multipart field exceeded max_field_bytes ({limit})"),
+            },
+        }
+    }
+}
+
+impl std::error::Error for StreamError {}
+
+async fn drive_multipart(
+    mut multipart: Multipart,
+    outer_tx: mpsc::Sender<Result<MultipartField, StreamError>>,
+    config: MultipartStreamConfig,
+) {
+    let inner_capacity = config.field_bytes_capacity.max(1);
+    let max_field_bytes = config.max_field_bytes;
+    loop {
+        let next = match multipart.next_field().await {
+            Ok(Some(field)) => field,
+            Ok(None) => return,
+            Err(error) => {
+                let _ = outer_tx
+                    .send(Err(StreamError::Multipart(error.to_string())))
+                    .await;
+                return;
+            }
+        };
+
+        // Snapshot the field metadata before we move the field into
+        // the byte-pumping loop — `next_field` reuses the underlying
+        // parser state, so the field handle is shape-bound here.
+        let name = match next.name() {
+            Some(value) => value.to_string(),
+            None => {
+                if outer_tx
+                    .send(Err(StreamError::MissingFieldName))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                continue;
+            }
+        };
+        let filename = next.file_name().map(str::to_string);
+        let content_type = next.content_type().map(str::to_string);
+
+        let (inner_tx, inner_rx) = mpsc::channel::<Result<Bytes, StreamError>>(inner_capacity);
+        let field = MultipartField {
+            name: name.clone(),
+            filename,
+            content_type,
+            bytes: inner_rx,
+        };
+        if outer_tx.send(Ok(field)).await.is_err() {
+            return;
+        }
+
+        let inner_tx = Arc::new(inner_tx);
+        let outcome = pump_field_bytes(next, inner_tx.clone(), max_field_bytes, &name).await;
+        // Drop our reference so the consumer side sees a clean close
+        // once the producer is done with this field.
+        drop(inner_tx);
+
+        match outcome {
+            FieldOutcome::Complete => continue,
+            FieldOutcome::ConsumerDropped => return,
+            FieldOutcome::ParserFailed(message) => {
+                let _ = outer_tx.send(Err(StreamError::Multipart(message))).await;
+                return;
+            }
+        }
+    }
+}
+
+enum FieldOutcome {
+    /// Field fully drained — keep parsing.
+    Complete,
+    /// Consumer dropped the inner channel — stop early but the outer
+    /// channel may still be open, so the producer cooperatively
+    /// returns rather than poisoning sibling fields. (axum's parser
+    /// can't resume mid-field, so we close the whole stream.)
+    ConsumerDropped,
+    /// `multer` reported a parse error mid-field. The producer
+    /// terminates the stream after surfacing this on the outer
+    /// channel.
+    ParserFailed(String),
+}
+
+async fn pump_field_bytes(
+    mut field: axum::extract::multipart::Field<'_>,
+    inner_tx: Arc<mpsc::Sender<Result<Bytes, StreamError>>>,
+    max_field_bytes: u64,
+    field_name: &str,
+) -> FieldOutcome {
+    let mut bytes_so_far: u64 = 0;
+    loop {
+        match field.chunk().await {
+            Ok(Some(chunk)) => {
+                let len = chunk.len() as u64;
+                if bytes_so_far.saturating_add(len) > max_field_bytes {
+                    let _ = inner_tx
+                        .send(Err(StreamError::FieldTooLarge {
+                            field: Some(field_name.to_string()),
+                            limit: max_field_bytes,
+                        }))
+                        .await;
+                    // Drain the rest of the field so the multer parser
+                    // can advance to the next one. If the consumer
+                    // dropped, the next send below will detect it.
+                    while let Ok(Some(_)) = field.chunk().await {}
+                    return FieldOutcome::Complete;
+                }
+                bytes_so_far += len;
+                if inner_tx.send(Ok(chunk)).await.is_err() {
+                    return FieldOutcome::ConsumerDropped;
+                }
+            }
+            Ok(None) => return FieldOutcome::Complete,
+            Err(error) => return FieldOutcome::ParserFailed(error.to_string()),
+        }
+    }
+}
+
+async fn drive_body(body: Body, tx: mpsc::Sender<Result<Bytes, StreamError>>) {
+    let mut stream = body.into_data_stream();
+    while let Some(next) = stream.next().await {
+        let send_result = match next {
+            Ok(chunk) => tx.send(Ok(chunk)).await,
+            Err(error) => tx.send(Err(StreamError::Body(error.to_string()))).await,
+        };
+        if send_result.is_err() {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::extract::Multipart;
+    use axum::http::{header, Method, Request, StatusCode};
+    use axum::response::{IntoResponse, Response};
+    use axum::routing::post;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    async fn echo_multipart_handler(multipart: Multipart) -> Response {
+        let mut stream = MultipartStream::start(multipart, MultipartStreamConfig::default());
+        let mut summary = String::new();
+        while let Some(mut field) = match stream.next_field().await {
+            Ok(field) => field,
+            Err(error) => return (StatusCode::BAD_REQUEST, error.to_string()).into_response(),
+        } {
+            let mut total = 0u64;
+            while let Some(chunk_result) = field.bytes.recv().await {
+                match chunk_result {
+                    Ok(chunk) => total += chunk.len() as u64,
+                    Err(error) => {
+                        return (StatusCode::PAYLOAD_TOO_LARGE, error.to_string()).into_response();
+                    }
+                }
+            }
+            summary.push_str(&format!("{}:{}\n", field.name, total));
+        }
+        summary.into_response()
+    }
+
+    async fn echo_body_handler(req: Request<Body>) -> Response {
+        let (_parts, body) = req.into_parts();
+        let mut channel = RequestBodyChannel::start(body, BodyChannelConfig::default());
+        let mut total: u64 = 0;
+        while let Some(chunk_result) = match channel.recv().await {
+            Ok(value) => value.map(Ok),
+            Err(error) => Some(Err(error)),
+        } {
+            match chunk_result {
+                Ok(chunk) => total += chunk.len() as u64,
+                Err(error) => {
+                    return (StatusCode::BAD_REQUEST, error.to_string()).into_response();
+                }
+            }
+        }
+        total.to_string().into_response()
+    }
+
+    fn build_app() -> Router {
+        Router::new()
+            .route("/multipart", post(echo_multipart_handler))
+            .route("/body", post(echo_body_handler))
+    }
+
+    fn boundary() -> &'static str {
+        "----streaming-unit-test"
+    }
+
+    fn multipart_body(fields: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (name, value) in fields {
+            out.extend_from_slice(format!("--{}\r\n", boundary()).as_bytes());
+            out.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+            );
+            out.extend_from_slice(value);
+            out.extend_from_slice(b"\r\n");
+        }
+        out.extend_from_slice(format!("--{}--\r\n", boundary()).as_bytes());
+        out
+    }
+
+    async fn read_text(response: Response) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn multipart_stream_yields_one_field_at_a_time() {
+        let body = multipart_body(&[("a", b"hello"), ("b", b"world!!")]);
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/multipart")
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={}", boundary()),
+            )
+            .body(Body::from(body))
+            .unwrap();
+        let response = build_app().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let summary = read_text(response).await;
+        assert_eq!(summary, "a:5\nb:7\n");
+    }
+
+    #[tokio::test]
+    async fn multipart_stream_enforces_field_size_cap() {
+        async fn capped_handler(multipart: Multipart) -> Response {
+            let mut stream = MultipartStream::start(
+                multipart,
+                MultipartStreamConfig {
+                    max_field_bytes: 4,
+                    ..Default::default()
+                },
+            );
+            let mut errors = Vec::new();
+            while let Some(mut field) = stream.next_field().await.unwrap() {
+                while let Some(chunk_result) = field.bytes.recv().await {
+                    if let Err(error) = chunk_result {
+                        errors.push(error.to_string());
+                    }
+                }
+            }
+            errors.join("|").into_response()
+        }
+
+        let body = multipart_body(&[("big", b"this body is more than four bytes")]);
+        let app = Router::new().route("/c", post(capped_handler));
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/c")
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={}", boundary()),
+            )
+            .body(Body::from(body))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        let summary = read_text(response).await;
+        assert!(
+            summary.contains("max_field_bytes (4)"),
+            "expected size-cap error, got `{summary}`"
+        );
+        assert!(
+            summary.contains("`big`"),
+            "expected field name in error, got `{summary}`"
+        );
+    }
+
+    #[tokio::test]
+    async fn body_channel_streams_chunked_upload() {
+        let payload = vec![0xABu8; 1024];
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/body")
+            .body(Body::from(payload.clone()))
+            .unwrap();
+        let response = build_app().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let summary = read_text(response).await;
+        assert_eq!(summary, "1024");
+    }
+}

--- a/crates/harn-serve/tests/streaming_conformance.rs
+++ b/crates/harn-serve/tests/streaming_conformance.rs
@@ -1,0 +1,262 @@
+//! End-to-end streaming-upload conformance for the A.12 transport
+//! follow-up.
+//!
+//! Exercises both [`harn_serve::MultipartStream`] and
+//! [`harn_serve::RequestBodyChannel`] against a 50 MiB payload — large
+//! enough that the buffered
+//! [`harn_vm::stdlib::multipart::multipart_parse`] would have to
+//! allocate the full body plus a per-field copy (≥100 MiB live), but
+//! small enough that test runtime stays under a second on a modest CI
+//! box. The handlers never collect the body: each chunk flows straight
+//! into a [`sha2::Sha256`] hasher and an `AtomicU64` byte counter, and
+//! the test asserts the in-handler **peak chunk size** stays well below
+//! the payload size — the practical proof that the consumer never sat
+//! on the full upload.
+//!
+//! The buffered baseline isn't run here (it would defeat the point of
+//! the test by allocating the 50 MiB body twice); the comparison
+//! against it is documented in [`crate::streaming`]'s module preamble.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{DefaultBodyLimit, Multipart};
+use axum::http::{header, Method, Request, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::Router;
+use bytes::Bytes;
+use futures_util::stream::{self, StreamExt};
+use harn_serve::{BodyChannelConfig, MultipartStream, MultipartStreamConfig, RequestBodyChannel};
+use sha2::{Digest, Sha256};
+use tower::ServiceExt;
+
+const FIFTY_MIB: usize = 50 * 1024 * 1024;
+const CHUNK_BYTES: usize = 64 * 1024;
+const BOUNDARY: &str = "----streaming-50mib-conformance";
+
+#[derive(Clone, Default)]
+struct StreamingMetrics {
+    peak_chunk: Arc<AtomicU64>,
+    total_bytes: Arc<AtomicU64>,
+    /// Hex-encoded final hash, populated when the handler finishes.
+    digest_hex: Arc<std::sync::Mutex<Option<String>>>,
+}
+
+impl StreamingMetrics {
+    fn record(&self, chunk: &[u8]) {
+        let len = chunk.len() as u64;
+        self.peak_chunk.fetch_max(len, Ordering::Relaxed);
+        self.total_bytes.fetch_add(len, Ordering::Relaxed);
+    }
+
+    fn finish(&self, hasher: Sha256) {
+        let digest = hex::encode(hasher.finalize());
+        *self.digest_hex.lock().unwrap() = Some(digest);
+    }
+
+    fn snapshot(&self) -> (u64, u64, Option<String>) {
+        (
+            self.peak_chunk.load(Ordering::Relaxed),
+            self.total_bytes.load(Ordering::Relaxed),
+            self.digest_hex.lock().unwrap().clone(),
+        )
+    }
+}
+
+fn deterministic_payload(size: usize) -> Vec<u8> {
+    // PCG-style xorshift to produce a payload that compresses badly and
+    // gives a non-trivial hash — both important so the test cannot pass
+    // by accident on an all-zero body.
+    let mut state: u64 = 0x9E3779B97F4A7C15;
+    let mut out = Vec::with_capacity(size);
+    while out.len() < size {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(size);
+    out
+}
+
+fn expected_digest(payload: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(payload);
+    hex::encode(hasher.finalize())
+}
+
+/// Build a `Bytes`-yielding stream that delivers `payload` in
+/// [`CHUNK_BYTES`] pieces and returns `Poll::Pending` between each via
+/// `tokio::task::yield_now`. This mirrors how a real TCP connection
+/// stages chunks — multer's `poll_stream` only stops accumulating when
+/// the source goes pending, so without the explicit yield it would
+/// swallow the whole payload in one tick and the streaming property
+/// would be invisible to the consumer.
+fn make_paced_chunk_stream(
+    payload: Vec<u8>,
+) -> impl futures_util::Stream<Item = Result<Bytes, std::convert::Infallible>> {
+    let chunks: Vec<Bytes> = payload
+        .chunks(CHUNK_BYTES)
+        .map(Bytes::copy_from_slice)
+        .collect();
+    stream::iter(chunks).then(|chunk| async move {
+        tokio::task::yield_now().await;
+        Ok::<_, std::convert::Infallible>(chunk)
+    })
+}
+
+fn multipart_envelope(field_name: &str, body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(body.len() + 256);
+    out.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+    out.extend_from_slice(
+        format!(
+            "Content-Disposition: form-data; name=\"{field_name}\"; filename=\"payload.bin\"\r\n"
+        )
+        .as_bytes(),
+    );
+    out.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+    out.extend_from_slice(body);
+    out.extend_from_slice(b"\r\n");
+    out.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+    out
+}
+
+#[tokio::test]
+async fn multipart_stream_processes_50_mib_without_buffering() {
+    let payload = deterministic_payload(FIFTY_MIB);
+    let expected = expected_digest(&payload);
+    let metrics = StreamingMetrics::default();
+
+    let handler_metrics = metrics.clone();
+    let handler = move |multipart: Multipart| {
+        let metrics = handler_metrics.clone();
+        async move {
+            let mut stream = MultipartStream::start(multipart, MultipartStreamConfig::default());
+            let mut hasher = Sha256::new();
+            while let Some(mut field) = stream
+                .next_field()
+                .await
+                .expect("multipart parse should succeed")
+            {
+                while let Some(chunk_result) = field.bytes.recv().await {
+                    let chunk = chunk_result.expect("field bytes should arrive intact");
+                    metrics.record(&chunk);
+                    hasher.update(&chunk);
+                }
+            }
+            metrics.finish(hasher);
+            StatusCode::OK.into_response()
+        }
+    };
+    // axum applies a 2 MiB DefaultBodyLimit to every request. The
+    // streaming primitive doesn't need it — its own per-field cap is
+    // what stops malicious uploads — so disable the request-wide cap
+    // for this route and prove the producer can walk the full 50 MiB.
+    let app = Router::new()
+        .route("/upload", post(handler))
+        .layer(DefaultBodyLimit::disable());
+
+    // Feed the multipart envelope as a chunked stream so the producer
+    // task sees wire-shaped chunks the same way it would on a real
+    // connection. `Body::from(Vec<u8>)` is a single-chunk body —
+    // multer can only emit what hyper hands it, so the field would
+    // look like a 50 MiB chunk and the streaming property would be
+    // invisible.
+    //
+    // Multer's `poll_stream` aggressively drains the source stream
+    // until it sees `Pending`, so we also have to interleave a
+    // `yield_now` between chunks. `stream::iter` always returns
+    // `Ready` and would let multer accumulate the whole 50 MiB into
+    // its internal buffer before yielding the first chunk — also
+    // defeating the streaming proof.
+    let body = multipart_envelope("payload", &payload);
+    let chunked = Body::from_stream(make_paced_chunk_stream(body));
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/upload")
+        .header(
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={BOUNDARY}"),
+        )
+        .body(chunked)
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let (peak_chunk, total_bytes, digest) = metrics.snapshot();
+    assert_eq!(
+        total_bytes, FIFTY_MIB as u64,
+        "handler should have observed every byte"
+    );
+    assert_eq!(
+        digest.as_deref(),
+        Some(expected.as_str()),
+        "hash mismatch — handler did not see the full payload"
+    );
+    // multer can coalesce small chunks while scanning for the next
+    // boundary, but it cannot legally hand the consumer more than a
+    // small multiple of the wire chunk size in one go without
+    // buffering the whole field — which is exactly what we're proving
+    // it doesn't do. 4× the input chunk size is comfortable headroom.
+    assert!(
+        peak_chunk <= (4 * CHUNK_BYTES) as u64,
+        "peak streamed chunk was {peak_chunk} bytes — multer should hand off in wire-shaped \
+         pieces, not the full 50 MiB"
+    );
+}
+
+#[tokio::test]
+async fn body_channel_processes_50_mib_chunked_upload() {
+    let payload = deterministic_payload(FIFTY_MIB);
+    let expected = expected_digest(&payload);
+    let metrics = StreamingMetrics::default();
+
+    let handler_metrics = metrics.clone();
+    let handler = move |req: Request<Body>| {
+        let metrics = handler_metrics.clone();
+        async move {
+            let (_parts, body) = req.into_parts();
+            let mut channel = RequestBodyChannel::start(body, BodyChannelConfig::default());
+            let mut hasher = Sha256::new();
+            while let Some(chunk) = channel
+                .recv()
+                .await
+                .expect("body stream should arrive intact")
+            {
+                metrics.record(&chunk);
+                hasher.update(&chunk);
+            }
+            metrics.finish(hasher);
+            StatusCode::OK.into_response()
+        }
+    };
+    let app = Router::new()
+        .route("/upload", post(handler))
+        .layer(DefaultBodyLimit::disable());
+
+    // Build the body as a chunked stream so axum sees the upload arrive
+    // in pieces rather than as a single buffered payload — that's the
+    // shape `Transfer-Encoding: chunked` hits in production. The
+    // pacing helper interleaves `yield_now` so each chunk is delivered
+    // on its own task tick rather than coalesced.
+    let chunked = Body::from_stream(make_paced_chunk_stream(payload.clone()));
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/upload")
+        .body(chunked)
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let (peak_chunk, total_bytes, digest) = metrics.snapshot();
+    assert_eq!(total_bytes, FIFTY_MIB as u64);
+    assert_eq!(digest.as_deref(), Some(expected.as_str()));
+    assert!(
+        peak_chunk <= (2 * CHUNK_BYTES) as u64,
+        "peak streamed chunk was {peak_chunk} bytes — body must be delivered in wire-size \
+         chunks, not the full 50 MiB"
+    );
+}


### PR DESCRIPTION
Follow-up to #2571 (now merged). Adds the two streaming primitives #2571 deferred from the A.12 epic (#2515): per-part multipart streaming and a chunked-body channel, both Rust-level today, with a 50 MiB conformance test that proves the buffered baseline's allocation cliff is avoided.

## Summary

- Adds `harn_serve::MultipartStream` — wraps `axum::extract::Multipart` so each `MultipartField { name, filename, content_type, bytes }` carries its own bounded bytes channel. Configurable per-field byte cap (default 256 MiB) is enforced in the producer so a malicious payload can't slip a multi-gigabyte chunk past route-level limits.
- Adds `harn_serve::RequestBodyChannel` — wraps `Body::into_data_stream()` for `Transfer-Encoding: chunked` consumers that want the raw bytes (not parsed multipart) — hashing, forwarding, disk spooling, etc.
- Both primitives are Rust-level today (mirroring how `crate::ws::WsSession` lives in `harn-serve` while its `.harn` channel bridge waits on the future `.harn` HTTP handler host — see #1870). The `.harn` builtins `http.multipart(req) -> Stream<Part>` and `req.body_channel() -> Channel<bytes>` will land together with that hosting work.
- Adds `crates/harn-serve/tests/streaming_conformance.rs` covering both primitives against a 50 MiB payload. Asserts: total bytes match, SHA-256 digest matches, **peak in-flight chunk** stays ≤4× the wire chunk size (multipart) / ≤2× (raw body) — the practical bound that lets these primitives serve gigabyte uploads without the buffered baseline's allocation cliff.

## Why the test interleaves yield_now

`multer`'s `poll_stream` aggressively drains its source until it sees `Pending`. `stream::iter` always returns `Ready`, so without an interleaved `tokio::task::yield_now` between chunks `multer` would buffer the full 50 MiB into its internal `BytesMut` before yielding anything to the consumer — and the streaming property would be invisible. The `make_paced_chunk_stream` helper mirrors what TCP pacing does in production.

## Relationship to #2515

A.12 epic #2515 stays open — this PR ships the multipart-streaming + chunked-upload acceptance bullets that #2571 deferred. The other A.12 bullets (WS, compression, ETag, CORS, codec response/builtins) already landed with #2571.

## Test plan

- [x] `cargo test -p harn-serve` — full package tests, all green
- [x] `cargo test -p harn-serve --test streaming_conformance` — 2 new 50 MiB conformance tests pass
- [x] `cargo clippy -p harn-serve --all-targets -- -D warnings` — clean
- [ ] Merge queue green

🤖 Generated with [Claude Code](https://claude.com/claude-code)