### PR TITLE
Harden sandbox mount target normalization

### DIFF
--- a/changelog.d/2516.fixed.md
+++ b/changelog.d/2516.fixed.md
@@ -1,0 +1,3 @@
+- **Sandbox mount targets reject parent traversal (#2516).** Hostlib-backed
+  sandbox sessions now reject guest mount and cwd targets containing `..`
+  components before resolving them against host paths.

--- a/crates/harn-hostlib/src/sandbox/mod.rs
+++ b/crates/harn-hostlib/src/sandbox/mod.rs
@@ -339,6 +339,11 @@ pub(crate) fn normalized_mount_target(target: &str) -> SandboxResult<String> {
             "mount target `{target}` must be absolute"
         )));
     }
+    if trimmed.split('/').any(|segment| segment == "..") {
+        return Err(SandboxError::InvalidRequest(format!(
+            "mount target `{target}` must not contain a `..` component"
+        )));
+    }
     Ok(trimmed.to_string())
 }
 
@@ -399,5 +404,13 @@ mod tests {
     fn quotes_shell_values() {
         assert_eq!(sh_quote("a'b"), "'a'\"'\"'b'");
         assert_eq!(sh_quote(""), "''");
+    }
+
+    #[test]
+    fn normalized_mount_target_rejects_parent_traversal() {
+        let err = normalized_mount_target("/mnt/memory/../../etc/passwd").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must not contain a `..` component"));
     }
 }


### PR DESCRIPTION
## Summary

- reject `..` path components in `harn-hostlib::sandbox` guest mount-target normalization
- add a hostlib regression test for parent traversal targets
- add a changelog fragment for the sandbox hardening

Refs #2516.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-a796-2516 cargo test -p harn-hostlib sandbox::tests::normalized_mount_target_rejects_parent_traversal`
- `CARGO_TARGET_DIR=/tmp/harn-target-a796-2516 cargo clippy -p harn-hostlib --all-targets -- -D warnings`
- pre-commit hook: formatting, changed-package clippy, markdownlint
- pre-push hook: targeted local checks, markdownlint
