### PR TITLE
run_command: preserve full output past `| tail`-style filters

### DIFF
--- a/changelog.d/2625.added.md
+++ b/changelog.d/2625.added.md
@@ -1,0 +1,8 @@
+- **`run_command` preserves a slow command's full output past a `| tail`-style filter (#2625).** When an
+  agent runs a `producer | tail/wc/grep/sort/…` shell pipeline, the new `std/agent/command_capture`
+  recognizer transparently rewrites it to `producer | tee '<capture>' 2>/dev/null | filter` so the model
+  still sees exactly the filtered output while the producer's complete output is preserved to a temp file —
+  a post-run `output_capture` field points the model at it so it never has to re-run the slow command. The
+  rewrite is conservative (it leaves `head`, `grep -q`/`-m`, command substitution, subshells, and anything
+  it can't parse safely untouched) and on by default; set `preserve_filtered_output: false` on
+  `agent_command_tools` / `agent_host_tools` to disable it.

--- a/conformance/tests/agents/command_capture_rewrite.expected
+++ b/conformance/tests/agents/command_capture_rewrite.expected
@@ -1,0 +1,19 @@
+seq 100 | tee '/tmp/cap.out' 2>/dev/null | tail -3
+cd foo && make 2>&1 | tee '/tmp/cap.out' 2>/dev/null | tail -50
+find . -name '*.rs' | xargs wc -l | sort -n | tee '/tmp/cap.out' 2>/dev/null | tail -1
+grep 'a|b' file | tee '/tmp/cap.out' 2>/dev/null | wc -l
+echo start; seq 10 | tee '/tmp/cap.out' 2>/dev/null | wc -l
+true
+true
+true
+true
+true
+true
+true
+true
+true
+seq 100
+tail -n 3
+100
+3
+true

--- a/conformance/tests/agents/command_capture_rewrite.harn
+++ b/conformance/tests/agents/command_capture_rewrite.harn
@@ -1,0 +1,48 @@
+import { command_capture_rewrite } from "std/agent/command_capture"
+import { agent_command_tools } from "std/agent/host_tools"
+
+pipeline main() {
+  let cap = "/tmp/cap.out"
+  // --- pure rewrite cases (deterministic capture path) --------------------
+  // 1. plain producer | tail
+  __io_println(command_capture_rewrite("seq 100 | tail -3", cap))
+  // 2. verbatim `cd … &&` prefix + 2>&1 redirection ride along
+  __io_println(command_capture_rewrite("cd foo && make 2>&1 | tail -50", cap))
+  // 3. tee is inserted before the FINAL filter of a multi-stage pipeline
+  __io_println(command_capture_rewrite("find . -name '*.rs' | xargs wc -l | sort -n | tail -1", cap))
+  // 4. a pipe inside single quotes is not a split point
+  __io_println(command_capture_rewrite("grep 'a|b' file | wc -l", cap))
+  // 5. a `;` prefix is preserved verbatim; only the last statement rewrites
+  __io_println(command_capture_rewrite("echo start; seq 10 | wc -l", cap))
+  // --- bail cases (no rewrite -> nil) -------------------------------------
+  __io_println(command_capture_rewrite("ls | head -5", cap) == nil)  // head short-circuits
+  __io_println(command_capture_rewrite("ls | grep -q foo", cap) == nil)  // grep -q short-circuits
+  __io_println(command_capture_rewrite("cat \"$(cfg)\" | tail", cap) == nil)  // command substitution
+  __io_println(command_capture_rewrite("ls", cap) == nil)  // no pipe
+  __io_println(command_capture_rewrite("(a | b) | tail", cap) == nil)  // subshell grouping
+  __io_println(command_capture_rewrite("foo | sed 's/x/y/'", cap) == nil)  // filter not in allowlist
+  __io_println(command_capture_rewrite("echo hi & wc -l", cap) == nil)  // background job
+  __io_println(command_capture_rewrite("a | b && c", cap) == nil)  // last statement has no pipe
+  // --- end-to-end through the run_command tool ----------------------------
+  let root = path_join(harness.fs.temp_dir(), "harn-cap-int-" + uuid())
+  harness.fs.mkdir(root, true)
+  let tools = agent_command_tools(nil, {root: root, cwd: root, allow_argv_prefixes: [["sh", "-c"]]})
+  let run = agent_dispatch_tool_call(
+    {
+      id: "c1",
+      name: "run_command",
+      arguments: {argv: ["sh", "-c", "seq 100 | tail -n 3"], capture: {max_inline_bytes: 1000}},
+    },
+    tools,
+  )
+  let data = json_parse(run.rendered_result)
+  __io_println(run.ok)  // true
+  __io_println(data.output_capture.producer)  // seq 100
+  __io_println(data.output_capture.filter)  // tail -n 3
+  let captured = read_file(data.output_capture.full_output_path)
+  __io_println(len(captured.trim().split("\n")))  // 100 (full producer output preserved)
+  __io_println(len(data.stdout.trim().split("\n")))  // 3  (agent still sees only the filtered tail)
+  __io_println(data.stdout.trim().ends_with("100"))  // true
+  harness.fs.delete(data.output_capture.full_output_path)
+  harness.fs.delete(root)
+}

--- a/crates/harn-cli/assets/demo/command-capture/scenario.harn
+++ b/crates/harn-cli/assets/demo/command-capture/scenario.harn
@@ -1,0 +1,104 @@
+/**
+ * command-capture demo: never re-run a slow command just to see what a
+ * trailing filter threw away.
+ *
+ * When an agent runs `slow_cmd | tail -5`, the shell applies `tail` before
+ * Harn's command runner sees any bytes, so only the 5 surviving lines are
+ * captured and the full `slow_cmd` output is gone — recovering it means
+ * re-running the slow command. The std/agent/command_capture recognizer
+ * spots that shape and rewrites it to
+ *
+ *     slow_cmd | tee '<capture>' 2>/dev/null | tail -5
+ *
+ * `tee` is transparent (the filter sees identical bytes, the exit status is
+ * unchanged) so the agent still gets exactly the filtered output it asked
+ * for — but the producer's COMPLETE output is now preserved on disk, and a
+ * post-run `output_capture` hint points the agent at it.
+ *
+ * This scenario walks the recognizer through realistic commands, shows the
+ * cases it deliberately leaves untouched (false-negatives over false-
+ * positives), then materializes a capture file and demonstrates the
+ * `output_capture` hint an agent would receive. Fully offline — no LLM, no
+ * subprocess, no network.
+ */
+import {
+  command_capture_annotate,
+  command_capture_plan,
+  command_capture_rewrite,
+} from "std/agent/command_capture"
+
+pipeline default(_task) {
+  __io_println("=== command-capture demo ===")
+  __io_println("")
+  // 1. Rewrites: a `tee` is woven in just before the final consume-all
+  //    filter, capturing everything the filter would otherwise discard.
+  let cap = "/tmp/full-output.txt"
+  __io_println("rewritten (full output preserved):")
+  let rewritable = [
+    "cargo build 2>&1 | tail -20",
+    "find . -name '*.rs' | xargs wc -l | sort -n | tail -1",
+    "cd crates && git log --oneline | grep fix",
+  ]
+  for cmd in rewritable {
+    __io_println("  " + cmd)
+    __io_println("    -> " + command_capture_rewrite(cmd, cap))
+  }
+  __io_println("")
+  // 2. Left untouched on purpose. `head` and `grep -q` stop the producer
+  //    early (capturing them would be a partial lie); command substitution
+  //    and subshell grouping are refused rather than parsed heuristically.
+  __io_println("left untouched (bail-preferring):")
+  let bails = [
+    "build.sh | head -10",
+    "deploy.sh 2>&1 | grep -q DEPLOYED",
+    "cat \"$(config-path)\" | tail",
+    "(setup && teardown) | wc -l",
+  ]
+  for cmd in bails {
+    let result = command_capture_rewrite(cmd, cap)
+    let shown = if result == nil {
+      "(unchanged)"
+    } else {
+      result
+    }
+    __io_println("  " + cmd + "  ->  " + shown)
+  }
+  __io_println("")
+  // 3. End-to-end effect: materialize the full output `tee` would have
+  //    written, then show the post-run result an agent receives — the
+  //    filtered tail it asked for PLUS an output_capture hint pointing at
+  //    the complete output. The hint is added only because the capture file
+  //    exists, so a sandbox that blocks the write produces no false promise.
+  // Write under the workspace root so the demo stays inside its sandbox
+  // (a real run captures to the host temp dir instead).
+  let capture_path = path_join(execution_root(), "harn-demo-capture-" + uuid() + ".out")
+  var full = ""
+  var i = 1
+  while i <= 200 {
+    full = full + to_string(i) + "\n"
+    i = i + 1
+  }
+  harness.fs.write_text(capture_path, full)
+  let plan = command_capture_plan("seq 200 | tail -3", capture_path)
+  let agent_result = {stdout: "198\n199\n200\n", exit_code: 0, success: true}
+  let annotated = command_capture_annotate(agent_result, plan)
+  __io_println("agent's run_command result:")
+  __io_println("  stdout (filtered): " + json_stringify(annotated.stdout))
+  __io_println("  output_capture.producer: " + annotated.output_capture.producer)
+  __io_println("  output_capture.hint: " + annotated.output_capture.hint)
+  __io_println("")
+  let captured_lines = len(read_file(capture_path).trim().split("\n"))
+  let filtered_lines = len(annotated.stdout.trim().split("\n"))
+  harness.fs.delete(capture_path)
+  let receipt = {
+    receipt_kind: "command_capture_receipt",
+    rewrite_example: command_capture_rewrite("seq 200 | tail -3", "/tmp/full.out"),
+    head_left_untouched: command_capture_rewrite("ls | head -5", cap) == nil,
+    captured_lines: captured_lines,
+    filtered_lines: filtered_lines,
+    capture_hint_present: annotated?.output_capture != nil,
+    producer: plan.producer,
+  }
+  __io_println(json_stringify(receipt))
+  return receipt
+}

--- a/crates/harn-cli/assets/demo/command-capture/tape.jsonl
+++ b/crates/harn-cli/assets/demo/command-capture/tape.jsonl
@@ -1,0 +1,1 @@
+{"match":"*[command-capture-unused]*","consume_match":false,"text":"unused","model":"mock-noop","provider":"mock"}

--- a/crates/harn-cli/src/commands/demo.rs
+++ b/crates/harn-cli/src/commands/demo.rs
@@ -75,6 +75,20 @@ const SCENARIOS: &[Scenario] = &[
         tape: include_str!("../../assets/demo/stdlib-toolkit/tape.jsonl"),
     },
     Scenario {
+        id: "command-capture",
+        title: "run_command preserves a slow command's full output past a `| tail` filter",
+        description: "Walk the std/agent/command_capture recognizer: rewrite `producer | tail/wc/grep` \
+                      pipelines to `producer | tee '<capture>' 2>/dev/null | filter` so the agent \
+                      still sees the filtered output while the producer's COMPLETE output is \
+                      preserved on disk, show the cases it deliberately leaves untouched (head, \
+                      grep -q, command substitution, subshell grouping), then materialize a capture \
+                      and demonstrate the post-run `output_capture` hint that lets an agent read the \
+                      full output instead of re-running a slow command. Fully offline — no LLM, no \
+                      subprocess.",
+        script: include_str!("../../assets/demo/command-capture/scenario.harn"),
+        tape: include_str!("../../assets/demo/command-capture/tape.jsonl"),
+    },
+    Scenario {
         id: "compaction-policy",
         title: "compaction.{policy,check,run} drives a session through the lifecycle",
         description: "Declare a per-session compaction policy with thresholds, call \

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -426,6 +426,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/mcp.harn"),
     },
     StdlibSource {
+        module: "agent/command_capture",
+        source: include_str!("stdlib/agent/command_capture.harn"),
+    },
+    StdlibSource {
         module: "agent/host_tools",
         source: include_str!("stdlib/agent/host_tools.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/command_capture.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/command_capture.harn
@@ -1,0 +1,454 @@
+// std/agent/command_capture
+//
+// Preserve the full, unfiltered output of `producer | cheap-filter`
+// shell pipelines so an agent never has to re-run a slow command just to
+// see what the trailing filter discarded.
+//
+// When an agent runs `slow_cmd | tail -5`, the *shell* applies `tail`
+// before Harn's command runner ever sees the bytes, so only the 5
+// surviving lines are captured and the full `slow_cmd` output is lost.
+// This module recognizes that shape and rewrites it to
+//
+//     slow_cmd | tee '<capture>' 2>/dev/null | tail -5
+//
+// `tee` is transparent (the filter sees identical bytes, the exit status
+// is unchanged) and the `2>/dev/null` + POSIX "tee keeps copying to stdout
+// even when a file operand fails to open" guarantee means the rewrite can
+// never break the agent's command. After the run we attach an
+// `output_capture` field pointing at the captured file — but only if it
+// actually materialized, so a sandbox that blocks the temp write produces
+// no misleading hint.
+//
+// Everything here is a pure, conservative, bail-preferring recognizer:
+// it rewrites ONLY a clean single pipeline (optionally behind a verbatim
+// `cd … && ` / `… ; ` prefix) and refuses the moment it sees anything it
+// cannot reason about (command/process substitution, here-docs, subshell
+// grouping, background jobs, unbalanced quotes, …). False negatives are
+// always preferred over false positives.
+
+// -------------------------------------------------------------------------------------------------
+// Filter allowlist
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Commands that read their entire stdin before producing output. A `tee`
+ * placed immediately upstream of one of these captures the COMPLETE
+ * producer output. We deliberately EXCLUDE early-terminating filters
+ * (`head`, `grep -m/-q/-l`, `sed …q`): there `tee` would only see a
+ * partial stream, and those filters exist precisely to stop a slow
+ * producer early — preserving the agent's intent is the safe choice.
+ */
+fn __cc_consume_all_filters() {
+  return [
+    "tail",
+    "wc",
+    "sort",
+    "uniq",
+    "cat",
+    "nl",
+    "tac",
+    "rev",
+    "column",
+    "fold",
+    "fmt",
+    "cut",
+    "tr",
+    "grep",
+    "egrep",
+    "fgrep",
+    "md5sum",
+    "sha1sum",
+    "sha256sum",
+    "shasum",
+    "base64",
+    "od",
+    "hexdump",
+    "xxd",
+  ]
+}
+
+fn __cc_list_has(items, needle) {
+  for item in items {
+    if item == needle {
+      return true
+    }
+  }
+  return false
+}
+
+fn __cc_basename(word) {
+  let slash = word.last_index_of("/")
+  if slash < 0 {
+    return word
+  }
+  return word.substring(slash + 1, word.len())
+}
+
+fn __cc_first_token(segment) {
+  for raw in segment.split(" ") {
+    let token = raw.trim()
+    if token != "" {
+      return token
+    }
+  }
+  return ""
+}
+
+/**
+ * grep / egrep / fgrep short-circuit (and SIGPIPE the producer) with any
+ * of these flags. We over-match on purpose: a false bail is harmless, a
+ * missed short-circuit would make the "full output" hint a lie.
+ */
+fn __cc_grep_short_circuits(segment) {
+  for raw in segment.split(" ") {
+    let token = raw.trim()
+    if token != "" {
+      if token == "--max-count"
+        || token.starts_with("--max-count=")
+        || token == "--quiet"
+        || token == "--silent"
+        || token == "--files-with-matches"
+        || token == "--files-without-match" {
+        return true
+      }
+      if token.starts_with("-") && !token.starts_with("--") && token.len() > 1 {
+        let cluster = token.substring(1, token.len())
+        if cluster.contains("q") || cluster.contains("m") || cluster.contains("l")
+          || cluster.contains("L") {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+fn __cc_filter_allowed(filter) {
+  let word = __cc_first_token(filter)
+  if word == "" {
+    return false
+  }
+  // A leading `VAR=val` assignment or env prefix is unusual in this slot;
+  // refuse rather than guess.
+  if word.contains("=") {
+    return false
+  }
+  let name = __cc_basename(word).lowercase()
+  if !__cc_list_has(__cc_consume_all_filters(), name) {
+    return false
+  }
+  if name == "grep" || name == "egrep" || name == "fgrep" {
+    if __cc_grep_short_circuits(filter) {
+      return false
+    }
+  }
+  return true
+}
+
+// -------------------------------------------------------------------------------------------------
+// Conservative top-level scanner
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Blunt pre-check: bail outright if the command contains any construct we
+ * refuse to reason about. Over-bails when these appear inside single
+ * quotes (where they would be literal) — which is safe.
+ */
+fn __cc_hazardous(command) {
+  return command.contains("$(")
+    || command.contains("`")
+    || command.contains("<(")
+    || command.contains(">(")
+    || command.contains("<<")
+    || command.contains("\n")
+    || command.contains("\r")
+    || command.contains("|&")
+    || command.contains("&>")
+    || command.contains(" tee ")
+    || command.contains("| tee")
+}
+
+/**
+ * Walk the command tracking single/double quote and backslash-escape state,
+ * recording top-level statement separators (`;`, `&&`, `||`) and pipes
+ * (`|`). Returns nil to bail on a subshell group `(`, a background `&`, a
+ * `|&` pipe, or unbalanced quotes.
+ */
+fn __cc_scan_cuts(command) {
+  let n = command.len()
+  var i = 0
+  var squote = false
+  var dquote = false
+  var cuts = []
+  while i < n {
+    let ch = command.char_at(i)
+    if squote {
+      if ch == "'" {
+        squote = false
+      }
+      i = i + 1
+    } else if dquote {
+      if ch == "\\" {
+        // Skip the escaped character (correct for locating the close quote).
+        i = i + 2
+      } else if ch == "\"" {
+        dquote = false
+        i = i + 1
+      } else {
+        i = i + 1
+      }
+    } else if ch == "\\" {
+      i = i + 2
+    } else if ch == "'" {
+      squote = true
+      i = i + 1
+    } else if ch == "\"" {
+      dquote = true
+      i = i + 1
+    } else if ch == "(" {
+      return nil
+    } else if ch == ";" {
+      cuts = cuts.push({pos: i, len: 1, kind: "stmt"})
+      i = i + 1
+    } else if ch == "&" {
+      if command.char_at(i + 1) == "&" {
+        cuts = cuts.push({pos: i, len: 2, kind: "stmt"})
+        i = i + 2
+      } else if i > 0 && (command.char_at(i - 1) == ">" || command.char_at(i - 1) == "<") {
+        // fd-duplication redirection (e.g. `2>&1`, `>&2`), not a
+        // background job — leave it verbatim inside the segment.
+        i = i + 1
+      } else {
+        return nil
+      }
+    } else if ch == "|" {
+      let next = command.char_at(i + 1)
+      if next == "|" {
+        cuts = cuts.push({pos: i, len: 2, kind: "stmt"})
+        i = i + 2
+      } else if next == "&" {
+        return nil
+      } else {
+        cuts = cuts.push({pos: i, len: 1, kind: "pipe"})
+        i = i + 1
+      }
+    } else {
+      i = i + 1
+    }
+  }
+  if squote || dquote {
+    return nil
+  }
+  return cuts
+}
+
+/**
+ * Recognize a rewritable `producer | consume-all-filter` pipeline.
+ *
+ * Returns `{prefix, producer, filter}` where `prefix` is the verbatim
+ * leading text up to and including the last top-level statement separator
+ * (so `cd foo && cmd | tail` keeps `cd foo && `), or nil when the command
+ * is not a safe rewrite target.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: command_capture_detect("seq 100 | tail -3")
+ */
+pub fn command_capture_detect(command) {
+  if command == nil {
+    return nil
+  }
+  if command.trim() == "" {
+    return nil
+  }
+  if __cc_hazardous(command) {
+    return nil
+  }
+  let cuts = __cc_scan_cuts(command)
+  if cuts == nil {
+    return nil
+  }
+  // Start of the last top-level statement.
+  var start = 0
+  for cut in cuts {
+    if cut.kind == "stmt" {
+      start = cut.pos + cut.len
+    }
+  }
+  // Last top-level pipe within that statement.
+  var pipe_pos = -1
+  for cut in cuts {
+    if cut.kind == "pipe" && cut.pos >= start {
+      pipe_pos = cut.pos
+    }
+  }
+  if pipe_pos < 0 {
+    return nil
+  }
+  let n = command.len()
+  let prefix = command.substring(0, start)
+  let producer = command.substring(start, pipe_pos).trim()
+  let filter = command.substring(pipe_pos + 1, n).trim()
+  if producer == "" || filter == "" {
+    return nil
+  }
+  if !__cc_filter_allowed(filter) {
+    return nil
+  }
+  return {prefix: prefix, producer: producer, filter: filter}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Rewrite + plan
+// -------------------------------------------------------------------------------------------------
+
+/** Single-quote a path for POSIX sh, escaping embedded single quotes. */
+fn __cc_shquote(value) {
+  return "'" + value.replace("'", "'\\''") + "'"
+}
+
+/**
+ * Build a capture plan for a raw shell command and a chosen capture path.
+ *
+ * Returns `{rewritten, producer, filter, capture_path}` (the `rewritten`
+ * command inserts `| tee '<capture_path>' 2>/dev/null |` before the final
+ * filter) or nil when the command is not a safe rewrite target.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: command_capture_plan("seq 100 | tail -3", "/tmp/out")
+ */
+pub fn command_capture_plan(command, capture_path) {
+  let detected = command_capture_detect(command)
+  if detected == nil {
+    return nil
+  }
+  let head = if detected.prefix.trim() == "" {
+    ""
+  } else {
+    detected.prefix.trim_end() + " "
+  }
+  let rewritten = head + detected.producer + " | tee " + __cc_shquote(capture_path)
+    + " 2>/dev/null | "
+    + detected.filter
+  return {
+    rewritten: rewritten,
+    producer: detected.producer,
+    filter: detected.filter,
+    capture_path: capture_path,
+  }
+}
+
+/**
+ * Convenience wrapper returning just the rewritten command string (or nil).
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: command_capture_rewrite("ls | wc -l", "/tmp/out")
+ */
+pub fn command_capture_rewrite(command, capture_path) {
+  return command_capture_plan(command, capture_path)?.rewritten
+}
+
+fn __cc_new_capture_path() {
+  return path_join(harness.fs.temp_dir(), "harn-capture-" + uuid() + ".out")
+}
+
+fn __cc_posix_shell(word) {
+  let name = __cc_basename(word).lowercase()
+  return name == "sh" || name == "bash" || name == "zsh" || name == "dash" || name == "ksh"
+}
+
+/**
+ * Plan a capture rewrite for a `run_command` request dict.
+ *
+ * Handles `{mode: "shell", command}` (POSIX hosts only) and
+ * `{mode: "argv", argv: [sh|bash|…, "-c", cmd, …]}`. Returns
+ * `{run_request, plan}` with the producer's full output redirected to a
+ * fresh temp file, or nil when no safe rewrite applies.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: command_capture_plan_request({mode: "shell", command: "ls | wc -l"})
+ */
+pub fn command_capture_plan_request(request) {
+  if request == nil {
+    return nil
+  }
+  let mode = request?.mode
+  if mode == "argv" {
+    let argv = request?.argv ?? []
+    if len(argv) >= 3 && argv[1] == "-c" && __cc_posix_shell(argv[0]) {
+      let capture_path = __cc_new_capture_path()
+      let plan = command_capture_plan(argv[2], capture_path)
+      if plan == nil {
+        return nil
+      }
+      var new_argv = []
+      var i = 0
+      while i < len(argv) {
+        if i == 2 {
+          new_argv = new_argv.push(plan.rewritten)
+        } else {
+          new_argv = new_argv.push(argv[i])
+        }
+        i = i + 1
+      }
+      return {run_request: request + {argv: new_argv}, plan: plan}
+    }
+    return nil
+  }
+  if mode == "shell" {
+    if platform() == "windows" {
+      return nil
+    }
+    let capture_path = __cc_new_capture_path()
+    let plan = command_capture_plan(request?.command ?? "", capture_path)
+    if plan == nil {
+      return nil
+    }
+    return {run_request: request + {command: plan.rewritten}, plan: plan}
+  }
+  return nil
+}
+
+/**
+ * Attach an `output_capture` hint to a command result, pointing the agent
+ * at the captured full output — but only when the capture file actually
+ * materialized (so a blocked temp write produces no misleading hint).
+ *
+ * @effects: [fs]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: command_capture_annotate(result, plan)
+ */
+pub fn command_capture_annotate(result, plan) {
+  if result == nil || plan == nil {
+    return result
+  }
+  let path = plan?.capture_path
+  if path == nil {
+    return result
+  }
+  if !harness.fs.exists(path) {
+    return result
+  }
+  let hint = "Filtered output is shown above. The full, unfiltered output of `"
+    + plan.producer
+    + "` was captured to "
+    + path
+    + " — read it (read_command_output {path: \""
+    + path
+    + "\"} or read_file) instead of re-running the command."
+  return result
+    + {output_capture: {full_output_path: path, producer: plan.producer, filter: plan.filter, hint: hint}}
+}

--- a/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
@@ -1,3 +1,5 @@
+import { command_capture_annotate, command_capture_plan_request } from "std/agent/command_capture"
+
 fn __agent_host_options(options) {
   return options ?? {}
 }
@@ -741,7 +743,19 @@ pub fn agent_command_tools(registry = nil, options = nil) {
             if req?.blocked ?? false {
               return __agent_host_render(req, opts, key)
             }
-            return __agent_host_render(hostlib_tools_run_command(req), opts, key)
+            let planned = if opts?.preserve_filtered_output ?? true {
+              command_capture_plan_request(req)
+            } else {
+              nil
+            }
+            let run_req = planned?.run_request ?? req
+            let result = hostlib_tools_run_command(run_req)
+            let final_result = if planned != nil {
+              command_capture_annotate(result, planned.plan)
+            } else {
+              result
+            }
+            return __agent_host_render(final_result, opts, key)
           },
         },
       ),

--- a/docs/src/llm/tools.md
+++ b/docs/src/llm/tools.md
@@ -211,6 +211,21 @@ want BM25, hybrid ranking, embeddings, or an LLM reranker for deferred tools.
 - `read_command_output_tail` — read the last bytes of command output without
   requiring the model to calculate offsets
 
+When `run_command` runs a `producer | tail/wc/grep/sort/…` shell pipeline (a
+shell-mode command, or `argv: ["sh", "-c", …]`), the trailing consume-all
+filter is applied by the shell *before* Harn captures any output, so the
+producer's full output would normally be lost — recovering it means re-running
+a potentially slow command. The command runner detects this shape and
+transparently rewrites it to `producer | tee '<capture>' 2>/dev/null | filter`:
+the model still sees exactly the filtered output it asked for, while the
+producer's complete output is preserved to a temp file. A post-run
+`output_capture` field then points the model at that file (read it with
+`read_command_output`/`read_file` instead of re-running). The rewrite is
+deliberately conservative — it leaves early-terminating filters (`head`,
+`grep -q`/`-m`) and anything it cannot parse safely (command substitution,
+subshells, backgrounded jobs, …) untouched — and is on by default; set
+`preserve_filtered_output: false` to disable it.
+
 `agent_read_tools(...)` installs root-scoped `read_file`, `read_file_tail`,
 `list_directory`, `get_file_outline`, `search_files`, and read-only
 `git_inspect`. `agent_host_tools(...)` composes both groups.
@@ -281,6 +296,7 @@ Useful options:
 | `search_max_matches` / `max_search_matches` | Default `search_files.max_matches` when the model omits one; callers can still request a different cap per call. |
 | `exclude_globs` / `search_exclude_globs` | Baseline exclusions for `search_files` using root-relative globs. Tool-call `exclude_globs` are merged with these defaults, not substituted for them. |
 | `allow_argv_prefixes` | Deny `run_command` calls unless `argv` starts with a listed string or list prefix. |
+| `preserve_filtered_output` | Default `true`. For a `producer \| tail/wc/grep/…` pipeline, tee the producer's full output to a temp file so the model can read it via `output_capture` instead of re-running a slow command. Conservative (skips `head`, `grep -q`/`-m`, command substitution, subshells, …). Set `false` to disable. |
 | `command_policy` / `allow_command` | Closure hook for custom command approval, denial, or rewrite. |
 | `annotations` | Merge extra annotations into generated tool definitions. |
 | `tool_config` | Advanced raw `tool_define(...)` config overrides per logical tool or `"*"`. |


### PR DESCRIPTION
## Problem

Agents constantly pipe a slow command into a cheap trailing filter — `cargo build 2>&1 | tail -50`, `find . | wc -l`, `git log | grep fix`. The **shell** applies the filter before Harn's command runner sees any bytes, so only the surviving lines are captured. The producer's full output is gone, and recovering it means **re-running the slow command** — exactly the loop our prompting tries (and often fails) to prevent.

## Approach

A new pure-Harn stdlib module, `std/agent/command_capture`, recognizes the `producer | consume-all-filter` shape and rewrites it to:

```
producer | tee '<capture>' 2>/dev/null | filter
```

`tee` is transparent — the filter sees identical bytes and the exit status is unchanged — so the agent still gets **exactly the filtered output it asked for**, while the producer's **complete** output is preserved to a temp file. After the run, an `output_capture` field is attached to the result pointing the agent at the full output (read it via `read_command_output {path}` / `read_file` instead of re-running).

Wired into the stdlib `run_command` tool handler (`agent_command_tools`): **on by default**, opt out with `preserve_filtered_output: false`.

## Why it's safe (false-negatives over false-positives)

- **Never breaks a command.** `2>/dev/null` + the POSIX guarantee that `tee` keeps copying to stdout even when a file operand can't be opened, plus a post-run `file_exists` check before emitting the hint, mean a sandbox that blocks the temp write produces neither a broken command nor a misleading hint.
- **Conservative recognizer.** A small, auditable, quote-aware top-level scanner. It rewrites only a clean single pipeline (optionally behind a verbatim `cd … && ` / `… ; ` prefix, with inline `2>&1`/`2>/dev/null` riding along) and **bails** on anything it can't reason about: command/process substitution, here-docs, subshell grouping, background jobs, `|&`, unbalanced quotes.
- **Leaves early-terminating filters alone.** `head`, `grep -q`/`-m`/`-l` intentionally stop a slow producer early; capturing them would be a partial lie, so they're left untouched. Filter set is an allowlist of consume-all tools (`tail`, `wc`, `sort`, `uniq`, `grep`, `cut`, `tr`, `cat`, …).
- **Cross-platform.** Shell-mode rewrites are POSIX-only (skipped on Windows); explicit `argv: ["sh", "-c", …]` is rewritten regardless.

I evaluated trusted Rust shell parsers (`conch-parser`, `yash-syntax`, `flash`) but a full POSIX AST is the wrong tool here: it would add a heavy dependency, split the logic across Rust+Harn, and *widen* the surface for a confidently-wrong rewrite. A narrow recognizer that bails on the unusual is both safer and keeps the deterministic logic in one auditable Harn file.

## Verification

- `conformance/tests/agents/command_capture_rewrite.harn` — detector cases (rewrites: plain `| tail`, `cd && … 2>&1 | tail`, multi-stage, quoted pipe, `;` prefix; bails: `head`, `grep -q`, `$(…)`, subshell, background, non-allowlisted filter) **plus a real end-to-end run** asserting the agent sees only the 3 filtered lines while the capture file holds all 100 producer lines.
- `harn demo command-capture` — offline showcase (no LLM, no subprocess).
- Existing `agent_host_tools` / `command_runner_v2` conformance tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)