### PR TITLE
feat(acp): AcpServerConfig read-only sandbox roots for bundled embedder assets

### DIFF
--- a/changelog.d/acp-readonly-sandbox-roots.added.md
+++ b/changelog.d/acp-readonly-sandbox-roots.added.md
@@ -1,0 +1,8 @@
+- **ACP read-only sandbox roots for bundled embedder assets.**
+  `AcpServerConfig::with_read_only_roots` lets an in-process ACP host register
+  read-only sandbox roots outside the user's `workspace_roots`. The configured
+  roots are unioned into the per-turn capability policy at
+  `ModePolicyGuard::enter`, so `check_fs_path_scope` permits reads under them
+  while still denying writes, deletes, and reads outside every root. This
+  unblocks embedders (e.g. burin's Rust TUI) that ship bundled pipelines and
+  their `@partials` outside the user's project tree.

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -509,6 +509,14 @@ pub struct AcpServerConfig {
     pub llm_capability_overrides: Option<harn_vm::llm::capabilities::CapabilitiesFile>,
     pub profile: AcpProfileConfig,
     pub budget: Option<BudgetSpec>,
+    /// Read-only sandbox roots the embedder grants on top of the user's
+    /// `workspace_roots`. Paths resolving under one of these are readable
+    /// during a turn even though they sit outside the user workspace, but
+    /// they are never writable or executable. Intended for an in-process
+    /// host (e.g. burin's Rust TUI) that ships bundled assets — pipelines
+    /// and their `@partials` — outside the user's project tree. Empty by
+    /// default so embedders that do not set it keep the stock sandbox.
+    pub read_only_roots: Vec<String>,
 }
 
 impl AcpServerConfig {
@@ -521,6 +529,7 @@ impl AcpServerConfig {
             llm_capability_overrides: None,
             profile: AcpProfileConfig::default(),
             budget: None,
+            read_only_roots: Vec::new(),
         }
     }
 
@@ -574,6 +583,36 @@ impl AcpServerConfig {
         self.budget = normalize_budget_spec(budget);
         self
     }
+
+    /// Register read-only sandbox roots that the embedder grants on top of
+    /// the user's `workspace_roots`. Each path is canonicalized so the
+    /// per-turn policy compares against the same normalized form the
+    /// sandbox scope check uses; entries that cannot be canonicalized
+    /// (e.g. they do not exist yet) fall back to their input string.
+    /// Empty/blank entries are dropped.
+    pub fn with_read_only_roots(mut self, roots: Vec<String>) -> Self {
+        self.read_only_roots = canonicalize_read_only_roots(roots);
+        self
+    }
+}
+
+/// Canonicalize embedder-supplied read-only roots, dropping blank entries.
+/// Falls back to the trimmed input when canonicalization fails so a root
+/// that does not exist on disk yet is still carried verbatim.
+fn canonicalize_read_only_roots(roots: Vec<String>) -> Vec<String> {
+    roots
+        .into_iter()
+        .filter_map(|root| {
+            let trimmed = root.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let canonical = std::fs::canonicalize(trimmed)
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| trimmed.to_string());
+            Some(canonical)
+        })
+        .collect()
 }
 
 /// Cached compiled pipeline. The ACP server re-uses the same pipeline file
@@ -639,6 +678,10 @@ pub struct AcpServer {
     profile: AcpProfileConfig,
     /// Server-level budget inherited by sessions unless they override it.
     default_budget: Option<BudgetSpec>,
+    /// Embedder-granted read-only sandbox roots, unioned into the per-turn
+    /// capability policy so bundled assets outside the user workspace stay
+    /// readable. Empty for embedders that do not opt in.
+    read_only_roots: Vec<String>,
 }
 
 impl AcpServer {
@@ -671,6 +714,7 @@ impl AcpServer {
             vm_baseline_cache: None,
             profile: config.profile,
             default_budget: config.budget,
+            read_only_roots: config.read_only_roots,
         }
     }
 
@@ -1595,7 +1639,7 @@ impl AcpServer {
             })),
         );
         let profile_turn = self.begin_profile_turn(&session_id);
-        let _mode_guard = modes::ModePolicyGuard::enter(&current_mode_id);
+        let _mode_guard = modes::ModePolicyGuard::enter(&current_mode_id, &self.read_only_roots);
         let (vm_baseline, vm_baseline_cache_hit, vm_baseline_prepare_ms) = match self
             .prepare_vm_baseline_cached(
                 &source,

--- a/crates/harn-serve/src/adapters/acp/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/modes.rs
@@ -390,7 +390,17 @@ fn split_provider_prefix(value: &str) -> Option<(&str, &str)> {
 
 /// Capability ceiling enforced while a prompt runs in this mode. Harn's
 /// autonomy-tier policy remains authoritative; ACP modes only select the tier.
-pub(super) fn policy_for_mode(mode_id: &str) -> Option<CapabilityPolicy> {
+///
+/// `read_only_roots` carries the embedder's extra read-only sandbox roots
+/// (see [`super::AcpServerConfig::with_read_only_roots`]). They are unioned
+/// into the per-turn policy's `read_only_roots` so they survive the push and
+/// are honored by `check_fs_path_scope`. Because they only populate the
+/// read-only dimension, they grant reads under those roots without widening
+/// write or exec scope.
+pub(super) fn policy_for_mode(
+    mode_id: &str,
+    read_only_roots: &[String],
+) -> Option<CapabilityPolicy> {
     let mode = definition(mode_id)?;
     if mode.autonomy_tier == AutonomyTier::ActAuto {
         // Full-access mode leaves the ambient host/runtime policy as the
@@ -398,7 +408,24 @@ pub(super) fn policy_for_mode(mode_id: &str) -> Option<CapabilityPolicy> {
         // fallbacks look policy-governed and block them.
         return None;
     }
-    Some(harn_vm::policy_for_autonomy_tier(mode.autonomy_tier))
+    let mut policy = harn_vm::policy_for_autonomy_tier(mode.autonomy_tier);
+    union_read_only_roots(&mut policy, read_only_roots);
+    Some(policy)
+}
+
+/// Add `roots` to `policy.read_only_roots`, skipping duplicates. The autonomy
+/// tier seeds an empty read-only set, so this is the union that lets embedder
+/// bundled-asset roots survive the per-turn policy push.
+fn union_read_only_roots(policy: &mut CapabilityPolicy, roots: &[String]) {
+    for root in roots {
+        if !policy
+            .read_only_roots
+            .iter()
+            .any(|existing| existing == root)
+        {
+            policy.read_only_roots.push(root.clone());
+        }
+    }
 }
 
 /// RAII guard that pushes a CapabilityPolicy on construction and pops it on
@@ -408,8 +435,8 @@ pub(super) struct ModePolicyGuard {
 }
 
 impl ModePolicyGuard {
-    pub(super) fn enter(mode_id: &str) -> Self {
-        match policy_for_mode(mode_id) {
+    pub(super) fn enter(mode_id: &str, read_only_roots: &[String]) -> Self {
+        match policy_for_mode(mode_id, read_only_roots) {
             Some(policy) => {
                 harn_vm::orchestration::push_execution_policy(policy);
                 Self { pushed: true }
@@ -611,31 +638,66 @@ mod tests {
 
     #[test]
     fn policy_for_code_is_none() {
-        assert!(policy_for_mode("code").is_none());
+        assert!(policy_for_mode("code", &[]).is_none());
     }
 
     #[test]
     fn policy_for_architect_clamps_to_read_only() {
-        let policy = policy_for_mode("architect").expect("architect has policy");
+        let policy = policy_for_mode("architect", &[]).expect("architect has policy");
         assert_eq!(policy.side_effect_level.as_deref(), Some("read_only"));
     }
 
     #[test]
     fn policy_for_ask_clamps_to_read_only() {
-        let policy = policy_for_mode("ask").expect("ask has policy");
+        let policy = policy_for_mode("ask", &[]).expect("ask has policy");
         assert_eq!(policy.side_effect_level.as_deref(), Some("read_only"));
     }
 
     #[test]
     fn policy_for_shadow_blocks_side_effects() {
-        let policy = policy_for_mode("shadow").expect("shadow has policy");
+        let policy = policy_for_mode("shadow", &[]).expect("shadow has policy");
         assert_eq!(policy.side_effect_level.as_deref(), Some("none"));
         assert_eq!(policy.recursion_limit, Some(0));
     }
 
     #[test]
     fn policy_for_unknown_mode_is_none() {
-        assert!(policy_for_mode("not-a-real-mode").is_none());
+        assert!(policy_for_mode("not-a-real-mode", &[]).is_none());
+    }
+
+    #[test]
+    fn embedder_read_only_roots_union_into_per_turn_policy() {
+        let roots = vec![
+            "/opt/burin/pipelines".to_string(),
+            "/opt/burin/pipelines/partials".to_string(),
+        ];
+        let policy = policy_for_mode("architect", &roots).expect("architect has policy");
+        // Embedder roots survive the per-turn push as read-only entries...
+        assert_eq!(policy.read_only_roots, roots);
+        // ...without widening the writable workspace or relaxing the side
+        // effect ceiling (reads only).
+        assert!(policy.workspace_roots.is_empty());
+        assert_eq!(policy.side_effect_level.as_deref(), Some("read_only"));
+    }
+
+    #[test]
+    fn embedder_read_only_roots_dedupe_on_union() {
+        let roots = vec![
+            "/opt/burin/pipelines".to_string(),
+            "/opt/burin/pipelines".to_string(),
+        ];
+        let policy = policy_for_mode("ask", &roots).expect("ask has policy");
+        assert_eq!(
+            policy.read_only_roots,
+            vec!["/opt/burin/pipelines".to_string()]
+        );
+    }
+
+    #[test]
+    fn code_mode_ignores_embedder_read_only_roots() {
+        // Full-access mode pushes no per-turn policy; the ambient sandbox is
+        // already unrestricted so there is nothing to union into.
+        assert!(policy_for_mode("code", &["/opt/burin/pipelines".to_string()]).is_none());
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -905,6 +905,57 @@ mod tests {
     }
 
     #[test]
+    fn read_only_root_outside_workspace_allows_read_denies_write() {
+        // Models an embedder (burin's in-process TUI) that grants a
+        // read-only root R holding bundled pipelines/partials outside the
+        // user's writable workspace. A read under R passes; a write under R
+        // is denied; a read outside both R and the workspace is denied.
+        let workspace = tempfile::tempdir().unwrap();
+        let read_only = tempfile::tempdir().unwrap();
+        push_execution_policy(CapabilityPolicy {
+            sandbox_profile: SandboxProfile::Worktree,
+            workspace_roots: vec![workspace.path().to_string_lossy().into_owned()],
+            read_only_roots: vec![read_only.path().to_string_lossy().into_owned()],
+            ..CapabilityPolicy::default()
+        });
+
+        let asset = read_only
+            .path()
+            .join("partials/agent-web-tools.harn.prompt");
+        // READ under the read-only root is allowed.
+        assert!(
+            check_fs_path_scope(&asset, FsAccess::Read).is_ok(),
+            "read under a configured read-only root must be allowed"
+        );
+
+        // WRITE under the read-only root is denied, flagged read_only.
+        let write_err = check_fs_path_scope(&asset, FsAccess::Write)
+            .expect_err("write under a read-only root must be denied");
+        assert!(write_err.read_only, "write rejection must set read_only");
+
+        // DELETE under the read-only root is likewise denied.
+        assert!(
+            check_fs_path_scope(&asset, FsAccess::Delete).is_err(),
+            "delete under a read-only root must be denied"
+        );
+
+        // A read inside the writable workspace still passes.
+        assert!(check_fs_path_scope(&workspace.path().join("src/main.rs"), FsAccess::Read).is_ok());
+
+        // A read outside BOTH the workspace and the read-only root is denied
+        // and is NOT flagged read_only (it fell outside every root).
+        let stranger = tempfile::tempdir().unwrap();
+        let outside_err = check_fs_path_scope(&stranger.path().join("secret.txt"), FsAccess::Read)
+            .expect_err("read outside all roots must be denied");
+        assert!(
+            !outside_err.read_only,
+            "out-of-scope rejection must not be flagged read_only"
+        );
+
+        pop_execution_policy();
+    }
+
+    #[test]
     fn path_within_root_accepts_root_and_children() {
         let root = Path::new("/tmp/harn-root");
         assert!(path_is_within(root, root));


### PR DESCRIPTION
## Why

An in-process ACP host — burin's Rust TUI — runs `harn serve acp` in-process and ships its **bundled pipelines and their `@partials` outside the user's project tree**. A foreign-workspace turn failed:

```
sandbox violation: ... attempted to read .../pipelines/partials/agent-web-tools.harn.prompt outside workspace_roots [/tmp/userrepo]
```

There was no way for an embedder to register a read-only sandbox root:
- `check_fs_path_scope` consults only `current_execution_policy().read_only_roots` (top of the thread-local stack).
- The per-turn policy built at `ModePolicyGuard::enter` → `policy_for_autonomy_tier` seeds an **empty `read_only_roots`** and is pushed on top of the stack, shadowing any base read root.
- `AcpServerConfig` / `run_acp_channel_server` had **no roots field** to carry one through.

## What

- Add `AcpServerConfig::with_read_only_roots(Vec<String>)` (canonicalizes each path; drops blanks). Carried onto `AcpServer` and into `ModePolicyGuard::enter`.
- **Union mechanism:** at the per-turn construction site (`policy_for_mode` → `policy_for_autonomy_tier`), the configured roots are unioned (deduped) into the policy's `read_only_roots` so they survive the push and are honored by `check_fs_path_scope`.
- **Read-only, tight:** reads under those roots pass; writes/deletes under them, and reads outside every root, stay denied. Full-access `code` mode pushes no policy (ambient sandbox is already unrestricted), so it ignores the roots. Embedders that do not opt in keep the stock sandbox.

## Tests

- `harn-vm` `stdlib::sandbox`: a configured read-only root R outside the workspace ALLOWS a read under R, DENIES a write and a delete under R, and DENIES a read outside both R and the workspace (and only the write/delete are flagged `read_only`).
- `harn-serve` `modes`: embedder roots union into the per-turn policy without widening `workspace_roots` or the side-effect ceiling; dedupe on union; `code` mode ignores them.
- `cargo build -p harn-serve -p harn-vm`, `cargo clippy -p harn-serve -p harn-vm --all-targets -- -D warnings`, `cargo fmt --all --check`, and the harn-serve acp + harn-vm policy/sandbox suites all pass.

## Unblocks

burin's standalone/flip gate: burin already resolves the pipelines root and marks the `with_read_only_roots(resolve_pipelines_root())` call-site in `engine_driver.rs`, pending this API in the next harn release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)