### PR TITLE
Add web grounding helpers

### DIFF
--- a/changelog.d/2711.added.md
+++ b/changelog.d/2711.added.md
@@ -1,0 +1,4 @@
+- **Web grounding helpers in `std/web` (#2711).** Added provider-agnostic
+  `web_search`, deterministic `verify_imports`, and `web_grounding_tools` for
+  provenance-carrying search, post-edit import verification, and
+  capability-gated model guidance.

--- a/conformance/tests/stdlib/web_search_grounding.expected
+++ b/conformance/tests/stdlib/web_search_grounding.expected
@@ -1,0 +1,1 @@
+web_search_grounding_ok

--- a/conformance/tests/stdlib/web_search_grounding.harn
+++ b/conformance/tests/stdlib/web_search_grounding.harn
@@ -1,0 +1,173 @@
+import { verify_imports, web_grounding_tools, web_search } from "std/web"
+
+fn has_finding(items, kind, package) {
+  for item in items {
+    if item.kind == kind && item.package == package {
+      return true
+    }
+  }
+  return false
+}
+
+fn has_import_status(items, package, symbol, status) {
+  for item in items {
+    if item.package == package && item.symbol == symbol && item.status == status {
+      return true
+    }
+  }
+  return false
+}
+
+pipeline test(task) {
+  let curated = web_search(
+    "fastapi dependency injection",
+    {
+      limit: 1,
+      index: [
+        {
+          title: "FastAPI Dependencies",
+          url: "https://fastapi.tiangolo.com/tutorial/dependencies/",
+          snippet: "Dependency injection and Depends examples.",
+          source_type: "docs",
+          authority: true,
+          package: "fastapi",
+          version: "0.115",
+        },
+        {title: "Random blog", url: "https://example.net/post", snippet: "A generic overview."},
+      ],
+    },
+  )
+  assert_eq(curated.backend.kind, "curated_index")
+  assert_eq(curated.results[0].package, "fastapi")
+  assert_eq(curated.results[0].provenance.evidence, "curated_index")
+  http_mock_clear()
+  http_mock(
+    "GET",
+    "https://search.example/api*",
+    {
+      status: 200,
+      headers: {"content-type": "application/json"},
+      body: json_stringify(
+        {
+          items: [
+            {
+              title: "std/web",
+              link: "https://harnlang.com/docs/builtins.html#web",
+              summary: "Harn web_fetch and web_search helpers.",
+              source_type: "docs",
+            },
+          ],
+        },
+      ),
+    },
+  )
+  let api = web_search(
+    "harn web",
+    {
+      api: {
+        url: "https://search.example/api",
+        headers: {Authorization: "Bearer SECRET_SEARCH_TOKEN"},
+        results_path: "items",
+        url_path: "link",
+        snippet_path: "summary",
+      },
+    },
+  )
+  assert_eq(api.backend.kind, "api")
+  assert_eq(api.results[0].url, "https://harnlang.com/docs/builtins.html#web")
+  assert(api.backend.api == nil, "web_search does not expose backend request config")
+  assert(!contains(json_stringify(api), "SECRET_SEARCH_TOKEN"), "web_search redacts API credentials")
+  let calls = http_mock_calls({redact_sensitive: false})
+  assert(contains(calls[0].url, "https://search.example/api?"), "web_search used web_fetch/http mock")
+  assert(contains(calls[0].url, "q=harn"), "web_search forwarded query")
+  let root = path_join(harness.fs.temp_dir(), "harn-web-grounding-" + uuid_v7())
+  harness.fs.mkdir(root)
+  harness.fs
+    .write_text(
+    path_join(root, "package.json"),
+    "{\"dependencies\":{\"react\":\"19.0.0\",\"react-dom\":\"19.0.0\"}}\n",
+  )
+  harness.fs
+    .write_text(
+    path_join(root, "Cargo.toml"),
+    "[package]\nname=\"grounding-demo\"\nversion=\"0.1.0\"\n[dependencies]\nserde=\"1\"\n",
+  )
+  let app_py = path_join(root, "app.py")
+  let ui_ts = path_join(root, "ui.ts")
+  let lib_rs = path_join(root, "lib.rs")
+  harness.fs
+    .write_text(
+    app_py,
+    "import requests\nfrom fastapi import FastAPI, NopeSymbol\nimport madeup_package_zz\n",
+  )
+  harness.fs
+    .write_text(
+    ui_ts,
+    "import React from 'react'\nimport { createRoot } from 'react-dom/client'\nimport nope from 'fresh-slop'\n",
+  )
+  harness.fs.write_text(lib_rs, "use serde::Serialize;\nuse hallucinate_crate::Thing;\n")
+  let verified = verify_imports(
+    [app_py, ui_ts, lib_rs],
+    {
+      project_root: root,
+      now: "2026-05-31",
+      low_trust_threshold: 0.4,
+      min_package_age_days: 30,
+      registry: [
+        {
+          ecosystem: "python",
+          name: "requests",
+          symbols: [],
+          source_url: "https://pypi.org/project/requests/",
+        },
+        {
+          ecosystem: "python",
+          name: "fastapi",
+          symbols: ["FastAPI"],
+          source_url: "https://fastapi.tiangolo.com/",
+        },
+        {
+          ecosystem: "npm",
+          name: "react-dom",
+          symbols: ["createRoot"],
+          source_url: "https://www.npmjs.com/package/react-dom",
+        },
+        {ecosystem: "cargo", name: "serde", symbols: ["Serialize"], source_url: "https://docs.rs/serde/"},
+        {
+          ecosystem: "npm",
+          name: "fresh-slop",
+          exists: true,
+          trust_score: 0.1,
+          first_seen: "2026-05-30",
+          source_url: "https://www.npmjs.com/package/fresh-slop",
+        },
+      ],
+    },
+  )
+  assert_eq(verified.status, "fail")
+  assert(
+    has_finding(verified.unresolved, "package_not_found", "madeup_package_zz"),
+    "missing Python package",
+  )
+  assert(
+    has_finding(verified.unresolved, "package_not_found", "hallucinate_crate"),
+    "missing Rust crate",
+  )
+  assert(has_finding(verified.unresolved, "symbol_not_found", "fastapi"), "missing Python symbol")
+  assert(has_import_status(verified.imports, "fastapi", "FastAPI", "resolved"), "known Python symbol")
+  assert(
+    has_import_status(verified.imports, "react-dom", "createRoot", "resolved"),
+    "known npm symbol",
+  )
+  assert(has_import_status(verified.imports, "serde", "Serialize", "resolved"), "known Rust symbol")
+  assert(
+    has_finding(verified.warnings, "low_trust_package", "fresh-slop"),
+    "low-trust package warning",
+  )
+  assert(has_finding(verified.warnings, "fresh_package", "fresh-slop"), "fresh package warning")
+  let explained = prompt_explain({tools: web_grounding_tools()})
+  assert(contains(explained.system, "call web_search"), "search guidance is gated with the tool")
+  assert(contains(explained.system, "call verify_imports"), "verify guidance is gated with the tool")
+  harness.fs.delete(root)
+  __io_println("web_search_grounding_ok")
+}

--- a/crates/harn-stdlib/src/stdlib/stdlib_web.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_web.harn
@@ -1,5 +1,6 @@
 // std/web — deterministic HTTP-backed source ingest and extraction helpers.
 import { cache_get, cache_put } from "std/cache"
+import { safe_parse } from "std/json"
 
 fn __web_header(headers, name) {
   let wanted = lowercase(name)
@@ -176,6 +177,417 @@ pub fn web_fetch(url: string, options = nil) -> dict {
     cache_put(cache_key, envelope, store_opts)
   }
   return envelope
+}
+
+fn __web_search_tokens(query) {
+  let normalized = regex_replace("[^A-Za-z0-9_./@:-]+", " ", lowercase(query ?? ""))
+  var out = []
+  for token in split(trim(normalized), " ") {
+    if token != "" && len(token) > 1 && !out.contains(token) {
+      out = out.push(token)
+    }
+  }
+  return out
+}
+
+fn __web_search_text(entry) {
+  return lowercase(
+    to_string(entry?.title ?? "")
+      + " "
+      + to_string(entry?.name ?? "")
+      + " "
+      + to_string(entry?.url ?? entry?.href ?? entry?.source_url ?? "")
+      + " "
+      + to_string(entry?.snippet ?? entry?.description ?? entry?.text ?? "")
+      + " "
+      + join(entry?.tags ?? [], " ")
+      + " "
+      + to_string(entry?.package ?? ""),
+  )
+}
+
+fn __web_search_score(entry, query, tokens) {
+  let haystack = __web_search_text(entry)
+  var score = 0
+  let phrase = lowercase(trim(query ?? ""))
+  if phrase != "" && contains(haystack, phrase) {
+    score = score + 25
+  }
+  let title = lowercase(to_string(entry?.title ?? entry?.name ?? ""))
+  let url = lowercase(to_string(entry?.url ?? entry?.href ?? entry?.source_url ?? ""))
+  for token in tokens {
+    if contains(title, token) {
+      score = score + 8
+    } else if contains(url, token) {
+      score = score + 5
+    } else if contains(haystack, token) {
+      score = score + 2
+    }
+  }
+  let source_type = entry?.source_type ?? entry?.kind
+  if ["docs", "pinned_docs", "package_registry", "registry"].contains(source_type) {
+    score = score + 6
+  }
+  if entry?.authority || entry?.authoritative {
+    score = score + 8
+  }
+  if entry?.version != nil || entry?.pinned_version != nil {
+    score = score + 2
+  }
+  return score
+}
+
+fn __web_search_take(items, limit) {
+  var out = []
+  for item in items {
+    if len(out) >= limit {
+      return out
+    }
+    out = out.push(item)
+  }
+  return out
+}
+
+fn __web_search_path_get(value, path, fallback = nil) {
+  if path == nil {
+    return fallback
+  }
+  let parts = if type_of(path) == "list" {
+    path
+  } else {
+    split(to_string(path), ".").filter({ part -> part != "" })
+  }
+  var current = value
+  for part in parts {
+    if current == nil {
+      return fallback
+    }
+    current = current[part]
+  }
+  return current ?? fallback
+}
+
+fn __web_search_merge_headers(left, right) {
+  let merged = left ?? {}
+  let extra = right ?? {}
+  return merged + extra
+}
+
+fn __web_search_tool_options(base, args) {
+  let merged = base ?? {}
+  let extra = args?.options ?? args ?? {}
+  return merged + extra
+}
+
+fn __web_search_backend(opts) {
+  let explicit = opts?.backend
+  if type_of(explicit) == "dict" {
+    return explicit
+      + {
+      kind: explicit?.kind ?? explicit?.type ?? "curated_index",
+      id: explicit?.id ?? explicit?.name ?? explicit?.kind ?? "configured",
+      deterministic: true,
+    }
+  }
+  if type_of(explicit) == "string" {
+    return {kind: explicit, id: explicit, deterministic: true}
+  }
+  if opts?.provider_results != nil {
+    return {kind: "provider_hosted", id: "provider_results", deterministic: true, evidence: "provider_results"}
+  }
+  if opts?.api != nil {
+    let api = opts.api
+    return {
+      kind: "api",
+      id: api?.id ?? api?.name ?? api?.url ?? "configured_search_api",
+      deterministic: true,
+      evidence: "search_api",
+      api: api,
+    }
+  }
+  let env_url = harness.env.get("HARN_WEB_SEARCH_URL")
+  if env_url != nil && env_url != "" {
+    var headers = {}
+    let bearer = harness.env.get("HARN_WEB_SEARCH_BEARER_TOKEN")
+    if bearer != nil && bearer != "" {
+      headers = {Authorization: "Bearer " + bearer}
+    }
+    return {
+      kind: "api",
+      id: "env:HARN_WEB_SEARCH_URL",
+      deterministic: true,
+      evidence: "search_api",
+      api: {
+        url: env_url,
+        query_param: harness.env.get_or("HARN_WEB_SEARCH_QUERY_PARAM", "q"),
+        headers: headers,
+      },
+    }
+  }
+  return {
+    kind: "curated_index",
+    id: opts?.index_id ?? "inline",
+    deterministic: true,
+    evidence: "curated_index",
+  }
+}
+
+fn __web_search_public_backend(backend) {
+  var public = {
+    kind: backend.kind,
+    id: backend.id,
+    deterministic: backend?.deterministic ?? true,
+    evidence: backend?.evidence ?? backend.kind,
+  }
+  if backend?.source_url != nil {
+    public = public + {source_url: backend.source_url}
+  }
+  if backend?.final_url != nil {
+    public = public + {final_url: backend.final_url}
+  }
+  return public
+}
+
+fn __web_search_normalize(entry, rank, backend, score = nil) {
+  let url = entry?.url ?? entry?.href ?? entry?.source_url ?? entry?.docs_url
+  return {
+    rank: rank,
+    title: to_string(entry?.title ?? entry?.name ?? url ?? ""),
+    url: url,
+    snippet: to_string(entry?.snippet ?? entry?.description ?? entry?.text ?? ""),
+    source_url: entry?.source_url ?? url,
+    final_url: entry?.final_url ?? url,
+    source_type: entry?.source_type ?? entry?.kind ?? "web",
+    authority: entry?.authority ?? entry?.authoritative ?? false,
+    package: entry?.package ?? entry?.name,
+    registry: entry?.registry ?? entry?.ecosystem,
+    version: entry?.version ?? entry?.pinned_version,
+    provenance: {
+      backend_kind: backend.kind,
+      backend_id: backend.id,
+      evidence: backend?.evidence ?? backend.kind,
+      score: score,
+      source_url: entry?.source_url ?? url,
+      trust_score: entry?.trust_score,
+      first_seen: entry?.first_seen,
+      fetched_at: backend?.fetched_at,
+    },
+  }
+}
+
+fn __web_search_curated(query, opts, backend) {
+  let tokens = __web_search_tokens(query)
+  let limit = opts?.limit ?? 10
+  var scored = []
+  for entry in opts?.index ?? opts?.results ?? backend?.index ?? [] {
+    let score = __web_search_score(entry, query, tokens)
+    if score > 0 || opts?.include_zero_score {
+      scored = scored.push({entry: entry, score: score})
+    }
+  }
+  let ordered = scored.sort_by({ item -> 0 - item.score })
+  var results = []
+  var rank = 1
+  for item in __web_search_take(ordered, limit) {
+    results = results.push(__web_search_normalize(item.entry, rank, backend, item.score))
+    rank = rank + 1
+  }
+  return {
+    ok: true,
+    query: query,
+    backend: __web_search_public_backend(backend),
+    results: results,
+    provenance: {resolver: "std/web", result_count: len(results), authoritative_first: true},
+  }
+}
+
+fn __web_search_provider_results(query, opts, backend) {
+  var results = []
+  var rank = 1
+  for entry in __web_search_take(opts.provider_results ?? [], opts?.limit ?? 10) {
+    results = results.push(__web_search_normalize(entry, rank, backend))
+    rank = rank + 1
+  }
+  return {
+    ok: true,
+    query: query,
+    backend: __web_search_public_backend(backend),
+    results: results,
+    provenance: {resolver: "std/web", result_count: len(results), authoritative_first: false},
+  }
+}
+
+fn __web_search_api_item(item, api) {
+  if type_of(item) != "dict" {
+    return {title: to_string(item), snippet: to_string(item)}
+  }
+  return item
+    + {
+    title: __web_search_path_get(item, api?.title_path ?? "title", item?.title ?? item?.name),
+    url: __web_search_path_get(item, api?.url_path ?? "url", item?.url ?? item?.href),
+    snippet: __web_search_path_get(
+      item,
+      api?.snippet_path ?? "snippet",
+      item?.snippet ?? item?.description ?? item?.text,
+    ),
+    source_url: __web_search_path_get(item, api?.source_url_path ?? "source_url", item?.source_url),
+  }
+}
+
+fn __web_search_api(query, opts, backend) {
+  let api = backend.api ?? opts.api
+  let limit = opts?.limit ?? api?.limit ?? 10
+  var fetch_options = api?.fetch_options ?? {}
+  let method = uppercase(api?.method ?? fetch_options?.method ?? "GET")
+  if method == "GET" {
+    let query_param = api?.query_param ?? "q"
+    let existing_query = fetch_options?.query ?? {}
+    fetch_options = fetch_options + {method: method, query: existing_query + {[query_param]: query}}
+  } else {
+    let headers = __web_search_merge_headers(fetch_options?.headers, api?.headers)
+    fetch_options = fetch_options
+      + {method: method, headers: headers, body: api?.body ?? json_stringify({query: query, limit: limit})}
+  }
+  if api?.headers != nil && method == "GET" {
+    fetch_options = fetch_options + {headers: __web_search_merge_headers(fetch_options?.headers, api.headers)}
+  }
+  let fetched = web_fetch(api.url, fetch_options)
+  let parsed = safe_parse(fetched.body)
+  let items = __web_search_path_get(parsed, api?.results_path ?? "results", [])
+  let raw_results = if type_of(items) == "list" {
+    items
+  } else {
+    []
+  }
+  var results = []
+  var rank = 1
+  for item in __web_search_take(raw_results, limit) {
+    let normalized = __web_search_api_item(item, api)
+    results = results
+      .push(
+      __web_search_normalize(
+        normalized,
+        rank,
+        backend + {fetched_at: fetched.fetched_at},
+        normalized?.score,
+      ),
+    )
+    rank = rank + 1
+  }
+  let fetch_ok = fetched.ok ?? false
+  let parsed_ok = parsed != nil
+  return {
+    ok: fetch_ok && parsed_ok,
+    query: query,
+    backend: __web_search_public_backend(
+      backend + {source_url: fetched.source_url, final_url: fetched.final_url},
+    ),
+    results: results,
+    provenance: {
+      resolver: "std/web",
+      result_count: len(results),
+      authoritative_first: false,
+      fetched_at: fetched.fetched_at,
+      cache_status: fetched.cache_status,
+      source_url: fetched.source_url,
+      final_url: fetched.final_url,
+    },
+  }
+}
+
+/**
+ * Search authoritative web, docs, or registry evidence through a normalized
+ * backend contract.
+ *
+ * Backends:
+ *   - `index` / `results`: deterministic curated entries scored locally.
+ *   - `api`: configured JSON search API fetched through `web_fetch`.
+ *   - `provider_results`: externally captured hosted-tool results normalized
+ *     without coupling this primitive to any provider.
+ *   - `HARN_WEB_SEARCH_URL`: optional process configuration for an API backend.
+ *
+ * @effects: [net, time]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: web_search(query, options)
+ */
+pub fn web_search(query: string, options = nil) -> dict {
+  let opts = options ?? {}
+  let backend = __web_search_backend(opts)
+  if backend.kind == "api" {
+    return __web_search_api(query, opts, backend)
+  }
+  if backend.kind == "provider_hosted" {
+    return __web_search_provider_results(query, opts, backend)
+  }
+  return __web_search_curated(query, opts, backend)
+}
+
+/**
+ * Deterministically verify package imports and optional symbol evidence for
+ * source files. Options include `project_root`, `installed_packages`,
+ * `registry`, `now`, `low_trust_threshold`, and `min_package_age_days`.
+ *
+ * @effects: [fs]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: verify_imports(paths, options)
+ */
+pub fn verify_imports(paths, options = nil) -> dict {
+  return __verify_imports(paths, options ?? {})
+}
+
+/**
+ * Add model-callable `web_search` and `verify_imports` tools with
+ * capability-gated grounding guidance.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: experimental
+ * @example: web_grounding_tools(registry, options)
+ */
+pub fn web_grounding_tools(registry = nil, options = nil) {
+  let opts = options ?? {}
+  var tools = registry ?? tool_registry()
+  tools = tool_define(
+    tools,
+    opts?.search_tool_name ?? "web_search",
+    "Search authoritative docs, package registries, or a configured search API and return normalized results with provenance.",
+    {
+      parameters: {
+        type: "object",
+        required: ["query"],
+        properties: {query: {type: "string"}, limit: {type: "integer"}, index: {type: "array"}, api: {type: "object"}},
+      },
+      annotations: {readOnlyHint: true},
+      handler: { args -> web_search(args.query, __web_search_tool_options(opts, args)) },
+      guidance: "For unfamiliar APIs, package names, or recent behavior, call web_search against authoritative docs or registries before coding. Prefer pinned docs and registry evidence over general web snippets, and carry source URLs into the answer or follow-up prompt.",
+    },
+  )
+  tools = tool_define(
+    tools,
+    opts?.verify_tool_name ?? "verify_imports",
+    "Verify imports in source files against manifests, installed-package hints, registry evidence, symbol metadata, and package trust signals.",
+    {
+      parameters: {
+        type: "object",
+        required: ["paths"],
+        properties: {
+          paths: {type: "array", items: {type: "string"}},
+          project_root: {type: "string"},
+          registry: {type: "array"},
+          installed_packages: {},
+        },
+      },
+      annotations: {readOnlyHint: true},
+      handler: { args -> verify_imports(args.paths ?? [args.path], __web_search_tool_options(opts, args)) },
+      guidance: "After generating or editing code with imports, call verify_imports on the touched source files. Treat package_not_found and symbol_not_found as blockers. Treat fresh_package or low_trust_package warnings as a forced lookup trigger before proceeding.",
+    },
+  )
+  return tools
 }
 
 /**

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -43,6 +43,7 @@ pub(crate) mod files;
 mod flow;
 mod fs;
 mod git;
+mod grounding;
 pub(crate) mod harn_entry;
 pub(crate) mod hitl;
 mod hitl_read;
@@ -174,6 +175,7 @@ pub fn register_io_stdlib(vm: &mut Vm) {
     clock::register_clock_builtins(vm);
     testbench::register_testbench_builtins(vm);
     project::register_project_builtins(vm);
+    grounding::register_grounding_builtins(vm);
     tracing::register_tracing_builtins(vm);
     observability::register_observability_builtins(vm);
     timing::register_timing_builtins(vm);

--- a/crates/harn-vm/src/stdlib/grounding.rs
+++ b/crates/harn-vm/src/stdlib/grounding.rs
@@ -1,0 +1,1187 @@
+//! Deterministic code-grounding helpers for package/API verification.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::NaiveDate;
+use regex::Regex;
+use serde_json::{json, Map, Value};
+
+use crate::llm::helpers::vm_value_to_json;
+use crate::stdlib::json_to_vm_value;
+use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
+use crate::value::{VmError, VmValue};
+use crate::vm::Vm;
+
+use super::process::resolve_source_relative_path;
+
+#[derive(Debug, Clone)]
+struct ImportRef {
+    path: String,
+    language: String,
+    ecosystem: String,
+    raw: String,
+    package: String,
+    symbol: Option<String>,
+    local: bool,
+    standard: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RegistryEntry {
+    ecosystem: String,
+    name: String,
+    aliases: BTreeSet<String>,
+    exists: bool,
+    symbols: Option<BTreeSet<String>>,
+    source_url: Option<String>,
+    docs_url: Option<String>,
+    version: Option<String>,
+    trust_score: Option<f64>,
+    first_seen: Option<String>,
+    published_at: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct ManifestPackages {
+    packages: BTreeMap<String, BTreeSet<String>>,
+    paths: BTreeSet<String>,
+}
+
+#[derive(Debug)]
+struct VerifyOptions {
+    project_root: PathBuf,
+    registry: Vec<RegistryEntry>,
+    installed: BTreeMap<String, BTreeSet<String>>,
+    low_trust_threshold: f64,
+    min_package_age_days: i64,
+    now: Option<NaiveDate>,
+}
+
+impl Default for VerifyOptions {
+    fn default() -> Self {
+        Self {
+            project_root: resolve_source_relative_path("."),
+            registry: Vec::new(),
+            installed: BTreeMap::new(),
+            low_trust_threshold: 0.35,
+            min_package_age_days: 30,
+            now: None,
+        }
+    }
+}
+
+pub(crate) fn register_grounding_builtins(vm: &mut Vm) {
+    for def in MODULE_BUILTINS {
+        vm.register_builtin_def(def);
+    }
+}
+
+pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[&VERIFY_IMPORTS_IMPL_DEF];
+
+#[harn_builtin(
+    sig = "__verify_imports(paths: list|string, options?: dict) -> dict",
+    category = "grounding"
+)]
+fn verify_imports_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
+    let paths = parse_paths(args.first())?;
+    let options = parse_verify_options(args.get(1))?;
+    let resolved_paths = paths
+        .iter()
+        .map(|path| resolve_source_relative_path(path))
+        .collect::<Vec<_>>();
+    let manifests = collect_manifest_packages(&options.project_root, &resolved_paths);
+
+    let mut import_records = Vec::new();
+    let mut unresolved = Vec::new();
+    let mut warnings = Vec::new();
+    let mut scanned_paths = Vec::new();
+
+    for path in &resolved_paths {
+        let display_path = path.to_string_lossy().into_owned();
+        let language = language_for_path(path);
+        scanned_paths.push(display_path.clone());
+        let Ok(source) = std::fs::read_to_string(path) else {
+            unresolved.push(json!({
+                "kind": "source_unreadable",
+                "path": display_path,
+                "message": "source file could not be read",
+            }));
+            continue;
+        };
+        let Some(language) = language else {
+            continue;
+        };
+        for import in extract_imports(&display_path, language, &source) {
+            let resolved = resolve_import(&import, &options, &manifests);
+            if let Some(finding) = resolved.unresolved.clone() {
+                unresolved.push(finding);
+            }
+            warnings.extend(resolved.warnings.iter().cloned());
+
+            import_records.push(json!({
+                "path": import.path,
+                "language": import.language,
+                "ecosystem": import.ecosystem,
+                "raw": import.raw,
+                "package": import.package,
+                "symbol": import.symbol,
+                "status": resolved.status,
+                "evidence": resolved.evidence,
+            }));
+        }
+    }
+
+    let status = if !unresolved.is_empty() {
+        "fail"
+    } else if !warnings.is_empty() {
+        "warn"
+    } else {
+        "pass"
+    };
+    let result = json!({
+        "ok": unresolved.is_empty(),
+        "status": status,
+        "checked": import_records.len(),
+        "paths": scanned_paths,
+        "imports": import_records,
+        "unresolved": unresolved,
+        "warnings": warnings,
+        "evidence": {
+            "project_root": options.project_root.to_string_lossy(),
+            "manifest_paths": manifests.paths.into_iter().collect::<Vec<_>>(),
+            "registry_entries": options.registry.len(),
+            "installed_packages": options.installed.values().map(BTreeSet::len).sum::<usize>(),
+        },
+    });
+    Ok(json_to_vm_value(&result))
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedImport {
+    status: String,
+    evidence: Vec<Value>,
+    unresolved: Option<Value>,
+    warnings: Vec<Value>,
+}
+
+fn parse_paths(value: Option<&VmValue>) -> Result<Vec<String>, VmError> {
+    match value {
+        Some(VmValue::List(items)) => Ok(items.iter().map(VmValue::display).collect()),
+        Some(VmValue::String(path)) if !path.is_empty() => Ok(vec![path.to_string()]),
+        Some(other) => Err(vm_error(format!(
+            "__verify_imports: paths must be a string or list, got {}",
+            other.type_name()
+        ))),
+        None => Err(vm_error("__verify_imports: paths are required")),
+    }
+}
+
+fn parse_verify_options(value: Option<&VmValue>) -> Result<VerifyOptions, VmError> {
+    let mut opts = VerifyOptions::default();
+    let Some(value) = value else {
+        return Ok(opts);
+    };
+    let Value::Object(map) = vm_value_to_json(value) else {
+        return Ok(opts);
+    };
+    if let Some(project_root) = map.get("project_root").and_then(Value::as_str) {
+        opts.project_root = resolve_source_relative_path(project_root);
+    } else if let Some(project_root) = map.get("root").and_then(Value::as_str) {
+        opts.project_root = resolve_source_relative_path(project_root);
+    }
+    if let Some(threshold) = map.get("low_trust_threshold").and_then(Value::as_f64) {
+        opts.low_trust_threshold = threshold;
+    }
+    if let Some(days) = map.get("min_package_age_days").and_then(Value::as_i64) {
+        opts.min_package_age_days = days;
+    }
+    if let Some(now) = map.get("now").and_then(Value::as_str).and_then(parse_date) {
+        opts.now = Some(now);
+    }
+    opts.registry = parse_registry_entries(map.get("registry"));
+    opts.installed = parse_installed_packages(map.get("installed_packages"));
+    Ok(opts)
+}
+
+fn parse_registry_entries(value: Option<&Value>) -> Vec<RegistryEntry> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    match value {
+        Value::Array(items) => items.iter().filter_map(parse_registry_entry).collect(),
+        Value::Object(map) => map
+            .iter()
+            .filter_map(|(name, entry)| {
+                let mut parsed = parse_registry_entry(entry)?;
+                if parsed.name.is_empty() {
+                    parsed.name = name.clone();
+                }
+                Some(parsed)
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn parse_registry_entry(value: &Value) -> Option<RegistryEntry> {
+    let dict = value.as_object()?;
+    let name = string_field(dict, &["name", "package", "module"])?;
+    let ecosystem = string_field(dict, &["ecosystem", "registry", "language"])
+        .map(|value| normalize_ecosystem(&value))
+        .unwrap_or_else(|| "unknown".to_string());
+    let mut aliases = BTreeSet::new();
+    aliases.insert(normalize_package_name(&ecosystem, &name));
+    for key in ["alias", "aliases", "import_name", "import_names"] {
+        match dict.get(key) {
+            Some(Value::String(alias)) => {
+                aliases.insert(normalize_package_name(&ecosystem, alias));
+            }
+            Some(Value::Array(items)) => {
+                for item in items.iter().filter_map(Value::as_str) {
+                    aliases.insert(normalize_package_name(&ecosystem, item));
+                }
+            }
+            _ => {}
+        }
+    }
+    let symbols = dict.get("symbols").and_then(|value| match value {
+        Value::Array(items) => Some(
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect::<BTreeSet<_>>(),
+        ),
+        _ => None,
+    });
+    Some(RegistryEntry {
+        ecosystem,
+        name,
+        aliases,
+        exists: dict.get("exists").and_then(Value::as_bool).unwrap_or(true),
+        symbols,
+        source_url: string_field(dict, &["source_url", "registry_url", "url"]),
+        docs_url: string_field(dict, &["docs_url", "documentation_url"]),
+        version: string_field(dict, &["version", "latest_version"]),
+        trust_score: dict.get("trust_score").and_then(Value::as_f64),
+        first_seen: string_field(dict, &["first_seen", "created_at"]),
+        published_at: string_field(dict, &["published_at", "release_date"]),
+    })
+}
+
+fn parse_installed_packages(value: Option<&Value>) -> BTreeMap<String, BTreeSet<String>> {
+    let mut out = BTreeMap::new();
+    let Some(value) = value else {
+        return out;
+    };
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                add_installed_value(&mut out, "*", item);
+            }
+        }
+        Value::Object(map) => {
+            for (ecosystem, entries) in map {
+                add_installed_value(&mut out, &normalize_ecosystem(ecosystem), entries);
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+fn add_installed_value(
+    out: &mut BTreeMap<String, BTreeSet<String>>,
+    ecosystem: &str,
+    value: &Value,
+) {
+    match value {
+        Value::String(name) => {
+            let (ecosystem, name) = split_ecosystem_name(ecosystem, name);
+            out.entry(ecosystem.clone())
+                .or_default()
+                .insert(normalize_package_name(&ecosystem, &name));
+        }
+        Value::Array(items) => {
+            for item in items {
+                add_installed_value(out, ecosystem, item);
+            }
+        }
+        Value::Object(dict) => {
+            if let Some(name) = string_field(dict, &["name", "package", "module"]) {
+                let ecosystem = string_field(dict, &["ecosystem", "registry", "language"])
+                    .map(|value| normalize_ecosystem(&value))
+                    .unwrap_or_else(|| ecosystem.to_string());
+                out.entry(ecosystem.clone())
+                    .or_default()
+                    .insert(normalize_package_name(&ecosystem, &name));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn split_ecosystem_name(default_ecosystem: &str, value: &str) -> (String, String) {
+    if let Some((ecosystem, name)) = value.split_once(':') {
+        (normalize_ecosystem(ecosystem), name.to_string())
+    } else {
+        (default_ecosystem.to_string(), value.to_string())
+    }
+}
+
+fn string_field(map: &Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| map.get(*key).and_then(Value::as_str))
+        .map(str::to_string)
+        .filter(|value| !value.is_empty())
+}
+
+fn collect_manifest_packages(root: &Path, paths: &[PathBuf]) -> ManifestPackages {
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let mut dirs = BTreeSet::new();
+    dirs.insert(root.clone());
+    for path in paths {
+        let mut current = path.parent();
+        while let Some(dir) = current {
+            dirs.insert(dir.to_path_buf());
+            if dir == root {
+                break;
+            }
+            current = dir.parent();
+        }
+    }
+
+    let mut out = ManifestPackages::default();
+    for dir in dirs {
+        collect_package_json(&dir, &mut out);
+        collect_pyproject(&dir, &mut out);
+        collect_requirements(&dir, &mut out);
+        collect_cargo_toml(&dir, &mut out);
+    }
+    out
+}
+
+fn collect_package_json(dir: &Path, out: &mut ManifestPackages) {
+    let path = dir.join("package.json");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(parsed) = serde_json::from_str::<Value>(&text) else {
+        return;
+    };
+    let Some(map) = parsed.as_object() else {
+        return;
+    };
+    out.paths.insert(path.to_string_lossy().into_owned());
+    for key in [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ] {
+        let Some(deps) = map.get(key).and_then(Value::as_object) else {
+            continue;
+        };
+        for name in deps.keys() {
+            add_manifest_package(out, "npm", name);
+        }
+    }
+}
+
+fn collect_pyproject(dir: &Path, out: &mut ManifestPackages) {
+    let path = dir.join("pyproject.toml");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(parsed) = toml::from_str::<toml::Value>(&text) else {
+        return;
+    };
+    out.paths.insert(path.to_string_lossy().into_owned());
+    if let Some(project) = parsed.get("project") {
+        collect_python_dependency_array(project.get("dependencies"), out);
+        if let Some(optional) = project
+            .get("optional-dependencies")
+            .and_then(toml::Value::as_table)
+        {
+            for deps in optional.values() {
+                collect_python_dependency_array(Some(deps), out);
+            }
+        }
+    }
+    if let Some(poetry) = parsed.get("tool").and_then(|tool| tool.get("poetry")) {
+        collect_poetry_dependency_table(poetry.get("dependencies"), out);
+        if let Some(groups) = poetry.get("group").and_then(toml::Value::as_table) {
+            for group in groups.values() {
+                collect_poetry_dependency_table(group.get("dependencies"), out);
+            }
+        }
+    }
+}
+
+fn collect_requirements(dir: &Path, out: &mut ManifestPackages) {
+    for name in [
+        "requirements.txt",
+        "requirements-dev.txt",
+        "requirements-test.txt",
+    ] {
+        let path = dir.join(name);
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        out.paths.insert(path.to_string_lossy().into_owned());
+        for line in text.lines() {
+            if let Some(package) = parse_python_requirement_name(line) {
+                add_manifest_package(out, "python", &package);
+            }
+        }
+    }
+}
+
+fn collect_cargo_toml(dir: &Path, out: &mut ManifestPackages) {
+    let path = dir.join("Cargo.toml");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(parsed) = toml::from_str::<toml::Value>(&text) else {
+        return;
+    };
+    out.paths.insert(path.to_string_lossy().into_owned());
+    for section in [
+        &["dependencies"][..],
+        &["dev-dependencies"][..],
+        &["build-dependencies"][..],
+        &["workspace", "dependencies"][..],
+    ] {
+        let Some(table) = lookup_toml_path(&parsed, section).and_then(toml::Value::as_table) else {
+            continue;
+        };
+        for name in table.keys() {
+            add_manifest_package(out, "cargo", name);
+        }
+    }
+}
+
+fn collect_python_dependency_array(value: Option<&toml::Value>, out: &mut ManifestPackages) {
+    let Some(items) = value.and_then(toml::Value::as_array) else {
+        return;
+    };
+    for item in items.iter().filter_map(toml::Value::as_str) {
+        if let Some(name) = parse_python_requirement_name(item) {
+            add_manifest_package(out, "python", &name);
+        }
+    }
+}
+
+fn collect_poetry_dependency_table(value: Option<&toml::Value>, out: &mut ManifestPackages) {
+    let Some(table) = value.and_then(toml::Value::as_table) else {
+        return;
+    };
+    for name in table.keys().filter(|name| name.as_str() != "python") {
+        add_manifest_package(out, "python", name);
+    }
+}
+
+fn lookup_toml_path<'a>(value: &'a toml::Value, path: &[&str]) -> Option<&'a toml::Value> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    Some(current)
+}
+
+fn add_manifest_package(out: &mut ManifestPackages, ecosystem: &str, name: &str) {
+    out.packages
+        .entry(ecosystem.to_string())
+        .or_default()
+        .insert(normalize_package_name(ecosystem, name));
+}
+
+fn parse_python_requirement_name(raw: &str) -> Option<String> {
+    let clean = raw.split('#').next()?.trim();
+    if clean.is_empty() || clean.starts_with('-') {
+        return None;
+    }
+    let name = clean
+        .split(['<', '>', '=', '!', '~', ';', '[', ' '])
+        .next()
+        .unwrap_or_default()
+        .trim();
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+fn language_for_path(path: &Path) -> Option<&'static str> {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("py") => Some("python"),
+        Some("js") | Some("jsx") | Some("ts") | Some("tsx") | Some("mjs") | Some("cjs") => {
+            Some("typescript")
+        }
+        Some("rs") => Some("rust"),
+        Some("harn") => Some("harn"),
+        _ => None,
+    }
+}
+
+fn extract_imports(path: &str, language: &str, source: &str) -> Vec<ImportRef> {
+    match language {
+        "python" => extract_python_imports(path, source),
+        "typescript" => extract_node_imports(path, source),
+        "rust" => extract_rust_imports(path, source),
+        "harn" => extract_harn_imports(path, source),
+        _ => Vec::new(),
+    }
+}
+
+fn extract_python_imports(path: &str, source: &str) -> Vec<ImportRef> {
+    let import_re = Regex::new(
+        r"(?m)^\s*import\s+([A-Za-z_][A-Za-z0-9_\.]*(?:\s+as\s+[A-Za-z_][A-Za-z0-9_]*)?(?:\s*,\s*[A-Za-z_][A-Za-z0-9_\.]*(?:\s+as\s+[A-Za-z_][A-Za-z0-9_]*)?)*)",
+    )
+    .expect("static regex parses");
+    let from_re = Regex::new(r"(?m)^\s*from\s+([A-Za-z_][A-Za-z0-9_\.]*)\s+import\s+([^\n#]+)")
+        .expect("static regex parses");
+    let mut out = Vec::new();
+    for capture in import_re.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        for item in capture[1].split(',') {
+            let module = item.split_whitespace().next().unwrap_or_default().trim();
+            push_python_import(path, &raw, module, None, &mut out);
+        }
+    }
+    for capture in from_re.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        let module = capture[1].trim();
+        for symbol in capture[2].split(',') {
+            let symbol = symbol.split_whitespace().next().unwrap_or_default().trim();
+            let symbol = (!symbol.is_empty() && symbol != "*").then(|| symbol.to_string());
+            push_python_import(path, &raw, module, symbol, &mut out);
+        }
+    }
+    dedupe_imports(out)
+}
+
+fn push_python_import(
+    path: &str,
+    raw: &str,
+    module: &str,
+    symbol: Option<String>,
+    out: &mut Vec<ImportRef>,
+) {
+    if module.starts_with('.') || module.is_empty() {
+        return;
+    }
+    let package = module.split('.').next().unwrap_or(module).to_string();
+    out.push(ImportRef {
+        path: path.to_string(),
+        language: "python".to_string(),
+        ecosystem: "python".to_string(),
+        raw: raw.to_string(),
+        standard: PYTHON_STDLIB.contains(&package.as_str()),
+        local: false,
+        package,
+        symbol,
+    });
+}
+
+fn extract_node_imports(path: &str, source: &str) -> Vec<ImportRef> {
+    let import_from = Regex::new(r#"(?m)\bimport\s+([^;\n]*?)\s+from\s*["']([^"']+)["']"#)
+        .expect("static regex parses");
+    let side_effect =
+        Regex::new(r#"(?m)\bimport\s*["']([^"']+)["']"#).expect("static regex parses");
+    let require =
+        Regex::new(r#"\brequire\s*\(\s*["']([^"']+)["']\s*\)"#).expect("static regex parses");
+    let dynamic =
+        Regex::new(r#"\bimport\s*\(\s*["']([^"']+)["']\s*\)"#).expect("static regex parses");
+    let mut out = Vec::new();
+    for capture in import_from.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        let module = capture[2].trim();
+        for symbol in node_import_symbols(capture[1].trim()) {
+            push_node_import(path, &raw, module, symbol, &mut out);
+        }
+    }
+    for capture in side_effect.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        push_node_import(path, &raw, capture[1].trim(), None, &mut out);
+    }
+    for capture in require.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        push_node_import(path, &raw, capture[1].trim(), None, &mut out);
+    }
+    for capture in dynamic.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        push_node_import(path, &raw, capture[1].trim(), None, &mut out);
+    }
+    dedupe_imports(out)
+}
+
+fn node_import_symbols(prefix: &str) -> Vec<Option<String>> {
+    if let Some(start) = prefix.find('{') {
+        if let Some(end) = prefix[start + 1..].find('}') {
+            let body = &prefix[start + 1..start + 1 + end];
+            let symbols = body
+                .split(',')
+                .filter_map(|part| {
+                    let name = part.split_whitespace().next().unwrap_or_default().trim();
+                    (!name.is_empty()).then(|| Some(name.to_string()))
+                })
+                .collect::<Vec<_>>();
+            if !symbols.is_empty() {
+                return symbols;
+            }
+        }
+    }
+    if prefix.trim().is_empty() {
+        vec![None]
+    } else {
+        vec![Some("default".to_string())]
+    }
+}
+
+fn push_node_import(
+    path: &str,
+    raw: &str,
+    module: &str,
+    symbol: Option<String>,
+    out: &mut Vec<ImportRef>,
+) {
+    let local = module.starts_with('.') || module.starts_with('/');
+    let package = node_package_name(module);
+    let standard = NODE_BUILTINS.contains(&module);
+    out.push(ImportRef {
+        path: path.to_string(),
+        language: "typescript".to_string(),
+        ecosystem: "npm".to_string(),
+        raw: raw.to_string(),
+        package,
+        symbol,
+        local,
+        standard,
+    });
+}
+
+fn node_package_name(module: &str) -> String {
+    if module.starts_with('@') {
+        let mut parts = module.split('/');
+        let scope = parts.next().unwrap_or_default();
+        let name = parts.next().unwrap_or_default();
+        if name.is_empty() {
+            module.to_string()
+        } else {
+            format!("{scope}/{name}")
+        }
+    } else {
+        module.split('/').next().unwrap_or(module).to_string()
+    }
+}
+
+fn extract_rust_imports(path: &str, source: &str) -> Vec<ImportRef> {
+    let use_re = Regex::new(r"(?m)^\s*(?:pub\s+)?use\s+([^;]+);").expect("static regex parses");
+    let extern_re = Regex::new(r"(?m)^\s*extern\s+crate\s+([A-Za-z_][A-Za-z0-9_]*)")
+        .expect("static regex parses");
+    let mut out = Vec::new();
+    for capture in use_re.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        let import_path = capture[1].trim().trim_start_matches("::");
+        let package = import_path.split("::").next().unwrap_or_default();
+        if package.is_empty() {
+            continue;
+        }
+        for symbol in rust_symbols(import_path) {
+            push_rust_import(path, &raw, package, symbol, &mut out);
+        }
+    }
+    for capture in extern_re.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        push_rust_import(path, &raw, capture[1].trim(), None, &mut out);
+    }
+    dedupe_imports(out)
+}
+
+fn rust_symbols(import_path: &str) -> Vec<Option<String>> {
+    if let Some(start) = import_path.find('{') {
+        if let Some(end) = import_path[start + 1..].find('}') {
+            let body = &import_path[start + 1..start + 1 + end];
+            let symbols = body
+                .split(',')
+                .filter_map(|part| {
+                    let name = part.trim();
+                    (!name.is_empty() && name != "*").then(|| Some(name.to_string()))
+                })
+                .collect::<Vec<_>>();
+            if !symbols.is_empty() {
+                return symbols;
+            }
+        }
+    }
+    import_path
+        .rsplit("::")
+        .next()
+        .filter(|symbol| *symbol != "*" && *symbol != import_path.split("::").next().unwrap_or(""))
+        .map(|symbol| vec![Some(symbol.to_string())])
+        .unwrap_or_else(|| vec![None])
+}
+
+fn push_rust_import(
+    path: &str,
+    raw: &str,
+    package: &str,
+    symbol: Option<String>,
+    out: &mut Vec<ImportRef>,
+) {
+    out.push(ImportRef {
+        path: path.to_string(),
+        language: "rust".to_string(),
+        ecosystem: "cargo".to_string(),
+        raw: raw.to_string(),
+        package: package.to_string(),
+        symbol,
+        local: false,
+        standard: RUST_STDLIB.contains(&package),
+    });
+}
+
+fn extract_harn_imports(path: &str, source: &str) -> Vec<ImportRef> {
+    let import_re =
+        Regex::new(r#"(?m)^\s*(?:pub\s+)?import\s+(?:\{[^}]*\}\s+from\s+)?["']([^"']+)["']"#)
+            .expect("static regex parses");
+    let mut out = Vec::new();
+    for capture in import_re.captures_iter(source) {
+        let raw = capture.get(0).unwrap().as_str().trim().to_string();
+        let module = capture[1].trim();
+        let local = module.starts_with('.') || module.starts_with('/');
+        let package = module.split('/').next().unwrap_or(module).to_string();
+        out.push(ImportRef {
+            path: path.to_string(),
+            language: "harn".to_string(),
+            ecosystem: "harn".to_string(),
+            raw,
+            package: package.clone(),
+            symbol: None,
+            local,
+            standard: package == "std",
+        });
+    }
+    dedupe_imports(out)
+}
+
+fn dedupe_imports(imports: Vec<ImportRef>) -> Vec<ImportRef> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for import in imports {
+        let key = format!(
+            "{}\0{}\0{}\0{}",
+            import.path,
+            import.package,
+            import.symbol.clone().unwrap_or_default(),
+            import.raw
+        );
+        if seen.insert(key) {
+            out.push(import);
+        }
+    }
+    out
+}
+
+fn resolve_import(
+    import: &ImportRef,
+    options: &VerifyOptions,
+    manifests: &ManifestPackages,
+) -> ResolvedImport {
+    let mut evidence = Vec::new();
+    let mut warnings = Vec::new();
+    if import.local {
+        evidence.push(json!({"kind": "local_path"}));
+        return ResolvedImport {
+            status: "resolved".to_string(),
+            evidence,
+            unresolved: None,
+            warnings,
+        };
+    }
+    if import.standard {
+        evidence.push(json!({"kind": "standard_library"}));
+        return ResolvedImport {
+            status: "resolved".to_string(),
+            evidence,
+            unresolved: None,
+            warnings,
+        };
+    }
+
+    let normalized = normalize_package_name(&import.ecosystem, &import.package);
+    let registry_entry = find_registry_entry(options, &import.ecosystem, &normalized);
+    let mut package_resolved = false;
+
+    if package_set_contains(&options.installed, &import.ecosystem, &normalized) {
+        evidence.push(json!({"kind": "installed_environment"}));
+        package_resolved = true;
+    }
+    if package_set_contains(&manifests.packages, &import.ecosystem, &normalized) {
+        evidence.push(json!({"kind": "manifest"}));
+        package_resolved = true;
+    }
+    if let Some(entry) = registry_entry {
+        if entry.exists {
+            evidence.push(registry_evidence(entry));
+            package_resolved = true;
+            warnings.extend(low_trust_warnings(import, entry, options));
+        } else {
+            evidence.push(json!({"kind": "registry", "exists": false, "name": entry.name}));
+        }
+    }
+
+    if !package_resolved {
+        let finding = json!({
+            "kind": "package_not_found",
+            "path": import.path,
+            "language": import.language,
+            "ecosystem": import.ecosystem,
+            "package": import.package,
+            "symbol": import.symbol,
+            "raw": import.raw,
+            "evidence": evidence,
+        });
+        return ResolvedImport {
+            status: "not_found".to_string(),
+            evidence,
+            unresolved: Some(finding),
+            warnings,
+        };
+    }
+
+    if let Some(symbol) = import.symbol.as_deref() {
+        if let Some(entry) = registry_entry {
+            if let Some(symbols) = &entry.symbols {
+                if symbol != "default" && !symbols.contains(symbol) {
+                    let finding = json!({
+                        "kind": "symbol_not_found",
+                        "path": import.path,
+                        "language": import.language,
+                        "ecosystem": import.ecosystem,
+                        "package": import.package,
+                        "symbol": symbol,
+                        "raw": import.raw,
+                        "evidence": evidence,
+                    });
+                    return ResolvedImport {
+                        status: "unresolved_symbol".to_string(),
+                        evidence,
+                        unresolved: Some(finding),
+                        warnings,
+                    };
+                }
+                evidence.push(json!({"kind": "symbol_registry", "symbol": symbol}));
+            } else {
+                warnings.push(json!({
+                    "kind": "symbol_unverified",
+                    "path": import.path,
+                    "ecosystem": import.ecosystem,
+                    "package": import.package,
+                    "symbol": symbol,
+                    "raw": import.raw,
+                    "message": "package resolved but registry evidence did not include symbol metadata",
+                }));
+            }
+        }
+    }
+
+    ResolvedImport {
+        status: if warnings.is_empty() {
+            "resolved".to_string()
+        } else {
+            "warning".to_string()
+        },
+        evidence,
+        unresolved: None,
+        warnings,
+    }
+}
+
+fn find_registry_entry<'a>(
+    options: &'a VerifyOptions,
+    ecosystem: &str,
+    normalized_name: &str,
+) -> Option<&'a RegistryEntry> {
+    options.registry.iter().find(|entry| {
+        (entry.ecosystem == ecosystem || entry.ecosystem == "unknown")
+            && entry.aliases.contains(normalized_name)
+    })
+}
+
+fn registry_evidence(entry: &RegistryEntry) -> Value {
+    let mut value = Map::new();
+    value.insert("kind".to_string(), json!("registry"));
+    value.insert("exists".to_string(), json!(entry.exists));
+    value.insert("name".to_string(), json!(entry.name));
+    value.insert("ecosystem".to_string(), json!(entry.ecosystem));
+    if let Some(source_url) = &entry.source_url {
+        value.insert("source_url".to_string(), json!(source_url));
+    }
+    if let Some(docs_url) = &entry.docs_url {
+        value.insert("docs_url".to_string(), json!(docs_url));
+    }
+    if let Some(version) = &entry.version {
+        value.insert("version".to_string(), json!(version));
+    }
+    if let Some(trust_score) = entry.trust_score {
+        value.insert("trust_score".to_string(), json!(trust_score));
+    }
+    if let Some(first_seen) = &entry.first_seen {
+        value.insert("first_seen".to_string(), json!(first_seen));
+    }
+    Value::Object(value)
+}
+
+fn low_trust_warnings(
+    import: &ImportRef,
+    entry: &RegistryEntry,
+    options: &VerifyOptions,
+) -> Vec<Value> {
+    let mut warnings = Vec::new();
+    if let Some(score) = entry.trust_score {
+        if score < options.low_trust_threshold {
+            warnings.push(json!({
+                "kind": "low_trust_package",
+                "path": import.path,
+                "ecosystem": import.ecosystem,
+                "package": import.package,
+                "trust_score": score,
+                "threshold": options.low_trust_threshold,
+                "source_url": entry.source_url,
+            }));
+        }
+    }
+    if options.min_package_age_days > 0 {
+        if let (Some(now), Some(first_seen)) = (
+            options.now,
+            entry
+                .first_seen
+                .as_deref()
+                .or(entry.published_at.as_deref())
+                .and_then(parse_date),
+        ) {
+            let age_days = now.signed_duration_since(first_seen).num_days();
+            if age_days >= 0 && age_days < options.min_package_age_days {
+                warnings.push(json!({
+                    "kind": "fresh_package",
+                    "path": import.path,
+                    "ecosystem": import.ecosystem,
+                    "package": import.package,
+                    "age_days": age_days,
+                    "min_age_days": options.min_package_age_days,
+                    "first_seen": first_seen.to_string(),
+                    "source_url": entry.source_url,
+                }));
+            }
+        }
+    }
+    warnings
+}
+
+fn package_set_contains(
+    packages: &BTreeMap<String, BTreeSet<String>>,
+    ecosystem: &str,
+    normalized_name: &str,
+) -> bool {
+    packages
+        .get(ecosystem)
+        .is_some_and(|items| items.contains(normalized_name))
+        || packages
+            .get("*")
+            .is_some_and(|items| items.contains(normalized_name))
+}
+
+fn normalize_ecosystem(value: &str) -> String {
+    match value.to_ascii_lowercase().as_str() {
+        "node" | "javascript" | "typescript" | "js" | "ts" => "npm".to_string(),
+        "rust" | "crates.io" => "cargo".to_string(),
+        "py" | "pypi" => "python".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn normalize_package_name(ecosystem: &str, name: &str) -> String {
+    let lower = name.trim().to_ascii_lowercase();
+    match ecosystem {
+        "cargo" | "python" => lower.replace('_', "-"),
+        _ => lower,
+    }
+}
+
+fn parse_date(value: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(value.get(..10)?, "%Y-%m-%d").ok()
+}
+
+fn vm_error(message: impl Into<String>) -> VmError {
+    VmError::Thrown(VmValue::String(Arc::from(message.into())))
+}
+
+const PYTHON_STDLIB: &[&str] = &[
+    "abc",
+    "argparse",
+    "asyncio",
+    "collections",
+    "contextlib",
+    "csv",
+    "dataclasses",
+    "datetime",
+    "decimal",
+    "enum",
+    "functools",
+    "glob",
+    "hashlib",
+    "importlib",
+    "inspect",
+    "io",
+    "itertools",
+    "json",
+    "logging",
+    "math",
+    "os",
+    "pathlib",
+    "queue",
+    "random",
+    "re",
+    "shutil",
+    "signal",
+    "sqlite3",
+    "statistics",
+    "string",
+    "subprocess",
+    "sys",
+    "tempfile",
+    "textwrap",
+    "threading",
+    "time",
+    "typing",
+    "unittest",
+    "urllib",
+    "uuid",
+    "xml",
+];
+
+const NODE_BUILTINS: &[&str] = &[
+    "assert",
+    "buffer",
+    "child_process",
+    "crypto",
+    "events",
+    "fs",
+    "fs/promises",
+    "http",
+    "https",
+    "net",
+    "node:assert",
+    "node:buffer",
+    "node:child_process",
+    "node:crypto",
+    "node:events",
+    "node:fs",
+    "node:fs/promises",
+    "node:http",
+    "node:https",
+    "node:net",
+    "node:os",
+    "node:path",
+    "node:process",
+    "node:stream",
+    "node:url",
+    "node:util",
+    "os",
+    "path",
+    "process",
+    "stream",
+    "url",
+    "util",
+];
+
+const RUST_STDLIB: &[&str] = &["alloc", "core", "crate", "self", "std", "super"];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn verify_imports_flags_missing_symbol_and_low_trust_packages() {
+        let dir = tempdir().unwrap();
+        let py = dir.path().join("app.py");
+        std::fs::write(
+            &py,
+            "import requests\nfrom fastapi import FastAPI, NopeSymbol\nimport madeup_package_zz\n",
+        )
+        .unwrap();
+        let ts = dir.path().join("ui.ts");
+        std::fs::write(
+            &ts,
+            "import React from 'react'\nimport { createRoot } from 'react-dom/client'\nimport nope from 'fresh-slop'\n",
+        )
+        .unwrap();
+        let rs = dir.path().join("lib.rs");
+        std::fs::write(
+            &rs,
+            "use serde::Serialize;\nuse hallucinate_crate::Thing;\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"dependencies":{"react":"19.0.0","react-dom":"19.0.0"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n[dependencies]\nserde = \"1\"\n",
+        )
+        .unwrap();
+
+        let args = vec![
+            json_to_vm_value(&json!([
+                py.to_string_lossy(),
+                ts.to_string_lossy(),
+                rs.to_string_lossy()
+            ])),
+            json_to_vm_value(&json!({
+                "project_root": dir.path().to_string_lossy(),
+                "now": "2026-05-31",
+                "registry": [
+                    {"ecosystem":"python","name":"requests","symbols":[],"source_url":"https://pypi.org/project/requests/"},
+                    {"ecosystem":"python","name":"fastapi","symbols":["FastAPI"],"source_url":"https://fastapi.tiangolo.com/"},
+                    {"ecosystem":"npm","name":"react-dom","symbols":["createRoot"],"source_url":"https://www.npmjs.com/package/react-dom"},
+                    {"ecosystem":"cargo","name":"serde","symbols":["Serialize"],"source_url":"https://docs.rs/serde/"},
+                    {"ecosystem":"npm","name":"fresh-slop","exists":true,"trust_score":0.1,"first_seen":"2026-05-30","source_url":"https://www.npmjs.com/package/fresh-slop"}
+                ]
+            })),
+        ];
+        let result = verify_imports_impl(&args, &mut String::new()).unwrap();
+        let json = vm_value_to_json(&result);
+        assert_eq!(json["status"], "fail");
+        assert!(json["unresolved"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["package"] == "madeup_package_zz"));
+        assert!(json["unresolved"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["package"] == "hallucinate_crate"));
+        assert!(json["unresolved"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["kind"] == "symbol_not_found"
+                && item["package"] == "fastapi"
+                && item["symbol"] == "NopeSymbol"));
+        assert!(json["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["kind"] == "fresh_package"));
+        assert!(json["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["kind"] == "low_trust_package"));
+    }
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2543,6 +2543,26 @@ query_stringify([{key: "name", value: "ali ce"}])
 - `http_mock(method, url_pattern, response)` can script multiple responses
   with `{responses: [...]}` and `http_mock_calls()` records each attempt.
 
+### `std/web` grounding helpers
+
+Import with `import { web_fetch, web_search, verify_imports, web_grounding_tools } from "std/web"`.
+
+- `web_fetch(url, options?)` wraps the HTTP stack with source provenance,
+  conditional fetch support, and `{ok, status, body, headers, source_url,
+  final_url, fetched_at, cache_status}` envelopes.
+- `web_search(query, options?)` normalizes curated `index` / `results`,
+  configured JSON `api`, `provider_results`, or `HARN_WEB_SEARCH_URL` search
+  backends into ranked results with per-result provenance. Result envelopes
+  expose only public backend metadata, not configured API headers or bodies.
+- `verify_imports(paths, options?)` checks Python, JavaScript/TypeScript,
+  Rust, and Harn imports against nearby manifests, `installed_packages`, and
+  registry evidence with optional `symbols`, `trust_score`, and package age
+  metadata. Treat `package_not_found` and `symbol_not_found` as blockers;
+  `low_trust_package`, `fresh_package`, and `symbol_unverified` are warnings.
+- `web_grounding_tools(registry?, options?)` registers read-only
+  `web_search` and `verify_imports` tools plus capability-gated model guidance
+  for unfamiliar packages, APIs, or post-edit import verification.
+
 ### Connector HTTP policy
 
 Package authors should prefer `std/connectors/shared` for provider API calls:

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1104,6 +1104,9 @@ log response bodies by itself.
 | Function | Args | Returns | Description |
 |---|---|---|---|
 | `web_fetch(url, options?)` | url: string, options: dict | dict | Fetch a source and return `{ok, status, body, headers, content_type, etag, last_modified, fetched_at, cache_status, source_url, final_url, not_modified}` |
+| `web_search(query, options?)` | query: string, options: dict | dict | Search curated docs/registry entries, a configured JSON API, provider-hosted result captures, or `HARN_WEB_SEARCH_URL`; returns normalized results with per-result provenance |
+| `verify_imports(paths, options?)` | paths: string or list, options: dict | dict | Verify imports in source files against manifests, installed-package hints, registry evidence, symbol metadata, and package trust signals |
+| `web_grounding_tools(registry?, options?)` | registry: tool registry or nil, options: dict | tool registry | Add read-only `web_search` and `verify_imports` tools with capability-gated model guidance |
 | `web_parse_html(html, source_url?)` | html: string, source_url: string or nil | dict | Extract `{title, meta, canonical_url, links, tables, json_ld, text}` from deterministic HTTP-fetched HTML |
 | `web_resolve_url(base_url, href)` | base_url: string, href: string | string or nil | Resolve a relative URL reference against a source URL |
 | `web_origin_url(url, path?)` | url: string, path: string | string | Return the URL origin with a replacement path and no query or fragment. Relative paths are rooted at `/` |
@@ -1122,6 +1125,25 @@ cache key, `conditional: false` to suppress conditional headers, and
 method plus the effective request URL after `query` options are applied, so
 distinct query variants do not share a cached envelope.
 
+`web_search` is provider-agnostic. Pass `index` or `results` for deterministic
+curated entries, `api` for a JSON search service fetched through `web_fetch`,
+`provider_results` to normalize externally captured hosted-search results, or
+configure `HARN_WEB_SEARCH_URL` for process-level search. Each result includes
+`title`, `url`, `snippet`, `source_url`, ranking metadata, and a `provenance`
+record with backend id, evidence type, score, source URL, and trust metadata
+when available. Result envelopes expose only public backend metadata; configured
+API request headers and bodies are not echoed back.
+
+`verify_imports` scans Python, JavaScript/TypeScript, Rust, and Harn imports.
+It resolves packages from nearby `package.json`, `pyproject.toml`,
+`requirements*.txt`, and `Cargo.toml` manifests, optional
+`installed_packages`, and optional registry entries with `symbols`,
+`source_url`, `trust_score`, `first_seen`, or `published_at`. The return status
+is `pass`, `warn`, or `fail`; `package_not_found` and `symbol_not_found` are
+blocking unresolved findings, while `low_trust_package`, `fresh_package`, and
+`symbol_unverified` are warnings intended to force a lookup before coding
+continues.
+
 `robots_allowed` implements a deterministic robots subset for source-ingest
 workflows: exact user-agent groups take precedence over wildcard groups,
 multiple matching groups at the same specificity are combined, and
@@ -1129,7 +1151,7 @@ Allow/Disallow decisions use longest-prefix matching with Allow winning ties.
 
 ```harn
 import { mem_cache } from "std/cache"
-import { web_fetch, web_parse_html, robots_allowed, sitemap_urls } from "std/web"
+import { verify_imports, web_fetch, web_parse_html, web_search, robots_allowed, sitemap_urls } from "std/web"
 
 let store = mem_cache({namespace: "weekly-doc-monitor"})
 let page = web_fetch("https://docs.example.com/models", {store: store})
@@ -1138,6 +1160,20 @@ if page.cache_status != "not_modified" && robots_allowed(page.final_url) {
   log(parsed.title)
   log(sitemap_urls(page.final_url))
 }
+
+let docs = web_search("fastapi dependency injection", {
+  index: [
+    {
+      title: "FastAPI Dependencies",
+      url: "https://fastapi.tiangolo.com/tutorial/dependencies/",
+      source_type: "docs",
+      authority: true,
+    },
+  ],
+})
+let imports = verify_imports("app.py", {
+  registry: [{ecosystem: "python", name: "fastapi", symbols: ["FastAPI"]}],
+})
 ```
 
 HTTP server TLS helper builtins only describe listener/security policy. Runtime

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -402,6 +402,9 @@ Imports starting with `std/` load embedded stdlib modules:
 - `import "std/signal"` — cooperative process interruption helpers
   (on_interrupt, off_interrupt, interrupted, with_interrupt)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
+- `import "std/web"` — deterministic web-source and grounding helpers
+  (web_fetch, web_search, verify_imports, web_grounding_tools,
+  web_parse_html, robots_allowed, sitemap_urls)
 - `import "std/io"` — terminal IO helpers (is_tty, read_line,
   read_password, write_stderr)
 - `import "std/prompt_library"` — reusable prompt fragments, cache metadata,

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -400,6 +400,9 @@ Imports starting with `std/` load embedded stdlib modules:
 - `import "std/signal"` — cooperative process interruption helpers
   (on_interrupt, off_interrupt, interrupted, with_interrupt)
 - `import "std/vision"` — deterministic OCR helpers (`ocr(image, options?)`)
+- `import "std/web"` — deterministic web-source and grounding helpers
+  (web_fetch, web_search, verify_imports, web_grounding_tools,
+  web_parse_html, robots_allowed, sitemap_urls)
 - `import "std/io"` — terminal IO helpers (is_tty, read_line,
   read_password, write_stderr)
 - `import "std/prompt_library"` — reusable prompt fragments, cache metadata,


### PR DESCRIPTION
## Summary
- Add `std/web::web_search` with normalized curated/API/provider-result backends, scoring, provenance, and secret-safe backend metadata.
- Add `std/web::verify_imports` backed by a Rust stdlib builtin that parses Python, JS/TS, Rust, and Harn imports, checks local manifests plus registry evidence, and separates unresolved imports from low-trust/fresh-package warnings.
- Add `web_grounding_tools`, conformance coverage, docs, spec mirror updates, and a changelog fragment.

Closes #2711

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/stdlib_web.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/stdlib_web.harn conformance/tests/stdlib/web_search_grounding.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_web.harn conformance/tests/stdlib/web_search_grounding.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check cargo test -p harn-vm --lib grounding::tests::verify_imports_flags_missing_symbol_and_low_trust_packages`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check cargo run --quiet --bin harn -- test conformance --filter web_`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711 cargo test -p harn-vm --test builtin_registry_alignment --test builtin_signature_text_drift`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check make check-docs-snippets`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2711-check make lint-harn`
- `git diff --check`
- `cargo fmt --check`
- commit hook passed
- pre-push hook passed

## Local model smoke
- Ran a local Ollama `devstral-small-2:24b` smoke comparing baseline prompts against prompts supplied with `verify_imports`/`web_search` evidence.
- Baseline used blocked fake/fresh packages in 2/2 scenarios; grounded-evidence prompts avoided the blocked packages in 2/2 scenarios.