### PR TITLE
harn: send RFC 8707 resource indicator in MCP OAuth (#2643)

### DIFF
--- a/changelog.d/2643.added.md
+++ b/changelog.d/2643.added.md
@@ -1,0 +1,7 @@
+- **MCP OAuth now sends the RFC 8707 `resource` indicator (#2643).** The MCP authorization profile
+  requires the client to send `resource=<canonical MCP server URI>` in both the authorization request
+  and the token request — regardless of whether the authorization server advertises support. A new
+  `harn_vm::mcp_auth::canonical_resource_indicator` helper canonicalizes the server URL (lowercased
+  scheme/host, default ports and the query/fragment dropped, lone trailing slash stripped), and the
+  `harn mcp login` flow now threads that canonical resource into the authorization URL, the
+  authorization-code exchange, and refresh-token requests.

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -5,8 +5,8 @@ use std::{env, fs, process};
 
 use base64::Engine;
 use harn_vm::mcp_auth::{
-    determine_token_endpoint_auth_method, discover_mcp_oauth, dynamic_client_registration_body,
-    ensure_pkce_s256_supported, select_client_registration_mode,
+    canonical_resource_indicator, determine_token_endpoint_auth_method, discover_mcp_oauth,
+    dynamic_client_registration_body, ensure_pkce_s256_supported, select_client_registration_mode,
     validate_authorization_response_issuer, validate_issuer_binding,
     validate_token_endpoint_auth_method, OAuthClientRegistrationMode,
     OAuthClientRegistrationOptions,
@@ -181,6 +181,9 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         target: options.target.clone(),
         url: options.url.clone(),
     })?;
+    // RFC 8707 resource indicator: the MCP server's canonical URI, sent in both
+    // the authorization and token requests regardless of AS advertisement.
+    let resource = canonical_resource_indicator(&server.url).map_err(|error| error.to_string())?;
     let discovery = discover_oauth_server(&server.url).await?;
     ensure_pkce_support(&discovery.metadata)?;
     let requested_scopes = options
@@ -245,7 +248,7 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         &options.redirect_uri,
         &state,
         &code_challenge,
-        &server.url,
+        &resource,
         requested_scopes.as_deref(),
     )?;
 
@@ -267,7 +270,7 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
             client_secret: client_secret.as_deref(),
             token_auth_method: &token_auth_method,
             redirect_uri: &options.redirect_uri,
-            resource: &server.url,
+            resource: &resource,
             scopes: requested_scopes.as_deref(),
             code: &callback.code,
             code_verifier: &code_verifier,
@@ -286,7 +289,7 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
         client_secret,
         token_endpoint_auth_method: token_auth_method,
         issuer: discovery.issuer,
-        resource: server.url.clone(),
+        resource,
         scopes: requested_scopes,
     };
     save_stored_token(&stored).await?;
@@ -574,12 +577,16 @@ async fn refresh_token_if_needed(
     let refresh_token = token.refresh_token.clone().ok_or_else(|| {
         "Stored OAuth token has expired and does not include a refresh token".to_string()
     })?;
+    // Re-send the RFC 8707 resource indicator on refresh. Canonicalize again so
+    // tokens persisted before this change still emit the canonical form.
+    let resource =
+        canonical_resource_indicator(&token.resource).unwrap_or_else(|_| token.resource.clone());
     let client = reqwest::Client::new();
     let form = vec![
         ("grant_type", "refresh_token".to_string()),
         ("refresh_token", refresh_token),
         ("client_id", token.client_id.clone()),
-        ("resource", token.resource.clone()),
+        ("resource", resource),
     ];
     let refreshed = request_token(
         &client,
@@ -865,5 +872,28 @@ mod tests {
         let response = html_response(400, "<script>alert('x')</script>&");
         assert!(response.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;&amp;"));
         assert!(!response.contains("<script>"));
+    }
+
+    #[test]
+    fn authorization_url_includes_canonical_resource_indicator() {
+        let resource = canonical_resource_indicator("https://MCP.Example.com:443/mcp/").unwrap();
+        let url = build_authorization_url(
+            "https://auth.example.com/authorize",
+            "client-123",
+            "http://127.0.0.1:9783/oauth/callback",
+            "state-abc",
+            "challenge-xyz",
+            &resource,
+            Some("mcp.read"),
+        )
+        .unwrap();
+        let resource_param = url
+            .query_pairs()
+            .find(|(key, _)| key == "resource")
+            .map(|(_, value)| value.into_owned());
+        assert_eq!(
+            resource_param.as_deref(),
+            Some("https://mcp.example.com/mcp/")
+        );
     }
 }

--- a/crates/harn-vm/src/mcp_auth.rs
+++ b/crates/harn-vm/src/mcp_auth.rs
@@ -259,6 +259,45 @@ pub fn bearer_challenge_from_headers<'a>(
     first_bearer
 }
 
+/// Canonicalize an MCP server URL into the RFC 8707 resource indicator that
+/// MUST be sent as `resource` in both the authorization request and the token
+/// request.
+///
+/// The MCP authorization profile reuses RFC 8707 §2 resource-indicator
+/// canonicalization: the scheme and host are lowercased, a default port for the
+/// scheme is dropped, the fragment and query are removed, and a lone trailing
+/// slash on an otherwise empty path is stripped. A non-empty path is preserved
+/// because RFC 8707 treats the path as part of the resource identity.
+pub fn canonical_resource_indicator(server_url: &str) -> Result<String, McpOAuthDiscoveryError> {
+    let mut url = Url::parse(server_url)
+        .map_err(|error| McpOAuthDiscoveryError::InvalidResourceUrl(error.to_string()))?;
+    // The `url` crate already lowercases the scheme and host on parse, but be
+    // explicit so the canonical form is stable regardless of input casing.
+    url.set_fragment(None);
+    url.set_query(None);
+    let _ = url.set_scheme(&url.scheme().to_ascii_lowercase());
+    if let Some(host) = url.host_str() {
+        let lowered = host.to_ascii_lowercase();
+        if lowered != host {
+            let _ = url.set_host(Some(&lowered));
+        }
+    }
+    // Drop a default port so `https://host:443` and `https://host` canonicalize
+    // identically, while leaving non-default ports intact.
+    if let Some(port) = url.port() {
+        if Some(port) == default_port_for_scheme(url.scheme()) {
+            let _ = url.set_port(None);
+        }
+    }
+    let mut canonical = url.to_string();
+    // Strip a lone trailing slash when the path carries no other segments, e.g.
+    // `https://mcp.example.com/` -> `https://mcp.example.com`.
+    if url.path() == "/" && canonical.ends_with('/') {
+        canonical.pop();
+    }
+    Ok(canonical)
+}
+
 pub fn protected_resource_metadata_candidates(resource_url: &Url) -> Vec<Url> {
     let mut urls = Vec::new();
     let path = resource_url
@@ -825,6 +864,14 @@ fn quote_auth_value(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+fn default_port_for_scheme(scheme: &str) -> Option<u16> {
+    match scheme {
+        "http" | "ws" => Some(80),
+        "https" | "wss" => Some(443),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -845,6 +892,64 @@ mod tests {
             authorization_response_iss_parameter_supported: false,
             extra: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn canonical_resource_indicator_strips_trailing_slash() {
+        assert_eq!(
+            canonical_resource_indicator("https://mcp.example.com/").unwrap(),
+            "https://mcp.example.com"
+        );
+        assert_eq!(
+            canonical_resource_indicator("https://mcp.example.com").unwrap(),
+            "https://mcp.example.com"
+        );
+    }
+
+    #[test]
+    fn canonical_resource_indicator_strips_fragment_and_query() {
+        assert_eq!(
+            canonical_resource_indicator("https://mcp.example.com/mcp?token=secret#section")
+                .unwrap(),
+            "https://mcp.example.com/mcp"
+        );
+    }
+
+    #[test]
+    fn canonical_resource_indicator_lowercases_scheme_and_host() {
+        assert_eq!(
+            canonical_resource_indicator("HTTPS://MCP.Example.COM/Path").unwrap(),
+            "https://mcp.example.com/Path"
+        );
+    }
+
+    #[test]
+    fn canonical_resource_indicator_drops_default_ports() {
+        assert_eq!(
+            canonical_resource_indicator("https://mcp.example.com:443/").unwrap(),
+            "https://mcp.example.com"
+        );
+        assert_eq!(
+            canonical_resource_indicator("http://mcp.example.com:80").unwrap(),
+            "http://mcp.example.com"
+        );
+        assert_eq!(
+            canonical_resource_indicator("https://mcp.example.com:8443/mcp").unwrap(),
+            "https://mcp.example.com:8443/mcp"
+        );
+    }
+
+    #[test]
+    fn canonical_resource_indicator_preserves_non_empty_path() {
+        assert_eq!(
+            canonical_resource_indicator("https://example.com/mcp/notion/").unwrap(),
+            "https://example.com/mcp/notion/"
+        );
+    }
+
+    #[test]
+    fn canonical_resource_indicator_rejects_invalid_url() {
+        assert!(canonical_resource_indicator("not a url").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The MCP Authorization spec (RFC 8707 §2 + the MCP authorization profile) **requires** the client to send `resource=<canonical MCP server URI>` in **both** the authorization request and the token request, **regardless of whether the authorization server advertises support** for resource indicators. This wires that MUST into harn's MCP OAuth flow.

`mcp_auth.rs` already carried the discovery / PKCE / CIMD machinery; this PR adds the missing canonical-resource-URI helper and threads the canonical value through the request builders.

## Changes

- **`crates/harn-vm/src/mcp_auth.rs`** — new `canonical_resource_indicator(server_url) -> Result<String, McpOAuthDiscoveryError>`. RFC 8707 canonicalization:
  - lowercase scheme + host
  - drop a default port (`:443` for https/wss, `:80` for http/ws)
  - strip the query and fragment
  - remove a lone trailing slash on an otherwise-empty path (`https://host/` → `https://host`)
  - preserve a non-empty path (RFC 8707 treats the path as part of resource identity)

  Plus six focused unit tests (trailing slash, fragment+query, scheme/host case, default ports vs non-default ports, non-empty path preservation, invalid-URL rejection).
- **`crates/harn-cli/src/commands/mcp/mod.rs`** — `harn mcp login` now canonicalizes the server URL once and injects it as the `resource` indicator into the authorization URL, the authorization-code exchange, the stored token, and refresh-token requests. The refresh path re-canonicalizes so tokens persisted before this change still emit the canonical form. Adds an inline test asserting the authorization URL carries the canonical `resource`.
- **`changelog.d/2643.added.md`** — changelog fragment.

This is **additive and non-breaking**. Response parsing and the CIMD/DCR registration logic are untouched (separate issues #2644/#2645/#2646).

## Verification (all clean)

- `cargo build -p harn-vm` — Finished
- `cargo test -p harn-vm` — 3027 passed, 0 failed
- `cargo test -p harn-cli --lib commands::mcp` — 43 passed, 0 failed (incl. new `authorization_url_includes_canonical_resource_indicator` + OAuth metadata/introspection tests)
- `cargo test -p harn-cli --lib commands::connect` — all failed=0
- `cargo clippy -p harn-vm --all-targets -- -D warnings` — clean
- `cargo clippy -p harn-cli --all-targets -- -D warnings` — clean
- `cargo fmt -p harn-vm -- --check` / `cargo fmt -p harn-cli -- --check` — clean
- markdownlint — 0 errors

No conformance fixture asserts the OAuth request query/form shape, so none required updating; the request shape is covered by the new unit tests.

Targets the v0.8.51 patch. Part of MCP sub-epic burin-labs/burin-code#1428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)