### PR TITLE
Make VM dispatch Send-ready

### DIFF
--- a/changelog.d/2690.changed.md
+++ b/changelog.d/2690.changed.md
@@ -1,0 +1,5 @@
+- **VM dispatch, inline caches, and pool fan-out are now `Send`-ready (#2690, #2691).**
+  Builtin ABIs, VM shared state, host bridges, isolate-local inline caches, and
+  the first pool worker path now use `Send`/`Sync` handles, with pool workers
+  scheduled on `tokio::spawn` and scoped through a VM-owned pool registry for
+  multi-thread execution.

--- a/crates/harn-cli/src/commands/playground.rs
+++ b/crates/harn-cli/src/commands/playground.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use harn_parser::{DiagnosticSeverity, Node, SNode, TypeChecker};
 
@@ -203,7 +203,7 @@ async fn execute_playground(config: &PlaygroundConfig) -> Result<String, String>
                 store_base,
             )
             .await?;
-            let bridge = Rc::new(
+            let bridge = Arc::new(
                 harn_vm::bridge::HostBridge::from_harn_module(host_vm, &config.host)
                     .await
                     .map_err(|error| format!("error: {error}\n"))?,

--- a/crates/harn-dap/src/debugger/state.rs
+++ b/crates/harn-dap/src/debugger/state.rs
@@ -1,6 +1,5 @@
-use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use harn_vm::{DebugState, Vm, VmValue};
@@ -83,7 +82,7 @@ pub struct Debugger {
     /// so a filter can gate on e.g. `err.kind == "disk_full"`.
     pub(crate) exception_filters: BTreeMap<String, Option<String>>,
     /// Latest VM debug snapshot captured through the VM debug hook.
-    pub(crate) latest_debug_state: Rc<RefCell<Option<DebugState>>>,
+    pub(crate) latest_debug_state: Arc<Mutex<Option<DebugState>>>,
     /// Optional bridge that round-trips unhandled `host_call` ops to the
     /// DAP client as reverse requests. When `None`, scripts only see the
     /// harn-vm fallbacks.
@@ -203,7 +202,7 @@ impl Debugger {
             runtime: None,
             break_on_exceptions: false,
             exception_filters: BTreeMap::new(),
-            latest_debug_state: Rc::new(RefCell::new(None)),
+            latest_debug_state: Arc::new(Mutex::new(None)),
             host_bridge: None,
             running: false,
             bp_conditions: Vec::new(),
@@ -325,7 +324,7 @@ impl Debugger {
         self.running && self.vm.is_some()
     }
 
-    /// Install a host bridge. Cloned into an `Rc` and registered with
+    /// Install a host bridge. Cloned into an `Arc` and registered with
     /// harn-vm via `set_host_call_bridge` whenever a fresh VM is built.
     pub fn attach_host_bridge(&mut self, bridge: std::sync::Arc<DapHostBridge>) {
         self.host_bridge = Some((*bridge).clone());
@@ -333,7 +332,8 @@ impl Debugger {
 
     pub(crate) fn current_debug_state(&self) -> DebugState {
         self.latest_debug_state
-            .borrow()
+            .lock()
+            .expect("debug state mutex poisoned")
             .clone()
             .or_else(|| self.vm.as_ref().map(|vm| vm.debug_state()))
             .unwrap_or(DebugState {

--- a/crates/harn-dap/src/debugger/stepping.rs
+++ b/crates/harn-dap/src/debugger/stepping.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use harn_vm::llm::enable_tracing;
 use harn_vm::{
@@ -86,7 +86,7 @@ impl Debugger {
         // DAP client via reverse requests instead of erroring out.
         clear_host_call_bridge();
         if let Some(bridge) = &self.host_bridge {
-            set_host_call_bridge(Rc::new(bridge.clone()));
+            set_host_call_bridge(Arc::new(bridge.clone()));
         }
 
         if let Some(ref path) = self.source_path {
@@ -119,16 +119,24 @@ impl Debugger {
                 .map(|fb| fb.name.clone())
                 .collect(),
         );
-        *self.latest_debug_state.borrow_mut() = None;
-        let latest_debug_state = Rc::clone(&self.latest_debug_state);
+        *self
+            .latest_debug_state
+            .lock()
+            .expect("debug state mutex poisoned") = None;
+        let latest_debug_state = Arc::clone(&self.latest_debug_state);
         vm.set_debug_hook(move |state| {
-            *latest_debug_state.borrow_mut() = Some(state.clone());
+            *latest_debug_state
+                .lock()
+                .expect("debug state mutex poisoned") = Some(state.clone());
             DebugAction::Continue
         });
 
         // Push the initial frame but don't run -- the first continue/step drives execution.
         vm.start(&chunk);
-        *self.latest_debug_state.borrow_mut() = Some(vm.debug_state());
+        *self
+            .latest_debug_state
+            .lock()
+            .expect("debug state mutex poisoned") = Some(vm.debug_state());
         self.vm = Some(vm);
         Ok(())
     }

--- a/crates/harn-serve/src/adapters/acp/builtins.rs
+++ b/crates/harn-serve/src/adapters/acp/builtins.rs
@@ -4,14 +4,13 @@
 //! `host_call`, ...) to the ACP client via the `AcpBridge`.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use super::AcpBridge;
 
 /// Register builtins that delegate to the ACP client (editor).
-pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Rc<AcpBridge>) {
+pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Arc<AcpBridge>) {
     let host_capability_manifest = bridge
         .call_client(
             "host/capabilities",

--- a/crates/harn-serve/src/adapters/acp/execute.rs
+++ b/crates/harn-serve/src/adapters/acp/execute.rs
@@ -3,7 +3,6 @@
 
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -91,8 +90,8 @@ pub(super) async fn prepare_vm_baseline(
 /// Execute a compiled chunk with ACP bridge builtins.
 pub(super) async fn execute_chunk(
     chunk: harn_vm::Chunk,
-    bridge: Rc<AcpBridge>,
-    host_bridge: Rc<harn_vm::bridge::HostBridge>,
+    bridge: Arc<AcpBridge>,
+    host_bridge: Arc<harn_vm::bridge::HostBridge>,
     prompt: PromptGlobals<'_>,
     setup: VmSetup<'_>,
 ) -> Result<String, String> {
@@ -223,7 +222,7 @@ pub(super) async fn execute_chunk(
 }
 
 pub(super) async fn load_host_mcp_clients(
-    host_bridge: Rc<harn_vm::bridge::HostBridge>,
+    host_bridge: Arc<harn_vm::bridge::HostBridge>,
 ) -> BTreeMap<String, harn_vm::VmValue> {
     let mut mcp_dict = BTreeMap::new();
     let capabilities = host_bridge

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -51,7 +51,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
@@ -1583,7 +1582,7 @@ impl AcpServer {
             Arc::new(AcpAgentEventSink::new(output.clone())),
         );
 
-        let bridge = Rc::new(AcpBridge {
+        let bridge = Arc::new(AcpBridge {
             session_id: sid.clone(),
             output: output.clone(),
             pending: pending.clone(),
@@ -1593,7 +1592,7 @@ impl AcpServer {
             assistant_state: std::sync::Mutex::new(VisibleTextState::default()),
         });
         let bridge_output = output.clone();
-        let host_bridge = Rc::new(
+        let host_bridge = Arc::new(
             harn_vm::bridge::HostBridge::from_parts_with_writer_cancel_notify_and_injection_state(
                 bridge.pending.clone(),
                 cancellation.cancelled.clone(),

--- a/crates/harn-serve/src/adapters/acp/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/sessions.rs
@@ -77,7 +77,7 @@ pub(super) struct Session {
     /// If a cancel was requested for the current prompt execution.
     pub(super) cancellation: SessionCancellation,
     /// Host bridge for the active prompt, if one is running.
-    pub(super) host_bridge: Option<Rc<harn_vm::bridge::HostBridge>>,
+    pub(super) host_bridge: Option<Arc<harn_vm::bridge::HostBridge>>,
     /// Pending user-message inject state that survives prompt cancellation
     /// and active bridge replacement until delivery or explicit revoke.
     pub(super) inject_state: harn_vm::bridge::HostBridgeInjectionState,

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -10,7 +10,6 @@ use crate::{ApiKeyAuthConfig, AuthMethodConfig, AuthPolicy};
 use harn_vm::visible_text::VisibleTextState;
 use harn_vm::VmValue;
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::{Mutex, OnceLock};
@@ -126,14 +125,14 @@ async fn start_acp_code_session_with_config(
 fn attach_test_host_bridge(
     server: &mut AcpServer,
     session_id: &str,
-) -> Rc<harn_vm::bridge::HostBridge> {
+) -> Arc<harn_vm::bridge::HostBridge> {
     let inject_state = server
         .sessions
         .get(session_id)
         .expect("session")
         .inject_state
         .clone();
-    let host_bridge = Rc::new(
+    let host_bridge = Arc::new(
         harn_vm::bridge::HostBridge::from_parts_with_writer_cancel_notify_and_injection_state(
             std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -846,7 +845,7 @@ async fn session_inject_state_survives_prompt_bridge_replacement() {
     assert_eq!(replace["result"]["messageId"], message_id);
     assert_eq!(replace["result"]["status"], "replaced");
 
-    let replacement_bridge = Rc::new(
+    let replacement_bridge = Arc::new(
         harn_vm::bridge::HostBridge::from_parts_with_writer_cancel_notify_and_injection_state(
             std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -151,6 +151,10 @@ harness = false
 name = "callable_vectorcall"
 harness = false
 
+[[bench]]
+name = "pool_parallel"
+harness = false
+
 [lints]
 workspace = true
 

--- a/crates/harn-vm/benches/pool_parallel.rs
+++ b/crates/harn-vm/benches/pool_parallel.rs
@@ -1,0 +1,77 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use harn_vm::{compile_source, register_vm_stdlib, Chunk, Vm, VmValue};
+use tokio::runtime::{Builder, Runtime};
+
+const TASKS: usize = 16;
+const INNER_ITERS: usize = 120_000;
+
+fn pool_source(max_concurrent: usize) -> String {
+    format!(
+        r#"
+import {{ pool_create, pool_wait }} from "std/lifecycle/pool"
+
+fn crunch(seed) {{
+  var i = 0
+  var total = seed + 1
+  while i < {INNER_ITERS} {{
+    total = ((total * 1664525) + i + 1013904223) % 2147483647
+    i = i + 1
+  }}
+  return total
+}}
+
+pipeline default() {{
+  let pool = pool_create({{name: "pool-parallel-bench", max_concurrent: {max_concurrent}}})
+  var handles = []
+  for i in 0 to {TASKS} exclusive {{
+    let seed = i
+    handles = handles.push(pool.submit({{ -> crunch(seed) }}))
+  }}
+  let results = pool_wait(handles)
+  return len(results)
+}}
+"#
+    )
+}
+
+fn compile_pool_fixture(max_concurrent: usize) -> Chunk {
+    compile_source(&pool_source(max_concurrent)).expect("pool parallel bench fixture compiles")
+}
+
+fn runtime() -> Runtime {
+    Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("pool parallel bench runtime")
+}
+
+fn execute(rt: &Runtime, chunk: &Chunk) -> VmValue {
+    harn_vm::reset_thread_local_state();
+    rt.block_on(async {
+        let mut vm = Vm::new();
+        register_vm_stdlib(&mut vm);
+        vm.execute(chunk).await.expect("pool fixture executes")
+    })
+}
+
+fn bench_pool_parallel(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pool_parallel_cpu_fanout");
+    for workers in [1_usize, 2, 4] {
+        let chunk = compile_pool_fixture(workers);
+        let rt = runtime();
+        group.bench_with_input(BenchmarkId::from_parameter(workers), &workers, |b, _| {
+            b.iter(|| black_box(execute(&rt, &chunk)));
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_pool_parallel
+}
+criterion_main!(benches);

--- a/crates/harn-vm/src/autonomy.rs
+++ b/crates/harn-vm/src/autonomy.rs
@@ -200,7 +200,7 @@ pub fn needs_async_side_effect_enforcement(name: &str) -> bool {
 pub fn enforce_builtin_side_effect_boxed<'a>(
     name: &'a str,
     args: &'a [VmValue],
-) -> Pin<Box<dyn Future<Output = Result<Option<AutonomyDecision>, VmError>> + 'a>> {
+) -> Pin<Box<dyn Future<Output = Result<Option<AutonomyDecision>, VmError>> + Send + 'a>> {
     Box::pin(enforce_builtin_side_effect(name, args))
 }
 

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -106,7 +106,7 @@ impl InProcessHost {
         &'a self,
         method: &'a str,
         params: serde_json::Value,
-    ) -> Pin<Box<dyn Future<Output = Result<serde_json::Value, VmError>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<serde_json::Value, VmError>> + Send + 'a>> {
         Box::pin(async move {
             match method {
                 "builtin_call" => {

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use harn_parser::TypeExpr;
@@ -16,6 +17,11 @@ use crate::runtime_guards::RuntimeParamGuard;
 /// by code length (one slot per cacheable opcode), so `u32::MAX` is safely
 /// out of the addressable slot range.
 pub(crate) const NO_INLINE_CACHE_SLOT: u32 = u32::MAX;
+static NEXT_CHUNK_CACHE_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_chunk_cache_id() -> u64 {
+    NEXT_CHUNK_CACHE_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 /// Bytecode opcodes for the Harn VM. The enum, the byte-to-variant
 /// mapping, the sync and async dispatch tables, the disassembly
@@ -238,8 +244,12 @@ impl fmt::Display for Constant {
 }
 
 /// A compiled chunk of bytecode.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Chunk {
+    /// Runtime-only identity for VM-local inline cache storage. It is not
+    /// serialized; freshly compiled or loaded chunks get new ids, while clones
+    /// keep the same id because they represent the same bytecode object.
+    cache_id: u64,
     /// The bytecode instructions.
     pub code: Vec<u8>,
     /// Constant pool.
@@ -272,8 +282,9 @@ pub struct Chunk {
     /// index instead of a `BTreeMap::get` (O(1) vs O(log n) with the
     /// associated pointer chasing). Derived; intentionally not serialized.
     inline_cache_index: Vec<u32>,
-    /// Shared cache entries so cloned chunks in call frames warm the same side
-    /// table as the compiled chunk used by tests/debugging.
+    /// Test/bench scratch entries for validating inline-cache transitions.
+    /// Runtime execution keeps live cache entries on each `Vm` isolate so
+    /// parallel workers do not contend on shared compiled chunks.
     inline_caches: Arc<Mutex<Vec<InlineCacheEntry>>>,
     /// Lazily-materialized shared string cache for `Constant::String` entries,
     /// parallel to `constants`. String constants are materialized once per
@@ -319,9 +330,37 @@ pub struct Chunk {
 pub type ChunkRef = Arc<Chunk>;
 pub type CompiledFunctionRef = Arc<CompiledFunction>;
 
+impl Clone for Chunk {
+    fn clone(&self) -> Self {
+        Self {
+            cache_id: self.cache_id,
+            code: self.code.clone(),
+            constants: self.constants.clone(),
+            lines: self.lines.clone(),
+            columns: self.columns.clone(),
+            source_file: self.source_file.clone(),
+            current_col: self.current_col,
+            functions: self.functions.clone(),
+            inline_cache_slots: self.inline_cache_slots.clone(),
+            inline_cache_index: self.inline_cache_index.clone(),
+            inline_caches: Arc::new(Mutex::new(vec![
+                InlineCacheEntry::Empty;
+                self.inline_cache_slot_count()
+            ])),
+            constant_strings: Arc::new(Mutex::new(vec![None; self.constants.len()])),
+            local_slots: self.local_slots.clone(),
+            references_outer_names: self.references_outer_names,
+            #[cfg(debug_assertions)]
+            balance_depth: self.balance_depth,
+            #[cfg(debug_assertions)]
+            balance_nonlinear: self.balance_nonlinear,
+        }
+    }
+}
+
 /// Serializable snapshot of a [`Chunk`] suitable for the on-disk bytecode
 /// cache and for in-memory stdlib artifact caches. Inline-cache state is
-/// dropped at freeze time because it warms at runtime per-process; the
+/// dropped at freeze time because it warms at runtime per VM isolate; the
 /// rest of the chunk round-trips byte-identically.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CachedChunk {
@@ -584,6 +623,7 @@ fn op_stack_delta(op: Op, count: u16) -> Option<i32> {
 impl Chunk {
     pub fn new() -> Self {
         Self {
+            cache_id: next_chunk_cache_id(),
             code: Vec::new(),
             constants: Vec::new(),
             lines: Vec::new(),
@@ -870,6 +910,14 @@ impl Chunk {
         }
     }
 
+    pub(crate) fn inline_cache_slot_count(&self) -> usize {
+        self.inline_cache_slots.len()
+    }
+
+    pub(crate) fn cache_id(&self) -> u64 {
+        self.cache_id
+    }
+
     /// Pre-optimization control path: the `BTreeMap`-backed lookup the
     /// dispatcher used before the flat `Vec<u32>` side-table. Exposed
     /// only behind the `vm-bench-internals` feature so the criterion
@@ -926,6 +974,7 @@ impl Chunk {
     /// savings compound across the millions of dispatches a typical
     /// loop body issues.
     #[inline]
+    #[cfg(any(test, feature = "vm-bench-internals"))]
     pub(crate) fn peek_adaptive_binary_cache(
         &self,
         slot: usize,
@@ -948,6 +997,7 @@ impl Chunk {
     /// per-dispatch savings compound across the millions of method calls a
     /// typical pipeline (`xs.filter(...).map(...).count()`) issues.
     #[inline]
+    #[cfg(any(test, feature = "vm-bench-internals"))]
     pub(crate) fn peek_method_cache(&self, slot: usize) -> Option<(u16, usize, MethodCacheTarget)> {
         match self.inline_caches.lock().get(slot)? {
             &InlineCacheEntry::Method {
@@ -969,6 +1019,7 @@ impl Chunk {
     /// memcpy. Fires on every `Op::GetProperty` / `Op::GetPropertyOpt`
     /// dispatch, which is the dominant opcode for any field-read-heavy code.
     #[inline]
+    #[cfg(any(test, feature = "vm-bench-internals"))]
     pub(crate) fn peek_property_cache(&self, slot: usize) -> Option<(u16, PropertyCacheTarget)> {
         match self.inline_caches.lock().get(slot)? {
             InlineCacheEntry::Property { name_idx, target } => Some((*name_idx, target.clone())),
@@ -986,6 +1037,7 @@ impl Chunk {
     /// fast path inside `Op::CallBuiltin`. Single peek per dispatch covers
     /// both the read check and the write-back computation.
     #[inline]
+    #[cfg(any(test, feature = "vm-bench-internals"))]
     pub(crate) fn peek_direct_call_state(&self, slot: usize) -> Option<DirectCallState> {
         match self.inline_caches.lock().get(slot)? {
             InlineCacheEntry::DirectCall { state } => Some(state.clone()),
@@ -993,6 +1045,7 @@ impl Chunk {
         }
     }
 
+    #[cfg(any(test, feature = "vm-bench-internals"))]
     pub(crate) fn set_inline_cache_entry(&self, slot: usize, entry: InlineCacheEntry) {
         if let Some(existing) = self.inline_caches.lock().get_mut(slot) {
             *existing = entry;
@@ -1035,6 +1088,7 @@ impl Chunk {
             }
         }
         Self {
+            cache_id: next_chunk_cache_id(),
             code: cached.code.clone(),
             constants: cached.constants.clone(),
             lines: cached.lines.clone(),
@@ -1075,11 +1129,6 @@ impl Chunk {
             scope_depth,
         });
         idx as u16
-    }
-
-    #[cfg(test)]
-    pub(crate) fn inline_cache_entries(&self) -> Vec<InlineCacheEntry> {
-        self.inline_caches.lock().clone()
     }
 
     /// Read a u64 argument at the given position.

--- a/crates/harn-vm/src/composition/hosts.rs
+++ b/crates/harn-vm/src/composition/hosts.rs
@@ -20,7 +20,7 @@ impl StaticCompositionToolHost {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl CompositionToolHost for StaticCompositionToolHost {
     async fn call(&self, binding: &BindingManifestEntry, input: Value) -> CompositionToolOutput {
         if let Some(value) = self.outputs.get(&binding.name) {
@@ -55,7 +55,7 @@ impl ClosureCompositionToolHost {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl CompositionToolHost for ClosureCompositionToolHost {
     async fn call(&self, binding: &BindingManifestEntry, input: Value) -> CompositionToolOutput {
         let mut vm = self.ctx.child_vm();

--- a/crates/harn-vm/src/composition/mod.rs
+++ b/crates/harn-vm/src/composition/mod.rs
@@ -5,9 +5,7 @@
 //! opaque "execute code" blob, so policy, transcript, replay, and host approval
 //! surfaces can keep reasoning about each child call normally.
 
-use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
-use std::rc::Rc;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -205,7 +203,7 @@ impl ExecutionState {
 /// Execute a read-only Harn-native composition snippet against a manifest.
 pub async fn execute_harn_composition(
     mut request: CompositionExecutionRequest,
-    host: Rc<dyn CompositionToolHost>,
+    host: Arc<dyn CompositionToolHost>,
 ) -> CompositionExecutionReport {
     if request.run_id.trim().is_empty() {
         request.run_id = uuid::Uuid::now_v7().to_string();
@@ -294,7 +292,7 @@ pub async fn execute_harn_composition(
 
 async fn execute_harn_composition_inner(
     request: CompositionExecutionRequest,
-    host: Rc<dyn CompositionToolHost>,
+    host: Arc<dyn CompositionToolHost>,
 ) -> Result<
     (
         Value,
@@ -349,7 +347,7 @@ async fn execute_harn_composition_inner(
 
     let execution_clock = harn_clock::RealClock::arc();
     let execution_started_ms = execution_clock.monotonic_ms();
-    let state = Rc::new(RefCell::new(ExecutionState {
+    let state = Arc::new(parking_lot::Mutex::new(ExecutionState {
         request,
         calls: Vec::new(),
         results: Vec::new(),
@@ -359,7 +357,7 @@ async fn execute_harn_composition_inner(
     let mut vm = Vm::new();
     crate::register_core_stdlib(&mut vm);
     register_composition_call_builtin(&mut vm, state.clone(), host);
-    if let Some(timeout_ms) = state.borrow().request.limits.timeout_ms {
+    if let Some(timeout_ms) = state.lock().request.limits.timeout_ms {
         vm.push_deadline_after(std::time::Duration::from_millis(timeout_ms));
     }
     vm.set_source_info("composition://snippet.harn", &source);
@@ -367,7 +365,7 @@ async fn execute_harn_composition_inner(
         Ok(value) => {
             let json = crate::llm::vm_value_to_json(&value);
             let stdout = vm.output().to_string();
-            let state = state.borrow();
+            let state = state.lock();
             let result_size = serde_json::to_vec(&json)
                 .map(|bytes| bytes.len())
                 .unwrap_or(0);
@@ -386,7 +384,7 @@ async fn execute_harn_composition_inner(
             Ok((json, stdout, state.calls.clone(), state.results.clone()))
         }
         Err(error) => {
-            let state = state.borrow();
+            let state = state.lock();
             let category = if error.to_string().contains("denied")
                 || error.to_string().contains("side-effect")
                 || error.to_string().contains("approval")
@@ -419,8 +417,8 @@ async fn execute_harn_composition_inner(
 
 fn register_composition_call_builtin(
     vm: &mut Vm,
-    state: Rc<RefCell<ExecutionState>>,
-    host: Rc<dyn CompositionToolHost>,
+    state: Arc<parking_lot::Mutex<ExecutionState>>,
+    host: Arc<dyn CompositionToolHost>,
 ) {
     vm.register_async_builtin("__composition_call", move |_ctx, args| {
         let state = state.clone();
@@ -435,14 +433,14 @@ fn register_composition_call_builtin(
                 .map(crate::llm::vm_value_to_json)
                 .unwrap_or_else(|| serde_json::json!({}));
             let (binding, call, clock) = {
-                let mut state = state.borrow_mut();
+                let mut state = state.lock();
                 let (binding, call) = state.next_call(&tool_name, input.clone())?;
                 (binding, call, state.clock.clone())
             };
             let started_ms = clock.monotonic_ms();
             let output = host.call(&binding, input).await;
             {
-                let mut state = state.borrow_mut();
+                let mut state = state.lock();
                 state.push_result(&call, &output, elapsed_ms(&*clock, started_ms));
             }
             if let Some(error) = output.error {
@@ -795,9 +793,9 @@ pub fn register_composition_builtins(vm: &mut Vm) {
                 request.limits.max_output_bytes = max_output_bytes;
             }
         }
-        let host: Rc<dyn CompositionToolHost> = match dispatcher {
-            Some(closure) => Rc::new(ClosureCompositionToolHost::new(closure, ctx.clone())),
-            None => Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
+        let host: Arc<dyn CompositionToolHost> = match dispatcher {
+            Some(closure) => Arc::new(ClosureCompositionToolHost::new(closure, ctx.clone())),
+            None => Arc::new(StaticCompositionToolHost::new(BTreeMap::new())),
         };
         let report = execute_harn_composition(request, host).await;
         Ok(crate::json_to_vm_value(

--- a/crates/harn-vm/src/composition/tests.rs
+++ b/crates/harn-vm/src/composition/tests.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use serde_json::Value;
 
@@ -224,7 +224,7 @@ async fn harn_composition_executes_read_only_binding_and_records_child_trace() {
             manifest,
             ..CompositionExecutionRequest::default()
         },
-        Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
+        Arc::new(StaticCompositionToolHost::new(BTreeMap::new())),
     )
     .await;
     assert!(report.ok, "{}", report.summary);
@@ -253,7 +253,7 @@ async fn harn_composition_denies_mutating_binding_calls() {
             manifest,
             ..CompositionExecutionRequest::default()
         },
-        Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
+        Arc::new(StaticCompositionToolHost::new(BTreeMap::new())),
     )
     .await;
     assert!(!report.ok);
@@ -289,7 +289,7 @@ async fn harn_composition_records_denied_manifest_binding_as_child_failure() {
             manifest,
             ..CompositionExecutionRequest::default()
         },
-        Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
+        Arc::new(StaticCompositionToolHost::new(BTreeMap::new())),
     )
     .await;
     assert!(!report.ok);
@@ -324,7 +324,7 @@ async fn harn_composition_enforces_child_call_cap() {
             },
             ..CompositionExecutionRequest::default()
         },
-        Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
+        Arc::new(StaticCompositionToolHost::new(BTreeMap::new())),
     )
     .await;
     assert!(!report.ok);
@@ -337,7 +337,7 @@ async fn harn_composition_enforces_child_call_cap() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn harn_composition_dispatcher_closure_receives_real_inputs_and_returns_outputs() {
-    use std::cell::RefCell;
+    use parking_lot::Mutex;
     let tools = serde_json::json!([
         {
             "name": "read_file",
@@ -348,9 +348,9 @@ async fn harn_composition_dispatcher_closure_receives_real_inputs_and_returns_ou
     let manifest = binding_manifest_from_tool_surface(&tools, BindingManifestOptions::default());
 
     struct CapturingHost {
-        calls: RefCell<Vec<(String, Value)>>,
+        calls: Mutex<Vec<(String, Value)>>,
     }
-    #[async_trait::async_trait(?Send)]
+    #[async_trait::async_trait]
     impl CompositionToolHost for CapturingHost {
         async fn call(
             &self,
@@ -358,7 +358,7 @@ async fn harn_composition_dispatcher_closure_receives_real_inputs_and_returns_ou
             input: Value,
         ) -> CompositionToolOutput {
             self.calls
-                .borrow_mut()
+                .lock()
                 .push((binding.name.clone(), input.clone()));
             CompositionToolOutput::ok(serde_json::json!({
                 "path": input.get("path").cloned().unwrap_or(Value::Null),
@@ -366,8 +366,8 @@ async fn harn_composition_dispatcher_closure_receives_real_inputs_and_returns_ou
             }))
         }
     }
-    let host = Rc::new(CapturingHost {
-        calls: RefCell::new(Vec::new()),
+    let host = Arc::new(CapturingHost {
+        calls: Mutex::new(Vec::new()),
     });
     let report = execute_harn_composition(
         CompositionExecutionRequest {
@@ -380,10 +380,10 @@ async fn harn_composition_dispatcher_closure_receives_real_inputs_and_returns_ou
     )
     .await;
     assert!(report.ok, "{}", report.summary);
-    assert_eq!(host.calls.borrow().len(), 1);
-    assert_eq!(host.calls.borrow()[0].0, "read_file");
+    assert_eq!(host.calls.lock().len(), 1);
+    assert_eq!(host.calls.lock()[0].0, "read_file");
     assert_eq!(
-        host.calls.borrow()[0].1.get("path").and_then(Value::as_str),
+        host.calls.lock()[0].1.get("path").and_then(Value::as_str),
         Some("README.md")
     );
     assert_eq!(
@@ -404,7 +404,7 @@ async fn harn_composition_enforces_output_cap() {
             },
             ..CompositionExecutionRequest::default()
         },
-        Rc::new(StaticCompositionToolHost::new(BTreeMap::new())),
+        Arc::new(StaticCompositionToolHost::new(BTreeMap::new())),
     )
     .await;
     assert!(!report.ok);

--- a/crates/harn-vm/src/composition/types.rs
+++ b/crates/harn-vm/src/composition/types.rs
@@ -282,7 +282,7 @@ impl CompositionToolOutput {
     }
 }
 
-#[async_trait::async_trait(?Send)]
-pub trait CompositionToolHost {
+#[async_trait::async_trait]
+pub trait CompositionToolHost: Send + Sync {
     async fn call(&self, binding: &BindingManifestEntry, input: Value) -> CompositionToolOutput;
 }

--- a/crates/harn-vm/src/http/client.rs
+++ b/crates/harn-vm/src/http/client.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use crate::value::{VmError, VmValue};
@@ -98,7 +98,7 @@ struct HttpStreamHandle {
 }
 
 enum HttpStreamKind {
-    Real(Rc<tokio::sync::Mutex<reqwest::Response>>),
+    Real(Arc<tokio::sync::Mutex<reqwest::Response>>),
     Fake,
 }
 
@@ -1478,7 +1478,7 @@ pub(super) async fn vm_http_stream_open(
     let status = response.status().as_u16() as i64;
     let headers = response_headers(response.headers());
     let handle = HttpStreamHandle {
-        kind: HttpStreamKind::Real(Rc::new(tokio::sync::Mutex::new(response))),
+        kind: HttpStreamKind::Real(Arc::new(tokio::sync::Mutex::new(response))),
         status,
         headers,
         pending: VecDeque::new(),

--- a/crates/harn-vm/src/http/streaming.rs
+++ b/crates/harn-vm/src/http/streaming.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::TcpStream;
-use std::rc::Rc;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc, Arc, RwLock,
@@ -48,8 +47,8 @@ struct SseHandle {
 }
 
 enum SseHandleKind {
-    Real(Rc<tokio::sync::Mutex<EventSource>>),
-    Fake(Rc<tokio::sync::Mutex<FakeSseStream>>),
+    Real(Arc<tokio::sync::Mutex<EventSource>>),
+    Fake(Arc<tokio::sync::Mutex<FakeSseStream>>),
 }
 
 struct FakeSseStream {
@@ -98,9 +97,9 @@ struct WebSocketHandle {
 }
 
 enum WebSocketHandleKind {
-    Real(Rc<tokio::sync::Mutex<RealWebSocket>>),
-    Fake(Rc<tokio::sync::Mutex<FakeWebSocket>>),
-    Server(Rc<tokio::sync::Mutex<ServerWebSocket>>),
+    Real(Arc<tokio::sync::Mutex<RealWebSocket>>),
+    Fake(Arc<tokio::sync::Mutex<FakeWebSocket>>),
+    Server(Arc<tokio::sync::Mutex<ServerWebSocket>>),
 }
 
 struct FakeWebSocket {
@@ -112,7 +111,7 @@ struct FakeWebSocket {
 struct WebSocketServer {
     addr: String,
     routes: Arc<RwLock<HashMap<String, WebSocketRoute>>>,
-    events: Rc<tokio::sync::Mutex<mpsc::Receiver<WebSocketServerEvent>>>,
+    events: Arc<tokio::sync::Mutex<mpsc::Receiver<WebSocketServerEvent>>>,
     running: Arc<AtomicBool>,
 }
 
@@ -941,7 +940,7 @@ pub(super) async fn vm_sse_connect(
 
     if let Some(events) = consume_sse_mock(url) {
         let handle = SseHandle {
-            kind: SseHandleKind::Fake(Rc::new(tokio::sync::Mutex::new(FakeSseStream {
+            kind: SseHandleKind::Fake(Arc::new(tokio::sync::Mutex::new(FakeSseStream {
                 events: events.into(),
                 opened: false,
                 closed: false,
@@ -998,7 +997,7 @@ pub(super) async fn vm_sse_connect(
     let stream = EventSource::new(request)
         .map_err(|error| vm_error(format!("sse_connect: failed to create stream: {error}")))?;
     let handle = SseHandle {
-        kind: SseHandleKind::Real(Rc::new(tokio::sync::Mutex::new(stream))),
+        kind: SseHandleKind::Real(Arc::new(tokio::sync::Mutex::new(stream))),
         url: url.to_string(),
         max_events,
         max_message_bytes,

--- a/crates/harn-vm/src/http/streaming/websocket.rs
+++ b/crates/harn-vm/src/http/streaming/websocket.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::{Shutdown, TcpListener, TcpStream};
-use std::rc::Rc;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc, Arc, RwLock,
@@ -298,7 +297,7 @@ pub(super) fn vm_websocket_server(
             WebSocketServer {
                 addr: addr.clone(),
                 routes,
-                events: Rc::new(tokio::sync::Mutex::new(event_rx)),
+                events: Arc::new(tokio::sync::Mutex::new(event_rx)),
                 running,
             },
         );
@@ -394,7 +393,7 @@ fn register_accepted_websocket(event: WebSocketServerEvent) -> Result<VmValue, V
         handles.insert(
             id.clone(),
             WebSocketHandle {
-                kind: WebSocketHandleKind::Server(Rc::new(tokio::sync::Mutex::new(handle))),
+                kind: WebSocketHandleKind::Server(Arc::new(tokio::sync::Mutex::new(handle))),
                 url: path.clone(),
                 max_messages,
                 max_message_bytes,
@@ -644,7 +643,7 @@ pub(super) async fn vm_websocket_connect(
 
     if let Some((messages, echo)) = consume_websocket_mock(url) {
         let handle = WebSocketHandle {
-            kind: WebSocketHandleKind::Fake(Rc::new(tokio::sync::Mutex::new(FakeWebSocket {
+            kind: WebSocketHandleKind::Fake(Arc::new(tokio::sync::Mutex::new(FakeWebSocket {
                 messages: messages.into(),
                 echo,
                 closed: false,
@@ -689,7 +688,7 @@ pub(super) async fn vm_websocket_connect(
     .max(0) as u64;
     let socket = connect_with_retry(url, options, timeout_ms).await?;
     let handle = WebSocketHandle {
-        kind: WebSocketHandleKind::Real(Rc::new(tokio::sync::Mutex::new(socket))),
+        kind: WebSocketHandleKind::Real(Arc::new(tokio::sync::Mutex::new(socket))),
         url: url.to_string(),
         max_messages,
         max_message_bytes,

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -1,7 +1,7 @@
 //! Agent loop configuration, builtin registration, and result building
 //! extracted from `agent.rs` for maintainability.
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::stdlib::harn_entry::register_harn_entrypoint_category;
 use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
@@ -298,7 +298,7 @@ pub(crate) fn register_agent_loop(vm: &mut Vm) {
     register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
 }
 
-pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::HostBridge>) {
+pub fn register_agent_loop_with_bridge(vm: &mut Vm, bridge: Arc<crate::bridge::HostBridge>) {
     super::agent_runtime::install_current_host_bridge(bridge);
     register_harn_entrypoint_category(vm, AGENT_STDLIB_ENTRYPOINT_CATEGORY);
 }
@@ -402,7 +402,7 @@ fn prompt_explain_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
 }
 
 /// Register a bridge-aware `llm_call` that emits call_start/call_end notifications.
-pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::HostBridge>) {
+pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Arc<crate::bridge::HostBridge>) {
     let b = bridge;
     let metadata = VmBuiltinMetadata::async_static("llm_call")
         .signature_static("llm_call(prompt, system?, options?)")
@@ -461,7 +461,7 @@ pub fn register_llm_call_with_bridge(vm: &mut Vm, bridge: Rc<crate::bridge::Host
 /// `register_llm_call_with_bridge` in the ACP setup.
 pub fn register_llm_call_structured_with_bridge(
     vm: &mut Vm,
-    bridge: Rc<crate::bridge::HostBridge>,
+    bridge: Arc<crate::bridge::HostBridge>,
 ) {
     let b1 = bridge.clone();
     let structured = VmBuiltinMetadata::async_static("llm_call_structured")

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -37,7 +37,7 @@
 //! `message` up to (but not including) the matching `provider_call_request`.
 
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::event_log::EventLog;
 use crate::value::VmError;
@@ -744,7 +744,7 @@ pub(crate) struct StreamingDetectorContext {
 /// events via the global session sink registry as the buffer grows
 /// (harn#692).
 pub(super) fn spawn_progress_forwarder(
-    bridge: &Rc<crate::bridge::HostBridge>,
+    bridge: &Arc<crate::bridge::HostBridge>,
     call_id: String,
     user_visible: bool,
     detector_ctx: Option<StreamingDetectorContext>,
@@ -871,7 +871,7 @@ fn llm_retry_backoff_ms(
 pub(crate) async fn observed_llm_call(
     opts: &super::api::LlmCallOptions,
     tool_format: Option<&str>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
     retry_config: &LlmRetryConfig,
     iteration: Option<usize>,
     user_visible: bool,

--- a/crates/harn-vm/src/llm/agent_runtime.rs
+++ b/crates/harn-vm/src/llm/agent_runtime.rs
@@ -9,7 +9,6 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::agent_events::{self, AgentEvent, AgentEventSink};
@@ -20,7 +19,7 @@ use crate::value::VmValue;
 pub type SessionEndHook = Arc<dyn Fn(&str) + Send + Sync>;
 
 thread_local! {
-    static CURRENT_HOST_BRIDGE: RefCell<Option<Rc<crate::bridge::HostBridge>>> =
+    static CURRENT_HOST_BRIDGE: RefCell<Option<Arc<crate::bridge::HostBridge>>> =
         const { RefCell::new(None) };
     /// Stack of per-loop event sinks installed via `LoopSinkGuard`. The
     /// agent loop pushes on entry and pops on drop; `emit_agent_event`
@@ -171,7 +170,7 @@ pub(crate) fn fire_session_end_hooks(session_id: &str) {
     }
 }
 
-pub(crate) fn install_current_host_bridge(bridge: Rc<crate::bridge::HostBridge>) {
+pub(crate) fn install_current_host_bridge(bridge: Arc<crate::bridge::HostBridge>) {
     CURRENT_HOST_BRIDGE.with(|slot| {
         *slot.borrow_mut() = Some(bridge);
     });
@@ -183,7 +182,7 @@ pub(crate) fn clear_current_host_bridge() {
     });
 }
 
-pub(crate) fn current_host_bridge() -> Option<Rc<crate::bridge::HostBridge>> {
+pub(crate) fn current_host_bridge() -> Option<Arc<crate::bridge::HostBridge>> {
     CURRENT_HOST_BRIDGE.with(|slot| slot.borrow().clone())
 }
 

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -8,7 +8,7 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::agent_events::AgentEvent;
 use crate::orchestration::{
@@ -78,7 +78,7 @@ struct AgentHostSession {
     resumed_iterations: usize,
     daemon_watch_state: BTreeMap<String, u64>,
     daemon_idle_backoff_ms: u64,
-    host_bridge: Option<Rc<crate::bridge::HostBridge>>,
+    host_bridge: Option<Arc<crate::bridge::HostBridge>>,
     /// Provider-reported `stop_reason` from the most recent `llm_call`
     /// in this loop. Used by finalize to detect ACP `max_tokens` (when
     /// the last call truncated due to its `max_tokens` parameter) and
@@ -2306,7 +2306,7 @@ fn host_agent_daemon_snapshot_builtin(
 fn host_bridge_for_session(
     session_id: &str,
     builtin_name: &str,
-) -> Option<Rc<crate::bridge::HostBridge>> {
+) -> Option<Arc<crate::bridge::HostBridge>> {
     with_session(session_id, builtin_name, |session| {
         Ok(session.host_bridge.clone())
     })

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -1,6 +1,6 @@
 //! Tool dispatch helpers used by the agent-loop host primitives.
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::agent_events::ToolExecutor;
 use crate::value::{ErrorCategory, VmClosure, VmError, VmValue};
@@ -81,7 +81,7 @@ pub(super) async fn dispatch_tool_execution(
     tool_name: &str,
     tool_args: &serde_json::Value,
     tools_val: Option<&VmValue>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
     tool_retries: usize,
     tool_backoff_ms: u64,
 ) -> ToolDispatchOutcome {
@@ -104,7 +104,7 @@ pub(super) async fn dispatch_tool_execution_with_mcp(
     tool_args: &serde_json::Value,
     tools_val: Option<&VmValue>,
     mcp_clients: Option<&std::collections::BTreeMap<String, crate::mcp::VmMcpClientHandle>>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
     tool_retries: usize,
     tool_backoff_ms: u64,
 ) -> ToolDispatchOutcome {
@@ -630,7 +630,7 @@ mod tests {
             Arc::new(|_| Err("test bridge: no host attached".to_string())),
             1,
         );
-        let bridge = Rc::new(bridge);
+        let bridge = Arc::new(bridge);
         let args = serde_json::json!({});
         let outcome =
             dispatch_tool_execution("custom_host_tool", &args, None, Some(&bridge), 0, 0).await;
@@ -651,7 +651,7 @@ mod tests {
             Arc::new(|_| Err("test bridge".to_string())),
             1,
         );
-        let bridge = Rc::new(bridge);
+        let bridge = Arc::new(bridge);
         let mut entry = BTreeMap::new();
         entry.insert(
             "_mcp_server".to_string(),
@@ -692,7 +692,7 @@ mod tests {
             Arc::new(|_| Err("test bridge".to_string())),
             1,
         );
-        let bridge = Rc::new(bridge);
+        let bridge = Arc::new(bridge);
         let mut entry = BTreeMap::new();
         entry.insert(
             "executor".to_string(),
@@ -749,7 +749,7 @@ mod tests {
             Arc::new(|_| Err("test bridge".to_string())),
             1,
         );
-        let bridge = Rc::new(bridge);
+        let bridge = Arc::new(bridge);
         let mut entry = BTreeMap::new();
         entry.insert(
             "executor".to_string(),

--- a/crates/harn-vm/src/llm/api/options.rs
+++ b/crates/harn-vm/src/llm/api/options.rs
@@ -307,7 +307,7 @@ pub(crate) struct LlmCallOptions {
     /// fields above still hold the "first link" defaults so callers
     /// that ignore the policy (e.g. transcript builders) see a
     /// coherent placeholder.
-    pub routing_policy: Option<std::rc::Rc<crate::llm::routing::RoutingPolicyConfig>>,
+    pub routing_policy: Option<std::sync::Arc<crate::llm::routing::RoutingPolicyConfig>>,
 
     // --- Observability ---
     /// Agent session id, when this call is driven from `run_agent_loop_internal`.

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::{json_to_vm_value, schema_result_value};
@@ -458,7 +458,7 @@ pub(crate) async fn execute_llm_call(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
     opts: api::LlmCallOptions,
     options: Option<std::collections::BTreeMap<String, VmValue>>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<VmValue, VmError> {
     // Publish the resolved provider/model facts for the introspection
     // tool surface (current_model() / current_provider() / ...). All
@@ -504,10 +504,10 @@ pub(crate) async fn execute_llm_call(
 /// a `routing` block summarizing every attempt.
 async fn execute_routing_schema_retry_loop(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
-    policy: Rc<routing::RoutingPolicyConfig>,
+    policy: Arc<routing::RoutingPolicyConfig>,
     mut opts: api::LlmCallOptions,
     options: Option<std::collections::BTreeMap<String, VmValue>>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<SchemaLoopOutcome, VmError> {
     let _ = structural_experiments::apply_structural_experiment(ctx, &mut opts, None).await?;
     let schema_retries = helpers::opt_int(&options, "schema_retries")
@@ -658,7 +658,7 @@ pub(crate) async fn execute_schema_retry_loop(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
     mut opts: api::LlmCallOptions,
     options: Option<std::collections::BTreeMap<String, VmValue>>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<SchemaLoopOutcome, VmError> {
     let _ = structural_experiments::apply_structural_experiment(ctx, &mut opts, None).await?;
     let retry_config = agent_observe::LlmRetryConfig {
@@ -1056,7 +1056,7 @@ mod schema_stream_abort_retry_tests {
         opts
     }
 
-    fn fake_routing_policy() -> Rc<routing::RoutingPolicyConfig> {
+    fn fake_routing_policy() -> Arc<routing::RoutingPolicyConfig> {
         routing::clear_policy_registry();
         let chain = VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
             std::sync::Arc::new(BTreeMap::from([

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -179,7 +179,7 @@ pub(crate) fn ensure_real_llm_allowed(provider: &str) -> Result<(), crate::value
 use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use self::api::{vm_build_llm_result, vm_call_completion_full};
 use self::call::{llm_call_impl, llm_safe_envelope_err, llm_safe_envelope_ok};
@@ -210,7 +210,7 @@ pub mod bench_internals {
     }
 }
 
-pub fn install_current_host_bridge(bridge: Rc<crate::bridge::HostBridge>) {
+pub fn install_current_host_bridge(bridge: Arc<crate::bridge::HostBridge>) {
     agent_runtime::install_current_host_bridge(bridge);
 }
 

--- a/crates/harn-vm/src/llm/routing.rs
+++ b/crates/harn-vm/src/llm/routing.rs
@@ -9,8 +9,8 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::json;
@@ -180,7 +180,7 @@ impl RoutingPolicyConfig {
 // ---------------------------------------------------------------------------
 
 thread_local! {
-    static POLICY_REGISTRY: RefCell<BTreeMap<u64, Rc<RoutingPolicyConfig>>> =
+    static POLICY_REGISTRY: RefCell<BTreeMap<u64, Arc<RoutingPolicyConfig>>> =
         const { RefCell::new(BTreeMap::new()) };
 }
 
@@ -189,12 +189,12 @@ static POLICY_COUNTER: AtomicU64 = AtomicU64::new(1);
 fn intern_policy(policy: RoutingPolicyConfig) -> u64 {
     let handle = POLICY_COUNTER.fetch_add(1, Ordering::SeqCst);
     POLICY_REGISTRY.with(|registry| {
-        registry.borrow_mut().insert(handle, Rc::new(policy));
+        registry.borrow_mut().insert(handle, Arc::new(policy));
     });
     handle
 }
 
-fn lookup_policy(handle: u64) -> Option<Rc<RoutingPolicyConfig>> {
+fn lookup_policy(handle: u64) -> Option<Arc<RoutingPolicyConfig>> {
     POLICY_REGISTRY.with(|registry| registry.borrow().get(&handle).cloned())
 }
 
@@ -676,7 +676,7 @@ fn observe_value(observe: &ObserveRules) -> VmValue {
 /// present but the handle is missing (corruption indicator).
 pub(crate) fn extract_routing_policy(
     options: Option<&BTreeMap<String, VmValue>>,
-) -> Result<Option<Rc<RoutingPolicyConfig>>, VmError> {
+) -> Result<Option<Arc<RoutingPolicyConfig>>, VmError> {
     let Some(opts) = options else {
         return Ok(None);
     };
@@ -1110,7 +1110,7 @@ fn duration_ms(elapsed: Duration) -> u64 {
 /// the user-visible budget.
 async fn execute_link(
     opts: &LlmCallOptions,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<super::api::LlmResult, VmError> {
     let retry_config = super::agent_observe::LlmRetryConfig {
         retries: 0,
@@ -1276,7 +1276,7 @@ fn emit_verifier_signal_event(
 pub(crate) async fn execute_with_routing(
     policy: &RoutingPolicyConfig,
     mut base_opts: LlmCallOptions,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<(super::api::LlmResult, RoutingTrace), VmError> {
     let dispatch = policy.dispatch_label();
     let mut trace = RoutingTrace {
@@ -1582,7 +1582,7 @@ async fn run_race(
     link: &ChainLink,
     link_label: &str,
     opts: &LlmCallOptions,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
     race_after_ms: u64,
     primary_timeout_ms: u64,
     backup_label: String,

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -44,7 +44,7 @@
 //! wants to recover the schema-shaped payload after the fact.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
 
@@ -70,7 +70,7 @@ const ERR_TRANSPORT: &str = "transport";
 /// agent loop. Pass `None` from non-bridge call sites.
 pub(crate) async fn schema_recover_impl(
     args: Vec<VmValue>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<VmValue, VmError> {
     if args.len() < 2 {
         return Err(VmError::Runtime(
@@ -546,7 +546,7 @@ async fn run_llm_repair(
     schema: &VmValue,
     repair: &LlmRepairConfig,
     base_opts: &Option<BTreeMap<String, VmValue>>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<Option<VmValue>, String> {
     let prompt = build_repair_prompt(text, schema);
     let merged_options = merge_repair_options(base_opts.as_ref(), &repair.overrides, schema);

--- a/crates/harn-vm/src/llm/skill_score.rs
+++ b/crates/harn-vm/src/llm/skill_score.rs
@@ -5,7 +5,7 @@
 //! primitive host/embedding bridge adapter for semantic matchers.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::bridge::HostBridge;
 use crate::value::{VmError, VmValue};
@@ -54,7 +54,7 @@ pub(crate) async fn score_skill_registry(
     context: &VmValue,
     registry: &VmValue,
     options: &VmValue,
-    bridge: Option<Rc<HostBridge>>,
+    bridge: Option<Arc<HostBridge>>,
 ) -> Result<VmValue, VmError> {
     let skills = extract_skills(registry);
     let options = options.as_dict().cloned().unwrap_or_default();

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -27,7 +27,7 @@
 //! since there is no raw text to salvage.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::value::{VmError, VmValue};
 
@@ -40,7 +40,7 @@ use super::{execute_schema_retry_loop, rewrite_structured_args, SchemaLoopOutcom
 /// `ok` / `error_category`.
 pub(crate) async fn run_structured_envelope(
     args: Vec<VmValue>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<VmValue, VmError> {
     let mut rewritten = match rewrite_structured_args(args) {
         Ok(v) => v,
@@ -216,7 +216,7 @@ async fn run_repair_pass(
     main_outcome: &SchemaLoopOutcome,
     repair: &RepairConfig,
     base_options: Option<&BTreeMap<String, VmValue>>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Option<VmValue> {
     let prompt = build_repair_prompt(&main_outcome.raw_text, &main_outcome.errors);
     let merged_options = merge_repair_options(base_options, &repair.overrides);
@@ -522,7 +522,7 @@ fn detect_extracted_json(outcome: &SchemaLoopOutcome) -> bool {
 /// behavior-identical.
 pub(crate) async fn llm_call_structured_result_impl(
     args: Vec<VmValue>,
-    bridge: Option<&Rc<crate::bridge::HostBridge>>,
+    bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<VmValue, VmError> {
     run_structured_envelope(args, bridge).await
 }

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -54,7 +54,14 @@ impl ProvidersConfig {
     }
 
     pub fn merge_from(&mut self, overlay: &ProvidersConfig) {
-        self.providers.extend(overlay.providers.clone());
+        for (name, provider) in &overlay.providers {
+            match self.providers.get_mut(name) {
+                Some(existing) => existing.merge_from(provider),
+                None => {
+                    self.providers.insert(name.clone(), provider.clone());
+                }
+            }
+        }
         self.aliases.extend(overlay.aliases.clone());
         self.alias_tool_calling
             .extend(overlay.alias_tool_calling.clone());
@@ -90,68 +97,137 @@ impl ProvidersConfig {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ProviderDef {
-    #[serde(default)]
     pub display_name: Option<String>,
-    #[serde(default)]
     pub icon: Option<String>,
     /// Provider protocol. Omitted providers use Harn's normal HTTP provider
     /// path; `acp` launches an Agent Client Protocol server and drives it as
     /// an agent-backed provider.
-    #[serde(default)]
     pub protocol: Option<String>,
-    #[serde(default)]
     pub base_url: String,
-    #[serde(default)]
     pub base_url_env: Option<String>,
-    #[serde(default = "default_bearer")]
     pub auth_style: String,
-    #[serde(default)]
     pub auth_header: Option<String>,
-    #[serde(default)]
     pub auth_env: AuthEnv,
-    #[serde(default)]
     pub extra_headers: BTreeMap<String, String>,
-    #[serde(default)]
     pub chat_endpoint: String,
-    #[serde(default)]
     pub completion_endpoint: Option<String>,
-    #[serde(default)]
     pub command: Option<String>,
-    #[serde(default)]
     pub args: Vec<String>,
-    #[serde(default)]
     pub env: BTreeMap<String, String>,
-    #[serde(default)]
     pub cwd: Option<String>,
-    #[serde(default)]
     pub mcp_servers: Vec<serde_json::Value>,
-    #[serde(default)]
     pub healthcheck: Option<HealthcheckDef>,
-    #[serde(default)]
     pub features: Vec<String>,
     /// Fallback provider name to try if this provider fails.
-    #[serde(default)]
     pub fallback: Option<String>,
     /// Number of retries before falling back (default 0).
-    #[serde(default)]
     pub retry_count: Option<u32>,
     /// Delay between retries in milliseconds (default 1000).
-    #[serde(default)]
     pub retry_delay_ms: Option<u64>,
     /// Maximum requests per minute. None = unlimited.
-    #[serde(default)]
     pub rpm: Option<u32>,
     /// Provider/catalog pricing in USD per 1k input tokens.
-    #[serde(default)]
     pub cost_per_1k_in: Option<f64>,
     /// Provider/catalog pricing in USD per 1k output tokens.
-    #[serde(default)]
     pub cost_per_1k_out: Option<f64>,
     /// Observed or configured p50 latency in milliseconds.
-    #[serde(default)]
     pub latency_p50_ms: Option<u64>,
+    #[doc(hidden)]
+    pub auth_style_explicit: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ProviderDefWire {
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    icon: Option<String>,
+    #[serde(default)]
+    protocol: Option<String>,
+    #[serde(default)]
+    base_url: String,
+    #[serde(default)]
+    base_url_env: Option<String>,
+    #[serde(default)]
+    auth_style: Option<String>,
+    #[serde(default)]
+    auth_header: Option<String>,
+    #[serde(default)]
+    auth_env: AuthEnv,
+    #[serde(default)]
+    extra_headers: BTreeMap<String, String>,
+    #[serde(default)]
+    chat_endpoint: String,
+    #[serde(default)]
+    completion_endpoint: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    mcp_servers: Vec<serde_json::Value>,
+    #[serde(default)]
+    healthcheck: Option<HealthcheckDef>,
+    #[serde(default)]
+    features: Vec<String>,
+    #[serde(default)]
+    fallback: Option<String>,
+    #[serde(default)]
+    retry_count: Option<u32>,
+    #[serde(default)]
+    retry_delay_ms: Option<u64>,
+    #[serde(default)]
+    rpm: Option<u32>,
+    #[serde(default)]
+    cost_per_1k_in: Option<f64>,
+    #[serde(default)]
+    cost_per_1k_out: Option<f64>,
+    #[serde(default)]
+    latency_p50_ms: Option<u64>,
+}
+
+impl<'de> Deserialize<'de> for ProviderDef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = ProviderDefWire::deserialize(deserializer)?;
+        let auth_style_explicit = wire.auth_style.is_some();
+        Ok(Self {
+            display_name: wire.display_name,
+            icon: wire.icon,
+            protocol: wire.protocol,
+            base_url: wire.base_url,
+            base_url_env: wire.base_url_env,
+            auth_style: wire.auth_style.unwrap_or_else(default_bearer),
+            auth_header: wire.auth_header,
+            auth_env: wire.auth_env,
+            extra_headers: wire.extra_headers,
+            chat_endpoint: wire.chat_endpoint,
+            completion_endpoint: wire.completion_endpoint,
+            command: wire.command,
+            args: wire.args,
+            env: wire.env,
+            cwd: wire.cwd,
+            mcp_servers: wire.mcp_servers,
+            healthcheck: wire.healthcheck,
+            features: wire.features,
+            fallback: wire.fallback,
+            retry_count: wire.retry_count,
+            retry_delay_ms: wire.retry_delay_ms,
+            rpm: wire.rpm,
+            cost_per_1k_in: wire.cost_per_1k_in,
+            cost_per_1k_out: wire.cost_per_1k_out,
+            latency_p50_ms: wire.latency_p50_ms,
+            auth_style_explicit,
+        })
+    }
 }
 
 impl Default for ProviderDef {
@@ -182,7 +258,66 @@ impl Default for ProviderDef {
             cost_per_1k_in: None,
             cost_per_1k_out: None,
             latency_p50_ms: None,
+            auth_style_explicit: false,
         }
+    }
+}
+
+impl ProviderDef {
+    fn merge_from(&mut self, overlay: &ProviderDef) {
+        merge_option(&mut self.display_name, &overlay.display_name);
+        merge_option(&mut self.icon, &overlay.icon);
+        merge_option(&mut self.protocol, &overlay.protocol);
+        merge_string(&mut self.base_url, &overlay.base_url);
+        merge_option(&mut self.base_url_env, &overlay.base_url_env);
+        let overlay_uses_default_auth_style = overlay.auth_style == default_bearer();
+        if overlay.auth_style_explicit
+            || !overlay_uses_default_auth_style
+            || self.auth_style == default_bearer()
+        {
+            self.auth_style = overlay.auth_style.clone();
+            self.auth_style_explicit |=
+                overlay.auth_style_explicit || !overlay_uses_default_auth_style;
+        }
+        merge_option(&mut self.auth_header, &overlay.auth_header);
+        if !overlay.auth_env.is_none() {
+            self.auth_env = overlay.auth_env.clone();
+        }
+        self.extra_headers.extend(overlay.extra_headers.clone());
+        merge_string(&mut self.chat_endpoint, &overlay.chat_endpoint);
+        merge_option(&mut self.completion_endpoint, &overlay.completion_endpoint);
+        merge_option(&mut self.command, &overlay.command);
+        merge_vec(&mut self.args, &overlay.args);
+        self.env.extend(overlay.env.clone());
+        merge_option(&mut self.cwd, &overlay.cwd);
+        merge_vec(&mut self.mcp_servers, &overlay.mcp_servers);
+        merge_option(&mut self.healthcheck, &overlay.healthcheck);
+        merge_vec(&mut self.features, &overlay.features);
+        merge_option(&mut self.fallback, &overlay.fallback);
+        merge_option(&mut self.retry_count, &overlay.retry_count);
+        merge_option(&mut self.retry_delay_ms, &overlay.retry_delay_ms);
+        merge_option(&mut self.rpm, &overlay.rpm);
+        merge_option(&mut self.cost_per_1k_in, &overlay.cost_per_1k_in);
+        merge_option(&mut self.cost_per_1k_out, &overlay.cost_per_1k_out);
+        merge_option(&mut self.latency_p50_ms, &overlay.latency_p50_ms);
+    }
+}
+
+fn merge_option<T: Clone>(base: &mut Option<T>, overlay: &Option<T>) {
+    if overlay.is_some() {
+        *base = overlay.clone();
+    }
+}
+
+fn merge_string(base: &mut String, overlay: &str) {
+    if !overlay.is_empty() {
+        *base = overlay.to_string();
+    }
+}
+
+fn merge_vec<T: Clone>(base: &mut Vec<T>, overlay: &[T]) {
+    if !overlay.is_empty() {
+        *base = overlay.to_vec();
     }
 }
 
@@ -199,6 +334,12 @@ pub enum AuthEnv {
     None,
     Single(String),
     Multiple(Vec<String>),
+}
+
+impl AuthEnv {
+    fn is_none(&self) -> bool {
+        matches!(self, AuthEnv::None)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -549,12 +690,14 @@ pub fn load_config() -> &'static ProvidersConfig {
                 return config;
             }
         }
-        if let Some(home) = dirs_or_home() {
-            let path = format!("{home}/.config/harn/providers.toml");
-            if let Some(overlay) = read_external_config(&path, false) {
-                config.merge_from(&overlay);
-                let _ = CONFIG_PATH.set(path);
-                return config;
+        if should_load_home_config() {
+            if let Some(home) = dirs_or_home() {
+                let path = format!("{home}/.config/harn/providers.toml");
+                if let Some(overlay) = read_external_config(&path, false) {
+                    config.merge_from(&overlay);
+                    let _ = CONFIG_PATH.set(path);
+                    return config;
+                }
             }
         }
         config
@@ -587,6 +730,12 @@ fn read_external_config(path: &str, verbose: bool) -> Option<ProvidersConfig> {
             None
         }
     }
+}
+
+fn should_load_home_config() -> bool {
+    // Unit tests should cover embedded defaults plus explicit overlays, not
+    // whichever provider file happens to exist on the developer machine.
+    !cfg!(test)
 }
 
 /// Parse a provider/model catalog overlay in the same shape as
@@ -2118,6 +2267,64 @@ mod tests {
         assert!(merged.providers.contains_key("anthropic"));
         assert!(merged.providers.contains_key("ollama"));
         assert_eq!(merged.aliases["quickstart"].id, "llama3.2");
+    }
+
+    #[test]
+    fn partial_provider_overlay_preserves_builtin_provider_metadata() {
+        let overlay = parse_config_toml(
+            r#"
+            [providers.ollama]
+            base_url = "http://localhost:11435"
+            extra_headers = { "x-local" = "1" }
+            "#,
+        )
+        .expect("provider overlay parses");
+
+        let merged = merge_global_config(overlay);
+        let ollama = merged
+            .providers
+            .get("ollama")
+            .expect("ollama remains configured");
+
+        assert_eq!(ollama.base_url, "http://localhost:11435");
+        assert_eq!(ollama.auth_style, "none");
+        assert_eq!(ollama.chat_endpoint, "/api/chat");
+        assert_eq!(ollama.completion_endpoint.as_deref(), Some("/api/generate"));
+        assert_eq!(ollama.cost_per_1k_in, Some(0.0));
+        assert_eq!(ollama.cost_per_1k_out, Some(0.0));
+        assert_eq!(
+            ollama
+                .healthcheck
+                .as_ref()
+                .and_then(|healthcheck| healthcheck.path.as_deref()),
+            Some("/api/tags")
+        );
+        assert_eq!(
+            ollama.extra_headers.get("x-local").map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn partial_provider_overlay_can_explicitly_replace_default_auth_style() {
+        let overlay = parse_config_toml(
+            r#"
+            [providers.ollama]
+            auth_style = "bearer"
+            auth_env = "OLLAMA_API_KEY"
+            "#,
+        )
+        .expect("provider overlay parses");
+
+        let merged = merge_global_config(overlay);
+        let ollama = merged
+            .providers
+            .get("ollama")
+            .expect("ollama remains configured");
+
+        assert_eq!(ollama.auth_style, "bearer");
+        assert_eq!(auth_env_names(&ollama.auth_env), vec!["OLLAMA_API_KEY"]);
+        assert_eq!(ollama.chat_endpoint, "/api/chat");
     }
 
     #[test]

--- a/crates/harn-vm/src/mcp_sampling.rs
+++ b/crates/harn-vm/src/mcp_sampling.rs
@@ -522,7 +522,7 @@ fn build_spec_response(outcome: LlmOutcome, parsed: &SamplingRequest) -> JsonVal
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     fn minimal_request() -> JsonValue {
         json!({
@@ -836,7 +836,7 @@ mod tests {
             "model".to_string(),
             VmValue::String(std::sync::Arc::from("mock-model")),
         );
-        crate::stdlib::host::set_host_call_bridge(Rc::new(ApproveSamplingBridge { overrides }));
+        crate::stdlib::host::set_host_call_bridge(Arc::new(ApproveSamplingBridge { overrides }));
 
         let request = json!({
             "jsonrpc": "2.0",

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -3,7 +3,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use regex::Regex;
@@ -16,22 +15,22 @@ use crate::llm::helpers::{ReminderPropagate, ReminderRoleHint, ReminderSource, S
 use crate::value::{VmClosure, VmError, VmValue};
 
 tokio::task_local! {
-    static HOOK_REMINDER_REPORTS_TASK: Rc<RefCell<Vec<serde_json::Value>>>;
+    static HOOK_REMINDER_REPORTS_TASK: Arc<parking_lot::Mutex<Vec<serde_json::Value>>>;
 }
 
 fn record_hook_reminder_report(report: serde_json::Value) {
-    let _ = HOOK_REMINDER_REPORTS_TASK.try_with(|reports| reports.borrow_mut().push(report));
+    let _ = HOOK_REMINDER_REPORTS_TASK.try_with(|reports| reports.lock().push(report));
 }
 
 pub async fn scope_hook_reminder_reports<F, T>(future: F) -> (T, Vec<serde_json::Value>)
 where
     F: Future<Output = T>,
 {
-    let reports = Rc::new(RefCell::new(Vec::new()));
+    let reports = Arc::new(parking_lot::Mutex::new(Vec::new()));
     let output = HOOK_REMINDER_REPORTS_TASK
         .scope(reports.clone(), future)
         .await;
-    let reports = std::mem::take(&mut *reports.borrow_mut());
+    let reports = std::mem::take(&mut *reports.lock());
     (output, reports)
 }
 
@@ -357,8 +356,8 @@ pub enum PostToolAction {
 }
 
 /// Callback types for legacy tool lifecycle hooks.
-pub type PreToolHookFn = Rc<dyn Fn(&str, &serde_json::Value) -> PreToolAction>;
-pub type PostToolHookFn = Rc<dyn Fn(&str, &str) -> PostToolAction>;
+pub type PreToolHookFn = Arc<dyn Fn(&str, &serde_json::Value) -> PreToolAction + Send + Sync>;
+pub type PostToolHookFn = Arc<dyn Fn(&str, &str) -> PostToolAction + Send + Sync>;
 
 /// A registered tool hook with a name pattern and callbacks.
 #[derive(Clone)]

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -4,7 +4,7 @@ use super::records::{myers_diff, DiffOp};
 use super::*;
 use futures::StreamExt;
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::event_log::EventLog;
 
@@ -1236,7 +1236,7 @@ async fn pre_tool_hook_deny_blocks_execution() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "dangerous_*".to_string(),
-        pre: Some(Rc::new(|_name, _args| {
+        pre: Some(Arc::new(|_name, _args| {
             PreToolAction::Deny("blocked by policy".to_string())
         })),
         post: None,
@@ -1253,7 +1253,7 @@ async fn pre_tool_hook_allow_passes_through() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "safe_*".to_string(),
-        pre: Some(Rc::new(|_name, _args| PreToolAction::Allow)),
+        pre: Some(Arc::new(|_name, _args| PreToolAction::Allow)),
         post: None,
     });
     let result = run_pre_tool_hooks("safe_read", &serde_json::json!({}))
@@ -1268,7 +1268,7 @@ async fn pre_tool_hook_modify_rewrites_args() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "*".to_string(),
-        pre: Some(Rc::new(|_name, _args| {
+        pre: Some(Arc::new(|_name, _args| {
             PreToolAction::Modify(serde_json::json!({"path": "/sanitized"}))
         })),
         post: None,
@@ -1289,7 +1289,7 @@ async fn post_tool_hook_modifies_result() {
     register_tool_hook(ToolHook {
         pattern: "exec".to_string(),
         pre: None,
-        post: Some(Rc::new(|_name, result| {
+        post: Some(Arc::new(|_name, result: &str| {
             if result.contains("SECRET") {
                 PostToolAction::Modify("[REDACTED]".to_string())
             } else {
@@ -1313,7 +1313,7 @@ async fn unmatched_hook_pattern_does_not_fire() {
     clear_tool_hooks();
     register_tool_hook(ToolHook {
         pattern: "exec".to_string(),
-        pre: Some(Rc::new(|_name, _args| {
+        pre: Some(Arc::new(|_name, _args| {
             PreToolAction::Deny("should not match".to_string())
         })),
         post: None,

--- a/crates/harn-vm/src/provider_catalog.rs
+++ b/crates/harn-vm/src/provider_catalog.rs
@@ -758,6 +758,7 @@ fn provider_def_from_catalog(provider: &CatalogProvider) -> llm_config::Provider
         base_url: provider.endpoint.base_url.clone(),
         base_url_env: provider.endpoint.base_url_env.clone(),
         auth_style: provider.auth.style.clone(),
+        auth_style_explicit: true,
         auth_header: provider.auth.header.clone(),
         auth_env: match provider.auth.env.as_slice() {
             [] => llm_config::AuthEnv::None,

--- a/crates/harn-vm/src/shared_state.rs
+++ b/crates/harn-vm/src/shared_state.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -45,9 +44,9 @@ struct Mailbox {
 
 #[derive(Default)]
 pub(crate) struct VmSharedStateRuntime {
-    cells: RefCell<BTreeMap<ScopedKey, SharedCell>>,
-    maps: RefCell<BTreeMap<ScopedKey, SharedMap>>,
-    mailboxes: RefCell<BTreeMap<ScopedKey, Mailbox>>,
+    cells: parking_lot::Mutex<BTreeMap<ScopedKey, SharedCell>>,
+    maps: parking_lot::Mutex<BTreeMap<ScopedKey, SharedMap>>,
+    mailboxes: parking_lot::Mutex<BTreeMap<ScopedKey, Mailbox>>,
 }
 
 impl VmSharedStateRuntime {
@@ -57,7 +56,7 @@ impl VmSharedStateRuntime {
 
     pub(crate) fn open_cell(&self, scoped: ScopedKey, initial: VmValue) -> VmValue {
         self.cells
-            .borrow_mut()
+            .lock()
             .entry(scoped.clone())
             .or_insert_with(|| SharedCell {
                 value: initial,
@@ -68,21 +67,21 @@ impl VmSharedStateRuntime {
     }
 
     pub(crate) fn cell_get(&self, scoped: &ScopedKey) -> VmValue {
-        let mut cells = self.cells.borrow_mut();
+        let mut cells = self.cells.lock();
         let cell = cells.entry(scoped.clone()).or_default();
         cell.metrics.read_count += 1;
         cell.value.clone()
     }
 
     pub(crate) fn cell_snapshot(&self, scoped: &ScopedKey) -> VmValue {
-        let mut cells = self.cells.borrow_mut();
+        let mut cells = self.cells.lock();
         let cell = cells.entry(scoped.clone()).or_default();
         cell.metrics.read_count += 1;
         snapshot_value(cell.value.clone(), cell.version)
     }
 
     pub(crate) fn cell_set(&self, scoped: &ScopedKey, value: VmValue) -> VmValue {
-        let mut cells = self.cells.borrow_mut();
+        let mut cells = self.cells.lock();
         let cell = cells.entry(scoped.clone()).or_default();
         let old = std::mem::replace(&mut cell.value, value);
         cell.version = cell.version.saturating_add(1);
@@ -96,7 +95,7 @@ impl VmSharedStateRuntime {
         expected: &VmValue,
         new_value: VmValue,
     ) -> bool {
-        let mut cells = self.cells.borrow_mut();
+        let mut cells = self.cells.lock();
         let cell = cells.entry(scoped.clone()).or_default();
         let (expected_value, expected_version) = snapshot_expected(expected);
         let version_matches = expected_version.is_none_or(|version| version == cell.version);
@@ -122,7 +121,7 @@ impl VmSharedStateRuntime {
         initial: Option<BTreeMap<String, VmValue>>,
     ) -> VmValue {
         self.maps
-            .borrow_mut()
+            .lock()
             .entry(scoped.clone())
             .or_insert_with(|| SharedMap {
                 entries: initial.unwrap_or_default(),
@@ -133,14 +132,14 @@ impl VmSharedStateRuntime {
     }
 
     pub(crate) fn map_get(&self, scoped: &ScopedKey, key: &str, default: VmValue) -> VmValue {
-        let mut maps = self.maps.borrow_mut();
+        let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
         map.metrics.read_count += 1;
         map.entries.get(key).cloned().unwrap_or(default)
     }
 
     pub(crate) fn map_snapshot(&self, scoped: &ScopedKey, key: &str) -> VmValue {
-        let mut maps = self.maps.borrow_mut();
+        let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
         map.metrics.read_count += 1;
         snapshot_value(
@@ -150,14 +149,14 @@ impl VmSharedStateRuntime {
     }
 
     pub(crate) fn map_entries(&self, scoped: &ScopedKey) -> VmValue {
-        let mut maps = self.maps.borrow_mut();
+        let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
         map.metrics.read_count += 1;
         VmValue::Dict(std::sync::Arc::new(map.entries.clone()))
     }
 
     pub(crate) fn map_set(&self, scoped: &ScopedKey, key: String, value: VmValue) -> VmValue {
-        let mut maps = self.maps.borrow_mut();
+        let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
         let old = map.entries.insert(key, value).unwrap_or(VmValue::Nil);
         map.version = map.version.saturating_add(1);
@@ -166,7 +165,7 @@ impl VmSharedStateRuntime {
     }
 
     pub(crate) fn map_delete(&self, scoped: &ScopedKey, key: &str) -> VmValue {
-        let mut maps = self.maps.borrow_mut();
+        let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
         let old = map.entries.remove(key).unwrap_or(VmValue::Nil);
         if !matches!(old, VmValue::Nil) {
@@ -183,7 +182,7 @@ impl VmSharedStateRuntime {
         expected: &VmValue,
         new_value: VmValue,
     ) -> bool {
-        let mut maps = self.maps.borrow_mut();
+        let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
         let current = map.entries.get(&key).cloned().unwrap_or(VmValue::Nil);
         let (expected_value, expected_version) = snapshot_expected(expected);
@@ -210,7 +209,7 @@ impl VmSharedStateRuntime {
 
     pub(crate) fn open_mailbox(&self, scoped: ScopedKey, capacity: usize) -> VmValue {
         self.mailboxes
-            .borrow_mut()
+            .lock()
             .entry(scoped.clone())
             .or_insert_with(|| {
                 let capacity = capacity.max(1);
@@ -237,7 +236,7 @@ impl VmSharedStateRuntime {
     }
 
     pub(crate) fn mailbox(&self, scoped: &ScopedKey) -> Option<VmValue> {
-        if self.mailboxes.borrow().contains_key(scoped) {
+        if self.mailboxes.lock().contains_key(scoped) {
             Some(handle_value("mailbox", scoped))
         } else {
             None
@@ -246,13 +245,13 @@ impl VmSharedStateRuntime {
 
     pub(crate) fn mailbox_channel(&self, scoped: &ScopedKey) -> Option<VmChannelHandle> {
         self.mailboxes
-            .borrow()
+            .lock()
             .get(scoped)
             .map(|mailbox| mailbox.channel.clone())
     }
 
     pub(crate) fn note_mailbox_send(&self, scoped: &ScopedKey, ok: bool) {
-        if let Some(mailbox) = self.mailboxes.borrow().get(scoped) {
+        if let Some(mailbox) = self.mailboxes.lock().get(scoped) {
             if ok {
                 mailbox.sent_count.fetch_add(1, Ordering::SeqCst);
                 mailbox.depth.fetch_add(1, Ordering::SeqCst);
@@ -263,7 +262,7 @@ impl VmSharedStateRuntime {
     }
 
     pub(crate) fn note_mailbox_receive(&self, scoped: &ScopedKey) {
-        if let Some(mailbox) = self.mailboxes.borrow().get(scoped) {
+        if let Some(mailbox) = self.mailboxes.lock().get(scoped) {
             mailbox.received_count.fetch_add(1, Ordering::SeqCst);
             let _ = mailbox
                 .depth
@@ -274,7 +273,7 @@ impl VmSharedStateRuntime {
     }
 
     pub(crate) fn close_mailbox(&self, scoped: &ScopedKey) -> bool {
-        let Some(mailbox) = self.mailboxes.borrow().get(scoped).cloned() else {
+        let Some(mailbox) = self.mailboxes.lock().get(scoped).cloned() else {
             return false;
         };
         !mailbox.channel.closed.swap(true, Ordering::SeqCst)
@@ -284,39 +283,39 @@ impl VmSharedStateRuntime {
         match (kind, scoped) {
             (Some("shared_cell"), Some(scoped)) => self
                 .cells
-                .borrow()
+                .lock()
                 .get(scoped)
                 .map(|cell| shared_metrics_value(&cell.metrics, cell.version))
                 .unwrap_or_else(empty_shared_metrics),
             (Some("shared_map"), Some(scoped)) => self
                 .maps
-                .borrow()
+                .lock()
                 .get(scoped)
                 .map(|map| shared_metrics_value(&map.metrics, map.version))
                 .unwrap_or_else(empty_shared_metrics),
             (Some("mailbox"), Some(scoped)) => self
                 .mailboxes
-                .borrow()
+                .lock()
                 .get(scoped)
                 .map(mailbox_metrics_value)
                 .unwrap_or_else(empty_mailbox_metrics),
             _ => {
                 let mut values = Vec::new();
-                for (scoped, cell) in self.cells.borrow().iter() {
+                for (scoped, cell) in self.cells.lock().iter() {
                     values.push(with_scope_fields(
                         "shared_cell",
                         scoped,
                         shared_metrics_value(&cell.metrics, cell.version),
                     ));
                 }
-                for (scoped, map) in self.maps.borrow().iter() {
+                for (scoped, map) in self.maps.lock().iter() {
                     values.push(with_scope_fields(
                         "shared_map",
                         scoped,
                         shared_metrics_value(&map.metrics, map.version),
                     ));
                 }
-                for (scoped, mailbox) in self.mailboxes.borrow().iter() {
+                for (scoped, mailbox) in self.mailboxes.lock().iter() {
                     values.push(with_scope_fields(
                         "mailbox",
                         scoped,

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -12,9 +12,7 @@ mod sub_agent;
 #[path = "workflow/mod.rs"]
 pub(super) mod workflow;
 
-use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -371,11 +369,11 @@ fn apply_sub_agent_replay_config(spec: &mut SubAgentRunSpec, next_task: &str, re
 }
 
 fn respawn_worker_task(
-    state: Rc<RefCell<WorkerState>>,
+    state: Arc<parking_lot::Mutex<WorkerState>>,
     ctx: &AsyncBuiltinCtx,
 ) -> Result<(), VmError> {
     {
-        let worker = state.borrow();
+        let worker = state.lock();
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker)?;
         }
@@ -385,18 +383,18 @@ fn respawn_worker_task(
 }
 
 async fn wait_for_worker_terminal(
-    state: Rc<RefCell<WorkerState>>,
+    state: Arc<parking_lot::Mutex<WorkerState>>,
     context: &str,
 ) -> Result<(), VmError> {
     loop {
-        let handle = state.borrow_mut().handle.take();
+        let handle = state.lock().handle.take();
         if let Some(handle) = handle {
             let _ = handle
                 .await
                 .map_err(|error| VmError::Runtime(format!("{context} join error: {error}")))??;
             continue;
         }
-        if !worker_wait_blocks(&state.borrow().status) {
+        if !worker_wait_blocks(&state.lock().status) {
             return Ok(());
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -448,7 +446,10 @@ async fn sub_agent_run_builtin(
     finalize_and_run_worker(&ctx, state, false, "sub_agent worker").await
 }
 
-fn fresh_worker_state(worker_id: String, mut init: WorkerInit) -> Rc<RefCell<WorkerState>> {
+fn fresh_worker_state(
+    worker_id: String,
+    mut init: WorkerInit,
+) -> Arc<parking_lot::Mutex<WorkerState>> {
     let created_at = uuid::Uuid::now_v7().to_string();
     ensure_worker_config_session_ids(&mut init.config, &worker_id);
     let mode = worker_mode_label(&init.config).to_string();
@@ -456,7 +457,7 @@ fn fresh_worker_state(worker_id: String, mut init: WorkerInit) -> Rc<RefCell<Wor
     audit.worker_id = Some(worker_id.clone());
     audit.execution_kind = Some(mode.clone());
     let request = worker_request_for_config(&init.task, &init.config);
-    Rc::new(RefCell::new(WorkerState {
+    Arc::new(parking_lot::Mutex::new(WorkerState {
         id: worker_id.clone(),
         name: init.name,
         task: init.task.clone(),
@@ -493,17 +494,17 @@ fn fresh_worker_state(worker_id: String, mut init: WorkerInit) -> Rc<RefCell<Wor
 /// it reaches a terminal state before returning the worker summary dict.
 async fn finalize_and_run_worker(
     ctx: &AsyncBuiltinCtx,
-    state: Rc<RefCell<WorkerState>>,
+    state: Arc<parking_lot::Mutex<WorkerState>>,
     wait_for_terminal: bool,
     wait_context: &'static str,
 ) -> Result<VmValue, VmError> {
     {
-        let worker = state.borrow();
+        let worker = state.lock();
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker)?;
         }
     }
-    let worker_id = state.borrow().id.clone();
+    let worker_id = state.lock().id.clone();
     WORKER_REGISTRY.with(|registry| {
         registry.borrow_mut().insert(worker_id, state.clone());
     });
@@ -511,7 +512,7 @@ async fn finalize_and_run_worker(
     if wait_for_terminal {
         wait_for_worker_terminal(state.clone(), wait_context).await?;
     }
-    worker_summary(&state.borrow())
+    worker_summary(&state.lock())
 }
 
 fn worker_mode_label(config: &WorkerConfig) -> &'static str {
@@ -566,7 +567,7 @@ async fn send_input_builtin(
         ));
     }
     with_worker_state(&worker_id, |state| {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         if worker.status == "running" {
             return Err(VmError::Runtime(format!(
                 "send_input: worker {} is still running",
@@ -576,7 +577,7 @@ async fn send_input_builtin(
         restart_worker_run(&mut worker, &next_task, true)?;
         drop(worker);
         respawn_worker_task(state.clone(), &ctx)?;
-        let summary = worker_summary(&state.borrow())?;
+        let summary = worker_summary(&state.lock())?;
         Ok(summary)
     })
 }
@@ -610,7 +611,7 @@ async fn worker_trigger_builtin(
     // await the lifecycle event emission, so we pull the snapshot
     // out and run `emit_worker_event` after the closure returns.
     let progressed_snapshot = with_worker_state(&worker_id, |state| {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         if !worker.carry_policy.retriggerable {
             return Err(VmError::Runtime(format!(
                 "worker_trigger: worker {} is not retriggerable",
@@ -644,7 +645,7 @@ async fn worker_trigger_builtin(
         crate::agent_events::WorkerEvent::WorkerProgressed,
     )
     .await?;
-    with_worker_state(&worker_id, |state| worker_summary(&state.borrow()))
+    with_worker_state(&worker_id, |state| worker_summary(&state.lock()))
 }
 
 /// Cooperatively suspend a running worker.
@@ -710,7 +711,7 @@ async fn suspend_agent_builtin(
         } => {
             // Blocked suspend: leave the worker running and return its summary.
             return with_worker_state(&worker_id, |state| {
-                let mut summary = worker_summary(&state.borrow())?;
+                let mut summary = worker_summary(&state.lock())?;
                 if let VmValue::Dict(map) = &mut summary {
                     let mut entries = (**map).clone();
                     entries.insert(
@@ -734,7 +735,7 @@ async fn suspend_agent_builtin(
 
     let mut suspension_span: Option<LifecycleSpanGuard> = None;
     let (mut snapshot, mut summary, should_emit) = with_worker_state(&worker_id, |state| {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         if worker.status == "suspended" {
             return Ok((
                 worker_event_snapshot(&worker),
@@ -807,7 +808,7 @@ async fn suspend_agent_builtin(
         .await?
         {
             (snapshot, summary) = with_worker_state(&worker_id, |state| {
-                let mut worker = state.borrow_mut();
+                let mut worker = state.lock();
                 if let Some(suspension) = worker.suspension.as_mut() {
                     suspension.auto_resume_trigger = Some(auto_resume_trigger);
                 }
@@ -903,7 +904,7 @@ pub(crate) async fn panic_suspend_worker(
     };
 
     let (snapshot, outcome) = {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         if worker.status == "suspended" {
             return Ok(PanicSuspendOutcome::AlreadySuspended);
         }
@@ -1105,7 +1106,7 @@ async fn top_level_agent_suspend_builtin(
     persist_worker_state_snapshot(&worker)?;
     let mut snapshot = worker_event_snapshot(&worker);
     let mut summary = worker_summary(&worker)?;
-    let state = Rc::new(RefCell::new(worker));
+    let state = Arc::new(parking_lot::Mutex::new(worker));
     WORKER_REGISTRY.with(|registry| {
         registry.borrow_mut().insert(worker_id.clone(), state);
     });
@@ -1117,7 +1118,7 @@ async fn top_level_agent_suspend_builtin(
     .await?
     {
         (snapshot, summary) = with_worker_state(&worker_id, |state| {
-            let mut worker = state.borrow_mut();
+            let mut worker = state.lock();
             if let Some(suspension) = worker.suspension.as_mut() {
                 suspension.auto_resume_trigger = Some(auto_resume_trigger);
             }
@@ -1375,7 +1376,7 @@ async fn resume_agent_builtin(
         }
         (cold_load_worker(&snapshot_target)?, true)
     };
-    if state.borrow().status == "suspended" {
+    if state.lock().status == "suspended" {
         warm_resume_worker(&ctx, state, options).await
     } else if loaded_from_snapshot {
         // A snapshot path can be used as a restore/read operation for
@@ -1383,16 +1384,16 @@ async fn resume_agent_builtin(
         // contract, but only warm-resume live registry handles when they
         // are actually suspended.
         {
-            let mut worker = state.borrow_mut();
+            let mut worker = state.lock();
             apply_resume_transcript_policy(&mut worker, options.continue_transcript, None);
             apply_resume_input(&mut worker, options.resume_input.as_ref())?;
             if worker.carry_policy.persist_state {
                 persist_worker_state_snapshot(&worker)?;
             }
         }
-        worker_summary(&state.borrow())
+        worker_summary(&state.lock())
     } else {
-        Err(resume_rejected_error(&state.borrow()))
+        Err(resume_rejected_error(&state.lock()))
     }
 }
 
@@ -1590,9 +1591,11 @@ async fn unregister_suspension_auto_resume(
     super::triggers_stdlib::unregister_auto_resume_trigger(&handle).await
 }
 
-async fn join_checkpointed_worker_handle(state: Rc<RefCell<WorkerState>>) -> Result<(), VmError> {
+async fn join_checkpointed_worker_handle(
+    state: Arc<parking_lot::Mutex<WorkerState>>,
+) -> Result<(), VmError> {
     let handle = {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         let Some(handle) = worker.handle.as_ref() else {
             return Ok(());
         };
@@ -1614,13 +1617,13 @@ async fn join_checkpointed_worker_handle(state: Rc<RefCell<WorkerState>>) -> Res
 
 async fn warm_resume_worker(
     ctx: &AsyncBuiltinCtx,
-    state: Rc<RefCell<WorkerState>>,
+    state: Arc<parking_lot::Mutex<WorkerState>>,
     mut options: WorkerResumeOptions,
 ) -> Result<VmValue, VmError> {
     join_checkpointed_worker_handle(state.clone()).await?;
     // PreResume lifecycle gate. Block keeps the worker suspended; Modify can
     // amend the resume input before the transcript policy runs.
-    let pre_worker_id = state.borrow().id.clone();
+    let pre_worker_id = state.lock().id.clone();
     let pre_payload = serde_json::json!({
         "event": crate::orchestration::HookEvent::PreResume.as_str(),
         "worker": { "id": &pre_worker_id },
@@ -1641,7 +1644,7 @@ async fn warm_resume_worker(
         crate::orchestration::HookControl::Allow => {}
         crate::orchestration::HookControl::Block { reason } => {
             // Blocked resume: do not transition out of suspended.
-            let mut summary = worker_summary(&state.borrow())?;
+            let mut summary = worker_summary(&state.lock())?;
             if let VmValue::Dict(map) = &mut summary {
                 let mut entries = (**map).clone();
                 entries.insert(
@@ -1664,11 +1667,11 @@ async fn warm_resume_worker(
     let resume_digest = if options.continue_transcript {
         None
     } else {
-        let transcript = state.borrow().transcript.clone();
+        let transcript = state.lock().transcript.clone();
         resume_digest_from_transcript(ctx, transcript.as_ref()).await?
     };
     let (worker_id, span_links) = {
-        let worker = state.borrow();
+        let worker = state.lock();
         if worker.status != "suspended" {
             return Err(diagnostic_error(
                 Code::ConcurrentResumeConflict,
@@ -1714,7 +1717,7 @@ async fn warm_resume_worker(
         link_count,
     );
     let (snapshot, suspension) = {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         if worker.status != "suspended" {
             return Err(diagnostic_error(
                 Code::ConcurrentResumeConflict,
@@ -1768,7 +1771,7 @@ async fn warm_resume_worker(
         &post_payload,
     )
     .await?;
-    let summary = worker_summary(&state.borrow())?;
+    let summary = worker_summary(&state.lock())?;
     Ok(summary)
 }
 
@@ -1824,7 +1827,7 @@ async fn fail_suspended_worker_from_auto_resume_timeout(
 ) -> Result<VmValue, VmError> {
     let state = with_worker_state(worker_id, Ok)?;
     let (snapshot, summary, suspension) = {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         if worker.status != "suspended" {
             return Err(diagnostic_error(
                 Code::ConcurrentResumeConflict,
@@ -1858,8 +1861,10 @@ async fn fail_suspended_worker_from_auto_resume_timeout(
     Ok(summary)
 }
 
-fn cold_load_worker(snapshot_target: &str) -> Result<Rc<RefCell<WorkerState>>, VmError> {
-    let state = Rc::new(RefCell::new(
+fn cold_load_worker(
+    snapshot_target: &str,
+) -> Result<Arc<parking_lot::Mutex<WorkerState>>, VmError> {
+    let state = Arc::new(parking_lot::Mutex::new(
         load_worker_state_snapshot(snapshot_target).map_err(|error| {
             diagnostic_error(
                 Code::ResumeSnapshotInvalid,
@@ -1867,9 +1872,9 @@ fn cold_load_worker(snapshot_target: &str) -> Result<Rc<RefCell<WorkerState>>, V
             )
         })?,
     ));
-    let worker_id = state.borrow().id.clone();
+    let worker_id = state.lock().id.clone();
     {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         ensure_worker_config_session_ids(&mut worker.config, &worker_id);
     }
     WORKER_REGISTRY.with(|registry| {
@@ -1877,8 +1882,8 @@ fn cold_load_worker(snapshot_target: &str) -> Result<Rc<RefCell<WorkerState>>, V
             .borrow_mut()
             .insert(worker_id.clone(), state.clone());
     });
-    if state.borrow().carry_policy.persist_state {
-        persist_worker_state_snapshot(&state.borrow())?;
+    if state.lock().carry_policy.persist_state {
+        persist_worker_state_snapshot(&state.lock())?;
     }
     Ok(state)
 }
@@ -1903,14 +1908,14 @@ async fn wait_agent_builtin(
             let worker_id = worker_id_from_value(item)?;
             let state = with_worker_state(&worker_id, Ok)?;
             wait_for_worker_terminal(state.clone(), "wait_agent").await?;
-            results.push(worker_summary(&state.borrow())?);
+            results.push(worker_summary(&state.lock())?);
         }
         return Ok(VmValue::List(std::sync::Arc::new(results)));
     }
     let worker_id = worker_id_from_value(target)?;
     let state = with_worker_state(&worker_id, Ok)?;
     wait_for_worker_terminal(state.clone(), "wait_agent").await?;
-    let summary = worker_summary(&state.borrow())?;
+    let summary = worker_summary(&state.lock())?;
     Ok(summary)
 }
 
@@ -1931,7 +1936,7 @@ async fn close_agent_builtin(
     let worker_id = worker_id_from_value(target)?;
     let state = with_worker_state(&worker_id, Ok)?;
     let (snapshot, summary, suspension) = {
-        let mut worker = state.borrow_mut();
+        let mut worker = state.lock();
         worker.cancel_token.store(true, Ordering::SeqCst);
         worker.suspend_signal.store(false, Ordering::SeqCst);
         if let Some(handle) = worker.handle.take() {
@@ -1975,7 +1980,7 @@ fn list_agents_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValue, 
         registry
             .borrow()
             .values()
-            .map(|state| worker_summary(&state.borrow()))
+            .map(|state| worker_summary(&state.lock()))
             .collect::<Result<Vec<_>, _>>()
     })?;
     Ok(VmValue::List(std::sync::Arc::new(workers)))
@@ -2160,7 +2165,7 @@ pub(crate) fn snapshot_suspended_subagents() -> Vec<serde_json::Value> {
             .borrow()
             .values()
             .filter_map(|state| {
-                let worker = state.borrow();
+                let worker = state.lock();
                 if worker.status == "suspended" {
                     let suspension = worker.suspension.as_ref();
                     let suspended_at_ms =
@@ -2276,7 +2281,7 @@ mod suspend_tests {
         unsafe { std::env::set_var("HARN_WORKER_STATE_DIR", &dir) };
         let worker_id = format!("worker_{}", uuid::Uuid::now_v7());
         let snapshot_path = worker_snapshot_path(&worker_id);
-        let state = Rc::new(RefCell::new(WorkerState {
+        let state = Arc::new(parking_lot::Mutex::new(WorkerState {
             id: worker_id.clone(),
             name: name.to_string(),
             task: "do the thing".to_string(),
@@ -2435,7 +2440,7 @@ mod suspend_tests {
     fn worker_status_and_task(worker_id: &str) -> (String, String) {
         WORKER_REGISTRY.with(|registry| {
             let state = registry.borrow().get(worker_id).cloned().unwrap();
-            let worker = state.borrow();
+            let worker = state.lock();
             (worker.status.clone(), worker.task.clone())
         })
     }
@@ -2609,7 +2614,7 @@ mod suspend_tests {
         // Verify the worker is in the suspended state with the panic
         // reason recorded and the WorkerSuspension envelope installed.
         with_worker_state(&worker_id, |state| {
-            let worker = state.borrow();
+            let worker = state.lock();
             assert_eq!(worker.status, "suspended");
             assert!(worker.suspend_signal.load(Ordering::SeqCst));
             let suspension = worker.suspension.as_ref().expect("suspension envelope");
@@ -2662,7 +2667,7 @@ mod suspend_tests {
         // suspension reason.
         with_worker_state(&already_suspended, |state| {
             let suspension = state
-                .borrow()
+                .lock()
                 .suspension
                 .clone()
                 .expect("original suspension still present");
@@ -2675,7 +2680,7 @@ mod suspend_tests {
         // must be skipped with a `not_running` outcome.
         let (terminal, dir2) = seed_test_worker("worker-panic-terminal");
         with_worker_state(&terminal, |state| {
-            state.borrow_mut().status = "completed".to_string();
+            state.lock().status = "completed".to_string();
             Ok(())
         })
         .unwrap();
@@ -3061,7 +3066,7 @@ mod suspend_tests {
 
         WORKER_REGISTRY.with(|registry| {
             let state = registry.borrow().get(&worker_id).cloned().unwrap();
-            state.borrow_mut().transcript = Some(crate::llm::helpers::new_transcript_with(
+            state.lock().transcript = Some(crate::llm::helpers::new_transcript_with(
                 Some(format!("session_{worker_id}")),
                 vec![
                     message_value("user", "old request"),
@@ -3104,7 +3109,7 @@ mod suspend_tests {
                 .borrow()
                 .get(&worker_id)
                 .unwrap()
-                .borrow()
+                .lock()
                 .transcript
                 .clone()
         });
@@ -3122,7 +3127,7 @@ mod suspend_tests {
         let resume_context = WORKER_REGISTRY
             .with(|registry| {
                 let state = registry.borrow().get(&worker_id).cloned().unwrap();
-                let worker = state.borrow();
+                let worker = state.lock();
                 match &worker.config {
                     WorkerConfig::SubAgent { spec } => {
                         spec.options.get("_resume_continuity").cloned()
@@ -3179,7 +3184,7 @@ mod suspend_tests {
                 .borrow()
                 .get(&worker_id)
                 .unwrap()
-                .borrow()
+                .lock()
                 .snapshot_path
                 .clone()
         });
@@ -3217,9 +3222,10 @@ mod suspend_tests {
         // Rehydrate into the registry and warm-resume — the operator
         // wakes the worker back up after restart.
         WORKER_REGISTRY.with(|registry| {
-            registry
-                .borrow_mut()
-                .insert(worker_id.clone(), Rc::new(RefCell::new(reloaded)));
+            registry.borrow_mut().insert(
+                worker_id.clone(),
+                Arc::new(parking_lot::Mutex::new(reloaded)),
+            );
         });
         let resumed = resume_agent_for_test(vec![handle_value(&worker_id)])
             .await
@@ -3240,7 +3246,7 @@ mod suspend_tests {
                 .borrow()
                 .get(&worker_id)
                 .unwrap()
-                .borrow()
+                .lock()
                 .snapshot_path
                 .clone()
         });
@@ -3286,9 +3292,10 @@ mod suspend_tests {
         );
 
         WORKER_REGISTRY.with(|registry| {
-            registry
-                .borrow_mut()
-                .insert(worker_id.clone(), Rc::new(RefCell::new(reloaded)));
+            registry.borrow_mut().insert(
+                worker_id.clone(),
+                Arc::new(parking_lot::Mutex::new(reloaded)),
+            );
         });
         resume_agent_for_test(vec![handle_value(&worker_id)])
             .await
@@ -3759,7 +3766,7 @@ mod suspend_tests {
         let (worker_id, dir) = seed_test_worker("worker-suspend-terminal");
         WORKER_REGISTRY.with(|registry| {
             let state = registry.borrow().get(&worker_id).cloned().unwrap();
-            state.borrow_mut().status = "completed".to_string();
+            state.lock().status = "completed".to_string();
         });
 
         let err = suspend_agent_builtin(

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::bridge::HostBridge;
 use crate::llm::daemon::{load_snapshot, DaemonSnapshot};
@@ -80,7 +80,7 @@ struct DaemonState {
     persist_root: String,
     snapshot_path: String,
     options: BTreeMap<String, VmValue>,
-    bridge: Rc<HostBridge>,
+    bridge: Arc<HostBridge>,
     handle: Option<tokio::task::JoinHandle<Result<VmValue, VmError>>>,
     monitor_handle: Option<tokio::task::JoinHandle<()>>,
     status: String,
@@ -97,7 +97,7 @@ struct DaemonState {
 }
 
 thread_local! {
-    static DAEMON_REGISTRY: RefCell<BTreeMap<String, Rc<RefCell<DaemonState>>>> =
+    static DAEMON_REGISTRY: RefCell<BTreeMap<String, Arc<parking_lot::Mutex<DaemonState>>>> =
         const { RefCell::new(BTreeMap::new()) };
     static DAEMON_COUNTER: Cell<u64> = const { Cell::new(0) };
 }
@@ -120,8 +120,7 @@ async fn daemon_spawn_builtin(
     let child_vm = ctx.child_vm();
     let config = options::dict_arg(&args, 0, "daemon_spawn", "config", ErrorKind::Runtime)?;
     let spec = parse_spawn_spec(config, None, None)?;
-    if find_daemon_by_root(&spec.persist_root)
-        .is_some_and(|state| state.borrow().status == "running")
+    if find_daemon_by_root(&spec.persist_root).is_some_and(|state| state.lock().status == "running")
     {
         return Err(VmError::Runtime(format!(
             "daemon_spawn: a daemon is already running for '{}'",
@@ -129,7 +128,7 @@ async fn daemon_spawn_builtin(
         )));
     }
 
-    let state = Rc::new(RefCell::new(DaemonState {
+    let state = Arc::new(parking_lot::Mutex::new(DaemonState {
         id: spec.id.clone(),
         name: spec.name.clone(),
         prompt: spec.prompt.clone(),
@@ -154,7 +153,7 @@ async fn daemon_spawn_builtin(
         stop_requested: false,
     }));
     {
-        let daemon = state.borrow();
+        let daemon = state.lock();
         persist_daemon_meta(&daemon)?;
     }
     register_daemon(state.clone());
@@ -169,7 +168,7 @@ async fn daemon_spawn_builtin(
         summarize_text(&spec.prompt),
     );
     let summary = {
-        let daemon = state.borrow();
+        let daemon = state.lock();
         daemon_summary(&daemon)?
     };
     Ok(summary)
@@ -193,7 +192,7 @@ async fn daemon_trigger_builtin(
     let daemon_id = daemon_id_from_value(target)?;
     let state = with_daemon_state(&daemon_id, |state| Ok(state.clone()))?;
     {
-        let mut daemon = state.borrow_mut();
+        let mut daemon = state.lock();
         refresh_snapshot(&mut daemon)?;
         reconcile_inflight_event(&mut daemon)?;
         if daemon.status != "running" {
@@ -218,7 +217,7 @@ async fn daemon_trigger_builtin(
         persist_daemon_meta(&daemon)?;
     }
     {
-        let daemon = state.borrow();
+        let daemon = state.lock();
         record_daemon_event(
             &daemon.id,
             &daemon.name,
@@ -229,7 +228,7 @@ async fn daemon_trigger_builtin(
     }
     maybe_deliver_next_event(state.clone()).await?;
     let summary = {
-        let daemon = state.borrow();
+        let daemon = state.lock();
         daemon_summary(&daemon)?
     };
     Ok(summary)
@@ -245,7 +244,7 @@ fn daemon_snapshot_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
         .ok_or_else(|| VmError::Runtime("daemon_snapshot: missing daemon handle".to_string()))?;
     let daemon_id = daemon_id_from_value(target)?;
     with_daemon_state(&daemon_id, |state| {
-        let mut daemon = state.borrow_mut();
+        let mut daemon = state.lock();
         let snapshot = refresh_snapshot(&mut daemon)?;
         reconcile_inflight_event(&mut daemon)?;
         record_daemon_event(
@@ -280,7 +279,7 @@ async fn daemon_stop_builtin(
     let daemon_id = daemon_id_from_value(target)?;
     let state = with_daemon_state(&daemon_id, |state| Ok(state.clone()))?;
     {
-        let mut daemon = state.borrow_mut();
+        let mut daemon = state.lock();
         if daemon.status == "stopped" {
             return daemon_summary(&daemon);
         }
@@ -294,7 +293,7 @@ async fn daemon_stop_builtin(
     let started = std::time::Instant::now();
     while (started.elapsed().as_millis() as u64) < DAEMON_STOP_WAIT_MS {
         {
-            let daemon = state.borrow();
+            let daemon = state.lock();
             if daemon.status != "running" || daemon.bridge.is_daemon_idle() {
                 break;
             }
@@ -303,7 +302,7 @@ async fn daemon_stop_builtin(
     }
 
     let summary = {
-        let mut daemon = state.borrow_mut();
+        let mut daemon = state.lock();
         refresh_snapshot(&mut daemon)?;
         reconcile_inflight_event(&mut daemon)?;
         requeue_inflight_event(&mut daemon)?;
@@ -384,14 +383,14 @@ async fn daemon_resume_builtin(
     )?;
 
     if let Some(state) = find_daemon_by_root(&persist_root) {
-        if state.borrow().status == "running" {
+        if state.lock().status == "running" {
             return Err(VmError::Runtime(format!(
                 "daemon_resume: daemon '{persist_root}' is already running"
             )));
         }
         let bridge = new_daemon_bridge(&ctx).await?;
         {
-            let mut daemon = state.borrow_mut();
+            let mut daemon = state.lock();
             daemon.id = spec.id.clone();
             daemon.name = spec.name.clone();
             daemon.prompt = spec.prompt.clone();
@@ -438,7 +437,7 @@ async fn daemon_resume_builtin(
         start_daemon_monitor(state.clone());
         wait_for_snapshot(state.clone(), Some(snapshot.saved_at.clone()), 500).await;
         let summary = {
-            let daemon = state.borrow();
+            let daemon = state.lock();
             record_daemon_event(
                 &daemon.id,
                 &daemon.name,
@@ -467,7 +466,7 @@ async fn daemon_resume_builtin(
         VmValue::String(std::sync::Arc::from(spec.snapshot_path.clone())),
     );
 
-    let state = Rc::new(RefCell::new(DaemonState {
+    let state = Arc::new(parking_lot::Mutex::new(DaemonState {
         id: spec.id.clone(),
         name: spec.name.clone(),
         prompt: spec.prompt.clone(),
@@ -492,10 +491,10 @@ async fn daemon_resume_builtin(
         stop_requested: false,
     }));
     {
-        let daemon = state.borrow();
+        let daemon = state.lock();
         persist_daemon_meta(&daemon)?;
     }
-    state.borrow().bridge.set_daemon_idle(true);
+    state.lock().bridge.set_daemon_idle(true);
     maybe_deliver_next_event(state.clone()).await?;
     register_daemon(state.clone());
     spawn_daemon_task(state.clone(), child_vm);
@@ -509,7 +508,7 @@ async fn daemon_resume_builtin(
         summarize_snapshot(Some(&snapshot)),
     );
     let summary = {
-        let daemon = state.borrow();
+        let daemon = state.lock();
         daemon_summary(&daemon)?
     };
     Ok(summary)
@@ -610,19 +609,19 @@ fn next_daemon_id() -> String {
     })
 }
 
-fn register_daemon(state: Rc<RefCell<DaemonState>>) {
-    let daemon_id = state.borrow().id.clone();
+fn register_daemon(state: Arc<parking_lot::Mutex<DaemonState>>) {
+    let daemon_id = state.lock().id.clone();
     DAEMON_REGISTRY.with(|registry| {
         registry.borrow_mut().insert(daemon_id, state);
     });
 }
 
-fn find_daemon_by_root(persist_root: &str) -> Option<Rc<RefCell<DaemonState>>> {
+fn find_daemon_by_root(persist_root: &str) -> Option<Arc<parking_lot::Mutex<DaemonState>>> {
     DAEMON_REGISTRY.with(|registry| {
         registry
             .borrow()
             .values()
-            .find(|state| state.borrow().persist_root == persist_root)
+            .find(|state| state.lock().persist_root == persist_root)
             .cloned()
     })
 }
@@ -645,7 +644,7 @@ fn daemon_id_from_value(value: &VmValue) -> Result<String, VmError> {
 
 fn with_daemon_state<T>(
     daemon_id: &str,
-    f: impl FnOnce(&Rc<RefCell<DaemonState>>) -> Result<T, VmError>,
+    f: impl FnOnce(&Arc<parking_lot::Mutex<DaemonState>>) -> Result<T, VmError>,
 ) -> Result<T, VmError> {
     let state = DAEMON_REGISTRY.with(|registry| registry.borrow().get(daemon_id).cloned());
     let state = state.ok_or_else(|| VmError::Runtime(format!("unknown daemon '{daemon_id}'")))?;
@@ -706,12 +705,12 @@ fn daemon_summary(daemon: &DaemonState) -> Result<VmValue, VmError> {
     Ok(crate::stdlib::json_to_vm_value(&summary))
 }
 
-async fn new_daemon_bridge(ctx: &crate::vm::AsyncBuiltinCtx) -> Result<Rc<HostBridge>, VmError> {
+async fn new_daemon_bridge(ctx: &crate::vm::AsyncBuiltinCtx) -> Result<Arc<HostBridge>, VmError> {
     let vm = ctx.child_vm();
     let module_path = daemon_bridge_module_path()?;
     HostBridge::from_harn_module(vm, &module_path)
         .await
-        .map(Rc::new)
+        .map(Arc::new)
 }
 
 fn daemon_bridge_module_path() -> Result<PathBuf, VmError> {
@@ -817,9 +816,9 @@ fn read_meta(meta_path: &str) -> Result<PersistedDaemonMeta, VmError> {
         .map_err(|error| VmError::Runtime(format!("daemon meta parse error: {error}")))
 }
 
-fn spawn_daemon_task(state: Rc<RefCell<DaemonState>>, mut vm: crate::vm::Vm) {
+fn spawn_daemon_task(state: Arc<parking_lot::Mutex<DaemonState>>, mut vm: crate::vm::Vm) {
     let (prompt, system, options, bridge) = {
-        let daemon = state.borrow();
+        let daemon = state.lock();
         (
             daemon.prompt.clone(),
             daemon.system.clone(),
@@ -856,7 +855,7 @@ fn spawn_daemon_task(state: Rc<RefCell<DaemonState>>, mut vm: crate::vm::Vm) {
         }
 
         {
-            let mut daemon = task_state.borrow_mut();
+            let mut daemon = task_state.lock();
             daemon.bridge.set_daemon_idle(false);
             match &result {
                 Ok(value) => {
@@ -878,15 +877,15 @@ fn spawn_daemon_task(state: Rc<RefCell<DaemonState>>, mut vm: crate::vm::Vm) {
         result
     });
 
-    state.borrow_mut().handle = Some(handle);
+    state.lock().handle = Some(handle);
 }
 
-fn start_daemon_monitor(state: Rc<RefCell<DaemonState>>) {
+fn start_daemon_monitor(state: Arc<parking_lot::Mutex<DaemonState>>) {
     let monitor_state = state.clone();
     let handle = tokio::task::spawn_local(async move {
         loop {
             let should_exit = {
-                let mut daemon = monitor_state.borrow_mut();
+                let mut daemon = monitor_state.lock();
                 let _ = refresh_snapshot(&mut daemon);
                 let _ = reconcile_inflight_event(&mut daemon);
                 daemon.status != "running" || daemon.stop_requested
@@ -898,12 +897,14 @@ fn start_daemon_monitor(state: Rc<RefCell<DaemonState>>) {
             tokio::time::sleep(tokio::time::Duration::from_millis(DAEMON_MONITOR_POLL_MS)).await;
         }
     });
-    state.borrow_mut().monitor_handle = Some(handle);
+    state.lock().monitor_handle = Some(handle);
 }
 
-async fn maybe_deliver_next_event(state: Rc<RefCell<DaemonState>>) -> Result<(), VmError> {
+async fn maybe_deliver_next_event(
+    state: Arc<parking_lot::Mutex<DaemonState>>,
+) -> Result<(), VmError> {
     let delivery = {
-        let mut daemon = state.borrow_mut();
+        let mut daemon = state.lock();
         if daemon.status != "running"
             || daemon.stop_requested
             || daemon.inflight_event.is_some()
@@ -986,14 +987,14 @@ fn requeue_inflight_event(daemon: &mut DaemonState) -> Result<(), VmError> {
 }
 
 async fn wait_for_snapshot(
-    state: Rc<RefCell<DaemonState>>,
+    state: Arc<parking_lot::Mutex<DaemonState>>,
     baseline_saved_at: Option<String>,
     timeout_ms: u64,
 ) {
     let start = std::time::Instant::now();
     loop {
         let maybe_saved_at = {
-            let mut daemon = state.borrow_mut();
+            let mut daemon = state.lock();
             match refresh_snapshot(&mut daemon) {
                 Ok(snapshot) => snapshot.map(|snapshot| snapshot.saved_at),
                 Err(_) => None,

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -1,6 +1,4 @@
-use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -283,7 +281,10 @@ async fn execute_worker_config(
     }
 }
 
-pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>, ctx: AsyncBuiltinCtx) {
+pub(in super::super) fn spawn_worker_task(
+    state: Arc<parking_lot::Mutex<WorkerState>>,
+    ctx: AsyncBuiltinCtx,
+) {
     let worker_ctx = ctx.child_ctx();
     let (
         worker_id,
@@ -296,7 +297,7 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>, ctx: 
         transcript_mode,
         audit,
     ) = {
-        let worker = state.borrow();
+        let worker = state.lock();
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker).ok();
         }
@@ -322,7 +323,7 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>, ctx: 
             });
         }
         let spawned_snapshot = {
-            let worker = state_for_task.borrow();
+            let worker = state_for_task.lock();
             worker_event_snapshot(&worker)
         };
         emit_worker_event(
@@ -385,7 +386,7 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>, ctx: 
         }
         {
             let completion = {
-                let mut worker = state_for_task.borrow_mut();
+                let mut worker = state_for_task.lock();
                 worker.awaiting_since = None;
                 worker.awaiting_started_at = None;
                 match &result {
@@ -484,7 +485,7 @@ pub(in super::super) fn spawn_worker_task(state: Rc<RefCell<WorkerState>>, ctx: 
         result
     });
 
-    state.borrow_mut().handle = Some(handle);
+    state.lock().handle = Some(handle);
 }
 
 fn worker_result_artifact(
@@ -575,7 +576,7 @@ pub(in super::super) async fn execute_delegated_stage(
         transcript,
     };
     let original_request = worker_request_for_config(task, &config);
-    let state = Rc::new(RefCell::new(WorkerState {
+    let state = Arc::new(parking_lot::Mutex::new(WorkerState {
         id: worker_id.clone(),
         name: worker_name.clone(),
         task: task.to_string(),
@@ -622,7 +623,7 @@ pub(in super::super) async fn execute_delegated_stage(
         .normalize(),
     }));
     {
-        let worker = state.borrow();
+        let worker = state.lock();
         if worker.carry_policy.persist_state {
             persist_worker_state_snapshot(&worker)?;
         }
@@ -634,7 +635,7 @@ pub(in super::super) async fn execute_delegated_stage(
     });
     spawn_worker_task(state.clone(), ctx.child_ctx());
     let handle = state
-        .borrow_mut()
+        .lock()
         .handle
         .take()
         .ok_or_else(|| VmError::Runtime("delegated stage did not start".to_string()))?;
@@ -642,7 +643,7 @@ pub(in super::super) async fn execute_delegated_stage(
         .await
         .map_err(|error| VmError::Runtime(format!("delegated stage join error: {error}")))??;
     let mut result = executed.payload.clone();
-    result["worker"] = clone_worker_state(&state.borrow());
+    result["worker"] = clone_worker_state(&state.lock());
     let mut produced = executed.artifacts.clone();
     for artifact in &mut produced {
         artifact
@@ -658,7 +659,7 @@ pub(in super::super) async fn execute_delegated_stage(
     }
     produced.push(worker_result_artifact(
         node_id,
-        &state.borrow(),
+        &state.lock(),
         &result,
         &executed.artifacts,
         &artifacts

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -1,7 +1,6 @@
 use super::*;
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -212,7 +211,7 @@ pub(super) struct WorkerState {
 }
 
 thread_local! {
-    pub(super) static WORKER_REGISTRY: RefCell<BTreeMap<String, Rc<RefCell<WorkerState>>>> = const { RefCell::new(BTreeMap::new()) };
+    pub(super) static WORKER_REGISTRY: RefCell<BTreeMap<String, Arc<parking_lot::Mutex<WorkerState>>>> = const { RefCell::new(BTreeMap::new()) };
     static WORKER_COUNTER: Cell<u64> = const { Cell::new(0) };
 }
 
@@ -228,7 +227,7 @@ pub(super) fn reset_worker_registry() {
     WORKER_REGISTRY.with(|registry| {
         let mut registry = registry.borrow_mut();
         for state in registry.values() {
-            let mut worker = state.borrow_mut();
+            let mut worker = state.lock();
             worker.cancel_token.store(true, Ordering::SeqCst);
             worker.suspend_signal.store(true, Ordering::SeqCst);
             if let Some(handle) = worker.handle.take() {
@@ -482,7 +481,7 @@ pub(super) fn worker_summary(state: &WorkerState) -> Result<VmValue, VmError> {
 
 pub(super) fn with_worker_state<T>(
     worker_id: &str,
-    f: impl FnOnce(Rc<RefCell<WorkerState>>) -> Result<T, VmError>,
+    f: impl FnOnce(Arc<parking_lot::Mutex<WorkerState>>) -> Result<T, VmError>,
 ) -> Result<T, VmError> {
     WORKER_REGISTRY.with(|registry| {
         let state = registry

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Instant;
 
 use serde_json::Value as JsonValue;
@@ -398,7 +398,7 @@ pub(crate) fn dispatch_mock_host_call(
 /// blocking channel — see `harn-dap`'s `DapHostBridge` for the canonical
 /// pattern. Sync keeps the boundary simple and avoids forcing the entire
 /// dispatch path into an opaque future.
-pub trait HostCallBridge {
+pub trait HostCallBridge: Send + Sync {
     fn dispatch(
         &self,
         capability: &str,
@@ -416,14 +416,14 @@ pub trait HostCallBridge {
 }
 
 thread_local! {
-    static HOST_CALL_BRIDGE: RefCell<Option<Rc<dyn HostCallBridge>>> = const { RefCell::new(None) };
+    static HOST_CALL_BRIDGE: RefCell<Option<Arc<dyn HostCallBridge>>> = const { RefCell::new(None) };
 }
 
 /// Install a bridge for the current thread. The bridge is consulted on
 /// every `host_call` *after* mock matching but *before* the built-in
 /// match arms, so embedders can override anything they like (and equally
 /// punt on anything they don't, by returning `Ok(None)`).
-pub fn set_host_call_bridge(bridge: Rc<dyn HostCallBridge>) {
+pub fn set_host_call_bridge(bridge: Arc<dyn HostCallBridge>) {
     HOST_CALL_BRIDGE.with(|b| *b.borrow_mut() = Some(bridge));
 }
 
@@ -458,7 +458,9 @@ fn empty_tool_list_value() -> VmValue {
     VmValue::List(std::sync::Arc::new(Vec::new()))
 }
 
-fn current_vm_host_bridge(ctx: Option<&AsyncBuiltinCtx>) -> Option<Rc<crate::bridge::HostBridge>> {
+fn current_vm_host_bridge(
+    ctx: Option<&AsyncBuiltinCtx>,
+) -> Option<std::sync::Arc<crate::bridge::HostBridge>> {
     ctx.and_then(|ctx| ctx.child_vm().bridge.clone())
 }
 
@@ -697,7 +699,7 @@ async fn dispatch_process_exec_after_policy(
     // attacker-controlled code) pass `sandbox_profile: "os_hardened"`
     // without having to rewrite the surrounding policy. The override
     // is scoped to this call and pops with the guard at end-of-scope.
-    let _profile_guard = match optional_string(params, "sandbox_profile") {
+    let profile_guard = match optional_string(params, "sandbox_profile") {
         Some(value) => Some(push_sandbox_profile_override(&value)?),
         None => None,
     };
@@ -737,6 +739,7 @@ async fn dispatch_process_exec_after_policy(
     let child = cmd
         .spawn()
         .map_err(|e| VmError::Runtime(format!("host_call process.exec: {e}")))?;
+    drop(profile_guard);
     let pid = child.id();
     let timed_out;
     let output_result = if let Some(timeout_ms) = timeout_ms {
@@ -1159,9 +1162,11 @@ mod tests {
         dispatch_host_tool_call, dispatch_host_tool_list, dispatch_mock_host_call, push_host_mock,
         reset_host_state, resolve_process_exec_cwd, set_host_call_bridge, HostCallBridge, HostMock,
     };
-    use std::cell::Cell;
     use std::collections::BTreeMap;
-    use std::rc::Rc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     use crate::value::{VmError, VmValue};
 
@@ -1351,7 +1356,7 @@ mod tests {
     }
 
     struct CountingProcessExecBridge {
-        calls: Rc<Cell<usize>>,
+        calls: Arc<AtomicUsize>,
     }
 
     impl HostCallBridge for CountingProcessExecBridge {
@@ -1364,7 +1369,7 @@ mod tests {
             if (capability, operation) != ("process", "exec") {
                 return Ok(None);
             }
-            self.calls.set(self.calls.get() + 1);
+            self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
                 (
                     "status".to_string(),
@@ -1395,7 +1400,7 @@ mod tests {
     fn host_tool_list_uses_installed_host_call_bridge() {
         run_host_async_test(|| async {
             reset_host_state();
-            set_host_call_bridge(Rc::new(TestHostToolBridge));
+            set_host_call_bridge(Arc::new(TestHostToolBridge));
             let tools = dispatch_host_tool_list().await.expect("tool list");
             clear_host_call_bridge();
 
@@ -1412,7 +1417,7 @@ mod tests {
     #[test]
     fn host_tool_call_uses_installed_host_call_bridge() {
         run_host_async_test(|| async {
-            set_host_call_bridge(Rc::new(TestHostToolBridge));
+            set_host_call_bridge(Arc::new(TestHostToolBridge));
             let args = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
                 "path".to_string(),
                 VmValue::String(std::sync::Arc::from("README.md".to_string())),
@@ -1429,8 +1434,8 @@ mod tests {
     fn process_exec_bridge_is_gated_by_command_policy() {
         run_host_async_test(|| async {
             crate::orchestration::clear_command_policies();
-            let calls = Rc::new(Cell::new(0));
-            set_host_call_bridge(Rc::new(CountingProcessExecBridge {
+            let calls = Arc::new(AtomicUsize::new(0));
+            set_host_call_bridge(Arc::new(CountingProcessExecBridge {
                 calls: calls.clone(),
             }));
             crate::orchestration::push_command_policy(crate::orchestration::CommandPolicy {
@@ -1464,7 +1469,11 @@ mod tests {
             crate::orchestration::clear_command_policies();
             clear_host_call_bridge();
 
-            assert_eq!(calls.get(), 0, "blocked command must not reach host bridge");
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                0,
+                "blocked command must not reach host bridge"
+            );
             let result = result.as_dict().expect("blocked result dict");
             assert_eq!(result.get("status").unwrap().display(), "blocked");
             assert!(

--- a/crates/harn-vm/src/stdlib/macros.rs
+++ b/crates/harn-vm/src/stdlib/macros.rs
@@ -36,7 +36,7 @@ pub use linkme::distributed_slice;
 pub static ALL_BUILTIN_DEFS: [&'static VmBuiltinDef];
 
 /// Pinned future returned by async builtin handlers.
-pub type AsyncBuiltinFuture = Pin<Box<dyn Future<Output = Result<VmValue, VmError>>>>;
+pub type AsyncBuiltinFuture = Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + Send>>;
 
 /// Sync builtin handler signature (matches `crate::vm::dispatch`'s register_builtin shape).
 pub type SyncHandler = fn(&[VmValue], &mut String) -> Result<VmValue, VmError>;

--- a/crates/harn-vm/src/stdlib/path_scope_guard.rs
+++ b/crates/harn-vm/src/stdlib/path_scope_guard.rs
@@ -9,7 +9,7 @@
 //! reanchor, fork to sub-agent) before rejecting the call.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::llm::helpers::{ReminderPropagate, ReminderRoleHint, ReminderSource, SystemReminder};
 use crate::orchestration::{
@@ -86,7 +86,7 @@ fn register_path_scope_guard(args: &[VmValue], _out: &mut String) -> Result<VmVa
     let on_violation = parse_on_violation(&opts)?;
     let mount_modes = parse_mount_modes(&opts)?;
 
-    let pre: PreToolHookFn = Rc::new(move |tool_name: &str, args: &serde_json::Value| {
+    let pre: PreToolHookFn = Arc::new(move |tool_name: &str, args: &serde_json::Value| {
         let Some(session_id) = crate::agent_sessions::current_session_id() else {
             return PreToolAction::Allow;
         };

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -1,6 +1,6 @@
 //! Named agent thread pools (PL-01/PL-03/PL-05).
 //!
-//! Foundation for the agent pool epic (#1883). Provides a thread-local
+//! Foundation for the agent pool epic (#1883). Provides a VM-scoped
 //! registry of named pools that bound the number of concurrent Harn
 //! closure executions and queue excess submissions. Queue strategy ships
 //! here, with bounded backpressure policies layered on the single submit
@@ -18,10 +18,10 @@
 //!   today they fail with a clear "host-routed (harn-cloud) — not
 //!   wired" diagnostic until the host capability ships.
 
-use std::cell::RefCell;
+use std::any::Any;
 use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::future::Future;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::event_log::{
@@ -31,6 +31,7 @@ use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmClosure, VmError, VmValue};
 use crate::vm::{AsyncBuiltinCtx, Vm};
+use futures::FutureExt;
 use harn_parser::diagnostic_codes::Code;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -62,7 +63,7 @@ const DEFAULT_STALE_AFTER_MS: i64 = 30_000;
 struct PendingTask {
     task_id: String,
     closure: Arc<VmClosure>,
-    state: Rc<RefCell<TaskState>>,
+    state: Arc<parking_lot::Mutex<TaskState>>,
     priority: i64,
     key: Option<String>,
     /// Tiebreaker so FIFO order is preserved among equal priorities.
@@ -155,8 +156,8 @@ struct PoolEntry {
     queue_strategy: QueueStrategy,
     backpressure: BackpressureStrategy,
     round_robin_after: Option<String>,
-    active: HashMap<String, Rc<RefCell<TaskState>>>,
-    tasks: BTreeMap<String, Rc<RefCell<TaskState>>>,
+    active: HashMap<String, Arc<parking_lot::Mutex<TaskState>>>,
+    tasks: BTreeMap<String, Arc<parking_lot::Mutex<TaskState>>>,
     space_waiters: Vec<tokio::sync::oneshot::Sender<()>>,
     /// Optional per-create user-supplied config (queue strategy, priority
     /// fn, backpressure). Queue strategy is evaluated by this module;
@@ -180,7 +181,7 @@ struct PoolEntry {
     stale_after_ms: i64,
     /// Optional durable store the pool serializes state mutations into.
     /// `None` for session-scoped pools.
-    store: Option<Rc<RefCell<PoolDurableStore>>>,
+    store: Option<Arc<parking_lot::Mutex<PoolDurableStore>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -440,12 +441,58 @@ impl QueueStrategy {
     }
 }
 
-thread_local! {
-    static POOLS: RefCell<HashMap<String, Rc<RefCell<PoolEntry>>>> =
-        RefCell::new(HashMap::new());
+#[derive(Default)]
+pub(crate) struct PoolRegistry {
+    inner: parking_lot::Mutex<PoolRegistryState>,
+}
+
+#[derive(Default)]
+struct PoolRegistryState {
+    pools: HashMap<String, Arc<parking_lot::Mutex<PoolEntry>>>,
     /// Name → pool_id lookup so `pool_get("...")` and `pool_create({name: ...})`
     /// duplicate detection stay O(1).
-    static POOL_NAMES: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+    names: HashMap<String, String>,
+}
+
+impl PoolRegistryState {
+    fn clear(&mut self) {
+        self.pools.clear();
+        self.names.clear();
+    }
+}
+
+tokio::task_local! {
+    static ACTIVE_POOL_REGISTRY: Arc<PoolRegistry>;
+}
+
+static FALLBACK_POOL_REGISTRY: std::sync::OnceLock<Arc<PoolRegistry>> = std::sync::OnceLock::new();
+
+pub(crate) fn new_pool_registry() -> Arc<PoolRegistry> {
+    Arc::new(PoolRegistry::default())
+}
+
+pub(crate) async fn with_pool_registry_scope<F>(registry: Arc<PoolRegistry>, future: F) -> F::Output
+where
+    F: Future,
+{
+    ACTIVE_POOL_REGISTRY.scope(registry, future).await
+}
+
+fn fallback_pool_registry() -> Arc<PoolRegistry> {
+    FALLBACK_POOL_REGISTRY
+        .get_or_init(|| Arc::new(PoolRegistry::default()))
+        .clone()
+}
+
+fn current_pool_registry() -> Arc<PoolRegistry> {
+    ACTIVE_POOL_REGISTRY
+        .try_with(Arc::clone)
+        .unwrap_or_else(|_| fallback_pool_registry())
+}
+
+fn pool_registry_for_ctx(ctx: Option<&AsyncBuiltinCtx>) -> Arc<PoolRegistry> {
+    ctx.map(AsyncBuiltinCtx::pool_registry)
+        .unwrap_or_else(current_pool_registry)
 }
 
 fn next_pool_id() -> String {
@@ -473,14 +520,33 @@ fn next_task_id(pool: &PoolEntry) -> String {
     format!("{}_task_{}", pool.id, uuid::Uuid::now_v7())
 }
 
-fn lookup_pool(pool_id: &str) -> Result<Rc<RefCell<PoolEntry>>, VmError> {
-    POOLS.with(|pools| {
-        pools
-            .borrow()
-            .get(pool_id)
-            .cloned()
-            .ok_or_else(|| VmError::Runtime(format!("pool not found: {pool_id}")))
-    })
+fn lookup_pool(pool_id: &str) -> Result<Arc<parking_lot::Mutex<PoolEntry>>, VmError> {
+    lookup_pool_in_registry(&current_pool_registry(), pool_id)
+}
+
+fn lookup_pool_in_registry(
+    registry: &Arc<PoolRegistry>,
+    pool_id: &str,
+) -> Result<Arc<parking_lot::Mutex<PoolEntry>>, VmError> {
+    registry
+        .inner
+        .lock()
+        .pools
+        .get(pool_id)
+        .cloned()
+        .ok_or_else(|| VmError::Runtime(format!("pool not found: {pool_id}")))
+}
+
+fn lookup_pool_by_name_or_id_in_registry(
+    registry: &Arc<PoolRegistry>,
+    name_or_id: &str,
+) -> Option<Arc<parking_lot::Mutex<PoolEntry>>> {
+    let registry_ref = registry.inner.lock();
+    if let Some(id) = registry_ref.names.get(name_or_id) {
+        registry_ref.pools.get(id).cloned()
+    } else {
+        registry_ref.pools.get(name_or_id).cloned()
+    }
 }
 
 fn pool_id_from_value(value: &VmValue, builtin: &str) -> Result<String, VmError> {
@@ -815,7 +881,7 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
     let mut tasks: Vec<VmValue> = pool
         .tasks
         .values()
-        .map(|task| task_snapshot_value(&task.borrow()))
+        .map(|task| task_snapshot_value(&task.lock()))
         .collect();
     tasks.sort_by_key(task_sort_key);
     let queued: i64 = pool.queue.len() as i64;
@@ -824,7 +890,7 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
     let mut failed: i64 = 0;
     let mut rejected: i64 = 0;
     for task in pool.tasks.values() {
-        match task.borrow().status {
+        match task.lock().status {
             TaskStatus::Completed => completed += 1,
             TaskStatus::Failed => failed += 1,
             TaskStatus::Rejected => rejected += 1,
@@ -1075,10 +1141,14 @@ async fn pool_create_sync(
 ) -> Result<VmValue, VmError> {
     let opts = parse_options(args.first(), "pool_create")?;
     let name = parse_name(&opts).unwrap_or_else(|| format!("pool_{}", uuid::Uuid::now_v7()));
-    if let Some(existing) = POOL_NAMES.with(|names| names.borrow().get(&name).cloned()) {
-        return Err(VmError::Runtime(format!(
-            "pool_create: pool '{name}' already exists (id={existing}); use pool_get to reuse"
-        )));
+    let registry = ctx.pool_registry();
+    {
+        let registry_ref = registry.inner.lock();
+        if let Some(existing) = registry_ref.names.get(&name) {
+            return Err(VmError::Runtime(format!(
+                "pool_create: pool '{name}' already exists (id={existing}); use pool_get to reuse"
+            )));
+        }
     }
     let max_concurrent = parse_max_concurrent(&opts)?;
     let queue_strategy = parse_queue_strategy(&opts)?;
@@ -1107,7 +1177,7 @@ async fn pool_create_sync(
             (
                 id,
                 pipeline_id,
-                Some(Rc::new(RefCell::new(store))),
+                Some(Arc::new(parking_lot::Mutex::new(store))),
                 persisted,
             )
         }
@@ -1122,7 +1192,7 @@ async fn pool_create_sync(
         .map(|state| state.meta.submit_counter)
         .unwrap_or(0);
 
-    let entry = Rc::new(RefCell::new(PoolEntry {
+    let entry = Arc::new(parking_lot::Mutex::new(PoolEntry {
         id: id.clone(),
         name: name.clone(),
         max_concurrent,
@@ -1150,13 +1220,21 @@ async fn pool_create_sync(
     } else if let Some(store_ref) = store {
         // Fresh pipeline-scope pool: stamp the header so reloads find a
         // well-formed log even if no tasks have been submitted yet.
-        let meta = persisted_meta_from_entry(&entry.borrow());
-        store_ref.borrow().compact(&meta, &[])?;
+        let meta = persisted_meta_from_entry(&entry.lock());
+        store_ref.lock().compact(&meta, &[])?;
     }
 
-    POOLS.with(|pools| pools.borrow_mut().insert(id.clone(), entry.clone()));
-    POOL_NAMES.with(|names| names.borrow_mut().insert(name, id.clone()));
-    let snapshot = pool_snapshot_value(&entry.borrow());
+    {
+        let mut registry_ref = registry.inner.lock();
+        if let Some(existing) = registry_ref.names.get(&name) {
+            return Err(VmError::Runtime(format!(
+                "pool_create: pool '{name}' already exists (id={existing}); use pool_get to reuse"
+            )));
+        }
+        registry_ref.pools.insert(id.clone(), entry.clone());
+        registry_ref.names.insert(name, id);
+    }
+    let snapshot = pool_snapshot_value(&entry.lock());
     Ok(snapshot)
 }
 
@@ -1204,32 +1282,29 @@ fn pool_get_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
         .map(VmValue::display)
         .filter(|s| !s.is_empty())
         .ok_or_else(|| VmError::Runtime("pool_get: name is required".to_string()))?;
-    let pool_id = POOL_NAMES.with(|names| names.borrow().get(&key).cloned());
-    let id = match pool_id {
-        Some(id) => id,
-        None => {
-            if POOLS.with(|pools| pools.borrow().contains_key(&key)) {
-                key
-            } else {
-                return Ok(VmValue::Nil);
-            }
-        }
+    let registry = current_pool_registry();
+    let Some(entry) = lookup_pool_by_name_or_id_in_registry(&registry, &key) else {
+        return Ok(VmValue::Nil);
     };
-    let entry = lookup_pool(&id)?;
-    let snapshot = pool_snapshot_value(&entry.borrow());
+    let snapshot = pool_snapshot_value(&entry.lock());
     Ok(snapshot)
 }
 
 /// List every pool registered in the local pool registry.
 #[harn_builtin(sig = "__pool_list() -> list", category = "pool", runtime_only = true)]
 fn pool_list_sync(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let mut entries: Vec<Rc<RefCell<PoolEntry>>> =
-        POOLS.with(|pools| pools.borrow().values().cloned().collect());
-    entries.sort_by(|a, b| a.borrow().created_at.cmp(&b.borrow().created_at));
+    let mut entries: Vec<Arc<parking_lot::Mutex<PoolEntry>>> = current_pool_registry()
+        .inner
+        .lock()
+        .pools
+        .values()
+        .cloned()
+        .collect();
+    entries.sort_by_key(|entry| entry.lock().created_at.clone());
     Ok(VmValue::List(std::sync::Arc::new(
         entries
             .iter()
-            .map(|entry| pool_snapshot_value(&entry.borrow()))
+            .map(|entry| pool_snapshot_value(&entry.lock()))
             .collect(),
     )))
 }
@@ -1247,7 +1322,7 @@ fn pool_size_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         "pool.size",
     )?;
     let entry = lookup_pool(&pool_id)?;
-    let entry = entry.borrow();
+    let entry = entry.lock();
     Ok(VmValue::Int(
         (entry.active.len() + entry.queue.len()) as i64,
     ))
@@ -1283,7 +1358,7 @@ fn pool_snapshot_sync(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
         "pool.snapshot",
     )?;
     let entry = lookup_pool(&pool_id)?;
-    let snapshot = pool_snapshot_value(&entry.borrow());
+    let snapshot = pool_snapshot_value(&entry.lock());
     Ok(snapshot)
 }
 
@@ -1321,15 +1396,16 @@ async fn pool_submit_builtin(
     let priority = parse_priority(&opts)?;
     let idempotency_key = parse_idempotency_key(&opts)?;
 
-    let entry = lookup_pool(&pool_id)?;
+    let registry = ctx.pool_registry();
+    let entry = lookup_pool_in_registry(&registry, &pool_id)?;
     let key = {
-        let pool = entry.borrow();
+        let pool = entry.lock();
         parse_submit_key(&opts, &pool.queue_strategy)?
     };
 
     let state =
         submit_to_pool_entry(Some(&ctx), &entry, closure, key, priority, idempotency_key).await?;
-    let handle = task_handle_value(&state.borrow());
+    let handle = task_handle_value(&state.lock());
     Ok(handle)
 }
 
@@ -1337,20 +1413,6 @@ async fn pool_submit_builtin(
 /// Returns `None` when no pool matches. Used by the trigger dispatcher's
 /// SpawnToPool handler (#1889) so it can route inbound events into named
 /// pools without going through the Harn-level builtin surface.
-fn lookup_pool_by_name_or_id(name_or_id: &str) -> Option<Rc<RefCell<PoolEntry>>> {
-    let id = POOL_NAMES
-        .with(|names| names.borrow().get(name_or_id).cloned())
-        .or_else(|| {
-            POOLS.with(|pools| {
-                pools
-                    .borrow()
-                    .contains_key(name_or_id)
-                    .then(|| name_or_id.to_string())
-            })
-        })?;
-    POOLS.with(|pools| pools.borrow().get(&id).cloned())
-}
-
 /// Public submission outcome returned by [`submit_closure_to_named_pool`].
 /// The dispatcher inspects this to distinguish accepted-and-running tasks
 /// from accepted-but-dropped (drop_newest) tasks so it can emit the right
@@ -1384,7 +1446,8 @@ pub async fn submit_closure_to_named_pool(
     priority: i64,
     key: Option<String>,
 ) -> Result<PoolSubmitOutcome, VmError> {
-    let entry = lookup_pool_by_name_or_id(pool_name).ok_or_else(|| {
+    let registry = pool_registry_for_ctx(ctx);
+    let entry = lookup_pool_by_name_or_id_in_registry(&registry, pool_name).ok_or_else(|| {
         VmError::Runtime(format!(
             "pool: pool '{pool_name}' not found; create it with pool_create first"
         ))
@@ -1392,7 +1455,7 @@ pub async fn submit_closure_to_named_pool(
     // Trigger-dispatcher pool submissions don't carry a caller-supplied
     // idempotency key today; the dispatcher's own dedupe runs upstream.
     let state = submit_to_pool_entry(ctx, &entry, closure, key, priority, None).await?;
-    let task = state.borrow();
+    let task = state.lock();
     Ok(PoolSubmitOutcome {
         pool_id: task.pool_id.clone(),
         pool_name: task.pool_name.clone(),
@@ -1408,12 +1471,12 @@ pub async fn submit_closure_to_named_pool(
 /// the corresponding policies, and fails on `FailFast`/`FailSubmitter`.
 async fn submit_to_pool_entry(
     ctx: Option<&AsyncBuiltinCtx>,
-    entry: &Rc<RefCell<PoolEntry>>,
+    entry: &Arc<parking_lot::Mutex<PoolEntry>>,
     closure: Arc<VmClosure>,
     key: Option<String>,
     priority: i64,
     idempotency_key: Option<String>,
-) -> Result<Rc<RefCell<TaskState>>, VmError> {
+) -> Result<Arc<parking_lot::Mutex<TaskState>>, VmError> {
     // Idempotency short-circuit: if the caller previously submitted with
     // the same key, return the existing task (terminal snapshot or
     // pending handle). Mirrors the durable channel `id`-based dedupe
@@ -1425,7 +1488,7 @@ async fn submit_to_pool_entry(
     }
     let submitted_by = current_submitter(ctx);
     let (pool_id_for_span, pool_name_for_span) = {
-        let pool = entry.borrow();
+        let pool = entry.lock();
         (pool.id.clone(), pool.name.clone())
     };
     loop {
@@ -1451,7 +1514,7 @@ async fn submit_to_pool_entry(
         let submit_link = submit_span.link();
 
         let attempt = {
-            let mut pool = entry.borrow_mut();
+            let mut pool = entry.lock();
             submit_or_wait(
                 ctx,
                 &mut pool,
@@ -1466,13 +1529,14 @@ async fn submit_to_pool_entry(
         match attempt {
             SubmitAttempt::Submitted { task, audits } => {
                 {
-                    let task_ref = task.borrow();
+                    let task_ref = task.lock();
                     submit_span.set_metadata("task_id", serde_json::json!(task_ref.id));
                     submit_span.set_metadata("status", serde_json::json!(task_ref.status.as_str()));
                 }
                 let receipt = {
-                    let task_ref = task.borrow();
-                    pool_submit_receipt(&entry.borrow(), &task_ref)
+                    let pool_ref = entry.lock();
+                    let task_ref = task.lock();
+                    pool_submit_receipt(&pool_ref, &task_ref)
                 };
                 emit_pool_submit_receipt(receipt).await;
                 for audit in audits {
@@ -1524,17 +1588,17 @@ fn current_submitter(ctx: Option<&AsyncBuiltinCtx>) -> String {
 }
 
 fn lookup_idempotency_match(
-    entry: &Rc<RefCell<PoolEntry>>,
+    entry: &Arc<parking_lot::Mutex<PoolEntry>>,
     idempotency_key: &str,
-) -> Option<Rc<RefCell<TaskState>>> {
-    let pool = entry.borrow();
+) -> Option<Arc<parking_lot::Mutex<TaskState>>> {
+    let pool = entry.lock();
     let task_id = pool.idempotency_index.get(idempotency_key)?.clone();
     pool.tasks.get(&task_id).cloned()
 }
 
 enum SubmitAttempt {
     Submitted {
-        task: Rc<RefCell<TaskState>>,
+        task: Arc<parking_lot::Mutex<TaskState>>,
         audits: Vec<PoolDropAudit>,
     },
     Wait(tokio::sync::oneshot::Receiver<()>),
@@ -1698,7 +1762,7 @@ fn submit_with_oldest_drop(
         submit_span_link,
         submitted_by,
     );
-    let replacement_task_id = state.borrow().id.clone();
+    let replacement_task_id = state.lock().id.clone();
     let mut audits = Vec::new();
     if let Some(dropped) = pool.queue.pop_front() {
         audits.push(reject_pending_task(
@@ -1743,10 +1807,10 @@ fn submit_with_newest_drop(
         submit_span_link,
         submitted_by,
     );
-    let task_id = state.borrow().id.clone();
+    let task_id = state.lock().id.clone();
     let waiters = reject_task_state(&state, reason, policy);
     wake_task_waiters(waiters);
-    persist_task_if_durable(pool, &state.borrow());
+    persist_task_if_durable(pool, &state.lock());
     let audit = pool_drop_audit(pool, &task_id, None, reason, policy, queue_depth, max_depth);
     SubmitAttempt::Submitted {
         task: state,
@@ -1763,12 +1827,12 @@ fn create_pending_task(
     idempotency_key: Option<String>,
     submit_span_link: Option<crate::tracing::SpanLink>,
     submitted_by: String,
-) -> (Rc<RefCell<TaskState>>, PendingTask) {
+) -> (Arc<parking_lot::Mutex<TaskState>>, PendingTask) {
     pool.submit_counter += 1;
     let seq = pool.submit_counter;
     let task_id = next_task_id(pool);
     let now_ms = now_ms_for_pool();
-    let state = Rc::new(RefCell::new(TaskState {
+    let state = Arc::new(parking_lot::Mutex::new(TaskState {
         id: task_id.clone(),
         pool_id: pool.id.clone(),
         pool_name: pool.name.clone(),
@@ -1793,7 +1857,7 @@ fn create_pending_task(
         pool.idempotency_index.insert(idem.clone(), task_id.clone());
     }
     pool.tasks.insert(task_id.clone(), state.clone());
-    persist_task_if_durable(pool, &state.borrow());
+    persist_task_if_durable(pool, &state.lock());
     let pending = PendingTask {
         task_id,
         closure,
@@ -1820,7 +1884,7 @@ fn persist_task_if_durable(pool: &PoolEntry, state: &TaskState) {
     let record = PoolRecord::Task {
         task: persisted_task_from_state(state),
     };
-    if let Err(err) = store.borrow().append(&record) {
+    if let Err(err) = store.lock().append(&record) {
         // Best-effort: log + swallow rather than poisoning the submit
         // path. A genuine fsync failure surfaces on the next compact.
         let _ = err;
@@ -1869,22 +1933,22 @@ fn persisted_task_from_state(state: &TaskState) -> PersistedTask {
 /// without violating idempotency. The pool file is compacted in place
 /// so the next process restart sees a tidy log.
 fn rehydrate_persisted_state(
-    entry: &Rc<RefCell<PoolEntry>>,
-    store: &Rc<RefCell<PoolDurableStore>>,
+    entry: &Arc<parking_lot::Mutex<PoolEntry>>,
+    store: &Arc<parking_lot::Mutex<PoolDurableStore>>,
     persisted: PersistedPoolState,
     stale_after_ms: i64,
 ) -> Result<(), VmError> {
     let now = now_ms_for_pool();
     let mut idempotency_index: HashMap<String, String> = HashMap::new();
-    let mut tasks: BTreeMap<String, Rc<RefCell<TaskState>>> = BTreeMap::new();
+    let mut tasks: BTreeMap<String, Arc<parking_lot::Mutex<TaskState>>> = BTreeMap::new();
     let mut rehydrated_persisted: Vec<PersistedTask> = Vec::new();
 
     {
-        let mut pool = entry.borrow_mut();
+        let mut pool = entry.lock();
         for (_, task) in persisted.tasks {
             let live = task_state_from_persisted(&pool, &task, now, stale_after_ms);
             let (task_id, idem) = {
-                let borrowed = live.borrow();
+                let borrowed = live.lock();
                 rehydrated_persisted.push(persisted_task_from_state(&borrowed));
                 (borrowed.id.clone(), borrowed.idempotency_key.clone())
             };
@@ -1899,8 +1963,8 @@ fn rehydrate_persisted_state(
 
     // Rewrite the file with the compacted snapshot. Atomic so a crash
     // mid-rewrite leaves the previous log intact.
-    let meta = persisted_meta_from_entry(&entry.borrow());
-    store.borrow().compact(&meta, &rehydrated_persisted)?;
+    let meta = persisted_meta_from_entry(&entry.lock());
+    store.lock().compact(&meta, &rehydrated_persisted)?;
     Ok(())
 }
 
@@ -1909,7 +1973,7 @@ fn task_state_from_persisted(
     persisted: &PersistedTask,
     now: i64,
     stale_after_ms: i64,
-) -> Rc<RefCell<TaskState>> {
+) -> Arc<parking_lot::Mutex<TaskState>> {
     let status = match persisted.status.as_str() {
         "queued" | "running" => {
             // Both `queued` and `running` survive a crash as "stale"
@@ -1959,7 +2023,7 @@ fn task_state_from_persisted(
         .as_ref()
         .map(|text| VmValue::String(std::sync::Arc::from(text.as_str())));
 
-    Rc::new(RefCell::new(TaskState {
+    Arc::new(parking_lot::Mutex::new(TaskState {
         id: persisted.id.clone(),
         pool_id: pool.id.clone(),
         pool_name: pool.name.clone(),
@@ -1992,11 +2056,11 @@ fn enqueue_task(pool: &mut PoolEntry, pending: PendingTask) {
     pool.queue.push_back(pending);
 }
 
-fn dispatch_ready(pool: &Rc<RefCell<PoolEntry>>) {
+fn dispatch_ready(pool: &Arc<parking_lot::Mutex<PoolEntry>>) {
     let mut freed_queue_space = false;
     loop {
         let next = {
-            let mut pool_ref = pool.borrow_mut();
+            let mut pool_ref = pool.lock();
             if pool_ref.active.len() >= pool_ref.max_concurrent {
                 break;
             }
@@ -2026,7 +2090,7 @@ fn reject_pending_task(
     let task_id = pending.task_id.clone();
     let waiters = reject_task_state(&pending.state, reason, policy);
     wake_task_waiters(waiters);
-    persist_task_if_durable(pool, &pending.state.borrow());
+    persist_task_if_durable(pool, &pending.state.lock());
     pool_drop_audit(
         pool,
         &task_id,
@@ -2039,11 +2103,11 @@ fn reject_pending_task(
 }
 
 fn reject_task_state(
-    state: &Rc<RefCell<TaskState>>,
+    state: &Arc<parking_lot::Mutex<TaskState>>,
     reason: &str,
     policy: &str,
 ) -> Vec<tokio::sync::oneshot::Sender<()>> {
-    let mut state_ref = state.borrow_mut();
+    let mut state_ref = state.lock();
     state_ref.status = TaskStatus::Rejected;
     state_ref.finished_at = Some(uuid::Uuid::now_v7().to_string());
     state_ref.heartbeat_at_ms = now_ms_for_pool();
@@ -2059,9 +2123,9 @@ fn wake_task_waiters(waiters: Vec<tokio::sync::oneshot::Sender<()>>) {
     }
 }
 
-fn wake_space_waiters(pool: &Rc<RefCell<PoolEntry>>) {
+fn wake_space_waiters(pool: &Arc<parking_lot::Mutex<PoolEntry>>) {
     let waiters = {
-        let mut pool_ref = pool.borrow_mut();
+        let mut pool_ref = pool.lock();
         std::mem::take(&mut pool_ref.space_waiters)
     };
     for waiter in waiters {
@@ -2170,7 +2234,10 @@ fn pool_dequeue_receipt(
     }
 }
 
-async fn emit_pool_dequeue_receipt(receipt: PoolDequeueReceipt) {
+async fn emit_pool_dequeue_receipt(
+    event_log: Arc<crate::event_log::AnyEventLog>,
+    receipt: PoolDequeueReceipt,
+) {
     let topic = Topic::new(POOL_AUDIT_TOPIC).expect("static pool audit topic is valid");
     let mut headers = BTreeMap::new();
     headers.insert("schema".to_string(), "harn.pool_dequeue.v1".to_string());
@@ -2182,7 +2249,7 @@ async fn emit_pool_dequeue_receipt(receipt: PoolDequeueReceipt) {
         "queued_for_ms": receipt.queued_for_ms,
         "slot_index": receipt.slot_index,
     });
-    let _ = ensure_pool_event_log()
+    let _ = event_log
         .append(
             &topic,
             LogEvent::new("pool_dequeue", payload).with_headers(headers),
@@ -2258,7 +2325,7 @@ fn fair_key(pending: &PendingTask) -> String {
     pending.key.clone().unwrap_or_default()
 }
 
-fn spawn_task(pool: Rc<RefCell<PoolEntry>>, pending: PendingTask) {
+fn spawn_task(pool: Arc<parking_lot::Mutex<PoolEntry>>, pending: PendingTask) {
     let PendingTask {
         task_id,
         closure,
@@ -2273,7 +2340,7 @@ fn spawn_task(pool: Rc<RefCell<PoolEntry>>, pending: PendingTask) {
     // and the natural parent of that work is the submitter's pipeline,
     // not the unrelated current span. Linking back to the submit span
     // via `set_span_link` is what stitches the trace tree together.
-    let submit_link = state.borrow().submit_span_link.clone();
+    let submit_link = state.lock().submit_span_link.clone();
     let span_links: Vec<crate::tracing::SpanLink> = submit_link
         .into_iter()
         .map(|link| {
@@ -2284,7 +2351,7 @@ fn spawn_task(pool: Rc<RefCell<PoolEntry>>, pending: PendingTask) {
         })
         .collect();
     let (pool_id_for_span, pool_name_for_span) = {
-        let pool_ref = pool.borrow();
+        let pool_ref = pool.lock();
         (pool_ref.id.clone(), pool_ref.name.clone())
     };
     let mut dequeue_span = PoolSpanGuard::start_detached(
@@ -2297,17 +2364,17 @@ fn spawn_task(pool: Rc<RefCell<PoolEntry>>, pending: PendingTask) {
     dequeue_span.set_metadata("task_id", serde_json::json!(task_id));
 
     {
-        let mut state_ref = state.borrow_mut();
+        let mut state_ref = state.lock();
         state_ref.status = TaskStatus::Running;
         state_ref.started_at = Some(uuid::Uuid::now_v7().to_string());
         state_ref.heartbeat_at_ms = now_ms_for_pool();
     }
     let dequeue_receipt = {
-        let mut pool_ref = pool.borrow_mut();
+        let mut pool_ref = pool.lock();
         pool_ref.active.insert(task_id, state.clone());
         let slot_index = pool_ref.active.len().saturating_sub(1);
-        let receipt = pool_dequeue_receipt(&pool_ref, &state.borrow(), slot_index);
-        persist_task_if_durable(&pool_ref, &state.borrow());
+        let receipt = pool_dequeue_receipt(&pool_ref, &state.lock(), slot_index);
+        persist_task_if_durable(&pool_ref, &state.lock());
         receipt
     };
 
@@ -2317,10 +2384,11 @@ fn spawn_task(pool: Rc<RefCell<PoolEntry>>, pending: PendingTask) {
     );
     dequeue_span.set_metadata("slot_index", serde_json::json!(dequeue_receipt.slot_index));
 
-    // Hand the dequeue receipt off to a tokio task. Append is async; we
-    // already hold a sync borrow on the pool registry here so awaiting in
-    // place would deadlock the next caller of `dispatch_ready`.
-    tokio::task::spawn_local(emit_pool_dequeue_receipt(dequeue_receipt));
+    // Hand the dequeue receipt off to a Tokio task. Capture the active event
+    // log before crossing the work-stealing boundary so audit events stay on
+    // the submitter's log instead of binding to a worker thread default.
+    let event_log = ensure_pool_event_log();
+    tokio::spawn(emit_pool_dequeue_receipt(event_log, dequeue_receipt));
 
     let Some(ctx) = context else {
         dequeue_span.end();
@@ -2338,26 +2406,43 @@ fn spawn_task(pool: Rc<RefCell<PoolEntry>>, pending: PendingTask) {
     // under whatever spans it opens for its own work.
     dequeue_span.end();
 
-    tokio::task::spawn_local(async move {
-        let mut runner = ctx.child_vm();
-        let outcome = runner
-            .call_closure_args(&closure, crate::vm::CallArgs::Empty)
-            .await
-            .map_err(|error| error.to_string());
-        ctx.forward_output(&runner.take_output());
+    let registry = ctx.pool_registry();
+    tokio::spawn(with_pool_registry_scope(registry, async move {
+        tokio::task::yield_now().await;
+        let outcome = std::panic::AssertUnwindSafe(async {
+            let mut runner = ctx.child_vm();
+            let outcome = runner
+                .call_closure_args(&closure, crate::vm::CallArgs::Empty)
+                .await
+                .map_err(|error| error.to_string());
+            ctx.forward_output(&runner.take_output());
+            outcome
+        })
+        .catch_unwind()
+        .await
+        .unwrap_or_else(|payload| Err(pool_panic_error(payload)));
         finalize_task(&pool, &state, outcome);
-    });
+    }));
+}
+
+fn pool_panic_error(payload: Box<dyn Any + Send>) -> String {
+    let message = payload
+        .downcast_ref::<&'static str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload");
+    format!("pool task panicked: {message}")
 }
 
 fn finalize_task(
-    pool: &Rc<RefCell<PoolEntry>>,
-    state: &Rc<RefCell<TaskState>>,
+    pool: &Arc<parking_lot::Mutex<PoolEntry>>,
+    state: &Arc<parking_lot::Mutex<TaskState>>,
     outcome: Result<VmValue, String>,
 ) {
     let waiters: Vec<tokio::sync::oneshot::Sender<()>>;
     let task_id;
     {
-        let mut state_ref = state.borrow_mut();
+        let mut state_ref = state.lock();
         state_ref.finished_at = Some(uuid::Uuid::now_v7().to_string());
         state_ref.heartbeat_at_ms = now_ms_for_pool();
         match outcome {
@@ -2374,9 +2459,9 @@ fn finalize_task(
         waiters = std::mem::take(&mut state_ref.waiters);
     }
     {
-        let mut pool_ref = pool.borrow_mut();
+        let mut pool_ref = pool.lock();
         pool_ref.active.remove(&task_id);
-        persist_task_if_durable(&pool_ref, &state.borrow());
+        persist_task_if_durable(&pool_ref, &state.lock());
     }
     wake_task_waiters(waiters);
     dispatch_ready(pool);
@@ -2391,36 +2476,40 @@ fn finalize_task(
     runtime_only = true
 )]
 async fn pool_wait_builtin(
-    _ctx: crate::vm::AsyncBuiltinCtx,
+    ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let target = args
         .first()
         .ok_or_else(|| VmError::Runtime("pool_wait: task handle is required".to_string()))?;
+    let registry = ctx.pool_registry();
     match target {
         VmValue::List(items) => {
             let mut results = Vec::with_capacity(items.len());
             for item in items.iter() {
-                results.push(wait_single_task(item).await?);
+                results.push(wait_single_task(&registry, item).await?);
             }
             Ok(VmValue::List(std::sync::Arc::new(results)))
         }
-        _ => wait_single_task(target).await,
+        _ => wait_single_task(&registry, target).await,
     }
 }
 
-async fn wait_single_task(value: &VmValue) -> Result<VmValue, VmError> {
+async fn wait_single_task(
+    registry: &Arc<PoolRegistry>,
+    value: &VmValue,
+) -> Result<VmValue, VmError> {
     let (pool_id, task_id) = task_handle_from_value(value, "pool_wait")?;
-    let entry = lookup_pool(&pool_id)?;
+    let entry = lookup_pool_in_registry(registry, &pool_id)?;
     let state = {
-        let pool = entry.borrow();
+        let pool = entry.lock();
         pool.tasks
             .get(&task_id)
             .cloned()
             .ok_or_else(|| VmError::Runtime(format!("pool_wait: task not found: {task_id}")))?
     };
     let receiver = {
-        let mut state_ref = state.borrow_mut();
+        let mut state_ref = state.lock();
         if state_ref.status.is_terminal() {
             return Ok(task_snapshot_value(&state_ref));
         }
@@ -2432,7 +2521,7 @@ async fn wait_single_task(value: &VmValue) -> Result<VmValue, VmError> {
     // receiver. Either is fine: we only care that the task reached a
     // terminal state, which `finalize_task` guarantees before signaling.
     let _ = receiver.await;
-    let snapshot = task_snapshot_value(&state.borrow());
+    let snapshot = task_snapshot_value(&state.lock());
     Ok(snapshot)
 }
 
@@ -2460,8 +2549,7 @@ pub(crate) fn register_pool_builtins(vm: &mut Vm) {
 /// `.harn/pools/` are intentionally NOT removed — that is the whole
 /// point of pipeline-scope durability.
 pub fn reset_pool_state() {
-    POOLS.with(|pools| pools.borrow_mut().clear());
-    POOL_NAMES.with(|names| names.borrow_mut().clear());
+    current_pool_registry().inner.lock().clear();
 }
 
 /// Snapshot every pool task that has not yet reached a terminal state.
@@ -2470,37 +2558,40 @@ pub fn reset_pool_state() {
 /// `UnsettledStateSnapshot` so pipeline `on_finish` callbacks (drain,
 /// abandon, handoff presets) can observe pool work alongside suspended
 /// sub-agents, queued triggers, partial handoffs, and in-flight LLM
-/// calls. Walks the thread-local `POOLS` registry once, emitting one
+/// calls. Walks the active pool registry once, emitting one
 /// JSON entry per task whose status is `queued` or `running`. Order is
 /// pool-id ascending, then queued tasks in queue order followed by
-/// running tasks in `tasks` btree order, so successive snapshots within
-/// a single thread are deterministic.
+/// running tasks in `tasks` btree order, so successive snapshots from
+/// one logical execution are deterministic.
 pub(crate) fn snapshot_pending_tasks() -> Vec<serde_json::Value> {
     let now_ms = crate::stdlib::clock::now_wall_ms();
-    POOLS.with(|pools| {
-        let registry = pools.borrow();
-        let mut ordered: Vec<(&String, &Rc<RefCell<PoolEntry>>)> = registry.iter().collect();
-        ordered.sort_by(|a, b| a.0.cmp(b.0));
-        let mut out = Vec::new();
-        for (_pool_id, entry) in ordered {
-            let pool = entry.borrow();
-            for pending in &pool.queue {
-                let task = pending.state.borrow();
-                if task.status.is_terminal() {
-                    continue;
-                }
-                out.push(pending_task_snapshot_json(&pool, &task, now_ms));
+    let mut ordered: Vec<(String, Arc<parking_lot::Mutex<PoolEntry>>)> = current_pool_registry()
+        .inner
+        .lock()
+        .pools
+        .iter()
+        .map(|(pool_id, entry)| (pool_id.clone(), entry.clone()))
+        .collect();
+    ordered.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = Vec::new();
+    for (_pool_id, entry) in ordered {
+        let pool = entry.lock();
+        for pending in &pool.queue {
+            let task = pending.state.lock();
+            if task.status.is_terminal() {
+                continue;
             }
-            for state in pool.tasks.values() {
-                let task = state.borrow();
-                if task.status != TaskStatus::Running {
-                    continue;
-                }
-                out.push(pending_task_snapshot_json(&pool, &task, now_ms));
-            }
+            out.push(pending_task_snapshot_json(&pool, &task, now_ms));
         }
-        out
-    })
+        for state in pool.tasks.values() {
+            let task = state.lock();
+            if task.status != TaskStatus::Running {
+                continue;
+            }
+            out.push(pending_task_snapshot_json(&pool, &task, now_ms));
+        }
+    }
+    out
 }
 
 fn pending_task_snapshot_json(

--- a/crates/harn-vm/src/stdlib/postgres/introspect.rs
+++ b/crates/harn-vm/src/stdlib/postgres/introspect.rs
@@ -556,7 +556,7 @@ fn prune_subtree<'a>(
     dry_run: bool,
     builtin: &'static str,
     pruned: &'a mut Vec<VmValue>,
-) -> Pin<Box<dyn Future<Output = Result<(), VmError>> + 'a>> {
+) -> Pin<Box<dyn Future<Output = Result<(), VmError>> + Send + 'a>> {
     Box::pin(async move {
         let rows = bind_params(query(PARTITION_CHILDREN_SQL), &[VmValue::Int(parent_oid)])
             .fetch_all(pool)

--- a/crates/harn-vm/src/stdlib/postgres/migrate.rs
+++ b/crates/harn-vm/src/stdlib/postgres/migrate.rs
@@ -9,8 +9,10 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
+use sqlx_core::executor::Executor;
 use sqlx_core::row::Row;
 use sqlx_postgres::PgPool;
 
@@ -25,7 +27,7 @@ const MIGRATION_LOCK_KEY: i64 = 0x4861_726E_4D67_7201;
 
 const DEFAULT_TABLE: &str = "harn_migrations";
 
-pub(super) async fn run(args: &[VmValue]) -> Result<VmValue, VmError> {
+pub(super) async fn run(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let pool_handle = args.first().ok_or_else(|| {
         runtime_error("pg_migrate: pool handle is required as the first argument")
     })?;
@@ -53,27 +55,27 @@ pub(super) async fn run(args: &[VmValue]) -> Result<VmValue, VmError> {
     let entries = discover_migrations(&dir)?;
 
     let started = Instant::now();
-    acquire_lock(&pool).await?;
+    acquire_lock(pool.clone()).await?;
     let result = async {
-        ensure_migrations_table(&pool, &table_name).await?;
-        let applied = applied_set(&pool, &table_name).await?;
+        ensure_migrations_table(pool.clone(), table_name.clone()).await?;
+        let applied = applied_set(pool.clone(), table_name.clone()).await?;
 
         let mut applied_now = Vec::new();
         let mut skipped = Vec::new();
-        for entry in &entries {
+        for entry in entries.iter().cloned() {
             if applied.contains(&entry.name) {
                 skipped.push(entry.name.clone());
                 continue;
             }
             if !dry_run {
-                apply_one(&pool, &table_name, entry).await?;
+                apply_one(pool.clone(), table_name.clone(), entry.clone()).await?;
             }
             applied_now.push(entry.name.clone());
         }
         Ok::<_, VmError>((applied_now, skipped))
     }
     .await;
-    release_lock(&pool).await;
+    release_lock(pool.clone()).await;
     let (applied_now, skipped) = result?;
 
     let mut response = BTreeMap::new();
@@ -130,6 +132,7 @@ fn dir_arg(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<PathBuf, VmErr
     }
 }
 
+#[derive(Clone)]
 struct MigrationEntry {
     name: String,
     path: PathBuf,
@@ -164,7 +167,7 @@ fn discover_migrations(dir: &Path) -> Result<Vec<MigrationEntry>, VmError> {
     Ok(entries)
 }
 
-async fn ensure_migrations_table(pool: &PgPool, table: &str) -> Result<(), VmError> {
+async fn ensure_migrations_table(pool: Arc<PgPool>, table: String) -> Result<(), VmError> {
     let sql = format!(
         "CREATE TABLE IF NOT EXISTS \"{table}\" (\
              name TEXT PRIMARY KEY,\
@@ -172,17 +175,17 @@ async fn ensure_migrations_table(pool: &PgPool, table: &str) -> Result<(), VmErr
              checksum BYTEA NOT NULL\
          )"
     );
-    sqlx_core::raw_sql::raw_sql(&sql)
-        .execute(pool)
+    pool.as_ref()
+        .execute(sql.as_str())
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: ensure table failed: {error}")))?;
     Ok(())
 }
 
-async fn applied_set(pool: &PgPool, table: &str) -> Result<BTreeSet<String>, VmError> {
+async fn applied_set(pool: Arc<PgPool>, table: String) -> Result<BTreeSet<String>, VmError> {
     let sql = format!("SELECT name FROM \"{table}\"");
     let rows = sqlx_core::query::query::<sqlx_postgres::Postgres>(&sql)
-        .fetch_all(pool)
+        .fetch_all(pool.as_ref())
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: select applied failed: {error}")))?;
     Ok(rows
@@ -191,7 +194,7 @@ async fn applied_set(pool: &PgPool, table: &str) -> Result<BTreeSet<String>, VmE
         .collect::<BTreeSet<_>>())
 }
 
-async fn apply_one(pool: &PgPool, table: &str, entry: &MigrationEntry) -> Result<(), VmError> {
+async fn apply_one(pool: Arc<PgPool>, table: String, entry: MigrationEntry) -> Result<(), VmError> {
     let sql = std::fs::read_to_string(&entry.path).map_err(|error| {
         runtime_error(format!(
             "pg_migrate: could not read {}: {error}",
@@ -205,8 +208,8 @@ async fn apply_one(pool: &PgPool, table: &str, entry: &MigrationEntry) -> Result
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: begin failed: {error}")))?;
 
-    sqlx_core::raw_sql::raw_sql(&sql)
-        .execute(&mut *tx)
+    (&mut *tx)
+        .execute(sql.as_str())
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: applying {}: {error}", entry.name)))?;
 
@@ -225,19 +228,19 @@ async fn apply_one(pool: &PgPool, table: &str, entry: &MigrationEntry) -> Result
     })
 }
 
-async fn acquire_lock(pool: &PgPool) -> Result<(), VmError> {
+async fn acquire_lock(pool: Arc<PgPool>) -> Result<(), VmError> {
     sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT pg_advisory_lock($1)")
         .bind(MIGRATION_LOCK_KEY)
-        .execute(pool)
+        .execute(pool.as_ref())
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: advisory lock failed: {error}")))?;
     Ok(())
 }
 
-async fn release_lock(pool: &PgPool) {
+async fn release_lock(pool: Arc<PgPool>) {
     let _ = sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT pg_advisory_unlock($1)")
         .bind(MIGRATION_LOCK_KEY)
-        .execute(pool)
+        .execute(pool.as_ref())
         .await;
 }
 

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Bound;
-use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -9,6 +8,7 @@ use std::time::Duration;
 
 use sqlx_core::column::Column;
 use sqlx_core::connection::Connection;
+use sqlx_core::executor::Executor;
 use sqlx_core::query::{query, Query};
 use sqlx_core::row::Row;
 use sqlx_core::transaction::Transaction;
@@ -61,7 +61,7 @@ struct MockPool {
     calls: Vec<VmValue>,
 }
 
-type PgTxCell = Rc<Mutex<Option<Transaction<'static, Postgres>>>>;
+type PgTxCell = Arc<Mutex<Option<Transaction<'static, Postgres>>>>;
 type PgTxRegistry = BTreeMap<String, PgTxCell>;
 
 thread_local! {
@@ -399,7 +399,7 @@ pub(super) async fn run_managed_transaction(
     prepare: impl FnOnce(
         &str,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<(), VmError>> + '_>,
+        Box<dyn std::future::Future<Output = Result<(), VmError>> + Send + '_>,
     >,
 ) -> Result<VmValue, VmError> {
     let pool = pool_by_id(pool_id)?;
@@ -408,8 +408,8 @@ pub(super) async fn run_managed_transaction(
         .await
         .map_err(|error| runtime_error(format!("{builtin}: begin failed: {error}")))?;
     let tx_id = next_id("pgtx");
-    let tx_cell = Rc::new(Mutex::new(Some(tx)));
-    register_tx(&tx_id, Rc::clone(&tx_cell));
+    let tx_cell = Arc::new(Mutex::new(Some(tx)));
+    register_tx(&tx_id, Arc::clone(&tx_cell));
     let tx_handle = handle_value(HANDLE_TX, &tx_id, BTreeMap::new());
 
     if let Err(error) = prepare(&tx_id).await {
@@ -489,7 +489,7 @@ async fn pg_migrate_impl(
     _ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
-    migrate::run(&args).await
+    migrate::run(args).await
 }
 
 #[harn_builtin(
@@ -851,8 +851,8 @@ async fn savepoint_op(
         .as_mut()
         .ok_or_else(|| runtime_error(format!("{builtin}: transaction is closed")))?;
     let sql = render_savepoint_sql(op, &name);
-    sqlx_core::raw_sql::raw_sql(&sql)
-        .execute(&mut **tx)
+    (&mut **tx)
+        .execute(sql.as_str())
         .await
         .map_err(|error| runtime_error(format!("{builtin}: {error}")))?;
     Ok(VmValue::Bool(true))

--- a/crates/harn-vm/src/stdlib/supervisor.rs
+++ b/crates/harn-vm/src/stdlib/supervisor.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -94,7 +93,7 @@ struct SupervisorState {
 
 #[derive(Clone)]
 struct SupervisorHandle {
-    state: Rc<RefCell<SupervisorState>>,
+    state: Arc<parking_lot::Mutex<SupervisorState>>,
     _tx: mpsc::UnboundedSender<SupervisorMsg>,
 }
 
@@ -144,7 +143,7 @@ async fn supervisor_start_impl(
         .first()
         .ok_or_else(|| VmError::Runtime("supervisor_start: spec is required".to_string()))?;
     let handle = start_supervisor(base_vm, spec)?;
-    let value = supervisor_handle_value(&handle.state.borrow());
+    let value = supervisor_handle_value(&handle.state.lock());
     Ok(value)
 }
 
@@ -154,7 +153,7 @@ async fn supervisor_start_impl(
 )]
 fn supervisor_state_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let state = supervisor_from_args(args, "supervisor_state")?;
-    let value = supervisor_state_value(&state.borrow());
+    let value = supervisor_state_value(&state.lock());
     Ok(value)
 }
 
@@ -164,7 +163,7 @@ fn supervisor_state_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue,
 )]
 fn supervisor_events_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let state = supervisor_from_args(args, "supervisor_events")?;
-    let value = events_value(&state.borrow());
+    let value = events_value(&state.lock());
     Ok(value)
 }
 
@@ -174,7 +173,7 @@ fn supervisor_events_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue
 )]
 fn supervisor_metrics_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let state = supervisor_from_args(args, "supervisor_metrics")?;
-    let value = metrics_value(&state.borrow());
+    let value = metrics_value(&state.lock());
     Ok(value)
 }
 
@@ -191,12 +190,12 @@ async fn supervisor_stop_impl(
     let timeout_ms = args
         .get(1)
         .and_then(duration_ms)
-        .unwrap_or_else(|| supervisor_lookup(&id).map_or(5000, |h| h.state.borrow().shutdown_ms));
+        .unwrap_or_else(|| supervisor_lookup(&id).map_or(5000, |h| h.state.lock().shutdown_ms));
     let handle = supervisor_lookup(&id)
         .ok_or_else(|| VmError::Runtime(format!("supervisor_stop: unknown supervisor '{id}'")))?;
 
     {
-        let mut state = handle.state.borrow_mut();
+        let mut state = handle.state.lock();
         if state.status != "stopped" {
             state.status = "draining".to_string();
             state.stop_requested = true;
@@ -217,7 +216,7 @@ async fn supervisor_stop_impl(
     loop {
         if handle
             .state
-            .borrow()
+            .lock()
             .children
             .iter()
             .all(|child| !matches!(child.status.as_str(), "running" | "draining"))
@@ -231,7 +230,7 @@ async fn supervisor_stop_impl(
     }
 
     {
-        let mut state = handle.state.borrow_mut();
+        let mut state = handle.state.lock();
         let mut forced = false;
         for idx in 0..state.children.len() {
             let child = &mut state.children[idx];
@@ -266,11 +265,11 @@ async fn supervisor_stop_impl(
         );
     }
 
-    if let Some(join) = handle.state.borrow_mut().supervisor_join.take() {
+    if let Some(join) = handle.state.lock().supervisor_join.take() {
         join.abort();
     }
 
-    let value = supervisor_state_value(&handle.state.borrow());
+    let value = supervisor_state_value(&handle.state.lock());
     Ok(value)
 }
 
@@ -321,7 +320,7 @@ fn start_supervisor(base_vm: Vm, spec_value: &VmValue) -> Result<SupervisorHandl
         })
         .collect();
 
-    let state = Rc::new(RefCell::new(SupervisorState {
+    let state = Arc::new(parking_lot::Mutex::new(SupervisorState {
         id,
         name,
         strategy,
@@ -348,26 +347,26 @@ fn start_supervisor(base_vm: Vm, spec_value: &VmValue) -> Result<SupervisorHandl
     SUPERVISORS.with(|registry| {
         registry
             .borrow_mut()
-            .insert(state.borrow().id.clone(), handle.clone());
+            .insert(state.lock().id.clone(), handle.clone());
     });
 
     let supervisor_join =
-        tokio::task::spawn_local(supervisor_loop(state.clone(), tx, rx, Rc::new(base_vm)));
-    state.borrow_mut().supervisor_join = Some(supervisor_join);
+        tokio::task::spawn_local(supervisor_loop(state.clone(), tx, rx, Arc::new(base_vm)));
+    state.lock().supervisor_join = Some(supervisor_join);
     Ok(handle)
 }
 
 async fn supervisor_loop(
-    state: Rc<RefCell<SupervisorState>>,
+    state: Arc<parking_lot::Mutex<SupervisorState>>,
     tx: mpsc::UnboundedSender<SupervisorMsg>,
     mut rx: mpsc::UnboundedReceiver<SupervisorMsg>,
-    base_vm: Rc<Vm>,
+    base_vm: Arc<Vm>,
 ) {
     {
-        let mut state_ref = state.borrow_mut();
+        let mut state_ref = state.lock();
         push_event(&mut state_ref, None, "supervisor_started", None);
     }
-    let len = state.borrow().children.len();
+    let len = state.lock().children.len();
     for index in 0..len {
         spawn_child(state.clone(), tx.clone(), base_vm.clone(), index, false);
     }
@@ -381,7 +380,7 @@ async fn supervisor_loop(
                 output,
             } => {
                 if !output.is_empty() {
-                    let mut state_ref = state.borrow_mut();
+                    let mut state_ref = state.lock();
                     let name = state_ref
                         .children
                         .get(index)
@@ -399,7 +398,7 @@ async fn supervisor_loop(
             }
             SupervisorMsg::RestartDue { index, generation } => {
                 let should_spawn = {
-                    let state_ref = state.borrow();
+                    let state_ref = state.lock();
                     state_ref.children.get(index).is_some_and(|child| {
                         child.generation == generation && !state_ref.stop_requested
                     })
@@ -410,8 +409,8 @@ async fn supervisor_loop(
             }
         }
 
-        if supervisor_terminal(&state.borrow()) {
-            let mut state_ref = state.borrow_mut();
+        if supervisor_terminal(&state.lock()) {
+            let mut state_ref = state.lock();
             if state_ref.status == "running" {
                 state_ref.status = "completed".to_string();
                 push_event(&mut state_ref, None, "supervisor_completed", None);
@@ -422,9 +421,9 @@ async fn supervisor_loop(
 }
 
 fn handle_child_exit(
-    state: Rc<RefCell<SupervisorState>>,
+    state: Arc<parking_lot::Mutex<SupervisorState>>,
     tx: mpsc::UnboundedSender<SupervisorMsg>,
-    base_vm: Rc<Vm>,
+    base_vm: Arc<Vm>,
     index: usize,
     generation: u64,
     result: Result<VmValue, String>,
@@ -433,7 +432,7 @@ fn handle_child_exit(
     let mut restart_plan = Vec::new();
 
     {
-        let mut state_ref = state.borrow_mut();
+        let mut state_ref = state.lock();
         if index >= state_ref.children.len() || state_ref.children[index].generation != generation {
             return;
         }
@@ -663,14 +662,14 @@ fn restart_decision(
 }
 
 fn spawn_child(
-    state: Rc<RefCell<SupervisorState>>,
+    state: Arc<parking_lot::Mutex<SupervisorState>>,
     tx: mpsc::UnboundedSender<SupervisorMsg>,
-    base_vm: Rc<Vm>,
+    base_vm: Arc<Vm>,
     index: usize,
     is_restart: bool,
 ) {
     let (spec, supervisor_id, generation, cancel_token) = {
-        let mut state_ref = state.borrow_mut();
+        let mut state_ref = state.lock();
         if state_ref.stop_requested || index >= state_ref.children.len() {
             return;
         }
@@ -725,7 +724,7 @@ fn spawn_child(
         });
     });
 
-    if let Some(child) = state.borrow_mut().children.get_mut(index) {
+    if let Some(child) = state.lock().children.get_mut(index) {
         child.join = Some(join);
     }
 }
@@ -926,7 +925,7 @@ fn require_dict<'a>(
 fn supervisor_from_args(
     args: &[VmValue],
     builtin: &str,
-) -> Result<Rc<RefCell<SupervisorState>>, VmError> {
+) -> Result<Arc<parking_lot::Mutex<SupervisorState>>, VmError> {
     let id = supervisor_id_from_args(args, builtin)?;
     supervisor_lookup(&id)
         .map(|handle| handle.state)
@@ -1068,7 +1067,7 @@ pub(crate) fn supervisor_debug_values() -> VmValue {
             registry
                 .borrow()
                 .values()
-                .map(|handle| supervisor_state_value(&handle.state.borrow()))
+                .map(|handle| supervisor_state_value(&handle.state.lock()))
                 .collect(),
         ))
     })
@@ -1078,7 +1077,7 @@ pub(crate) fn reset_supervisor_state() {
     SUPERVISORS.with(|registry| {
         let mut registry = registry.borrow_mut();
         for handle in registry.values_mut() {
-            let mut state = handle.state.borrow_mut();
+            let mut state = handle.state.lock();
             for child in &mut state.children {
                 if let Some(token) = &child.cancel_token {
                     token.store(true, Ordering::SeqCst);

--- a/crates/harn-vm/src/stdlib/vision.rs
+++ b/crates/harn-vm/src/stdlib/vision.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::path::Path;
 use std::process::Stdio;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use base64::Engine;
@@ -16,7 +16,7 @@ use crate::vm::Vm;
 const VISION_OCR_AUDIT_TOPIC: &str = "audit.vision_ocr";
 
 thread_local! {
-    static OCR_BACKEND_OVERRIDE: RefCell<Option<Rc<dyn OcrBackend>>> = RefCell::new(None);
+    static OCR_BACKEND_OVERRIDE: RefCell<Option<Arc<dyn OcrBackend>>> = RefCell::new(None);
 }
 
 #[derive(Clone, Debug)]
@@ -195,8 +195,8 @@ struct OcrBlockState {
     confidence: ConfidenceAccumulator,
 }
 
-#[async_trait(?Send)]
-trait OcrBackend {
+#[async_trait]
+trait OcrBackend: Send + Sync {
     fn name(&self) -> &'static str;
 
     async fn recognize(
@@ -215,7 +215,7 @@ pub(crate) fn reset_vision_state() {
 }
 
 #[cfg(test)]
-fn install_test_backend(backend: Rc<dyn OcrBackend>) {
+fn install_test_backend(backend: Arc<dyn OcrBackend>) {
     OCR_BACKEND_OVERRIDE.with(|slot| {
         *slot.borrow_mut() = Some(backend);
     });
@@ -238,11 +238,11 @@ pub(crate) fn register_vision_builtins(vm: &mut Vm) {
     });
 }
 
-fn current_backend() -> Rc<dyn OcrBackend> {
+fn current_backend() -> Arc<dyn OcrBackend> {
     OCR_BACKEND_OVERRIDE.with(|slot| {
         slot.borrow()
             .clone()
-            .unwrap_or_else(|| Rc::new(TesseractCliBackend))
+            .unwrap_or_else(|| Arc::new(TesseractCliBackend))
     })
 }
 
@@ -670,7 +670,7 @@ async fn audit_vision_ocr_active(
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl OcrBackend for TesseractCliBackend {
     fn name(&self) -> &'static str {
         "tesseract_cli"
@@ -866,7 +866,7 @@ mod tests {
         words: Vec<OcrWordText>,
     }
 
-    #[async_trait(?Send)]
+    #[async_trait]
     impl OcrBackend for MockBackend {
         fn name(&self) -> &'static str {
             "mock_ocr"
@@ -1009,7 +1009,7 @@ mod tests {
         reset_vision_state();
         crate::event_log::reset_active_event_log();
         let log = crate::event_log::install_memory_for_current_thread(32);
-        install_test_backend(Rc::new(MockBackend {
+        install_test_backend(Arc::new(MockBackend {
             words: vec![
                 word(1, 1, 1, 1, 1, 0, 0, 12, 10, 98.0, "Alpha"),
                 word(1, 1, 1, 1, 2, 14, 0, 10, 10, 97.0, "Beta"),

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -1,13 +1,13 @@
 //! Tool, persona, and step hook registration builtins for workflow execution.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::stdlib::macros::harn_builtin;
 use crate::value::{VmError, VmValue};
 
-pub(super) type PostHookFn = Rc<dyn Fn(&str, &str) -> crate::orchestration::PostToolAction>;
+pub(super) type PostHookFn =
+    Arc<dyn Fn(&str, &str) -> crate::orchestration::PostToolAction + Send + Sync>;
 
 /// Register low-level pre/post tool hooks for workflow execution.
 #[harn_builtin(
@@ -63,13 +63,13 @@ pub(super) fn register_tool_hook_builtin(
     };
 
     let pre: Option<crate::orchestration::PreToolHookFn> = deny_reason.map(|reason| {
-        Rc::new(move |_name: &str, _args: &serde_json::Value| {
+        Arc::new(move |_name: &str, _args: &serde_json::Value| {
             crate::orchestration::PreToolAction::Deny(reason.clone())
         }) as _
     });
 
     let post: Option<PostHookFn> = max_output.map(|max| {
-        Rc::new(move |_name: &str, result: &str| {
+        Arc::new(move |_name: &str, result: &str| {
             if result.len() > max {
                 crate::orchestration::PostToolAction::Modify(
                     crate::orchestration::microcompact_tool_output(result, max),

--- a/crates/harn-vm/src/store.rs
+++ b/crates/harn-vm/src/store.rs
@@ -4,10 +4,9 @@
 //! `store_save`, and `store_clear` builtins. The store file is created
 //! lazily on first mutation.
 
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
@@ -143,35 +142,33 @@ pub fn register_store_builtins(vm: &mut Vm, base_dir: &Path) {
     if let Err(error) = crate::event_log::install_lazy_default_for_base_dir(base_dir) {
         crate::events::log_warn("event_log.init", &error.to_string());
     }
-    let state = Rc::new(RefCell::new(StoreState::new(base_dir)));
+    let state = Arc::new(parking_lot::Mutex::new(StoreState::new(base_dir)));
 
-    let s = Rc::clone(&state);
+    let s = Arc::clone(&state);
     vm.register_builtin("store_get", move |args, _out| {
         let key = args.first().map(|a| a.display()).unwrap_or_default();
-        Ok(s.borrow_mut().get(&key))
+        Ok(s.lock().get(&key))
     });
 
-    let s = Rc::clone(&state);
+    let s = Arc::clone(&state);
     vm.register_builtin("store_set", move |args, _out| {
         let key = args.first().map(|a| a.display()).unwrap_or_default();
         let value = args.get(1).unwrap_or(&VmValue::Nil);
         let json_val = vm_to_json(value);
-        s.borrow_mut()
-            .set(key, json_val)
-            .map_err(VmError::Runtime)?;
+        s.lock().set(key, json_val).map_err(VmError::Runtime)?;
         Ok(VmValue::Nil)
     });
 
-    let s = Rc::clone(&state);
+    let s = Arc::clone(&state);
     vm.register_builtin("store_delete", move |args, _out| {
         let key = args.first().map(|a| a.display()).unwrap_or_default();
-        s.borrow_mut().delete(&key).map_err(VmError::Runtime)?;
+        s.lock().delete(&key).map_err(VmError::Runtime)?;
         Ok(VmValue::Nil)
     });
 
-    let s = Rc::clone(&state);
+    let s = Arc::clone(&state);
     vm.register_builtin("store_list", move |_args, _out| {
-        let keys = s.borrow_mut().list();
+        let keys = s.lock().list();
         Ok(VmValue::List(std::sync::Arc::new(
             keys.into_iter()
                 .map(|k| VmValue::String(std::sync::Arc::from(k)))
@@ -179,15 +176,15 @@ pub fn register_store_builtins(vm: &mut Vm, base_dir: &Path) {
         )))
     });
 
-    let s = Rc::clone(&state);
+    let s = Arc::clone(&state);
     vm.register_builtin("store_save", move |_args, _out| {
-        s.borrow().save().map_err(VmError::Runtime)?;
+        s.lock().save().map_err(VmError::Runtime)?;
         Ok(VmValue::Nil)
     });
 
-    let s = Rc::clone(&state);
+    let s = Arc::clone(&state);
     vm.register_builtin("store_clear", move |_args, _out| {
-        s.borrow_mut().clear().map_err(VmError::Runtime)?;
+        s.lock().clear().map_err(VmError::Runtime)?;
         Ok(VmValue::Nil)
     });
 }

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -8,7 +8,6 @@
 //! the dispatch state machine across modules without a natural seam.
 
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -135,7 +134,7 @@ impl Dispatcher {
         });
         let (cancel_tx, _) = broadcast::channel(32);
         Self {
-            base_vm: Rc::new(base_vm),
+            base_vm: Arc::new(base_vm),
             event_log,
             cancel_tx,
             state,

--- a/crates/harn-vm/src/triggers/dispatcher/types.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/types.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -38,7 +37,7 @@ impl Drop for DispatchExecutionPolicyGuard {
 
 #[derive(Clone)]
 pub struct Dispatcher {
-    pub(super) base_vm: Rc<Vm>,
+    pub(super) base_vm: Arc<Vm>,
     pub(super) event_log: Arc<AnyEventLog>,
     pub(super) cancel_tx: broadcast::Sender<()>,
     pub(super) state: Arc<DispatcherRuntimeState>,

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::{future::Future, pin::Pin};
@@ -19,11 +18,13 @@ use super::{
 /// dispatch loop + the `#[harn_builtin]` macro) so handlers mint child VMs and
 /// forward output through the ctx they were given instead of relying on hidden
 /// task state.
-pub type VmAsyncBuiltinFn = Rc<
+pub type VmAsyncBuiltinFn = Arc<
     dyn Fn(
-        crate::vm::AsyncBuiltinCtx,
-        Vec<VmValue>,
-    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>>>>,
+            crate::vm::AsyncBuiltinCtx,
+            Vec<VmValue>,
+        ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + Send>>
+        + Send
+        + Sync,
 >;
 
 type Shared<T> = Arc<T>;
@@ -597,4 +598,5 @@ pub fn struct_fields_to_map(
 }
 
 /// Sync builtin function for the VM.
-pub type VmBuiltinFn = Rc<dyn Fn(&[VmValue], &mut String) -> Result<VmValue, VmError>>;
+pub type VmBuiltinFn =
+    Arc<dyn Fn(&[VmValue], &mut String) -> Result<VmValue, VmError> + Send + Sync>;

--- a/crates/harn-vm/src/value/tests.rs
+++ b/crates/harn-vm/src/value/tests.rs
@@ -3,6 +3,10 @@ use std::sync::Arc;
 use super::*;
 
 static_assertions::assert_impl_all!(VmValue: Send, Sync);
+static_assertions::assert_impl_all!(crate::Chunk: Send, Sync);
+static_assertions::assert_impl_all!(crate::vm::Vm: Send);
+static_assertions::assert_impl_all!(VmBuiltinFn: Send, Sync);
+static_assertions::assert_impl_all!(VmAsyncBuiltinFn: Send, Sync);
 
 #[cfg(target_pointer_width = "64")]
 #[test]

--- a/crates/harn-vm/src/vm/async_builtin.rs
+++ b/crates/harn-vm/src/vm/async_builtin.rs
@@ -1,6 +1,5 @@
-use std::cell::RefCell;
 use std::future::Future;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::Vm;
 
@@ -14,17 +13,17 @@ use super::Vm;
 /// [`AsyncBuiltinCtx::child_vm`], and whose `output` buffer collects text
 /// forwarded from VM-side closures via [`AsyncBuiltinCtx::forward_output`]. The
 /// dispatch loop drains that buffer back to the original parent VM after the
-/// async builtin returns. Cheap to clone — it is an `Rc` handle and everything
-/// heavy inside the `Vm` is `Rc`/`Arc`-shared.
+/// async builtin returns. Cheap to clone: it is an `Arc` handle and everything
+/// heavy inside the `Vm` is shared.
 #[derive(Clone)]
 pub struct AsyncBuiltinCtx {
-    child: Rc<RefCell<Vm>>,
+    child: Arc<parking_lot::Mutex<Vm>>,
 }
 
 impl AsyncBuiltinCtx {
     fn new(vm: Vm) -> Self {
         Self {
-            child: Rc::new(RefCell::new(vm)),
+            child: Arc::new(parking_lot::Mutex::new(vm)),
         }
     }
 
@@ -43,10 +42,16 @@ impl AsyncBuiltinCtx {
     }
 
     /// Clone a fresh child VM from this context. The returned `Vm` shares the
-    /// parent's heavy state (env, builtins, bridge, module_cache) via `Arc`/`Rc`,
-    /// so each closure-invoking handler gets its own cheap execution context.
+    /// parent's heavy state, so each closure-invoking handler gets its own
+    /// cheap execution context.
     pub fn child_vm(&self) -> Vm {
-        self.child.borrow().child_vm()
+        self.child.lock().child_vm()
+    }
+
+    /// Pool tasks may execute on any Tokio worker thread, so pool lookup state
+    /// is shared through the VM context rather than thread-local storage.
+    pub(crate) fn pool_registry(&self) -> Arc<crate::stdlib::pool::PoolRegistry> {
+        self.child.lock().pool_registry.clone()
     }
 
     /// Create an independent context rooted at a fresh child VM. Long-lived
@@ -69,7 +74,7 @@ impl AsyncBuiltinCtx {
         if text.is_empty() {
             return;
         }
-        self.child.borrow_mut().append_output(text);
+        self.child.lock().append_output(text);
     }
 }
 
@@ -85,21 +90,22 @@ pub(crate) fn run_async_builtin_with<F, M>(
     make_fut: M,
 ) -> impl Future<Output = (F::Output, String)>
 where
-    F: Future,
+    F: Future + Send,
     M: FnOnce(AsyncBuiltinCtx) -> F,
 {
     // Build the context + scope synchronously so the by-value `child: Vm` moves
-    // onto the heap (Rc) *before* any async state machine exists. If this were
+    // onto the heap *before* any async state machine exists. If this were
     // an `async fn`, the future would reserve a Vm-sized slot for `child` up to
     // its first await, and that bloat propagates into every caller's stack
     // frame, which can trip clippy::large_stack_frames in large dispatch
     // functions.
     let ctx = AsyncBuiltinCtx::new(child);
-    let sink = Rc::clone(&ctx.child);
+    let registry = ctx.pool_registry();
+    let sink = Arc::clone(&ctx.child);
     let fut = make_fut(ctx);
     async move {
-        let output = fut.await;
-        let captured = sink.borrow_mut().take_output();
+        let output = crate::stdlib::pool::with_pool_registry_scope(registry, fut).await;
+        let captured = sink.lock().take_output();
         (output, captured)
     }
 }

--- a/crates/harn-vm/src/vm/cache.rs
+++ b/crates/harn-vm/src/vm/cache.rs
@@ -1,0 +1,95 @@
+use crate::chunk::{
+    AdaptiveBinaryOp, AdaptiveBinaryState, ChunkRef, DirectCallState, InlineCacheEntry,
+    MethodCacheTarget, PropertyCacheTarget,
+};
+
+use super::Vm;
+
+impl Vm {
+    fn inline_cache_entries_mut(&mut self, chunk: &ChunkRef) -> &mut Vec<InlineCacheEntry> {
+        let slot_count = chunk.inline_cache_slot_count();
+        let entries = self
+            .inline_caches
+            .entry(chunk.cache_id())
+            .or_insert_with(|| vec![InlineCacheEntry::Empty; slot_count]);
+        if entries.len() < slot_count {
+            entries.resize(slot_count, InlineCacheEntry::Empty);
+        }
+        entries
+    }
+
+    #[inline]
+    pub(crate) fn peek_adaptive_binary_cache(
+        &mut self,
+        chunk: &ChunkRef,
+        slot: usize,
+    ) -> Option<(AdaptiveBinaryOp, AdaptiveBinaryState)> {
+        match self.inline_cache_entries_mut(chunk).get(slot)? {
+            &InlineCacheEntry::AdaptiveBinary { op, state } => Some((op, state)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn peek_method_cache(
+        &mut self,
+        chunk: &ChunkRef,
+        slot: usize,
+    ) -> Option<(u16, usize, MethodCacheTarget)> {
+        match self.inline_cache_entries_mut(chunk).get(slot)? {
+            &InlineCacheEntry::Method {
+                name_idx,
+                argc,
+                target,
+            } => Some((name_idx, argc, target)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn peek_property_cache(
+        &mut self,
+        chunk: &ChunkRef,
+        slot: usize,
+    ) -> Option<(u16, PropertyCacheTarget)> {
+        match self.inline_cache_entries_mut(chunk).get(slot)? {
+            InlineCacheEntry::Property { name_idx, target } => Some((*name_idx, target.clone())),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn peek_direct_call_state(
+        &mut self,
+        chunk: &ChunkRef,
+        slot: usize,
+    ) -> Option<DirectCallState> {
+        match self.inline_cache_entries_mut(chunk).get(slot)? {
+            InlineCacheEntry::DirectCall { state } => Some(state.clone()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn set_inline_cache_entry(
+        &mut self,
+        chunk: &ChunkRef,
+        slot: usize,
+        entry: InlineCacheEntry,
+    ) {
+        let entries = self.inline_cache_entries_mut(chunk);
+        if let Some(existing) = entries.get_mut(slot) {
+            *existing = entry;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inline_cache_entries_for_chunk(
+        &self,
+        chunk: &crate::chunk::Chunk,
+    ) -> Vec<InlineCacheEntry> {
+        self.inline_caches
+            .get(&chunk.cache_id())
+            .cloned()
+            .unwrap_or_else(|| vec![InlineCacheEntry::Empty; chunk.inline_cache_slot_count()])
+    }
+}

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -23,7 +23,7 @@ pub struct DebugState {
     pub frame_depth: usize,
 }
 
-pub(super) type DebugHook = dyn FnMut(&DebugState) -> DebugAction;
+pub(super) type DebugHook = dyn FnMut(&DebugState) -> DebugAction + Send;
 
 impl Vm {
     /// Replace breakpoints for a single source file. Pass an empty string
@@ -123,9 +123,9 @@ impl Vm {
     /// Register a debug hook invoked whenever execution advances to a new source line.
     pub fn set_debug_hook<F>(&mut self, hook: F)
     where
-        F: FnMut(&DebugState) -> DebugAction + 'static,
+        F: FnMut(&DebugState) -> DebugAction + Send + 'static,
     {
-        self.debug_hook = Some(Box::new(hook));
+        self.debug_hook = Some(parking_lot::Mutex::new(Box::new(hook)));
     }
 
     /// Clear the current debug hook.
@@ -396,8 +396,9 @@ impl Vm {
             self.last_line = current_line;
 
             let state = self.debug_state();
-            if let Some(hook) = self.debug_hook.as_mut() {
-                if matches!(hook(&state), DebugAction::Stop) {
+            if let Some(hook) = &self.debug_hook {
+                let mut hook = hook.lock();
+                if matches!((*hook)(&state), DebugAction::Stop) {
                     self.stopped = true;
                     return Ok(Some((VmValue::Nil, true)));
                 }

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::value::{ErrorCategory, VmBuiltinFn, VmClosure, VmError, VmValue};
 use crate::BuiltinId;
@@ -102,12 +102,12 @@ impl Vm {
         }
         if let Some(existing) = self.builtins_by_id.get(&id) {
             if existing.name.as_ref() != name {
-                Rc::make_mut(&mut self.builtins_by_id).remove(&id);
-                Rc::make_mut(&mut self.builtin_id_collisions).insert(id);
+                Arc::make_mut(&mut self.builtins_by_id).remove(&id);
+                Arc::make_mut(&mut self.builtin_id_collisions).insert(id);
                 return;
             }
         }
-        Rc::make_mut(&mut self.builtins_by_id).insert(
+        Arc::make_mut(&mut self.builtins_by_id).insert(
             id,
             VmBuiltinEntry {
                 name: std::sync::Arc::from(name),
@@ -128,7 +128,7 @@ impl Vm {
                 .get(&id)
                 .is_some_and(|entry| entry.name.as_ref() == name)
             {
-                Rc::make_mut(&mut self.builtins_by_id).remove(&id);
+                Arc::make_mut(&mut self.builtins_by_id).remove(&id);
             }
         }
     }
@@ -136,10 +136,10 @@ impl Vm {
     /// Register a sync builtin function.
     pub fn register_builtin<F>(&mut self, name: &str, f: F)
     where
-        F: Fn(&[VmValue], &mut String) -> Result<VmValue, VmError> + 'static,
+        F: Fn(&[VmValue], &mut String) -> Result<VmValue, VmError> + Send + Sync + 'static,
     {
-        Rc::make_mut(&mut self.builtins).insert(name.to_string(), Rc::new(f));
-        Rc::make_mut(&mut self.builtin_metadata)
+        Arc::make_mut(&mut self.builtins).insert(name.to_string(), Arc::new(f));
+        Arc::make_mut(&mut self.builtin_metadata)
             .insert(name.to_string(), VmBuiltinMetadata::sync(name.to_string()));
         self.refresh_builtin_id(name);
     }
@@ -147,11 +147,11 @@ impl Vm {
     /// Register a sync builtin function with discoverable metadata.
     pub fn register_builtin_with_metadata<F>(&mut self, metadata: VmBuiltinMetadata, f: F)
     where
-        F: Fn(&[VmValue], &mut String) -> Result<VmValue, VmError> + 'static,
+        F: Fn(&[VmValue], &mut String) -> Result<VmValue, VmError> + Send + Sync + 'static,
     {
         let name = metadata.name().to_string();
-        Rc::make_mut(&mut self.builtins).insert(name.clone(), Rc::new(f));
-        Rc::make_mut(&mut self.builtin_metadata)
+        Arc::make_mut(&mut self.builtins).insert(name.clone(), Arc::new(f));
+        Arc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Sync));
         self.refresh_builtin_id(&name);
     }
@@ -181,7 +181,7 @@ impl Vm {
                     let meta = builtin_def_metadata(def, name, arity, VmBuiltinKind::Async);
                     // Wrap the function pointer that already returns an
                     // AsyncBuiltinFuture so register_async_builtin_with_metadata's
-                    // generic bound `F: Fn(Vec<VmValue>) -> Fut + 'static` is met.
+                    // generic handler/future bounds are met.
                     self.register_async_builtin_with_metadata(meta, f);
                 }
                 VmBuiltinHandler::None => {
@@ -198,14 +198,14 @@ impl Vm {
 
     /// Remove a sync builtin (so an async version can take precedence).
     pub fn unregister_builtin(&mut self, name: &str) {
-        Rc::make_mut(&mut self.builtins).remove(name);
+        Arc::make_mut(&mut self.builtins).remove(name);
         if self.async_builtins.contains_key(name) {
-            Rc::make_mut(&mut self.builtin_metadata).insert(
+            Arc::make_mut(&mut self.builtin_metadata).insert(
                 name.to_string(),
                 VmBuiltinMetadata::async_builtin(name.to_string()),
             );
         } else {
-            Rc::make_mut(&mut self.builtin_metadata).remove(name);
+            Arc::make_mut(&mut self.builtin_metadata).remove(name);
         }
         self.refresh_builtin_id(name);
     }
@@ -214,14 +214,14 @@ impl Vm {
     /// [`crate::vm::AsyncBuiltinCtx`] threaded by the dispatch loop.
     pub fn register_async_builtin<F, Fut>(&mut self, name: &str, f: F)
     where
-        F: Fn(crate::vm::AsyncBuiltinCtx, Vec<VmValue>) -> Fut + 'static,
-        Fut: Future<Output = Result<VmValue, VmError>> + 'static,
+        F: Fn(crate::vm::AsyncBuiltinCtx, Vec<VmValue>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<VmValue, VmError>> + Send + 'static,
     {
-        Rc::make_mut(&mut self.async_builtins).insert(
+        Arc::make_mut(&mut self.async_builtins).insert(
             name.to_string(),
-            Rc::new(move |ctx, args| Box::pin(f(ctx, args))),
+            Arc::new(move |ctx, args| Box::pin(f(ctx, args))),
         );
-        Rc::make_mut(&mut self.builtin_metadata).insert(
+        Arc::make_mut(&mut self.builtin_metadata).insert(
             name.to_string(),
             VmBuiltinMetadata::async_builtin(name.to_string()),
         );
@@ -235,15 +235,15 @@ impl Vm {
         metadata: VmBuiltinMetadata,
         f: F,
     ) where
-        F: Fn(crate::vm::AsyncBuiltinCtx, Vec<VmValue>) -> Fut + 'static,
-        Fut: Future<Output = Result<VmValue, VmError>> + 'static,
+        F: Fn(crate::vm::AsyncBuiltinCtx, Vec<VmValue>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<VmValue, VmError>> + Send + 'static,
     {
         let name = metadata.name().to_string();
-        Rc::make_mut(&mut self.async_builtins).insert(
+        Arc::make_mut(&mut self.async_builtins).insert(
             name.clone(),
-            Rc::new(move |ctx, args| Box::pin(f(ctx, args))),
+            Arc::new(move |ctx, args| Box::pin(f(ctx, args))),
         );
-        Rc::make_mut(&mut self.builtin_metadata)
+        Arc::make_mut(&mut self.builtin_metadata)
             .insert(name.clone(), metadata.with_kind(VmBuiltinKind::Async));
         self.refresh_builtin_id(&name);
     }

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -32,6 +32,14 @@ impl Vm {
 
     /// Execute a compiled chunk.
     pub async fn execute(&mut self, chunk: &Chunk) -> Result<VmValue, VmError> {
+        let registry = self.pool_registry.clone();
+        crate::stdlib::pool::with_pool_registry_scope(registry, async {
+            self.execute_scoped(chunk).await
+        })
+        .await
+    }
+
+    async fn execute_scoped(&mut self, chunk: &Chunk) -> Result<VmValue, VmError> {
         let span_id = crate::tracing::span_start(crate::tracing::SpanKind::Pipeline, "main".into());
         let result = self.run_chunk(chunk).await;
         let result = match result {

--- a/crates/harn-vm/src/vm/interrupts.rs
+++ b/crates/harn-vm/src/vm/interrupts.rs
@@ -91,7 +91,7 @@ impl Vm {
     pub(crate) fn dispatch_interrupt_handlers<'a>(
         &'a mut self,
         signal: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<bool, VmError>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<bool, VmError>> + Send + 'a>> {
         Box::pin(async move {
             let signal = normalize_signal(signal)?;
             self.interrupted = true;

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -186,8 +186,9 @@ impl VmIter {
     pub fn next<'a>(
         &'a mut self,
         vm: &'a mut crate::vm::Vm,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<VmValue>, VmError>> + 'a>>
-    {
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Option<VmValue>, VmError>> + Send + 'a>,
+    > {
         Box::pin(async move { self.next_impl(vm).await })
     }
 
@@ -884,7 +885,9 @@ fn empty_broadcast_state() -> VmBroadcastState {
 fn try_next_ready<'a>(
     handle: &'a VmIterHandle,
     vm: &'a mut crate::vm::Vm,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Option<VmValue>, VmError>> + 'a>> {
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<Option<VmValue>, VmError>> + Send + 'a>,
+> {
     Box::pin(async move {
         let mut state = std::mem::replace(&mut *handle.lock(), VmIter::Exhausted);
         let result = state.try_next_ready_impl(vm).await;

--- a/crates/harn-vm/src/vm/methods/dispatch.rs
+++ b/crates/harn-vm/src/vm/methods/dispatch.rs
@@ -44,7 +44,7 @@ impl crate::vm::Vm {
         obj: VmValue,
         method: &'a str,
         args: &'a [VmValue],
-    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + Send + 'a>> {
         Box::pin(async move {
             if let Some(result) = Self::call_method_sync(&obj, method, args) {
                 return result;

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -1,5 +1,6 @@
 mod async_builtin;
 mod builtin;
+mod cache;
 mod call_args;
 mod debug;
 mod dispatch;

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -3,7 +3,6 @@ use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::bytecode_cache;
@@ -111,14 +110,14 @@ impl Vm {
         if let Some(loaded) = self.module_cache.get(&synthetic).cloned() {
             return Ok(loaded);
         }
-        Rc::make_mut(&mut self.source_cache).insert(synthetic.clone(), source.to_string());
+        Arc::make_mut(&mut self.source_cache).insert(synthetic.clone(), source.to_string());
 
         let artifact = compile_module_artifact_from_source(&synthetic, source)?;
 
         self.imported_paths.push(synthetic.clone());
         let loaded = self.instantiate_module(None, &artifact).await?;
         self.imported_paths.pop();
-        Rc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
+        Arc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
         Ok(loaded)
     }
 
@@ -131,13 +130,13 @@ impl Vm {
         if let Some(loaded) = self.module_cache.get(&synthetic).cloned() {
             return Ok(loaded);
         }
-        Rc::make_mut(&mut self.source_cache).insert(synthetic.clone(), source.to_string());
+        Arc::make_mut(&mut self.source_cache).insert(synthetic.clone(), source.to_string());
 
         let artifact = stdlib_module_artifact(module, &synthetic, source)?;
         self.imported_paths.push(synthetic.clone());
         let loaded = self.instantiate_stdlib_module(artifact.as_ref()).await?;
         self.imported_paths.pop();
-        Rc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
+        Arc::make_mut(&mut self.module_cache).insert(synthetic, loaded.clone());
         Ok(loaded)
     }
 
@@ -311,7 +310,7 @@ impl Vm {
         &'a mut self,
         path: &'a str,
         selected_names: Option<&'a [String]>,
-    ) -> Pin<Box<dyn Future<Output = Result<(), VmError>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<(), VmError>> + Send + 'a>> {
         Box::pin(async move {
             let _import_span = ScopeSpan::new(crate::tracing::SpanKind::Import, path.to_string());
 
@@ -358,8 +357,8 @@ impl Vm {
                     file_path.display()
                 ))
             })?;
-            Rc::make_mut(&mut self.source_cache).insert(canonical.clone(), source.clone());
-            Rc::make_mut(&mut self.source_cache).insert(file_path.clone(), source.clone());
+            Arc::make_mut(&mut self.source_cache).insert(canonical.clone(), source.clone());
+            Arc::make_mut(&mut self.source_cache).insert(file_path.clone(), source.clone());
 
             // Disk cache first: hits skip parse + compile for the imported
             // module's whole function pool, not just the entry pipeline.
@@ -384,7 +383,7 @@ impl Vm {
                 .instantiate_module(module_source_dir, &artifact)
                 .await?;
             self.imported_paths.pop();
-            Rc::make_mut(&mut self.module_cache).insert(canonical.clone(), loaded.clone());
+            Arc::make_mut(&mut self.module_cache).insert(canonical.clone(), loaded.clone());
             self.export_loaded_module(&canonical, &loaded, selected_names)?;
 
             Ok(())

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -65,16 +65,17 @@ impl super::super::Vm {
         // that the variant-checking match would just throw away. Since
         // `AdaptiveBinaryState: Copy`, the read here is a single scalar
         // move (`u8`/`u64` fields, all stack-resident).
-        let (cache_slot, cached_state) = {
+        let (chunk, cache_slot) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
+            let chunk = Arc::clone(&frame.chunk);
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cached_state = cache_slot
-                .and_then(|slot| frame.chunk.peek_adaptive_binary_cache(slot))
-                .filter(|(cached_op, _)| *cached_op == op)
-                .map(|(_, state)| state);
-            (cache_slot, cached_state)
+            (chunk, cache_slot)
         };
+        let cached_state = cache_slot
+            .and_then(|slot| self.peek_adaptive_binary_cache(&chunk, slot))
+            .filter(|(cached_op, _)| *cached_op == op)
+            .map(|(_, state)| state);
 
         let b = self.pop()?;
         let a = self.pop()?;
@@ -84,8 +85,8 @@ impl super::super::Vm {
             Self::try_specialized_binary(op, cached_state, &a, &b)
         {
             if let Some(slot) = cache_slot {
-                let frame = self.frames.last().unwrap();
-                frame.chunk.set_inline_cache_entry(
+                self.set_inline_cache_entry(
+                    &chunk,
                     slot,
                     InlineCacheEntry::AdaptiveBinary {
                         op,
@@ -98,8 +99,8 @@ impl super::super::Vm {
             let result = Self::generic_binary_result(self, op, a, b)?;
             if let (Some(slot), Some(shape)) = (cache_slot, shape) {
                 let next_state = Self::next_adaptive_binary_state(cached_state, shape);
-                let frame = self.frames.last().unwrap();
-                frame.chunk.set_inline_cache_entry(
+                self.set_inline_cache_entry(
+                    &chunk,
                     slot,
                     InlineCacheEntry::AdaptiveBinary {
                         op,

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -350,7 +350,7 @@ impl super::super::Vm {
         &'a mut self,
         handler: &'a Arc<VmClosure>,
         payload: VmValue,
-    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<VmValue, VmError>> + Send + 'a>> {
         Box::pin(async move {
             let snapshot = crate::step_runtime::take_active_context();
             let result = self
@@ -736,14 +736,15 @@ impl super::super::Vm {
     /// leaves `ip` untouched so [`execute_call_async`] can read the operand
     /// exactly once.
     pub(super) fn execute_call_sync(&mut self) -> Option<Result<(), VmError>> {
-        let (argc, cache_slot, cached_state) = {
+        let (chunk, argc, cache_slot) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
+            let chunk = Arc::clone(&frame.chunk);
             let argc = frame.chunk.code[frame.ip] as usize;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cached_state = cache_slot.and_then(|slot| frame.chunk.peek_direct_call_state(slot));
-            (argc, cache_slot, cached_state)
+            (chunk, argc, cache_slot)
         };
+        let cached_state = cache_slot.and_then(|slot| self.peek_direct_call_state(&chunk, slot));
         let callee_idx = self.stack.len().checked_sub(argc + 1)?;
         let closure = match self.try_cached_direct_call(cached_state.as_ref(), argc, callee_idx) {
             Some(closure) => closure,
@@ -762,8 +763,7 @@ impl super::super::Vm {
                 argc,
                 DirectCallTarget::Closure(Arc::clone(&closure)),
             );
-            let frame = self.frames.last().unwrap();
-            frame.chunk.set_inline_cache_entry(slot, next_entry);
+            self.set_inline_cache_entry(&chunk, slot, next_entry);
         }
 
         let frame = self.frames.last_mut().unwrap();
@@ -959,17 +959,17 @@ impl super::super::Vm {
     /// resolves synchronously in the hot case but still pays the
     /// future-state-machine tax.
     pub(super) fn execute_call_builtin_sync(&mut self) -> Option<Result<(), VmError>> {
-        let (name_idx, argc, cache_slot, cached_state) = {
+        let (chunk, name_idx, argc, cache_slot) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
+            let chunk = Arc::clone(&frame.chunk);
             let name_idx = frame.chunk.read_u16(frame.ip + 8) as usize;
             let argc = frame.chunk.code[frame.ip + 10] as usize;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cached_state = cache_slot.and_then(|slot| frame.chunk.peek_direct_call_state(slot));
-            (name_idx, argc, cache_slot, cached_state)
+            (chunk, name_idx, argc, cache_slot)
         };
-        let frame = self.frames.last().unwrap();
-        let name = Self::const_str(&frame.chunk.constants[name_idx]).ok()?;
+        let cached_state = cache_slot.and_then(|slot| self.peek_direct_call_state(&chunk, slot));
+        let name = Self::const_str(&chunk.constants[name_idx]).ok()?;
 
         // Names handled by `try_call_special_name` are runtime constructs
         // (`await`, `cancel`, ...) that must run on the async path even if
@@ -993,8 +993,7 @@ impl super::super::Vm {
                 argc,
                 DirectCallTarget::Closure(Arc::clone(&closure)),
             );
-            let frame = self.frames.last().unwrap();
-            frame.chunk.set_inline_cache_entry(slot, next_entry);
+            self.set_inline_cache_entry(&chunk, slot, next_entry);
         }
 
         let frame = self.frames.last_mut().unwrap();
@@ -1299,17 +1298,18 @@ impl super::super::Vm {
     }
 
     pub(super) async fn execute_method_call(&mut self, optional: bool) -> Result<(), VmError> {
-        let (name_idx, argc, cache_slot, cached_method) = {
+        let (chunk, name_idx, argc, cache_slot) = {
             let frame = self.frames.last_mut().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
+            let chunk = Arc::clone(&frame.chunk);
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
             let argc = frame.chunk.code[frame.ip] as usize;
             frame.ip += 1;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cached_method = cache_slot.and_then(|slot| frame.chunk.peek_method_cache(slot));
-            (name_idx, argc, cache_slot, cached_method)
+            (chunk, name_idx, argc, cache_slot)
         };
+        let cached_method = cache_slot.and_then(|slot| self.peek_method_cache(&chunk, slot));
         let args_start = self.stack_arg_start(argc)?;
         let obj_idx = args_start
             .checked_sub(1)
@@ -1332,10 +1332,6 @@ impl super::super::Vm {
             self.stack.truncate(obj_idx);
             self.stack.push(result);
         } else {
-            let chunk = {
-                let frame = self.frames.last().unwrap();
-                Arc::clone(&frame.chunk)
-            };
             let method = Self::const_str(&chunk.constants[name_idx as usize])?;
             let cache_target = Self::method_cache_target(&obj, method, argc);
             let result = if let Some(result) =
@@ -1349,8 +1345,8 @@ impl super::super::Vm {
                 self.call_method_async(obj, method, &args).await?
             };
             if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-                let frame = self.frames.last().unwrap();
-                frame.chunk.set_inline_cache_entry(
+                self.set_inline_cache_entry(
+                    &chunk,
                     slot,
                     InlineCacheEntry::Method {
                         name_idx,
@@ -1370,15 +1366,16 @@ impl super::super::Vm {
         &mut self,
         optional: bool,
     ) -> Option<Result<(), VmError>> {
-        let (name_idx, argc, cache_slot, cached_method) = {
+        let (chunk, name_idx, argc, cache_slot) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
+            let chunk = Arc::clone(&frame.chunk);
             let name_idx = frame.chunk.read_u16(frame.ip);
             let argc = frame.chunk.code[frame.ip + 2] as usize;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cached_method = cache_slot.and_then(|slot| frame.chunk.peek_method_cache(slot));
-            (name_idx, argc, cache_slot, cached_method)
+            (chunk, name_idx, argc, cache_slot)
         };
+        let cached_method = cache_slot.and_then(|slot| self.peek_method_cache(&chunk, slot));
 
         let args_start = match self.stack.len().checked_sub(argc) {
             Some(args_start) => args_start,
@@ -1392,6 +1389,7 @@ impl super::super::Vm {
 
         if optional && matches!(obj, VmValue::Nil) {
             return Some(self.finish_method_call_sync(
+                &chunk,
                 argc,
                 Ok(VmValue::Nil),
                 name_idx,
@@ -1407,15 +1405,28 @@ impl super::super::Vm {
             obj,
             &self.stack[args_start..],
         ) {
-            return Some(self.finish_method_call_sync(argc, Ok(result), name_idx, None, None));
+            return Some(self.finish_method_call_sync(
+                &chunk,
+                argc,
+                Ok(result),
+                name_idx,
+                None,
+                None,
+            ));
         }
 
         let (result, cache_target) = {
-            let frame = self.frames.last().unwrap();
-            let method = match Self::const_str(&frame.chunk.constants[name_idx as usize]) {
+            let method = match Self::const_str(&chunk.constants[name_idx as usize]) {
                 Ok(method) => method,
                 Err(err) => {
-                    return Some(self.finish_method_call_sync(argc, Err(err), name_idx, None, None))
+                    return Some(self.finish_method_call_sync(
+                        &chunk,
+                        argc,
+                        Err(err),
+                        name_idx,
+                        None,
+                        None,
+                    ))
                 }
             };
             let args = &self.stack[args_start..];
@@ -1424,11 +1435,12 @@ impl super::super::Vm {
             (result, cache_target)
         };
 
-        Some(self.finish_method_call_sync(argc, result, name_idx, cache_slot, cache_target))
+        Some(self.finish_method_call_sync(&chunk, argc, result, name_idx, cache_slot, cache_target))
     }
 
     fn finish_method_call_sync(
         &mut self,
+        chunk: &crate::chunk::ChunkRef,
         argc: usize,
         result: Result<VmValue, VmError>,
         name_idx: u16,
@@ -1447,8 +1459,8 @@ impl super::super::Vm {
 
         let result = result?;
         if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-            let frame = self.frames.last().unwrap();
-            frame.chunk.set_inline_cache_entry(
+            self.set_inline_cache_entry(
+                chunk,
                 slot,
                 InlineCacheEntry::Method {
                     name_idx,
@@ -1462,15 +1474,16 @@ impl super::super::Vm {
     }
 
     pub(super) async fn execute_method_call_spread(&mut self) -> Result<(), VmError> {
-        let (name_idx, cache_slot, cached_method) = {
+        let (chunk, name_idx, cache_slot) = {
             let frame = self.frames.last_mut().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
+            let chunk = Arc::clone(&frame.chunk);
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cached_method = cache_slot.and_then(|slot| frame.chunk.peek_method_cache(slot));
-            (name_idx, cache_slot, cached_method)
+            (chunk, name_idx, cache_slot)
         };
+        let cached_method = cache_slot.and_then(|slot| self.peek_method_cache(&chunk, slot));
         let args_val = self.pop()?;
         let obj = self.pop()?;
         let args = match args_val {
@@ -1486,10 +1499,6 @@ impl super::super::Vm {
         {
             self.stack.push(result);
         } else {
-            let chunk = {
-                let frame = self.frames.last().unwrap();
-                Arc::clone(&frame.chunk)
-            };
             let method = Self::const_str(&chunk.constants[name_idx as usize])?;
             let cache_target = Self::method_cache_target(&obj, method, args.len());
             let result = if let Some(result) = Self::call_method_sync(&obj, method, &args) {
@@ -1498,8 +1507,8 @@ impl super::super::Vm {
                 self.call_method_async(obj, method, &args).await?
             };
             if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-                let frame = self.frames.last().unwrap();
-                frame.chunk.set_inline_cache_entry(
+                self.set_inline_cache_entry(
+                    &chunk,
                     slot,
                     InlineCacheEntry::Method {
                         name_idx,

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -413,15 +413,16 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_get_property(&mut self, optional: bool) -> Result<(), VmError> {
-        let (name_idx, cache_slot, cached_property) = {
+        let (chunk, name_idx, cache_slot) = {
             let frame = self.frames.last_mut().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
+            let chunk = Arc::clone(&frame.chunk);
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            let cached_property = cache_slot.and_then(|slot| frame.chunk.peek_property_cache(slot));
-            (name_idx, cache_slot, cached_property)
+            (chunk, name_idx, cache_slot)
         };
+        let cached_property = cache_slot.and_then(|slot| self.peek_property_cache(&chunk, slot));
 
         let obj = self.pop()?;
         if optional && matches!(obj, VmValue::Nil) {
@@ -432,8 +433,7 @@ impl super::super::Vm {
             self.stack.push(result);
         } else {
             let (result, target) = {
-                let frame = self.frames.last().unwrap();
-                let name = Self::const_str(&frame.chunk.constants[name_idx as usize])?;
+                let name = Self::const_str(&chunk.constants[name_idx as usize])?;
                 (
                     Self::resolve_property(&obj, name, optional)?,
                     Self::property_cache_target(&obj, name),
@@ -441,10 +441,11 @@ impl super::super::Vm {
             };
 
             if let (Some(slot), Some(target)) = (cache_slot, target) {
-                let frame = self.frames.last().unwrap();
-                frame
-                    .chunk
-                    .set_inline_cache_entry(slot, InlineCacheEntry::Property { name_idx, target });
+                self.set_inline_cache_entry(
+                    &chunk,
+                    slot,
+                    InlineCacheEntry::Property { name_idx, target },
+                );
             }
             self.stack.push(result);
         }

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -165,14 +165,21 @@ impl super::super::Vm {
                     "parallel",
                     Some(task_group_id.clone()),
                 );
+                let registry = child.pool_registry.clone();
                 let closure = closure.clone();
-                futures.push(async move {
-                    let arg = VmValue::Int(i as i64);
-                    let result = child
-                        .call_closure_args(&closure, CallArgs::One(&arg))
-                        .await?;
-                    Ok::<(VmValue, String), VmError>((result, std::mem::take(&mut child.output)))
-                });
+                futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                    registry,
+                    async move {
+                        let arg = VmValue::Int(i as i64);
+                        let result = child
+                            .call_closure_args(&closure, CallArgs::One(&arg))
+                            .await?;
+                        Ok::<(VmValue, String), VmError>((
+                            result,
+                            std::mem::take(&mut child.output),
+                        ))
+                    },
+                ));
             }
             let joined = run_capped_ordered(futures, cap, "Parallel task error").await?;
             let mut results = Vec::with_capacity(count);
@@ -209,17 +216,21 @@ impl super::super::Vm {
                         "parallel each",
                         Some(task_group_id.clone()),
                     );
+                    let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(async move {
-                        let result = child
-                            .call_closure_args(&closure, CallArgs::One(&item))
-                            .await?;
-                        Ok::<(VmValue, String), VmError>((
-                            result,
-                            std::mem::take(&mut child.output),
-                        ))
-                    });
+                    futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                        registry,
+                        async move {
+                            let result = child
+                                .call_closure_args(&closure, CallArgs::One(&item))
+                                .await?;
+                            Ok::<(VmValue, String), VmError>((
+                                result,
+                                std::mem::take(&mut child.output),
+                            ))
+                        },
+                    ));
                 }
                 let joined = run_capped_ordered(futures, cap, "Parallel map error").await?;
                 let mut results = Vec::with_capacity(len);
@@ -256,13 +267,17 @@ impl super::super::Vm {
                         "parallel each as stream",
                         Some(task_group_id.clone()),
                     );
+                    let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(async move {
-                        child
-                            .call_closure_args(&closure, CallArgs::One(&item))
-                            .await
-                    });
+                    futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                        registry,
+                        async move {
+                            child
+                                .call_closure_args(&closure, CallArgs::One(&item))
+                                .await
+                        },
+                    ));
                 }
 
                 let (tx, rx) = tokio::sync::mpsc::channel::<Result<VmValue, VmError>>(1);
@@ -306,15 +321,19 @@ impl super::super::Vm {
                         "parallel settle",
                         Some(task_group_id.clone()),
                     );
+                    let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(async move {
-                        let result = child
-                            .call_closure_args(&closure, CallArgs::One(&item))
-                            .await;
-                        let output = std::mem::take(&mut child.output);
-                        (result, output)
-                    });
+                    futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                        registry,
+                        async move {
+                            let result = child
+                                .call_closure_args(&closure, CallArgs::One(&item))
+                                .await;
+                            let output = std::mem::take(&mut child.output);
+                            (result, output)
+                        },
+                    ));
                 }
                 let joined = run_capped_ordered(futures, cap, "Parallel settle error").await?;
                 let mut results = Vec::with_capacity(len);
@@ -369,10 +388,14 @@ impl super::super::Vm {
             );
             let cancel_token = Arc::new(std::sync::atomic::AtomicBool::new(false));
             child.cancel_token = Some(cancel_token.clone());
-            let handle = tokio::task::spawn_local(async move {
-                let result = child.call_closure_args(&closure, CallArgs::Empty).await?;
-                Ok((result, std::mem::take(&mut child.output)))
-            });
+            let registry = child.pool_registry.clone();
+            let handle = tokio::task::spawn_local(crate::stdlib::pool::with_pool_registry_scope(
+                registry,
+                async move {
+                    let result = child.call_closure_args(&closure, CallArgs::Empty).await?;
+                    Ok((result, std::mem::take(&mut child.output)))
+                },
+            ));
             self.spawned_tasks.insert(
                 task_id.clone(),
                 VmTaskHandle {

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -1,5 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
-use std::rc::Rc;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -147,15 +146,15 @@ pub struct Vm {
     pub(crate) stack: Vec<VmValue>,
     pub(crate) env: VmEnv,
     pub(crate) output: String,
-    pub(crate) builtins: Rc<BTreeMap<String, VmBuiltinFn>>,
-    pub(crate) async_builtins: Rc<BTreeMap<String, VmAsyncBuiltinFn>>,
-    pub(crate) builtin_metadata: Rc<BTreeMap<String, VmBuiltinMetadata>>,
+    pub(crate) builtins: Arc<BTreeMap<String, VmBuiltinFn>>,
+    pub(crate) async_builtins: Arc<BTreeMap<String, VmAsyncBuiltinFn>>,
+    pub(crate) builtin_metadata: Arc<BTreeMap<String, VmBuiltinMetadata>>,
     /// Numeric side index for builtins. Name-keyed maps remain authoritative;
     /// this index is the hot path for direct builtin bytecode and callback refs.
-    pub(crate) builtins_by_id: Rc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
+    pub(crate) builtins_by_id: Arc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
     /// IDs with detected name collisions. Collided names safely fall back to
     /// the authoritative name-keyed lookup path.
-    pub(crate) builtin_id_collisions: Rc<HashSet<BuiltinId>>,
+    pub(crate) builtin_id_collisions: Arc<HashSet<BuiltinId>>,
     /// Iterator state for for-in loops.
     pub(crate) iterators: Vec<IterState>,
     /// Call frame stack.
@@ -167,7 +166,11 @@ pub struct Vm {
     /// Shared process-local synchronization primitives inherited by child VMs.
     pub(crate) sync_runtime: Arc<crate::synchronization::VmSyncRuntime>,
     /// Shared process-local cells, maps, and mailboxes inherited by child VMs.
-    pub(crate) shared_state_runtime: Rc<crate::shared_state::VmSharedStateRuntime>,
+    pub(crate) shared_state_runtime: Arc<crate::shared_state::VmSharedStateRuntime>,
+    /// Per-isolate inline cache entries keyed by compiled chunk identity.
+    pub(crate) inline_caches: HashMap<u64, Vec<crate::chunk::InlineCacheEntry>>,
+    /// VM-scoped pool registry inherited by child VMs and scoped into Tokio tasks.
+    pub(crate) pool_registry: Arc<crate::stdlib::pool::PoolRegistry>,
     /// Permits acquired by lexical synchronization blocks in this VM.
     pub(crate) held_sync_guards: Vec<crate::synchronization::VmSyncHeldGuard>,
     /// Counter for generating unique task IDs.
@@ -207,17 +210,17 @@ pub struct Vm {
     /// Modules currently being imported (cycle prevention).
     pub(crate) imported_paths: Vec<std::path::PathBuf>,
     /// Loaded module cache keyed by canonical or synthetic module path.
-    pub(crate) module_cache: Rc<BTreeMap<std::path::PathBuf, LoadedModule>>,
+    pub(crate) module_cache: Arc<BTreeMap<std::path::PathBuf, LoadedModule>>,
     /// Source text keyed by canonical or synthetic module path for debugger retrieval.
-    pub(crate) source_cache: Rc<BTreeMap<std::path::PathBuf, String>>,
+    pub(crate) source_cache: Arc<BTreeMap<std::path::PathBuf, String>>,
     /// Source file path for error reporting.
     pub(crate) source_file: Option<String>,
     /// Source text for error reporting.
     pub(crate) source_text: Option<String>,
     /// Optional bridge for delegating unknown builtins in bridge mode.
-    pub(crate) bridge: Option<Rc<crate::bridge::HostBridge>>,
+    pub(crate) bridge: Option<Arc<crate::bridge::HostBridge>>,
     /// Builtins denied by sandbox mode (`--deny` / `--allow` flags).
-    pub(crate) denied_builtins: Rc<HashSet<String>>,
+    pub(crate) denied_builtins: Arc<HashSet<String>>,
     /// Cancellation token for cooperative graceful shutdown (set by parent).
     pub(crate) cancel_token: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     pub(crate) interrupt_signal_token: Option<std::sync::Arc<std::sync::Mutex<Option<String>>>>,
@@ -243,9 +246,9 @@ pub struct Vm {
     pub(crate) project_root: Option<std::path::PathBuf>,
     /// Global constants (e.g. `pi`, `e`). Checked as a fallback in `GetVar`
     /// after the environment, so user-defined variables can shadow them.
-    pub(crate) globals: Rc<BTreeMap<String, VmValue>>,
+    pub(crate) globals: Arc<BTreeMap<String, VmValue>>,
     /// Optional debugger hook invoked when execution advances to a new source line.
-    pub(crate) debug_hook: Option<Box<DebugHook>>,
+    pub(crate) debug_hook: Option<parking_lot::Mutex<Box<DebugHook>>>,
     /// Effective runtime ceilings for this VM execution.
     pub(crate) runtime_limits: RuntimeLimits,
 }
@@ -256,37 +259,37 @@ pub struct Vm {
 /// The baseline intentionally does not snapshot execution state. Each
 /// instantiation gets fresh stacks, frames, tasks, cancellation fields, sync
 /// primitives, shared cells/maps/mailboxes, and debug state. Builtin tables are
-/// shared through `Rc` until a per-execution rebind needs copy-on-write.
+/// shared through `Arc` until a per-execution rebind needs copy-on-write.
 #[derive(Clone)]
 pub struct VmBaseline {
-    builtins: Rc<BTreeMap<String, VmBuiltinFn>>,
-    async_builtins: Rc<BTreeMap<String, VmAsyncBuiltinFn>>,
-    builtin_metadata: Rc<BTreeMap<String, VmBuiltinMetadata>>,
-    builtins_by_id: Rc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
-    builtin_id_collisions: Rc<HashSet<BuiltinId>>,
+    builtins: Arc<BTreeMap<String, VmBuiltinFn>>,
+    async_builtins: Arc<BTreeMap<String, VmAsyncBuiltinFn>>,
+    builtin_metadata: Arc<BTreeMap<String, VmBuiltinMetadata>>,
+    builtins_by_id: Arc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
+    builtin_id_collisions: Arc<HashSet<BuiltinId>>,
     source_dir: Option<std::path::PathBuf>,
     source_file: Option<String>,
     source_text: Option<String>,
     project_root: Option<std::path::PathBuf>,
-    globals: Rc<BTreeMap<String, VmValue>>,
-    denied_builtins: Rc<HashSet<String>>,
+    globals: Arc<BTreeMap<String, VmValue>>,
+    denied_builtins: Arc<HashSet<String>>,
     runtime_limits: RuntimeLimits,
 }
 
 impl VmBaseline {
     pub fn from_vm(vm: &Vm) -> Self {
         Self {
-            builtins: Rc::clone(&vm.builtins),
-            async_builtins: Rc::clone(&vm.async_builtins),
-            builtin_metadata: Rc::clone(&vm.builtin_metadata),
-            builtins_by_id: Rc::clone(&vm.builtins_by_id),
-            builtin_id_collisions: Rc::clone(&vm.builtin_id_collisions),
+            builtins: Arc::clone(&vm.builtins),
+            async_builtins: Arc::clone(&vm.async_builtins),
+            builtin_metadata: Arc::clone(&vm.builtin_metadata),
+            builtins_by_id: Arc::clone(&vm.builtins_by_id),
+            builtin_id_collisions: Arc::clone(&vm.builtin_id_collisions),
             source_dir: vm.source_dir.clone(),
             source_file: vm.source_file.clone(),
             source_text: vm.source_text.clone(),
             project_root: vm.project_root.clone(),
-            globals: Rc::clone(&vm.globals),
-            denied_builtins: Rc::clone(&vm.denied_builtins),
+            globals: Arc::clone(&vm.globals),
+            denied_builtins: Arc::clone(&vm.denied_builtins),
             runtime_limits: vm.runtime_limits,
         }
     }
@@ -304,17 +307,19 @@ impl VmBaseline {
             stack: Vec::with_capacity(256),
             env: VmEnv::new(),
             output: String::new(),
-            builtins: Rc::clone(&self.builtins),
-            async_builtins: Rc::clone(&self.async_builtins),
-            builtin_metadata: Rc::clone(&self.builtin_metadata),
-            builtins_by_id: Rc::clone(&self.builtins_by_id),
-            builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
+            builtins: Arc::clone(&self.builtins),
+            async_builtins: Arc::clone(&self.async_builtins),
+            builtin_metadata: Arc::clone(&self.builtin_metadata),
+            builtins_by_id: Arc::clone(&self.builtins_by_id),
+            builtin_id_collisions: Arc::clone(&self.builtin_id_collisions),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
             spawned_tasks: BTreeMap::new(),
             sync_runtime: Arc::new(crate::synchronization::VmSyncRuntime::new()),
-            shared_state_runtime: Rc::new(crate::shared_state::VmSharedStateRuntime::new()),
+            shared_state_runtime: Arc::new(crate::shared_state::VmSharedStateRuntime::new()),
+            inline_caches: HashMap::new(),
+            pool_registry: crate::stdlib::pool::new_pool_registry(),
             held_sync_guards: Vec::new(),
             task_counter: 0,
             runtime_context_counter: 0,
@@ -329,12 +334,12 @@ impl VmBaseline {
             last_line: 0,
             source_dir: self.source_dir.clone(),
             imported_paths: Vec::new(),
-            module_cache: Rc::new(BTreeMap::new()),
-            source_cache: Rc::new(source_cache),
+            module_cache: Arc::new(BTreeMap::new()),
+            source_cache: Arc::new(source_cache),
             source_file: self.source_file.clone(),
             source_text: self.source_text.clone(),
             bridge: None,
-            denied_builtins: Rc::clone(&self.denied_builtins),
+            denied_builtins: Arc::clone(&self.denied_builtins),
             cancel_token: None,
             interrupt_signal_token: None,
             cancel_grace_instructions_remaining: None,
@@ -347,7 +352,7 @@ impl VmBaseline {
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: self.project_root.clone(),
-            globals: Rc::clone(&self.globals),
+            globals: Arc::clone(&self.globals),
             debug_hook: None,
             runtime_limits: self.runtime_limits,
         };
@@ -527,17 +532,19 @@ impl Vm {
             stack: Vec::with_capacity(256),
             env: VmEnv::new(),
             output: String::new(),
-            builtins: Rc::new(BTreeMap::new()),
-            async_builtins: Rc::new(BTreeMap::new()),
-            builtin_metadata: Rc::new(BTreeMap::new()),
-            builtins_by_id: Rc::new(BTreeMap::new()),
-            builtin_id_collisions: Rc::new(HashSet::new()),
+            builtins: Arc::new(BTreeMap::new()),
+            async_builtins: Arc::new(BTreeMap::new()),
+            builtin_metadata: Arc::new(BTreeMap::new()),
+            builtins_by_id: Arc::new(BTreeMap::new()),
+            builtin_id_collisions: Arc::new(HashSet::new()),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
             spawned_tasks: BTreeMap::new(),
             sync_runtime: Arc::new(crate::synchronization::VmSyncRuntime::new()),
-            shared_state_runtime: Rc::new(crate::shared_state::VmSharedStateRuntime::new()),
+            shared_state_runtime: Arc::new(crate::shared_state::VmSharedStateRuntime::new()),
+            inline_caches: HashMap::new(),
+            pool_registry: crate::stdlib::pool::new_pool_registry(),
             held_sync_guards: Vec::new(),
             task_counter: 0,
             runtime_context_counter: 0,
@@ -552,12 +559,12 @@ impl Vm {
             last_line: 0,
             source_dir: None,
             imported_paths: Vec::new(),
-            module_cache: Rc::new(BTreeMap::new()),
-            source_cache: Rc::new(BTreeMap::new()),
+            module_cache: Arc::new(BTreeMap::new()),
+            source_cache: Arc::new(BTreeMap::new()),
             source_file: None,
             source_text: None,
             bridge: None,
-            denied_builtins: Rc::new(HashSet::new()),
+            denied_builtins: Arc::new(HashSet::new()),
             cancel_token: None,
             interrupt_signal_token: None,
             cancel_grace_instructions_remaining: None,
@@ -570,7 +577,7 @@ impl Vm {
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: None,
-            globals: Rc::new(BTreeMap::new()),
+            globals: Arc::new(BTreeMap::new()),
             debug_hook: None,
             runtime_limits: RuntimeLimits::default(),
         }
@@ -611,21 +618,21 @@ impl Vm {
     }
 
     /// Set the bridge for delegating unknown builtins in bridge mode.
-    pub fn set_bridge(&mut self, bridge: Rc<crate::bridge::HostBridge>) {
+    pub fn set_bridge(&mut self, bridge: Arc<crate::bridge::HostBridge>) {
         self.bridge = Some(bridge);
     }
 
     /// Set builtins that are denied in sandbox mode.
     /// When called, the given builtin names will produce a permission error.
     pub fn set_denied_builtins(&mut self, denied: HashSet<String>) {
-        self.denied_builtins = Rc::new(denied);
+        self.denied_builtins = Arc::new(denied);
     }
 
     /// Set source info for error reporting (file path and source text).
     pub fn set_source_info(&mut self, file: &str, text: &str) {
         self.source_file = Some(file.to_string());
         self.source_text = Some(text.to_string());
-        Rc::make_mut(&mut self.source_cache)
+        Arc::make_mut(&mut self.source_cache)
             .insert(std::path::PathBuf::from(file), text.to_string());
     }
 
@@ -674,17 +681,19 @@ impl Vm {
             stack: Vec::with_capacity(64),
             env: self.env.clone(),
             output: String::new(),
-            builtins: Rc::clone(&self.builtins),
-            async_builtins: Rc::clone(&self.async_builtins),
-            builtin_metadata: Rc::clone(&self.builtin_metadata),
-            builtins_by_id: Rc::clone(&self.builtins_by_id),
-            builtin_id_collisions: Rc::clone(&self.builtin_id_collisions),
+            builtins: Arc::clone(&self.builtins),
+            async_builtins: Arc::clone(&self.async_builtins),
+            builtin_metadata: Arc::clone(&self.builtin_metadata),
+            builtins_by_id: Arc::clone(&self.builtins_by_id),
+            builtin_id_collisions: Arc::clone(&self.builtin_id_collisions),
             iterators: Vec::new(),
             frames: Vec::new(),
             exception_handlers: Vec::new(),
             spawned_tasks: BTreeMap::new(),
             sync_runtime: self.sync_runtime.clone(),
             shared_state_runtime: self.shared_state_runtime.clone(),
+            inline_caches: HashMap::new(),
+            pool_registry: self.pool_registry.clone(),
             held_sync_guards: Vec::new(),
             task_counter: 0,
             runtime_context_counter: self.runtime_context_counter,
@@ -699,12 +708,12 @@ impl Vm {
             last_line: 0,
             source_dir: self.source_dir.clone(),
             imported_paths: Vec::new(),
-            module_cache: Rc::clone(&self.module_cache),
-            source_cache: Rc::clone(&self.source_cache),
+            module_cache: Arc::clone(&self.module_cache),
+            source_cache: Arc::clone(&self.source_cache),
             source_file: self.source_file.clone(),
             source_text: self.source_text.clone(),
             bridge: self.bridge.clone(),
-            denied_builtins: Rc::clone(&self.denied_builtins),
+            denied_builtins: Arc::clone(&self.denied_builtins),
             cancel_token: self.cancel_token.clone(),
             interrupt_signal_token: self.interrupt_signal_token.clone(),
             cancel_grace_instructions_remaining: None,
@@ -717,7 +726,7 @@ impl Vm {
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: self.project_root.clone(),
-            globals: Rc::clone(&self.globals),
+            globals: Arc::clone(&self.globals),
             debug_hook: None,
             runtime_limits: self.runtime_limits,
         }
@@ -783,7 +792,7 @@ impl Vm {
     /// Set a global constant (e.g. `pi`, `e`).
     /// Stored separately from the environment so user-defined variables can shadow them.
     pub fn set_global(&mut self, name: &str, value: VmValue) {
-        Rc::make_mut(&mut self.globals).insert(name.to_string(), value);
+        Arc::make_mut(&mut self.globals).insert(name.to_string(), value);
     }
 
     /// Read a previously-installed global (the value `set_global` /

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1,13 +1,12 @@
-use std::cell::Cell;
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::compiler::{Compiler, CompilerOptions};
 use crate::stdlib::register_vm_stdlib;
 use crate::{
-    AdaptiveBinaryOp, AdaptiveBinaryState, BinaryShape, Chunk, DirectCallState, InlineCacheEntry,
+    AdaptiveBinaryOp, AdaptiveBinaryState, BinaryShape, DirectCallState, InlineCacheEntry,
     MethodCacheTarget, PropertyCacheTarget, VmError, VmValue,
 };
 use harn_lexer::Lexer;
@@ -75,7 +74,7 @@ fn run_harn_result_display_with_options(
     })
 }
 
-fn run_harn_with_chunk(source: &str) -> (Chunk, String, VmValue) {
+fn run_harn_with_inline_cache_entries(source: &str) -> (Vec<InlineCacheEntry>, String, VmValue) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -93,7 +92,8 @@ fn run_harn_with_chunk(source: &str) -> (Chunk, String, VmValue) {
                 let mut vm = Vm::new();
                 register_vm_stdlib(&mut vm);
                 let result = vm.execute(&chunk).await.unwrap();
-                (chunk, vm.output().to_string(), result)
+                let inline_cache_entries = vm.inline_cache_entries_for_chunk(&chunk);
+                (inline_cache_entries, vm.output().to_string(), result)
             })
             .await
     })
@@ -577,7 +577,7 @@ fn test_list_properties() {
 
 #[test]
 fn test_inline_cache_warms_property_sites() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r#"pipeline t(task) {
 let list = [1, 2, 3]
 let text = ""
@@ -600,7 +600,6 @@ log(total)
         out.trim_end(),
         "[harn] right\n[harn] right\n[harn] right\n[harn] 12"
     );
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -635,7 +634,7 @@ log(total)
 
 #[test]
 fn test_inline_cache_warms_dict_and_struct_property_sites() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r"pipeline t(task) {
 struct Point {
   x: int
@@ -654,7 +653,6 @@ log(total)
     );
 
     assert_eq!(out.trim_end(), "[harn] 30");
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -679,7 +677,7 @@ log(total)
 
 #[test]
 fn test_inline_cache_replaces_polymorphic_property_site() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r#"pipeline t(task) {
 for value in [[1, 2], "ab"] {
   log(value.count)
@@ -688,7 +686,6 @@ for value in [[1, 2], "ab"] {
     );
 
     assert_eq!(out.trim_end(), "[harn] 2\n[harn] 2");
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -703,7 +700,7 @@ for value in [[1, 2], "ab"] {
 
 #[test]
 fn test_inline_cache_warms_method_sites() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r#"pipeline t(task) {
 let list = [1, 2, 3]
 let text = "abc"
@@ -729,7 +726,6 @@ log(total)
     );
 
     assert_eq!(out.trim_end(), "[harn] 45");
-    let entries = chunk.inline_cache_entries();
     for target in [
         MethodCacheTarget::ListCount,
         MethodCacheTarget::ListContains,
@@ -756,7 +752,7 @@ log(total)
 
 #[test]
 fn test_adaptive_inline_cache_specializes_generic_integer_add_site() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r"pipeline t(task) {
 fn erase(x) {
   return x
@@ -772,7 +768,6 @@ log(total)
     );
 
     assert_eq!(out.trim_end(), "[harn] 28");
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -791,7 +786,7 @@ log(total)
 
 #[test]
 fn test_adaptive_inline_cache_deoptimizes_mixed_binary_shapes() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r"pipeline t(task) {
 fn erase(x) {
   return x
@@ -806,7 +801,6 @@ log(acc)
     );
 
     assert_eq!(out.trim_end(), "[harn] 15.0");
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -825,7 +819,7 @@ log(acc)
 
 #[test]
 fn test_adaptive_inline_cache_specializes_named_closure_call_site() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r"pipeline t(task) {
 fn inc(x) {
   return x + 1
@@ -841,7 +835,6 @@ log(total)
     );
 
     assert_eq!(out.trim_end(), "[harn] 36");
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -855,7 +848,7 @@ log(total)
 
 #[test]
 fn test_adaptive_inline_cache_deoptimizes_rebound_closure_call_site() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r"pipeline t(task) {
 fn inc(x) {
   return x + 1
@@ -878,7 +871,6 @@ log(total)
     );
 
     assert_eq!(out.trim_end(), "[harn] 51");
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -892,7 +884,7 @@ log(total)
 
 #[test]
 fn test_inline_cache_warms_spread_method_site() {
-    let (chunk, out, _) = run_harn_with_chunk(
+    let (entries, out, _) = run_harn_with_inline_cache_entries(
         r"pipeline t(task) {
 let list = [1, 2, 3]
 let args = []
@@ -905,7 +897,6 @@ while i < 3 {
     );
 
     assert_eq!(out.trim_end(), "[harn] 3\n[harn] 3\n[harn] 3");
-    let entries = chunk.inline_cache_entries();
     assert!(
         entries.iter().any(|entry| matches!(
             entry,
@@ -1067,7 +1058,7 @@ fn test_direct_builtin_call_falls_back_to_bridge() {
 
                 let mut vm = Vm::new();
                 register_vm_stdlib(&mut vm);
-                vm.set_bridge(Rc::new(bridge));
+                vm.set_bridge(Arc::new(bridge));
                 vm.execute(&chunk).await.unwrap();
                 vm.output().trim().to_string()
             })
@@ -1728,7 +1719,7 @@ await(handle)
             let program = parser.parse().unwrap();
             let chunk = Compiler::new().compile(&program).unwrap();
 
-            let marker = Rc::new(Cell::new(false));
+            let marker = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let marker_for_builtin = marker.clone();
             let cancel_token = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
             let vm_cancel_token = cancel_token.clone();
@@ -1736,7 +1727,7 @@ await(handle)
                 let mut vm = Vm::new();
                 register_vm_stdlib(&mut vm);
                 vm.register_builtin("mark", move |_, _| {
-                    marker_for_builtin.set(true);
+                    marker_for_builtin.store(true, std::sync::atomic::Ordering::SeqCst);
                     Ok(VmValue::Nil)
                 });
                 vm.install_cancel_token(vm_cancel_token);
@@ -1755,7 +1746,7 @@ await(handle)
             tokio::time::advance(Duration::from_secs(1)).await;
             tokio::task::yield_now().await;
             assert!(
-                !marker.get(),
+                !marker.load(std::sync::atomic::Ordering::SeqCst),
                 "spawned task should be aborted when parent await is cancelled"
             );
         })

--- a/crates/harn-vm/tests/agent_loop_steering_seams.rs
+++ b/crates/harn-vm/tests/agent_loop_steering_seams.rs
@@ -19,7 +19,6 @@
 //! unchanged versus a control run, and the `loop_exit` checkpoint
 //! reports the delivery.
 
-use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
@@ -37,7 +36,7 @@ fn run_with_bridge(source: &str) -> Result<String, String> {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
-                let bridge = Rc::new(HostBridge::from_parts(
+                let bridge = Arc::new(HostBridge::from_parts(
                     Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
                     Arc::new(AtomicBool::new(false)),
                     Arc::new(Mutex::new(())),

--- a/crates/harn-vm/tests/pool_multithread.rs
+++ b/crates/harn-vm/tests/pool_multithread.rs
@@ -1,0 +1,81 @@
+#![recursion_limit = "256"]
+
+use harn_vm::value::VmError;
+
+fn run_on_multithread(source: &str) -> Result<Vec<String>, String> {
+    harn_vm::reset_thread_local_state();
+    let chunk = harn_vm::compile_source(source)?;
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .map_err(|error| error.to_string())?;
+    let output = rt.block_on(async {
+        let mut vm = harn_vm::Vm::new();
+        harn_vm::register_vm_stdlib(&mut vm);
+        vm.execute(&chunk)
+            .await
+            .map_err(|error: VmError| format!("{error:?}"))?;
+        Ok::<_, String>(vm.output().to_string())
+    })?;
+    Ok(output
+        .lines()
+        .filter_map(|line| line.strip_prefix("[harn] "))
+        .map(str::to_string)
+        .collect())
+}
+
+#[test]
+fn pool_workers_run_on_multithread_runtime_without_localset() {
+    let lines = run_on_multithread(
+        r#"
+import { pool_create, pool_wait } from "std/lifecycle/pool"
+
+pipeline main(task) {
+  let pool = pool_create({name: "multithread-no-localset", max_concurrent: 4})
+  var handles = []
+  for i in 0 to 8 exclusive {
+    let seed = i
+    handles = handles.push(pool.submit({ -> seed + 10 }))
+  }
+  let results = pool_wait(handles)
+  var completed = 0
+  for result in results {
+    if result.status == "completed" && result.result >= 10 {
+      completed = completed + 1
+    }
+  }
+  log(completed)
+}
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(lines, vec!["8"]);
+}
+
+#[test]
+fn pool_worker_inherits_registry_for_nested_waits() {
+    let lines = run_on_multithread(
+        r#"
+import { pool_create, pool_wait } from "std/lifecycle/pool"
+
+pipeline main(task) {
+  let pool = pool_create({name: "worker-nested-wait", max_concurrent: 2})
+  let inner = pool.submit({ -> "inner-ok" })
+  let outer = pool.submit({ ->
+    let done = pool_wait(inner)
+    return done.result
+  })
+  let outer_done = pool_wait(outer)
+  let inner_done = pool_wait(inner)
+  log(outer_done.status)
+  log(outer_done.result)
+  log(inner_done.result)
+}
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(lines, vec!["completed", "inner-ok", "inner-ok"]);
+}

--- a/crates/harn-vm/tests/tool_call_cancellation.rs
+++ b/crates/harn-vm/tests/tool_call_cancellation.rs
@@ -6,7 +6,6 @@
 //! `cancel_in_flight_tool_call`, and the dispatched tool's result is
 //! shaped as `status: "cancelled"`.
 
-use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
@@ -24,7 +23,7 @@ fn run_with_bridge(source: &str) -> Result<String, String> {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
-                let bridge = Rc::new(HostBridge::from_parts(
+                let bridge = Arc::new(HostBridge::from_parts(
                     Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
                     Arc::new(AtomicBool::new(false)),
                     Arc::new(Mutex::new(())),
@@ -338,7 +337,7 @@ pipeline main(_) {
         let local = tokio::task::LocalSet::new();
         local
             .run_until(async {
-                let bridge = Rc::new(HostBridge::from_parts(
+                let bridge = Arc::new(HostBridge::from_parts(
                     Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
                     Arc::new(AtomicBool::new(false)),
                     Arc::new(Mutex::new(())),


### PR DESCRIPTION
## Summary

- Moves the VM/builtin dispatch ABI onto `Send`/`Sync` handles and `Send` async builtin futures, with static assertions for `VmValue`, `Chunk`, `Vm`, and builtin function types.
- Converts remaining VM shared state, DAP/debug hooks, and host/runtime registries needed by dispatch from `Rc`/`RefCell` patterns to `Arc` plus appropriate mutexes.
- Makes live inline-cache entries VM-isolate-local, keyed by a runtime-only chunk cache id, so parallel workers do not contend on shared compiled chunks or alias stale pointer keys.
- Converts the pool registry from thread-local state into a VM-scoped registry and runs pool workers with `tokio::spawn`, including scoped registry inheritance, panic cleanup, and a cooperative first yield for batch distribution.
- Adds multithread pool tests and a Criterion pool fan-out benchmark.

Fixes #2690.
Refs #2691 and #2692.

## Notes

This ships the first `tokio::spawn` pool worker path and benchmark coverage for #2691, but I am not closing #2691 here. On this local machine the Criterion run validates the benchmark and shows the 4-worker lane no longer has the earlier shared-cache contention cliff, but it does not demonstrate the issue's requested ~0.7xN CPU speedup target.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo check -p harn-vm`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo check -p harn-vm --benches`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo check -p harn-vm --features vm-bench-internals`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo check -p harn-dap`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo test -p harn-vm vm_value_layout_budget`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo test -p harn-vm --test pool_multithread`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo check -p harn-cli -p harn-serve`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target make check-ported-handler-loc`
- `CARGO_TARGET_DIR=/tmp/harn-2690-target cargo bench -p harn-vm --bench pool_parallel`
- pre-commit and pre-push hooks passed on the rebased `origin/main` (`d02c1444`) base