### PR TITLE
MCP OAuth: default to CIMD auth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ harn mcp redirect-uri
 harn mcp login https://mcp.notion.com/mcp
 ```
 
+`harn mcp login` prefers Harn's published CIMD client metadata document and
+falls back to dynamic client registration when the authorization server does
+not advertise CIMD support.
+
 Simple LLM call:
 
 ```harn

--- a/changelog.d/2645.added.md
+++ b/changelog.d/2645.added.md
@@ -1,0 +1,8 @@
+- **MCP OAuth now defaults to CIMD before dynamic registration (#2645).** Harn
+  publishes a stable Client ID Metadata Document at
+  `https://harnlang.com/.well-known/oauth-client.json`, selects it for MCP
+  OAuth when the authorization server advertises CIMD support, falls back to
+  dynamic client registration otherwise, and adds a unified `auth = { mode =
+  "cimd" | "dcr" | "static" | "byo", ... }` MCP config shape. Static bearer
+  tokens reuse `harn connect api-key` secrets; BYO client secrets are referenced
+  from the same secret store instead of being embedded in host-generated config.

--- a/crates/harn-cli/src/commands/connect.rs
+++ b/crates/harn-cli/src/commands/connect.rs
@@ -12,7 +12,7 @@ mod github;
 mod linear;
 mod oauth;
 mod status;
-mod store;
+pub(crate) mod store;
 mod workspace;
 
 use self::github::run_connect_github;

--- a/crates/harn-cli/src/commands/connect/oauth.rs
+++ b/crates/harn-cli/src/commands/connect/oauth.rs
@@ -1,10 +1,9 @@
 use base64::Engine;
 use harn_vm::mcp_auth::{
     determine_token_endpoint_auth_method, discover_mcp_oauth, dynamic_client_registration_body,
-    ensure_pkce_s256_supported, select_client_registration_mode,
-    validate_authorization_response_issuer, validate_issuer_binding,
-    validate_token_endpoint_auth_method, OAuthClientRegistrationMode,
-    OAuthClientRegistrationOptions,
+    ensure_pkce_s256_supported, select_oauth_client_auth, validate_authorization_response_issuer,
+    validate_issuer_binding, validate_token_endpoint_auth_method, OAuthClientAuthMode,
+    OAuthClientAuthOptions, DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL,
 };
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
@@ -337,26 +336,62 @@ pub(super) async fn resolve_oauth_client(
     discovery: Option<&OAuthDiscoveryResult>,
     registration_endpoint: Option<&str>,
 ) -> Result<(String, Option<String>, String), String> {
-    let registration_mode = discovery
-        .map(|discovery| {
-            select_client_registration_mode(
-                &discovery.metadata,
-                OAuthClientRegistrationOptions {
-                    client_id: request.client_id.as_deref(),
-                    client_secret: request.client_secret.as_deref(),
-                    client_id_metadata_document_url: request.client_id.as_deref(),
-                },
-            )
-        })
-        .unwrap_or_else(|| {
-            if request.client_id.is_some() {
-                OAuthClientRegistrationMode::PreRegistered
-            } else if registration_endpoint.is_some() {
-                OAuthClientRegistrationMode::DynamicClientRegistration
-            } else {
-                OAuthClientRegistrationMode::Manual
+    if let Some(discovery) = discovery {
+        let auth_selection = select_oauth_client_auth(
+            &discovery.metadata,
+            OAuthClientAuthOptions {
+                client_id: request.client_id.as_deref(),
+                client_secret: request.client_secret.as_deref(),
+                client_id_metadata_document_url: request.client_id.as_deref(),
+                ..OAuthClientAuthOptions::default()
+            },
+        )?;
+        return match auth_selection.mode {
+            OAuthClientAuthMode::Cimd => Ok((
+                auth_selection
+                    .client_id
+                    .unwrap_or(DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL)
+                    .to_string(),
+                None,
+                "none".to_string(),
+            )),
+            OAuthClientAuthMode::Byo => {
+                let token_auth_method = request
+                    .token_auth_method
+                    .clone()
+                    .or_else(|| {
+                        determine_token_auth_method(&discovery.metadata, request.client_secret.as_ref())
+                            .ok()
+                    })
+                    .unwrap_or_else(|| {
+                        if request.client_secret.is_some() {
+                            "client_secret_post".to_string()
+                        } else {
+                            "none".to_string()
+                        }
+                    });
+                validate_token_auth_method(&token_auth_method)?;
+                Ok((
+                    auth_selection
+                        .client_id
+                        .ok_or_else(|| "BYO OAuth auth requires client_id".to_string())?
+                        .to_string(),
+                    request.client_secret.clone(),
+                    token_auth_method,
+                ))
             }
-        });
+            OAuthClientAuthMode::Dcr => {
+                let registration_endpoint = registration_endpoint.ok_or_else(|| {
+                    "dynamic client registration endpoint missing".to_string()
+                })?;
+                register_dynamic_client(request, registration_endpoint).await
+            }
+            OAuthClientAuthMode::Static => Err(
+                "static auth does not run the OAuth browser flow; store the token with `harn connect api-key`".to_string(),
+            ),
+        };
+    }
+
     if let Some(client_id) = request.client_id.clone() {
         let token_auth_method = request
             .token_auth_method
@@ -378,14 +413,16 @@ pub(super) async fn resolve_oauth_client(
         return Ok((client_id, request.client_secret.clone(), token_auth_method));
     }
 
-    if registration_mode != OAuthClientRegistrationMode::DynamicClientRegistration {
-        return Err(
-            "No client_id available. Supply --client-id, use a Client ID Metadata Document URL as --client-id when supported, or use a server that supports dynamic client registration.".to_string()
-        );
-    }
     let registration_endpoint = registration_endpoint.ok_or_else(|| {
         "No client_id available. Supply --client-id or use a server that supports dynamic client registration.".to_string()
     })?;
+    register_dynamic_client(request, registration_endpoint).await
+}
+
+async fn register_dynamic_client(
+    request: &OAuthConnectRequest,
+    registration_endpoint: &str,
+) -> Result<(String, Option<String>, String), String> {
     let registration = dynamic_client_registration(
         registration_endpoint,
         &request.redirect_uri,

--- a/crates/harn-cli/src/commands/connect/store.rs
+++ b/crates/harn-cli/src/commands/connect/store.rs
@@ -138,7 +138,7 @@ pub(super) async fn run_connect_revoke(
     Ok(())
 }
 
-pub(super) fn parse_secret_id(raw: &str) -> Option<harn_vm::secrets::SecretId> {
+pub(crate) fn parse_secret_id(raw: &str) -> Option<harn_vm::secrets::SecretId> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return None;
@@ -157,13 +157,26 @@ pub(super) fn parse_secret_id(raw: &str) -> Option<harn_vm::secrets::SecretId> {
     Some(harn_vm::secrets::SecretId::new(namespace, name).with_version(version))
 }
 
-pub(super) fn connect_secret_provider() -> Result<KeyringSecretProvider, String> {
+pub(crate) fn connect_secret_provider() -> Result<KeyringSecretProvider, String> {
     let manifest_dir = resolve_manifest_path(None)
         .map(|(_, dir)| dir)
         .unwrap_or_else(|_| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
     Ok(KeyringSecretProvider::new(secret_namespace_for(
         &manifest_dir,
     )))
+}
+
+pub(crate) async fn load_connect_secret_text(secret_id: &str) -> Result<String, String> {
+    let id = parse_secret_id(secret_id)
+        .ok_or_else(|| format!("invalid secret id `{secret_id}`; expected namespace/name"))?;
+    let provider = connect_secret_provider()?;
+    let secret = provider
+        .get(&id)
+        .await
+        .map_err(|error| format!("failed to load {id}: {error}"))?;
+    secret
+        .with_exposed(|bytes| String::from_utf8(bytes.to_vec()))
+        .map_err(|error| format!("secret {id} is not valid UTF-8: {error}"))
 }
 
 pub(super) async fn save_connector_token(token: &StoredConnectorToken) -> Result<(), String> {

--- a/crates/harn-cli/src/commands/connect/tests.rs
+++ b/crates/harn-cli/src/commands/connect/tests.rs
@@ -479,6 +479,73 @@ async fn generic_mcp_oauth_discovers_metadata_and_registers_client() {
     server.join().expect("mock oauth server");
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn generic_oauth_prefers_default_cimd_client_before_dcr() {
+    let mut metadata = harn_vm::mcp_auth::OAuthAuthorizationServerMetadata {
+        issuer: "https://auth.example.com".to_string(),
+        authorization_endpoint: "https://auth.example.com/oauth/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/oauth/token".to_string(),
+        registration_endpoint: Some("https://auth.example.com/oauth/register".to_string()),
+        token_endpoint_auth_methods_supported: vec!["none".to_string()],
+        code_challenge_methods_supported: vec!["S256".to_string()],
+        scopes_supported: vec![],
+        client_id_metadata_document_supported: true,
+        authorization_response_iss_parameter_supported: false,
+        extra: Default::default(),
+    };
+    let request = OAuthConnectRequest {
+        provider: "remote".to_string(),
+        resource: "https://mcp.example.com/mcp".to_string(),
+        authorization_endpoint: None,
+        token_endpoint: None,
+        registration_endpoint: None,
+        client_id: None,
+        client_secret: None,
+        scopes: None,
+        redirect_uri: "http://127.0.0.1:49152/oauth/callback".to_string(),
+        token_auth_method: None,
+        no_open: true,
+        json: false,
+    };
+    let discovery = OAuthDiscoveryResult {
+        metadata: metadata.clone(),
+        issuer: metadata.issuer.clone(),
+        scopes: vec![],
+    };
+    let (client_id, client_secret, auth_method) = resolve_oauth_client(
+        &request,
+        Some(&discovery),
+        metadata.registration_endpoint.as_deref(),
+    )
+    .await
+    .expect("client auth");
+    assert_eq!(
+        client_id,
+        harn_vm::mcp_auth::DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL
+    );
+    assert_eq!(client_secret, None);
+    assert_eq!(auth_method, "none");
+
+    metadata.client_id_metadata_document_supported = false;
+    let discovery = OAuthDiscoveryResult {
+        metadata: metadata.clone(),
+        issuer: metadata.issuer.clone(),
+        scopes: vec![],
+    };
+    let (base_url, server) = spawn_dynamic_registration_only_server();
+    let mut request = request;
+    request.registration_endpoint = Some(format!("{base_url}/oauth/register"));
+    let (client_id, _, _) = resolve_oauth_client(
+        &request,
+        Some(&discovery),
+        request.registration_endpoint.as_deref(),
+    )
+    .await
+    .expect("dcr client auth");
+    assert_eq!(client_id, "dynamic-client");
+    server.join().expect("mock dcr server");
+}
+
 fn spawn_token_endpoint<F>(assert_form: F) -> String
 where
     F: FnOnce(BTreeMap<String, String>) + Send + 'static,
@@ -499,6 +566,22 @@ where
         );
     });
     format!("http://127.0.0.1:{port}/oauth/token")
+}
+
+fn spawn_dynamic_registration_only_server() -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("mock dcr listener");
+    let port = listener.local_addr().unwrap().port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("registration request");
+        let request = read_http_request(&mut stream);
+        assert!(request.contains("http://127.0.0.1:49152/oauth/callback"));
+        write_json_response(
+            &mut stream,
+            r#"{"client_id":"dynamic-client","token_endpoint_auth_method":"none"}"#,
+        );
+    });
+    (base_url, handle)
 }
 
 fn spawn_generic_mcp_oauth_server() -> (String, thread::JoinHandle<()>) {

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -185,6 +185,7 @@ const MCP_OAUTH_CLIENT_REGISTRATION_MODES: &[&str] = &[
     "dynamic_client_registration",
     "manual",
 ];
+const MCP_OAUTH_AUTH_MODES: &[&str] = &["cimd", "dcr", "static", "byo"];
 const MCP_OAUTH_APPLICATION_TYPES: &[&str] = &["native", "web"];
 const MCP_LOGGING_LEVELS: &[&str] = &[
     "debug",
@@ -435,6 +436,7 @@ fn generate_manifest() -> Result<String, String> {
                 "message": MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR_MESSAGE,
             },
             "oauthClientRegistrationModes": MCP_OAUTH_CLIENT_REGISTRATION_MODES,
+            "oauthAuthModes": MCP_OAUTH_AUTH_MODES,
             "oauthApplicationTypes": MCP_OAUTH_APPLICATION_TYPES,
             "loggingLevels": MCP_LOGGING_LEVELS,
         },
@@ -680,6 +682,11 @@ fn generate_typescript() -> String {
         "MCP_OAUTH_CLIENT_REGISTRATION_MODES",
         MCP_OAUTH_CLIENT_REGISTRATION_MODES,
         "MCPOAuthClientRegistrationMode",
+    ));
+    out.push_str(&ts_array(
+        "MCP_OAUTH_AUTH_MODES",
+        MCP_OAUTH_AUTH_MODES,
+        "MCPOAuthAuthMode",
     ));
     out.push_str(&ts_array(
         "MCP_OAUTH_APPLICATION_TYPES",
@@ -1164,6 +1171,10 @@ fn generate_swift() -> String {
         MCP_OAUTH_CLIENT_REGISTRATION_MODES,
     ));
     out.push_str(&swift_string_array(
+        "mcpOAuthAuthModes",
+        MCP_OAUTH_AUTH_MODES,
+    ));
+    out.push_str(&swift_string_array(
         "mcpOAuthApplicationTypes",
         MCP_OAUTH_APPLICATION_TYPES,
     ));
@@ -1260,6 +1271,10 @@ fn generate_swift() -> String {
     out.push_str(&swift_enum(
         "HarnMCPOAuthClientRegistrationMode",
         &strs_to_strings(MCP_OAUTH_CLIENT_REGISTRATION_MODES),
+    ));
+    out.push_str(&swift_enum(
+        "HarnMCPOAuthAuthMode",
+        &strs_to_strings(MCP_OAUTH_AUTH_MODES),
     ));
     out.push_str(&swift_enum(
         "HarnMCPOAuthApplicationType",
@@ -4078,6 +4093,7 @@ mod tests {
         assert!(ts.contains("export interface MCPInputRequiredResult"));
         assert!(ts.contains("export interface MCPOAuthDiscoveryResult"));
         assert!(ts.contains("MCP_OAUTH_CLIENT_REGISTRATION_MODES"));
+        assert!(ts.contains("MCP_OAUTH_AUTH_MODES"));
         assert!(ts.contains("application_type: MCPOAuthApplicationType"));
         assert!(ts.contains("MCP_UNSUPPORTED_PROTOCOL_VERSION_ERROR"));
         assert!(ts.contains("server/discover"));
@@ -4102,6 +4118,7 @@ mod tests {
         assert!(swift.contains("public struct HarnMCPInputRequiredResult"));
         assert!(swift.contains("public struct HarnMCPOAuthDiscoveryResult"));
         assert!(swift.contains("public enum HarnMCPOAuthClientRegistrationMode"));
+        assert!(swift.contains("public enum HarnMCPOAuthAuthMode"));
         assert!(swift.contains("case applicationType = \"application_type\""));
         assert!(swift.contains("HarnMCPUnsupportedProtocolVersionError"));
         assert!(

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -7,11 +7,11 @@ use base64::Engine;
 use harn_vm::mcp_auth::{
     authorization_code_token_form, build_oauth_authorization_url, canonical_resource_indicator,
     determine_token_endpoint_auth_method, discover_mcp_oauth, dynamic_client_registration_body,
-    ensure_pkce_s256_supported, refresh_token_form, select_client_registration_mode,
+    ensure_pkce_s256_supported, refresh_token_form, select_oauth_client_auth,
     validate_authorization_response_issuer, validate_issuer_binding,
     validate_token_endpoint_auth_method, OAuthAuthorizationCodeTokenForm,
-    OAuthAuthorizationUrlOptions, OAuthClientRegistrationMode, OAuthClientRegistrationOptions,
-    OAuthRefreshTokenForm,
+    OAuthAuthorizationUrlOptions, OAuthClientAuthMode, OAuthClientAuthOptions,
+    OAuthRefreshTokenForm, DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL,
 };
 use harn_vm::secrets::{KeyringSecretProvider, SecretBytes, SecretId, SecretProvider};
 use serde::{Deserialize, Serialize};
@@ -19,7 +19,7 @@ use sha2::{Digest, Sha256};
 use url::Url;
 
 use crate::cli::{McpCommand, McpLoginArgs, McpServerRefArgs};
-use crate::package::{self, McpServerConfig};
+use crate::package::{self, McpAuthConfig, McpServerConfig};
 
 mod oauth_resource;
 pub(crate) mod presets;
@@ -34,6 +34,7 @@ use harn_vm::mcp_protocol::PROTOCOL_VERSION as MCP_PROTOCOL_VERSION;
 pub(crate) struct ResolvedMcpServer {
     pub name: String,
     pub url: String,
+    pub auth: Option<McpAuthConfig>,
     pub client_id: Option<String>,
     pub client_secret: Option<String>,
     pub scopes: Option<String>,
@@ -282,8 +283,8 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
 
     let mut last_error = None;
     let state = if transport == "http" && !server.url.is_empty() {
-        // A configured static bearer token is treated as connected; an
-        // OAuth server is `auth_required` until a token is stored.
+        // HTTP servers are connected when a static bearer token or stored OAuth
+        // token is available; otherwise callers need to run the configured auth flow.
         if server.auth_token.as_deref().is_some_and(|t| !t.is_empty()) {
             "connected".to_string()
         } else {
@@ -322,6 +323,20 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
 pub(crate) async fn resolve_auth_for_server(
     server: &McpServerConfig,
 ) -> Result<AuthResolution, String> {
+    if let Some(auth) = server.auth.as_ref() {
+        if auth.mode == Some(OAuthClientAuthMode::Static) || auth.secret_id.is_some() {
+            let secret_id = auth.secret_id.as_deref().ok_or_else(|| {
+                format!(
+                    "MCP server '{}' uses static auth but does not set auth.secret_id",
+                    server.name
+                )
+            })?;
+            let token =
+                crate::commands::connect::store::load_connect_secret_text(secret_id).await?;
+            return Ok(AuthResolution::Bearer(token));
+        }
+    }
+
     if let Some(token) = &server.auth_token {
         if !token.is_empty() {
             return Ok(AuthResolution::Bearer(token.clone()));
@@ -362,53 +377,92 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
     let requested_scopes = options
         .scope
         .clone()
+        .or_else(|| server.auth.as_ref().and_then(|auth| auth.scopes.clone()))
         .or(server.scopes.clone())
         .or_else(|| (!discovery.scopes.is_empty()).then(|| discovery.scopes.join(" ")));
 
-    let configured_client_id = options.client_id.clone().or(server.client_id.clone());
-    let configured_client_secret = options
-        .client_secret
+    let configured_client_id = options
+        .client_id
         .clone()
-        .or(server.client_secret.clone());
-    let registration_mode = select_client_registration_mode(
+        .or_else(|| server.auth.as_ref().and_then(|auth| auth.client_id.clone()))
+        .or(server.client_id.clone());
+    let configured_client_secret = if let Some(secret) = options.client_secret.clone() {
+        Some(secret)
+    } else if let Some(secret_id) = server
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.client_secret_id.as_deref())
+    {
+        Some(crate::commands::connect::store::load_connect_secret_text(secret_id).await?)
+    } else {
+        server.client_secret.clone()
+    };
+    let auth_selection = select_oauth_client_auth(
         &discovery.metadata,
-        OAuthClientRegistrationOptions {
+        OAuthClientAuthOptions {
+            mode: server.auth.as_ref().and_then(|auth| auth.mode),
             client_id: configured_client_id.as_deref(),
             client_secret: configured_client_secret.as_deref(),
             client_id_metadata_document_url: configured_client_id.as_deref(),
+            static_secret_id: server
+                .auth
+                .as_ref()
+                .and_then(|auth| auth.secret_id.as_deref()),
         },
-    );
-    let (client_id, client_secret, token_auth_method) = if let Some(client_id) =
-        configured_client_id.clone()
-    {
-        let token_auth_method =
-            determine_token_auth_method(&discovery.metadata, configured_client_secret.as_ref())?;
-        (client_id, configured_client_secret, token_auth_method)
-    } else if registration_mode == OAuthClientRegistrationMode::DynamicClientRegistration {
-        let registration_endpoint = discovery
-            .metadata
-            .registration_endpoint
-            .as_deref()
-            .ok_or_else(|| "dynamic client registration endpoint missing".to_string())?;
-        let registration = dynamic_client_registration(
-            registration_endpoint,
-            &options.redirect_uri,
-            requested_scopes.as_deref(),
-        )
-        .await?;
-        let auth_method = registration
-            .token_endpoint_auth_method
-            .clone()
-            .unwrap_or_else(|| "none".to_string());
-        (
-            registration.client_id,
-            registration.client_secret,
-            auth_method,
-        )
-    } else {
-        return Err(
-            "No client_id available. Supply --client-id, use a Client ID Metadata Document URL as --client-id when supported, or use a server that supports dynamic client registration.".to_string()
-        );
+    )?;
+    let (client_id, client_secret, token_auth_method) = match auth_selection.mode {
+        OAuthClientAuthMode::Cimd => {
+            let client_id = auth_selection
+                .client_id
+                .unwrap_or(DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL)
+                .to_string();
+            (client_id, None, "none".to_string())
+        }
+        OAuthClientAuthMode::Byo => {
+            let client_id = auth_selection
+                .client_id
+                .ok_or_else(|| "BYO OAuth auth requires client_id".to_string())?
+                .to_string();
+            let token_auth_method = server
+                .auth
+                .as_ref()
+                .and_then(|auth| auth.token_endpoint_auth_method.clone())
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    determine_token_auth_method(
+                        &discovery.metadata,
+                        configured_client_secret.as_ref(),
+                    )
+                })?;
+            (client_id, configured_client_secret, token_auth_method)
+        }
+        OAuthClientAuthMode::Dcr => {
+            let registration_endpoint = discovery
+                .metadata
+                .registration_endpoint
+                .as_deref()
+                .ok_or_else(|| "dynamic client registration endpoint missing".to_string())?;
+            let registration = dynamic_client_registration(
+                registration_endpoint,
+                &options.redirect_uri,
+                requested_scopes.as_deref(),
+            )
+            .await?;
+            let auth_method = registration
+                .token_endpoint_auth_method
+                .clone()
+                .unwrap_or_else(|| "none".to_string());
+            (
+                registration.client_id,
+                registration.client_secret,
+                auth_method,
+            )
+        }
+        OAuthClientAuthMode::Static => {
+            return Err(
+                "static MCP auth uses a stored bearer token and does not run OAuth login; use `harn connect api-key --connector <name> --secret-id <namespace/name>` to store it".to_string()
+            );
+        }
     };
 
     let (code_verifier, code_challenge) = generate_pkce_pair();
@@ -478,6 +532,7 @@ fn resolve_server_reference(server_ref: &McpServerRefArgs) -> Result<ResolvedMcp
                 .clone()
                 .unwrap_or_else(|| infer_name_from_url(url)),
             url: url.clone(),
+            auth: None,
             client_id: None,
             client_secret: None,
             scopes: None,
@@ -492,6 +547,7 @@ fn resolve_server_reference(server_ref: &McpServerRefArgs) -> Result<ResolvedMcp
         return Ok(ResolvedMcpServer {
             name: infer_name_from_url(target),
             url: target.clone(),
+            auth: None,
             client_id: None,
             client_secret: None,
             scopes: None,
@@ -513,6 +569,7 @@ fn resolve_server_reference(server_ref: &McpServerRefArgs) -> Result<ResolvedMcp
     Ok(ResolvedMcpServer {
         name: server.name,
         url: server.url,
+        auth: server.auth,
         client_id: server.client_id,
         client_secret: server.client_secret,
         scopes: server.scopes,
@@ -1045,6 +1102,27 @@ mod tests {
 
     fn parse_server(toml_table: &str) -> McpServerConfig {
         toml::from_str::<McpServerConfig>(toml_table).expect("mcp server config")
+    }
+
+    #[test]
+    fn mcp_server_parses_unified_auth_config() {
+        let server = parse_server(
+            r#"
+name = "remote"
+transport = "http"
+url = "https://mcp.example.com/mcp"
+auth = { mode = "byo", client_id = "registered-client", client_secret_id = "mcp/client-secret", token_auth_method = "client_secret_post", scopes = "read write" }
+"#,
+        );
+        let auth = server.auth.expect("auth config");
+        assert_eq!(auth.mode, Some(OAuthClientAuthMode::Byo));
+        assert_eq!(auth.client_id.as_deref(), Some("registered-client"));
+        assert_eq!(auth.client_secret_id.as_deref(), Some("mcp/client-secret"));
+        assert_eq!(
+            auth.token_endpoint_auth_method.as_deref(),
+            Some("client_secret_post")
+        );
+        assert_eq!(auth.scopes.as_deref(), Some("read write"));
     }
 
     #[tokio::test]

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -644,6 +644,8 @@ pub struct McpServerConfig {
     #[serde(default)]
     pub auth_token: Option<String>,
     #[serde(default)]
+    pub auth: Option<McpAuthConfig>,
+    #[serde(default)]
     pub client_id: Option<String>,
     #[serde(default)]
     pub client_secret: Option<String>,
@@ -670,6 +672,33 @@ pub struct McpServerConfig {
     /// immediately. Ignored for non-lazy servers.
     #[serde(default, alias = "keep-alive-ms", alias = "keep_alive")]
     pub keep_alive_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct McpAuthConfig {
+    #[serde(default)]
+    pub mode: Option<harn_vm::mcp_auth::OAuthClientAuthMode>,
+    #[serde(default, alias = "client-id")]
+    pub client_id: Option<String>,
+    #[serde(
+        default,
+        alias = "client_secret_id",
+        alias = "client-secret-id",
+        alias = "client_secret_ref",
+        alias = "client-secret-ref"
+    )]
+    pub client_secret_id: Option<String>,
+    #[serde(
+        default,
+        alias = "secret_id",
+        alias = "secret-id",
+        alias = "token-secret-id"
+    )]
+    pub secret_id: Option<String>,
+    #[serde(default, alias = "scope")]
+    pub scopes: Option<String>,
+    #[serde(default, alias = "token_auth_method", alias = "token-auth-method")]
+    pub token_endpoint_auth_method: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/harn-vm/src/mcp_auth.rs
+++ b/crates/harn-vm/src/mcp_auth.rs
@@ -17,6 +17,8 @@ pub const OAUTH_PROTECTED_RESOURCE_WELL_KNOWN_PATH: &str = "/.well-known/oauth-p
 pub const OAUTH_AUTHORIZATION_SERVER_WELL_KNOWN_PATH: &str =
     "/.well-known/oauth-authorization-server";
 pub const OIDC_CONFIGURATION_WELL_KNOWN_PATH: &str = "/.well-known/openid-configuration";
+pub const DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL: &str =
+    "https://harnlang.com/.well-known/oauth-client.json";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WwwAuthenticateChallenge {
@@ -117,6 +119,26 @@ impl OAuthClientRegistrationMode {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OAuthClientAuthMode {
+    Cimd,
+    Dcr,
+    Static,
+    Byo,
+}
+
+impl OAuthClientAuthMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cimd => "cimd",
+            Self::Dcr => "dcr",
+            Self::Static => "static",
+            Self::Byo => "byo",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OAuthApplicationType {
@@ -138,6 +160,21 @@ pub struct OAuthClientRegistrationOptions<'a> {
     pub client_id: Option<&'a str>,
     pub client_secret: Option<&'a str>,
     pub client_id_metadata_document_url: Option<&'a str>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OAuthClientAuthOptions<'a> {
+    pub mode: Option<OAuthClientAuthMode>,
+    pub client_id: Option<&'a str>,
+    pub client_secret: Option<&'a str>,
+    pub client_id_metadata_document_url: Option<&'a str>,
+    pub static_secret_id: Option<&'a str>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OAuthClientAuthSelection<'a> {
+    pub mode: OAuthClientAuthMode,
+    pub client_id: Option<&'a str>,
 }
 
 #[derive(Clone, Debug)]
@@ -639,23 +676,126 @@ pub fn select_client_registration_mode(
     metadata: &OAuthAuthorizationServerMetadata,
     options: OAuthClientRegistrationOptions<'_>,
 ) -> OAuthClientRegistrationMode {
-    if let Some(client_id) = options.client_id {
-        if options.client_secret.is_none() && is_client_id_metadata_document_url(client_id) {
-            return OAuthClientRegistrationMode::ClientIdMetadataDocument;
-        }
-        return OAuthClientRegistrationMode::PreRegistered;
+    match select_oauth_client_auth(
+        metadata,
+        OAuthClientAuthOptions {
+            client_id: options.client_id,
+            client_secret: options.client_secret,
+            client_id_metadata_document_url: options.client_id_metadata_document_url,
+            ..OAuthClientAuthOptions::default()
+        },
+    ) {
+        Ok(selection) => match selection.mode {
+            OAuthClientAuthMode::Cimd => OAuthClientRegistrationMode::ClientIdMetadataDocument,
+            OAuthClientAuthMode::Dcr => OAuthClientRegistrationMode::DynamicClientRegistration,
+            OAuthClientAuthMode::Byo => OAuthClientRegistrationMode::PreRegistered,
+            OAuthClientAuthMode::Static => OAuthClientRegistrationMode::Manual,
+        },
+        Err(_) => OAuthClientRegistrationMode::Manual,
     }
-    if options
-        .client_id_metadata_document_url
-        .is_some_and(is_client_id_metadata_document_url)
-        && metadata.client_id_metadata_document_supported
-    {
-        return OAuthClientRegistrationMode::ClientIdMetadataDocument;
+}
+
+pub fn select_oauth_client_auth<'a>(
+    metadata: &OAuthAuthorizationServerMetadata,
+    options: OAuthClientAuthOptions<'a>,
+) -> Result<OAuthClientAuthSelection<'a>, String> {
+    if let Some(mode) = options.mode {
+        return match mode {
+            OAuthClientAuthMode::Static => {
+                if options.static_secret_id.is_none() {
+                    return Err("static MCP auth requires a secret_id".to_string());
+                }
+                Ok(OAuthClientAuthSelection {
+                    mode,
+                    client_id: None,
+                })
+            }
+            OAuthClientAuthMode::Byo => {
+                let client_id = options
+                    .client_id
+                    .ok_or_else(|| "BYO OAuth auth requires client_id".to_string())?;
+                Ok(OAuthClientAuthSelection {
+                    mode,
+                    client_id: Some(client_id),
+                })
+            }
+            OAuthClientAuthMode::Cimd => {
+                if !metadata.client_id_metadata_document_supported {
+                    return Err(
+                        "authorization server does not advertise Client ID Metadata Document support"
+                            .to_string(),
+                    );
+                }
+                let client_id = cimd_client_id(options);
+                if !is_client_id_metadata_document_url(client_id) {
+                    return Err(
+                        "CIMD OAuth auth requires an HTTPS client metadata document URL"
+                            .to_string(),
+                    );
+                }
+                Ok(OAuthClientAuthSelection {
+                    mode,
+                    client_id: Some(client_id),
+                })
+            }
+            OAuthClientAuthMode::Dcr => {
+                if metadata.registration_endpoint.is_none() {
+                    return Err(
+                        "authorization server does not advertise dynamic client registration"
+                            .to_string(),
+                    );
+                }
+                Ok(OAuthClientAuthSelection {
+                    mode,
+                    client_id: None,
+                })
+            }
+        };
+    }
+
+    if options.static_secret_id.is_some() {
+        return Ok(OAuthClientAuthSelection {
+            mode: OAuthClientAuthMode::Static,
+            client_id: None,
+        });
+    }
+
+    if let Some(client_id) = options.client_id {
+        if options.client_secret.is_none()
+            && is_client_id_metadata_document_url(client_id)
+            && metadata.client_id_metadata_document_supported
+        {
+            return Ok(OAuthClientAuthSelection {
+                mode: OAuthClientAuthMode::Cimd,
+                client_id: Some(client_id),
+            });
+        }
+        return Ok(OAuthClientAuthSelection {
+            mode: OAuthClientAuthMode::Byo,
+            client_id: Some(client_id),
+        });
+    }
+
+    if metadata.client_id_metadata_document_supported {
+        return Ok(OAuthClientAuthSelection {
+            mode: OAuthClientAuthMode::Cimd,
+            client_id: Some(cimd_client_id(options)),
+        });
     }
     if metadata.registration_endpoint.is_some() {
-        return OAuthClientRegistrationMode::DynamicClientRegistration;
+        return Ok(OAuthClientAuthSelection {
+            mode: OAuthClientAuthMode::Dcr,
+            client_id: None,
+        });
     }
-    OAuthClientRegistrationMode::Manual
+    Err("No OAuth client authentication mode is available. Configure auth.mode = \"byo\" with a client_id, auth.mode = \"static\" with a secret_id, or use an authorization server that supports CIMD or dynamic client registration.".to_string())
+}
+
+fn cimd_client_id<'a>(options: OAuthClientAuthOptions<'a>) -> &'a str {
+    options
+        .client_id_metadata_document_url
+        .or(options.client_id)
+        .unwrap_or(DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL)
 }
 
 pub fn is_client_id_metadata_document_url(client_id: &str) -> bool {
@@ -1194,6 +1334,10 @@ mod tests {
         );
         meta.client_id_metadata_document_supported = true;
         assert_eq!(
+            select_client_registration_mode(&meta, OAuthClientRegistrationOptions::default()),
+            OAuthClientRegistrationMode::ClientIdMetadataDocument
+        );
+        assert_eq!(
             select_client_registration_mode(
                 &meta,
                 OAuthClientRegistrationOptions {
@@ -1203,6 +1347,65 @@ mod tests {
             ),
             OAuthClientRegistrationMode::ClientIdMetadataDocument
         );
+    }
+
+    #[test]
+    fn oauth_client_auth_prefers_cimd_before_dcr() {
+        let mut meta = metadata(
+            "https://auth.example.com",
+            Some("https://auth.example.com/reg"),
+        );
+        meta.client_id_metadata_document_supported = true;
+        let selection = select_oauth_client_auth(&meta, OAuthClientAuthOptions::default()).unwrap();
+        assert_eq!(selection.mode, OAuthClientAuthMode::Cimd);
+        assert_eq!(
+            selection.client_id,
+            Some(DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL)
+        );
+    }
+
+    #[test]
+    fn oauth_client_auth_falls_back_to_dcr_without_cimd() {
+        let meta = metadata(
+            "https://auth.example.com",
+            Some("https://auth.example.com/reg"),
+        );
+        let selection = select_oauth_client_auth(&meta, OAuthClientAuthOptions::default()).unwrap();
+        assert_eq!(selection.mode, OAuthClientAuthMode::Dcr);
+        assert_eq!(selection.client_id, None);
+    }
+
+    #[test]
+    fn oauth_client_auth_accepts_byo_secret_references_as_byo() {
+        let meta = metadata("https://auth.example.com", None);
+        let selection = select_oauth_client_auth(
+            &meta,
+            OAuthClientAuthOptions {
+                mode: Some(OAuthClientAuthMode::Byo),
+                client_id: Some("registered-client"),
+                client_secret: Some("secret-from-store"),
+                ..OAuthClientAuthOptions::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(selection.mode, OAuthClientAuthMode::Byo);
+        assert_eq!(selection.client_id, Some("registered-client"));
+    }
+
+    #[test]
+    fn explicit_cimd_auth_requires_metadata_document_url() {
+        let mut meta = metadata("https://auth.example.com", None);
+        meta.client_id_metadata_document_supported = true;
+        let error = select_oauth_client_auth(
+            &meta,
+            OAuthClientAuthOptions {
+                mode: Some(OAuthClientAuthMode::Cimd),
+                client_id: Some("registered-client"),
+                ..OAuthClientAuthOptions::default()
+            },
+        )
+        .expect_err("invalid CIMD client id");
+        assert!(error.contains("metadata document URL"));
     }
 
     #[test]

--- a/docs/src/.well-known/oauth-client.json
+++ b/docs/src/.well-known/oauth-client.json
@@ -1,0 +1,15 @@
+{
+  "client_name": "Harn MCP Client",
+  "client_uri": "https://harnlang.com/",
+  "redirect_uris": [
+    "http://127.0.0.1/oauth/callback",
+    "http://localhost/oauth/callback",
+    "http://127.0.0.1:9783/oauth/callback",
+    "http://localhost:9783/oauth/callback"
+  ],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none",
+  "application_type": "native",
+  "scope": "mcp.read mcp.write"
+}

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -328,21 +328,50 @@ harn mcp redirect-uri
 harn mcp login notion
 ```
 
-If the server uses a pre-registered OAuth client, you can provide those
-values in `harn.toml` or on the CLI:
+OAuth client authentication uses one `auth` table. With no explicit
+configuration, `harn mcp login` prefers Client ID Metadata Document (CIMD)
+registration using Harn's published metadata document at
+`https://harnlang.com/.well-known/oauth-client.json`; if the authorization
+server does not advertise CIMD support, Harn falls back to dynamic client
+registration.
+
+For a pre-registered client, store the client secret with `harn connect
+api-key` and reference it from `auth.client_secret_id`:
+
+```bash
+harn connect api-key \
+  --connector internal-mcp \
+  --secret-id mcp/internal-client-secret
+```
 
 ```toml
 [[mcp]]
 name = "internal"
 transport = "http"
 url = "https://mcp.example.com"
-client_id = "https://client.example.com/metadata.json"
-client_secret = "super-secret"
-scopes = "read:docs write:docs"
+auth = { mode = "byo", client_id = "registered-client", client_secret_id = "mcp/internal-client-secret", scopes = "read:docs write:docs" }
 ```
 
-When no `client_id` is provided, Harn will attempt dynamic client
-registration if the authorization server advertises it.
+For a static bearer token or API key, reuse the same secret-store path:
+
+```bash
+harn connect api-key \
+  --connector internal-mcp \
+  --secret-id mcp/internal-bearer
+```
+
+```toml
+[[mcp]]
+name = "internal"
+transport = "http"
+url = "https://mcp.example.com"
+auth = { mode = "static", secret_id = "mcp/internal-bearer" }
+```
+
+The older top-level `client_id`, `client_secret`, `scopes`, and `auth_token`
+fields are accepted for local manifests, but new host-generated config should
+write the `auth = { mode = ... }` form so TUI and GUI clients do not need their
+own OAuth configuration model.
 
 ### Example: filesystem MCP server
 

--- a/docs/src/orchestrator/oauth.md
+++ b/docs/src/orchestrator/oauth.md
@@ -84,9 +84,12 @@ transient_provider_outage = "Retry after the provider or credential backend reco
 `transient_provider_outage`.
 
 When endpoints are not supplied, Harn discovers protected-resource metadata,
-then authorization-server metadata. If the server advertises dynamic client
-registration and no `--client-id` is supplied, Harn registers a loopback client
-for the selected redirect URI.
+then authorization-server metadata. For MCP login, the default client
+registration mode is CIMD: Harn sends
+`https://harnlang.com/.well-known/oauth-client.json` as its client id when the
+authorization server advertises Client ID Metadata Document support. If CIMD is
+not available and the server advertises dynamic client registration, Harn
+registers a loopback client for the selected redirect URI.
 
 GitHub App setup is separate from OAuth access tokens:
 

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -48,6 +48,12 @@ public enum HarnProtocolConstants {
         "dynamic_client_registration",
         "manual",
     ]
+    public static let mcpOAuthAuthModes: [String] = [
+        "cimd",
+        "dcr",
+        "static",
+        "byo",
+    ]
     public static let mcpOAuthApplicationTypes: [String] = [
         "native",
         "web",
@@ -527,6 +533,20 @@ public enum HarnMCPOAuthClientRegistrationMode: String, Codable, Sendable, CaseI
         "client_id_metadata_document",
         "dynamic_client_registration",
         "manual",
+    ].map { Self(rawValue: $0)! }
+}
+
+public enum HarnMCPOAuthAuthMode: String, Codable, Sendable, CaseIterable {
+    case cimd = "cimd"
+    case dcr = "dcr"
+    case `static` = "static"
+    case byo = "byo"
+
+    public static let allCases: [Self] = [
+        "cimd",
+        "dcr",
+        "static",
+        "byo",
     ].map { Self(rawValue: $0)! }
 }
 

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -338,6 +338,14 @@ export const MCP_OAUTH_CLIENT_REGISTRATION_MODES = [
 ] as const
 export type MCPOAuthClientRegistrationMode = (typeof MCP_OAUTH_CLIENT_REGISTRATION_MODES)[number]
 
+export const MCP_OAUTH_AUTH_MODES = [
+  "cimd",
+  "dcr",
+  "static",
+  "byo",
+] as const
+export type MCPOAuthAuthMode = (typeof MCP_OAUTH_AUTH_MODES)[number]
+
 export const MCP_OAUTH_APPLICATION_TYPES = [
   "native",
   "web",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -292,6 +292,12 @@
       "native",
       "web"
     ],
+    "oauthAuthModes": [
+      "cimd",
+      "dcr",
+      "static",
+      "byo"
+    ],
     "oauthClientRegistrationModes": [
       "pre_registered",
       "client_id_metadata_document",


### PR DESCRIPTION
## Summary
- add a unified MCP OAuth auth config shape with `cimd`, `dcr`, `static`, and `byo` modes
- default MCP OAuth client selection to Harn’s published CIMD metadata document, with DCR fallback
- let static bearer tokens and BYO client secrets reference the existing `harn connect api-key` secret store
- publish the CIMD metadata document and expose the new auth mode vocabulary in TS/Swift protocol artifacts

Closes #2645

## Verification
- `cargo test -p harn-vm mcp_auth::tests -- --nocapture`
- `cargo test -p harn-cli commands::mcp::tests -- --nocapture`
- `cargo test -p harn-cli commands::connect::tests::generic_oauth_prefers_default_cimd_client_before_dcr -- --nocapture`
- `make check-protocol-artifacts`
- `mdbook build docs`
- `make lint-test-patterns`
- `git diff --check`
- pre-commit hook
- pre-push hook