### PR TITLE
harn serve site: diagnose malformed @route / @scopes args; fix serve-site arg shim (#2623)

### DIFF
--- a/changelog.d/2623.fixed.md
+++ b/changelog.d/2623.fixed.md
@@ -1,0 +1,12 @@
+`harn serve site` now diagnoses malformed `@route(...)` / `@scopes(...)`
+attributes instead of silently dropping them. A `@route` with a
+non-string argument, zero arguments, or more than a method and a path
+emits a `HARN-SRV-001` / `HARN-SRV-002` warning at startup and leaves the
+handler unmounted (rather than mis-routing it, e.g. collapsing
+`@route("GET", some_var)` to `/GET`); a non-string `@scopes` argument
+emits `HARN-SRV-003` and is dropped, flagging the unintended loosening of
+the route's scope requirement. The same parsing bug also meant
+`harn serve site <file>` itself never reached the site server — the
+legacy `serve`→`a2a` argument shim didn't recognize the `site`
+subcommand and rewrote it; the shim now derives the transport list from
+the command tree so new transports are handled automatically. (#2623)

--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -113,6 +113,7 @@ pub(crate) async fn run_a2a_server(args: &A2aServeArgs) -> Result<(), String> {
     let mut config = DispatchCoreConfig::for_script(&args.file);
     config.auth_policy = auth_policy;
     let core = DispatchCore::new(config).map_err(|error| error.to_string())?;
+    harn_serve::emit_export_diagnostics(core.catalog().diagnostics());
     let mut server_config = A2aServerConfig::new(core);
     server_config.card_signing_secret = args.card_signing_secret.clone();
     let server = Arc::new(A2aServer::new(server_config));
@@ -160,6 +161,7 @@ pub(crate) async fn run_site_server(args: &SiteServeArgs) -> Result<(), String> 
     // effects — so swap the default replay cache for the no-op one.
     config.replay_cache = Arc::new(harn_serve::NoReplayCache);
     let core = DispatchCore::new(config).map_err(|error| error.to_string())?;
+    harn_serve::emit_export_diagnostics(core.catalog().diagnostics());
     SiteServer::new(SiteServerConfig::new(core))
         .run_http(SiteHttpServeOptions {
             bind: args.bind,
@@ -186,6 +188,7 @@ pub(crate) async fn run_mcp_server(args: &ServeMcpArgs) -> Result<(), String> {
     // route incoming MCP calls to `pub fn` exports.
     let catalog = ExportCatalog::from_path(Path::new(&args.file))
         .map_err(|error| format!("failed to load script: {error}"))?;
+    harn_serve::emit_export_diagnostics(catalog.diagnostics());
     let has_pub_fn_exports = catalog
         .functions
         .values()

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1585,17 +1585,39 @@ fn print_completions(shell: CompletionShell) {
     clap_complete::generate(shell, &mut command, "harn", &mut std::io::stdout());
 }
 
+/// Back-compat shim for the legacy `harn serve [flags] agent.harn` shape,
+/// which predates the explicit transport subcommands and defaulted to
+/// A2A. When the token after `serve` is not a known transport subcommand
+/// (nor a help flag), assume the legacy shape and inject `a2a`.
+///
+/// The set of transports is read from the clap command tree rather than
+/// hard-coded, so a newly added transport (e.g. `site`) is recognized
+/// automatically instead of being silently rewritten to `a2a`.
 fn normalize_serve_args(mut raw_args: Vec<String>) -> Vec<String> {
-    if raw_args.len() > 2
-        && raw_args.get(1).is_some_and(|arg| arg == "serve")
-        && !matches!(
-            raw_args.get(2).map(String::as_str),
-            Some("acp" | "a2a" | "api" | "mcp" | "-h" | "--help")
-        )
-    {
-        raw_args.insert(2, "a2a".to_string());
+    if raw_args.len() > 2 && raw_args.get(1).is_some_and(|arg| arg == "serve") {
+        let token = raw_args.get(2).map(String::as_str).unwrap_or_default();
+        let is_explicit = token == "-h"
+            || token == "--help"
+            || serve_subcommand_names().iter().any(|name| name == token);
+        if !is_explicit {
+            raw_args.insert(2, "a2a".to_string());
+        }
     }
     raw_args
+}
+
+/// Names of the transport subcommands clap knows under `harn serve`.
+fn serve_subcommand_names() -> Vec<String> {
+    use clap::CommandFactory;
+    Cli::command()
+        .find_subcommand("serve")
+        .map(|serve| {
+            serve
+                .get_subcommands()
+                .map(|sub| sub.get_name().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn print_version() {
@@ -3092,7 +3114,7 @@ fn connector_secret_namespace(base_dir: &Path) -> String {
 #[cfg(test)]
 mod main_tests {
     use super::{
-        is_broken_pipe_panic_payload, normalize_serve_args,
+        is_broken_pipe_panic_payload, normalize_serve_args, serve_subcommand_names,
         should_install_default_connector_clients,
     };
     use std::path::Path;
@@ -3121,21 +3143,39 @@ mod main_tests {
 
     #[test]
     fn normalize_serve_args_preserves_explicit_subcommands() {
+        // Every transport clap knows must pass through untouched — a new
+        // transport that the shim failed to recognize would be rewritten
+        // to `a2a` and mis-parsed (the `site` regression that motivated
+        // deriving the list from clap rather than hard-coding it).
+        for transport in serve_subcommand_names() {
+            let args = normalize_serve_args(vec![
+                "harn".to_string(),
+                "serve".to_string(),
+                transport.clone(),
+                "server.harn".to_string(),
+            ]);
+            assert_eq!(
+                args,
+                vec![
+                    "harn".to_string(),
+                    "serve".to_string(),
+                    transport.clone(),
+                    "server.harn".to_string(),
+                ],
+                "transport `{transport}` should not be rewritten",
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_serve_args_recognizes_site_subcommand() {
         let args = normalize_serve_args(vec![
             "harn".to_string(),
             "serve".to_string(),
-            "acp".to_string(),
+            "site".to_string(),
             "server.harn".to_string(),
         ]);
-        assert_eq!(
-            args,
-            vec![
-                "harn".to_string(),
-                "serve".to_string(),
-                "acp".to_string(),
-                "server.harn".to_string(),
-            ]
-        );
+        assert_eq!(args.get(2).map(String::as_str), Some("site"));
     }
 
     #[test]

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -64,10 +64,62 @@ pub struct RouteSpec {
     pub path: String,
 }
 
+/// A `HARN-SRV-*` diagnostic raised while building the export catalog.
+///
+/// These flag the malformed `@route(...)` / `@scopes(...)` attribute
+/// forms that the collector would otherwise drop silently — leaving a
+/// handler mis-routed, unmounted, or less scope-restricted than the
+/// author intended. They are surfaced by the serve adapters at startup
+/// (see [`emit_export_diagnostics`]) rather than aborting catalog
+/// construction, so one bad attribute doesn't take down a script whose
+/// other handlers are fine.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExportDiagnostic {
+    /// Stable code so log scanners and editors can key on the condition.
+    pub code: &'static str,
+    /// 1-based source line of the offending attribute (0 when unknown).
+    pub line: usize,
+    pub message: String,
+}
+
+/// `@route` carries an argument that is not a string literal, so the
+/// method/path positions are ambiguous and the handler is not mounted.
+pub const ROUTE_ARG_NOT_STRING: &str = "HARN-SRV-001";
+/// `@route` has the wrong number of arguments — it takes a path, or a
+/// method and a path. The handler is not mounted.
+pub const ROUTE_BAD_ARITY: &str = "HARN-SRV-002";
+/// `@scopes` carries an argument that is not a string literal; that
+/// scope requirement is dropped, leaving the route less restricted.
+pub const SCOPES_ARG_NOT_STRING: &str = "HARN-SRV-003";
+
+impl std::fmt::Display for ExportDiagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.line > 0 {
+            write!(f, "{}: {} (line {})", self.code, self.message, self.line)
+        } else {
+            write!(f, "{}: {}", self.code, self.message)
+        }
+    }
+}
+
+/// Print catalog diagnostics to stderr at server startup, matching the
+/// `[harn] …` banner the adapters already emit. Standalone serve
+/// commands call this so authors see malformed attributes immediately;
+/// embedders that build a router directly can read
+/// [`ExportCatalog::diagnostics`] and render them in their own UI.
+pub fn emit_export_diagnostics(diagnostics: &[ExportDiagnostic]) {
+    for diagnostic in diagnostics {
+        eprintln!("[harn] warning: {diagnostic}");
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ExportCatalog {
     pub script_path: PathBuf,
     pub functions: BTreeMap<String, ExportedFunction>,
+    /// Non-fatal `HARN-SRV-*` diagnostics gathered while collecting the
+    /// route/scope attributes. Empty for a well-formed script.
+    pub diagnostics: Vec<ExportDiagnostic>,
 }
 
 impl ExportCatalog {
@@ -80,6 +132,7 @@ impl ExportCatalog {
         })?;
 
         let mut functions = BTreeMap::new();
+        let mut diagnostics = Vec::new();
         for node in &program {
             let (attrs, inner) = harn_parser::peel_attributes(node);
             let Node::FnDecl {
@@ -108,10 +161,10 @@ impl ExportCatalog {
                     output_schema: return_type
                         .as_ref()
                         .and_then(harn_vm::json_schema_for_type_expr),
-                    required_scopes: scopes_from_attributes(attrs),
+                    required_scopes: scopes_from_attributes(attrs, name, &mut diagnostics),
                     limits,
                     budget,
-                    route: route_from_attributes(attrs, name),
+                    route: route_from_attributes(attrs, name, &mut diagnostics),
                 },
             );
         }
@@ -132,7 +185,7 @@ impl ExportCatalog {
             if has_public_exports && !*is_pub {
                 continue;
             }
-            let required_scopes = scopes_from_attributes(attrs);
+            let required_scopes = scopes_from_attributes(attrs, name, &mut diagnostics);
             let (limits, budget) = limits_and_budget_from_attributes(attrs);
             functions
                 .entry(name.clone())
@@ -158,11 +211,18 @@ impl ExportCatalog {
         Ok(Self {
             script_path: path.to_path_buf(),
             functions,
+            diagnostics,
         })
     }
 
     pub fn function(&self, name: &str) -> Option<&ExportedFunction> {
         self.functions.get(name)
+    }
+
+    /// Non-fatal `HARN-SRV-*` diagnostics gathered while collecting the
+    /// route/scope attributes. Empty for a well-formed script.
+    pub fn diagnostics(&self) -> &[ExportDiagnostic] {
+        &self.diagnostics
     }
 }
 
@@ -202,7 +262,11 @@ fn pipeline_exported_params(params: &[String]) -> Vec<ExportedParam> {
 /// in callers that prefer key-value form); only string literals
 /// contribute. Multiple `@scopes` attributes on the same declaration
 /// union into one set.
-fn scopes_from_attributes(attrs: &[Attribute]) -> BTreeSet<String> {
+fn scopes_from_attributes(
+    attrs: &[Attribute],
+    fn_name: &str,
+    diagnostics: &mut Vec<ExportDiagnostic>,
+) -> BTreeSet<String> {
     let mut set = BTreeSet::new();
     for attr in attrs {
         if attr.name != "scopes" {
@@ -213,7 +277,17 @@ fn scopes_from_attributes(attrs: &[Attribute]) -> BTreeSet<String> {
                 Node::StringLiteral(value) | Node::RawStringLiteral(value) => {
                     set.insert(value.clone());
                 }
-                _ => {}
+                // A non-string scope is silently dropped by the
+                // collector, which would leave the route *less*
+                // restricted than the author wrote — worth a loud warning.
+                _ => diagnostics.push(ExportDiagnostic {
+                    code: SCOPES_ARG_NOT_STRING,
+                    line: arg.span.line,
+                    message: format!(
+                        "`@scopes` on `{fn_name}` requires string-literal arguments; \
+                         dropping a non-string scope leaves the route less restricted"
+                    ),
+                }),
             }
         }
     }
@@ -235,26 +309,58 @@ fn scopes_from_attributes(attrs: &[Attribute]) -> BTreeSet<String> {
 ///    calls for ("mounts every exported `pub fn handler_*` at `/<name>`")
 ///    while letting authors opt into precise routing with the attribute.
 ///
+/// A present-but-malformed `@route` does not fall back to the naming
+/// convention: it records a `HARN-SRV-*` diagnostic and returns `None`,
+/// so the author sees the mistake instead of a silently different route.
+///
 /// Returns `None` for any other `pub fn`, so a script can export helper
 /// functions (reachable via the API/A2A/MCP dispatch adapters) without
 /// every one of them grabbing an HTTP path.
-fn route_from_attributes(attrs: &[Attribute], fn_name: &str) -> Option<RouteSpec> {
-    if let Some(route) = explicit_route_attribute(attrs) {
-        return Some(route);
+fn route_from_attributes(
+    attrs: &[Attribute],
+    fn_name: &str,
+    diagnostics: &mut Vec<ExportDiagnostic>,
+) -> Option<RouteSpec> {
+    // An explicit (even if malformed) `@route` overrides the naming
+    // convention: an author who wrote one expects that path, not a
+    // surprise fallback to `/<name>`. A malformed one yields `None` plus
+    // a diagnostic, leaving the handler unmounted until they fix it.
+    if attrs.iter().any(|attr| attr.name == "route") {
+        return explicit_route_attribute(attrs, fn_name, diagnostics);
     }
     handler_convention_route(fn_name)
 }
 
-fn explicit_route_attribute(attrs: &[Attribute]) -> Option<RouteSpec> {
+fn explicit_route_attribute(
+    attrs: &[Attribute],
+    fn_name: &str,
+    diagnostics: &mut Vec<ExportDiagnostic>,
+) -> Option<RouteSpec> {
     let attr = attrs.iter().find(|attr| attr.name == "route")?;
-    let literals: Vec<String> = attr
+    let literals: Vec<&str> = attr
         .args
         .iter()
         .filter_map(|arg| match &arg.value.node {
-            Node::StringLiteral(value) | Node::RawStringLiteral(value) => Some(value.clone()),
+            Node::StringLiteral(value) | Node::RawStringLiteral(value) => Some(value.as_str()),
             _ => None,
         })
         .collect();
+
+    // Any non-string argument makes the method/path positions ambiguous
+    // (e.g. `@route("GET", some_var)` would otherwise collapse to the
+    // single-arg form and mis-mount at `/GET`), so refuse to guess.
+    if literals.len() != attr.args.len() {
+        diagnostics.push(ExportDiagnostic {
+            code: ROUTE_ARG_NOT_STRING,
+            line: attr.span.line,
+            message: format!(
+                "`@route` on `{fn_name}` requires string-literal arguments \
+                 (`@route(\"/path\")` or `@route(\"METHOD\", \"/path\")`); handler not mounted"
+            ),
+        });
+        return None;
+    }
+
     match literals.as_slice() {
         // `@route("/path")` — method defaults to GET.
         [path] => Some(RouteSpec {
@@ -262,11 +368,25 @@ fn explicit_route_attribute(attrs: &[Attribute]) -> Option<RouteSpec> {
             path: normalize_route_path(path),
         }),
         // `@route("METHOD", "/path")` — explicit method.
-        [method, path, ..] => Some(RouteSpec {
+        [method, path] => Some(RouteSpec {
             method: normalize_route_method(method),
             path: normalize_route_path(path),
         }),
-        [] => None,
+        // Zero args (`@route()`) or three-plus: the method/path pair is
+        // under- or over-specified, so the route is undefined.
+        _ => {
+            diagnostics.push(ExportDiagnostic {
+                code: ROUTE_BAD_ARITY,
+                line: attr.span.line,
+                message: format!(
+                    "`@route` on `{fn_name}` takes a path or a method and a path \
+                     (`@route(\"/path\")` or `@route(\"METHOD\", \"/path\")`), \
+                     found {} arguments; handler not mounted",
+                    literals.len()
+                ),
+            });
+            None
+        }
     }
 }
 
@@ -528,5 +648,108 @@ pipeline default(task) {
         let default = catalog.function("default").expect("default pipeline");
         assert_eq!(default.kind, ExportedCallableKind::Pipeline);
         assert_eq!(default.params[0].name, "task");
+    }
+
+    /// Build a catalog from inline source, asserting it parses cleanly.
+    fn catalog_from_source(source: &str) -> ExportCatalog {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("server.harn");
+        std::fs::write(&path, source).expect("write script");
+        ExportCatalog::from_path(&path).expect("catalog")
+    }
+
+    #[test]
+    fn well_formed_attributes_emit_no_diagnostics() {
+        let catalog = catalog_from_source(
+            r#"
+@scopes("personas:read")
+@route("POST", "/users/{id}")
+pub fn update_user(req: dict) -> dict { return req }
+
+@route("/health")
+pub fn liveness(req: dict) -> dict { return req }
+"#,
+        );
+        assert!(
+            catalog.diagnostics().is_empty(),
+            "unexpected diagnostics: {:?}",
+            catalog.diagnostics()
+        );
+    }
+
+    #[test]
+    fn route_with_non_string_arg_is_diagnosed_and_unmounted() {
+        // The second arg is an identifier, not a string literal. Left
+        // unchecked the collector would treat this as `@route("GET")` and
+        // mis-mount the handler at `/GET`.
+        let catalog = catalog_from_source(
+            r#"
+pub fn make_path(req: dict) -> string { return "/x" }
+
+@route("GET", make_path)
+pub fn handler_users(req: dict) -> dict { return req }
+"#,
+        );
+        let handler = catalog.function("handler_users").expect("handler_users");
+        assert_eq!(
+            handler.route, None,
+            "a malformed @route must not fall back to the handler_ convention route"
+        );
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![ROUTE_ARG_NOT_STRING]);
+    }
+
+    #[test]
+    fn route_with_zero_args_is_diagnosed_and_unmounted() {
+        let catalog = catalog_from_source(
+            r"
+@route()
+pub fn handler_status(req: dict) -> dict { return req }
+",
+        );
+        let handler = catalog.function("handler_status").expect("handler_status");
+        assert_eq!(handler.route, None);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![ROUTE_BAD_ARITY]);
+    }
+
+    #[test]
+    fn route_with_too_many_args_is_diagnosed_and_unmounted() {
+        let catalog = catalog_from_source(
+            r#"
+@route("GET", "/x", "/y")
+pub fn handler_overspecified(req: dict) -> dict { return req }
+"#,
+        );
+        let handler = catalog
+            .function("handler_overspecified")
+            .expect("handler_overspecified");
+        assert_eq!(handler.route, None);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![ROUTE_BAD_ARITY]);
+    }
+
+    #[test]
+    fn scopes_with_non_string_arg_is_diagnosed_but_keeps_valid_scopes() {
+        let catalog = catalog_from_source(
+            r#"
+pub fn make_scope(req: dict) -> string { return "sessions:write" }
+
+@scopes("personas:read", make_scope)
+pub fn list_sessions() -> string { return "ok" }
+"#,
+        );
+        let list = catalog.function("list_sessions").expect("list_sessions");
+        // The valid literal is still enforced; only the bad arg is dropped.
+        assert_eq!(
+            list.required_scopes,
+            BTreeSet::from(["personas:read".to_string()])
+        );
+        let diagnostic = catalog
+            .diagnostics()
+            .iter()
+            .find(|d| d.code == SCOPES_ARG_NOT_STRING)
+            .expect("scopes diagnostic");
+        assert!(diagnostic.message.contains("list_sessions"));
     }
 }

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -51,7 +51,8 @@ pub use core::{
 };
 pub use error::{forbidden_data_payload, forbidden_message, DispatchError};
 pub use exports::{
-    ExportCatalog, ExportedCallableKind, ExportedFunction, ExportedParam, RouteSpec,
+    emit_export_diagnostics, ExportCatalog, ExportDiagnostic, ExportedCallableKind,
+    ExportedFunction, ExportedParam, RouteSpec,
 };
 pub use http_codec::{
     axum_response_from_call, axum_response_from_dispatch_error, classify_ws_upgrade,

--- a/crates/harn-serve/tests/site_hosting.rs
+++ b/crates/harn-serve/tests/site_hosting.rs
@@ -160,6 +160,59 @@ async fn handler_naming_convention_mounts_route() {
 }
 
 #[tokio::test]
+async fn malformed_route_is_diagnosed_and_unmounted_without_breaking_siblings() {
+    // A script where one handler's `@route` is malformed (a non-string
+    // method position) and a sibling is well-formed. The startup catalog
+    // must carry a `HARN-SRV-*` diagnostic and leave the bad handler
+    // unmounted (404), while the good handler still serves (200).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(
+        &path,
+        r#"
+pub fn bad_method(req: dict) -> string { return "GET" }
+
+@route(bad_method, "/broken")
+pub fn handler_broken(req: dict) -> dict { return http_ok({}) }
+
+@route("GET", "/fine")
+pub fn handler_fine(req: dict) -> dict { return http_ok({ "ok": true }) }
+"#,
+    )
+    .expect("write script");
+
+    let core = build_core(&path);
+    let diagnostics = core.catalog().diagnostics();
+    assert_eq!(diagnostics.len(), 1, "got {diagnostics:?}");
+    assert_eq!(diagnostics[0].code, "HARN-SRV-001");
+    assert!(diagnostics[0].message.contains("handler_broken"));
+
+    let router = SiteServer::new(SiteServerConfig::new(core))
+        .router()
+        .expect("site router");
+
+    let broken = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/broken")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(broken.status(), StatusCode::NOT_FOUND);
+
+    let fine = router
+        .oneshot(Request::builder().uri("/fine").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let (status, body) = read_json(fine).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+}
+
+#[tokio::test]
 async fn unknown_method_on_known_path_yields_405() {
     let (_dir, router) = site_router();
     // /hello is GET-only; DELETE has no handler.


### PR DESCRIPTION
## What

Closes #2623.

`@route(...)` / `@scopes(...)` attribute args were parsed leniently in `harn-serve`'s export collector and silently dropped on any malformed input — a typo or wrong-typed arg produced a handler that was silently mis-routed or never mounted, with no feedback. This adds `HARN-SRV-*` diagnostics at export-collection time (issue's recommended **option 2** — keeps route semantics in `harn-serve`, no leak into the language layer) and surfaces them at serve startup.

### Diagnostics
- **`HARN-SRV-001`** — a `@route` argument that is not a string literal. The method/path positions become ambiguous (`@route("GET", some_var)` would otherwise collapse to the single-arg form and mis-mount at `/GET`), so the handler is left **unmounted** rather than guessed at.
- **`HARN-SRV-002`** — a `@route` with zero args (`@route()`) or more than a method + path; under-/over-specified, so unmounted.
- **`HARN-SRV-003`** — a non-string `@scopes` argument, dropped with a warning that flags the unintended **loosening** of the route's scope requirement (valid scopes are still enforced).

A present-but-malformed `@route` no longer falls back to the `handler_*` naming convention — an author who wrote one expects that route, not a silently different one. Diagnostics are non-fatal: one bad attribute doesn't take down a script whose other handlers are fine.

`ExportCatalog` gains a `diagnostics: Vec<ExportDiagnostic>` field + accessor; the serve CLI surfaces them at startup via the shared `harn_serve::emit_export_diagnostics` (site / a2a / mcp), and embedders read `ExportCatalog::diagnostics()` to render in their own UI.

### Drive-by fix: `harn serve site <file>` never reached the site server
While writing the startup smoke test I found `harn serve site x.harn` errored with `unexpected argument 'x.harn'` (usage: `harn serve a2a`). The legacy `serve`→`a2a` argument shim (`normalize_serve_args`) had a hard-coded subcommand allowlist that omitted `site` (added in #2574), so it rewrote `serve site x.harn` → `serve a2a site x.harn`. The shim now derives the transport list from the clap command tree, so future transports are recognized automatically and can't regress this way.

## Verification
- Unit tests in `exports.rs`: each malformed form yields the expected code + leaves the handler unmounted; a well-formed script yields zero diagnostics; `@scopes` keeps its valid literals.
- Integration test in `site_hosting.rs`: a script mixing a malformed and a well-formed route carries the diagnostic at startup, 404s the bad path, and still serves the good one (200).
- `normalize_serve_args` tests: every clap-known transport passes through untouched; `site` is recognized.
- Manual `harn serve site` smoke: startup prints `[harn] warning: HARN-SRV-001: …`, `/fine` → 200, `/users` (malformed) → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)