### PR TITLE
llm: reconcile config builtin sigs between runtime descriptor + parser registry

### DIFF
--- a/changelog.d/2588-llm-sig-drift.fixed.md
+++ b/changelog.d/2588-llm-sig-drift.fixed.md
@@ -1,0 +1,14 @@
+- **LLM config builtin signatures now agree between the runtime descriptor
+  and the parser registry (found while fixing #2588).** The `#[harn_builtin]`
+  cutover (#2575) left several `runtime_only = true` LLM builtins with a
+  hand-written static parser signature that had drifted from the authored
+  `sig`. `provider_capabilities`' `model` parameter is now `string|nil`
+  (matching the runtime, which accepts a nil model) instead of the narrower
+  `string`, and the coarse runtime `sig` strings that `harn explain` / LSP
+  surface are corrected to match actual return values:
+  `provider_capabilities_clear`, `provider_capabilities_install`, and
+  `provider_register` return `bool`, `llm_config` returns `dict|nil`, and
+  `llm_rate_limit` returns `bool|int|nil`. No runtime behavior changes — only
+  the advertised types. `runtime_only` is retained because the parser entries
+  for the richer LLM builtins (`llm_call`, transcript helpers, …)
+  intentionally carry typed shapes the `sig` grammar cannot express.

--- a/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/integrations.rs
@@ -496,7 +496,7 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
         "provider_capabilities",
         &[
             Param::new("provider", TY_STRING),
-            Param::optional("model", TY_STRING),
+            Param::optional("model", TY_STRING_OR_NIL),
         ],
         TY_DICT,
     ),

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -65,7 +65,7 @@ fn provider_capabilities_builtin(args: &[VmValue], _out: &mut String) -> Result<
 
 /// Install raw TOML capability overrides for provider/model capability lookup.
 #[harn_builtin(
-    sig = "provider_capabilities_install(toml_src: string) -> nil",
+    sig = "provider_capabilities_install(toml_src: string) -> bool",
     category = "llm.config",
     runtime_only = true
 )]
@@ -87,7 +87,7 @@ fn provider_capabilities_install_builtin(
 
 /// Clear installed provider/model capability overrides.
 #[harn_builtin(
-    sig = "provider_capabilities_clear() -> nil",
+    sig = "provider_capabilities_clear() -> bool",
     category = "llm.config",
     runtime_only = true
 )]
@@ -359,7 +359,7 @@ fn llm_providers_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue
 
 /// Register a custom OpenAI-compatible provider name for runtime dispatch.
 #[harn_builtin(
-    sig = "provider_register(name: string) -> nil",
+    sig = "provider_register(name: string) -> bool",
     category = "llm.config",
     runtime_only = true
 )]
@@ -472,7 +472,7 @@ fn llm_provider_status_builtin(_args: &[VmValue], _out: &mut String) -> Result<V
 
 /// Return configured provider settings, or all provider settings when no provider is passed.
 #[harn_builtin(
-    sig = "llm_config(provider?: string|nil) -> dict",
+    sig = "llm_config(provider?: string|nil) -> dict|nil",
     category = "llm.config",
     runtime_only = true
 )]
@@ -500,7 +500,7 @@ fn llm_config_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
 
 /// Set, query, or clear per-provider requests-per-minute rate limits.
 #[harn_builtin(
-    sig = "llm_rate_limit(provider: string, options?: dict|nil) -> dict",
+    sig = "llm_rate_limit(provider: string, options?: dict|nil) -> bool|int|nil",
     category = "llm.rate_limit",
     runtime_only = true
 )]


### PR DESCRIPTION
## Summary

Fixes a latent drift in the builtin-signature registry for the LLM config
builtins, found while working on #2588.

The `#[harn_builtin]` cutover (#2575) marked the LLM config builtins
`runtime_only = true` (which suppresses publishing the macro's
`BuiltinSignature` to the parser) but kept their pre-existing hand-written
static parser signatures in `signatures/integrations.rs`. The two sources
then drifted with nothing to catch it — the existing drift test only
compares each macro's `signature_text` vs its own parsed `sig`, and the
alignment test only checks **name-level** presence, not types.

### Investigation: why `runtime_only` + duplicate static entries?

`runtime_only` is **load-bearing** and is kept. The static parser entries for
the richer LLM builtins (`llm_call`, `llm_completion`, transcript helpers, …)
intentionally reference typed shapes (`LLM_CALL_RESULT`, `LLM_CALL_OPTIONS`,
`Transcript`, `SessionSnapshot`) and curated unions that the coarse runtime
`sig` strings can't express. Dropping `runtime_only` and publishing the macro
sig would **regress** type precision for those. So this takes option (b) from
the issue framing — reconcile rather than collapse — but reconciles each side
to *actual runtime behavior* (the descriptor `sig` strings were themselves
wrong in several cases, so a literal "match the descriptor" would have
corrupted the correct static entries).

### Changes (metadata only — no runtime behavior change)

| builtin | fix | reason |
|---|---|---|
| `provider_capabilities` | parser `model?: string` → `string\|nil` | runtime accepts a nil model; static was narrower |
| `provider_capabilities_clear` | `sig` `-> nil` → `-> bool` | returns `Bool(true)`; parser entry already said `bool` |
| `provider_capabilities_install` | `sig` `-> nil` → `-> bool` | returns `Bool(true)` |
| `provider_register` | `sig` `-> nil` → `-> bool` | returns `Bool(true)` |
| `llm_config` | `sig` `-> dict` → `-> dict\|nil` | returns `Nil` when a provider is absent |
| `llm_rate_limit` | `sig` `-> dict` → `-> bool\|int\|nil` | setter returns bool, getter returns int/nil |

After this, the runtime descriptor (`harn explain` / LSP `signature_text`) and
the parser registry (typechecker) agree for the whole config family.

## Test plan

- [x] `cargo test -p harn-parser` — 395 + doctests pass
- [x] `cargo test -p harn-vm --test builtin_signature_text_drift --test builtin_registry_alignment` — 7 pass (incl. `signature_text` round-trip for the new `dict|nil` / `bool|int|nil` returns)
- [x] `cargo test -p harn-vm --lib llm::config_builtins` — 7 pass
- [x] pre-commit (clippy + fmt + ratchets + markdownlint) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)