### PR TITLE
[A.11] harn-serve: enforce @budget(mcp_calls, pg_queries) call-count ceilings

### DIFF
--- a/changelog.d/2514.added.md
+++ b/changelog.d/2514.added.md
@@ -16,7 +16,5 @@
   details, request_id }` body that every adapter (mcp, a2a, api)
   shares. Subsumes the per-tenant / per-IP / queue-depth enforcement
   that `harn-cloud-gateway::http_utils::check_rate_limits` encoded as
-  bespoke middleware. `@budget(mcp_calls, pg_queries)` enforcement is
-  scaffolded but deferred to follow-up (#2576) since their increment
-  sites sit in primitives owned by sibling tickets. Closes #2514 (epic
-  #2496, A.11).
+  bespoke middleware. `@budget(mcp_calls, pg_queries)` enforcement
+  lands in the follow-up #2576. Closes #2514 (epic #2496, A.11).

--- a/changelog.d/2576.added.md
+++ b/changelog.d/2576.added.md
@@ -1,0 +1,18 @@
+- **`@budget(mcp_calls, pg_queries)` enforcement on `harn-serve` (#2576).**
+  Completes the A.11 budget surface scaffolded in #2570: declaring
+  `@budget(mcp_calls: 20, pg_queries: 50)` on an exported `.harn`
+  handler now installs per-dispatch ceilings backed by new harn-vm
+  `install_mcp_call_budget` / `install_pg_query_budget` RAII guards.
+  Each `mcp.call` charges one slot at the MCP host's call entry point
+  (ahead of the response cache, so a runaway tool loop is capped even
+  when it keeps hitting cached results), and each `pg_query` /
+  `pg_query_one` / `pg_execute` charges one slot at the Postgres
+  hostlib's query/execute entry points (mock pools included).
+  Crossing a ceiling raises a structured `BudgetExceeded` error whose
+  `limit` field names the dimension, which `http_codec` renders as
+  HTTP 429 with `code = "budget_exceeded"` and
+  `details.category = "mcp_calls"` / `"pg_queries"`. The dispatcher's
+  per-class rejection telemetry now also distinguishes `llm_tokens`
+  from `llm_cost_usd` exhaustion instead of collapsing both to the
+  latter. Closes #2576 and the last open acceptance items of #2514
+  (epic #2496, A.11).

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -68,10 +68,12 @@ fn classify_vm_error(error: harn_vm::VmError) -> DispatchError {
 }
 
 /// Best-effort attempt to recover the specific budget dimension that
-/// fired (e.g. `llm_cost_usd`) from a `VmError`. The structured form
-/// (`VmError::Thrown(Dict)`) carries it as the `limit` field; for the
-/// categorised mid-call variant we fall back to inferring from the
-/// error message.
+/// fired (one of `llm_cost_usd`, `llm_tokens`, `mcp_calls`,
+/// `pg_queries`) from a `VmError` so per-class rejection telemetry stays
+/// accurate. The structured form (`VmError::Thrown(Dict)` — the
+/// preflight LLM check and the mcp/pg call-count guards) carries it as
+/// the `limit` field. The LLM cost/token guards raise the categorised
+/// mid-call variant instead, where we disambiguate on the message.
 fn budget_category_from_error(error: &harn_vm::VmError) -> Option<String> {
     match error {
         harn_vm::VmError::Thrown(harn_vm::VmValue::Dict(d)) => d
@@ -79,20 +81,25 @@ fn budget_category_from_error(error: &harn_vm::VmError) -> Option<String> {
             .map(|value| value.display())
             .filter(|s| !s.is_empty()),
         harn_vm::VmError::CategorizedError { message, .. } if message.contains("LLM") => {
-            Some("llm_cost_usd".to_string())
+            if message.contains("token") {
+                Some("llm_tokens".to_string())
+            } else {
+                Some("llm_cost_usd".to_string())
+            }
         }
         _ => None,
     }
 }
 
 /// Install per-dispatch resource ceilings from the route's
-/// `@budget(...)` declaration. The LLM-cost and LLM-token caps route
-/// through `harn-vm`'s pre-existing per-thread counters; `pg_queries`
-/// and `mcp_calls` are parsed and reserved on the [`BudgetSpec`] but
-/// enforcement waits on their respective primitive integrations
-/// (Postgres hostlib A.3, the MCP host call-count meter) — both
-/// tracked as follow-ups so a runaway tool loop can be capped once
-/// the call sites exist.
+/// `@budget(...)` declaration. Every cap routes through a `harn-vm`
+/// per-thread counter installed for the lifetime of the returned guard:
+/// `llm_cost_usd` / `llm_tokens` meter LLM spend at the provider call
+/// site, while `mcp_calls` / `pg_queries` meter outbound tool-call and
+/// query counts at the MCP host and Postgres hostlib entry points. Each
+/// fires a `BudgetExceeded`-categorised error (mapped to HTTP 429 by
+/// [`classify_vm_error`]) the moment its ceiling is crossed, so a
+/// runaway `.harn` tool loop is capped at the dispatcher boundary.
 fn install_route_budget(spec: &BudgetSpec) -> Option<RouteBudgetGuard> {
     if spec.is_empty() {
         return None;
@@ -100,6 +107,8 @@ fn install_route_budget(spec: &BudgetSpec) -> Option<RouteBudgetGuard> {
     Some(RouteBudgetGuard {
         _llm_cost: spec.llm_cost_usd.map(harn_vm::install_llm_cost_budget),
         _llm_tokens: spec.llm_tokens.map(harn_vm::install_llm_token_budget),
+        _mcp_calls: spec.mcp_calls.map(harn_vm::install_mcp_call_budget),
+        _pg_queries: spec.pg_queries.map(harn_vm::install_pg_query_budget),
     })
 }
 
@@ -110,6 +119,8 @@ fn install_route_budget(spec: &BudgetSpec) -> Option<RouteBudgetGuard> {
 pub(crate) struct RouteBudgetGuard {
     _llm_cost: Option<harn_vm::LlmBudgetGuard>,
     _llm_tokens: Option<harn_vm::LlmTokenBudgetGuard>,
+    _mcp_calls: Option<harn_vm::McpCallBudgetGuard>,
+    _pg_queries: Option<harn_vm::PgQueryBudgetGuard>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1280,5 +1291,53 @@ pub fn whoami(harness: Harness) -> string {
             .expect("dispatch");
 
         assert_eq!(response.value, serde_json::json!("override-tenant"));
+    }
+
+    #[test]
+    fn budget_category_recovers_every_dimension() {
+        // Structured guards (mcp/pg call counts, LLM preflight) carry the
+        // dimension on the `limit` field.
+        let structured = |limit: &str| {
+            harn_vm::VmError::Thrown(harn_vm::VmValue::Dict(std::rc::Rc::new(
+                std::collections::BTreeMap::from([
+                    (
+                        "category".to_string(),
+                        harn_vm::VmValue::String(std::rc::Rc::from("budget_exceeded")),
+                    ),
+                    (
+                        "limit".to_string(),
+                        harn_vm::VmValue::String(std::rc::Rc::from(limit)),
+                    ),
+                ]),
+            )))
+        };
+        assert_eq!(
+            budget_category_from_error(&structured("mcp_calls")).as_deref(),
+            Some("mcp_calls"),
+        );
+        assert_eq!(
+            budget_category_from_error(&structured("pg_queries")).as_deref(),
+            Some("pg_queries"),
+        );
+
+        // LLM cost/token mid-call exhaustion raises the categorised
+        // variant; the message disambiguates cost from tokens so the
+        // per-class telemetry is accurate.
+        let categorized = |message: &str| harn_vm::VmError::CategorizedError {
+            message: message.to_string(),
+            category: harn_vm::ErrorCategory::BudgetExceeded,
+        };
+        assert_eq!(
+            budget_category_from_error(&categorized("LLM budget exceeded: spent $0.01 of $0.00"))
+                .as_deref(),
+            Some("llm_cost_usd"),
+        );
+        assert_eq!(
+            budget_category_from_error(&categorized(
+                "LLM token budget exceeded: spent 11 of 10 tokens"
+            ))
+            .as_deref(),
+            Some("llm_tokens"),
+        );
     }
 }

--- a/crates/harn-serve/src/limits/mod.rs
+++ b/crates/harn-serve/src/limits/mod.rs
@@ -35,11 +35,17 @@
 //! 3. Rejected dispatches surface as
 //!    [`crate::DispatchError::RateLimited`] → HTTP 429 with `Retry-After`
 //!    via [`crate::http_codec`].
-//! 4. Budget caps install on the dispatch's thread-local (the LLM
-//!    cost budget reuses `harn-vm`'s existing
-//!    [`harn_vm::install_llm_cost_budget`]; mid-call exhaustion raises a
-//!    typed runtime error which the codec maps to 429 with
-//!    `code = "budget_exceeded"`).
+//! 4. Budget caps install on the dispatch's thread-local via
+//!    `harn-vm` guards ([`harn_vm::install_llm_cost_budget`],
+//!    [`harn_vm::install_llm_token_budget`],
+//!    [`harn_vm::install_mcp_call_budget`],
+//!    [`harn_vm::install_pg_query_budget`]). Mid-call exhaustion raises a
+//!    `BudgetExceeded`-categorised runtime error which the codec maps to
+//!    429 with `code = "budget_exceeded"`. The `details.limit` field
+//!    names the dimension that fired using the same identifier as the
+//!    `@budget(...)` argument — one of `llm_cost_usd`, `llm_tokens`,
+//!    `mcp_calls`, or `pg_queries` — so clients can attribute the
+//!    rejection without parsing the message.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};

--- a/crates/harn-serve/tests/limits_loadgen.rs
+++ b/crates/harn-serve/tests/limits_loadgen.rs
@@ -382,6 +382,89 @@ async fn budget_exhaustion_renders_429_with_budget_exceeded_code() {
     assert_eq!(body["details"]["category"], "llm_cost_usd");
 }
 
+#[tokio::test]
+async fn pg_query_budget_rejects_third_query_as_429_via_dispatch() {
+    // End-to-end through `DispatchCore`: a handler declaring
+    // `@budget(pg_queries: 2)` runs three queries against a mock pool.
+    // The third is rejected at the `harness.pg.query` entry point with a
+    // `BudgetExceeded` error the codec renders as HTTP 429 carrying
+    // `details.category = "pg_queries"`. Uses a mock pool so the test
+    // needs no live Postgres and stays deterministic.
+    let dir = TempDir::new().expect("tempdir");
+    let path = write_script(
+        &dir,
+        r#"
+@budget(pg_queries: 2)
+pub fn run_queries() -> int {
+  let pool = pg_mock_pool([{sql: "SELECT 1", rows: []}])
+  pg_query(pool, "SELECT 1")
+  pg_query(pool, "SELECT 1")
+  pg_query(pool, "SELECT 1")
+  return 3
+}
+"#,
+    );
+
+    let core = DispatchCore::new(DispatchCoreConfig::for_script(&path)).expect("dispatch core");
+
+    let err = core
+        .dispatch(synth_request("run_queries"))
+        .await
+        .expect_err("third query must exceed pg_queries: 2");
+    let DispatchError::BudgetExceeded { category, .. } = &err else {
+        panic!("expected BudgetExceeded, got {err:?}");
+    };
+    assert_eq!(category, "pg_queries");
+
+    let request_id = fresh_request_id();
+    let response = axum_response_from_dispatch_error(err, &request_id);
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok()),
+        Some("60"),
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), 4_096)
+        .await
+        .expect("body bytes");
+    let body: Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(body["code"], "budget_exceeded");
+    assert_eq!(body["details"]["category"], "pg_queries");
+}
+
+#[tokio::test]
+async fn mcp_call_budget_renders_429_with_mcp_calls_category() {
+    // The mcp-call charge site lives in `harn-vm`'s `mcp_host::call`
+    // (exercised directly in the harn-vm suite); here we lock in the
+    // harn-serve half of the contract — a `mcp_calls` budget exhaustion
+    // maps to HTTP 429 with `details.category = "mcp_calls"` through the
+    // shared codec every adapter uses.
+    let err = DispatchError::BudgetExceeded {
+        category: "mcp_calls".to_string(),
+        message: "mcp_calls budget exceeded: this dispatch attempted 3 of 2 permitted MCP calls"
+            .to_string(),
+    };
+    let request_id = fresh_request_id();
+    let response = axum_response_from_dispatch_error(err, &request_id);
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok()),
+        Some("60"),
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), 4_096)
+        .await
+        .expect("body bytes");
+    let body: Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(body["code"], "budget_exceeded");
+    assert_eq!(body["details"]["category"], "mcp_calls");
+}
+
 /// Suppress an `AuthPolicy` warning that would otherwise complain when
 /// these tests run in a workspace that lints unused crate items.
 #[allow(dead_code)]

--- a/crates/harn-vm/src/call_budget.rs
+++ b/crates/harn-vm/src/call_budget.rs
@@ -1,0 +1,283 @@
+//! Per-dispatch ceilings on outbound *call counts* — MCP tool calls and
+//! Postgres queries — mirroring the LLM cost/token budgets in
+//! [`crate::llm::cost`]. A `.harn` handler exported through `harn-serve`
+//! declares `@budget(mcp_calls: 20, pg_queries: 50)`; the dispatcher
+//! installs the matching guards for the lifetime of the call. Each
+//! charge increments a per-thread counter and, once the ceiling is
+//! crossed, raises a structured `BudgetExceeded`-categorised error that
+//! adapter codecs render as HTTP 429.
+//!
+//! Counters only advance while a budget is installed, so dispatches
+//! without a `@budget` declaration pay nothing and never accumulate
+//! cross-call state. Guards restore the prior ceiling and count on drop,
+//! keeping nested dispatches (a handler that re-enters the dispatcher)
+//! from leaking a tighter budget outward or a wider one back into a
+//! finished inner scope.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::thread::LocalKey;
+
+use crate::value::{VmError, VmValue};
+
+thread_local! {
+    static MCP_CALL_BUDGET: RefCell<Option<u64>> = const { RefCell::new(None) };
+    static MCP_CALL_COUNT: RefCell<u64> = const { RefCell::new(0) };
+    static PG_QUERY_BUDGET: RefCell<Option<u64>> = const { RefCell::new(None) };
+    static PG_QUERY_COUNT: RefCell<u64> = const { RefCell::new(0) };
+}
+
+/// Reset thread-local call-budget state. Call between test runs so a
+/// guard that outlived an unwinding test cannot leak a ceiling.
+pub(crate) fn reset_call_budget_state() {
+    MCP_CALL_BUDGET.with(|b| *b.borrow_mut() = None);
+    MCP_CALL_COUNT.with(|c| *c.borrow_mut() = 0);
+    PG_QUERY_BUDGET.with(|b| *b.borrow_mut() = None);
+    PG_QUERY_COUNT.with(|c| *c.borrow_mut() = 0);
+}
+
+/// The two call-count dimensions. Each names the `@budget(...)` field it
+/// backs so the structured error carries the dimension that fired and
+/// `harn-serve`'s `budget_category_from_error` can recover it from the
+/// `limit` field without inspecting the message.
+#[derive(Clone, Copy)]
+enum CallBudgetKind {
+    McpCalls,
+    PgQueries,
+}
+
+impl CallBudgetKind {
+    /// The `@budget(...)` field name, surfaced as the error's `limit`.
+    fn limit_label(self) -> &'static str {
+        match self {
+            CallBudgetKind::McpCalls => "mcp_calls",
+            CallBudgetKind::PgQueries => "pg_queries",
+        }
+    }
+
+    /// Human-readable noun for the error message, pluralised to agree
+    /// with the ceiling count.
+    fn noun(self, plural: bool) -> &'static str {
+        match (self, plural) {
+            (CallBudgetKind::McpCalls, false) => "MCP call",
+            (CallBudgetKind::McpCalls, true) => "MCP calls",
+            (CallBudgetKind::PgQueries, false) => "Postgres query",
+            (CallBudgetKind::PgQueries, true) => "Postgres queries",
+        }
+    }
+}
+
+/// Increment the counter behind `budget`/`count` and raise once the
+/// ceiling is crossed. A `None` budget short-circuits — no install, no
+/// charge. The counter only advances while a ceiling is present so
+/// budget-free dispatches stay zero-cost.
+fn charge(
+    budget: &'static LocalKey<RefCell<Option<u64>>>,
+    count: &'static LocalKey<RefCell<u64>>,
+    kind: CallBudgetKind,
+) -> Result<(), VmError> {
+    let Some(max) = budget.with(|b| *b.borrow()) else {
+        return Ok(());
+    };
+    let spent = count.with(|c| {
+        let mut slot = c.borrow_mut();
+        *slot = slot.saturating_add(1);
+        *slot
+    });
+    if spent > max {
+        return Err(budget_exceeded_error(kind, spent, max));
+    }
+    Ok(())
+}
+
+/// Build the structured error rendered as HTTP 429. The `category` field
+/// routes it through `ErrorCategory::BudgetExceeded`; the `limit` field
+/// names the dimension so adapters report `code: "budget_exceeded"` with
+/// the precise `@budget(...)` field that fired.
+fn budget_exceeded_error(kind: CallBudgetKind, spent: u64, max: u64) -> VmError {
+    let mut dict = BTreeMap::new();
+    dict.insert(
+        "category".to_string(),
+        VmValue::String(Rc::from("budget_exceeded")),
+    );
+    dict.insert("kind".to_string(), VmValue::String(Rc::from("terminal")));
+    dict.insert(
+        "reason".to_string(),
+        VmValue::String(Rc::from("budget_exceeded")),
+    );
+    dict.insert(
+        "limit".to_string(),
+        VmValue::String(Rc::from(kind.limit_label())),
+    );
+    dict.insert("limit_value".to_string(), VmValue::Int(max as i64));
+    dict.insert("spent".to_string(), VmValue::Int(spent as i64));
+    dict.insert(
+        "message".to_string(),
+        VmValue::String(Rc::from(format!(
+            "{} budget exceeded: this dispatch attempted {} of {} permitted {}",
+            kind.limit_label(),
+            spent,
+            max,
+            kind.noun(max != 1),
+        ))),
+    );
+    VmError::Thrown(VmValue::Dict(Rc::new(dict)))
+}
+
+/// RAII guard for [`install_mcp_call_budget`]. Restores the prior MCP
+/// call ceiling and count on drop.
+#[must_use = "dropping the guard immediately restores the prior MCP call budget"]
+pub struct McpCallBudgetGuard {
+    previous_budget: Option<u64>,
+    previous_count: u64,
+}
+
+impl Drop for McpCallBudgetGuard {
+    fn drop(&mut self) {
+        MCP_CALL_BUDGET.with(|b| *b.borrow_mut() = self.previous_budget);
+        MCP_CALL_COUNT.with(|c| *c.borrow_mut() = self.previous_count);
+    }
+}
+
+/// Pin the per-dispatch MCP tool-call ceiling at `max` for the lifetime
+/// of the returned guard. Sourced from `@budget(mcp_calls: …)` on
+/// `.harn` handlers in `harn-serve`; the `(max + 1)`-th call raises a
+/// `BudgetExceeded`-categorised error adapters render as HTTP 429.
+pub fn install_mcp_call_budget(max: u64) -> McpCallBudgetGuard {
+    let previous_budget = MCP_CALL_BUDGET.with(|b| *b.borrow());
+    let previous_count = MCP_CALL_COUNT.with(|c| *c.borrow());
+    MCP_CALL_BUDGET.with(|b| *b.borrow_mut() = Some(max));
+    MCP_CALL_COUNT.with(|c| *c.borrow_mut() = 0);
+    McpCallBudgetGuard {
+        previous_budget,
+        previous_count,
+    }
+}
+
+/// Charge one MCP tool call against the active `@budget(mcp_calls: …)`
+/// ceiling, if any. Called once per logical `mcp.call` dispatch.
+pub fn charge_mcp_call() -> Result<(), VmError> {
+    charge(&MCP_CALL_BUDGET, &MCP_CALL_COUNT, CallBudgetKind::McpCalls)
+}
+
+/// RAII guard for [`install_pg_query_budget`]. Restores the prior
+/// Postgres query ceiling and count on drop.
+#[must_use = "dropping the guard immediately restores the prior Postgres query budget"]
+pub struct PgQueryBudgetGuard {
+    previous_budget: Option<u64>,
+    previous_count: u64,
+}
+
+impl Drop for PgQueryBudgetGuard {
+    fn drop(&mut self) {
+        PG_QUERY_BUDGET.with(|b| *b.borrow_mut() = self.previous_budget);
+        PG_QUERY_COUNT.with(|c| *c.borrow_mut() = self.previous_count);
+    }
+}
+
+/// Pin the per-dispatch Postgres query ceiling at `max` for the lifetime
+/// of the returned guard. Sourced from `@budget(pg_queries: …)` on
+/// `.harn` handlers in `harn-serve`; the `(max + 1)`-th query raises a
+/// `BudgetExceeded`-categorised error adapters render as HTTP 429.
+pub fn install_pg_query_budget(max: u64) -> PgQueryBudgetGuard {
+    let previous_budget = PG_QUERY_BUDGET.with(|b| *b.borrow());
+    let previous_count = PG_QUERY_COUNT.with(|c| *c.borrow());
+    PG_QUERY_BUDGET.with(|b| *b.borrow_mut() = Some(max));
+    PG_QUERY_COUNT.with(|c| *c.borrow_mut() = 0);
+    PgQueryBudgetGuard {
+        previous_budget,
+        previous_count,
+    }
+}
+
+/// Charge one Postgres query against the active `@budget(pg_queries: …)`
+/// ceiling, if any. Called once per `pg_query` / `pg_query_one` /
+/// `pg_execute` statement (including mock-pool statements).
+pub fn charge_pg_query() -> Result<(), VmError> {
+    charge(&PG_QUERY_BUDGET, &PG_QUERY_COUNT, CallBudgetKind::PgQueries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::{error_to_category, ErrorCategory};
+
+    #[test]
+    fn charge_is_noop_without_installed_budget() {
+        reset_call_budget_state();
+        for _ in 0..1000 {
+            assert!(charge_mcp_call().is_ok());
+            assert!(charge_pg_query().is_ok());
+        }
+        // No guard installed → counters never advance.
+        assert_eq!(MCP_CALL_COUNT.with(|c| *c.borrow()), 0);
+        assert_eq!(PG_QUERY_COUNT.with(|c| *c.borrow()), 0);
+    }
+
+    #[test]
+    fn mcp_budget_admits_up_to_ceiling_then_rejects() {
+        reset_call_budget_state();
+        let _guard = install_mcp_call_budget(2);
+        assert!(charge_mcp_call().is_ok());
+        assert!(charge_mcp_call().is_ok());
+        let third = charge_mcp_call();
+        let err = third.expect_err("third call must exceed mcp_calls: 2");
+        assert_eq!(error_to_category(&err), ErrorCategory::BudgetExceeded);
+        match &err {
+            VmError::Thrown(VmValue::Dict(d)) => {
+                assert_eq!(
+                    d.get("limit").map(|v| v.display()).as_deref(),
+                    Some("mcp_calls")
+                );
+                assert_eq!(d.get("limit_value").and_then(VmValue::as_int), Some(2));
+                assert_eq!(d.get("spent").and_then(VmValue::as_int), Some(3));
+            }
+            other => panic!("expected structured Thrown dict, got {other:?}"),
+        }
+        reset_call_budget_state();
+    }
+
+    #[test]
+    fn pg_budget_message_pluralises_and_names_dimension() {
+        reset_call_budget_state();
+        let _guard = install_pg_query_budget(1);
+        assert!(charge_pg_query().is_ok());
+        let err = charge_pg_query().expect_err("second query must exceed pg_queries: 1");
+        match &err {
+            VmError::Thrown(VmValue::Dict(d)) => {
+                let message = d.get("message").map(|v| v.display()).unwrap_or_default();
+                assert!(
+                    message.contains("pg_queries budget exceeded"),
+                    "got: {message}"
+                );
+                assert!(message.contains("Postgres query"), "got: {message}");
+            }
+            other => panic!("expected structured Thrown dict, got {other:?}"),
+        }
+        reset_call_budget_state();
+    }
+
+    #[test]
+    fn nested_guard_restores_outer_budget_and_count_on_drop() {
+        reset_call_budget_state();
+        let outer = install_mcp_call_budget(5);
+        assert!(charge_mcp_call().is_ok());
+        assert_eq!(MCP_CALL_COUNT.with(|c| *c.borrow()), 1);
+
+        {
+            // Nested dispatch installs a tighter ceiling and starts fresh.
+            let _inner = install_mcp_call_budget(1);
+            assert_eq!(MCP_CALL_COUNT.with(|c| *c.borrow()), 0);
+            assert!(charge_mcp_call().is_ok());
+            assert!(charge_mcp_call().is_err());
+        }
+
+        // Inner drop restores the outer ceiling and its accumulated count.
+        assert_eq!(MCP_CALL_BUDGET.with(|b| *b.borrow()), Some(5));
+        assert_eq!(MCP_CALL_COUNT.with(|c| *c.borrow()), 1);
+        drop(outer);
+        assert_eq!(MCP_CALL_BUDGET.with(|b| *b.borrow()), None);
+        reset_call_budget_state();
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod aws_sigv4;
 pub mod bridge;
 mod builtin_id;
 pub mod bytecode_cache;
+pub mod call_budget;
 pub mod channel_guardrails;
 pub mod channels;
 pub mod checkpoint;
@@ -120,6 +121,10 @@ pub mod workspace_anchor;
 pub mod workspace_path;
 
 pub use builtin_id::BuiltinId;
+pub use call_budget::{
+    charge_mcp_call, charge_pg_query, install_mcp_call_budget, install_pg_query_budget,
+    McpCallBudgetGuard, PgQueryBudgetGuard,
+};
 pub use checkpoint::register_checkpoint_builtins;
 pub use chunk::*;
 pub use compiler::*;
@@ -427,5 +432,6 @@ pub fn reset_thread_local_state() {
     agent_sessions::reset_session_store();
     mcp_registry::reset();
     mcp_host::reset_for_tests();
+    call_budget::reset_call_budget_state();
     clock_mock::leak_audit::reset();
 }

--- a/crates/harn-vm/src/mcp_host.rs
+++ b/crates/harn-vm/src/mcp_host.rs
@@ -520,6 +520,12 @@ pub async fn call(name: &str, tool: &str, args: JsonValue) -> Result<JsonValue, 
         }
     }
 
+    // Charge the logical call against any active `@budget(mcp_calls: …)`
+    // ceiling before doing work — including cache hits, since the budget
+    // caps how many tool calls a dispatch may *issue*, not how many miss
+    // the cache. Caps a runaway tool loop at the dispatcher boundary.
+    crate::call_budget::charge_mcp_call()?;
+
     let now = Instant::now();
     let args_hash = hash_args(&args);
     if let Some(payload) = take_cache_hit(name, tool, &args_hash, now) {

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -574,6 +574,7 @@ pub(super) async fn query_rows(
     params: &[VmValue],
     routing: QueryRouting,
 ) -> Result<Vec<VmValue>, VmError> {
+    crate::call_budget::charge_pg_query()?;
     match handle_kind(target).as_deref() {
         Some(HANDLE_MOCK) => return mock_query(target, sql, params, false),
         Some(HANDLE_TX) => {
@@ -615,6 +616,7 @@ pub(super) async fn execute_stmt(
     sql: &str,
     params: &[VmValue],
 ) -> Result<VmValue, VmError> {
+    crate::call_budget::charge_pg_query()?;
     let started = std::time::Instant::now();
     if handle_kind(target).as_deref() == Some(HANDLE_MOCK) {
         let rows = mock_query(target, sql, params, true)?;

--- a/crates/harn-vm/tests/mcp_call_budget.rs
+++ b/crates/harn-vm/tests/mcp_call_budget.rs
@@ -1,0 +1,62 @@
+#![recursion_limit = "256"]
+//! Proves the `@budget(mcp_calls: N)` ceiling is enforced at the real
+//! `mcp_host::call` charge site: once `N` calls have been issued, the
+//! `(N + 1)`-th is rejected with a `BudgetExceeded`-categorised error
+//! before it can touch a transport — exactly how `harn-serve` caps a
+//! runaway `.harn` tool loop. No MCP server is spawned: the charge runs
+//! ahead of connection setup, so calls against an unregistered server
+//! still consume the budget and the over-limit call rejects deterministically.
+
+use harn_vm::{error_to_category, ErrorCategory, VmError, VmValue};
+use serde_json::json;
+
+#[tokio::test]
+async fn mcp_call_budget_rejects_call_past_ceiling() {
+    harn_vm::reset_thread_local_state();
+    let _guard = harn_vm::install_mcp_call_budget(2);
+
+    // Calls 1 and 2 are within budget; they still fail because no server
+    // is registered, but the failure is a transport/lookup error — not a
+    // budget rejection. The point is that they consume a slot apiece.
+    for attempt in 1..=2 {
+        let err = harn_vm::mcp_host::call("ghost", "tool", json!({}))
+            .await
+            .expect_err("unregistered server fails to connect");
+        assert_ne!(
+            error_to_category(&err),
+            ErrorCategory::BudgetExceeded,
+            "call {attempt} is within budget and must not be a budget rejection"
+        );
+    }
+
+    // The third call crosses the ceiling and rejects up front.
+    let err = harn_vm::mcp_host::call("ghost", "tool", json!({}))
+        .await
+        .expect_err("third call exceeds mcp_calls: 2");
+    assert_eq!(error_to_category(&err), ErrorCategory::BudgetExceeded);
+    match &err {
+        VmError::Thrown(VmValue::Dict(d)) => {
+            assert_eq!(
+                d.get("limit").map(|v| v.display()).as_deref(),
+                Some("mcp_calls"),
+            );
+        }
+        other => panic!("expected structured Thrown dict, got {other:?}"),
+    }
+
+    harn_vm::reset_thread_local_state();
+}
+
+#[tokio::test]
+async fn mcp_calls_without_budget_are_uncapped() {
+    harn_vm::reset_thread_local_state();
+    // No guard installed → the charge is a no-op and every call reaches
+    // the transport (failing only because `ghost` is unregistered).
+    for _ in 0..5 {
+        let err = harn_vm::mcp_host::call("ghost", "tool", json!({}))
+            .await
+            .expect_err("unregistered server fails to connect");
+        assert_ne!(error_to_category(&err), ErrorCategory::BudgetExceeded);
+    }
+    harn_vm::reset_thread_local_state();
+}


### PR DESCRIPTION
## Summary

Completes the deferred acceptance items of #2514 (epic A.11). #2570 parsed `mcp_calls` / `pg_queries` onto `BudgetSpec` but left enforcement to follow-up #2576 because the charge sites live in primitives owned by sibling tickets — A.3 Postgres hostlib (#2500) and A.7 MCP host (#2504), both now landed.

- **New `harn-vm` `call_budget` module** mirrors the LLM cost/token budget shape: per-thread ceilings behind RAII guards (`install_mcp_call_budget` / `install_pg_query_budget`) that restore the prior ceiling **and** count on drop, so nested dispatches stay isolated. Counters only advance while a ceiling is installed, so budget-free dispatches stay zero-cost.
- **MCP charge site:** `mcp_host::call` charges one slot *ahead of the response cache*, so a runaway tool loop is capped even when it keeps hitting cached results.
- **Postgres charge site:** `query_rows` / `execute_stmt` charge one slot each, covering `pg_query` / `pg_query_one` / `pg_execute` (mock pools included — no live Postgres needed to test).
- **Error → 429:** crossing a ceiling raises a structured `BudgetExceeded` error whose `limit` field names the dimension; `harn-serve` maps it to HTTP 429 with `code = "budget_exceeded"` and `details.category = "mcp_calls"` / `"pg_queries"` via the shared `http_codec` every adapter uses. Wired through `install_route_budget` alongside the existing LLM guards.
- **Telemetry fix:** `budget_category_from_error` now distinguishes `llm_tokens` from `llm_cost_usd` exhaustion instead of collapsing both to `llm_cost_usd`, keeping the A.11 per-class rejection telemetry accurate.

## Acceptance against #2576 / remaining #2514 items

- [x] `harn_vm::install_mcp_call_budget` lands + wired through `install_route_budget`
- [x] MCP call entry point increments + raises `BudgetExceeded` on overflow
- [x] `harn_vm::install_pg_query_budget` lands + wired (A.3 now merged)
- [x] Pg-query entry point increments + raises
- [x] Integration test for each: `@budget(mcp_calls: 2)` rejects the 3rd MCP call; `@budget(pg_queries: 2)` rejects the 3rd query as HTTP 429
- [x] Categorisation strings documented in the A.11 module docstring

## Test plan

- [x] `cargo test -p harn-vm --lib call_budget` (4 unit tests: no-op without budget, ceiling+reject, message/dimension, nested-guard restore)
- [x] `cargo test -p harn-vm --test mcp_call_budget` (2 tests: real `mcp_host::call` charge site rejects past ceiling; uncapped without budget)
- [x] `cargo test -p harn-serve --test limits_loadgen` (10 tests incl. new pg E2E through `DispatchCore` → 429 codec, and `mcp_calls` codec category)
- [x] `cargo test -p harn-serve --lib` (336 pass; new `budget_category_recovers_every_dimension`)
- [x] `cargo clippy -p harn-vm -p harn-serve --tests -- -D warnings` clean
- [x] `make lint-test-patterns` (wall-clock audit) clean

Closes #2576. Completes the final acceptance items of #2514 (A.11), so closes #2514 (epic #2496).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
