### PR TITLE
harn-vm: fingerprint compiler in bytecode cache key (#2621)

### DIFF
--- a/changelog.d/2621.fixed.md
+++ b/changelog.d/2621.fixed.md
@@ -1,0 +1,4 @@
+Bytecode cache entries are now keyed on a build-time fingerprint of the compiler
+front-end, so a compiler change that alters emitted bytecode for unchanged source
+invalidates stale `.harnbc` artifacts automatically — no version bump or manual
+cache wipe required.

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -150,3 +150,6 @@ harness = false
 
 [lints]
 workspace = true
+
+[build-dependencies]
+sha2 = "0.11"

--- a/crates/harn-vm/build.rs
+++ b/crates/harn-vm/build.rs
@@ -1,0 +1,92 @@
+//! Computes a fingerprint of the compiler front-end at build time so the
+//! bytecode cache key tracks the *compiler's behavior*, not just the released
+//! version.
+//!
+//! `harn run` caches compiled bytecode on disk keyed by source content and the
+//! crate version. Within a single version the compiler still changes constantly
+//! during development, so an entry produced by an older compiler would be
+//! replayed silently — masking the new compiler's output. This is exactly what
+//! hid the #2610 fix until `~/.cache/harn/bytecode` was manually cleared, and
+//! is tracked as #2621.
+//!
+//! We close that gap by hashing the source of every crate that determines the
+//! bytecode emitted for a given program — the lexer, parser, and IR
+//! (source → typed AST) plus this crate's code generator and bytecode/`Chunk`
+//! types — and baking the digest into the binary as `HARN_CODEGEN_FINGERPRINT`.
+//! The `cargo:rerun-if-changed` lines recompute it whenever any of those files
+//! change, so the cache invalidates itself with no manual wipe and no
+//! hand-maintained version constant. Over-inclusion only costs an occasional
+//! recompile; omitting a code-generation input would reintroduce the bug, so
+//! the set is deliberately drawn wide around the front-end.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let crates_dir = manifest_dir.parent().expect("crate dir has a parent");
+
+    // Directory roots whose `.rs` content determines emitted bytecode.
+    let roots = [
+        crates_dir.join("harn-lexer").join("src"),
+        crates_dir.join("harn-parser").join("src"),
+        crates_dir.join("harn-ir").join("src"),
+        manifest_dir.join("src").join("compiler"),
+    ];
+    // Single files outside those roots that still shape the bytecode/`Chunk`
+    // format written to and read from the cache.
+    let single_files = [manifest_dir.join("src").join("chunk.rs")];
+
+    let mut files = Vec::new();
+    for root in &roots {
+        collect_rs_files(root, &mut files);
+    }
+    for file in &single_files {
+        if file.is_file() {
+            files.push(file.clone());
+        }
+    }
+    // Stable order → reproducible digest across builds.
+    files.sort();
+
+    let mut hasher = Sha256::new();
+    for path in &files {
+        println!("cargo:rerun-if-changed={}", path.display());
+        // Mix the path in too, so adding/removing/renaming a file shifts the
+        // digest even when total content is unchanged.
+        hasher.update(path.to_string_lossy().as_bytes());
+        hasher.update([0u8]);
+        if let Ok(bytes) = std::fs::read(path) {
+            hasher.update(&bytes);
+        }
+    }
+    // Watch the roots themselves so file additions and removals also retrigger
+    // the build script, not just edits to already-tracked files.
+    for root in &roots {
+        println!("cargo:rerun-if-changed={}", root.display());
+    }
+
+    // `sha2`'s digest is a byte `Array` that does not implement `LowerHex`, so
+    // hex-encode it ourselves.
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
+    println!("cargo:rustc-env=HARN_CODEGEN_FINGERPRINT={hex}");
+}
+
+/// Recursively collect every `.rs` file under `dir`. A missing directory is
+/// skipped so the build still succeeds outside the workspace (e.g. a packaged
+/// crate), degrading to whatever sources are present.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -57,6 +57,15 @@ pub const SCHEMA_VERSION: u32 = 4;
 /// are rejected on load.
 pub const HARN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Build-time fingerprint of the compiler front-end — the lexer, parser, IR,
+/// and code generator — computed in `build.rs` from those crates' source and
+/// baked in via `cargo:rustc-env`. Folded into the cache key so a compiler
+/// change that alters emitted bytecode for unchanged source invalidates stale
+/// entries automatically, within a single version, with no manual cache wipe.
+/// `HARN_VERSION` only busts the cache across release bumps; this closes the
+/// same gap for the within-version compiler edits that masked #2610. See #2621.
+pub const CODEGEN_FINGERPRINT: &str = env!("HARN_CODEGEN_FINGERPRINT");
+
 /// Conventional extension for entry-chunk cache files.
 pub const CACHE_EXTENSION: &str = "harnbc";
 
@@ -708,6 +717,17 @@ fn embedded_stdlib_digest() -> &'static [u8; 32] {
 /// disk files), so without this fold a stdlib edit between development
 /// builds would leave user-file caches pinned to a stale stdlib snapshot.
 fn hash_transitive_user_imports(source_path: &Path, source: &str) -> [u8; 32] {
+    hash_transitive_user_imports_fingerprinted(source_path, source, CODEGEN_FINGERPRINT)
+}
+
+/// Inner form of [`hash_transitive_user_imports`] parameterized on the compiler
+/// fingerprint so tests can vary it; production always passes
+/// [`CODEGEN_FINGERPRINT`].
+fn hash_transitive_user_imports_fingerprinted(
+    source_path: &Path,
+    source: &str,
+    codegen_fingerprint: &str,
+) -> [u8; 32] {
     let mut visited: std::collections::BTreeMap<PathBuf, ImportNode> =
         std::collections::BTreeMap::new();
     let mut frontier: Vec<(PathBuf, String)> = collect_user_imports(source)
@@ -757,6 +777,13 @@ fn hash_transitive_user_imports(source_path: &Path, source: &str) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(b"stdlib-digest\0");
     hasher.update(embedded_stdlib_digest());
+    hasher.update(b"\0");
+    // Fold in the compiler's code-generation fingerprint so a compiler change
+    // that alters emitted bytecode for unchanged source busts stale cache
+    // entries within a single version — the gap that masked the #2610 fix until
+    // the cache was cleared by hand. See `build.rs` and `CODEGEN_FINGERPRINT`.
+    hasher.update(b"codegen-fingerprint\0");
+    hasher.update(codegen_fingerprint.as_bytes());
     hasher.update(b"\0");
     for (path, node) in &visited {
         hasher.update(path.to_string_lossy().as_bytes());
@@ -850,6 +877,38 @@ mod tests {
             read_chunk_if_matches(&path, &other).unwrap().is_none(),
             "flipped HARN_DISABLE_OPTIMIZATIONS must not reuse a chunk \
              compiled under the opposite setting"
+        );
+    }
+
+    #[test]
+    fn codegen_fingerprint_is_populated() {
+        // In-workspace builds always hash real compiler sources, so the
+        // fingerprint must be a non-empty digest; an empty value would silently
+        // disable the within-version compiler-staleness guard.
+        assert!(!CODEGEN_FINGERPRINT.is_empty());
+    }
+
+    #[test]
+    fn codegen_fingerprint_changes_cache_key() {
+        // A compiler whose code-generation source differs must produce a
+        // different cache key for the *same* user source, so a stale artifact
+        // compiled by a prior compiler at the same version misses on load
+        // rather than being replayed (#2621). The fingerprint is a compile-time
+        // constant, so exercise the parameterized inner hash directly.
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = tmp.path().join("entry.harn");
+        std::fs::write(&entry, "__io_println(\"hi\")\n").unwrap();
+        let source = std::fs::read_to_string(&entry).unwrap();
+        let a = hash_transitive_user_imports_fingerprinted(&entry, &source, "compiler-A");
+        let b = hash_transitive_user_imports_fingerprinted(&entry, &source, "compiler-B");
+        let a_again = hash_transitive_user_imports_fingerprinted(&entry, &source, "compiler-A");
+        assert_ne!(
+            a, b,
+            "differing compiler fingerprints must change the cache key"
+        );
+        assert_eq!(
+            a, a_again,
+            "an unchanged compiler fingerprint must be stable"
         );
     }
 


### PR DESCRIPTION
## Problem

The on-disk bytecode cache (`crates/harn-vm/src/bytecode_cache.rs`) keyed entries
on source content + transitive imports + crate version (`CARGO_PKG_VERSION`) + a
`CompilerOptions` bitmask — but **not** the compiler's code-generation behavior. A
compiler change that altered the bytecode emitted for *unchanged* source, without a
version bump, was silently masked: `harn run` replayed the stale `.harnbc`.

This is not theoretical — it hid the #2610 fix. A correct compiler fix kept "not
working" because the default cache path replayed pre-fix bytecode;
`HARN_BYTECODE_CACHE=0` ran clean. The key was identical before and after the fix
because neither source, imports, version, nor the compiler tag changed — only the
compiler's *output* did.

## Fix

A new `crates/harn-vm/build.rs` hashes the source of every crate that determines
emitted bytecode — the lexer, parser, IR (source → typed AST), the code generator
(`harn-vm/src/compiler/`), and the bytecode/`Chunk` format (`harn-vm/src/chunk.rs`)
— into `HARN_CODEGEN_FINGERPRINT`, baked into the binary via `cargo:rustc-env`.
`cargo:rerun-if-changed` directives recompute it whenever any of those files change.

The fingerprint is folded into the cache key right beside the existing embedded
stdlib digest (which already closes the same gap for within-version *stdlib* edits).
A compiler change now invalidates stale entries automatically, within a single
version, with no manual cache wipe and no hand-maintained version constant.

## Tests

- `codegen_fingerprint_is_populated` — the fingerprint is a non-empty digest for
  in-workspace builds (an empty value would silently disable the guard).
- `codegen_fingerprint_changes_cache_key` — differing compiler fingerprints produce
  different cache keys for the same source (so a stale artifact from a prior compiler
  misses on `load()` rather than being replayed), and an unchanged fingerprint is
  stable.

The #2610 hermetic-cache test guard is unaffected.

Closes #2621

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
