### PR TITLE
[A.13] sandbox: permission-policy runtime arm in harn-hostlib + harn-serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,6 +2337,7 @@ dependencies = [
 name = "harn-hostlib"
 version = "0.8.47"
 dependencies = [
+ "async-trait",
  "base64",
  "criterion",
  "filetime",
@@ -2382,6 +2383,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "tree-sitter-zig",
+ "uuid",
  "walkdir",
  "windows-sys 0.61.2",
 ]

--- a/changelog.d/2516.added.md
+++ b/changelog.d/2516.added.md
@@ -1,0 +1,17 @@
+- **Sandbox runtime arm for the permission primitive (#2516).** A
+  sandbox is now the runtime answer to a declared permission policy.
+  `harn-hostlib` gains a `sandbox` module — the pluggable
+  `SandboxBackend` contract (`SandboxSpec`, `ExecRequest`/`ExecResult`,
+  `NetworkPolicy`, mounts, limits) plus a `LocalSandbox` backend that
+  confines every command through `harn-vm`'s process sandbox
+  (Landlock/seccomp, `sandbox-exec`, Job Objects, `pledge`/`unveil`)
+  rather than reimplementing OS confinement. `harn-serve`'s
+  `permissions::enforcement` lowers a `PermissionPolicy` into the
+  enforcement vocabularies it already uses: `to_capability_policy`
+  derives the in-VM `CapabilityPolicy` ceiling (read/write/exec →
+  capabilities + `side_effect_level`), and `to_sandbox_spec` /
+  `to_network_policy` (with the `hostlib` feature) turn the `net`
+  allowlist into an egress policy. This is the canonical home for the
+  enforcement contract that `harn-cloud-sandbox` previously duplicated,
+  and the abstraction the planned Modal/E2B/Daytona/Fly backends build
+  on.

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -18,14 +18,17 @@ include = [
 
 [dependencies]
 harn-vm = { path = "../harn-vm", version = "0.8" }
+async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
 hex = "0.4"
 time = { version = "0.3", features = ["formatting"] }
-tokio = { version = "1", features = ["rt", "macros", "sync", "fs", "process", "time"] }
+tokio = { version = "1", features = ["rt", "macros", "sync", "fs", "net", "process", "time"] }
 thiserror = "2"
 tracing = "0.1"
+tempfile = "3"
+uuid = { version = "1", features = ["v7"] }
 
 # Foundational dependencies for the upcoming module implementations
 # (B2/B3/B4/C1/C2/C3). They are wired in here so the workspace lockfile is
@@ -89,7 +92,6 @@ windows-sys = { version = "0.61.2", features = [
 ] }
 
 [dev-dependencies]
-tempfile = "3"
 serde_json = "1"
 filetime = "0.2"
 criterion = "0.8"

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -34,6 +34,7 @@ pub mod fs;
 pub mod fs_snapshot;
 pub mod fs_watch;
 pub mod process;
+pub mod sandbox;
 pub mod scanner;
 pub mod schemas;
 pub mod secret_store;

--- a/crates/harn-hostlib/src/sandbox/local.rs
+++ b/crates/harn-hostlib/src/sandbox/local.rs
@@ -535,6 +535,9 @@ fn dict_int(map: &BTreeMap<String, VmValue>, key: &str) -> SandboxResult<i32> {
 mod tests {
     use super::*;
 
+    // Exercises a real `sh -c` invocation with POSIX env expansion and
+    // `printf`, so it only runs where a POSIX shell exists.
+    #[cfg(unix)]
     #[tokio::test]
     async fn local_backend_execs_inside_session_outputs() {
         let backend = LocalSandbox::default();

--- a/crates/harn-hostlib/src/sandbox/local.rs
+++ b/crates/harn-hostlib/src/sandbox/local.rs
@@ -1,0 +1,628 @@
+//! Local enforcement backend.
+//!
+//! Runs each command through `harn-vm`'s process sandbox, so the
+//! kernel-level confinement (Landlock/seccomp on Linux, `sandbox-exec`
+//! on macOS, Job Objects on Windows, `pledge`/`unveil` on OpenBSD) is
+//! reused rather than reimplemented. Filesystem scope comes from the
+//! session's mounts; network egress is limited to deny-all or
+//! allow-all, since per-host egress filtering for a local process is a
+//! remote-backend capability (see [`SandboxCapabilities::network_policy`]).
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use harn_vm::orchestration::{
+    pop_execution_policy, push_execution_policy, CapabilityPolicy, SandboxProfile,
+};
+use harn_vm::{compile_source, stdlib::register_vm_stdlib, Vm, VmValue};
+use tempfile::TempDir;
+
+use super::{
+    duration_secs, harn_string, normalized_mount_target, sh_quote, ExecRequest, ExecResult,
+    FilesystemAccess, FilesystemMount, NetworkPolicy, ResolvedMount, ResourceLimits,
+    SandboxBackend, SandboxCapabilities, SandboxError, SandboxResult, SandboxSession,
+    SandboxSessionId, SandboxSnapshot, SandboxSpec, SandboxState, MEMORY_MOUNT, OUTPUTS_MOUNT,
+};
+
+/// Configuration for a [`LocalSandbox`].
+#[derive(Clone, Debug)]
+pub struct LocalSandboxConfig {
+    /// Directory under which session roots are created. When `None`,
+    /// sessions are rooted under the current working directory.
+    pub root_dir: Option<PathBuf>,
+    /// The `harn-vm` sandbox profile applied to every command in this
+    /// backend.
+    pub sandbox_profile: SandboxProfile,
+}
+
+impl Default for LocalSandboxConfig {
+    fn default() -> Self {
+        Self {
+            root_dir: None,
+            sandbox_profile: SandboxProfile::OsHardened,
+        }
+    }
+}
+
+/// Local [`SandboxBackend`] that confines commands with `harn-vm`'s
+/// process sandbox.
+#[derive(Clone, Debug)]
+pub struct LocalSandbox {
+    config: LocalSandboxConfig,
+    sessions: Arc<Mutex<HashMap<SandboxSessionId, Arc<LocalSession>>>>,
+}
+
+impl LocalSandbox {
+    /// Construct a backend with the given configuration.
+    pub fn new(config: LocalSandboxConfig) -> Self {
+        Self {
+            config,
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn session(&self, session_id: &SandboxSessionId) -> SandboxResult<Arc<LocalSession>> {
+        self.sessions
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local session lock poisoned".to_string()))?
+            .get(session_id)
+            .cloned()
+            .ok_or_else(|| SandboxError::SessionNotFound(session_id.to_string()))
+    }
+}
+
+impl Default for LocalSandbox {
+    fn default() -> Self {
+        Self::new(LocalSandboxConfig::default())
+    }
+}
+
+#[async_trait]
+impl SandboxBackend for LocalSandbox {
+    fn name(&self) -> &'static str {
+        "local"
+    }
+
+    fn capabilities(&self) -> SandboxCapabilities {
+        SandboxCapabilities {
+            local_process_sandbox: true,
+            network_policy: false,
+            snapshot: true,
+            resume: true,
+            suspend_on_idle: false,
+        }
+    }
+
+    async fn provision(&self, mut spec: SandboxSpec) -> SandboxResult<SandboxSession> {
+        let id = spec.session_id.take().unwrap_or_else(|| {
+            SandboxSessionId(format!("local-{}", uuid::Uuid::now_v7().simple()))
+        });
+        let tempdir = match &self.config.root_dir {
+            Some(root) => tempfile::Builder::new()
+                .prefix("harn-sandbox-")
+                .tempdir_in(root)?,
+            None => tempfile::Builder::new()
+                .prefix("harn-sandbox-")
+                .tempdir_in(std::env::current_dir()?)?,
+        };
+
+        let root = tempdir.path().to_path_buf();
+        let memory = root.join("mnt/memory");
+        let outputs = root.join("mnt/session/outputs");
+        std::fs::create_dir_all(&memory)?;
+        std::fs::create_dir_all(&outputs)?;
+
+        let mut mounts = vec![
+            ResolvedMount {
+                target: MEMORY_MOUNT.to_string(),
+                access: FilesystemAccess::ReadWrite,
+                host_path: Some(memory),
+            },
+            ResolvedMount {
+                target: OUTPUTS_MOUNT.to_string(),
+                access: FilesystemAccess::ReadWrite,
+                host_path: Some(outputs),
+            },
+        ];
+        for mount in spec.mounts {
+            mounts.push(resolve_local_mount(&root, mount)?);
+        }
+
+        let session = Arc::new(LocalSession {
+            id: id.clone(),
+            tempdir,
+            mounts: Mutex::new(mounts),
+            network_policy: Mutex::new(spec.network_policy),
+            limits: spec.limits,
+            state: Mutex::new(SandboxState::Running),
+            sandbox_profile: self.config.sandbox_profile,
+        });
+
+        self.sessions
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local session lock poisoned".to_string()))?
+            .insert(id, session.clone());
+
+        session.to_public()
+    }
+
+    async fn attach_filesystem(
+        &self,
+        session_id: &SandboxSessionId,
+        mount: FilesystemMount,
+    ) -> SandboxResult<SandboxSession> {
+        let session = self.session(session_id)?;
+        let resolved = resolve_local_mount(session.tempdir.path(), mount)?;
+        session
+            .mounts
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local mount lock poisoned".to_string()))?
+            .push(resolved);
+        session.to_public()
+    }
+
+    async fn apply_network_policy(
+        &self,
+        session_id: &SandboxSessionId,
+        policy: NetworkPolicy,
+    ) -> SandboxResult<SandboxSession> {
+        if let NetworkPolicy::Limited { allowed_hosts } = &policy {
+            if !allowed_hosts.is_empty() {
+                return Err(SandboxError::Unsupported {
+                    backend: "local",
+                    operation: "limited network allow-lists",
+                });
+            }
+        }
+        let session = self.session(session_id)?;
+        *session
+            .network_policy
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local network lock poisoned".to_string()))? =
+            policy;
+        session.to_public()
+    }
+
+    async fn exec(
+        &self,
+        session_id: &SandboxSessionId,
+        request: ExecRequest,
+    ) -> SandboxResult<ExecResult> {
+        let session = self.session(session_id)?;
+        session.exec(request).await
+    }
+
+    async fn snapshot(&self, session_id: &SandboxSessionId) -> SandboxResult<SandboxSnapshot> {
+        let session = self.session(session_id)?;
+        Ok(SandboxSnapshot {
+            session_id: session.id.clone(),
+            backend: "local".to_string(),
+            snapshot_id: format!("local:{}", session.id),
+            metadata: BTreeMap::from([(
+                "root".to_string(),
+                session.tempdir.path().display().to_string(),
+            )]),
+        })
+    }
+
+    async fn resume(&self, session_id: &SandboxSessionId) -> SandboxResult<SandboxSession> {
+        let session = self.session(session_id)?;
+        *session
+            .state
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local state lock poisoned".to_string()))? =
+            SandboxState::Running;
+        session.to_public()
+    }
+
+    async fn terminate(&self, session_id: &SandboxSessionId) -> SandboxResult<()> {
+        let session = self
+            .sessions
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local session lock poisoned".to_string()))?
+            .remove(session_id)
+            .ok_or_else(|| SandboxError::SessionNotFound(session_id.to_string()))?;
+        *session
+            .state
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local state lock poisoned".to_string()))? =
+            SandboxState::Terminated;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct LocalSession {
+    id: SandboxSessionId,
+    tempdir: TempDir,
+    mounts: Mutex<Vec<ResolvedMount>>,
+    network_policy: Mutex<NetworkPolicy>,
+    limits: ResourceLimits,
+    state: Mutex<SandboxState>,
+    sandbox_profile: SandboxProfile,
+}
+
+impl LocalSession {
+    fn to_public(&self) -> SandboxResult<SandboxSession> {
+        let mounts = self
+            .mounts
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local mount lock poisoned".to_string()))?
+            .clone();
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local state lock poisoned".to_string()))?
+            .clone();
+        Ok(SandboxSession {
+            id: self.id.clone(),
+            backend: "local".to_string(),
+            state,
+            mounts,
+            metadata: BTreeMap::from([(
+                "root".to_string(),
+                self.tempdir.path().display().to_string(),
+            )]),
+        })
+    }
+
+    async fn exec(self: Arc<Self>, request: ExecRequest) -> SandboxResult<ExecResult> {
+        if request.command.trim().is_empty() {
+            return Err(SandboxError::InvalidRequest(
+                "exec command cannot be empty".to_string(),
+            ));
+        }
+        let timeout = request.timeout.or(self.limits.wall_time);
+        let source = self.harn_exec_source(&request)?;
+        let policy = self.execution_policy()?;
+
+        let task = tokio::task::spawn_blocking(move || run_harn_shell(source, policy));
+        match timeout {
+            Some(timeout) => tokio::time::timeout(timeout, task)
+                .await
+                .map_err(|_| SandboxError::Exec("local exec timed out".to_string()))??,
+            None => task.await?,
+        }
+    }
+
+    fn harn_exec_source(&self, request: &ExecRequest) -> SandboxResult<String> {
+        let cwd = self.resolve_cwd(request.cwd.as_deref())?;
+        let mut shell = String::new();
+        for (key, value) in mount_env(&self.mounts()?) {
+            shell.push_str("export ");
+            shell.push_str(&key);
+            shell.push('=');
+            shell.push_str(&sh_quote(&value));
+            shell.push_str("; ");
+        }
+        for (key, value) in &request.env {
+            validate_env_key(key)?;
+            shell.push_str("export ");
+            shell.push_str(key);
+            shell.push('=');
+            shell.push_str(&sh_quote(value));
+            shell.push_str("; ");
+        }
+        if let Some(stdin) = &request.stdin {
+            shell.push_str("printf %s ");
+            shell.push_str(&sh_quote(stdin));
+            shell.push_str(" | ");
+        }
+        if let Some(timeout) = request.timeout.or(self.limits.wall_time) {
+            shell.push_str("timeout ");
+            shell.push_str(&duration_secs(timeout).to_string());
+            shell.push(' ');
+        }
+        shell.push_str(&sh_quote(&request.command));
+        for arg in &request.args {
+            shell.push(' ');
+            shell.push_str(&sh_quote(arg));
+        }
+        Ok(format!(
+            "pipeline local_sandbox_exec(task) {{ return shell_at({}, {}) }}",
+            harn_string(&cwd.display().to_string()),
+            harn_string(&shell),
+        ))
+    }
+
+    fn execution_policy(&self) -> SandboxResult<CapabilityPolicy> {
+        let mut roots = vec![self.tempdir.path().display().to_string()];
+        for mount in self.mounts()? {
+            if let Some(path) = mount.host_path {
+                roots.push(path.display().to_string());
+            }
+        }
+        let mut capabilities = BTreeMap::new();
+        capabilities.insert("process".to_string(), vec!["exec".to_string()]);
+        capabilities.insert(
+            "workspace".to_string(),
+            vec![
+                "read_text".to_string(),
+                "list".to_string(),
+                "exists".to_string(),
+                "write_text".to_string(),
+                "delete".to_string(),
+            ],
+        );
+
+        Ok(CapabilityPolicy {
+            capabilities,
+            workspace_roots: roots,
+            side_effect_level: Some("process_exec".to_string()),
+            sandbox_profile: self.sandbox_profile,
+            ..Default::default()
+        })
+    }
+
+    fn resolve_cwd(&self, cwd: Option<&str>) -> SandboxResult<PathBuf> {
+        let Some(cwd) = cwd else {
+            return Ok(self.tempdir.path().to_path_buf());
+        };
+        if cwd.trim().is_empty() {
+            return Ok(self.tempdir.path().to_path_buf());
+        }
+        if let Some(path) = self.resolve_mount_path(cwd)? {
+            return Ok(path);
+        }
+        let path = PathBuf::from(cwd);
+        if path.is_absolute() {
+            return Ok(path);
+        }
+        Ok(self.tempdir.path().join(path))
+    }
+
+    fn resolve_mount_path(&self, path: &str) -> SandboxResult<Option<PathBuf>> {
+        if !path.trim_start().starts_with('/') {
+            return Ok(None);
+        }
+        let normalized = normalized_mount_target(path)?;
+        for mount in self.mounts()?.into_iter().rev() {
+            if normalized == mount.target || normalized.starts_with(&(mount.target.clone() + "/")) {
+                let Some(host_path) = mount.host_path else {
+                    continue;
+                };
+                let suffix = normalized
+                    .trim_start_matches(&mount.target)
+                    .trim_start_matches('/');
+                return Ok(Some(host_path.join(suffix)));
+            }
+        }
+        Ok(None)
+    }
+
+    fn mounts(&self) -> SandboxResult<Vec<ResolvedMount>> {
+        Ok(self
+            .mounts
+            .lock()
+            .map_err(|_| SandboxError::Lifecycle("local mount lock poisoned".to_string()))?
+            .clone())
+    }
+}
+
+fn resolve_local_mount(root: &Path, mount: FilesystemMount) -> SandboxResult<ResolvedMount> {
+    let target = normalized_mount_target(&mount.target)?;
+    let source = if mount.source.as_os_str().is_empty() {
+        let relative = target.trim_start_matches('/');
+        root.join(relative)
+    } else if mount.source.is_absolute() {
+        mount.source
+    } else {
+        root.join(mount.source)
+    };
+    std::fs::create_dir_all(&source)?;
+    Ok(ResolvedMount {
+        target,
+        access: mount.access,
+        host_path: Some(source),
+    })
+}
+
+fn mount_env(mounts: &[ResolvedMount]) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    for mount in mounts {
+        let Some(path) = &mount.host_path else {
+            continue;
+        };
+        if mount.target == MEMORY_MOUNT {
+            env.insert("HARN_MEMORY_DIR".to_string(), path.display().to_string());
+        }
+        if mount.target == OUTPUTS_MOUNT {
+            env.insert("HARN_OUTPUTS_DIR".to_string(), path.display().to_string());
+        }
+    }
+    env
+}
+
+fn validate_env_key(key: &str) -> SandboxResult<()> {
+    if key.is_empty()
+        || key
+            .chars()
+            .any(|ch| !(ch == '_' || ch.is_ascii_alphanumeric()))
+        || key.as_bytes()[0].is_ascii_digit()
+    {
+        return Err(SandboxError::InvalidRequest(format!(
+            "invalid environment key `{key}`"
+        )));
+    }
+    Ok(())
+}
+
+fn run_harn_shell(source: String, policy: CapabilityPolicy) -> SandboxResult<ExecResult> {
+    let chunk = compile_source(&source).map_err(SandboxError::Exec)?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(SandboxError::Io)?;
+
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async move {
+                let _guard = ExecutionPolicyGuard::push(policy);
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                let value = vm.execute(&chunk).await.map_err(|error| {
+                    SandboxError::Exec(format!("harn-vm process sandbox rejected exec: {error}"))
+                })?;
+                exec_result_from_value(value)
+            })
+            .await
+    })
+}
+
+struct ExecutionPolicyGuard;
+
+impl ExecutionPolicyGuard {
+    fn push(policy: CapabilityPolicy) -> Self {
+        push_execution_policy(policy);
+        Self
+    }
+}
+
+impl Drop for ExecutionPolicyGuard {
+    fn drop(&mut self) {
+        pop_execution_policy();
+    }
+}
+
+fn exec_result_from_value(value: VmValue) -> SandboxResult<ExecResult> {
+    let VmValue::Dict(map) = value else {
+        return Err(SandboxError::Exec(format!(
+            "expected exec result dict from harn-vm, got {}",
+            value.display()
+        )));
+    };
+    let stdout = dict_string(&map, "stdout")?;
+    let stderr = dict_string(&map, "stderr")?;
+    let exit_code = dict_int(&map, "status")?;
+    Ok(ExecResult {
+        stdout,
+        stderr,
+        exit_code,
+        timed_out: false,
+    })
+}
+
+fn dict_string(map: &BTreeMap<String, VmValue>, key: &str) -> SandboxResult<String> {
+    match map.get(key) {
+        Some(VmValue::String(value)) => Ok(value.to_string()),
+        Some(other) => Err(SandboxError::Exec(format!(
+            "expected `{key}` string, got {}",
+            other.display()
+        ))),
+        None => Err(SandboxError::Exec(format!(
+            "missing `{key}` in exec result"
+        ))),
+    }
+}
+
+fn dict_int(map: &BTreeMap<String, VmValue>, key: &str) -> SandboxResult<i32> {
+    match map.get(key) {
+        Some(VmValue::Int(value)) => Ok(*value as i32),
+        Some(other) => Err(SandboxError::Exec(format!(
+            "expected `{key}` int, got {}",
+            other.display()
+        ))),
+        None => Err(SandboxError::Exec(format!(
+            "missing `{key}` in exec result"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_backend_execs_inside_session_outputs() {
+        let backend = LocalSandbox::default();
+        let session = backend.provision(SandboxSpec::default()).await.unwrap();
+
+        let result = backend
+            .exec(
+                &session.id,
+                ExecRequest {
+                    command: "sh".to_string(),
+                    args: vec![
+                        "-c".to_string(),
+                        "printf ok > \"$HARN_OUTPUTS_DIR/result.txt\" && cat \"$HARN_OUTPUTS_DIR/result.txt\""
+                            .to_string(),
+                    ],
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.exit_code, 0, "{result:?}");
+        assert_eq!(result.stdout, "ok");
+    }
+
+    #[tokio::test]
+    async fn local_backend_rejects_limited_network_policy() {
+        let backend = LocalSandbox::default();
+        let session = backend.provision(SandboxSpec::default()).await.unwrap();
+        let deny_all = backend
+            .apply_network_policy(
+                &session.id,
+                NetworkPolicy::Limited {
+                    allowed_hosts: Vec::new(),
+                },
+            )
+            .await
+            .expect("deny-all egress policy is enforceable locally");
+        assert_eq!(deny_all.id, session.id);
+
+        let err = backend
+            .apply_network_policy(
+                &session.id,
+                NetworkPolicy::Limited {
+                    allowed_hosts: vec!["example.com".to_string()],
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SandboxError::Unsupported { .. }));
+    }
+
+    #[tokio::test]
+    async fn local_backend_defaults_to_os_hardened_sandbox_profile() {
+        let backend = LocalSandbox::default();
+        let session = backend.provision(SandboxSpec::default()).await.unwrap();
+        let local = backend.session(&session.id).unwrap();
+
+        let policy = local.execution_policy().unwrap();
+
+        assert_eq!(policy.sandbox_profile, SandboxProfile::OsHardened);
+    }
+
+    #[tokio::test]
+    async fn local_backend_threads_configured_sandbox_profile_into_policy() {
+        let backend = LocalSandbox::new(LocalSandboxConfig {
+            root_dir: None,
+            sandbox_profile: SandboxProfile::Unrestricted,
+        });
+        let session = backend.provision(SandboxSpec::default()).await.unwrap();
+        let local = backend.session(&session.id).unwrap();
+
+        let policy = local.execution_policy().unwrap();
+
+        assert_eq!(policy.sandbox_profile, SandboxProfile::Unrestricted);
+    }
+
+    #[test]
+    fn mount_env_uses_canonical_mount_names() {
+        let mounts = vec![ResolvedMount {
+            target: OUTPUTS_MOUNT.to_string(),
+            access: FilesystemAccess::ReadWrite,
+            host_path: Some(PathBuf::from("/tmp/out")),
+        }];
+        assert_eq!(
+            mount_env(&mounts).get("HARN_OUTPUTS_DIR"),
+            Some(&"/tmp/out".to_string())
+        );
+    }
+}

--- a/crates/harn-hostlib/src/sandbox/mod.rs
+++ b/crates/harn-hostlib/src/sandbox/mod.rs
@@ -1,0 +1,403 @@
+//! The runtime arm of the permission primitive: pluggable sandbox
+//! backends that *enforce* a declared policy rather than merely gating
+//! tool dispatch.
+//!
+//! A sandbox is the runtime answer to a permission policy. The
+//! authoritative policy model lives in `harn-serve`'s `permissions`
+//! module (the `policy { read, write, exec, net }` block); this module
+//! is where that policy becomes true at execution time. `harn-serve`
+//! lowers a `PermissionPolicy` into a [`SandboxSpec`] and a backend
+//! makes the spec real:
+//!
+//! - **filesystem** — mounts scope what the spawned process can touch;
+//!   reads and writes outside the declared roots are rejected by the
+//!   underlying OS sandbox.
+//! - **process** — every command runs through `harn-vm`'s process
+//!   sandbox, which maps the policy onto Landlock/seccomp (Linux),
+//!   `sandbox-exec` (macOS), Job Objects (Windows), and `pledge`/
+//!   `unveil` (OpenBSD).
+//! - **network** — egress is governed by [`NetworkPolicy`]; a backend
+//!   advertises whether it can honour a per-host allowlist via
+//!   [`SandboxCapabilities::network_policy`].
+//!
+//! The [`LocalSandbox`] backend ships here because the process/fs
+//! enforcement it relies on already lives in `harn-vm`; remote backends
+//! (Fly Machines, Modal, E2B, …) implement the same [`SandboxBackend`]
+//! contract from wherever they run.
+
+mod local;
+
+pub use local::{LocalSandbox, LocalSandboxConfig};
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Canonical guest mount for durable agent memory, read-only by
+/// default. Backends expose its host path through the `HARN_MEMORY_DIR`
+/// environment variable.
+pub const MEMORY_MOUNT: &str = "/mnt/memory";
+
+/// Canonical guest mount for a session's writable scratch/output
+/// directory. Backends expose its host path through the
+/// `HARN_OUTPUTS_DIR` environment variable.
+pub const OUTPUTS_MOUNT: &str = "/mnt/session/outputs";
+
+/// Errors surfaced by a [`SandboxBackend`].
+#[derive(Debug, Error)]
+pub enum SandboxError {
+    /// No live session matches the supplied id.
+    #[error("sandbox session `{0}` was not found")]
+    SessionNotFound(String),
+    /// The backend cannot honour the requested operation (e.g. a local
+    /// backend asked for a per-host egress allowlist).
+    #[error("backend `{backend}` does not support {operation}")]
+    Unsupported {
+        /// The backend that rejected the operation.
+        backend: &'static str,
+        /// A human-readable name for the unsupported operation.
+        operation: &'static str,
+    },
+    /// The request was malformed (empty command, relative mount, …).
+    #[error("sandbox request was invalid: {0}")]
+    InvalidRequest(String),
+    /// A provision/suspend/resume/terminate step failed.
+    #[error("sandbox lifecycle operation failed: {0}")]
+    Lifecycle(String),
+    /// Executing the requested command failed.
+    #[error("sandbox exec failed: {0}")]
+    Exec(String),
+    /// Applying or enforcing a network policy failed.
+    #[error("sandbox network policy failed: {0}")]
+    NetworkPolicy(String),
+    /// An underlying I/O operation failed.
+    #[error("sandbox I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+    /// JSON (de)serialisation failed.
+    #[error("sandbox JSON failed: {0}")]
+    Json(#[from] serde_json::Error),
+    /// A spawned async task failed to join.
+    #[error("sandbox task failed: {0}")]
+    Task(#[from] tokio::task::JoinError),
+}
+
+/// Result alias for sandbox operations.
+pub type SandboxResult<T> = Result<T, SandboxError>;
+
+/// Stable identifier for a provisioned sandbox session.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(transparent)]
+pub struct SandboxSessionId(pub String);
+
+impl SandboxSessionId {
+    /// Construct a session id, rejecting blank values.
+    pub fn new(value: impl Into<String>) -> SandboxResult<Self> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(SandboxError::InvalidRequest(
+                "session id cannot be empty".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+}
+
+impl std::fmt::Display for SandboxSessionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Egress policy for a sandbox session. The wire shape matches the
+/// Anthropic sandbox network-policy contract so cloud backends can
+/// forward it verbatim.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum NetworkPolicy {
+    /// No egress restrictions.
+    #[default]
+    Unrestricted,
+    /// Egress restricted to the listed hosts. An empty list denies all
+    /// network access.
+    Limited {
+        /// Host allowlist; empty means deny-all.
+        allowed_hosts: Vec<String>,
+    },
+}
+
+/// Whether a mount is writable by the guest.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FilesystemAccess {
+    /// The guest may read but not write.
+    ReadOnly,
+    /// The guest may read and write.
+    ReadWrite,
+}
+
+/// A requested mount: a host `source` exposed to the guest at `target`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FilesystemMount {
+    /// Host path to expose. Empty means "allocate a fresh directory
+    /// under the session root".
+    pub source: PathBuf,
+    /// Absolute guest path the source is mounted at.
+    pub target: String,
+    /// Read-only or read-write.
+    pub access: FilesystemAccess,
+}
+
+/// Resource ceilings applied to a session.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceLimits {
+    /// Maximum wall-clock duration for any single exec.
+    pub wall_time: Option<Duration>,
+    /// CPU count hint for backends that can allocate it.
+    pub cpu_count: Option<u32>,
+    /// Memory ceiling in megabytes.
+    pub memory_mb: Option<u32>,
+    /// Idle timeout before a backend may suspend the session.
+    pub idle_timeout: Option<Duration>,
+}
+
+/// The full request to provision a session: the runtime lowering of a
+/// declared permission policy.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SandboxSpec {
+    /// Optional caller-chosen id; backends mint one when absent.
+    pub session_id: Option<SandboxSessionId>,
+    /// Free-form labels propagated to the backend (tenant, persona, …).
+    pub labels: BTreeMap<String, String>,
+    /// Egress policy.
+    pub network_policy: NetworkPolicy,
+    /// Mounts beyond the canonical memory/outputs pair.
+    pub mounts: Vec<FilesystemMount>,
+    /// Resource ceilings.
+    pub limits: ResourceLimits,
+}
+
+/// Lifecycle state of a session.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxState {
+    /// Provisioned but not yet running.
+    Provisioned,
+    /// Live and accepting exec requests.
+    Running,
+    /// Suspended; resumes on next exec.
+    Suspended,
+    /// Torn down.
+    Terminated,
+}
+
+/// A provisioned session as seen by callers.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SandboxSession {
+    /// Session id.
+    pub id: SandboxSessionId,
+    /// Name of the backend that owns the session.
+    pub backend: String,
+    /// Current lifecycle state.
+    pub state: SandboxState,
+    /// Mounts resolved to their host/guest paths.
+    pub mounts: Vec<ResolvedMount>,
+    /// Backend-specific metadata (e.g. the session root path).
+    pub metadata: BTreeMap<String, String>,
+}
+
+/// A mount resolved to concrete host/guest paths.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedMount {
+    /// Absolute guest path.
+    pub target: String,
+    /// Read-only or read-write.
+    pub access: FilesystemAccess,
+    /// Host path, when the backend exposes one (remote guests may not).
+    pub host_path: Option<PathBuf>,
+}
+
+/// A command to run inside a session.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecRequest {
+    /// Executable or shell builtin to run.
+    pub command: String,
+    /// Arguments.
+    pub args: Vec<String>,
+    /// Working directory; resolved against mounts then the session root.
+    pub cwd: Option<String>,
+    /// Extra environment variables.
+    pub env: BTreeMap<String, String>,
+    /// Data piped to the command's stdin.
+    pub stdin: Option<String>,
+    /// Per-exec timeout; falls back to [`ResourceLimits::wall_time`].
+    pub timeout: Option<Duration>,
+}
+
+/// The outcome of an [`ExecRequest`].
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecResult {
+    /// Captured stdout.
+    pub stdout: String,
+    /// Captured stderr.
+    pub stderr: String,
+    /// Process exit code.
+    pub exit_code: i32,
+    /// Whether the exec hit its timeout.
+    pub timed_out: bool,
+}
+
+impl ExecResult {
+    /// True when the command exited zero and did not time out.
+    pub fn success(&self) -> bool {
+        self.exit_code == 0 && !self.timed_out
+    }
+}
+
+/// A point-in-time snapshot handle for a session.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SandboxSnapshot {
+    /// Session the snapshot belongs to.
+    pub session_id: SandboxSessionId,
+    /// Backend that produced it.
+    pub backend: String,
+    /// Backend-specific snapshot identifier.
+    pub snapshot_id: String,
+    /// Snapshot metadata.
+    pub metadata: BTreeMap<String, String>,
+}
+
+/// What a backend can do, so callers can degrade gracefully.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SandboxCapabilities {
+    /// Enforces an OS-level process sandbox locally.
+    pub local_process_sandbox: bool,
+    /// Honours a per-host network allowlist.
+    pub network_policy: bool,
+    /// Supports snapshots.
+    pub snapshot: bool,
+    /// Supports resuming a suspended session.
+    pub resume: bool,
+    /// Suspends sessions after an idle timeout.
+    pub suspend_on_idle: bool,
+}
+
+/// Pluggable enforcement backend. Implementations make a [`SandboxSpec`]
+/// (the runtime lowering of a permission policy) real and run commands
+/// under it.
+#[async_trait]
+pub trait SandboxBackend: Send + Sync {
+    /// Stable backend name (used in [`SandboxSession::backend`]).
+    fn name(&self) -> &'static str;
+
+    /// What this backend can enforce.
+    fn capabilities(&self) -> SandboxCapabilities;
+
+    /// Provision a session from a spec.
+    async fn provision(&self, spec: SandboxSpec) -> SandboxResult<SandboxSession>;
+
+    /// Attach an additional mount to a live session.
+    async fn attach_filesystem(
+        &self,
+        session_id: &SandboxSessionId,
+        mount: FilesystemMount,
+    ) -> SandboxResult<SandboxSession>;
+
+    /// Apply (or update) the egress policy on a live session.
+    async fn apply_network_policy(
+        &self,
+        session_id: &SandboxSessionId,
+        policy: NetworkPolicy,
+    ) -> SandboxResult<SandboxSession>;
+
+    /// Run a command inside a session.
+    async fn exec(
+        &self,
+        session_id: &SandboxSessionId,
+        request: ExecRequest,
+    ) -> SandboxResult<ExecResult>;
+
+    /// Snapshot a session.
+    async fn snapshot(&self, session_id: &SandboxSessionId) -> SandboxResult<SandboxSnapshot>;
+
+    /// Resume a suspended session.
+    async fn resume(&self, session_id: &SandboxSessionId) -> SandboxResult<SandboxSession>;
+
+    /// Tear a session down.
+    async fn terminate(&self, session_id: &SandboxSessionId) -> SandboxResult<()>;
+}
+
+/// Normalise a guest mount target: trim trailing slashes and require an
+/// absolute path.
+pub(crate) fn normalized_mount_target(target: &str) -> SandboxResult<String> {
+    let trimmed = target.trim().trim_end_matches('/');
+    if !trimmed.starts_with('/') {
+        return Err(SandboxError::InvalidRequest(format!(
+            "mount target `{target}` must be absolute"
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+/// POSIX-shell-quote a value for safe inclusion in a generated command.
+pub(crate) fn sh_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    let escaped = value.replace('\'', "'\"'\"'");
+    format!("'{escaped}'")
+}
+
+/// Quote a value as a Harn string literal.
+pub(crate) fn harn_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Whole seconds for a duration, clamped to at least one so `timeout(1)`
+/// never receives a zero argument.
+pub(crate) fn duration_secs(duration: Duration) -> u64 {
+    duration.as_secs().max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_policy_uses_anthropic_compatible_shape() {
+        let json = serde_json::to_value(NetworkPolicy::Limited {
+            allowed_hosts: vec!["api.github.com".to_string()],
+        })
+        .unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "mode": "limited",
+                "allowed_hosts": ["api.github.com"]
+            })
+        );
+    }
+
+    #[test]
+    fn quotes_shell_values() {
+        assert_eq!(sh_quote("a'b"), "'a'\"'\"'b'");
+        assert_eq!(sh_quote(""), "''");
+    }
+}

--- a/crates/harn-serve/src/permissions/enforcement.rs
+++ b/crates/harn-serve/src/permissions/enforcement.rs
@@ -1,0 +1,213 @@
+//! The runtime arm of the permission primitive: lowering a declared
+//! [`PermissionPolicy`] into the types the runtime enforces against.
+//!
+//! A sandbox is the runtime answer to a permission policy. The policy
+//! declares *what an agent may do*; this module turns that declaration
+//! into the two enforcement vocabularies the rest of the stack already
+//! understands:
+//!
+//! - [`CapabilityPolicy`] (`harn-vm`) — the in-VM ceiling consulted
+//!   before every builtin dispatch and pushed onto the execution-policy
+//!   stack. This is what makes `policy { read, write, exec }` gate tool
+//!   calls live rather than only at request time.
+//! - [`SandboxSpec`](harn_hostlib::sandbox::SandboxSpec) — the spec a
+//!   [`SandboxBackend`](harn_hostlib::sandbox::SandboxBackend) provisions
+//!   from, carrying the `net` allowlist as an egress policy. This is the
+//!   process/filesystem/network isolation arm (the
+//!   [`harn_hostlib::sandbox`] module).
+//!
+//! The `SandboxSpec` lowering is only available with the `hostlib`
+//! feature, since it depends on `harn-hostlib`; the `CapabilityPolicy`
+//! lowering is always available.
+
+use harn_vm::orchestration::{CapabilityPolicy, SandboxProfile};
+
+use super::policy::PermissionPolicy;
+
+#[cfg(feature = "hostlib")]
+pub use harn_hostlib::sandbox;
+
+impl PermissionPolicy {
+    /// The lowest [`side_effect_level`](CapabilityPolicy::side_effect_level)
+    /// the policy needs to permit, derived from which action classes the
+    /// policy grants. The ladder mirrors `harn-vm`'s ranking:
+    /// `none < read_only < workspace_write < process_exec < network`.
+    fn required_side_effect_level(&self) -> &'static str {
+        if !self.net.is_empty() {
+            "network"
+        } else if !self.exec.is_empty() {
+            "process_exec"
+        } else if !self.write.is_empty() {
+            "workspace_write"
+        } else if !self.read.is_empty() {
+            "read_only"
+        } else {
+            "none"
+        }
+    }
+
+    /// Lower the policy into a [`CapabilityPolicy`] for in-VM
+    /// enforcement. `workspace_roots` are the host directories the
+    /// workload is confined to (the deployment supplies these; the
+    /// policy globs constrain access *within* them). `sandbox_profile`
+    /// selects the OS-confinement strength applied to spawned
+    /// subprocesses.
+    ///
+    /// The coarse `capabilities`/`side_effect_level` ceiling produced
+    /// here is the runtime backstop; fine-grained per-glob matching of a
+    /// concrete request still flows through the permission store's
+    /// `evaluate`.
+    pub fn to_capability_policy(
+        &self,
+        sandbox_profile: SandboxProfile,
+        workspace_roots: Vec<String>,
+    ) -> CapabilityPolicy {
+        let mut capabilities = std::collections::BTreeMap::new();
+
+        let mut workspace = Vec::new();
+        if !self.read.is_empty() {
+            workspace.extend(["read_text", "list", "exists"].map(String::from));
+        }
+        if !self.write.is_empty() {
+            workspace.extend(["write_text", "delete"].map(String::from));
+        }
+        if !workspace.is_empty() {
+            capabilities.insert("workspace".to_string(), workspace);
+        }
+        if !self.exec.is_empty() {
+            capabilities.insert("process".to_string(), vec!["exec".to_string()]);
+        }
+
+        CapabilityPolicy {
+            capabilities,
+            workspace_roots,
+            side_effect_level: Some(self.required_side_effect_level().to_string()),
+            sandbox_profile,
+            ..Default::default()
+        }
+    }
+
+    /// Lower the policy's `net` allowlist into an egress
+    /// [`NetworkPolicy`](harn_hostlib::sandbox::NetworkPolicy). An empty
+    /// allowlist denies all egress; a wildcard entry (`*` or `**`)
+    /// lifts the restriction; anything else is treated as a host
+    /// allowlist.
+    #[cfg(feature = "hostlib")]
+    pub fn to_network_policy(&self) -> sandbox::NetworkPolicy {
+        if self.net.iter().any(|host| host == "*" || host == "**") {
+            sandbox::NetworkPolicy::Unrestricted
+        } else {
+            sandbox::NetworkPolicy::Limited {
+                allowed_hosts: self.net.clone(),
+            }
+        }
+    }
+
+    /// Lower the policy into a [`SandboxSpec`](harn_hostlib::sandbox::SandboxSpec)
+    /// for a [`SandboxBackend`](harn_hostlib::sandbox::SandboxBackend) to
+    /// provision. The spec carries the policy's egress allowlist; mounts,
+    /// resource limits, and labels are deployment concerns the caller
+    /// fills in (the policy does not declare host paths).
+    #[cfg(feature = "hostlib")]
+    pub fn to_sandbox_spec(&self) -> sandbox::SandboxSpec {
+        sandbox::SandboxSpec {
+            network_policy: self.to_network_policy(),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_dev_lowers_to_process_exec_capability_policy() {
+        let policy = PermissionPolicy::local_dev();
+        let cap =
+            policy.to_capability_policy(SandboxProfile::OsHardened, vec!["/work".to_string()]);
+
+        assert_eq!(cap.side_effect_level.as_deref(), Some("process_exec"));
+        assert_eq!(cap.sandbox_profile, SandboxProfile::OsHardened);
+        assert_eq!(cap.workspace_roots, vec!["/work".to_string()]);
+        assert_eq!(
+            cap.capabilities.get("process"),
+            Some(&vec!["exec".to_string()])
+        );
+        let workspace = cap.capabilities.get("workspace").expect("workspace caps");
+        assert!(workspace.contains(&"read_text".to_string()));
+        assert!(workspace.contains(&"write_text".to_string()));
+    }
+
+    #[test]
+    fn read_only_policy_grants_only_read_capabilities() {
+        let policy = PermissionPolicy {
+            read: vec!["src/**".to_string()],
+            ..PermissionPolicy::empty()
+        };
+        let cap = policy.to_capability_policy(SandboxProfile::Worktree, Vec::new());
+
+        assert_eq!(cap.side_effect_level.as_deref(), Some("read_only"));
+        assert_eq!(cap.capabilities.get("process"), None);
+        let workspace = cap.capabilities.get("workspace").expect("workspace caps");
+        assert!(workspace.contains(&"read_text".to_string()));
+        assert!(!workspace.contains(&"write_text".to_string()));
+    }
+
+    #[test]
+    fn empty_policy_lowers_to_none_level_with_no_capabilities() {
+        let cap =
+            PermissionPolicy::empty().to_capability_policy(SandboxProfile::Worktree, Vec::new());
+        assert_eq!(cap.side_effect_level.as_deref(), Some("none"));
+        assert!(cap.capabilities.is_empty());
+    }
+
+    #[cfg(feature = "hostlib")]
+    #[test]
+    fn net_allowlist_lowers_to_egress_policy() {
+        use sandbox::NetworkPolicy;
+
+        let deny_all = PermissionPolicy::empty().to_network_policy();
+        assert_eq!(
+            deny_all,
+            NetworkPolicy::Limited {
+                allowed_hosts: Vec::new()
+            }
+        );
+
+        let allowlist = PermissionPolicy {
+            net: vec!["api.github.com".to_string()],
+            ..PermissionPolicy::empty()
+        }
+        .to_network_policy();
+        assert_eq!(
+            allowlist,
+            NetworkPolicy::Limited {
+                allowed_hosts: vec!["api.github.com".to_string()]
+            }
+        );
+
+        let wildcard = PermissionPolicy {
+            net: vec!["*".to_string()],
+            ..PermissionPolicy::empty()
+        }
+        .to_network_policy();
+        assert_eq!(wildcard, NetworkPolicy::Unrestricted);
+    }
+
+    #[cfg(feature = "hostlib")]
+    #[test]
+    fn sandbox_spec_carries_egress_policy() {
+        let spec = PermissionPolicy {
+            net: vec!["api.github.com".to_string()],
+            ..PermissionPolicy::empty()
+        }
+        .to_sandbox_spec();
+        assert_eq!(
+            spec.network_policy,
+            sandbox::NetworkPolicy::Limited {
+                allowed_hosts: vec!["api.github.com".to_string()]
+            }
+        );
+    }
+}

--- a/crates/harn-serve/src/permissions/mod.rs
+++ b/crates/harn-serve/src/permissions/mod.rs
@@ -25,14 +25,22 @@
 //!   without touching any caller.
 //! - [`audit`] — [`AuditEntry`] events emitted on every grant / deny /
 //!   escalation, queryable through `store.history(filter)`.
+//! - [`enforcement`] — the runtime arm: lowers a [`PermissionPolicy`]
+//!   into the [`CapabilityPolicy`](harn_vm::orchestration::CapabilityPolicy)
+//!   the VM enforces and (with the `hostlib` feature) the
+//!   [`SandboxSpec`](harn_hostlib::sandbox::SandboxSpec) a sandbox
+//!   backend provisions from.
 
 pub mod audit;
+pub mod enforcement;
 pub mod policy;
 pub mod request;
 pub mod rules;
 pub mod store;
 
 pub use audit::{AuditEntry, AuditFilter, AuditOutcome};
+#[cfg(feature = "hostlib")]
+pub use enforcement::sandbox;
 pub use policy::{LlmPolicy, PermissionPolicy, PolicyVersion, RedactionPolicy};
 pub use request::{ActionClass, DecisionScope, PermissionDecision, PermissionRequest, Risk};
 pub use rules::{RememberRule, RuleId};

--- a/docs/src/sandboxing.md
+++ b/docs/src/sandboxing.md
@@ -178,6 +178,28 @@ compile time via `cfg`-gated `mod` declarations. Adding a new
 backend means writing one file under `sandbox/` and adding the
 `mod` plus `type ActiveBackend` lines.
 
+## Sandboxes are the runtime arm of a permission policy
+
+A sandbox is the runtime answer to a declared permission policy. The
+authoritative policy model (`policy { read, write, exec, net }`) lives
+in `harn-serve`'s `permissions` module; `permissions::enforcement`
+lowers it into the two enforcement vocabularies described above:
+
+- `to_capability_policy` derives the in-VM `CapabilityPolicy` ceiling
+  — `read`/`write`/`exec` become `workspace`/`process` capabilities and
+  the `side_effect_level`, threaded with a chosen `SandboxProfile`.
+- `to_sandbox_spec` / `to_network_policy` (behind the `hostlib`
+  feature) turn the `net` allowlist into a `SandboxSpec` egress policy
+  for a `SandboxBackend` to provision against.
+
+The pluggable backend contract — `SandboxBackend`, `SandboxSpec`,
+`ExecRequest`/`ExecResult`, `NetworkPolicy`, mounts, and limits — lives
+in `harn-hostlib`'s `sandbox` module, alongside the `LocalSandbox`
+backend. `LocalSandbox` does not reimplement OS confinement: it pushes
+a `CapabilityPolicy` and runs each command through the same `harn-vm`
+process sandbox documented here. Remote backends (Fly Machines, Modal,
+E2B, …) implement the same trait from wherever they run.
+
 ## Diagnostics from a script
 
 Three Harn builtins surface backend identity for `harn doctor`-style
@@ -204,8 +226,9 @@ mechanism.
 
 ## Out of scope
 
-- gVisor / Firecracker / Kata containers — those belong to
-  `harn-cloud`'s `SandboxBackend` impl, not the local runtime.
+- gVisor / Firecracker / Kata containers — those belong to a remote
+  `SandboxBackend` impl (Fly Machines, Modal, …), not the local
+  runtime; the trait lives in `harn-hostlib`'s `sandbox` module.
 - Destination-level network egress allow/deny — use `egress_policy(...)`
   or `HARN_EGRESS_*` once a host policy allows network side effects.
 - Sandboxing for in-process work (LLM calls, deterministic Harn


### PR DESCRIPTION
## Summary

First half of #2516 (one-loop A.13). Promotes the per-agent sandbox
enforcement contract into `harn` as the **runtime arm of the permission
primitive (A.6)**, so a sandbox is literally the runtime answer to a
declared `policy { read, write, exec, net }`.

- **`harn-hostlib::sandbox`** — the canonical pluggable backend
  contract: `SandboxBackend` trait, `SandboxSpec`, `ExecRequest` /
  `ExecResult`, `NetworkPolicy`, mounts, limits, plus a `LocalSandbox`
  backend. `LocalSandbox` does **not** reimplement OS confinement — it
  pushes a `CapabilityPolicy` and runs each command through `harn-vm`'s
  existing process sandbox (Landlock/seccomp, `sandbox-exec`, Job
  Objects, `pledge`/`unveil`). Ported faithfully from the
  `harn-cloud-sandbox` local backend, with its unit tests.
- **`harn-serve::permissions::enforcement`** — lowers a
  `PermissionPolicy` into the enforcement vocabularies already in use:
  - `to_capability_policy` → in-VM `CapabilityPolicy` ceiling
    (`read`/`write`/`exec` → `workspace`/`process` caps + the
    `side_effect_level` ladder), threaded with a `SandboxProfile`. This
    is what makes a declared policy gate tool dispatch **live**.
  - `to_sandbox_spec` / `to_network_policy` (behind the `hostlib`
    feature) → the `net` allowlist becomes an egress `NetworkPolicy`.
- Docs (`sandboxing.md`) gain a "sandboxes are the runtime arm of a
  permission policy" section; the stale "belongs to harn-cloud" note is
  corrected to point at the new `harn-hostlib` home.

### Why this is the canonical home, not a delete

[harn-cloud#76](https://github.com/burin-labs/harn-cloud/issues/76)
(Modal/E2B/Daytona backends), [#484](https://github.com/burin-labs/harn-cloud/issues/484)
(budget fields on the sandbox spec), and [#494](https://github.com/burin-labs/harn-cloud/issues/494)
(try-sandbox endpoint) all build on this `SandboxBackend` abstraction —
so the contract is promoted into `harn` rather than deleted.

### Follow-up (release-gated)

`harn-cloud` pins published `harn` crates, so retiring the
`harn-cloud-sandbox` crate (relocating the Fly + Code-Mode backends into
`harn-cloud-factory`, repointing `hosted_persona.rs` at
`harn_hostlib::sandbox`) lands in a second PR once this releases. #2516
stays open until that merges.

## Test plan

- [x] `cargo test -p harn-hostlib` (sandbox contract + LocalSandbox exec/policy fixtures)
- [x] `cargo test -p harn-serve` and `--features hostlib` (enforcement lowering, both feature configs)
- [x] `cargo clippy` clean on both crates; full-workspace clippy via pre-commit
- [x] `cargo doc` intra-links resolve for the new modules
- [x] markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)