### PR TITLE
docs: restore dropped changelog fragment for #2657 (mcp presets)

### DIFF
--- a/changelog.d/2657.added.md
+++ b/changelog.d/2657.added.md
@@ -1,0 +1,5 @@
+`harn mcp presets [--json]` prints a harn-owned catalog of well-known MCP
+server presets (Notion, Linear, GitHub, filesystem) — transport,
+command/url template, auth kind, and required placeholders — so thin clients
+render one identical, drift-free "one-click server" list. The `--json`
+envelope is a versioned stable contract. (#2657)


### PR DESCRIPTION
#2657 (mcp presets) merged but its `changelog.d/2657.added.md` fragment was dropped from the squash, so the feature would be missing from the v0.8.51 changelog. The presets code (`crates/harn-vm/src/mcp_presets.rs`, `crates/harn-cli/src/commands/mcp/presets.rs`) is on main; this restores only the fragment. Found while prepping the v0.8.51 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)