### PR TITLE
test-runner: memory-aware default parallel worker sizing (cgroup-v2 aware)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,6 +2286,7 @@ dependencies = [
  "serde_yml",
  "sha2 0.11.0",
  "subtle",
+ "sysinfo",
  "tar",
  "tempfile",
  "thiserror 2.0.18",

--- a/changelog.d/2659.changed.md
+++ b/changelog.d/2659.changed.md
@@ -1,0 +1,8 @@
+`harn test --parallel` now sizes its default worker count by available
+memory as well as CPU count, capping at
+`min(cores, (available - reserve) / per-worker-budget)`. Available memory is
+the lesser of the host figure and (on Linux) this process's cgroup-v2 slice
+headroom, so a container or a self-hosted runner that shares a box no longer
+oversubscribes RAM and triggers swap-thrash runner-loss. The cap only ever
+lowers the core-based default; explicit `--jobs` / `HARN_TEST_JOBS` still win,
+and the per-worker budget is tunable via `HARN_TEST_WORKER_MEMORY_MB`. (#2659)

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -89,6 +89,9 @@ tracing = "0.1"
 fs2 = "0.4"
 thiserror = "2"
 which = "8"
+# Cross-platform host memory for memory-aware test-worker sizing. Already in
+# the tree via harn-vm; matched features keep the build unified.
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/harn-cli/src/cli/test.rs
+++ b/crates/harn-cli/src/cli/test.rs
@@ -36,8 +36,12 @@ pub(crate) struct TestArgs {
     #[arg(long)]
     pub parallel: bool,
     /// Maximum number of concurrent test workers. Defaults to available
-    /// parallelism, capped to keep system load bounded. Also honored via
-    /// the `HARN_TEST_JOBS` env var. Ignored unless `--parallel` is set.
+    /// parallelism, capped both by core count and by currently-available
+    /// system memory (so an auto-sized run backs off on a small or already-
+    /// loaded host instead of overcommitting RAM). Tune the per-worker memory
+    /// budget with `HARN_TEST_WORKER_MEMORY_MB`. This flag (also honored via
+    /// the `HARN_TEST_JOBS` env var) overrides both caps. Ignored unless
+    /// `--parallel` is set.
     #[arg(long = "jobs", short = 'j', value_name = "N", env = "HARN_TEST_JOBS")]
     pub jobs: Option<usize>,
     /// Re-run user tests when watched files change.

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -129,6 +129,24 @@ const DEFAULT_PARALLEL_JOBS_CAP: usize = 8;
 const TIMINGS_CACHE_RELATIVE_PATH: &str = ".harn/test-timings.json";
 const HARN_TEST_JOBS_ENV: &str = "HARN_TEST_JOBS";
 
+/// Per-worker memory budget (MiB) used to cap *auto-detected* parallelism on
+/// memory-constrained or oversubscribed hosts. Overridable via
+/// `HARN_TEST_WORKER_MEMORY_MB`. A worker runs a full VM and may drive nested
+/// agent loops, so this is a deliberately conservative estimate. The cap only
+/// ever *lowers* the core-based default — it never raises it, and an explicit
+/// `--jobs` / `HARN_TEST_JOBS` always wins.
+const DEFAULT_WORKER_MEMORY_MB: u64 = 1024;
+const HARN_TEST_WORKER_MEMORY_MB_ENV: &str = "HARN_TEST_WORKER_MEMORY_MB";
+
+/// Memory (MiB) held back for the OS, the CI runner agent, and any co-tenant
+/// job, so an auto-sized suite cannot consume the last scrap of RAM and starve
+/// the runner's heartbeat. This is the failure mode behind the self-hosted
+/// "The operation was canceled" runner-loss cancellations: two runner agents
+/// share one box, two heavy jobs overcommit RAM + swap, and the kernel never
+/// fires the OOM-killer — instead a starved runner agent stops phoning home
+/// and the control plane declares the job lost.
+const RESERVED_SYSTEM_MEMORY_MB: u64 = 1024;
+
 /// Options that shape how a user-test suite is discovered and executed.
 ///
 /// Held separately from the positional path so call sites (one-shot run,
@@ -377,7 +395,119 @@ fn resolve_workers(options: &RunOptions) -> usize {
     let detected = thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1);
-    detected.clamp(1, DEFAULT_PARALLEL_JOBS_CAP)
+    let core_cap = detected.clamp(1, DEFAULT_PARALLEL_JOBS_CAP);
+    apply_memory_cap(core_cap)
+}
+
+/// Lower `core_cap` to what currently-available system memory can hold, so an
+/// auto-sized parallel suite backs off on a loaded or small host instead of
+/// overcommitting RAM. Returns `core_cap` unchanged when memory is plentiful
+/// or cannot be measured. Emits a one-line notice when the cap bites so CI
+/// logs explain the reduced parallelism.
+fn apply_memory_cap(core_cap: usize) -> usize {
+    let Some(available_mb) = available_memory_mb() else {
+        return core_cap;
+    };
+    let budget = per_worker_memory_mb();
+    let mem_cap = memory_worker_cap(available_mb, budget, RESERVED_SYSTEM_MEMORY_MB);
+    if mem_cap < core_cap {
+        eprintln!(
+            "harn test: capping workers {core_cap} -> {mem_cap} \
+             (~{available_mb} MiB available, {budget} MiB/worker; \
+             override with --jobs / HARN_TEST_JOBS)"
+        );
+        return mem_cap;
+    }
+    core_cap
+}
+
+/// Pure worker-count-from-memory math, factored out so it is unit-testable
+/// without touching the host. Always yields at least one worker.
+fn memory_worker_cap(available_mb: u64, per_worker_mb: u64, reserved_mb: u64) -> usize {
+    let usable = available_mb.saturating_sub(reserved_mb);
+    let per_worker = per_worker_mb.max(1);
+    ((usable / per_worker).max(1)) as usize
+}
+
+/// Per-worker memory budget, honoring the `HARN_TEST_WORKER_MEMORY_MB`
+/// override (values `>= 1`), else [`DEFAULT_WORKER_MEMORY_MB`].
+fn per_worker_memory_mb() -> u64 {
+    std::env::var(HARN_TEST_WORKER_MEMORY_MB_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_WORKER_MEMORY_MB)
+}
+
+/// Best-effort "memory available for new work" in MiB: the lesser of the
+/// host's available memory and (on Linux) this process's cgroup-v2 headroom.
+///
+/// Host memory comes from `sysinfo`, so it is correct on Linux, macOS, and
+/// Windows. The cgroup min means a container or a systemd-sliced CI runner
+/// sizes to its *slice* rather than the whole host — the key to stopping two
+/// runner agents on one box from each sizing to ~100% and collectively
+/// overcommitting RAM (the "thundering herd" behind the self-hosted
+/// runner-loss cancellations). Returns `None` when nothing can be measured,
+/// leaving the core-based cap in force.
+fn available_memory_mb() -> Option<u64> {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    let host_mb = match sys.available_memory() {
+        0 => None, // unsupported / detection failed — don't over-throttle
+        bytes => Some(bytes / (1024 * 1024)),
+    };
+    match (host_mb, cgroup_v2_headroom_mb()) {
+        (Some(h), Some(c)) => Some(h.min(c)),
+        (Some(h), None) => Some(h),
+        (None, c) => c,
+    }
+}
+
+/// cgroup-v2 memory headroom (MiB) for this process's own cgroup, or `None`
+/// when not on cgroup v2, no limit is set, or the files cannot be read.
+#[cfg(target_os = "linux")]
+fn cgroup_v2_headroom_mb() -> Option<u64> {
+    let dir = own_cgroup_v2_dir()?;
+    let max_raw = fs::read_to_string(dir.join("memory.max")).ok()?;
+    let current_raw = fs::read_to_string(dir.join("memory.current")).ok()?;
+    cgroup_headroom_mb(&max_raw, &current_raw)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn cgroup_v2_headroom_mb() -> Option<u64> {
+    None
+}
+
+/// Resolve this process's own cgroup-v2 directory under `/sys/fs/cgroup` from
+/// the unified-hierarchy line (`0::<path>`) in `/proc/self/cgroup`. A limit
+/// set directly on a systemd service slice or on a container's namespaced
+/// root lives here; ancestor-only limits are not chased (the host min still
+/// backstops those). `None` on cgroup v1 / hybrid (no `0::` line).
+#[cfg(target_os = "linux")]
+fn own_cgroup_v2_dir() -> Option<PathBuf> {
+    let content = fs::read_to_string("/proc/self/cgroup").ok()?;
+    let rel = content
+        .lines()
+        .find_map(|line| line.strip_prefix("0::"))?
+        .trim();
+    let rel = rel.strip_prefix('/').unwrap_or(rel);
+    Some(Path::new("/sys/fs/cgroup").join(rel))
+}
+
+/// Pure headroom math from raw `memory.max` / `memory.current` file contents
+/// (both bytes; `memory.max` may be the literal `"max"` sentinel = unlimited).
+/// `memory.current` counts reclaimable page cache, so the result is a
+/// conservative (under-)estimate of true headroom — the safe direction for
+/// OOM avoidance.
+#[cfg(any(target_os = "linux", test))]
+fn cgroup_headroom_mb(memory_max: &str, memory_current: &str) -> Option<u64> {
+    let max = memory_max.trim();
+    if max == "max" {
+        return None;
+    }
+    let max: u64 = max.parse().ok()?;
+    let current: u64 = memory_current.trim().parse().ok()?;
+    Some(max.saturating_sub(current) / (1024 * 1024))
 }
 
 struct Discovery {
@@ -1103,6 +1233,50 @@ pipeline test_cli_skills(task) {
         opts.parallel = false;
         opts.jobs = Some(8);
         assert_eq!(resolve_workers(&opts), 1);
+    }
+
+    #[test]
+    fn memory_worker_cap_backs_off_under_pressure() {
+        // ~4 GiB available, 1 GiB reserved, 1 GiB/worker -> 3 workers.
+        assert_eq!(memory_worker_cap(4096, 1024, 1024), 3);
+    }
+
+    #[test]
+    fn memory_worker_cap_is_generous_when_memory_is_plentiful() {
+        // A roomy box dwarfs the core cap; resolve_workers then min()s this
+        // against DEFAULT_PARALLEL_JOBS_CAP, so the core cap stays in force.
+        assert!(memory_worker_cap(32_768, 1024, 1024) >= DEFAULT_PARALLEL_JOBS_CAP);
+    }
+
+    #[test]
+    fn memory_worker_cap_never_starves_to_zero() {
+        // Even when reserved >= available, at least one worker must run.
+        assert_eq!(memory_worker_cap(512, 1024, 1024), 1);
+    }
+
+    #[test]
+    fn cgroup_headroom_unlimited_is_none() {
+        // The `max` sentinel means no cgroup limit -> defer to host memory.
+        assert_eq!(cgroup_headroom_mb("max\n", "1048576\n"), None);
+    }
+
+    #[test]
+    fn cgroup_headroom_computes_slice_remainder() {
+        // 4 GiB limit, 1 GiB in use -> 3 GiB (3072 MiB) headroom.
+        let four_gib = (4_u64 * 1024 * 1024 * 1024).to_string();
+        let one_gib = (1024_u64 * 1024 * 1024).to_string();
+        assert_eq!(cgroup_headroom_mb(&four_gib, &one_gib), Some(3072));
+    }
+
+    #[test]
+    fn cgroup_headroom_saturates_when_over_limit() {
+        // A transient current > max must yield 0, not an underflow panic.
+        assert_eq!(cgroup_headroom_mb("1024", "999999999"), Some(0));
+    }
+
+    #[test]
+    fn cgroup_headroom_rejects_garbage() {
+        assert_eq!(cgroup_headroom_mb("not-a-number", "123"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`harn test --parallel` chose its default worker count as `min(logical_cpus, 8)` — **memory-blind**. On a self-hosted CI box where two GitHub Actions runner agents share one machine (12 cores / 15 GiB), two concurrent harn jobs each spun up to 8 VM-backed workers (many driving nested `agent_loop` mock sessions), oversubscribed RAM, thrashed swap, and starved a runner agent's heartbeat. GitHub then reported the job as `The operation was canceled` — **runner loss, no kernel OOM line** — intermittently failing unrelated PRs.

## Fix

Cap the *auto-detected* default by currently-available memory too:

```
workers = min(core_cap, max(1, (available_mb - reserved) / per_worker_mb))
```

- **Available memory** = the lesser of the host figure (`sysinfo`; cross-platform Linux/macOS/Windows) and, on Linux, this process's **cgroup-v2 headroom** (`memory.max - memory.current` for its own slice / namespaced root, resolved via `/proc/self/cgroup`). The cgroup `min` is the key: a container or a systemd-sliced runner sizes to its **slice**, not the whole host — which dissolves the "thundering herd" of N runners each independently sizing to ~100%.
- The cap only ever **lowers** the core-based default — a roomy box is unchanged (`min` with the core cap).
- Explicit `--jobs` / `HARN_TEST_JOBS` still win outright.
- Per-worker budget defaults to 1 GiB, tunable via `HARN_TEST_WORKER_MEMORY_MB`. A one-line notice prints when the cap bites, so CI logs explain reduced parallelism.

## Design notes

Mirrors the SOTA pattern: Bazel is the mainstream precedent for RAM-aware local scheduling (`--local_ram_resources`), and the cgroup-v2 memory controller semantics (`memory.max` `"max"` sentinel; `memory.current` includes reclaimable cache, so headroom is a conservative under-estimate — the safe direction). `sysinfo` was already in the tree via `harn-vm`, so this adds ~no build cost.

Pairs with per-runner systemd `MemoryHigh`/`MemoryMax`/`CPUWeight` on the host as the enforcement backstop.

## Tests

`test_runner` unit tests (23 pass), incl. memory-cap math (back-off / generous / never-zero) and cgroup headroom parsing (unlimited sentinel, slice remainder, over-limit saturation, garbage rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)