### PR TITLE
sandbox: hermetic nested read-only roots in OS profile renderers (#2654)

### DIFF
--- a/changelog.d/2654.added.md
+++ b/changelog.d/2654.added.md
@@ -1,0 +1,9 @@
+The macOS `sandbox-exec` renderer now emits a trailing `(deny file-write*
+(subpath "<root>"))` for every `read_only_roots` entry after the broad
+workspace write allow, so a read-only root nested under a writable workspace
+root stays hermetically unwritable (`sandbox-exec` is last-match-wins,
+defeating a chmod-back write). The Linux Landlock renderer's read-only access
+bits (read + dir-read + execute, never write/create/remove) are extracted into
+a tested `read_only_access()` helper; Landlock rules are additive (no deny), so
+the two root lists must stay disjoint when targeting the Linux backend. No-op
+when `read_only_roots` is empty. (#2654)

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -169,10 +169,8 @@ fn landlock_profile(
     for root in process_sandbox_roots(policy) {
         push_rule(&mut profile, root, workspace_access, false)?;
     }
-    let read_only_access =
-        LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR | LANDLOCK_ACCESS_FS_EXECUTE;
     for root in process_sandbox_readonly_roots(policy) {
-        push_rule(&mut profile, root, read_only_access, false)?;
+        push_rule(&mut profile, root, read_only_access(), false)?;
     }
     Ok(Some(profile))
 }
@@ -347,6 +345,16 @@ fn denied_syscalls(policy: &CapabilityPolicy) -> Vec<libc::c_long> {
     syscalls
 }
 
+/// Access rights granted to every `read_only_roots` entry: read +
+/// directory-read + execute, and never any write/create/remove right —
+/// regardless of the policy's `workspace.*` capabilities. Landlock rules
+/// are additive (there is no deny), so a read-only root nested under a
+/// writable workspace root still inherits the parent's write grant; the
+/// two lists are intended to be disjoint (see `docs/src/sandboxing.md`).
+fn read_only_access() -> u64 {
+    LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR | LANDLOCK_ACCESS_FS_EXECUTE
+}
+
 fn workspace_access(policy: &CapabilityPolicy) -> u64 {
     let read_access =
         LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR | LANDLOCK_ACCESS_FS_EXECUTE;
@@ -449,3 +457,69 @@ const LANDLOCK_ACCESS_FS_MAKE_BLOCK: u64 = 1 << 11;
 const LANDLOCK_ACCESS_FS_MAKE_SYM: u64 = 1 << 12;
 const LANDLOCK_ACCESS_FS_REFER: u64 = 1 << 13;
 const LANDLOCK_ACCESS_FS_TRUNCATE: u64 = 1 << 14;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WRITE_BITS: u64 = LANDLOCK_ACCESS_FS_WRITE_FILE
+        | LANDLOCK_ACCESS_FS_REMOVE_DIR
+        | LANDLOCK_ACCESS_FS_REMOVE_FILE
+        | LANDLOCK_ACCESS_FS_MAKE_CHAR
+        | LANDLOCK_ACCESS_FS_MAKE_DIR
+        | LANDLOCK_ACCESS_FS_MAKE_REG
+        | LANDLOCK_ACCESS_FS_MAKE_SOCK
+        | LANDLOCK_ACCESS_FS_MAKE_FIFO
+        | LANDLOCK_ACCESS_FS_MAKE_BLOCK
+        | LANDLOCK_ACCESS_FS_MAKE_SYM
+        | LANDLOCK_ACCESS_FS_REFER
+        | LANDLOCK_ACCESS_FS_TRUNCATE;
+
+    fn linux_policy_with_workspace_ops(ops: &[&str]) -> CapabilityPolicy {
+        CapabilityPolicy {
+            tools: Vec::new(),
+            capabilities: std::collections::BTreeMap::from([(
+                "workspace".to_string(),
+                ops.iter().map(|op| op.to_string()).collect(),
+            )]),
+            workspace_roots: vec!["/ws".to_string()],
+            read_only_roots: Vec::new(),
+            side_effect_level: Some("read_only".to_string()),
+            recursion_limit: None,
+            tool_arg_constraints: Vec::new(),
+            tool_annotations: std::collections::BTreeMap::new(),
+            sandbox_profile: SandboxProfile::Worktree,
+        }
+    }
+
+    #[test]
+    fn read_only_access_grants_read_and_execute_but_never_write() {
+        let access = read_only_access();
+        assert_ne!(access & LANDLOCK_ACCESS_FS_READ_FILE, 0, "read file");
+        assert_ne!(access & LANDLOCK_ACCESS_FS_READ_DIR, 0, "read dir");
+        assert_ne!(access & LANDLOCK_ACCESS_FS_EXECUTE, 0, "execute");
+        assert_eq!(
+            access & WRITE_BITS,
+            0,
+            "read-only access must not carry any write/create/remove right",
+        );
+    }
+
+    #[test]
+    fn read_only_access_is_independent_of_workspace_write_capability() {
+        // Even when the policy otherwise allows workspace writes, the
+        // read-only access bits are unchanged: a read-only root gets
+        // read+execute only.
+        let writable = linux_policy_with_workspace_ops(&["read_text", "write_text", "delete"]);
+        assert_ne!(
+            workspace_access(&writable) & LANDLOCK_ACCESS_FS_WRITE_FILE,
+            0,
+            "writable workspace root should carry write",
+        );
+        assert_eq!(
+            read_only_access() & WRITE_BITS,
+            0,
+            "read-only roots stay unwritable regardless of workspace write capability",
+        );
+    }
+}

--- a/crates/harn-vm/src/stdlib/sandbox/macos.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/macos.rs
@@ -117,6 +117,18 @@ fn render_profile(policy: &CapabilityPolicy) -> String {
                 sandbox_profile_escape(&root.display().to_string())
             ));
         }
+        // A read-only root nested under a writable workspace root would
+        // otherwise inherit write from the broad allow above —
+        // `sandbox-exec` is last-match-wins, so an explicit deny emitted
+        // *after* every write allow re-asserts hermetic read-only scope
+        // even when the lists are not disjoint. The deny is a no-op for
+        // disjoint read-only roots (which never received a write allow).
+        for root in read_only_roots.iter() {
+            profile.push_str(&format!(
+                "(deny file-write* (subpath \"{}\"))\n",
+                sandbox_profile_escape(&root.display().to_string())
+            ));
+        }
     }
     if policy_allows_network(policy) {
         profile.push_str("(allow network*)\n");
@@ -210,6 +222,54 @@ mod tests {
                 .any(|line| line.starts_with("(allow file-write*")
                     && line.contains("harn-workspace")),
             "writable workspace root should still get write: {profile}"
+        );
+    }
+
+    #[test]
+    fn nested_read_only_root_is_denied_write_after_broad_workspace_allow() {
+        // /ws/vendor is a read-only root nested under the writable /ws.
+        let mut policy = macos_policy_with_workspace_ops(&["write_text"]);
+        policy.workspace_roots = vec!["/ws".to_string()];
+        policy.read_only_roots = vec!["/ws/vendor".to_string()];
+        let profile = render_profile(&policy);
+
+        // /ws/vendor is readable.
+        assert!(
+            profile.contains("(allow file-read* (subpath \"/ws/vendor\"))"),
+            "nested read-only root should be granted read: {profile}"
+        );
+        // /ws is writable.
+        assert!(
+            profile.contains("(allow file-write* (subpath \"/ws\"))"),
+            "writable workspace root should still get write: {profile}"
+        );
+        // The broad /ws write allow must be neutralized for /ws/vendor by a
+        // deny emitted after it (sandbox-exec is last-match-wins).
+        let write_allow = profile
+            .lines()
+            .position(|line| line == "(allow file-write* (subpath \"/ws\"))")
+            .expect("expected a write allow for /ws");
+        let vendor_deny = profile
+            .lines()
+            .position(|line| line == "(deny file-write* (subpath \"/ws/vendor\"))")
+            .expect("expected a write deny for /ws/vendor");
+        assert!(
+            vendor_deny > write_allow,
+            "deny for the nested read-only root must come after the broad write allow \
+             so last-match-wins keeps it unwritable: {profile}"
+        );
+    }
+
+    #[test]
+    fn read_only_root_deny_is_omitted_when_no_workspace_write() {
+        // No write capability: there is no broad write allow to neutralize,
+        // so no deny rule is emitted (pure read-only profile stays minimal).
+        let mut policy = macos_policy_with_workspace_ops(&["read_text"]);
+        policy.read_only_roots = vec!["/mnt/memory".to_string()];
+        let profile = render_profile(&policy);
+        assert!(
+            !profile.contains("(deny file-write*"),
+            "read-only profile must not emit spurious deny rules: {profile}"
         );
     }
 }

--- a/docs/src/sandboxing.md
+++ b/docs/src/sandboxing.md
@@ -50,7 +50,13 @@ a path under one passes `read_text`/`list`/`exists` checks but
 `write_text`/`delete` are rejected with a `tool_rejected` "read-only
 workspace root" violation, and the generated OS profile grants the root
 read but never write — even when the policy otherwise allows workspace
-writes. The two lists are intended to be disjoint. This lets a caller
+writes. The two lists are intended to be disjoint. macOS additionally
+re-denies write to each read-only root *after* the broad workspace
+write allow (`sandbox-exec` is last-match-wins), so a read-only root
+nested under a writable root stays hermetically unwritable; Linux
+Landlock rules are purely additive (no deny), so a nested read-only
+root under a writable parent inherits the parent's write grant — keep
+the lists disjoint when targeting the Linux backend. This lets a caller
 mount a reference tree (a shared memory dir, a persona bundle) that the
 workload can read but cannot mutate. `CapabilityPolicy::intersect`
 narrows each list to the roots common to both sides, with an empty list
@@ -134,7 +140,7 @@ falls back to the warn/enforce decision documented above.
 | always | `(allow process*)` + `(allow sysctl-read)` + `(allow mach-lookup)` + `(allow file-read-data (literal "/"))` + `(allow file-write* (subpath "/dev"))` | minimum surface required to exec a binary and reach `/dev` |
 | always | `(allow file-read* (subpath "/bin" \| "/etc" \| "/Library" \| "/opt/homebrew" \| "/private/etc" \| "/System" \| "/usr"))` | read access to the directories the dynamic linker and most CLI tools need |
 | `workspace_roots: [...]` / `read_only_roots: [...]` | `(allow file-read* (subpath "<root>"))` | workspace and read-only roots are readable |
-| `workspace.write_text` / `workspace.delete` (or empty `capabilities`) | `(allow file-write* (subpath "/tmp" \| "/private/tmp" \| "/var/tmp"))` + `(allow file-write* (subpath "<root>"))` | scratch dirs and writable `workspace_roots` are writable; `read_only_roots` get no write rule |
+| `workspace.write_text` / `workspace.delete` (or empty `capabilities`) | `(allow file-write* (subpath "/tmp" \| "/private/tmp" \| "/var/tmp"))` + `(allow file-write* (subpath "<root>"))` + `(deny file-write* (subpath "<read_only_root>"))` | scratch dirs and writable `workspace_roots` are writable; each `read_only_roots` entry is then re-denied write. `sandbox-exec` is last-match-wins, so the trailing deny keeps a read-only root nested under a writable root unwritable even though the two lists are nominally disjoint |
 | `side_effect_level >= network` | `(allow network*)` | otherwise outbound network is denied |
 
 `sandbox-exec` is officially deprecated but remains the platform


### PR DESCRIPTION
Closes #2654

## Problem

`CapabilityPolicy::read_only_roots` and the OS sandbox profile renderers already grant read-only roots read-but-no-write when the lists are **disjoint** (#2634 / #2638). They did **not** defend the realistic *nested* case the harn-cloud audit cares about: a read-only root (a persona bundle at `/ws/vendor`) declared **under** a writable workspace root `/ws`. There, the broad `(allow file-write* (subpath "/ws"))` rule on macOS still granted write to the nested subtree — a same-uid snippet could `chmod +w` and write the protected bundle (the chmod-back residual).

## Change

**macOS (`stdlib/sandbox/macos.rs`):** `sandbox-exec` is **last-match-wins**, so for every `read_only_roots` entry we now emit an explicit `(deny file-write* (subpath "<root>"))` **after** the broad workspace write allow. This neutralizes write to a nested read-only root while leaving the surrounding writable root writable. The deny:
- is a no-op for disjoint read-only roots (they never received a write allow), and
- is only emitted inside the `policy_allows_workspace_write` branch, so the no-`read_only_roots` profile is **byte-identical** to before (pure addition).

**Linux (`stdlib/sandbox/linux.rs`):** Landlock rules are purely **additive** (there is no deny), so a read-only root nested under a writable parent inherits the parent's grant and cannot be carved out — the two lists must stay disjoint on Linux (documented). The read-only access bits (`READ_FILE | READ_DIR | EXECUTE`, never write/create/remove) are extracted into a `read_only_access()` helper so the renderer logic is unit-testable on any host. Rendered access is unchanged; seccomp untouched.

## Precedence approach

**deny-after-allow** on macOS (verified by ordering assertion); Linux relies on the additive-only model plus the disjoint-lists invariant (no deny available in Landlock).

## Tests

- macOS `nested_read_only_root_is_denied_write_after_broad_workspace_allow` — `workspace_roots=[/ws]` + `read_only_roots=[/ws/vendor]` + `write_text`: `/ws/vendor` gets `file-read*`, `/ws` gets `file-write*`, and the `(deny file-write* (subpath "/ws/vendor"))` line appears **after** the `(allow file-write* (subpath "/ws"))` line.
- macOS `read_only_root_deny_is_omitted_when_no_workspace_write` — no spurious deny in a pure read-only profile.
- Linux `read_only_access_grants_read_and_execute_but_never_write` — asserts READ_FILE|READ_DIR|EXECUTE set and all write/remove/make bits clear.
- Linux `read_only_access_is_independent_of_workspace_write_capability` — read-only bits stay unwritable even when the policy carries `write_text`/`delete`.

Existing disjoint-root tests (`read_only_roots_are_granted_read_but_never_write`) retained.

`cargo build -p harn-vm`, `cargo clippy --workspace --all-targets -- -D warnings`, and the macOS sandbox unit tests are green locally; Linux module tests run on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)