### PR TITLE
feat(serve,acp): pass ACP Agent Registry auth gate (#2664)

### DIFF
--- a/changelog.d/2664.added.md
+++ b/changelog.d/2664.added.md
@@ -1,0 +1,13 @@
+- **`harn serve acp` now passes the ACP Agent Registry auth gate (#2664).** Two changes make the bare
+  `harn serve acp` command launchable and conformant the way the agentclientprotocol/registry validator
+  expects:
+  - The positional `<FILE>` is now **optional**. With no file, `harn serve acp` boots a file-less ("attach")
+    ACP stdio server that waits for `initialize` / `session/new` from the connecting editor instead of
+    requiring a script path up front (previously it exited code 2 before the ACP loop started). The existing
+    file-provided mode is unchanged.
+  - `initialize` always advertises a **non-empty, spec-conformant `authMethods` array**. Each credentialed
+    method (API key / HMAC / OAuth 2.1) now carries an explicit top-level `type: "agent"`, and a policy with
+    no configured credentials (the local attach default) advertises a single `agent`-type `"none"` method
+    representing harn's local/anonymous flow. Authenticating against that `"none"` method id is honoured as a
+    no-op success. Verified against the registry's own `client.py` auth-check: harn now reports
+    `Found 1 valid auth method(s)`. Unblocks the deferred registry submission (#2672).

--- a/crates/harn-cli/src/cli/serve.rs
+++ b/crates/harn-cli/src/cli/serve.rs
@@ -94,8 +94,11 @@ pub(crate) struct ServeAcpArgs {
     pub obs: ServeObsMode,
     #[command(flatten)]
     pub profile: ProfileArgs,
-    /// Path to the .harn file to serve.
-    pub file: String,
+    /// Path to the `.harn` file to serve. Optional: when omitted, `harn
+    /// serve acp` boots a file-less ("attach") ACP stdio server that
+    /// waits for `initialize` / `session/new` from the connecting editor
+    /// instead of binding to a script up front.
+    pub file: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -763,7 +763,22 @@ fn test_parses_serve_acp() {
         serve.profile.json_path.as_deref(),
         Some(std::path::Path::new("profiles/acp.ndjson"))
     );
-    assert_eq!(serve.file, "agent.harn");
+    assert_eq!(serve.file.as_deref(), Some("agent.harn"));
+}
+
+#[test]
+fn test_parses_serve_acp_without_file_for_attach_mode() {
+    // The ACP registry launches the bare `harn serve acp` with no
+    // positional file; the parse must succeed and leave `file` unset so
+    // the command boots the file-less attach server.
+    let cli = Cli::parse_from(["harn", "serve", "acp"]);
+    let Command::Serve(args) = cli.command.unwrap() else {
+        panic!("expected serve command");
+    };
+    let crate::cli::ServeCommand::Acp(serve) = args.command else {
+        panic!("expected serve acp");
+    };
+    assert_eq!(serve.file, None);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/tests.rs
@@ -458,7 +458,16 @@ async fn acp_websocket_requires_configured_bearer_auth() {
             .get("fork")
             .is_none()
     );
-    assert_eq!(response["result"]["authMethods"], json!([]));
+    // The WebSocket transport gates the upgrade on the bearer token, so
+    // the ACP-level auth policy is empty. `initialize` still advertises
+    // the spec-conformant local "none" method (agent type) rather than
+    // an empty array, so the response passes the ACP registry auth gate.
+    let auth_methods = response["result"]["authMethods"]
+        .as_array()
+        .expect("authMethods array");
+    assert_eq!(auth_methods.len(), 1);
+    assert_eq!(auth_methods[0]["id"], "none");
+    assert_eq!(auth_methods[0]["type"], "agent");
 
     listener
         .shutdown(Duration::from_secs(5))

--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -89,7 +89,7 @@ fn guard_serve_bind_auth(
 pub(crate) async fn run_acp_server(args: &ServeAcpArgs) -> Result<(), String> {
     apply_obs_mode(args.obs)?;
     crate::acp::run_acp_server(
-        Some(&args.file),
+        args.file.as_deref(),
         build_auth_policy(&args.api_key, args.hmac_secret.as_ref()),
         args.trace,
         harn_serve::AcpProfileConfig {

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -805,6 +805,35 @@ impl AcpServer {
                 return;
             }
         };
+        // A policy with no configured methods advertises the synthetic
+        // local "none" flow (see `AuthPolicy::acp_auth_methods`). Honour
+        // an explicit authenticate against it as a no-op success so the
+        // advertised method is real: the caller is already an anonymous
+        // principal.
+        if self.auth_policy.methods.is_empty() && method_id == crate::ACP_LOCAL_NONE_METHOD_ID {
+            let principal = AuthenticatedPrincipal {
+                subject: "anonymous".to_string(),
+                scheme: "none".to_string(),
+                granted_scopes: std::collections::BTreeSet::new(),
+                tenant_id: None,
+            };
+            self.authenticated_principal = Some(principal.clone());
+            self.send_response(
+                id,
+                serde_json::json!({
+                    "_meta": {
+                        "harn": {
+                            "authenticated": true,
+                            "principal": {
+                                "subject": principal.subject,
+                                "scheme": principal.scheme,
+                            }
+                        }
+                    }
+                }),
+            );
+            return;
+        }
         let Some(method) = self.auth_policy.method_by_acp_id(method_id) else {
             self.send_error_with_data(
                 id,

--- a/crates/harn-serve/src/adapters/acp/tests/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/modes.rs
@@ -164,6 +164,45 @@ async fn acp_authenticate_uses_shared_auth_policy() {
         .await;
 }
 
+/// A file-less attach server (default allow-all policy) advertises the
+/// local "none" method in `initialize` and honours an explicit
+/// `authenticate` against it as a no-op success.
+#[tokio::test(flavor = "current_thread")]
+async fn acp_attach_server_advertises_and_authenticates_local_none_method() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+        }))
+        .await;
+    let initialize = recv_json(&mut rx).await;
+    let methods = initialize["result"]["authMethods"]
+        .as_array()
+        .expect("authMethods array");
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0]["id"], "none");
+    assert_eq!(methods[0]["type"], "agent");
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "authenticate",
+            "params": {"methodId": "none"},
+        }))
+        .await;
+    let authenticated = recv_json(&mut rx).await;
+    assert_eq!(authenticated["id"], 2);
+    assert_eq!(
+        authenticated["result"]["_meta"]["harn"]["principal"]["scheme"],
+        "none"
+    );
+}
+
 /// `session/new` returns the legacy `SessionModeState` and the
 /// preferred `configOptions` selector from the same catalog.
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -137,7 +137,24 @@ async fn acp_server_handles_session_flow_and_prompt_updates() {
             let initialize = recv_json(&mut response_rx).await;
             assert_eq!(initialize["id"], 1);
             assert_eq!(initialize["result"]["agentInfo"]["name"], "harn");
-            assert_eq!(initialize["result"]["authMethods"], serde_json::json!([]));
+            // A file-less attach server (no configured auth methods)
+            // still advertises the spec-conformant local "none" method so
+            // `initialize` passes the ACP registry auth gate.
+            assert_eq!(
+                initialize["result"]["authMethods"],
+                serde_json::json!([{
+                    "id": "none",
+                    "type": "agent",
+                    "name": "Local (no authentication)",
+                    "description": "Connect without credentials. The agent runs locally and accepts the session as an anonymous principal.",
+                    "_meta": {
+                        "harn": {
+                            "scheme": "none",
+                            "challenge": { "type": "none" }
+                        }
+                    }
+                }])
+            );
             assert_eq!(
                 initialize["result"]["agentCapabilities"]["loadSession"],
                 true

--- a/crates/harn-serve/src/auth.rs
+++ b/crates/harn-serve/src/auth.rs
@@ -298,6 +298,18 @@ impl AuthPolicy {
     }
 
     pub fn acp_auth_methods(&self) -> Vec<serde_json::Value> {
+        // The ACP spec (and the agentclientprotocol/registry auth gate)
+        // require `initialize` to advertise a NON-EMPTY `authMethods`
+        // array with at least one method whose `type` is `agent` or
+        // `terminal`. A policy with no configured methods is the common
+        // local/attach case (`harn serve acp` with no `--api-key` /
+        // `--hmac-secret`): callers are accepted as `anonymous` without a
+        // credential exchange. Advertise that local flow as a single
+        // `agent`-type "none" method so the handshake is still spec
+        // conformant rather than emitting an empty array.
+        if self.methods.is_empty() {
+            return vec![acp_local_none_auth_method()];
+        }
         let mut counts = BTreeMap::new();
         self.methods
             .iter()
@@ -411,6 +423,34 @@ impl AuthPolicy {
     }
 }
 
+/// Stable ACP `methodId` for harn's local "no credential required"
+/// flow. Advertised when an `AuthPolicy` has no configured methods so
+/// the `initialize` handshake stays spec conformant (a non-empty
+/// `authMethods` array). Authenticating against this id is a no-op:
+/// callers are already accepted as `anonymous`.
+pub const ACP_LOCAL_NONE_METHOD_ID: &str = "none";
+
+/// Build the synthetic `agent`-type "none" auth method advertised when a
+/// policy has no configured credentials. The top-level `type: "agent"`
+/// is what the ACP registry validator keys on; the `_meta.harn` block
+/// mirrors the shape of the credentialed methods for harn-aware clients.
+fn acp_local_none_auth_method() -> serde_json::Value {
+    serde_json::json!({
+        "id": ACP_LOCAL_NONE_METHOD_ID,
+        "type": "agent",
+        "name": "Local (no authentication)",
+        "description": "Connect without credentials. The agent runs locally and accepts the session as an anonymous principal.",
+        "_meta": {
+            "harn": {
+                "scheme": "none",
+                "challenge": {
+                    "type": "none"
+                }
+            }
+        }
+    })
+}
+
 fn acp_auth_method_kind(method: &AuthMethodConfig) -> &'static str {
     match method {
         AuthMethodConfig::ApiKey(_) => "apiKey",
@@ -438,6 +478,7 @@ fn acp_auth_method(method: &AuthMethodConfig, id: String) -> serde_json::Value {
     match method {
         AuthMethodConfig::ApiKey(_) => serde_json::json!({
             "id": id,
+            "type": "agent",
             "name": "Harn API key",
             "description": "Authenticate with an API key supplied as `Authorization: Bearer <key>` or `X-API-Key`.",
             "_meta": {
@@ -453,6 +494,7 @@ fn acp_auth_method(method: &AuthMethodConfig, id: String) -> serde_json::Value {
         }),
         AuthMethodConfig::Hmac(config) => serde_json::json!({
             "id": id,
+            "type": "agent",
             "name": "Harn HMAC signature",
             "description": "Authenticate with an HMAC-SHA256 canonical request signature.",
             "_meta": {
@@ -473,6 +515,7 @@ fn acp_auth_method(method: &AuthMethodConfig, id: String) -> serde_json::Value {
         }),
         AuthMethodConfig::OAuth21(config) => serde_json::json!({
             "id": id,
+            "type": "agent",
             "name": "OAuth 2.1 bearer token",
             "description": "Authenticate with a bearer token validated by the transport.",
             "_meta": {
@@ -638,6 +681,9 @@ mod tests {
         };
 
         let methods = policy.acp_auth_methods();
+        // Every credentialed method advertises a top-level ACP `type`
+        // (the registry auth gate keys on it) of `agent`.
+        assert!(methods.iter().all(|m| m["type"] == "agent"));
         assert_eq!(methods[0]["id"], "apiKey");
         assert_eq!(methods[1]["id"], "hmac");
         assert_eq!(methods[2]["id"], "apiKey-2");
@@ -645,6 +691,56 @@ mod tests {
             policy.method_by_acp_id("hmac"),
             Some(AuthMethodConfig::Hmac(_))
         ));
+    }
+
+    /// Mirror of the agentclientprotocol/registry validator's type
+    /// resolution (`client.py::parse_auth_methods`): direct `type` wins,
+    /// then `_meta` `terminal-auth`/`agent-auth` keys, else default
+    /// `agent`. Returns the resolved type for one advertised method.
+    fn registry_resolved_type(method: &serde_json::Value) -> &str {
+        if let Some(direct) = method.get("type").and_then(|value| value.as_str()) {
+            return direct;
+        }
+        if let Some(meta) = method.get("_meta").and_then(|value| value.as_object()) {
+            if meta.contains_key("terminal-auth") {
+                return "terminal";
+            }
+            if meta.contains_key("agent-auth") {
+                return "agent";
+            }
+        }
+        "agent"
+    }
+
+    /// The registry gate requires `initialize` to advertise a non-empty
+    /// `authMethods` with at least one method whose resolved type is
+    /// `agent` or `terminal`. An allow-all policy (no credentials, the
+    /// `harn serve acp` attach default) must still pass.
+    #[test]
+    fn allow_all_policy_advertises_conformant_local_auth_method() {
+        let methods = AuthPolicy::allow_all().acp_auth_methods();
+        assert!(!methods.is_empty(), "authMethods must not be empty");
+        let valid = methods
+            .iter()
+            .filter(|method| matches!(registry_resolved_type(method), "agent" | "terminal"))
+            .count();
+        assert!(valid >= 1, "at least one agent/terminal method required");
+        assert_eq!(methods[0]["id"], ACP_LOCAL_NONE_METHOD_ID);
+        assert_eq!(methods[0]["type"], "agent");
+    }
+
+    /// Credentialed policies must also resolve to `agent`/`terminal`
+    /// under the registry's type-resolution rules.
+    #[test]
+    fn credentialed_policy_passes_registry_type_resolution() {
+        let policy = AuthPolicy {
+            methods: vec![AuthMethodConfig::ApiKey(ApiKeyAuthConfig::single("secret"))],
+            mcp_allowlist: None,
+        };
+        let methods = policy.acp_auth_methods();
+        assert!(methods
+            .iter()
+            .any(|method| matches!(registry_resolved_type(method), "agent" | "terminal")));
     }
 
     #[tokio::test]

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -45,7 +45,7 @@ pub use adapters::site::{SiteHttpServeOptions, SiteServer, SiteServerConfig};
 pub use auth::{
     AllowlistOutcome, ApiKeyAuthConfig, ApiKeyEntry, AuthMethodConfig, AuthPolicy, AuthRequest,
     AuthenticatedPrincipal, AuthorizationDecision, HmacAuthConfig, McpAllowlist, McpAllowlistTools,
-    OAuth21AuthConfig, OAuthClaims,
+    OAuth21AuthConfig, OAuthClaims, ACP_LOCAL_NONE_METHOD_ID,
 };
 pub use core::{
     CallArguments, CallRequest, CallResponse, DispatchCore, DispatchCoreConfig, NoopVmConfigurator,


### PR DESCRIPTION
Refs #2664. Unblocks the deferred #2672 registry submission.

## Problem

PR #2679 landed a ready-to-submit registry manifest, but harn empirically **fails** the agentclientprotocol/registry auth gate (`verify_agents.py --auth-check`) for two reasons:

1. `harn serve acp` required a positional `<FILE>`. The registry launches the bare `cmd`+`args` (`./harn serve acp`) with no file, so harn exited code 2 before the ACP loop started.
2. `initialize` returned an **empty** `authMethods` array under the default allow-all policy, which the registry validator rejects.

## Fix (scoped to the serve CLI command + harn-serve ACP adapter)

1. **`<FILE>` is now optional.** With no file, `harn serve acp` boots a file-less ("attach") ACP stdio server that waits for `initialize` / `session/new` from the connecting editor. File-provided mode is unchanged.
2. **Non-empty, spec-conformant `authMethods`.** `AuthPolicy::acp_auth_methods()` now:
   - tags every credentialed method (API key / HMAC / OAuth 2.1) with an explicit top-level `type: "agent"`, and
   - when no credentials are configured (the local attach default), advertises a single `agent`-type `"none"` method representing harn's local/anonymous flow.
   `handle_authenticate` honours an explicit `authenticate` against the `"none"` id as a no-op success.

## Verification

- `cargo build -p harn-cli -p harn-serve` — green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p harn-cli -p harn-serve` — green (the one failing `cli/pg.rs` **doctest** is pre-existing on `main` and untouched by this change).
- New tests: CLI parse of `serve acp` with no file → `file == None`; allow-all + credentialed policies pass the registry's own type-resolution rules; the attach server advertises + authenticates the local `"none"` method; updated the WS-listener and channel-server `initialize` assertions to the conformant shape.
- **End-to-end against the registry's own `client.py`** (`agentclientprotocol/registry`), driving the bare `harn serve acp` command over stdio:
  ```
  success: True
  auth_methods:
    - id='none' type='agent' name='Local (no authentication)'
  validate_auth_methods: True - Found 1 valid auth method(s)
  ```
  harn now **passes** `verify_agents.py --auth-check`.

Out of scope (owned by other sessions): `spec/acp-registry/` (#2679), MCP OAuth (#2643), async-builtin (#2668).

🤖 Generated with [Claude Code](https://claude.com/claude-code)