### PR TITLE
harn-cli: reuse parsed modules during check

### DIFF
--- a/crates/harn-cli/src/commands/check/config.rs
+++ b/crates/harn-cli/src/commands/check/config.rs
@@ -1,9 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process;
 
 use crate::config as harn_config;
 use crate::package::CheckConfig;
+use harn_parser::analysis::{AnalysisDatabase, SourceId, SourceVersion};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct HarnLintConfig {
@@ -101,11 +102,59 @@ pub(crate) fn collect_cross_file_imports(
 }
 
 pub(crate) fn build_module_graph(files: &[PathBuf]) -> harn_modules::ModuleGraph {
+    ensure_module_dependencies(files);
+    harn_modules::build(files)
+}
+
+pub(crate) fn build_module_graph_and_seed_analysis(
+    files: &[PathBuf],
+    analysis: &mut AnalysisDatabase,
+) -> harn_modules::ModuleGraph {
+    ensure_module_dependencies(files);
+    let mut build = harn_modules::build_with_parsed_sources(files);
+    let mut targets_by_canonical: HashMap<PathBuf, Vec<&PathBuf>> = HashMap::new();
+    for (canonical, file) in files.iter().filter_map(|file| {
+        std::fs::canonicalize(file)
+            .ok()
+            .map(|canonical| (canonical, file))
+    }) {
+        targets_by_canonical
+            .entry(canonical)
+            .or_default()
+            .push(file);
+    }
+    for (canonical, files) in targets_by_canonical {
+        if let Some(parsed) = build.parsed_sources.remove(&canonical) {
+            let mut files = files;
+            if let Some(file) = files.pop() {
+                for file in files {
+                    seed_parsed_source(analysis, file, parsed.clone());
+                }
+                seed_parsed_source(analysis, file, parsed);
+            }
+        }
+    }
+    build.graph
+}
+
+fn seed_parsed_source(
+    analysis: &mut AnalysisDatabase,
+    path: &Path,
+    parsed: harn_modules::ParsedModuleSource,
+) {
+    analysis.set_parsed_source(
+        SourceId::path(path),
+        parsed.source,
+        SourceVersion(1),
+        parsed.program,
+    );
+}
+
+fn ensure_module_dependencies(files: &[PathBuf]) {
     for file in files {
         if let Err(error) = crate::package::ensure_dependencies_materialized(file) {
             eprintln!("error: {error}");
             process::exit(1);
         }
     }
-    harn_modules::build(files)
 }

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -27,8 +27,9 @@ pub(crate) use check_cmd::{
 };
 pub(crate) use config::{
     apply_harn_lint_config, apply_loaded_harn_lint_config, build_module_graph,
-    collect_cross_file_imports, collect_harn_targets, harn_lint_complexity_threshold,
-    harn_lint_persona_step_allowlist, harn_lint_require_file_header, load_harn_lint_config,
+    build_module_graph_and_seed_analysis, collect_cross_file_imports, collect_harn_targets,
+    harn_lint_complexity_threshold, harn_lint_persona_step_allowlist,
+    harn_lint_require_file_header, load_harn_lint_config,
 };
 pub(crate) use fmt::{fmt_targets, fmt_targets_json, FmtMode, FMT_SCHEMA_VERSION};
 pub(crate) use host_capabilities::load_host_capabilities;

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -11,7 +11,9 @@ use crate::package::CheckConfig;
 use super::bundle::build_bundle_manifest;
 use super::check_cmd::{check_file_inner, check_file_report};
 use super::config::collect_harn_targets;
-use super::config::{build_module_graph, collect_cross_file_imports};
+use super::config::{
+    build_module_graph, build_module_graph_and_seed_analysis, collect_cross_file_imports,
+};
 use super::host_capabilities::parse_host_capability_value;
 use super::lint::lint_file_inner;
 use super::lint_report::lint_file_report;
@@ -1678,6 +1680,46 @@ pipeline main() {
     assert_eq!(after_check.typecheck_runs, 1);
     assert_eq!(after_lint.typecheck_runs, 1);
     assert_eq!(after_lint.parse_runs, after_check.parse_runs);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn seeded_module_graph_avoids_reparsing_for_check() {
+    let dir = unique_temp_dir("harn-check-seeded-parse");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.harn");
+    std::fs::write(
+        &file,
+        r#"
+pipeline main() {
+  log("ready")
+}
+"#,
+    )
+    .unwrap();
+
+    let files = vec![file.clone()];
+    let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
+    let module_graph = build_module_graph_and_seed_analysis(&files, &mut analysis);
+    let cross_file_imports = collect_cross_file_imports(&module_graph);
+    let config = CheckConfig::default();
+
+    let report = check_file_report(
+        &mut analysis,
+        &file,
+        &config,
+        &cross_file_imports,
+        &module_graph,
+        false,
+    );
+    assert!(matches!(
+        report.status,
+        super::check_cmd::CheckFileStatus::Ok
+    ));
+    let stats = analysis.stats();
+    assert_eq!(stats.lex_runs, 0);
+    assert_eq!(stats.parse_runs, 0);
+    assert_eq!(stats.typecheck_runs, 1);
     let _ = std::fs::remove_dir_all(&dir);
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -451,9 +451,10 @@ async fn async_main() {
                 }
                 command_error("no .harn files found under the given target(s)");
             }
-            let module_graph = commands::check::build_module_graph(&files);
-            let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
             let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
+            let module_graph =
+                commands::check::build_module_graph_and_seed_analysis(&files, &mut analysis);
+            let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
             let mut should_fail = false;
             let mut json_files = Vec::new();
             for file in &files {
@@ -568,9 +569,10 @@ async fn async_main() {
                 }
                 command_error("no .harn or .harn.prompt files found under the given target(s)");
             }
-            let module_graph = commands::check::build_module_graph(&files);
-            let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
             let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
+            let module_graph =
+                commands::check::build_module_graph_and_seed_analysis(&files, &mut analysis);
+            let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
             if args.json {
                 // `--json` always reports without modifying source — `--fix`
                 // is intentionally orthogonal to structured output so agents

--- a/crates/harn-modules/src/lib.rs
+++ b/crates/harn-modules/src/lib.rs
@@ -49,6 +49,18 @@ pub struct ModuleGraph {
     modules: HashMap<PathBuf, ModuleInfo>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ParsedModuleSource {
+    pub source: String,
+    pub program: Vec<SNode>,
+}
+
+#[derive(Debug, Default)]
+pub struct ModuleGraphBuild {
+    pub graph: ModuleGraph,
+    pub parsed_sources: HashMap<PathBuf, ParsedModuleSource>,
+}
+
 #[derive(Debug, Default)]
 struct ModuleInfo {
     /// All declarations visible in this module (for local symbol lookup and
@@ -139,7 +151,25 @@ pub fn read_module_source(path: &Path) -> Option<String> {
 /// graph contains every module reachable from the seed set. Cycles and
 /// already-loaded files are skipped via a visited set.
 pub fn build(files: &[PathBuf]) -> ModuleGraph {
+    build_inner(files, None).graph
+}
+
+/// Build a module graph while retaining parsed sources for the seed files.
+///
+/// Imported-only modules still participate in the graph, but their ASTs are
+/// dropped after graph extraction so callers do not pay extra peak memory for
+/// parsed sources they will not reuse.
+pub fn build_with_parsed_sources(files: &[PathBuf]) -> ModuleGraphBuild {
+    let parsed_source_targets = files.iter().map(|file| normalize_path(file)).collect();
+    build_inner(files, Some(&parsed_source_targets))
+}
+
+fn build_inner(
+    files: &[PathBuf],
+    parsed_source_targets: Option<&HashSet<PathBuf>>,
+) -> ModuleGraphBuild {
     let mut modules: HashMap<PathBuf, ModuleInfo> = HashMap::new();
+    let mut parsed_sources: HashMap<PathBuf, ParsedModuleSource> = HashMap::new();
     let mut seen: HashSet<PathBuf> = HashSet::new();
     let mut queue: VecDeque<PathBuf> = VecDeque::new();
     for file in files {
@@ -152,7 +182,14 @@ pub fn build(files: &[PathBuf]) -> ModuleGraph {
         if modules.contains_key(&path) {
             continue;
         }
-        let module = load_module(&path);
+        let retain_parsed_source =
+            parsed_source_targets.is_some_and(|targets| targets.contains(&path));
+        let (module, parsed) = load_module(&path);
+        if retain_parsed_source {
+            if let Some(parsed) = parsed {
+                parsed_sources.insert(path.clone(), parsed);
+            }
+        }
         // Enqueue resolved import targets so the whole reachable graph is
         // discovered without the caller having to pre-walk imports.
         //
@@ -180,7 +217,10 @@ pub fn build(files: &[PathBuf]) -> ModuleGraph {
         modules.insert(path, module);
     }
     resolve_re_exports(&mut modules);
-    ModuleGraph { modules }
+    ModuleGraphBuild {
+        graph: ModuleGraph { modules },
+        parsed_sources,
+    }
 }
 
 /// Iteratively expand each module's `exports` set to include the transitive
@@ -858,19 +898,19 @@ pub struct ReExportConflict {
     pub sources: Vec<PathBuf>,
 }
 
-fn load_module(path: &Path) -> ModuleInfo {
+fn load_module(path: &Path) -> (ModuleInfo, Option<ParsedModuleSource>) {
     let Some(source) = read_module_source(path) else {
-        return ModuleInfo::default();
+        return (ModuleInfo::default(), None);
     };
     let mut lexer = harn_lexer::Lexer::new(&source);
     let tokens = match lexer.tokenize() {
         Ok(tokens) => tokens,
-        Err(_) => return ModuleInfo::default(),
+        Err(_) => return (ModuleInfo::default(), None),
     };
     let mut parser = Parser::new(tokens);
     let program = match parser.parse() {
         Ok(program) => program,
-        Err(_) => return ModuleInfo::default(),
+        Err(_) => return (ModuleInfo::default(), None),
     };
 
     let mut module = ModuleInfo::default();
@@ -893,7 +933,8 @@ fn load_module(path: &Path) -> ModuleInfo {
     module
         .exports
         .extend(module.selective_re_exports.keys().cloned());
-    module
+    let parsed = ParsedModuleSource { source, program };
+    (module, Some(parsed))
 }
 
 /// Extract the stdlib module name when `path` is a `<std>/<name>`

--- a/crates/harn-parser/src/analysis.rs
+++ b/crates/harn-parser/src/analysis.rs
@@ -244,7 +244,50 @@ impl AnalysisDatabase {
         }
     }
 
+    pub fn set_parsed_source(
+        &mut self,
+        id: SourceId,
+        source: String,
+        version: SourceVersion,
+        program: Vec<SNode>,
+    ) -> SourceUpdate {
+        let digest = SourceDigest::from_source(&source);
+        match self.entries.get_mut(&id) {
+            None => {
+                let mut entry = SourceEntry::new(source, version, digest);
+                entry.program = Some(Ok(program));
+                self.entries.insert(id, entry);
+                SourceUpdate::Inserted
+            }
+            Some(entry) if entry.digest == digest => {
+                entry.version = version;
+                entry.program = Some(Ok(program));
+                SourceUpdate::Unchanged
+            }
+            Some(entry) => {
+                entry.replace_source(source, version, digest);
+                entry.program = Some(Ok(program));
+                SourceUpdate::Changed
+            }
+        }
+    }
+
     pub fn parse(&mut self, id: &SourceId) -> Result<ParseOutput, AnalysisError> {
+        if let Some(entry) = self.entries.get(id) {
+            if let Some(program) = &entry.program {
+                return match program {
+                    Ok(program) => Ok(ParseOutput {
+                        source: entry.source.clone(),
+                        program: program.clone(),
+                    }),
+                    Err(errors) => Err(AnalysisError::Parse {
+                        source: entry.source.clone(),
+                        errors: errors.clone(),
+                    }),
+                };
+            }
+        }
+
         let mut lexed = false;
         let mut parsed_now = false;
         let entry = self.entry_mut(id)?;
@@ -424,6 +467,27 @@ mod tests {
         assert_eq!(db.stats().lex_runs, 2);
         assert_eq!(db.stats().parse_runs, 2);
         assert_eq!(db.stats().typecheck_runs, 2);
+    }
+
+    #[test]
+    fn parsed_source_seed_skips_lex_and_parse() {
+        let mut db = AnalysisDatabase::new();
+        let id = source_id();
+        let source = "let x = 1\n".to_string();
+        let mut lexer = Lexer::new(&source);
+        let tokens = lexer.tokenize().expect("tokenize");
+        let mut parser = Parser::new(tokens);
+        let program = parser.parse().expect("parse");
+
+        assert_eq!(
+            db.set_parsed_source(id.clone(), source, SourceVersion(1), program),
+            SourceUpdate::Inserted
+        );
+        db.typecheck(&id, TypeCheckConfig::new())
+            .expect("seeded check");
+        assert_eq!(db.stats().lex_runs, 0);
+        assert_eq!(db.stats().parse_runs, 0);
+        assert_eq!(db.stats().typecheck_runs, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Seed `AnalysisDatabase` with parsed source/programs retained from module graph construction for the files the CLI will actually check or lint.
- Keep normal `harn_modules::build` lightweight; the parsed-source build path retains ASTs only for seed files and drops imported-only ASTs after graph extraction.
- Let seeded parser entries satisfy `parse()` without a second lex/parse pass, with regression coverage for parser stats and the CLI check path.

## Benchmarks
Release binaries, median of warmed local runs after the generated-directory source-walk fix:

| Project | Command | Before | After |
| --- | --- | ---: | ---: |
| `harn-bump-fleet` | `harn lint .` | 0.550s | 0.547s |
| `harn-bump-fleet` | `harn check . --preflight warning` | 0.958s | 0.954s |
| `burin-code` | `harn lint .` | 1.928s | 1.608s |
| `burin-code` | `harn check . --preflight warning` | 20.788s | 20.084s |

The `burin-code` commands still exit non-zero because of existing fixture/project diagnostics; timings are comparable between binaries.

## Validation
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-module-cache-final-target cargo test -p harn-parser parsed_source_seed_skips_lex_and_parse`
- `CARGO_TARGET_DIR=/tmp/harn-module-cache-final-target cargo test -p harn-cli seeded_module_graph_avoids_reparsing_for_check`
- `CARGO_TARGET_DIR=/tmp/harn-module-cache-final-target cargo check -p harn-parser -p harn-modules -p harn-cli`
- Pre-commit hook
- `CARGO_TARGET_DIR=/tmp/harn-module-cache-push-target git push -u origin codex/module-graph-analysis-cache` pre-push hook