### PR TITLE
harn replay: time-travel a session to a past event with `--at` (#2522)

### DIFF
--- a/changelog.d/2522.added.md
+++ b/changelog.d/2522.added.md
@@ -1,0 +1,3 @@
+`harn replay --session-id <id> --events-db <path> --at <event-id>`
+time-travels a recorded agent session, rehydrating and replaying it as
+it stood at a past event. (#2522)

--- a/crates/harn-cli/src/cli/runs.rs
+++ b/crates/harn-cli/src/cli/runs.rs
@@ -39,6 +39,11 @@ pub(crate) struct ReplayArgs {
     /// SQLite EventLog database to read for `--session-id`.
     #[arg(long, value_name = "PATH", requires = "session_id")]
     pub events_db: Option<String>,
+    /// Time-travel: rehydrate the session only up to (and including) this
+    /// event id, replaying it as it stood at that point. Requires
+    /// `--session-id`; omit to replay the whole session.
+    #[arg(long, value_name = "EVENT_ID", requires = "session_id")]
+    pub at: Option<u64>,
     /// Number of replay reads to compare for deterministic output.
     #[arg(long, default_value_t = 1)]
     pub runs: usize,

--- a/crates/harn-cli/src/commands/replay.rs
+++ b/crates/harn-cli/src/commands/replay.rs
@@ -79,6 +79,10 @@ pub(crate) struct ReplaySourceSummary {
     pub session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events_db: Option<String>,
+    /// Time-travel cutoff event id (`--at`), when the replay was
+    /// rehydrated to a past point. `None` for a full-session replay.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub at_event_id: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -108,6 +112,10 @@ enum ReplaySource {
     Session {
         session_id: String,
         events_db: PathBuf,
+        /// Time-travel cutoff: when set, only events with `event_id <=
+        /// at` are rehydrated, replaying the session as it stood at that
+        /// point. `None` replays the whole session.
+        at: Option<u64>,
     },
 }
 
@@ -119,21 +127,25 @@ impl ReplaySource {
                 path: Some(path.to_string_lossy().into_owned()),
                 session_id: None,
                 events_db: None,
+                at_event_id: None,
             },
             Self::ReplayTrace { path, .. } => ReplaySourceSummary {
                 kind: "replay_trace".to_string(),
                 path: Some(path.to_string_lossy().into_owned()),
                 session_id: None,
                 events_db: None,
+                at_event_id: None,
             },
             Self::Session {
                 session_id,
                 events_db,
+                at,
             } => ReplaySourceSummary {
                 kind: "event_log_session".to_string(),
                 path: None,
                 session_id: Some(session_id.clone()),
                 events_db: Some(events_db.to_string_lossy().into_owned()),
+                at_event_id: *at,
             },
         }
     }
@@ -254,6 +266,9 @@ fn run_human(source: ReplaySource, runs: usize) -> i32 {
             return 1;
         }
     };
+    if let ReplaySource::Session { at: Some(at), .. } = &source {
+        println!("Time-travelled to event {at}: replaying the session as it stood at that point.");
+    }
     for (index, execution) in executions.iter().enumerate() {
         if runs > 1 {
             println!("Replay run {}:", index + 1);
@@ -287,6 +302,7 @@ fn resolve_source(args: &ReplayArgs) -> Result<ReplaySource, String> {
         return Ok(ReplaySource::Session {
             session_id: session_id.clone(),
             events_db: PathBuf::from(events_db),
+            at: args.at,
         });
     }
     if let Some(fixture) = &args.fixture {
@@ -333,7 +349,8 @@ fn execute_once(source: &ReplaySource, index: usize) -> Result<ReplayExecution, 
         ReplaySource::Session {
             session_id,
             events_db,
-        } => execute_session_replay(session_id, events_db),
+            at,
+        } => execute_session_replay(session_id, events_db, *at),
     }
 }
 
@@ -355,7 +372,28 @@ fn execute_run_record(path: &Path) -> Result<ReplayExecution, String> {
     })
 }
 
-fn execute_session_replay(session_id: &str, events_db: &Path) -> Result<ReplayExecution, String> {
+/// Number of leading events to keep for a `--at <event-id>` time-travel
+/// cutoff. Agent-session events arrive in ascending `event_id` order, so
+/// the events with `event_id <= at` form a contiguous prefix and replaying
+/// it reconstructs the run as it stood at that point. Errors when the
+/// cutoff precedes every recorded event — a usage mistake, not a silent
+/// empty replay.
+fn time_travel_keep_count(event_ids: &[u64], at: u64, session_id: &str) -> Result<usize, String> {
+    let keep = event_ids.partition_point(|&id| id <= at);
+    if keep == 0 {
+        return Err(format!(
+            "session {session_id:?} has no events at or before event id {at} \
+             (the earliest recorded event is later)"
+        ));
+    }
+    Ok(keep)
+}
+
+fn execute_session_replay(
+    session_id: &str,
+    events_db: &Path,
+    at: Option<u64>,
+) -> Result<ReplayExecution, String> {
     let log = AnyEventLog::Sqlite(
         SqliteEventLog::open_read_only(events_db.to_path_buf(), 1).map_err(|error| {
             format!(
@@ -364,7 +402,7 @@ fn execute_session_replay(session_id: &str, events_db: &Path) -> Result<ReplayEx
             )
         })?,
     );
-    let events =
+    let mut events =
         futures::executor::block_on(load_agent_session_replay_events_from_log(&log, session_id))
             .map_err(|error| format!("failed to read session events: {error}"))?;
     if events.is_empty() {
@@ -372,6 +410,14 @@ fn execute_session_replay(session_id: &str, events_db: &Path) -> Result<ReplayEx
             "event log {} does not contain events for session_id {session_id:?}",
             events_db.display()
         ));
+    }
+
+    // Time-travel: rehydrate the session as it stood at `--at` by keeping
+    // only the event prefix up to and including the cutoff.
+    if let Some(cutoff) = at {
+        let event_ids: Vec<u64> = events.iter().map(|event| event.event_id).collect();
+        let keep = time_travel_keep_count(&event_ids, cutoff, session_id)?;
+        events.truncate(keep);
     }
     let run =
         harn_vm::session_bundle::import_run_record_from_agent_session_events(session_id, &events)
@@ -745,4 +791,42 @@ fn print_json_error(code: &str, message: impl Into<String>) {
 
 fn to_string_pretty<T: Serialize>(value: &T) -> String {
     serde_json::to_string_pretty(value).expect("replay JSON payload serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::time_travel_keep_count;
+
+    #[test]
+    fn time_travel_keeps_prefix_through_inclusive_cutoff() {
+        let ids = [1, 2, 3, 4, 5];
+        // The cutoff is inclusive: `--at 3` keeps events 1..=3.
+        assert_eq!(time_travel_keep_count(&ids, 3, "s").unwrap(), 3);
+    }
+
+    #[test]
+    fn time_travel_cutoff_past_the_end_keeps_everything() {
+        let ids = [1, 2, 3];
+        assert_eq!(time_travel_keep_count(&ids, 99, "s").unwrap(), 3);
+    }
+
+    #[test]
+    fn time_travel_cutoff_between_ids_keeps_the_lower_prefix() {
+        // Event ids need not be contiguous; `--at 4` over [2,4,6] keeps the
+        // events at or before 4 (i.e. 2 and 4), and a cutoff that falls in
+        // a gap keeps only the events below it.
+        let ids = [2, 4, 6];
+        assert_eq!(time_travel_keep_count(&ids, 4, "s").unwrap(), 2);
+        assert_eq!(time_travel_keep_count(&ids, 5, "s").unwrap(), 2);
+    }
+
+    #[test]
+    fn time_travel_cutoff_before_first_event_is_an_error() {
+        let ids = [10, 11, 12];
+        let error = time_travel_keep_count(&ids, 9, "sess-abc").unwrap_err();
+        assert!(
+            error.contains("sess-abc") && error.contains("event id 9"),
+            "error should name the session and cutoff: {error}"
+        );
+    }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -36,6 +36,7 @@
 - [Rename a symbol cookbook](./cookbooks/rename-symbol.md)
 - [Structured refactorings cookbook](./cookbooks/structured-refactorings.md)
 - [Burin compass cookbook](./cookbooks/burin-compass.md)
+- [Replay time-travel cookbook](./cookbooks/replay-time-travel.md)
 - [OAuth client + provider cookbook](./oauth.md)
 - [Debugging agent runs](./debugging.md)
 

--- a/docs/src/cookbooks/replay-time-travel.md
+++ b/docs/src/cookbooks/replay-time-travel.md
@@ -1,0 +1,73 @@
+# Replay time-travel cookbook
+
+`harn replay` rehydrates a recorded agent session from a SQLite EventLog
+and replays it deterministically. With `--at <event-id>` you can rewind
+to **any past event** and replay the session as it stood at that point —
+the foundation for auditing "what had the agent seen by the time it made
+this decision?".
+
+## Replay a whole session
+
+Every agent session writes its events to a durable EventLog. Point
+`harn replay` at that database and a session id:
+
+```bash
+harn replay --session-id sess_42 --events-db ./.harn/agent-events.db
+```
+
+The command reconstructs the run record from the session's events,
+replays it, and reports the stages, transitions, and the replay-fixture
+verdict. Add `--json` for the structured `JsonEnvelope` shape (see
+[the CLI JSON contract](../cli-json-contract.md)).
+
+## Rewind to a past event with `--at`
+
+Agent-session events carry a monotonically increasing `event_id`. Pass
+`--at <event-id>` to rehydrate only the prefix up to **and including**
+that event — the session is replayed exactly as it stood at that moment,
+with everything after the cutoff dropped:
+
+```bash
+# Replay sess_42 as it was right after event 7.
+harn replay --session-id sess_42 --events-db ./.harn/agent-events.db --at 7
+```
+
+The cutoff is inclusive and need not name an event that exists — `--at 5`
+over a session whose events are `[2, 4, 6]` keeps events `2` and `4`. A
+cutoff that precedes the first recorded event is rejected with a clear
+error rather than producing a silent empty replay.
+
+In `--json` mode the source summary records the cutoff:
+
+```json
+{
+  "source": {
+    "kind": "event_log_session",
+    "session_id": "sess_42",
+    "events_db": "./.harn/agent-events.db",
+    "at_event_id": 7
+  }
+}
+```
+
+The replay report's `transcript_event_count` reflects the truncated
+prefix, so you can diff the determinism of "the session up to event N"
+against the full run.
+
+## Audit a past run, ask what-if, ship the fix
+
+The typical loop:
+
+1. **Find the decision.** Replay the whole session (`--json`) and scan
+   the stages/transitions for the step you want to interrogate; note its
+   `event_id`.
+2. **Rewind.** Replay again with `--at <that-event-id>` to see exactly
+   the context the agent had at that point — no later events leak in.
+3. **Vary and verify.** Re-run the slice while changing the workspace or
+   inputs the agent saw, and compare the new replay against the recorded
+   one to confirm your fix changes the outcome you expected and nothing
+   else.
+
+Because replay is deterministic and the EventLog is append-only, the
+audit is reproducible: the same `--session-id … --at N` always rehydrates
+the same prefix.


### PR DESCRIPTION
## What

Part of **B.10 #2522** (session time-travel + counterfactual replay). `harn replay --session-id <id> --events-db <path>` already rehydrates and replays a recorded agent session deterministically. This adds the **time-travel** half: `--at <event-id>` rewinds to any past event and replays the session exactly as it stood at that point.

```bash
# Replay sess_42 as it was right after event 7.
harn replay --session-id sess_42 --events-db ./.harn/agent-events.db --at 7
```

## Behaviour

- `--at` requires `--session-id`. The cutoff is **inclusive** and need not name an existing id — `--at 5` over events `[2, 4, 6]` keeps `2` and `4`. A cutoff before the first recorded event is rejected with a clear error rather than a silent empty replay.
- The prefix filter is a pure helper, `time_travel_keep_count`, over the ascending event-id list — unit-tested for the inclusive boundary, gaps, past-the-end, and before-first-event cases (4 tests).
- `--json` surfaces the cutoff as `source.at_event_id`; human mode prints a one-line "time-travelled to event N" note. The report's `transcript_event_count` reflects the truncated prefix.

## Docs

A **Replay time-travel** cookbook chapter (audit a past run → rewind → ask what-if), linked from `SUMMARY.md`, plus a changelog fragment.

## Verification

- `cargo test -p harn-cli --lib commands::replay` — 4 time-travel unit tests green.
- `cargo clippy -p harn-cli --all-targets` clean.

## Scope note

This lands the `--at` time-travel core. The `--counterfactual <plan>` dry-run divergence from the #2522 acceptance is a larger sub-feature (it composes B.5 `edit.dry_run`) and is tracked as follow-up #2611 so this increment stays small and well-tested; #2522 stays open until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
