### PR TITLE
Make pool fan-out thread-local audit enforceable

### DIFF
--- a/changelog.d/2691.changed.md
+++ b/changelog.d/2691.changed.md
@@ -1,0 +1,5 @@
+- **Pool multithreading now has an enforceable thread-local audit guard and CPU fan-out benchmark (#2691, #2692).**
+  The VM keeps a checked-in inventory for every `thread_local!` site, tests that
+  new sites are classified before landing, documents the `tokio::spawn`
+  pool-worker boundary that must stay task-local or explicitly scoped, and
+  avoids hot shared-closure refcount contention in adaptive arithmetic dispatch.

--- a/crates/harn-vm/benches/pool_parallel.rs
+++ b/crates/harn-vm/benches/pool_parallel.rs
@@ -1,17 +1,15 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use harn_vm::{compile_source, register_vm_stdlib, Chunk, Vm, VmValue};
 use tokio::runtime::{Builder, Runtime};
 
 const TASKS: usize = 16;
-const INNER_ITERS: usize = 120_000;
+const INNER_ITERS: usize = 90_000;
 
-fn pool_source(max_concurrent: usize) -> String {
+fn crunch_function() -> String {
     format!(
         r#"
-import {{ pool_create, pool_wait }} from "std/lifecycle/pool"
-
 fn crunch(seed) {{
   var i = 0
   var total = seed + 1
@@ -19,8 +17,39 @@ fn crunch(seed) {{
     total = ((total * 1664525) + i + 1013904223) % 2147483647
     i = i + 1
   }}
-  return total
+  return {{
+    seed: seed,
+    total: total,
+    payload: [seed, total, "pool-parallel"]
+  }}
 }}
+"#
+    )
+}
+
+fn serial_source() -> String {
+    format!(
+        r"
+{}
+
+pipeline default() {{
+  var results = []
+  for i in 0 to {TASKS} exclusive {{
+    results = results.push(crunch(i))
+  }}
+  return len(results)
+}}
+",
+        crunch_function()
+    )
+}
+
+fn pool_source(max_concurrent: usize) -> String {
+    format!(
+        r#"
+import {{ pool_create, pool_wait }} from "std/lifecycle/pool"
+
+{}
 
 pipeline default() {{
   let pool = pool_create({{name: "pool-parallel-bench", max_concurrent: {max_concurrent}}})
@@ -32,12 +61,17 @@ pipeline default() {{
   let results = pool_wait(handles)
   return len(results)
 }}
-"#
+"#,
+        crunch_function()
     )
 }
 
 fn compile_pool_fixture(max_concurrent: usize) -> Chunk {
     compile_source(&pool_source(max_concurrent)).expect("pool parallel bench fixture compiles")
+}
+
+fn compile_serial_fixture() -> Chunk {
+    compile_source(&serial_source()).expect("serial pool baseline bench fixture compiles")
 }
 
 fn runtime() -> Runtime {
@@ -59,6 +93,12 @@ fn execute(rt: &Runtime, chunk: &Chunk) -> VmValue {
 
 fn bench_pool_parallel(c: &mut Criterion) {
     let mut group = c.benchmark_group("pool_parallel_cpu_fanout");
+    group.throughput(Throughput::Elements(TASKS as u64));
+    let serial_chunk = compile_serial_fixture();
+    let serial_rt = runtime();
+    group.bench_function(BenchmarkId::new("serial", 1), |b| {
+        b.iter(|| black_box(execute(&serial_rt, &serial_chunk)));
+    });
     for workers in [1_usize, 2, 4] {
         let chunk = compile_pool_fixture(workers);
         let rt = runtime();

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -2407,7 +2407,7 @@ fn spawn_task(pool: Arc<parking_lot::Mutex<PoolEntry>>, pending: PendingTask) {
     dequeue_span.end();
 
     let registry = ctx.pool_registry();
-    tokio::spawn(with_pool_registry_scope(registry, async move {
+    spawn_pool_worker(registry, async move {
         tokio::task::yield_now().await;
         let outcome = std::panic::AssertUnwindSafe(async {
             let mut runner = ctx.child_vm();
@@ -2422,7 +2422,14 @@ fn spawn_task(pool: Arc<parking_lot::Mutex<PoolEntry>>, pending: PendingTask) {
         .await
         .unwrap_or_else(|payload| Err(pool_panic_error(payload)));
         finalize_task(&pool, &state, outcome);
-    }));
+    });
+}
+
+fn spawn_pool_worker<F>(registry: Arc<PoolRegistry>, future: F) -> tokio::task::JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(with_pool_registry_scope(registry, future))
 }
 
 fn pool_panic_error(payload: Box<dyn Any + Send>) -> String {

--- a/crates/harn-vm/src/vm/cache.rs
+++ b/crates/harn-vm/src/vm/cache.rs
@@ -6,11 +6,14 @@ use crate::chunk::{
 use super::Vm;
 
 impl Vm {
-    fn inline_cache_entries_mut(&mut self, chunk: &ChunkRef) -> &mut Vec<InlineCacheEntry> {
-        let slot_count = chunk.inline_cache_slot_count();
+    fn inline_cache_entries_mut_by_key(
+        &mut self,
+        cache_id: u64,
+        slot_count: usize,
+    ) -> &mut Vec<InlineCacheEntry> {
         let entries = self
             .inline_caches
-            .entry(chunk.cache_id())
+            .entry(cache_id)
             .or_insert_with(|| vec![InlineCacheEntry::Empty; slot_count]);
         if entries.len() < slot_count {
             entries.resize(slot_count, InlineCacheEntry::Empty);
@@ -18,13 +21,21 @@ impl Vm {
         entries
     }
 
+    fn inline_cache_entries_mut(&mut self, chunk: &ChunkRef) -> &mut Vec<InlineCacheEntry> {
+        self.inline_cache_entries_mut_by_key(chunk.cache_id(), chunk.inline_cache_slot_count())
+    }
+
     #[inline]
-    pub(crate) fn peek_adaptive_binary_cache(
+    pub(crate) fn peek_adaptive_binary_cache_by_key(
         &mut self,
-        chunk: &ChunkRef,
+        cache_id: u64,
+        slot_count: usize,
         slot: usize,
     ) -> Option<(AdaptiveBinaryOp, AdaptiveBinaryState)> {
-        match self.inline_cache_entries_mut(chunk).get(slot)? {
+        match self
+            .inline_cache_entries_mut_by_key(cache_id, slot_count)
+            .get(slot)?
+        {
             &InlineCacheEntry::AdaptiveBinary { op, state } => Some((op, state)),
             _ => None,
         }
@@ -76,7 +87,22 @@ impl Vm {
         slot: usize,
         entry: InlineCacheEntry,
     ) {
-        let entries = self.inline_cache_entries_mut(chunk);
+        self.set_inline_cache_entry_by_key(
+            chunk.cache_id(),
+            chunk.inline_cache_slot_count(),
+            slot,
+            entry,
+        );
+    }
+
+    pub(crate) fn set_inline_cache_entry_by_key(
+        &mut self,
+        cache_id: u64,
+        slot_count: usize,
+        slot: usize,
+        entry: InlineCacheEntry,
+    ) {
+        let entries = self.inline_cache_entries_mut_by_key(cache_id, slot_count);
         if let Some(existing) = entries.get_mut(slot) {
             *existing = entry;
         }

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -57,23 +57,20 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_adaptive_binary(&mut self, op: AdaptiveBinaryOp) -> Result<(), VmError> {
-        // Read the cache slot index from the flat side-table (O(1) `Vec`
-        // index after #2470) and, if a slot exists, peek the cached
-        // `AdaptiveBinaryState` by value. The peek avoids cloning the
-        // wrapping `InlineCacheEntry` enum — that clone used to fire on
-        // every dispatch of every binary op, paying a 24-32B memcpy
-        // that the variant-checking match would just throw away. Since
-        // `AdaptiveBinaryState: Copy`, the read here is a single scalar
-        // move (`u8`/`u64` fields, all stack-resident).
-        let (chunk, cache_slot) = {
+        // Read the cache slot from the chunk side table, then access the
+        // VM-local cache by scalar chunk metadata. Avoiding a shared Chunk
+        // clone here keeps parallel workers from contending on the same
+        // compiled closure refcount in arithmetic-heavy pool tasks.
+        let (cache_id, slot_count, cache_slot) = {
             let frame = self.frames.last().unwrap();
             let op_offset = frame.ip.saturating_sub(1);
-            let chunk = Arc::clone(&frame.chunk);
+            let cache_id = frame.chunk.cache_id();
+            let slot_count = frame.chunk.inline_cache_slot_count();
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (chunk, cache_slot)
+            (cache_id, slot_count, cache_slot)
         };
         let cached_state = cache_slot
-            .and_then(|slot| self.peek_adaptive_binary_cache(&chunk, slot))
+            .and_then(|slot| self.peek_adaptive_binary_cache_by_key(cache_id, slot_count, slot))
             .filter(|(cached_op, _)| *cached_op == op)
             .map(|(_, state)| state);
 
@@ -85,8 +82,9 @@ impl super::super::Vm {
             Self::try_specialized_binary(op, cached_state, &a, &b)
         {
             if let Some(slot) = cache_slot {
-                self.set_inline_cache_entry(
-                    &chunk,
+                self.set_inline_cache_entry_by_key(
+                    cache_id,
+                    slot_count,
                     slot,
                     InlineCacheEntry::AdaptiveBinary {
                         op,
@@ -99,8 +97,9 @@ impl super::super::Vm {
             let result = Self::generic_binary_result(self, op, a, b)?;
             if let (Some(slot), Some(shape)) = (cache_slot, shape) {
                 let next_state = Self::next_adaptive_binary_state(cached_state, shape);
-                self.set_inline_cache_entry(
-                    &chunk,
+                self.set_inline_cache_entry_by_key(
+                    cache_id,
+                    slot_count,
                     slot,
                     InlineCacheEntry::AdaptiveBinary {
                         op,
@@ -115,13 +114,11 @@ impl super::super::Vm {
         Ok(())
     }
 
-    /// Adaptive-binary specialization fast path. Takes the peeked
-    /// `Copy` `AdaptiveBinaryState` (already filtered for the current
-    /// op by [`execute_adaptive_binary`]) instead of `&InlineCacheEntry`,
-    /// so the helper no longer destructures the outer enum on every
-    /// dispatch. Returns `(result, next_state)` on a hit; the caller
-    /// is responsible for wrapping `next_state` into `InlineCacheEntry`
-    /// before writing it back through `set_inline_cache_entry`.
+    /// Adaptive-binary specialization fast path. The caller supplies the
+    /// peeked `Copy` state after filtering for the current op, which keeps
+    /// this helper focused on shape matching and result production. Returns
+    /// `(result, next_state)` on a hit; the caller wraps `next_state` into an
+    /// `InlineCacheEntry` before writing it back.
     fn try_specialized_binary(
         op: AdaptiveBinaryOp,
         cached_state: Option<AdaptiveBinaryState>,

--- a/crates/harn-vm/tests/thread_local_audit.rs
+++ b/crates/harn-vm/tests/thread_local_audit.rs
@@ -1,0 +1,182 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ThreadLocalAudit {
+    plans: BTreeMap<String, String>,
+    #[serde(rename = "thread_local")]
+    entries: Vec<AuditEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditEntry {
+    path: String,
+    statics: Vec<String>,
+    category: String,
+    plan: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct ThreadLocalSite {
+    path: String,
+    statics: Vec<String>,
+}
+
+#[test]
+fn thread_local_audit_tracks_every_vm_thread_local_site() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source_dir = manifest_dir.join("src");
+    let audit_path = manifest_dir.join("thread_local_audit.toml");
+
+    let actual = scan_thread_local_sites(&manifest_dir, &source_dir);
+    let audit = parse_audit(&audit_path);
+
+    let mut audited = BTreeSet::new();
+    for entry in &audit.entries {
+        assert!(
+            matches!(
+                entry.category.as_str(),
+                "logical_task" | "runtime_registry" | "thread_private"
+            ),
+            "unknown thread-local audit category {:?} for {}",
+            entry.category,
+            entry.path
+        );
+        assert!(
+            audit
+                .plans
+                .get(&entry.plan)
+                .is_some_and(|plan| !plan.trim().is_empty()),
+            "thread-local audit entry for {} references missing or empty plan {:?}",
+            entry.path,
+            entry.plan
+        );
+        audited.insert(ThreadLocalSite {
+            path: entry.path.clone(),
+            statics: entry.statics.clone(),
+        });
+    }
+
+    let missing: Vec<_> = actual.difference(&audited).cloned().collect();
+    let stale: Vec<_> = audited.difference(&actual).cloned().collect();
+    assert!(
+        missing.is_empty() && stale.is_empty(),
+        "thread_local! audit drift\nmissing: {missing:#?}\nstale: {stale:#?}"
+    );
+}
+
+#[test]
+fn pool_worker_boundary_uses_task_local_registry_not_thread_local_registry() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let pool_source =
+        fs::read_to_string(manifest_dir.join("src/stdlib/pool/mod.rs")).expect("read pool module");
+
+    assert!(
+        thread_local_blocks(&pool_source).is_empty(),
+        "pool workers run on tokio::spawn; pool registry state must not regress to thread_local!"
+    );
+    assert!(
+        pool_source.contains("tokio::task_local!") && pool_source.contains("ACTIVE_POOL_REGISTRY"),
+        "pool registry must be scoped through a Tokio task-local so it follows spawned work"
+    );
+    assert!(
+        pool_source.contains("spawn_pool_worker"),
+        "pool worker spawning should stay behind the documented work-stealing boundary helper"
+    );
+}
+
+fn parse_audit(path: &Path) -> ThreadLocalAudit {
+    let contents = fs::read_to_string(path).expect("read thread_local_audit.toml");
+    toml::from_str(&contents).expect("parse thread_local_audit.toml")
+}
+
+fn scan_thread_local_sites(manifest_dir: &Path, source_dir: &Path) -> BTreeSet<ThreadLocalSite> {
+    let mut sites = BTreeSet::new();
+    for path in rust_files(source_dir) {
+        let source = fs::read_to_string(&path).expect("read Rust source");
+        let relative_path = path
+            .strip_prefix(manifest_dir)
+            .expect("source under crate")
+            .to_string_lossy()
+            .replace('\\', "/");
+        for block in thread_local_blocks(&source) {
+            sites.insert(ThreadLocalSite {
+                path: relative_path.clone(),
+                statics: static_names(block),
+            });
+        }
+    }
+    sites
+}
+
+fn rust_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut dirs = vec![root.to_path_buf()];
+    while let Some(dir) = dirs.pop() {
+        for entry in fs::read_dir(dir).expect("read source directory") {
+            let path = entry.expect("read source entry").path();
+            if path.is_dir() {
+                dirs.push(path);
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+fn thread_local_blocks(source: &str) -> Vec<&str> {
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+    while let Some(relative_start) = source[offset..].find("thread_local!") {
+        let start = offset + relative_start;
+        let line_start = source[..start].rfind('\n').map_or(0, |index| index + 1);
+        if !source[line_start..start].trim().is_empty() {
+            offset = start + "thread_local!".len();
+            continue;
+        }
+        let Some(open_relative) = source[start..].find('{') else {
+            break;
+        };
+        let open = start + open_relative;
+        let mut depth = 0_i32;
+        for (relative_index, ch) in source[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let close = open + relative_index;
+                        blocks.push(&source[open + 1..close]);
+                        offset = close + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if offset <= start {
+            break;
+        }
+    }
+    blocks
+}
+
+fn static_names(block: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in block.lines() {
+        let trimmed = line.trim_start();
+        let Some(static_index) = trimmed.find("static ") else {
+            continue;
+        };
+        let rest = &trimmed[static_index + "static ".len()..];
+        if let Some((name, _)) = rest.split_once(':') {
+            names.push(name.trim().to_string());
+        }
+    }
+    names
+}

--- a/crates/harn-vm/thread_local_audit.toml
+++ b/crates/harn-vm/thread_local_audit.toml
@@ -1,0 +1,693 @@
+# Every `thread_local!` macro under `src/` must be listed here so
+# work-stealing changes have an explicit migration plan or safe
+# thread-private rationale before they cross a spawned-worker boundary.
+
+[plans]
+task_local_or_explicit = "Logical execution state. Convert to tokio::task_local! scope or explicit Vm/AsyncBuiltinCtx state before it is read from work-stealing tasks."
+arc_registry_scope = "Runtime/resource registry. Promote to an Arc-backed VM/runtime registry and scope or pass the handle into spawned work before the surface crosses a work-stealing boundary."
+thread_private_cache = "Thread-private cache, mock, or warning de-dupe state. Safe to keep thread-local because it is non-authoritative and resettable."
+thread_private_test = "Test harness state. Safe to keep thread-local because tests install/reset it on the owning thread and production work-stealing tasks must not depend on it."
+
+[[thread_local]]
+path = "src/agent_sessions.rs"
+statics = ["SESSIONS", "SESSION_CAP", "DEFAULT_TRANSCRIPT_BUDGET_POLICY", "CURRENT_SESSION_STACK", "CURRENT_TOOL_CALL_STACK"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/autonomy.rs"
+statics = ["AUTONOMY_POLICY_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/call_budget.rs"
+statics = ["MCP_CALL_BUDGET", "MCP_CALL_COUNT", "PG_QUERY_BUDGET", "PG_QUERY_COUNT"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/channel_guardrails.rs"
+statics = ["REGISTRY"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/checkpoint.rs"
+statics = ["CHECKPOINT_STATE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/compiler/state.rs"
+statics = ["FORCE_DISCARDED_PRODUCES_VALUE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/connectors/harn_module.rs"
+statics = ["ACTIVE_HARN_CONNECTOR_CTX"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/connectors/mod.rs"
+statics = ["ACTIVE_CONNECTOR_CLIENTS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/egress.rs"
+statics = ["REQUIRE_EXPLICIT_EGRESS_POLICY_DEPTH"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/event_log/mod.rs"
+statics = ["ACTIVE_EVENT_LOG", "PENDING_DEFAULT_EVENT_LOG"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/events.rs"
+statics = ["EVENT_SINKS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/harness_tenant.rs"
+statics = ["ACTIVE_TENANT_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/http/client.rs"
+statics = ["HTTP_CLIENTS", "HTTP_SESSIONS", "HTTP_STREAMS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/http/mock.rs"
+statics = ["HTTP_MOCKS", "HTTP_MOCK_CALLS"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/http/mod.rs"
+statics = ["TRANSPORT_HANDLE_COUNTER", "HTTP_SERVERS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/http/streaming.rs"
+statics = ["SSE_MOCKS", "SSE_HANDLES", "SSE_SERVER_HANDLES", "WEBSOCKET_MOCKS", "WEBSOCKET_HANDLES", "WEBSOCKET_SERVERS", "TRANSPORT_MOCK_CALLS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/llm/agent_observe.rs"
+statics = ["LAST_SYSTEM_PROMPT_HASH", "LAST_TOOL_SCHEMAS_HASH", "TRANSCRIPT_DIR_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/agent_runtime.rs"
+statics = ["CURRENT_HOST_BRIDGE", "CURRENT_LOOP_SINKS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/agent_session_host.rs"
+statics = ["AGENT_HOST_SESSIONS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/llm/autonomy_budget.rs"
+statics = ["AUTONOMY_COUNTERS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/cache.rs"
+statics = ["ACCESS_CLOCK"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/llm/cache.rs"
+statics = ["MEM_STORE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/llm/cache.rs"
+statics = ["METRICS"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/llm/call.rs"
+statics = ["IN_FLIGHT_LLM_CALLS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/capabilities.rs"
+statics = ["USER_OVERRIDES"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/cost.rs"
+statics = ["LLM_BUDGET", "LLM_ACCUMULATED_COST", "LLM_TOKEN_BUDGET", "LLM_ACCUMULATED_TOKENS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/fake.rs"
+statics = ["FAKE_LLM_TURNS", "FAKE_LLM_CALLS"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/llm/introspection.rs"
+statics = ["LAST_RESOLVED_LLM_CALL"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/mock.rs"
+statics = ["LLM_REPLAY_MODE", "LLM_FIXTURE_DIR", "TOOL_RECORDINGS", "LLM_MOCKS", "CLI_LLM_MOCK_MODE", "CLI_LLM_MOCKS", "CLI_LLM_RECORDINGS", "LLM_MOCK_CALLS", "LLM_PROMPT_CACHE", "LLM_MOCK_SCOPES"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/llm/permissions.rs"
+statics = ["DYNAMIC_PERMISSION_STACK", "SESSION_PERMISSION_GRANTS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/provider.rs"
+statics = ["PROVIDER_NAMES"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/providers/anthropic.rs"
+statics = ["ANTHROPIC_PREFILL_WARN_ONCE", "ANTHROPIC_SAMPLING_WARN_ONCE", "ANTHROPIC_ADAPTIVE_WARN_ONCE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/llm/rate_limit.rs"
+statics = ["LIMITERS", "INITIALIZED_FROM_CONFIG"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/reminder_providers.rs"
+statics = ["USER_PROVIDERS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/routing.rs"
+statics = ["POLICY_REGISTRY"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/trace.rs"
+statics = ["LLM_TRACE", "LLM_TRACING_ENABLED"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/trace.rs"
+statics = ["AGENT_TRACE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm/trigger_predicate.rs"
+statics = ["ACTIVE_PREDICATE_EVALUATION"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/llm_config.rs"
+statics = ["USER_OVERRIDES"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/mcp_elicit.rs"
+statics = ["CURRENT_BUS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/mcp_file_upload.rs"
+statics = ["FILE_UPLOAD_CONFIG"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/mcp_progress.rs"
+statics = ["ACTIVE_BUS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/mcp_server/register.rs"
+statics = ["MCP_SERVE_REGISTRY", "MCP_SERVE_RESOURCES", "MCP_SERVE_RESOURCE_TEMPLATES", "MCP_SERVE_PROMPTS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/metadata.rs"
+statics = ["METADATA_STATE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/observability/request_id.rs"
+statics = ["ACTIVE_REQUEST_ID_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/command_policy.rs"
+statics = ["COMMAND_POLICY_STACK", "COMMAND_POLICY_HOOK_DEPTH"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/compaction_policy_registry.rs"
+statics = ["POLICIES"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/handoffs.rs"
+statics = ["HANDOFF_ROUTES"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/orchestration/hooks.rs"
+statics = ["RUNTIME_HOOKS", "FILE_EDIT_QUEUE", "SINGLETON_PRE_TOOL_HOOK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/lifecycle_receipts.rs"
+statics = ["LIFECYCLE_RECEIPT_LOG", "LIFECYCLE_RECEIPT_SEQ"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/mod.rs"
+statics = ["CURRENT_MUTATION_SESSION", "CURRENT_WORKFLOW_SKILL_CONTEXT"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/pipeline_lifecycle.rs"
+statics = ["PIPELINE_ON_FINISH", "LIFECYCLE_AUDIT_LOG", "PARTIAL_HANDOFF_REGISTRY", "PIPELINE_DISPOSITION", "LIFECYCLE_SEQ"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/policy/approval_rules.rs"
+statics = ["APPROVAL_CALL_COUNTS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/policy/mod.rs"
+statics = ["EXECUTION_POLICY_STACK", "EXECUTION_APPROVAL_POLICY_STACK", "TRUSTED_BRIDGE_CALL_DEPTH"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/orchestration/settlement_agent.rs"
+statics = ["SETTLEMENT_AGENT_ACTIVE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/redact/mod.rs"
+statics = ["REDACTION_POLICY_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/redact/patterns.rs"
+statics = ["CUSTOM_PATTERNS", "AUDIT_SINK", "AUDIT_RING"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/runtime_context.rs"
+statics = ["RUNTIME_CONTEXT_OVERLAY_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/schema/api.rs"
+statics = ["PARAM_SCHEMA_CACHE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/shells.rs"
+statics = ["SELECTED_DEFAULT_SHELL_ID"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/skills/runtime.rs"
+statics = ["CURRENT_SKILL_REGISTRY"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/agents_daemon.rs"
+statics = ["DAEMON_REGISTRY", "DAEMON_COUNTER"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/agents_workers/mod.rs"
+statics = ["WORKER_REGISTRY", "WORKER_COUNTER"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/clock.rs"
+statics = ["MOCK_TIME_GUARDS"]
+category = "thread_private"
+plan = "thread_private_test"
+
+[[thread_local]]
+path = "src/stdlib/concurrency.rs"
+statics = ["CIRCUITS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/durable_step.rs"
+statics = ["STEP_CALL_COUNTS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/fs.rs"
+statics = ["FILE_TEXT_CACHE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/hitl.rs"
+statics = ["REQUEST_SEQUENCE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/host.rs"
+statics = ["HOST_MOCKS", "HOST_MOCK_CALLS", "HOST_MOCK_SCOPES"]
+category = "thread_private"
+plan = "thread_private_test"
+
+[[thread_local]]
+path = "src/stdlib/host.rs"
+statics = ["HOST_CALL_BRIDGE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/io.rs"
+statics = ["STDIN_MOCK", "STDIN_LINES", "STDERR_BUFFER", "STDERR_CAPTURING", "STDOUT_PASSTHROUGH", "TTY_MOCK", "COLOR_MODE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/json.rs"
+statics = ["JSON_PARSE_CACHE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/json_stream.rs"
+statics = ["JSON_STREAM_VALIDATORS", "NEXT_JSON_STREAM_VALIDATOR_ID"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/jsonrpc.rs"
+statics = ["JSONRPC_ID_COUNTER"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/logging.rs"
+statics = ["VM_TRACE_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/monitors.rs"
+statics = ["MONITOR_WAIT_SEQUENCE"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/oauth_dynreg.rs"
+statics = ["DYNREG_STORES"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/oauth_storage.rs"
+statics = ["MEMORY_STORE", "FILE_SECRETS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/observability.rs"
+statics = ["OBS_STATE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/postgres/listen.rs"
+statics = ["LISTENERS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/postgres/mod.rs"
+statics = ["POOLS", "TXS", "MOCKS"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/process.rs"
+statics = ["VM_SOURCE_DIR", "VM_EXECUTION_CONTEXT"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/records.rs"
+statics = ["EVAL_METRICS", "FRICTION_EVENTS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/regex.rs"
+statics = ["REGEX_CACHE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/sandbox/mod.rs"
+statics = ["WARNED_KEYS"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/shapes.rs"
+statics = ["SHAPE_SPEC_CACHE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/supervisor.rs"
+statics = ["SUPERVISORS", "SUPERVISOR_COUNTER"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/template/assets.rs"
+statics = ["TEMPLATE_CACHE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/template/llm_context.rs"
+statics = ["LLM_RENDER_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/template/mod.rs"
+statics = ["PROMPT_REGISTRY", "PROMPT_RENDER_INDICES", "PROMPT_RENDER_ORDINAL"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/template/mod.rs"
+statics = ["PROMPT_SERIAL"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/timing.rs"
+statics = ["FINALIZED"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/tool_hooks.rs"
+statics = ["CLASSIFIER_CACHE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/tools.rs"
+statics = ["CURRENT_TOOL_REGISTRY", "TOOL_SYNTHESIS_CACHE"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/stdlib/triggers_stdlib.rs"
+statics = ["AUTO_RESUME_TIMEOUTS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/vision.rs"
+statics = ["OCR_BACKEND_OVERRIDE"]
+category = "thread_private"
+plan = "thread_private_cache"
+
+[[thread_local]]
+path = "src/stdlib/waitpoint.rs"
+statics = ["CREATE_SEQUENCE", "WAIT_SEQUENCE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/waitpoints.rs"
+statics = ["WAITPOINT_ID_SEQUENCE", "WAITPOINT_WAIT_SEQUENCE"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/stdlib/workflow/state.rs"
+statics = ["WORKFLOW_RUN_STATES"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/step_runtime.rs"
+statics = ["STEP_REGISTRY", "PERSONA_REGISTRY", "STEP_REGISTRY_LEN", "PERSONA_REGISTRY_LEN", "PERSONA_STACK", "STEP_STACK", "COMPLETED_STEPS", "PERSONA_HOOKS"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/testbench/overlay_fs.rs"
+statics = ["ACTIVE_OVERLAY"]
+category = "thread_private"
+plan = "thread_private_test"
+
+[[thread_local]]
+path = "src/testbench/process_tape.rs"
+statics = ["ACTIVE_TAPE"]
+category = "thread_private"
+plan = "thread_private_test"
+
+[[thread_local]]
+path = "src/testbench/tape.rs"
+statics = ["ACTIVE_RECORDER"]
+category = "thread_private"
+plan = "thread_private_test"
+
+[[thread_local]]
+path = "src/testbench/wasi_process.rs"
+statics = ["ACTIVE_WASI_TOOLCHAIN"]
+category = "thread_private"
+plan = "thread_private_test"
+
+[[thread_local]]
+path = "src/tool_call_cancellations.rs"
+statics = ["REGISTRY"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/tracing.rs"
+statics = ["COLLECTOR", "TRACING_ENABLED"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
+path = "src/triggers/aggregation.rs"
+statics = ["REGISTRY"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/triggers/dispatcher/state.rs"
+statics = ["ACTIVE_DISPATCHER_STATE", "ACTIVE_DISPATCH_CONTEXT", "ACTIVE_DISPATCH_WAIT_LEASE", "TEST_INBOX_DEQUEUED_SIGNAL"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/triggers/registry.rs"
+statics = ["TRIGGER_REGISTRY"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/triggers/registry.rs"
+statics = ["ORCHESTRATOR_BUDGET"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/triggers/test_util/clock.rs"
+statics = ["MOCK_CLOCK_STACK"]
+category = "thread_private"
+plan = "thread_private_test"
+
+[[thread_local]]
+path = "src/triggers/webhook_intake.rs"
+statics = ["REGISTRY"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/triggers/webhook_intake.rs"
+statics = ["CACHED_INBOX"]
+category = "runtime_registry"
+plan = "arc_registry_scope"
+
+[[thread_local]]
+path = "src/waitpoints.rs"
+statics = ["TEST_WAIT_SIGNALS"]
+category = "thread_private"
+plan = "thread_private_test"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -250,6 +250,7 @@
 - [Platform compatibility](./dev/platform-compatibility.md)
 - [Windows test coverage](./dev/windows-test-coverage.md)
 - [Deterministic test patterns](./dev/testing.md)
+- [Thread-local work-stealing audit](./dev/thread-local-work-stealing-audit.md)
 - [Testbench mode](./dev/testbench.md)
 - [Tape format](./dev/tape-format.md)
 - [Annotation tape format](./dev/annotation-tape-format.md)

--- a/docs/src/dev/thread-local-work-stealing-audit.md
+++ b/docs/src/dev/thread-local-work-stealing-audit.md
@@ -1,0 +1,28 @@
+# Thread-Local Work-Stealing Audit
+
+Harn still has VM runtime state stored in `thread_local!` slots. That was
+acceptable while VM work was pinned to one `LocalSet`, but pool workers now
+cross the first work-stealing boundary: `std/lifecycle/pool` runs submitted
+closures on `tokio::spawn` so they can execute on Tokio's multi-thread runtime.
+
+The authoritative inventory is
+`crates/harn-vm/thread_local_audit.toml`. It classifies every
+`thread_local!` macro site under `crates/harn-vm/src` into one of three
+categories:
+
+| Category | Meaning | Required action |
+| --- | --- | --- |
+| `logical_task` | Execution context that must follow a logical VM task. | Convert to `tokio::task_local!` scope or explicit `Vm` / `AsyncBuiltinCtx` fields before relying on it from work-stealing tasks. |
+| `runtime_registry` | Runtime/resource registry that a VM or host owns. | Promote to an `Arc`-backed registry and scope or pass that handle into spawned work. |
+| `thread_private` | Cache, mock, warning de-dupe, or test harness state. | Keep thread-local only while it stays non-authoritative and resettable. |
+
+`crates/harn-vm/tests/thread_local_audit.rs` scans the VM source tree and
+fails when a new `thread_local!` site is added without an audit entry. The
+same test also protects the pool worker boundary: pool registry state must
+stay `tokio::task_local!`, not regress to a process-thread-local registry.
+
+When adding a new pool, trigger, agent, or supervisor path that uses
+`tokio::spawn`, audit the reachable builtins against this inventory first.
+Do not copy a `thread_local!` value into a spawned task as a shortcut; convert
+the owning state to a task-local or an explicit handle so it follows the
+logical VM task rather than the OS worker thread.


### PR DESCRIPTION
## Summary
- route pool worker spawning through a single `spawn_pool_worker` work-stealing boundary that preserves the task-local pool registry
- add a checked `thread_local!` audit manifest, scanner test, and dev docs for work-stealing-safe migrations
- expand the pool CPU fan-out benchmark with a serial baseline and remove hot shared `Chunk` refcount contention from adaptive arithmetic dispatch

## Benchmark
`cargo bench -p harn-vm --bench pool_parallel -- --sample-size 10 --measurement-time 8`

- serial/1 median: 452.70 ms
- pool/1 median: 459.33 ms
- pool/2 median: 234.08 ms
- pool/4 median: 128.93 ms (~3.51x vs serial, above the 0.7 * 4 target)

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-2691-target RUSTFLAGS='-D warnings' cargo check -p harn-vm --benches`
- `CARGO_TARGET_DIR=/tmp/harn-2691-target cargo test -p harn-vm --test pool_multithread -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-2691-target cargo test -p harn-vm --test thread_local_audit -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-2691-target cargo test -p harn-vm --lib vm::tests_runtime::test_adaptive_inline_cache_specializes_generic_integer_add_site -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-2691-target HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- test conformance` (1499 passed)
- `make lint-test-patterns`
- `make check-ported-handler-loc`
- `cargo fmt --check`
- pre-commit and pre-push hooks

Closes #2691
Closes #2692

Notes: #2689 and #2690 are already closed on `origin/main` via earlier Send-readiness work.
