### PR TITLE
harn-vm: thread explicit AsyncBuiltinCtx into async builtins (Refs #2668)

### DIFF
--- a/changelog.d/2668.changed.md
+++ b/changelog.d/2668.changed.md
@@ -1,0 +1,11 @@
+- **Async builtins now receive an explicit `AsyncBuiltinCtx` handle (#2668).** The async-builtin ABI
+  (`VmAsyncBuiltinFn`, `AsyncHandler`) and the `#[harn_builtin(kind = "async")]` macro now thread a `ctx`
+  parameter from the dispatch loop into every async handler, so a handler mints its per-call child VM
+  (`ctx.child_vm()`) and forwards closure output (`ctx.forward_output(..)`) through the context it was *given*
+  rather than reaching for an ambient `tokio::task_local`. This makes "context lost across a spawn boundary"
+  structurally impossible at the handler entry point and replaces the entry-point ambient reads in `iter`,
+  `concurrency` (sleep now always polls for cancellation), `supervisor`, `agents_daemon`, `testing`, and the
+  agent host primitives. The `ASYNC_BUILTIN_CTX` task-local survives only as a bridge for deep sync helpers
+  not yet threaded (pool submitter/scope resolution, channel context, HITL host notification, daemon bridge
+  construction); fully removing it is the remaining follow-up (#2668). Cancel-safety and multi-thread
+  correctness from #2667 are preserved — the ctx is owned/borrowed explicitly and dropped with the future.

--- a/crates/harn-builtin-macros/src/lib.rs
+++ b/crates/harn-builtin-macros/src/lib.rs
@@ -252,15 +252,21 @@ fn expand(attrs: BuiltinAttrs, item_fn: ItemFn) -> syn::Result<TokenStream2> {
         (_, true) => (quote!(#support::VmBuiltinHandler::None), quote!()),
         (BuiltinKind::Sync, _) => (quote!(#support::VmBuiltinHandler::Sync(#fn_name)), quote!()),
         (BuiltinKind::Async, _) => {
+            // Async builtins receive an explicit `AsyncBuiltinCtx` handle as
+            // their first parameter (harn#2668). The macro threads it from the
+            // dispatch loop into the user fn so handler bodies mint child VMs /
+            // forward output through the ctx they were given, never an ambient
+            // task-local.
             let is_async_fn = item_fn.sig.asyncness.is_some();
             if is_async_fn {
                 let thunk = quote! {
                     #[doc(hidden)]
                     #[allow(non_snake_case)]
                     fn #async_thunk_ident(
+                        ctx: crate::vm::AsyncBuiltinCtx,
                         args: ::std::vec::Vec<#support::VmValue>,
                     ) -> #support::AsyncBuiltinFuture {
-                        ::std::boxed::Box::pin(#fn_name(args))
+                        ::std::boxed::Box::pin(#fn_name(ctx, args))
                     }
                 };
                 (

--- a/crates/harn-serve/src/adapters/acp/builtins.rs
+++ b/crates/harn-serve/src/adapters/acp/builtins.rs
@@ -63,7 +63,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
     });
 
     let b = bridge.clone();
-    vm.register_async_builtin("host_call", move |args| {
+    vm.register_async_builtin("host_call", move |_ctx, args| {
         let bridge = b.clone();
         async move {
             let name = args.first().map(|a| a.display()).unwrap_or_default();
@@ -121,7 +121,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
 
     let b = bridge.clone();
     let shell = selected_shell.clone();
-    vm.register_async_builtin("run_command", move |args| {
+    vm.register_async_builtin("run_command", move |_ctx, args| {
         let bridge = b.clone();
         let shell = shell.clone();
         async move { acp_terminal_exec(&bridge, &args, &shell).await }
@@ -196,7 +196,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
 
     let b = bridge.clone();
     let shell = selected_shell.clone();
-    vm.register_async_builtin("exec", move |args| {
+    vm.register_async_builtin("exec", move |_ctx, args| {
         let bridge = b.clone();
         let shell = shell.clone();
         async move { acp_terminal_exec(&bridge, &args, &shell).await }
@@ -204,7 +204,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBr
 
     let b = bridge;
     let shell = selected_shell;
-    vm.register_async_builtin("shell", move |args| {
+    vm.register_async_builtin("shell", move |_ctx, args| {
         let bridge = b.clone();
         let shell = shell.clone();
         async move { acp_terminal_exec(&bridge, &args, &shell).await }

--- a/crates/harn-vm/src/composition/mod.rs
+++ b/crates/harn-vm/src/composition/mod.rs
@@ -420,7 +420,7 @@ fn register_composition_call_builtin(
     state: Rc<RefCell<ExecutionState>>,
     host: Rc<dyn CompositionToolHost>,
 ) {
-    vm.register_async_builtin("__composition_call", move |args| {
+    vm.register_async_builtin("__composition_call", move |_ctx, args| {
         let state = state.clone();
         let host = host.clone();
         async move {
@@ -737,7 +737,7 @@ pub fn register_composition_builtins(vm: &mut Vm) {
         )))
     });
 
-    vm.register_async_builtin("composition_execute", |args| async move {
+    vm.register_async_builtin("composition_execute", |_ctx, args| async move {
         let snippet = args
             .first()
             .map(VmValue::display)

--- a/crates/harn-vm/src/http/client.rs
+++ b/crates/harn-vm/src/http/client.rs
@@ -1556,25 +1556,25 @@ pub(super) fn vm_http_stream_info(stream_id: &str) -> Result<VmValue, VmError> {
 }
 
 pub(super) fn register_http_verb_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("http_get", |args| async move {
+    vm.register_async_builtin("http_get", |_ctx, args| async move {
         http_verb_handler("GET", false, args).await
     });
-    vm.register_async_builtin("http_post", |args| async move {
+    vm.register_async_builtin("http_post", |_ctx, args| async move {
         http_verb_handler("POST", true, args).await
     });
-    vm.register_async_builtin("http_put", |args| async move {
+    vm.register_async_builtin("http_put", |_ctx, args| async move {
         http_verb_handler("PUT", true, args).await
     });
-    vm.register_async_builtin("http_patch", |args| async move {
+    vm.register_async_builtin("http_patch", |_ctx, args| async move {
         http_verb_handler("PATCH", true, args).await
     });
-    vm.register_async_builtin("http_delete", |args| async move {
+    vm.register_async_builtin("http_delete", |_ctx, args| async move {
         http_verb_handler("DELETE", false, args).await
     });
 }
 
 pub(super) fn register_http_client_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("http_request", |args| async move {
+    vm.register_async_builtin("http_request", |_ctx, args| async move {
         let method = args
             .first()
             .map(|a| a.display())
@@ -1598,7 +1598,7 @@ pub(super) fn register_http_client_builtins(vm: &mut Vm) {
         vm_execute_http_request(&method, &url, &options).await
     });
 
-    vm.register_async_builtin("http_download", |args| async move {
+    vm.register_async_builtin("http_download", |_ctx, args| async move {
         let url = args.first().map(|a| a.display()).unwrap_or_default();
         if url.is_empty() {
             return Err(vm_error("http_download: URL is required"));
@@ -1611,7 +1611,7 @@ pub(super) fn register_http_client_builtins(vm: &mut Vm) {
         vm_http_download(&url, &dst_path, &options).await
     });
 
-    vm.register_async_builtin("http_stream_open", |args| async move {
+    vm.register_async_builtin("http_stream_open", |_ctx, args| async move {
         let url = args.first().map(|a| a.display()).unwrap_or_default();
         if url.is_empty() {
             return Err(vm_error("http_stream_open: URL is required"));
@@ -1620,7 +1620,7 @@ pub(super) fn register_http_client_builtins(vm: &mut Vm) {
         vm_http_stream_open(&url, &options).await
     });
 
-    vm.register_async_builtin("http_stream_read", |args| async move {
+    vm.register_async_builtin("http_stream_read", |_ctx, args| async move {
         let Some(handle) = args.first() else {
             return Err(vm_error("http_stream_read: requires a stream handle"));
         };
@@ -1668,7 +1668,7 @@ pub(super) fn register_http_client_builtins(vm: &mut Vm) {
         Ok(VmValue::String(Rc::from(id)))
     });
 
-    vm.register_async_builtin("http_session_request", |args| async move {
+    vm.register_async_builtin("http_session_request", |_ctx, args| async move {
         if args.len() < 3 {
             return Err(vm_error(
                 "http_session_request: requires session, method, and URL",

--- a/crates/harn-vm/src/http/mod.rs
+++ b/crates/harn-vm/src/http/mod.rs
@@ -802,7 +802,7 @@ fn register_http_server_builtins(vm: &mut Vm) {
         Ok(http_server_handle_value(&server_id))
     });
 
-    vm.register_async_builtin("http_server_request", |args| async move {
+    vm.register_async_builtin("http_server_request", |_ctx, args| async move {
         if args.len() < 2 {
             return Err(vm_error("http_server_request: requires server and request"));
         }
@@ -810,7 +810,7 @@ fn register_http_server_builtins(vm: &mut Vm) {
         run_http_server_request(&server_id, args[1].clone()).await
     });
 
-    vm.register_async_builtin("http_server_test", |args| async move {
+    vm.register_async_builtin("http_server_test", |_ctx, args| async move {
         if args.len() < 2 {
             return Err(vm_error("http_server_test: requires server and request"));
         }
@@ -860,7 +860,7 @@ fn register_http_server_builtins(vm: &mut Vm) {
         Ok(http_server_handle_value(&server_id))
     });
 
-    vm.register_async_builtin("http_server_ready", |args| async move {
+    vm.register_async_builtin("http_server_ready", |_ctx, args| async move {
         let Some(server_arg) = args.first() else {
             return Err(vm_error("http_server_ready: requires server"));
         };
@@ -907,7 +907,7 @@ fn register_http_server_builtins(vm: &mut Vm) {
         Ok(http_server_handle_value(&server_id))
     });
 
-    vm.register_async_builtin("http_server_shutdown", |args| async move {
+    vm.register_async_builtin("http_server_shutdown", |_ctx, args| async move {
         let Some(server_arg) = args.first() else {
             return Err(vm_error("http_server_shutdown: requires server"));
         };

--- a/crates/harn-vm/src/http/streaming.rs
+++ b/crates/harn-vm/src/http/streaming.rs
@@ -1081,7 +1081,7 @@ pub(super) fn register_http_streaming_builtins(vm: &mut Vm) {
         Ok(VmValue::Nil)
     });
 
-    vm.register_async_builtin("sse_connect", |args| async move {
+    vm.register_async_builtin("sse_connect", |_ctx, args| async move {
         let method = args
             .first()
             .map(|arg| arg.display())
@@ -1096,7 +1096,7 @@ pub(super) fn register_http_streaming_builtins(vm: &mut Vm) {
         vm_sse_connect(&method, &url, &options).await
     });
 
-    vm.register_async_builtin("sse_receive", |args| async move {
+    vm.register_async_builtin("sse_receive", |_ctx, args| async move {
         let Some(handle) = args.first() else {
             return Err(vm_error("sse_receive: requires a stream handle"));
         };

--- a/crates/harn-vm/src/http/streaming/websocket.rs
+++ b/crates/harn-vm/src/http/streaming/websocket.rs
@@ -1164,7 +1164,7 @@ pub(super) fn register_websocket_builtins(vm: &mut Vm) {
         Ok(VmValue::Nil)
     });
 
-    vm.register_async_builtin("websocket_connect", |args| async move {
+    vm.register_async_builtin("websocket_connect", |_ctx, args| async move {
         let url = args.first().map(|arg| arg.display()).unwrap_or_default();
         if url.is_empty() {
             return Err(vm_error("websocket_connect: URL is required"));
@@ -1198,7 +1198,7 @@ pub(super) fn register_websocket_builtins(vm: &mut Vm) {
         vm_websocket_route(&server_id, &path, &options)
     });
 
-    vm.register_async_builtin("websocket_accept", |args| async move {
+    vm.register_async_builtin("websocket_accept", |_ctx, args| async move {
         let Some(handle) = args.first() else {
             return Err(vm_error("websocket_accept: requires a server handle"));
         };
@@ -1207,7 +1207,7 @@ pub(super) fn register_websocket_builtins(vm: &mut Vm) {
         vm_websocket_accept(&server_id, timeout_ms).await
     });
 
-    vm.register_async_builtin("websocket_send", |args| async move {
+    vm.register_async_builtin("websocket_send", |_ctx, args| async move {
         if args.len() < 2 {
             return Err(vm_error(
                 "websocket_send: requires socket handle and message",
@@ -1219,7 +1219,7 @@ pub(super) fn register_websocket_builtins(vm: &mut Vm) {
         vm_websocket_send(&socket_id, message, &options).await
     });
 
-    vm.register_async_builtin("websocket_receive", |args| async move {
+    vm.register_async_builtin("websocket_receive", |_ctx, args| async move {
         let Some(handle) = args.first() else {
             return Err(vm_error("websocket_receive: requires a socket handle"));
         };
@@ -1228,7 +1228,7 @@ pub(super) fn register_websocket_builtins(vm: &mut Vm) {
         vm_websocket_receive(&socket_id, timeout_ms).await
     });
 
-    vm.register_async_builtin("websocket_close", |args| async move {
+    vm.register_async_builtin("websocket_close", |_ctx, args| async move {
         let Some(handle) = args.first() else {
             return Err(vm_error("websocket_close: requires a socket handle"));
         };

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -400,7 +400,7 @@ pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Host
         .arity(VmBuiltinArity::Range { min: 1, max: 3 })
         .category_static("llm.host")
         .doc_static("Execute one bridge-observed LLM call and return the normalized result dict.");
-    vm.register_async_builtin_with_metadata(metadata, move |args| {
+    vm.register_async_builtin_with_metadata(metadata, move |_ctx, args| {
         let bridge = b.clone();
         async move {
             let mut opts = extract_llm_options(&args)?;
@@ -457,7 +457,7 @@ pub fn register_llm_call_structured_with_bridge(
         .arity(VmBuiltinArity::Range { min: 2, max: 3 })
         .category_static("llm.structured")
         .doc_static("Call an LLM through the bridge for schema-valid JSON data.");
-    vm.register_async_builtin_with_metadata(structured, move |args| {
+    vm.register_async_builtin_with_metadata(structured, move |_ctx, args| {
         let bridge = b1.clone();
         async move {
             let rewritten = crate::llm::rewrite_structured_args(args)?;
@@ -473,7 +473,7 @@ pub fn register_llm_call_structured_with_bridge(
         .arity(VmBuiltinArity::Range { min: 2, max: 3 })
         .category_static("llm.structured")
         .doc_static("Call an LLM through the bridge and return a non-throwing schema envelope.");
-    vm.register_async_builtin_with_metadata(structured_safe, move |args| {
+    vm.register_async_builtin_with_metadata(structured_safe, move |_ctx, args| {
         let bridge = b2.clone();
         async move {
             let rewritten = match crate::llm::rewrite_structured_args(args) {
@@ -501,7 +501,7 @@ pub fn register_llm_call_structured_with_bridge(
         .doc_static(
             "Call an LLM through the bridge and return a diagnostic structured-output envelope.",
         );
-    vm.register_async_builtin_with_metadata(structured_result, move |args| {
+    vm.register_async_builtin_with_metadata(structured_result, move |_ctx, args| {
         let bridge = b3.clone();
         async move {
             crate::llm::structured_envelope::llm_call_structured_result_impl(args, Some(&bridge))

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -37,7 +37,10 @@ impl crate::agent_events::AgentEventSink for CapturingAgentEventSink {
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_capture_events_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_capture_events_impl(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = match args.first() {
         Some(VmValue::String(text)) if !text.is_empty() => text.to_string(),
         Some(VmValue::String(_)) => {
@@ -73,14 +76,10 @@ async fn host_agent_capture_events_impl(args: Vec<VmValue>) -> Result<VmValue, V
         events: captured_events.clone(),
     });
     let _guard = agent_runtime::LoopSinkGuard::install(Some(sink));
-    let mut child_vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime(
-            "__host_agent_capture_events requires an async builtin VM context".to_string(),
-        )
-    })?;
+    let mut child_vm = ctx.child_vm();
     let result = child_vm.call_closure_pub(&body, &[]).await;
     let output = child_vm.take_output();
-    crate::vm::forward_child_output_to_parent(&output);
+    ctx.forward_output(&output);
     let result = result?;
     let events = captured_events
         .lock()
@@ -314,7 +313,10 @@ fn attach_hook_reminder_audit(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_parse_tool_calls_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_parse_tool_calls_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let text = match args.first() {
         Some(VmValue::String(text)) => text.to_string(),
         Some(other) => {
@@ -409,7 +411,10 @@ async fn host_agent_dispatch_tool_batch_capped(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_dispatch_tool_batch_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_dispatch_tool_batch_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let mut args = args.into_iter();
     let calls = match args.next() {
         Some(VmValue::List(calls)) => {
@@ -452,7 +457,10 @@ async fn host_agent_dispatch_tool_batch_impl(args: Vec<VmValue>) -> Result<VmVal
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_dispatch_tool_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_dispatch_tool_call_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let mut args = args.into_iter();
     let call = args.next().ok_or_else(|| {
         VmError::Runtime(
@@ -1098,7 +1106,10 @@ fn tag_mcp_tool(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_mcp_bootstrap_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_mcp_bootstrap_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     use std::collections::BTreeMap;
 
     let session_id = match args.first() {
@@ -1223,7 +1234,10 @@ async fn host_mcp_bootstrap_impl(args: Vec<VmValue>) -> Result<VmValue, VmError>
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_mcp_disconnect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_mcp_disconnect_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = match args.first() {
         Some(VmValue::String(s)) => s.to_string(),
         Some(other) => {
@@ -1253,7 +1267,10 @@ async fn host_mcp_disconnect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_reminder_providers_fire_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_reminder_providers_fire_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = match args.first() {
         Some(VmValue::String(s)) if !s.trim().is_empty() => s.to_string(),
         Some(other) => {

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -207,7 +207,10 @@ fn now_id() -> String {
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_session_init(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_session_init(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let message = args.first().map(|v| v.display()).unwrap_or_default();
     let system = match args.get(1) {
         Some(VmValue::String(s)) => Some(s.to_string()),
@@ -498,7 +501,10 @@ fn agent_init_control_done(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_session_finalize(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_session_finalize(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args
         .first()
         .map(|v| v.display())
@@ -1445,7 +1451,10 @@ fn host_agent_session_replace_messages_builtin(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_skill_score(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_skill_score(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let context = args.first().cloned().unwrap_or(VmValue::Nil);
     let registry = args.get(1).cloned().unwrap_or(VmValue::Nil);
     let options = args.get(2).cloned().unwrap_or(VmValue::Nil);
@@ -1478,7 +1487,10 @@ fn host_agent_budget_pre_call_builtin(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_emit_event(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_emit_event(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = match args.first() {
         Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
         _ => {
@@ -2030,7 +2042,10 @@ fn host_agent_record_compaction_builtin(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_session_project_turn(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_session_project_turn(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = match args.first() {
         Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
         _ => {
@@ -2322,7 +2337,10 @@ async fn daemon_checkpoint_drain(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_session_push_bridge_injection(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_session_push_bridge_injection(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     if session_id.trim().is_empty() {
         return Err(VmError::Runtime(format!(
@@ -2358,7 +2376,10 @@ async fn host_agent_session_push_bridge_injection(args: Vec<VmValue>) -> Result<
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_session_pending_injections(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_session_pending_injections(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     if session_id.trim().is_empty() {
         return Err(VmError::Runtime(format!(
@@ -2381,7 +2402,10 @@ async fn host_agent_session_pending_injections(args: Vec<VmValue>) -> Result<VmV
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_session_revoke_reminder(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_session_revoke_reminder(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     if session_id.trim().is_empty() {
         return Err(VmError::Runtime(format!(
@@ -2420,6 +2444,7 @@ async fn host_agent_session_revoke_reminder(args: Vec<VmValue>) -> Result<VmValu
     runtime_only = true
 )]
 async fn host_agent_session_drain_bridge_injections(
+    _ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
@@ -2455,7 +2480,10 @@ async fn host_agent_session_drain_bridge_injections(
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_agent_daemon_wait(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_agent_daemon_wait(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args.first().map(|v| v.display()).unwrap_or_default();
     let timeout_ms = args
         .get(1)
@@ -2516,7 +2544,10 @@ fn nil_json() -> serde_json::Value {
     category = "agent.host",
     runtime_only = true
 )]
-async fn host_autonomy_budget_check(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_autonomy_budget_check(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args
         .first()
         .map(|value| value.display())

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -492,7 +492,10 @@ fn llm_rate_limit_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
     kind = "async",
     category = "llm.config"
 )]
-async fn llm_healthcheck_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_healthcheck_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let (provider_name, api_key) = parse_healthcheck_args(&args);
 
     // Ollama-specific readiness probe (issue #675): supports `model`,

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -377,7 +377,7 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
         ))
     });
 
-    vm.register_async_builtin("transcript_summarize", |args| async move {
+    vm.register_async_builtin("transcript_summarize", |_ctx, args| async move {
         let transcript = require_transcript(&args, "transcript_summarize")?;
         let mut opts = extract_llm_options(&[
             VmValue::String(Rc::from("")),

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -299,7 +299,10 @@ pub fn reset_llm_state() {
     category = "llm.host",
     runtime_only = true
 )]
-async fn cost_route_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn cost_route_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     cost_route::cost_route_impl(args).await
 }
 
@@ -309,7 +312,10 @@ async fn cost_route_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "llm.host"
 )]
-async fn llm_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_call_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     llm_call_impl(args).await
 }
 
@@ -319,7 +325,10 @@ async fn llm_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "llm.host"
 )]
-async fn llm_stream_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_stream_call_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     llm_stream_call_impl(args).await
 }
 
@@ -447,7 +456,10 @@ const LLM_RUNTIME_PRIMITIVE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "llm.host"
 )]
-async fn llm_call_safe_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_call_safe_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     match llm_call_impl(args).await {
         Ok(response) => Ok(llm_safe_envelope_ok(response)),
         Err(err) => Ok(llm_safe_envelope_err(&err)),
@@ -460,7 +472,10 @@ async fn llm_call_safe_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "llm.structured"
 )]
-async fn llm_call_structured_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_call_structured_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let rewritten = rewrite_structured_args(args)?;
     let response = llm_call_impl(rewritten).await?;
     Ok(extract_structured_data(response))
@@ -472,7 +487,10 @@ async fn llm_call_structured_builtin(args: Vec<VmValue>) -> Result<VmValue, VmEr
     kind = "async",
     category = "llm.structured"
 )]
-async fn llm_call_structured_safe_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_call_structured_safe_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let rewritten = match rewrite_structured_args(args) {
         Ok(v) => v,
         Err(err) => return Ok(structured_safe_envelope_err(&err)),
@@ -491,7 +509,10 @@ async fn llm_call_structured_safe_builtin(args: Vec<VmValue>) -> Result<VmValue,
     kind = "async",
     category = "llm.structured"
 )]
-async fn llm_call_structured_result_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_call_structured_result_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     structured_envelope::llm_call_structured_result_impl(args, None).await
 }
 
@@ -501,7 +522,10 @@ async fn llm_call_structured_result_builtin(args: Vec<VmValue>) -> Result<VmValu
     kind = "async",
     category = "schema.recovery"
 )]
-async fn schema_recover_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn schema_recover_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     schema_recover::schema_recover_impl(args, None).await
 }
 
@@ -511,7 +535,10 @@ async fn schema_recover_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     kind = "async",
     category = "llm.rate_limit"
 )]
-async fn with_rate_limit_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn with_rate_limit_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let provider = args.first().map(|a| a.display()).unwrap_or_default();
     if provider.is_empty() {
         return Err(VmError::Runtime(
@@ -571,7 +598,10 @@ async fn with_rate_limit_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError>
     kind = "async",
     category = "llm.host"
 )]
-async fn llm_completion_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_completion_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let prefix = args.first().map(|a| a.display()).unwrap_or_default();
     let suffix = args.get(1).and_then(|a| {
         if matches!(a, VmValue::Nil) {
@@ -624,7 +654,10 @@ async fn llm_completion_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     kind = "async",
     category = "llm.host"
 )]
-async fn llm_stream_builtin_wrap(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn llm_stream_builtin_wrap(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     llm_stream_builtin(args).await
 }
 

--- a/crates/harn-vm/src/llm/rerank.rs
+++ b/crates/harn-vm/src/llm/rerank.rs
@@ -19,7 +19,10 @@ const RERANK_BUILTINS: &[&VmBuiltinDef] = &[&SELF_CERTAINTY_BUILTIN_DEF];
     kind = "async",
     category = "llm.rerank"
 )]
-async fn self_certainty_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn self_certainty_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let text = match args.first() {
         Some(VmValue::String(text)) => text.to_string(),
         Some(VmValue::Dict(dict)) => {

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -2035,7 +2035,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
     register_harn_mcp_namespace(vm);
     register_supervised_mcp_host_builtins(vm);
 
-    vm.register_async_builtin("mcp_connect", |args| async move {
+    vm.register_async_builtin("mcp_connect", |_ctx, args| async move {
         let command = args.first().map(|a| a.display()).unwrap_or_default();
         if command.is_empty() {
             return Err(VmError::Thrown(VmValue::String(Rc::from(
@@ -2063,7 +2063,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
     // Lazy registry: ensure a registered server is booted and return its
     // live client handle. Used by skill activation (`requires_mcp`) and
     // by user code that wants to trigger a lazy connect explicitly.
-    vm.register_async_builtin("mcp_ensure_active", |args| async move {
+    vm.register_async_builtin("mcp_ensure_active", |_ctx, args| async move {
         let name = match args.first() {
             Some(VmValue::String(s)) => s.to_string(),
             Some(other) => other.display(),
@@ -2126,7 +2126,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
     // `mcp_server_card("notion")`           -> looks up `card = ...` in harn.toml
     // `mcp_server_card("https://.../card")` -> fetches that URL directly
     // `mcp_server_card("./card.json")`      -> reads that file directly
-    vm.register_async_builtin("mcp_server_card", |args| async move {
+    vm.register_async_builtin("mcp_server_card", |_ctx, args| async move {
         let target = match args.first() {
             Some(VmValue::String(s)) => s.to_string(),
             Some(other) => other.display(),
@@ -2176,7 +2176,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         Ok(json_to_vm_value(&card))
     });
 
-    vm.register_async_builtin("mcp_list_tools", |args| async move {
+    vm.register_async_builtin("mcp_list_tools", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2214,7 +2214,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(vm_tools)))
     });
 
-    vm.register_async_builtin("mcp_call", |args| async move {
+    vm.register_async_builtin("mcp_call", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2247,7 +2247,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         ))
     });
 
-    vm.register_async_builtin("mcp_server_info", |args| async move {
+    vm.register_async_builtin("mcp_server_info", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2303,7 +2303,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         Ok(VmValue::Dict(Rc::new(info)))
     });
 
-    vm.register_async_builtin("mcp_disconnect", |args| async move {
+    vm.register_async_builtin("mcp_disconnect", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2317,7 +2317,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         Ok(VmValue::Nil)
     });
 
-    vm.register_async_builtin("mcp_list_resources", |args| async move {
+    vm.register_async_builtin("mcp_list_resources", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2339,7 +2339,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(vm_resources)))
     });
 
-    vm.register_async_builtin("mcp_read_resource", |args| async move {
+    vm.register_async_builtin("mcp_read_resource", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2382,7 +2382,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         }
     });
 
-    vm.register_async_builtin("mcp_list_resource_templates", |args| async move {
+    vm.register_async_builtin("mcp_list_resource_templates", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2409,7 +2409,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(vm_templates)))
     });
 
-    vm.register_async_builtin("mcp_list_prompts", |args| async move {
+    vm.register_async_builtin("mcp_list_prompts", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2432,7 +2432,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(vm_prompts)))
     });
 
-    vm.register_async_builtin("mcp_get_prompt", |args| async move {
+    vm.register_async_builtin("mcp_get_prompt", |_ctx, args| async move {
         let client = match args.first() {
             Some(VmValue::McpClient(c)) => c.clone(),
             _ => {
@@ -2556,7 +2556,7 @@ fn register_harn_mcp_namespace(vm: &mut Vm) {
 /// and delegates to the host module. The host module owns supervision
 /// state, the response cache, allowlist enforcement, and tracing spans.
 fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("harn.mcp.spawn", |args| async move {
+    vm.register_async_builtin("harn.mcp.spawn", |_ctx, args| async move {
         let spec_value = args
             .first()
             .ok_or_else(|| VmError::Runtime("harn.mcp.spawn: spec dict is required".into()))?;
@@ -2574,7 +2574,7 @@ fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
         Ok(VmValue::String(Rc::from(name)))
     });
 
-    vm.register_async_builtin("harn.mcp.tools", |args| async move {
+    vm.register_async_builtin("harn.mcp.tools", |_ctx, args| async move {
         let name = match args.first() {
             Some(VmValue::String(s)) => s.to_string(),
             Some(other) => other.display(),
@@ -2590,7 +2590,7 @@ fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
         )))
     });
 
-    vm.register_async_builtin("harn.mcp.call", |args| async move {
+    vm.register_async_builtin("harn.mcp.call", |_ctx, args| async move {
         let name = match args.first() {
             Some(VmValue::String(s)) => s.to_string(),
             Some(other) => other.display(),
@@ -2652,7 +2652,7 @@ fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
         Ok(VmValue::Nil)
     });
 
-    vm.register_async_builtin("harn.mcp.discover", |_args| async move {
+    vm.register_async_builtin("harn.mcp.discover", |_ctx, _args| async move {
         let entries = crate::mcp_host::discover().await?;
         Ok(VmValue::List(Rc::new(
             entries.iter().map(json_to_vm_value).collect(),

--- a/crates/harn-vm/src/mcp_file_upload.rs
+++ b/crates/harn-vm/src/mcp_file_upload.rs
@@ -55,11 +55,13 @@ pub fn register_mcp_file_upload_builtins(vm: &mut Vm) {
         file_input_schema(args.first().unwrap_or(&VmValue::Nil))
     });
 
-    vm.register_async_builtin("mcp_upload_file", |args| async move { upload_file(&args) });
     vm.register_async_builtin(
-        "harn.mcp.upload_file",
-        |args| async move { upload_file(&args) },
+        "mcp_upload_file",
+        |_ctx, args| async move { upload_file(&args) },
     );
+    vm.register_async_builtin("harn.mcp.upload_file", |_ctx, args| async move {
+        upload_file(&args)
+    });
 }
 
 fn configure(config: &VmValue) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/mcp_server/register.rs
+++ b/crates/harn-vm/src/mcp_server/register.rs
@@ -228,7 +228,7 @@ pub fn register_mcp_server_builtins(vm: &mut Vm) {
     //   - {action: "cancel"}
     //
     // Spec: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation
-    vm.register_async_builtin("mcp_elicit", |args| async move {
+    vm.register_async_builtin("mcp_elicit", |_ctx, args| async move {
         let dict = match args.first() {
             Some(VmValue::Dict(d)) => d.clone(),
             _ => {

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -870,7 +870,10 @@ const REANCHOR_OPT_KEYS: &[&str] = &["carry_transcript", "compact", "reason"];
     category = "agent.session",
     doc = "Atomically replace a session primary workspace anchor (#2218)."
 )]
-async fn agent_session_reanchor_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn agent_session_reanchor_builtin(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let id = arg_string_required(&args, 0, "agent_session_reanchor", "id")?;
     if !agent_sessions::exists(&id) {
         return Err(err(format!(
@@ -930,8 +933,11 @@ async fn agent_session_reanchor_builtin(args: Vec<VmValue>) -> Result<VmValue, V
     };
     let mut compacted = false;
     if compact {
-        let _ = agent_session_compact_builtin(vec![VmValue::String(Rc::from(target_id.clone()))])
-            .await?;
+        let _ = agent_session_compact_builtin(
+            ctx.clone(),
+            vec![VmValue::String(Rc::from(target_id.clone()))],
+        )
+        .await?;
         compacted = true;
     }
     let outcome = agent_sessions::reanchor_session(
@@ -958,7 +964,10 @@ async fn agent_session_reanchor_builtin(args: Vec<VmValue>) -> Result<VmValue, V
     category = "agent.session",
     doc = "Compact an agent session transcript with the host compaction runtime."
 )]
-async fn agent_session_compact_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn agent_session_compact_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let id = arg_string_required(&args, 0, "agent_session_compact", "id")?;
     if !agent_sessions::exists(&id) {
         return Err(err(format!(
@@ -1119,7 +1128,10 @@ const CANCEL_TOOL_CALL_DEFAULT_TIMEOUT_MS: i64 = 5_000;
     category = "agent.session",
     doc = "Abort a specific in-flight tool call."
 )]
-async fn cancel_in_flight_tool_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn cancel_in_flight_tool_call_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = arg_string_required(&args, 0, "cancel_in_flight_tool_call", "session_id")?;
     let call_id = arg_string_required(&args, 1, "cancel_in_flight_tool_call", "call_id")?;
     if call_id.trim().is_empty() {

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -415,7 +415,10 @@ pub(crate) fn register_agent_builtins(vm: &mut Vm) {
     runtime_only = true,
     doc = "Run or spawn a normalized Harn-authored sub-agent request."
 )]
-async fn sub_agent_run_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sub_agent_run_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let request = parse_sub_agent_request(&args)?;
     if !request.background {
         let result = execute_sub_agent(request.spec).await?;
@@ -522,7 +525,10 @@ fn worker_mode_label(config: &WorkerConfig) -> &'static str {
     runtime_only = true,
     doc = "Spawn a workflow, stage, or sub-agent host worker."
 )]
-async fn spawn_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn spawn_agent_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let config = args
         .first()
         .ok_or_else(|| VmError::Runtime("spawn_agent: missing config".to_string()))?;
@@ -539,7 +545,10 @@ async fn spawn_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     runtime_only = true,
     doc = "Resume a stopped host worker with new task input."
 )]
-async fn send_input_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn send_input_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Runtime(
             "send_input: requires worker handle and task text".to_string(),
@@ -575,7 +584,10 @@ async fn send_input_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     runtime_only = true,
     doc = "Trigger an awaiting retriggerable host worker."
 )]
-async fn worker_trigger_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn worker_trigger_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Runtime(
             "worker_trigger: requires worker handle and payload".to_string(),
@@ -648,7 +660,10 @@ async fn worker_trigger_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     runtime_only = true,
     doc = "Cooperatively suspend a host worker at the next turn boundary."
 )]
-async fn suspend_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn suspend_agent_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| VmError::Runtime("suspend_agent: missing worker handle".to_string()))?;
@@ -943,7 +958,10 @@ pub(crate) fn all_registered_worker_ids() -> Vec<String> {
     runtime_only = true,
     doc = "Persist a top-level agent_loop suspend checkpoint as a resumable worker."
 )]
-async fn top_level_agent_suspend_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn top_level_agent_suspend_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args
         .first()
         .map(|value| value.display())
@@ -1295,7 +1313,10 @@ fn apply_resume_transcript_policy(
     runtime_only = true,
     doc = "Resume a suspended or persisted worker into the local host worker registry."
 )]
-async fn resume_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn resume_agent_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target_value = args
         .first()
         .ok_or_else(|| VmError::Runtime("resume_agent: missing worker handle".to_string()))?
@@ -1832,7 +1853,10 @@ fn cold_load_worker(snapshot_target: &str) -> Result<Rc<RefCell<WorkerState>>, V
     runtime_only = true,
     doc = "Wait for one or more host workers to reach a terminal state."
 )]
-async fn wait_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn wait_agent_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| VmError::Runtime("wait_agent: missing worker handle".to_string()))?;
@@ -1860,7 +1884,10 @@ async fn wait_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     runtime_only = true,
     doc = "Cancel a host worker and emit the cancellation lifecycle event."
 )]
-async fn close_agent_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn close_agent_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| VmError::Runtime("close_agent: missing worker handle".to_string()))?;
@@ -2464,14 +2491,17 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-suspend-snapshot");
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("waiting on external review")),
-            VmValue::Dict(Rc::new(BTreeMap::from([(
-                "initiator".to_string(),
-                VmValue::String(Rc::from("parent")),
-            )]))),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("waiting on external review")),
+                VmValue::Dict(Rc::new(BTreeMap::from([(
+                    "initiator".to_string(),
+                    VmValue::String(Rc::from("parent")),
+                )]))),
+            ],
+        )
         .await
         .expect("suspend worker");
 
@@ -2543,10 +2573,13 @@ mod suspend_tests {
         // verify the panic broadcast is a no-op (no double-suspend, no
         // overwritten reason, no second event).
         let (already_suspended, dir1) = seed_test_worker("worker-panic-already-suspended");
-        suspend_agent_builtin(vec![
-            handle_value(&already_suspended),
-            VmValue::String(Rc::from("operator pause")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&already_suspended),
+                VmValue::String(Rc::from("operator pause")),
+            ],
+        )
         .await
         .expect("operator-suspend first");
 
@@ -2620,10 +2653,13 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-reset-snapshot");
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("waiting on external review")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("waiting on external review")),
+            ],
+        )
         .await
         .expect("suspend worker");
         assert!(
@@ -2651,10 +2687,13 @@ mod suspend_tests {
         // Idempotency: second suspend on an already-suspended worker is
         // a no-op summary read, and the suspension metadata recorded on
         // the first call is preserved verbatim.
-        let first = suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("waiting on external review")),
-        ])
+        let first = suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("waiting on external review")),
+            ],
+        )
         .await
         .expect("first suspend");
         assert_eq!(summary_status(&first), "suspended");
@@ -2663,10 +2702,13 @@ mod suspend_tests {
             first_suspension.is_some() && first_suspension.as_ref().unwrap().display() != "nil"
         );
 
-        let second = suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("different reason — should be ignored")),
-        ])
+        let second = suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("different reason — should be ignored")),
+            ],
+        )
         .await
         .expect("second suspend");
         assert_eq!(summary_status(&second), "suspended");
@@ -2683,10 +2725,13 @@ mod suspend_tests {
 
         // Resume transitions back to running and wires the resume input
         // into the worker's task slot.
-        let resumed = resume_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("next: write the report")),
-        ])
+        let resumed = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("next: write the report")),
+            ],
+        )
         .await
         .expect("resume");
         assert_eq!(summary_status(&resumed), "running");
@@ -2708,9 +2753,12 @@ mod suspend_tests {
         // Closing a (re-)running worker still works the same way as
         // before — proves that the close path is not gated on a
         // specific upstream status.
-        let closed = close_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect("close");
+        let closed = close_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect("close");
         assert_eq!(summary_status(&closed), "cancelled");
 
         teardown(&dir, &worker_id);
@@ -2723,11 +2771,14 @@ mod suspend_tests {
         crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
         let (worker_id, dir) = seed_test_worker("worker-auto-resume-register");
 
-        let suspended = suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("waiting for review")),
-            suspend_options(auto_resume_conditions("review.approved")),
-        ])
+        let suspended = suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("waiting for review")),
+                suspend_options(auto_resume_conditions("review.approved")),
+            ],
+        )
         .await
         .expect("suspend with auto-resume trigger");
         assert_eq!(summary_status(&suspended), "suspended");
@@ -2738,9 +2789,12 @@ mod suspend_tests {
         assert_eq!(binding.handler.kind(), "auto_resume");
         assert_eq!(binding.match_events, vec!["review.approved".to_string()]);
 
-        let resumed = resume_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect("operator resume");
+        let resumed = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect("operator resume");
         assert_eq!(summary_status(&resumed), "running");
         let snapshot = crate::triggers::snapshot_trigger_bindings()
             .into_iter()
@@ -2765,14 +2819,17 @@ mod suspend_tests {
         std::fs::create_dir_all(&dir).unwrap();
         unsafe { std::env::set_var("HARN_WORKER_STATE_DIR", &dir) };
 
-        let suspended = top_level_agent_suspend_builtin(vec![
-            VmValue::String(Rc::from("session-top-level-auto-resume")),
-            VmValue::String(Rc::from("continue the top-level task")),
-            VmValue::Nil,
-            VmValue::Dict(Rc::new(BTreeMap::new())),
-            VmValue::String(Rc::from("waiting for review")),
-            auto_resume_conditions("review.approved"),
-        ])
+        let suspended = top_level_agent_suspend_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                VmValue::String(Rc::from("session-top-level-auto-resume")),
+                VmValue::String(Rc::from("continue the top-level task")),
+                VmValue::Nil,
+                VmValue::Dict(Rc::new(BTreeMap::new())),
+                VmValue::String(Rc::from("waiting for review")),
+                auto_resume_conditions("review.approved"),
+            ],
+        )
         .await
         .expect("top-level suspend with auto-resume trigger");
         assert_eq!(summary_status(&suspended), "suspended");
@@ -2807,11 +2864,14 @@ mod suspend_tests {
                 let log = crate::event_log::install_memory_for_current_thread(128);
                 let (worker_id, dir) = seed_test_worker("worker-auto-resume-dispatch");
 
-                let suspended = suspend_agent_builtin(vec![
-                    handle_value(&worker_id),
-                    VmValue::String(Rc::from("waiting for review")),
-                    suspend_options(auto_resume_conditions("review.approved")),
-                ])
+                let suspended = suspend_agent_builtin(
+                    crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+                    vec![
+                        handle_value(&worker_id),
+                        VmValue::String(Rc::from("waiting for review")),
+                        suspend_options(auto_resume_conditions("review.approved")),
+                    ],
+                )
                 .await
                 .expect("suspend with auto-resume trigger");
                 let trigger_id = auto_resume_trigger_id(&suspended);
@@ -2886,14 +2946,17 @@ mod suspend_tests {
                     crate::triggers::test_util::clock::install_override(clock.clone());
                 let (worker_id, dir) = seed_test_worker("worker-auto-resume-timeout");
 
-                let suspended = suspend_agent_builtin(vec![
-                    handle_value(&worker_id),
-                    VmValue::String(Rc::from("waiting for review or timeout")),
-                    suspend_options(auto_resume_conditions_with_timeout(
-                        "review.approved",
-                        "resume_with_input",
-                    )),
-                ])
+                let suspended = suspend_agent_builtin(
+                    crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+                    vec![
+                        handle_value(&worker_id),
+                        VmValue::String(Rc::from("waiting for review or timeout")),
+                        suspend_options(auto_resume_conditions_with_timeout(
+                            "review.approved",
+                            "resume_with_input",
+                        )),
+                    ],
+                )
                 .await
                 .expect("suspend with auto-resume timeout");
                 let trigger_id = auto_resume_trigger_id(&suspended);
@@ -2947,23 +3010,29 @@ mod suspend_tests {
                 None,
             ));
         });
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("park before fresh prompt")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("park before fresh prompt")),
+            ],
+        )
         .await
         .expect("suspend");
 
-        let resumed = resume_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::Dict(Rc::new(BTreeMap::from([
-                (
-                    "input".to_string(),
-                    VmValue::String(Rc::from("fresh prompt")),
-                ),
-                ("continue_transcript".to_string(), VmValue::Bool(false)),
-            ]))),
-        ])
+        let resumed = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::Dict(Rc::new(BTreeMap::from([
+                    (
+                        "input".to_string(),
+                        VmValue::String(Rc::from("fresh prompt")),
+                    ),
+                    ("continue_transcript".to_string(), VmValue::Bool(false)),
+                ]))),
+            ],
+        )
         .await
         .expect("resume with transcript reset");
         assert_eq!(summary_status(&resumed), "running");
@@ -3022,16 +3091,22 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-suspend-close");
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("park me")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("park me")),
+            ],
+        )
         .await
         .expect("suspend");
 
-        let summary = close_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect("close");
+        let summary = close_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect("close");
         assert_eq!(summary_status(&summary), "cancelled");
 
         teardown(&dir, &worker_id);
@@ -3051,10 +3126,13 @@ mod suspend_tests {
                 .clone()
         });
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("checkpoint before restart")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("checkpoint before restart")),
+            ],
+        )
         .await
         .expect("suspend");
 
@@ -3085,9 +3163,12 @@ mod suspend_tests {
                 .borrow_mut()
                 .insert(worker_id.clone(), Rc::new(RefCell::new(reloaded)));
         });
-        let resumed = resume_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect("resume after restart");
+        let resumed = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect("resume after restart");
         assert_eq!(summary_status(&resumed), "running");
 
         teardown(&dir, &worker_id);
@@ -3113,10 +3194,13 @@ mod suspend_tests {
             crate::tracing::span_start(crate::tracing::SpanKind::Pipeline, "pipeline".to_string());
         let pipeline_span_link =
             crate::tracing::span_link(pipeline_span_id).expect("open pipeline span link");
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("checkpoint before restart")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("checkpoint before restart")),
+            ],
+        )
         .await
         .expect("suspend");
         crate::tracing::span_end(pipeline_span_id);
@@ -3151,9 +3235,12 @@ mod suspend_tests {
                 .borrow_mut()
                 .insert(worker_id.clone(), Rc::new(RefCell::new(reloaded)));
         });
-        resume_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect("resume after restart");
+        resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect("resume after restart");
 
         let spans = crate::tracing::peek_spans();
         let suspension = spans
@@ -3209,28 +3296,34 @@ mod suspend_tests {
 
         let pipeline_span_id =
             crate::tracing::span_start(crate::tracing::SpanKind::Pipeline, "pipeline".to_string());
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("waiting on review")),
-            VmValue::Dict(Rc::new(BTreeMap::from([(
-                "initiator".to_string(),
-                VmValue::String(Rc::from("triggered")),
-            )]))),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("waiting on review")),
+                VmValue::Dict(Rc::new(BTreeMap::from([(
+                    "initiator".to_string(),
+                    VmValue::String(Rc::from("triggered")),
+                )]))),
+            ],
+        )
         .await
         .expect("suspend");
         crate::tracing::span_end(pipeline_span_id);
 
-        resume_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::Dict(Rc::new(BTreeMap::from([
-                (
-                    "input".to_string(),
-                    VmValue::String(Rc::from("CONFIDENTIAL_DO_NOT_LEAK_INTO_SPAN_ATTRS")),
-                ),
-                ("continue_transcript".to_string(), VmValue::Bool(false)),
-            ]))),
-        ])
+        resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::Dict(Rc::new(BTreeMap::from([
+                    (
+                        "input".to_string(),
+                        VmValue::String(Rc::from("CONFIDENTIAL_DO_NOT_LEAK_INTO_SPAN_ATTRS")),
+                    ),
+                    ("continue_transcript".to_string(), VmValue::Bool(false)),
+                ]))),
+            ],
+        )
         .await
         .expect("resume");
 
@@ -3341,10 +3434,13 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-loop-suspend");
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("pause before another model call")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("pause before another model call")),
+            ],
+        )
         .await
         .expect("suspend");
 
@@ -3398,10 +3494,13 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-sub-agent-suspend");
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("checkpoint the child loop")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("checkpoint the child loop")),
+            ],
+        )
         .await
         .expect("suspend");
 
@@ -3439,9 +3538,12 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-resume-not-suspended");
 
-        let err = resume_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect_err("running worker should reject warm resume");
+        let err = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect_err("running worker should reject warm resume");
         assert_error_code(err, Code::ResumeWorkerNotSuspended);
 
         teardown(&dir, &worker_id);
@@ -3452,19 +3554,28 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-resume-closed");
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("park before close")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("park before close")),
+            ],
+        )
         .await
         .expect("suspend");
-        close_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect("close");
+        close_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect("close");
 
-        let err = resume_agent_builtin(vec![handle_value(&worker_id)])
-            .await
-            .expect_err("closed worker should reject resume");
+        let err = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id)],
+        )
+        .await
+        .expect_err("closed worker should reject resume");
         assert_error_code(err, Code::ResumeWorkerClosed);
 
         teardown(&dir, &worker_id);
@@ -3475,16 +3586,19 @@ mod suspend_tests {
         let _guard = suspend_test_lock().await;
         let (worker_id, dir) = seed_test_worker("worker-empty-resume-input");
 
-        suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("park before empty input")),
-        ])
+        suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("park before empty input")),
+            ],
+        )
         .await
         .expect("suspend");
-        let err = resume_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("")),
-        ])
+        let err = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![handle_value(&worker_id), VmValue::String(Rc::from(""))],
+        )
         .await
         .expect_err("empty resume input should be rejected");
         assert_error_code(err, Code::ResumeInputInvalid);
@@ -3502,9 +3616,10 @@ mod suspend_tests {
         std::fs::create_dir_all(&dir).unwrap();
         let missing = dir.join("missing-worker.json");
 
-        let err = resume_agent_builtin(vec![VmValue::String(Rc::from(
-            missing.display().to_string(),
-        ))])
+        let err = resume_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![VmValue::String(Rc::from(missing.display().to_string()))],
+        )
         .await
         .expect_err("missing snapshot should reject resume");
         assert_error_code(err, Code::ResumeSnapshotInvalid);
@@ -3537,11 +3652,14 @@ mod suspend_tests {
             VmValue::Dict(Rc::new(BTreeMap::new())),
         )])));
 
-        let err = suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("bad trigger")),
-            suspend_options(invalid_trigger),
-        ])
+        let err = suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("bad trigger")),
+                suspend_options(invalid_trigger),
+            ],
+        )
         .await
         .expect_err("invalid raw trigger registration should fail");
         assert_error_code(err, Code::ResumeTriggerRegistrationFailed);
@@ -3558,14 +3676,17 @@ mod suspend_tests {
         crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
         let (worker_id, dir) = seed_test_worker("worker-timeout-action-error");
 
-        let err = suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("bad timeout")),
-            suspend_options(auto_resume_conditions_with_timeout(
-                "review.approved",
-                "explode",
-            )),
-        ])
+        let err = suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("bad timeout")),
+                suspend_options(auto_resume_conditions_with_timeout(
+                    "review.approved",
+                    "explode",
+                )),
+            ],
+        )
         .await
         .expect_err("unsupported raw timeout action should fail");
         assert_error_code(err, Code::ResumeTimeoutUnsupported);
@@ -3584,10 +3705,13 @@ mod suspend_tests {
             state.borrow_mut().status = "completed".to_string();
         });
 
-        let err = suspend_agent_builtin(vec![
-            handle_value(&worker_id),
-            VmValue::String(Rc::from("late suspend")),
-        ])
+        let err = suspend_agent_builtin(
+            crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+            vec![
+                handle_value(&worker_id),
+                VmValue::String(Rc::from("late suspend")),
+            ],
+        )
         .await
         .expect_err("terminal worker should reject suspend");
         match err {

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -114,10 +114,11 @@ pub fn register_daemon_builtins(vm: &mut Vm) {
     kind = "async",
     category = "agent.daemon"
 )]
-async fn daemon_spawn_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
-    let child_vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("daemon_spawn requires an async builtin VM context".to_string())
-    })?;
+async fn daemon_spawn_builtin(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
+    let child_vm = ctx.child_vm();
     let config = options::dict_arg(&args, 0, "daemon_spawn", "config", ErrorKind::Runtime)?;
     let spec = parse_spawn_spec(config, None, None)?;
     if find_daemon_by_root(&spec.persist_root)
@@ -180,7 +181,10 @@ async fn daemon_spawn_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "agent.daemon"
 )]
-async fn daemon_trigger_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn daemon_trigger_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| VmError::Runtime("daemon_trigger: missing daemon handle".to_string()))?;
@@ -267,7 +271,10 @@ fn daemon_snapshot_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
     kind = "async",
     category = "agent.daemon"
 )]
-async fn daemon_stop_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn daemon_stop_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| VmError::Runtime("daemon_stop: missing daemon handle".to_string()))?;
@@ -326,10 +333,11 @@ async fn daemon_stop_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "agent.daemon"
 )]
-async fn daemon_resume_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
-    let child_vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("daemon_resume requires an async builtin VM context".to_string())
-    })?;
+async fn daemon_resume_builtin(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
+    let child_vm = ctx.child_vm();
     let persist_root =
         options::required_string_arg(&args, 0, "daemon_resume", "path", ErrorKind::Runtime)?;
     let paths = daemon_paths(&persist_root);

--- a/crates/harn-vm/src/stdlib/assemble.rs
+++ b/crates/harn-vm/src/stdlib/assemble.rs
@@ -18,7 +18,7 @@ use crate::vm::Vm;
 use super::agents::parse_artifact_list;
 
 pub(crate) fn register_assemble_context_builtin(vm: &mut Vm) {
-    vm.register_async_builtin("assemble_context", |args| async move {
+    vm.register_async_builtin("assemble_context", |_ctx, args| async move {
         assemble_context_impl(args).await
     });
 }

--- a/crates/harn-vm/src/stdlib/channels.rs
+++ b/crates/harn-vm/src/stdlib/channels.rs
@@ -2,17 +2,17 @@ use crate::value::VmValue;
 use crate::vm::Vm;
 
 pub(crate) fn register_channel_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("emit_channel", |args| async move {
+    vm.register_async_builtin("emit_channel", |_ctx, args| async move {
         crate::channels::emit_channel_from_vm(args).await
     });
-    vm.register_async_builtin("channel_events", |args| async move {
+    vm.register_async_builtin("channel_events", |_ctx, args| async move {
         crate::channels::channel_events_from_vm(args).await
     });
     // CH-04 (#1875): explicit flush so tests can deterministically
     // exercise window-expire semantics together with `advance_time(ms)`.
     // Production code may call this from a periodic task; the implicit
     // sweep in `emit_channel(...)` already covers the common case.
-    vm.register_async_builtin("flush_trigger_aggregations", |_args| async move {
+    vm.register_async_builtin("flush_trigger_aggregations", |_ctx, _args| async move {
         crate::channels::flush_expired_aggregations_inner().await;
         Ok(VmValue::Nil)
     });

--- a/crates/harn-vm/src/stdlib/clock.rs
+++ b/crates/harn-vm/src/stdlib/clock.rs
@@ -178,7 +178,10 @@ fn now_ms_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError>
     kind = "async",
     category = "clock"
 )]
-async fn sleep_ms_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sleep_ms_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let ms = args.first().and_then(|a| a.as_int()).unwrap_or(0);
     if ms <= 0 {
         return Ok(VmValue::Nil);

--- a/crates/harn-vm/src/stdlib/collections.rs
+++ b/crates/harn-vm/src/stdlib/collections.rs
@@ -85,7 +85,7 @@ pub(crate) fn string_discriminator(value: &VmValue, builtin: &str) -> Result<Str
 }
 
 pub(crate) fn register_collection_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("chunk", |args| async move {
+    vm.register_async_builtin("chunk", |_ctx, args| async move {
         let items = list_arg(&args, "chunk")?;
         let size = positive_usize_arg(&args, 1, 1, "chunk");
         Ok(VmValue::List(Rc::new(
@@ -96,7 +96,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         )))
     });
 
-    vm.register_async_builtin("window", |args| async move {
+    vm.register_async_builtin("window", |_ctx, args| async move {
         let items = list_arg(&args, "window")?;
         let size = positive_usize_arg(&args, 1, 2, "window");
         let step = positive_usize_arg(&args, 2, 1, "window");
@@ -112,7 +112,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(windows)))
     });
 
-    vm.register_async_builtin("group_by", |args| async move {
+    vm.register_async_builtin("group_by", |_ctx, args| async move {
         let items = list_arg(&args, "group_by")?;
         let callable = args
             .get(1)
@@ -138,7 +138,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         )))
     });
 
-    vm.register_async_builtin("partition", |args| async move {
+    vm.register_async_builtin("partition", |_ctx, args| async move {
         let items = list_arg(&args, "partition")?;
         let callable = args
             .get(1)
@@ -166,7 +166,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         ]))))
     });
 
-    vm.register_async_builtin("dedup_by", |args| async move {
+    vm.register_async_builtin("dedup_by", |_ctx, args| async move {
         let items = list_arg(&args, "dedup_by")?;
         let callable = args
             .get(1)
@@ -189,7 +189,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(out)))
     });
 
-    vm.register_async_builtin("flat_map", |args| async move {
+    vm.register_async_builtin("flat_map", |_ctx, args| async move {
         let items = list_arg(&args, "flat_map")?;
         let callable = args
             .get(1)
@@ -211,7 +211,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(out)))
     });
 
-    vm.register_async_builtin("take_while", |args| async move {
+    vm.register_async_builtin("take_while", |_ctx, args| async move {
         let items = list_arg(&args, "take_while")?;
         let callable = args
             .get(1)
@@ -234,7 +234,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(out)))
     });
 
-    vm.register_async_builtin("drop_while", |args| async move {
+    vm.register_async_builtin("drop_while", |_ctx, args| async move {
         let items = list_arg(&args, "drop_while")?;
         let callable = args
             .get(1)
@@ -261,7 +261,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         Ok(VmValue::List(Rc::new(out)))
     });
 
-    vm.register_async_builtin("count_by", |args| async move {
+    vm.register_async_builtin("count_by", |_ctx, args| async move {
         let items = list_arg(&args, "count_by")?;
         let callable = args
             .get(1)

--- a/crates/harn-vm/src/stdlib/compaction.rs
+++ b/crates/harn-vm/src/stdlib/compaction.rs
@@ -120,7 +120,10 @@ fn compaction_check_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue,
     kind = "async",
     category = "compaction"
 )]
-async fn compaction_run_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn compaction_run_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = resolve_session_id(args.first(), "compaction.run")?;
     let plan = match args.get(1) {
         Some(VmValue::Dict(map)) => (**map).clone(),

--- a/crates/harn-vm/src/stdlib/concurrency.rs
+++ b/crates/harn-vm/src/stdlib/concurrency.rs
@@ -326,7 +326,10 @@ pub(crate) fn register_concurrency_builtins(vm: &mut Vm) {
     category = "concurrency",
     doc = "Acquire a named mutex permit."
 )]
-async fn sync_mutex_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sync_mutex_acquire_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("sync_mutex_acquire")?;
     let key = args
         .first()
@@ -347,7 +350,10 @@ async fn sync_mutex_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErr
     category = "concurrency",
     doc = "Acquire permits from a named semaphore."
 )]
-async fn sync_semaphore_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sync_semaphore_acquire_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("sync_semaphore_acquire")?;
     let key = args
         .first()
@@ -377,7 +383,10 @@ async fn sync_semaphore_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, V
     category = "concurrency",
     doc = "Acquire one permit from a named gate."
 )]
-async fn sync_gate_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sync_gate_acquire_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("sync_gate_acquire")?;
     let key = args
         .first()
@@ -399,7 +408,10 @@ async fn sync_gate_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErro
     category = "concurrency",
     doc = "Acquire a read or write permit from a named read-write lock."
 )]
-async fn sync_rwlock_acquire_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sync_rwlock_acquire_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     const RWLOCK_CAPACITY: u32 = 1024;
     let vm = current_async_vm("sync_rwlock_acquire")?;
     let key = args
@@ -455,7 +467,10 @@ fn sync_release_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     category = "concurrency",
     doc = "Return synchronization runtime metrics."
 )]
-async fn sync_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sync_metrics_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("sync_metrics")?;
     let kind = args.first().map(|v| v.display());
     let key = args.get(1).map(|v| v.display());
@@ -468,7 +483,10 @@ async fn sync_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Resolve a shared-state scope identifier."
 )]
-async fn shared_scope_id_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_scope_id_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_scope_id")?;
     let options = args.get(1).and_then(VmValue::as_dict);
     let raw_scope = args.first().map(VmValue::display);
@@ -486,7 +504,10 @@ async fn shared_scope_id_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError>
     category = "concurrency",
     doc = "Open or create a scoped shared cell."
 )]
-async fn shared_cell_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_cell_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_cell")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let (scoped, options) = scoped_from_open_args(&vm, &args, "shared_cell", "key")?;
@@ -504,7 +525,10 @@ async fn shared_cell_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Read a shared cell value."
 )]
-async fn shared_get_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_get_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_get")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let handle = args
@@ -520,7 +544,10 @@ async fn shared_get_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Return a shared cell snapshot."
 )]
-async fn shared_snapshot_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_snapshot_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_snapshot")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let handle = args
@@ -536,7 +563,10 @@ async fn shared_snapshot_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError>
     category = "concurrency",
     doc = "Set a shared cell value."
 )]
-async fn shared_set_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_set_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_set")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let handle = args
@@ -553,7 +583,10 @@ async fn shared_set_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Compare and swap a shared cell value."
 )]
-async fn shared_cas_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_cas_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 3 {
         return Err(VmError::Runtime(
             "shared_cas: requires handle, expected, and new value".to_string(),
@@ -575,7 +608,10 @@ async fn shared_cas_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Open or create a scoped shared map."
 )]
-async fn shared_map_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_map_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_map")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let (scoped, options) = scoped_from_open_args(&vm, &args, "shared_map", "key")?;
@@ -594,7 +630,10 @@ async fn shared_map_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Read a shared map entry."
 )]
-async fn shared_map_get_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_map_get_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Runtime(
             "shared_map_get: requires handle and key".to_string(),
@@ -613,7 +652,10 @@ async fn shared_map_get_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     category = "concurrency",
     doc = "Return a shared map entry snapshot."
 )]
-async fn shared_map_snapshot_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_map_snapshot_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Runtime(
             "shared_map_snapshot: requires handle and key".to_string(),
@@ -631,7 +673,10 @@ async fn shared_map_snapshot_builtin(args: Vec<VmValue>) -> Result<VmValue, VmEr
     category = "concurrency",
     doc = "Return all shared map entries."
 )]
-async fn shared_map_entries_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_map_entries_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_map_entries")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let handle = args
@@ -647,7 +692,10 @@ async fn shared_map_entries_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErr
     category = "concurrency",
     doc = "Set a shared map entry."
 )]
-async fn shared_map_set_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_map_set_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 3 {
         return Err(VmError::Runtime(
             "shared_map_set: requires handle, key, and value".to_string(),
@@ -665,7 +713,10 @@ async fn shared_map_set_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     category = "concurrency",
     doc = "Delete a shared map entry."
 )]
-async fn shared_map_delete_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_map_delete_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Runtime(
             "shared_map_delete: requires handle and key".to_string(),
@@ -683,7 +734,10 @@ async fn shared_map_delete_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErro
     category = "concurrency",
     doc = "Compare and swap a shared map entry."
 )]
-async fn shared_map_cas_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_map_cas_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 4 {
         return Err(VmError::Runtime(
             "shared_map_cas: requires handle, key, expected, and new value".to_string(),
@@ -706,7 +760,10 @@ async fn shared_map_cas_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     category = "concurrency",
     doc = "Return shared-state runtime metrics."
 )]
-async fn shared_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn shared_metrics_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("shared_metrics")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let Some(handle) = args.first() else {
@@ -727,7 +784,10 @@ async fn shared_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     category = "concurrency",
     doc = "Open or create a scoped mailbox."
 )]
-async fn mailbox_open_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn mailbox_open_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("mailbox_open")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let (scoped, options) = scoped_from_open_args(&vm, &args, "mailbox_open", "name")?;
@@ -745,7 +805,10 @@ async fn mailbox_open_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Look up a scoped mailbox handle."
 )]
-async fn mailbox_lookup_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn mailbox_lookup_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("mailbox_lookup")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let target = args.first().ok_or_else(|| {
@@ -761,7 +824,10 @@ async fn mailbox_lookup_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     category = "concurrency",
     doc = "Send a value to a mailbox."
 )]
-async fn mailbox_send_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn mailbox_send_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Runtime(
             "mailbox_send: requires target and value".to_string(),
@@ -788,7 +854,10 @@ async fn mailbox_send_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Try to receive one mailbox value without blocking."
 )]
-async fn mailbox_try_receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn mailbox_try_receive_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("mailbox_try_receive")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let target = args
@@ -816,7 +885,10 @@ async fn mailbox_try_receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmEr
     category = "concurrency",
     doc = "Receive one mailbox value."
 )]
-async fn mailbox_receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn mailbox_receive_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("mailbox_receive")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let cancel_token = vm.cancel_token.clone();
@@ -868,7 +940,10 @@ async fn mailbox_receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError>
     category = "concurrency",
     doc = "Close a scoped mailbox."
 )]
-async fn mailbox_close_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn mailbox_close_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("mailbox_close")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let target = args
@@ -884,7 +959,10 @@ async fn mailbox_close_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Return metrics for a scoped mailbox."
 )]
-async fn mailbox_metrics_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn mailbox_metrics_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let vm = current_async_vm("mailbox_metrics")?;
     let shared_runtime = vm.shared_state_runtime.clone();
     let target = args
@@ -1062,7 +1140,10 @@ fn atomic_cas_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
     category = "concurrency",
     doc = "Suspend execution for a duration in milliseconds."
 )]
-async fn sleep_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn sleep_builtin(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let ms = match args.first() {
         Some(VmValue::Duration(ms)) => (*ms).max(0) as u64,
         Some(VmValue::Int(n)) => (*n).max(0) as u64,
@@ -1077,20 +1158,19 @@ async fn sleep_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     }
     let sleep = tokio::time::sleep(tokio::time::Duration::from_millis(ms));
     tokio::pin!(sleep);
-    if let Some(vm) = crate::vm::clone_async_builtin_child_vm() {
-        let mut poll = tokio::time::interval(Duration::from_millis(10));
-        loop {
-            tokio::select! {
-                _ = &mut sleep => break,
-                _ = poll.tick() => {
-                    if vm.is_cancel_requested() {
-                        return Err(cancelled_vm_error());
-                    }
+    // The explicit ctx always carries a child VM, so we always poll for
+    // cancellation while sleeping rather than blocking opaquely.
+    let vm = ctx.child_vm();
+    let mut poll = tokio::time::interval(Duration::from_millis(10));
+    loop {
+        tokio::select! {
+            _ = &mut sleep => break,
+            _ = poll.tick() => {
+                if vm.is_cancel_requested() {
+                    return Err(cancelled_vm_error());
                 }
             }
         }
-    } else {
-        sleep.await;
     }
     Ok(VmValue::Nil)
 }
@@ -1101,7 +1181,10 @@ async fn sleep_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Yield cooperatively to other scheduled tasks."
 )]
-async fn yield_now_builtin(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn yield_now_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    _args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     tokio::task::yield_now().await;
     Ok(VmValue::Nil)
 }
@@ -1112,7 +1195,10 @@ async fn yield_now_builtin(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Send a value to a channel."
 )]
-async fn send_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn send_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Thrown(VmValue::String(Rc::from(
             "send: requires channel and value",
@@ -1140,7 +1226,10 @@ async fn send_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Receive one value from a channel."
 )]
-async fn receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn receive_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.is_empty() {
         return Err(VmError::Thrown(VmValue::String(Rc::from(
             "receive: requires a channel",
@@ -1172,7 +1261,10 @@ async fn receive_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Wait until one of the provided channels yields a value."
 )]
-async fn select_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn select_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.is_empty() {
         return Err(VmError::Thrown(VmValue::String(Rc::from(
             "select: requires at least one channel",
@@ -1203,7 +1295,10 @@ async fn select_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Select from a channel list with a timeout."
 )]
-async fn select_timeout_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn select_timeout_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Thrown(VmValue::String(Rc::from(
             "__select_timeout: requires channel list and timeout",
@@ -1241,7 +1336,10 @@ async fn select_timeout_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     category = "concurrency",
     doc = "Select from a channel list without blocking."
 )]
-async fn select_try_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn select_try_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.is_empty() {
         return Err(VmError::Thrown(VmValue::String(Rc::from(
             "__select_try: requires channel list",
@@ -1269,7 +1367,10 @@ async fn select_try_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Wait until one channel in a list yields a value."
 )]
-async fn select_list_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn select_list_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     if args.is_empty() {
         return Err(VmError::Thrown(VmValue::String(Rc::from(
             "__select_list: requires channel list",
@@ -1301,7 +1402,10 @@ async fn select_list_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     category = "concurrency",
     doc = "Select over a list of channels with an optional timeout."
 )]
-async fn channel_select_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn channel_select_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let channels = require_channel_list(&args, "channel_select")?;
     let timeout_ms = optional_timeout_ms(args.get(1));
     let deadline =

--- a/crates/harn-vm/src/stdlib/connectors.rs
+++ b/crates/harn-vm/src/stdlib/connectors.rs
@@ -35,7 +35,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "connectors"
 )]
-async fn connector_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn connector_call_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let provider = required_string_arg(&args, 0, "connector_call", "provider")?;
     let method = required_string_arg(&args, 1, "connector_call", "method")?;
     let params = match args.get(2) {
@@ -66,7 +69,10 @@ async fn connector_call_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "connectors"
 )]
-async fn secret_get_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn secret_get_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let raw = required_string_arg(&args, 0, "secret_get", "secret_id")?;
     let ctx = active_harn_connector_ctx().ok_or_else(|| {
         VmError::Thrown(VmValue::String(Rc::from(
@@ -97,7 +103,10 @@ async fn secret_get_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "connectors"
 )]
-async fn event_log_emit_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn event_log_emit_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let topic_name = required_string_arg(&args, 0, "event_log_emit", "topic")?;
     let kind = required_string_arg(&args, 1, "event_log_emit", "kind")?;
     let payload = args
@@ -132,7 +141,10 @@ async fn event_log_emit_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "connectors"
 )]
-async fn metrics_inc_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn metrics_inc_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let name = required_string_arg(&args, 0, "metrics_inc", "name")?;
     let amount = match args.get(1) {
         Some(VmValue::Int(value)) => *value,
@@ -160,7 +172,10 @@ async fn metrics_inc_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "connectors"
 )]
-async fn connector_shared_verify_jwt_inline_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn connector_shared_verify_jwt_inline_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let token = required_string_arg(&args, 0, "connector_shared_verify_jwt_inline", "token")?;
     let jwks = required_json_arg(&args, 1, "connector_shared_verify_jwt_inline", "jwks")?;
     let options = optional_json_arg(&args, 2, "connector_shared_verify_jwt_inline")?;

--- a/crates/harn-vm/src/stdlib/durable_step.rs
+++ b/crates/harn-vm/src/stdlib/durable_step.rs
@@ -67,7 +67,10 @@ pub(crate) fn register_durable_step_builtins(vm: &mut Vm) {
     kind = "async",
     category = "durable_step"
 )]
-async fn step_run_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn step_run_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     step_run(args).await
 }
 
@@ -76,7 +79,10 @@ async fn step_run_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "durable_step"
 )]
-async fn step_inspect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn step_inspect_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     step_inspect(args).await
 }
 

--- a/crates/harn-vm/src/stdlib/event_log.rs
+++ b/crates/harn-vm/src/stdlib/event_log.rs
@@ -26,7 +26,10 @@ pub(crate) fn register_event_log_builtins(vm: &mut Vm) {
     kind = "async",
     category = "event_log"
 )]
-async fn event_log_emit_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn event_log_emit_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let topic = parse_topic(args.first(), "event_log.emit")?;
     let kind = required_string(args.get(1), "event_log.emit", "kind")?;
     let payload = args
@@ -46,7 +49,10 @@ async fn event_log_emit_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "event_log"
 )]
-async fn event_log_latest_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn event_log_latest_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let topic = parse_topic(args.first(), "event_log.latest")?;
     let latest = ensure_event_log().latest(&topic).await.map_err(log_error)?;
     Ok(latest
@@ -59,7 +65,10 @@ async fn event_log_latest_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "event_log"
 )]
-async fn event_log_subscribe_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn event_log_subscribe_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let options = parse_subscribe_options(&args)?;
     let log = ensure_event_log();
     let mut events = log

--- a/crates/harn-vm/src/stdlib/files.rs
+++ b/crates/harn-vm/src/stdlib/files.rs
@@ -299,7 +299,7 @@ async fn upload_file(path: String, provider: String) -> Result<String, VmError> 
 }
 
 pub(crate) fn register_file_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("__files_upload", |args| async move {
+    vm.register_async_builtin("__files_upload", |_ctx, args| async move {
         let path = expect_string(&args, 0, "__files_upload")?;
         let provider = expect_string(&args, 1, "__files_upload")?;
         let file_id = upload_file(path, provider).await?;

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -53,7 +53,7 @@ enum GitDataParser {
 pub(crate) fn register_git_builtins(vm: &mut Vm) {
     register_git_namespace(vm);
 
-    vm.register_async_builtin("git.repo.discover", |args| async move {
+    vm.register_async_builtin("git.repo.discover", |_ctx, args| async move {
         let path = required_path_arg(&args, 0, "git.repo.discover")?;
         run_git_command(GitCommand {
             operation: "git.repo.discover",
@@ -76,7 +76,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.worktree.create", |args| async move {
+    vm.register_async_builtin("git.worktree.create", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.worktree.create")?;
         let branch = required_string_arg(&args, 1, "git.worktree.create", "branch")?;
         let path = required_string_arg(&args, 2, "git.worktree.create", "path")?;
@@ -112,7 +112,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.worktree.remove", |args| async move {
+    vm.register_async_builtin("git.worktree.remove", |_ctx, args| async move {
         let path = required_string_arg(&args, 0, "git.worktree.remove", "path")?;
         let options = optional_dict_arg(&args, 1);
         let force = bool_option(options, "force").unwrap_or(false);
@@ -163,7 +163,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.fetch", |args| async move {
+    vm.register_async_builtin("git.fetch", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.fetch")?;
         let remote = required_string_arg(&args, 1, "git.fetch", "remote")?;
         let refspecs = string_list_arg(&args, 2, "git.fetch", "refspecs")?.unwrap_or_default();
@@ -181,7 +181,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.rebase", |args| async move {
+    vm.register_async_builtin("git.rebase", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.rebase")?;
         let base_ref = required_string_arg(&args, 1, "git.rebase", "base_ref")?;
         run_git_command(GitCommand {
@@ -196,7 +196,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.status", |args| async move {
+    vm.register_async_builtin("git.status", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.status")?;
         run_git_command(GitCommand {
             operation: "git.status",
@@ -215,7 +215,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.conflicts", |args| async move {
+    vm.register_async_builtin("git.conflicts", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.conflicts")?;
         run_git_command(GitCommand {
             operation: "git.conflicts",
@@ -233,7 +233,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.push", |args| async move {
+    vm.register_async_builtin("git.push", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.push")?;
         let remote = required_string_arg(&args, 1, "git.push", "remote")?;
         let refspec = required_string_arg(&args, 2, "git.push", "refspec")?;
@@ -303,7 +303,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.diff", |args| async move {
+    vm.register_async_builtin("git.diff", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.diff")?;
         let selector = args.get(1);
         let mut argv = vec!["git".to_string(), "diff".to_string()];
@@ -336,7 +336,7 @@ pub(crate) fn register_git_builtins(vm: &mut Vm) {
         .await
     });
 
-    vm.register_async_builtin("git.merge_base", |args| async move {
+    vm.register_async_builtin("git.merge_base", |_ctx, args| async move {
         let repo = repo_path_arg(&args, 0, "git.merge_base")?;
         let left = required_string_arg(&args, 1, "git.merge_base", "left")?;
         let right = required_string_arg(&args, 2, "git.merge_base", "right")?;

--- a/crates/harn-vm/src/stdlib/harn_entry.rs
+++ b/crates/harn-vm/src/stdlib/harn_entry.rs
@@ -57,7 +57,7 @@ struct HarnEntrypoint {
 
 impl HarnEntrypoint {
     fn register(self, vm: &mut Vm) {
-        vm.register_async_builtin_with_metadata(self.metadata(), move |args| {
+        vm.register_async_builtin_with_metadata(self.metadata(), move |_ctx, args| {
             let entrypoint = self.clone();
             Box::pin(async move { call_harn_export(entrypoint, args).await })
         });

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -288,7 +288,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "hitl"
 )]
-async fn ask_user_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn ask_user_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     ask_user_impl(&args).await
 }
 
@@ -297,7 +300,10 @@ async fn ask_user_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "hitl"
 )]
-async fn request_approval_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn request_approval_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     request_approval_impl(&args).await
 }
 
@@ -306,7 +312,10 @@ async fn request_approval_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "hitl"
 )]
-async fn dual_control_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn dual_control_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     dual_control_impl(&args).await
 }
 
@@ -315,7 +324,10 @@ async fn dual_control_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "hitl"
 )]
-async fn escalate_to_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn escalate_to_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     escalate_to_impl(&args).await
 }
 

--- a/crates/harn-vm/src/stdlib/hitl_read.rs
+++ b/crates/harn-vm/src/stdlib/hitl_read.rs
@@ -68,7 +68,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[&HITL_PENDING_BUILTIN_DEF
     kind = "async",
     category = "hitl"
 )]
-async fn hitl_pending_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn hitl_pending_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     hitl_pending_impl(&args).await
 }
 

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -1051,7 +1051,10 @@ fn host_has_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     kind = "async",
     category = "host"
 )]
-async fn host_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_call_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let name = args.first().map(|a| a.display()).unwrap_or_default();
     let params = args
         .get(1)
@@ -1067,7 +1070,10 @@ async fn host_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
 }
 
 #[harn_builtin(sig = "host_tool_list() -> list", kind = "async", category = "host")]
-async fn host_tool_list_builtin(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_tool_list_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    _args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     dispatch_host_tool_list().await
 }
 
@@ -1076,7 +1082,10 @@ async fn host_tool_list_builtin(_args: Vec<VmValue>) -> Result<VmValue, VmError>
     kind = "async",
     category = "host"
 )]
-async fn host_tool_call_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn host_tool_call_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let name = args.first().map(|a| a.display()).unwrap_or_default();
     if name.is_empty() {
         return Err(VmError::Thrown(VmValue::String(Rc::from(

--- a/crates/harn-vm/src/stdlib/http_response.rs
+++ b/crates/harn-vm/src/stdlib/http_response.rs
@@ -124,7 +124,10 @@ fn http_reply_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     kind = "async",
     category = "http_response"
 )]
-async fn http_stream_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn http_stream_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let source = args
         .first()
         .cloned()
@@ -153,7 +156,10 @@ async fn http_stream_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "http_response"
 )]
-async fn http_sse_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn http_sse_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let source = args
         .first()
         .cloned()
@@ -1077,10 +1083,13 @@ mod tests {
             VmValue::String(Rc::from("b")),
         ];
         let response = run_sync(|| {
-            http_stream_impl(vec![
-                VmValue::List(Rc::new(items.clone())),
-                VmValue::String(Rc::from("text/plain")),
-            ])
+            http_stream_impl(
+                crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+                vec![
+                    VmValue::List(Rc::new(items.clone())),
+                    VmValue::String(Rc::from("text/plain")),
+                ],
+            )
         })
         .expect("stream");
         let map = dict(&response);
@@ -1115,10 +1124,10 @@ mod tests {
             VmValue::String(Rc::from("ping")),
         )])))];
         let response = run_sync(|| {
-            http_sse_impl(vec![
-                VmValue::List(Rc::new(events.clone())),
-                VmValue::Int(2500),
-            ])
+            http_sse_impl(
+                crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
+                vec![VmValue::List(Rc::new(events.clone())), VmValue::Int(2500)],
+            )
         })
         .expect("sse");
         let map = dict(&response);

--- a/crates/harn-vm/src/stdlib/iter.rs
+++ b/crates/harn-vm/src/stdlib/iter.rs
@@ -394,12 +394,13 @@ fn stream_debounce_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     kind = "async",
     category = "iter"
 )]
-async fn stream_collect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn stream_collect_impl(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let inner = iter_handle_from_value(require_arg(&args, 0, "stream.collect")?)?;
     let max = collect_max_arg(&args)?;
-    let mut vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("stream.collect: builtin requires VM execution context".to_string())
-    })?;
+    let mut vm = ctx.child_vm();
     Ok(VmValue::List(Rc::new(
         drain_capped(&inner, &mut vm, max).await?,
     )))
@@ -410,13 +411,14 @@ async fn stream_collect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "iter"
 )]
-async fn stream_fold_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn stream_fold_impl(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let inner = iter_handle_from_value(require_arg(&args, 0, "stream.fold")?)?;
     let mut acc = require_arg(&args, 1, "stream.fold")?;
     let f = require_callable(&args, 2, "stream.fold")?;
-    let mut vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("stream.fold: builtin requires VM execution context".to_string())
-    })?;
+    let mut vm = ctx.child_vm();
     loop {
         match next_handle(&inner, &mut vm).await? {
             Some(v) => acc = vm.call_callable_two(&f, &acc, &v).await?,
@@ -430,11 +432,12 @@ async fn stream_fold_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "iter"
 )]
-async fn stream_first_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn stream_first_impl(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let inner = iter_handle_from_value(require_arg(&args, 0, "stream.first")?)?;
-    let mut vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("stream.first: builtin requires VM execution context".to_string())
-    })?;
+    let mut vm = ctx.child_vm();
     Ok(next_handle(&inner, &mut vm).await?.unwrap_or(VmValue::Nil))
 }
 
@@ -443,7 +446,10 @@ async fn stream_first_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "iter"
 )]
-async fn parallel_race_impl_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn parallel_race_impl_builtin(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let items = match require_arg(&args, 0, "parallel_race")? {
         VmValue::List(items) => items,
         other => {
@@ -455,9 +461,7 @@ async fn parallel_race_impl_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErr
     };
     let callable = require_callable(&args, 1, "parallel_race")?;
     let cap = parallel_race_cap(args.get(2), items.len())?;
-    let parent_vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("parallel_race: builtin requires VM execution context".to_string())
-    })?;
+    let parent_vm = ctx.child_vm();
     parallel_race_impl(parent_vm, items.iter().cloned().collect(), callable, cap).await
 }
 

--- a/crates/harn-vm/src/stdlib/jsonrpc.rs
+++ b/crates/harn-vm/src/stdlib/jsonrpc.rs
@@ -39,7 +39,7 @@ pub(crate) fn reset_jsonrpc_state() {
 }
 
 pub(crate) fn register_jsonrpc_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("jsonrpc_call", |args| async move {
+    vm.register_async_builtin("jsonrpc_call", |_ctx, args| async move {
         let url = args.first().map(|a| a.display()).unwrap_or_default();
         if url.is_empty() {
             return Err(jsonrpc_err("jsonrpc_call: url is required"));
@@ -74,7 +74,7 @@ pub(crate) fn register_jsonrpc_builtins(vm: &mut Vm) {
         unwrap_jsonrpc_response(response)
     });
 
-    vm.register_async_builtin("jsonrpc_batch", |args| async move {
+    vm.register_async_builtin("jsonrpc_batch", |_ctx, args| async move {
         let url = args.first().map(|a| a.display()).unwrap_or_default();
         if url.is_empty() {
             return Err(jsonrpc_err("jsonrpc_batch: url is required"));

--- a/crates/harn-vm/src/stdlib/macros.rs
+++ b/crates/harn-vm/src/stdlib/macros.rs
@@ -40,8 +40,10 @@ pub type AsyncBuiltinFuture = Pin<Box<dyn Future<Output = Result<VmValue, VmErro
 
 /// Sync builtin handler signature (matches `crate::vm::dispatch`'s register_builtin shape).
 pub type SyncHandler = fn(&[VmValue], &mut String) -> Result<VmValue, VmError>;
-/// Async builtin handler signature.
-pub type AsyncHandler = fn(Vec<VmValue>) -> AsyncBuiltinFuture;
+/// Async builtin handler signature. Receives an explicit
+/// [`crate::vm::AsyncBuiltinCtx`] handle (see harn#2668) so handlers thread the
+/// context they were given instead of reading an ambient task-local.
+pub type AsyncHandler = fn(crate::vm::AsyncBuiltinCtx, Vec<VmValue>) -> AsyncBuiltinFuture;
 
 /// Runtime handler attached to a `VmBuiltinDef`. `None` covers parser-only
 /// builtins (method-dispatched at runtime, but the parser still wants a

--- a/crates/harn-vm/src/stdlib/memory.rs
+++ b/crates/harn-vm/src/stdlib/memory.rs
@@ -200,7 +200,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "memory"
 )]
-async fn memory_store_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn memory_store_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let namespace = required_string(&args, 0, "__memory_store", "namespace")?;
     let key = required_string(&args, 1, "__memory_store", "key")?;
     let value = args.get(2).cloned().ok_or_else(|| {
@@ -240,7 +243,10 @@ async fn memory_store_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "memory"
 )]
-async fn memory_recall_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn memory_recall_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let namespace = required_string(&args, 0, "__memory_recall", "namespace")?;
     let query = required_string(&args, 1, "__memory_recall", "query")?;
     let limit = optional_usize(args.get(2))
@@ -282,7 +288,10 @@ async fn memory_recall_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "memory"
 )]
-async fn memory_open_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn memory_open_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let namespace = required_string(&args, 0, "__memory_open", "namespace")?;
     let options = args.get(1).and_then(VmValue::as_dict);
     let backend = match option_string(options, "backend") {

--- a/crates/harn-vm/src/stdlib/monitors.rs
+++ b/crates/harn-vm/src/stdlib/monitors.rs
@@ -118,7 +118,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[&MONITOR_WAIT_FOR_NATIVE_
     kind = "async",
     category = "monitor"
 )]
-async fn monitor_wait_for_native_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn monitor_wait_for_native_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     monitor_wait_for_impl(&args).await
 }
 

--- a/crates/harn-vm/src/stdlib/oauth_storage.rs
+++ b/crates/harn-vm/src/stdlib/oauth_storage.rs
@@ -161,7 +161,10 @@ fn oauth_storage_cloud_handle_impl(
     kind = "async",
     category = "oauth_storage"
 )]
-async fn oauth_storage_get_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn oauth_storage_get_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let handle = require_handle(&args, 0, "__oauth_storage_get")?;
     let key = required_string_arg(&args, 1, "__oauth_storage_get", "key")?;
     backend_get(&handle, &key).await
@@ -172,7 +175,10 @@ async fn oauth_storage_get_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     kind = "async",
     category = "oauth_storage"
 )]
-async fn oauth_storage_set_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn oauth_storage_set_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let handle = require_handle(&args, 0, "__oauth_storage_set")?;
     let key = required_string_arg(&args, 1, "__oauth_storage_set", "key")?;
     let token_dict = require_dict_arg(&args, 2, "__oauth_storage_set", "token_set")?;
@@ -186,7 +192,10 @@ async fn oauth_storage_set_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     kind = "async",
     category = "oauth_storage"
 )]
-async fn oauth_storage_delete_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn oauth_storage_delete_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let handle = require_handle(&args, 0, "__oauth_storage_delete")?;
     let key = required_string_arg(&args, 1, "__oauth_storage_delete", "key")?;
     backend_delete(&handle, &key).await?;

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -1281,7 +1281,10 @@ fn pool_snapshot_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
     category = "pool",
     runtime_only = true
 )]
-async fn pool_submit_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pool_submit_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool_id = pool_id_from_value(
         args.first()
             .ok_or_else(|| VmError::Runtime("pool.submit: pool handle is required".to_string()))?,
@@ -2381,7 +2384,10 @@ fn finalize_task(
     category = "pool",
     runtime_only = true
 )]
-async fn pool_wait_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pool_wait_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| VmError::Runtime("pool_wait: task handle is required".to_string()))?;

--- a/crates/harn-vm/src/stdlib/postgres/advisory.rs
+++ b/crates/harn-vm/src/stdlib/postgres/advisory.rs
@@ -50,7 +50,10 @@ use super::{
     kind = "async",
     category = "postgres"
 )]
-async fn pg_advisory_xact_lock_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_advisory_xact_lock_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     advisory_xact_op(&args, false).await
 }
 
@@ -63,7 +66,10 @@ async fn pg_advisory_xact_lock_impl(args: Vec<VmValue>) -> Result<VmValue, VmErr
     kind = "async",
     category = "postgres"
 )]
-async fn pg_try_advisory_xact_lock_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_try_advisory_xact_lock_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     advisory_xact_op(&args, true).await
 }
 
@@ -76,7 +82,10 @@ async fn pg_try_advisory_xact_lock_impl(args: Vec<VmValue>) -> Result<VmValue, V
     kind = "async",
     category = "postgres"
 )]
-async fn pg_with_advisory_lock_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_with_advisory_lock_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool_handle = required_arg(&args, 0, "pg_with_advisory_lock", "pool handle")?;
     let pool_id = handle_id(Some(pool_handle), HANDLE_POOL, "pg_with_advisory_lock")?;
     let key_value = required_arg(&args, 1, "pg_with_advisory_lock", "key")?;

--- a/crates/harn-vm/src/stdlib/postgres/introspect.rs
+++ b/crates/harn-vm/src/stdlib/postgres/introspect.rs
@@ -66,7 +66,10 @@ use super::{
     kind = "async",
     category = "postgres"
 )]
-async fn pg_introspect_tables_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_introspect_tables_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool = pool_arg(&args, "pg_introspect_tables")?;
     let options = args.get(1).and_then(VmValue::as_dict);
     let schema = options
@@ -111,7 +114,10 @@ async fn pg_introspect_tables_impl(args: Vec<VmValue>) -> Result<VmValue, VmErro
     kind = "async",
     category = "postgres"
 )]
-async fn pg_introspect_columns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_introspect_columns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool = pool_arg(&args, "pg_introspect_columns")?;
     let (schema, table) = split_qualified(
         args.get(1).map(VmValue::display).as_deref().unwrap_or(""),
@@ -148,7 +154,10 @@ async fn pg_introspect_columns_impl(args: Vec<VmValue>) -> Result<VmValue, VmErr
     kind = "async",
     category = "postgres"
 )]
-async fn pg_introspect_indexes_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_introspect_indexes_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool = pool_arg(&args, "pg_introspect_indexes")?;
     let (schema, table) = split_qualified(
         args.get(1).map(VmValue::display).as_deref().unwrap_or(""),
@@ -186,7 +195,10 @@ async fn pg_introspect_indexes_impl(args: Vec<VmValue>) -> Result<VmValue, VmErr
     kind = "async",
     category = "postgres"
 )]
-async fn pg_pool_stats_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_pool_stats_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool_handle = required_arg(&args, 0, "pg_pool_stats", "pool handle")?;
     let pool_id = handle_id(Some(pool_handle), HANDLE_POOL, "pg_pool_stats")?;
     let record = pool_record_by_id(&pool_id)?;
@@ -253,7 +265,10 @@ async fn pg_pool_stats_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_partition_attach_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_partition_attach_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool = pool_arg(&args, "pg_partition_attach")?;
     let parent = qualified_identifier(
         args.get(1).map(VmValue::display).as_deref().unwrap_or(""),
@@ -292,7 +307,10 @@ async fn pg_partition_attach_impl(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "postgres"
 )]
-async fn pg_partition_detach_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_partition_detach_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool = pool_arg(&args, "pg_partition_detach")?;
     let parent = qualified_identifier(
         args.get(1).map(VmValue::display).as_deref().unwrap_or(""),
@@ -330,7 +348,10 @@ async fn pg_partition_detach_impl(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "postgres"
 )]
-async fn pg_partition_prune_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_partition_prune_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool = pool_arg(&args, "pg_partition_prune")?;
     let parent = qualified_identifier(
         args.get(1).map(VmValue::display).as_deref().unwrap_or(""),
@@ -365,7 +386,10 @@ async fn pg_partition_prune_impl(args: Vec<VmValue>) -> Result<VmValue, VmError>
     kind = "async",
     category = "postgres"
 )]
-async fn pg_partition_retain_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_partition_retain_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool = pool_arg(&args, "pg_partition_retain")?;
     let parent = qualified_identifier(
         args.get(1).map(VmValue::display).as_deref().unwrap_or(""),
@@ -399,7 +423,10 @@ async fn pg_partition_retain_impl(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "postgres"
 )]
-async fn pg_partition_create_for_window_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_partition_create_for_window_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let builtin = "pg_partition_create_for_window";
     let pool = pool_arg(&args, builtin)?;
     let parent = qualified_identifier(

--- a/crates/harn-vm/src/stdlib/postgres/listen.rs
+++ b/crates/harn-vm/src/stdlib/postgres/listen.rs
@@ -82,7 +82,10 @@ pub(super) fn reset_state() {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_listen_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_listen_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool_handle = required_arg(&args, 0, "pg_listen", "pool handle")?;
     let pool_id = handle_id(Some(pool_handle), HANDLE_POOL, "pg_listen")?;
     let pool = pool_by_id(&pool_id)?;
@@ -140,7 +143,10 @@ async fn pg_listen_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_listener_recv_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_listener_recv_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let handle = required_arg(&args, 0, "pg_listener_recv", "listener handle")?;
     let id = handle_id(Some(handle), HANDLE_LISTENER, "pg_listener_recv")?;
     let record = listener_by_id(&id)?;
@@ -207,7 +213,10 @@ async fn pg_listener_recv_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_listener_close_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_listener_close_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let handle = required_arg(&args, 0, "pg_listener_close", "listener handle")?;
     let id = handle_id(Some(handle), HANDLE_LISTENER, "pg_listener_close")?;
     let removed = LISTENERS.with(|listeners| listeners.borrow_mut().remove(&id));
@@ -229,7 +238,10 @@ async fn pg_listener_close_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     kind = "async",
     category = "postgres"
 )]
-async fn pg_notify_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_notify_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = required_arg(&args, 0, "pg_notify", "pool or transaction handle")?;
     let channel = required_arg(&args, 1, "pg_notify", "channel name")?;
     let channel = match channel {

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -130,7 +130,10 @@ mod migrate;
     kind = "async",
     category = "postgres"
 )]
-async fn pg_pool_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_pool_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let source = args.first().ok_or_else(|| {
         runtime_error("pg_pool: url, env:, secret:, or {url|env|secret} is required")
     })?;
@@ -143,7 +146,10 @@ async fn pg_pool_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_connect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_connect_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let source = args.first().ok_or_else(|| {
         runtime_error("pg_connect: url, env:, secret:, or {url|env|secret} is required")
     })?;
@@ -156,7 +162,10 @@ async fn pg_connect_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_close_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_close_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let id = handle_id(args.first(), HANDLE_POOL, "pg_close")?;
     let removed = POOLS.with(|pools| pools.borrow_mut().remove(&id));
     if let Some(record) = removed {
@@ -175,7 +184,10 @@ async fn pg_close_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_stmt_cache_clear_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_stmt_cache_clear_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = required_arg(&args, 0, "pg_stmt_cache_clear", "pool handle")?;
     if handle_kind(target).as_deref() == Some(HANDLE_MOCK) {
         handle_id(Some(target), HANDLE_MOCK, "pg_stmt_cache_clear")?;
@@ -244,7 +256,10 @@ async fn clear_idle_statement_caches(
     kind = "async",
     category = "postgres"
 )]
-async fn pg_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_query_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| runtime_error("pg_query: pool or transaction handle is required"))?;
@@ -260,7 +275,10 @@ async fn pg_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_query_one_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_query_one_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| runtime_error("pg_query_one: pool or transaction handle is required"))?;
@@ -277,7 +295,10 @@ async fn pg_query_one_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_execute_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_execute_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| runtime_error("pg_execute: pool or transaction handle is required"))?;
@@ -291,7 +312,10 @@ async fn pg_execute_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_transaction_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_transaction_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let pool_id = handle_id(args.first(), HANDLE_POOL, "pg_transaction")?;
     let closure = match args.get(1) {
         Some(VmValue::Closure(closure)) => closure.clone(),
@@ -382,7 +406,10 @@ pub(super) async fn run_managed_transaction(
     kind = "async",
     category = "postgres"
 )]
-async fn pg_savepoint_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_savepoint_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     savepoint_op(&args, "pg_savepoint", SavepointOp::Create).await
 }
 
@@ -391,7 +418,10 @@ async fn pg_savepoint_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "postgres"
 )]
-async fn pg_release_savepoint_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_release_savepoint_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     savepoint_op(&args, "pg_release_savepoint", SavepointOp::Release).await
 }
 
@@ -400,7 +430,10 @@ async fn pg_release_savepoint_impl(args: Vec<VmValue>) -> Result<VmValue, VmErro
     kind = "async",
     category = "postgres"
 )]
-async fn pg_rollback_to_savepoint_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_rollback_to_savepoint_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     savepoint_op(&args, "pg_rollback_to_savepoint", SavepointOp::RollbackTo).await
 }
 
@@ -409,7 +442,10 @@ async fn pg_rollback_to_savepoint_impl(args: Vec<VmValue>) -> Result<VmValue, Vm
     kind = "async",
     category = "postgres"
 )]
-async fn pg_migrate_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn pg_migrate_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     migrate::run(&args).await
 }
 

--- a/crates/harn-vm/src/stdlib/project_enrich.rs
+++ b/crates/harn-vm/src/stdlib/project_enrich.rs
@@ -65,7 +65,7 @@ struct CacheRecord {
 }
 
 pub(crate) fn register_project_enrich_builtin(vm: &mut Vm) {
-    vm.register_async_builtin("project_enrich_native", |args| async move {
+    vm.register_async_builtin("project_enrich_native", |_ctx, args| async move {
         project_enrich_impl(args).await
     });
 }

--- a/crates/harn-vm/src/stdlib/review.rs
+++ b/crates/harn-vm/src/stdlib/review.rs
@@ -99,10 +99,9 @@ struct ReviewTrustInput<'a> {
 }
 
 pub(crate) fn register_review_builtins(vm: &mut Vm) {
-    vm.register_async_builtin(
-        "self_review",
-        |args| async move { self_review_impl(args).await },
-    );
+    vm.register_async_builtin("self_review", |_ctx, args| async move {
+        self_review_impl(args).await
+    });
 }
 
 async fn self_review_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {

--- a/crates/harn-vm/src/stdlib/runtime_scope.rs
+++ b/crates/harn-vm/src/stdlib/runtime_scope.rs
@@ -60,7 +60,10 @@ fn current_policy_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     kind = "async",
     category = "runtime_scope"
 )]
-async fn with_autonomy_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn with_autonomy_policy_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let policy_value = args
         .first()
         .ok_or_else(|| VmError::Runtime("with_autonomy_policy: policy is required".into()))?;
@@ -78,7 +81,10 @@ async fn with_autonomy_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmErro
     kind = "async",
     category = "runtime_scope"
 )]
-async fn with_execution_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn with_execution_policy_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let policy_value = args
         .first()
         .ok_or_else(|| VmError::Runtime("with_execution_policy: policy is required".into()))?;
@@ -102,7 +108,10 @@ async fn with_execution_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmErr
     category = "runtime_scope",
     runtime_only = true
 )]
-async fn harn_with_execution_policy_override_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn harn_with_execution_policy_override_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let policy_value = args.first().ok_or_else(|| {
         VmError::Runtime("__harn_with_execution_policy_override: policy is required".into())
     })?;
@@ -125,7 +134,10 @@ async fn harn_with_execution_policy_override_impl(args: Vec<VmValue>) -> Result<
     kind = "async",
     category = "runtime_scope"
 )]
-async fn with_approval_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn with_approval_policy_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let policy_value = args
         .first()
         .ok_or_else(|| VmError::Runtime("with_approval_policy: policy is required".into()))?;
@@ -144,7 +156,10 @@ async fn with_approval_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmErro
     kind = "async",
     category = "runtime_scope"
 )]
-async fn with_command_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn with_command_policy_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let policy =
         crate::orchestration::parse_command_policy_value(args.first(), "with_command_policy")?
             .ok_or_else(|| VmError::Runtime("with_command_policy: policy is required".into()))?;
@@ -159,7 +174,10 @@ async fn with_command_policy_impl(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "runtime_scope"
 )]
-async fn with_dynamic_permissions_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn with_dynamic_permissions_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let permissions = crate::llm::permissions::parse_dynamic_permission_policy(
         args.first(),
         "with_dynamic_permissions",

--- a/crates/harn-vm/src/stdlib/secret_scan.rs
+++ b/crates/harn-vm/src/stdlib/secret_scan.rs
@@ -176,7 +176,7 @@ pub async fn audit_secret_scan_active(
 }
 
 pub(crate) fn register_secret_scan_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("secret_scan", |args| async move {
+    vm.register_async_builtin("secret_scan", |_ctx, args| async move {
         let content = match args.first() {
             Some(VmValue::Nil) | None => {
                 return Err(VmError::Runtime("secret_scan: content is required".into()));

--- a/crates/harn-vm/src/stdlib/skills.rs
+++ b/crates/harn-vm/src/stdlib/skills.rs
@@ -739,7 +739,10 @@ fn skill_render_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     category = "skills",
     kind = "async"
 )]
-async fn load_skill_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn load_skill_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let (requested, inline_options) = parse_load_skill_request(args.first())?;
     let call_options = parse_load_skill_options(args.get(1))?;
     let session_id = call_options

--- a/crates/harn-vm/src/stdlib/supervisor.rs
+++ b/crates/harn-vm/src/stdlib/supervisor.rs
@@ -135,10 +135,11 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "supervisor"
 )]
-async fn supervisor_start_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
-    let base_vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("supervisor_start: requires VM execution context".to_string())
-    })?;
+async fn supervisor_start_impl(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
+    let base_vm = ctx.child_vm();
     let spec = args
         .first()
         .ok_or_else(|| VmError::Runtime("supervisor_start: spec is required".to_string()))?;
@@ -182,7 +183,10 @@ fn supervisor_metrics_impl(args: &[VmValue], _out: &mut String) -> Result<VmValu
     kind = "async",
     category = "supervisor"
 )]
-async fn supervisor_stop_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn supervisor_stop_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let id = supervisor_id_from_args(&args, "supervisor_stop")?;
     let timeout_ms = args
         .get(1)

--- a/crates/harn-vm/src/stdlib/testing.rs
+++ b/crates/harn-vm/src/stdlib/testing.rs
@@ -27,7 +27,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "testing"
 )]
-async fn testing_call_body_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn testing_call_body_impl(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let body = args
         .first()
         .cloned()
@@ -55,11 +58,9 @@ async fn testing_call_body_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> 
         _ => Vec::new(),
     };
 
-    let mut vm = crate::vm::clone_async_builtin_child_vm().ok_or_else(|| {
-        VmError::Runtime("__testing_call_body: builtin requires VM execution context".to_string())
-    })?;
+    let mut vm = ctx.child_vm();
     let result = vm.call_callable_owned(&body, call_args).await;
-    crate::vm::forward_child_output_to_parent(&vm.take_output());
+    ctx.forward_output(&vm.take_output());
     result
 }
 

--- a/crates/harn-vm/src/stdlib/tool_hooks.rs
+++ b/crates/harn-vm/src/stdlib/tool_hooks.rs
@@ -786,7 +786,10 @@ fn tool_hooks_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     category = "tool_hooks",
     kind = "async"
 )]
-async fn tool_hooks_match_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn tool_hooks_match_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let registry = require_tagged(
         args.first()
             .ok_or_else(|| err("tool_hooks_match: requires a registry"))?,

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -135,7 +135,10 @@ fn tool_synthesize_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     category = "tools",
     kind = "async"
 )]
-async fn tool_synth_invoke_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn tool_synth_invoke_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let id = match args.first() {
         Some(VmValue::String(s)) if !s.is_empty() => s.to_string(),
         _ => {

--- a/crates/harn-vm/src/stdlib/transcript_compact.rs
+++ b/crates/harn-vm/src/stdlib/transcript_compact.rs
@@ -16,7 +16,7 @@ use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
 pub(crate) fn register_transcript_compaction_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("transcript_compact", |args| async move {
+    vm.register_async_builtin("transcript_compact", |_ctx, args| async move {
         let transcript = args
             .first()
             .and_then(|value| value.as_dict())

--- a/crates/harn-vm/src/stdlib/transcript_project.rs
+++ b/crates/harn-vm/src/stdlib/transcript_project.rs
@@ -31,7 +31,7 @@ use crate::vm::Vm;
 pub(crate) const TRANSCRIPT_PROJECTION_EVENT_KIND: &str = "transcript.projection";
 
 pub(crate) fn register_transcript_projection_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("transcript_project", |args| async move {
+    vm.register_async_builtin("transcript_project", |_ctx, args| async move {
         let transcript_value = args.first().cloned().unwrap_or(VmValue::Nil);
         let transcript = transcript_value
             .as_dict()

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -162,7 +162,10 @@ fn trigger_list_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
     kind = "async",
     category = "triggers"
 )]
-async fn trigger_register_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trigger_register_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let config = require_dict_arg(&args, 0, "trigger_register")?;
     let spec = parse_trigger_config(config)?;
     let id = dynamic_register(spec)
@@ -178,7 +181,10 @@ async fn trigger_register_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trigger_fire_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trigger_fire_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let (binding_id, binding_version) = trigger_handle_from_args(&args, "trigger_fire")?;
     let raw_event = args
         .get(1)
@@ -192,7 +198,10 @@ async fn trigger_fire_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trigger_replay_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trigger_replay_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let event_id = args
         .first()
         .and_then(|value| match value {
@@ -208,7 +217,10 @@ async fn trigger_replay_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trigger_inspect_dlq_impl(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trigger_inspect_dlq_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    _args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let entries = inspect_dlq_entries().await?;
     Ok(VmValue::List(Rc::new(
         entries
@@ -223,7 +235,10 @@ async fn trigger_inspect_dlq_impl(_args: Vec<VmValue>) -> Result<VmValue, VmErro
     kind = "async",
     category = "triggers"
 )]
-async fn trigger_inspect_lifecycle_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trigger_inspect_lifecycle_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let kind = args.first().and_then(|value| match value {
         VmValue::String(text) => Some(text.to_string()),
         VmValue::Nil => None,
@@ -243,7 +258,10 @@ async fn trigger_inspect_lifecycle_impl(args: Vec<VmValue>) -> Result<VmValue, V
     kind = "async",
     category = "triggers"
 )]
-async fn trigger_inspect_action_graph_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trigger_inspect_action_graph_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let trace_id = args.first().and_then(|value| match value {
         VmValue::String(text) => Some(text.to_string()),
         VmValue::Nil => None,
@@ -263,7 +281,10 @@ async fn trigger_inspect_action_graph_impl(args: Vec<VmValue>) -> Result<VmValue
     kind = "async",
     category = "triggers"
 )]
-async fn trust_record_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_record_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     append_trust_record_from_parts("trust_record", &args)
         .await
         .map(|record| value_from_serde(&record))
@@ -274,7 +295,10 @@ async fn trust_record_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trust_graph_record_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_graph_record_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let decision = args.first().ok_or_else(|| {
         VmError::Runtime("trust_graph_record: expected decision dict".to_string())
     })?;
@@ -287,7 +311,10 @@ async fn trust_graph_record_impl(args: Vec<VmValue>) -> Result<VmValue, VmError>
     kind = "async",
     category = "triggers"
 )]
-async fn trust_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_query_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let filters = args
         .first()
         .map(parse_trust_query_filters)
@@ -313,7 +340,10 @@ async fn trust_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trust_graph_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_graph_query_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let agent = required_string_arg(&args, 0, "trust_graph_query", "agent")?;
     let action = optional_string_arg(&args, 1, "trust_graph_query", "action")?;
     let log = ensure_trigger_event_log();
@@ -328,7 +358,10 @@ async fn trust_graph_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     kind = "async",
     category = "triggers"
 )]
-async fn trust_graph_policy_for_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_graph_policy_for_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let agent = required_string_arg(&args, 0, "trust_graph_policy_for", "agent")?;
     let log = ensure_trigger_event_log();
     let policy = policy_for_agent(&log, &agent)
@@ -342,7 +375,10 @@ async fn trust_graph_policy_for_impl(args: Vec<VmValue>) -> Result<VmValue, VmEr
     kind = "async",
     category = "triggers"
 )]
-async fn trust_graph_verify_chain_impl(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_graph_verify_chain_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    _args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let log = ensure_trigger_event_log();
     let report = verify_trust_chain(&log)
         .await
@@ -355,7 +391,10 @@ async fn trust_graph_verify_chain_impl(_args: Vec<VmValue>) -> Result<VmValue, V
     kind = "async",
     category = "triggers"
 )]
-async fn trust_query_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_query_ns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let filters = args
         .first()
         .map(parse_trust_query_filters)
@@ -378,7 +417,10 @@ async fn trust_query_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trust_record_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_record_ns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let decision = args
         .first()
         .ok_or_else(|| VmError::Runtime("trust.record: expected decision dict".to_string()))?;
@@ -391,7 +433,10 @@ async fn trust_record_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trust_score_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_score_ns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let agent = required_string_arg(&args, 0, "trust.score", "actor_id")?;
     let action = optional_string_arg(&args, 1, "trust.score", "action")?;
     let log = ensure_trigger_event_log();
@@ -406,7 +451,10 @@ async fn trust_score_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn trust_policy_for_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_policy_for_ns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let agent = required_string_arg(&args, 0, "trust.policy_for", "actor_id")?;
     let log = ensure_trigger_event_log();
     let policy = policy_for_agent(&log, &agent)
@@ -420,7 +468,10 @@ async fn trust_policy_for_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "triggers"
 )]
-async fn trust_verify_chain_ns_impl(_args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trust_verify_chain_ns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    _args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let log = ensure_trigger_event_log();
     let report = verify_trust_chain(&log)
         .await
@@ -433,7 +484,10 @@ async fn trust_verify_chain_ns_impl(_args: Vec<VmValue>) -> Result<VmValue, VmEr
     kind = "async",
     category = "triggers"
 )]
-async fn correction_record_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn correction_record_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let value = args.first().ok_or_else(|| {
         VmError::Runtime("correction_record: expected correction dict".to_string())
     })?;
@@ -450,7 +504,10 @@ async fn correction_record_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> 
     kind = "async",
     category = "triggers"
 )]
-async fn correction_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn correction_query_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let filters = args
         .first()
         .map(|value| correction_query_filters_from_value("correction_query", value))
@@ -473,7 +530,10 @@ async fn correction_query_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     kind = "async",
     category = "triggers"
 )]
-async fn corrections_record_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn corrections_record_ns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let value = args.first().ok_or_else(|| {
         VmError::Runtime("corrections.record: expected correction dict".to_string())
     })?;
@@ -490,7 +550,10 @@ async fn corrections_record_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmErr
     kind = "async",
     category = "triggers"
 )]
-async fn corrections_query_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn corrections_query_ns_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let filters = args
         .first()
         .map(|value| correction_query_filters_from_value("corrections.query", value))
@@ -513,7 +576,10 @@ async fn corrections_query_ns_impl(args: Vec<VmValue>) -> Result<VmValue, VmErro
     kind = "async",
     category = "triggers"
 )]
-async fn webhook_intake_register_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn webhook_intake_register_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let config = require_dict_arg(&args, 0, "webhook_intake_register")?;
     let parsed = parse_webhook_intake_config(config)?;
     let snapshot = register_webhook_intake(parsed).map_err(webhook_intake_error)?;
@@ -525,7 +591,10 @@ async fn webhook_intake_register_impl(args: Vec<VmValue>) -> Result<VmValue, VmE
     kind = "async",
     category = "triggers"
 )]
-async fn webhook_intake_feed_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn webhook_intake_feed_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let intake_id = required_string_arg(&args, 0, "webhook_intake_feed", "intake_id")?;
     let request_dict = require_dict_arg(&args, 1, "webhook_intake_feed")?;
     let request = parse_webhook_intake_request(request_dict)?;
@@ -540,7 +609,10 @@ async fn webhook_intake_feed_impl(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "triggers"
 )]
-async fn webhook_intake_deregister_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn webhook_intake_deregister_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let intake_id = required_string_arg(&args, 0, "webhook_intake_deregister", "intake_id")?;
     Ok(VmValue::Bool(deregister_webhook_intake(&intake_id)))
 }
@@ -563,7 +635,10 @@ fn webhook_intake_list_impl(_args: &[VmValue], _out: &mut String) -> Result<VmVa
     kind = "async",
     category = "triggers"
 )]
-async fn webhook_intake_recent_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn webhook_intake_recent_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let intake_id = required_string_arg(&args, 0, "webhook_intake_recent", "intake_id")?;
     let limit = match args.get(1) {
         Some(VmValue::Int(value)) if *value >= 0 => *value as usize,
@@ -591,7 +666,10 @@ async fn webhook_intake_recent_impl(args: Vec<VmValue>) -> Result<VmValue, VmErr
     kind = "async",
     category = "triggers"
 )]
-async fn trigger_test_harness_impl(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn trigger_test_harness_impl(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let fixture = match args.first() {
         Some(VmValue::String(text)) => text.to_string(),
         Some(VmValue::Dict(map)) => required_string(map, "fixture", "trigger_test_harness")?,

--- a/crates/harn-vm/src/stdlib/vision.rs
+++ b/crates/harn-vm/src/stdlib/vision.rs
@@ -222,7 +222,7 @@ fn install_test_backend(backend: Rc<dyn OcrBackend>) {
 }
 
 pub(crate) fn register_vision_builtins(vm: &mut Vm) {
-    vm.register_async_builtin("vision_ocr", |args| async move {
+    vm.register_async_builtin("vision_ocr", |_ctx, args| async move {
         let input = normalize_image_input(args.first())?;
         let options = parse_ocr_options(args.get(1))?;
         let backend = current_backend();

--- a/crates/harn-vm/src/stdlib/waitpoint.rs
+++ b/crates/harn-vm/src/stdlib/waitpoint.rs
@@ -179,7 +179,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_create_builtin_macro(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_create_builtin_macro(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_create_builtin(&args).await
 }
 
@@ -188,7 +191,10 @@ async fn waitpoint_create_builtin_macro(args: Vec<VmValue>) -> Result<VmValue, V
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_wait_builtin_macro(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_wait_builtin_macro(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_wait_builtin(&args).await
 }
 
@@ -197,7 +203,10 @@ async fn waitpoint_wait_builtin_macro(args: Vec<VmValue>) -> Result<VmValue, VmE
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_complete_builtin_macro(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_complete_builtin_macro(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_complete_builtin(&args).await
 }
 
@@ -206,7 +215,10 @@ async fn waitpoint_complete_builtin_macro(args: Vec<VmValue>) -> Result<VmValue,
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_cancel_builtin_macro(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_cancel_builtin_macro(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_cancel_builtin(&args).await
 }
 

--- a/crates/harn-vm/src/stdlib/waitpoints.rs
+++ b/crates/harn-vm/src/stdlib/waitpoints.rs
@@ -85,7 +85,10 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_create_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_create_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_create_impl(&args).await
 }
 
@@ -94,7 +97,10 @@ async fn waitpoint_create_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_complete_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_complete_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_complete_impl(&args).await
 }
 
@@ -103,7 +109,10 @@ async fn waitpoint_complete_builtin(args: Vec<VmValue>) -> Result<VmValue, VmErr
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_cancel_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_cancel_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_cancel_impl(&args).await
 }
 
@@ -112,7 +121,10 @@ async fn waitpoint_cancel_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError
     kind = "async",
     category = "waitpoint"
 )]
-async fn waitpoint_wait_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn waitpoint_wait_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     waitpoint_wait_impl(&args).await
 }
 

--- a/crates/harn-vm/src/stdlib/workflow/compact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/compact.rs
@@ -88,6 +88,7 @@ fn non_negative_usize(value: &VmValue, builtin: &str, key: &str) -> Result<usize
     category = "workflow.host"
 )]
 pub(super) async fn transcript_auto_compact_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let mut messages: Vec<serde_json::Value> = match args.first() {

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -577,7 +577,10 @@ pub(super) fn settlement_agent_active_builtin(
     category = "workflow.host",
     runtime_only = true
 )]
-pub(super) async fn fire_session_hook_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+pub(super) async fn fire_session_hook_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let event_name = args
         .first()
         .map(VmValue::display)
@@ -668,7 +671,10 @@ pub(super) fn notify_file_edited_builtin(
     category = "workflow.host",
     runtime_only = true
 )]
-pub(super) async fn drain_file_edits_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+pub(super) async fn drain_file_edits_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let session_id = args.first().map(VmValue::display).unwrap_or_default();
     let drained = crate::orchestration::drain_file_edits();
     let mut paths: Vec<VmValue> = Vec::with_capacity(drained.len());

--- a/crates/harn-vm/src/stdlib/workflow/host.rs
+++ b/crates/harn-vm/src/stdlib/workflow/host.rs
@@ -64,6 +64,7 @@ pub(super) fn host_workflow_prepare_run_builtin(
     runtime_only = true
 )]
 pub(super) async fn host_workflow_stage_prepare_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let state_id = parse_state_id_arg(args.first(), "__host_workflow_stage_prepare")?;
@@ -91,6 +92,7 @@ pub(super) async fn host_workflow_stage_prepare_builtin(
     runtime_only = true
 )]
 pub(super) async fn host_workflow_stage_complete_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let state_id = parse_state_id_arg(args.first(), "__host_workflow_stage_complete")?;
@@ -179,7 +181,10 @@ pub(super) fn host_workflow_finalize_run_builtin(
     category = "workflow.host",
     runtime_only = true
 )]
-pub(super) async fn host_workflow_map_plan_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+pub(super) async fn host_workflow_map_plan_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let node: crate::orchestration::WorkflowNode =
         parse_json_arg(args.first(), HOST_WORKFLOW_MAP_PLAN_BUILTIN)?;
     let artifacts = parse_artifact_list(args.get(1))?;
@@ -220,6 +225,7 @@ pub(super) fn host_workflow_map_branch_artifact_builtin(
     runtime_only = true
 )]
 pub(super) async fn host_workflow_map_execute_branch_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let node_id = args
@@ -315,6 +321,7 @@ pub(super) async fn host_workflow_map_execute_branch_builtin(
     runtime_only = true
 )]
 pub(super) async fn host_workflow_map_finalize_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let strategy = args

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -587,7 +587,10 @@ fn workflow_query_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
     kind = "async",
     category = "workflow.messages"
 )]
-async fn workflow_update_builtin(args: Vec<VmValue>) -> Result<VmValue, VmError> {
+async fn workflow_update_builtin(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
     let target = parse_target_vm(args.first(), None, "workflow.update")?;
     let name = args
         .get(1)

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -13,8 +13,17 @@ use super::{
 };
 
 /// An async builtin function for the VM.
-pub type VmAsyncBuiltinFn =
-    Rc<dyn Fn(Vec<VmValue>) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>>>>>;
+///
+/// Receives an explicit [`crate::vm::AsyncBuiltinCtx`] handle (threaded by the
+/// dispatch loop + the `#[harn_builtin]` macro) so handlers mint child VMs and
+/// forward output through the ctx they were given rather than an ambient
+/// task-local that may not be bound on the current task. See harn#2668.
+pub type VmAsyncBuiltinFn = Rc<
+    dyn Fn(
+        crate::vm::AsyncBuiltinCtx,
+        Vec<VmValue>,
+    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>>>>,
+>;
 
 /// Indexed runtime layout for a Harn struct instance.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/harn-vm/src/vm/async_builtin.rs
+++ b/crates/harn-vm/src/vm/async_builtin.rs
@@ -20,15 +20,32 @@ tokio::task_local! {
     /// stack would silently read the wrong (or empty) context. Nesting is
     /// handled by nested `scope` calls: `with` sees the innermost binding,
     /// which restores the parent on unwind. See harn#2667.
+    ///
+    /// As of harn#2668 the canonical path is an *explicit* [`AsyncBuiltinCtx`]
+    /// handle threaded into every async builtin's signature by the
+    /// `#[harn_builtin]` macro + the dispatch loop, so builtin bodies no longer
+    /// read this ambient binding. The task-local survives only as a bridge for
+    /// the deep sync helpers (pool submitter resolution, channel context,
+    /// HITL host notification, daemon bridge construction, …) that have not yet
+    /// been threaded; those still resolve via [`clone_async_builtin_child_vm`].
+    /// Removing the task-local entirely is the remaining follow-up — see #2668.
     static ASYNC_BUILTIN_CTX: AsyncBuiltinCtx;
 }
 
-/// Shared handle to the parent VM's execution context for the duration of one
-/// async-builtin call. Holds the "template" child VM that closure-invoking
-/// host helpers clone via [`clone_async_builtin_child_vm`], and whose `output`
-/// buffer collects text forwarded from VM-side closures via
-/// [`forward_child_output_to_parent`]. Cheap to construct — everything heavy
-/// inside the `Vm` is `Rc`/`Arc`-shared.
+/// Explicit handle to the parent VM's execution context for the duration of one
+/// async-builtin call. Threaded into every async builtin by the dispatch loop
+/// (and the `#[harn_builtin]` macro), so context can no longer be "lost across a
+/// spawn boundary": a handler that needs a child VM holds the `ctx` it was given
+/// rather than reaching for an ambient task-local that may not be bound on the
+/// current task.
+///
+/// Holds the "template" child VM that closure-invoking host helpers clone via
+/// [`AsyncBuiltinCtx::child_vm`], and whose `output` buffer collects text
+/// forwarded from VM-side closures via [`AsyncBuiltinCtx::forward_output`]. The
+/// dispatch loop drains that buffer back to the original parent VM after the
+/// async builtin returns. Cheap to clone — it is an `Rc` handle and everything
+/// heavy inside the `Vm` is `Rc`/`Arc`-shared.
+#[derive(Clone)]
 pub struct AsyncBuiltinCtx {
     child: Rc<RefCell<Vm>>,
 }
@@ -39,28 +56,58 @@ impl AsyncBuiltinCtx {
             child: Rc::new(RefCell::new(vm)),
         }
     }
+
+    /// Construct a standalone ctx around `vm` for unit tests that drive an async
+    /// builtin handler directly (outside the dispatch loop). Production code
+    /// receives its ctx from the dispatch path, never this.
+    #[cfg(test)]
+    pub fn for_test(vm: Vm) -> Self {
+        Self::new(vm)
+    }
+
+    /// Clone a fresh child VM from this context. The returned `Vm` shares the
+    /// parent's heavy state (env, builtins, bridge, module_cache) via `Arc`/`Rc`,
+    /// so each closure-invoking handler gets its own cheap execution context.
+    pub fn child_vm(&self) -> Vm {
+        self.child.borrow().child_vm()
+    }
+
+    /// Forward captured output from a transient child VM (typically created via
+    /// [`AsyncBuiltinCtx::child_vm`] and used to invoke a closure) back into this
+    /// context's output buffer. The dispatch loop drains that buffer back to the
+    /// original parent VM after the async builtin returns.
+    ///
+    /// Without this hook, `log()`/`__io_print()` calls inside
+    /// `post_turn_callback` closures, tool handlers, and other VM-side closures
+    /// invoked from async builtins would silently disappear because the transient
+    /// child VM's output buffer is dropped on scope exit.
+    pub fn forward_output(&self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        self.child.borrow_mut().append_output(text);
+    }
 }
 
-/// Clone a fresh child VM from the current async-builtin context. Returns
-/// `None` when called outside any async-builtin scope (e.g. top-level sync
-/// code), matching the old empty-stack behaviour. The returned `Vm` shares the
-/// parent's heavy state (env, builtins, bridge, module_cache) via `Arc`/`Rc`,
-/// so each closure-invoking handler gets its own cheap execution context.
+/// Clone a fresh child VM from the current ambient async-builtin context.
+/// Returns `None` when called outside any async-builtin scope (e.g. top-level
+/// sync code), matching the old empty-stack behaviour.
+///
+/// Prefer the explicit [`AsyncBuiltinCtx::child_vm`] threaded into the builtin's
+/// signature. This ambient accessor survives only for the deep sync helpers not
+/// yet threaded (see #2668) and for spawn boundaries that re-scope the context.
 pub fn clone_async_builtin_child_vm() -> Option<Vm> {
     ASYNC_BUILTIN_CTX
         .try_with(|ctx| ctx.child.borrow().child_vm())
         .ok()
 }
 
-/// Forward captured output from a transient child VM (typically created via
-/// [`clone_async_builtin_child_vm`] and used to invoke a closure) back into the
-/// current async-builtin context's output buffer. The dispatch loop drains
-/// that buffer back to the original parent VM after the async builtin returns.
+/// Forward output into the current ambient async-builtin context's output
+/// buffer. A no-op outside any async-builtin scope.
 ///
-/// Without this hook, `log()`/`__io_print()` calls inside `post_turn_callback`
-/// closures, tool handlers, and other VM-side closures invoked from async
-/// builtins would silently disappear because the transient child VM's output
-/// buffer is dropped on scope exit. A no-op outside any async-builtin scope.
+/// Prefer the explicit [`AsyncBuiltinCtx::forward_output`]. This ambient
+/// accessor survives only for the deep sync helpers not yet threaded (see
+/// #2668).
 pub fn forward_child_output_to_parent(text: &str) {
     if text.is_empty() {
         return;
@@ -68,17 +115,21 @@ pub fn forward_child_output_to_parent(text: &str) {
     let _ = ASYNC_BUILTIN_CTX.try_with(|ctx| ctx.child.borrow_mut().append_output(text));
 }
 
-/// Run `fut` (an async builtin's future) with `child` installed as the current
-/// async-builtin context, returning the future's output plus any output that
-/// VM-side closures forwarded into the context. The dispatch loop appends the
-/// captured output to the real parent VM. Cancel-safe: if `fut` is dropped, the
-/// task-local binding and the child `Vm` are dropped with it — no strand.
-pub(crate) fn run_async_builtin_with<F>(
+/// Run an async builtin's future with `child` installed as its explicit
+/// [`AsyncBuiltinCtx`] (also bound as the ambient task-local for the deep sync
+/// helpers that have not yet been threaded). `make_fut` receives the ctx handle
+/// and returns the handler's future; the ctx is moved into the future, so it
+/// lives exactly as long as the call. Returns the future's output plus any
+/// output that VM-side closures forwarded into the context, which the dispatch
+/// loop appends to the real parent VM. Cancel-safe: if the returned future is
+/// dropped, the ctx + child `Vm` are dropped with it — no strand.
+pub(crate) fn run_async_builtin_with<F, M>(
     child: Vm,
-    fut: F,
+    make_fut: M,
 ) -> impl Future<Output = (F::Output, String)>
 where
     F: Future,
+    M: FnOnce(AsyncBuiltinCtx) -> F,
 {
     // Build the context + scope synchronously so the by-value `child: Vm` moves
     // onto the heap (Rc) *before* any async state machine exists. If this were
@@ -88,6 +139,7 @@ where
     // harn#2667.
     let ctx = AsyncBuiltinCtx::new(child);
     let sink = Rc::clone(&ctx.child);
+    let fut = make_fut(ctx.clone());
     let scoped = ASYNC_BUILTIN_CTX.scope(ctx, fut);
     async move {
         let output = scoped.await;
@@ -164,22 +216,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scope_binds_ctx_and_captures_forwarded_output() {
-        let visible_inside = run_async_builtin_with(Vm::new(), async {
+    async fn explicit_ctx_mints_child_and_captures_forwarded_output() {
+        let (present, captured) = run_async_builtin_with(Vm::new(), |ctx| async move {
+            // The handler holds the explicit ctx — no ambient lookup needed.
+            let _child = ctx.child_vm();
+            ctx.forward_output("hello ");
+            ctx.forward_output("world");
+            true
+        })
+        .await;
+        assert!(present);
+        // `forward_output` appends into the same buffer the dispatch loop drains.
+        assert_eq!(captured, "hello world");
+    }
+
+    #[tokio::test]
+    async fn ambient_bridge_still_visible_inside_scope() {
+        // The deep sync helpers (not yet threaded) still resolve a child via the
+        // ambient task-local that dispatch binds. Verify the bridge is live
+        // inside the scope and gone after.
+        let (visible_inside, captured) = run_async_builtin_with(Vm::new(), |_ctx| async move {
             let present = clone_async_builtin_child_vm().is_some();
             forward_child_output_to_parent("hello ");
             forward_child_output_to_parent("world");
             present
         })
         .await;
-        assert_eq!(visible_inside, (true, "hello world".to_string()));
-        // The binding is dropped with the future — no strand, context gone.
+        assert!(visible_inside);
+        assert_eq!(captured, "hello world");
         assert!(clone_async_builtin_child_vm().is_none());
     }
 
     #[tokio::test]
     async fn nested_scopes_restore_the_parent_context() {
-        run_async_builtin_with(Vm::new(), async {
+        run_async_builtin_with(Vm::new(), |_ctx| async move {
             assert!(clone_async_builtin_child_vm().is_some());
             scope_async_builtin(Vm::new(), async {
                 assert!(clone_async_builtin_child_vm().is_some());
@@ -199,7 +269,7 @@ mod tests {
         // polling to completion. With the old thread_local stack a manual
         // push with no matching pop would strand the child Vm; with a
         // task_local scope the binding only exists while the future is live.
-        let never = run_async_builtin_with(Vm::new(), pending::<()>());
+        let never = run_async_builtin_with(Vm::new(), |_ctx| pending::<()>());
         drop(never);
         assert!(clone_async_builtin_child_vm().is_none());
     }

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -210,14 +210,17 @@ impl Vm {
         self.refresh_builtin_id(name);
     }
 
-    /// Register an async builtin function.
+    /// Register an async builtin function. The handler receives the explicit
+    /// [`crate::vm::AsyncBuiltinCtx`] threaded by the dispatch loop (harn#2668).
     pub fn register_async_builtin<F, Fut>(&mut self, name: &str, f: F)
     where
-        F: Fn(Vec<VmValue>) -> Fut + 'static,
+        F: Fn(crate::vm::AsyncBuiltinCtx, Vec<VmValue>) -> Fut + 'static,
         Fut: Future<Output = Result<VmValue, VmError>> + 'static,
     {
-        Rc::make_mut(&mut self.async_builtins)
-            .insert(name.to_string(), Rc::new(move |args| Box::pin(f(args))));
+        Rc::make_mut(&mut self.async_builtins).insert(
+            name.to_string(),
+            Rc::new(move |ctx, args| Box::pin(f(ctx, args))),
+        );
         Rc::make_mut(&mut self.builtin_metadata).insert(
             name.to_string(),
             VmBuiltinMetadata::async_builtin(name.to_string()),
@@ -225,18 +228,21 @@ impl Vm {
         self.refresh_builtin_id(name);
     }
 
-    /// Register an async builtin function with discoverable metadata.
+    /// Register an async builtin function with discoverable metadata. The
+    /// handler receives the explicit [`crate::vm::AsyncBuiltinCtx`] (harn#2668).
     pub fn register_async_builtin_with_metadata<F, Fut>(
         &mut self,
         metadata: VmBuiltinMetadata,
         f: F,
     ) where
-        F: Fn(Vec<VmValue>) -> Fut + 'static,
+        F: Fn(crate::vm::AsyncBuiltinCtx, Vec<VmValue>) -> Fut + 'static,
         Fut: Future<Output = Result<VmValue, VmError>> + 'static,
     {
         let name = metadata.name().to_string();
-        Rc::make_mut(&mut self.async_builtins)
-            .insert(name.clone(), Rc::new(move |args| Box::pin(f(args))));
+        Rc::make_mut(&mut self.async_builtins).insert(
+            name.clone(),
+            Rc::new(move |ctx, args| Box::pin(f(ctx, args))),
+        );
         Rc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Async));
         self.refresh_builtin_id(&name);
@@ -577,11 +583,16 @@ impl Vm {
             VmBuiltinDispatch::Sync(builtin) => builtin(&args, &mut self.output),
             VmBuiltinDispatch::Async(async_builtin) => {
                 // Bind a fresh child VM as the async-builtin context for the
-                // duration of this future (cancel-safe task-local scope), then
-                // drain any output VM-side closures forwarded into it back to
-                // the parent. See `vm::async_builtin`.
+                // duration of this future, threading the explicit ctx handle
+                // into the handler (harn#2668) and also binding it as the
+                // ambient task-local for deep sync helpers not yet threaded.
+                // Drain any output VM-side closures forwarded into the ctx back
+                // to the parent. See `vm::async_builtin`.
                 let (result, captured) =
-                    crate::vm::run_async_builtin_with(self.child_vm(), async_builtin(args)).await;
+                    crate::vm::run_async_builtin_with(self.child_vm(), |ctx| {
+                        async_builtin(ctx, args)
+                    })
+                    .await;
                 if !captured.is_empty() {
                     self.output.push_str(&captured);
                 }

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -987,7 +987,7 @@ let value = test_async("ok")
 log(value)
 }"#,
         |vm| {
-            vm.register_async_builtin("test_async", |args| async move {
+            vm.register_async_builtin("test_async", |_ctx, args| async move {
                 Ok(VmValue::String(Rc::from(format!(
                     "async:{}",
                     args[0].display()


### PR DESCRIPTION
## What

Threads an **explicit `AsyncBuiltinCtx` handle** into every async builtin instead of having handler bodies reach for the ambient `ASYNC_BUILTIN_CTX` `tokio::task_local`. This is the north-star follow-up to #2667 (the task_local cutover).

- `VmAsyncBuiltinFn` / `AsyncHandler` ABI now takes `(ctx: AsyncBuiltinCtx, args)`.
- The `#[harn_builtin(kind = "async")]` proc-macro threads `ctx` from the dispatch loop into the user fn / generated async thunk (proc-macro registration **kept**, per the hard constraint).
- Dispatch (`call_builtin_entry`) constructs the per-call ctx once and passes it explicitly; `run_async_builtin_with` now takes a `FnOnce(AsyncBuiltinCtx) -> Future` so the handler receives the same handle that backs the output-drain buffer.
- `AsyncBuiltinCtx` is now a cheap clonable handle with public `child_vm()` and `forward_output(&str)`.

All ~199 macro async builtins + ~85 manual `register_async_builtin*` closures gained the `ctx` param (mostly `_ctx`, mechanical). The **entry-point** ambient reads were converted to the explicit ctx in `iter` (`stream.*`, `parallel_race`), `concurrency` (`sleep` now always polls for cancellation — the explicit ctx is always present), `supervisor`, `agents_daemon` (`daemon_spawn`/`daemon_resume`), `testing` (`__testing_call_body`), and the agent host primitives (`__host_agent_capture_events`).

## Scope (incremental — `Refs #2668`, not `Closes`)

The `ASYNC_BUILTIN_CTX` task-local **survives only as a bridge** for the deep *sync* helpers that read it ambiently from inside async call graphs and are not yet threaded:
- `pool` submitter / scope-id / durable-context resolution
- `channels::ChannelContext::current`
- `hitl::maybe_notify_host`
- `agents_daemon::new_daemon_bridge`
- the trigger dispatcher / worker spawn re-scopes

Dispatch still binds the task-local around the future, so these keep working unchanged. Fully threading those helpers + **removing the task-local** is the tracked follow-up (filed against #2668). This PR makes "context lost across a spawn boundary" structurally impossible *at the handler entry point* and is the keystone that makes the remaining helper threading mechanical.

Cancel-safety + multi-thread-correctness from #2667 are preserved: the ctx is owned/borrowed explicitly and dropped with the future. No new data-parallelism barriers (Arc-ifying VmValue is out of scope, #48).

## Verification

- `cargo build -p harn-vm -p harn-cli -p harn-serve` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` (strict) — clean
- `cargo test -p harn-vm` — **2979 passing** (the only intermittent failure is the pre-existing `*_long_running_*` fs timing flake, which passes in isolation and is documented in-test as poison-cascade flakiness; unrelated to this change — those tests use the sync `call()` path, not async dispatch)
- `HARN_LLM_CALLS_DISABLED=1 harn test conformance` — **1493 passed, 0 failed** (full suite; pool/triggers/suspend/hitl subsets all green — the categories that caught #2667's subtle regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)