### PR TITLE
compiler: debug-build stack-balance assertion to catch unbalanced top-level Op::Pop (#2622)

### DIFF
--- a/changelog.d/2622.fixed.md
+++ b/changelog.d/2622.fixed.md
@@ -1,0 +1,14 @@
+A `produces_value` misclassification — the compiler's "did this statement
+leave a value on the operand stack?" rule that drives every value-discarding
+`Op::Pop` — is now caught at compile time in debug builds instead of
+surfacing only as a runtime "Stack underflow" (the class of bug fixed in the
+attributed-decl regression, often masked further by the bytecode cache). A
+lightweight balance model folds each emitted opcode's net stack effect into
+the chunk and asserts that straight-line statements net exactly what their
+classification predicts; the seven duplicated "compile node, then pop its
+value" loops are unified behind one helper that carries the check. The model
+surfaced two pre-existing imbalances, now fixed: metadata-only declarations
+(`enum`/`type`/`interface`/`override`/nested pipelines) and `defer`
+statements each emitted an unpopped placeholder `Nil`, leaking an
+operand-stack slot per execution — unbounded in a loop body for `defer`.
+(#2622)

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -304,6 +304,23 @@ pub struct Chunk {
     /// shape) emit none of the flagged opcodes, so the walk is wasted
     /// work on every invocation.
     pub(crate) references_outer_names: bool,
+    /// Compile-time operand-stack-depth tracking for the debug-build
+    /// balance assertion (issue #2622). `balance_depth` is the running net
+    /// effect of every *linearly-modeled* opcode emitted so far;
+    /// `balance_nonlinear` counts emits whose effect can't be tracked by a
+    /// straight-line sum (jumps, `return`, async/handler ops, variadic ops
+    /// whose count isn't an emit argument). A statement is "balance-exact"
+    /// only when `balance_nonlinear` is unchanged across its compilation,
+    /// at which point `balance_depth`'s delta is its true net stack effect.
+    /// Transient compile-time state: reset by [`Chunk::new`], never
+    /// serialized into [`CachedChunk`], and read only by debug assertions —
+    /// so a wrong absolute value (which a non-exact statement can leave
+    /// behind) is harmless; only per-statement *deltas over exact spans*
+    /// are ever trusted.
+    #[cfg(debug_assertions)]
+    balance_depth: i32,
+    #[cfg(debug_assertions)]
+    balance_nonlinear: u32,
 }
 
 pub type ChunkRef = Rc<Chunk>;
@@ -504,6 +521,73 @@ impl CompiledFunction {
     }
 }
 
+/// A snapshot of [`Chunk`]'s compile-time balance model, returned by
+/// [`Chunk::balance_probe`] and consumed by [`Chunk::balance_delta_since`].
+#[cfg(debug_assertions)]
+#[derive(Clone, Copy)]
+pub(crate) struct BalanceProbe {
+    depth: i32,
+    nonlinear: u32,
+}
+
+/// Net operand-stack effect (`pushes - pops`) of one emitted opcode, for
+/// the debug-build balance assertion (issue #2622). `count` is the opcode's
+/// variadic arity when that arity is the emit-call argument (`BuildList`
+/// length, `Call` argc, …) and `0` otherwise.
+///
+/// `Some(delta)` means the effect is exactly modeled. `None` marks an
+/// opcode a straight-line running sum can't track — control flow that
+/// branches or terminates (`Jump*`, `Return`, `Throw`, `TailCall`),
+/// async/handler ops, and variadic ops whose arity rides in a raw operand
+/// byte rather than the emit argument (`BuildEnum`, `MatchEnum`). Such an
+/// opcode taints its enclosing statement as non-exact, so the assertion
+/// skips it instead of risking a false trip.
+///
+/// The `match` is intentionally exhaustive with no `_` arm: adding an
+/// opcode forces a classification here (a compile error otherwise), so the
+/// balance model can't silently drift out of sync with the instruction set.
+#[cfg(debug_assertions)]
+fn op_stack_delta(op: Op, count: u16) -> Option<i32> {
+    use Op::*;
+    let count = count as i32;
+    Some(match op {
+        // Push one value.
+        Constant | Nil | True | False | GetVar | GetArgc | GetLocalSlot | Closure | Dup => 1,
+        // Consume one value (into a binding / property / discard). `SetVar`,
+        // `SetProperty` and the local-slot stores read their target by name
+        // or slot index, so they only pop the value being stored.
+        DefLet | DefVar | SetVar | DefLocalSlot | SetLocalSlot | SetProperty | Pop => -1,
+        // Value-preserving: unary ops, by-name lookups/checks, and scope /
+        // iterator / exception-handler bookkeeping (the last three touch
+        // side stacks, not the operand stack).
+        Negate | Not | GetProperty | GetPropertyOpt | CheckType | TryUnwrap | TryWrapOk | Swap
+        | PushScope | PopScope | PopIterator | PopHandler => 0,
+        // Pop two, push one.
+        Add | Sub | Mul | Div | Mod | Pow | AddInt | SubInt | MulInt | DivInt | ModInt
+        | AddFloat | SubFloat | MulFloat | DivFloat | ModFloat | Equal | NotEqual | Less
+        | Greater | LessEqual | GreaterEqual | EqualInt | NotEqualInt | LessInt | GreaterInt
+        | LessEqualInt | GreaterEqualInt | EqualFloat | NotEqualFloat | LessFloat
+        | GreaterFloat | LessEqualFloat | GreaterEqualFloat | EqualBool | NotEqualBool
+        | EqualString | NotEqualString | Contains | Subscript | SubscriptOpt => -1,
+        // `IterInit` consumes the iterable and pushes nothing (the iterator
+        // lives on a side stack).
+        IterInit => -1,
+        // Pop three (or two values + a by-name target), push one.
+        Slice | SetSubscript => -2,
+        // Variadic whose arity is the emit argument: pop `count`, push one.
+        BuildList | Concat | CallBuiltin => 1 - count,
+        BuildDict => 1 - 2 * count,
+        // Calls also pop the callee/receiver beneath the args.
+        Call | MethodCall | MethodCallOpt => -count,
+        // Non-linear (see doc comment): branches, terminators, async/handler
+        // ops, and variadic ops whose arity isn't the emit argument.
+        Jump | JumpIfFalse | JumpIfTrue | IterNext | Return | TailCall | Throw | TryCatchSetup
+        | Spawn | Pipe | Parallel | ParallelMap | ParallelMapStream | ParallelSettle
+        | SyncMutexEnter | Import | SelectiveImport | DeadlineSetup | DeadlineEnd | BuildEnum
+        | MatchEnum | Yield | CallSpread | CallBuiltinSpread | MethodCallSpread => return None,
+    })
+}
+
 impl Chunk {
     pub fn new() -> Self {
         Self {
@@ -520,6 +604,10 @@ impl Chunk {
             constant_strings: Rc::new(RefCell::new(Vec::new())),
             local_slots: Vec::new(),
             references_outer_names: false,
+            #[cfg(debug_assertions)]
+            balance_depth: 0,
+            #[cfg(debug_assertions)]
+            balance_nonlinear: 0,
         }
     }
 
@@ -542,6 +630,8 @@ impl Chunk {
 
     /// Emit a single-byte instruction.
     pub fn emit(&mut self, op: Op, line: u32) {
+        #[cfg(debug_assertions)]
+        self.note_balance(op, 0);
         let col = self.current_col;
         let op_offset = self.code.len();
         self.code.push(op as u8);
@@ -557,6 +647,8 @@ impl Chunk {
 
     /// Emit an instruction with a u16 argument.
     pub fn emit_u16(&mut self, op: Op, arg: u16, line: u32) {
+        #[cfg(debug_assertions)]
+        self.note_balance(op, arg);
         let col = self.current_col;
         let op_offset = self.code.len();
         self.code.push(op as u8);
@@ -581,6 +673,8 @@ impl Chunk {
 
     /// Emit an instruction with a u8 argument.
     pub fn emit_u8(&mut self, op: Op, arg: u8, line: u32) {
+        #[cfg(debug_assertions)]
+        self.note_balance(op, arg as u16);
         let col = self.current_col;
         let op_offset = self.code.len();
         self.code.push(op as u8);
@@ -605,6 +699,8 @@ impl Chunk {
         arg_count: u8,
         line: u32,
     ) {
+        #[cfg(debug_assertions)]
+        self.note_balance(Op::CallBuiltin, arg_count as u16);
         let col = self.current_col;
         let op_offset = self.code.len();
         self.code.push(Op::CallBuiltin as u8);
@@ -622,6 +718,8 @@ impl Chunk {
 
     /// Emit a direct builtin spread call.
     pub fn emit_call_builtin_spread(&mut self, id: crate::BuiltinId, name_idx: u16, line: u32) {
+        #[cfg(debug_assertions)]
+        self.note_balance(Op::CallBuiltinSpread, 0);
         let col = self.current_col;
         self.code.push(Op::CallBuiltinSpread as u8);
         self.code.extend_from_slice(&id.raw().to_be_bytes());
@@ -645,6 +743,8 @@ impl Chunk {
     }
 
     fn emit_method_call_inner(&mut self, op: Op, name_idx: u16, arg_count: u8, line: u32) {
+        #[cfg(debug_assertions)]
+        self.note_balance(op, arg_count as u16);
         let col = self.current_col;
         let op_offset = self.code.len();
         self.code.push(op as u8);
@@ -669,6 +769,8 @@ impl Chunk {
 
     /// Emit a jump instruction with a placeholder offset. Returns the position to patch.
     pub fn emit_jump(&mut self, op: Op, line: u32) -> usize {
+        #[cfg(debug_assertions)]
+        self.note_balance(op, 0);
         let col = self.current_col;
         self.code.push(op as u8);
         let patch_pos = self.code.len();
@@ -700,6 +802,41 @@ impl Chunk {
     /// Read a u16 argument at the given position.
     pub fn read_u16(&self, pos: usize) -> u16 {
         ((self.code[pos] as u16) << 8) | (self.code[pos + 1] as u16)
+    }
+
+    /// Fold one just-emitted opcode into the compile-time operand-stack
+    /// balance model (issue #2622). See [`op_stack_delta`] for the
+    /// linear-vs-non-linear classification.
+    #[cfg(debug_assertions)]
+    fn note_balance(&mut self, op: Op, count: u16) {
+        match op_stack_delta(op, count) {
+            Some(delta) => self.balance_depth += delta,
+            None => self.balance_nonlinear += 1,
+        }
+    }
+
+    /// Snapshot the balance model before compiling a statement; pair with
+    /// [`Chunk::balance_delta_since`].
+    #[cfg(debug_assertions)]
+    pub(crate) fn balance_probe(&self) -> BalanceProbe {
+        BalanceProbe {
+            depth: self.balance_depth,
+            nonlinear: self.balance_nonlinear,
+        }
+    }
+
+    /// Net operand-stack effect emitted since `probe`, or `None` when any
+    /// non-linearly-modeled opcode was emitted in that span (which makes
+    /// the running sum untrustworthy, so callers must not assert on it).
+    /// The absolute `balance_depth` may be meaningless after a non-exact
+    /// span — only deltas over a fully-exact span are valid.
+    #[cfg(debug_assertions)]
+    pub(crate) fn balance_delta_since(&self, probe: BalanceProbe) -> Option<i32> {
+        if self.balance_nonlinear == probe.nonlinear {
+            Some(self.balance_depth - probe.depth)
+        } else {
+            None
+        }
     }
 
     fn register_inline_cache(&mut self, op_offset: usize) {
@@ -925,6 +1062,10 @@ impl Chunk {
             constant_strings: Rc::new(RefCell::new(vec![None; constants_count])),
             local_slots: cached.local_slots.clone(),
             references_outer_names: cached.references_outer_names,
+            #[cfg(debug_assertions)]
+            balance_depth: 0,
+            #[cfg(debug_assertions)]
+            balance_nonlinear: 0,
         }
     }
 

--- a/crates/harn-vm/src/compiler/closures.rs
+++ b/crates/harn-vm/src/compiler/closures.rs
@@ -278,17 +278,11 @@ impl Compiler {
             }
 
             for sn in body {
-                self.compile_node(sn)?;
-                if Self::produces_value(&sn.node) {
-                    self.chunk.emit(Op::Pop, self.line);
-                }
+                self.compile_discarded_stmt(sn)?;
             }
             if let Some(summary_body) = summarize {
                 for sn in summary_body {
-                    self.compile_node(sn)?;
-                    if Self::produces_value(&sn.node) {
-                        self.chunk.emit(Op::Pop, self.line);
-                    }
+                    self.compile_discarded_stmt(sn)?;
                 }
             }
             self.drain_finallys_to_floor(finally_floor)?;

--- a/crates/harn-vm/src/compiler/mod.rs
+++ b/crates/harn-vm/src/compiler/mod.rs
@@ -457,20 +457,23 @@ impl Compiler {
                 let key_idx = self.string_constant("__default__");
                 self.chunk.emit_u16(Op::SyncMutexEnter, key_idx, self.line);
                 for sn in body {
-                    self.compile_node(sn)?;
-                    if Self::produces_value(&sn.node) {
-                        self.chunk.emit(Op::Pop, self.line);
-                    }
+                    self.compile_discarded_stmt(sn)?;
                 }
                 self.drain_finallys_to_floor(finally_floor)?;
                 self.chunk.emit(Op::Nil, self.line);
                 self.end_scope();
             }
             Node::DeferStmt { body } => {
-                // Push onto the finally stack so it runs on return/throw/scope-exit.
+                // Register the body to run on return/throw/scope-exit. The
+                // statement emits no bytecode of its own — the deferred body
+                // is inlined later by the finally-draining machinery — so it
+                // leaves the operand stack untouched, matching
+                // `produces_value` == false. Emitting a `Nil` here instead
+                // leaked an unpopped slot per execution, which in a loop body
+                // grew the operand stack without bound (surfaced by the
+                // #2622 balance assertion).
                 self.finally_bodies
                     .push(FinallyEntry::Finally(body.clone()));
-                self.chunk.emit(Op::Nil, self.line);
             }
             Node::YieldExpr { value } => {
                 if let Some(val) = value {
@@ -544,14 +547,21 @@ impl Compiler {
             Node::StructDecl { name, fields, .. } => {
                 self.compile_struct_decl(name, fields)?;
             }
-            // Metadata-only declarations (no runtime effect).
+            // Metadata-only declarations: resolved entirely at compile time
+            // (enum names, type aliases, struct/interface layouts are
+            // pre-scanned), so they emit no bytecode and leave the operand
+            // stack untouched. `produces_value` classifies them as
+            // non-value-producing to match; contexts that require a block to
+            // yield a value (last statement of a block, match-arm body) emit
+            // their own `Nil` placeholder. Emitting one here instead left an
+            // unpopped `Nil` on the stack in every value-discarding context
+            // (`compile_top_level_declarations` pops nothing) — a latent
+            // imbalance surfaced by the #2622 balance assertion.
             Node::Pipeline { .. }
             | Node::OverrideDecl { .. }
             | Node::TypeDecl { .. }
             | Node::EnumDecl { .. }
-            | Node::InterfaceDecl { .. } => {
-                self.chunk.emit(Op::Nil, self.line);
-            }
+            | Node::InterfaceDecl { .. } => {}
             Node::TryCatch {
                 has_catch: _,
                 body,

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -10,6 +10,18 @@ use super::error::CompileError;
 use super::yield_scan::body_contains_yield;
 use super::{peel_node, Compiler, CompilerOptions, FinallyEntry};
 
+#[cfg(test)]
+thread_local! {
+    /// Test-only override for the value-discarding classification used by
+    /// [`Compiler::compile_discarded_stmt`]. Setting it forces a
+    /// `produces_value` answer regardless of the node, letting tests
+    /// deliberately miswire the classification and prove the #2622 balance
+    /// assertion fires (see
+    /// `compiler::tests::miswired_produces_value_trips_balance_assertion`).
+    pub(super) static FORCE_DISCARDED_PRODUCES_VALUE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
 impl Compiler {
     pub fn new() -> Self {
         Self::with_options(CompilerOptions::from_env())
@@ -239,10 +251,7 @@ impl Compiler {
                 })
                 .collect();
             for sn in &top_level {
-                self.compile_node(sn)?;
-                if Self::produces_value(&sn.node) {
-                    self.chunk.emit(Op::Pop, self.line);
-                }
+                self.compile_discarded_stmt(sn)?;
             }
             // E4.1 entrypoint convention: a top-level `fn main(harness: Harness)`
             // is invoked automatically with the runtime-provided `harness`
@@ -334,10 +343,7 @@ impl Compiler {
                     self.compile_parent_pipeline(program, grandparent)?;
                 }
                 for stmt in body {
-                    self.compile_node(stmt)?;
-                    if Self::produces_value(&stmt.node) {
-                        self.chunk.emit(Op::Pop, self.line);
-                    }
+                    self.compile_discarded_stmt(stmt)?;
                 }
             }
         }
@@ -861,10 +867,7 @@ impl Compiler {
         self.begin_scope();
         let finally_floor = self.finally_bodies.len();
         for sn in stmts {
-            self.compile_node(sn)?;
-            if Self::produces_value(&sn.node) {
-                self.chunk.emit(Op::Pop, self.line);
-            }
+            self.compile_discarded_stmt(sn)?;
         }
         self.drain_finallys_to_floor(finally_floor)?;
         self.end_scope();
@@ -923,17 +926,64 @@ impl Compiler {
         self.finally_bodies.push(FinallyEntry::Finally(vec![call]));
     }
 
+    /// Compile a statement that appears in a value-discarding sequence —
+    /// the script-mode module body, an inherited pipeline body, and block
+    /// interiors — then pop its value when `produces_value` says it left
+    /// one.
+    ///
+    /// In debug builds this also asserts the operand stack stayed balanced
+    /// across the statement: a straight-line statement must net exactly one
+    /// value when `produces_value` is true and zero otherwise. That turns a
+    /// `produces_value` misclassification — like the attributed-decl gap
+    /// fixed in #2610, where the loop popped against an empty stack — from a
+    /// latent runtime "Stack underflow" (often masked further by the
+    /// bytecode cache, #2621) into a loud compile-time failure in tests/CI.
+    /// Statements containing branches or other non-linearly-modeled opcodes
+    /// can't be summed by the lightweight model, so the assertion skips them
+    /// (see [`Chunk::balance_delta_since`]).
+    pub(super) fn compile_discarded_stmt(&mut self, sn: &SNode) -> Result<(), CompileError> {
+        #[cfg(debug_assertions)]
+        let probe = self.chunk.balance_probe();
+        self.compile_node(sn)?;
+        #[allow(unused_mut)]
+        let mut produces = Self::produces_value(&sn.node);
+        // Test-only hook: deliberately miswire the classification to prove
+        // the balance assertion below trips on a `produces_value` gap (the
+        // #2622 verification). No-op in non-test builds.
+        #[cfg(test)]
+        if let Some(forced) = FORCE_DISCARDED_PRODUCES_VALUE.with(std::cell::Cell::get) {
+            produces = forced;
+        }
+        #[cfg(debug_assertions)]
+        if let Some(delta) = self.chunk.balance_delta_since(probe) {
+            let expected = i32::from(produces);
+            debug_assert_eq!(
+                delta, expected,
+                "operand-stack imbalance at line {}: produces_value={produces} but the \
+                 node's emitted bytecode netted {delta} (expected {expected}). A \
+                 `produces_value` arm is out of sync with this node's codegen — see #2622.\n\
+                 node: {:?}",
+                self.line, sn.node,
+            );
+        }
+        if produces {
+            self.chunk.emit(Op::Pop, self.line);
+        }
+        Ok(())
+    }
+
     pub(super) fn compile_block(&mut self, stmts: &[SNode]) -> Result<(), CompileError> {
         for (i, snode) in stmts.iter().enumerate() {
-            self.compile_node(snode)?;
-            let is_last = i == stmts.len() - 1;
-            if is_last {
-                // Ensure the block always leaves exactly one value on the stack.
+            if i == stmts.len() - 1 {
+                // The block's value is its last statement's. Backfill a `Nil`
+                // when that statement produced none, so the block always
+                // leaves exactly one value on the stack.
+                self.compile_node(snode)?;
                 if !Self::produces_value(&snode.node) {
                     self.chunk.emit(Op::Nil, self.line);
                 }
-            } else if Self::produces_value(&snode.node) {
-                self.chunk.emit(Op::Pop, self.line);
+            } else {
+                self.compile_discarded_stmt(snode)?;
             }
         }
         Ok(())
@@ -1264,6 +1314,10 @@ impl Compiler {
             | Node::EnumDecl { .. }
             | Node::InterfaceDecl { .. }
             | Node::TypeDecl { .. }
+            // Metadata-only declarations that emit no bytecode — see the
+            // matching arm in `compile_node`.
+            | Node::OverrideDecl { .. }
+            | Node::Pipeline { .. }
             | Node::ThrowStmt { .. }
             | Node::BreakStmt
             | Node::ContinueStmt

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -170,10 +170,7 @@ impl Compiler {
         self.compile_destructuring(pattern, true)?;
         self.record_binding_type(pattern, item_type);
         for sn in body {
-            self.compile_node(sn)?;
-            if Self::produces_value(&sn.node) {
-                self.chunk.emit(Op::Pop, self.line);
-            }
+            self.compile_discarded_stmt(sn)?;
         }
         self.drain_finallys_to_floor(finally_floor)?;
         self.end_scope();

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -376,3 +376,61 @@ fn attributed_top_level_fn_does_not_emit_spurious_pop() {
         attributed.disassemble("module"),
     );
 }
+
+/// #2622: the debug-build balance model classifies straight-line statements
+/// exactly. A bare `Op::Closure` leaves one value (`Some(1)`); pairing it
+/// with the matching bind (`Op::DefVar`) nets zero (`Some(0)`); and emitting
+/// a branch taints the span so the model declines to judge it (`None`).
+#[test]
+fn balance_model_tracks_straight_line_and_declines_branches() {
+    let mut chunk = Chunk::new();
+
+    let push_probe = chunk.balance_probe();
+    chunk.emit_u16(Op::Closure, 0, 1);
+    assert_eq!(chunk.balance_delta_since(push_probe), Some(1));
+
+    // Closure + matching bind is the shape every top-level `fn`/`struct`
+    // declaration lowers to — it must net zero.
+    let decl_probe = chunk.balance_probe();
+    chunk.emit_u16(Op::Closure, 0, 1);
+    chunk.emit_u16(Op::DefVar, 0, 1);
+    assert_eq!(chunk.balance_delta_since(decl_probe), Some(0));
+
+    // A jump is non-linear: the running sum can't be trusted across it, so
+    // the model reports `None` rather than risk a false assertion.
+    let branch_probe = chunk.balance_probe();
+    let _ = chunk.emit_jump(Op::JumpIfFalse, 1);
+    assert_eq!(chunk.balance_delta_since(branch_probe), None);
+}
+
+/// #2622: a `produces_value` gap must fail loudly at compile time. We force
+/// the value-discarding classification to lie (`true` for a top-level `fn`,
+/// which emits a balanced `Closure; DefVar` and leaves nothing to pop) and
+/// confirm the balance assertion panics instead of letting the compiler emit
+/// the unbalanced `Op::Pop` that #2610 only caught as a runtime underflow.
+#[test]
+fn miswired_produces_value_trips_balance_assertion() {
+    struct ResetGuard;
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            super::state::FORCE_DISCARDED_PRODUCES_VALUE.with(|c| c.set(None));
+        }
+    }
+
+    let _guard = ResetGuard;
+    super::state::FORCE_DISCARDED_PRODUCES_VALUE.with(|c| c.set(Some(true)));
+
+    // Swallow the expected panic's backtrace so it doesn't clutter test output.
+    let prior_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        compile_source("fn f() -> int { return 1 }\nfn main(harness: Harness) { let _ = 1 }")
+    }));
+    std::panic::set_hook(prior_hook);
+
+    assert!(
+        result.is_err(),
+        "miswiring produces_value to `true` for a balanced top-level decl \
+         must trip the #2622 stack-balance assertion",
+    );
+}


### PR DESCRIPTION
Closes #2622.

## What

The bytecode compiler classifies each statement with `produces_value` — "did this leave a value on the operand stack?" — and emits an `Op::Pop` after every value-discarding statement that did. A wrong answer emits an unbalanced `Pop` that surfaces only as a runtime **"Stack underflow"** (the [#2610](https://github.com/burin-labs/harn/issues/2610) bug), often masked further by the bytecode cache ([#2621](https://github.com/burin-labs/harn/issues/2621)).

This adds a **lightweight, debug-build-only operand-stack balance model**:

- Each emit folds the opcode's net stack effect into the chunk via an **exhaustive** `op_stack_delta` classifier — a newly added opcode forces a classification arm (compile error otherwise), so the model can't silently drift out of sync with the instruction set.
- A statement that emits only linearly-modeled opcodes is *balance-exact*; for those, a `debug_assert_eq!` checks the net stack delta equals what `produces_value` predicted.
- Branches, terminators, and async/handler ops **taint** the span as non-exact, so the assertion skips them rather than risk a false trip. No per-opcode CFG model is required (the issue's preferred lightweight first cut, approach **(b)**).

The issue noted a verifier would have to either thread a `stack_effect` table through a depth counter (a) or do a lighter-weight scoped check (b). A bytecode-walking verifier turned out to be unsound here anyway — `SetProperty`/`SetSubscript` carry raw-pushed operand bytes beyond their disasm width, and `IterNext` branches *inside* the opcode — so this takes the incremental, taint-on-uncertainty route, which is sound by construction.

## DRY

The seven duplicated *"compile node, then pop its value if it produced one"* loops are unified behind a single `compile_discarded_stmt` helper that carries the check — covering the script-mode module body, inherited pipeline bodies, block interiors, loop bodies, mutex bodies, and eval-pack bodies.

## Latent bugs surfaced + fixed

The model immediately caught two pre-existing imbalances:

- **Metadata-only declarations** (`enum`/`type`/`interface`/`override`/nested pipelines) emitted an unpopped placeholder `Nil`, leaking an operand-stack slot in every value-discarding context (`compile_top_level_declarations` pops nothing). They're resolved entirely at compile time and now emit no bytecode; `produces_value` already classified them as non-value-producing.
- **`defer`** emitted an unpopped `Nil` per execution — unbounded operand-stack growth in a loop body. It only registers a finally and now emits nothing.

## Verification

- `1490/1490` conformance tests pass under the **debug** binary (assertions active, `HARN_BYTECODE_CACHE=0`).
- New test: a test-hook miswiring of `produces_value` to `true` for a balanced top-level decl trips the assertion (`miswired_produces_value_trips_balance_assertion`).
- New test: the balance model reports `Some(1)` / `Some(0)` for straight-line spans and `None` across a branch (`balance_model_tracks_straight_line_and_declines_branches`).
- The existing `attributed_top_level_fn_does_not_emit_spurious_pop` (#2610) regression still holds.
- Release build compiles clean (all balance machinery is `#[cfg(debug_assertions)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)