### PR TITLE
harn: canonical ACP v0.12.2 session/request_permission wire shape (#2639)

### DIFF
--- a/changelog.d/2639.breaking.md
+++ b/changelog.d/2639.breaking.md
@@ -1,0 +1,14 @@
+- **ACP `session/request_permission` now uses the canonical ACP v0.12.2 wire
+  shape (#2639).** The request the agent sends is
+  `{ sessionId, toolCall: <ToolCallUpdate>, options: [{ optionId, name, kind }] }`,
+  and the only accepted responses are `{ outcome: { outcome: "selected",
+  optionId } }` and `{ outcome: { outcome: "cancelled" } }`. The pre-#2639
+  harn shapes — the top-level `toolName`/`rawInput` request fields and the
+  `{ outcome: "approved" }` / `{ granted: true }` responses — are no longer
+  emitted or honored; a `selected` outcome on the `allow` option grants the
+  call, `reject` and `cancelled` stop it (fail-closed on anything else). Harn's
+  internal permission *policy* decision (allow / deny / suspend), the
+  `ApprovalPolicy` receipt, and the out-of-band `harn.hitl.respond` HITL path
+  are unchanged — they now ride alongside the canonical fields as a vendor
+  extension under `toolCall._meta.harn`. ACP clients (e.g. the Burin IDE) must
+  send the canonical `selected`/`cancelled` response.

--- a/conformance/protocols/fixtures/acp/session_request_permission.valid.json
+++ b/conformance/protocols/fixtures/acp/session_request_permission.valid.json
@@ -10,16 +10,22 @@
       "method": "session/request_permission",
       "params": {
         "sessionId": "session-1",
-        "toolCallId": "tool-1",
-        "toolName": "edit",
+        "toolCall": {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tool-1",
+          "title": "edit",
+          "kind": "other"
+        },
         "options": [
           {
-            "id": "approve",
-            "label": "Approve"
+            "optionId": "allow",
+            "name": "Allow",
+            "kind": "allow_once"
           },
           {
-            "id": "deny",
-            "label": "Deny"
+            "optionId": "reject",
+            "name": "Reject",
+            "kind": "reject_once"
           }
         ]
       }
@@ -28,7 +34,10 @@
       "jsonrpc": "2.0",
       "id": 77,
       "result": {
-        "outcome": "approved"
+        "outcome": {
+          "outcome": "selected",
+          "optionId": "allow"
+        }
       }
     }
   ],
@@ -39,7 +48,7 @@
     "source": {
       "kind": "adapter_generated",
       "generator": "cargo test -p harn-serve adapters::acp::tests::acp_bridge_routes_session_request_permission_response",
-      "description": "Permission request and response shape from AcpBridge::call_client."
+      "description": "Canonical ACP v0.12.2 permission request/response shape from AcpBridge::call_client (#2639)."
     }
   }
 }

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -50,18 +50,46 @@
             "method": { "const": "session/request_permission" },
             "params": {
               "type": "object",
-              "required": ["sessionId"],
+              "required": ["sessionId", "toolCall", "options"],
               "additionalProperties": true,
               "properties": {
                 "sessionId": { "type": "string", "minLength": 1 },
-                "toolCallId": { "type": "string", "minLength": 1 },
-                "toolName": { "type": "string", "minLength": 1 },
-                "options": { "type": "array" }
+                "toolCall": { "$ref": "#/$defs/PermissionToolCall" },
+                "options": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "$ref": "#/$defs/PermissionOption" }
+                }
               }
             }
           }
         }
       ]
+    },
+    "PermissionToolCall": {
+      "type": "object",
+      "required": ["toolCallId"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "tool_call_update" },
+        "toolCallId": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "kind": { "type": "string" },
+        "rawInput": {},
+        "_meta": { "$ref": "#/$defs/HarnExtensionMeta" }
+      }
+    },
+    "PermissionOption": {
+      "type": "object",
+      "required": ["optionId", "name", "kind"],
+      "additionalProperties": true,
+      "properties": {
+        "optionId": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "kind": {
+          "enum": ["allow_once", "allow_always", "reject_once", "reject_always"]
+        }
+      }
     },
     "HarnAgentEventNotification": {
       "type": "object",

--- a/conformance/replay-oracle/fixtures/approval_tool_call.valid.json
+++ b/conformance/replay-oracle/fixtures/approval_tool_call.valid.json
@@ -42,7 +42,7 @@
         "boundary": "session/request_permission",
         "fixture_ref": "conformance/protocols/fixtures/acp/session_request_permission.valid.json",
         "request": {"method": "session/request_permission", "action": "write_file", "resource": "notes/triage.md"},
-        "response": {"outcome": "approved", "reviewer": "operator"},
+        "response": {"outcome": {"outcome": "selected", "optionId": "allow"}, "reviewer": "operator"},
         "latency_ms": 42
       }
     ],
@@ -80,7 +80,7 @@
         "boundary": "session/request_permission",
         "fixture_ref": "conformance/protocols/fixtures/acp/session_request_permission.valid.json",
         "request": {"method": "session/request_permission", "action": "write_file", "resource": "notes/triage.md"},
-        "response": {"outcome": "approved", "reviewer": "operator"},
+        "response": {"outcome": {"outcome": "selected", "optionId": "allow"}, "reviewer": "operator"},
         "latency_ms": 7
       }
     ],

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -1092,15 +1092,21 @@ async fn acp_bridge_routes_session_request_permission_response() {
         assistant_state: Mutex::new(VisibleTextState::default()),
     });
 
+    // Canonical ACP v0.12.2 request shape (#2639): `{ sessionId, toolCall,
+    // options: [{ optionId, name, kind }] }`.
     let call = bridge.call_client(
         "session/request_permission",
         serde_json::json!({
             "sessionId": "session-1",
-            "toolCallId": "tool-1",
-            "toolName": "edit",
+            "toolCall": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tool-1",
+                "title": "edit",
+                "kind": "other"
+            },
             "options": [
-                {"id": "approve", "label": "Approve"},
-                {"id": "deny", "label": "Deny"}
+                {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+                {"optionId": "reject", "name": "Reject", "kind": "reject_once"}
             ]
         }),
     );
@@ -1113,10 +1119,12 @@ async fn acp_bridge_routes_session_request_permission_response() {
     assert_eq!(outgoing["id"], 77);
     assert_eq!(outgoing["method"], "session/request_permission");
 
+    // Canonical ACP response shape: `{ outcome: { outcome: "selected",
+    // optionId } }`. No `{outcome: "approved"}` / `{granted}` in ACP.
     let response = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 77,
-        "result": {"outcome": "approved"},
+        "result": {"outcome": {"outcome": "selected", "optionId": "allow"}},
     });
     crate::protocol_fixture_tests::assert_fixture_documents_match(
         "conformance/protocols/fixtures/acp/session_request_permission.valid.json",
@@ -1126,7 +1134,8 @@ async fn acp_bridge_routes_session_request_permission_response() {
     let mut server = server;
     server.handle_incoming_message(response).await;
     let result = call.await.expect("permission response");
-    assert_eq!(result["outcome"], "approved");
+    assert_eq!(result["outcome"]["outcome"], "selected");
+    assert_eq!(result["outcome"]["optionId"], "allow");
 }
 
 #[test]

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -348,7 +348,9 @@ impl ApiState {
             .and_then(Value::as_str)
             .map(str::to_string);
         let request_id = params
-            .pointer("/approvalRequest/id")
+            .pointer("/toolCall/toolCallId")
+            .or_else(|| params.pointer("/toolCall/_meta/harn/approvalRequest/id"))
+            .or_else(|| params.pointer("/approvalRequest/id"))
             .or_else(|| params.get("toolCallId"))
             .and_then(Value::as_str)
             .map(str::to_string)
@@ -367,7 +369,14 @@ impl ApiState {
             "task_id": task_id,
             "status": "pending",
             "source": "acp",
-            "action": params.pointer("/approvalRequest/action")
+            // Canonical ACP request carries the action under the harn vendor
+            // extension on `toolCall`; older shapes used top-level/approval
+            // fields. Read all of them so the public resource stays stable
+            // across the #2639 wire change.
+            "action": params.pointer("/toolCall/_meta/harn/toolName")
+                .or_else(|| params.pointer("/toolCall/toolName"))
+                .or_else(|| params.pointer("/toolCall/title"))
+                .or_else(|| params.pointer("/approvalRequest/action"))
                 .or_else(|| params.get("toolName"))
                 .cloned()
                 .unwrap_or(Value::Null),
@@ -1934,11 +1943,14 @@ async fn respond_permission_request(
             return api_error(StatusCode::BAD_GATEWAY, "acp_error", &error);
         }
     } else if let Some(rpc_id) = rpc_id {
+        // Canonical ACP `RequestPermissionResponse` (#2639): a `selected`
+        // outcome on the allow/reject option. There is no `{outcome:
+        // "approved"}` in canonical ACP — that was the pre-#2639 harn shape.
         let result = if approved {
-            json!({"outcome": "approved"})
+            json!({"outcome": {"outcome": "selected", "optionId": "allow"}})
         } else {
             json!({
-                "outcome": "denied",
+                "outcome": {"outcome": "selected", "optionId": "reject"},
                 "reason": input.get("reason").and_then(Value::as_str).unwrap_or("denied by API client")
             })
         };

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -169,17 +169,20 @@ impl InProcessHost {
         &self,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, VmError> {
+        // No exported `request_permission` ⇒ default-allow: emit a canonical
+        // `selected` outcome on the allow option (#2639).
         let Some(closure) = self.exported_functions.get("request_permission") else {
-            return Ok(serde_json::json!({ "granted": true }));
+            return Ok(canonical_allow_response());
         };
 
-        let tool_name = params
-            .get("toolCall")
-            .and_then(|tool_call| tool_call.get("toolName"))
+        let tool_call = params.get("toolCall");
+        let tool_name = tool_call
+            .and_then(|tool_call| tool_call.pointer("/_meta/harn/toolName"))
+            .or_else(|| tool_call.and_then(|tool_call| tool_call.get("toolName")))
+            .or_else(|| tool_call.and_then(|tool_call| tool_call.get("title")))
             .and_then(|value| value.as_str())
             .unwrap_or_default();
-        let tool_args = params
-            .get("toolCall")
+        let tool_args = tool_call
             .and_then(|tool_call| tool_call.get("rawInput"))
             .map(json_result_to_vm_value)
             .unwrap_or(VmValue::Nil);
@@ -202,27 +205,69 @@ impl InProcessHost {
 
         let mut vm = self.vm.child_vm_for_host();
         let result = vm.call_closure_pub(closure, &args).await?;
+        // Translate the script's verdict into a canonical ACP response
+        // (`{ outcome: { outcome: "selected" | "cancelled", optionId? } }`).
+        // The script API stays ergonomic — bool / string-reason / dict — but
+        // the wire shape is canonical.
         let payload = match result {
-            VmValue::Bool(granted) => serde_json::json!({ "granted": granted }),
+            VmValue::Bool(granted) => {
+                if granted {
+                    canonical_allow_response()
+                } else {
+                    canonical_reject_response(None)
+                }
+            }
             VmValue::String(reason) if !reason.is_empty() => {
-                serde_json::json!({ "granted": false, "reason": reason.to_string() })
+                canonical_reject_response(Some(reason.to_string()))
             }
             other => {
                 let json = crate::llm::vm_value_to_json(&other);
-                if json
-                    .get("granted")
-                    .and_then(|value| value.as_bool())
-                    .is_some()
-                    || json.get("outcome").is_some()
-                {
+                if let Some(granted) = json.get("granted").and_then(|value| value.as_bool()) {
+                    if granted {
+                        canonical_allow_response()
+                    } else {
+                        canonical_reject_response(
+                            json.get("reason")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string),
+                        )
+                    }
+                } else if json.get("outcome").is_some() {
+                    // The script already returned a canonical-shaped outcome.
                     json
+                } else if other.is_truthy() {
+                    canonical_allow_response()
                 } else {
-                    serde_json::json!({ "granted": other.is_truthy() })
+                    canonical_reject_response(None)
                 }
             }
         };
         Ok(payload)
     }
+}
+
+/// Canonical ACP `RequestPermissionResponse` granting the call: a
+/// `selected` outcome on the `allow` option (#2639).
+fn canonical_allow_response() -> serde_json::Value {
+    serde_json::json!({
+        "outcome": { "outcome": "selected", "optionId": "allow" }
+    })
+}
+
+/// Canonical ACP `RequestPermissionResponse` rejecting the call: a
+/// `selected` outcome on the `reject` option, with an optional harn-vendor
+/// `reason` extension (#2639).
+fn canonical_reject_response(reason: Option<String>) -> serde_json::Value {
+    let mut response = serde_json::json!({
+        "outcome": { "outcome": "selected", "optionId": "reject" }
+    });
+    if let Some(reason) = reason {
+        response
+            .as_object_mut()
+            .expect("object")
+            .insert("reason".to_string(), serde_json::Value::String(reason));
+    }
+    response
 }
 
 /// How a queued bridge injection is delivered into the agent loop.

--- a/crates/harn-vm/src/llm/acp_permission.rs
+++ b/crates/harn-vm/src/llm/acp_permission.rs
@@ -1,0 +1,210 @@
+//! Canonical ACP `session/request_permission` wire helpers (#2639).
+//!
+//! ACP v0.12.2 makes the request/response shapes for
+//! `session/request_permission` canonical:
+//!
+//! - Request (agent -> client):
+//!   `{ sessionId, toolCall: <ToolCallUpdate>, options: [{ optionId, name, kind }] }`
+//! - Response (client -> agent):
+//!   `{ outcome: { outcome: "selected", optionId } }` or
+//!   `{ outcome: { outcome: "cancelled" } }`.
+//!
+//! There is no `{ outcome: "approved" }` / `{ granted }` in canonical ACP.
+//!
+//! This module owns *only* the canonical wire vocabulary. Harn's internal
+//! permission *policy* decision (allow / deny / suspend), the
+//! `ApprovalPolicy` receipt, and the out-of-band `harn.hitl.respond` HITL
+//! path are deliberately untouched — they are harn semantics carried as
+//! vendor extensions alongside the canonical fields.
+
+use serde_json::{json, Value as JsonValue};
+
+/// Stable `optionId` for the canonical "allow this call" option. The
+/// agent maps a `selected` response on this id to a grant.
+pub(crate) const OPTION_ALLOW: &str = "allow";
+/// Stable `optionId` for the canonical "reject this call" option.
+pub(crate) const OPTION_REJECT: &str = "reject";
+
+/// The two canonical [`PermissionOption`]s the agent offers for a
+/// host-gated tool call: allow-once and reject-once. The client renders
+/// these and answers with `{ outcome: { outcome: "selected", optionId } }`.
+fn canonical_options() -> JsonValue {
+    json!([
+        { "optionId": OPTION_ALLOW, "name": "Allow", "kind": "allow_once" },
+        { "optionId": OPTION_REJECT, "name": "Reject", "kind": "reject_once" },
+    ])
+}
+
+/// Build the canonical `session/request_permission` request params.
+///
+/// `tool_call` is rooted as a canonical ACP `ToolCallUpdate`
+/// (`{ sessionUpdate, toolCallId, title, kind, rawInput }`). Harn's
+/// vendor extensions — the HITL `approvalRequest` envelope and the
+/// `policyDecision` receipt — ride along under `toolCall._meta.harn` so
+/// the canonical fields stay clean while harn-aware hosts (the Burin IDE,
+/// the REST surface) can still read them.
+pub(crate) fn request_params(
+    session_id: Option<&str>,
+    tool_call_id: &str,
+    tool_name: &str,
+    raw_input: &JsonValue,
+    approval_request: JsonValue,
+    policy_decision: &JsonValue,
+) -> JsonValue {
+    let mut params = serde_json::Map::new();
+    if let Some(session_id) = session_id {
+        params.insert("sessionId".to_string(), json!(session_id));
+    }
+    params.insert(
+        "toolCall".to_string(),
+        json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": tool_call_id,
+            "title": tool_name,
+            "kind": "other",
+            "rawInput": raw_input,
+            "_meta": {
+                "harn": {
+                    "toolName": tool_name,
+                    "approvalRequest": approval_request,
+                    "policyDecision": policy_decision,
+                }
+            }
+        }),
+    );
+    params.insert("options".to_string(), canonical_options());
+    JsonValue::Object(params)
+}
+
+/// The agent's interpretation of a canonical permission response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WireOutcome {
+    /// `{ outcome: { outcome: "selected", optionId: "allow" } }`.
+    Allowed,
+    /// `{ outcome: { outcome: "selected", optionId: "reject" } }` or a
+    /// `cancelled` outcome (the client dismissed the prompt). Both stop
+    /// the tool call; `cancelled` is distinguished only by the default
+    /// reason.
+    Rejected { reason: String },
+}
+
+/// Parse a canonical `RequestPermissionResponse` result into a
+/// [`WireOutcome`].
+///
+/// Canonical only: the response `result` is `{ outcome: <outcome> }` where
+/// `<outcome>` is `{ outcome: "selected", optionId }` or
+/// `{ outcome: "cancelled" }`. A `selected` outcome whose `optionId` is
+/// not the allow option (including a missing id) is treated as a rejection
+/// — fail closed.
+pub(crate) fn parse_response(response: &JsonValue) -> WireOutcome {
+    let outcome = response.get("outcome");
+    let kind = outcome
+        .and_then(|outcome| outcome.get("outcome"))
+        .and_then(JsonValue::as_str)
+        .unwrap_or("");
+    match kind {
+        "selected" => {
+            let option_id = outcome
+                .and_then(|outcome| outcome.get("optionId"))
+                .and_then(JsonValue::as_str)
+                .unwrap_or("");
+            if option_id == OPTION_ALLOW {
+                WireOutcome::Allowed
+            } else {
+                WireOutcome::Rejected {
+                    reason: response
+                        .get("reason")
+                        .and_then(JsonValue::as_str)
+                        .map(str::to_string)
+                        .unwrap_or_else(|| "host rejected the tool call".to_string()),
+                }
+            }
+        }
+        "cancelled" => WireOutcome::Rejected {
+            reason: "permission request was cancelled".to_string(),
+        },
+        _ => WireOutcome::Rejected {
+            reason: "host did not return a canonical permission outcome".to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_params_carry_canonical_options_and_tool_call() {
+        let params = request_params(
+            Some("session-1"),
+            "tool-1",
+            "edit",
+            &json!({"path": "src/lib.rs"}),
+            json!({"id": "tool-1", "action": "edit"}),
+            &json!({"decision": "ask"}),
+        );
+        assert_eq!(params["sessionId"], "session-1");
+        assert_eq!(params["toolCall"]["sessionUpdate"], "tool_call_update");
+        assert_eq!(params["toolCall"]["toolCallId"], "tool-1");
+        assert_eq!(params["toolCall"]["title"], "edit");
+        assert_eq!(params["toolCall"]["rawInput"]["path"], "src/lib.rs");
+        assert_eq!(params["toolCall"]["_meta"]["harn"]["toolName"], "edit");
+        assert_eq!(
+            params["toolCall"]["_meta"]["harn"]["policyDecision"]["decision"],
+            "ask"
+        );
+        let options = params["options"].as_array().expect("options array");
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[0]["optionId"], OPTION_ALLOW);
+        assert_eq!(options[0]["kind"], "allow_once");
+        assert_eq!(options[1]["optionId"], OPTION_REJECT);
+        assert_eq!(options[1]["kind"], "reject_once");
+    }
+
+    #[test]
+    fn selected_allow_is_allowed() {
+        let response = json!({"outcome": {"outcome": "selected", "optionId": "allow"}});
+        assert_eq!(parse_response(&response), WireOutcome::Allowed);
+    }
+
+    #[test]
+    fn selected_reject_is_rejected() {
+        let response = json!({"outcome": {"outcome": "selected", "optionId": "reject"}});
+        assert!(matches!(
+            parse_response(&response),
+            WireOutcome::Rejected { .. }
+        ));
+    }
+
+    #[test]
+    fn cancelled_is_rejected() {
+        let response = json!({"outcome": {"outcome": "cancelled"}});
+        match parse_response(&response) {
+            WireOutcome::Rejected { reason } => assert!(reason.contains("cancelled")),
+            other => panic!("expected rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_canonical_outcome_fails_closed() {
+        // Legacy `{ outcome: "approved" }` and `{ granted: true }` are no
+        // longer honored — canonical ACP carries no such shape.
+        assert!(matches!(
+            parse_response(&json!({"outcome": "approved"})),
+            WireOutcome::Rejected { .. }
+        ));
+        assert!(matches!(
+            parse_response(&json!({"granted": true})),
+            WireOutcome::Rejected { .. }
+        ));
+    }
+
+    #[test]
+    fn selected_missing_option_id_fails_closed() {
+        let response = json!({"outcome": {"outcome": "selected"}});
+        assert!(matches!(
+            parse_response(&response),
+            WireOutcome::Rejected { .. }
+        ));
+    }
+}

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -671,35 +671,24 @@ async fn host_agent_dispatch_tool_call(
                 serde_json::json!({"policy_decision": decision.receipt.clone()}),
                 vec![format!("tool.{tool_name}")],
             );
+            let approval_request_json =
+                serde_json::to_value(&approval_request).unwrap_or(serde_json::Value::Null);
             let response = bridge
                 .call(
                     "session/request_permission",
-                    serde_json::json!({
-                        "sessionId": session_id,
-                        "approvalRequest": approval_request,
-                        "policyDecision": decision.receipt.clone(),
-                        "toolCall": {
-                            "toolCallId": approval_id,
-                            "toolName": tool_name,
-                            "rawInput": tool_args,
-                        },
-                    }),
+                    crate::llm::acp_permission::request_params(
+                        Some(&session_id),
+                        &approval_id,
+                        &tool_name,
+                        &tool_args,
+                        approval_request_json,
+                        &decision.receipt,
+                    ),
                 )
                 .await;
             match response {
-                Ok(response) => {
-                    let outcome = response
-                        .get("outcome")
-                        .and_then(|value| value.get("outcome"))
-                        .and_then(|value| value.as_str())
-                        .or_else(|| response.get("outcome").and_then(|value| value.as_str()))
-                        .unwrap_or("");
-                    let granted = matches!(outcome, "selected" | "allow")
-                        || response
-                            .get("granted")
-                            .and_then(|value| value.as_bool())
-                            .unwrap_or(false);
-                    if granted {
+                Ok(response) => match crate::llm::acp_permission::parse_response(&response) {
+                    crate::llm::acp_permission::WireOutcome::Allowed => {
                         if let Some(new_args) = response.get("args") {
                             tool_args = new_args.clone();
                         }
@@ -713,17 +702,14 @@ async fn host_agent_dispatch_tool_call(
                             true,
                             Some(decision.receipt.clone()),
                         );
-                    } else {
-                        let reason = response
-                            .get("reason")
-                            .and_then(|value| value.as_str())
-                            .unwrap_or("host did not grant approval");
+                    }
+                    crate::llm::acp_permission::WireOutcome::Rejected { reason } => {
                         emit_permission_event_with_policy(
                             &session_id,
                             "PermissionDeny",
                             &tool_name,
                             &tool_args,
-                            reason,
+                            &reason,
                             true,
                             Some(decision.receipt.clone()),
                         );
@@ -735,7 +721,7 @@ async fn host_agent_dispatch_tool_call(
                             crate::agent_events::ToolCallErrorCategory::PermissionDenied,
                         )));
                     }
-                }
+                },
                 Err(_) => {
                     let reason =
                         "approval request failed or host does not implement session/request_permission";

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -8,6 +8,7 @@
 //! - `helpers`: option extraction, provider/model/key resolution, and JSON conversion
 //! - `mock`, `trace`, and `stream`: process-local test doubles, tracing, and streaming support
 
+pub(crate) mod acp_permission;
 mod agent_config;
 mod agent_host_primitives;
 pub(crate) mod agent_observe;

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -599,42 +599,28 @@ async fn request_permission(
             .unwrap_or(JsonValue::Null),
         vec![format!("stdlib.{operation}")],
     );
+    let approval_request_json = serde_json::to_value(&approval_request).unwrap_or(JsonValue::Null);
     let response = bridge
         .call(
             "session/request_permission",
-            json!({
-                "approvalRequest": approval_request,
-                "policyDecision": policy_decision,
-                "toolCall": {
-                    "toolCallId": approval_id,
-                    "toolName": operation,
-                    "rawInput": args,
-                },
-            }),
+            crate::llm::acp_permission::request_params(
+                crate::llm::current_agent_session_id().as_deref(),
+                &approval_id,
+                operation,
+                args,
+                approval_request_json,
+                &policy_decision.clone().unwrap_or(JsonValue::Null),
+            ),
         )
         .await?;
-    let outcome = response
-        .get("outcome")
-        .and_then(|value| value.get("outcome"))
-        .and_then(|value| value.as_str())
-        .or_else(|| response.get("outcome").and_then(|value| value.as_str()))
-        .unwrap_or("");
-    let granted = matches!(outcome, "selected" | "allow")
-        || response
-            .get("granted")
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
-    if granted {
-        Ok(response)
-    } else {
-        let reason = response
-            .get("reason")
-            .and_then(|value| value.as_str())
-            .unwrap_or("host did not grant approval");
-        Err(VmError::CategorizedError {
-            message: format!("{operation}: approval denied: {reason}"),
-            category: crate::value::ErrorCategory::ToolRejected,
-        })
+    match crate::llm::acp_permission::parse_response(&response) {
+        crate::llm::acp_permission::WireOutcome::Allowed => Ok(response),
+        crate::llm::acp_permission::WireOutcome::Rejected { reason } => {
+            Err(VmError::CategorizedError {
+                message: format!("{operation}: approval denied: {reason}"),
+                category: crate::value::ErrorCategory::ToolRejected,
+            })
+        }
     }
 }
 

--- a/spec/protocol-artifacts/schemas/acp-session-update.schema.json
+++ b/spec/protocol-artifacts/schemas/acp-session-update.schema.json
@@ -50,18 +50,46 @@
             "method": { "const": "session/request_permission" },
             "params": {
               "type": "object",
-              "required": ["sessionId"],
+              "required": ["sessionId", "toolCall", "options"],
               "additionalProperties": true,
               "properties": {
                 "sessionId": { "type": "string", "minLength": 1 },
-                "toolCallId": { "type": "string", "minLength": 1 },
-                "toolName": { "type": "string", "minLength": 1 },
-                "options": { "type": "array" }
+                "toolCall": { "$ref": "#/$defs/PermissionToolCall" },
+                "options": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "$ref": "#/$defs/PermissionOption" }
+                }
               }
             }
           }
         }
       ]
+    },
+    "PermissionToolCall": {
+      "type": "object",
+      "required": ["toolCallId"],
+      "additionalProperties": true,
+      "properties": {
+        "sessionUpdate": { "const": "tool_call_update" },
+        "toolCallId": { "type": "string", "minLength": 1 },
+        "title": { "type": "string" },
+        "kind": { "type": "string" },
+        "rawInput": {},
+        "_meta": { "$ref": "#/$defs/HarnExtensionMeta" }
+      }
+    },
+    "PermissionOption": {
+      "type": "object",
+      "required": ["optionId", "name", "kind"],
+      "additionalProperties": true,
+      "properties": {
+        "optionId": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "kind": {
+          "enum": ["allow_once", "allow_always", "reject_once", "reject_always"]
+        }
+      }
     },
     "HarnAgentEventNotification": {
       "type": "object",


### PR DESCRIPTION
**BREAKING (wire).** The ACP `session/request_permission` request and response now use canonical ACP v0.12.2. harn's internal policy decision (allow/deny/suspend), the `ApprovalPolicy` receipt, and the out-of-band `harn.hitl.respond` HITL/suspend path are untouched — they ride alongside the canonical fields as a vendor extension under `toolCall._meta.harn`.

## Wire change
**Request** (agent → client): `{ sessionId, toolCall: <ToolCallUpdate: sessionUpdate:"tool_call_update", toolCallId, title:<toolName>, kind:"other", rawInput, _meta.harn:{toolName, approvalRequest, policyDecision}>, options:[{optionId:"allow"|"reject", name, kind:"allow_once"|"reject_once"}] }`.

**Response** (client → agent): only `{ outcome:{outcome:"selected", optionId} }` and `{ outcome:{outcome:"cancelled"} }` are honored. `selected`+`allow` → granted; `selected`+`reject` or `cancelled` → denied; **fail-closed** on anything else (incl. legacy `{outcome:"approved"}` / `{granted}`).

## Implementation
New `crates/harn-vm/src/llm/acp_permission.rs` (`request_params()` + `parse_response()`, 6 unit tests); emit/parse updated on the tool-call path (`agent_host_primitives.rs`), git path (`stdlib/git.rs`), playground `InProcessHost` (`bridge.rs`), and REST→ACP bridge (`harn-serve/api.rs` — still accepts the REST `{approved}` body and translates to canonical). Conformance fixtures + the `acp-session-update` schema tightened to require `toolCall` + `options`.

## Gates
`harn-serve` 362 passed; `harn-vm` all suites `failed=0` (6 new `acp_permission` tests, 41 bridge tests); clippy/fmt clean; `harn test protocols acp` 10 passed; replay-oracle 6 passed; hitl 11 + consent 1 passed.

## ⚠️ Downstream coordination (lands at v0.8.51 adoption, NOT here)
Tracked in **burin-labs/burin-code** — every burin ACP client that responds to a permission request must switch to the nested canonical shape: the Swift IDE (`PermissionPolicy.swift` + `HarnHostServer+Permissions.swift`), the Node TUI (`host-handlers/permission.ts`), the Rust TUI in-process host (`burin-tui-host::PermissionPolicy::decide`, currently `{granted}`), and the Rust TUI render helper (`render/src/approval.rs::permission_response`, currently emits **flat** `{outcome:"selected"}` — a latent non-canonical shape that this PR's parser would reject; must become nested). Targets v0.8.51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)