### PR TITLE
postgres: harn pg codegen — Harn record types from .sql migrations (#2577)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,31 @@
+name: Free disk space
+description: >-
+  Reclaim disk on GitHub-hosted Ubuntu runners before a full-workspace Rust
+  build. The default image ships ~30 GB of preinstalled SDKs (Android, .NET,
+  GHC/Haskell, CodeQL) the Rust jobs never touch; the cold `target/` tree plus
+  sccache and nextest archives for this workspace otherwise push the ~14 GB of
+  free root space over the edge ("No space left on device").
+
+runs:
+  using: composite
+  steps:
+    - name: Remove unused preinstalled SDKs
+      shell: bash
+      run: |
+        echo "Disk before reclaim:"
+        df -h /
+        # Each path is removed best-effort; a missing one on a future image
+        # revision must not fail the build.
+        for path in \
+          /usr/local/lib/android \
+          /usr/share/dotnet \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/powershell \
+          /usr/local/share/chromium; do
+          sudo rm -rf "$path" || true
+        done
+        sudo docker image prune --all --force >/dev/null 2>&1 || true
+        echo "Disk after reclaim:"
+        df -h /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
@@ -94,6 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
@@ -129,6 +131,7 @@ jobs:
           # Full history + tags so the changelog retroactive-edit check can
           # traverse BASE..HEAD and inspect commit trailers.
           fetch-depth: 0
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The

--- a/changelog.d/2577.added.md
+++ b/changelog.d/2577.added.md
@@ -1,0 +1,15 @@
+- **Typed Postgres rows: `harn pg codegen` (#2577).** Generate one Harn
+  record type per table from a directory of `.sql` migrations so query
+  results can be type-checked without a live database. Replays every
+  forward migration (`.sql`, excluding `.down.sql`) in lexicographic
+  order — the same discovery rule `pg_migrate` uses — applying
+  `CREATE TABLE`, `ALTER TABLE … ADD/DROP/ALTER/RENAME COLUMN`,
+  `RENAME TO`, and `DROP TABLE` so the emitted `type <Table>Row = {…}`
+  always mirrors the live schema. SQL types map to the same Harn types
+  the runtime row decoder produces (`int`/`float`/`string`/`any`/`bytes`,
+  `T[]` → `list<T>`); nullable columns become optional (`field: T?`).
+  Annotate a result (`let r: ReceiptsRow = pg_query_one(...)`) and the
+  type-checker proves every field access against the schema on disk.
+  `--check` verifies the generated `--out` file is current for CI.
+  Completes the typed-row-mapping bullet deferred from the A.9 hostlib
+  v2 sweep (#2512).

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -38,6 +38,7 @@ mod pack;
 mod package;
 mod parse_tokens;
 mod persona;
+mod pg;
 mod playground;
 mod portal;
 mod precompile;
@@ -149,6 +150,7 @@ pub(crate) use persona::{
     PersonaSupervisionCommand, PersonaSupervisionTailArgs, PersonaTemplateKind, PersonaTickArgs,
     PersonaTriggerArgs,
 };
+pub(crate) use pg::{PgArgs, PgCodegenArgs, PgCommand};
 pub(crate) use playground::PlaygroundArgs;
 pub(crate) use portal::PortalArgs;
 pub use precompile::PrecompileArgs;
@@ -441,6 +443,8 @@ SCRIPTING
     Publish(PublishArgs),
     /// List and inspect durable agent persona manifests.
     Persona(PersonaArgs),
+    /// Postgres developer tooling (codegen Harn record types from migrations).
+    Pg(PgArgs),
     /// Merge Captain transcript oracle and audit (#1013).
     #[command(name = "merge-captain")]
     MergeCaptain(MergeCaptainArgs),

--- a/crates/harn-cli/src/cli/pg.rs
+++ b/crates/harn-cli/src/cli/pg.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct PgArgs {
+    #[command(subcommand)]
+    pub command: PgCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum PgCommand {
+    /// Generate Harn record types from a directory of `.sql` migrations.
+    ///
+    /// Replays every forward migration (`.sql`, excluding `*.down.sql`) in
+    /// lexicographic order and emits one `type <Table>Row = {…}` per table,
+    /// mirroring the live column set. Annotate a query result with the
+    /// generated type to type-check field access without a live database:
+    ///
+    ///     let receipt: ReceiptRow = pg_query_one(pool, sql, params)
+    ///
+    /// Pass `--check` to verify the `--out` file is current (for CI).
+    Codegen(PgCodegenArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PgCodegenArgs {
+    /// Directory holding `.sql` migration files.
+    #[arg(long, default_value = "migrations", value_name = "DIR")]
+    pub dir: PathBuf,
+    /// Write the generated types to this file. Prints to stdout when omitted.
+    #[arg(long, value_name = "FILE")]
+    pub out: Option<PathBuf>,
+    /// Verify `--out` is up to date without writing; exit non-zero on drift.
+    #[arg(long, requires = "out")]
+    pub check: bool,
+    /// Suffix appended to each PascalCase table name (default `Row`).
+    #[arg(long, value_name = "SUFFIX")]
+    pub suffix: Option<String>,
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub mod persona;
 pub mod persona_doctor;
 pub mod persona_scaffold;
 pub mod persona_supervision;
+pub(crate) mod pg_codegen;
 pub mod playground;
 pub(crate) mod portal;
 pub mod precompile;

--- a/crates/harn-cli/src/commands/pg_codegen/ddl.rs
+++ b/crates/harn-cli/src/commands/pg_codegen/ddl.rs
@@ -1,0 +1,758 @@
+//! A focused parser for the DDL subset that appears in Postgres migration
+//! files. It tracks the live shape of every table across an ordered sequence
+//! of migrations so a downstream emitter can render one Harn record type per
+//! table that mirrors the schema state on disk.
+//!
+//! This is deliberately *not* a general SQL parser. It understands only the
+//! statements that change a table's column set — `CREATE TABLE`,
+//! `ALTER TABLE`, and `DROP TABLE` — and silently ignores everything else
+//! (indexes, functions, `INSERT`s, `CREATE TYPE`, …). Sizes and precisions
+//! (`varchar(255)`, `numeric(10, 2)`) are accepted and discarded; the runtime
+//! row decode never distinguishes them.
+
+use std::collections::BTreeMap;
+
+/// A single column's source-level type, normalized to a lowercase base name
+/// plus a count of trailing array dimensions. Sizes/precisions are dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SqlType {
+    /// Lowercase canonical base name, e.g. `integer`, `timestamp with time zone`.
+    pub(crate) base: String,
+    /// Number of `[]` suffixes; 0 for a scalar column.
+    pub(crate) array_dims: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Column {
+    pub(crate) name: String,
+    pub(crate) sql_type: SqlType,
+    /// `true` when the column can never be SQL NULL (NOT NULL, PRIMARY KEY,
+    /// or a `serial`/identity column).
+    pub(crate) not_null: bool,
+}
+
+/// A table's column set, in definition order.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct Table {
+    pub(crate) columns: Vec<Column>,
+}
+
+impl Table {
+    fn column_mut(&mut self, name: &str) -> Option<&mut Column> {
+        self.columns.iter_mut().find(|col| col.name == name)
+    }
+
+    fn remove_column(&mut self, name: &str) {
+        self.columns.retain(|col| col.name != name);
+    }
+}
+
+/// The accumulated schema after replaying every migration in order. Tables are
+/// keyed by their unqualified name; emit order is the caller's concern.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Schema {
+    tables: BTreeMap<String, Table>,
+}
+
+impl Schema {
+    /// Tables in deterministic (name-sorted) order, skipping any that have no
+    /// columns left — an all-columns-dropped table has no record to emit.
+    pub(crate) fn tables(&self) -> impl Iterator<Item = (&str, &Table)> {
+        self.tables
+            .iter()
+            .filter(|(_, table)| !table.columns.is_empty())
+            .map(|(name, table)| (name.as_str(), table))
+    }
+
+    fn rename_table(&mut self, from: &str, to: &str) {
+        if let Some(table) = self.tables.remove(from) {
+            self.tables.insert(to.to_string(), table);
+        }
+    }
+}
+
+/// Replay an ordered list of migration SQL sources into a single schema.
+///
+/// Infallible by design: any statement (or fragment) this focused parser does
+/// not recognize is silently skipped rather than rejected. The migrations have
+/// already been accepted by Postgres, so the goal is to extract the table
+/// shapes we *can* read, not to re-validate the SQL.
+pub(crate) fn parse_migrations(sources: &[String]) -> Schema {
+    let mut schema = Schema::default();
+    for source in sources {
+        for statement in split_statements(source) {
+            apply_statement(&mut schema, &statement);
+        }
+    }
+    schema
+}
+
+// --- Tokenizer ---------------------------------------------------------------
+
+/// A statement is a flat list of these tokens. String/dollar-quoted literals
+/// collapse to a single placeholder since DDL column shapes never depend on a
+/// literal's contents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Token {
+    /// An identifier or keyword. Stored verbatim; callers compare
+    /// case-insensitively for keywords and strip quotes for quoted idents.
+    Word(String),
+    LParen,
+    RParen,
+    Comma,
+    LBracket,
+    RBracket,
+    Dot,
+    /// A string, quoted-identifier, or dollar-quoted literal, contents elided.
+    Literal,
+    /// Any other punctuation (`=`, `::`, operators in CHECK clauses, …).
+    Other,
+}
+
+/// Split a source file into statements, each already tokenized. Comments and
+/// literal contents are stripped during tokenization so the splitter only ever
+/// sees structural tokens.
+fn split_statements(source: &str) -> Vec<Vec<Token>> {
+    let chars: Vec<char> = source.chars().collect();
+    let mut statements = Vec::new();
+    let mut current = Vec::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            _ if c.is_whitespace() => i += 1,
+            '-' if chars.get(i + 1) == Some(&'-') => i = skip_line_comment(&chars, i),
+            '/' if chars.get(i + 1) == Some(&'*') => i = skip_block_comment(&chars, i),
+            '\'' => {
+                i = skip_quoted(&chars, i, '\'');
+                current.push(Token::Literal);
+            }
+            '"' => {
+                let (ident, next) = read_quoted(&chars, i, '"');
+                current.push(Token::Word(ident));
+                i = next;
+            }
+            '$' if is_dollar_quote_start(&chars, i) => {
+                i = skip_dollar_quoted(&chars, i);
+                current.push(Token::Literal);
+            }
+            ';' => {
+                i += 1;
+                if !current.is_empty() {
+                    statements.push(std::mem::take(&mut current));
+                }
+            }
+            '(' => push_punct(&mut current, &mut i, Token::LParen),
+            ')' => push_punct(&mut current, &mut i, Token::RParen),
+            ',' => push_punct(&mut current, &mut i, Token::Comma),
+            '[' => push_punct(&mut current, &mut i, Token::LBracket),
+            ']' => push_punct(&mut current, &mut i, Token::RBracket),
+            '.' => push_punct(&mut current, &mut i, Token::Dot),
+            _ if c.is_alphanumeric() || c == '_' => {
+                let start = i;
+                while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
+                    i += 1;
+                }
+                current.push(Token::Word(chars[start..i].iter().collect()));
+            }
+            _ => push_punct(&mut current, &mut i, Token::Other),
+        }
+    }
+
+    if !current.is_empty() {
+        statements.push(current);
+    }
+    statements
+}
+
+fn push_punct(current: &mut Vec<Token>, i: &mut usize, token: Token) {
+    current.push(token);
+    *i += 1;
+}
+
+/// Index just past the end of a `--` line comment starting at `start`.
+fn skip_line_comment(chars: &[char], start: usize) -> usize {
+    let mut i = start;
+    while i < chars.len() && chars[i] != '\n' {
+        i += 1;
+    }
+    i
+}
+
+/// Index just past the closing `*/` of a block comment starting at `start`.
+fn skip_block_comment(chars: &[char], start: usize) -> usize {
+    let mut i = start + 2;
+    while i + 1 < chars.len() {
+        if chars[i] == '*' && chars[i + 1] == '/' {
+            return i + 2;
+        }
+        i += 1;
+    }
+    chars.len()
+}
+
+/// Read a `quote`-delimited identifier starting at `start`, returning its
+/// unescaped contents and the index past the closing quote. Postgres escapes
+/// an embedded delimiter by doubling it (`""`).
+fn read_quoted(chars: &[char], start: usize, quote: char) -> (String, usize) {
+    let mut out = String::new();
+    let mut i = start + 1; // past opening quote
+    while i < chars.len() {
+        if chars[i] == quote {
+            if chars.get(i + 1) == Some(&quote) {
+                out.push(quote);
+                i += 2;
+            } else {
+                i += 1;
+                break;
+            }
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    (out, i)
+}
+
+/// Index just past a `quote`-delimited run starting at `start`, discarding the
+/// contents (used for string literals, whose value never affects a row shape).
+fn skip_quoted(chars: &[char], start: usize, quote: char) -> usize {
+    read_quoted(chars, start, quote).1
+}
+
+/// Whether `chars[start]` begins a `$tag$` dollar-quote opener.
+fn is_dollar_quote_start(chars: &[char], start: usize) -> bool {
+    let mut i = start + 1; // past opening '$'
+    while i < chars.len() {
+        match chars[i] {
+            '$' => return true,
+            c if c.is_alphanumeric() || c == '_' => i += 1,
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// Index just past a dollar-quoted literal (`$tag$ … $tag$`) starting at
+/// `start`. Reads the opening tag, then scans for its matching close.
+fn skip_dollar_quoted(chars: &[char], start: usize) -> usize {
+    let mut i = start + 1; // past opening '$'
+    while i < chars.len() {
+        let c = chars[i];
+        i += 1;
+        if c == '$' {
+            break;
+        }
+    }
+    let tag = &chars[start..i];
+    while i + tag.len() <= chars.len() {
+        if &chars[i..i + tag.len()] == tag {
+            return i + tag.len();
+        }
+        i += 1;
+    }
+    chars.len()
+}
+
+// --- Statement application ---------------------------------------------------
+
+fn keyword_eq(token: &Token, keyword: &str) -> bool {
+    matches!(token, Token::Word(w) if w.eq_ignore_ascii_case(keyword))
+}
+
+fn apply_statement(schema: &mut Schema, tokens: &[Token]) {
+    if tokens.len() < 2 {
+        return;
+    }
+    if keyword_eq(&tokens[0], "create") && keyword_eq(&tokens[1], "table") {
+        apply_create_table(schema, &tokens[2..]);
+    } else if keyword_eq(&tokens[0], "alter") && keyword_eq(&tokens[1], "table") {
+        apply_alter_table(schema, &tokens[2..]);
+    } else if keyword_eq(&tokens[0], "drop") && keyword_eq(&tokens[1], "table") {
+        apply_drop_table(schema, &tokens[2..]);
+    }
+}
+
+/// Read an (optionally schema-qualified, optionally quoted) table name, leaving
+/// the cursor just past it. Returns the unqualified base name.
+fn read_table_name(tokens: &[Token], cursor: &mut usize) -> Option<String> {
+    let mut name = match tokens.get(*cursor) {
+        Some(Token::Word(w)) => w.clone(),
+        _ => return None,
+    };
+    *cursor += 1;
+    // `schema.table` — keep only the final component.
+    while matches!(tokens.get(*cursor), Some(Token::Dot)) {
+        *cursor += 1;
+        match tokens.get(*cursor) {
+            Some(Token::Word(w)) => {
+                name = w.clone();
+                *cursor += 1;
+            }
+            _ => break,
+        }
+    }
+    Some(name)
+}
+
+/// Skip leading `IF NOT EXISTS` / `IF EXISTS` / `ONLY` modifiers.
+fn skip_existence_modifiers(tokens: &[Token], cursor: &mut usize) {
+    loop {
+        match tokens.get(*cursor) {
+            Some(t) if keyword_eq(t, "if") => {
+                *cursor += 1;
+                if matches!(tokens.get(*cursor), Some(t) if keyword_eq(t, "not")) {
+                    *cursor += 1;
+                }
+                if matches!(tokens.get(*cursor), Some(t) if keyword_eq(t, "exists")) {
+                    *cursor += 1;
+                }
+            }
+            Some(t) if keyword_eq(t, "only") => *cursor += 1,
+            _ => break,
+        }
+    }
+}
+
+fn apply_create_table(schema: &mut Schema, tokens: &[Token]) {
+    let mut cursor = 0;
+    skip_existence_modifiers(tokens, &mut cursor);
+    let if_not_exists = tokens.iter().take(cursor).any(|t| keyword_eq(t, "exists"));
+    let Some(name) = read_table_name(tokens, &mut cursor) else {
+        return;
+    };
+    if if_not_exists && schema.tables.contains_key(&name) {
+        return;
+    }
+    // The column list lives inside the outermost parentheses.
+    let Some(body) = paren_body(&tokens[cursor..]) else {
+        // `CREATE TABLE x (LIKE y)` and `... AS SELECT` have no literal column
+        // list we can read; leave the table absent rather than guess.
+        return;
+    };
+
+    let mut table = Table::default();
+    let mut primary_key_cols: Vec<String> = Vec::new();
+    for item in split_top_level_commas(body) {
+        if item.is_empty() {
+            continue;
+        }
+        if let Some(cols) = table_level_primary_key(item) {
+            primary_key_cols.extend(cols);
+            continue;
+        }
+        if is_table_constraint(item) {
+            continue;
+        }
+        if let Some(column) = parse_column_def(item) {
+            table.columns.push(column);
+        }
+    }
+    for pk in primary_key_cols {
+        if let Some(col) = table.column_mut(&pk) {
+            col.not_null = true;
+        }
+    }
+
+    schema.tables.insert(name, table);
+}
+
+fn apply_alter_table(schema: &mut Schema, tokens: &[Token]) {
+    let mut cursor = 0;
+    skip_existence_modifiers(tokens, &mut cursor);
+    let Some(name) = read_table_name(tokens, &mut cursor) else {
+        return;
+    };
+    let rest = &tokens[cursor..];
+
+    // `RENAME` is its own statement form and never comma-combines.
+    if matches!(rest.first(), Some(t) if keyword_eq(t, "rename")) {
+        apply_alter_rename(schema, &name, &rest[1..]);
+        return;
+    }
+
+    for action in split_top_level_commas(rest) {
+        apply_alter_action(schema, &name, action);
+    }
+}
+
+fn apply_alter_rename(schema: &mut Schema, table_name: &str, tokens: &[Token]) {
+    // `RENAME TO new_table`
+    if matches!(tokens.first(), Some(t) if keyword_eq(t, "to")) {
+        if let Some(Token::Word(new_name)) = tokens.get(1) {
+            schema.rename_table(table_name, new_name);
+        }
+        return;
+    }
+    // `RENAME [COLUMN] old TO new`
+    let mut idx = 0;
+    if matches!(tokens.get(idx), Some(t) if keyword_eq(t, "column")) {
+        idx += 1;
+    }
+    let old = match tokens.get(idx) {
+        Some(Token::Word(w)) => w.clone(),
+        _ => return,
+    };
+    idx += 1;
+    if !matches!(tokens.get(idx), Some(t) if keyword_eq(t, "to")) {
+        return;
+    }
+    idx += 1;
+    if let Some(Token::Word(new)) = tokens.get(idx) {
+        if let Some(table) = schema.tables.get_mut(table_name) {
+            if let Some(col) = table.column_mut(&old) {
+                col.name = new.clone();
+            }
+        }
+    }
+}
+
+fn apply_alter_action(schema: &mut Schema, table_name: &str, action: &[Token]) {
+    let Some(first) = action.first() else {
+        return;
+    };
+    if keyword_eq(first, "add") {
+        apply_alter_add(schema, table_name, &action[1..]);
+    } else if keyword_eq(first, "drop") {
+        apply_alter_drop(schema, table_name, &action[1..]);
+    } else if keyword_eq(first, "alter") {
+        apply_alter_column(schema, table_name, &action[1..]);
+    }
+}
+
+/// Promote the listed columns of `table_name` to NOT NULL, if present.
+fn mark_primary_key(schema: &mut Schema, table_name: &str, cols: Vec<String>) {
+    if let Some(table) = schema.tables.get_mut(table_name) {
+        for pk in cols {
+            if let Some(col) = table.column_mut(&pk) {
+                col.not_null = true;
+            }
+        }
+    }
+}
+
+fn apply_alter_add(schema: &mut Schema, table_name: &str, tokens: &[Token]) {
+    let mut cursor = 0;
+    // `ADD CONSTRAINT ... PRIMARY KEY (cols)` promotes those columns to NOT NULL.
+    if matches!(tokens.get(cursor), Some(t) if keyword_eq(t, "constraint")) {
+        if let Some(cols) = table_level_primary_key(tokens) {
+            mark_primary_key(schema, table_name, cols);
+        }
+        return;
+    }
+    if matches!(tokens.get(cursor), Some(t) if keyword_eq(t, "column")) {
+        cursor += 1;
+    }
+    skip_existence_modifiers(tokens, &mut cursor);
+    // A bare `ADD PRIMARY KEY (cols)` (no CONSTRAINT keyword).
+    if matches!(tokens.get(cursor), Some(t) if keyword_eq(t, "primary")) {
+        if let Some(cols) = table_level_primary_key(&tokens[cursor..]) {
+            mark_primary_key(schema, table_name, cols);
+        }
+        return;
+    }
+    if let Some(column) = parse_column_def(&tokens[cursor..]) {
+        if let Some(table) = schema.tables.get_mut(table_name) {
+            // A re-added column replaces any prior definition of the same name.
+            table.remove_column(&column.name);
+            table.columns.push(column);
+        }
+    }
+}
+
+fn apply_alter_drop(schema: &mut Schema, table_name: &str, tokens: &[Token]) {
+    let mut cursor = 0;
+    if matches!(tokens.get(cursor), Some(t) if keyword_eq(t, "column")) {
+        cursor += 1;
+    }
+    skip_existence_modifiers(tokens, &mut cursor);
+    if let Some(Token::Word(col)) = tokens.get(cursor) {
+        if let Some(table) = schema.tables.get_mut(table_name) {
+            table.remove_column(col);
+        }
+    }
+}
+
+fn apply_alter_column(schema: &mut Schema, table_name: &str, tokens: &[Token]) {
+    let mut cursor = 0;
+    if matches!(tokens.get(cursor), Some(t) if keyword_eq(t, "column")) {
+        cursor += 1;
+    }
+    let col_name = match tokens.get(cursor) {
+        Some(Token::Word(w)) => w.clone(),
+        _ => return,
+    };
+    cursor += 1;
+    let rest = &tokens[cursor..];
+
+    let Some(table) = schema.tables.get_mut(table_name) else {
+        return;
+    };
+    let Some(column) = table.column_mut(&col_name) else {
+        return;
+    };
+
+    if matches!(rest.first(), Some(t) if keyword_eq(t, "set"))
+        && matches!(rest.get(1), Some(t) if keyword_eq(t, "not"))
+        && matches!(rest.get(2), Some(t) if keyword_eq(t, "null"))
+    {
+        column.not_null = true;
+    } else if matches!(rest.first(), Some(t) if keyword_eq(t, "drop"))
+        && matches!(rest.get(1), Some(t) if keyword_eq(t, "not"))
+        && matches!(rest.get(2), Some(t) if keyword_eq(t, "null"))
+    {
+        column.not_null = false;
+    } else if let Some(type_start) = type_keyword_offset(rest) {
+        if let Some(sql_type) = parse_type(&rest[type_start..]) {
+            column.sql_type = sql_type;
+        }
+    }
+}
+
+/// Offset just past `TYPE` / `SET DATA TYPE` in an `ALTER COLUMN` tail.
+fn type_keyword_offset(tokens: &[Token]) -> Option<usize> {
+    for (idx, token) in tokens.iter().enumerate() {
+        if keyword_eq(token, "type") {
+            return Some(idx + 1);
+        }
+    }
+    None
+}
+
+fn apply_drop_table(schema: &mut Schema, tokens: &[Token]) {
+    let mut cursor = 0;
+    skip_existence_modifiers(tokens, &mut cursor);
+    // `DROP TABLE a, b, c` — drop each named table.
+    while let Some(name) = read_table_name(tokens, &mut cursor) {
+        schema.tables.remove(&name);
+        if matches!(tokens.get(cursor), Some(Token::Comma)) {
+            cursor += 1;
+        } else {
+            break;
+        }
+    }
+}
+
+// --- Column / type parsing ---------------------------------------------------
+
+/// Parse a single column definition (`name type [constraints…]`). Returns
+/// `None` when the item turns out not to be a column after all.
+fn parse_column_def(tokens: &[Token]) -> Option<Column> {
+    let name = match tokens.first() {
+        Some(Token::Word(w)) => w.clone(),
+        _ => return None,
+    };
+    let sql_type = parse_type(&tokens[1..])?;
+    let not_null = is_serial(&sql_type.base)
+        || tokens_contain_phrase(tokens, &["not", "null"])
+        || tokens_contain_phrase(tokens, &["primary", "key"]);
+    Some(Column {
+        name,
+        sql_type,
+        not_null,
+    })
+}
+
+/// Multi-word base type names, longest first so greedy matching is correct.
+const MULTIWORD_TYPES: &[&[&str]] = &[
+    &["timestamp", "with", "time", "zone"],
+    &["timestamp", "without", "time", "zone"],
+    &["time", "with", "time", "zone"],
+    &["time", "without", "time", "zone"],
+    &["double", "precision"],
+    &["character", "varying"],
+    &["bit", "varying"],
+];
+
+/// Parse a type starting at `tokens[0]`. Recognizes multi-word base names,
+/// discards `(size[, scale])`, and counts trailing `[]` array dimensions.
+fn parse_type(tokens: &[Token]) -> Option<SqlType> {
+    let words: Vec<String> = tokens
+        .iter()
+        .map(|t| match t {
+            Token::Word(w) => Some(w.to_ascii_lowercase()),
+            _ => None,
+        })
+        .take_while(Option::is_some)
+        .flatten()
+        .collect();
+    if words.is_empty() {
+        return None;
+    }
+
+    let mut consumed = 1;
+    let mut base = words[0].clone();
+    for phrase in MULTIWORD_TYPES {
+        if words.len() >= phrase.len()
+            && words
+                .iter()
+                .zip(phrase.iter())
+                .take(phrase.len())
+                .all(|(w, p)| w == p)
+        {
+            base = phrase.join(" ");
+            consumed = phrase.len();
+            break;
+        }
+    }
+
+    // Re-walk the raw token stream to skip `(size)` and count `[]` suffixes,
+    // since those are punctuation tokens the `words` view dropped.
+    let mut idx = consumed;
+    if matches!(tokens.get(idx), Some(Token::LParen)) {
+        idx = skip_balanced_parens(tokens, idx);
+    }
+    let mut array_dims = 0;
+    // `int[]`, `int[][]`, and `int array` all denote arrays.
+    while matches!(tokens.get(idx), Some(Token::LBracket)) {
+        array_dims += 1;
+        idx += 1;
+        // Optional dimension size inside the brackets.
+        while matches!(tokens.get(idx), Some(Token::Word(_))) {
+            idx += 1;
+        }
+        if matches!(tokens.get(idx), Some(Token::RBracket)) {
+            idx += 1;
+        }
+    }
+    if matches!(tokens.get(idx), Some(t) if keyword_eq(t, "array")) {
+        array_dims += 1;
+    }
+
+    Some(SqlType { base, array_dims })
+}
+
+fn is_serial(base: &str) -> bool {
+    matches!(
+        base,
+        "serial" | "serial4" | "bigserial" | "serial8" | "smallserial" | "serial2"
+    )
+}
+
+// --- Token helpers -----------------------------------------------------------
+
+/// Contents of the first balanced `( … )` group in `tokens`, if any.
+fn paren_body(tokens: &[Token]) -> Option<&[Token]> {
+    let start = tokens.iter().position(|t| *t == Token::LParen)?;
+    let mut depth = 0;
+    for (idx, token) in tokens.iter().enumerate().skip(start) {
+        match token {
+            Token::LParen => depth += 1,
+            Token::RParen => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&tokens[start + 1..idx]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Index just past a balanced paren group that starts at `tokens[start]`.
+fn skip_balanced_parens(tokens: &[Token], start: usize) -> usize {
+    let mut depth = 0;
+    for (idx, token) in tokens.iter().enumerate().skip(start) {
+        match token {
+            Token::LParen => depth += 1,
+            Token::RParen => {
+                depth -= 1;
+                if depth == 0 {
+                    return idx + 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    tokens.len()
+}
+
+/// Split a token slice on commas that sit at paren depth 0.
+fn split_top_level_commas(tokens: &[Token]) -> Vec<&[Token]> {
+    let mut parts = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0;
+    for (idx, token) in tokens.iter().enumerate() {
+        match token {
+            Token::LParen => depth += 1,
+            Token::RParen => depth -= 1,
+            Token::Comma if depth == 0 => {
+                parts.push(&tokens[start..idx]);
+                start = idx + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&tokens[start..]);
+    parts
+}
+
+/// `true` when an item is a table-level constraint rather than a column.
+fn is_table_constraint(item: &[Token]) -> bool {
+    matches!(
+        item.first(),
+        Some(t) if keyword_eq(t, "constraint")
+            || keyword_eq(t, "primary")
+            || keyword_eq(t, "foreign")
+            || keyword_eq(t, "unique")
+            || keyword_eq(t, "check")
+            || keyword_eq(t, "exclude")
+            || keyword_eq(t, "like")
+    )
+}
+
+/// If `item` is a `PRIMARY KEY (a, b, …)` clause (optionally `CONSTRAINT name`
+/// prefixed), return the listed column names.
+fn table_level_primary_key(item: &[Token]) -> Option<Vec<String>> {
+    let mut idx = 0;
+    if matches!(item.get(idx), Some(t) if keyword_eq(t, "constraint")) {
+        idx += 1;
+        // Skip the optional constraint name.
+        if matches!(item.get(idx), Some(Token::Word(_))) {
+            idx += 1;
+        }
+    }
+    if !(matches!(item.get(idx), Some(t) if keyword_eq(t, "primary"))
+        && matches!(item.get(idx + 1), Some(t) if keyword_eq(t, "key")))
+    {
+        return None;
+    }
+    let body = paren_body(&item[idx..])?;
+    let cols = body
+        .iter()
+        .filter_map(|t| match t {
+            Token::Word(w) => Some(w.clone()),
+            _ => None,
+        })
+        .collect();
+    Some(cols)
+}
+
+/// Whether `tokens` contains `phrase` as consecutive case-insensitive words at
+/// paren depth 0 (so a `CHECK (x IS NOT NULL)` clause never trips `not null`).
+fn tokens_contain_phrase(tokens: &[Token], phrase: &[&str]) -> bool {
+    let mut depth = 0;
+    let mut matched = 0;
+    for token in tokens {
+        match token {
+            Token::LParen => {
+                depth += 1;
+                matched = 0;
+            }
+            Token::RParen => {
+                depth -= 1;
+                matched = 0;
+            }
+            Token::Word(w) if depth == 0 && w.eq_ignore_ascii_case(phrase[matched]) => {
+                matched += 1;
+                if matched == phrase.len() {
+                    return true;
+                }
+            }
+            _ => matched = 0,
+        }
+    }
+    false
+}

--- a/crates/harn-cli/src/commands/pg_codegen/emit.rs
+++ b/crates/harn-cli/src/commands/pg_codegen/emit.rs
@@ -1,0 +1,73 @@
+//! Render a parsed [`Schema`] into Harn `type` declarations.
+//!
+//! The SQL-to-Harn type mapping mirrors the runtime row decode in
+//! `harn-vm`'s `postgres::column_value`: whatever shape a column's value takes
+//! when a query returns it is the shape the generated record type promises.
+//! `NUMERIC`, timestamps, `UUID`, and friends surface as strings there, so they
+//! surface as `string` here.
+
+use super::ddl::{Schema, SqlType, Table};
+use crate::commands::scaffold_common::pascal_identifier_from_snake;
+
+/// Render the full generated file: a stable header plus one `type` per table.
+pub(crate) fn render(schema: &Schema, header: &str, type_suffix: &str) -> String {
+    let mut out = String::new();
+    out.push_str(header);
+
+    let mut first = true;
+    for (table_name, table) in schema.tables() {
+        if !first {
+            out.push('\n');
+        }
+        first = false;
+        out.push_str(&render_table(table_name, table, type_suffix));
+    }
+
+    out
+}
+
+fn render_table(table_name: &str, table: &Table, type_suffix: &str) -> String {
+    let type_name = format!("{}{type_suffix}", pascal_identifier_from_snake(table_name));
+    let mut out = format!("type {type_name} = {{\n");
+    for column in &table.columns {
+        let harn_type = harn_type_for(&column.sql_type, column.not_null);
+        out.push_str(&format!("  {}: {harn_type},\n", column.name));
+    }
+    out.push_str("}\n");
+    out
+}
+
+/// Map a column's SQL type + nullability to a Harn type expression.
+fn harn_type_for(sql_type: &SqlType, not_null: bool) -> String {
+    let mut ty = base_harn_type(&sql_type.base);
+    for _ in 0..sql_type.array_dims {
+        ty = format!("list<{ty}>");
+    }
+    if not_null {
+        ty
+    } else {
+        // Postfix `?` is the canonical optional form the linter prefers
+        // (HARN-LNT-048) over the equivalent `T | nil`.
+        format!("{ty}?")
+    }
+}
+
+/// The Harn scalar type for a normalized SQL base type name. Unknown types
+/// (user-defined enums, composites, …) fall back to `string`, matching the
+/// runtime decode's textual fallback.
+fn base_harn_type(base: &str) -> String {
+    match base {
+        "bool" | "boolean" => "bool",
+        "smallint" | "int2" | "smallserial" | "serial2" | "integer" | "int" | "int4" | "serial"
+        | "serial4" | "bigint" | "int8" | "bigserial" | "serial8" => "int",
+        "real" | "float4" | "double precision" | "float8" | "double" => "float",
+        "json" | "jsonb" => "any",
+        "bytea" => "bytes",
+        "hstore" => return "dict<string, string?>".to_string(),
+        "point" => return "{x: float, y: float}".to_string(),
+        // numeric/money, all text-ish, temporal, network, and bit types decode
+        // to strings; so does anything we do not recognize.
+        _ => "string",
+    }
+    .to_string()
+}

--- a/crates/harn-cli/src/commands/pg_codegen/mod.rs
+++ b/crates/harn-cli/src/commands/pg_codegen/mod.rs
@@ -1,0 +1,131 @@
+//! `harn pg codegen` — generate Harn record types from `.sql` migrations.
+//!
+//! Walks a migration directory, replays every forward (`.sql`, non-`.down.sql`)
+//! migration in lexicographic order — the same discovery rule `pg_migrate`
+//! uses at runtime — and emits one `type <Table>Row = {…}` per table whose
+//! columns mirror the live schema. The generated file lets callers annotate a
+//! query result (`let r: ReceiptRow = pg_query_one(pool, sql, params)`) so the
+//! type-checker proves every downstream field access against the schema on
+//! disk, with no live database round-trip.
+//!
+//! `--check` re-renders and compares against the existing `--out` file without
+//! writing, exiting non-zero on drift — wire it into CI to keep generated
+//! types synchronized with the migrations.
+
+mod ddl;
+mod emit;
+
+use std::path::{Path, PathBuf};
+
+use crate::cli::PgCodegenArgs;
+
+const DEFAULT_TYPE_SUFFIX: &str = "Row";
+
+pub(crate) fn run(args: &PgCodegenArgs) -> i32 {
+    match run_inner(args) {
+        Ok(code) => code,
+        Err(message) => {
+            eprintln!("harn pg codegen: {message}");
+            1
+        }
+    }
+}
+
+fn run_inner(args: &PgCodegenArgs) -> Result<i32, String> {
+    let sources = read_migrations(&args.dir)?;
+    let schema = ddl::parse_migrations(&sources);
+    let suffix = args.suffix.as_deref().unwrap_or(DEFAULT_TYPE_SUFFIX);
+    let header = header_for(&args.dir, args.out.as_deref(), suffix);
+    let rendered = emit::render(&schema, &header, suffix);
+
+    let Some(out) = args.out.as_deref() else {
+        print!("{rendered}");
+        return Ok(0);
+    };
+
+    if args.check {
+        return Ok(check_against(out, &rendered));
+    }
+
+    harn_vm::atomic_io::atomic_write(out, rendered.as_bytes())
+        .map_err(|error| format!("failed to write {}: {error}", out.display()))?;
+    let table_count = schema.tables().count();
+    eprintln!(
+        "wrote {table_count} type{} to {}",
+        if table_count == 1 { "" } else { "s" },
+        out.display()
+    );
+    Ok(0)
+}
+
+/// Read every forward migration in `dir`, lexicographically ordered.
+fn read_migrations(dir: &Path) -> Result<Vec<String>, String> {
+    if !dir.exists() {
+        return Err(format!(
+            "migrations directory does not exist: {}",
+            dir.display()
+        ));
+    }
+    let read_dir = std::fs::read_dir(dir)
+        .map_err(|error| format!("could not read {}: {error}", dir.display()))?;
+    let mut paths: Vec<PathBuf> = read_dir
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| is_forward_migration(path))
+        .collect();
+    paths.sort();
+
+    paths
+        .iter()
+        .map(|path| {
+            std::fs::read_to_string(path)
+                .map_err(|error| format!("could not read {}: {error}", path.display()))
+        })
+        .collect()
+}
+
+/// A forward migration is a `.sql` file that is not a `.down.sql` rollback —
+/// the same rule `pg_migrate` applies when discovering migrations to run.
+fn is_forward_migration(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    name.ends_with(".sql") && !name.ends_with(".down.sql")
+}
+
+fn check_against(out: &Path, rendered: &str) -> i32 {
+    match std::fs::read_to_string(out) {
+        Ok(existing) if existing == rendered => 0,
+        Ok(_) => {
+            eprintln!(
+                "{} is out of date; regenerate with `harn pg codegen`",
+                out.display()
+            );
+            1
+        }
+        Err(_) => {
+            eprintln!(
+                "{} is missing; generate it with `harn pg codegen`",
+                out.display()
+            );
+            1
+        }
+    }
+}
+
+fn header_for(dir: &Path, out: Option<&Path>, suffix: &str) -> String {
+    let mut cmd = format!("harn pg codegen --dir {}", dir.display());
+    if let Some(out) = out {
+        cmd.push_str(&format!(" --out {}", out.display()));
+    }
+    if suffix != DEFAULT_TYPE_SUFFIX {
+        cmd.push_str(&format!(" --suffix {suffix}"));
+    }
+    format!(
+        "// Code generated from SQL migrations by `harn pg codegen`. DO NOT EDIT.\n\
+         // Regenerate with: {cmd}\n\n"
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/harn-cli/src/commands/pg_codegen/tests.rs
+++ b/crates/harn-cli/src/commands/pg_codegen/tests.rs
@@ -1,0 +1,226 @@
+use super::ddl::parse_migrations;
+use super::emit::render;
+
+/// Parse `sources` and render the table bodies, dropping the file header so
+/// assertions focus on the generated types.
+fn codegen(sources: &[&str]) -> String {
+    let owned: Vec<String> = sources.iter().map(|s| s.to_string()).collect();
+    let schema = parse_migrations(&owned);
+    render(&schema, "", "Row")
+}
+
+#[test]
+fn create_table_maps_columns_and_nullability() {
+    let out = codegen(&[r"
+        CREATE TABLE receipts (
+            id BIGSERIAL PRIMARY KEY,
+            kind TEXT NOT NULL,
+            amount NUMERIC(10, 2) NOT NULL,
+            note TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        );
+    "]);
+    assert_eq!(
+        out,
+        "type ReceiptsRow = {\n  \
+         id: int,\n  \
+         kind: string,\n  \
+         amount: string,\n  \
+         note: string?,\n  \
+         created_at: string,\n\
+         }\n"
+    );
+}
+
+#[test]
+fn type_coverage_maps_each_family() {
+    let out = codegen(&[r"
+        CREATE TABLE t (
+            a boolean NOT NULL,
+            b integer NOT NULL,
+            c bigint NOT NULL,
+            d smallint NOT NULL,
+            e real NOT NULL,
+            f double precision NOT NULL,
+            g numeric NOT NULL,
+            h text NOT NULL,
+            i varchar(40) NOT NULL,
+            j uuid NOT NULL,
+            k jsonb NOT NULL,
+            l bytea NOT NULL,
+            m date NOT NULL,
+            n timestamp with time zone NOT NULL
+        );
+    "]);
+    for expected in [
+        "a: bool,",
+        "b: int,",
+        "c: int,",
+        "d: int,",
+        "e: float,",
+        "f: float,",
+        "g: string,",
+        "h: string,",
+        "i: string,",
+        "j: string,",
+        "k: any,",
+        "l: bytes,",
+        "m: string,",
+        "n: string,",
+    ] {
+        assert!(out.contains(expected), "missing {expected:?} in:\n{out}");
+    }
+}
+
+#[test]
+fn arrays_become_nested_lists() {
+    let out = codegen(&[r"
+        CREATE TABLE arr (
+            tags text[] NOT NULL,
+            grid int[][],
+            optional_ids bigint[]
+        );
+    "]);
+    assert!(out.contains("tags: list<string>,"), "{out}");
+    assert!(out.contains("grid: list<list<int>>?,"), "{out}");
+    assert!(out.contains("optional_ids: list<int>?,"), "{out}");
+}
+
+#[test]
+fn alter_add_and_drop_column_track_live_shape() {
+    let out = codegen(&[
+        "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, email TEXT NOT NULL, legacy TEXT);",
+        "ALTER TABLE users ADD COLUMN display_name TEXT;",
+        "ALTER TABLE users DROP COLUMN legacy;",
+        "ALTER TABLE users ALTER COLUMN display_name SET NOT NULL;",
+    ]);
+    assert_eq!(
+        out,
+        "type UsersRow = {\n  \
+         id: int,\n  \
+         email: string,\n  \
+         display_name: string,\n\
+         }\n"
+    );
+}
+
+#[test]
+fn rename_column_and_table_follow_through() {
+    let out = codegen(&[
+        "CREATE TABLE old_name (id INT NOT NULL, full_name TEXT NOT NULL);",
+        "ALTER TABLE old_name RENAME COLUMN full_name TO display_name;",
+        "ALTER TABLE old_name RENAME TO accounts;",
+    ]);
+    assert_eq!(
+        out,
+        "type AccountsRow = {\n  \
+         id: int,\n  \
+         display_name: string,\n\
+         }\n"
+    );
+}
+
+#[test]
+fn drop_table_removes_record() {
+    let out = codegen(&[
+        "CREATE TABLE keep (id INT NOT NULL);",
+        "CREATE TABLE temp (id INT NOT NULL);",
+        "DROP TABLE temp;",
+    ]);
+    assert!(out.contains("type KeepRow"));
+    assert!(!out.contains("TempRow"), "{out}");
+}
+
+#[test]
+fn table_level_primary_key_implies_not_null() {
+    let out = codegen(&[r"
+        CREATE TABLE memberships (
+            org_id BIGINT,
+            user_id BIGINT,
+            role TEXT,
+            PRIMARY KEY (org_id, user_id)
+        );
+    "]);
+    assert!(out.contains("org_id: int,"), "{out}");
+    assert!(out.contains("user_id: int,"), "{out}");
+    assert!(out.contains("role: string?,"), "{out}");
+}
+
+#[test]
+fn check_constraint_does_not_leak_not_null() {
+    // A `CHECK (... IS NOT NULL)` clause must not promote the column.
+    let out = codegen(&["CREATE TABLE t (val TEXT CHECK (val IS NOT NULL));"]);
+    assert!(out.contains("val: string?,"), "{out}");
+}
+
+#[test]
+fn comments_and_dollar_quotes_are_ignored() {
+    let out = codegen(&[r"
+        -- a leading comment
+        CREATE TABLE t ( /* inline */ id INT NOT NULL );
+        CREATE FUNCTION noop() RETURNS void AS $$
+            BEGIN
+                -- this ; should not split the function body
+                RETURN;
+            END;
+        $$ LANGUAGE plpgsql;
+    "]);
+    assert_eq!(out, "type TRow = {\n  id: int,\n}\n");
+}
+
+#[test]
+fn schema_qualified_names_strip_prefix() {
+    let out = codegen(&["CREATE TABLE public.events (id INT NOT NULL);"]);
+    assert!(out.contains("type EventsRow"), "{out}");
+}
+
+#[test]
+fn unknown_types_fall_back_to_string() {
+    // A user-defined enum decodes as text at runtime, so it maps to `string`.
+    let out = codegen(&[
+        "CREATE TYPE mood AS ENUM ('happy', 'sad');",
+        "CREATE TABLE t (current_mood mood NOT NULL);",
+    ]);
+    assert!(out.contains("current_mood: string,"), "{out}");
+}
+
+#[test]
+fn output_is_deterministically_sorted_by_table() {
+    let out = codegen(&[
+        "CREATE TABLE zebra (id INT NOT NULL);",
+        "CREATE TABLE alpha (id INT NOT NULL);",
+    ]);
+    let alpha = out.find("AlphaRow").expect("alpha present");
+    let zebra = out.find("ZebraRow").expect("zebra present");
+    assert!(alpha < zebra, "tables should sort alphabetically:\n{out}");
+}
+
+#[test]
+fn generated_types_parse_and_typecheck() {
+    // The whole point: generated declarations must be valid Harn that the
+    // type-checker accepts.
+    let types = codegen(&[r"
+        CREATE TABLE receipts (
+            id BIGSERIAL PRIMARY KEY,
+            kind TEXT NOT NULL,
+            tags TEXT[] NOT NULL,
+            meta JSONB,
+            note TEXT
+        );
+    "]);
+    let program = format!("{types}\nfn use_it(r: ReceiptsRow) -> string {{ return r.kind }}\n");
+
+    let mut lexer = harn_lexer::Lexer::new(&program);
+    let tokens = lexer.tokenize().expect("generated types should tokenize");
+    let mut parser = harn_parser::Parser::new(tokens);
+    let module = parser.parse().expect("generated types should parse");
+    let diagnostics = harn_parser::TypeChecker::new().check(&module);
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.severity == harn_parser::DiagnosticSeverity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "generated types should type-check, got: {errors:#?}\n\nprogram:\n{program}"
+    );
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -29,7 +29,7 @@ use std::{env, fs, panic, process, thread};
 use cli::{
     Cli, Command, CompletionShell, EvalCommand, MergeCaptainCommand, MergeCaptainMockCommand,
     ModelInfoArgs, PackageArtifactsCommand, PackageCacheCommand, PackageCommand,
-    PackageScaffoldCommand, PersonaCommand, PersonaSupervisionCommand, ProvidersCommand,
+    PackageScaffoldCommand, PersonaCommand, PersonaSupervisionCommand, PgCommand, ProvidersCommand,
     RunsCommand, ServeCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand, SkillsCommand,
     TimeCommand, ToolCommand,
 };
@@ -1374,6 +1374,14 @@ async fn async_main() {
                         commands::merge_captain_mock::run_scenarios()
                     }
                 };
+                if code != 0 {
+                    process::exit(code);
+                }
+            }
+        },
+        Command::Pg(args) => match args.command {
+            PgCommand::Codegen(codegen) => {
+                let code = commands::pg_codegen::run(&codegen);
                 if code != 0 {
                     process::exit(code);
                 }

--- a/crates/harn-cli/tests/pg_codegen_cli.rs
+++ b/crates/harn-cli/tests/pg_codegen_cli.rs
@@ -1,0 +1,123 @@
+//! CLI smoke tests for `harn pg codegen`.
+//!
+//! Spawns the binary to exercise the real clap parser and file IO. The DDL
+//! parsing and type emission are covered by unit tests in
+//! `commands::pg_codegen::tests`, so this file focuses on the CLI surface:
+//! stdout vs `--out`, and the `--check` drift gate.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+/// Create a migrations directory under a unique temp path and return it.
+fn migrations_dir(label: &str, files: &[(&str, &str)]) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "harn-pg-codegen-{label}-{}-{}",
+        std::process::id(),
+        // Monotonic-enough disambiguator without depending on wall-clock time.
+        files.len()
+    ));
+    let dir = root.join("migrations");
+    fs::create_dir_all(&dir).expect("create migrations dir");
+    for (name, body) in files {
+        fs::write(dir.join(name), body).expect("write migration");
+    }
+    root
+}
+
+#[test]
+fn codegen_to_stdout_emits_record_type() {
+    let root = migrations_dir(
+        "stdout",
+        &[(
+            "0001_init.sql",
+            "CREATE TABLE receipts (id BIGSERIAL PRIMARY KEY, note TEXT);",
+        )],
+    );
+    let output = Command::new(binary_path())
+        .args(["pg", "codegen", "--dir"])
+        .arg(root.join("migrations"))
+        .output()
+        .expect("spawn harn pg codegen");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("type ReceiptsRow = {"), "got:\n{stdout}");
+    assert!(stdout.contains("id: int,"), "got:\n{stdout}");
+    assert!(stdout.contains("note: string?,"), "got:\n{stdout}");
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn codegen_out_then_check_round_trips() {
+    let root = migrations_dir(
+        "check",
+        &[(
+            "0001_init.sql",
+            "CREATE TABLE accounts (id INT NOT NULL, email TEXT NOT NULL);",
+        )],
+    );
+    let dir = root.join("migrations");
+    let out = root.join("types.harn");
+
+    let write = Command::new(binary_path())
+        .args(["pg", "codegen", "--dir"])
+        .arg(&dir)
+        .arg("--out")
+        .arg(&out)
+        .output()
+        .expect("spawn write");
+    assert!(
+        write.status.success(),
+        "write exit={:?}",
+        write.status.code()
+    );
+    assert!(out.exists(), "expected generated file");
+
+    let check_ok = Command::new(binary_path())
+        .args(["pg", "codegen", "--dir"])
+        .arg(&dir)
+        .arg("--out")
+        .arg(&out)
+        .arg("--check")
+        .output()
+        .expect("spawn check");
+    assert!(
+        check_ok.status.success(),
+        "fresh file should pass --check, exit={:?}",
+        check_ok.status.code()
+    );
+
+    // Mutate the file: --check must now fail.
+    let mut contents = fs::read_to_string(&out).expect("read out");
+    contents.push_str("// drift\n");
+    fs::write(&out, contents).expect("tamper");
+    let check_drift = Command::new(binary_path())
+        .args(["pg", "codegen", "--dir"])
+        .arg(&dir)
+        .arg("--out")
+        .arg(&out)
+        .arg("--check")
+        .output()
+        .expect("spawn check drift");
+    assert!(
+        !check_drift.status.success(),
+        "tampered file should fail --check"
+    );
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn check_requires_out() {
+    let output = Command::new(binary_path())
+        .args(["pg", "codegen", "--dir", "migrations", "--check"])
+        .output()
+        .expect("spawn harn pg codegen --check");
+    assert!(
+        !output.status.success(),
+        "--check without --out should be rejected by clap"
+    );
+}

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -615,6 +615,27 @@ daily, hourly, run, and token budgets before recording expensive-work receipts.
 optional `persona_version`, `actor`, `update_kind`, `occurred_at`, and
 `payload`.
 
+## harn pg codegen
+
+Generate Harn record types from a directory of `.sql` migrations so
+Postgres query results can be type-checked without a live database.
+
+```bash
+harn pg codegen --dir migrations
+harn pg codegen --dir migrations --out src/db_types.harn
+harn pg codegen --dir migrations --out src/db_types.harn --check
+harn pg codegen --dir migrations --out src/db_types.harn --suffix Record
+```
+
+Replays every forward migration (`.sql`, excluding `.down.sql`) in
+lexicographic order — the same discovery rule `pg_migrate` uses —
+applying `CREATE TABLE`, `ALTER TABLE … ADD/DROP/ALTER/RENAME COLUMN`,
+`RENAME TO`, and `DROP TABLE`, then emits one `type <Table>Row = {…}`
+per table mirroring the live schema. Prints to stdout unless `--out` is
+given. `--check` (requires `--out`) verifies the file is current without
+writing and exits non-zero on drift — wire it into CI. See
+[Postgres → Typed rows from migrations](./postgres.md#typed-rows-from-migrations).
+
 ## harn fmt
 
 Format `.harn` source files. Accepts files or directories.

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -154,6 +154,50 @@ or branching — keep using SQLx CLI, Sqitch, or Flyway and call
 `pg_migrate` only when your `.harn` pipeline is the authoritative
 schema owner.
 
+## Typed rows from migrations
+
+`pg_query` / `pg_query_one` return rows as plain dicts. To get
+compile-time field checking, generate a Harn record type per table from
+your migration files and annotate the result:
+
+```sh
+harn pg codegen --dir migrations --out src/db_types.harn
+```
+
+This replays every forward migration (`.sql`, excluding `.down.sql`) in
+lexicographic order — the same discovery rule `pg_migrate` uses — and
+emits one `type <Table>Row = {…}` per table whose columns mirror the
+live schema. `CREATE TABLE`, `ALTER TABLE … ADD/DROP/ALTER/RENAME
+COLUMN`, `RENAME TO`, and `DROP TABLE` are all replayed, so the
+generated file always reflects the schema state on disk. No live
+database is required — this is build-time codegen.
+
+```harn,ignore
+import { ReceiptsRow } from "./db_types.harn"
+
+let receipt: ReceiptsRow = pg_query_one(pool, "select * from receipts where id = $1", [id])
+log(receipt.kind)   // type-checked against the column set
+```
+
+SQL types map to the same Harn types the row decoder produces at
+runtime: integer families → `int`, `real`/`double precision` → `float`,
+`numeric`/temporal/`uuid`/text families → `string`, `json`/`jsonb` →
+`any`, `bytea` → `bytes`, `T[]` → `list<T>`. Columns that are not
+`NOT NULL` (and not a primary key) become optional (`field: T?`).
+
+Pass `--check` (with `--out`) to verify the generated file is current
+without writing it — wire it into CI so a migration that changes a
+column fails the build until the types are regenerated:
+
+```sh
+harn pg codegen --dir migrations --out src/db_types.harn --check
+```
+
+Inferring types from arbitrary `SELECT` projections is out of scope —
+that needs a live `PREPARE` round-trip. Codegen reflects the table
+shape; annotate `select *` queries, or hand-write a narrower shape for
+projections.
+
 ## Advisory locks
 
 Advisory locks coordinate work across processes that share a Postgres


### PR DESCRIPTION
## Summary

Implements the typed-row-mapping bullet deferred from the A.9 Postgres hostlib v2 sweep ([#2512](https://github.com/burin-labs/harn/issues/2512)), closing [#2577](https://github.com/burin-labs/harn/issues/2577).

New `harn pg codegen` command generates one `type <Table>Row = {…}` per table from a directory of `.sql` migrations, so Postgres query results can be type-checked **without a live database**:

```sh
harn pg codegen --dir migrations --out src/db_types.harn
```

```harn
import { ReceiptsRow } from "./db_types.harn"
let r: ReceiptsRow = pg_query_one(pool, "select * from receipts where id = $1", [id])
log(r.kind)   // field access proven against the schema on disk
```

### How it works
- Replays every **forward** migration (`.sql`, excluding `*.down.sql`) in lexicographic order — the same discovery rule `pg_migrate` uses at runtime.
- A focused DDL parser (not a general SQL parser) applies `CREATE TABLE`, `ALTER TABLE … ADD/DROP/ALTER/RENAME COLUMN`, `RENAME TO`, and `DROP TABLE`, tracking the live column set so the emitted file always mirrors the schema state on disk. Everything else (indexes, functions, `INSERT`s, `CREATE TYPE`) is skipped; comments and dollar-quoted bodies are handled.
- SQL types map to the **same** Harn types the runtime row decoder (`postgres::column_value`) produces: integer families → `int`, `real`/`double precision` → `float`, `numeric`/temporal/`uuid`/text → `string`, `json`/`jsonb` → `any`, `bytea` → `bytes`, `T[]` → `list<T>`, `hstore` → `dict<string, string?>`, `point` → `{x: float, y: float}`. Unknown types (enums/composites) fall back to `string`, matching the runtime's textual fallback.
- Nullable columns (not `NOT NULL`, not a primary key) become optional via the canonical postfix `?` shorthand (`field: T?`), which is lint-clean.
- `--check` (with `--out`) re-renders and compares without writing, exiting non-zero on drift — wire it into CI to keep generated types synchronized with migrations.

### Scope
Per the issue's out-of-scope list, the motivating `pg_query_one(…, schema: ReceiptRow)` is realized via standard type annotations (Harn types are not first-class runtime values), which is the idiomatic path and is what the type-checker enforces. Inferring types from arbitrary `SELECT` projections (needs a live `PREPARE` round-trip) and live-PG validation remain out of scope.

## Test plan
- [x] 13 unit tests covering type-family mapping, arrays, nullability, ADD/DROP/ALTER/RENAME column, RENAME table, DROP table, table-level PK, `CHECK (… IS NOT NULL)` not leaking, comments/dollar-quotes, schema-qualified names, unknown-type fallback, deterministic ordering, and a round-trip that **parses + type-checks** the generated output.
- [x] 3 CLI integration tests: stdout emission, `--out` then `--check` round-trip (incl. drift detection), and `--check` requiring `--out`.
- [x] Manual e2e: generated file passes `harn check` lint-clean.
- [x] `cargo clippy -p harn-cli` clean; pre-commit hooks (rustfmt/clippy/markdownlint) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2577
