### PR TITLE
builtins: collapse deferred registration path to eager-only (#2586)

### DIFF
--- a/changelog.d/2586.removed.md
+++ b/changelog.d/2586.removed.md
@@ -1,0 +1,15 @@
+- **Deferred-builtin registration path collapsed to eager-only.** The
+  lazy `register_deferred_*` machinery — added pre-linkme so the LLM stack
+  stayed out of cold-start — only delayed ~74 `HashMap` inserts once per VM.
+  Measured delta was 0.15 ms per VM construction (1369 µs eager vs. 1217 µs
+  deferred), negligible against process spawn, while the path imposed a
+  `deferred_builtin_registrars` `BTreeMap` lookup on *every* builtin
+  dispatch plus a hand-maintained name list per LLM module that had to be
+  kept in sync with eager registration. Deleted
+  `register_vm_stdlib_with_deferred_llm`, `register_deferred_builtin_defs`,
+  `Vm::register_deferred_builtin` / `ensure_deferred_builtin`, the
+  `deferred_builtin_registrars` VM field, every `register_deferred_*`
+  module helper, and the duplicate `CONVERSATION_BUILTIN_NAMES` /
+  `COST_BUILTIN_NAMES` lists they fed. All call sites
+  (`harn run`, `harn bench`, the MCP test harness) now use the eager
+  `register_vm_stdlib`.

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -129,7 +129,7 @@ pub(crate) async fn run_bench(path: &str, iterations: usize, profile: RunProfile
         }
 
         let mut vm = harn_vm::Vm::new();
-        harn_vm::register_vm_stdlib_with_deferred_llm(&mut vm);
+        harn_vm::register_vm_stdlib(&mut vm);
         crate::install_default_hostlib(&mut vm);
         harn_vm::register_store_builtins(&mut vm, store_base);
         harn_vm::register_metadata_builtins(&mut vm, store_base);

--- a/crates/harn-cli/src/commands/run/mod.rs
+++ b/crates/harn-cli/src/commands/run/mod.rs
@@ -1410,7 +1410,7 @@ async fn execute_run_inner(inputs: ExecuteRunInputs<'_>) -> RunOutcome {
         vm.install_interrupt_signal_token(interrupt_tokens.signal_token);
         vm.install_cancel_token(interrupt_tokens.cancel_token);
     }
-    harn_vm::register_vm_stdlib_with_deferred_llm(&mut vm);
+    harn_vm::register_vm_stdlib(&mut vm);
     crate::install_default_hostlib(&mut vm);
     let source_parent = std::path::Path::new(path)
         .parent()

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -1297,7 +1297,22 @@ fn main(harness: Harness) {
         )
         .expect_err("wrong argument type fails");
 
-        assert!(error.contains("HarnessFs.read_text expects string argument 1, got int"));
+        // A wrong-typed argument is rejected by one of two layers, and which
+        // one fires depends on whether the process-global builtin-signature
+        // registry was already populated (by any prior `register_vm_stdlib`
+        // call in the test binary) when `compile_source` ran:
+        //   - empty registry  -> the harness runtime guard (`string_arg`)
+        //   - populated registry -> static type-check at compile time, which
+        //     matches the `read_text` method against the same-named stdlib
+        //     `read_text(path: string)` signature.
+        // Both correctly reject the int, so accept either message.
+        let runtime_rejection =
+            error.contains("HarnessFs.read_text expects string argument 1, got int");
+        let static_rejection = error.contains("argument 1 `path`: expected string, found int");
+        assert!(
+            runtime_rejection || static_rejection,
+            "expected a string/int type rejection for read_text, got: {error}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -275,7 +275,6 @@ pub use stdlib::workflow_messages::{
 };
 pub use stdlib::{
     register_agent_stdlib, register_core_stdlib, register_io_stdlib, register_vm_stdlib,
-    register_vm_stdlib_with_deferred_llm,
 };
 pub use store::register_store_builtins;
 pub use tenant::{

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -3,12 +3,8 @@
 
 use std::rc::Rc;
 
-use crate::stdlib::harn_entry::{
-    register_deferred_harn_entrypoint_category, register_harn_entrypoint_category,
-};
-use crate::stdlib::macros::{
-    harn_builtin, register_builtin_defs, register_deferred_builtin_defs, VmBuiltinDef,
-};
+use crate::stdlib::harn_entry::register_harn_entrypoint_category;
+use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
 
@@ -292,10 +288,6 @@ pub(crate) fn register_agent_loop(vm: &mut Vm) {
     register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
 }
 
-pub(crate) fn register_deferred_agent_loop(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    register_deferred_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY, registrar);
-}
-
 pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::HostBridge>) {
     super::agent_runtime::install_current_host_bridge(bridge);
     register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
@@ -303,10 +295,6 @@ pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Ho
 
 pub(crate) fn register_agent_control_primitives(vm: &mut Vm) {
     register_builtin_defs(vm, AGENT_CONTROL_BUILTINS);
-}
-
-pub(crate) fn register_deferred_agent_control_primitives(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    register_deferred_builtin_defs(vm, AGENT_CONTROL_BUILTINS, registrar);
 }
 
 /// Subscribe a Harn callback to events for an agent session.

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -16,9 +16,7 @@ use crate::orchestration::{
     push_command_policy, push_execution_policy, CapabilityPolicy, NestedExecutionGuard,
     NestedExecutionKind, ToolApprovalPolicy, NESTED_KIND_OPTION_KEY, NESTED_LABEL_OPTION_KEY,
 };
-use crate::stdlib::macros::{
-    harn_builtin, register_builtin_defs, register_deferred_builtin_defs, VmBuiltinDef,
-};
+use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -2761,10 +2759,6 @@ const HOST_SESSION_BUILTINS: &[&VmBuiltinDef] = &[
     &HOST_AGENT_DAEMON_WAIT_DEF,
     &HOST_AGENT_SESSION_PROJECT_TURN_DEF,
 ];
-
-pub fn register_deferred_agent_session_host_primitives(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    register_deferred_builtin_defs(vm, HOST_SESSION_BUILTINS, registrar);
-}
 
 pub fn register_agent_session_host_primitives(vm: &mut Vm) {
     register_builtin_defs(vm, HOST_SESSION_BUILTINS);

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -12,9 +12,7 @@ use sha2::{Digest, Sha256};
 
 use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::clock::now_wall_ms;
-use crate::stdlib::macros::{
-    harn_builtin, register_builtin_defs, register_deferred_builtin_defs, VmBuiltinDef,
-};
+use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -91,10 +89,6 @@ impl CacheRecord {
 
 pub(crate) fn register_cache_builtins(vm: &mut Vm) {
     register_builtin_defs(vm, CACHE_BUILTINS);
-}
-
-pub(crate) fn register_deferred_cache_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    register_deferred_builtin_defs(vm, CACHE_BUILTINS, registrar);
 }
 
 const CACHE_BUILTINS: &[&VmBuiltinDef] = &[

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -3,9 +3,7 @@ use std::rc::Rc;
 
 use crate::llm_config;
 use crate::stdlib::json_to_vm_value;
-use crate::stdlib::macros::{
-    harn_builtin, register_builtin_defs, register_deferred_builtin_defs, VmBuiltinDef,
-};
+use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -14,10 +12,6 @@ use super::helpers::vm_value_to_json;
 /// Register config-based LLM builtins (llm_infer_provider, llm_resolve_model, etc.).
 pub(crate) fn register_config_builtins(vm: &mut Vm) {
     register_builtin_defs(vm, LLM_CONFIG_DEFS);
-}
-
-pub(crate) fn register_deferred_config_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    register_deferred_builtin_defs(vm, LLM_CONFIG_DEFS, registrar);
 }
 
 const LLM_CONFIG_DEFS: &[&VmBuiltinDef] = &[

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -28,45 +28,6 @@ const INJECT_REMINDER_KEYS: &[&str] = &[
 ];
 const CLEAR_REMINDER_KEYS: &[&str] = &["id", "tag", "dedupe_key"];
 
-const CONVERSATION_BUILTIN_NAMES: &[&str] = &[
-    "conversation",
-    "transcript",
-    "transcript.inject_reminder",
-    "transcript.clear_reminders",
-    "transcript_from_messages",
-    "transcript_messages",
-    "transcript_assets",
-    "transcript_add_asset",
-    "transcript_events",
-    "transcript_reminder_event",
-    "transcript_suspension_event",
-    "transcript_resumption_event",
-    "transcript_drain_decision_event",
-    "transcript_summary",
-    "transcript_id",
-    "transcript_render_visible",
-    "transcript_render_full",
-    "transcript_summarize",
-    "transcript_export",
-    "transcript_import",
-    "transcript_fork",
-    "transcript_reset",
-    "transcript_archive",
-    "transcript_abandon",
-    "transcript_resume",
-    "add_message",
-    "add_user",
-    "add_assistant",
-    "add_system",
-    "add_tool_result",
-];
-
-pub(crate) fn register_deferred_conversation_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    for name in CONVERSATION_BUILTIN_NAMES {
-        vm.register_deferred_builtin(name, registrar);
-    }
-}
-
 /// Extract and validate a transcript dict from the first argument.
 fn require_transcript<'a>(
     args: &'a [VmValue],

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -611,24 +611,6 @@ pub(crate) fn record_llm_usage_for_provider(
     accumulate_cost_for_provider(provider, model, input_tokens, output_tokens)
 }
 
-const COST_BUILTIN_NAMES: &[&str] = &[
-    "llm_cost",
-    "llm_pricing",
-    "llm_format_usd",
-    "llm_compare_costs",
-    "llm_session_cost",
-    "llm_budget",
-    "llm_budget_remaining",
-    "tiktoken_count_tokens",
-    "tiktoken_tokenizer_info",
-];
-
-pub(crate) fn register_deferred_cost_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    for name in COST_BUILTIN_NAMES {
-        vm.register_deferred_builtin(name, registrar);
-    }
-}
-
 pub(crate) fn register_cost_builtins(vm: &mut Vm) {
     vm.register_builtin("llm_cost", |args, _out| {
         let model = args.first().map(|a| a.display()).unwrap_or_default();

--- a/crates/harn-vm/src/llm/mock_builtins.rs
+++ b/crates/harn-vm/src/llm/mock_builtins.rs
@@ -1,9 +1,7 @@
 use std::rc::Rc;
 
 use crate::stdlib::json_to_vm_value;
-use crate::stdlib::macros::{
-    harn_builtin, register_builtin_defs, register_deferred_builtin_defs, VmBuiltinDef,
-};
+use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -20,10 +18,6 @@ const LLM_MOCK_BUILTINS: &[&VmBuiltinDef] = &[
 /// Register llm_mock / llm_mock_calls / llm_mock_clear builtins.
 pub(super) fn register_llm_mock_builtins(vm: &mut Vm) {
     register_builtin_defs(vm, LLM_MOCK_BUILTINS);
-}
-
-pub(super) fn register_deferred_llm_mock_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    register_deferred_builtin_defs(vm, LLM_MOCK_BUILTINS, registrar);
 }
 
 /// Register a deterministic LLM mock response for tests.

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -172,9 +172,7 @@ pub(crate) fn ensure_real_llm_allowed(provider: &str) -> Result<(), crate::value
     )))
 }
 
-use crate::stdlib::macros::{
-    harn_builtin, register_builtin_defs, register_deferred_builtin_defs, VmBuiltinDef,
-};
+use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 use std::rc::Rc;
@@ -656,31 +654,11 @@ pub fn register_llm_builtins(vm: &mut Vm) {
     transcript_stats::register_transcript_builtins(vm);
 }
 
-/// Register LLM builtin names without installing their handlers. The first
-/// resolution of any deferred name installs the complete LLM surface.
-pub(crate) fn register_deferred_llm_builtins(vm: &mut Vm) {
-    agent_config::register_deferred_agent_control_primitives(vm, register_llm_builtins);
-    register_deferred_builtin_defs(vm, LLM_RUNTIME_PRIMITIVE_BUILTINS, register_llm_builtins);
-    agent_config::register_deferred_agent_loop(vm, register_llm_builtins);
-    agent_session_host::register_deferred_agent_session_host_primitives(vm, register_llm_builtins);
-
-    conversation::register_deferred_conversation_builtins(vm, register_llm_builtins);
-    cache::register_deferred_cache_builtins(vm, register_llm_builtins);
-    config_builtins::register_deferred_config_builtins(vm, register_llm_builtins);
-    cost::register_deferred_cost_builtins(vm, register_llm_builtins);
-    rerank::register_deferred_rerank_builtins(vm, register_llm_builtins);
-    mock_builtins::register_deferred_llm_mock_builtins(vm, register_llm_builtins);
-    transcript_stats::register_deferred_transcript_builtins(vm, register_llm_builtins);
-}
-
 #[cfg(test)]
 mod tests {
     use super::api::LlmCallOptions;
     use super::call::{build_schema_nudge, compute_validation_errors, SchemaNudge};
-    use super::{
-        execute_llm_call, register_deferred_llm_builtins, register_llm_builtins, reset_llm_state,
-        structured_output_errors,
-    };
+    use super::{execute_llm_call, reset_llm_state, structured_output_errors};
     use crate::llm::mock;
     use crate::value::VmValue;
     use std::rc::Rc;
@@ -751,24 +729,7 @@ mod tests {
     }
 
     #[test]
-    fn deferred_llm_builtins_install_on_first_resolution() {
-        let mut vm = crate::Vm::new();
-        crate::register_vm_stdlib_with_deferred_llm(&mut vm);
-
-        assert!(!vm
-            .builtin_names()
-            .iter()
-            .any(|name| name == "llm_rate_limit"));
-        assert!(vm.ensure_deferred_builtin("llm_rate_limit"));
-        assert!(vm
-            .builtin_names()
-            .iter()
-            .any(|name| name == "llm_rate_limit"));
-        assert!(vm.builtin_names().iter().any(|name| name == "llm_call"));
-    }
-
-    #[test]
-    fn deferred_sync_llm_builtin_installs_on_direct_call() {
+    fn llm_stack_registers_and_dispatches_through_full_stdlib() {
         mock::reset_llm_mock_state();
         let chunk = crate::compile_source("llm_mock({text: \"ok\"})\n").expect("compile");
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -781,34 +742,15 @@ mod tests {
             local
                 .run_until(async {
                     let mut vm = crate::Vm::new();
-                    crate::register_vm_stdlib_with_deferred_llm(&mut vm);
+                    crate::register_vm_stdlib(&mut vm);
                     vm.execute(&chunk).await.expect("execute");
                     assert!(mock::builtin_llm_mock_active());
                     assert!(vm.builtin_names().iter().any(|name| name == "llm_mock"));
+                    assert!(vm.builtin_names().iter().any(|name| name == "llm_call"));
                 })
                 .await;
         });
         mock::reset_llm_mock_state();
-    }
-
-    #[test]
-    fn deferred_llm_builtin_names_match_eager_registration() {
-        let mut eager = crate::Vm::new();
-        register_llm_builtins(&mut eager);
-        let eager_names = eager
-            .builtin_names()
-            .into_iter()
-            .collect::<std::collections::BTreeSet<_>>();
-
-        let mut deferred = crate::Vm::new();
-        register_deferred_llm_builtins(&mut deferred);
-        let deferred_names = deferred
-            .deferred_builtin_registrars
-            .keys()
-            .cloned()
-            .collect::<std::collections::BTreeSet<_>>();
-
-        assert_eq!(deferred_names, eager_names);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/rerank.rs
+++ b/crates/harn-vm/src/llm/rerank.rs
@@ -1,8 +1,6 @@
 use std::rc::Rc;
 
-use crate::stdlib::macros::{
-    harn_builtin, register_builtin_defs, register_deferred_builtin_defs, VmBuiltinDef,
-};
+use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -11,10 +9,6 @@ const SELF_CERTAINTY_PROMPT_SUFFIX: &str = "\n</text>";
 
 pub(crate) fn register_rerank_builtins(vm: &mut Vm) {
     register_builtin_defs(vm, RERANK_BUILTINS);
-}
-
-pub(crate) fn register_deferred_rerank_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    register_deferred_builtin_defs(vm, RERANK_BUILTINS, registrar);
 }
 
 const RERANK_BUILTINS: &[&VmBuiltinDef] = &[&SELF_CERTAINTY_BUILTIN_DEF];

--- a/crates/harn-vm/src/llm/transcript_stats.rs
+++ b/crates/harn-vm/src/llm/transcript_stats.rs
@@ -8,12 +8,6 @@ use std::rc::Rc;
 use crate::value::VmValue;
 use crate::vm::Vm;
 
-pub(crate) fn register_deferred_transcript_builtins(vm: &mut Vm, registrar: fn(&mut Vm)) {
-    for name in ["transcript_stats", "transcript_events_by_kind"] {
-        vm.register_deferred_builtin(name, registrar);
-    }
-}
-
 pub(crate) fn register_transcript_builtins(vm: &mut Vm) {
     vm.register_builtin("transcript_stats", |args, _out| {
         let transcript = args.first().cloned().unwrap_or(VmValue::Nil);

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -3046,7 +3046,7 @@ llm_mock_clear()
     async fn execute_test_harn(source: &str) {
         let chunk = crate::compile_source(source).expect("test Harn source should compile");
         let mut vm = crate::Vm::new();
-        crate::register_vm_stdlib_with_deferred_llm(&mut vm);
+        crate::register_vm_stdlib(&mut vm);
         vm.execute(&chunk)
             .await
             .expect("test Harn source should execute");

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -107,7 +107,7 @@ pub mod workflow_messages;
 mod xml;
 
 use crate::http::register_http_builtins;
-use crate::llm::{register_deferred_llm_builtins, register_llm_builtins};
+use crate::llm::register_llm_builtins;
 use crate::mcp::register_mcp_builtins;
 use crate::mcp_server::register_mcp_server_builtins;
 use crate::vm::Vm;
@@ -228,12 +228,6 @@ pub fn register_agent_stdlib(vm: &mut Vm) {
     register_agent_stdlib_after_llm(vm);
 }
 
-fn register_agent_stdlib_with_deferred_llm(vm: &mut Vm) {
-    register_agent_stdlib_before_llm(vm);
-    register_deferred_llm_builtins(vm);
-    register_agent_stdlib_after_llm(vm);
-}
-
 /// Register all standard builtins on a VM (core + io + agent). Also
 /// installs the macro-emitted signature slice into the parser registry
 /// (idempotent under repeat calls with the same slice pointer).
@@ -241,15 +235,6 @@ pub fn register_vm_stdlib(vm: &mut Vm) {
     register_core_stdlib(vm);
     register_io_stdlib(vm);
     register_agent_stdlib(vm);
-    harn_builtin_registry::install_builtin_signatures(all_builtin_signatures());
-}
-
-/// Register the stdlib shape used by latency-sensitive CLI execution. Also
-/// installs the macro-emitted signature slice into the parser registry.
-pub fn register_vm_stdlib_with_deferred_llm(vm: &mut Vm) {
-    register_core_stdlib(vm);
-    register_io_stdlib(vm);
-    register_agent_stdlib_with_deferred_llm(vm);
     harn_builtin_registry::install_builtin_signatures(all_builtin_signatures());
 }
 

--- a/crates/harn-vm/src/stdlib/harn_entry.rs
+++ b/crates/harn-vm/src/stdlib/harn_entry.rs
@@ -31,24 +31,6 @@ pub(crate) fn register_harn_entrypoint_category(vm: &mut Vm, category: &str) {
     }
 }
 
-pub(crate) fn register_deferred_harn_entrypoint_category(
-    vm: &mut Vm,
-    category: &str,
-    registrar: fn(&mut Vm),
-) {
-    for module in harn_stdlib::entrypoint_modules() {
-        if module.category != category {
-            continue;
-        }
-        let Some(module_name) = module.import_path.strip_prefix("std/") else {
-            continue;
-        };
-        for export in harn_stdlib::public_functions_for_module(module_name) {
-            vm.register_deferred_builtin(&export.name, registrar);
-        }
-    }
-}
-
 fn arity_for_export(export: &harn_stdlib::StdlibPublicFunction) -> VmBuiltinArity {
     if export.variadic {
         VmBuiltinArity::Variadic

--- a/crates/harn-vm/src/stdlib/macros.rs
+++ b/crates/harn-vm/src/stdlib/macros.rs
@@ -63,20 +63,3 @@ pub fn register_builtin_defs(vm: &mut crate::vm::Vm, defs: &'static [&'static Vm
         vm.register_builtin_def(def);
     }
 }
-
-/// Deferred-registration helper: register names + aliases as deferred
-/// builtins on `vm`. The first time any of them dispatches, `registrar`
-/// runs (typically installs the LLM stack), which re-registers the real
-/// impls.
-pub fn register_deferred_builtin_defs(
-    vm: &mut crate::vm::Vm,
-    defs: &[&'static VmBuiltinDef],
-    registrar: fn(&mut crate::vm::Vm),
-) {
-    for def in defs {
-        vm.register_deferred_builtin(def.sig.name, registrar);
-        for alias in def.aliases {
-            vm.register_deferred_builtin(alias, registrar);
-        }
-    }
-}

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -142,7 +142,6 @@ impl Vm {
         Rc::make_mut(&mut self.builtins).insert(name.to_string(), Rc::new(f));
         Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.to_string(), VmBuiltinMetadata::sync(name.to_string()));
-        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(name);
         self.refresh_builtin_id(name);
     }
 
@@ -155,7 +154,6 @@ impl Vm {
         Rc::make_mut(&mut self.builtins).insert(name.clone(), Rc::new(f));
         Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Sync));
-        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(&name);
         self.refresh_builtin_id(&name);
     }
 
@@ -225,7 +223,6 @@ impl Vm {
             name.to_string(),
             VmBuiltinMetadata::async_builtin(name.to_string()),
         );
-        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(name);
         self.refresh_builtin_id(name);
     }
 
@@ -243,26 +240,7 @@ impl Vm {
             .insert(name.clone(), Rc::new(move |args| Box::pin(f(args))));
         Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Async));
-        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(&name);
         self.refresh_builtin_id(&name);
-    }
-
-    /// Register a builtin name whose implementation should be installed only
-    /// if a script actually resolves that name.
-    pub(crate) fn register_deferred_builtin(&mut self, name: &str, registrar: fn(&mut Vm)) {
-        if self.builtins.contains_key(name) || self.async_builtins.contains_key(name) {
-            return;
-        }
-        Rc::make_mut(&mut self.deferred_builtin_registrars).insert(name.to_string(), registrar);
-    }
-
-    pub(crate) fn ensure_deferred_builtin(&mut self, name: &str) -> bool {
-        let Some(registrar) = self.deferred_builtin_registrars.get(name).copied() else {
-            return false;
-        };
-        registrar(self);
-        Rc::make_mut(&mut self.deferred_builtin_registrars).remove(name);
-        self.builtins.contains_key(name) || self.async_builtins.contains_key(name)
     }
 
     pub(crate) fn registered_builtin_id(&self, name: &str) -> Option<BuiltinId> {
@@ -467,7 +445,6 @@ impl Vm {
                 category: ErrorCategory::ToolRejected,
             }));
         }
-        self.ensure_deferred_builtin(name);
         let builtin = match self.resolve_sync_builtin_id_or_name(direct_id, name)? {
             Ok(builtin) => builtin,
             Err(error) => return Some(Err(error)),
@@ -493,7 +470,6 @@ impl Vm {
                 category: ErrorCategory::ToolRejected,
             }));
         }
-        self.ensure_deferred_builtin(name);
         let builtin = match self.resolve_sync_builtin_id_or_name(direct_id, name)? {
             Ok(builtin) => builtin,
             Err(error) => return Some(Err(error)),
@@ -553,8 +529,6 @@ impl Vm {
             return result;
         }
 
-        self.ensure_deferred_builtin(name);
-
         if let Some(id) = direct_id {
             if let Some(entry) = self.builtins_by_id.get(&id).cloned() {
                 if entry.name.as_ref() == name {
@@ -585,7 +559,6 @@ impl Vm {
                 .builtins
                 .keys()
                 .chain(self.async_builtins.keys())
-                .chain(self.deferred_builtin_registrars.keys())
                 .map(|s| s.as_str());
             if let Some(suggestion) = crate::value::closest_match(name, all_builtins) {
                 return Err(VmError::Runtime(format!(

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -81,17 +81,6 @@ impl super::super::Vm {
             self.stack.push(VmValue::BuiltinRef(Self::constant_name_rc(
                 &chunk, idx, name,
             )));
-        } else if self.ensure_deferred_builtin(name) {
-            if let Some(id) = self.registered_builtin_id(name) {
-                self.stack.push(VmValue::BuiltinRefId {
-                    id,
-                    name: Self::constant_name_rc(&chunk, idx, name),
-                });
-            } else {
-                self.stack.push(VmValue::BuiltinRef(Self::constant_name_rc(
-                    &chunk, idx, name,
-                )));
-            }
         } else {
             let mut all_vars = self.visible_variables();
             for (k, v) in self.globals.iter() {
@@ -101,7 +90,6 @@ impl super::super::Vm {
             let mut candidates: Vec<String> = all_vars.keys().cloned().collect();
             candidates.extend(self.builtins.keys().cloned());
             candidates.extend(self.async_builtins.keys().cloned());
-            candidates.extend(self.deferred_builtin_registrars.keys().cloned());
             if let Some(suggestion) =
                 crate::value::closest_match(name, candidates.iter().map(|s| s.as_str()))
             {

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -142,8 +142,6 @@ pub(crate) struct VmBuiltinEntry {
     pub(crate) dispatch: VmBuiltinDispatch,
 }
 
-pub(crate) type DeferredBuiltinRegistrar = fn(&mut Vm);
-
 /// The Harn bytecode virtual machine.
 pub struct Vm {
     pub(crate) stack: Vec<VmValue>,
@@ -158,8 +156,6 @@ pub struct Vm {
     /// IDs with detected name collisions. Collided names safely fall back to
     /// the authoritative name-keyed lookup path.
     pub(crate) builtin_id_collisions: Rc<HashSet<BuiltinId>>,
-    /// Builtins whose registration can be deferred until first use.
-    pub(crate) deferred_builtin_registrars: Rc<BTreeMap<String, DeferredBuiltinRegistrar>>,
     /// Iterator state for for-in loops.
     pub(crate) iterators: Vec<IterState>,
     /// Call frame stack.
@@ -268,7 +264,6 @@ pub struct VmBaseline {
     builtin_metadata: Rc<BTreeMap<String, VmBuiltinMetadata>>,
     builtins_by_id: Rc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
     builtin_id_collisions: Rc<HashSet<BuiltinId>>,
-    deferred_builtin_registrars: Rc<BTreeMap<String, DeferredBuiltinRegistrar>>,
     source_dir: Option<std::path::PathBuf>,
     source_file: Option<String>,
     source_text: Option<String>,
@@ -286,7 +281,6 @@ impl VmBaseline {
             builtin_metadata: Rc::clone(&vm.builtin_metadata),
             builtins_by_id: Rc::clone(&vm.builtins_by_id),
             builtin_id_collisions: Rc::clone(&vm.builtin_id_collisions),
-            deferred_builtin_registrars: Rc::clone(&vm.deferred_builtin_registrars),
             source_dir: vm.source_dir.clone(),
             source_file: vm.source_file.clone(),
             source_text: vm.source_text.clone(),
@@ -315,7 +309,6 @@ impl VmBaseline {
             builtin_metadata: Rc::clone(&self.builtin_metadata),
             builtins_by_id: Rc::clone(&self.builtins_by_id),
             builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
-            deferred_builtin_registrars: Rc::clone(&self.deferred_builtin_registrars),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
@@ -539,7 +532,6 @@ impl Vm {
             builtin_metadata: Rc::new(BTreeMap::new()),
             builtins_by_id: Rc::new(BTreeMap::new()),
             builtin_id_collisions: Rc::new(HashSet::new()),
-            deferred_builtin_registrars: Rc::new(BTreeMap::new()),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
@@ -687,7 +679,6 @@ impl Vm {
             builtin_metadata: Rc::clone(&self.builtin_metadata),
             builtins_by_id: Rc::clone(&self.builtins_by_id),
             builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
-            deferred_builtin_registrars: Rc::clone(&self.deferred_builtin_registrars),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),


### PR DESCRIPTION
## Summary

Closes #2586. The `#[harn_builtin]` cutover shipped a `register_deferred_*` path that registered the ~74 LLM-stack builtins lazily (name stubs installed eagerly, real handlers on first dispatch) to keep the LLM stack out of cold-start. That predates linkme; post-linkme it only delayed ~74 `HashMap` inserts.

**Measured the delta** (release, 2000 iters, full stdlib registration per VM):

| path | µs / VM construction |
| --- | --- |
| eager full stdlib | 1369.65 |
| deferred-llm stdlib | 1216.86 |
| **delta** | **152.79 µs (~0.15 ms)** |

0.15 ms per VM is negligible against process spawn + dynamic linking, while the deferred path charged a `deferred_builtin_registrars` BTreeMap lookup on **every** builtin dispatch and required a hand-maintained name list per LLM module kept in sync with eager registration (guarded only by a parity test). Decision: collapse to eager-only.

## Changes

- Remove `register_vm_stdlib_with_deferred_llm`, `register_deferred_builtin_defs`, `Vm::register_deferred_builtin` / `ensure_deferred_builtin`, the `deferred_builtin_registrars` VM field + `DeferredBuiltinRegistrar` type, every per-module `register_deferred_*` helper, and the duplicate `CONVERSATION_BUILTIN_NAMES` / `COST_BUILTIN_NAMES` lists they fed.
- `harn run`, `harn bench`, and the MCP test harness now call eager `register_vm_stdlib`.
- Drop the two deferred-only LLM tests; convert the third into an eager end-to-end smoke (`llm_stack_registers_and_dispatches_through_full_stdlib`).
- Net: **−279 / +32 LOC**. The hand-crafted `register_llm_call_with_bridge` family is untouched (it never used the deferred path).

### Drive-by: fix a pre-existing test-order flake

`harness::tests::mock_harness_rejects_wrong_argument_types` is order-dependent (reproduces on clean `main` under `--test-threads=1`, surfaced here once via parallel scheduling). A wrong-typed `harness.fs.read_text(1)` is rejected either by the harness runtime guard or by compile-time static type-check — depending on whether a prior test populated the process-global builtin-signature registry. Both are correct type rejections, so the assertion now accepts either message.

## Test plan

- [x] `cargo build -p harn-vm -p harn-cli` (post-rebase, clean)
- [x] `cargo clippy -p harn-vm -p harn-cli --all-targets` (clean)
- [x] `cargo test -p harn-vm -p harn-cli` — 2886 lib tests + all integration suites green
- [x] `cargo test -p harn-vm --lib harness::tests:: -- --test-threads=1` — flake fix holds deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)