### PR TITLE
ACP session prompt budgets

### DIFF
--- a/changelog.d/2681.added.md
+++ b/changelog.d/2681.added.md
@@ -1,0 +1,3 @@
+- **ACP sessions can now own prompt budgets (#2681).** Embedders can pass
+  `AcpServerConfig::with_budget(...)`, and ACP clients can re-arm or disable the
+  session budget through `session/set_config_option(configId="budget")`.

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -39,7 +39,7 @@ pub use schema::{
 };
 use sessions::{
     lookup_session_cancellation, preempt_session_interruption, prepare_session_prompt, Session,
-    SessionCancellation, SessionInfo,
+    SessionBudget, SessionCancellation, SessionInfo,
 };
 pub(crate) use transport::run_acp_channel_server_with_existing_handle;
 pub use transport::{
@@ -63,7 +63,7 @@ use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 
 use crate::{
     AdapterDescriptor, AuthMethodConfig, AuthPolicy, AuthRequest, AuthenticatedPrincipal,
-    AuthorizationDecision,
+    AuthorizationDecision, BudgetSpec,
 };
 use commands::{
     discover_commands, parse_slash_invocation, render_available_commands, DiscoveredCommand,
@@ -306,6 +306,109 @@ fn nonnegative_usize_param(
     Ok(None)
 }
 
+fn budget_config_value(spec: &BudgetSpec) -> String {
+    let mut value = serde_json::Map::new();
+    if let Some(cost) = spec.llm_cost_usd {
+        value.insert("llm_cost_usd".to_string(), serde_json::json!(cost));
+    }
+    if let Some(tokens) = spec.llm_tokens {
+        value.insert("llm_tokens".to_string(), serde_json::json!(tokens));
+    }
+    if let Some(calls) = spec.mcp_calls {
+        value.insert("mcp_calls".to_string(), serde_json::json!(calls));
+    }
+    if let Some(queries) = spec.pg_queries {
+        value.insert("pg_queries".to_string(), serde_json::json!(queries));
+    }
+    serde_json::to_string(&serde_json::Value::Object(value)).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn normalize_budget_spec(mut spec: BudgetSpec) -> Option<BudgetSpec> {
+    spec.llm_cost_usd = spec
+        .llm_cost_usd
+        .and_then(|value| value.is_finite().then_some(value.max(0.0)));
+    (!spec.is_empty()).then_some(spec)
+}
+
+fn budget_field<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    names: &[&str],
+) -> Option<&'a serde_json::Value> {
+    names.iter().find_map(|name| object.get(*name))
+}
+
+fn parse_budget_cost_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    names: &[&str],
+    label: &str,
+) -> Result<Option<f64>, String> {
+    let Some(value) = budget_field(object, names) else {
+        return Ok(None);
+    };
+    let Some(number) = value.as_f64() else {
+        return Err(format!(
+            "invalid_budget: {label} must be a non-negative number"
+        ));
+    };
+    if !number.is_finite() || number < 0.0 {
+        return Err(format!(
+            "invalid_budget: {label} must be a non-negative finite number"
+        ));
+    }
+    Ok(Some(number))
+}
+
+fn parse_budget_count_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    names: &[&str],
+    label: &str,
+) -> Result<Option<u64>, String> {
+    let Some(value) = budget_field(object, names) else {
+        return Ok(None);
+    };
+    value
+        .as_u64()
+        .map(Some)
+        .ok_or_else(|| format!("invalid_budget: {label} must be a non-negative integer"))
+}
+
+fn parse_budget_config_value(raw: &str) -> Result<SessionBudget, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == modes::BUDGET_INHERIT_VALUE {
+        return Ok(SessionBudget::Inherit);
+    }
+    if matches!(trimmed, modes::BUDGET_OFF_VALUE | "none" | "unlimited") {
+        return Ok(SessionBudget::Unlimited);
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed).map_err(|error| {
+        format!(
+            "invalid_budget: expected @inherit, off, or JSON object with llm_cost_usd/llm_tokens fields: {error}"
+        )
+    })?;
+    if value.is_null() {
+        return Ok(SessionBudget::Inherit);
+    }
+    let Some(object) = value.as_object() else {
+        return Err(
+            "invalid_budget: expected a JSON object with llm_cost_usd, llm_tokens, mcp_calls, or pg_queries".to_string(),
+        );
+    };
+    let spec = BudgetSpec {
+        llm_cost_usd: parse_budget_cost_field(
+            object,
+            &["llm_cost_usd", "llmCostUsd"],
+            "llm_cost_usd",
+        )?,
+        llm_tokens: parse_budget_count_field(object, &["llm_tokens", "llmTokens"], "llm_tokens")?,
+        mcp_calls: parse_budget_count_field(object, &["mcp_calls", "mcpCalls"], "mcp_calls")?,
+        pg_queries: parse_budget_count_field(object, &["pg_queries", "pgQueries"], "pg_queries")?,
+    };
+    if spec.is_empty() {
+        return Err("invalid_budget: budget object must include at least one limit".to_string());
+    }
+    Ok(SessionBudget::Custom(spec))
+}
+
 fn append_profile_json_line(
     path: &std::path::Path,
     session_id: &str,
@@ -374,6 +477,7 @@ pub struct AcpServerConfig {
     pub llm_config_overrides: Option<harn_vm::llm_config::ProvidersConfig>,
     pub llm_capability_overrides: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
     pub profile: AcpProfileConfig,
+    pub budget: Option<BudgetSpec>,
 }
 
 impl AcpServerConfig {
@@ -385,6 +489,7 @@ impl AcpServerConfig {
             llm_config_overrides: None,
             llm_capability_overrides: None,
             profile: AcpProfileConfig::default(),
+            budget: None,
         }
     }
 
@@ -417,6 +522,25 @@ impl AcpServerConfig {
 
     pub fn with_profile(mut self, profile: AcpProfileConfig) -> Self {
         self.profile = profile;
+        self
+    }
+
+    pub fn with_budget(mut self, budget: BudgetSpec) -> Self {
+        self.budget = normalize_budget_spec(budget);
+        self
+    }
+
+    pub fn with_llm_cost_budget(mut self, max_cost_usd: f64) -> Self {
+        let mut budget = self.budget.unwrap_or_default();
+        budget.llm_cost_usd = Some(max_cost_usd);
+        self.budget = normalize_budget_spec(budget);
+        self
+    }
+
+    pub fn with_llm_token_budget(mut self, max_tokens: u64) -> Self {
+        let mut budget = self.budget.unwrap_or_default();
+        budget.llm_tokens = Some(max_tokens);
+        self.budget = normalize_budget_spec(budget);
         self
     }
 }
@@ -482,6 +606,8 @@ pub struct AcpServer {
     vm_baseline_cache: Option<VmBaselineCacheEntry>,
     /// Per-turn profile emission settings.
     profile: AcpProfileConfig,
+    /// Server-level budget inherited by sessions unless they override it.
+    default_budget: Option<BudgetSpec>,
 }
 
 impl AcpServer {
@@ -513,6 +639,7 @@ impl AcpServer {
             compile_cache: None,
             vm_baseline_cache: None,
             profile: config.profile,
+            default_budget: config.budget,
         }
     }
 
@@ -925,6 +1052,7 @@ impl AcpServer {
                 info,
                 advertised_commands: Vec::new(),
                 current_mode_id: modes::DEFAULT_MODE_ID.to_string(),
+                budget: SessionBudget::Inherit,
                 profile_turn: 0,
             },
         );
@@ -954,11 +1082,7 @@ impl AcpServer {
                 "sessionId": session_id,
                 "session": session,
                 "modes": modes::session_mode_state(modes::DEFAULT_MODE_ID),
-                "configOptions": modes::config_options_state(
-                    modes::DEFAULT_MODE_ID,
-                    self.pinned_model(&session_id).as_deref(),
-                    self.pinned_reasoning_policy(&session_id).as_deref(),
-                ),
+                "configOptions": self.config_options_for_session(&session_id, modes::DEFAULT_MODE_ID),
             }),
         );
 
@@ -1142,6 +1266,11 @@ impl AcpServer {
             .get(&src_id)
             .map(|session| session.current_mode_id.clone())
             .unwrap_or_else(|| modes::DEFAULT_MODE_ID.to_string());
+        let parent_budget = self
+            .sessions
+            .get(&src_id)
+            .map(|session| session.budget.clone())
+            .unwrap_or_default();
         let cancellation = self.register_session_cancellation(&new_session_id);
         self.sessions.insert(
             new_session_id.clone(),
@@ -1153,6 +1282,7 @@ impl AcpServer {
                 info: info.clone(),
                 advertised_commands: Vec::new(),
                 current_mode_id: parent_mode_id.clone(),
+                budget: parent_budget,
                 profile_turn: 0,
             },
         );
@@ -1166,11 +1296,7 @@ impl AcpServer {
                 "parent_id": src_id,
                 "branched_at": branched_at,
                 "modes": modes::session_mode_state(&parent_mode_id),
-                "configOptions": modes::config_options_state(
-                    &parent_mode_id,
-                    self.pinned_model(&new_session_id).as_deref(),
-                    self.pinned_reasoning_policy(&new_session_id).as_deref(),
-                ),
+                "configOptions": self.config_options_for_session(&new_session_id, &parent_mode_id),
             }),
         );
     }
@@ -1259,7 +1385,7 @@ impl AcpServer {
         };
         let prompt_text = prompt.text.clone();
 
-        let (cwd, cancellation, current_mode_id, inject_state) =
+        let (cwd, cancellation, current_mode_id, inject_state, session_budget) =
             match self.sessions.get_mut(&session_id) {
                 Some(s) => {
                     s.cancellation.begin_prompt();
@@ -1269,6 +1395,7 @@ impl AcpServer {
                         s.cancellation.clone(),
                         s.current_mode_id.clone(),
                         s.inject_state.clone(),
+                        s.budget.clone(),
                     )
                 }
                 None => {
@@ -1276,6 +1403,11 @@ impl AcpServer {
                     return;
                 }
             };
+        let prompt_budget = match session_budget {
+            SessionBudget::Inherit => self.default_budget.clone(),
+            SessionBudget::Unlimited => None,
+            SessionBudget::Custom(spec) => Some(spec),
+        };
         harn_vm::agent_sessions::open_or_create(Some(session_id.clone()));
         let _session_guard = harn_vm::agent_sessions::enter_current_session(session_id.clone());
         #[cfg(feature = "hostlib")]
@@ -1454,6 +1586,7 @@ impl AcpServer {
         let id_owned = id.clone();
         let send_output = self.output.clone();
         let host_bridge_for_response = host_bridge.clone();
+        let _budget_guard = prompt_budget.as_ref().and_then(BudgetSpec::install);
         let result = execute::execute_chunk(
             chunk,
             bridge.clone(),
@@ -2440,11 +2573,7 @@ impl AcpServer {
         Some(serde_json::json!({
             "session": session_value,
             "modes": modes::session_mode_state(&session.current_mode_id),
-            "configOptions": modes::config_options_state(
-                &session.current_mode_id,
-                self.pinned_model(session_id).as_deref(),
-                self.pinned_reasoning_policy(session_id).as_deref(),
-            ),
+            "configOptions": self.config_options_for_session(session_id, &session.current_mode_id),
         }))
     }
 
@@ -2670,6 +2799,39 @@ impl AcpServer {
         harn_vm::agent_sessions::pinned_reasoning_policy(session_id)
     }
 
+    fn session_budget_config_value(&self, session_id: &str) -> Option<String> {
+        match &self.sessions.get(session_id)?.budget {
+            SessionBudget::Inherit => None,
+            SessionBudget::Unlimited => Some(modes::BUDGET_OFF_VALUE.to_string()),
+            SessionBudget::Custom(spec) => Some(budget_config_value(spec)),
+        }
+    }
+
+    fn config_options_for_session(&self, session_id: &str, mode_id: &str) -> serde_json::Value {
+        let budget_value = self.session_budget_config_value(session_id);
+        modes::config_options_state(
+            mode_id,
+            self.pinned_model(session_id).as_deref(),
+            self.pinned_reasoning_policy(session_id).as_deref(),
+            budget_value.as_deref(),
+        )
+    }
+
+    fn set_session_budget(
+        &mut self,
+        session_id: &str,
+        budget: SessionBudget,
+    ) -> Result<bool, String> {
+        let Some(session) = self.sessions.get_mut(session_id) else {
+            return Err(format!("Unknown session: {session_id}"));
+        };
+        if session.budget == budget {
+            return Ok(false);
+        }
+        session.budget = budget;
+        Ok(true)
+    }
+
     fn emit_current_mode_update(&self, session_id: &str, mode_id: &str) {
         self.send_notification(
             "session/update",
@@ -2690,11 +2852,7 @@ impl AcpServer {
                 "sessionId": session_id,
                 "update": {
                     "sessionUpdate": "config_option_update",
-                    "configOptions": modes::config_options_state(
-                        mode_id,
-                        self.pinned_model(session_id).as_deref(),
-                        self.pinned_reasoning_policy(session_id).as_deref(),
-                    ),
+                    "configOptions": self.config_options_for_session(session_id, mode_id),
                 },
             }),
         );
@@ -3020,10 +3178,13 @@ impl AcpServer {
             "thought_level" | "reasoning_policy" => {
                 self.apply_set_reasoning_policy_config_option(id, &session_id, value);
             }
+            "budget" => self.apply_set_budget_config_option(id, &session_id, value),
             other => self.send_error(
                 id,
                 -32602,
-                &format!("Unknown config option '{other}'. Available: mode, model, thought_level"),
+                &format!(
+                    "Unknown config option '{other}'. Available: mode, model, thought_level, budget"
+                ),
             ),
         }
     }
@@ -3039,11 +3200,7 @@ impl AcpServer {
                 self.send_response(
                     id,
                     serde_json::json!({
-                        "configOptions": modes::config_options_state(
-                            mode_id,
-                            self.pinned_model(session_id).as_deref(),
-                            self.pinned_reasoning_policy(session_id).as_deref(),
-                        ),
+                        "configOptions": self.config_options_for_session(session_id, mode_id),
                     }),
                 );
                 if changed {
@@ -3068,7 +3225,7 @@ impl AcpServer {
                 return;
             }
         };
-        match self.set_session_model(session_id, normalized.clone()) {
+        match self.set_session_model(session_id, normalized) {
             Ok(changed) => {
                 let current_mode_id = self
                     .sessions
@@ -3078,11 +3235,7 @@ impl AcpServer {
                 self.send_response(
                     id,
                     serde_json::json!({
-                        "configOptions": modes::config_options_state(
-                            &current_mode_id,
-                            normalized.as_deref(),
-                            self.pinned_reasoning_policy(session_id).as_deref(),
-                        ),
+                        "configOptions": self.config_options_for_session(session_id, &current_mode_id),
                     }),
                 );
                 if changed {
@@ -3106,7 +3259,7 @@ impl AcpServer {
                 return;
             }
         };
-        match self.set_session_reasoning_policy(session_id, normalized.clone()) {
+        match self.set_session_reasoning_policy(session_id, normalized) {
             Ok(changed) => {
                 let current_mode_id = self
                     .sessions
@@ -3116,11 +3269,41 @@ impl AcpServer {
                 self.send_response(
                     id,
                     serde_json::json!({
-                        "configOptions": modes::config_options_state(
-                            &current_mode_id,
-                            self.pinned_model(session_id).as_deref(),
-                            normalized.as_deref(),
-                        ),
+                        "configOptions": self.config_options_for_session(session_id, &current_mode_id),
+                    }),
+                );
+                if changed {
+                    self.emit_config_option_update(session_id, &current_mode_id);
+                }
+            }
+            Err(message) => self.send_error(id, -32602, &message),
+        }
+    }
+
+    fn apply_set_budget_config_option(
+        &mut self,
+        id: &serde_json::Value,
+        session_id: &str,
+        raw_value: &str,
+    ) {
+        let budget = match parse_budget_config_value(raw_value) {
+            Ok(value) => value,
+            Err(message) => {
+                self.send_error(id, -32602, &message);
+                return;
+            }
+        };
+        match self.set_session_budget(session_id, budget) {
+            Ok(changed) => {
+                let current_mode_id = self
+                    .sessions
+                    .get(session_id)
+                    .map(|session| session.current_mode_id.clone())
+                    .unwrap_or_else(|| modes::DEFAULT_MODE_ID.to_string());
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "configOptions": self.config_options_for_session(session_id, &current_mode_id),
                     }),
                 );
                 if changed {

--- a/crates/harn-serve/src/adapters/acp/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/modes.rs
@@ -83,6 +83,7 @@ pub(super) fn config_options_state(
     current_mode_id: &str,
     pinned_model: Option<&str>,
     pinned_reasoning_policy: Option<&str>,
+    budget_value: Option<&str>,
 ) -> serde_json::Value {
     serde_json::json!([
         {
@@ -96,6 +97,7 @@ pub(super) fn config_options_state(
         },
         model_config_option(pinned_model),
         reasoning_policy_config_option(pinned_reasoning_policy),
+        budget_config_option(budget_value),
     ])
 }
 
@@ -126,6 +128,8 @@ fn mode_entries(id_key: &str) -> Vec<serde_json::Value> {
 /// clearly signals "fall through to the ambient default" instead of
 /// being mistaken for a real model id.
 pub(super) const MODEL_INHERIT_VALUE: &str = "@inherit";
+pub(super) const BUDGET_INHERIT_VALUE: &str = "@inherit";
+pub(super) const BUDGET_OFF_VALUE: &str = "off";
 
 fn model_config_option(pinned_model: Option<&str>) -> serde_json::Value {
     serde_json::json!({
@@ -198,6 +202,63 @@ fn reasoning_policy_config_option(pinned_policy: Option<&str>) -> serde_json::Va
         "currentValue": pinned_policy.unwrap_or(harn_vm::llm::reasoning_policy::INHERIT_POLICY_VALUE),
         "options": reasoning_policy_select_options(),
     })
+}
+
+fn budget_config_option(budget_value: Option<&str>) -> serde_json::Value {
+    let current_value = budget_value.unwrap_or(BUDGET_INHERIT_VALUE);
+    serde_json::json!({
+        "id": "budget",
+        "name": "Call Budget",
+        "description": "Per-prompt resource ceiling installed before Harn runs the next ACP turn. \
+                        Values are compact JSON objects such as \
+                        {\"llm_cost_usd\":0.05,\"llm_tokens\":200000}; pick `@inherit` to use \
+                        the server default or `off` to disable the session override.",
+        "category": "_harn_budget",
+        "type": "select",
+        "currentValue": current_value,
+        "options": budget_select_options(current_value),
+    })
+}
+
+fn budget_select_options(current_value: &str) -> Vec<serde_json::Value> {
+    let mut entries = vec![
+        serde_json::json!({
+            "value": BUDGET_INHERIT_VALUE,
+            "name": "Inherit server default",
+            "description": "Use the budget configured by the ACP server embedder.",
+        }),
+        serde_json::json!({
+            "value": BUDGET_OFF_VALUE,
+            "name": "No session budget",
+            "description": "Do not install an ACP session budget for subsequent prompt turns.",
+        }),
+        serde_json::json!({
+            "value": "{\"llm_cost_usd\":0.01}",
+            "name": "$0.01 per prompt",
+            "description": "Stop the prompt after roughly one cent of model spend.",
+        }),
+        serde_json::json!({
+            "value": "{\"llm_cost_usd\":0.05,\"llm_tokens\":200000}",
+            "name": "$0.05 and 200k tokens",
+            "description": "Cap both model spend and input+output tokens for the prompt.",
+        }),
+        serde_json::json!({
+            "value": "{\"llm_tokens\":50000}",
+            "name": "50k tokens",
+            "description": "Token-only ceiling for local or unknown-price providers.",
+        }),
+    ];
+    if !entries
+        .iter()
+        .any(|entry| entry["value"].as_str() == Some(current_value))
+    {
+        entries.push(serde_json::json!({
+            "value": current_value,
+            "name": "Current custom budget",
+            "description": "Session budget supplied by the client.",
+        }));
+    }
+    entries
 }
 
 fn reasoning_policy_select_options() -> Vec<serde_json::Value> {
@@ -382,9 +443,9 @@ mod tests {
 
     #[test]
     fn config_options_state_contains_mode_selector() {
-        let state = config_options_state("code", None, None);
+        let state = config_options_state("code", None, None, None);
         let options = state.as_array().expect("config options array");
-        assert_eq!(options.len(), 3);
+        assert_eq!(options.len(), 4);
         assert_eq!(options[0]["id"], "mode");
         assert_eq!(options[0]["currentValue"], "code");
         assert!(options[0]["options"]
@@ -396,7 +457,7 @@ mod tests {
 
     #[test]
     fn config_options_state_includes_model_selector_with_pin_clear_sentinel() {
-        let state = config_options_state("code", None, None);
+        let state = config_options_state("code", None, None, None);
         let options = state.as_array().expect("config options array");
         let model_option = options
             .iter()
@@ -419,7 +480,7 @@ mod tests {
 
     #[test]
     fn config_options_state_surfaces_free_form_pinned_model() {
-        let state = config_options_state("code", Some("custom-model-not-in-catalog"), None);
+        let state = config_options_state("code", Some("custom-model-not-in-catalog"), None, None);
         let model_option = state
             .as_array()
             .expect("config options array")
@@ -448,7 +509,7 @@ mod tests {
 
     #[test]
     fn config_options_state_includes_thought_level_selector() {
-        let state = config_options_state("code", None, Some("high"));
+        let state = config_options_state("code", None, Some("high"), None);
         let thought_option = state
             .as_array()
             .expect("config options array")
@@ -469,6 +530,27 @@ mod tests {
         assert!(values.contains(&"auto"));
         assert!(values.contains(&"off"));
         assert!(values.contains(&"xhigh"));
+    }
+
+    #[test]
+    fn config_options_state_includes_budget_selector_with_custom_value() {
+        let custom = "{\"llm_tokens\":123}";
+        let state = config_options_state("code", None, None, Some(custom));
+        let budget_option = state
+            .as_array()
+            .expect("config options array")
+            .iter()
+            .find(|entry| entry["id"] == "budget")
+            .cloned()
+            .expect("budget config option");
+        assert_eq!(budget_option["category"], "_harn_budget");
+        assert_eq!(budget_option["type"], "select");
+        assert_eq!(budget_option["currentValue"], custom);
+        assert!(budget_option["options"]
+            .as_array()
+            .expect("budget options")
+            .iter()
+            .any(|entry| entry["value"] == custom));
     }
 
     #[test]

--- a/crates/harn-serve/src/adapters/acp/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/sessions.rs
@@ -7,6 +7,14 @@ pub(super) struct SessionInfo {
     pub(super) meta: serde_json::Map<String, serde_json::Value>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(super) enum SessionBudget {
+    #[default]
+    Inherit,
+    Unlimited,
+    Custom(BudgetSpec),
+}
+
 #[derive(Clone)]
 pub(super) struct SessionCancellation {
     pub(super) cancelled: Arc<AtomicBool>,
@@ -81,6 +89,8 @@ pub(super) struct Session {
     /// Active session mode id (one of [`modes::MODE_CATALOG`]). Drives
     /// the capability ceiling pushed for the next `session/prompt`.
     pub(super) current_mode_id: String,
+    /// Session-level budget override applied to subsequent prompt turns.
+    pub(super) budget: SessionBudget,
     /// Prompt executions emitted to profile output for this ACP session.
     pub(super) profile_turn: u64,
 }

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -117,7 +117,8 @@ async fn start_acp_code_session_with_config(
         }))
         .expect("send session/set_mode");
     let _ack = recv_json(&mut response_rx).await;
-    let _notification = recv_json(&mut response_rx).await;
+    let _mode_notification = recv_json(&mut response_rx).await;
+    let _config_notification = recv_json(&mut response_rx).await;
     (request_tx, response_rx, server, session_id)
 }
 

--- a/crates/harn-serve/src/adapters/acp/tests/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/modes.rs
@@ -41,6 +41,59 @@ fn install_test_agent_event_log_sink(
         harn_vm::agent_events::EventLogSink::new(log.clone(), session_id),
     );
 }
+
+async fn run_mock_llm_prompt(
+    request_tx: &mpsc::UnboundedSender<serde_json::Value>,
+    response_rx: &mut mpsc::UnboundedReceiver<String>,
+    session_id: &str,
+    id: u64,
+) -> serde_json::Value {
+    request_tx
+        .send(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{
+                    "type": "text",
+                    "text": "llm_mock_clear()\nllm_mock({text: \"ok\", input_tokens: 1, output_tokens: 1, model: \"mock\", provider: \"mock\"})\nlet r = llm_call(\"hello\", nil, {provider: \"mock\", model: \"mock\", llm_retries: 0})\n__io_println(r.text)",
+                }],
+            },
+        }))
+        .expect("send session/prompt");
+
+    for _ in 0..32 {
+        let message = recv_json(response_rx).await;
+        if message["method"] == "host/capabilities" {
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": message["id"].clone(),
+                    "result": {},
+                }))
+                .expect("send host capabilities response");
+            continue;
+        }
+        if message["id"] == id {
+            return message;
+        }
+    }
+    panic!("timed out waiting for session/prompt response {id}");
+}
+
+async fn recv_response_with_id(
+    response_rx: &mut mpsc::UnboundedReceiver<String>,
+    id: u64,
+) -> serde_json::Value {
+    for _ in 0..32 {
+        let message = recv_json(response_rx).await;
+        if message["id"] == id {
+            return message;
+        }
+    }
+    panic!("timed out waiting for response {id}");
+}
 #[tokio::test(flavor = "current_thread")]
 async fn acp_authenticate_uses_shared_auth_policy() {
     let local = tokio::task::LocalSet::new();
@@ -1205,6 +1258,147 @@ async fn acp_set_config_option_pins_thought_level_and_emits_update() {
     assert_eq!(cleared_value, "@inherit");
     let _clear_notification = recv_json(&mut rx).await;
     assert!(harn_vm::agent_sessions::pinned_reasoning_policy(&session_id).is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_prompt_installs_default_llm_token_budget() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let config = AcpServerConfig::new(None).with_llm_token_budget(0);
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_code_session_with_config(config, serde_json::json!(".")).await;
+
+            let response = run_mock_llm_prompt(&request_tx, &mut response_rx, &session_id, 3).await;
+            assert_eq!(response["id"], 3);
+            assert_eq!(response["error"]["code"], -32000);
+            let message = response["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string();
+            assert!(
+                message.contains("LLM token budget exceeded"),
+                "prompt should fail under the inherited token budget: {message}"
+            );
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_set_config_option_budget_rearms_next_prompt() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_code_session_with_config(
+                    AcpServerConfig::new(None),
+                    serde_json::json!("."),
+                )
+                .await;
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "session/set_config_option",
+                    "params": {
+                        "sessionId": session_id,
+                        "configId": "budget",
+                        "value": "{\"llm_tokens\":0}",
+                    },
+                }))
+                .expect("send budget cap");
+            let ack = recv_response_with_id(&mut response_rx, 3).await;
+            assert_eq!(ack["id"], 3);
+            let budget_value = ack["result"]["configOptions"]
+                .as_array()
+                .expect("configOptions array")
+                .iter()
+                .find(|entry| entry["id"] == "budget")
+                .expect("budget option")
+                .get("currentValue")
+                .and_then(|value| value.as_str())
+                .expect("budget currentValue");
+            assert_eq!(budget_value, "{\"llm_tokens\":0}");
+            let _notification = recv_json(&mut response_rx).await;
+
+            let exhausted =
+                run_mock_llm_prompt(&request_tx, &mut response_rx, &session_id, 4).await;
+            assert_eq!(exhausted["error"]["code"], -32000);
+            assert!(exhausted["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("LLM token budget exceeded"));
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "session/set_config_option",
+                    "params": {
+                        "sessionId": session_id,
+                        "configId": "budget",
+                        "value": "{\"llm_tokens\":100}",
+                    },
+                }))
+                .expect("send budget re-arm");
+            let rearm_ack = recv_response_with_id(&mut response_rx, 5).await;
+            assert_eq!(rearm_ack["id"], 5);
+            let _rearm_notification = recv_json(&mut response_rx).await;
+
+            let ok = run_mock_llm_prompt(&request_tx, &mut response_rx, &session_id, 6).await;
+            assert_eq!(ok["result"]["stopReason"], "end_turn");
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_set_config_option_budget_off_disables_inherited_default() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let config = AcpServerConfig::new(None).with_llm_token_budget(0);
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_code_session_with_config(config, serde_json::json!(".")).await;
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "session/set_config_option",
+                    "params": {
+                        "sessionId": session_id,
+                        "configId": "budget",
+                        "value": "off",
+                    },
+                }))
+                .expect("send budget off");
+            let ack = recv_response_with_id(&mut response_rx, 3).await;
+            let budget_value = ack["result"]["configOptions"]
+                .as_array()
+                .expect("configOptions array")
+                .iter()
+                .find(|entry| entry["id"] == "budget")
+                .expect("budget option")
+                .get("currentValue")
+                .and_then(|value| value.as_str())
+                .expect("budget currentValue");
+            assert_eq!(budget_value, "off");
+            let _notification = recv_json(&mut response_rx).await;
+
+            let ok = run_mock_llm_prompt(&request_tx, &mut response_rx, &session_id, 4).await;
+            assert_eq!(ok["result"]["stopReason"], "end_turn");
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
 }
 
 /// `session/set_config_option(configId="model")` rejects selectors that

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -91,38 +91,6 @@ fn budget_category_from_error(error: &harn_vm::VmError) -> Option<String> {
     }
 }
 
-/// Install per-dispatch resource ceilings from the route's
-/// `@budget(...)` declaration. Every cap routes through a `harn-vm`
-/// per-thread counter installed for the lifetime of the returned guard:
-/// `llm_cost_usd` / `llm_tokens` meter LLM spend at the provider call
-/// site, while `mcp_calls` / `pg_queries` meter outbound tool-call and
-/// query counts at the MCP host and Postgres hostlib entry points. Each
-/// fires a `BudgetExceeded`-categorised error (mapped to HTTP 429 by
-/// [`classify_vm_error`]) the moment its ceiling is crossed, so a
-/// runaway `.harn` tool loop is capped at the dispatcher boundary.
-fn install_route_budget(spec: &BudgetSpec) -> Option<RouteBudgetGuard> {
-    if spec.is_empty() {
-        return None;
-    }
-    Some(RouteBudgetGuard {
-        _llm_cost: spec.llm_cost_usd.map(harn_vm::install_llm_cost_budget),
-        _llm_tokens: spec.llm_tokens.map(harn_vm::install_llm_token_budget),
-        _mcp_calls: spec.mcp_calls.map(harn_vm::install_mcp_call_budget),
-        _pg_queries: spec.pg_queries.map(harn_vm::install_pg_query_budget),
-    })
-}
-
-/// Aggregate of per-cap guards held for the lifetime of one dispatch.
-/// Dropping the aggregate restores every cap simultaneously, keeping
-/// nested dispatches safe even when guards land in different
-/// thread-locals.
-pub(crate) struct RouteBudgetGuard {
-    _llm_cost: Option<harn_vm::LlmBudgetGuard>,
-    _llm_tokens: Option<harn_vm::LlmTokenBudgetGuard>,
-    _mcp_calls: Option<harn_vm::McpCallBudgetGuard>,
-    _pg_queries: Option<harn_vm::PgQueryBudgetGuard>,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CallArguments {
     Named(BTreeMap<String, serde_json::Value>),
@@ -364,7 +332,7 @@ impl DispatchCore {
 
         // Per-dispatch resource budget caps live on `function.budget`
         // and are installed inside `invoke_function` / `invoke_pipeline`
-        // — the thread-local backing (`harn_vm::install_llm_cost_budget`)
+        // — the thread-local backing (`BudgetSpec::install`)
         // must be set on the same OS thread the VM runs on, which the
         // tokio `LocalSet` inside each invoker pins.
 
@@ -531,7 +499,7 @@ impl DispatchCore {
                     harn_vm::agent_sessions::enter_current_session(session_id.to_string())
                 });
                 let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
-                let _budget_guard = budget.as_ref().and_then(install_route_budget);
+                let _budget_guard = budget.as_ref().and_then(BudgetSpec::install);
                 let _request_id_guard = request_id.map(harn_vm::enter_request_id);
 
                 let mut vm = Vm::new();
@@ -610,7 +578,7 @@ impl DispatchCore {
                     harn_vm::agent_sessions::enter_current_session(session_id.to_string())
                 });
                 let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
-                let _budget_guard = budget.as_ref().and_then(install_route_budget);
+                let _budget_guard = budget.as_ref().and_then(BudgetSpec::install);
                 let _request_id_guard = request_id.map(harn_vm::enter_request_id);
 
                 let mut vm = Vm::new();

--- a/crates/harn-serve/src/limits/mod.rs
+++ b/crates/harn-serve/src/limits/mod.rs
@@ -179,7 +179,7 @@ impl RouteLimits {
 /// Per-call resource budget declared on the route. Enforced inside the
 /// dispatch (mid-call) so a runaway tool loop hits the ceiling before
 /// it can melt the host.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct BudgetSpec {
     pub llm_cost_usd: Option<f64>,
     pub llm_tokens: Option<u64>,
@@ -194,6 +194,31 @@ impl BudgetSpec {
             && self.pg_queries.is_none()
             && self.mcp_calls.is_none()
     }
+
+    /// Install the resource ceilings represented by this budget on the
+    /// current thread. The returned guard restores all prior ceilings when
+    /// dropped, so nested dispatches can temporarily override budget state.
+    pub(crate) fn install(&self) -> Option<BudgetGuard> {
+        if self.is_empty() {
+            return None;
+        }
+        Some(BudgetGuard {
+            _llm_cost: self.llm_cost_usd.map(harn_vm::install_llm_cost_budget),
+            _llm_tokens: self.llm_tokens.map(harn_vm::install_llm_token_budget),
+            _mcp_calls: self.mcp_calls.map(harn_vm::install_mcp_call_budget),
+            _pg_queries: self.pg_queries.map(harn_vm::install_pg_query_budget),
+        })
+    }
+}
+
+/// Aggregate of per-cap guards held for the lifetime of one dispatch.
+/// Dropping the aggregate restores every cap simultaneously, keeping nested
+/// dispatches safe even when guards land in different thread-locals.
+pub(crate) struct BudgetGuard {
+    _llm_cost: Option<harn_vm::LlmBudgetGuard>,
+    _llm_tokens: Option<harn_vm::LlmTokenBudgetGuard>,
+    _mcp_calls: Option<harn_vm::McpCallBudgetGuard>,
+    _pg_queries: Option<harn_vm::PgQueryBudgetGuard>,
 }
 
 /// Context the registry needs to evaluate a route's limits for one

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -575,7 +575,7 @@ The ACP server supports these JSON-RPC methods:
 | `session/close` | Close a session and cancel any active prompt |
 | `session/stop` | Deprecated alias for `session/close` |
 | `session/set_mode` | Switch the active session mode |
-| `session/set_config_option` | Switch a preferred ACP session config option (`mode`, `model`, or `thought_level`) |
+| `session/set_config_option` | Switch a preferred ACP session config option (`mode`, `model`, `thought_level`, or `budget`) |
 | `workflow/signal` | Enqueue a workflow signal message in the current session workspace |
 | `workflow/query` | Read a named workflow query value from the current session workspace |
 | `workflow/update` | Send a workflow update request and wait for a response |
@@ -692,6 +692,18 @@ it; Harn keeps `modes` available for clients still on `session/set_mode`.
         { "value": "medium",   "name": "Medium", "description": "..." },
         { "value": "high",     "name": "High",   "description": "..." },
         { "value": "xhigh",    "name": "Extra High", "description": "..." }
+      ]
+    },
+    {
+      "id": "budget",
+      "name": "Call Budget",
+      "category": "_harn_budget",
+      "type": "select",
+      "currentValue": "@inherit",
+      "options": [
+        { "value": "@inherit", "name": "Inherit server default", "description": "..." },
+        { "value": "off", "name": "No session budget", "description": "..." },
+        { "value": "{\"llm_cost_usd\":0.05,\"llm_tokens\":200000}", "name": "$0.05 and 200k tokens", "description": "..." }
       ]
     }
   ],
@@ -849,6 +861,38 @@ Per-call options still win: `llm_call(..., {thinking: ...})` and
 `llm_call(..., {reasoning_effort: ...})` bypass the session thought pin.
 `session/fork` carries the parent's thought pin to the child, and later
 changes remain branch-local.
+
+### Session budget
+
+`AcpServerConfig::with_budget(BudgetSpec)` installs an inherited resource
+budget for every ACP session. The guard is applied around each
+`session/prompt` turn on the same runtime thread that executes the VM, using
+the same `BudgetSpec`/`call_budget` path as HTTP `@budget(...)` dispatch.
+Use `with_llm_cost_budget(...)` or `with_llm_token_budget(...)` when the
+embedder only needs an LLM-specific ceiling.
+
+Clients can re-arm or disable the session budget without restarting the
+server by setting `configId: "budget"`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 44,
+  "method": "session/set_config_option",
+  "params": {
+    "sessionId": "sess_abc",
+    "configId": "budget",
+    "value": "{\"llm_cost_usd\":0.05,\"llm_tokens\":200000}"
+  }
+}
+```
+
+The value is a string because ACP config options are string selectors. Harn
+accepts `@inherit` to use the server default, `off` to disable the session
+budget, or a compact JSON object with any of `llm_cost_usd`, `llm_tokens`,
+`mcp_calls`, and `pg_queries`. Exhaustion uses the existing budget error and
+agent-event path, so hosts that already render `_harn/agentEvent`
+`budget_exhausted` updates do not need a new event type.
 
 ### Queued user messages and reminders during agent execution
 


### PR DESCRIPTION
Closes #2681.

## Summary
- add ACP server default prompt budgets via AcpServerConfig::with_budget / LLM convenience builders
- expose a live session/set_config_option budget selector with inherit/off/custom JSON values
- share BudgetSpec guard installation between HTTP dispatch and ACP prompt execution
- document the ACP budget selector and add a changelog fragment

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/tmp/harn-target-4e98-2681 cargo test -p harn-serve budget --lib
- CARGO_TARGET_DIR=/tmp/harn-target-4e98-2681 cargo test -p harn-serve
- CARGO_TARGET_DIR=/tmp/harn-target-4e98-2681 cargo clippy -p harn-serve --all-targets -- -D warnings
- make lint-test-patterns
- pre-commit hook
- pre-push hook