### PR TITLE
harn-cli: reuse module graph during preflight

### DIFF
--- a/changelog.d/toolchain-preflight-graph.fixed.md
+++ b/changelog.d/toolchain-preflight-graph.fixed.md
@@ -1,0 +1,3 @@
+- **Harn preflight reuses the existing module graph for re-export checks.**
+  `harn check` avoids rebuilding a module graph for every file while scanning
+  re-export conflicts.

--- a/crates/harn-cli/src/commands/check/check_cmd.rs
+++ b/crates/harn-cli/src/commands/check/check_cmd.rs
@@ -12,7 +12,7 @@ use super::analysis::{
     span_from_parser_error, FileAnalysisError,
 };
 use super::outcome::{print_lint_diagnostics, CommandOutcome};
-use super::preflight::{collect_preflight_diagnostics, is_preflight_allowed};
+use super::preflight::{collect_preflight_diagnostics_with_module_graph, is_preflight_allowed};
 
 pub(crate) const CHECK_SCHEMA_VERSION: u32 = 1;
 
@@ -216,7 +216,13 @@ fn check_file_report_inner(
         help: diag.suggestion.clone(),
     }));
 
-    let preflight_diagnostics = collect_preflight_diagnostics(path, &source, &program, config);
+    let preflight_diagnostics = collect_preflight_diagnostics_with_module_graph(
+        path,
+        &source,
+        &program,
+        config,
+        module_graph,
+    );
     let preflight_severity = PreflightSeverity::from_opt(config.preflight_severity.as_deref());
     if preflight_severity != PreflightSeverity::Off {
         let (severity_label, category) = match preflight_severity {

--- a/crates/harn-cli/src/commands/check/imports.rs
+++ b/crates/harn-cli/src/commands/check/imports.rs
@@ -109,9 +109,9 @@ pub(super) fn scan_re_export_conflicts(
     file_path: &Path,
     source: &str,
     program: &[SNode],
+    graph: &harn_modules::ModuleGraph,
     diagnostics: &mut Vec<PreflightDiagnostic>,
 ) {
-    let graph = harn_modules::build(std::slice::from_ref(&file_path.to_path_buf()));
     let conflicts = graph.re_export_conflicts(file_path);
     if conflicts.is_empty() {
         return;

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -48,6 +48,17 @@ pub(crate) fn collect_preflight_diagnostics(
     program: &[SNode],
     config: &CheckConfig,
 ) -> Vec<PreflightDiagnostic> {
+    let module_graph = harn_modules::build(std::slice::from_ref(&path.to_path_buf()));
+    collect_preflight_diagnostics_with_module_graph(path, source, program, config, &module_graph)
+}
+
+pub(crate) fn collect_preflight_diagnostics_with_module_graph(
+    path: &Path,
+    source: &str,
+    program: &[SNode],
+    config: &CheckConfig,
+    module_graph: &harn_modules::ModuleGraph,
+) -> Vec<PreflightDiagnostic> {
     let mut diagnostics = Vec::new();
     let mut visited = HashSet::new();
     let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -71,7 +82,7 @@ pub(crate) fn collect_preflight_diagnostics(
     );
 
     scan_import_collisions(&canonical, source, program, &mut diagnostics);
-    scan_re_export_conflicts(&canonical, source, program, &mut diagnostics);
+    scan_re_export_conflicts(&canonical, source, program, module_graph, &mut diagnostics);
     scan_static_tool_surface_preflight(&canonical, source, program, config, &mut diagnostics);
     scan_effect_inheritance_preflight(&canonical, source, program, &mut diagnostics);
 

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -15,7 +15,10 @@ use super::config::{build_module_graph, collect_cross_file_imports};
 use super::host_capabilities::parse_host_capability_value;
 use super::lint::lint_file_inner;
 use super::lint_report::lint_file_report;
-use super::preflight::{collect_preflight_diagnostics, is_preflight_allowed};
+use super::preflight::{
+    collect_preflight_diagnostics, collect_preflight_diagnostics_with_module_graph,
+    is_preflight_allowed,
+};
 
 fn parse_program(source: &str) -> Vec<SNode> {
     let mut lexer = Lexer::new(source);
@@ -589,6 +592,39 @@ pipeline main() {
             .iter()
             .all(|d| !d.message.contains("import collision")),
         "unexpected collision: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn preflight_re_export_conflicts_use_supplied_module_graph() {
+    let dir = unique_temp_dir("harn-check-re-export-conflict");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("a.harn"), "pub fn helper() { 1 }\n").unwrap();
+    std::fs::write(dir.join("b.harn"), "pub fn helper() { 2 }\n").unwrap();
+    let file = dir.join("main.harn");
+    let source = r#"
+pub import { helper } from "a.harn"
+pub import { helper } from "b.harn"
+
+pipeline main() {}
+"#;
+    std::fs::write(&file, source).unwrap();
+    let program = parse_program(source);
+    let module_graph = build_module_graph(&[file.clone(), dir.join("a.harn"), dir.join("b.harn")]);
+    let diagnostics = collect_preflight_diagnostics_with_module_graph(
+        &file,
+        source,
+        &program,
+        &CheckConfig::default(),
+        &module_graph,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("re-export conflict")),
+        "expected re-export conflict diagnostic, got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Summary
- reuse the already-built module graph when preflight scans re-export conflicts
- keep the existing standalone preflight helper by building a one-file graph only for that path
- add regression coverage for re-export conflict diagnostics with a supplied graph

## Benchmarks
Debug binaries, local Mac, comparing against the post-source-walk baseline from PR #2697.

- `harn-bump-fleet`: `harn check . --preflight warning` improved from ~4.5-4.9s to ~2.9-3.2s on warmed runs.
- `burin-code`: `harn check . --preflight warning` improved from 118.57s to 75.96s. Both runs exit 1 on the existing intentional parse-error fixture under `conformance/errors/missing_close_brace.harn`.

## Verification
- `cargo fmt --check`
- `cargo test -p harn-cli --lib preflight_re_export_conflicts_use_supplied_module_graph`
- `cargo test -p harn-cli --lib check_and_lint_json_share_typecheck_cache`
- pre-commit changed-package clippy/markdown hooks
- pre-push targeted local checks with isolated `CARGO_TARGET_DIR=/tmp/harn-toolchain-config-cache-push-target`
