### PR TITLE
Align ACP session/request_permission bindings

### DIFF
--- a/changelog.d/2639.fixed.md
+++ b/changelog.d/2639.fixed.md
@@ -1,0 +1,3 @@
+- Align ACP `session/request_permission` generated bindings and bridge tests with
+  the canonical v0.12.2 `{toolCall, options}` request and
+  `{outcome: {outcome: "selected" | "cancelled"}}` response shape.

--- a/conformance/protocols/fixtures/acp/session_request_permission.valid.json
+++ b/conformance/protocols/fixtures/acp/session_request_permission.valid.json
@@ -48,7 +48,7 @@
     "source": {
       "kind": "adapter_generated",
       "generator": "cargo test -p harn-serve adapters::acp::tests::acp_bridge_routes_session_request_permission_response",
-      "description": "Canonical ACP v0.12.2 permission request/response shape from AcpBridge::call_client (#2639)."
+      "description": "Canonical ACP v0.12.2 permission request/response shape from AcpBridge::call_client."
     }
   }
 }

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -856,16 +856,40 @@ export interface HarnAgentEventNotification {
   }
 }
 
+export interface ACPPermissionToolCall {
+  sessionUpdate?: "tool_call_update"
+  toolCallId: string
+  title?: string
+  kind?: string
+  rawInput?: ACPValue
+  _meta?: HarnExtensionMeta
+}
+
+export type ACPPermissionOptionKind =
+  | "allow_once"
+  | "allow_always"
+  | "reject_once"
+  | "reject_always"
+
+export interface ACPPermissionOption {
+  optionId: string
+  name: string
+  kind: ACPPermissionOptionKind
+}
+
 export interface ACPSessionRequestPermissionParams {
   sessionId: string
-  approvalRequest?: ACPObject
-  toolCall?: {
-    toolCallId: string
-    toolName: string
-    rawInput?: ACPValue
-  }
-  mutation?: ACPObject
-  options?: ACPValue[]
+  toolCall: ACPPermissionToolCall
+  options: ACPPermissionOption[]
+}
+
+export type ACPPermissionOutcome =
+  | { outcome: "selected"; optionId: string }
+  | { outcome: "cancelled" }
+
+export interface ACPSessionRequestPermissionResult {
+  outcome: ACPPermissionOutcome
+  reason?: string
 }
 
 export interface ACPPromptCapabilities {

--- a/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
@@ -2196,8 +2196,16 @@ mod tests {
                     "method": "session/request_permission",
                     "params": {
                         "sessionId": "session-1",
-                        "toolCallId": "tool-1",
-                        "toolName": "edit"
+                        "toolCall": {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": "tool-1",
+                            "title": "edit",
+                            "kind": "other"
+                        },
+                        "options": [
+                            {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+                            {"optionId": "reject", "name": "Reject", "kind": "reject_once"}
+                        ]
                     },
                 })
                 .to_string(),
@@ -2219,14 +2227,15 @@ mod tests {
                 json!({
                     "jsonrpc": "2.0",
                     "id": 77,
-                    "result": {"outcome": "approved"},
+                    "result": {"outcome": {"outcome": "selected", "optionId": "allow"}},
                 }),
             )
             .await
             .expect("first controller decision wins");
         let forwarded = request_rx.recv().await.expect("forwarded response");
         assert_eq!(forwarded["id"], 77);
-        assert_eq!(forwarded["result"]["outcome"], "approved");
+        assert_eq!(forwarded["result"]["outcome"]["outcome"], "selected");
+        assert_eq!(forwarded["result"]["outcome"]["optionId"], "allow");
 
         let duplicate = worker
             .send_client_request(
@@ -2235,7 +2244,7 @@ mod tests {
                 json!({
                     "jsonrpc": "2.0",
                     "id": 77,
-                    "result": {"outcome": "approved"},
+                    "result": {"outcome": {"outcome": "selected", "optionId": "allow"}},
                 }),
             )
             .await
@@ -2252,7 +2261,7 @@ mod tests {
                 json!({
                     "jsonrpc": "2.0",
                     "id": 77,
-                    "result": {"outcome": "denied"},
+                    "result": {"outcome": {"outcome": "selected", "optionId": "reject"}},
                 }),
             )
             .await
@@ -2265,7 +2274,7 @@ mod tests {
             } => {
                 assert_eq!(decision.actor.client_id, "controller");
                 assert_eq!(attempted_actor.client_id, "owner");
-                assert_eq!(attempted_payload["result"]["outcome"], "denied");
+                assert_eq!(attempted_payload["result"]["outcome"]["optionId"], "reject");
             }
             other => panic!("expected AlreadyDecided, got {other:?}"),
         }

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -1167,8 +1167,6 @@ async fn acp_bridge_routes_session_request_permission_response() {
         assistant_state: Mutex::new(VisibleTextState::default()),
     });
 
-    // Canonical ACP v0.12.2 request shape (#2639): `{ sessionId, toolCall,
-    // options: [{ optionId, name, kind }] }`.
     let call = bridge.call_client(
         "session/request_permission",
         serde_json::json!({
@@ -1194,8 +1192,6 @@ async fn acp_bridge_routes_session_request_permission_response() {
     assert_eq!(outgoing["id"], 77);
     assert_eq!(outgoing["method"], "session/request_permission");
 
-    // Canonical ACP response shape: `{ outcome: { outcome: "selected",
-    // optionId } }`. No `{outcome: "approved"}` / `{granted}` in ACP.
     let response = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 77,

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -350,8 +350,6 @@ impl ApiState {
         let request_id = params
             .pointer("/toolCall/toolCallId")
             .or_else(|| params.pointer("/toolCall/_meta/harn/approvalRequest/id"))
-            .or_else(|| params.pointer("/approvalRequest/id"))
-            .or_else(|| params.get("toolCallId"))
             .and_then(Value::as_str)
             .map(str::to_string)
             .unwrap_or_else(|| format!("permission_{}", Uuid::now_v7()));
@@ -369,15 +367,8 @@ impl ApiState {
             "task_id": task_id,
             "status": "pending",
             "source": "acp",
-            // Canonical ACP request carries the action under the harn vendor
-            // extension on `toolCall`; older shapes used top-level/approval
-            // fields. Read all of them so the public resource stays stable
-            // across the #2639 wire change.
             "action": params.pointer("/toolCall/_meta/harn/toolName")
-                .or_else(|| params.pointer("/toolCall/toolName"))
                 .or_else(|| params.pointer("/toolCall/title"))
-                .or_else(|| params.pointer("/approvalRequest/action"))
-                .or_else(|| params.get("toolName"))
                 .cloned()
                 .unwrap_or(Value::Null),
             "request": params,
@@ -1943,9 +1934,6 @@ async fn respond_permission_request(
             return api_error(StatusCode::BAD_GATEWAY, "acp_error", &error);
         }
     } else if let Some(rpc_id) = rpc_id {
-        // Canonical ACP `RequestPermissionResponse` (#2639): a `selected`
-        // outcome on the allow/reject option. There is no `{outcome:
-        // "approved"}` in canonical ACP — that was the pre-#2639 harn shape.
         let result = if approved {
             json!({"outcome": {"outcome": "selected", "optionId": "allow"}})
         } else {

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -169,10 +169,10 @@ impl InProcessHost {
         &self,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, VmError> {
-        // No exported `request_permission` ⇒ default-allow: emit a canonical
-        // `selected` outcome on the allow option (#2639).
+        // No exported `request_permission` means the playground host has no
+        // approval policy, so it grants through the canonical ACP option.
         let Some(closure) = self.exported_functions.get("request_permission") else {
-            return Ok(canonical_allow_response());
+            return Ok(crate::llm::acp_permission::allow_response());
         };
 
         let tool_call = params.get("toolCall");
@@ -212,21 +212,21 @@ impl InProcessHost {
         let payload = match result {
             VmValue::Bool(granted) => {
                 if granted {
-                    canonical_allow_response()
+                    crate::llm::acp_permission::allow_response()
                 } else {
-                    canonical_reject_response(None)
+                    crate::llm::acp_permission::reject_response(None)
                 }
             }
             VmValue::String(reason) if !reason.is_empty() => {
-                canonical_reject_response(Some(reason.to_string()))
+                crate::llm::acp_permission::reject_response(Some(reason.to_string()))
             }
             other => {
                 let json = crate::llm::vm_value_to_json(&other);
                 if let Some(granted) = json.get("granted").and_then(|value| value.as_bool()) {
                     if granted {
-                        canonical_allow_response()
+                        crate::llm::acp_permission::allow_response()
                     } else {
-                        canonical_reject_response(
+                        crate::llm::acp_permission::reject_response(
                             json.get("reason")
                                 .and_then(|value| value.as_str())
                                 .map(str::to_string),
@@ -236,38 +236,14 @@ impl InProcessHost {
                     // The script already returned a canonical-shaped outcome.
                     json
                 } else if other.is_truthy() {
-                    canonical_allow_response()
+                    crate::llm::acp_permission::allow_response()
                 } else {
-                    canonical_reject_response(None)
+                    crate::llm::acp_permission::reject_response(None)
                 }
             }
         };
         Ok(payload)
     }
-}
-
-/// Canonical ACP `RequestPermissionResponse` granting the call: a
-/// `selected` outcome on the `allow` option (#2639).
-fn canonical_allow_response() -> serde_json::Value {
-    serde_json::json!({
-        "outcome": { "outcome": "selected", "optionId": "allow" }
-    })
-}
-
-/// Canonical ACP `RequestPermissionResponse` rejecting the call: a
-/// `selected` outcome on the `reject` option, with an optional harn-vendor
-/// `reason` extension (#2639).
-fn canonical_reject_response(reason: Option<String>) -> serde_json::Value {
-    let mut response = serde_json::json!({
-        "outcome": { "outcome": "selected", "optionId": "reject" }
-    });
-    if let Some(reason) = reason {
-        response
-            .as_object_mut()
-            .expect("object")
-            .insert("reason".to_string(), serde_json::Value::String(reason));
-    }
-    response
 }
 
 /// How a queued bridge injection is delivered into the agent loop.

--- a/crates/harn-vm/src/llm/acp_permission.rs
+++ b/crates/harn-vm/src/llm/acp_permission.rs
@@ -1,4 +1,4 @@
-//! Canonical ACP `session/request_permission` wire helpers (#2639).
+//! Canonical ACP `session/request_permission` wire helpers.
 //!
 //! ACP v0.12.2 makes the request/response shapes for
 //! `session/request_permission` canonical:
@@ -33,6 +33,27 @@ fn canonical_options() -> JsonValue {
         { "optionId": OPTION_ALLOW, "name": "Allow", "kind": "allow_once" },
         { "optionId": OPTION_REJECT, "name": "Reject", "kind": "reject_once" },
     ])
+}
+
+/// Canonical ACP `RequestPermissionResponse` granting the call.
+pub(crate) fn allow_response() -> JsonValue {
+    json!({
+        "outcome": { "outcome": "selected", "optionId": OPTION_ALLOW }
+    })
+}
+
+/// Canonical ACP `RequestPermissionResponse` rejecting the call.
+pub(crate) fn reject_response(reason: Option<String>) -> JsonValue {
+    let mut response = json!({
+        "outcome": { "outcome": "selected", "optionId": OPTION_REJECT }
+    });
+    if let Some(reason) = reason {
+        response
+            .as_object_mut()
+            .expect("object")
+            .insert("reason".to_string(), JsonValue::String(reason));
+    }
+    response
 }
 
 /// Build the canonical `session/request_permission` request params.
@@ -163,13 +184,13 @@ mod tests {
 
     #[test]
     fn selected_allow_is_allowed() {
-        let response = json!({"outcome": {"outcome": "selected", "optionId": "allow"}});
+        let response = allow_response();
         assert_eq!(parse_response(&response), WireOutcome::Allowed);
     }
 
     #[test]
     fn selected_reject_is_rejected() {
-        let response = json!({"outcome": {"outcome": "selected", "optionId": "reject"}});
+        let response = reject_response(None);
         assert!(matches!(
             parse_response(&response),
             WireOutcome::Rejected { .. }
@@ -187,8 +208,6 @@ mod tests {
 
     #[test]
     fn non_canonical_outcome_fails_closed() {
-        // Legacy `{ outcome: "approved" }` and `{ granted: true }` are no
-        // longer honored — canonical ACP carries no such shape.
         assert!(matches!(
             parse_response(&json!({"outcome": "approved"})),
             WireOutcome::Rejected { .. }

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -512,16 +512,40 @@ export interface HarnAgentEventNotification {
   }
 }
 
+export interface ACPPermissionToolCall {
+  sessionUpdate?: "tool_call_update"
+  toolCallId: string
+  title?: string
+  kind?: string
+  rawInput?: ACPValue
+  _meta?: HarnExtensionMeta
+}
+
+export type ACPPermissionOptionKind =
+  | "allow_once"
+  | "allow_always"
+  | "reject_once"
+  | "reject_always"
+
+export interface ACPPermissionOption {
+  optionId: string
+  name: string
+  kind: ACPPermissionOptionKind
+}
+
 export interface ACPSessionRequestPermissionParams {
   sessionId: string
-  approvalRequest?: ACPObject
-  toolCall?: {
-    toolCallId: string
-    toolName: string
-    rawInput?: ACPValue
-  }
-  mutation?: ACPObject
-  options?: ACPValue[]
+  toolCall: ACPPermissionToolCall
+  options: ACPPermissionOption[]
+}
+
+export type ACPPermissionOutcome =
+  | { outcome: "selected"; optionId: string }
+  | { outcome: "cancelled" }
+
+export interface ACPSessionRequestPermissionResult {
+  outcome: ACPPermissionOutcome
+  reason?: string
 }
 
 export interface ACPPromptCapabilities {


### PR DESCRIPTION
## Summary

- publish canonical ACP v0.12.2 `session/request_permission` TypeScript request/result bindings
- switch ACP hub arbitration coverage to canonical `{toolCall, options}` requests and `{outcome: {outcome: "selected", optionId}}` responses
- tighten REST permission-request registration to read canonical `toolCall` fields and centralize VM canonical response builders
- add changelog fragment for #2639

Closes #2639.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-2639 cargo run --quiet -p harn-cli -- dump-protocol-artifacts --check`
- `python3 scripts/check_protocol_bindings.py`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-2639 cargo test -p harn-vm llm::acp_permission`
- `CARGO_TARGET_DIR=/tmp/harn-target-2639 cargo test -p harn-serve acp_bridge_routes_session_request_permission_response`
- `CARGO_TARGET_DIR=/tmp/harn-target-2639 cargo test -p harn-cli acp_hub_arbitrates_permission_responses`
- `CARGO_TARGET_DIR=/tmp/harn-target-2639 HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols`
- pre-commit hook: formatting, changed-package clippy, CI ratchets, markdown
- pre-push hook: targeted local checks and markdown
