### PR TITLE
mcp: generalize connector-OAuth to any MCP server + ACP auth_required/oauth_callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,6 +2590,7 @@ dependencies = [
  "data-encoding",
  "ed25519-dalek",
  "flate2",
+ "fs2",
  "futures",
  "globset",
  "harn-builtin-macros",

--- a/changelog.d/2646.added.md
+++ b/changelog.d/2646.added.md
@@ -1,0 +1,13 @@
+Generalized MCP OAuth so any MCP server can be authorized over ACP, not just
+named connectors. A new harn-owned flow engine (`harn_vm::mcp_oauth`) does
+discovery, client resolution (DCR/CIMD/BYO), PKCE, the code exchange, the
+single-flight refresh (in-process mutex + cross-process file lock,
+per-`client_id` keyed), and keyring storage in one place; `harn mcp login` and
+the ACP path now share it instead of each carrying a copy. When a server
+answers `401` mid-session harn emits an additive
+`mcp_auth_required` agent event (server + canonical resource + challenge scope)
+as a cue, and two new ACP requests complete the loop: `mcp/authorize` mints the
+browser URL + `state`, and `mcp/oauth_callback` exchanges the returned
+`code`/`state` (or a captured client-scheme redirect URL). Token exchange and
+storage stay in harn; thin clients only open the URL and forward the callback.
+(#2646)

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -105,6 +105,10 @@ const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.workflow.resume",
     "mcp/catalog",
     "harn.mcp.catalog",
+    "mcp/authorize",
+    "harn.mcp.authorize",
+    "mcp/oauth_callback",
+    "harn.mcp.oauth_callback",
 ];
 const ACP_AGENT_NOTIFICATIONS: &[&str] = &["session/message", "session/update", "terminal/output"];
 const ACP_CONTENT_BLOCK_TYPES: &[&str] = &["text", "resource_link", "resource", "image", "audio"];

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -1,27 +1,11 @@
-use std::collections::HashMap;
-use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::path::PathBuf;
 use std::{env, fs, process};
 
-use async_trait::async_trait;
-use base64::Engine;
-use fs2::FileExt;
-use harn_vm::mcp_auth::{
-    authorization_code_token_form, build_oauth_authorization_url, canonical_resource_indicator,
-    determine_token_endpoint_auth_method, discover_mcp_oauth, dynamic_client_registration_body,
-    ensure_pkce_s256_supported, refresh_token_form, select_oauth_client_auth,
-    validate_authorization_response_issuer, validate_issuer_binding,
-    validate_token_endpoint_auth_method, OAuthAuthorizationCodeTokenForm,
-    OAuthAuthorizationUrlOptions, OAuthClientAuthMode, OAuthClientAuthOptions,
-    OAuthRefreshTokenForm, DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL,
-};
-use harn_vm::secrets::{KeyringSecretProvider, SecretBytes, SecretId, SecretProvider};
+use harn_vm::mcp_auth::OAuthClientAuthMode;
+use harn_vm::mcp_oauth::{self, BeginAuthorization};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use tokio::sync::Mutex as AsyncMutex;
 use url::Url;
 
 use crate::cli::{McpCommand, McpLoginArgs, McpServerRefArgs};
@@ -32,10 +16,6 @@ pub(crate) mod presets;
 pub(crate) mod serve;
 
 const DEFAULT_REDIRECT_URI: &str = "http://127.0.0.1:9783/oauth/callback";
-const KEYRING_SERVICE: &str = "dev.harn.mcp";
-const OAUTH_LOCK_DIR_ENV: &str = "HARN_MCP_OAUTH_LOCK_DIR";
-const HARN_HOME_ENV: &str = "HARN_HOME";
-const TOKEN_REFRESH_SKEW_SECS: i64 = 60;
 use harn_vm::mcp_protocol::PROTOCOL_VERSION as MCP_PROTOCOL_VERSION;
 
 #[derive(Clone)]
@@ -46,96 +26,6 @@ pub(crate) struct ResolvedMcpServer {
     pub client_id: Option<String>,
     pub client_secret: Option<String>,
     pub scopes: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct StoredOAuthToken {
-    pub access_token: String,
-    pub refresh_token: Option<String>,
-    pub expires_at_unix: Option<i64>,
-    pub token_endpoint: String,
-    pub client_id: String,
-    pub client_secret: Option<String>,
-    pub token_endpoint_auth_method: String,
-    pub issuer: String,
-    pub resource: String,
-    pub scopes: Option<String>,
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct OAuthTokenStoreKey {
-    resource: String,
-    issuer: String,
-    client_id: String,
-}
-
-impl OAuthTokenStoreKey {
-    fn new(resource: &str, issuer: &str, client_id: &str) -> Self {
-        Self {
-            resource: resource.to_string(),
-            issuer: issuer.to_string(),
-            client_id: client_id.to_string(),
-        }
-    }
-
-    fn from_token(token: &StoredOAuthToken) -> Self {
-        Self::new(&token.resource, &token.issuer, &token.client_id)
-    }
-
-    fn account(&self) -> String {
-        token_store_account(&self.resource, &self.issuer, &self.client_id)
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct StoredOAuthClientIndex {
-    client_id: String,
-}
-
-#[async_trait]
-trait OAuthTokenStorage: Send + Sync {
-    async fn load_token(
-        &self,
-        key: &OAuthTokenStoreKey,
-    ) -> Result<Option<StoredOAuthToken>, String>;
-    async fn save_token(&self, token: &StoredOAuthToken) -> Result<(), String>;
-    async fn delete_token(&self, key: &OAuthTokenStoreKey) -> Result<(), String>;
-    async fn load_active_client_id(
-        &self,
-        resource: &str,
-        issuer: &str,
-    ) -> Result<Option<String>, String>;
-    async fn save_active_client_id(
-        &self,
-        resource: &str,
-        issuer: &str,
-        client_id: &str,
-    ) -> Result<(), String>;
-    async fn delete_active_client_id(&self, resource: &str, issuer: &str) -> Result<(), String>;
-}
-
-struct KeyringOAuthTokenStorage {
-    provider: KeyringSecretProvider,
-}
-
-impl Default for KeyringOAuthTokenStorage {
-    fn default() -> Self {
-        Self {
-            provider: oauth_token_provider(),
-        }
-    }
-}
-
-type OAuthServerMetadata = harn_vm::mcp_auth::OAuthAuthorizationServerMetadata;
-type DynamicClientRegistrationResponse = harn_vm::mcp_auth::OAuthDynamicClientRegistrationResponse;
-
-#[derive(Clone, Debug, Deserialize)]
-struct TokenResponse {
-    access_token: String,
-    #[serde(default)]
-    refresh_token: Option<String>,
-    #[serde(default)]
-    expires_in: Option<i64>,
 }
 
 pub(crate) enum AuthResolution {
@@ -162,7 +52,7 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            let discovery = discover_oauth_server(&server.url)
+            let discovery = mcp_oauth::discover(&server.url)
                 .await
                 .unwrap_or_else(|error| {
                     eprintln!("error: {error}");
@@ -172,12 +62,16 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            delete_stored_token(&resource, &discovery.issuer, server.client_id.as_deref())
-                .await
-                .unwrap_or_else(|error| {
-                    eprintln!("error: {error}");
-                    process::exit(1);
-                });
+            mcp_oauth::delete_token(
+                &resource,
+                &discovery.authorization_server_issuer,
+                server.client_id.as_deref(),
+            )
+            .await
+            .unwrap_or_else(|error| {
+                eprintln!("error: {error}");
+                process::exit(1);
+            });
             println!(
                 "Removed stored OAuth token for {} ({})",
                 server.name, server.url
@@ -197,7 +91,7 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            let discovery = discover_oauth_server(&server.url)
+            let discovery = mcp_oauth::discover(&server.url)
                 .await
                 .unwrap_or_else(|error| {
                     eprintln!("error: {error}");
@@ -207,7 +101,12 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                 eprintln!("error: {error}");
                 process::exit(1);
             });
-            match load_stored_token(&resource, &discovery.issuer, server.client_id.as_deref()).await
+            match mcp_oauth::load_token(
+                &resource,
+                &discovery.authorization_server_issuer,
+                server.client_id.as_deref(),
+            )
+            .await
             {
                 Ok(Some(token)) => {
                     println!("Server: {}", server.name);
@@ -356,8 +255,8 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
 
     let mut last_error = None;
     let state = if transport == "http" && !server.url.is_empty() {
-        // HTTP servers are connected when a static bearer token or stored OAuth
-        // token is available; otherwise callers need to run the configured auth flow.
+        // A configured static bearer token is treated as connected; an
+        // OAuth server is `auth_required` until a token is stored.
         if server.auth_token.as_deref().is_some_and(|t| !t.is_empty()) {
             "connected".to_string()
         } else {
@@ -396,6 +295,8 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
 pub(crate) async fn resolve_auth_for_server(
     server: &McpServerConfig,
 ) -> Result<AuthResolution, String> {
+    // Static `[mcp.auth]`: the bearer lives in the connect secret store, not
+    // an OAuth flow. Resolve it up front so it wins over discovery/refresh.
     if let Some(auth) = server.auth.as_ref() {
         if auth.mode == Some(OAuthClientAuthMode::Static) || auth.secret_id.is_some() {
             let secret_id = auth.secret_id.as_deref().ok_or_else(|| {
@@ -421,52 +322,27 @@ pub(crate) async fn resolve_auth_for_server(
         return Ok(AuthResolution::None);
     }
 
-    let discovery = discover_oauth_server(&server.url).await?;
-    let resource = canonical_server_resource(&server.url)?;
-    let store = KeyringOAuthTokenStorage::default();
-    let Some(mut stored) = load_stored_token_from_store(
-        &store,
-        &resource,
-        &discovery.issuer,
-        server.client_id.as_deref(),
-    )
-    .await?
-    else {
-        return Ok(AuthResolution::None);
-    };
-    validate_issuer_binding(&stored.issuer, &discovery.issuer)?;
-
-    if token_needs_refresh(&stored) {
-        stored = refresh_stored_token_with_store(&store, &stored, &discovery, None).await?;
+    match mcp_oauth::resolve_bearer(&server.url).await? {
+        Some(bearer) => Ok(AuthResolution::Bearer(bearer)),
+        None => Ok(AuthResolution::None),
     }
-
-    Ok(AuthResolution::Bearer(stored.access_token))
 }
 
+/// Run the interactive `harn mcp login` flow: harn mints the authorization URL
+/// (discovery + client resolution + PKCE), opens the browser, captures the
+/// redirect on a local loopback listener, then exchanges and stores the token.
+/// All OAuth state lives in [`harn_vm::mcp_oauth`]; this command only owns the
+/// browser + loopback IO.
 async fn login(options: &McpLoginArgs) -> Result<(), String> {
     let server = resolve_server_reference(&McpServerRefArgs {
         target: options.target.clone(),
         url: options.url.clone(),
         json: false,
     })?;
-    // RFC 8707 resource indicator: the MCP server's canonical URI, sent in both
-    // the authorization and token requests regardless of AS advertisement.
-    let resource = canonical_server_resource(&server.url)?;
-    let discovery = discover_oauth_server(&server.url).await?;
-    ensure_pkce_support(&discovery.metadata)?;
-    let requested_scopes = options
-        .scope
-        .clone()
-        .or_else(|| server.auth.as_ref().and_then(|auth| auth.scopes.clone()))
-        .or(server.scopes.clone())
-        .or_else(|| (!discovery.scopes.is_empty()).then(|| discovery.scopes.join(" ")));
 
-    let configured_client_id = options
-        .client_id
-        .clone()
-        .or_else(|| server.auth.as_ref().and_then(|auth| auth.client_id.clone()))
-        .or(server.client_id.clone());
-    let configured_client_secret = if let Some(secret) = options.client_secret.clone() {
+    // Resolve an optional BYO client secret stored in the connect secret store
+    // (`auth.client_secret_id`) before handing the flow to the engine.
+    let client_secret = if let Some(secret) = options.client_secret.clone() {
         Some(secret)
     } else if let Some(secret_id) = server
         .auth
@@ -477,129 +353,40 @@ async fn login(options: &McpLoginArgs) -> Result<(), String> {
     } else {
         server.client_secret.clone()
     };
-    let auth_selection = select_oauth_client_auth(
-        &discovery.metadata,
-        OAuthClientAuthOptions {
-            mode: server.auth.as_ref().and_then(|auth| auth.mode),
-            client_id: configured_client_id.as_deref(),
-            client_secret: configured_client_secret.as_deref(),
-            client_id_metadata_document_url: configured_client_id.as_deref(),
-            static_secret_id: server
-                .auth
-                .as_ref()
-                .and_then(|auth| auth.secret_id.as_deref()),
-        },
-    )?;
-    let (client_id, client_secret, token_auth_method) = match auth_selection.mode {
-        OAuthClientAuthMode::Cimd => {
-            let client_id = auth_selection
-                .client_id
-                .unwrap_or(DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL)
-                .to_string();
-            (client_id, None, "none".to_string())
-        }
-        OAuthClientAuthMode::Byo => {
-            let client_id = auth_selection
-                .client_id
-                .ok_or_else(|| "BYO OAuth auth requires client_id".to_string())?
-                .to_string();
-            let token_auth_method = server
-                .auth
-                .as_ref()
-                .and_then(|auth| auth.token_endpoint_auth_method.clone())
-                .map(Ok)
-                .unwrap_or_else(|| {
-                    determine_token_auth_method(
-                        &discovery.metadata,
-                        configured_client_secret.as_ref(),
-                    )
-                })?;
-            (client_id, configured_client_secret, token_auth_method)
-        }
-        OAuthClientAuthMode::Dcr => {
-            let registration_endpoint = discovery
-                .metadata
-                .registration_endpoint
-                .as_deref()
-                .ok_or_else(|| "dynamic client registration endpoint missing".to_string())?;
-            let registration = dynamic_client_registration(
-                registration_endpoint,
-                &options.redirect_uri,
-                requested_scopes.as_deref(),
-            )
-            .await?;
-            let auth_method = registration
-                .token_endpoint_auth_method
-                .clone()
-                .unwrap_or_else(|| "none".to_string());
-            (
-                registration.client_id,
-                registration.client_secret,
-                auth_method,
-            )
-        }
-        OAuthClientAuthMode::Static => {
-            return Err(
-                "static MCP auth uses a stored bearer token and does not run OAuth login; use `harn connect api-key --connector <name> --secret-id <namespace/name>` to store it".to_string()
-            );
-        }
-    };
 
-    let (code_verifier, code_challenge) = generate_pkce_pair();
-    let state = random_hex(16);
     let callback_listener = bind_callback_listener(&options.redirect_uri)?;
-
-    let auth_url = build_oauth_authorization_url(OAuthAuthorizationUrlOptions {
-        authorization_endpoint: &discovery.metadata.authorization_endpoint,
-        client_id: &client_id,
-        redirect_uri: &options.redirect_uri,
-        state: &state,
-        code_challenge: &code_challenge,
-        resource: &resource,
-        scopes: requested_scopes.as_deref(),
-    })?;
+    let pending = mcp_oauth::begin_authorization(BeginAuthorization {
+        server_url: server.url.clone(),
+        redirect_uri: options.redirect_uri.clone(),
+        mode: server.auth.as_ref().and_then(|auth| auth.mode),
+        client_id: options
+            .client_id
+            .clone()
+            .or_else(|| server.auth.as_ref().and_then(|auth| auth.client_id.clone()))
+            .or(server.client_id.clone()),
+        client_secret,
+        static_secret_id: server.auth.as_ref().and_then(|auth| auth.secret_id.clone()),
+        scopes: options
+            .scope
+            .clone()
+            .or_else(|| server.auth.as_ref().and_then(|auth| auth.scopes.clone()))
+            .or(server.scopes.clone()),
+    })
+    .await?;
 
     println!("Server: {} ({})", server.name, server.url);
     println!("Redirect URI: {}", options.redirect_uri);
     println!("Protocol Version: {MCP_PROTOCOL_VERSION}");
     println!("Opening browser for OAuth authorization...");
 
-    if webbrowser::open(auth_url.as_str()).is_err() {
-        println!("Open this URL manually:\n{auth_url}");
+    if webbrowser::open(&pending.authorize_url).is_err() {
+        println!("Open this URL manually:\n{}", pending.authorize_url);
     }
 
-    let callback = wait_for_oauth_response(callback_listener, &options.redirect_uri, &state)?;
-    validate_authorization_response_issuer(&discovery.metadata, callback.issuer.as_deref())?;
-    let token = exchange_authorization_code(
-        &discovery.metadata,
-        AuthorizationCodeExchange {
-            client_id: &client_id,
-            client_secret: client_secret.as_deref(),
-            token_auth_method: &token_auth_method,
-            redirect_uri: &options.redirect_uri,
-            resource: &resource,
-            scopes: requested_scopes.as_deref(),
-            code: &callback.code,
-            code_verifier: &code_verifier,
-        },
-    )
-    .await?;
-
-    let stored = StoredOAuthToken {
-        access_token: token.access_token,
-        refresh_token: token.refresh_token,
-        expires_at_unix: token
-            .expires_in
-            .map(|seconds| current_unix_timestamp().saturating_add(seconds)),
-        token_endpoint: discovery.metadata.token_endpoint.clone(),
-        client_id,
-        client_secret,
-        token_endpoint_auth_method: token_auth_method,
-        issuer: discovery.issuer,
-        resource,
-        scopes: requested_scopes,
-    };
-    save_stored_token(&stored).await?;
+    let callback =
+        wait_for_oauth_response(callback_listener, &options.redirect_uri, &pending.state)?;
+    mcp_oauth::complete_authorization(&pending.state, &callback.code, callback.issuer.as_deref())
+        .await?;
     println!("OAuth token stored for {}.", server.name);
     Ok(())
 }
@@ -675,57 +462,8 @@ fn find_manifest() -> Result<(PathBuf, package::Manifest), String> {
     Err("No harn.toml found in the current directory or its parents".to_string())
 }
 
-async fn discover_oauth_server(server_url: &str) -> Result<OAuthDiscoveryResult, String> {
-    let client = reqwest::Client::new();
-    let discovery = discover_mcp_oauth(&client, server_url)
-        .await
-        .map_err(|error| error.to_string())?;
-    Ok(OAuthDiscoveryResult {
-        metadata: discovery.authorization_server_metadata,
-        issuer: discovery.authorization_server_issuer,
-        scopes: discovery.scopes,
-    })
-}
-
 fn canonical_server_resource(server_url: &str) -> Result<String, String> {
-    canonical_resource_indicator(server_url).map_err(|error| error.to_string())
-}
-
-fn ensure_pkce_support(metadata: &OAuthServerMetadata) -> Result<(), String> {
-    ensure_pkce_s256_supported(metadata)
-}
-
-async fn dynamic_client_registration(
-    registration_endpoint: &str,
-    redirect_uri: &str,
-    scopes: Option<&str>,
-) -> Result<DynamicClientRegistrationResponse, String> {
-    let client = reqwest::Client::new();
-    let body = dynamic_client_registration_body("Harn CLI", [redirect_uri], scopes);
-    let response = client
-        .post(registration_endpoint)
-        .json(&body)
-        .send()
-        .await
-        .map_err(|error| format!("Dynamic client registration failed: {error}"))?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "Dynamic client registration failed: {status} {body}"
-        ));
-    }
-    response
-        .json::<DynamicClientRegistrationResponse>()
-        .await
-        .map_err(|error| format!("Invalid dynamic client registration response: {error}"))
-}
-
-fn determine_token_auth_method(
-    metadata: &OAuthServerMetadata,
-    client_secret: Option<&String>,
-) -> Result<String, String> {
-    determine_token_endpoint_auth_method(metadata, client_secret.map(String::as_str))
+    harn_vm::mcp_auth::canonical_resource_indicator(server_url).map_err(|error| error.to_string())
 }
 
 fn bind_callback_listener(redirect_uri: &str) -> Result<TcpListener, String> {
@@ -814,477 +552,6 @@ fn wait_for_oauth_response(
     Ok(OAuthCallbackResponse { code, issuer })
 }
 
-async fn exchange_authorization_code(
-    metadata: &OAuthServerMetadata,
-    request: AuthorizationCodeExchange<'_>,
-) -> Result<TokenResponse, String> {
-    let client = reqwest::Client::new();
-    let form = authorization_code_token_form(OAuthAuthorizationCodeTokenForm {
-        client_id: request.client_id,
-        redirect_uri: request.redirect_uri,
-        code: request.code,
-        code_verifier: request.code_verifier,
-        resource: request.resource,
-        scopes: request.scopes,
-    });
-    request_token(
-        &client,
-        &metadata.token_endpoint,
-        request.token_auth_method,
-        request.client_id,
-        request.client_secret,
-        &form,
-    )
-    .await
-}
-
-struct AuthorizationCodeExchange<'a> {
-    client_id: &'a str,
-    client_secret: Option<&'a str>,
-    token_auth_method: &'a str,
-    redirect_uri: &'a str,
-    resource: &'a str,
-    scopes: Option<&'a str>,
-    code: &'a str,
-    code_verifier: &'a str,
-}
-
-async fn refresh_token_if_needed(
-    token: &StoredOAuthToken,
-    discovery: &OAuthDiscoveryResult,
-) -> Result<StoredOAuthToken, String> {
-    if !token_needs_refresh(token) {
-        return Ok(token.clone());
-    }
-    validate_issuer_binding(&token.issuer, &discovery.issuer)?;
-
-    let refresh_token = token.refresh_token.clone().ok_or_else(|| {
-        "Stored OAuth token has expired and does not include a refresh token".to_string()
-    })?;
-    // Re-send the RFC 8707 resource indicator on refresh and keep the stored
-    // key aligned with the canonical resource.
-    let resource =
-        canonical_resource_indicator(&token.resource).unwrap_or_else(|_| token.resource.clone());
-    let client = reqwest::Client::new();
-    let form = refresh_token_form(OAuthRefreshTokenForm {
-        client_id: &token.client_id,
-        refresh_token: &refresh_token,
-        resource: &resource,
-    });
-    let refreshed = request_token(
-        &client,
-        &discovery.metadata.token_endpoint,
-        &token.token_endpoint_auth_method,
-        &token.client_id,
-        token.client_secret.as_deref(),
-        &form,
-    )
-    .await?;
-    Ok(StoredOAuthToken {
-        access_token: refreshed.access_token,
-        refresh_token: refreshed
-            .refresh_token
-            .or_else(|| token.refresh_token.clone()),
-        expires_at_unix: refreshed
-            .expires_in
-            .map(|seconds| current_unix_timestamp().saturating_add(seconds)),
-        token_endpoint: discovery.metadata.token_endpoint.clone(),
-        client_id: token.client_id.clone(),
-        client_secret: token.client_secret.clone(),
-        token_endpoint_auth_method: token.token_endpoint_auth_method.clone(),
-        issuer: token.issuer.clone(),
-        resource,
-        scopes: token.scopes.clone(),
-    })
-}
-
-async fn request_token(
-    client: &reqwest::Client,
-    token_endpoint: &str,
-    token_auth_method: &str,
-    client_id: &str,
-    client_secret: Option<&str>,
-    form: &[(&str, String)],
-) -> Result<TokenResponse, String> {
-    validate_token_endpoint_auth_method(token_auth_method)?;
-    let mut request = client.post(token_endpoint).form(form);
-    match token_auth_method {
-        "client_secret_basic" => {
-            let client_secret = client_secret
-                .ok_or_else(|| "Missing client secret for client_secret_basic".to_string())?;
-            request = request.basic_auth(client_id, Some(client_secret));
-        }
-        "client_secret_post" => {
-            let client_secret = client_secret
-                .ok_or_else(|| "Missing client secret for client_secret_post".to_string())?;
-            let mut extended = form.to_vec();
-            extended.push(("client_secret", client_secret.to_string()));
-            request = client.post(token_endpoint).form(&extended);
-        }
-        _ => {}
-    }
-    let response = request
-        .send()
-        .await
-        .map_err(|error| format!("Token request failed: {error}"))?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!("Token request failed: {status} {body}"));
-    }
-    response
-        .json::<TokenResponse>()
-        .await
-        .map_err(|error| format!("Invalid token response: {error}"))
-}
-
-fn generate_pkce_pair() -> (String, String) {
-    let verifier = random_hex(32);
-    let digest = Sha256::digest(verifier.as_bytes());
-    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
-    (verifier, challenge)
-}
-
-fn random_hex(bytes: usize) -> String {
-    let raw: Vec<u8> = (0..bytes).map(|_| rand::random::<u8>()).collect();
-    raw.iter().map(|byte| format!("{byte:02x}")).collect()
-}
-
-fn token_needs_refresh(token: &StoredOAuthToken) -> bool {
-    match token.expires_at_unix {
-        Some(expires_at) => {
-            expires_at <= current_unix_timestamp().saturating_add(TOKEN_REFRESH_SKEW_SECS)
-        }
-        None => false,
-    }
-}
-
-fn current_unix_timestamp() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_secs() as i64)
-        .unwrap_or_default()
-}
-
-async fn refresh_stored_token_with_store<S: OAuthTokenStorage + ?Sized>(
-    store: &S,
-    token: &StoredOAuthToken,
-    discovery: &OAuthDiscoveryResult,
-    lock_dir_override: Option<PathBuf>,
-) -> Result<StoredOAuthToken, String> {
-    let key = OAuthTokenStoreKey::from_token(token);
-    let _guard = acquire_oauth_refresh_lock(&key, lock_dir_override.as_deref()).await?;
-    let Some(current) = store.load_token(&key).await? else {
-        return Err("Stored OAuth token disappeared before it could be refreshed".to_string());
-    };
-    validate_issuer_binding(&current.issuer, &discovery.issuer)?;
-    if !token_needs_refresh(&current) {
-        return Ok(current);
-    }
-
-    let refreshed = refresh_token_if_needed(&current, discovery).await?;
-    store.save_token(&refreshed).await?;
-    Ok(refreshed)
-}
-
-struct OAuthRefreshLockGuard {
-    _async_guard: tokio::sync::OwnedMutexGuard<()>,
-    file: fs::File,
-}
-
-impl Drop for OAuthRefreshLockGuard {
-    fn drop(&mut self) {
-        let _ = self.file.unlock();
-    }
-}
-
-async fn acquire_oauth_refresh_lock(
-    key: &OAuthTokenStoreKey,
-    lock_dir_override: Option<&Path>,
-) -> Result<OAuthRefreshLockGuard, String> {
-    let mutex = oauth_refresh_mutex(key);
-    let async_guard = mutex.lock_owned().await;
-    let lock_path = oauth_refresh_lock_path(key, lock_dir_override);
-    let file = tokio::task::spawn_blocking(move || {
-        if let Some(parent) = lock_path.parent() {
-            fs::create_dir_all(parent).map_err(|error| {
-                format!(
-                    "Failed to create OAuth token lock directory `{}`: {error}",
-                    parent.display()
-                )
-            })?;
-        }
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&lock_path)
-            .map_err(|error| {
-                format!(
-                    "Failed to open OAuth token lock `{}`: {error}",
-                    lock_path.display()
-                )
-            })?;
-        file.lock_exclusive().map_err(|error| {
-            format!(
-                "Failed to acquire OAuth token lock `{}`: {error}",
-                lock_path.display()
-            )
-        })?;
-        Ok::<fs::File, String>(file)
-    })
-    .await
-    .map_err(|error| format!("OAuth token lock task failed: {error}"))??;
-    Ok(OAuthRefreshLockGuard {
-        _async_guard: async_guard,
-        file,
-    })
-}
-
-fn oauth_refresh_mutex(key: &OAuthTokenStoreKey) -> Arc<AsyncMutex<()>> {
-    static LOCKS: OnceLock<std::sync::Mutex<HashMap<String, Arc<AsyncMutex<()>>>>> =
-        OnceLock::new();
-    let locks = LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
-    let mut locks = locks.lock().expect("OAuth refresh lock registry poisoned");
-    locks
-        .entry(key.account())
-        .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-        .clone()
-}
-
-fn oauth_refresh_lock_path(key: &OAuthTokenStoreKey, lock_dir_override: Option<&Path>) -> PathBuf {
-    let dir = lock_dir_override
-        .map(Path::to_path_buf)
-        .unwrap_or_else(default_oauth_lock_dir);
-    dir.join(format!("{}.lock", key.account()))
-}
-
-fn default_oauth_lock_dir() -> PathBuf {
-    if let Some(path) = env::var_os(OAUTH_LOCK_DIR_ENV) {
-        return PathBuf::from(path);
-    }
-    harn_home_dir().join("mcp-oauth-locks")
-}
-
-fn harn_home_dir() -> PathBuf {
-    if let Some(path) = env::var_os(HARN_HOME_ENV) {
-        return PathBuf::from(path);
-    }
-    if let Some(home) = env::var_os("HOME") {
-        return PathBuf::from(home).join(".harn");
-    }
-    if let Some(home) = env::var_os("USERPROFILE") {
-        return PathBuf::from(home).join(".harn");
-    }
-    env::temp_dir().join("harn")
-}
-
-#[async_trait]
-impl OAuthTokenStorage for KeyringOAuthTokenStorage {
-    async fn load_token(
-        &self,
-        key: &OAuthTokenStoreKey,
-    ) -> Result<Option<StoredOAuthToken>, String> {
-        let payload = match self.provider.get(&token_secret_id(key)).await {
-            Ok(secret) => secret,
-            Err(harn_vm::secrets::SecretError::NotFound { .. }) => return Ok(None),
-            Err(error) => return Err(format!("Failed to read OAuth token from keyring: {error}")),
-        };
-        let token = payload
-            .with_exposed(|bytes| serde_json::from_slice::<StoredOAuthToken>(bytes))
-            .map_err(|error| format!("Stored OAuth token was invalid JSON: {error}"))?;
-        validate_token_store_binding(&token, key)?;
-        Ok(Some(token))
-    }
-
-    async fn save_token(&self, token: &StoredOAuthToken) -> Result<(), String> {
-        let payload = serde_json::to_string(token)
-            .map_err(|error| format!("Failed to serialize OAuth token: {error}"))?;
-        self.provider
-            .put(
-                &token_secret_id(&OAuthTokenStoreKey::from_token(token)),
-                SecretBytes::from(payload.into_bytes()),
-            )
-            .await
-            .map_err(|error| format!("Failed to store OAuth token in keyring: {error}"))?;
-        self.save_active_client_id(&token.resource, &token.issuer, &token.client_id)
-            .await
-    }
-
-    async fn delete_token(&self, key: &OAuthTokenStoreKey) -> Result<(), String> {
-        self.provider
-            .delete(&token_secret_id(key))
-            .await
-            .map_err(|error| format!("Failed to delete OAuth token from keyring: {error}"))
-    }
-
-    async fn load_active_client_id(
-        &self,
-        resource: &str,
-        issuer: &str,
-    ) -> Result<Option<String>, String> {
-        let payload = match self
-            .provider
-            .get(&token_client_index_secret_id(resource, issuer))
-            .await
-        {
-            Ok(secret) => secret,
-            Err(harn_vm::secrets::SecretError::NotFound { .. }) => return Ok(None),
-            Err(error) => {
-                return Err(format!(
-                    "Failed to read OAuth client index from keyring: {error}"
-                ))
-            }
-        };
-        let index = payload
-            .with_exposed(|bytes| serde_json::from_slice::<StoredOAuthClientIndex>(bytes))
-            .map_err(|error| format!("Stored OAuth client index was invalid JSON: {error}"))?;
-        Ok(Some(index.client_id))
-    }
-
-    async fn save_active_client_id(
-        &self,
-        resource: &str,
-        issuer: &str,
-        client_id: &str,
-    ) -> Result<(), String> {
-        let payload = serde_json::to_string(&StoredOAuthClientIndex {
-            client_id: client_id.to_string(),
-        })
-        .map_err(|error| format!("Failed to serialize OAuth client index: {error}"))?;
-        self.provider
-            .put(
-                &token_client_index_secret_id(resource, issuer),
-                SecretBytes::from(payload.into_bytes()),
-            )
-            .await
-            .map_err(|error| format!("Failed to store OAuth client index in keyring: {error}"))
-    }
-
-    async fn delete_active_client_id(&self, resource: &str, issuer: &str) -> Result<(), String> {
-        self.provider
-            .delete(&token_client_index_secret_id(resource, issuer))
-            .await
-            .map_err(|error| format!("Failed to delete OAuth client index from keyring: {error}"))
-    }
-}
-
-async fn save_stored_token(token: &StoredOAuthToken) -> Result<(), String> {
-    let store = KeyringOAuthTokenStorage::default();
-    let key = OAuthTokenStoreKey::from_token(token);
-    let _guard = acquire_oauth_refresh_lock(&key, None).await?;
-    store.save_token(token).await
-}
-
-async fn load_stored_token(
-    resource: &str,
-    issuer: &str,
-    client_id_hint: Option<&str>,
-) -> Result<Option<StoredOAuthToken>, String> {
-    let store = KeyringOAuthTokenStorage::default();
-    load_stored_token_from_store(&store, resource, issuer, client_id_hint).await
-}
-
-async fn load_stored_token_from_store<S: OAuthTokenStorage + ?Sized>(
-    store: &S,
-    resource: &str,
-    issuer: &str,
-    client_id_hint: Option<&str>,
-) -> Result<Option<StoredOAuthToken>, String> {
-    let client_id = match client_id_hint {
-        Some(client_id) => client_id.to_string(),
-        None => match store.load_active_client_id(resource, issuer).await? {
-            Some(client_id) => client_id,
-            None => return Ok(None),
-        },
-    };
-    store
-        .load_token(&OAuthTokenStoreKey::new(resource, issuer, &client_id))
-        .await
-}
-
-async fn delete_stored_token(
-    resource: &str,
-    issuer: &str,
-    client_id_hint: Option<&str>,
-) -> Result<(), String> {
-    let store = KeyringOAuthTokenStorage::default();
-    let client_id = match client_id_hint {
-        Some(client_id) => client_id.to_string(),
-        None => match store.load_active_client_id(resource, issuer).await? {
-            Some(client_id) => client_id,
-            None => {
-                store.delete_active_client_id(resource, issuer).await?;
-                return Ok(());
-            }
-        },
-    };
-    let key = OAuthTokenStoreKey::new(resource, issuer, &client_id);
-    let _guard = acquire_oauth_refresh_lock(&key, None).await?;
-    store.delete_token(&key).await?;
-    if store
-        .load_active_client_id(resource, issuer)
-        .await?
-        .as_deref()
-        == Some(client_id.as_str())
-    {
-        store.delete_active_client_id(resource, issuer).await?;
-    }
-    Ok(())
-}
-
-fn token_store_account(resource: &str, issuer: &str, client_id: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(issuer.as_bytes());
-    hasher.update([0]);
-    hasher.update(resource.as_bytes());
-    hasher.update([0]);
-    hasher.update(client_id.as_bytes());
-    let digest = hasher.finalize();
-    format!(
-        "mcp-token-{}",
-        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
-    )
-}
-
-fn token_client_index_account(resource: &str, issuer: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(issuer.as_bytes());
-    hasher.update([0]);
-    hasher.update(resource.as_bytes());
-    let digest = hasher.finalize();
-    format!(
-        "mcp-client-index-{}",
-        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
-    )
-}
-
-fn oauth_token_provider() -> KeyringSecretProvider {
-    KeyringSecretProvider::new(KEYRING_SERVICE)
-}
-
-fn token_secret_id(key: &OAuthTokenStoreKey) -> SecretId {
-    SecretId::new("", key.account())
-}
-
-fn token_client_index_secret_id(resource: &str, issuer: &str) -> SecretId {
-    SecretId::new("", token_client_index_account(resource, issuer))
-}
-
-fn validate_token_store_binding(
-    token: &StoredOAuthToken,
-    key: &OAuthTokenStoreKey,
-) -> Result<(), String> {
-    if token.resource != key.resource
-        || token.issuer != key.issuer
-        || token.client_id != key.client_id
-    {
-        return Err("Stored OAuth token key does not match its token binding".to_string());
-    }
-    Ok(())
-}
-
 fn format_expiry(unix: i64) -> String {
     unix.to_string()
 }
@@ -1358,27 +625,14 @@ fn html_escape(text: &str) -> String {
     escaped
 }
 
-#[derive(Clone)]
-struct OAuthDiscoveryResult {
-    metadata: OAuthServerMetadata,
-    issuer: String,
-    scopes: Vec<String>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap as StdHashMap;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use axum::extract::State;
-    use axum::routing::post;
-    use axum::{Form, Json, Router};
     use harn_vm::mcp_auth::{
-        authorization_server_metadata_candidates, protected_resource_metadata_candidates,
+        authorization_server_metadata_candidates, build_oauth_authorization_url,
+        canonical_resource_indicator, protected_resource_metadata_candidates,
+        OAuthAuthorizationUrlOptions,
     };
-    use serde_json::json;
-    use tokio::sync::Mutex;
 
     #[test]
     fn protected_resource_candidate_prefers_path_specific_url() {
@@ -1413,193 +667,6 @@ mod tests {
     }
 
     #[test]
-    fn token_store_account_is_stable() {
-        let first =
-            token_store_account("https://mcp.notion.com", "https://auth.example", "client-a");
-        let second =
-            token_store_account("https://mcp.notion.com", "https://auth.example", "client-a");
-        let other_issuer = token_store_account(
-            "https://mcp.notion.com",
-            "https://other.example",
-            "client-a",
-        );
-        let other_client =
-            token_store_account("https://mcp.notion.com", "https://auth.example", "client-b");
-        assert_eq!(first, second);
-        assert_ne!(first, other_issuer);
-        assert_ne!(first, other_client);
-    }
-
-    #[tokio::test]
-    async fn expired_token_refresh_is_singleflight() {
-        #[derive(Clone, Default)]
-        struct MemoryOAuthTokenStorage {
-            tokens: Arc<Mutex<StdHashMap<OAuthTokenStoreKey, StoredOAuthToken>>>,
-            index: Arc<Mutex<StdHashMap<(String, String), String>>>,
-        }
-
-        #[async_trait]
-        impl OAuthTokenStorage for MemoryOAuthTokenStorage {
-            async fn load_token(
-                &self,
-                key: &OAuthTokenStoreKey,
-            ) -> Result<Option<StoredOAuthToken>, String> {
-                Ok(self.tokens.lock().await.get(key).cloned())
-            }
-
-            async fn save_token(&self, token: &StoredOAuthToken) -> Result<(), String> {
-                self.tokens
-                    .lock()
-                    .await
-                    .insert(OAuthTokenStoreKey::from_token(token), token.clone());
-                self.save_active_client_id(&token.resource, &token.issuer, &token.client_id)
-                    .await
-            }
-
-            async fn delete_token(&self, key: &OAuthTokenStoreKey) -> Result<(), String> {
-                self.tokens.lock().await.remove(key);
-                Ok(())
-            }
-
-            async fn load_active_client_id(
-                &self,
-                resource: &str,
-                issuer: &str,
-            ) -> Result<Option<String>, String> {
-                Ok(self
-                    .index
-                    .lock()
-                    .await
-                    .get(&(resource.to_string(), issuer.to_string()))
-                    .cloned())
-            }
-
-            async fn save_active_client_id(
-                &self,
-                resource: &str,
-                issuer: &str,
-                client_id: &str,
-            ) -> Result<(), String> {
-                self.index.lock().await.insert(
-                    (resource.to_string(), issuer.to_string()),
-                    client_id.to_string(),
-                );
-                Ok(())
-            }
-
-            async fn delete_active_client_id(
-                &self,
-                resource: &str,
-                issuer: &str,
-            ) -> Result<(), String> {
-                self.index
-                    .lock()
-                    .await
-                    .remove(&(resource.to_string(), issuer.to_string()));
-                Ok(())
-            }
-        }
-
-        #[derive(Clone)]
-        struct TokenEndpointState {
-            calls: Arc<AtomicUsize>,
-        }
-
-        async fn token_endpoint(
-            State(state): State<TokenEndpointState>,
-            Form(form): Form<StdHashMap<String, String>>,
-        ) -> Json<serde_json::Value> {
-            assert_eq!(
-                form.get("grant_type").map(String::as_str),
-                Some("refresh_token")
-            );
-            assert_eq!(
-                form.get("refresh_token").map(String::as_str),
-                Some("refresh-old")
-            );
-            state.calls.fetch_add(1, Ordering::SeqCst);
-            Json(json!({
-                "access_token": "access-new",
-                "refresh_token": "refresh-new",
-                "expires_in": 3600
-            }))
-        }
-
-        let calls = Arc::new(AtomicUsize::new(0));
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let token_endpoint_url = format!("http://{}/token", listener.local_addr().unwrap());
-        let app = Router::new()
-            .route("/token", post(token_endpoint))
-            .with_state(TokenEndpointState {
-                calls: calls.clone(),
-            });
-        let server = tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-
-        let store = Arc::new(MemoryOAuthTokenStorage::default());
-        let stale = StoredOAuthToken {
-            access_token: "access-old".to_string(),
-            refresh_token: Some("refresh-old".to_string()),
-            expires_at_unix: Some(current_unix_timestamp().saturating_sub(1)),
-            token_endpoint: token_endpoint_url.clone(),
-            client_id: "client-a".to_string(),
-            client_secret: None,
-            token_endpoint_auth_method: "none".to_string(),
-            issuer: "https://auth.example".to_string(),
-            resource: "https://mcp.example/mcp".to_string(),
-            scopes: None,
-        };
-        store.save_token(&stale).await.unwrap();
-
-        let discovery = OAuthDiscoveryResult {
-            metadata: OAuthServerMetadata {
-                issuer: stale.issuer.clone(),
-                authorization_endpoint: "https://auth.example/authorize".to_string(),
-                token_endpoint: token_endpoint_url,
-                registration_endpoint: None,
-                token_endpoint_auth_methods_supported: vec!["none".to_string()],
-                code_challenge_methods_supported: vec!["S256".to_string()],
-                scopes_supported: Vec::new(),
-                client_id_metadata_document_supported: false,
-                authorization_response_iss_parameter_supported: false,
-                extra: Default::default(),
-            },
-            issuer: stale.issuer.clone(),
-            scopes: Vec::new(),
-        };
-        let lock_dir = tempfile::tempdir().unwrap();
-
-        let mut tasks = Vec::new();
-        for _ in 0..8 {
-            let store = store.clone();
-            let token = stale.clone();
-            let discovery = discovery.clone();
-            let lock_dir = lock_dir.path().to_path_buf();
-            tasks.push(tokio::spawn(async move {
-                refresh_stored_token_with_store(store.as_ref(), &token, &discovery, Some(lock_dir))
-                    .await
-                    .unwrap()
-            }));
-        }
-
-        for task in tasks {
-            let refreshed = task.await.unwrap();
-            assert_eq!(refreshed.access_token, "access-new");
-            assert_eq!(refreshed.refresh_token.as_deref(), Some("refresh-new"));
-        }
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-        let stored = store
-            .load_token(&OAuthTokenStoreKey::from_token(&stale))
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(stored.access_token, "access-new");
-        assert_eq!(stored.refresh_token.as_deref(), Some("refresh-new"));
-        server.abort();
-    }
-
-    #[test]
     fn callback_html_response_escapes_message() {
         let response = html_response(400, "<script>alert('x')</script>&");
         assert!(response.contains("&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;&amp;"));
@@ -1631,27 +698,6 @@ mod tests {
 
     fn parse_server(toml_table: &str) -> McpServerConfig {
         toml::from_str::<McpServerConfig>(toml_table).expect("mcp server config")
-    }
-
-    #[test]
-    fn mcp_server_parses_unified_auth_config() {
-        let server = parse_server(
-            r#"
-name = "remote"
-transport = "http"
-url = "https://mcp.example.com/mcp"
-auth = { mode = "byo", client_id = "registered-client", client_secret_id = "mcp/client-secret", token_auth_method = "client_secret_post", scopes = "read write" }
-"#,
-        );
-        let auth = server.auth.expect("auth config");
-        assert_eq!(auth.mode, Some(OAuthClientAuthMode::Byo));
-        assert_eq!(auth.client_id.as_deref(), Some("registered-client"));
-        assert_eq!(auth.client_secret_id.as_deref(), Some("mcp/client-secret"));
-        assert_eq!(
-            auth.token_endpoint_auth_method.as_deref(),
-            Some("client_secret_post")
-        );
-        assert_eq!(auth.scopes.as_deref(), Some("read write"));
     }
 
     #[tokio::test]

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1472,6 +1472,22 @@ impl AgentEventSink for AcpAgentEventSink {
                     }),
                 );
             }
+            AgentEvent::McpAuthRequired {
+                session_id,
+                server,
+                resource,
+                scope,
+            } => {
+                self.emit_agent_event_ext(
+                    "mcp_auth_required",
+                    session_id,
+                    serde_json::json!({
+                        "server": server,
+                        "resource": resource,
+                        "scope": scope,
+                    }),
+                );
+            }
         }
     }
 }

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -741,6 +741,45 @@ async fn mcp_catalog_changed_allows_serverless_allowlist_update() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn mcp_auth_required_reaches_acp_as_ext_event() {
+    let actual = collect_notifications(vec![AgentEvent::McpAuthRequired {
+        session_id: "session-1".to_string(),
+        server: "notion".to_string(),
+        resource: "https://mcp.notion.com".to_string(),
+        scope: Some("read write".to_string()),
+    }])
+    .await;
+
+    let notification = &actual[0];
+    assert_eq!(notification["method"], HARN_AGENT_EVENT_METHOD);
+    let params = &notification["params"];
+    assert_eq!(params["kind"], "mcp_auth_required");
+    assert_eq!(params["sessionId"], "session-1");
+    assert_eq!(params["server"], "notion");
+    assert_eq!(params["resource"], "https://mcp.notion.com");
+    assert_eq!(params["scope"], "read write");
+    assert!(
+        HARN_AGENT_EVENT_KINDS.contains(&"mcp_auth_required"),
+        "mcp_auth_required must be advertised so clients can subscribe"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn mcp_auth_required_omits_absent_scope() {
+    let actual = collect_notifications(vec![AgentEvent::McpAuthRequired {
+        session_id: "session-1".to_string(),
+        server: "notion".to_string(),
+        resource: "https://mcp.notion.com".to_string(),
+        scope: None,
+    }])
+    .await;
+
+    let params = &actual[0]["params"];
+    assert_eq!(params["kind"], "mcp_auth_required");
+    assert!(params["scope"].is_null());
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn harn_extension_session_update_fixtures_are_pinned() {
     let actual = collect_notifications(extension_fixture_events()).await;
     let expected: serde_json::Value = serde_json::from_str(include_str!(

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -73,6 +73,37 @@ use io::send_json_response;
 
 const ACP_AUTH_REQUIRED_CODE: i64 = -32000;
 
+/// Default loopback redirect for `mcp/authorize` when the client does not
+/// supply one. TUI/headless clients capture this with a loopback listener
+/// (matching `harn mcp login`); GUI clients pass their own URL scheme instead.
+const MCP_DEFAULT_OAUTH_REDIRECT_URI: &str = "http://127.0.0.1:9783/oauth/callback";
+
+/// Parse `state`, `code`, and the optional `iss` issuer out of a captured OAuth
+/// redirect URL (e.g. `burin://oauth/callback?code=…&state=…&iss=…`). Returns
+/// an error describing what the provider sent back when `code`/`state` are
+/// absent (including a propagated `error`/`error_description` query).
+fn parse_oauth_redirect_url(
+    redirect_url: &str,
+) -> Result<(String, String, Option<String>), String> {
+    let parsed =
+        url::Url::parse(redirect_url).map_err(|error| format!("invalid redirectUrl: {error}"))?;
+    let query = |key: &str| {
+        parsed
+            .query_pairs()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.into_owned())
+    };
+    if let Some(error) = query("error") {
+        let description = query("error_description")
+            .map(|description| format!(": {description}"))
+            .unwrap_or_default();
+        return Err(format!("authorization failed: {error}{description}"));
+    }
+    let state = query("state").ok_or_else(|| "redirectUrl is missing state".to_string())?;
+    let code = query("code").ok_or_else(|| "redirectUrl is missing code".to_string())?;
+    Ok((state, code, query("iss")))
+}
+
 #[derive(Clone)]
 struct InjectControlRecord {
     owner: serde_json::Value,
@@ -2422,6 +2453,123 @@ impl AcpServer {
         }
     }
 
+    /// `mcp/authorize`: begin an interactive OAuth authorization for an MCP
+    /// server. harn does discovery + client resolution + PKCE, registers the
+    /// pending flow, and returns the browser URL plus the `state` the matching
+    /// `mcp/oauth_callback` must echo. The client opens `authorizeUrl`; the
+    /// redirect's `code`+`state` come back via `mcp/oauth_callback`. Token
+    /// exchange and storage stay in harn.
+    async fn handle_mcp_authorize(&self, id: &serde_json::Value, params: &serde_json::Value) {
+        let Some(url) = params
+            .get("url")
+            .or_else(|| params.get("resource"))
+            .and_then(|value| value.as_str())
+        else {
+            self.send_error(
+                id,
+                -32602,
+                "mcp/authorize requires url (the MCP server URL)",
+            );
+            return;
+        };
+        let redirect_uri = params
+            .get("redirectUri")
+            .and_then(|value| value.as_str())
+            .unwrap_or(MCP_DEFAULT_OAUTH_REDIRECT_URI)
+            .to_string();
+        let string_param = |key: &str| {
+            params
+                .get(key)
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        };
+        // An explicit auth mode (cimd/dcr/static/byo) is optional; harn
+        // auto-selects (CIMD-default) when the client omits it.
+        let mode = match params.get("mode").and_then(|value| value.as_str()) {
+            Some(raw) => match serde_json::from_value(serde_json::json!(raw)) {
+                Ok(mode) => Some(mode),
+                Err(_) => {
+                    self.send_error(
+                        id,
+                        -32602,
+                        "mcp/authorize: invalid mode (expected cimd|dcr|static|byo)",
+                    );
+                    return;
+                }
+            },
+            None => None,
+        };
+        let request = harn_vm::mcp_oauth::BeginAuthorization {
+            server_url: url.to_string(),
+            redirect_uri,
+            mode,
+            client_id: string_param("clientId"),
+            client_secret: string_param("clientSecret"),
+            static_secret_id: string_param("staticSecretId"),
+            scopes: string_param("scope"),
+        };
+        match harn_vm::mcp_oauth::begin_authorization(request).await {
+            Ok(pending) => self.send_response(
+                id,
+                serde_json::json!({
+                    "authorizeUrl": pending.authorize_url,
+                    "state": pending.state,
+                    "redirectUri": pending.redirect_uri,
+                    "resource": pending.resource,
+                    "issuer": pending.issuer,
+                }),
+            ),
+            Err(error) => self.send_error(id, -32000, &error),
+        }
+    }
+
+    /// `mcp/oauth_callback`: complete an authorization begun by `mcp/authorize`.
+    /// Accepts either explicit `state`+`code` (+optional `issuer`) or a full
+    /// `redirectUrl` (the captured `burin://…?code=…&state=…&iss=…`) to parse
+    /// them from. harn exchanges the code and stores the token.
+    async fn handle_mcp_oauth_callback(&self, id: &serde_json::Value, params: &serde_json::Value) {
+        let parsed = params
+            .get("redirectUrl")
+            .and_then(|value| value.as_str())
+            .map(parse_oauth_redirect_url);
+        let (state, code, issuer) = match parsed {
+            Some(Ok(parts)) => parts,
+            Some(Err(error)) => {
+                self.send_error(id, -32602, &error);
+                return;
+            }
+            None => {
+                let field = |key: &str| {
+                    params
+                        .get(key)
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                };
+                let (Some(state), Some(code)) = (field("state"), field("code")) else {
+                    self.send_error(
+                        id,
+                        -32602,
+                        "mcp/oauth_callback requires state and code (or redirectUrl)",
+                    );
+                    return;
+                };
+                (state, code, field("issuer"))
+            }
+        };
+        match harn_vm::mcp_oauth::complete_authorization(&state, &code, issuer.as_deref()).await {
+            Ok(token) => self.send_response(
+                id,
+                serde_json::json!({
+                    "ok": true,
+                    "resource": token.resource,
+                    "issuer": token.issuer,
+                    "expiresAt": token.expires_at_unix,
+                }),
+            ),
+            Err(error) => self.send_error(id, -32000, &error),
+        }
+    }
+
     async fn handle_hitl_respond(&self, id: &serde_json::Value, params: &serde_json::Value) {
         let session_cwd = params
             .get("sessionId")
@@ -3519,6 +3667,18 @@ impl AcpServer {
                     return;
                 }
                 self.handle_mcp_catalog(&id, &params);
+            }
+            "mcp/authorize" | "harn.mcp.authorize" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_mcp_authorize(&id, &params).await;
+            }
+            "mcp/oauth_callback" | "harn.mcp.oauth_callback" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_mcp_oauth_callback(&id, &params).await;
             }
             _ => {
                 if !id.is_null() {

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -67,6 +67,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "judge_decision",
     "loop_control_decision",
     "loop_stuck",
+    "mcp_auth_required",
     "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -1558,6 +1558,34 @@ async fn vm_baseline_cached_serves_file_backed_context_until_key_changes() {
     assert_eq!(ms5, 0);
 }
 
+#[test]
+fn parse_oauth_redirect_url_extracts_code_state_issuer() {
+    let (state, code, issuer) = parse_oauth_redirect_url(
+        "burin://oauth/callback?code=auth-code&state=xyz&iss=https://auth.example",
+    )
+    .expect("parse");
+    assert_eq!(state, "xyz");
+    assert_eq!(code, "auth-code");
+    assert_eq!(issuer.as_deref(), Some("https://auth.example"));
+}
+
+#[test]
+fn parse_oauth_redirect_url_propagates_provider_error() {
+    let error = parse_oauth_redirect_url(
+        "http://127.0.0.1/cb?error=access_denied&error_description=nope&state=xyz",
+    )
+    .expect_err("error param");
+    assert!(error.contains("access_denied"), "{error}");
+    assert!(error.contains("nope"), "{error}");
+}
+
+#[test]
+fn parse_oauth_redirect_url_requires_code() {
+    let error =
+        parse_oauth_redirect_url("http://127.0.0.1/cb?state=xyz").expect_err("missing code");
+    assert!(error.contains("code"), "{error}");
+}
+
 mod commands;
 mod modes;
 mod sessions;

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -593,6 +593,98 @@ async fn acp_mcp_catalog_projects_allowlist_over_advertised_items() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn acp_mcp_authorize_requires_url() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (request_tx, mut response_rx, server, _session_id) =
+                start_acp_channel_session().await;
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 11,
+                    "method": "mcp/authorize",
+                    "params": {},
+                }))
+                .expect("send mcp/authorize");
+
+            let mut response = None;
+            for _ in 0..6 {
+                let message = recv_json(&mut response_rx).await;
+                if message["id"] == 11 {
+                    response = Some(message);
+                    break;
+                }
+            }
+            let response = response.expect("mcp/authorize response");
+            assert_eq!(response["error"]["code"], -32602);
+            assert!(response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("url"));
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_mcp_oauth_callback_validates_and_rejects_unknown_state() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let (request_tx, mut response_rx, server, _session_id) =
+                start_acp_channel_session().await;
+
+            // Missing state/code → invalid params.
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 12,
+                    "method": "mcp/oauth_callback",
+                    "params": {"code": "abc"},
+                }))
+                .expect("send mcp/oauth_callback");
+            // Well-formed but no pending flow matches the state → -32000.
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 13,
+                    "method": "mcp/oauth_callback",
+                    "params": {"state": "no-such", "code": "abc"},
+                }))
+                .expect("send mcp/oauth_callback");
+
+            let mut invalid = None;
+            let mut unknown = None;
+            for _ in 0..8 {
+                let message = recv_json(&mut response_rx).await;
+                if message["id"] == 12 {
+                    invalid = Some(message);
+                } else if message["id"] == 13 {
+                    unknown = Some(message);
+                }
+                if invalid.is_some() && unknown.is_some() {
+                    break;
+                }
+            }
+            assert_eq!(invalid.expect("invalid response")["error"]["code"], -32602);
+            let unknown = unknown.expect("unknown-state response");
+            assert_eq!(unknown["error"]["code"], -32000);
+            assert!(unknown["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("no pending MCP authorization"));
+
+            drop(request_tx);
+            server.await.expect("ACP channel server task");
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn acp_session_truncate_validates_inputs() {
     let local = tokio::task::LocalSet::new();
     local

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -87,6 +87,7 @@ sqlx-postgres = { version = "0.8", default-features = false, features = ["json",
 rust_decimal = "1"
 tokio-util = { version = "0.7", features = ["io"] }
 futures = "0.3"
+fs2 = "0.4"
 httpdate = "1"
 ipnet = "2"
 ignore = "0.4"

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -693,6 +693,22 @@ pub enum AgentEvent {
         server: Option<String>,
         reason: String,
     },
+    /// Surfaced when an MCP server harn is acting as a client for answers a
+    /// request with `401 Unauthorized` mid-session, meaning its OAuth token is
+    /// missing or expired. This is a cue for a thin ACP client (the burin-code
+    /// TUI / GUI) to start an authorization: call `mcp/authorize` to mint a
+    /// browser URL, open it, and forward the redirect's `code`+`state` back via
+    /// `mcp/oauth_callback`. Token exchange and storage stay in harn. `server`
+    /// is the configured server name; `resource` is its canonical RFC 8707
+    /// resource indicator; `scope` is the `scope` parameter from the
+    /// `WWW-Authenticate` challenge, when present.
+    McpAuthRequired {
+        session_id: String,
+        server: String,
+        resource: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        scope: Option<String>,
+    },
 }
 
 fn is_zero_usize(value: &usize) -> bool {
@@ -754,7 +770,8 @@ impl AgentEvent {
             | Self::CompositionError { session_id, .. }
             | Self::LoopCheckpoint { session_id, .. }
             | Self::McpNotification { session_id, .. }
-            | Self::McpCatalogChanged { session_id, .. } => session_id,
+            | Self::McpCatalogChanged { session_id, .. }
+            | Self::McpAuthRequired { session_id, .. } => session_id,
         }
     }
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -45,6 +45,7 @@ pub mod mcp_card;
 pub mod mcp_elicit;
 pub mod mcp_file_upload;
 pub mod mcp_host;
+pub mod mcp_oauth;
 pub mod mcp_presets;
 pub mod mcp_progress;
 pub mod mcp_protocol;

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -542,6 +542,35 @@ fn emit_mcp_notification_event(
     });
 }
 
+/// Emit an `AgentEvent::McpAuthRequired` when a server answers with `401` so a
+/// thin ACP client can start an interactive OAuth authorization. Token exchange
+/// and storage stay in harn (see [`crate::mcp_oauth`]); this is purely the cue.
+/// No-op outside an agent session (e.g. ad hoc CLI MCP calls).
+fn emit_mcp_auth_required_event(
+    server_name: &str,
+    server_url: &str,
+    headers: &reqwest::header::HeaderMap,
+) {
+    let Some(session_id) = crate::llm::current_agent_session_id() else {
+        return;
+    };
+    let resource = crate::mcp_auth::canonical_resource_indicator(server_url)
+        .unwrap_or_else(|_| server_url.to_string());
+    let challenges: Vec<&str> = headers
+        .get_all(reqwest::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .collect();
+    let scope = crate::mcp_auth::bearer_challenge_from_headers(challenges.iter().copied())
+        .and_then(|challenge| challenge.bearer_scope().map(str::to_string));
+    crate::agent_events::emit_event(&crate::agent_events::AgentEvent::McpAuthRequired {
+        session_id,
+        server: server_name.to_string(),
+        resource,
+        scope,
+    });
+}
+
 fn relay_log_notification(server_name: &str, msg: &serde_json::Value) {
     let Some(session_id) = crate::llm::current_agent_session_id() else {
         return;
@@ -684,6 +713,7 @@ async fn send_http_request(
         }
 
         if status == 401 {
+            emit_mcp_auth_required_event(server_name, &inner.url, &headers);
             return Err(VmError::Thrown(VmValue::String(Rc::from(
                 "MCP authorization required",
             ))));

--- a/crates/harn-vm/src/mcp_auth.rs
+++ b/crates/harn-vm/src/mcp_auth.rs
@@ -612,23 +612,32 @@ pub fn validate_authorization_response_issuer(
     metadata: &OAuthAuthorizationServerMetadata,
     response_issuer: Option<&str>,
 ) -> Result<(), String> {
-    match (
+    validate_authorization_response_issuer_value(
+        &metadata.issuer,
         metadata.authorization_response_iss_parameter_supported,
         response_issuer,
-    ) {
-        (true, Some(actual)) if actual == metadata.issuer => Ok(()),
-        (true, Some(actual)) => Err(format!(
-            "authorization response issuer mismatch: expected '{}', got '{}'",
-            metadata.issuer, actual
+    )
+}
+
+/// Validate the RFC 9207 `iss` authorization-response parameter against the
+/// expected issuer. A redirect's `iss` (when present) must match; when the
+/// authorization server advertises `iss` support it MUST also be present.
+/// Callers that hold the parsed metadata should prefer
+/// [`validate_authorization_response_issuer`]; this value form is for paths
+/// that only retain the issuer + support flag (e.g. a pending OAuth flow).
+pub fn validate_authorization_response_issuer_value(
+    expected_issuer: &str,
+    iss_supported: bool,
+    response_issuer: Option<&str>,
+) -> Result<(), String> {
+    match (iss_supported, response_issuer) {
+        (_, Some(actual)) if actual == expected_issuer => Ok(()),
+        (_, Some(actual)) => Err(format!(
+            "authorization response issuer mismatch: expected '{expected_issuer}', got '{actual}'"
         )),
         (true, None) => Err(
             "authorization response did not include required RFC 9207 iss parameter".to_string(),
         ),
-        (false, Some(actual)) if actual == metadata.issuer => Ok(()),
-        (false, Some(actual)) => Err(format!(
-            "authorization response issuer mismatch: expected '{}', got '{}'",
-            metadata.issuer, actual
-        )),
         (false, None) => Ok(()),
     }
 }

--- a/crates/harn-vm/src/mcp_oauth.rs
+++ b/crates/harn-vm/src/mcp_oauth.rs
@@ -1,0 +1,1161 @@
+//! Interactive MCP OAuth flow engine — the harn-owned core that every
+//! surface (the `harn mcp login` CLI, and the ACP `mcp/authorize` /
+//! `mcp/oauth_callback` requests) drives. It builds the authorization URL,
+//! exchanges the authorization code, refreshes tokens (single-flight, with a
+//! cross-process advisory lock), and stores them in the OS keyring. No client
+//! ever speaks OAuth directly: token exchange and storage stay in harn.
+//!
+//! The pure protocol rules (discovery, PKCE policy, issuer binding,
+//! registration-mode selection, RFC 8707 resource indicators) live in
+//! [`crate::mcp_auth`]; this module is the network/IO/state orchestration on
+//! top of them.
+//!
+//! Flow:
+//! 1. [`begin_authorization`] does discovery + client resolution, mints a PKCE
+//!    pair + `state`, registers a [`PendingAuthorization`] keyed by `state`,
+//!    and returns the browser authorization URL.
+//! 2. The caller opens the URL. The redirect (loopback for TUI/headless, a
+//!    client URL scheme for the GUI) carries `code` + `state` back.
+//! 3. [`complete_authorization`] pops the pending flow by `state`, validates
+//!    the issuer, exchanges the code, and persists the token.
+//!
+//! Tokens are keyed by `(resource, issuer, client_id)`, with a per-`(resource,
+//! issuer)` index recording the active client so callers that don't know the
+//! client id (status, logout, a 401-triggered refresh) resolve the right one.
+//! Refreshes are single-flight: an in-process async mutex plus a file lock
+//! serialize concurrent refreshers (clients + daemon) so they don't stampede
+//! the token endpoint or revoke each other's rotated refresh tokens.
+
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use async_trait::async_trait;
+use base64::Engine;
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::mcp_auth::{
+    authorization_code_token_form, build_oauth_authorization_url, canonical_resource_indicator,
+    determine_token_endpoint_auth_method, discover_mcp_oauth, dynamic_client_registration_body,
+    ensure_pkce_s256_supported, refresh_token_form, select_oauth_client_auth,
+    validate_authorization_response_issuer_value, validate_issuer_binding,
+    validate_token_endpoint_auth_method, McpOAuthDiscovery, OAuthAuthorizationCodeTokenForm,
+    OAuthAuthorizationServerMetadata, OAuthAuthorizationUrlOptions, OAuthClientAuthMode,
+    OAuthClientAuthOptions, OAuthDynamicClientRegistrationResponse, OAuthRefreshTokenForm,
+    DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL,
+};
+use crate::secrets::{KeyringSecretProvider, SecretBytes, SecretError, SecretId, SecretProvider};
+
+/// Keyring service namespace for stored MCP OAuth tokens. Shared by every
+/// surface so a token minted by `harn mcp login` is the same one the ACP
+/// `mcp/oauth_callback` path reads and refreshes.
+const KEYRING_SERVICE: &str = "dev.harn.mcp";
+
+/// Override directory for the cross-process refresh lock files (tests).
+const OAUTH_LOCK_DIR_ENV: &str = "HARN_MCP_OAUTH_LOCK_DIR";
+const HARN_HOME_ENV: &str = "HARN_HOME";
+
+/// Refresh a token this many seconds before its advertised expiry so a call
+/// never races the clock against the authorization server.
+const TOKEN_REFRESH_SKEW_SECS: i64 = 60;
+
+/// Upper bound on concurrently pending (begun-but-not-completed) authorizations.
+/// Caps memory from abandoned flows in a long-lived server.
+const MAX_PENDING_FLOWS: usize = 32;
+
+/// A persisted MCP OAuth token plus everything needed to refresh it without
+/// re-running discovery. Keyed in the keyring by `(resource, issuer, client_id)`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StoredMcpToken {
+    pub access_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    #[serde(default)]
+    pub expires_at_unix: Option<i64>,
+    pub token_endpoint: String,
+    pub client_id: String,
+    #[serde(default)]
+    pub client_secret: Option<String>,
+    pub token_endpoint_auth_method: String,
+    pub issuer: String,
+    pub resource: String,
+    #[serde(default)]
+    pub scopes: Option<String>,
+}
+
+/// The raw token-endpoint response shape (a subset; unknown fields ignored).
+#[derive(Clone, Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    expires_in: Option<i64>,
+}
+
+/// Inputs to [`begin_authorization`]. The server is identified by its URL; the
+/// client may be pre-registered (`client_id`/`client_secret`) or left to
+/// dynamic registration. `redirect_uri` is the loopback or client-scheme URL
+/// the authorization server will redirect to. `mode`/`static_secret_id` carry
+/// an explicit `[mcp.auth]` selection so the engine resolves the same client
+/// auth the runtime does (CIMD by default when unset).
+#[derive(Clone, Debug, Default)]
+pub struct BeginAuthorization {
+    pub server_url: String,
+    pub redirect_uri: String,
+    pub mode: Option<OAuthClientAuthMode>,
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+    pub static_secret_id: Option<String>,
+    pub scopes: Option<String>,
+}
+
+/// The browser-facing result of [`begin_authorization`]: the URL to open and
+/// the `state` that the matching [`complete_authorization`] call must echo.
+#[derive(Clone, Debug, Serialize)]
+pub struct PendingAuthorization {
+    pub authorize_url: String,
+    pub state: String,
+    pub redirect_uri: String,
+    /// Canonical RFC 8707 resource indicator for the server.
+    pub resource: String,
+    /// Authorization server issuer resolved during discovery.
+    pub issuer: String,
+}
+
+/// Server-side flow state held between [`begin_authorization`] and
+/// [`complete_authorization`], keyed by `state`. Holds the PKCE verifier and
+/// resolved client credentials — never leaves the harn process.
+#[derive(Clone, Debug)]
+struct PendingFlow {
+    code_verifier: String,
+    redirect_uri: String,
+    client_id: String,
+    client_secret: Option<String>,
+    token_auth_method: String,
+    token_endpoint: String,
+    issuer: String,
+    resource: String,
+    scopes: Option<String>,
+    /// Whether the authorization server advertised RFC 9207 `iss` support, so
+    /// [`complete_authorization`] can enforce the response binding.
+    iss_response_supported: bool,
+}
+
+fn pending_flows() -> &'static Mutex<HashMap<String, PendingFlow>> {
+    static FLOWS: OnceLock<Mutex<HashMap<String, PendingFlow>>> = OnceLock::new();
+    FLOWS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Begin an interactive authorization for an MCP server: discover the
+/// authorization server, resolve (or dynamically register) the client, mint a
+/// PKCE pair + `state`, and register a pending flow. Returns the URL to open.
+pub async fn begin_authorization(
+    request: BeginAuthorization,
+) -> Result<PendingAuthorization, String> {
+    let resource = canonical_resource_indicator(&request.server_url).map_err(|e| e.to_string())?;
+    let discovery = discover(&request.server_url).await?;
+    ensure_pkce_s256_supported(&discovery.authorization_server_metadata)?;
+
+    let scopes = request
+        .scopes
+        .clone()
+        .or_else(|| (!discovery.scopes.is_empty()).then(|| discovery.scopes.join(" ")));
+
+    let (client_id, client_secret, token_auth_method) = resolve_client(
+        &discovery.authorization_server_metadata,
+        request.mode,
+        request.client_id.clone(),
+        request.client_secret.clone(),
+        request.static_secret_id.as_deref(),
+        &request.redirect_uri,
+        scopes.as_deref(),
+    )
+    .await?;
+
+    let (code_verifier, code_challenge) = generate_pkce_pair();
+    let state = random_hex(16);
+    let authorize_url = build_oauth_authorization_url(OAuthAuthorizationUrlOptions {
+        authorization_endpoint: &discovery
+            .authorization_server_metadata
+            .authorization_endpoint,
+        client_id: &client_id,
+        redirect_uri: &request.redirect_uri,
+        state: &state,
+        code_challenge: &code_challenge,
+        resource: &resource,
+        scopes: scopes.as_deref(),
+    })?;
+
+    let mut flows = pending_flows()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    // Bound the registry so abandoned flows (begun but never completed) cannot
+    // grow without limit in a long-lived server. Authorization is user-driven
+    // and rare, so a modest cap is ample; evict an arbitrary stale entry when
+    // full rather than tracking timestamps.
+    if flows.len() >= MAX_PENDING_FLOWS {
+        if let Some(stale) = flows.keys().next().cloned() {
+            flows.remove(&stale);
+        }
+    }
+    flows.insert(
+        state.clone(),
+        PendingFlow {
+            code_verifier,
+            redirect_uri: request.redirect_uri.clone(),
+            client_id,
+            client_secret,
+            token_auth_method,
+            token_endpoint: discovery
+                .authorization_server_metadata
+                .token_endpoint
+                .clone(),
+            issuer: discovery.authorization_server_issuer.clone(),
+            resource: resource.clone(),
+            scopes,
+            iss_response_supported: discovery
+                .authorization_server_metadata
+                .authorization_response_iss_parameter_supported,
+        },
+    );
+    drop(flows);
+
+    Ok(PendingAuthorization {
+        authorize_url: authorize_url.to_string(),
+        state,
+        redirect_uri: request.redirect_uri,
+        resource,
+        issuer: discovery.authorization_server_issuer,
+    })
+}
+
+/// Complete an authorization started by [`begin_authorization`]: look up the
+/// pending flow by `state`, validate the issuer binding, exchange the code,
+/// and persist the token (recording it as the active client for the resource).
+pub async fn complete_authorization(
+    state: &str,
+    code: &str,
+    issuer: Option<&str>,
+) -> Result<StoredMcpToken, String> {
+    let flow = pending_flows()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .remove(state)
+        .ok_or_else(|| "no pending MCP authorization matches this state".to_string())?;
+
+    // RFC 9207: a returned `iss` must match the bound issuer, and when the AS
+    // advertises `iss` support it MUST be present.
+    validate_authorization_response_issuer_value(
+        &flow.issuer,
+        flow.iss_response_supported,
+        issuer,
+    )?;
+
+    let client = reqwest::Client::new();
+    let form = authorization_code_token_form(OAuthAuthorizationCodeTokenForm {
+        client_id: &flow.client_id,
+        redirect_uri: &flow.redirect_uri,
+        code,
+        code_verifier: &flow.code_verifier,
+        resource: &flow.resource,
+        scopes: flow.scopes.as_deref(),
+    });
+    let token = request_token(
+        &client,
+        &flow.token_endpoint,
+        &flow.token_auth_method,
+        &flow.client_id,
+        flow.client_secret.as_deref(),
+        &form,
+    )
+    .await?;
+
+    let stored = StoredMcpToken {
+        access_token: token.access_token,
+        refresh_token: token.refresh_token,
+        expires_at_unix: token
+            .expires_in
+            .map(|seconds| current_unix_timestamp().saturating_add(seconds)),
+        token_endpoint: flow.token_endpoint,
+        client_id: flow.client_id,
+        client_secret: flow.client_secret,
+        token_endpoint_auth_method: flow.token_auth_method,
+        issuer: flow.issuer,
+        resource: flow.resource,
+        scopes: flow.scopes,
+    };
+    save_stored_token(&stored).await?;
+    Ok(stored)
+}
+
+/// Resolve a bearer token for an already-authorized MCP server, refreshing it
+/// (single-flight) if it is within the expiry skew. Returns `None` when no
+/// token is stored (the caller should treat this as "auth required").
+pub async fn resolve_bearer(server_url: &str) -> Result<Option<String>, String> {
+    let discovery = discover(server_url).await?;
+    let resource = canonical_resource_indicator(server_url).map_err(|e| e.to_string())?;
+    let store = KeyringOAuthTokenStorage::default();
+    let Some(mut stored) = load_stored_token_from_store(
+        &store,
+        &resource,
+        &discovery.authorization_server_issuer,
+        None,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    validate_issuer_binding(&stored.issuer, &discovery.authorization_server_issuer)?;
+    if token_needs_refresh(&stored) {
+        stored = refresh_stored_token_with_store(&store, &stored, &discovery, None).await?;
+    }
+    Ok(Some(stored.access_token))
+}
+
+/// Discover the OAuth authorization server protecting an MCP server URL.
+pub async fn discover(server_url: &str) -> Result<McpOAuthDiscovery, String> {
+    let client = reqwest::Client::new();
+    discover_mcp_oauth(&client, server_url)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+/// Load a stored token by `(resource, issuer)`, using `client_id_hint` when
+/// known and otherwise the recorded active client. `None` when none is stored.
+pub async fn load_token(
+    resource: &str,
+    issuer: &str,
+    client_id_hint: Option<&str>,
+) -> Result<Option<StoredMcpToken>, String> {
+    let store = KeyringOAuthTokenStorage::default();
+    load_stored_token_from_store(&store, resource, issuer, client_id_hint).await
+}
+
+/// Delete a stored token by `(resource, issuer)`, resolving `client_id_hint` or
+/// the active client, and clearing the active-client index when it pointed here.
+pub async fn delete_token(
+    resource: &str,
+    issuer: &str,
+    client_id_hint: Option<&str>,
+) -> Result<(), String> {
+    let store = KeyringOAuthTokenStorage::default();
+    let client_id = match client_id_hint {
+        Some(client_id) => client_id.to_string(),
+        None => match store.load_active_client_id(resource, issuer).await? {
+            Some(client_id) => client_id,
+            None => {
+                store.delete_active_client_id(resource, issuer).await?;
+                return Ok(());
+            }
+        },
+    };
+    let key = OAuthTokenStoreKey::new(resource, issuer, &client_id);
+    let _guard = acquire_oauth_refresh_lock(&key, None).await?;
+    store.delete_token(&key).await?;
+    if store
+        .load_active_client_id(resource, issuer)
+        .await?
+        .as_deref()
+        == Some(client_id.as_str())
+    {
+        store.delete_active_client_id(resource, issuer).await?;
+    }
+    Ok(())
+}
+
+/// Resolve the `(client_id, client_secret, token_endpoint_auth_method)` for a
+/// flow via the unified auth selection (CIMD by default when the server
+/// advertises it; otherwise BYO client id, dynamic registration, or an error).
+async fn resolve_client(
+    metadata: &OAuthAuthorizationServerMetadata,
+    mode: Option<OAuthClientAuthMode>,
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    static_secret_id: Option<&str>,
+    redirect_uri: &str,
+    scopes: Option<&str>,
+) -> Result<(String, Option<String>, String), String> {
+    let selection = select_oauth_client_auth(
+        metadata,
+        OAuthClientAuthOptions {
+            mode,
+            client_id: client_id.as_deref(),
+            client_secret: client_secret.as_deref(),
+            client_id_metadata_document_url: client_id.as_deref(),
+            static_secret_id,
+        },
+    )?;
+    match selection.mode {
+        OAuthClientAuthMode::Cimd => {
+            // CIMD presents an HTTPS client-metadata-document URL as the
+            // `client_id`; the client is public, so token auth is `none`.
+            let resolved_client_id = selection
+                .client_id
+                .unwrap_or(DEFAULT_MCP_OAUTH_CLIENT_ID_METADATA_DOCUMENT_URL)
+                .to_string();
+            Ok((resolved_client_id, None, "none".to_string()))
+        }
+        OAuthClientAuthMode::Byo => {
+            let resolved_client_id = selection
+                .client_id
+                .ok_or_else(|| "BYO OAuth auth requires client_id".to_string())?
+                .to_string();
+            let token_auth_method =
+                determine_token_endpoint_auth_method(metadata, client_secret.as_deref())?;
+            Ok((resolved_client_id, client_secret, token_auth_method))
+        }
+        OAuthClientAuthMode::Dcr => {
+            let registration_endpoint = metadata
+                .registration_endpoint
+                .as_deref()
+                .ok_or_else(|| "dynamic client registration endpoint missing".to_string())?;
+            let registration =
+                dynamic_client_registration(registration_endpoint, redirect_uri, scopes).await?;
+            let auth_method = registration
+                .token_endpoint_auth_method
+                .clone()
+                .unwrap_or_else(|| "none".to_string());
+            validate_token_endpoint_auth_method(&auth_method)?;
+            Ok((
+                registration.client_id,
+                registration.client_secret,
+                auth_method,
+            ))
+        }
+        OAuthClientAuthMode::Static => Err(
+            "static MCP auth uses a stored bearer token and does not run interactive OAuth"
+                .to_string(),
+        ),
+    }
+}
+
+async fn dynamic_client_registration(
+    registration_endpoint: &str,
+    redirect_uri: &str,
+    scopes: Option<&str>,
+) -> Result<OAuthDynamicClientRegistrationResponse, String> {
+    let client = reqwest::Client::new();
+    let body = dynamic_client_registration_body("Harn", [redirect_uri], scopes);
+    let response = client
+        .post(registration_endpoint)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| format!("Dynamic client registration failed: {error}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "Dynamic client registration failed: {status} {body}"
+        ));
+    }
+    response
+        .json::<OAuthDynamicClientRegistrationResponse>()
+        .await
+        .map_err(|error| format!("Invalid dynamic client registration response: {error}"))
+}
+
+/// Build the refreshed token from a successful refresh response, re-sending the
+/// RFC 8707 resource indicator and keeping the stored key canonicalized.
+async fn refresh_token(
+    token: &StoredMcpToken,
+    discovery: &McpOAuthDiscovery,
+) -> Result<StoredMcpToken, String> {
+    validate_issuer_binding(&token.issuer, &discovery.authorization_server_issuer)?;
+    let refresh_token = token.refresh_token.clone().ok_or_else(|| {
+        "Stored OAuth token has expired and does not include a refresh token".to_string()
+    })?;
+    let resource =
+        canonical_resource_indicator(&token.resource).unwrap_or_else(|_| token.resource.clone());
+    let client = reqwest::Client::new();
+    let form = refresh_token_form(OAuthRefreshTokenForm {
+        client_id: &token.client_id,
+        refresh_token: &refresh_token,
+        resource: &resource,
+    });
+    let token_endpoint = discovery
+        .authorization_server_metadata
+        .token_endpoint
+        .clone();
+    let refreshed = request_token(
+        &client,
+        &token_endpoint,
+        &token.token_endpoint_auth_method,
+        &token.client_id,
+        token.client_secret.as_deref(),
+        &form,
+    )
+    .await?;
+    Ok(StoredMcpToken {
+        access_token: refreshed.access_token,
+        refresh_token: refreshed
+            .refresh_token
+            .or_else(|| token.refresh_token.clone()),
+        expires_at_unix: refreshed
+            .expires_in
+            .map(|seconds| current_unix_timestamp().saturating_add(seconds)),
+        token_endpoint,
+        client_id: token.client_id.clone(),
+        client_secret: token.client_secret.clone(),
+        token_endpoint_auth_method: token.token_endpoint_auth_method.clone(),
+        issuer: token.issuer.clone(),
+        resource,
+        scopes: token.scopes.clone(),
+    })
+}
+
+async fn request_token(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    token_auth_method: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    form: &[(&str, String)],
+) -> Result<TokenResponse, String> {
+    validate_token_endpoint_auth_method(token_auth_method)?;
+    let mut request = client.post(token_endpoint).form(form);
+    match token_auth_method {
+        "client_secret_basic" => {
+            let client_secret = client_secret
+                .ok_or_else(|| "Missing client secret for client_secret_basic".to_string())?;
+            request = request.basic_auth(client_id, Some(client_secret));
+        }
+        "client_secret_post" => {
+            let client_secret = client_secret
+                .ok_or_else(|| "Missing client secret for client_secret_post".to_string())?;
+            let mut extended = form.to_vec();
+            extended.push(("client_secret", client_secret.to_string()));
+            request = client.post(token_endpoint).form(&extended);
+        }
+        _ => {}
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|error| format!("Token request failed: {error}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("Token request failed: {status} {body}"));
+    }
+    response
+        .json::<TokenResponse>()
+        .await
+        .map_err(|error| format!("Invalid token response: {error}"))
+}
+
+fn token_needs_refresh(token: &StoredMcpToken) -> bool {
+    match token.expires_at_unix {
+        Some(expires_at) => {
+            expires_at <= current_unix_timestamp().saturating_add(TOKEN_REFRESH_SKEW_SECS)
+        }
+        None => false,
+    }
+}
+
+// --- single-flight refresh + cross-process lock ------------------------------
+
+/// Refresh a stored token under both an in-process async mutex and a
+/// cross-process file lock, re-loading and re-checking inside the lock so
+/// concurrent refreshers (clients + daemon) collapse to a single token request
+/// and never revoke each other's rotated refresh token.
+async fn refresh_stored_token_with_store<S: OAuthTokenStorage + ?Sized>(
+    store: &S,
+    token: &StoredMcpToken,
+    discovery: &McpOAuthDiscovery,
+    lock_dir_override: Option<PathBuf>,
+) -> Result<StoredMcpToken, String> {
+    let key = OAuthTokenStoreKey::from_token(token);
+    let _guard = acquire_oauth_refresh_lock(&key, lock_dir_override.as_deref()).await?;
+    let Some(current) = store.load_token(&key).await? else {
+        return Err("Stored OAuth token disappeared before it could be refreshed".to_string());
+    };
+    validate_issuer_binding(&current.issuer, &discovery.authorization_server_issuer)?;
+    if !token_needs_refresh(&current) {
+        return Ok(current);
+    }
+    let refreshed = refresh_token(&current, discovery).await?;
+    store.save_token(&refreshed).await?;
+    Ok(refreshed)
+}
+
+struct OAuthRefreshLockGuard {
+    _async_guard: tokio::sync::OwnedMutexGuard<()>,
+    file: File,
+}
+
+impl Drop for OAuthRefreshLockGuard {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+async fn acquire_oauth_refresh_lock(
+    key: &OAuthTokenStoreKey,
+    lock_dir_override: Option<&Path>,
+) -> Result<OAuthRefreshLockGuard, String> {
+    let mutex = oauth_refresh_mutex(key);
+    let async_guard = mutex.lock_owned().await;
+    let lock_path = oauth_refresh_lock_path(key, lock_dir_override);
+    let file = tokio::task::spawn_blocking(move || {
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "Failed to create OAuth token lock directory `{}`: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|error| {
+                format!(
+                    "Failed to open OAuth token lock `{}`: {error}",
+                    lock_path.display()
+                )
+            })?;
+        file.lock_exclusive().map_err(|error| {
+            format!(
+                "Failed to acquire OAuth token lock `{}`: {error}",
+                lock_path.display()
+            )
+        })?;
+        Ok::<File, String>(file)
+    })
+    .await
+    .map_err(|error| format!("OAuth token lock task failed: {error}"))??;
+    Ok(OAuthRefreshLockGuard {
+        _async_guard: async_guard,
+        file,
+    })
+}
+
+fn oauth_refresh_mutex(key: &OAuthTokenStoreKey) -> Arc<AsyncMutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<String, Arc<AsyncMutex<()>>>>> = OnceLock::new();
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut locks = locks.lock().unwrap_or_else(|poison| poison.into_inner());
+    locks
+        .entry(key.account())
+        .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+}
+
+fn oauth_refresh_lock_path(key: &OAuthTokenStoreKey, lock_dir_override: Option<&Path>) -> PathBuf {
+    let dir = lock_dir_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_oauth_lock_dir);
+    dir.join(format!("{}.lock", key.account()))
+}
+
+fn default_oauth_lock_dir() -> PathBuf {
+    if let Some(path) = std::env::var_os(OAUTH_LOCK_DIR_ENV) {
+        return PathBuf::from(path);
+    }
+    harn_home_dir().join("mcp-oauth-locks")
+}
+
+fn harn_home_dir() -> PathBuf {
+    if let Some(path) = std::env::var_os(HARN_HOME_ENV) {
+        return PathBuf::from(path);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home).join(".harn");
+    }
+    if let Some(home) = std::env::var_os("USERPROFILE") {
+        return PathBuf::from(home).join(".harn");
+    }
+    std::env::temp_dir().join("harn")
+}
+
+// --- keyring storage ---------------------------------------------------------
+
+/// Keyring key for one token: `(resource, issuer, client_id)`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct OAuthTokenStoreKey {
+    resource: String,
+    issuer: String,
+    client_id: String,
+}
+
+impl OAuthTokenStoreKey {
+    fn new(resource: &str, issuer: &str, client_id: &str) -> Self {
+        Self {
+            resource: resource.to_string(),
+            issuer: issuer.to_string(),
+            client_id: client_id.to_string(),
+        }
+    }
+
+    fn from_token(token: &StoredMcpToken) -> Self {
+        Self::new(&token.resource, &token.issuer, &token.client_id)
+    }
+
+    fn account(&self) -> String {
+        token_store_account(&self.resource, &self.issuer, &self.client_id)
+    }
+}
+
+/// The active client id for a `(resource, issuer)` pair, so callers that don't
+/// supply a client id resolve the most recently authorized one.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StoredOAuthClientIndex {
+    client_id: String,
+}
+
+/// Storage abstraction over the keyring so the single-flight refresh path can
+/// be exercised against an in-memory double in tests.
+#[async_trait]
+trait OAuthTokenStorage: Send + Sync {
+    async fn load_token(&self, key: &OAuthTokenStoreKey) -> Result<Option<StoredMcpToken>, String>;
+    async fn save_token(&self, token: &StoredMcpToken) -> Result<(), String>;
+    async fn delete_token(&self, key: &OAuthTokenStoreKey) -> Result<(), String>;
+    async fn load_active_client_id(
+        &self,
+        resource: &str,
+        issuer: &str,
+    ) -> Result<Option<String>, String>;
+    async fn save_active_client_id(
+        &self,
+        resource: &str,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<(), String>;
+    async fn delete_active_client_id(&self, resource: &str, issuer: &str) -> Result<(), String>;
+}
+
+struct KeyringOAuthTokenStorage {
+    provider: KeyringSecretProvider,
+}
+
+impl Default for KeyringOAuthTokenStorage {
+    fn default() -> Self {
+        Self {
+            provider: KeyringSecretProvider::new(KEYRING_SERVICE),
+        }
+    }
+}
+
+#[async_trait]
+impl OAuthTokenStorage for KeyringOAuthTokenStorage {
+    async fn load_token(&self, key: &OAuthTokenStoreKey) -> Result<Option<StoredMcpToken>, String> {
+        let payload = match self.provider.get(&token_secret_id(key)).await {
+            Ok(secret) => secret,
+            Err(SecretError::NotFound { .. }) => return Ok(None),
+            Err(error) => return Err(format!("Failed to read OAuth token from keyring: {error}")),
+        };
+        let token = payload
+            .with_exposed(|bytes| serde_json::from_slice::<StoredMcpToken>(bytes))
+            .map_err(|error| format!("Stored OAuth token was invalid JSON: {error}"))?;
+        validate_token_store_binding(&token, key)?;
+        Ok(Some(token))
+    }
+
+    async fn save_token(&self, token: &StoredMcpToken) -> Result<(), String> {
+        let payload = serde_json::to_string(token)
+            .map_err(|error| format!("Failed to serialize OAuth token: {error}"))?;
+        self.provider
+            .put(
+                &token_secret_id(&OAuthTokenStoreKey::from_token(token)),
+                SecretBytes::from(payload.into_bytes()),
+            )
+            .await
+            .map_err(|error| format!("Failed to store OAuth token in keyring: {error}"))?;
+        self.save_active_client_id(&token.resource, &token.issuer, &token.client_id)
+            .await
+    }
+
+    async fn delete_token(&self, key: &OAuthTokenStoreKey) -> Result<(), String> {
+        self.provider
+            .delete(&token_secret_id(key))
+            .await
+            .map_err(|error| format!("Failed to delete OAuth token from keyring: {error}"))
+    }
+
+    async fn load_active_client_id(
+        &self,
+        resource: &str,
+        issuer: &str,
+    ) -> Result<Option<String>, String> {
+        let payload = match self
+            .provider
+            .get(&token_client_index_secret_id(resource, issuer))
+            .await
+        {
+            Ok(secret) => secret,
+            Err(SecretError::NotFound { .. }) => return Ok(None),
+            Err(error) => {
+                return Err(format!(
+                    "Failed to read OAuth client index from keyring: {error}"
+                ))
+            }
+        };
+        let index = payload
+            .with_exposed(|bytes| serde_json::from_slice::<StoredOAuthClientIndex>(bytes))
+            .map_err(|error| format!("Stored OAuth client index was invalid JSON: {error}"))?;
+        Ok(Some(index.client_id))
+    }
+
+    async fn save_active_client_id(
+        &self,
+        resource: &str,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<(), String> {
+        let payload = serde_json::to_string(&StoredOAuthClientIndex {
+            client_id: client_id.to_string(),
+        })
+        .map_err(|error| format!("Failed to serialize OAuth client index: {error}"))?;
+        self.provider
+            .put(
+                &token_client_index_secret_id(resource, issuer),
+                SecretBytes::from(payload.into_bytes()),
+            )
+            .await
+            .map_err(|error| format!("Failed to store OAuth client index in keyring: {error}"))
+    }
+
+    async fn delete_active_client_id(&self, resource: &str, issuer: &str) -> Result<(), String> {
+        self.provider
+            .delete(&token_client_index_secret_id(resource, issuer))
+            .await
+            .map_err(|error| format!("Failed to delete OAuth client index from keyring: {error}"))
+    }
+}
+
+/// Persist a token (under the refresh lock) and record it as the active client.
+async fn save_stored_token(token: &StoredMcpToken) -> Result<(), String> {
+    let store = KeyringOAuthTokenStorage::default();
+    let key = OAuthTokenStoreKey::from_token(token);
+    let _guard = acquire_oauth_refresh_lock(&key, None).await?;
+    store.save_token(token).await
+}
+
+async fn load_stored_token_from_store<S: OAuthTokenStorage + ?Sized>(
+    store: &S,
+    resource: &str,
+    issuer: &str,
+    client_id_hint: Option<&str>,
+) -> Result<Option<StoredMcpToken>, String> {
+    let client_id = match client_id_hint {
+        Some(client_id) => client_id.to_string(),
+        None => match store.load_active_client_id(resource, issuer).await? {
+            Some(client_id) => client_id,
+            None => return Ok(None),
+        },
+    };
+    store
+        .load_token(&OAuthTokenStoreKey::new(resource, issuer, &client_id))
+        .await
+}
+
+fn token_store_account(resource: &str, issuer: &str, client_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(issuer.as_bytes());
+    hasher.update([0]);
+    hasher.update(resource.as_bytes());
+    hasher.update([0]);
+    hasher.update(client_id.as_bytes());
+    let digest = hasher.finalize();
+    format!(
+        "mcp-token-{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+    )
+}
+
+fn token_client_index_account(resource: &str, issuer: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(issuer.as_bytes());
+    hasher.update([0]);
+    hasher.update(resource.as_bytes());
+    let digest = hasher.finalize();
+    format!(
+        "mcp-client-index-{}",
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+    )
+}
+
+fn token_secret_id(key: &OAuthTokenStoreKey) -> SecretId {
+    SecretId::new("", key.account())
+}
+
+fn token_client_index_secret_id(resource: &str, issuer: &str) -> SecretId {
+    SecretId::new("", token_client_index_account(resource, issuer))
+}
+
+fn validate_token_store_binding(
+    token: &StoredMcpToken,
+    key: &OAuthTokenStoreKey,
+) -> Result<(), String> {
+    if token.resource != key.resource
+        || token.issuer != key.issuer
+        || token.client_id != key.client_id
+    {
+        return Err("Stored OAuth token key does not match its token binding".to_string());
+    }
+    Ok(())
+}
+
+// --- crypto/util -------------------------------------------------------------
+
+fn generate_pkce_pair() -> (String, String) {
+    let verifier = random_hex(32);
+    let digest = Sha256::digest(verifier.as_bytes());
+    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+    (verifier, challenge)
+}
+
+fn random_hex(bytes: usize) -> String {
+    (0..bytes)
+        .map(|_| format!("{:02x}", rand::random::<u8>()))
+        .collect()
+}
+
+fn current_unix_timestamp() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap as StdHashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn token_store_account_is_stable_and_dimension_sensitive() {
+        let first =
+            token_store_account("https://mcp.notion.com", "https://auth.example", "client-a");
+        let second =
+            token_store_account("https://mcp.notion.com", "https://auth.example", "client-a");
+        let other_issuer = token_store_account(
+            "https://mcp.notion.com",
+            "https://other.example",
+            "client-a",
+        );
+        let other_resource =
+            token_store_account("https://mcp.linear.app", "https://auth.example", "client-a");
+        let other_client =
+            token_store_account("https://mcp.notion.com", "https://auth.example", "client-b");
+        assert_eq!(first, second);
+        assert_ne!(first, other_issuer);
+        assert_ne!(first, other_resource);
+        assert_ne!(first, other_client);
+        assert!(first.starts_with("mcp-token-"));
+    }
+
+    #[test]
+    fn pkce_challenge_is_s256_of_verifier() {
+        let (verifier, challenge) = generate_pkce_pair();
+        let expected = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(Sha256::digest(verifier.as_bytes()));
+        assert_eq!(challenge, expected);
+        assert_eq!(verifier.len(), 64);
+    }
+
+    #[test]
+    fn token_needs_refresh_respects_skew() {
+        let mut token = StoredMcpToken {
+            access_token: "a".into(),
+            refresh_token: Some("r".into()),
+            expires_at_unix: None,
+            token_endpoint: "https://auth/token".into(),
+            client_id: "c".into(),
+            client_secret: None,
+            token_endpoint_auth_method: "none".into(),
+            issuer: "https://auth".into(),
+            resource: "https://mcp".into(),
+            scopes: None,
+        };
+        assert!(!token_needs_refresh(&token));
+        token.expires_at_unix = Some(current_unix_timestamp() + 3600);
+        assert!(!token_needs_refresh(&token));
+        token.expires_at_unix = Some(current_unix_timestamp() + TOKEN_REFRESH_SKEW_SECS - 1);
+        assert!(token_needs_refresh(&token));
+    }
+
+    #[tokio::test]
+    async fn complete_authorization_rejects_unknown_state() {
+        let error = complete_authorization("no-such-state", "code", None)
+            .await
+            .unwrap_err();
+        assert!(error.contains("no pending MCP authorization"), "{error}");
+    }
+
+    /// Concurrent refreshers must collapse to a single token-endpoint call and
+    /// converge on the rotated token.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn expired_token_refresh_is_singleflight() {
+        #[derive(Clone, Default)]
+        struct MemoryStore {
+            tokens: Arc<AsyncMutex<StdHashMap<OAuthTokenStoreKey, StoredMcpToken>>>,
+            index: Arc<AsyncMutex<StdHashMap<(String, String), String>>>,
+        }
+
+        #[async_trait]
+        impl OAuthTokenStorage for MemoryStore {
+            async fn load_token(
+                &self,
+                key: &OAuthTokenStoreKey,
+            ) -> Result<Option<StoredMcpToken>, String> {
+                Ok(self.tokens.lock().await.get(key).cloned())
+            }
+            async fn save_token(&self, token: &StoredMcpToken) -> Result<(), String> {
+                self.tokens
+                    .lock()
+                    .await
+                    .insert(OAuthTokenStoreKey::from_token(token), token.clone());
+                self.save_active_client_id(&token.resource, &token.issuer, &token.client_id)
+                    .await
+            }
+            async fn delete_token(&self, key: &OAuthTokenStoreKey) -> Result<(), String> {
+                self.tokens.lock().await.remove(key);
+                Ok(())
+            }
+            async fn load_active_client_id(
+                &self,
+                resource: &str,
+                issuer: &str,
+            ) -> Result<Option<String>, String> {
+                Ok(self
+                    .index
+                    .lock()
+                    .await
+                    .get(&(resource.to_string(), issuer.to_string()))
+                    .cloned())
+            }
+            async fn save_active_client_id(
+                &self,
+                resource: &str,
+                issuer: &str,
+                client_id: &str,
+            ) -> Result<(), String> {
+                self.index.lock().await.insert(
+                    (resource.to_string(), issuer.to_string()),
+                    client_id.to_string(),
+                );
+                Ok(())
+            }
+            async fn delete_active_client_id(
+                &self,
+                resource: &str,
+                issuer: &str,
+            ) -> Result<(), String> {
+                self.index
+                    .lock()
+                    .await
+                    .remove(&(resource.to_string(), issuer.to_string()));
+                Ok(())
+            }
+        }
+
+        // A minimal token endpoint over a raw TCP listener that counts hits.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let token_endpoint_url = format!("http://{}/token", listener.local_addr().unwrap());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let server_calls = calls.clone();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                server_calls.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 4096];
+                let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut buf).await;
+                let body = r#"{"access_token":"access-new","refresh_token":"refresh-new","expires_in":3600}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes()).await;
+            }
+        });
+
+        let store = Arc::new(MemoryStore::default());
+        let stale = StoredMcpToken {
+            access_token: "access-old".to_string(),
+            refresh_token: Some("refresh-old".to_string()),
+            expires_at_unix: Some(current_unix_timestamp().saturating_sub(1)),
+            token_endpoint: token_endpoint_url.clone(),
+            client_id: "client-a".to_string(),
+            client_secret: None,
+            token_endpoint_auth_method: "none".to_string(),
+            issuer: "https://auth.example".to_string(),
+            resource: "https://mcp.example/mcp".to_string(),
+            scopes: None,
+        };
+        store.save_token(&stale).await.unwrap();
+
+        let discovery_meta = OAuthAuthorizationServerMetadata {
+            issuer: stale.issuer.clone(),
+            authorization_endpoint: "https://auth.example/authorize".to_string(),
+            token_endpoint: token_endpoint_url,
+            registration_endpoint: None,
+            token_endpoint_auth_methods_supported: vec!["none".to_string()],
+            code_challenge_methods_supported: vec!["S256".to_string()],
+            scopes_supported: Vec::new(),
+            client_id_metadata_document_supported: false,
+            authorization_response_iss_parameter_supported: false,
+            extra: Default::default(),
+        };
+        let discovery = McpOAuthDiscovery {
+            protected_resource_metadata_url: url::Url::parse(
+                "https://mcp.example/.well-known/oauth-protected-resource",
+            )
+            .unwrap(),
+            protected_resource_metadata: Default::default(),
+            authorization_server_issuer: stale.issuer.clone(),
+            authorization_server_metadata_url: url::Url::parse(
+                "https://auth.example/.well-known/oauth-authorization-server",
+            )
+            .unwrap(),
+            authorization_server_metadata_kind:
+                crate::mcp_auth::OAuthAuthorizationServerMetadataKind::OAuthAuthorizationServer,
+            authorization_server_metadata: discovery_meta,
+            challenge: None,
+            scopes: Vec::new(),
+        };
+        let lock_dir = tempfile::tempdir().unwrap();
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let store = store.clone();
+            let token = stale.clone();
+            let discovery = discovery.clone();
+            let lock_dir = lock_dir.path().to_path_buf();
+            tasks.push(tokio::spawn(async move {
+                refresh_stored_token_with_store(store.as_ref(), &token, &discovery, Some(lock_dir))
+                    .await
+                    .unwrap()
+            }));
+        }
+        for task in tasks {
+            let refreshed = task.await.unwrap();
+            assert_eq!(refreshed.access_token, "access-new");
+            assert_eq!(refreshed.refresh_token.as_deref(), Some("refresh-new"));
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "refresh must be single-flight"
+        );
+        let stored = store
+            .load_token(&OAuthTokenStoreKey::from_token(&stale))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.access_token, "access-new");
+        server.abort();
+    }
+}

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -437,6 +437,10 @@ NON_TEST_WALL_CLOCK_ALLOWLIST=(
   # Agent host primitive tool dispatch records actual host monotonic
   # elapsed time for transcript / portal execution telemetry.
   "crates/harn-vm/src/llm/agent_host_primitives.rs"
+  # MCP OAuth stamps and compares token expiry against the host wall clock:
+  # the authorization server's `expires_in` is real-world time, so a
+  # VM-scheduled clock cannot decide when a stored token must be refreshed.
+  "crates/harn-vm/src/mcp_oauth.rs"
   "crates/harn-vm/src/llm/agent_runtime.rs"
   # `agent_inbox::wait_sync` is a sync blocking primitive for sync
   # builtins that already block the runtime thread (e.g.

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -93,6 +93,7 @@ public enum HarnProtocolConstants {
         "judge_decision",
         "loop_control_decision",
         "loop_stuck",
+        "mcp_auth_required",
         "mcp_catalog_changed",
         "mcp_notification",
         "progress_reported",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -168,6 +168,7 @@ var HarnAgentEventKinds = []HarnAgentEventKind{
 	"judge_decision",
 	"loop_control_decision",
 	"loop_stuck",
+	"mcp_auth_required",
 	"mcp_catalog_changed",
 	"mcp_notification",
 	"progress_reported",

--- a/spec/protocol-artifacts/harn-protocol.rs
+++ b/spec/protocol-artifacts/harn-protocol.rs
@@ -92,6 +92,10 @@ pub const ACP_DISPATCHED_METHOD_WORKFLOW_RESUME: &str = "workflow/resume";
 pub const ACP_DISPATCHED_METHOD_HARN_WORKFLOW_RESUME: &str = "harn.workflow.resume";
 pub const ACP_DISPATCHED_METHOD_MCP_CATALOG: &str = "mcp/catalog";
 pub const ACP_DISPATCHED_METHOD_HARN_MCP_CATALOG: &str = "harn.mcp.catalog";
+pub const ACP_DISPATCHED_METHOD_MCP_AUTHORIZE: &str = "mcp/authorize";
+pub const ACP_DISPATCHED_METHOD_HARN_MCP_AUTHORIZE: &str = "harn.mcp.authorize";
+pub const ACP_DISPATCHED_METHOD_MCP_OAUTH_CALLBACK: &str = "mcp/oauth_callback";
+pub const ACP_DISPATCHED_METHOD_HARN_MCP_OAUTH_CALLBACK: &str = "harn.mcp.oauth_callback";
 
 /// Every JSON-RPC method the ACP adapter actually dispatches, including the workspace-management, workflow-control, and HITL methods the stable bindings do not yet expose as typed enums. Reconciled against the `match` arms in `harn-serve`'s ACP adapter.
 pub const ACP_DISPATCHED_METHODS: &[&str] = &[
@@ -133,6 +137,10 @@ pub const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.workflow.resume",
     "mcp/catalog",
     "harn.mcp.catalog",
+    "mcp/authorize",
+    "harn.mcp.authorize",
+    "mcp/oauth_callback",
+    "harn.mcp.oauth_callback",
 ];
 
 pub const ACP_CLIENT_METHOD_FS_READ_TEXT_FILE: &str = "fs/read_text_file";
@@ -276,6 +284,7 @@ pub const HARN_AGENT_EVENT_KIND_ITERATION_START: &str = "iteration_start";
 pub const HARN_AGENT_EVENT_KIND_JUDGE_DECISION: &str = "judge_decision";
 pub const HARN_AGENT_EVENT_KIND_LOOP_CONTROL_DECISION: &str = "loop_control_decision";
 pub const HARN_AGENT_EVENT_KIND_LOOP_STUCK: &str = "loop_stuck";
+pub const HARN_AGENT_EVENT_KIND_MCP_AUTH_REQUIRED: &str = "mcp_auth_required";
 pub const HARN_AGENT_EVENT_KIND_MCP_CATALOG_CHANGED: &str = "mcp_catalog_changed";
 pub const HARN_AGENT_EVENT_KIND_MCP_NOTIFICATION: &str = "mcp_notification";
 pub const HARN_AGENT_EVENT_KIND_PROGRESS_REPORTED: &str = "progress_reported";
@@ -304,6 +313,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "judge_decision",
     "loop_control_decision",
     "loop_stuck",
+    "mcp_auth_required",
     "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -134,6 +134,7 @@ export const HARN_AGENT_EVENT_KINDS = [
   "judge_decision",
   "loop_control_decision",
   "loop_stuck",
+  "mcp_auth_required",
   "mcp_catalog_changed",
   "mcp_notification",
   "progress_reported",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -93,6 +93,7 @@
       "judge_decision",
       "loop_control_decision",
       "loop_stuck",
+      "mcp_auth_required",
       "mcp_catalog_changed",
       "mcp_notification",
       "progress_reported",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -220,6 +220,7 @@ HARN_AGENT_EVENT_KINDS: tuple = (
     "judge_decision",
     "loop_control_decision",
     "loop_stuck",
+    "mcp_auth_required",
     "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",


### PR DESCRIPTION
Closes #2646. Part of the MCP comprehensiveness sub-epic (burin-labs/burin-code#1428): one harn-owned MCP implementation; the TUI and GUI stay thin.

## What this does

### `harn_vm::mcp_oauth` — one engine, every surface
Token exchange and storage move into a single harn-owned flow engine. It owns discovery, client resolution (DCR / CIMD / BYO client id), PKCE, the authorization-code exchange, **single-flight refresh** (in-process async mutex + cross-process file lock, keyed per `(resource, issuer, client_id)` with an active-client index), and OS-keyring storage. The pure protocol rules stay in `mcp_auth`; this module is the network/IO/state orchestration on top.

This **subsumes** the just-landed `harn mcp login` CLI copy (#2694's single-flight + per-`client_id` keying are now in the shared engine, reachable from ACP too): `harn mcp login` drops ~1000 lines of duplicated crypto/token/store code and only keeps the browser + loopback IO.

### ACP surface (thin clients drive it; tokens never leave harn)
- **`mcp_auth_required`** — additive agent event emitted when a server answers `401` mid-session (`server` + canonical RFC 8707 `resource` + challenge `scope`), as a cue for a thin client to start authorization. Registered in `HARN_AGENT_EVENT_KINDS`; protocol artifacts regenerated.
- **`mcp/authorize`** request — harn does discovery + client resolution + PKCE, registers a pending flow, returns `{ authorizeUrl, state, redirectUri, resource, issuer }`. `redirectUri` defaults to harn's loopback (TUI/headless) or the client's URL scheme (GUI).
- **`mcp/oauth_callback`** request — harn exchanges the returned `state`+`code` (+optional `iss`), or parses them from a captured client-scheme `redirectUrl`, and stores the token.

`mcp_auth` gains `validate_authorization_response_issuer_value` so the engine enforces RFC 9207 without reconstructing a full metadata struct.

## Tests
- harn-vm: PKCE/skew/account-key unit tests + `complete_authorization` unknown-state guard + a **single-flight** test (8 concurrent refreshers collapse to one token-endpoint call and converge on the rotated token, against a raw-TCP token endpoint).
- harn-serve: `mcp_auth_required` ext-event round-trips (with/without scope); `mcp/authorize` + `mcp/oauth_callback` ACP request validation + unknown-state rejection; `parse_oauth_redirect_url` unit tests.
- harn-cli: existing `mcp` suite green on the thin login path.
- clippy clean on all three crates; protocol-artifact drift check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)