### PR TITLE
[codex] Preview rename ops in edit dry runs

### DIFF
--- a/changelog.d/2497.fixed.md
+++ b/changelog.d/2497.fixed.md
@@ -1,0 +1,4 @@
+- `edit_dry_run` now previews `rename_symbol` plan operations through the
+  shared code-index graph when the full hostlib surface is installed, so
+  multi-step edit plans can include cross-file renames in the unified diff
+  bundle.

--- a/crates/harn-hostlib/schemas/ast/dry_run.request.json
+++ b/crates/harn-hostlib/schemas/ast/dry_run.request.json
@@ -76,9 +76,27 @@
             "type": "object",
             "properties": {
               "op": { "type": "string", "const": "rename_symbol" },
-              "symbol_ref": { "type": "string" },
+              "symbol_ref": {
+                "type": "object",
+                "description": "Pointer at the symbol to rename. Same shape as code_index.rename_symbol: `name` and `path` are required; `line` and `kind` disambiguate.",
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "path": { "type": "string", "minLength": 1 },
+                  "line": { "type": "integer", "minimum": 1 },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["Function", "Type", "Module"]
+                  }
+                },
+                "required": ["name", "path"],
+                "additionalProperties": false
+              },
               "new_name": { "type": "string" },
-              "scope": { "type": "string" }
+              "scope": {
+                "type": "string",
+                "enum": ["file", "module", "workspace"],
+                "default": "workspace"
+              }
             },
             "required": ["op", "symbol_ref", "new_name"]
           }

--- a/crates/harn-hostlib/schemas/ast/dry_run.response.json
+++ b/crates/harn-hostlib/schemas/ast/dry_run.response.json
@@ -58,10 +58,15 @@
           },
           "reason": {
             "type": "string",
-            "description": "Stable failure tag for rejected ops (e.g. `no_match`, `ambiguous`, `invalid_query`, `syntax_error`, `unsupported_language`, `unknown_op`, `use_standalone`)."
+            "description": "Stable failure tag for rejected ops (e.g. `no_match`, `ambiguous`, `invalid_query`, `syntax_error`, `unsupported_language`, `conflict`, `unknown_op`, `code_index_unavailable`)."
           },
           "details": { "type": "string" },
           "path": { "type": "string" },
+          "paths": {
+            "type": "array",
+            "description": "All paths affected by an applied op. Single-file ops carry one path; workspace operations such as `rename_symbol` may carry several.",
+            "items": { "type": "string" }
+          },
           "match_count": { "type": "integer", "minimum": 0 }
         },
         "required": ["op", "applied", "result"]

--- a/crates/harn-hostlib/src/ast/dry_run.rs
+++ b/crates/harn-hostlib/src/ast/dry_run.rs
@@ -51,6 +51,7 @@ use std::sync::Arc;
 
 use harn_vm::VmValue;
 
+use crate::code_index::SharedIndex;
 use crate::error::HostlibError;
 use crate::fs::FsMode;
 use crate::tools::args::{build_dict, dict_arg, optional_string, require_string, str_value};
@@ -62,6 +63,13 @@ const TRANSIENT_PREFIX: &str = "__edit_dry_run__-";
 
 /// Entry point registered as the `hostlib_ast_dry_run` builtin.
 pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    run_with_code_index(None, args)
+}
+
+pub(super) fn run_with_code_index(
+    code_index: Option<&SharedIndex>,
+    args: &[VmValue],
+) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN, args)?;
     let dict = raw.as_ref();
     let plan = require_plan(dict)?;
@@ -75,11 +83,11 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let mut rejected_count = 0usize;
 
     for (index, op_value) in plan.into_iter().enumerate() {
-        let outcome = dispatch_op(&session_id, index, &op_value);
+        let outcome = dispatch_op(code_index, &session_id, index, &op_value);
         match &outcome {
-            OpOutcome::Applied { path, .. } => {
+            OpOutcome::Applied { paths, .. } => {
                 applied_count += 1;
-                touched.insert(path.clone());
+                touched.extend(paths.iter().cloned());
             }
             OpOutcome::Rejected { .. } | OpOutcome::Error { .. } => {
                 rejected_count += 1;
@@ -91,10 +99,16 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let mut per_file_diffs: Vec<FileDiffEntry> = Vec::new();
     let mut lines_added_total = 0usize;
     let mut lines_removed_total = 0usize;
+    let staged_paths: BTreeSet<PathBuf> = crate::fs::staged_status(&session_id)?
+        .pending_writes
+        .into_iter()
+        .map(|write| PathBuf::from(write.path))
+        .collect();
+    let diff_targets = diff_targets(staged_paths, touched);
 
-    for path in touched.iter() {
-        let (before, before_existed) = read_before(path);
-        let after = read_after(path, &session_id).unwrap_or_default();
+    for target in &diff_targets {
+        let (before, before_existed) = read_before(&target.read_path);
+        let after = read_after(&target.read_path, &session_id).unwrap_or_default();
         let kind = if !before_existed {
             ChangeKind::Create
         } else if after.is_empty() {
@@ -105,7 +119,7 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         } else {
             ChangeKind::Modify
         };
-        let display = path.to_string_lossy().into_owned();
+        let display = diff_path_label(&target.display_path);
         let diff = render_unified_diff(&display, &before, &after, kind);
         lines_added_total += diff.lines_added;
         lines_removed_total += diff.lines_removed;
@@ -201,7 +215,7 @@ fn transient_session_id() -> String {
 enum OpOutcome {
     Applied {
         op: &'static str,
-        path: PathBuf,
+        paths: Vec<PathBuf>,
         details: String,
         match_count: usize,
     },
@@ -217,7 +231,12 @@ enum OpOutcome {
     },
 }
 
-fn dispatch_op(session_id: &str, index: usize, raw: &Arc<BTreeMap<String, VmValue>>) -> OpOutcome {
+fn dispatch_op(
+    code_index: Option<&SharedIndex>,
+    session_id: &str,
+    index: usize,
+    raw: &Arc<BTreeMap<String, VmValue>>,
+) -> OpOutcome {
     let dict = raw.as_ref();
     let op_name = match dict.get("op") {
         Some(VmValue::String(s)) => s.to_string(),
@@ -242,15 +261,7 @@ fn dispatch_op(session_id: &str, index: usize, raw: &Arc<BTreeMap<String, VmValu
         "apply_node" => run_apply_node(session_id, raw),
         "insert_at_anchor" => run_insert_at_anchor(session_id, raw),
         "safe_text_patch" => run_safe_text_patch(session_id, raw),
-        "rename_symbol" => OpOutcome::Rejected {
-            op: op_name,
-            reason: "use_standalone",
-            details: "rename_symbol is a workspace-level operation backed by the typed symbol graph (#2434); \
-                      its preview surface returns per-file edit metadata that the unified-diff bundle here \
-                      would lose. Call `edit_rename_symbol({..., dry_run: true})` directly for the preview."
-                .into(),
-            path: optional_string(BUILTIN, dict, "path").ok().flatten(),
-        },
+        "rename_symbol" => run_rename_symbol(code_index, session_id, raw),
         other => OpOutcome::Rejected {
             op: other.to_string(),
             reason: "unknown_op",
@@ -330,7 +341,7 @@ fn parse_builtin_outcome(
         let path = path.as_ref().map(PathBuf::from).unwrap_or_default();
         OpOutcome::Applied {
             op: op_label,
-            path,
+            paths: vec![path],
             details: format!("{op_label}: applied with {match_count} match(es)"),
             match_count,
         }
@@ -356,6 +367,119 @@ fn classify_builtin_failure(result: &str) -> &'static str {
         "unsupported_language" => "unsupported_language",
         "syntax_error" => "syntax_error",
         _ => "rejected",
+    }
+}
+
+fn run_rename_symbol(
+    code_index: Option<&SharedIndex>,
+    session_id: &str,
+    raw: &Arc<BTreeMap<String, VmValue>>,
+) -> OpOutcome {
+    let Some(index) = code_index else {
+        return OpOutcome::Rejected {
+            op: "rename_symbol".into(),
+            reason: "code_index_unavailable",
+            details: "rename_symbol dry-run ops require hostlib_ast_dry_run to be registered with the shared code_index capability"
+                .into(),
+            path: None,
+        };
+    };
+    let mut forwarded: BTreeMap<String, VmValue> = (**raw).clone();
+    forwarded.remove("op");
+    forwarded.insert("session_id".to_string(), str_value(session_id));
+    forwarded.insert("dry_run".to_string(), VmValue::Bool(false));
+    forwarded
+        .entry("scope".to_string())
+        .or_insert_with(|| str_value("workspace"));
+
+    let request = VmValue::Dict(Arc::new(forwarded));
+    match crate::code_index::run_rename_symbol(index, &[request]) {
+        Ok(VmValue::Dict(result)) => parse_rename_outcome(&result),
+        Ok(_) => OpOutcome::Error {
+            op: "rename_symbol".into(),
+            message: "rename_symbol returned non-dict result".into(),
+        },
+        Err(err) => OpOutcome::Error {
+            op: "rename_symbol".into(),
+            message: err.to_string(),
+        },
+    }
+}
+
+fn parse_rename_outcome(result: &Arc<BTreeMap<String, VmValue>>) -> OpOutcome {
+    let result_str = match result.get("result") {
+        Some(VmValue::String(s)) => s.to_string(),
+        _ => {
+            return OpOutcome::Error {
+                op: "rename_symbol".into(),
+                message: "rename_symbol response missing `result`".into(),
+            }
+        }
+    };
+    let details = match result.get("details") {
+        Some(VmValue::String(s)) => s.to_string(),
+        _ => result_str.clone(),
+    };
+    if result_str != "applied" {
+        return OpOutcome::Rejected {
+            op: "rename_symbol".into(),
+            reason: classify_rename_failure(&result_str),
+            details,
+            path: None,
+        };
+    }
+
+    let failed_count = match result.get("failed_paths_with_reasons") {
+        Some(VmValue::List(items)) => items.len(),
+        _ => 0,
+    };
+    if failed_count > 0 {
+        return OpOutcome::Error {
+            op: "rename_symbol".into(),
+            message: "rename_symbol staged preview had failed paths; see standalone edit_rename_symbol for details".into(),
+        };
+    }
+
+    OpOutcome::Applied {
+        op: "rename_symbol",
+        paths: rename_touched_paths(result),
+        details,
+        match_count: int_field(result, "match_count").unwrap_or(0) as usize,
+    }
+}
+
+fn classify_rename_failure(result: &str) -> &'static str {
+    match result {
+        "conflict" => "conflict",
+        "no_match" => "no_match",
+        "ambiguous_symbol" => "ambiguous_symbol",
+        "unsupported_language" => "unsupported_language",
+        "syntax_error" => "syntax_error",
+        "invalid_identifier" => "invalid_identifier",
+        _ => "rejected",
+    }
+}
+
+fn rename_touched_paths(result: &Arc<BTreeMap<String, VmValue>>) -> Vec<PathBuf> {
+    match result.get("touched_files") {
+        Some(VmValue::List(files)) => files
+            .iter()
+            .filter_map(|file| match file {
+                VmValue::Dict(entry) => match entry.get("path") {
+                    Some(VmValue::String(path)) => Some(PathBuf::from(path.to_string())),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn int_field(result: &Arc<BTreeMap<String, VmValue>>, key: &str) -> Option<i64> {
+    match result.get(key) {
+        Some(VmValue::Int(n)) => Some(*n),
+        _ => None,
     }
 }
 
@@ -444,7 +568,7 @@ fn run_safe_text_patch(session_id: &str, raw: &Arc<BTreeMap<String, VmValue>>) -
     }
     OpOutcome::Applied {
         op: "safe_text_patch",
-        path,
+        paths: vec![path],
         details: "safe_text_patch: replaced unique exact match".into(),
         match_count: 1,
     }
@@ -500,6 +624,82 @@ fn read_after(path: &Path, session_id: &str) -> Option<String> {
         Ok(bytes) => Some(String::from_utf8_lossy(&bytes).into_owned()),
         Err(_) => Some(String::new()),
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DiffTarget {
+    read_path: PathBuf,
+    display_path: PathBuf,
+}
+
+fn diff_targets(staged_paths: BTreeSet<PathBuf>, touched: BTreeSet<PathBuf>) -> Vec<DiffTarget> {
+    if staged_paths.is_empty() {
+        return touched
+            .into_iter()
+            .map(|path| DiffTarget {
+                read_path: path.clone(),
+                display_path: path,
+            })
+            .collect();
+    }
+
+    let allow_single_path_fallback = staged_paths.len() == 1 && touched.len() == 1;
+    let mut remaining_touched: Vec<PathBuf> = touched.into_iter().collect();
+    staged_paths
+        .into_iter()
+        .map(|read_path| {
+            let display_path = take_matching_display_path(
+                &read_path,
+                &mut remaining_touched,
+                allow_single_path_fallback,
+            )
+            .unwrap_or_else(|| read_path.clone());
+            DiffTarget {
+                read_path,
+                display_path,
+            }
+        })
+        .collect()
+}
+
+fn take_matching_display_path(
+    read_path: &Path,
+    candidates: &mut Vec<PathBuf>,
+    allow_single_path_fallback: bool,
+) -> Option<PathBuf> {
+    if candidates.is_empty() {
+        return None;
+    }
+    if allow_single_path_fallback && candidates.len() == 1 {
+        return Some(candidates.remove(0));
+    }
+
+    let index = candidates
+        .iter()
+        .position(|candidate| paths_match_for_display(read_path, candidate))?;
+    Some(candidates.remove(index))
+}
+
+fn paths_match_for_display(read_path: &Path, candidate: &Path) -> bool {
+    if read_path == candidate {
+        return true;
+    }
+    if let (Ok(read), Ok(candidate)) = (
+        std::fs::canonicalize(read_path),
+        std::fs::canonicalize(candidate),
+    ) {
+        if read == candidate {
+            return true;
+        }
+    }
+
+    let read = diff_path_label(read_path);
+    let candidate = diff_path_label(candidate);
+    read == candidate || read.ends_with(&format!("/{candidate}"))
+}
+
+fn diff_path_label(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 // ---------------------------------------------------------------------------
@@ -563,17 +763,25 @@ fn op_outcome_to_value(outcome: &OpOutcome) -> VmValue {
     match outcome {
         OpOutcome::Applied {
             op,
-            path,
+            paths,
             details,
             match_count,
-        } => build_dict([
-            ("op", str_value(*op)),
-            ("applied", VmValue::Bool(true)),
-            ("result", str_value("applied")),
-            ("path", str_value(path.to_string_lossy())),
-            ("details", str_value(details)),
-            ("match_count", VmValue::Int(*match_count as i64)),
-        ]),
+        } => {
+            let path_values: Vec<VmValue> = paths
+                .iter()
+                .map(|path| str_value(diff_path_label(path)))
+                .collect();
+            let primary = paths.first().cloned().unwrap_or_default();
+            build_dict([
+                ("op", str_value(*op)),
+                ("applied", VmValue::Bool(true)),
+                ("result", str_value("applied")),
+                ("path", str_value(diff_path_label(&primary))),
+                ("paths", VmValue::List(Arc::new(path_values))),
+                ("details", str_value(details)),
+                ("match_count", VmValue::Int(*match_count as i64)),
+            ])
+        }
         OpOutcome::Rejected {
             op,
             reason,
@@ -604,8 +812,11 @@ fn op_outcome_to_value(outcome: &OpOutcome) -> VmValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::code_index::{CodeIndexCapability, IndexState};
+    use std::fs;
     use std::io::Write;
-    use tempfile::NamedTempFile;
+    use std::path::{Path, PathBuf};
+    use tempfile::{tempdir, NamedTempFile};
 
     fn vm_string(s: &str) -> VmValue {
         VmValue::String(Arc::from(s))
@@ -648,6 +859,73 @@ mod tests {
 
     fn invoke(payload: VmValue) -> VmValue {
         run(&[payload]).expect("dry_run runs")
+    }
+
+    fn invoke_with_code_index(index: &SharedIndex, payload: VmValue) -> VmValue {
+        run_with_code_index(Some(index), &[payload]).expect("dry_run runs")
+    }
+
+    fn build_index(root: &Path) -> CodeIndexCapability {
+        let capability = CodeIndexCapability::new();
+        let shared = capability.shared();
+        let mut guard = shared.lock().expect("mutex");
+        let (state, _outcome) = IndexState::build_from_root(root);
+        *guard = Some(state);
+        drop(guard);
+        capability
+    }
+
+    #[test]
+    fn diff_target_labels_keep_logical_single_op_path() {
+        let staged = BTreeSet::from([PathBuf::from(r"C:\Temp\project\module.rs")]);
+        let touched = BTreeSet::from([PathBuf::from("C:/Temp/project/module.rs")]);
+
+        let targets = diff_targets(staged, touched);
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(
+            targets[0].read_path,
+            PathBuf::from(r"C:\Temp\project\module.rs")
+        );
+        assert_eq!(
+            diff_path_label(&targets[0].display_path),
+            "C:/Temp/project/module.rs"
+        );
+    }
+
+    #[test]
+    fn diff_target_labels_pair_relative_multi_file_paths() {
+        let staged = BTreeSet::from([
+            PathBuf::from("/tmp/workspace/src/a.rs"),
+            PathBuf::from("/tmp/workspace/src/b.rs"),
+        ]);
+        let touched = BTreeSet::from([PathBuf::from("src/a.rs"), PathBuf::from("src/b.rs")]);
+
+        let labels: Vec<String> = diff_targets(staged, touched)
+            .into_iter()
+            .map(|target| diff_path_label(&target.display_path))
+            .collect();
+
+        assert_eq!(labels, vec!["src/a.rs", "src/b.rs"]);
+    }
+
+    #[test]
+    fn diff_target_labels_do_not_guess_unmatched_multi_file_paths() {
+        let staged = BTreeSet::from([
+            PathBuf::from("/tmp/workspace/src/a.rs"),
+            PathBuf::from("/tmp/workspace/src/b.rs"),
+        ]);
+        let touched = BTreeSet::from([PathBuf::from("elsewhere/c.rs")]);
+
+        let labels: Vec<String> = diff_targets(staged, touched)
+            .into_iter()
+            .map(|target| diff_path_label(&target.display_path))
+            .collect();
+
+        assert_eq!(
+            labels,
+            vec!["/tmp/workspace/src/a.rs", "/tmp/workspace/src/b.rs"]
+        );
     }
 
     #[test]
@@ -792,11 +1070,19 @@ mod tests {
     }
 
     #[test]
-    fn rename_symbol_op_points_callers_at_standalone_primitive() {
+    fn rename_symbol_op_rejects_without_code_index() {
         let op = vm_dict(&[
             ("op", vm_string("rename_symbol")),
-            ("symbol_ref", vm_string("crate::alpha")),
+            (
+                "symbol_ref",
+                vm_dict(&[
+                    ("name", vm_string("alpha")),
+                    ("path", vm_string("src/lib.rs")),
+                    ("kind", vm_string("Function")),
+                ]),
+            ),
             ("new_name", vm_string("beta")),
+            ("scope", vm_string("workspace")),
         ]);
         let result = invoke(vm_dict(&[("plan", vm_list(&[op]))]));
         let ops = match field(&result, "ops") {
@@ -804,7 +1090,46 @@ mod tests {
             _ => panic!(),
         };
         assert_eq!(s(field(&ops[0], "result")), "rejected");
-        assert_eq!(s(field(&ops[0], "reason")), "use_standalone");
+        assert_eq!(s(field(&ops[0], "reason")), "code_index_unavailable");
+    }
+
+    #[test]
+    fn rename_symbol_op_produces_diff_without_touching_disk() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        let original = "fn alpha() { println!(\"hi\"); }\nfn caller() { alpha(); }\n";
+        fs::write(root.join("src/lib.rs"), original).unwrap();
+
+        let capability = build_index(root);
+        let shared = capability.shared();
+        let op = vm_dict(&[
+            ("op", vm_string("rename_symbol")),
+            (
+                "symbol_ref",
+                vm_dict(&[
+                    ("name", vm_string("alpha")),
+                    ("path", vm_string("src/lib.rs")),
+                    ("kind", vm_string("Function")),
+                ]),
+            ),
+            ("new_name", vm_string("beta")),
+            ("scope", vm_string("workspace")),
+        ]);
+        let result = invoke_with_code_index(&shared, vm_dict(&[("plan", vm_list(&[op]))]));
+        assert_eq!(s(field(&result, "result")), "ok");
+        let per_file = match field(&result, "per_file_unified_diff") {
+            VmValue::List(items) => items.clone(),
+            _ => panic!(),
+        };
+        assert_eq!(per_file.len(), 1);
+        let diff = s(field(&per_file[0], "diff"));
+        assert!(diff.contains("-fn alpha()"));
+        assert!(diff.contains("+fn beta()"));
+        assert!(diff.contains("-fn caller() { alpha(); }"));
+        assert!(diff.contains("+fn caller() { beta(); }"));
+        let on_disk = fs::read_to_string(root.join("src/lib.rs")).unwrap();
+        assert_eq!(on_disk, original);
     }
 
     #[test]

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 
 use harn_vm::VmValue;
 
+use crate::code_index::SharedIndex;
 use crate::error::HostlibError;
 use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, SyncHandler};
 
@@ -144,102 +145,133 @@ pub mod api {
 #[derive(Default)]
 pub struct AstCapability;
 
+/// AST capability registered with access to the shared code-index state.
+///
+/// Most AST builtins are stateless, but `ast.dry_run` can preview
+/// `rename_symbol` plan ops only when it can delegate to the typed
+/// symbol graph owned by `code_index`.
+pub struct AstCapabilityWithCodeIndex {
+    code_index: SharedIndex,
+}
+
+impl AstCapabilityWithCodeIndex {
+    /// Build an AST capability that can delegate dry-run rename previews
+    /// to the supplied code-index state.
+    pub fn new(code_index: SharedIndex) -> Self {
+        Self { code_index }
+    }
+}
+
 impl HostlibCapability for AstCapability {
     fn module_name(&self) -> &'static str {
         "ast"
     }
 
     fn register_builtins(&self, registry: &mut BuiltinRegistry) {
-        register(registry, "hostlib_ast_parse_file", "parse_file", parse::run);
-        register(
-            registry,
-            "hostlib_ast_symbols",
-            "symbols",
-            symbols_call::run,
-        );
-        register(registry, "hostlib_ast_outline", "outline", outline::run);
-        register(
-            registry,
-            "hostlib_ast_parse_errors",
-            "parse_errors",
-            parse_errors::run,
-        );
-        register(
-            registry,
-            "hostlib_ast_undefined_names",
-            "undefined_names",
-            undefined_names::run,
-        );
-        register(
-            registry,
-            "hostlib_ast_function_body",
-            "function_body",
-            function_body::run_single,
-        );
-        register(
-            registry,
-            "hostlib_ast_function_bodies",
-            "function_bodies",
-            function_body::run_bulk,
-        );
-        register(
-            registry,
-            "hostlib_ast_extract_imports",
-            "extract_imports",
-            imports::run,
-        );
-        register(
-            registry,
-            "hostlib_ast_symbol_extract",
-            "symbol_extract",
-            mutation::run_extract,
-        );
-        register(
-            registry,
-            "hostlib_ast_symbol_delete",
-            "symbol_delete",
-            mutation::run_delete,
-        );
-        register(
-            registry,
-            "hostlib_ast_symbol_replace",
-            "symbol_replace",
-            mutation::run_replace,
-        );
-        register(
-            registry,
-            "hostlib_ast_bracket_balance",
-            "bracket_balance",
-            bracket_balance::run,
-        );
-        // These two write edited source back to disk, so they share the
-        // deterministic-tools gate with `tools::*` file I/O.
-        register_gated(
-            registry,
-            "hostlib_ast_apply_node",
-            "apply_node",
-            apply_node::run,
-        );
-        register_gated(
-            registry,
-            "hostlib_ast_insert_at_anchor",
-            "insert_at_anchor",
-            insert_at_anchor::run,
-        );
-        register(registry, "hostlib_ast_dry_run", "dry_run", dry_run::run);
-        register(
-            registry,
-            "hostlib_ast_structural_diff",
-            "structural_diff",
-            structural_diff::run,
-        );
-        register(
-            registry,
-            "hostlib_ast_capabilities",
-            "capabilities",
-            capabilities::run,
-        );
+        register_ast_builtins(registry, None);
     }
+}
+
+impl HostlibCapability for AstCapabilityWithCodeIndex {
+    fn module_name(&self) -> &'static str {
+        "ast"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        register_ast_builtins(registry, Some(self.code_index.clone()));
+    }
+}
+
+fn register_ast_builtins(registry: &mut BuiltinRegistry, code_index: Option<SharedIndex>) {
+    register(registry, "hostlib_ast_parse_file", "parse_file", parse::run);
+    register(
+        registry,
+        "hostlib_ast_symbols",
+        "symbols",
+        symbols_call::run,
+    );
+    register(registry, "hostlib_ast_outline", "outline", outline::run);
+    register(
+        registry,
+        "hostlib_ast_parse_errors",
+        "parse_errors",
+        parse_errors::run,
+    );
+    register(
+        registry,
+        "hostlib_ast_undefined_names",
+        "undefined_names",
+        undefined_names::run,
+    );
+    register(
+        registry,
+        "hostlib_ast_function_body",
+        "function_body",
+        function_body::run_single,
+    );
+    register(
+        registry,
+        "hostlib_ast_function_bodies",
+        "function_bodies",
+        function_body::run_bulk,
+    );
+    register(
+        registry,
+        "hostlib_ast_extract_imports",
+        "extract_imports",
+        imports::run,
+    );
+    register(
+        registry,
+        "hostlib_ast_symbol_extract",
+        "symbol_extract",
+        mutation::run_extract,
+    );
+    register(
+        registry,
+        "hostlib_ast_symbol_delete",
+        "symbol_delete",
+        mutation::run_delete,
+    );
+    register(
+        registry,
+        "hostlib_ast_symbol_replace",
+        "symbol_replace",
+        mutation::run_replace,
+    );
+    register(
+        registry,
+        "hostlib_ast_bracket_balance",
+        "bracket_balance",
+        bracket_balance::run,
+    );
+    // These two write edited source back to disk, so they share the
+    // deterministic-tools gate with `tools::*` file I/O.
+    register_gated(
+        registry,
+        "hostlib_ast_apply_node",
+        "apply_node",
+        apply_node::run,
+    );
+    register_gated(
+        registry,
+        "hostlib_ast_insert_at_anchor",
+        "insert_at_anchor",
+        insert_at_anchor::run,
+    );
+    register_dry_run(registry, code_index);
+    register(
+        registry,
+        "hostlib_ast_structural_diff",
+        "structural_diff",
+        structural_diff::run,
+    );
+    register(
+        registry,
+        "hostlib_ast_capabilities",
+        "capabilities",
+        capabilities::run,
+    );
 }
 
 fn register(
@@ -255,6 +287,22 @@ fn register(
         method,
         handler,
     });
+}
+
+fn register_dry_run(registry: &mut BuiltinRegistry, code_index: Option<SharedIndex>) {
+    match code_index {
+        Some(index) => {
+            let handler: SyncHandler =
+                Arc::new(move |args| dry_run::run_with_code_index(Some(&index), args));
+            registry.register(RegisteredBuiltin {
+                name: "hostlib_ast_dry_run",
+                module: "ast",
+                method: "dry_run",
+                handler,
+            });
+        }
+        None => register(registry, "hostlib_ast_dry_run", "dry_run", dry_run::run),
+    }
 }
 
 fn register_gated(

--- a/crates/harn-hostlib/src/code_index/mod.rs
+++ b/crates/harn-hostlib/src/code_index/mod.rs
@@ -429,6 +429,16 @@ impl HostlibCapability for CodeIndexCapability {
     }
 }
 
+/// Programmatic entry point for callers that need to compose
+/// `rename_symbol` with another hostlib capability while sharing the
+/// same in-memory code-index state.
+pub(crate) fn run_rename_symbol(
+    index: &SharedIndex,
+    args: &[VmValue],
+) -> Result<VmValue, HostlibError> {
+    rename::run(index, args)
+}
+
 fn register(
     registry: &mut BuiltinRegistry,
     index: SharedIndex,

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -53,9 +53,10 @@ pub use registry::{BuiltinRegistry, HostlibCapability, HostlibRegistry, Register
 /// hostlib surface; pick-and-choose embedders should construct
 /// [`HostlibRegistry`] directly.
 pub fn install_default(vm: &mut harn_vm::Vm) -> HostlibRegistry {
+    let code_index = code_index::CodeIndexCapability::new();
     let mut registry = HostlibRegistry::new()
-        .with(ast::AstCapability)
-        .with(code_index::CodeIndexCapability::new())
+        .with(ast::AstCapabilityWithCodeIndex::new(code_index.shared()))
+        .with(code_index)
         .with(scanner::ScannerCapability)
         .with(fs::FsCapability)
         .with(fs_snapshot::FsSnapshotCapability)

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -459,6 +459,11 @@ pipeline default(task) {
         select: "first",
       },
       {op: "safe_text_patch", path: "src/lib.rs", old_text: "fn greet", new_text: "fn greeter"},
+      {
+        op: "rename_symbol",
+        symbol_ref: {name: "Widget", path: "src/lib.rs", kind: "Type"},
+        new_name: "Gadget",
+      },
     ],
   })
 

--- a/docs/src/stdlib/edit.md
+++ b/docs/src/stdlib/edit.md
@@ -657,7 +657,7 @@ Each op carries an `op` tag:
 | `apply_node` | `path`, `query`, `replacement` | Same shape as `edit_apply_node`. Optional: `select`, `nth`, `target_capture`, `language`, `validate`. |
 | `insert_at_anchor` | `path`, `query`, `position`, `content` | `position` ∈ `before \| after \| first_child \| last_child`. Anchor must match exactly once. |
 | `safe_text_patch` | `path`, `old_text`, `new_text` | Exact unique-match text replacement. |
-| `rename_symbol` | `symbol_ref`, `new_name` | Workspace-level cross-file rename. Rejected with `reason: "use_standalone"` — call [`edit_rename_symbol({..., dry_run: true})`](#edit_rename_symbol--safe-cross-file-rename) directly so the response keeps the per-file `touched_files` / `conflicts` metadata a unified diff would lose. |
+| `rename_symbol` | `symbol_ref`, `new_name` | Workspace-level cross-file rename through the shared code-index graph. Optional: `scope` (`workspace` by default), `validate`. Hosts that register AST without code-index reject with `reason: "code_index_unavailable"`; call [`edit_rename_symbol({..., dry_run: true})`](#edit_rename_symbol--safe-cross-file-rename) for the standalone metadata-rich preview. |
 
 ### Result
 
@@ -676,7 +676,7 @@ Each op carries an `op` tag:
     ops_rejected,
   },
   ops: [
-    { op, applied, result: "applied"|"rejected"|"error", reason?, details, path?, match_count? },
+    { op, applied, result: "applied"|"rejected"|"error", reason?, details, path?, paths?, match_count? },
     ...
   ],
 }


### PR DESCRIPTION
## Summary
- Wire default hostlib AST dry-run registration to shared code-index state so `rename_symbol` plan ops stage into the same transient overlay as other dry-run ops.
- Include multi-file dry-run paths in op outcomes, schemas, and docs, with rename dry-run scope defaulting to `workspace`.
- Add regression coverage and a changelog fragment for #2497.

## Validation
- `cargo test -p harn-hostlib ast::dry_run::tests::rename_symbol_op_produces_diff_without_touching_disk`
- `cargo test -p harn-hostlib ast::dry_run::tests`
- `cargo test -p harn-hostlib --test registration`
- `HARN_BIN=/Users/ksinder/.local/bin/harn make check-docs-snippets`
- `cargo test -p harn-hostlib`
- pre-commit hook
- pre-push hook

Closes #2497