### PR TITLE
prompt-assembly: decompose agent_build_turn_system into per-part fragments (#2632)

### DIFF
--- a/changelog.d/2632.changed.md
+++ b/changelog.d/2632.changed.md
@@ -1,0 +1,8 @@
+- Prompt assembly: the agent's per-turn primary system block is now decomposed
+  into individually auditable fragments. `agent_build_turn_system_fragments`
+  emits one `{id, source, body}` per internal part (system text, MCP advisory,
+  active skills, skill catalog, progress nudge, loop/tool contracts); the agent
+  loop forwards them to `llm_call` over the `_system_fragments` channel so the
+  whole primary block — not just host parts and reminders — shows up in
+  `prompt_explain` provenance under `primary:<part>` ids. The assembled prompt
+  is byte-for-byte unchanged; only its provenance is finer-grained.

--- a/conformance/tests/scenarios/llm_rewrite_supersedes_system_fragments.expected
+++ b/conformance/tests/scenarios/llm_rewrite_supersedes_system_fragments.expected
@@ -1,0 +1,1 @@
+[harn] llm_rewrite_supersedes_system_fragments tests passed

--- a/conformance/tests/scenarios/llm_rewrite_supersedes_system_fragments.harn
+++ b/conformance/tests/scenarios/llm_rewrite_supersedes_system_fragments.harn
@@ -1,0 +1,38 @@
+/**
+ * A `with_prompt_rewrite` middleware that replaces the primary `system` must
+ * win over the decomposed `_system_fragments` channel the agent loop attaches
+ * (#2632). Clearing the channel on a system rewrite keeps the two assembly
+ * inputs from fighting — otherwise the assembler would reduce the stale
+ * fragments and silently ignore the rewrite.
+ */
+import { default_llm_caller, with_prompt_rewrite } from "std/llm/handlers"
+
+pipeline test(task) {
+  // The shape the agent loop hands a caller: a joined `system` string plus the
+  // per-part `_system_fragments` list in opts.
+  let call = {
+    prompt: "hi",
+    system: "ORIGINAL JOINED",
+    opts: {
+      provider: "mock",
+      _system_fragments: [{id: "primary:system", source: "primary", body: "ORIGINAL JOINED"}],
+    },
+    turn: {iteration: 0, session_id: "", attempt: 1},
+  }
+  // Rewriting `system` supersedes the decomposed fragments.
+  llm_mock_clear()
+  llm_mock({text: "ok"})
+  let rewriter = with_prompt_rewrite(
+    default_llm_caller(),
+    fn(prompt, system, opts) { return {system: "REWRITTEN PRIMARY"} },
+  )
+  let _ = rewriter(call)
+  assert(llm_mock_calls()[0].system == "REWRITTEN PRIMARY", "system rewrite wins over fragments")
+  // Leaving `system` untouched keeps the decomposed fragments authoritative.
+  llm_mock_clear()
+  llm_mock({text: "ok"})
+  let passthrough = with_prompt_rewrite(default_llm_caller(), fn(prompt, system, opts) { return {} })
+  let _ = passthrough(call)
+  assert(llm_mock_calls()[0].system == "ORIGINAL JOINED", "fragments retained when system untouched")
+  log("llm_rewrite_supersedes_system_fragments tests passed")
+}

--- a/conformance/tests/scenarios/prompt_fragments_decompose.expected
+++ b/conformance/tests/scenarios/prompt_fragments_decompose.expected
@@ -1,0 +1,1 @@
+[harn] prompt_fragments_decompose tests passed

--- a/conformance/tests/scenarios/prompt_fragments_decompose.harn
+++ b/conformance/tests/scenarios/prompt_fragments_decompose.harn
@@ -1,0 +1,73 @@
+/**
+ * The per-turn primary system block is decomposed into individually
+ * auditable fragments (#2632). `agent_build_turn_system_fragments` emits one
+ * `{id, source, body}` per internal part; joining the bodies reproduces the
+ * legacy `agent_build_turn_system` string byte-for-byte, and feeding the
+ * fragments through `prompt_explain` traces each part on its own instead of
+ * one opaque `primary` block.
+ */
+import { agent_build_turn_system, agent_build_turn_system_fragments } from "std/agent/preflight"
+
+fn contains_id(items, needle) {
+  for item in items {
+    if item == needle {
+      return true
+    }
+  }
+  return false
+}
+
+pipeline test(task) {
+  let session = {session_id: "prompt-fragments-decompose"}
+  let opts = {
+    system: "You are a careful operator.",
+    active_skills: [{id: "disk_cleanup", description: "Free up disk space", when_to_use: "when low"}],
+    skill_catalog_prompt: "## Skills\nUse skills wisely.",
+    loop_until_done: true,
+    done_sentinel: "STOP",
+    tools: {tools: [{name: "read", description: "Read a file"}]},
+    tool_format: "text",
+  }
+  // Joining the fragment bodies reproduces the legacy string exactly.
+  let fragments = agent_build_turn_system_fragments(session, opts, 0)
+  let joined = join(fragments.map(fn(f) { return f.body }), "\n\n")
+  let legacy = agent_build_turn_system(session, opts, 0)
+  assert(joined == legacy, "joined fragment bodies equal agent_build_turn_system")
+  assert(len(fragments) >= 4, "primary block decomposed into multiple parts")
+  // Every fragment is namespaced under the primary region.
+  for fragment in fragments {
+    assert(fragment.source == "primary", "fragment source is primary")
+    assert(starts_with(fragment.id, "primary:"), "fragment id is primary-namespaced")
+  }
+  // prompt_explain expands the channel as the primary region and traces each
+  // part individually — no opaque single `primary` fragment remains.
+  let explained = prompt_explain({_system_fragments: fragments, tools: opts.tools})
+  assert(explained.system == legacy, "prompt_explain system equals legacy string")
+  let ids = explained.fragments.map(fn(t) { return t.id })
+  assert(contains_id(ids, "primary:system"), "traces primary:system")
+  assert(contains_id(ids, "primary:active_skills"), "traces primary:active_skills")
+  assert(contains_id(ids, "primary:skill_catalog"), "traces primary:skill_catalog")
+  assert(contains_id(ids, "primary:loop_contract"), "traces primary:loop_contract")
+  assert(contains_id(ids, "primary:text_tool_contract"), "traces primary:text_tool_contract")
+  assert(!contains_id(ids, "primary"), "no opaque single primary fragment")
+  // The live agent loop forwards the channel: the composed system surfaces the
+  // decomposed parts and carries no triple-newline runs from un-trimmed parts.
+  skill disk_cleanup {
+    description "Clean disk space by deleting caches"
+    when_to_use "Use when the user asks to reclaim disk space"
+    prompt "Remove disk caches carefully."
+  }
+  llm_mock_clear()
+  llm_mock({text: "Cleanup done."})
+  let res = agent_loop(
+    "run disk cleanup please",
+    "You are a careful operator.",
+    {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+  )
+  assert(res?.status == "done", "live loop completes")
+  let recorded = llm_mock_calls()[0].system
+  assert(contains(recorded, "## Active skills"), "live system surfaces active skills")
+  assert(contains(recorded, "You are a careful operator."), "live system surfaces primary text")
+  assert(!contains(recorded, "\n\n\n"), "no triple-newline runs in composed system")
+  log("prompt_fragments_decompose tests passed")
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -15,7 +15,7 @@ import {
   agent_compute_post_turn,
   agent_reset_tool_surface_narrowing,
 } from "std/agent/postturn"
-import { agent_build_turn_messages, agent_build_turn_system } from "std/agent/preflight"
+import { agent_build_turn_messages, agent_build_turn_system_fragments } from "std/agent/preflight"
 import { agent_dispatch_tool_batch, agent_dispatch_tool_call } from "std/agent/primitives"
 import { agent_progress_apply_options } from "std/agent/progress"
 import { native_tool_contract_feedback_prompt } from "std/agent/prompts"
@@ -1732,7 +1732,12 @@ fn __agent_loop_run(message, session, initial_opts) {
         stop_reason = "out_of_scope"
         break
       }
-      let turn_system = agent_build_turn_system(session, turn_opts, iteration_index)
+      let turn_system_fragments = agent_build_turn_system_fragments(session, turn_opts, iteration_index)
+      var turn_system_parts = []
+      for fragment in turn_system_fragments {
+        turn_system_parts = turn_system_parts.push(fragment.body)
+      }
+      let turn_system = join(turn_system_parts, "\n\n")
       let turn_messages = agent_build_turn_messages(session, turn_opts, iteration_index)
       let llm_overrides = turn_opts?.llm_options ?? {}
       let base_opts = turn_opts + llm_overrides
@@ -1742,6 +1747,7 @@ fn __agent_loop_run(message, session, initial_opts) {
         session_id: session.session_id,
         tool_format: turn_opts.tool_format,
         _iteration: iteration_index + 1,
+        _system_fragments: turn_system_fragments,
       }
       let call = __invoke_llm(message, turn_system, llm_opts)
       if !call.ok {

--- a/crates/harn-stdlib/src/stdlib/agent/preflight.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/preflight.harn
@@ -274,6 +274,79 @@ fn __agent_has_system_prompt_options(opts) {
     || __agent_system_prompt_option_present(opts?.system_suffix)
 }
 
+fn __agent_push_system_fragment(fragments, id, body) {
+  let trimmed = trim(body ?? "")
+  if trimmed == "" {
+    return fragments
+  }
+  return fragments.push({id: "primary:" + id, source: "primary", body: trimmed})
+}
+
+fn __agent_primary_system_text(session, opts) {
+  if opts?.system != nil && opts.system != "" {
+    return opts.system
+  }
+  if !__agent_has_system_prompt_options(opts) {
+    let stored_system = agent_session_system_prompt(session.session_id)
+    if stored_system != nil && stored_system != "" {
+      return stored_system
+    }
+  }
+  return ""
+}
+
+/**
+ * agent_build_turn_system_fragments decomposes the per-turn primary system
+ * block into an ordered list of `{id, source, body}` fragments — one per
+ * internal part (system text, MCP advisory, active skills, skill catalog,
+ * progress nudge, loop contract, native/text tool contracts). The agent loop
+ * forwards this list to `llm_call` via the `_system_fragments` channel so the
+ * Rust assembler records per-part provenance instead of treating the whole
+ * primary block as one opaque string. Bodies are trimmed and empty parts are
+ * dropped, so joining the bodies with `\n\n` reproduces the string
+ * `agent_build_turn_system` returns.
+ *
+ * @effects: [agent, mcp]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: agent_build_turn_system_fragments(session, opts, iteration)
+ */
+pub fn agent_build_turn_system_fragments(session, opts, iteration) {
+  var fragments = []
+  fragments = __agent_push_system_fragment(fragments, "system", __agent_primary_system_text(session, opts))
+  fragments = __agent_push_system_fragment(
+    fragments,
+    "mcp_advisory",
+    __agent_mcp_initialize_advisory_prompt(opts),
+  )
+  fragments = __agent_push_system_fragment(
+    fragments,
+    "active_skills",
+    __agent_active_skill_prompt(opts?.active_skills),
+  )
+  fragments = __agent_push_system_fragment(fragments, "skill_catalog", opts?.skill_catalog_prompt ?? "")
+  fragments = __agent_push_system_fragment(
+    fragments,
+    "progress_nudge",
+    opts?._progress_tool_system_prompt_nudge ?? "",
+  )
+  fragments = __agent_push_system_fragment(fragments, "loop_contract", __agent_loop_contract_prompt(opts))
+  fragments = __agent_push_system_fragment(
+    fragments,
+    "native_tool_contract",
+    __agent_native_tool_contract_prompt(opts),
+  )
+  if opts?.tools != nil && __agent_tool_format(opts) != "native" {
+    fragments = __agent_push_system_fragment(
+      fragments,
+      "text_tool_contract",
+      __agent_text_tool_contract_prompt(opts),
+    )
+  }
+  return fragments
+}
+
 /**
  * agent_build_turn_system.
  *
@@ -285,43 +358,8 @@ fn __agent_has_system_prompt_options(opts) {
  */
 pub fn agent_build_turn_system(session, opts, iteration) {
   var parts = []
-  if opts?.system != nil && opts.system != "" {
-    parts = parts.push(opts.system)
-  } else if !__agent_has_system_prompt_options(opts) {
-    let stored_system = agent_session_system_prompt(session.session_id)
-    if stored_system != nil && stored_system != "" {
-      parts = parts.push(stored_system)
-    }
-  }
-  let mcp_advisory = __agent_mcp_initialize_advisory_prompt(opts)
-  if mcp_advisory != "" {
-    parts = parts.push(mcp_advisory)
-  }
-  let active_skill_prompt = __agent_active_skill_prompt(opts?.active_skills)
-  if active_skill_prompt != "" {
-    parts = parts.push(active_skill_prompt)
-  }
-  let skill_catalog_prompt = trim(opts?.skill_catalog_prompt ?? "")
-  if skill_catalog_prompt != "" {
-    parts = parts.push(skill_catalog_prompt)
-  }
-  let progress_tool_nudge = trim(opts?._progress_tool_system_prompt_nudge ?? "")
-  if progress_tool_nudge != "" {
-    parts = parts.push(progress_tool_nudge)
-  }
-  let loop_contract = __agent_loop_contract_prompt(opts)
-  if loop_contract != "" {
-    parts = parts.push(loop_contract)
-  }
-  let native_contract = __agent_native_tool_contract_prompt(opts)
-  if native_contract != "" {
-    parts = parts.push(native_contract)
-  }
-  if opts?.tools != nil && __agent_tool_format(opts) != "native" {
-    let text_contract = __agent_text_tool_contract_prompt(opts)
-    if text_contract != "" {
-      parts = parts.push(text_contract)
-    }
+  for fragment in agent_build_turn_system_fragments(session, opts, iteration) {
+    parts = parts.push(fragment.body)
   }
   return join(parts, "\n\n")
 }

--- a/crates/harn-stdlib/src/stdlib/llm/handlers.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/handlers.harn
@@ -564,10 +564,15 @@ pub fn with_prompt_rewrite(next, rewriter) {
     } else {
       call?.system
     }
-    let new_opts = if patch_dict?.opts != nil {
+    let base_opts = if patch_dict?.opts != nil {
       patch_dict.opts
     } else {
       call?.opts
+    }
+    let new_opts = if patch_dict?.system != nil {
+      base_opts + {_system_fragments: nil}
+    } else {
+      base_opts
     }
     let new_call = {
       prompt: new_prompt,
@@ -578,6 +583,11 @@ pub fn with_prompt_rewrite(next, rewriter) {
     return __safe_invoke(next, new_call)
   }
 }
+
+// A rewritten primary system supersedes the decomposed `_system_fragments`
+// channel the agent loop attaches: clearing it lets the new system text win
+// as the primary block, otherwise the assembler would keep reducing the
+// stale fragments and ignore the rewrite.
 
 // -------------------------------------------------------------------------------------------------
 // with_logging

--- a/crates/harn-stdlib/src/stdlib/llm/options.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/options.harn
@@ -23,6 +23,7 @@ fn __llm_call_option_keys() {
     "system_prompt_parts",
     "system_appendix",
     "system_suffix",
+    "_system_fragments",
     "previous_response_id",
     "max_tokens",
     "temperature",

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -1247,22 +1247,32 @@ pub(crate) fn assemble_system_prompt(
         )?;
     }
 
-    let primary_system = system
-        .filter(|system| !system.trim().is_empty())
-        .or_else(|| {
-            options
-                .and_then(|options| options.get("system"))
-                .filter(|value| !matches!(value, VmValue::Nil | VmValue::Bool(false)))
-                .map(VmValue::display)
-                .filter(|system| !system.trim().is_empty())
-        });
-    if let Some(system) = primary_system {
-        fragments.push(PromptFragment::new(
-            "primary",
-            "primary",
-            FragmentBucket::Before,
-            system,
-        ));
+    // The agent loop hands us the primary block pre-decomposed into its
+    // constituent parts (system text, MCP advisory, active skills, skill
+    // catalog, progress nudge, loop/tool contracts) via `_system_fragments`,
+    // so each part is individually auditable instead of opaque inside one
+    // joined string. When present it fully supersedes the single-string
+    // primary path (the `system` arg / `opts.system` is already represented as
+    // one of those fragments).
+    let decomposed = append_decomposed_primary_fragments(&mut fragments, options);
+    if !decomposed {
+        let primary_system = system
+            .filter(|system| !system.trim().is_empty())
+            .or_else(|| {
+                options
+                    .and_then(|options| options.get("system"))
+                    .filter(|value| !matches!(value, VmValue::Nil | VmValue::Bool(false)))
+                    .map(VmValue::display)
+                    .filter(|system| !system.trim().is_empty())
+            });
+        if let Some(system) = primary_system {
+            fragments.push(PromptFragment::new(
+                "primary",
+                "primary",
+                FragmentBucket::Before,
+                system,
+            ));
+        }
     }
 
     // Capability-gated tool guidance: each active tool that declares a
@@ -1362,6 +1372,53 @@ fn append_tool_guidance_fragments(
             .requiring_tools(vec![name]),
         );
     }
+}
+
+/// Expand the agent loop's `_system_fragments` channel — an ordered list of
+/// `{id, source?, body, requires_tools?}` dicts — into primary-region
+/// [`PromptFragment`]s. This is how `agent_build_turn_system` ships the
+/// primary block already decomposed into its parts, so the whole system prompt
+/// (not just the host parts and reminders) is auditable through `assemble`.
+///
+/// Returns `true` if the channel was present (a list), in which case the
+/// caller skips the single-string primary path. An empty list still counts as
+/// present: the agent computed zero non-empty parts, so there is no primary.
+fn append_decomposed_primary_fragments(
+    fragments: &mut Vec<crate::llm::prompt::PromptFragment>,
+    options: Option<&BTreeMap<String, VmValue>>,
+) -> bool {
+    use crate::llm::prompt::{FragmentBucket, PromptFragment};
+    let Some(VmValue::List(items)) = options.and_then(|options| options.get("_system_fragments"))
+    else {
+        return false;
+    };
+    for (index, item) in items.iter().enumerate() {
+        let Some(dict) = item.as_dict() else {
+            continue;
+        };
+        let Some(body) = dict.get("body").map(VmValue::display) else {
+            continue;
+        };
+        let id = dict
+            .get("id")
+            .map(VmValue::display)
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| format!("primary[{index}]"));
+        let source = dict
+            .get("source")
+            .map(VmValue::display)
+            .filter(|source| !source.is_empty())
+            .unwrap_or_else(|| "primary".to_string());
+        let requires_tools = match dict.get("requires_tools") {
+            Some(VmValue::List(tools)) => tools.iter().map(VmValue::display).collect(),
+            _ => Vec::new(),
+        };
+        fragments.push(
+            PromptFragment::new(id, source, FragmentBucket::Before, body)
+                .requiring_tools(requires_tools),
+        );
+    }
+    true
 }
 
 fn assemble_ctx(options: Option<&BTreeMap<String, VmValue>>) -> crate::llm::prompt::AssembleCtx {
@@ -2822,6 +2879,102 @@ mod reminder_render_tests {
             .expect("todo guidance trace");
         assert!(todo.included);
         assert!(todo.reason.contains("tool(s) present: todo"));
+    }
+
+    fn fragment(id: &str, body: &str) -> VmValue {
+        dict(&[("id", s(id)), ("source", s("primary")), ("body", s(body))])
+    }
+
+    #[test]
+    fn system_fragments_expand_in_place_of_the_single_primary() {
+        // The decomposed channel yields the same bytes as the equivalent
+        // joined-string primary, while keeping each part individually traced.
+        let decomposed = BTreeMap::from([
+            ("system_prefix".to_string(), s("X")),
+            (
+                "_system_fragments".to_string(),
+                list(vec![
+                    fragment("primary:system", "base"),
+                    fragment("primary:active_skills", "## Active skills"),
+                    fragment("primary:loop_contract", "Keep going until done."),
+                ]),
+            ),
+            ("system_appendix".to_string(), s("A")),
+        ]);
+        let joined = "base\n\n## Active skills\n\nKeep going until done.";
+        let baseline = BTreeMap::from([
+            ("system_prefix".to_string(), s("X")),
+            ("system_appendix".to_string(), s("A")),
+        ]);
+
+        let from_fragments = compose_system_prompt(None, Some(&decomposed))
+            .expect("system prompt")
+            .expect("non-empty prompt");
+        let from_string = compose_system_prompt(Some(joined.to_string()), Some(&baseline))
+            .expect("system prompt")
+            .expect("non-empty prompt");
+        assert_eq!(from_fragments, from_string);
+        assert_eq!(
+            from_fragments,
+            "X\n\nbase\n\n## Active skills\n\nKeep going until done.\n\nA"
+        );
+
+        // Each part is its own provenance entry; there is no opaque `primary`.
+        let assembled = assemble_system_prompt(None, Some(&decomposed), &[]).expect("assembled");
+        let ids: Vec<&str> = assembled.provenance.iter().map(|t| t.id.as_str()).collect();
+        assert!(ids.contains(&"primary:system"));
+        assert!(ids.contains(&"primary:active_skills"));
+        assert!(ids.contains(&"primary:loop_contract"));
+        assert!(!ids.contains(&"primary"));
+    }
+
+    #[test]
+    fn system_fragments_supersede_the_system_arg() {
+        // When the channel is present, the `system` arg / `opts.system` no
+        // longer contributes a primary fragment — the channel owns that block.
+        let options = BTreeMap::from([
+            ("system".to_string(), s("ignored opts.system")),
+            (
+                "_system_fragments".to_string(),
+                list(vec![fragment("primary:system", "decomposed")]),
+            ),
+        ]);
+        let prompt = compose_system_prompt(Some("ignored system arg".to_string()), Some(&options))
+            .expect("system prompt")
+            .expect("non-empty prompt");
+        assert_eq!(prompt, "decomposed");
+    }
+
+    #[test]
+    fn empty_system_fragments_yield_no_primary() {
+        // An empty list still claims the primary block: the agent computed zero
+        // non-empty parts, so the `system` arg must not leak back in.
+        let options = BTreeMap::from([("_system_fragments".to_string(), list(vec![]))]);
+        let prompt = compose_system_prompt(Some("should not appear".to_string()), Some(&options))
+            .expect("system prompt");
+        assert_eq!(prompt, None);
+    }
+
+    #[test]
+    fn system_fragments_honor_per_part_tool_gating() {
+        let options = BTreeMap::from([(
+            "_system_fragments".to_string(),
+            list(vec![dict(&[
+                ("id", s("primary:todo_nudge")),
+                ("body", s("Keep the TODO list current.")),
+                ("requires_tools", list(vec![s("todo")])),
+            ])]),
+        )]);
+        // Tool absent → gated out, recorded with a reason.
+        let assembled = assemble_system_prompt(None, Some(&options), &[]).expect("assembled");
+        assert_eq!(assembled.system, None);
+        let trace = assembled
+            .provenance
+            .iter()
+            .find(|t| t.id == "primary:todo_nudge")
+            .expect("nudge trace");
+        assert!(!trace.included);
+        assert!(trace.reason.contains("requires tool `todo`"));
     }
 }
 

--- a/docs/src/prompt-assembly.md
+++ b/docs/src/prompt-assembly.md
@@ -20,7 +20,7 @@ A fragment is one contributor to the system string:
 
 | field | meaning |
 | --- | --- |
-| `id` | stable identifier, e.g. `host:system_preamble`, `primary`, `tool:todo.guidance` |
+| `id` | stable identifier, e.g. `host:system_preamble`, `primary:active_skills`, `tool:todo.guidance` |
 | `source` | who contributed it (`host:*`, `primary`, `reminder`, `tool:<name>`) |
 | `bucket` | `before` (preamble … primary … reminders) or `after` (appendix/suffix) |
 | `requires_tools` | included only when every named tool is in the active tool set |
@@ -29,6 +29,20 @@ A fragment is one contributor to the system string:
 
 The reducer emits all included `before` fragments in declaration order, then all
 included `after` fragments, joined by a blank line.
+
+## The primary block is decomposed
+
+The agent's per-turn primary system text is itself a composite — the base system
+prompt, MCP advisory context, active skills, the skill catalog, the progress-tool
+nudge, and the loop/tool contracts. Rather than glue these into one opaque
+`primary` string, [`agent_loop`](./agents.md) hands the assembler each part as its
+own fragment through the internal `_system_fragments` channel, so every part is
+traced on its own (`primary:system`, `primary:active_skills`,
+`primary:loop_contract`, …) and can be gated with `requires_tools` independently.
+Joining the fragment bodies with a blank line reproduces the single string the
+legacy path produced, so the assembled prompt is unchanged — only its provenance
+is finer-grained. `agent_build_turn_system_fragments` is the stdlib helper that
+emits the list; `agent_build_turn_system` is the thin wrapper that joins it.
 
 ## Tool guidance rides with the tool
 


### PR DESCRIPTION
Closes #2632. Follow-up to the unified prompt-fragment assembler (#2631).

## What

The agent's per-turn primary system block was built by `agent_build_turn_system` (`crates/harn-stdlib/src/stdlib/agent/preflight.harn`) as one joined string, which the Rust assembler then wrapped as a single opaque `primary` fragment. Host parts, tool guidance, and reminders were already individually traced in provenance; the **eight internal parts** were not.

This decomposes the primary block into structured fragments so the *entire* system prompt — not just the host parts and reminders — is auditable via `prompt_explain` / provenance, and each part can be gated/inspected on its own.

### Harn side
- **`agent_build_turn_system_fragments`** (new, `pub`) emits one `{id, source, body}` fragment per internal part (system text, MCP advisory, active skills, skill catalog, progress nudge, loop contract, native/text tool contracts), namespaced `primary:<part>`. `agent_build_turn_system` is now the thin wrapper that joins their bodies.
- The agent loop computes the fragments once and forwards them to `llm_call` over a new internal `_system_fragments` options channel (added to the `llm_call_options` whitelist).

### Rust side
- `assemble_system_prompt` expands `_system_fragments` as the primary-region fragments (each gateable via `requires_tools`) and **skips the single-string primary path** when the channel is present — the `system` arg / `opts.system` is already represented as one of those fragments.
- The assembled prompt is **byte-for-byte unchanged**; only its provenance is finer-grained. Parts are trimmed individually — matching how `assemble` already trims the primary — which also drops accidental triple-newline runs from un-trimmed parts (MCP advisory / active skills).

### Drift guard
- `with_prompt_rewrite` clears `_system_fragments` when a middleware rewrites the primary `system`, so the rewrite stays authoritative instead of being silently superseded by the now-stale decomposed channel. (Caught during self-review — this would otherwise be a regression.)

## Verification
- 4 new `assemble_system_prompt` unit tests (byte-identity vs. joined string, supersedes the `system` arg, empty list yields no primary, per-part tool gating).
- 2 new conformance scenarios: `prompt_fragments_decompose` (byte-identity + per-part provenance + live-loop composition) and `llm_rewrite_supersedes_system_fragments` (rewrite interplay).
- Full suites green: `harn-vm` lib (2922), conformance `agents`/`reminders`/`scenarios`/`llm`/`skills`, `demo_cli`, and the `prompt-guidance` demo (back-compat: direct `prompt_explain` callers still get a single `primary`).
- `_system_fragments` is consumed only by the assembler — never forwarded to the provider request or serialized into transcripts.

Docs: extended `docs/src/prompt-assembly.md` with a "primary block is decomposed" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)