### PR TITLE
harn-cli: replay --counterfactual <plan.harn> (#2611, closes #2522)

### DIFF
--- a/changelog.d/2611.added.md
+++ b/changelog.d/2611.added.md
@@ -1,0 +1,8 @@
+- **`harn replay --counterfactual <plan.harn>` answers "what if the agent had
+  edited differently?" (#2611).** After rehydrating a session at the `--at`
+  cutoff, the flag evaluates an alternate `.harn` edit plan through
+  `edit.dry_run` against a throw-away staged-fs overlay (#1722) and reports the
+  divergent file set — the files the plan's edits would touch, each tagged
+  `created`/`modified`/`deleted` with line deltas — in both human and `--json`
+  (`data.counterfactual`) modes. The recorded session and the on-disk tree are
+  never mutated. Closes #2522.

--- a/crates/harn-cli/src/cli/runs.rs
+++ b/crates/harn-cli/src/cli/runs.rs
@@ -44,6 +44,14 @@ pub(crate) struct ReplayArgs {
     /// `--session-id`; omit to replay the whole session.
     #[arg(long, value_name = "EVENT_ID", requires = "session_id")]
     pub at: Option<u64>,
+    /// Counterfactual: after rehydrating the session at `--at` (or its full
+    /// state), evaluate this `.harn` plan and report how the workspace
+    /// *would have* diverged — the set of files the plan's edits would
+    /// touch. The plan runs through `edit.dry_run` against a throw-away
+    /// staged-fs overlay (#1722), so the recorded session and the on-disk
+    /// tree are never mutated. Requires `--session-id`.
+    #[arg(long, value_name = "PLAN", requires = "session_id")]
+    pub counterfactual: Option<String>,
     /// Number of replay reads to compare for deterministic output.
     #[arg(long, default_value_t = 1)]
     pub runs: usize,

--- a/crates/harn-cli/src/commands/counterfactual.rs
+++ b/crates/harn-cli/src/commands/counterfactual.rs
@@ -1,0 +1,390 @@
+//! `harn replay --counterfactual <plan.harn>` — evaluate an alternate edit
+//! plan against the workspace as it stood at a `--at` cutoff and report the
+//! divergent file set without mutating the recorded session or the disk.
+//!
+//! This composes two shipped primitives rather than reimplementing any of
+//! their machinery:
+//!
+//! - **B.5 `edit.dry_run`** (`std/edit::edit_dry_run`, backed by the
+//!   `hostlib_ast_dry_run` builtin) lowers an ordered edit plan into a
+//!   per-file unified-diff bundle.
+//! - **#1722 staged-fs** isolates that dry-run inside a throw-away overlay
+//!   so the on-disk tree is byte-identical before and after the call.
+//!
+//! The CLI's only job here is to (1) evaluate the operator's `plan.harn`
+//! into an edit plan, (2) run it through `edit_dry_run`, and (3) project the
+//! dry-run result down to a *divergence* — the set of files that would
+//! differ from the recorded outcome at the cutoff.
+//!
+//! ## Plan contract
+//!
+//! The `plan.harn` program `return`s one of (a bare trailing expression
+//! returns `nil` in Harn, so the plan must use `return`):
+//!
+//! - a **list** of edit ops — the `plan` argument to `edit_dry_run`
+//!   (`return [{op: "apply_node", path, query, replacement}, ...]`); the CLI
+//!   calls `edit_dry_run` for you, or
+//! - a **dict** that is already an `edit_dry_run` result (carries
+//!   `per_file_unified_diff`) — for plans that prefer to call `edit_dry_run`
+//!   themselves and shape the result (`return edit_dry_run({plan: [...]})`).
+//!
+//! Either way the divergence is read off the same `per_file_unified_diff` /
+//! `summary` shape, so the CLI never reimplements diffing.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use harn_lexer::Lexer;
+use harn_parser::{DiagnosticSeverity, Parser, TypeChecker};
+
+/// One file the counterfactual plan would touch — the unit of divergence.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DivergedFile {
+    pub path: String,
+    /// `created`, `modified`, or `deleted` — derived from the dry-run line
+    /// deltas the same way `edit.dry_run` classifies a change.
+    pub status: String,
+    pub lines_added: u64,
+    pub lines_removed: u64,
+}
+
+/// Structured divergence summary stitched into the replay envelope under
+/// `counterfactual`. Mirrors the `edit.dry_run` roll-up so callers can
+/// reconcile the two without a second lookup.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CounterfactualReport {
+    /// Absolute or workspace-relative path to the evaluated plan.
+    pub plan_path: String,
+    /// `ok`, `partial`, or `no_ops_applied`, straight from `edit.dry_run`.
+    pub result: String,
+    /// The divergent file set — every file the plan's edits would touch.
+    pub diverged: Vec<DivergedFile>,
+    pub files_touched: u64,
+    pub lines_added: u64,
+    pub lines_removed: u64,
+    pub ops_applied: u64,
+    pub ops_rejected: u64,
+}
+
+/// Evaluate `plan_path` and return its divergence. `Err` carries a
+/// human-readable message suitable for both the `error.message` JSON field
+/// and the human `error:` line.
+pub(crate) fn evaluate(plan_path: &Path) -> Result<CounterfactualReport, String> {
+    let source = std::fs::read_to_string(plan_path).map_err(|error| {
+        format!(
+            "failed to read counterfactual plan {}: {error}",
+            plan_path.display()
+        )
+    })?;
+    let plan_value = run_plan_source(&source, plan_path)?;
+    let dry_run = ensure_dry_run(plan_value, plan_path)?;
+    project_divergence(&dry_run, plan_path)
+}
+
+/// Compile and execute `plan.harn`, returning its final value as JSON. The
+/// VM is wired exactly like `harn run`'s — stdlib plus the default hostlib —
+/// so `edit_dry_run` and the staged-fs overlay it relies on are available.
+fn run_plan_source(source: &str, plan_path: &Path) -> Result<JsonValue, String> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer
+        .tokenize()
+        .map_err(|error| format!("counterfactual plan lex error: {error}"))?;
+    let mut parser = Parser::new(tokens);
+    let program = parser
+        .parse()
+        .map_err(|error| format!("counterfactual plan parse error: {error}"))?;
+
+    let mut checker = TypeChecker::new();
+    let graph = harn_modules::build(&[plan_path.to_path_buf()]);
+    if let Some(imported) = graph.imported_names_for_file(plan_path) {
+        checker = checker.with_imported_names(imported);
+    }
+    if let Some(imported) = graph.imported_type_declarations_for_file(plan_path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
+    if let Some(imported) = graph.imported_callable_declarations_for_file(plan_path) {
+        checker = checker.with_imported_callable_decls(imported);
+    }
+    for diag in checker.check(&program) {
+        if matches!(diag.severity, DiagnosticSeverity::Error) {
+            return Err(format!("counterfactual plan type error: {}", diag.message));
+        }
+    }
+
+    let chunk = harn_vm::Compiler::new()
+        .compile(&program)
+        .map_err(|error| format!("counterfactual plan compile error: {error}"))?;
+
+    let source_parent = plan_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let project_root = harn_vm::stdlib::process::find_project_root(&source_parent);
+    let store_base = project_root
+        .clone()
+        .unwrap_or_else(|| source_parent.clone());
+
+    let local = tokio::task::LocalSet::new();
+    futures::executor::block_on(local.run_until(async move {
+        let mut vm = harn_vm::Vm::new();
+        harn_vm::register_vm_stdlib(&mut vm);
+        crate::install_default_hostlib(&mut vm);
+        harn_vm::register_store_builtins(&mut vm, &store_base);
+        harn_vm::register_metadata_builtins(&mut vm, &store_base);
+        let pipeline_name = plan_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("counterfactual");
+        harn_vm::register_checkpoint_builtins(&mut vm, &store_base, pipeline_name);
+        vm.set_source_info(&plan_path.to_string_lossy(), source);
+        if let Some(root) = project_root.as_ref() {
+            vm.set_project_root(root);
+        }
+        vm.set_source_dir(&source_parent);
+        vm.set_harness(harn_vm::Harness::real());
+        let value = vm
+            .execute(&chunk)
+            .await
+            .map_err(|error| format!("counterfactual plan runtime error: {error}"))?;
+        Ok(harn_vm::llm::vm_value_to_json(&value))
+    }))
+}
+
+/// Normalize the plan program's final value into an `edit.dry_run` result.
+/// A list is treated as a raw edit plan and run through `edit_dry_run`; a
+/// dict that already carries `per_file_unified_diff` is used as-is.
+fn ensure_dry_run(value: JsonValue, plan_path: &Path) -> Result<JsonValue, String> {
+    match value {
+        JsonValue::Array(_) => run_edit_dry_run(value, plan_path),
+        JsonValue::Object(ref map) if map.contains_key("per_file_unified_diff") => Ok(value),
+        JsonValue::Object(ref map) if map.contains_key("plan") => {
+            run_edit_dry_run(map["plan"].clone(), plan_path)
+        }
+        other => Err(format!(
+            "counterfactual plan {} must `return` an edit-op list or an edit_dry_run result, \
+             got {} (a bare trailing expression returns nil in Harn — use `return`)",
+            plan_path.display(),
+            json_type_name(&other)
+        )),
+    }
+}
+
+/// Run a raw edit plan through `std/edit::edit_dry_run` (which opens and
+/// discards a transient staged-fs overlay) and return its result JSON.
+///
+/// The plan is a JSON value (lists/dicts/strings/numbers/bools), which is a
+/// subset of Harn's dict/list literal syntax — JSON-style quoted keys parse
+/// fine — so we embed it directly into a tiny driver program and run it
+/// through the same VM path as a plan that called `edit_dry_run` itself.
+/// This keeps a single execution path and avoids round-tripping the plan
+/// through a host global.
+///
+/// The driver is written to a temp `.harn` file beside the plan so the
+/// cross-module typechecker resolves the `std/edit` import the same way it
+/// does for an on-disk plan (the import graph is keyed by file path).
+fn run_edit_dry_run(plan: JsonValue, plan_path: &Path) -> Result<JsonValue, String> {
+    let plan_literal = serde_json::to_string(&plan)
+        .map_err(|error| format!("failed to serialize counterfactual plan: {error}"))?;
+    let driver = format!(
+        "import {{ edit_dry_run }} from \"std/edit\"\nreturn edit_dry_run({{plan: {plan_literal}}})\n"
+    );
+
+    let dir = plan_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(std::env::temp_dir);
+    let driver_file = tempfile::Builder::new()
+        .prefix(".harn-counterfactual-driver-")
+        .suffix(".harn")
+        .tempfile_in(&dir)
+        .map_err(|error| format!("failed to stage counterfactual dry-run driver: {error}"))?;
+    std::fs::write(driver_file.path(), &driver)
+        .map_err(|error| format!("failed to write counterfactual dry-run driver: {error}"))?;
+
+    run_plan_source(&driver, driver_file.path())
+}
+
+/// Read the divergent file set off the `edit.dry_run` result. The status of
+/// each file is classified from its line deltas exactly the way
+/// `edit.dry_run` itself does (pure additions → `created`, pure removals →
+/// `deleted`, both → `modified`).
+fn project_divergence(
+    dry_run: &JsonValue,
+    plan_path: &Path,
+) -> Result<CounterfactualReport, String> {
+    let summary = dry_run.get("summary").cloned().unwrap_or(JsonValue::Null);
+    let mut diverged = Vec::new();
+    if let Some(entries) = dry_run
+        .get("per_file_unified_diff")
+        .and_then(JsonValue::as_array)
+    {
+        for entry in entries {
+            let path = entry
+                .get("path")
+                .and_then(JsonValue::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let lines_added = entry
+                .get("lines_added")
+                .and_then(JsonValue::as_u64)
+                .unwrap_or(0);
+            let lines_removed = entry
+                .get("lines_removed")
+                .and_then(JsonValue::as_u64)
+                .unwrap_or(0);
+            let status = if lines_removed == 0 && lines_added > 0 {
+                "created"
+            } else if lines_added == 0 && lines_removed > 0 {
+                "deleted"
+            } else {
+                "modified"
+            };
+            diverged.push(DivergedFile {
+                path,
+                status: status.to_string(),
+                lines_added,
+                lines_removed,
+            });
+        }
+    }
+
+    Ok(CounterfactualReport {
+        plan_path: plan_path.to_string_lossy().into_owned(),
+        result: dry_run
+            .get("result")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("no_ops_applied")
+            .to_string(),
+        diverged,
+        files_touched: summary
+            .get("files_touched")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0),
+        lines_added: summary
+            .get("lines_added")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0),
+        lines_removed: summary
+            .get("lines_removed")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0),
+        ops_applied: summary
+            .get("ops_applied")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0),
+        ops_rejected: summary
+            .get("ops_rejected")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0),
+    })
+}
+
+fn json_type_name(value: &JsonValue) -> &'static str {
+    match value {
+        JsonValue::Null => "nil",
+        JsonValue::Bool(_) => "bool",
+        JsonValue::Number(_) => "number",
+        JsonValue::String(_) => "string",
+        JsonValue::Array(_) => "list",
+        JsonValue::Object(_) => "dict",
+    }
+}
+
+/// Render the divergence for the human (non-`--json`) replay path.
+pub(crate) fn print_human(report: &CounterfactualReport) {
+    println!("Counterfactual: {} ({})", report.plan_path, report.result);
+    if report.diverged.is_empty() {
+        println!("  no files would diverge from the recorded outcome.");
+    } else {
+        println!(
+            "  would touch {} file(s) (+{} / -{} lines, {} op(s) applied, {} rejected):",
+            report.files_touched,
+            report.lines_added,
+            report.lines_removed,
+            report.ops_applied,
+            report.ops_rejected,
+        );
+        for file in &report.diverged {
+            println!(
+                "    {} {} (+{} / -{})",
+                file.status, file.path, file.lines_added, file.lines_removed
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn plan_path() -> &'static Path {
+        Path::new("/tmp/what-if.harn")
+    }
+
+    #[test]
+    fn projects_diverged_files_and_classifies_status_by_line_deltas() {
+        let dry_run = json!({
+            "result": "ok",
+            "per_file_unified_diff": [
+                {"path": "a.rs", "diff": "...", "lines_added": 3, "lines_removed": 0},
+                {"path": "b.rs", "diff": "...", "lines_added": 0, "lines_removed": 4},
+                {"path": "c.rs", "diff": "...", "lines_added": 2, "lines_removed": 2},
+            ],
+            "summary": {
+                "files_touched": 3,
+                "lines_added": 5,
+                "lines_removed": 6,
+                "ops_applied": 3,
+                "ops_rejected": 0,
+            },
+        });
+        let report = project_divergence(&dry_run, plan_path()).expect("project");
+        assert_eq!(report.result, "ok");
+        assert_eq!(report.files_touched, 3);
+        assert_eq!(report.lines_added, 5);
+        assert_eq!(report.lines_removed, 6);
+        assert_eq!(report.ops_applied, 3);
+        assert_eq!(report.diverged.len(), 3);
+        assert_eq!(report.diverged[0].status, "created");
+        assert_eq!(report.diverged[1].status, "deleted");
+        assert_eq!(report.diverged[2].status, "modified");
+    }
+
+    #[test]
+    fn empty_dry_run_projects_to_no_divergence() {
+        let dry_run = json!({
+            "result": "no_ops_applied",
+            "per_file_unified_diff": [],
+            "summary": {"files_touched": 0, "lines_added": 0, "lines_removed": 0, "ops_applied": 0, "ops_rejected": 0},
+        });
+        let report = project_divergence(&dry_run, plan_path()).expect("project");
+        assert!(report.diverged.is_empty());
+        assert_eq!(report.result, "no_ops_applied");
+    }
+
+    #[test]
+    fn ensure_dry_run_rejects_a_nil_plan_with_a_return_hint() {
+        let error = ensure_dry_run(JsonValue::Null, plan_path()).unwrap_err();
+        assert!(error.contains("got nil"), "error: {error}");
+        assert!(
+            error.contains("return"),
+            "error should hint at `return`: {error}"
+        );
+    }
+
+    #[test]
+    fn ensure_dry_run_passes_through_an_existing_dry_run_result() {
+        let dry_run = json!({
+            "result": "ok",
+            "per_file_unified_diff": [{"path": "x.rs", "diff": "...", "lines_added": 1, "lines_removed": 0}],
+            "summary": {"files_touched": 1},
+        });
+        let passed = ensure_dry_run(dry_run.clone(), plan_path()).expect("passthrough");
+        assert_eq!(passed, dry_run);
+    }
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod config_cmd;
 pub(crate) mod connect;
 pub(crate) mod connector;
 pub(crate) mod contracts;
+pub(crate) mod counterfactual;
 pub(crate) mod crystallize;
 pub mod demo;
 pub(crate) mod dev;

--- a/crates/harn-cli/src/commands/replay.rs
+++ b/crates/harn-cli/src/commands/replay.rs
@@ -24,6 +24,10 @@ pub(crate) struct ReplayReport {
     pub transitions: Vec<ReplayTransition>,
     pub transcript_event_count: usize,
     pub fixture: ReplayFixtureResult,
+    /// Divergence from a `--counterfactual <plan.harn>` evaluated against
+    /// the workspace state at the `--at` cutoff. `None` for a plain replay.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub counterfactual: Option<crate::commands::counterfactual::CounterfactualReport>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -116,6 +120,9 @@ enum ReplaySource {
         /// at` are rehydrated, replaying the session as it stood at that
         /// point. `None` replays the whole session.
         at: Option<u64>,
+        /// Counterfactual: path to a `.harn` edit plan to evaluate against
+        /// the workspace state at the cutoff. `None` for a plain replay.
+        counterfactual: Option<PathBuf>,
     },
 }
 
@@ -140,6 +147,7 @@ impl ReplaySource {
                 session_id,
                 events_db,
                 at,
+                ..
             } => ReplaySourceSummary {
                 kind: "event_log_session".to_string(),
                 path: None,
@@ -162,6 +170,18 @@ impl ReplaySource {
             Self::RunRecord { .. } => "run_record_load_failed",
             Self::ReplayTrace { .. } => "replay_fixture_load_failed",
             Self::Session { .. } => "replay_load_failed",
+        }
+    }
+
+    /// Path to the counterfactual `.harn` plan, when `--counterfactual` was
+    /// passed (Session sources only).
+    fn counterfactual_plan(&self) -> Option<&Path> {
+        match self {
+            Self::Session {
+                counterfactual: Some(path),
+                ..
+            } => Some(path.as_path()),
+            _ => None,
         }
     }
 }
@@ -188,21 +208,52 @@ pub(crate) fn run(args: ReplayArgs) -> i32 {
         }
     };
 
+    // The counterfactual is composed *after* the recorded replay is
+    // reconstructed at the `--at` cutoff: the recorded path defines the
+    // baseline, and the plan's dry-run divergence is reported against it.
+    let counterfactual = match source.counterfactual_plan() {
+        Some(plan_path) => match crate::commands::counterfactual::evaluate(plan_path) {
+            Ok(report) => Some(report),
+            Err(error) => {
+                if args.json {
+                    print_json_error("replay_counterfactual_failed", error);
+                } else {
+                    eprintln!("error: {error}");
+                }
+                return 1;
+            }
+        },
+        None => None,
+    };
+
     if args.json {
-        run_json(source, args.runs)
+        run_json(source, args.runs, counterfactual)
     } else {
-        run_human(source, args.runs)
+        run_human(source, args.runs, counterfactual)
     }
 }
 
-fn run_json(source: ReplaySource, runs: usize) -> i32 {
-    let executions = match execute_runs(&source, runs) {
+fn run_json(
+    source: ReplaySource,
+    runs: usize,
+    counterfactual: Option<crate::commands::counterfactual::CounterfactualReport>,
+) -> i32 {
+    let mut executions = match execute_runs(&source, runs) {
         Ok(executions) => executions,
         Err(error) => {
             print_json_error(source.load_error_code(), error);
             return 1;
         }
     };
+
+    // The counterfactual divergence rides on the first replay read — it is
+    // a property of the rehydrated state at the cutoff, not of any one
+    // deterministic re-read.
+    if let Some(report) = counterfactual {
+        if let Some(first) = executions.first_mut() {
+            first.report.counterfactual = Some(report);
+        }
+    }
 
     if runs == 1 {
         let execution = executions
@@ -258,7 +309,11 @@ fn run_json(source: ReplaySource, runs: usize) -> i32 {
     exit
 }
 
-fn run_human(source: ReplaySource, runs: usize) -> i32 {
+fn run_human(
+    source: ReplaySource,
+    runs: usize,
+    counterfactual: Option<crate::commands::counterfactual::CounterfactualReport>,
+) -> i32 {
     let executions = match execute_runs(&source, runs) {
         Ok(executions) => executions,
         Err(error) => {
@@ -274,6 +329,9 @@ fn run_human(source: ReplaySource, runs: usize) -> i32 {
             println!("Replay run {}:", index + 1);
         }
         print_report_human(&execution.report);
+    }
+    if let Some(report) = &counterfactual {
+        crate::commands::counterfactual::print_human(report);
     }
     if runs > 1 {
         let determinism = determinism_summary(&source, &executions);
@@ -303,6 +361,7 @@ fn resolve_source(args: &ReplayArgs) -> Result<ReplaySource, String> {
             session_id: session_id.clone(),
             events_db: PathBuf::from(events_db),
             at: args.at,
+            counterfactual: args.counterfactual.as_ref().map(PathBuf::from),
         });
     }
     if let Some(fixture) = &args.fixture {
@@ -350,6 +409,7 @@ fn execute_once(source: &ReplaySource, index: usize) -> Result<ReplayExecution, 
             session_id,
             events_db,
             at,
+            ..
         } => execute_session_replay(session_id, events_db, *at),
     }
 }
@@ -475,6 +535,7 @@ fn execute_replay_trace(
         transitions: Vec::new(),
         transcript_event_count: trace_run.event_log_entries.len(),
         fixture,
+        counterfactual: None,
     };
     let event_sequence = canonical_event_sequence(&trace_run, &trace.allowlist)?;
     Ok(ReplayExecution {
@@ -532,6 +593,7 @@ fn replay_report_from_run(run: &harn_vm::orchestration::RunRecord) -> ReplayRepo
             failures: report.failures.clone(),
             stage_count: report.stage_count,
         },
+        counterfactual: None,
     }
 }
 

--- a/crates/harn-cli/tests/replay_session_cli.rs
+++ b/crates/harn-cli/tests/replay_session_cli.rs
@@ -234,6 +234,214 @@ fn replay_human_runs_fail_when_embedded_fixture_fails() {
 }
 
 #[test]
+fn replay_counterfactual_reports_diverged_files_without_touching_disk() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-counterfactual";
+    seed_session_db(&db, session_id);
+
+    // A real workspace file the counterfactual plan will (virtually) edit.
+    let target = temp.path().join("greeting.txt");
+    let original = "hello world\nsecond line\n";
+    std::fs::write(&target, original).expect("write target file");
+
+    // The alternate plan: a `.harn` program whose final value is an edit
+    // plan. The CLI runs it through `edit_dry_run` against a throw-away
+    // staged-fs overlay — disk is never mutated.
+    let plan = temp.path().join("plan.harn");
+    std::fs::write(
+        &plan,
+        format!(
+            r#"return [
+  {{
+    op: "safe_text_patch",
+    path: "{}",
+    old_text: "hello world",
+    new_text: "hello counterfactual",
+  }},
+]
+"#,
+            target.to_str().unwrap(),
+        ),
+    )
+    .expect("write counterfactual plan");
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--counterfactual",
+            plan.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --counterfactual");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = stdout_json(&out);
+    assert_eq!(parsed["ok"], true);
+    let counterfactual = &parsed["data"]["counterfactual"];
+    assert_eq!(counterfactual["result"], "ok");
+    assert_eq!(counterfactual["files_touched"], 1);
+    let diverged = counterfactual["diverged"]
+        .as_array()
+        .expect("diverged should be an array");
+    assert_eq!(diverged.len(), 1);
+    assert_eq!(
+        diverged[0]["path"].as_str().unwrap(),
+        target.to_str().unwrap()
+    );
+    assert_eq!(diverged[0]["status"], "modified");
+    assert_eq!(diverged[0]["lines_added"], 1);
+    assert_eq!(diverged[0]["lines_removed"], 1);
+
+    // The dry-run never touches disk — the file is byte-identical.
+    let on_disk = std::fs::read_to_string(&target).expect("read target after replay");
+    assert_eq!(on_disk, original);
+}
+
+#[test]
+fn replay_counterfactual_human_lists_diverged_files() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-counterfactual-human";
+    seed_session_db(&db, session_id);
+
+    let target = temp.path().join("notes.txt");
+    std::fs::write(&target, "alpha\nbeta\n").expect("write target file");
+
+    let plan = temp.path().join("plan.harn");
+    std::fs::write(
+        &plan,
+        format!(
+            r#"return [
+  {{op: "safe_text_patch", path: "{}", old_text: "alpha", new_text: "alpha-prime"}},
+]
+"#,
+            target.to_str().unwrap(),
+        ),
+    )
+    .expect("write plan");
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--counterfactual",
+            plan.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn harn replay --counterfactual (human)");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Counterfactual:"),
+        "human output should announce the counterfactual:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("would touch 1 file(s)"),
+        "human output should summarize the divergent file set:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(target.to_str().unwrap()),
+        "human output should name the diverged file:\n{stdout}"
+    );
+}
+
+#[test]
+fn replay_counterfactual_accepts_plan_that_returns_dry_run_result() {
+    // The alternate contract: the plan calls `edit_dry_run` itself and
+    // returns its result dict. The CLI reads divergence off the same
+    // `per_file_unified_diff` shape rather than re-running the dry-run.
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-counterfactual-dict";
+    seed_session_db(&db, session_id);
+
+    let target = temp.path().join("config.txt");
+    std::fs::write(&target, "mode = off\n").expect("write target file");
+
+    let plan = temp.path().join("plan.harn");
+    std::fs::write(
+        &plan,
+        format!(
+            r#"import {{ edit_dry_run }} from "std/edit"
+return edit_dry_run({{plan: [
+  {{op: "safe_text_patch", path: "{}", old_text: "mode = off", new_text: "mode = on"}},
+]}})
+"#,
+            target.to_str().unwrap(),
+        ),
+    )
+    .expect("write plan");
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--counterfactual",
+            plan.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --counterfactual (dict)");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = stdout_json(&out);
+    let counterfactual = &parsed["data"]["counterfactual"];
+    assert_eq!(counterfactual["result"], "ok");
+    assert_eq!(counterfactual["files_touched"], 1);
+    let diverged = counterfactual["diverged"].as_array().unwrap();
+    assert_eq!(diverged.len(), 1);
+    assert_eq!(diverged[0]["status"], "modified");
+}
+
+#[test]
+fn replay_counterfactual_rejects_missing_plan() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-counterfactual-missing";
+    seed_session_db(&db, session_id);
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--counterfactual",
+            temp.path().join("does-not-exist.harn").to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --counterfactual missing");
+    assert!(!out.status.success(), "expected missing plan to fail");
+    let parsed = stdout_json(&out);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"]["code"], "replay_counterfactual_failed");
+}
+
+#[test]
 fn replay_fixture_runs_use_oracle_allowlist() {
     let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json");

--- a/docs/src/cli-json-contract.md
+++ b/docs/src/cli-json-contract.md
@@ -172,6 +172,15 @@ allowlist-stripped replay comparison. `ok: false` with `error.code:
 `error.code: "replay_determinism_failed"` indicates the per-run event
 material diverged after applying the replay allowlist.
 
+`harn replay --session-id <id> --counterfactual <plan.harn>` evaluates an
+alternate edit plan through `edit.dry_run` against the workspace state at
+the `--at` cutoff and attaches the divergence to the single `ReplayReport`
+under `data.counterfactual`: `{ plan_path, result, diverged: [{ path,
+status, lines_added, lines_removed }], files_touched, lines_added,
+lines_removed, ops_applied, ops_rejected }`. The field is omitted for a
+plain replay. A plan that fails to load or evaluate exits non-zero with
+`error.code: "replay_counterfactual_failed"`.
+
 ### `harn run --emit-summary-json`
 
 The post-run summary is a raw NDJSON line, not a `JsonEnvelope`, because

--- a/docs/src/cookbooks/replay-time-travel.md
+++ b/docs/src/cookbooks/replay-time-travel.md
@@ -54,6 +54,89 @@ The replay report's `transcript_event_count` reflects the truncated
 prefix, so you can diff the determinism of "the session up to event N"
 against the full run.
 
+## Ask "what if?" with `--counterfactual`
+
+Rewinding shows you the state the agent saw. The next question is
+*"what if it had edited differently?"* — answer it without mutating the
+recorded session or the workspace. `--counterfactual <plan.harn>`
+evaluates an alternate edit plan against the workspace as it stood at the
+`--at` cutoff and reports the **divergent file set**: the files the plan's
+edits would touch.
+
+```bash
+harn replay --session-id sess_42 --events-db ./.harn/agent-events.db \
+  --at 7 --counterfactual ./what-if.harn
+```
+
+The `.harn` plan `return`s an edit plan — the same ordered list of typed
+ops [`edit_dry_run`](../stdlib/edit.md#edit_dry_run--preview-a-multi-op-plan)
+accepts. (A bare trailing expression returns `nil` in Harn, so the plan
+must use `return`.)
+
+```harn
+// what-if.harn — the edit the agent *could* have made at event 7.
+return [
+  {
+    op: "safe_text_patch",
+    path: "src/lib.rs",
+    old_text: "fn greet()",
+    new_text: "fn greeter()",
+  },
+  {
+    op: "apply_node",
+    path: "src/lib.rs",
+    query: "(function_item body: (block) @target)",
+    replacement: "{ format!(\"hi {name}!\") }",
+    select: "first",
+  },
+]
+```
+
+(A plan that prefers to call `edit_dry_run` itself works too —
+`return edit_dry_run({plan: [...]})` — the divergence is read off the same
+`per_file_unified_diff` / `summary` shape either way.)
+
+The plan runs through `edit.dry_run`, which opens and immediately discards
+a throw-away **staged-fs** overlay, so the on-disk tree is byte-identical
+before and after. The human output lists the divergent files:
+
+```text
+Time-travelled to event 7: replaying the session as it stood at that point.
+Replay: sess_42
+...
+Counterfactual: ./what-if.harn (ok)
+  would touch 1 file(s) (+2 / -2 lines, 2 op(s) applied, 0 rejected):
+    modified src/lib.rs (+2 / -2)
+```
+
+In `--json` mode the divergence rides on the replay report under
+`data.counterfactual`:
+
+```json
+{
+  "data": {
+    "counterfactual": {
+      "plan_path": "./what-if.harn",
+      "result": "ok",
+      "diverged": [
+        { "path": "src/lib.rs", "status": "modified", "lines_added": 2, "lines_removed": 2 }
+      ],
+      "files_touched": 1,
+      "lines_added": 2,
+      "lines_removed": 2,
+      "ops_applied": 2,
+      "ops_rejected": 0
+    }
+  }
+}
+```
+
+Each file's `status` is `created`, `modified`, or `deleted`, classified
+from its line deltas. **Counterfactual chains** are just a longer plan:
+list every op across the steps you want to compare, and the shared staged
+overlay collapses their cumulative effect into one diff per file — so the
+divergence already reflects the chained edits, not each step in isolation.
+
 ## Audit a past run, ask what-if, ship the fix
 
 The typical loop:


### PR DESCRIPTION
Closes #2522 (final bullet of #2522). Part of the v0.8.51 batch.

`harn replay --counterfactual <plan.harn> --session-id <id> [--at <cutoff>]` rehydrates a session at the cutoff, evaluates an alternate `.harn` edit plan through `edit.dry_run` against a throw-away staged-fs overlay, and reports the **divergent file set** the plan would touch — without mutating the recorded session or the on-disk tree.

## Composition (reused, not reimplemented)
- **B.5 `edit.dry_run`** (`std/edit::edit_dry_run` → `hostlib_ast_dry_run`) computes the per-file unified-diff bundle.
- **#1722 staged-fs** — `edit_dry_run` opens + discards a transient overlay, so nothing touches disk.
- Divergence is read off `per_file_unified_diff` + `summary`; no new diff logic.

## Contract / output
- `--counterfactual` requires `--session-id`; `--at` stays optional (omitted → divergence vs. current/full-session state).
- `plan.harn` must `return` either a list of edit ops or an `edit_dry_run`-shaped dict (a bare trailing expr returns `nil` in Harn — the error says so).
- `--json`: rides the single `ReplayReport` under `data.counterfactual` `{ plan_path, result, diverged:[{path,status,lines_added,lines_removed}], files_touched, lines_added, lines_removed, ops_applied, ops_rejected }`. Plain `replay` / `replay --at` unchanged.

## Gates
`cargo build/clippy/fmt -p harn-cli` clean; 4 unit + 4 integration tests pass; the 5 pre-existing `replay_session_cli` tests still pass. Additive, non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)