### PR TITLE
harn-serve: unify adapter edge glue on shared AuthRequest::from_http + DispatchRuntime (#2518)

### DIFF
--- a/changelog.d/2518.changed.md
+++ b/changelog.d/2518.changed.md
@@ -1,0 +1,6 @@
+- `harn-serve`: collapsed the transport adapters' edge glue onto shared
+  primitives. HTTP ingress now builds its `AuthRequest` through one
+  `AuthRequest::from_http` constructor (was copied across the `api`, `a2a`,
+  and `mcp` adapters), and the `a2a`/`mcp` adapters share a single
+  `DispatchRuntime` for off-thread `.harn` execution (was two byte-identical
+  `ExecutionRuntime` impls). Adapter wire behavior is unchanged.

--- a/crates/harn-serve/src/adapter.rs
+++ b/crates/harn-serve/src/adapter.rs
@@ -1,6 +1,72 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::LocalSet;
 
 use crate::{CallRequest, CallResponse, DispatchCore, DispatchError};
+
+/// A `.harn` dispatch job handed to a [`DispatchRuntime`] worker thread.
+struct DispatchJob {
+    request: CallRequest,
+    response_tx: oneshot::Sender<Result<CallResponse, DispatchError>>,
+}
+
+/// Dedicated single-threaded executor that runs [`DispatchCore::dispatch`]
+/// off the axum worker pool.
+///
+/// `.harn` execution is `!Send` (the VM holds `Rc`-backed values), so it
+/// cannot run on tokio's multi-threaded runtime directly. Each
+/// non-blocking HTTP transport (A2A, MCP) owns one of these: a thread
+/// running a current-thread runtime with a [`LocalSet`], fed by an
+/// unbounded channel. The transport handler `await`s the per-job
+/// [`oneshot`] reply, so the axum task stays cooperative while the VM
+/// runs on the dedicated thread.
+pub(crate) struct DispatchRuntime {
+    name: &'static str,
+    tx: mpsc::UnboundedSender<DispatchJob>,
+}
+
+impl DispatchRuntime {
+    /// Spawn the executor thread. `name` labels the runtime in panic and
+    /// error messages (e.g. `"A2A"`, `"MCP"`).
+    pub(crate) fn start(name: &'static str, core: Arc<DispatchCore>) -> Self {
+        let (tx, mut rx) = mpsc::unbounded_channel::<DispatchJob>();
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap_or_else(|error| panic!("build {name} dispatch runtime: {error}"));
+            let local = LocalSet::new();
+            local.block_on(&runtime, async move {
+                while let Some(job) = rx.recv().await {
+                    let core = core.clone();
+                    tokio::task::spawn_local(async move {
+                        let result = core.dispatch(job.request).await;
+                        let _ = job.response_tx.send(result);
+                    });
+                }
+            });
+        });
+        Self { name, tx }
+    }
+
+    /// Dispatch one request on the executor thread and await its reply.
+    pub(crate) async fn call(&self, request: CallRequest) -> Result<CallResponse, DispatchError> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .send(DispatchJob {
+                request,
+                response_tx,
+            })
+            .map_err(|_| {
+                DispatchError::Execution(format!("{} executor is not running", self.name))
+            })?;
+        response_rx.await.map_err(|_| {
+            DispatchError::Execution(format!("{} executor dropped response", self.name))
+        })?
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AdapterDescriptor {
@@ -31,5 +97,72 @@ pub trait TransportAdapter: Send + Sync {
         request: CallRequest,
     ) -> Result<CallResponse, DispatchError> {
         core.dispatch(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::auth::AuthRequest;
+    use crate::{CallArguments, DispatchCore, DispatchCoreConfig};
+
+    use super::*;
+
+    fn request(function: &str) -> CallRequest {
+        CallRequest {
+            adapter: "test".to_string(),
+            function: function.to_string(),
+            arguments: CallArguments::Named(BTreeMap::from([(
+                "name".to_string(),
+                serde_json::json!("ada"),
+            )])),
+            auth: AuthRequest::default(),
+            caller: "tester".to_string(),
+            replay_key: None,
+            trace_id: None,
+            parent_span_id: None,
+            metadata: BTreeMap::new(),
+            cancel_token: None,
+            agent_session_id: None,
+            progress: None,
+            tenant_id: None,
+            request_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_runtime_round_trips_through_dedicated_thread() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("server.harn");
+        std::fs::write(
+            &script,
+            "pub fn greet(name: string) -> string {\n  return name\n}\n",
+        )
+        .expect("write script");
+
+        let core =
+            Arc::new(DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core"));
+        let runtime = DispatchRuntime::start("TEST", core);
+        let response = runtime.call(request("greet")).await.expect("dispatch");
+        assert_eq!(response.value, serde_json::json!("ada"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_runtime_surfaces_named_executor_when_thread_is_gone() {
+        // A `DispatchRuntime` whose worker thread has exited (its channel
+        // receiver dropped) must report the failure with its label so the
+        // hosting adapter's error envelope is self-describing.
+        let (tx, rx) = mpsc::unbounded_channel::<DispatchJob>();
+        drop(rx);
+        let runtime = DispatchRuntime { name: "TEST", tx };
+        let error = runtime
+            .call(request("greet"))
+            .await
+            .expect_err("no receiver");
+        assert!(
+            matches!(&error, DispatchError::Execution(message) if message.contains("TEST executor")),
+            "expected named executor error, got: {error:?}"
+        );
     }
 }

--- a/crates/harn-serve/src/adapters/a2a.rs
+++ b/crates/harn-serve/src/adapters/a2a.rs
@@ -33,14 +33,12 @@ use serde_json::{json, Value as JsonValue};
 use sha2::Sha256;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-use tokio::sync::{mpsc, oneshot};
-use tokio::task::LocalSet;
 use uuid::Uuid;
 
 use crate::{
     AdapterDescriptor, AuthMethodConfig, AuthPolicy, AuthRequest, AuthorizationDecision,
-    CallArguments, CallRequest, CallResponse, DispatchCore, DispatchError, ExportCatalog,
-    HttpTlsConfig, TransportAdapter,
+    CallArguments, CallRequest, CallResponse, DispatchCore, DispatchError, DispatchRuntime,
+    ExportCatalog, HttpTlsConfig, TransportAdapter,
 };
 
 mod auth;
@@ -118,7 +116,7 @@ pub struct A2aServer {
     card_signing_secret: Option<String>,
     catalog: ExportCatalog,
     core: Arc<DispatchCore>,
-    executor: ExecutionRuntime,
+    executor: DispatchRuntime,
     tasks: TaskStore,
     push_configs: PushConfigStore,
 }
@@ -199,15 +197,6 @@ struct TaskState {
 type TaskStore = Arc<Mutex<HashMap<String, TaskState>>>;
 type PushConfigStore = Arc<Mutex<HashMap<String, BTreeMap<String, JsonValue>>>>;
 
-struct ExecutionRuntime {
-    tx: mpsc::UnboundedSender<ExecutionJob>,
-}
-
-struct ExecutionJob {
-    request: CallRequest,
-    response_tx: oneshot::Sender<Result<CallResponse, DispatchError>>,
-}
-
 struct PreparedTask {
     id: String,
     function: String,
@@ -254,7 +243,7 @@ impl A2aServer {
             agent_name,
             card_signing_secret: config.card_signing_secret,
             catalog,
-            executor: ExecutionRuntime::start(core.clone()),
+            executor: DispatchRuntime::start("A2A", core.clone()),
             core,
             tasks: Arc::new(Mutex::new(HashMap::new())),
             push_configs,

--- a/crates/harn-serve/src/adapters/a2a/schema.rs
+++ b/crates/harn-serve/src/adapters/a2a/schema.rs
@@ -1076,34 +1076,6 @@ pub(super) fn www_authenticate_header(policy: &AuthPolicy) -> HeaderValue {
         .unwrap_or_else(|_| HeaderValue::from_static("Bearer realm=\"harn-a2a\""))
 }
 
-pub(super) fn http_auth_request(
-    method: Method,
-    path: &str,
-    body: Vec<u8>,
-    headers: &HeaderMap,
-) -> AuthRequest {
-    AuthRequest {
-        method: method.as_str().to_string(),
-        path: path.to_string(),
-        body,
-        headers: normalized_headers(headers),
-        validated_oauth: None,
-        tenant_id: None,
-    }
-}
-
-pub(super) fn normalized_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
-        })
-        .collect()
-}
-
 pub(super) fn sign_card(card: &mut JsonValue, secret: &str) {
     let Ok(bytes) = serde_json::to_vec(card) else {
         return;

--- a/crates/harn-serve/src/adapters/a2a/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tasks.rs
@@ -533,39 +533,3 @@ impl A2aServer {
         });
     }
 }
-
-impl ExecutionRuntime {
-    pub(super) fn start(core: Arc<DispatchCore>) -> Self {
-        let (tx, mut rx) = mpsc::unbounded_channel::<ExecutionJob>();
-        std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build A2A runtime");
-            let local = LocalSet::new();
-            local.block_on(&runtime, async move {
-                while let Some(job) = rx.recv().await {
-                    let core = core.clone();
-                    tokio::task::spawn_local(async move {
-                        let result = core.dispatch(job.request).await;
-                        let _ = job.response_tx.send(result);
-                    });
-                }
-            });
-        });
-        Self { tx }
-    }
-
-    pub(super) async fn call(&self, request: CallRequest) -> Result<CallResponse, DispatchError> {
-        let (response_tx, response_rx) = oneshot::channel();
-        self.tx
-            .send(ExecutionJob {
-                request,
-                response_tx,
-            })
-            .map_err(|_| DispatchError::Execution("A2A executor is not running".to_string()))?;
-        response_rx
-            .await
-            .map_err(|_| DispatchError::Execution("A2A executor dropped response".to_string()))?
-    }
-}

--- a/crates/harn-serve/src/adapters/a2a/transport.rs
+++ b/crates/harn-serve/src/adapters/a2a/transport.rs
@@ -409,7 +409,7 @@ pub(super) async fn jsonrpc_request(
                 .into_response()
         }
     };
-    let auth = http_auth_request(method, "/", body.to_vec(), &headers);
+    let auth = AuthRequest::from_http(&method, "/", body.to_vec(), &headers);
     let processed = state
         .server
         .process_rpc_with_public_url(request, auth, &state.public_url)
@@ -722,7 +722,7 @@ pub(super) async fn rest_dispatch_no_body(
     params: JsonValue,
 ) -> Response {
     log_legacy_version_header(&headers);
-    let auth = http_auth_request(method, auth_path, Vec::new(), &headers);
+    let auth = AuthRequest::from_http(&method, auth_path, Vec::new(), &headers);
     let request = harn_vm::jsonrpc::request(Uuid::now_v7().to_string(), rpc_method, params);
     let processed = state
         .server
@@ -741,7 +741,7 @@ pub(super) async fn rest_dispatch_with_body(
     params: JsonValue,
 ) -> Response {
     log_legacy_version_header(&headers);
-    let auth = http_auth_request(method, auth_path, body.to_vec(), &headers);
+    let auth = AuthRequest::from_http(&method, auth_path, body.to_vec(), &headers);
     let request = harn_vm::jsonrpc::request(Uuid::now_v7().to_string(), rpc_method, params);
     let processed = state
         .server
@@ -792,7 +792,7 @@ pub(super) async fn rest_task_request(
         }
     };
     let auth_path = format!("/{rpc_method}");
-    let auth = http_auth_request(method, &auth_path, body.to_vec(), &headers);
+    let auth = AuthRequest::from_http(&method, &auth_path, body.to_vec(), &headers);
     let request = harn_vm::jsonrpc::request(Uuid::now_v7().to_string(), rpc_method, params);
     let mut processed = state
         .server

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -2295,14 +2295,7 @@ async fn authorize(
     headers: &HeaderMap,
     body: Bytes,
 ) -> Result<(), Response> {
-    let request = AuthRequest {
-        method: method.as_str().to_string(),
-        path: uri.path().to_string(),
-        body: body.to_vec(),
-        headers: headers_to_map(headers),
-        validated_oauth: None,
-        tenant_id: None,
-    };
+    let request = AuthRequest::from_http(&method, uri.path(), body.to_vec(), headers);
     match state.auth_policy.authorize(&request).await {
         AuthorizationDecision::Authorized(_) => Ok(()),
         AuthorizationDecision::Rejected(message) => Err(api_error(
@@ -2345,18 +2338,6 @@ fn forbidden_api_error(required: &BTreeSet<String>, granted: &BTreeSet<String>) 
         );
     }
     (StatusCode::FORBIDDEN, Json(json!({ "error": body }))).into_response()
-}
-
-fn headers_to_map(headers: &HeaderMap) -> BTreeMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
-        })
-        .collect()
 }
 
 fn parse_json_body(body: &Bytes) -> Result<Value, serde_json::Error> {

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -44,14 +44,13 @@ use harn_vm::mcp_protocol::{
 };
 use serde_json::{json, Value as JsonValue};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::{mpsc, oneshot};
-use tokio::task::LocalSet;
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::{
     mcp_context::McpContextCatalog, AdapterDescriptor, AuthPolicy, AuthRequest,
     AuthorizationDecision, CallArguments, CallRequest, CallResponse, DispatchCore, DispatchError,
-    ExportCatalog, HttpTlsConfig, TransportAdapter,
+    DispatchRuntime, ExportCatalog, HttpTlsConfig, TransportAdapter,
 };
 
 pub const MCP_PROTOCOL_VERSION: &str = mcp_protocol::PROTOCOL_VERSION;
@@ -113,7 +112,7 @@ pub struct McpServer {
     catalog: ExportCatalog,
     context: McpContextCatalog,
     auth_policy: AuthPolicy,
-    executor: ExecutionRuntime,
+    executor: DispatchRuntime,
 }
 
 #[derive(Clone, Debug)]
@@ -222,15 +221,6 @@ impl SharedSession {
     }
 }
 
-struct ExecutionRuntime {
-    tx: mpsc::UnboundedSender<ExecutionJob>,
-}
-
-struct ExecutionJob {
-    request: CallRequest,
-    response_tx: oneshot::Sender<Result<CallResponse, DispatchError>>,
-}
-
 #[derive(Clone)]
 struct HttpState {
     server: Arc<McpServer>,
@@ -281,7 +271,7 @@ impl McpServer {
             catalog,
             context,
             auth_policy,
-            executor: ExecutionRuntime::start(core),
+            executor: DispatchRuntime::start("MCP", core),
         }
     }
 
@@ -1013,41 +1003,5 @@ fn requires_protocol_auth(method: &str) -> bool {
 impl TransportAdapter for McpServer {
     fn descriptor(&self) -> AdapterDescriptor {
         self.descriptor.clone()
-    }
-}
-
-impl ExecutionRuntime {
-    fn start(core: Arc<DispatchCore>) -> Self {
-        let (tx, mut rx) = mpsc::unbounded_channel::<ExecutionJob>();
-        std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build MCP runtime");
-            let local = LocalSet::new();
-            local.block_on(&runtime, async move {
-                while let Some(job) = rx.recv().await {
-                    let core = core.clone();
-                    tokio::task::spawn_local(async move {
-                        let result = core.dispatch(job.request).await;
-                        let _ = job.response_tx.send(result);
-                    });
-                }
-            });
-        });
-        Self { tx }
-    }
-
-    async fn call(&self, request: CallRequest) -> Result<CallResponse, DispatchError> {
-        let (response_tx, response_rx) = oneshot::channel();
-        self.tx
-            .send(ExecutionJob {
-                request,
-                response_tx,
-            })
-            .map_err(|_| DispatchError::Execution("MCP executor is not running".to_string()))?;
-        response_rx
-            .await
-            .map_err(|_| DispatchError::Execution("MCP executor dropped response".to_string()))?
     }
 }

--- a/crates/harn-serve/src/adapters/mcp/auth.rs
+++ b/crates/harn-serve/src/adapters/mcp/auth.rs
@@ -1,34 +1,6 @@
 //! Transport auth metadata and request validation helpers.
 use super::*;
 
-pub(super) fn http_auth_request(
-    method: Method,
-    path: &str,
-    body: Vec<u8>,
-    headers: &HeaderMap,
-) -> AuthRequest {
-    AuthRequest {
-        method: method.as_str().to_string(),
-        path: path.to_string(),
-        body,
-        headers: normalized_headers(headers),
-        validated_oauth: None,
-        tenant_id: None,
-    }
-}
-
-pub(super) fn normalized_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
-        })
-        .collect()
-}
-
 pub(super) fn lookup_or_create_session(
     state: &HttpState,
     request: &JsonValue,

--- a/crates/harn-serve/src/adapters/mcp/transport.rs
+++ b/crates/harn-serve/src/adapters/mcp/transport.rs
@@ -1,6 +1,6 @@
 //! HTTP and SSE transport routing for MCP.
 use super::auth::{
-    accepts_media, attach_http_headers, attach_legacy_deprecation_headers, http_auth_request,
+    accepts_media, attach_http_headers, attach_legacy_deprecation_headers,
     lookup_or_create_session, should_stream_post_response, validate_origin,
     validate_protocol_header, validate_rc_routing_headers,
 };
@@ -48,7 +48,7 @@ pub(super) async fn http_post_request(
             Ok(value) => value,
             Err(response) => return *response,
         };
-    let auth = http_auth_request(method, &state.options.path, body.to_vec(), &headers);
+    let auth = AuthRequest::from_http(&method, &state.options.path, body.to_vec(), &headers);
     let response_protocol = response_protocol_version(&headers, &request);
 
     match state.server.process_message(request, session, auth).await {
@@ -237,8 +237,8 @@ pub(super) async fn legacy_sse_message(
             return response;
         }
     };
-    let auth = http_auth_request(
-        Method::POST,
+    let auth = AuthRequest::from_http(
+        &Method::POST,
         &state.options.messages_path,
         body.to_vec(),
         &headers,

--- a/crates/harn-serve/src/http_codec.rs
+++ b/crates/harn-serve/src/http_codec.rs
@@ -18,10 +18,11 @@
 //! request id. It can therefore back any axum-based HTTP surface
 //! built on `harn-serve` without coupling to a particular adapter.
 
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 
 use axum::body::{Body, Bytes};
-use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode};
+use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -32,7 +33,46 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::error::forbidden_data_payload;
-use crate::{CallResponse, DispatchError};
+use crate::{AuthRequest, CallResponse, DispatchError};
+
+impl AuthRequest {
+    /// Build an [`AuthRequest`] from an inbound HTTP request. Every
+    /// axum-based transport (`api`, `a2a`, `mcp`) decodes ingress the
+    /// same way, so the construction lives here — beside the HTTP codec
+    /// — rather than being copied per adapter.
+    ///
+    /// Header names are lower-cased so downstream lookups are
+    /// case-insensitive regardless of how the client cased them on the
+    /// wire; values that aren't valid UTF-8 are dropped. `validated_oauth`
+    /// and `tenant_id` start `None` — the configured [`crate::AuthPolicy`]
+    /// fills `validated_oauth`, and a tenant-resolving transport fills
+    /// `tenant_id` before authorization.
+    pub fn from_http(method: &Method, path: &str, body: Vec<u8>, headers: &HeaderMap) -> Self {
+        Self {
+            method: method.as_str().to_string(),
+            path: path.to_string(),
+            body,
+            headers: normalize_headers(headers),
+            validated_oauth: None,
+            tenant_id: None,
+        }
+    }
+}
+
+/// Lower-case header names into a `BTreeMap`, dropping any value that
+/// isn't valid UTF-8. Shared by [`AuthRequest::from_http`] and any
+/// adapter that needs the normalized header view.
+pub(crate) fn normalize_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|value| (name.as_str().to_ascii_lowercase(), value.to_string()))
+        })
+        .collect()
+}
 
 /// Return value class produced by the codec — what the caller renders
 /// to axum varies by body kind, so the codec exposes the discrete
@@ -563,6 +603,40 @@ mod tests {
     async fn body_text(response: Response) -> String {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[test]
+    fn auth_request_from_http_lowercases_headers_and_drops_invalid_utf8() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", HeaderValue::from_static("Bearer tok"));
+        headers.insert("X-Request-Id", HeaderValue::from_static("req_42"));
+        headers.insert("X-Binary", HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap());
+
+        let auth = AuthRequest::from_http(&Method::POST, "/v1/tasks", b"body".to_vec(), &headers);
+
+        assert_eq!(auth.method, "POST");
+        assert_eq!(auth.path, "/v1/tasks");
+        assert_eq!(auth.body, b"body");
+        assert_eq!(
+            auth.headers.get("authorization").map(String::as_str),
+            Some("Bearer tok")
+        );
+        assert_eq!(
+            auth.headers.get("x-request-id").map(String::as_str),
+            Some("req_42")
+        );
+        assert!(
+            !auth.headers.contains_key("x-binary"),
+            "non-UTF-8 header dropped"
+        );
+        assert!(auth
+            .headers
+            .keys()
+            .all(|key| key == &key.to_ascii_lowercase()));
+        assert!(auth.validated_oauth.is_none());
+        assert!(auth.tenant_id.is_none());
+        // The case-insensitive accessors resolve against the normalized map.
+        assert_eq!(auth.bearer_token(), Some("tok"));
     }
 
     #[tokio::test]

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -28,6 +28,7 @@ pub mod ws;
 /// handing it to a handler.
 pub const DEFAULT_HTTP_BODY_LIMIT_BYTES: usize = 10 * 1024 * 1024;
 
+pub(crate) use adapter::DispatchRuntime;
 pub use adapter::{AdapterDescriptor, TransportAdapter};
 pub use adapters::a2a::{A2aHttpServeOptions, A2aServer, A2aServerConfig, A2A_PROTOCOL_VERSION};
 pub use adapters::acp::{


### PR DESCRIPTION
## Summary

Closes #2518 (one-loop A.15). The `api`/`a2a`/`acp`/`mcp` transport adapters had drifted into parallel **edge** wiring even though every heavy concern the epic set out to unify — scope-aware auth (A.1), tenant plumbing (A.2), rate-limit/budget (A.11), observability spans (A.10), replay, trust records, and the HTTP response codec (A.4) — already routes through the shared `DispatchCore`/`http_codec`. That work landed incrementally across A.1–A.12, so this final consolidation closes the remaining gap rather than re-deriving it.

Two byte-identical pieces of glue were the last DRY violations; both are now single-sourced:

- **HTTP ingress → `AuthRequest`.** Three copies of the same "lower-case headers + fill the struct" logic (`api`'s `headers_to_map`, plus `a2a` and `mcp`'s `http_auth_request` + `normalized_headers`) collapse onto one `AuthRequest::from_http(method, path, body, headers)` constructor beside the HTTP codec. `auth.rs` stays axum-free.
- **Off-thread `.harn` execution.** `a2a` and `mcp` each carried a byte-identical `ExecutionRuntime` + `ExecutionJob` (a dedicated current-thread tokio runtime + `LocalSet`, fed over a channel, so the `!Send` VM runs off the axum pool). These collapse onto one `DispatchRuntime` in the transport-abstraction module (`adapter.rs`), labelled per adapter (`"A2A"`/`"MCP"`) so its error envelopes stay self-describing.

Net effect: adding a new transport is closer to "implement the decode/encode pair" — the auth-request decode and the dispatch hand-off are now shared rather than re-implemented.

### Scope note

`api` and `acp` remain proxy/subprocess adapters by design (the `api` REST surface drives an in-process ACP server; `acp` speaks JSON-RPC over stdio). They share the auth-request decode but legitimately don't use `DispatchRuntime`, since they don't dispatch `.harn` handlers directly. The epic's projected ~3–5 kLOC reduction was premised on the adapters *not* yet sharing the dispatch core; that bulk was already realized as A.1–A.12 built `DispatchCore` out, so this PR is the focused edge-glue close-out, not a rewrite.

## Changes

- `http_codec.rs`: `AuthRequest::from_http` + `normalize_headers` (shared HTTP ingress decode).
- `adapter.rs`: `DispatchRuntime` + `DispatchJob` (shared off-thread dispatch executor).
- `adapters/{api,a2a,mcp}`: drop the local copies, call the shared primitives.
- New unit tests: header lowercasing / non-UTF-8 drop / case-insensitive accessor for `from_http`; round-trip + named-executor error for `DispatchRuntime`.

## Test plan

- [x] `cargo test -p harn-serve` — all pass (lib + limits_loadgen + streaming_conformance + transport_conformance), incl. 3 new unit tests
- [x] `cargo clippy -p harn-serve --all-targets` clean
- [x] Adapter wire behavior unchanged: existing A2A/MCP/ACP/API conformance + protocol-fixture tests green
- [x] Pre-commit + pre-push hooks (fmt, clippy, lint, markdownlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)