### PR TITLE
burin compass: restore dropped provider + cookbook (repairs #2614)

### DIFF
--- a/changelog.d/2521.added.md
+++ b/changelog.d/2521.added.md
@@ -1,0 +1,5 @@
+Burin compass: a built-in, opt-in `compass_ast_edits` system-reminder
+provider that steers the agent loop toward the AST-precise edit
+primitives (`edit_apply_node`, `edit_rename_symbol`, the structured
+refactors, `edit_dry_run`) over freeform text edits at session start.
+Enable it with `reminders.providers.compass_ast_edits = true`. (#2521)

--- a/conformance/tests/reminders/reminder_provider_compass_opt_in.expected
+++ b/conformance/tests/reminders/reminder_provider_compass_opt_in.expected
@@ -1,0 +1,6 @@
+1
+compass_ast_edits
+stdlib_provider
+true
+true
+0

--- a/conformance/tests/reminders/reminder_provider_compass_opt_in.harn
+++ b/conformance/tests/reminders/reminder_provider_compass_opt_in.harn
@@ -1,0 +1,37 @@
+/**
+ * The burin compass (`compass_ast_edits`) is a canonical reminder
+ * provider that ships opt-in: it stays silent unless a session enables it
+ * via `reminders: {providers: ["compass_ast_edits"]}`, at which point it
+ * injects its AST-edit steer at session start.
+ */
+pipeline main() {
+  llm_mock_clear()
+  llm_mock({text: "done"})
+  let opted_in = agent_loop(
+    "compass opt-in",
+    nil,
+    {
+      provider: "mock",
+      model: "mock",
+      session_id: "reminder-compass-opt-in",
+      reminders: {providers: ["compass_ast_edits"]},
+    },
+  )
+  let on = transcript_events_by_kind(opted_in.transcript, "system_reminder")
+    .filter({ e -> e.reminder.tags[0] == "compass_ast_edits" })
+  llm_mock_clear()
+  llm_mock({text: "done"})
+  let default_off = agent_loop(
+    "compass default off",
+    nil,
+    {provider: "mock", model: "mock", session_id: "reminder-compass-default-off"},
+  )
+  let off = transcript_events_by_kind(default_off.transcript, "system_reminder")
+    .filter({ e -> e.reminder.tags[0] == "compass_ast_edits" })
+  __io_println(len(on))
+  __io_println(on[0].reminder.tags[0])
+  __io_println(on[0].reminder.source)
+  __io_println(on[0].reminder.body.contains("edit_apply_node"))
+  __io_println(on[0].reminder.preserve_on_compact)
+  __io_println(len(off))
+}

--- a/crates/harn-vm/src/llm/reminder_providers.rs
+++ b/crates/harn-vm/src/llm/reminder_providers.rs
@@ -17,6 +17,7 @@ const IDLE_NUDGE_ID: &str = "idle_nudge";
 const TOOL_OUTPUT_TRUNCATED_ID: &str = "tool_output_truncated";
 const POST_COMPACT_RECAP_ID: &str = "post_compact_recap";
 const RESUME_CONTINUITY_ID: &str = "resume_continuity";
+const COMPASS_AST_EDITS_ID: &str = "compass_ast_edits";
 const PROJECT_FACTS_ID: &str = "project_facts";
 const WORKSPACE_ANCHOR_ID: &str = "workspace_anchor";
 
@@ -28,6 +29,7 @@ const RESUME_CONTINUITY_EVENTS: &[HookEvent] = &[HookEvent::WorkerResumed];
 const PROJECT_FACTS_EVENTS: &[HookEvent] = &[HookEvent::SessionStart, HookEvent::OnBudgetThreshold];
 const WORKSPACE_ANCHOR_EVENTS: &[HookEvent] =
     &[HookEvent::SessionStart, HookEvent::OnBudgetThreshold];
+const COMPASS_AST_EDITS_EVENTS: &[HookEvent] = &[HookEvent::SessionStart, HookEvent::WorkerResumed];
 
 const PROJECT_FACTS_DEFAULT_NAMESPACE: &str = "project/facts";
 const PROJECT_FACTS_DEFAULT_MAX: i64 = 5;
@@ -481,7 +483,68 @@ pub async fn evaluate_and_inject(
     }))
 }
 
-fn canonical_providers() -> [&'static dyn ReminderProvider; 7] {
+/// Burin compass (B.9, #2521): steer the agent loop toward the
+/// AST-precise edit primitives over freeform text edits.
+///
+/// The `edit_*` stdlib surface (`edit_apply_node`, `edit_rename_symbol`,
+/// the structured refactors, `edit_dry_run`) is the moat tool for the
+/// "measure twice, cut once" burin metaphor — but it only pays off when
+/// agents reach for it first. Left to defaults, the path of least
+/// resistance is a freeform `str_replace`/text patch, the brittle
+/// string-collision failure mode the AST tools exist to kill. This
+/// provider injects a standing reminder at session start (and on resume)
+/// that inverts the default: structural is the expected tool, freeform is
+/// the conscious fallback. When enabled it always fires (the steer is
+/// relevant to any code-editing session) and preserves across compaction
+/// so the guidance persists through a long session.
+///
+/// It is registered in `canonical_providers` but ships **opt-in**: it is
+/// deliberately absent from the default-enabled set
+/// (`canonical_provider_ids`), so a session activates it explicitly with
+/// `reminders: {providers: ["compass_ast_edits"]}`. The other canonical
+/// providers are conditional (they stay silent without relevant data); an
+/// unconditional default-on steer would instead fire on every agent loop,
+/// including sub-agent and one-shot loops that never edit code. Flipping
+/// it on by default, alongside the tool-rewrite router, is tracked as
+/// follow-up #2612.
+struct CompassAstEditsProvider;
+
+const COMPASS_AST_EDITS_BODY: &str = "When editing source files, prefer the AST-precise edit \
+tools over freeform text edits: `edit_apply_node` / `edit_insert_at_anchor` for node-level \
+changes, `edit_rename_symbol` for safe cross-file renames, and the structured refactors \
+(`edit_extract_function`, `edit_change_signature`, `edit_inline`, `edit_move_decl`, …) for \
+compound changes. Preview any plan with `edit_dry_run` before committing. Reach for \
+`edit_safe_text_patch` only when the language has no grammar support — the structural tools \
+update semantic neighbours (callers, imports) that a string replace would silently miss.";
+
+impl ReminderProvider for CompassAstEditsProvider {
+    fn id(&self) -> &'static str {
+        COMPASS_AST_EDITS_ID
+    }
+
+    fn subscribes_to(&self) -> &'static [HookEvent] {
+        COMPASS_AST_EDITS_EVENTS
+    }
+
+    fn evaluate(&self, ctx: &ProviderContext) -> Option<ReminderSpec> {
+        let mut reminder = provider_reminder(
+            COMPASS_AST_EDITS_BODY.to_string(),
+            COMPASS_AST_EDITS_ID,
+            ctx,
+        );
+        reminder.tags = vec![COMPASS_AST_EDITS_ID.to_string()];
+        // One steer per session; the dedupe key suppresses a second
+        // emission if both SessionStart and a later resume fire.
+        reminder.dedupe_key = Some(COMPASS_AST_EDITS_ID.to_string());
+        reminder.ttl_turns = None;
+        reminder.preserve_on_compact = true;
+        reminder.propagate = ReminderPropagate::Session;
+        reminder.role_hint = ReminderRoleHint::System;
+        Some(reminder)
+    }
+}
+
+fn canonical_providers() -> [&'static dyn ReminderProvider; 8] {
     [
         &TokenPressureProvider,
         &IdleNudgeProvider,
@@ -490,6 +553,7 @@ fn canonical_providers() -> [&'static dyn ReminderProvider; 7] {
         &ResumeContinuityProvider,
         &ProjectFactsProvider,
         &WorkspaceAnchorProvider,
+        &CompassAstEditsProvider,
     ]
 }
 
@@ -530,6 +594,9 @@ fn enabled_provider_ids(
         return BTreeSet::new();
     }
 
+    // Default-enabled canonical providers. Opt-in-only providers (e.g. the
+    // burin compass) are intentionally excluded here and activate through an
+    // explicit `reminders.providers: ["<id>"]` entry handled below.
     let mut enabled: BTreeSet<String> = canonical_provider_ids()
         .into_iter()
         .map(str::to_string)
@@ -556,6 +623,10 @@ fn enabled_provider_ids(
     enabled
 }
 
+/// Ids of the canonical providers that are enabled by default. The burin
+/// compass (`COMPASS_AST_EDITS_ID`) is intentionally NOT listed: it is a
+/// registered canonical provider (see `canonical_providers`) but ships
+/// opt-in, activated per session via `reminders: {providers: [...]}`.
 fn canonical_provider_ids() -> [&'static str; 7] {
     [
         TOKEN_PRESSURE_ID,
@@ -969,6 +1040,33 @@ mod tests {
             payload,
             options,
         }
+    }
+
+    #[test]
+    fn compass_steers_to_ast_edits_and_survives_compaction() {
+        let spec = CompassAstEditsProvider
+            .evaluate(&ctx(HookEvent::SessionStart, json!({}), JsonValue::Null))
+            .expect("compass fires on session start");
+        // The reminder's `id` is an auto-generated per-instance UUID; the
+        // provider identity is carried by `dedupe_key` / `tags` (matching
+        // the other canonical providers, e.g. the workspace anchor test).
+        assert_eq!(spec.dedupe_key.as_deref(), Some(COMPASS_AST_EDITS_ID));
+        assert_eq!(spec.tags, vec![COMPASS_AST_EDITS_ID.to_string()]);
+        assert!(spec.body.contains("edit_apply_node"));
+        assert!(spec.body.contains("edit_rename_symbol"));
+        assert!(spec.body.contains("edit_dry_run"));
+        // The steer must outlive a context compaction, otherwise a long
+        // session silently reverts to freeform edits after the first squash.
+        assert!(spec.preserve_on_compact);
+    }
+
+    #[test]
+    fn compass_subscribes_to_session_lifecycle_only() {
+        let events = CompassAstEditsProvider.subscribes_to();
+        assert!(events.contains(&HookEvent::SessionStart));
+        assert!(events.contains(&HookEvent::WorkerResumed));
+        // Not per-tool-call — that would spam the transcript on every edit.
+        assert!(!events.contains(&HookEvent::PostToolUse));
     }
 
     #[test]

--- a/docs/src/cookbooks/burin-compass.md
+++ b/docs/src/cookbooks/burin-compass.md
@@ -1,0 +1,66 @@
+# Burin compass: steer toward AST edits
+
+Harn ships a moat-quality set of **AST-precise edit primitives** — see
+the [structured refactorings cookbook](./structured-refactorings.md).
+They only pay off, though, if the agent loop *reaches for them first*.
+Left to its own devices a model takes the path of least resistance — a
+freeform `str_replace` / line patch — which is exactly the brittle,
+string-collision failure mode the structural tools exist to eliminate.
+
+The **burin compass** inverts that default. It is a built-in
+[system-reminder](../system-reminders.md) provider, `compass_ast_edits`,
+that injects a standing reminder at session start (and on resume):
+
+> When editing source files, prefer the AST-precise edit tools over
+> freeform text edits: `edit_apply_node` / `edit_insert_at_anchor` for
+> node-level changes, `edit_rename_symbol` for safe cross-file renames,
+> and the structured refactors (`edit_extract_function`,
+> `edit_change_signature`, `edit_inline`, `edit_move_decl`, …) for
+> compound changes. Preview any plan with `edit_dry_run` before
+> committing. Reach for `edit_safe_text_patch` only when the language has
+> no grammar support.
+
+The compass ships **opt-in**. Unlike the other canonical providers —
+which are conditional and stay silent until they have something to say
+(project facts, a workspace anchor, token pressure) — a steer toward code
+edits is only wanted in code-editing sessions, not in every sub-agent or
+one-shot loop. So coding-agent personas and configs turn it on
+explicitly; once enabled it reaches every agent surface that runs the
+Harn agent loop — TUI, IDE, cloud-supervised. The reminder is marked
+`preserve_on_compact`, so the guidance survives a context compaction and
+keeps steering through a long session.
+
+## Why a reminder, not a hard router
+
+The compass *steers* rather than *rewrites*. A reminder keeps the model
+in control: it can still choose a freeform patch when a file has no
+tree-sitter grammar (the structural tools degrade to `Unsupported` there
+anyway), and it never silently changes the bytes a tool call would
+produce. That makes the behaviour predictable and auditable — the
+reminder is visible in the transcript like any other system reminder.
+
+## Turning it on
+
+The compass is a normal reminder provider, so the standard controls
+apply:
+
+- **Enable it** for a session or persona via the reminder config:
+  `reminders.providers.compass_ast_edits = true`. It is registered as a
+  canonical provider but ships `default_enabled: false`, so this opt-in is
+  what activates the steer.
+- **Inspect it** alongside the other canonical providers —
+  `compass_ast_edits` appears in the provider metadata listing with the
+  summary "Steer the agent toward AST edit primitives over freeform text
+  edits."
+
+Flipping the compass on by default, together with the tool-rewrite router
+that detects a freeform edit and rewrites it to the structural form, is
+tracked as follow-up #2612.
+
+## Composes with
+
+- [Structured refactorings cookbook](./structured-refactorings.md) — the
+  tools the compass points at.
+- [Rename a symbol cookbook](./rename-symbol.md) — the cross-file rename
+  the compass calls out by name.
+- [System reminders](../system-reminders.md) — the delivery mechanism.


### PR DESCRIPTION
Repairs the #2614 squash that merged only the SUMMARY cookbook link, leaving the `CompassAstEditsProvider`, the burin-compass cookbook, and the changelog fragment absent on main (dangling doc link + feature missing). Restores all three.

Verified locally: `cargo build -p harn-vm`, `cargo test -p harn-vm --lib reminder_providers` (10 ok), `cargo clippy -p harn-vm --all-targets` (0), `cargo check --workspace --locked` (0).

#2521 stays open per follow-up #2612 (tool-rewrite router + counters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)