### PR TITLE
fix(harn-vm): append transcript/daemon events synchronously to stop unbounded leak (#2660)

### DIFF
--- a/changelog.d/2660-spawn-leak.fixed.md
+++ b/changelog.d/2660-spawn-leak.fixed.md
@@ -1,0 +1,11 @@
+- **Fixed an unbounded memory leak in the test runner and long-running agent loops (#2660).** Transcript and daemon
+  event-log appends were dispatched as detached `tokio::runtime::Handle::spawn` tasks. The agent loop and
+  `harn test` drive their runtime with `LocalSet::run_until`, which stops polling once the driving future resolves,
+  so those detached append tasks were never run to completion — each stranded task pinned its transcript-sized
+  `LogEvent` payload plus an `Arc<AnyEventLog>` clone for the lifetime of the runtime. Across a
+  `harn test --parallel` worker this accumulated roughly one transcript per test (~18 MB) and OOM'd CI. The appends
+  now run synchronously via a private `futures::executor::block_on`; no event-log backend yields to the tokio
+  reactor on `append`, so this is leak-free and does not touch the ambient runtime. A counting-allocator probe
+  measured the regression at ~18 MB/round of steady-state growth before the fix; a regression test now asserts the
+  append lands in the log the instant the producing `run_until` future resolves, proving no detached task can
+  strand the payload.

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -401,13 +401,21 @@ fn append_llm_transcript_event_log(entry: &serde_json::Value) {
         }
     }
     let event = crate::event_log::LogEvent::new(kind, entry.clone()).with_headers(headers);
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        handle.spawn(async move {
-            let _ = log.append(&topic, event).await;
-        });
-    } else {
-        let _ = futures::executor::block_on(log.append(&topic, event));
-    }
+    // Append synchronously. Earlier this fire-and-forget `handle.spawn`ed the
+    // append on the ambient tokio runtime, but the agent loop and the test
+    // runner drive their runtime with `LocalSet::run_until`, which stops
+    // polling once the driving future resolves. Detached append tasks were
+    // therefore never polled to completion: each stranded task pinned its
+    // transcript-sized `LogEvent` payload plus an `Arc<AnyEventLog>` clone for
+    // the lifetime of the runtime — across an entire `harn test --parallel`
+    // worker, that accumulated ~one transcript per test and OOM'd CI (#2660).
+    //
+    // None of the event-log backends actually yield to the tokio reactor on
+    // `append` (memory = `Mutex`, sqlite = blocking `Mutex<Connection>`, file =
+    // blocking fs), so a private `futures::executor::block_on` runs the append
+    // to completion on this thread without touching the ambient runtime. This
+    // is the same path the non-runtime branch already used.
+    let _ = futures::executor::block_on(log.append(&topic, event));
 }
 
 /// Record a `template.render` transcript event for a `render()` /
@@ -1236,6 +1244,55 @@ mod retry_tests {
             Some("/tmp/harn-transcript-a")
         );
         pop_llm_transcript_dir();
+    }
+
+    // Regression for #2660. `append_llm_transcript_event_log` used to
+    // `handle.spawn` the event-log append as a detached task. The agent loop
+    // and the test runner drive their tokio runtime with
+    // `LocalSet::run_until`, which stops polling the moment the driving future
+    // resolves — so those detached appends were never run to completion. Each
+    // stranded task pinned a transcript-sized payload plus an
+    // `Arc<AnyEventLog>` clone for the lifetime of the runtime, leaking ~one
+    // transcript per test across a `harn test --parallel` worker until CI
+    // OOM'd. The append must therefore complete synchronously: the entry has
+    // to be readable from the log the instant the producing future resolves,
+    // without any further runtime polling.
+    #[test]
+    fn transcript_event_is_appended_synchronously_under_run_until() {
+        use crate::event_log::{
+            install_memory_for_current_thread, reset_active_event_log, EventLog, Topic,
+        };
+
+        reset_active_event_log();
+        let log = install_memory_for_current_thread(128);
+        let topic = Topic::new("agent.transcript.llm").expect("static topic");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let local = tokio::task::LocalSet::new();
+        runtime.block_on(local.run_until(async {
+            // Emit a transcript entry from inside the run_until future, exactly
+            // as the agent loop does. With the old detached-spawn path the
+            // append task is left scheduled-but-unpolled when this future
+            // resolves; with the synchronous path it has already landed.
+            append_llm_transcript_entry(&serde_json::json!({
+                "type": "provider_call_request",
+                "iteration": 0,
+                "marker": "regression-2660",
+            }));
+        }));
+
+        // The driving future has resolved and we are no longer polling the
+        // runtime. The event must already be in the log — proving the append
+        // ran synchronously rather than on a stranded detached task.
+        let latest = futures::executor::block_on(log.latest(&topic))
+            .expect("latest query")
+            .expect("transcript event must be present immediately after run_until resolves");
+        assert_eq!(latest, 1, "exactly one transcript event should be recorded");
+
+        reset_active_event_log();
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/daemon.rs
+++ b/crates/harn-vm/src/llm/daemon.rs
@@ -175,11 +175,11 @@ fn append_daemon_state_event(path: &str, kind: &str, snapshot: &DaemonSnapshot) 
     headers.insert("path".to_string(), path.to_string());
     let payload = serde_json::to_value(snapshot).unwrap_or(serde_json::Value::Null);
     let event = crate::event_log::LogEvent::new(kind, payload).with_headers(headers);
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        handle.spawn(async move {
-            let _ = log.append(&topic, event).await;
-        });
-    } else {
-        let _ = futures::executor::block_on(log.append(&topic, event));
-    }
+    // Append synchronously — see the note in `agent_observe.rs`'s
+    // `append_llm_transcript_event_log`. The old `handle.spawn` detached the
+    // append onto a `run_until`-driven runtime that stops polling once the
+    // driving future resolves, stranding the task (and the `Arc<AnyEventLog>` +
+    // payload it held) for the runtime's lifetime (#2660). The backends don't
+    // yield to the reactor on `append`, so a private `block_on` is leak-free.
+    let _ = futures::executor::block_on(log.append(&topic, event));
 }


### PR DESCRIPTION
## What

Root-causes and fixes the residual `harn test --parallel` memory leak tracked in #2660.

The original hypothesis (an external `Rc` holder retaining `SessionState.transcript` past `reset_session_store()`) was **disproven empirically**: a `Rc::strong_count` probe showed the transcript `Rc` is held by nothing — `strong_count == 1` at every reset, so it is freed correctly.

The real leak is a **detached-task / fire-and-forget spawn**:

- `append_llm_transcript_event_log` (and `append_daemon_state_event`) dispatched the event-log `append` as a detached `tokio::runtime::Handle::spawn` task.
- The agent loop and the `harn test` worker drive their runtime with `LocalSet::run_until`, which **stops polling once the driving future resolves**. Detached `Handle::spawn` tasks are left scheduled-but-unpolled and only run if the runtime is driven again — which never happens per test.
- Each stranded task pinned its **transcript-sized `LogEvent` payload** plus an `Arc<AnyEventLog>` clone for the lifetime of the worker runtime. Across a whole `--parallel` worker this accumulated ~one transcript per test and OOM'd CI.

This is **backend-independent** (a counting-allocator probe showed identical ~18 MB/round growth under both the sqlite and in-memory event-log backends, because the leaked memory is the queued payloads, not the on-disk/in-RAM log buffer).

## Fix

Append synchronously via a private `futures::executor::block_on`. No event-log backend yields to the tokio reactor on `append` (memory = `Mutex`, sqlite = blocking `Mutex<Connection>`, file = blocking fs), so `block_on` runs the append to completion inline without touching the ambient runtime — leak-free, and it also fixes the latent correctness bug that these events were silently never written under `run_until`.

## Verification

- **Empirical (pre-fix):** counting-allocator (`cap`) probe over repeated identical `unified_loop` test rounds measured `live` growth of ~18 MB/round (22 → 40 → 57 MB). The transcript `Rc::strong_count` was `1` at every `reset_session_store()`, ruling out the retained-`Rc` hypothesis.
- **Regression test:** `transcript_event_is_appended_synchronously_under_run_until` emits a transcript entry inside a `LocalSet::run_until` future and asserts the event is in the log the instant the future resolves — which fails on the old detached-spawn path and passes now.
- `cargo build -p harn-vm -p harn-cli` — green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p harn-vm` lib suite — 2965 passed, 0 failed.

All temporary instrumentation (the `cap` dev-dep, the `leak_repro` example, the strong-count / live-instance probes) was removed; the committed change is the two-line-of-logic fix plus the regression test.

## Dependencies

Builds atop **#2669** (async-builtin `task_local` context cutover) and **#2670** (reset-gap registry closures), both now on `main`. Does **not** revert either.

Closes #2660

🤖 Generated with [Claude Code](https://claude.com/claude-code)