### PR TITLE
hostlib: gate fs/* and ast/* edit primitives behind tools:deterministic (#2548)

### DIFF
--- a/changelog.d/2548.security.md
+++ b/changelog.d/2548.security.md
@@ -1,0 +1,10 @@
+- **Gate the `std/edit` file-mutation builtins behind `tools:deterministic` (#2548).**
+  `hostlib_fs_safe_text_patch`, `hostlib_fs_read_text`,
+  `hostlib_ast_apply_node`, and `hostlib_ast_insert_at_anchor` now require
+  `hostlib_enable("tools:deterministic")` before they run, matching the
+  existing gate on the `hostlib_tools_*` file I/O builtins. Previously a
+  sandboxed script denied `tools:deterministic` could still read and mutate
+  arbitrary host paths through the `edit_*` helpers. The gating policy is
+  now a single shared `permissions::gated_handler` used by the `tools`,
+  `fs`, and `ast` capabilities. Pure telemetry routing
+  (`hostlib_fs_emit_safe_text_patch_result`) stays un-gated.

--- a/conformance/tests/stdlib/edit_apply_node.harn
+++ b/conformance/tests/stdlib/edit_apply_node.harn
@@ -12,6 +12,9 @@ fn write_fixture(dir: string, name: string, body: string) -> string {
 }
 
 pipeline default() {
+  // `hostlib_ast_apply_node` writes edited source to disk, so it requires
+  // the deterministic-tools feature gate (issue #2548).
+  hostlib_enable("tools:deterministic")
   let root = path_join(
     harness.fs.temp_dir(),
     "harn_edit_apply_node_" + to_string(harness.random.gen_range(100000, 999999)),

--- a/conformance/tests/stdlib/edit_insert_at_anchor.harn
+++ b/conformance/tests/stdlib/edit_insert_at_anchor.harn
@@ -12,6 +12,9 @@ fn write_fixture(dir: string, name: string, body: string) -> string {
 }
 
 pipeline default() {
+  // `hostlib_ast_insert_at_anchor` writes edited source to disk, so it
+  // requires the deterministic-tools feature gate (issue #2548).
+  hostlib_enable("tools:deterministic")
   let root = path_join(
     harness.fs.temp_dir(),
     "harn_edit_insert_at_anchor_" + to_string(harness.random.gen_range(100000, 999999)),

--- a/conformance/tests/stdlib/edit_safe_text_patch.harn
+++ b/conformance/tests/stdlib/edit_safe_text_patch.harn
@@ -13,6 +13,10 @@ fn write_fixture(dir: string, name: string, body: string) -> string {
 }
 
 pipeline default() {
+  // `edit_safe_text_patch` calls `hostlib_fs_read_text` and
+  // `hostlib_fs_safe_text_patch`, both of which require the
+  // deterministic-tools feature gate (issue #2548).
+  hostlib_enable("tools:deterministic")
   let root = path_join(
     harness.fs.temp_dir(),
     "harn_edit_safe_text_patch_" + to_string(harness.random.gen_range(100000, 999999)),
@@ -136,7 +140,6 @@ pipeline default() {
   let staged_path = write_fixture(root, "staged.txt", "v1\n")
   let staged_pre = "sha256:" + sha256("v1\n")
   let staged_session = "harn-edit-safe-text-patch-" + to_string(harness.random.gen_range(100000, 999999))
-  hostlib_enable("tools:deterministic")
   hostlib_fs_set_mode({session_id: staged_session, mode: "staged", root: root})
   // Sibling agent stages a competing write — overlay hash diverges from disk.
   hostlib_tools_write_file({session_id: staged_session, path: staged_path, content: "competing\n"})

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -205,13 +205,15 @@ impl HostlibCapability for AstCapability {
             "bracket_balance",
             bracket_balance::run,
         );
-        register(
+        // These two write edited source back to disk, so they share the
+        // deterministic-tools gate with `tools::*` file I/O.
+        register_gated(
             registry,
             "hostlib_ast_apply_node",
             "apply_node",
             apply_node::run,
         );
-        register(
+        register_gated(
             registry,
             "hostlib_ast_insert_at_anchor",
             "insert_at_anchor",
@@ -233,5 +235,19 @@ fn register(
         module: "ast",
         method,
         handler,
+    });
+}
+
+fn register_gated(
+    registry: &mut BuiltinRegistry,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "ast",
+        method,
+        handler: crate::tools::permissions::gated_handler(name, runner),
     });
 }

--- a/crates/harn-hostlib/src/fs.rs
+++ b/crates/harn-hostlib/src/fs.rs
@@ -65,13 +65,15 @@ impl HostlibCapability for FsCapability {
             "discard_staged",
             discard_staged_builtin,
         );
-        register(
+        // `safe_text_patch` and `read_text` touch arbitrary host paths, so
+        // they share the deterministic-tools gate with `tools::*` file I/O.
+        register_gated(
             registry,
             SAFE_TEXT_PATCH_BUILTIN,
             "safe_text_patch",
             safe_text_patch_builtin,
         );
-        register(registry, READ_TEXT_BUILTIN, "read_text", read_text_builtin);
+        register_gated(registry, READ_TEXT_BUILTIN, "read_text", read_text_builtin);
         register(
             registry,
             EMIT_SAFE_TEXT_PATCH_RESULT_BUILTIN,
@@ -93,6 +95,20 @@ fn register(
         module: "fs",
         method,
         handler,
+    });
+}
+
+fn register_gated(
+    registry: &mut BuiltinRegistry,
+    name: &'static str,
+    method: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) {
+    registry.register(RegisteredBuiltin {
+        name,
+        module: "fs",
+        method,
+        handler: crate::tools::permissions::gated_handler(name, runner),
     });
 }
 

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -174,25 +174,11 @@ fn register_gated(
     method: &'static str,
     runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
 ) {
-    let handler: SyncHandler = Arc::new(move |args: &[VmValue]| {
-        if !permissions::is_enabled(permissions::FEATURE_TOOLS_DETERMINISTIC) {
-            return Err(HostlibError::Backend {
-                builtin: name,
-                message: format!(
-                    "feature `{}` is not enabled in this session — call \
-                     `hostlib_enable(\"{}\")` before invoking deterministic tools",
-                    permissions::FEATURE_TOOLS_DETERMINISTIC,
-                    permissions::FEATURE_TOOLS_DETERMINISTIC
-                ),
-            });
-        }
-        runner(args)
-    });
     registry.register(RegisteredBuiltin {
         name,
         module: "tools",
         method,
-        handler,
+        handler: permissions::gated_handler(name, runner),
     });
 }
 

--- a/crates/harn-hostlib/src/tools/permissions.rs
+++ b/crates/harn-hostlib/src/tools/permissions.rs
@@ -20,6 +20,12 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+use crate::registry::SyncHandler;
 
 /// Feature key for the deterministic-tools surface.
 ///
@@ -59,4 +65,32 @@ pub fn is_enabled(feature: &str) -> bool {
 /// current thread without needing to reach for the builtin.
 pub fn enable_for_test() {
     enable(FEATURE_TOOLS_DETERMINISTIC);
+}
+
+/// Wrap a builtin runner so it executes only when the deterministic-tools
+/// feature has been enabled on the current thread, returning a descriptive
+/// error otherwise.
+///
+/// This is the single gating policy shared by every hostlib builtin that
+/// reads or writes arbitrary host filesystem paths — the `tools::*` file
+/// I/O surface plus the `fs::*` and `ast::*` edit helpers — so a script
+/// denied `tools:deterministic` cannot mutate the working tree through any
+/// of them.
+pub fn gated_handler(
+    name: &'static str,
+    runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
+) -> SyncHandler {
+    Arc::new(move |args: &[VmValue]| {
+        if !is_enabled(FEATURE_TOOLS_DETERMINISTIC) {
+            return Err(HostlibError::Backend {
+                builtin: name,
+                message: format!(
+                    "feature `{FEATURE_TOOLS_DETERMINISTIC}` is not enabled in this \
+                     session — call `hostlib_enable(\"{FEATURE_TOOLS_DETERMINISTIC}\")` \
+                     before invoking deterministic tools"
+                ),
+            });
+        }
+        runner(args)
+    })
 }

--- a/crates/harn-hostlib/tests/fs_staging.rs
+++ b/crates/harn-hostlib/tests/fs_staging.rs
@@ -580,10 +580,8 @@ fn safe_text_patch_serializes_concurrent_staged_commits() {
         handles.push(thread::spawn(move || {
             // tools:deterministic is thread-local; each spawned thread
             // must re-enable the gate the registry helper installed on
-            // the main thread before driving any gated builtin. The
-            // safe-text-patch primitive itself is un-gated, but we
-            // enable here so future maintainers don't trip when adding
-            // a `tools_*` call to the race scenario.
+            // the main thread before driving `hostlib_fs_safe_text_patch`,
+            // which is gated on the deterministic-tools feature.
             permissions::enable_for_test();
             let response = (reg.find("hostlib_fs_safe_text_patch").unwrap().handler)(&dict_arg(&[
                 ("session_id", vm_string(&session)),

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -10,8 +10,8 @@
 use harn_hostlib::{
     ast::AstCapability, code_index::CodeIndexCapability, fs::FsCapability,
     fs_snapshot::FsSnapshotCapability, fs_watch::FsWatchCapability, scanner::ScannerCapability,
-    schemas, secret_store::SecretStoreCapability, tools::ToolsCapability, BuiltinRegistry,
-    HostlibCapability, HostlibError, HostlibRegistry,
+    schemas, secret_store::SecretStoreCapability, tools::permissions, tools::ToolsCapability,
+    BuiltinRegistry, HostlibCapability, HostlibError, HostlibRegistry,
 };
 
 fn collect_into_registry<C: HostlibCapability>(cap: C) -> BuiltinRegistry {
@@ -67,6 +67,10 @@ fn ast_capability_registers_documented_methods() {
         ("hostlib_ast_insert_at_anchor", "path"),
         ("hostlib_ast_dry_run", "plan"),
     ];
+    // `apply_node` / `insert_at_anchor` write edited source to disk and are
+    // gated on the deterministic-tools feature (#2548); enable it so the
+    // handlers reach their parameter validation rather than the gate.
+    permissions::enable_for_test();
     for (name, expected_param) in expected_missing {
         let entry = registry.find(name).expect("registered");
         let err = (entry.handler)(&[]).expect_err("must reject empty args");
@@ -193,6 +197,10 @@ fn fs_capability_registers_documented_methods() {
         ("hostlib_fs_read_text", "path"),
         ("hostlib_fs_emit_safe_text_patch_result", "path"),
     ];
+    // `safe_text_patch` / `read_text` touch arbitrary host paths and are
+    // gated on the deterministic-tools feature (#2548); enable it so the
+    // handlers reach their parameter validation rather than the gate.
+    permissions::enable_for_test();
     for (name, expected_param) in expected_missing {
         let entry = registry.find(name).expect("registered");
         let err = (entry.handler)(&[]).expect_err("must reject empty args");
@@ -203,6 +211,48 @@ fn fs_capability_registers_documented_methods() {
             }
             other => panic!("expected MissingParameter for {name}, got {other:?}"),
         }
+    }
+}
+
+/// Every hostlib builtin that reads or writes arbitrary host paths must
+/// refuse to run before `hostlib_enable("tools:deterministic")`, matching
+/// the `tools::*` file I/O gate (#2548). This guards against the asymmetry
+/// where the std/edit helpers could mutate files a sandboxed script was
+/// denied via the `tools` surface.
+#[test]
+fn fs_and_ast_edit_primitives_require_deterministic_gate() {
+    let mut registry = collect_into_registry(FsCapability);
+    AstCapability.register_builtins(&mut registry);
+    permissions::reset();
+    for name in [
+        "hostlib_fs_safe_text_patch",
+        "hostlib_fs_read_text",
+        "hostlib_ast_apply_node",
+        "hostlib_ast_insert_at_anchor",
+    ] {
+        let entry = registry.find(name).expect("registered");
+        let err = (entry.handler)(&[]).expect_err("gated before enable");
+        match err {
+            HostlibError::Backend { builtin, message } => {
+                assert_eq!(builtin, name);
+                assert!(
+                    message.contains("hostlib_enable"),
+                    "gating error must point users at hostlib_enable: {message}"
+                );
+            }
+            other => panic!("expected Backend gate error for {name}, got {other:?}"),
+        }
+    }
+    // Telemetry routing cannot mutate files, so it stays un-gated: an empty
+    // payload must surface parameter validation, not the feature gate.
+    let entry = registry
+        .find("hostlib_fs_emit_safe_text_patch_result")
+        .expect("registered");
+    match (entry.handler)(&[]).expect_err("must reject empty args") {
+        HostlibError::MissingParameter { builtin, .. } => {
+            assert_eq!(builtin, "hostlib_fs_emit_safe_text_patch_result");
+        }
+        other => panic!("emit result must stay un-gated, got {other:?}"),
     }
 }
 

--- a/crates/harn-hostlib/tests/smoke_harn_script.rs
+++ b/crates/harn-hostlib/tests/smoke_harn_script.rs
@@ -292,6 +292,7 @@ return {{
 
 #[test]
 fn end_to_end_apply_node_via_harn_script() {
+    permissions::reset();
     let dir = TempDir::new().unwrap();
     let root = dir.path();
     let source_path = root.join("hello.rs");
@@ -305,6 +306,7 @@ fn end_to_end_apply_node_via_harn_script() {
     let path = &path_str;
     let script = format!(
         r#"
+let _enable = hostlib_enable("tools:deterministic")
 let preview = hostlib_ast_apply_node({{
     path: "{path}",
     query: "(function_item name: (identifier) @name (#eq? @name \"greet\") body: (block) @target)",
@@ -349,6 +351,7 @@ return {{
 
 #[test]
 fn end_to_end_insert_at_anchor_via_harn_script() {
+    permissions::reset();
     let dir = TempDir::new().unwrap();
     let root = dir.path();
     let source_path = root.join("hello.rs");
@@ -362,6 +365,7 @@ fn end_to_end_insert_at_anchor_via_harn_script() {
     let path = &path_str;
     let script = format!(
         r#"
+let _enable = hostlib_enable("tools:deterministic")
 let preview = hostlib_ast_insert_at_anchor({{
     path: "{path}",
     query: "(function_item name: (identifier) @name (#eq? @name \"alpha\")) @anchor",

--- a/docs/src/stdlib/edit.md
+++ b/docs/src/stdlib/edit.md
@@ -24,6 +24,16 @@ source files. Three flavors live side by side:
   `edit_validate_changed_regions`, `edit_check_lazy_truncation`,
   `edit_explain_whitespace_difference`, `edit_strip_line_number_prefixes`.
 
+> **Feature gate.** Every helper that reads or writes a file on disk —
+> `edit_apply_node`, `edit_insert_at_anchor`, and `edit_safe_text_patch` —
+> is gated on the deterministic-tools feature, the same gate the
+> `hostlib_tools_*` file I/O builtins use. Call
+> `hostlib_enable("tools:deterministic")` once at the start of the
+> pipeline before invoking them; otherwise the underlying builtin returns
+> a structured error pointing you back here. Pure in-memory helpers
+> (`edit_apply_old_new_patch`, `edit_dry_run`, the validators) are not
+> gated.
+
 ## `edit_apply_node` — Tree-Sitter query → format-preserving replace
 
 `edit_apply_node({path, query, replacement, ...})` locates AST node(s)
@@ -36,6 +46,9 @@ Backed by the `hostlib_ast_apply_node` builtin (issue
 [#2506](https://github.com/burin-labs/harn/issues/2506)) under the
 `std/edit` umbrella epic
 [#2497](https://github.com/burin-labs/harn/issues/2497).
+
+Requires `hostlib_enable("tools:deterministic")` first — it writes the
+edited source to disk (see [Feature gate](#edit-stdlib)).
 
 ### Parameters
 
@@ -211,6 +224,9 @@ Backed by the `hostlib_ast_insert_at_anchor` builtin (issue
 [#2497](https://github.com/burin-labs/harn/issues/2497) umbrella epic
 as `edit_apply_node`.
 
+Requires `hostlib_enable("tools:deterministic")` first — it writes the
+edited source to disk (see [Feature gate](#edit-stdlib)).
+
 ### Parameters
 
 | Field | Required | Notes |
@@ -346,6 +362,10 @@ retry, never blindly clobber.
 
 Backed by the `hostlib_fs_safe_text_patch` builtin (issue
 [#2509](https://github.com/burin-labs/harn/issues/2509)).
+
+Requires `hostlib_enable("tools:deterministic")` first — it reads
+(`hostlib_fs_read_text`) and writes the target file on disk (see
+[Feature gate](#edit-stdlib)).
 
 ### Parameters
 


### PR DESCRIPTION
## Summary

Closes burin-labs/harn#2548 (adversarial-review finding **H1** on #2542).

Four hostlib builtins that read or write arbitrary host paths were
**un-gated**, so a sandboxed script denied `tools:deterministic` could
still read and mutate the working tree through the `std/edit` helpers —
even though `hostlib_tools_read_file` / `hostlib_tools_write_file` already
require the gate. This PR closes that asymmetry.

- Gate `hostlib_fs_safe_text_patch`, `hostlib_fs_read_text`,
  `hostlib_ast_apply_node`, and `hostlib_ast_insert_at_anchor` on
  `tools:deterministic`.
- Extract the gating policy into one shared
  `permissions::gated_handler` used by the `tools`, `fs`, and `ast`
  capabilities (was previously a private closure inside `tools/mod.rs`).
- `hostlib_fs_emit_safe_text_patch_result` stays **un-gated** — it is pure
  telemetry routing and cannot mutate files.
- Conformance tests and Rust integration tests that drive these helpers
  now call `hostlib_enable("tools:deterministic")` at setup.
- `docs/src/stdlib/edit.md` gains a top-level **Feature gate** note plus a
  per-section reminder on each disk-touching helper.

## Test plan

- [x] `cargo test -p harn-hostlib --test registration --test fs_staging --test smoke_harn_script` (new `fs_and_ast_edit_primitives_require_deterministic_gate` test asserts all four reject before enable; emit-result stays un-gated)
- [x] `harn test conformance --filter edit_apply_node|edit_insert_at_anchor|edit_safe_text_patch` all PASS
- [x] Swept all conformance + crate tests for gated-helper callers missing `hostlib_enable` — none remain
- [x] Confirmed `burin-code` and the agent host-tool path don't call these helpers without already enabling the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)