### PR TITLE
hostlib: workspace-root path-scope enforcement for fs/tools/ast builtins (#2600)

### DIFF
--- a/changelog.d/2600.security.md
+++ b/changelog.d/2600.security.md
@@ -1,0 +1,17 @@
+- **Workspace-root path-scope enforcement for the hostlib filesystem
+  builtins (#2600).** Follow-up to the coarse `tools:deterministic` gate
+  (#2548). `harn-vm` now exposes a public, `VmError`-free
+  `process_sandbox::check_fs_path_scope(path, FsAccess)` entrypoint, and
+  every path-accepting hostlib builtin — `tools` `read_file` /
+  `write_file` / `delete_file` / `list_directory` / `search` /
+  `get_file_outline`, `fs` `safe_text_patch` / `read_text`, and `ast`
+  `apply_node` / `insert_at_anchor` — now refuses paths that resolve
+  outside the active policy's `workspace_roots` under a restricted
+  `SandboxProfile`, via one shared `enforce_path_scope` helper. The
+  staged-fs commit flush validates each entry's working-tree *target*
+  path (not the in-workspace overlay path), so a write staged under a
+  looser policy can never escape the roots active at commit time.
+  Rejections surface as a new `HostlibError::SandboxViolation`
+  (`tool_rejected`) carrying the offending path, matching the message the
+  VM-native `harness.fs.*` surface already produces for the same
+  out-of-root path.

--- a/conformance/tests/sandbox_hardened/fs_path_scope_enforcement.expected
+++ b/conformance/tests/sandbox_hardened/fs_path_scope_enforcement.expected
@@ -1,0 +1,9 @@
+3
+tool_rejected
+hostlib_tools_write_file
+true
+true
+tool_rejected
+hostlib_fs_read_text
+true
+false

--- a/conformance/tests/sandbox_hardened/fs_path_scope_enforcement.harn
+++ b/conformance/tests/sandbox_hardened/fs_path_scope_enforcement.harn
@@ -1,0 +1,55 @@
+/**
+ * Workspace-root path-scope enforcement for the hostlib `tools` and `fs`
+ * filesystem builtins (issue #2600, follow-up to the coarse
+ * `tools:deterministic` gate from #2548).
+ *
+ * Under a restricted `worktree` sandbox profile scoped to a single
+ * workspace root, a path that resolves outside that root must be refused
+ * — for writes and reads alike — with a `tool_rejected` violation that
+ * names the offending path. In-root paths still succeed. This mirrors what
+ * the VM-native `harness.fs.*` surface enforces, so both filesystem
+ * surfaces reject the same out-of-root path identically.
+ */
+pipeline default() {
+  hostlib_enable("tools:deterministic")
+  let base = path_join(
+    harness.fs.temp_dir(),
+    "harn_fs_path_scope_" + to_string(harness.random.gen_range(100000, 999999)),
+  )
+  let root = path_join(base, "workspace")
+  harness.fs.mkdir(root)
+  let in_path = path_join(root, "in.txt")
+  let out_path = path_join(base, "outside.txt")
+  with_execution_policy(
+    {sandbox_profile: "worktree", workspace_roots: [root]},
+    { ->
+      let ok = hostlib_tools_write_file({path: in_path, content: "ok\n"})
+      __io_println(ok.bytes_written)
+      let write_err = try {
+        hostlib_tools_write_file({path: out_path, content: "nope\n"})
+        nil
+      } catch (e) {
+        e
+      }
+      __io_println(write_err.kind)
+      __io_println(write_err.builtin)
+      __io_println(contains(write_err.message, "outside workspace_roots"))
+      __io_println(contains(write_err.path, "outside.txt"))
+      let read_err = try {
+        hostlib_fs_read_text({path: out_path})
+        nil
+      } catch (e) {
+        e
+      }
+      __io_println(read_err.kind)
+      __io_println(read_err.builtin)
+    },
+  )
+  // The in-root write landed; the rejected out-of-root write never did.
+  __io_println(harness.fs.read_text(in_path) == "ok\n")
+  __io_println(harness.fs.exists(out_path))
+}
+// In-root write is allowed.
+// Out-of-root write is refused with the typed violation, before any
+// bytes reach disk.
+// Reads obey the same scope.

--- a/crates/harn-hostlib/src/ast/apply_node.rs
+++ b/crates/harn-hostlib/src/ast/apply_node.rs
@@ -39,6 +39,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use harn_vm::process_sandbox::FsAccess;
 use harn_vm::VmValue;
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Query, QueryCursor, QueryError};
@@ -47,6 +48,7 @@ use crate::error::HostlibError;
 use crate::tools::args::{
     build_dict, dict_arg, optional_bool, optional_int, optional_string, require_string, str_value,
 };
+use crate::tools::permissions::enforce_path_scope;
 
 use super::edit_common::{
     first_syntax_error, format_query_error, read_source, resolve_target_capture, sha256_hex,
@@ -139,6 +141,9 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     }
 
     let path = PathBuf::from(&path_str);
+    // Guards both the read below and the write-back; one scope check at the
+    // strongest access the builtin can perform.
+    enforce_path_scope(BUILTIN, &path, FsAccess::Write)?;
     let language = match Language::detect(&path, language_hint.as_deref()) {
         Some(l) => l,
         None => {

--- a/crates/harn-hostlib/src/ast/insert_at_anchor.rs
+++ b/crates/harn-hostlib/src/ast/insert_at_anchor.rs
@@ -40,6 +40,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use harn_vm::process_sandbox::FsAccess;
 use harn_vm::VmValue;
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Node, Query, QueryCursor, QueryError};
@@ -48,6 +49,7 @@ use crate::error::HostlibError;
 use crate::tools::args::{
     build_dict, dict_arg, optional_bool, optional_int, optional_string, require_string, str_value,
 };
+use crate::tools::permissions::enforce_path_scope;
 
 use super::edit_common::{
     first_syntax_error, format_query_error, read_source, resolve_target_capture, sha256_hex,
@@ -129,6 +131,9 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     }
 
     let path = PathBuf::from(&path_str);
+    // Guards both the read below and the write-back; one scope check at the
+    // strongest access the builtin can perform.
+    enforce_path_scope(BUILTIN, &path, FsAccess::Write)?;
     let language = match Language::detect(&path, language_hint.as_deref()) {
         Some(l) => l,
         None => {

--- a/crates/harn-hostlib/src/error.rs
+++ b/crates/harn-hostlib/src/error.rs
@@ -55,6 +55,21 @@ pub enum HostlibError {
         /// Human-readable failure description.
         message: String,
     },
+
+    /// A path the builtin resolved fell outside the session's workspace
+    /// roots under a restricted sandbox profile. The mirror of the
+    /// `harness.fs.*` `tool_rejected` rejection — both surfaces reject an
+    /// out-of-root path with the same message.
+    #[error("{message}")]
+    SandboxViolation {
+        /// Fully-qualified builtin name.
+        builtin: &'static str,
+        /// The normalized path that was rejected, for telemetry.
+        path: String,
+        /// The canonical rejection message (see
+        /// [`harn_vm::process_sandbox::SandboxViolation::message`]).
+        message: String,
+    },
 }
 
 impl HostlibError {
@@ -65,7 +80,8 @@ impl HostlibError {
             HostlibError::Unimplemented { builtin }
             | HostlibError::MissingParameter { builtin, .. }
             | HostlibError::InvalidParameter { builtin, .. }
-            | HostlibError::Backend { builtin, .. } => builtin,
+            | HostlibError::Backend { builtin, .. }
+            | HostlibError::SandboxViolation { builtin, .. } => builtin,
         }
     }
 }
@@ -80,6 +96,13 @@ impl From<HostlibError> for VmError {
             HostlibError::MissingParameter { .. } => "missing_parameter",
             HostlibError::InvalidParameter { .. } => "invalid_parameter",
             HostlibError::Backend { .. } => "backend_error",
+            HostlibError::SandboxViolation { .. } => "tool_rejected",
+        };
+        // Carry the offending path on sandbox violations so `catch` blocks
+        // and telemetry can branch on it without re-parsing the message.
+        let path = match &err {
+            HostlibError::SandboxViolation { path, .. } => Some(path.clone()),
+            _ => None,
         };
         let builtin = err.builtin();
         let message = err.to_string();
@@ -88,6 +111,9 @@ impl From<HostlibError> for VmError {
         dict.insert("kind".to_string(), VmValue::String(Rc::from(kind)));
         dict.insert("builtin".to_string(), VmValue::String(Rc::from(builtin)));
         dict.insert("message".to_string(), VmValue::String(Rc::from(message)));
+        if let Some(path) = path {
+            dict.insert("path".to_string(), VmValue::String(Rc::from(path)));
+        }
         VmError::Thrown(VmValue::Dict(Rc::new(dict)))
     }
 }

--- a/crates/harn-hostlib/src/fs.rs
+++ b/crates/harn-hostlib/src/fs.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 use std::sync::{Mutex, OnceLock};
 
 use harn_vm::agent_events::AgentEvent;
+use harn_vm::process_sandbox::{check_fs_path_scope, FsAccess};
 use harn_vm::VmValue;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -24,6 +25,7 @@ use crate::tools::args::{
     build_dict, dict_arg, optional_bool, optional_int, optional_string, optional_string_list,
     require_string, str_value,
 };
+use crate::tools::permissions::enforce_path_scope;
 
 const SET_MODE_BUILTIN: &str = "hostlib_fs_set_mode";
 const STATUS_BUILTIN: &str = "hostlib_fs_staged_status";
@@ -337,6 +339,19 @@ pub fn commit_staged(session_id: &str, paths: &[String]) -> Result<CommitResult,
             continue;
         };
         let path_label = path.to_string_lossy().into_owned();
+        // The overlay always lives inside the workspace, but commit flushes
+        // to the *target* working-tree path. Enforce workspace-root scope
+        // against that target so a staged entry — possibly persisted under
+        // a looser policy in an earlier session — can never write outside
+        // the roots active at commit time.
+        let access = match entry {
+            StagedEntry::Write { .. } => FsAccess::Write,
+            StagedEntry::Delete { .. } => FsAccess::Delete,
+        };
+        if let Err(violation) = check_fs_path_scope(&path, access) {
+            failed_paths_with_reasons.push((path_label, violation.message(COMMIT_BUILTIN)));
+            continue;
+        }
         match commit_entry(&state, &path, &entry) {
             Ok(()) => {
                 state.entries.remove(&path);
@@ -880,6 +895,7 @@ fn read_text_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let path_str = require_string(READ_TEXT_BUILTIN, dict, "path")?;
     let session_id = optional_string(READ_TEXT_BUILTIN, dict, "session_id")?;
     let path = Path::new(&path_str);
+    enforce_path_scope(READ_TEXT_BUILTIN, path, FsAccess::Read)?;
 
     let (bytes, existed) = read_existing(READ_TEXT_BUILTIN, path, session_id.as_deref())?;
     let hash = hash_label(&bytes);
@@ -913,6 +929,11 @@ fn safe_text_patch_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let create_parents = optional_bool(SAFE_TEXT_PATCH_BUILTIN, dict, "create_parents", true)?;
     let overwrite = optional_bool(SAFE_TEXT_PATCH_BUILTIN, dict, "overwrite", true)?;
 
+    enforce_path_scope(
+        SAFE_TEXT_PATCH_BUILTIN,
+        Path::new(&path_str),
+        FsAccess::Write,
+    )?;
     let outcome = safe_text_patch(
         Path::new(&path_str),
         &content,

--- a/crates/harn-hostlib/src/tools/file_io.rs
+++ b/crates/harn-hostlib/src/tools/file_io.rs
@@ -9,12 +9,14 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use base64::Engine;
+use harn_vm::process_sandbox::FsAccess;
 use harn_vm::VmValue;
 
 use crate::error::HostlibError;
 use crate::tools::args::{
     build_dict, dict_arg, optional_bool, optional_int, optional_string, require_string, str_value,
 };
+use crate::tools::permissions::enforce_path_scope;
 
 const READ_FILE_BUILTIN: &str = "hostlib_tools_read_file";
 const WRITE_FILE_BUILTIN: &str = "hostlib_tools_write_file";
@@ -69,6 +71,7 @@ pub(super) fn read_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     }
 
     let path = PathBuf::from(&path_str);
+    enforce_path_scope(READ_FILE_BUILTIN, &path, FsAccess::Read)?;
     let offset_u64 = offset as u64;
     let (buf, total_size) = read_bytes(
         &path,
@@ -119,6 +122,7 @@ pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let session_id = optional_string(WRITE_FILE_BUILTIN, dict, "session_id")?;
 
     let path = PathBuf::from(&path_str);
+    enforce_path_scope(WRITE_FILE_BUILTIN, &path, FsAccess::Write)?;
 
     let bytes: Vec<u8> = match encoding_raw.as_deref() {
         None | Some("utf-8") => content.into_bytes(),
@@ -197,6 +201,7 @@ pub(super) fn delete_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let session_id = optional_string(DELETE_FILE_BUILTIN, dict, "session_id")?;
 
     let path = PathBuf::from(&path_str);
+    enforce_path_scope(DELETE_FILE_BUILTIN, &path, FsAccess::Delete)?;
     if let Some(removed) = crate::fs::stage_delete_or_none(
         DELETE_FILE_BUILTIN,
         &path,
@@ -282,6 +287,7 @@ pub(super) fn list_directory(args: &[VmValue]) -> Result<VmValue, HostlibError> 
     };
 
     let path = PathBuf::from(&path_str);
+    enforce_path_scope(LIST_DIRECTORY_BUILTIN, &path, FsAccess::Read)?;
     let mut entries: Vec<(String, VmValue)> = Vec::new();
     let mut truncated = false;
     let mut all_names: Vec<(String, bool, bool, u64)> = Vec::new();

--- a/crates/harn-hostlib/src/tools/outline.rs
+++ b/crates/harn-hostlib/src/tools/outline.rs
@@ -10,10 +10,12 @@
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+use harn_vm::process_sandbox::FsAccess;
 use harn_vm::VmValue;
 
 use crate::error::HostlibError;
 use crate::tools::args::{build_dict, dict_arg, optional_int, require_string, str_value};
+use crate::tools::permissions::enforce_path_scope;
 
 const BUILTIN: &str = "hostlib_tools_get_file_outline";
 
@@ -34,6 +36,7 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let _ = max_depth;
 
     let path = PathBuf::from(&path_str);
+    enforce_path_scope(BUILTIN, &path, FsAccess::Read)?;
     let language = detect_language(&path);
 
     let content = match crate::fs::read_to_string(&path, session_id.as_deref()) {

--- a/crates/harn-hostlib/src/tools/permissions.rs
+++ b/crates/harn-hostlib/src/tools/permissions.rs
@@ -1,4 +1,13 @@
-//! Per-thread "enabled features" registry for the deterministic tools.
+//! Permission enforcement shared by the path-touching hostlib builtins.
+//!
+//! Two complementary layers live here:
+//!
+//! * The per-thread "enabled features" registry plus [`gated_handler`] —
+//!   the coarse "is this session allowed to touch the filesystem at all?"
+//!   gate (see the module body below).
+//! * [`enforce_path_scope`] — the granular "is this *specific path* inside
+//!   the session's workspace roots?" check, delegating to the VM-native
+//!   sandbox so the hostlib surface and `harness.fs.*` agree.
 //!
 //! `harn-hostlib` exposes the deterministic tool builtins on every VM that
 //! `install_default` runs against, but pipelines must explicitly opt in to
@@ -20,8 +29,10 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
+use std::path::Path;
 use std::sync::Arc;
 
+use harn_vm::process_sandbox::{check_fs_path_scope, FsAccess};
 use harn_vm::VmValue;
 
 use crate::error::HostlibError;
@@ -92,5 +103,29 @@ pub fn gated_handler(
             });
         }
         runner(args)
+    })
+}
+
+/// Reject `path` when it resolves outside the active execution policy's
+/// workspace roots, under a restricted sandbox profile.
+///
+/// This is the single path-scope policy shared by every hostlib builtin
+/// that resolves a host filesystem path — the `tools::*`, `fs::*`, and
+/// `ast::*` surfaces — so the granular workspace-root check stays
+/// consistent across all of them (the path-level complement to the coarse
+/// [`gated_handler`] feature gate). It delegates to
+/// [`harn_vm::process_sandbox::check_fs_path_scope`] so a path the
+/// `harness.fs.*` VM-native builtins would refuse is refused here too, with
+/// the same message. A no-op when no policy is active or the profile is
+/// unrestricted.
+pub fn enforce_path_scope(
+    builtin: &'static str,
+    path: &Path,
+    access: FsAccess,
+) -> Result<(), HostlibError> {
+    check_fs_path_scope(path, access).map_err(|violation| HostlibError::SandboxViolation {
+        builtin,
+        path: violation.attempted.display().to_string(),
+        message: violation.message(builtin),
     })
 }

--- a/crates/harn-hostlib/src/tools/search.rs
+++ b/crates/harn-hostlib/src/tools/search.rs
@@ -13,6 +13,7 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use grep_matcher::Matcher;
 use grep_regex::{RegexMatcher, RegexMatcherBuilder};
 use grep_searcher::{Searcher, SearcherBuilder, Sink, SinkContext, SinkContextKind, SinkMatch};
+use harn_vm::process_sandbox::FsAccess;
 use harn_vm::VmValue;
 use ignore::WalkBuilder;
 
@@ -21,6 +22,7 @@ use crate::tools::args::{
     build_dict, dict_arg, optional_bool, optional_int, optional_string, optional_string_list,
     require_string, str_value,
 };
+use crate::tools::permissions::enforce_path_scope;
 
 const BUILTIN: &str = "hostlib_tools_search";
 
@@ -41,6 +43,10 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let path = optional_string(BUILTIN, dict, "path")?
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
+    // The walk descends from `path`; workspace-root scope is a prefix
+    // check, so guarding the root rejects an out-of-scope search before it
+    // can enumerate any file beneath it.
+    enforce_path_scope(BUILTIN, &path, FsAccess::Read)?;
     let glob = optional_string(BUILTIN, dict, "glob")?;
     let exclude_globs = optional_string_list(BUILTIN, dict, "exclude_globs")?;
     let case_insensitive = optional_bool(BUILTIN, dict, "case_insensitive", false)?;

--- a/crates/harn-hostlib/tests/fs_path_scope.rs
+++ b/crates/harn-hostlib/tests/fs_path_scope.rs
@@ -1,0 +1,490 @@
+//! Workspace-root path-scope enforcement for the path-touching hostlib
+//! builtins (issue #2600, follow-up to the coarse `tools:deterministic`
+//! gate from #2548).
+//!
+//! Under a restricted `SandboxProfile` with explicit `workspace_roots`,
+//! every builtin that resolves a host filesystem path must reject paths
+//! outside the roots — for reads, writes, deletes, patches, AST edits, and
+//! the staged-fs commit flush — matching what `harness.fs.*` enforces
+//! VM-side. In-root paths must still succeed, and relative paths must be
+//! resolved before the check so the two surfaces agree.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::rc::Rc;
+
+use harn_hostlib::tools::permissions;
+use harn_hostlib::{
+    ast::AstCapability, fs::FsCapability, tools::ToolsCapability, BuiltinRegistry,
+    HostlibCapability, HostlibError,
+};
+use harn_vm::orchestration::{
+    pop_execution_policy, push_execution_policy, CapabilityPolicy, SandboxProfile,
+};
+use harn_vm::stdlib::process::set_thread_execution_context;
+use harn_vm::VmValue;
+use tempfile::TempDir;
+
+/// Build a registry carrying every path-touching capability surface, with
+/// the deterministic-tools feature enabled so the coarse gate never gets in
+/// the way of the scope assertions.
+fn registry() -> BuiltinRegistry {
+    permissions::reset();
+    permissions::enable_for_test();
+    let mut registry = BuiltinRegistry::new();
+    ToolsCapability.register_builtins(&mut registry);
+    FsCapability.register_builtins(&mut registry);
+    AstCapability.register_builtins(&mut registry);
+    registry
+}
+
+/// Push a restricted `Worktree` profile scoped to `roots`, returning a
+/// guard that pops the policy (and clears any thread execution context) on
+/// drop so a panicking assertion can't leak policy into a sibling test.
+struct PolicyGuard;
+
+impl PolicyGuard {
+    fn worktree(roots: &[&Path]) -> Self {
+        push_execution_policy(CapabilityPolicy {
+            sandbox_profile: SandboxProfile::Worktree,
+            workspace_roots: roots
+                .iter()
+                .map(|root| root.to_string_lossy().into_owned())
+                .collect(),
+            ..CapabilityPolicy::default()
+        });
+        PolicyGuard
+    }
+}
+
+impl Drop for PolicyGuard {
+    fn drop(&mut self) {
+        pop_execution_policy();
+        set_thread_execution_context(None);
+    }
+}
+
+fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
+    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    for (k, v) in entries {
+        map.insert(k.to_string(), v.clone());
+    }
+    vec![VmValue::Dict(Rc::new(map))]
+}
+
+fn vm_string(s: &str) -> VmValue {
+    VmValue::String(Rc::from(s))
+}
+
+fn path_string(p: &Path) -> String {
+    p.to_string_lossy().into_owned()
+}
+
+fn call(
+    reg: &BuiltinRegistry,
+    name: &str,
+    entries: &[(&str, VmValue)],
+) -> Result<VmValue, HostlibError> {
+    let entry = reg
+        .find(name)
+        .unwrap_or_else(|| panic!("{name} registered"));
+    (entry.handler)(&dict_arg(entries))
+}
+
+/// Assert a call rejected with the typed sandbox violation pointing at the
+/// builtin and carrying the canonical out-of-root message.
+fn assert_rejected(result: Result<VmValue, HostlibError>, expect_builtin: &str) {
+    match result {
+        Err(HostlibError::SandboxViolation {
+            builtin, message, ..
+        }) => {
+            assert_eq!(builtin, expect_builtin, "violation names the builtin");
+            assert!(
+                message.contains("outside workspace_roots"),
+                "message describes the scope rejection: {message}"
+            );
+        }
+        other => panic!("expected SandboxViolation from {expect_builtin}, got {other:?}"),
+    }
+}
+
+#[test]
+fn read_write_delete_list_respect_workspace_roots() {
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let in_file = root.path().join("in.txt");
+    fs::write(&in_file, "hello").unwrap();
+    let out_file = outside.path().join("out.txt");
+    fs::write(&out_file, "secret").unwrap();
+
+    let reg = registry();
+    let _guard = PolicyGuard::worktree(&[root.path()]);
+
+    // Reads
+    call(
+        &reg,
+        "hostlib_tools_read_file",
+        &[("path", vm_string(&path_string(&in_file)))],
+    )
+    .expect("in-root read succeeds");
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_tools_read_file",
+            &[("path", vm_string(&path_string(&out_file)))],
+        ),
+        "hostlib_tools_read_file",
+    );
+
+    // Lists
+    call(
+        &reg,
+        "hostlib_tools_list_directory",
+        &[("path", vm_string(&path_string(root.path())))],
+    )
+    .expect("in-root list succeeds");
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_tools_list_directory",
+            &[("path", vm_string(&path_string(outside.path())))],
+        ),
+        "hostlib_tools_list_directory",
+    );
+
+    // Writes
+    let new_in = root.path().join("created.txt");
+    call(
+        &reg,
+        "hostlib_tools_write_file",
+        &[
+            ("path", vm_string(&path_string(&new_in))),
+            ("content", vm_string("x")),
+        ],
+    )
+    .expect("in-root write succeeds");
+    assert!(new_in.exists());
+    let new_out = outside.path().join("created.txt");
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_tools_write_file",
+            &[
+                ("path", vm_string(&path_string(&new_out))),
+                ("content", vm_string("x")),
+            ],
+        ),
+        "hostlib_tools_write_file",
+    );
+    assert!(!new_out.exists(), "rejected write must not touch disk");
+
+    // Deletes
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_tools_delete_file",
+            &[("path", vm_string(&path_string(&out_file)))],
+        ),
+        "hostlib_tools_delete_file",
+    );
+    assert!(out_file.exists(), "rejected delete must not touch disk");
+    call(
+        &reg,
+        "hostlib_tools_delete_file",
+        &[("path", vm_string(&path_string(&in_file)))],
+    )
+    .expect("in-root delete succeeds");
+    assert!(!in_file.exists());
+}
+
+#[test]
+fn search_and_outline_respect_workspace_roots() {
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    fs::write(root.path().join("a.rs"), "fn alpha() {}\n").unwrap();
+    fs::write(outside.path().join("b.rs"), "fn beta() {}\n").unwrap();
+
+    let reg = registry();
+    let _guard = PolicyGuard::worktree(&[root.path()]);
+
+    call(
+        &reg,
+        "hostlib_tools_search",
+        &[
+            ("pattern", vm_string("fn ")),
+            ("path", vm_string(&path_string(root.path()))),
+        ],
+    )
+    .expect("in-root search succeeds");
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_tools_search",
+            &[
+                ("pattern", vm_string("fn ")),
+                ("path", vm_string(&path_string(outside.path()))),
+            ],
+        ),
+        "hostlib_tools_search",
+    );
+
+    call(
+        &reg,
+        "hostlib_tools_get_file_outline",
+        &[("path", vm_string(&path_string(&root.path().join("a.rs"))))],
+    )
+    .expect("in-root outline succeeds");
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_tools_get_file_outline",
+            &[(
+                "path",
+                vm_string(&path_string(&outside.path().join("b.rs"))),
+            )],
+        ),
+        "hostlib_tools_get_file_outline",
+    );
+}
+
+#[test]
+fn safe_text_patch_and_read_text_respect_workspace_roots() {
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let in_file = root.path().join("p.txt");
+    fs::write(&in_file, "v1\n").unwrap();
+    let out_file = outside.path().join("p.txt");
+    fs::write(&out_file, "v1\n").unwrap();
+
+    let reg = registry();
+    let _guard = PolicyGuard::worktree(&[root.path()]);
+
+    call(
+        &reg,
+        "hostlib_fs_read_text",
+        &[("path", vm_string(&path_string(&in_file)))],
+    )
+    .expect("in-root read_text succeeds");
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_fs_read_text",
+            &[("path", vm_string(&path_string(&out_file)))],
+        ),
+        "hostlib_fs_read_text",
+    );
+
+    call(
+        &reg,
+        "hostlib_fs_safe_text_patch",
+        &[
+            ("path", vm_string(&path_string(&in_file))),
+            ("content", vm_string("v2\n")),
+        ],
+    )
+    .expect("in-root patch succeeds");
+    assert_eq!(fs::read_to_string(&in_file).unwrap(), "v2\n");
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_fs_safe_text_patch",
+            &[
+                ("path", vm_string(&path_string(&out_file))),
+                ("content", vm_string("v2\n")),
+            ],
+        ),
+        "hostlib_fs_safe_text_patch",
+    );
+    assert_eq!(
+        fs::read_to_string(&out_file).unwrap(),
+        "v1\n",
+        "rejected patch must not touch disk"
+    );
+}
+
+#[test]
+fn ast_edits_respect_workspace_roots() {
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let src = "fn alpha() { return 1 }\n";
+    let in_file = root.path().join("edit.rs");
+    fs::write(&in_file, src).unwrap();
+    let out_file = outside.path().join("edit.rs");
+    fs::write(&out_file, src).unwrap();
+
+    let reg = registry();
+    let _guard = PolicyGuard::worktree(&[root.path()]);
+
+    // apply_node rewrites the integer literal in-place.
+    call(
+        &reg,
+        "hostlib_ast_apply_node",
+        &[
+            ("path", vm_string(&path_string(&in_file))),
+            ("query", vm_string("(integer_literal) @target")),
+            ("replacement", vm_string("2")),
+        ],
+    )
+    .expect("in-root apply_node succeeds");
+    assert!(fs::read_to_string(&in_file).unwrap().contains("return 2"));
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_ast_apply_node",
+            &[
+                ("path", vm_string(&path_string(&out_file))),
+                ("query", vm_string("(integer_literal) @target")),
+                ("replacement", vm_string("2")),
+            ],
+        ),
+        "hostlib_ast_apply_node",
+    );
+    assert_eq!(
+        fs::read_to_string(&out_file).unwrap(),
+        src,
+        "rejected AST edit must not touch disk"
+    );
+
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_ast_insert_at_anchor",
+            &[
+                ("path", vm_string(&path_string(&out_file))),
+                ("query", vm_string("(function_item) @anchor")),
+                ("content", vm_string("// added\n")),
+                ("position", vm_string("before")),
+            ],
+        ),
+        "hostlib_ast_insert_at_anchor",
+    );
+}
+
+#[test]
+fn staged_commit_enforces_scope_against_target_path() {
+    // The overlay path always lives inside the workspace; commit flushes to
+    // the logical target. A target outside the roots active at commit time
+    // must be refused even though staging it under a permissive context
+    // succeeded.
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let session = "fs-path-scope-commit";
+    let in_target = root.path().join("staged_in.txt");
+    let out_target = outside.path().join("staged_out.txt");
+
+    let reg = registry();
+
+    // Stage two writes with no active policy (unrestricted), so both land in
+    // the overlay regardless of where the target points.
+    call(
+        &reg,
+        "hostlib_fs_set_mode",
+        &[
+            ("session_id", vm_string(session)),
+            ("mode", vm_string("staged")),
+            ("root", vm_string(&path_string(root.path()))),
+        ],
+    )
+    .expect("set staged mode");
+    call(
+        &reg,
+        "hostlib_tools_write_file",
+        &[
+            ("session_id", vm_string(session)),
+            ("path", vm_string(&path_string(&in_target))),
+            ("content", vm_string("in\n")),
+        ],
+    )
+    .expect("stage in-root write");
+    call(
+        &reg,
+        "hostlib_tools_write_file",
+        &[
+            ("session_id", vm_string(session)),
+            ("path", vm_string(&path_string(&out_target))),
+            ("content", vm_string("out\n")),
+        ],
+    )
+    .expect("stage out-of-root write");
+
+    // Now commit under a restricted profile scoped to `root`. The in-root
+    // target flushes; the out-of-root target is rejected and left unwritten.
+    let result = {
+        let _guard = PolicyGuard::worktree(&[root.path()]);
+        call(
+            &reg,
+            "hostlib_fs_commit_staged",
+            &[("session_id", vm_string(session))],
+        )
+        .expect("commit returns a result envelope")
+    };
+
+    assert!(in_target.exists(), "in-root target flushed to disk");
+    assert!(!out_target.exists(), "out-of-root target must not flush");
+
+    let committed = match dict_field(&result, "committed_paths") {
+        VmValue::List(items) => items.clone(),
+        other => panic!("committed_paths is a list, got {other:?}"),
+    };
+    assert_eq!(committed.len(), 1, "exactly one path committed");
+    let failed = match dict_field(&result, "failed_paths_with_reasons") {
+        VmValue::List(items) => items.clone(),
+        other => panic!("failed_paths_with_reasons is a list, got {other:?}"),
+    };
+    assert_eq!(failed.len(), 1, "the out-of-root target is reported failed");
+    let reason = dict_field(&failed[0], "reason");
+    match reason {
+        VmValue::String(s) => assert!(
+            s.contains("outside workspace_roots"),
+            "failure reason is the scope rejection: {s}"
+        ),
+        other => panic!("reason is a string, got {other:?}"),
+    }
+
+    call(
+        &reg,
+        "hostlib_fs_discard_staged",
+        &[("session_id", vm_string(session))],
+    )
+    .ok();
+}
+
+#[test]
+fn relative_paths_are_resolved_before_the_scope_check() {
+    // Hostlib resolves relative paths against the process CWD, which cargo
+    // sets to the crate directory. Anchoring the workspace root there keeps
+    // the scope check and the actual I/O consistent, and lets us exercise
+    // `..` normalization against real files without chdir-ing the process.
+    let root = std::env::current_dir().unwrap();
+
+    let reg = registry();
+    let _guard = PolicyGuard::worktree(&[root.as_path()]);
+
+    // `src/../Cargo.toml` only lands in-root *after* `..` collapses — a
+    // literal prefix check would not recognize it as in-scope, so this
+    // proves the path is normalized before the scope decision.
+    call(
+        &reg,
+        "hostlib_tools_read_file",
+        &[("path", vm_string("src/../Cargo.toml"))],
+    )
+    .expect("relative in-root read succeeds after normalization");
+
+    // `..` that escapes the crate root (into a sibling crate) is rejected.
+    assert_rejected(
+        call(
+            &reg,
+            "hostlib_tools_read_file",
+            &[("path", vm_string("../harn-vm/Cargo.toml"))],
+        ),
+        "hostlib_tools_read_file",
+    );
+}
+
+fn dict_field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
+    match value {
+        VmValue::Dict(d) => d.get(key).unwrap_or_else(|| panic!("key {key} present")),
+        other => panic!("not a dict: {other:?}"),
+    }
+}

--- a/crates/harn-vm/src/process_sandbox.rs
+++ b/crates/harn-vm/src/process_sandbox.rs
@@ -7,13 +7,18 @@
 //! `sandbox-exec` wrapping, Windows AppContainer + Job Object launches
 //! through `command_output`, plus workspace-root cwd enforcement.
 //!
+//! The same surface also exposes [`check_fs_path_scope`] so embedders that
+//! resolve host *paths* on behalf of Harn scripts (the `harn-hostlib`
+//! `fs/*`, `tools/*`, and `ast/*` builtins) can enforce the active policy's
+//! workspace-root scope without depending on `VmError`.
+//!
 //! The helpers themselves live next to the rest of the sandbox state in
 //! [`crate::stdlib::sandbox`]. This module exists so external crates have a
 //! stable, documented surface to depend on without reaching into
 //! `stdlib::*` plumbing.
 
 pub use crate::stdlib::sandbox::{
-    active_backend_available, active_backend_name, command_output, enforce_process_cwd,
-    process_spawn_error, process_violation_error, std_command_for, tokio_command_for,
-    ProcessCommandConfig,
+    active_backend_available, active_backend_name, check_fs_path_scope, command_output,
+    enforce_process_cwd, process_spawn_error, process_violation_error, std_command_for,
+    tokio_command_for, FsAccess, ProcessCommandConfig, SandboxViolation,
 };

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -59,8 +59,12 @@ thread_local! {
     static WARNED_KEYS: RefCell<BTreeSet<String>> = const { RefCell::new(BTreeSet::new()) };
 }
 
-#[derive(Clone, Copy)]
-pub(crate) enum FsAccess {
+/// The kind of filesystem access a path-scope check is guarding. Drives
+/// only the verb rendered in a rejection message — the scope decision
+/// itself is identical for reads, writes, and deletes (a path is either
+/// inside the workspace roots or it is not).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FsAccess {
     Read,
     Write,
     Delete,
@@ -276,7 +280,57 @@ fn sandbox_active_profile_impl(_args: &[VmValue], _out: &mut String) -> Result<V
     Ok(VmValue::String(Rc::from(profile.as_str())))
 }
 
-pub(crate) fn enforce_fs_path(builtin: &str, path: &Path, access: FsAccess) -> Result<(), VmError> {
+/// A workspace-root scope violation: a path that resolved outside every
+/// configured workspace root under a restricted [`SandboxProfile`].
+///
+/// This is the `VmError`-free shape returned by [`check_fs_path_scope`] so
+/// that crates outside `harn-vm` (today: `harn-hostlib`) can enforce the
+/// same scope policy and render the violation onto their own error type.
+#[derive(Clone, Debug)]
+pub struct SandboxViolation {
+    /// The path the call attempted to touch, normalized against the
+    /// active policy (CWD-relative paths resolved to absolute, `..`
+    /// collapsed, symlinks canonicalized where the path exists).
+    pub attempted: PathBuf,
+    /// The workspace roots the path was checked against, normalized the
+    /// same way as `attempted`.
+    pub roots: Vec<PathBuf>,
+    /// Whether the rejected access was a read, write, or delete.
+    pub access: FsAccess,
+}
+
+impl SandboxViolation {
+    /// Render the canonical rejection message. Matches the text produced
+    /// by [`enforce_fs_path`] so the `harness.fs.*` and hostlib surfaces
+    /// reject an out-of-root path identically.
+    pub fn message(&self, builtin: &str) -> String {
+        format!(
+            "sandbox violation: builtin '{builtin}' attempted to {} '{}' outside workspace_roots [{}]",
+            self.access.verb(),
+            self.attempted.display(),
+            self.roots
+                .iter()
+                .map(|root| root.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+/// Check whether `path` is inside the active policy's workspace roots.
+///
+/// Returns `Ok(())` when no execution policy is active, when the active
+/// profile is [`SandboxProfile::Unrestricted`], or when the normalized
+/// path falls within one of the workspace roots. Otherwise returns a
+/// [`SandboxViolation`] describing the rejected path and the roots it was
+/// checked against.
+///
+/// This is the public, `VmError`-free entry point embedders use to apply
+/// workspace-root scoping to their own host calls. The in-crate
+/// `harness.fs.*` builtins funnel through [`enforce_fs_path`], which wraps
+/// this with a `VmError`; both share the same path normalization and
+/// rejection text.
+pub fn check_fs_path_scope(path: &Path, access: FsAccess) -> Result<(), SandboxViolation> {
     let Some(policy) = crate::orchestration::current_execution_policy() else {
         return Ok(());
     };
@@ -288,16 +342,16 @@ pub(crate) fn enforce_fs_path(builtin: &str, path: &Path, access: FsAccess) -> R
     if roots.iter().any(|root| path_is_within(&candidate, root)) {
         return Ok(());
     }
-    Err(sandbox_rejection(format!(
-        "sandbox violation: builtin '{builtin}' attempted to {} '{}' outside workspace_roots [{}]",
-        access.verb(),
-        candidate.display(),
-        roots
-            .iter()
-            .map(|root| root.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    )))
+    Err(SandboxViolation {
+        attempted: candidate,
+        roots,
+        access,
+    })
+}
+
+pub(crate) fn enforce_fs_path(builtin: &str, path: &Path, access: FsAccess) -> Result<(), VmError> {
+    check_fs_path_scope(path, access)
+        .map_err(|violation| sandbox_rejection(violation.message(builtin)))
 }
 
 pub fn enforce_process_cwd(path: &Path) -> Result<(), VmError> {


### PR DESCRIPTION
## Summary

Follow-up to #2548. The `tools:deterministic` gate from #2548 answers
*"is this session allowed to touch the filesystem at all?"* but is coarse —
once enabled, a script could read/write/delete/patch **any** absolute path
on the host even under a restricted sandbox profile. `harness.fs.*` (the
VM-native stdlib) already enforces workspace-root scope via
`enforce_fs_path`; the `harn-hostlib` `fs/*`, `tools/*`, and `ast/*` builtins
did not. This closes that asymmetry.

- **harn-vm**: new public, `VmError`-free entrypoint
  `process_sandbox::check_fs_path_scope(path, FsAccess) -> Result<(), SandboxViolation>`
  (plus public `FsAccess` + `SandboxViolation`). `enforce_fs_path` now
  delegates to it, so both filesystem surfaces share one path normalization
  and one rejection message.
- **harn-hostlib**: new `HostlibError::SandboxViolation` (maps to
  `tool_rejected`, carries the offending path for `catch`/telemetry) and one
  shared `tools::permissions::enforce_path_scope` helper — the path-level
  complement to the existing `gated_handler` feature gate.
- **Wired into every path-accepting builtin**: tools `read_file`,
  `write_file`, `delete_file`, `list_directory`, `search`,
  `get_file_outline`; fs `safe_text_patch`, `read_text`; ast `apply_node`,
  `insert_at_anchor`.
- **Staged-fs commit flush**: each entry is validated against its
  working-tree **target** path (not the in-workspace overlay path), so a
  write staged under a looser policy can never escape the roots active at
  commit time. Out-of-root targets are reported in
  `failed_paths_with_reasons` rather than aborting the whole commit.
- Relative paths are normalized (CWD-relative resolved, `..` collapsed)
  before the scope decision, so the check and the actual I/O agree.

## Test plan

- [x] `cargo test -p harn-hostlib --test fs_path_scope` — in-root vs
  out-of-root for read/write/delete/list/search/outline/patch/AST-edit/
  staged-commit, plus relative-path normalization (6 tests).
- [x] Conformance `sandbox_hardened/fs_path_scope_enforcement` — drives a
  restricted `worktree` profile end-to-end and asserts the `tool_rejected`
  rejection shape + message.
- [x] `cargo clippy -p harn-vm -p harn-hostlib --all-targets` clean; `cargo fmt --check` clean.
- [x] Existing `tools_file_io` / `tools_search` / `tools_outline` /
  `fs_staging` / `ast_builtins` / harn-vm sandbox suites still green.

Closes #2600

🤖 Generated with [Claude Code](https://claude.com/claude-code)