### PR TITLE
fix(tools): execute <tool_call>-wrapped calls in text mode + fail loud on model-less turns

### DIFF
--- a/changelog.d/agent-loop-no-llm-call.fixed.md
+++ b/changelog.d/agent-loop-no-llm-call.fixed.md
@@ -1,0 +1,7 @@
+- **Fail loud on a model-less agent turn.** When `agent_loop` finalizes a
+  completed turn that never actually called the provider (zero iterations and
+  zero tokens for a `done`/empty status), it now returns a clear `no_llm_call`
+  terminal error — "agent turn made no LLM call: no model resolved / empty
+  input" — instead of a silent success-with-empty-text. Intentional pauses
+  (`suspended`, `blocked`, `cancelled`, waitpoints) and already-errored turns
+  are unaffected.

--- a/changelog.d/toolcall-wrapper.fixed.md
+++ b/changelog.d/toolcall-wrapper.fixed.md
@@ -1,0 +1,7 @@
+- **Execute `<tool_call>`-wrapped calls in text/bare mode.** Text-format models
+  (e.g. OpenRouter `qwen/qwen3-coder`) wrap their bare `name({ ... })` calls in
+  `<tool_call>...</tool_call>` tags even when the prompt asks for bare calls. The
+  bare parser now strips those wrapper tags up front, so a same-line
+  `<tool_call>run({...})</tool_call>` is executed instead of dropped
+  (`tool_calls: []`) and a trailing `</tool_call>` no longer leaks into the
+  visible assistant text as a `_call>` fragment.

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -437,6 +437,32 @@ fn session_status_indicates_error(final_status: &str) -> bool {
     )
 }
 
+/// Detect a model-less agent turn: the loop finalized a *completed* turn
+/// (empty status or `done`) but never actually called the provider. We
+/// treat "no iterations AND no tokens recorded for this session" as the
+/// signal, since any real provider round-trip increments iterations and
+/// records token usage.
+///
+/// Only the success-completion statuses qualify. Intentional non-terminal
+/// states — `suspended`, `blocked`, `paused`, `cancelled`, waitpoints — and
+/// already-errored turns legitimately finalize with zero iterations and must
+/// be left alone; otherwise we would turn an intentional pause into a
+/// spurious failure.
+fn agent_turn_made_no_llm_call(
+    final_status: &str,
+    has_terminal_error: bool,
+    iterations: i64,
+    input_tokens: i64,
+    output_tokens: i64,
+) -> bool {
+    let is_success_completion = final_status.is_empty() || final_status == "done";
+    !has_terminal_error
+        && is_success_completion
+        && iterations == 0
+        && input_tokens == 0
+        && output_tokens == 0
+}
+
 fn build_user_prompt_block_result(session_id: &str, prompt: &str, reason: &str) -> VmValue {
     let transcript_json = crate::agent_sessions::transcript(session_id)
         .as_ref()
@@ -514,9 +540,10 @@ async fn host_agent_session_finalize(
         .filter(|s| !s.is_empty())
         .ok_or_else(|| VmError::Runtime(format!("{HOST_SESSION_FINALIZE}: missing session_id")))?;
     let status_dict = opts_dict(args.get(1));
-    let final_status = opt_str(&status_dict, "final_status").unwrap_or_default();
-    let stop_reason = opt_str(&status_dict, "stop_reason").unwrap_or_default();
-    let terminal_error = opt_json(&status_dict, "error");
+    let mut final_status = opt_str(&status_dict, "final_status").unwrap_or_default();
+    let mut stop_reason = opt_str(&status_dict, "stop_reason").unwrap_or_default();
+    let mut terminal_error = opt_json(&status_dict, "error");
+    let iterations = opt_int(&status_dict, "iterations").unwrap_or(0);
 
     let session = AGENT_HOST_SESSIONS
         .with(|sessions| sessions.borrow_mut().remove(&session_id))
@@ -529,6 +556,34 @@ async fn host_agent_session_finalize(
     crate::orchestration::clear_approval_policy_repeat_counts(&session_id);
     if session.pushed_transcript_dir {
         super::agent_observe::pop_llm_transcript_dir();
+    }
+
+    // Fail loud on a model-less turn. If the loop finalized a non-error,
+    // success-shaped result but never actually called the provider (zero
+    // iterations and zero input/output tokens recorded for this session),
+    // the turn silently short-circuited — typically because no model
+    // resolved or the input was empty. Returning success-with-empty-text
+    // here masks a configuration failure and costs hours of forensics, so
+    // promote it to a terminal error that flows through the normal
+    // SessionError path below.
+    if agent_turn_made_no_llm_call(
+        &final_status,
+        terminal_error.is_some(),
+        iterations,
+        session.input_tokens,
+        session.output_tokens,
+    ) {
+        terminal_error = Some(serde_json::json!({
+            "category": "no_llm_call",
+            "message": "agent turn made no LLM call: no model resolved / empty input. \
+                        The agent loop completed without ever calling the provider \
+                        (0 iterations, 0 tokens). Check that a model is configured and \
+                        the prompt is non-empty.",
+        }));
+        final_status = "error".to_string();
+        if stop_reason.is_empty() {
+            stop_reason = "no_llm_call".to_string();
+        }
     }
 
     let canonical_status = if final_status.is_empty() {
@@ -587,7 +642,6 @@ async fn host_agent_session_finalize(
     // the active map so hooks observe a fully-quiesced session.
     super::agent_runtime::fire_session_end_hooks(&session_id);
 
-    let iterations = opt_int(&status_dict, "iterations").unwrap_or(0);
     let tool_mode = opt_str(&status_dict, "tool_mode").unwrap_or(session.tool_mode);
     let acp_stop_reason = canonical_acp_stop_reason(
         &final_status,
@@ -2815,11 +2869,31 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        assistant_message_from_llm_result, canonical_acp_stop_reason,
+        agent_turn_made_no_llm_call, assistant_message_from_llm_result, canonical_acp_stop_reason,
         canonical_provider_stop_reason, initial_user_content, last_assistant_text,
         tool_result_message_for_provider, vm_to_json,
     };
     use std::collections::BTreeMap;
+
+    #[test]
+    fn model_less_turn_is_flagged_as_no_llm_call() {
+        // Zero iterations + zero tokens + non-error status = silent
+        // short-circuit. This is the model-less turn we must fail loud on.
+        assert!(agent_turn_made_no_llm_call("", false, 0, 0, 0));
+        assert!(agent_turn_made_no_llm_call("done", false, 0, 0, 0));
+    }
+
+    #[test]
+    fn real_turn_is_not_flagged_as_no_llm_call() {
+        // Any real provider round-trip records iterations and/or tokens.
+        assert!(!agent_turn_made_no_llm_call("done", false, 1, 0, 0));
+        assert!(!agent_turn_made_no_llm_call("done", false, 0, 12, 0));
+        assert!(!agent_turn_made_no_llm_call("done", false, 0, 0, 34));
+        // Already-errored or terminal-error turns are left as-is.
+        assert!(!agent_turn_made_no_llm_call("error", false, 0, 0, 0));
+        assert!(!agent_turn_made_no_llm_call("failed", false, 0, 0, 0));
+        assert!(!agent_turn_made_no_llm_call("", true, 0, 0, 0));
+    }
 
     #[test]
     fn native_tool_calls_replay_with_openai_wire_shape() {

--- a/crates/harn-vm/src/llm/tools/parse/bare.rs
+++ b/crates/harn-vm/src/llm/tools/parse/bare.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeSet;
 use super::native_json::parse_native_json_tool_calls;
 use super::syntax::{
     collapse_blank_lines, has_object_literal_arg_start, ident_length, parse_object_literal_from,
-    parse_ts_call_from, strip_empty_fences, strip_thinking_tags, unwrap_exact_code_wrapper,
+    parse_ts_call_from, strip_empty_fences, strip_thinking_tags, strip_tool_call_wrappers,
+    unwrap_exact_code_wrapper,
 };
 use super::TextToolParseResult;
 use crate::llm::tools::collect_tool_schemas;
@@ -25,17 +26,23 @@ use crate::value::VmValue;
 /// Scan a text body for bare `name({ ... })` tool calls and diagnostics.
 ///
 /// This is the body-level parser used inside `<tool_call>` tags by the
-/// tagged-protocol scanner. It is also called on whole responses as a
-/// diagnostic fallback: when a model emits calls without wrapping them in
-/// `<tool_call>` tags, we detect the calls here, report a grammar violation
-/// at the outer layer, and refuse to execute until the model re-emits
-/// properly wrapped.
+/// tagged-protocol scanner. It is also the parser the text/bare protocol
+/// runs on whole responses.
+///
+/// Text-format models emit `<tool_call>...</tool_call>` wrappers around their
+/// calls unpredictably even when the prompt asks for bare `name({ ... })`
+/// (OpenRouter `qwen/qwen3-coder` does this on most turns). To stay robust we
+/// strip those wrapper tags up front (see `strip_tool_call_wrappers`) and parse
+/// the inner call instead of dropping the turn — otherwise a same-line
+/// `<tool_call>run({...})</tool_call>` is invisible to the line-start scanner
+/// and a trailing `</tool_call>` leaks into the visible prose.
 pub(crate) fn parse_bare_calls_in_body(
     text: &str,
     tools_val: Option<&VmValue>,
 ) -> TextToolParseResult {
     let cleaned = strip_thinking_tags(text);
-    let text = cleaned.as_ref();
+    let unwrapped = strip_tool_call_wrappers(cleaned.as_ref());
+    let text = unwrapped.as_ref();
 
     if let Some(unwrapped) = unwrap_exact_code_wrapper(text) {
         let result = parse_bare_calls_in_body(unwrapped, tools_val);

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -25,6 +25,45 @@ pub(super) fn strip_thinking_tags(text: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(result)
 }
 
+/// Strip `<tool_call>`/`</tool_call>` (and the compact `<toolcall>` spelling)
+/// wrapper tags from a bare-mode body, replacing each with a newline.
+///
+/// Text-format models emit these wrappers unpredictably even when the prompt
+/// asks for bare `name({ ... })` calls (OpenRouter `qwen/qwen3-coder` does this
+/// on most turns). Without stripping, two failures occur in the bare scanner:
+///   1. `<tool_call>run({...})</tool_call>` on one line hides the call —
+///      `run(` is not at a line start, so the scanner never recognizes it and
+///      the whole turn comes back with zero tool calls.
+///   2. A trailing `</tool_call>` (or leading `<tool_call>`) on its own line is
+///      not a call, so it leaks into the visible prose as a `</tool_call>` /
+///      `_call>` fragment.
+///
+/// Replacing each tag token with `\n` fixes both: the inner call lands at a
+/// line start and the wrapper bytes never reach `prose`. Returns a borrowed
+/// `Cow` unchanged when no wrapper tags are present.
+pub(super) fn strip_tool_call_wrappers(text: &str) -> std::borrow::Cow<'_, str> {
+    use super::super::{
+        TEXT_TOOL_CALL_CLOSE, TEXT_TOOL_CALL_CLOSE_COMPACT, TEXT_TOOL_CALL_OPEN,
+        TEXT_TOOL_CALL_OPEN_COMPACT,
+    };
+    const TAGS: [&str; 4] = [
+        TEXT_TOOL_CALL_OPEN,
+        TEXT_TOOL_CALL_CLOSE,
+        TEXT_TOOL_CALL_OPEN_COMPACT,
+        TEXT_TOOL_CALL_CLOSE_COMPACT,
+    ];
+    if !TAGS.iter().any(|tag| text.contains(tag)) {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut result = text.to_string();
+    for tag in TAGS {
+        if result.contains(tag) {
+            result = result.replace(tag, "\n");
+        }
+    }
+    std::borrow::Cow::Owned(result)
+}
+
 /// Match a balanced `<tag>...</tag>` block starting at `start` in `src`.
 /// Returns `(body_slice, end_cursor)` on success. Does not support nested
 /// same-name tags — not needed for this grammar and attempting to support

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -3,6 +3,87 @@ use super::{
     sample_tool_registry, validate_tool_args,
 };
 
+// Regression: text/bare-mode models (OpenRouter `qwen/qwen3-coder`) wrap
+// their bare `name({ ... })` calls in `<tool_call>...</tool_call>` tags
+// unpredictably even when the prompt asks for bare calls. Before the fix a
+// same-line wrapper hid the call entirely (`tool_calls: []`) and a trailing
+// `</tool_call>` leaked into the visible prose as a `_call>` fragment.
+#[test]
+fn bare_parser_executes_same_line_tool_call_wrapper() {
+    let tools = sample_tool_registry();
+    let text = "<tool_call>run({ command: \"cargo test\" })</tool_call>";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "wrapped call must execute (violations: {:?}, errors: {:?})",
+        result.violations,
+        result.errors
+    );
+    assert_eq!(result.calls[0]["name"], "run");
+    assert_eq!(
+        result.calls[0]["arguments"]["command"], "cargo test",
+        "inner call args preserved"
+    );
+    assert!(result.errors.is_empty(), "no errors: {:?}", result.errors);
+    assert!(
+        !result.prose.contains("tool_call"),
+        "wrapper must not leak into prose: {:?}",
+        result.prose
+    );
+}
+
+#[test]
+fn bare_parser_strips_multiline_tool_call_wrapper_and_trailing_fragment() {
+    let tools = sample_tool_registry();
+    // Wrapper across its own lines, plus leading prose. This is the exact
+    // qwen3-coder shape from the failing transcript.
+    let text = "I'll find the file.\n<tool_call>\nrun({ command: \"cargo test\" })\n</tool_call>";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    assert_eq!(result.calls[0]["name"], "run");
+    assert_eq!(result.prose, "I'll find the file.");
+    assert!(
+        !result.prose.contains("_call>") && !result.prose.contains("tool_call"),
+        "wrapper fragments must not leak: {:?}",
+        result.prose
+    );
+
+    // A bare call with only a trailing `</tool_call>` fragment (model forgot
+    // the open tag). The fragment must not survive into prose.
+    let text = "run({ command: \"cargo test\" })\n</tool_call>";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1);
+    assert!(
+        result.prose.trim().is_empty(),
+        "trailing fragment must not leak: {:?}",
+        result.prose
+    );
+}
+
+// End-to-end through the tagged protocol the runtime actually uses: a
+// `<tool_call>`-wrapped call executes with no protocol violation and clean
+// visible text, regardless of which protocol the prompt selected.
+#[test]
+fn tagged_parser_executes_tool_call_wrapper_cleanly() {
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\nrun({ command: \"cargo test\" })\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "violations: {:?}", result.violations);
+    assert_eq!(result.calls[0]["name"], "run");
+    assert!(
+        result.violations.is_empty(),
+        "no violation for a properly wrapped call: {:?}",
+        result.violations
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert!(
+        !result.prose.contains("tool_call"),
+        "no wrapper leak: {:?}",
+        result.prose
+    );
+}
+
 #[test]
 fn validate_tool_args_reports_missing_required_params() {
     let tools = sample_tool_registry();


### PR DESCRIPTION
## BUG 1 (critical) — text-mode `<tool_call>`-wrapped calls were dropped

A model running under the text tool-call format (OpenRouter `qwen/qwen3-coder`) wraps its bare `name({ ... })` calls in `<tool_call>...</tool_call>` tags unpredictably, even when the prompt asks for bare calls. In a JSONL-verified steel-thread transcript, qwen3-coder emitted:

```
<tool_call>
glob({ pattern: "**/foo.py", reason: "find the file" })
</tool_call>
```

…and the turn came back with `tool_calls: []` — the call was never executed (the agent then said "I don't have permission to edit files" and gave up), while `</tool_call>` fragments leaked into the visible assistant text as `_call>`.

**Root cause:** the bare scanner (`parse/bare.rs`) only recognizes `name(` when its `(` sits at a line start. A same-line `<tool_call>run({...})</tool_call>` therefore hides the call entirely (`calls=0`), and a trailing `</tool_call>` survives into `prose`.

**Fix:** the bare parser strips `<tool_call>`/`</tool_call>` (and the compact `<toolcall>` spelling) wrapper tags up front (`strip_tool_call_wrappers`), replacing each with a newline so the inner call lands at a line start and the wrapper bytes never reach `prose`. This tolerates the wrapper regardless of which protocol the prompt selected, rather than relying on `prefers_xml_tools` routing — models emit the wrapper unpredictably. The strict tagged protocol (`parse/tagged.rs`), which already handled properly-wrapped calls, is unchanged and still flags genuinely-bare-outside-tags calls as soft violations.

## BUG 2 (defensive) — model-less turn silently returned empty success

When `agent_loop` finalizes a completed turn (`done`/empty status) that never actually called the provider — zero iterations and zero tokens recorded for the session — it returned success-with-empty-text instead of erroring. This silent short-circuit cost hours of forensics.

**Fix:** `__host_agent_session_finalize` now promotes that case to a loud `no_llm_call` terminal error — *"agent turn made no LLM call: no model resolved / empty input"* — which flows through the existing SessionError-hook and `agent_loop_terminal_error` transcript path. Restricted to success-completion statuses, so intentional pauses (`suspended`, `blocked`, `cancelled`, waitpoints) and already-errored turns are unaffected.

## Files changed
- `crates/harn-vm/src/llm/tools/parse/syntax.rs` — `strip_tool_call_wrappers` helper
- `crates/harn-vm/src/llm/tools/parse/bare.rs` — strip wrappers before scanning
- `crates/harn-vm/src/llm/agent_session_host.rs` — `agent_turn_made_no_llm_call` guard in finalize
- `crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs` — wrapper conformance tests
- `changelog.d/*.fixed.md` — towncrier fragments

## Tests
`cargo test -p harn-vm` green (3004 tests), `cargo clippy -p harn-vm --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean. New conformance tests cover same-line + multi-line `<tool_call>` wrappers and a trailing `</tool_call>` fragment in text mode (parse + execute, no violation, clean visible text), plus the no-llm-call guard predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)