### PR TITLE
mcp: persisted enable/disable allowlist + effective catalog over ACP (#2647)

### DIFF
--- a/changelog.d/2647.added.md
+++ b/changelog.d/2647.added.md
@@ -1,0 +1,7 @@
+New harn-owned MCP enable/disable allowlist (`harn_vm::mcp_allowlist`) covering
+tools, resources, and prompts from one persisted config plus an optional
+per-project overlay, and an effective-catalog projection (servers → items +
+`enabled`) exposed over ACP via the `mcp/catalog` request. A new additive
+`mcp_catalog_changed` agent event cues thin clients (the burin-code TUI / GUI)
+to re-fetch and re-render their MCP toggle UI, so no client stores toggle state
+of its own. (#2647)

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -103,6 +103,8 @@ const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.workflow.pause",
     "workflow/resume",
     "harn.workflow.resume",
+    "mcp/catalog",
+    "harn.mcp.catalog",
 ];
 const ACP_AGENT_NOTIFICATIONS: &[&str] = &["session/message", "session/update", "terminal/output"];
 const ACP_CONTENT_BLOCK_TYPES: &[&str] = &["text", "resource_link", "resource", "image", "audio"];

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1458,6 +1458,20 @@ impl AgentEventSink for AcpAgentEventSink {
                     }),
                 );
             }
+            AgentEvent::McpCatalogChanged {
+                session_id,
+                server,
+                reason,
+            } => {
+                self.emit_agent_event_ext(
+                    "mcp_catalog_changed",
+                    session_id,
+                    serde_json::json!({
+                        "server": server,
+                        "reason": reason,
+                    }),
+                );
+            }
         }
     }
 }

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -704,6 +704,43 @@ async fn mcp_elicitation_request_reaches_acp_as_ext_event() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn mcp_catalog_changed_reaches_acp_as_ext_event() {
+    let actual = collect_notifications(vec![AgentEvent::McpCatalogChanged {
+        session_id: "session-1".to_string(),
+        server: Some("github".to_string()),
+        reason: "list_changed".to_string(),
+    }])
+    .await;
+
+    let notification = &actual[0];
+    assert_eq!(notification["method"], HARN_AGENT_EVENT_METHOD);
+    let params = &notification["params"];
+    assert_eq!(params["kind"], "mcp_catalog_changed");
+    assert_eq!(params["sessionId"], "session-1");
+    assert_eq!(params["server"], "github");
+    assert_eq!(params["reason"], "list_changed");
+    assert!(
+        HARN_AGENT_EVENT_KINDS.contains(&"mcp_catalog_changed"),
+        "mcp_catalog_changed must be advertised so clients can subscribe"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn mcp_catalog_changed_allows_serverless_allowlist_update() {
+    let actual = collect_notifications(vec![AgentEvent::McpCatalogChanged {
+        session_id: "session-1".to_string(),
+        server: None,
+        reason: "allowlist_updated".to_string(),
+    }])
+    .await;
+
+    let params = &actual[0]["params"];
+    assert_eq!(params["kind"], "mcp_catalog_changed");
+    assert!(params["server"].is_null());
+    assert_eq!(params["reason"], "allowlist_updated");
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn harn_extension_session_update_fixtures_are_pinned() {
     let actual = collect_notifications(extension_fixture_events()).await;
     let expected: serde_json::Value = serde_json::from_str(include_str!(

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -2235,6 +2235,31 @@ impl AcpServer {
         self.send_response(id, serde_json::json!({"sessions": sessions}));
     }
 
+    /// `mcp/catalog`: project the persisted enable/disable allowlist (plus
+    /// optional per-project overlay) onto the advertised MCP items and
+    /// return the effective catalog (servers → items + `enabled`). The
+    /// merge/projection is harn-owned so thin clients (the burin-code TUI /
+    /// GUI) render the toggle UI without storing any toggle state. See
+    /// `harn_vm::mcp_allowlist`.
+    fn handle_mcp_catalog(&self, id: &serde_json::Value, params: &serde_json::Value) {
+        let request: harn_vm::McpCatalogRequest = match serde_json::from_value(params.clone()) {
+            Ok(request) => request,
+            Err(error) => {
+                self.send_error(id, -32602, &format!("Invalid mcp/catalog params: {error}"));
+                return;
+            }
+        };
+        let catalog = harn_vm::mcp_catalog_for_request(&request);
+        match serde_json::to_value(&catalog) {
+            Ok(value) => self.send_response(id, value),
+            Err(error) => self.send_error(
+                id,
+                -32000,
+                &format!("failed to encode mcp catalog: {error}"),
+            ),
+        }
+    }
+
     async fn handle_hitl_respond(&self, id: &serde_json::Value, params: &serde_json::Value) {
         let session_cwd = params
             .get("sessionId")
@@ -3276,6 +3301,12 @@ impl AcpServer {
                     return;
                 }
                 self.handle_session_list(&id, &params);
+            }
+            "mcp/catalog" | "harn.mcp.catalog" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_mcp_catalog(&id, &params);
             }
             _ => {
                 if !id.is_null() {

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -67,6 +67,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "judge_decision",
     "loop_control_decision",
     "loop_stuck",
+    "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",
     "scope_classifier_verdict",

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -518,6 +518,64 @@ __io_println(json_stringify({len: len(snap["messages"]), messages: snap["message
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn acp_mcp_catalog_projects_allowlist_over_advertised_items() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            harn_vm::reset_thread_local_state();
+            let (request_tx, mut response_rx, server, _session_id) =
+                start_acp_channel_session().await;
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "mcp/catalog",
+                    "params": {
+                        "allowlist": {
+                            "schemaVersion": 1,
+                            "defaultEnabled": true,
+                            "items": [
+                                {"server": "github", "kind": "tool", "name": "create_issue", "enabled": false}
+                            ]
+                        },
+                        "advertised": {
+                            "github": [
+                                {"kind": "tool", "name": "create_issue"},
+                                {"kind": "tool", "name": "list_issues"}
+                            ]
+                        }
+                    },
+                }))
+                .expect("send mcp/catalog");
+
+            let mut response = None;
+            for _ in 0..6 {
+                let message = recv_json(&mut response_rx).await;
+                if message["id"] == 7 {
+                    response = Some(message);
+                    break;
+                }
+            }
+            let response = response.expect("mcp/catalog response");
+            let result = &response["result"];
+            assert_eq!(result["schemaVersion"], 1);
+            assert_eq!(result["defaultEnabled"], true);
+            let github = &result["servers"][0];
+            assert_eq!(github["name"], "github");
+            // Items sorted by (kind, name): create_issue first, disabled by allowlist.
+            assert_eq!(github["items"][0]["name"], "create_issue");
+            assert_eq!(github["items"][0]["enabled"], false);
+            assert_eq!(github["items"][1]["name"], "list_issues");
+            assert_eq!(github["items"][1]["enabled"], true);
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn acp_session_truncate_validates_inputs() {
     let local = tokio::task::LocalSet::new();
     local

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -678,6 +678,21 @@ pub enum AgentEvent {
         direction: String,
         params: serde_json::Value,
     },
+    /// Surfaced when the effective MCP catalog changes — either because a
+    /// server emitted a `notifications/tools/list_changed` (or the
+    /// resource/prompt equivalents), or because the persisted enable/disable
+    /// allowlist was edited. A thin ACP client (the burin-code TUI / GUI)
+    /// treats this as a cue to re-fetch the catalog (e.g. via the
+    /// `mcp/catalog` request) and re-render its toggle UI, rather than
+    /// reconciling any local state. `server` is the server whose list
+    /// changed, or `None` when the change is allowlist-wide. `reason` is a
+    /// short tag (`"list_changed"` or `"allowlist_updated"`).
+    McpCatalogChanged {
+        session_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        server: Option<String>,
+        reason: String,
+    },
 }
 
 fn is_zero_usize(value: &usize) -> bool {
@@ -738,7 +753,8 @@ impl AgentEvent {
             | Self::CompositionFinish { session_id, .. }
             | Self::CompositionError { session_id, .. }
             | Self::LoopCheckpoint { session_id, .. }
-            | Self::McpNotification { session_id, .. } => session_id,
+            | Self::McpNotification { session_id, .. }
+            | Self::McpCatalogChanged { session_id, .. } => session_id,
         }
     }
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -39,6 +39,7 @@ pub mod jsonrpc;
 pub mod llm;
 pub mod llm_config;
 pub mod mcp;
+pub mod mcp_allowlist;
 pub mod mcp_auth;
 pub mod mcp_card;
 pub mod mcp_elicit;
@@ -174,6 +175,12 @@ pub use llm::{
     register_session_end_hook, LlmBudgetGuard, LlmTokenBudgetGuard,
 };
 pub use mcp::{connect_mcp_server_from_json, connect_mcp_server_from_spec, register_mcp_builtins};
+pub use mcp_allowlist::{
+    build_catalog as build_mcp_catalog, catalog_for_request as mcp_catalog_for_request,
+    AdvertisedItem as McpAdvertisedItem, CatalogRequest as McpCatalogRequest, McpAllowlist,
+    McpAllowlistItem, McpCatalog, McpCatalogItem, McpCatalogServer, McpItemKind,
+    MCP_ALLOWLIST_SCHEMA_VERSION,
+};
 pub use mcp_card::{fetch_server_card, load_server_card_from_path, CardError};
 pub use mcp_host::{
     cache_stats as mcp_host_cache_stats, set_allowlist as set_mcp_host_allowlist,

--- a/crates/harn-vm/src/mcp_allowlist.rs
+++ b/crates/harn-vm/src/mcp_allowlist.rs
@@ -1,0 +1,517 @@
+//! Persisted MCP enable/disable allowlist + effective catalog (harn#2647).
+//!
+//! Part of the MCP comprehensiveness sub-epic (burin-code#1428): one
+//! harn-owned MCP implementation, with thin clients (the burin-code Rust
+//! TUI and macOS GUI) that render toggle UIs **without storing any toggle
+//! state of their own**. This module is the single source of truth for
+//! which MCP **items** — tools, resources, and prompts — are enabled.
+//!
+//! ## Config shape
+//!
+//! The allowlist is a small, JSON-serializable document. The canonical
+//! on-disk form is `mcp.json` (the burin clients keep it at
+//! `~/.burin/mcp.json`) with an optional per-project overlay that layers on
+//! top. harn-vm never hardcodes those paths — callers (harn-cli / the burin
+//! host) pass file contents or paths in; this keeps the VM cross-platform
+//! and free of client-specific layout assumptions.
+//!
+//! ```jsonc
+//! {
+//!   "schemaVersion": 1,
+//!   "defaultEnabled": true,          // items absent from `items` use this
+//!   "items": [
+//!     { "server": "github", "kind": "tool",     "name": "create_issue", "enabled": false },
+//!     { "server": "notion", "kind": "resource", "name": "page://root",  "enabled": true  },
+//!     { "server": "notion", "kind": "prompt",   "name": "summarize",    "enabled": false }
+//!   ]
+//! }
+//! ```
+//!
+//! An **overlay** merges over a **base**: the overlay's `defaultEnabled`
+//! (when present) wins, and any overlay item replaces the matching base
+//! item by its `(server, kind, name)` key. This lets a project pin a
+//! narrower set than the user's global default.
+//!
+//! ## Effective catalog
+//!
+//! Given the live set of advertised items per server, [`build_catalog`]
+//! projects the allowlist onto them to produce the **effective catalog**:
+//! servers → items, each item carrying its resolved `enabled` flag. That
+//! catalog is the stable contract a thin client renders as a toggle list;
+//! the client reads it and never has to reconcile its own state.
+//!
+//! Both the [`McpAllowlist`] document and the [`McpCatalog`] projection are
+//! versioned (see [`MCP_ALLOWLIST_SCHEMA_VERSION`]); bump the version on any
+//! breaking shape change and coordinate consumers.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// JSON schema version shared by [`McpAllowlist`] and [`McpCatalog`].
+/// Increment on any breaking shape change and coordinate consumers.
+pub const MCP_ALLOWLIST_SCHEMA_VERSION: u32 = 1;
+
+/// The three categories of item an MCP server can advertise. Mirrors the
+/// MCP `tools/list`, `resources/list`, and `prompts/list` surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpItemKind {
+    Tool,
+    Resource,
+    Prompt,
+}
+
+impl McpItemKind {
+    /// Stable lowercase tag used in JSON and in dedup keys.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            McpItemKind::Tool => "tool",
+            McpItemKind::Resource => "resource",
+            McpItemKind::Prompt => "prompt",
+        }
+    }
+}
+
+/// One persisted enable/disable decision for a specific item. Items not
+/// listed in an [`McpAllowlist`] fall back to its `default_enabled`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAllowlistItem {
+    /// The owning MCP server's name (matches `harn.toml` `[[mcp]].name`).
+    pub server: String,
+    /// Which surface the item belongs to.
+    pub kind: McpItemKind,
+    /// The item's identifier within its server+kind: tool name, resource
+    /// URI, or prompt name.
+    pub name: String,
+    /// Whether the item is enabled. `false` hides it from the agent.
+    pub enabled: bool,
+}
+
+impl McpAllowlistItem {
+    /// Stable identity key for dedup/merge: `(server, kind, name)`.
+    fn key(&self) -> (String, McpItemKind, String) {
+        (self.server.clone(), self.kind, self.name.clone())
+    }
+}
+
+/// A persisted enable/disable allowlist covering tools, resources, and
+/// prompts across every configured MCP server. This is the document a
+/// client reads from / writes to disk; harn projects it into the effective
+/// catalog and (eventually) enforces it at dispatch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAllowlist {
+    /// Schema version of this document.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    /// Enablement for any item not explicitly listed in `items`. A
+    /// permissive default (`true`) means "allow everything except what is
+    /// explicitly disabled"; `false` means "deny everything except what is
+    /// explicitly enabled".
+    #[serde(default = "default_true")]
+    pub default_enabled: bool,
+    /// Explicit per-item decisions. Order is not significant; the
+    /// `(server, kind, name)` triple is the identity.
+    #[serde(default)]
+    pub items: Vec<McpAllowlistItem>,
+}
+
+fn default_schema_version() -> u32 {
+    MCP_ALLOWLIST_SCHEMA_VERSION
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for McpAllowlist {
+    fn default() -> Self {
+        Self {
+            schema_version: MCP_ALLOWLIST_SCHEMA_VERSION,
+            default_enabled: true,
+            items: Vec::new(),
+        }
+    }
+}
+
+impl McpAllowlist {
+    /// Parse an allowlist from a JSON string. Unknown fields are ignored so
+    /// older harn binaries can read documents written by newer clients.
+    pub fn from_json(json: &str) -> Result<Self, String> {
+        serde_json::from_str(json).map_err(|error| format!("invalid mcp allowlist JSON: {error}"))
+    }
+
+    /// Serialize to a stable, pretty-printed JSON document.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Resolve the enablement of one item: an explicit entry wins, else the
+    /// document default.
+    pub fn is_enabled(&self, server: &str, kind: McpItemKind, name: &str) -> bool {
+        self.items
+            .iter()
+            .find(|item| item.server == server && item.kind == kind && item.name == name)
+            .map(|item| item.enabled)
+            .unwrap_or(self.default_enabled)
+    }
+
+    /// Merge an overlay over `self` (the base), returning a new allowlist.
+    ///
+    /// - The overlay's `default_enabled` and `schema_version` win.
+    /// - Each overlay item replaces the base item with the same
+    ///   `(server, kind, name)` key; otherwise it is appended.
+    /// - Base items the overlay does not mention are preserved.
+    pub fn merge_overlay(&self, overlay: &McpAllowlist) -> McpAllowlist {
+        let mut merged: BTreeMap<(String, McpItemKind, String), McpAllowlistItem> = self
+            .items
+            .iter()
+            .map(|item| (item.key(), item.clone()))
+            .collect();
+        for item in &overlay.items {
+            merged.insert(item.key(), item.clone());
+        }
+        McpAllowlist {
+            schema_version: overlay.schema_version,
+            default_enabled: overlay.default_enabled,
+            items: merged.into_values().collect(),
+        }
+    }
+}
+
+/// One advertised item a server exposes, as seen by harn before the
+/// allowlist is applied. The caller assembles these from live
+/// `tools/list` / `resources/list` / `prompts/list` results.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdvertisedItem {
+    pub kind: McpItemKind,
+    /// Tool name, resource URI, or prompt name.
+    pub name: String,
+    /// Optional human-readable label/title for the client UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Optional one-line description for the client UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// The params shape for the `mcp/catalog` ACP request. A thin client (or
+/// the burin host) supplies the persisted allowlist, an optional
+/// per-project overlay, and the live advertised items per server; harn
+/// merges + projects them into the effective catalog. Keeping the merge in
+/// harn means clients store no toggle state of their own.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogRequest {
+    /// Base allowlist (e.g. `~/.burin/mcp.json`). Absent → permissive
+    /// defaults.
+    #[serde(default)]
+    pub allowlist: Option<McpAllowlist>,
+    /// Optional per-project overlay merged over `allowlist`.
+    #[serde(default)]
+    pub overlay: Option<McpAllowlist>,
+    /// Live advertised items per server name.
+    #[serde(default)]
+    pub advertised: BTreeMap<String, Vec<AdvertisedItem>>,
+}
+
+/// Build the effective catalog from a [`CatalogRequest`]. Merges the
+/// optional overlay over the base allowlist (or permissive defaults) and
+/// projects the result onto the advertised items.
+pub fn catalog_for_request(request: &CatalogRequest) -> McpCatalog {
+    let base = request.allowlist.clone().unwrap_or_default();
+    let effective = match &request.overlay {
+        Some(overlay) => base.merge_overlay(overlay),
+        None => base,
+    };
+    build_catalog(&effective, &request.advertised)
+}
+
+/// One item in the effective catalog: an advertised item with its resolved
+/// `enabled` flag from the allowlist.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpCatalogItem {
+    pub kind: McpItemKind,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub enabled: bool,
+}
+
+/// One server's slice of the effective catalog: its advertised items, each
+/// with its resolved enablement. Items are sorted by `(kind, name)` for
+/// stable diffs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpCatalogServer {
+    pub name: String,
+    pub items: Vec<McpCatalogItem>,
+}
+
+/// The effective catalog: the stable JSON contract a thin client renders as
+/// a toggle UI. Servers are sorted by name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpCatalog {
+    pub schema_version: u32,
+    /// Effective document default applied to items with no explicit entry.
+    pub default_enabled: bool,
+    pub servers: Vec<McpCatalogServer>,
+}
+
+/// Project `allowlist` onto the per-server advertised items to build the
+/// effective catalog. Servers and items are sorted for stable output.
+pub fn build_catalog(
+    allowlist: &McpAllowlist,
+    advertised: &BTreeMap<String, Vec<AdvertisedItem>>,
+) -> McpCatalog {
+    let mut servers = Vec::with_capacity(advertised.len());
+    for (server_name, items) in advertised {
+        let mut catalog_items: Vec<McpCatalogItem> = items
+            .iter()
+            .map(|item| McpCatalogItem {
+                kind: item.kind,
+                name: item.name.clone(),
+                title: item.title.clone(),
+                description: item.description.clone(),
+                enabled: allowlist.is_enabled(server_name, item.kind, &item.name),
+            })
+            .collect();
+        catalog_items
+            .sort_by(|left, right| (left.kind, &left.name).cmp(&(right.kind, &right.name)));
+        servers.push(McpCatalogServer {
+            name: server_name.clone(),
+            items: catalog_items,
+        });
+    }
+    servers.sort_by(|left, right| left.name.cmp(&right.name));
+    McpCatalog {
+        schema_version: MCP_ALLOWLIST_SCHEMA_VERSION,
+        default_enabled: allowlist.default_enabled,
+        servers,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(server: &str, kind: McpItemKind, name: &str, enabled: bool) -> McpAllowlistItem {
+        McpAllowlistItem {
+            server: server.to_string(),
+            kind,
+            name: name.to_string(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn default_is_permissive() {
+        let allowlist = McpAllowlist::default();
+        assert_eq!(allowlist.schema_version, MCP_ALLOWLIST_SCHEMA_VERSION);
+        assert!(allowlist.default_enabled);
+        assert!(allowlist.items.is_empty());
+        // Unlisted items follow the default.
+        assert!(allowlist.is_enabled("github", McpItemKind::Tool, "anything"));
+    }
+
+    #[test]
+    fn explicit_item_overrides_default() {
+        let allowlist = McpAllowlist {
+            schema_version: 1,
+            default_enabled: true,
+            items: vec![item("github", McpItemKind::Tool, "create_issue", false)],
+        };
+        assert!(!allowlist.is_enabled("github", McpItemKind::Tool, "create_issue"));
+        // A different name still follows the default.
+        assert!(allowlist.is_enabled("github", McpItemKind::Tool, "list_issues"));
+        // Same name, different kind is a different item.
+        assert!(allowlist.is_enabled("github", McpItemKind::Resource, "create_issue"));
+    }
+
+    #[test]
+    fn deny_by_default_requires_explicit_enable() {
+        let allowlist = McpAllowlist {
+            schema_version: 1,
+            default_enabled: false,
+            items: vec![item("notion", McpItemKind::Prompt, "summarize", true)],
+        };
+        assert!(allowlist.is_enabled("notion", McpItemKind::Prompt, "summarize"));
+        assert!(!allowlist.is_enabled("notion", McpItemKind::Prompt, "other"));
+    }
+
+    #[test]
+    fn roundtrips_through_json() {
+        let allowlist = McpAllowlist {
+            schema_version: 1,
+            default_enabled: false,
+            items: vec![
+                item("github", McpItemKind::Tool, "create_issue", false),
+                item("notion", McpItemKind::Resource, "page://root", true),
+            ],
+        };
+        let json = allowlist.to_json();
+        let parsed = McpAllowlist::from_json(&json).expect("parse");
+        assert_eq!(parsed, allowlist);
+    }
+
+    #[test]
+    fn parses_minimal_document_with_defaults() {
+        // No defaultEnabled / schemaVersion → serde defaults apply.
+        let parsed = McpAllowlist::from_json("{}").expect("parse");
+        assert_eq!(parsed.schema_version, MCP_ALLOWLIST_SCHEMA_VERSION);
+        assert!(parsed.default_enabled);
+        assert!(parsed.items.is_empty());
+    }
+
+    #[test]
+    fn ignores_unknown_fields() {
+        // Forward-compat: a newer client may add fields harn does not know.
+        let json = r#"{ "schemaVersion": 1, "futureField": 42, "items": [] }"#;
+        let parsed = McpAllowlist::from_json(json).expect("parse");
+        assert!(parsed.items.is_empty());
+    }
+
+    #[test]
+    fn overlay_replaces_matching_items_and_wins_default() {
+        let base = McpAllowlist {
+            schema_version: 1,
+            default_enabled: true,
+            items: vec![
+                item("github", McpItemKind::Tool, "create_issue", true),
+                item("github", McpItemKind::Tool, "delete_repo", false),
+            ],
+        };
+        let overlay = McpAllowlist {
+            schema_version: 1,
+            default_enabled: false,
+            // Re-enable delete_repo for this project, leave create_issue.
+            items: vec![item("github", McpItemKind::Tool, "delete_repo", true)],
+        };
+        let merged = base.merge_overlay(&overlay);
+        // Overlay default wins.
+        assert!(!merged.default_enabled);
+        // Overlay item replaces the base decision.
+        assert!(merged.is_enabled("github", McpItemKind::Tool, "delete_repo"));
+        // Base item the overlay didn't mention is preserved.
+        assert!(merged.is_enabled("github", McpItemKind::Tool, "create_issue"));
+        assert_eq!(merged.items.len(), 2);
+    }
+
+    fn advertised() -> BTreeMap<String, Vec<AdvertisedItem>> {
+        let mut map = BTreeMap::new();
+        map.insert(
+            "notion".to_string(),
+            vec![AdvertisedItem {
+                kind: McpItemKind::Prompt,
+                name: "summarize".to_string(),
+                title: Some("Summarize".to_string()),
+                description: None,
+            }],
+        );
+        map.insert(
+            "github".to_string(),
+            vec![
+                AdvertisedItem {
+                    kind: McpItemKind::Tool,
+                    name: "list_issues".to_string(),
+                    title: None,
+                    description: Some("List issues".to_string()),
+                },
+                AdvertisedItem {
+                    kind: McpItemKind::Tool,
+                    name: "create_issue".to_string(),
+                    title: None,
+                    description: None,
+                },
+            ],
+        );
+        map
+    }
+
+    #[test]
+    fn catalog_applies_allowlist_and_sorts() {
+        let allowlist = McpAllowlist {
+            schema_version: 1,
+            default_enabled: true,
+            items: vec![item("github", McpItemKind::Tool, "create_issue", false)],
+        };
+        let catalog = build_catalog(&allowlist, &advertised());
+        assert_eq!(catalog.schema_version, MCP_ALLOWLIST_SCHEMA_VERSION);
+        assert!(catalog.default_enabled);
+        // Servers sorted by name: github before notion.
+        assert_eq!(catalog.servers[0].name, "github");
+        assert_eq!(catalog.servers[1].name, "notion");
+        // github items sorted by (kind, name): create_issue before list_issues.
+        let github = &catalog.servers[0];
+        assert_eq!(github.items[0].name, "create_issue");
+        assert!(!github.items[0].enabled);
+        assert_eq!(github.items[1].name, "list_issues");
+        assert!(github.items[1].enabled);
+        // notion prompt follows default (enabled).
+        assert!(catalog.servers[1].items[0].enabled);
+    }
+
+    #[test]
+    fn catalog_for_request_merges_overlay_then_projects() {
+        let json = serde_json::json!({
+            "allowlist": { "schemaVersion": 1, "defaultEnabled": true, "items": [
+                { "server": "github", "kind": "tool", "name": "create_issue", "enabled": false }
+            ] },
+            "overlay": { "schemaVersion": 1, "defaultEnabled": true, "items": [
+                { "server": "github", "kind": "tool", "name": "create_issue", "enabled": true }
+            ] },
+            "advertised": {
+                "github": [ { "kind": "tool", "name": "create_issue" } ]
+            }
+        });
+        let request: CatalogRequest = serde_json::from_value(json).expect("parse request");
+        let catalog = catalog_for_request(&request);
+        // Overlay re-enabled create_issue.
+        assert!(catalog.servers[0].items[0].enabled);
+    }
+
+    #[test]
+    fn catalog_for_request_uses_permissive_defaults_when_absent() {
+        let request = CatalogRequest {
+            allowlist: None,
+            overlay: None,
+            advertised: advertised(),
+        };
+        let catalog = catalog_for_request(&request);
+        assert!(catalog.default_enabled);
+        // All items enabled under the permissive default.
+        for server in &catalog.servers {
+            for item in &server.items {
+                assert!(item.enabled);
+            }
+        }
+    }
+
+    #[test]
+    fn catalog_json_shape_is_stable() {
+        let allowlist = McpAllowlist {
+            schema_version: 1,
+            default_enabled: true,
+            items: vec![item("github", McpItemKind::Tool, "create_issue", false)],
+        };
+        let catalog = build_catalog(&allowlist, &advertised());
+        let value = serde_json::to_value(&catalog).expect("serialize");
+        assert_eq!(value["schemaVersion"], serde_json::json!(1));
+        assert_eq!(value["defaultEnabled"], serde_json::json!(true));
+        let github = &value["servers"][0];
+        assert_eq!(github["name"], serde_json::json!("github"));
+        let create_issue = &github["items"][0];
+        assert_eq!(create_issue["kind"], serde_json::json!("tool"));
+        assert_eq!(create_issue["name"], serde_json::json!("create_issue"));
+        assert_eq!(create_issue["enabled"], serde_json::json!(false));
+        // Optional fields omitted when absent.
+        assert!(create_issue.get("title").is_none());
+    }
+}

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -87,6 +87,7 @@ public enum HarnProtocolConstants {
         "judge_decision",
         "loop_control_decision",
         "loop_stuck",
+        "mcp_catalog_changed",
         "mcp_notification",
         "progress_reported",
         "scope_classifier_verdict",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -168,6 +168,7 @@ var HarnAgentEventKinds = []HarnAgentEventKind{
 	"judge_decision",
 	"loop_control_decision",
 	"loop_stuck",
+	"mcp_catalog_changed",
 	"mcp_notification",
 	"progress_reported",
 	"scope_classifier_verdict",

--- a/spec/protocol-artifacts/harn-protocol.rs
+++ b/spec/protocol-artifacts/harn-protocol.rs
@@ -90,6 +90,8 @@ pub const ACP_DISPATCHED_METHOD_WORKFLOW_PAUSE: &str = "workflow/pause";
 pub const ACP_DISPATCHED_METHOD_HARN_WORKFLOW_PAUSE: &str = "harn.workflow.pause";
 pub const ACP_DISPATCHED_METHOD_WORKFLOW_RESUME: &str = "workflow/resume";
 pub const ACP_DISPATCHED_METHOD_HARN_WORKFLOW_RESUME: &str = "harn.workflow.resume";
+pub const ACP_DISPATCHED_METHOD_MCP_CATALOG: &str = "mcp/catalog";
+pub const ACP_DISPATCHED_METHOD_HARN_MCP_CATALOG: &str = "harn.mcp.catalog";
 
 /// Every JSON-RPC method the ACP adapter actually dispatches, including the workspace-management, workflow-control, and HITL methods the stable bindings do not yet expose as typed enums. Reconciled against the `match` arms in `harn-serve`'s ACP adapter.
 pub const ACP_DISPATCHED_METHODS: &[&str] = &[
@@ -129,6 +131,8 @@ pub const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.workflow.pause",
     "workflow/resume",
     "harn.workflow.resume",
+    "mcp/catalog",
+    "harn.mcp.catalog",
 ];
 
 pub const ACP_CLIENT_METHOD_FS_READ_TEXT_FILE: &str = "fs/read_text_file";

--- a/spec/protocol-artifacts/harn-protocol.rs
+++ b/spec/protocol-artifacts/harn-protocol.rs
@@ -272,6 +272,7 @@ pub const HARN_AGENT_EVENT_KIND_ITERATION_START: &str = "iteration_start";
 pub const HARN_AGENT_EVENT_KIND_JUDGE_DECISION: &str = "judge_decision";
 pub const HARN_AGENT_EVENT_KIND_LOOP_CONTROL_DECISION: &str = "loop_control_decision";
 pub const HARN_AGENT_EVENT_KIND_LOOP_STUCK: &str = "loop_stuck";
+pub const HARN_AGENT_EVENT_KIND_MCP_CATALOG_CHANGED: &str = "mcp_catalog_changed";
 pub const HARN_AGENT_EVENT_KIND_MCP_NOTIFICATION: &str = "mcp_notification";
 pub const HARN_AGENT_EVENT_KIND_PROGRESS_REPORTED: &str = "progress_reported";
 pub const HARN_AGENT_EVENT_KIND_SCOPE_CLASSIFIER_VERDICT: &str = "scope_classifier_verdict";
@@ -299,6 +300,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "judge_decision",
     "loop_control_decision",
     "loop_stuck",
+    "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",
     "scope_classifier_verdict",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -134,6 +134,7 @@ export const HARN_AGENT_EVENT_KINDS = [
   "judge_decision",
   "loop_control_decision",
   "loop_stuck",
+  "mcp_catalog_changed",
   "mcp_notification",
   "progress_reported",
   "scope_classifier_verdict",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -93,6 +93,7 @@
       "judge_decision",
       "loop_control_decision",
       "loop_stuck",
+      "mcp_catalog_changed",
       "mcp_notification",
       "progress_reported",
       "scope_classifier_verdict",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -220,6 +220,7 @@ HARN_AGENT_EVENT_KINDS: tuple = (
     "judge_decision",
     "loop_control_decision",
     "loop_stuck",
+    "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",
     "scope_classifier_verdict",


### PR DESCRIPTION
Closes #2647. Part of the MCP comprehensiveness sub-epic (#1428): one
harn-owned MCP implementation, with thin clients (the burin-code Rust TUI
and macOS GUI) that render toggle UIs **without storing any toggle state of
their own**.

## What this adds

### `harn_vm::mcp_allowlist` — the persisted enable/disable model

- **`McpAllowlist`** — a small, versioned, JSON-serializable document
  covering **tools, resources, AND prompts** across every configured MCP
  server. Each `(server, kind, name)` item carries an `enabled` flag;
  unlisted items fall back to a document-level `defaultEnabled`
  (permissive `true` → "allow except disabled"; `false` → "deny except
  enabled"). Unknown fields are ignored for forward-compat.
- **`merge_overlay`** — layer a per-project overlay over the user-global
  base. The overlay's default + any matching items win; base items the
  overlay does not mention are preserved. This is the `~/.burin/mcp.json` +
  project-overlay merge from the issue. harn never hardcodes those paths —
  callers pass file contents/paths in, keeping the VM cross-platform.
- **`build_catalog` / `catalog_for_request`** — project the allowlist onto
  the live advertised items per server to produce the **effective catalog**
  (servers → items + resolved `enabled`), sorted for stable diffs. This is
  the stable contract a thin client renders directly.

### Exposed over ACP

- **`mcp/catalog`** request (alias `harn.mcp.catalog`) returns the effective
  catalog. The merge + projection is harn-owned: a client supplies its
  `allowlist`, optional `overlay`, and live `advertised` items, and gets
  back the resolved catalog. The client stores no toggle state of its own.
- **`mcp_catalog_changed`** additive agent event over the
  `_harn/agentEvent` channel. A `reason` tag (`list_changed` /
  `allowlist_updated`) and optional `server` cue a client to re-fetch the
  catalog and re-render its toggle UI on `notifications/*/list_changed` or
  an allowlist edit — no transcript parsing. Registered in
  `HARN_AGENT_EVENT_KINDS`; protocol artifacts regenerated and
  `committed_protocol_artifacts_match_generator` passes.

## How a thin client consumes it

1. Subscribe to agent events; on `mcp_catalog_changed`, (re)issue an
   `mcp/catalog` request passing the user's `~/.burin/mcp.json` allowlist
   (and any project overlay) plus the items it has from `tools/list` /
   `resources/list` / `prompts/list`.
2. Render the returned `servers[].items[]` as a toggle list using each
   item's `enabled` flag. Flipping a toggle is a write back to the
   allowlist document (the client owns the file bytes, harn owns the
   schema/merge/projection).

## Tests

- harn-vm: 11 unit tests (allowlist resolution, deny-by-default, JSON
  round-trip + minimal/unknown-field parsing, overlay merge, catalog
  projection + sort + stable JSON shape, request-envelope merge & defaults).
- harn-serve: `mcp_catalog_changed` ext-event tests (server-scoped and
  serverless) + an `mcp/catalog` round-trip through the ACP channel server.
- clippy clean on `harn-vm` + `harn-serve`; drift test green.

## Deferred (follow-ups)

- Wiring the new per-item **resource/prompt** enablement into live
  `mcp_host` dispatch enforcement (today's allowlist guard gates tools by
  `(server, tool)`); this PR establishes the model + surface.
- burin-code-side adoption: the `~/.burin/mcp.json` location, the
  allowlist write-back path, and the TUI/GUI toggle rendering — land after
  the next harn release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)