### PR TITLE
harn-serve: in-process ACP embedding API (AcpChannelHandle + EmbeddedAgent) (#2636)

### DIFF
--- a/changelog.d/2641.added.md
+++ b/changelog.d/2641.added.md
@@ -1,0 +1,6 @@
+- **`harn-serve` gains an in-process ACP embedding API (#2636).** `run_acp_channel_server_with_handle`
+  returns the (`!Send`) server future plus a `Send` `AcpChannelHandle` exposing graceful `shutdown()`,
+  `wait_ready()`, and `wait_terminated()`; and `EmbeddedAgent` packages the dedicated-thread +
+  current-thread-runtime setup an in-process host otherwise hand-rolls, handing back the request sender,
+  response receiver, and handle. Existing `run_acp_channel_server` / `run_acp_server` signatures and
+  behavior are unchanged.

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -41,7 +41,10 @@ use sessions::{
     lookup_session_cancellation, preempt_session_interruption, prepare_session_prompt, Session,
     SessionCancellation, SessionInfo,
 };
-pub use transport::{run_acp_channel_server, run_acp_server};
+pub(crate) use transport::run_acp_channel_server_with_existing_handle;
+pub use transport::{
+    run_acp_channel_server, run_acp_channel_server_with_handle, run_acp_server, AcpChannelHandle,
+};
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs;

--- a/crates/harn-serve/src/adapters/acp/transport.rs
+++ b/crates/harn-serve/src/adapters/acp/transport.rs
@@ -1,10 +1,203 @@
 //! ACP stdio and in-process channel transport loops.
 use super::*;
 
-pub async fn run_acp_channel_server(
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Cross-thread control surface for an in-process ACP channel server.
+///
+/// The channel-server future is `!Send` (it owns a [`tokio::task::LocalSet`]
+/// and `spawn_local`s onto it), so it must be driven on a dedicated
+/// current-thread runtime — it cannot be `tokio::spawn`ed onto a multi-thread
+/// runtime, and it cannot be moved between threads once polling starts.
+/// `AcpChannelHandle`, by contrast, is `Send + Sync + Clone`: it is the piece
+/// an embedder keeps on its own thread to observe and steer the server thread.
+///
+/// It exposes three signals:
+///
+/// * [`shutdown`](Self::shutdown) — request a graceful stop. The server stops
+///   accepting new requests and drains, then the driving future resolves. This
+///   is in addition to the existing teardown path of dropping the request
+///   sender (closing `request_rx`), which also stops the loop.
+/// * [`wait_ready`](Self::wait_ready) — resolves once the server has installed
+///   its [`AcpServer`] and entered its message loop, so an embedder can defer
+///   the first `session/new` until the runtime is live.
+/// * [`wait_terminated`](Self::wait_terminated) — resolves once the server loop
+///   has exited (for any reason: shutdown, closed channel, or completion),
+///   giving the embedder a join-style rendezvous that does not require holding
+///   the `!Send` future's `JoinHandle` across threads.
+#[derive(Clone)]
+pub struct AcpChannelHandle {
+    shutdown_requested: Arc<AtomicBool>,
+    shutdown_notify: Arc<Notify>,
+    ready: Arc<AtomicBool>,
+    ready_notify: Arc<Notify>,
+    terminated: Arc<AtomicBool>,
+    terminated_notify: Arc<Notify>,
+}
+
+impl AcpChannelHandle {
+    fn new() -> Self {
+        Self {
+            shutdown_requested: Arc::new(AtomicBool::new(false)),
+            shutdown_notify: Arc::new(Notify::new()),
+            ready: Arc::new(AtomicBool::new(false)),
+            ready_notify: Arc::new(Notify::new()),
+            terminated: Arc::new(AtomicBool::new(false)),
+            terminated_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Request a graceful shutdown of the channel server. Idempotent and safe
+    /// to call from any thread. Wakes the server loop, which stops accepting
+    /// further requests and resolves its driving future. Calling this when the
+    /// server has already terminated is a no-op.
+    pub fn shutdown(&self) {
+        self.shutdown_requested.store(true, Ordering::SeqCst);
+        self.shutdown_notify.notify_waiters();
+    }
+
+    /// Whether [`shutdown`](Self::shutdown) has been requested.
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown_requested.load(Ordering::SeqCst)
+    }
+
+    /// Whether the server has reached its message loop and is ready to accept
+    /// requests.
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::SeqCst)
+    }
+
+    /// Resolve once the server has entered its message loop. Returns
+    /// immediately if it is already ready.
+    pub async fn wait_ready(&self) {
+        // Register interest before checking the flag so a `notify_waiters()`
+        // from `mark_ready` cannot slip between the check and the await.
+        let notified = self.ready_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if self.is_ready() {
+            return;
+        }
+        notified.await;
+    }
+
+    /// Whether the server loop has exited.
+    pub fn is_terminated(&self) -> bool {
+        self.terminated.load(Ordering::SeqCst)
+    }
+
+    /// Resolve once the server loop has exited. Returns immediately if it has
+    /// already terminated.
+    pub async fn wait_terminated(&self) {
+        // Register interest before checking the flag so a `notify_waiters()`
+        // from `mark_terminated` cannot slip between the check and the await.
+        let notified = self.terminated_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if self.is_terminated() {
+            return;
+        }
+        notified.await;
+    }
+
+    fn mark_ready(&self) {
+        self.ready.store(true, Ordering::SeqCst);
+        self.ready_notify.notify_waiters();
+    }
+
+    fn mark_terminated(&self) {
+        self.terminated.store(true, Ordering::SeqCst);
+        self.terminated_notify.notify_waiters();
+    }
+}
+
+impl Default for AcpChannelHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// In-process ACP channel server with a cross-thread control [`AcpChannelHandle`].
+///
+/// Returns the `!Send` driving future and a `Send + Sync + Clone` handle. The
+/// future must be driven on a dedicated current-thread runtime (see
+/// [`AcpChannelHandle`] for why); the handle can be kept on any thread to
+/// observe readiness/termination and to trigger a graceful shutdown.
+///
+/// This is the building block behind both [`run_acp_channel_server`] (which
+/// drops the handle and just awaits the future) and the higher-level
+/// [`crate::embed::EmbeddedAgent`] wrapper (which owns the dedicated thread for
+/// you). Reach for this directly when you already manage your own dedicated
+/// thread + runtime but want the shutdown/readiness/termination signals.
+///
+/// Because the future is `!Send`, an embedder that wants to keep talking to
+/// the agent from its own thread must build the future *on* the dedicated
+/// worker thread (so it never crosses a boundary), passing the `Send` config +
+/// channels + handle across. The handle is created first so a clone can be
+/// returned to the caller. [`crate::embed::EmbeddedAgent`] packages exactly
+/// this pattern; reach for this function directly only when you need to own the
+/// dedicated thread + runtime yourself.
+///
+/// The simplest correct drive — building the runtime and awaiting the future
+/// on the *same* thread — looks like:
+///
+/// ```no_run
+/// use harn_serve::{run_acp_channel_server_with_handle, AcpServerConfig};
+/// use tokio::sync::mpsc;
+///
+/// let (request_tx, request_rx) = mpsc::unbounded_channel();
+/// let (response_tx, response_rx) = mpsc::unbounded_channel();
+/// let config = AcpServerConfig::new(None);
+///
+/// let (server_future, handle) =
+///     run_acp_channel_server_with_handle(config, request_rx, response_tx);
+///
+/// // Drive the `!Send` future on a current-thread runtime, on this thread.
+/// let runtime = tokio::runtime::Builder::new_current_thread()
+///     .enable_all()
+///     .build()
+///     .expect("start ACP runtime");
+/// // `handle` (cloneable + `Send`) can be shared elsewhere before this blocks;
+/// // `handle.shutdown()` then resolves the future from another thread.
+/// let _control = handle.clone();
+/// runtime.block_on(server_future);
+/// # let _ = (request_tx, response_rx);
+/// ```
+pub fn run_acp_channel_server_with_handle(
+    config: AcpServerConfig,
+    request_rx: mpsc::UnboundedReceiver<serde_json::Value>,
+    response_tx: mpsc::UnboundedSender<String>,
+) -> (impl Future<Output = ()>, AcpChannelHandle) {
+    let handle = AcpChannelHandle::new();
+    let future = run_acp_channel_server_with_existing_handle(
+        config,
+        request_rx,
+        response_tx,
+        handle.clone(),
+    );
+    (future, handle)
+}
+
+/// Build the channel-server future bound to a caller-supplied
+/// [`AcpChannelHandle`]. The handle is created on the embedder's thread (it is
+/// `Send`) while the `!Send` future is built and driven on the dedicated
+/// worker thread — see [`crate::embed::EmbeddedAgent`], which relies on this
+/// split so the `!Send` future never crosses a thread boundary.
+pub(crate) fn run_acp_channel_server_with_existing_handle(
+    config: AcpServerConfig,
+    request_rx: mpsc::UnboundedReceiver<serde_json::Value>,
+    response_tx: mpsc::UnboundedSender<String>,
+    handle: AcpChannelHandle,
+) -> impl Future<Output = ()> {
+    run_acp_channel_server_inner(config, request_rx, response_tx, handle)
+}
+
+async fn run_acp_channel_server_inner(
     config: AcpServerConfig,
     mut request_rx: mpsc::UnboundedReceiver<serde_json::Value>,
     response_tx: mpsc::UnboundedSender<String>,
+    handle: AcpChannelHandle,
 ) {
     let profile_enabled = config.profile.is_enabled();
     let local = tokio::task::LocalSet::new();
@@ -16,8 +209,39 @@ pub async fn run_acp_channel_server(
             let (routed_tx, mut routed_rx) =
                 tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();
 
+            // Shutdown signalling for the request-routing task. The router
+            // task is itself `spawn_local`, so it shares this thread with the
+            // loop below; a notify wake lets it stop draining `request_rx`
+            // when the embedder calls `handle.shutdown()`.
+            let router_shutdown = handle.shutdown_requested.clone();
+            let router_notify = handle.shutdown_notify.clone();
+
             tokio::task::spawn_local(async move {
-                while let Some(msg) = request_rx.recv().await {
+                loop {
+                    // Register interest in the shutdown notify *before* checking
+                    // the flag, so a `notify_waiters()` racing with this loop
+                    // iteration cannot be missed (an unpolled `Notified` does
+                    // not retain a `notify_waiters` wake).
+                    let notified = router_notify.notified();
+                    tokio::pin!(notified);
+                    notified.as_mut().enable();
+                    if router_shutdown.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let msg = tokio::select! {
+                        biased;
+                        () = notified.as_mut() => {
+                            if router_shutdown.load(Ordering::SeqCst) {
+                                break;
+                            }
+                            continue;
+                        }
+                        msg = request_rx.recv() => match msg {
+                            Some(msg) => msg,
+                            None => break,
+                        },
+                    };
+
                     if msg.get("method").is_none() && msg.get("id").is_some() {
                         if let Some(id) = msg["id"].as_u64() {
                             let mut pending = pending_clone.lock().await;
@@ -40,14 +264,53 @@ pub async fn run_acp_channel_server(
                 pending.clear();
             });
 
-            while let Some(msg) = routed_rx.recv().await {
-                server.handle_incoming_message(msg).await;
+            handle.mark_ready();
+
+            loop {
+                let shutdown_notify = handle.shutdown_notify.notified();
+                tokio::pin!(shutdown_notify);
+                shutdown_notify.as_mut().enable();
+                if handle.shutdown_requested.load(Ordering::SeqCst) {
+                    break;
+                }
+                tokio::select! {
+                    biased;
+                    () = shutdown_notify.as_mut() => {
+                        if handle.shutdown_requested.load(Ordering::SeqCst) {
+                            break;
+                        }
+                    }
+                    msg = routed_rx.recv() => match msg {
+                        Some(msg) => server.handle_incoming_message(msg).await,
+                        None => break,
+                    },
+                }
             }
+
+            handle.mark_terminated();
         })
         .await;
     if profile_enabled {
         harn_vm::tracing::set_tracing_enabled(false);
     }
+}
+
+/// In-process ACP channel server. Reads JSON-RPC requests from `request_rx`
+/// and writes responses / notifications to `response_tx`.
+///
+/// The returned future is `!Send` and must be driven on a dedicated
+/// current-thread runtime. Embedders that need a graceful-shutdown trigger,
+/// readiness signal, or join-style termination rendezvous should use
+/// [`run_acp_channel_server_with_handle`] instead (this function delegates to
+/// it and simply drops the handle), or the higher-level
+/// [`crate::embed::EmbeddedAgent`] wrapper.
+pub async fn run_acp_channel_server(
+    config: AcpServerConfig,
+    request_rx: mpsc::UnboundedReceiver<serde_json::Value>,
+    response_tx: mpsc::UnboundedSender<String>,
+) {
+    let (future, _handle) = run_acp_channel_server_with_handle(config, request_rx, response_tx);
+    future.await;
 }
 
 /// Start the ACP server. Reads JSON-RPC from stdin, writes to stdout.

--- a/crates/harn-serve/src/embed.rs
+++ b/crates/harn-serve/src/embed.rs
@@ -1,0 +1,352 @@
+//! Embedding helpers for running the in-process ACP agent loop.
+//!
+//! The ACP channel server future is `!Send` — it owns a
+//! [`tokio::task::LocalSet`] and `spawn_local`s onto it — so it cannot be
+//! `tokio::spawn`ed onto a multi-thread runtime. The canonical way to embed it
+//! is therefore: spawn a dedicated OS thread, build a current-thread tokio
+//! runtime on that thread, and `block_on` the server future there, talking to
+//! it over a pair of unbounded channels.
+//!
+//! Every in-process embedder (the orchestrator's ACP WebSocket hub, the API
+//! adapter, and Burin Code's Rust TUI) re-implements that exact dance.
+//! [`EmbeddedAgent`] packages it once: call [`EmbeddedAgent::spawn`], get back
+//! the request sender, the response receiver, and an [`AcpChannelHandle`] for
+//! graceful shutdown / readiness / termination, and let `Drop` join the worker
+//! thread for you.
+
+use std::thread::{self, JoinHandle};
+
+use tokio::sync::mpsc;
+
+use crate::adapters::acp::{
+    run_acp_channel_server_with_existing_handle, AcpChannelHandle, AcpServerConfig,
+};
+
+/// Default name for the dedicated ACP worker thread.
+const DEFAULT_THREAD_NAME: &str = "harn-acp-embed";
+
+/// A running in-process ACP agent: a dedicated worker thread driving the
+/// `!Send` channel-server future on its own current-thread tokio runtime.
+///
+/// Construct one with [`EmbeddedAgent::spawn`]. The embedder communicates over
+/// the [request sender](Self::requests) (host -> agent JSON-RPC) and
+/// [response receiver](Self::take_responses) (agent -> host JSON-RPC lines),
+/// and steers/observes the worker through [`handle`](Self::handle).
+///
+/// Dropping the `EmbeddedAgent` requests a graceful shutdown and joins the
+/// worker thread, so an embedder does not have to manage the `!Send` /
+/// dedicated-thread lifecycle by hand. Call [`shutdown`](Self::shutdown)
+/// (and optionally [`join`](Self::join)) for explicit, error-observable
+/// teardown.
+pub struct EmbeddedAgent {
+    // `Option` so `into_parts` can hand over the *owning* sender (the worker
+    // only ever sees the matching receiver). Dropping the last sender closes
+    // the request channel and is the legacy EOF-style teardown.
+    request_tx: Option<mpsc::UnboundedSender<serde_json::Value>>,
+    response_rx: Option<mpsc::UnboundedReceiver<String>>,
+    handle: AcpChannelHandle,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl EmbeddedAgent {
+    /// Spawn an in-process ACP agent on a dedicated worker thread.
+    ///
+    /// The worker thread builds a current-thread tokio runtime (`enable_all`)
+    /// and `block_on`s the channel server. The agent runs until the request
+    /// sender is dropped, [`shutdown`](Self::shutdown) is called, or the
+    /// `EmbeddedAgent` is dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the OS refuses to spawn the worker thread or the worker
+    /// thread cannot build its tokio runtime — both are unrecoverable
+    /// process-level failures at embed time.
+    pub fn spawn(config: AcpServerConfig) -> Self {
+        Self::spawn_named(config, DEFAULT_THREAD_NAME)
+    }
+
+    /// [`spawn`](Self::spawn) with a caller-chosen worker thread name (useful
+    /// when an embedder runs several agents and wants them distinguishable in
+    /// stack traces and profilers).
+    ///
+    /// # Panics
+    ///
+    /// See [`spawn`](Self::spawn).
+    pub fn spawn_named(config: AcpServerConfig, thread_name: impl Into<String>) -> Self {
+        let (request_tx, request_rx) = mpsc::unbounded_channel::<serde_json::Value>();
+        let (response_tx, response_rx) = mpsc::unbounded_channel::<String>();
+        // The handle is `Send`, so we build it here and hand a clone to the
+        // worker. The channel-server future is `!Send`, so it must be built and
+        // driven entirely on the worker thread — never moved across the
+        // boundary. `config`, the channels, and the handle clone are all
+        // `Send`, so only those cross.
+        let handle = AcpChannelHandle::default();
+        let worker_handle = handle.clone();
+
+        let thread = thread::Builder::new()
+            .name(thread_name.into())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("EmbeddedAgent: build current-thread tokio runtime");
+                let server_future = run_acp_channel_server_with_existing_handle(
+                    config,
+                    request_rx,
+                    response_tx,
+                    worker_handle,
+                );
+                runtime.block_on(server_future);
+            })
+            .expect("EmbeddedAgent: spawn ACP worker thread");
+
+        Self {
+            request_tx: Some(request_tx),
+            response_rx: Some(response_rx),
+            handle,
+            thread: Some(thread),
+        }
+    }
+
+    /// A clonable sender for host -> agent JSON-RPC requests
+    /// (`session/new`, `session/prompt`, `session/cancel`, …). Dropping every
+    /// clone of this sender (and the [`EmbeddedAgent`], which holds the owning
+    /// sender) stops the agent, mirroring stdin EOF.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called after [`into_parts`](Self::into_parts) took the
+    /// owning sender. (`into_parts` consumes `self`, so this only matters for
+    /// internal use.)
+    pub fn requests(&self) -> mpsc::UnboundedSender<serde_json::Value> {
+        self.request_tx
+            .as_ref()
+            .expect("EmbeddedAgent request sender was taken by into_parts")
+            .clone()
+    }
+
+    /// Take the agent -> host response receiver (JSON-RPC response and
+    /// `session/update` notification lines). Returns `None` if already taken;
+    /// the receiver is single-consumer.
+    pub fn take_responses(&mut self) -> Option<mpsc::UnboundedReceiver<String>> {
+        self.response_rx.take()
+    }
+
+    /// The cross-thread control handle for readiness, shutdown, and
+    /// termination signalling.
+    pub fn handle(&self) -> &AcpChannelHandle {
+        &self.handle
+    }
+
+    /// Consume the agent into its raw parts: the request sender, the response
+    /// receiver, and the control handle.
+    ///
+    /// The worker [`JoinHandle`] is detached when you take the parts this way
+    /// — the agent stops when the returned sender is dropped or
+    /// [`AcpChannelHandle::shutdown`] is called, and the thread exits on its
+    /// own. Use this when you want the bare channels and manage lifetime
+    /// through the handle; keep the [`EmbeddedAgent`] if you want `Drop` to
+    /// join the thread.
+    ///
+    /// Returns the response receiver as `None` if it was already taken with
+    /// [`take_responses`](Self::take_responses).
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        mut self,
+    ) -> (
+        mpsc::UnboundedSender<serde_json::Value>,
+        Option<mpsc::UnboundedReceiver<String>>,
+        AcpChannelHandle,
+    ) {
+        // Move out the *owning* sender (not a clone) so the worker's
+        // `request_rx` closes when the caller drops it — preserving the
+        // EOF teardown path.
+        let request_tx = self
+            .request_tx
+            .take()
+            .expect("EmbeddedAgent request sender was already taken");
+        let response_rx = self.response_rx.take();
+        let handle = self.handle.clone();
+        // Detach the worker thread; its lifetime is now owned by the handle
+        // and the moved-out sender. Clearing `thread` makes the subsequent
+        // `Drop` a no-op (it only shuts down / joins when a thread is owned),
+        // so no `mem::forget`/leak is needed.
+        self.thread.take();
+        (request_tx, response_rx, handle)
+    }
+
+    /// Request a graceful shutdown of the agent. Idempotent. Does not block;
+    /// pair with [`join`](Self::join) to wait for the worker thread to exit.
+    pub fn shutdown(&self) {
+        self.handle.shutdown();
+    }
+
+    /// Request shutdown and join the worker thread, returning the thread's
+    /// join result. Subsequent calls (and `Drop`) become no-ops.
+    pub fn join(&mut self) -> thread::Result<()> {
+        self.handle.shutdown();
+        match self.thread.take() {
+            Some(thread) => thread.join(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for EmbeddedAgent {
+    fn drop(&mut self) {
+        // Only own teardown when we still hold the worker thread. `into_parts`
+        // detaches it (sets `thread` to `None`), handing lifetime control to
+        // the returned sender + handle, so dropping the husk must be inert.
+        if let Some(thread) = self.thread.take() {
+            self.handle.shutdown();
+            let _ = thread.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn recv_json(rx: &mut mpsc::UnboundedReceiver<String>) -> serde_json::Value {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match rx.try_recv() {
+                Ok(line) => return serde_json::from_str(&line).expect("valid JSON-RPC line"),
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "timed out waiting for an ACP response line"
+                    );
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    panic!("ACP response channel closed before a response arrived")
+                }
+            }
+        }
+    }
+
+    fn wait_until(deadline: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+        let stop = std::time::Instant::now() + deadline;
+        while std::time::Instant::now() < stop {
+            if predicate() {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        predicate()
+    }
+
+    #[test]
+    fn embedded_agent_round_trips_session_new_and_shuts_down() {
+        let mut agent = EmbeddedAgent::spawn(AcpServerConfig::new(None));
+        let requests = agent.requests();
+        let mut responses = agent.take_responses().expect("responses receiver");
+
+        assert!(
+            wait_until(Duration::from_secs(5), || agent.handle().is_ready()),
+            "agent never became ready"
+        );
+
+        requests
+            .send(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .expect("send session/new");
+
+        let created = recv_json(&mut responses);
+        assert!(
+            created["result"]["sessionId"].as_str().is_some(),
+            "session/new should return a sessionId, got: {created}"
+        );
+
+        // Graceful shutdown stops the worker thread.
+        agent.shutdown();
+        assert!(agent.join().is_ok(), "worker thread should join cleanly");
+        assert!(agent.handle().is_shutdown());
+        assert!(agent.handle().is_terminated());
+    }
+
+    #[test]
+    fn shutdown_handle_terminates_idle_agent() {
+        let agent = EmbeddedAgent::spawn(AcpServerConfig::new(None));
+        let handle = agent.handle().clone();
+
+        assert!(
+            wait_until(Duration::from_secs(5), || handle.is_ready()),
+            "agent never became ready"
+        );
+        assert!(!handle.is_terminated());
+
+        // A shutdown trigger from a cloned handle (a different owner than the
+        // EmbeddedAgent) must stop an otherwise-idle server loop.
+        handle.shutdown();
+        assert!(
+            wait_until(Duration::from_secs(5), || handle.is_terminated()),
+            "shutdown() did not terminate the idle agent loop"
+        );
+
+        drop(agent); // Drop joins the worker; must not hang.
+        assert!(handle.is_shutdown());
+    }
+
+    #[test]
+    fn dropping_request_sender_terminates_agent() {
+        // `into_parts` detaches the worker thread and hands over the *only*
+        // request sender, so dropping it closes `request_rx`. That must stop
+        // the router and the loop even without an explicit shutdown() — the
+        // legacy EOF-style teardown that existing callers rely on.
+        let agent = EmbeddedAgent::spawn(AcpServerConfig::new(None));
+        let (requests, _responses, handle) = agent.into_parts();
+
+        assert!(
+            wait_until(Duration::from_secs(5), || handle.is_ready()),
+            "agent never became ready"
+        );
+        assert!(!handle.is_terminated());
+
+        drop(requests);
+        assert!(
+            wait_until(Duration::from_secs(5), || handle.is_terminated()),
+            "closing the request channel did not terminate the agent loop"
+        );
+        assert!(
+            !handle.is_shutdown(),
+            "EOF teardown must not set the shutdown flag"
+        );
+    }
+
+    #[test]
+    fn into_parts_detaches_thread_and_keeps_channels_live() {
+        let agent = EmbeddedAgent::spawn(AcpServerConfig::new(None));
+        let (requests, responses, handle) = agent.into_parts();
+        let mut responses = responses.expect("responses receiver");
+
+        assert!(
+            wait_until(Duration::from_secs(5), || handle.is_ready()),
+            "agent never became ready"
+        );
+
+        requests
+            .send(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "session/new",
+                "params": {"cwd": "."},
+            }))
+            .expect("send session/new");
+        let created = recv_json(&mut responses);
+        assert!(created["result"]["sessionId"].as_str().is_some());
+
+        handle.shutdown();
+        assert!(
+            wait_until(Duration::from_secs(5), || handle.is_terminated()),
+            "detached agent did not terminate after shutdown()"
+        );
+    }
+}

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -4,6 +4,7 @@ mod adapter;
 pub mod adapters;
 mod auth;
 mod core;
+pub mod embed;
 mod error;
 mod exports;
 pub mod http_codec;
@@ -32,8 +33,9 @@ pub(crate) use adapter::DispatchRuntime;
 pub use adapter::{AdapterDescriptor, TransportAdapter};
 pub use adapters::a2a::{A2aHttpServeOptions, A2aServer, A2aServerConfig, A2A_PROTOCOL_VERSION};
 pub use adapters::acp::{
-    run_acp_channel_server, run_acp_server, AcpProfileConfig, AcpRuntimeConfigurator, AcpServer,
-    AcpServerConfig, NoopAcpRuntimeConfigurator,
+    run_acp_channel_server, run_acp_channel_server_with_handle, run_acp_server, AcpChannelHandle,
+    AcpProfileConfig, AcpRuntimeConfigurator, AcpServer, AcpServerConfig,
+    NoopAcpRuntimeConfigurator,
 };
 pub use adapters::api::{ApiHttpServeOptions, ApiServer, ApiServerConfig};
 pub use adapters::mcp::{
@@ -49,6 +51,7 @@ pub use core::{
     CallArguments, CallRequest, CallResponse, DispatchCore, DispatchCoreConfig, NoopVmConfigurator,
     VmConfigurator,
 };
+pub use embed::EmbeddedAgent;
 pub use error::{forbidden_data_payload, forbidden_message, DispatchError};
 pub use exports::{
     emit_export_diagnostics, ExportCatalog, ExportDiagnostic, ExportedCallableKind,


### PR DESCRIPTION
## What

Additive, **non-breaking** embedding ergonomics for in-process ACP hosts (motivated by burin-code's Rust TUI, #1364; epic #2636 items a + c).

- `run_acp_channel_server_with_handle(config, rx, tx) -> (impl Future, AcpChannelHandle)` — the `!Send` server future + a `Send` `AcpChannelHandle` exposing graceful `shutdown()` / `wait_ready()` / `wait_terminated()` / `is_terminated()`. `run_acp_channel_server` now delegates to it with **unchanged signature + behavior** (biased `select!` on a shutdown `Notify`; identical path when no shutdown is requested).
- `EmbeddedAgent` (new `embed` module) — packages the dedicated-thread + current-thread-runtime dance an embedder otherwise hand-rolls (because the server future is `!Send`), handing back `(UnboundedSender<Value>, UnboundedReceiver<String>, AcpChannelHandle)`; `Drop` shuts down + joins.

The `!Send`/dedicated-thread requirement is documented on every public item. Existing in-tree embedders (`acp_hub.rs`, `api.rs`) compile unchanged.

## Tests

4 new tests (round-trip + shutdown/join + EOF teardown + into_parts detach). `cargo build -p harn-serve` + `-p harn-cli`, `cargo test -p harn-serve` (366 lib + integration, 0 failed), `clippy -D warnings`, `fmt --check` all clean. No new dependency (uses existing `tokio::sync::Notify` + `AtomicBool`).

For #2636. Unblocks burin-code#1364's engine adopting a clean shutdown/handle instead of the channel-drop + thread-join pattern.