### PR TITLE
harn-cli: skip generated source walks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,7 @@ dependencies = [
  "harn-stdlib",
  "harn-vm",
  "hmac 0.13.0",
+ "ignore",
  "include_dir",
  "ipnet",
  "jmespath",

--- a/changelog.d/toolchain-walk.fixed.md
+++ b/changelog.d/toolchain-walk.fixed.md
@@ -1,0 +1,4 @@
+- **Harn source discovery now skips generated and local cache directories.**
+  `harn check`, `harn lint`, and `harn fmt` no longer recursively scan
+  dependency caches, build outputs, local run artifacts, or worktree copies
+  when a project directory is passed as the target.

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -47,6 +47,7 @@ harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
+ignore = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time", "process"] }
 serde_json = "1"
 serde_yml = "0.0.12"

--- a/crates/harn-cli/src/commands/check/config.rs
+++ b/crates/harn-cli/src/commands/check/config.rs
@@ -5,19 +5,43 @@ use std::process;
 use crate::config as harn_config;
 use crate::package::CheckConfig;
 
+#[derive(Clone, Debug, Default)]
+pub(crate) struct HarnLintConfig {
+    pub(crate) disabled: Vec<String>,
+    pub(crate) require_file_header: bool,
+    pub(crate) complexity_threshold: Option<usize>,
+    pub(crate) persona_step_allowlist: Vec<String>,
+    pub(crate) template_variant_branch_threshold: Option<usize>,
+}
+
+pub(crate) fn load_harn_lint_config(path: &Path) -> HarnLintConfig {
+    match harn_config::load_for_path(path) {
+        Ok(cfg) => HarnLintConfig {
+            disabled: cfg.lint.disabled.unwrap_or_default(),
+            require_file_header: cfg.lint.require_file_header.unwrap_or(false),
+            complexity_threshold: cfg.lint.complexity_threshold,
+            persona_step_allowlist: cfg.lint.persona_step_allowlist,
+            template_variant_branch_threshold: cfg.lint.template_variant_branch_threshold,
+        },
+        Err(e) => {
+            eprintln!("warning: {e}");
+            HarnLintConfig::default()
+        }
+    }
+}
+
 /// Merge `[lint].disabled` from the nearest harn.toml into `disable_rules`.
 /// The `require_file_header` flag is handled separately via
 /// [`harn_lint_require_file_header`] so it can be enabled without a full
 /// `[check]` section.
 pub(crate) fn apply_harn_lint_config(path: &Path, config: &mut CheckConfig) {
-    let Ok(cfg) = harn_config::load_for_path(path) else {
-        return;
-    };
-    if let Some(disabled) = cfg.lint.disabled {
-        for rule in disabled {
-            if !config.disable_rules.iter().any(|r| r == &rule) {
-                config.disable_rules.push(rule);
-            }
+    apply_loaded_harn_lint_config(&load_harn_lint_config(path), config);
+}
+
+pub(crate) fn apply_loaded_harn_lint_config(lint: &HarnLintConfig, config: &mut CheckConfig) {
+    for rule in &lint.disabled {
+        if !config.disable_rules.iter().any(|r| r == rule) {
+            config.disable_rules.push(rule.clone());
         }
     }
 }
@@ -59,57 +83,8 @@ pub(crate) fn harn_lint_persona_step_allowlist(path: &Path) -> Vec<String> {
     }
 }
 
-/// Read `[lint] template_variant_branch_threshold` from the nearest
-/// harn.toml. Returns `None` when unset; the
-/// `template-variant-explosion` rule falls back to
-/// [`harn_lint::DEFAULT_TEMPLATE_VARIANT_BRANCH_THRESHOLD`].
-pub(crate) fn harn_lint_template_variant_branch_threshold(path: &Path) -> Option<usize> {
-    match harn_config::load_for_path(path) {
-        Ok(cfg) => cfg.lint.template_variant_branch_threshold,
-        Err(e) => {
-            eprintln!("warning: {e}");
-            None
-        }
-    }
-}
-
-/// Read `[lint] disabled` from the nearest harn.toml.
-pub(crate) fn harn_lint_disabled_rules(path: &Path) -> Vec<String> {
-    match harn_config::load_for_path(path) {
-        Ok(cfg) => cfg.lint.disabled.unwrap_or_default(),
-        Err(e) => {
-            eprintln!("warning: {e}");
-            Vec::new()
-        }
-    }
-}
-
 pub(crate) fn collect_harn_targets(targets: &[&str]) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    for target in targets {
-        let path = Path::new(target);
-        if path.is_dir() {
-            super::super::collect_harn_files(path, &mut files);
-        } else if is_harn_program_file(path) {
-            files.push(path.to_path_buf());
-        }
-    }
-    files.sort();
-    files.dedup();
-    files
-}
-
-/// Recognize `.harn` program files while excluding `.harn.prompt`
-/// (which `harn lint` routes through the prompt-template lint pass
-/// instead — see `commands::check::template_lint`).
-fn is_harn_program_file(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-        return false;
-    };
-    if name.ends_with(".harn.prompt") || name.ends_with(".prompt") {
-        return false;
-    }
-    path.extension().is_some_and(|ext| ext == "harn")
+    super::super::collect_source_targets(targets, true, false).harn
 }
 
 /// Collect every function name that appears in a selective import across

--- a/crates/harn-cli/src/commands/check/fmt.rs
+++ b/crates/harn-cli/src/commands/check/fmt.rs
@@ -106,11 +106,13 @@ pub(crate) fn fmt_targets_report(targets: &[&str], mode: FmtMode, opts: &FmtOpti
     for target in targets {
         let path = std::path::Path::new(target);
         if path.is_dir() {
-            super::super::collect_harn_files(path, &mut files);
+            files.extend(super::super::collect_source_targets(&[target], true, false).harn);
         } else {
             files.push(path.to_path_buf());
         }
     }
+    files.sort();
+    files.dedup();
     if files.is_empty() {
         return FmtReport {
             files: Vec::new(),

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -26,13 +26,13 @@ pub(crate) use check_cmd::{
     check_file_inner, check_file_report, CheckReport, CHECK_SCHEMA_VERSION,
 };
 pub(crate) use config::{
-    apply_harn_lint_config, build_module_graph, collect_cross_file_imports, collect_harn_targets,
-    harn_lint_complexity_threshold, harn_lint_disabled_rules, harn_lint_persona_step_allowlist,
-    harn_lint_require_file_header, harn_lint_template_variant_branch_threshold,
+    apply_harn_lint_config, apply_loaded_harn_lint_config, build_module_graph,
+    collect_cross_file_imports, collect_harn_targets, harn_lint_complexity_threshold,
+    harn_lint_persona_step_allowlist, harn_lint_require_file_header, load_harn_lint_config,
 };
 pub(crate) use fmt::{fmt_targets, fmt_targets_json, FmtMode, FMT_SCHEMA_VERSION};
 pub(crate) use host_capabilities::load_host_capabilities;
 pub(crate) use lint::{lint_file_inner, lint_fix_file, path_is_stdlib_source};
 pub(crate) use lint_report::{lint_file_report, LintFileReport, LintReport, LINT_SCHEMA_VERSION};
 pub(crate) use preflight::{collect_preflight_diagnostics, is_preflight_allowed};
-pub(crate) use template_lint::{collect_prompt_targets, lint_prompt_file_inner};
+pub(crate) use template_lint::{collect_lint_targets, lint_prompt_file_inner};

--- a/crates/harn-cli/src/commands/check/template_lint.rs
+++ b/crates/harn-cli/src/commands/check/template_lint.rs
@@ -17,45 +17,9 @@ use harn_lint::LintSeverity;
 
 use super::outcome::{print_lint_diagnostics, CommandOutcome};
 
-/// Recursively gather `.harn.prompt` / `.prompt` files under `targets`.
-/// Targets that are files themselves are returned as-is when they
-/// match one of those extensions.
-pub(crate) fn collect_prompt_targets(targets: &[&str]) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    for target in targets {
-        let path = Path::new(target);
-        if path.is_dir() {
-            collect_prompt_files(path, &mut files);
-        } else if is_prompt_file(path) {
-            files.push(path.to_path_buf());
-        }
-    }
-    files.sort();
-    files.dedup();
-    files
-}
-
-fn collect_prompt_files(dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
-    entries.sort_by_key(|e| e.path());
-    for entry in entries {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_prompt_files(&path, out);
-        } else if is_prompt_file(&path) {
-            out.push(path);
-        }
-    }
-}
-
-fn is_prompt_file(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-        return false;
-    };
-    name.ends_with(".harn.prompt") || name.ends_with(".prompt")
+pub(crate) fn collect_lint_targets(targets: &[&str]) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let files = super::super::collect_source_targets(targets, true, true);
+    (files.harn, files.prompts)
 }
 
 /// Lint a single `.harn.prompt` template. Prints diagnostics through

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -1067,8 +1067,52 @@ pipeline main() {
 fn collect_harn_targets_recurses_directories_and_deduplicates() {
     let dir = unique_temp_dir("harn-check-targets");
     std::fs::create_dir_all(dir.join("nested")).unwrap();
+    std::fs::create_dir_all(dir.join(".build").join("generated")).unwrap();
+    std::fs::create_dir_all(dir.join(".claude").join("worktrees").join("copy")).unwrap();
+    std::fs::create_dir_all(dir.join(".harn-eval-abc123")).unwrap();
+    std::fs::create_dir_all(dir.join("node_modules").join("pkg")).unwrap();
     std::fs::write(dir.join("a.harn"), "pipeline a() {}\n").unwrap();
     std::fs::write(dir.join("nested").join("b.harn"), "pipeline b() {}\n").unwrap();
+    std::fs::write(
+        dir.join("nested").join("skipped.harn"),
+        "pipeline skipped() {}\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join("nested").join("skipped.conformance-skip"), "").unwrap();
+    std::fs::write(
+        dir.join("ignored_by_gitignore.harn"),
+        "pipeline ignored() {}\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join(".gitignore"), "ignored_by_gitignore.harn\n").unwrap();
+    std::fs::write(
+        dir.join(".build").join("generated").join("ignored.harn"),
+        "pipeline generated() {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join(".claude")
+            .join("worktrees")
+            .join("copy")
+            .join("ignored.harn"),
+        "pipeline worktree_copy() {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join(".harn-eval-abc123").join("ignored.harn"),
+        "pipeline eval_scratch() {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join(".harn-eval-abc123.harn"),
+        "pipeline eval_scratch_file() {}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("node_modules").join("pkg").join("ignored.harn"),
+        "pipeline dependency() {}\n",
+    )
+    .unwrap();
     std::fs::write(dir.join("nested").join("ignore.txt"), "x\n").unwrap();
 
     let target_dir = dir.display().to_string();
@@ -1078,6 +1122,29 @@ fn collect_harn_targets_recurses_directories_and_deduplicates() {
     assert_eq!(files.len(), 2);
     assert!(files.contains(&dir.join("a.harn")));
     assert!(files.contains(&dir.join("nested").join("b.harn")));
+    assert!(!files.contains(&dir.join("ignored_by_gitignore.harn")));
+    assert!(!files.contains(&dir.join("nested").join("skipped.harn")));
+
+    let ignored_file = dir.join("ignored_by_gitignore.harn").display().to_string();
+    let skipped_file = dir
+        .join("nested")
+        .join("skipped.harn")
+        .display()
+        .to_string();
+    let explicit_files = collect_harn_targets(&[ignored_file.as_str(), skipped_file.as_str()]);
+    assert_eq!(
+        explicit_files,
+        vec![
+            dir.join("ignored_by_gitignore.harn"),
+            dir.join("nested").join("skipped.harn"),
+        ]
+    );
+    let explicit_generated_dir = dir.join(".harn-eval-abc123").display().to_string();
+    let generated_files = collect_harn_targets(&[explicit_generated_dir.as_str()]);
+    assert_eq!(
+        generated_files,
+        vec![dir.join(".harn-eval-abc123").join("ignored.harn")]
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -1448,17 +1515,38 @@ fn lint_prompt_file_respects_disabled_rules() {
 
 #[test]
 fn lint_collects_prompt_targets_from_directories() {
-    use super::template_lint::collect_prompt_targets;
+    use super::template_lint::collect_lint_targets;
     let dir = unique_temp_dir("harn-lint-prompt-collect");
     std::fs::create_dir_all(dir.join("nested")).unwrap();
+    std::fs::create_dir_all(dir.join("target").join("debug")).unwrap();
+    std::fs::create_dir_all(dir.join(".harn").join("cache")).unwrap();
     std::fs::write(dir.join("a.harn.prompt"), "x").unwrap();
     std::fs::write(dir.join("nested").join("b.harn.prompt"), "y").unwrap();
+    std::fs::write(dir.join("ignored_by_gitignore.prompt"), "ignored").unwrap();
+    std::fs::write(dir.join(".gitignore"), "ignored_by_gitignore.prompt\n").unwrap();
+    std::fs::write(
+        dir.join("target").join("debug").join("ignored.harn.prompt"),
+        "z",
+    )
+    .unwrap();
+    std::fs::write(dir.join(".harn").join("cache").join("ignored.prompt"), "z").unwrap();
     std::fs::write(dir.join("c.txt"), "ignore").unwrap();
     let target = dir.display().to_string();
-    let files = collect_prompt_targets(&[target.as_str()]);
+    let (_harn_files, files) = collect_lint_targets(&[target.as_str()]);
     assert_eq!(files.len(), 2);
     assert!(files.contains(&dir.join("a.harn.prompt")));
     assert!(files.contains(&dir.join("nested").join("b.harn.prompt")));
+    assert!(!files.contains(&dir.join("ignored_by_gitignore.prompt")));
+
+    let explicit = dir
+        .join("ignored_by_gitignore.prompt")
+        .display()
+        .to_string();
+    let (_harn_files, explicit_files) = collect_lint_targets(&[explicit.as_str()]);
+    assert_eq!(
+        explicit_files,
+        vec![dir.join("ignored_by_gitignore.prompt")]
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -78,6 +78,148 @@ pub(crate) mod workflow;
 
 use std::path::{Path, PathBuf};
 
+use ignore::WalkBuilder;
+
+const GENERATED_SOURCE_WALK_DIRS: &[&str] = &[
+    ".burin",
+    ".build",
+    ".claude",
+    ".codex",
+    ".git",
+    ".harn",
+    ".harn-runs",
+    ".next",
+    ".svelte-kit",
+    ".turbo",
+    ".venv",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "target",
+];
+
+pub(crate) fn should_skip_recursive_source_dir(dir: &Path) -> bool {
+    let Some(name) = dir.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    GENERATED_SOURCE_WALK_DIRS.contains(&name) || name.starts_with(".harn-")
+}
+
+pub(crate) fn should_skip_recursive_source_file(file: &Path) -> bool {
+    let Some(name) = file.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    name.starts_with(".harn-")
+}
+
+#[derive(Default)]
+pub(crate) struct SourceTargets {
+    pub(crate) harn: Vec<PathBuf>,
+    pub(crate) prompts: Vec<PathBuf>,
+}
+
+impl SourceTargets {
+    fn sort_and_dedup(&mut self) {
+        self.harn.sort();
+        self.harn.dedup();
+        self.prompts.sort();
+        self.prompts.dedup();
+    }
+}
+
+pub(crate) fn collect_source_targets(
+    targets: &[&str],
+    include_harn: bool,
+    include_prompts: bool,
+) -> SourceTargets {
+    let mut files = SourceTargets::default();
+    for target in targets {
+        let path = Path::new(target);
+        if path.is_dir() {
+            collect_source_targets_dir(path, include_harn, include_prompts, &mut files);
+        } else {
+            push_matching_source_target(path, include_harn, include_prompts, false, &mut files);
+        }
+    }
+    files.sort_and_dedup();
+    files
+}
+
+fn collect_source_targets_dir(
+    dir: &Path,
+    include_harn: bool,
+    include_prompts: bool,
+    files: &mut SourceTargets,
+) {
+    let root = dir.to_path_buf();
+    let mut walker = WalkBuilder::new(dir);
+    walker
+        .hidden(false)
+        .ignore(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .require_git(false)
+        .parents(true)
+        .follow_links(false)
+        .filter_entry(move |entry| {
+            let path = entry.path();
+            if path == root {
+                return true;
+            }
+            if path.is_dir() {
+                !should_skip_recursive_source_dir(path)
+            } else {
+                !should_skip_recursive_source_file(path)
+            }
+        });
+
+    for entry in walker.build().filter_map(Result::ok) {
+        let path = entry.path();
+        if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_file())
+        {
+            push_matching_source_target(path, include_harn, include_prompts, true, files);
+        }
+    }
+}
+
+fn push_matching_source_target(
+    path: &Path,
+    include_harn: bool,
+    include_prompts: bool,
+    honor_skip_marker: bool,
+    files: &mut SourceTargets,
+) {
+    if include_prompts && is_harn_prompt_file(path) {
+        files.prompts.push(path.to_path_buf());
+    } else if include_harn && is_harn_program_file(path) {
+        let skip_marker = path.with_extension("conformance-skip");
+        if !honor_skip_marker || !skip_marker.exists() {
+            files.harn.push(path.to_path_buf());
+        }
+    }
+}
+
+pub(crate) fn is_harn_program_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if name.ends_with(".harn.prompt") || name.ends_with(".prompt") {
+        return false;
+    }
+    path.extension().is_some_and(|ext| ext == "harn")
+}
+
+pub(crate) fn is_harn_prompt_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    name.ends_with(".harn.prompt") || name.ends_with(".prompt")
+}
+
 /// Recursively collect `.harn` files under `dir`, sorted by path. Files with a
 /// sibling `<name>.conformance-skip` marker are excluded — used to temporarily
 /// park tests that are tracking a known regression in an issue so `make test`
@@ -89,7 +231,12 @@ pub(crate) fn collect_harn_files(dir: &Path, out: &mut Vec<PathBuf>) {
         for entry in entries {
             let path = entry.path();
             if path.is_dir() {
+                if should_skip_recursive_source_dir(&path) {
+                    continue;
+                }
                 collect_harn_files(&path, out);
+            } else if should_skip_recursive_source_file(&path) {
+                continue;
             } else if path.extension().is_some_and(|ext| ext == "harn") {
                 let skip_marker = path.with_extension("conformance-skip");
                 if skip_marker.exists() {

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -558,8 +558,7 @@ async fn async_main() {
         }
         Command::Lint(args) => {
             let targets: Vec<&str> = args.targets.iter().map(String::as_str).collect();
-            let files = commands::check::collect_harn_targets(&targets);
-            let prompt_files = commands::check::collect_prompt_targets(&targets);
+            let (files, prompt_files) = commands::check::collect_lint_targets(&targets);
             if files.is_empty() && prompt_files.is_empty() {
                 if args.json {
                     print_lint_error(
@@ -581,13 +580,11 @@ async fn async_main() {
                 let mut json_files: Vec<commands::check::LintFileReport> = Vec::new();
                 for file in &files {
                     let mut config = package::load_check_config(Some(file));
-                    commands::check::apply_harn_lint_config(file, &mut config);
-                    let require_header = args.require_file_header
-                        || commands::check::harn_lint_require_file_header(file);
-                    let complexity_threshold =
-                        commands::check::harn_lint_complexity_threshold(file);
-                    let persona_step_allowlist =
-                        commands::check::harn_lint_persona_step_allowlist(file);
+                    let lint_config = commands::check::load_harn_lint_config(file);
+                    commands::check::apply_loaded_harn_lint_config(&lint_config, &mut config);
+                    let require_header =
+                        args.require_file_header || lint_config.require_file_header;
+                    let complexity_threshold = lint_config.complexity_threshold;
                     let report = commands::check::lint_file_report(
                         &mut analysis,
                         file,
@@ -596,7 +593,7 @@ async fn async_main() {
                         &module_graph,
                         require_header,
                         complexity_threshold,
-                        &persona_step_allowlist,
+                        &lint_config.persona_step_allowlist,
                     );
                     should_fail |= report.outcome().should_fail(config.strict);
                     json_files.push(report);
@@ -626,13 +623,11 @@ async fn async_main() {
             if args.fix {
                 for file in &files {
                     let mut config = package::load_check_config(Some(file));
-                    commands::check::apply_harn_lint_config(file, &mut config);
-                    let require_header = args.require_file_header
-                        || commands::check::harn_lint_require_file_header(file);
-                    let complexity_threshold =
-                        commands::check::harn_lint_complexity_threshold(file);
-                    let persona_step_allowlist =
-                        commands::check::harn_lint_persona_step_allowlist(file);
+                    let lint_config = commands::check::load_harn_lint_config(file);
+                    commands::check::apply_loaded_harn_lint_config(&lint_config, &mut config);
+                    let require_header =
+                        args.require_file_header || lint_config.require_file_header;
+                    let complexity_threshold = lint_config.complexity_threshold;
                     commands::check::lint_fix_file(
                         &mut analysis,
                         file,
@@ -641,30 +636,30 @@ async fn async_main() {
                         &module_graph,
                         require_header,
                         complexity_threshold,
-                        &persona_step_allowlist,
+                        &lint_config.persona_step_allowlist,
                     );
                 }
                 for file in &prompt_files {
-                    let threshold =
-                        commands::check::harn_lint_template_variant_branch_threshold(file);
-                    let disabled = commands::check::harn_lint_disabled_rules(file);
+                    let lint_config = commands::check::load_harn_lint_config(file);
                     // The template lint rules don't carry autofix
                     // edits yet (intentionally — see
                     // `template_provider_identity::make_diagnostic`),
                     // so `--fix` is equivalent to a regular run.
-                    commands::check::lint_prompt_file_inner(file, threshold, &disabled);
+                    commands::check::lint_prompt_file_inner(
+                        file,
+                        lint_config.template_variant_branch_threshold,
+                        &lint_config.disabled,
+                    );
                 }
             } else {
                 let mut should_fail = false;
                 for file in &files {
                     let mut config = package::load_check_config(Some(file));
-                    commands::check::apply_harn_lint_config(file, &mut config);
-                    let require_header = args.require_file_header
-                        || commands::check::harn_lint_require_file_header(file);
-                    let complexity_threshold =
-                        commands::check::harn_lint_complexity_threshold(file);
-                    let persona_step_allowlist =
-                        commands::check::harn_lint_persona_step_allowlist(file);
+                    let lint_config = commands::check::load_harn_lint_config(file);
+                    commands::check::apply_loaded_harn_lint_config(&lint_config, &mut config);
+                    let require_header =
+                        args.require_file_header || lint_config.require_file_header;
+                    let complexity_threshold = lint_config.complexity_threshold;
                     let outcome = commands::check::lint_file_inner(
                         &mut analysis,
                         file,
@@ -673,17 +668,18 @@ async fn async_main() {
                         &module_graph,
                         require_header,
                         complexity_threshold,
-                        &persona_step_allowlist,
+                        &lint_config.persona_step_allowlist,
                     );
                     should_fail |= outcome.should_fail(config.strict);
                 }
                 for file in &prompt_files {
-                    let threshold =
-                        commands::check::harn_lint_template_variant_branch_threshold(file);
-                    let disabled = commands::check::harn_lint_disabled_rules(file);
+                    let lint_config = commands::check::load_harn_lint_config(file);
                     let config = package::load_check_config(Some(file));
-                    let outcome =
-                        commands::check::lint_prompt_file_inner(file, threshold, &disabled);
+                    let outcome = commands::check::lint_prompt_file_inner(
+                        file,
+                        lint_config.template_variant_branch_threshold,
+                        &lint_config.disabled,
+                    );
                     should_fail |= outcome.should_fail(config.strict);
                 }
                 if should_fail {


### PR DESCRIPTION
## Summary

This PR makes recursive Harn source discovery bounded by project source instead of crawling generated and local cache trees:

- route `harn check`, `harn lint`, and directory-mode `harn fmt` through a shared source target collector backed by `ignore::WalkBuilder`
- skip known generated/local directories like `.harn-runs`, `.harn`, `.claude`, `target`, `node_modules`, `dist`, and root `.harn-*` scratch files
- respect `.gitignore` / git exclude data for recursive discovery while preserving explicit file and explicit root-directory targets
- load `[lint]` config once per linted file instead of repeatedly re-reading the same nearby `harn.toml` settings

This keeps the skip list in Rust rather than a JSON/TOML sidecar. The list is part of CLI traversal semantics, benefits from tests and code review, and avoids adding a second config surface before users actually need one.

## Benchmark

Release binaries were timed with stdout/stderr discarded. The baseline binary was current `origin/main`; the fixed binary was the source-walk patch from this branch before the final `ignore::WalkBuilder` and lint-config consolidation, so the final branch should be at least as favorable on recursive discovery.

| Project | Command | Baseline | Fixed |
| --- | --- | ---: | ---: |
| `harn-bump-fleet` | `fmt --check --json` | 0.235s, exit 1 | 0.040s, exit 0 |
| `harn-bump-fleet` | `lint --json` | 0.783s, exit 0 | 0.513s, exit 0 |
| `harn-bump-fleet` | `check --json --preflight warning` | 1.437s, exit 1 | 0.947s, exit 0 |
| `burin-code` | `fmt --check --json` | 33.009s, exit 1 | 0.519s, exit 1 |
| `burin-code` | `lint --json` | 149.047s, exit 1 | 2.138s, exit 1 |
| `burin-code` | `check --json --preflight warning` | timed out at 300s | 50.034s, exit 1 |

The biggest baseline issue was file discovery, not parser throughput: `burin-code` recursive format scanned 21,574 formatted files plus 138 errors, mostly from `.claude/worktrees`; the fixed build scanned 413 formatted files plus remaining real project errors before the final root `.harn-*` file filter landed.

## SOTA comparison

This matches how fast mature toolchains bound their input set before doing real analysis:

- Ruff skips files omitted by `.ignore`, `.gitignore`, git exclude, and global gitignore by default: https://docs.astral.sh/ruff/configuration/
- Oxlint documents default ignores for `.git`, `.gitignore`-matched files, and generated/minified inputs, and recommends central ignore patterns for large repositories: https://oxc.rs/docs/guide/usage/linter/ignore-files
- Biome’s scanner is responsible for discovering nested config and `.gitignore` files: https://biomejs.dev/reference/configuration/
- Sorbet explicitly recommends path-level ignores for large excluded regions because content-level ignores still require reading files: https://sorbet.org/docs/cli

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-toolchain-perf-final-target cargo test -p harn-cli collect_harn_targets_recurses_directories_and_deduplicates`
- `CARGO_TARGET_DIR=/tmp/harn-toolchain-perf-final-target cargo test -p harn-cli lint_collects_prompt_targets_from_directories`
- pre-commit hook passed, including changed-package `harn-cli` clippy
- pre-push hook passed, including targeted Rust checks, markdownlint, and generated highlight check
