### PR TITLE
burin compass: built-in `compass_ast_edits` reminder provider (#2521)

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Pool cookbook](./cookbooks/pools.md)
 - [Rename a symbol cookbook](./cookbooks/rename-symbol.md)
 - [Structured refactorings cookbook](./cookbooks/structured-refactorings.md)
+- [Burin compass cookbook](./cookbooks/burin-compass.md)
 - [OAuth client + provider cookbook](./oauth.md)
 - [Debugging agent runs](./debugging.md)
 


### PR DESCRIPTION
## What

Part of **B.9 #2521** (the burin compass). The AST-precise edit primitives (`edit_apply_node`, `edit_rename_symbol`, the structured refactors, `edit_dry_run`) are the moat tool for the "measure twice, cut once" burin metaphor — but they only pay off if agents reach for them **first**. Left to defaults, the path of least resistance is a freeform `str_replace`/text patch: the brittle string-collision failure mode the AST tools exist to kill.

This ships the **steer**: a built-in canonical [reminder provider](../system-reminders.md) `compass_ast_edits`, **on by default**, that injects a standing system reminder at `SessionStart` / `OnSessionResume` pointing the agent at the structural tools, with `edit_safe_text_patch` as the conscious fallback.

## Why a reminder, not a hard router

The compass *steers* rather than *rewrites* — the model stays in control (it can still choose a freeform patch where there's no tree-sitter grammar), the behaviour is predictable, and the reminder is visible in the transcript like any other. Because it's a **canonical** provider it reaches every agent surface that runs the Harn agent loop (TUI, IDE, cloud-supervised) with no per-persona opt-in, and it's `preserve_on_compact` so the steer survives a long session.

## Scope

- `crates/harn-vm/src/llm/reminder_providers.rs`: `CompassAstEditsProvider` + `COMPASS_AST_EDITS_ID`, registered in `canonical_providers` / `canonical_provider_ids` / `canonical_provider_metadata` (the existing lockstep test enforces all three stay in sync). Default-on via the config's "unknown ids are enabled" rule — no config migration. 2 new unit tests.
- Docs: a **Burin compass** cookbook chapter (why a reminder not a hard router; escape hatches), linked from `SUMMARY.md`; changelog fragment.

## Verification

- `cargo test -p harn-vm --lib reminder_providers` — 8 green (existing + 2 compass).
- `cargo clippy -p harn-vm --all-targets` clean.

## Scope note

This ships the steer half. The tool-rewrite router (detect a freeform edit → rewrite to the structural form with an equivalence proof) plus the `harn.compass.{suggested,rewritten,fell_back}` counters are tracked as follow-up #2612. #2521 stays open until they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
