### PR TITLE
Add reachability-aware transcript projection GC

### DIFF
--- a/changelog.d/2714.added.md
+++ b/changelog.d/2714.added.md
@@ -1,0 +1,5 @@
+- **Transcript projection can now reclaim stale tool-result bodies by
+  reachability (#2714).** The new `reachability_gc` policy preserves raw
+  transcript/audit history while replacing unreachable projected tool-result
+  bodies with redaction pointers, reclaimed-token estimates, and root-set audit
+  metadata.

--- a/conformance/tests/scenarios/transcript_projection_policies.expected
+++ b/conformance/tests/scenarios/transcript_projection_policies.expected
@@ -16,3 +16,16 @@ blocked_safety:true
 blocked_dropped:0
 bypassed_safety:false
 bypassed_dropped:2
+gc_policy:reachability_gc
+gc_redacted:1
+gc_reclaimed:true
+gc_old_reclaimed:true
+gc_live_preserved:true
+gc_roots:true
+gc_pointer:transcript.messages[2].content
+gc_barrier_blocked:true
+long_raw_redacted:0
+long_gc_redacted:60
+long_gc_reclaimed:true
+long_gc_live_preserved:true
+long_barrier_gc_redacted:60

--- a/conformance/tests/scenarios/transcript_projection_policies.harn
+++ b/conformance/tests/scenarios/transcript_projection_policies.harn
@@ -34,6 +34,68 @@ fn signed_reasoning_transcript() {
   )
 }
 
+fn gc_transcript() {
+  var stale = "src/old.rs\n"
+  var rooted = "src/live.rs\nIMPORTANT_LIVE_VALUE\n"
+  for i in range(0, 80) {
+    stale = stale + "old stale line " + to_string(i) + "\n"
+    rooted = rooted + "live rooted line " + to_string(i) + "\n"
+  }
+  return transcript_from_messages(
+    [
+      {role: "user", content: "inspect old and live files"},
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{id: "old_call", name: "read", arguments: {path: "src/old.rs"}}],
+      },
+      {role: "tool", tool_call_id: "old_call", name: "read", content: stale},
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{id: "live_call", name: "read", arguments: {path: "src/live.rs"}}],
+      },
+      {role: "tool", tool_call_id: "live_call", name: "read", content: rooted},
+      {role: "assistant", content: "The active change is in src/live.rs."},
+      {role: "user", content: "Continue from the live file finding."},
+    ],
+  )
+}
+
+fn long_gc_transcript(stale_count) {
+  var messages = [{role: "user", content: "inspect many stale files and one live file"}]
+  for i in range(0, stale_count) {
+    let path = "src/stale_" + to_string(i) + ".rs"
+    let call_id = "stale_call_" + to_string(i)
+    var body = path + "\n"
+    for j in range(0, 24) {
+      body = body + "stale output " + to_string(i) + " line " + to_string(j) + "\n"
+    }
+    messages = messages
+      .push(
+      {role: "assistant", content: "", tool_calls: [{id: call_id, name: "read", arguments: {path: path}}]},
+    )
+    messages = messages.push({role: "tool", tool_call_id: call_id, name: "read", content: body})
+  }
+  var live_body = "src/live.rs\nIMPORTANT_LIVE_VALUE\n"
+  for k in range(0, 24) {
+    live_body = live_body + "live output line " + to_string(k) + "\n"
+  }
+  messages = messages
+    .push(
+    {
+      role: "assistant",
+      content: "",
+      tool_calls: [{id: "live_call", name: "read", arguments: {path: "src/live.rs"}}],
+    },
+  )
+  let live_result_index = messages.count
+  messages = messages.push({role: "tool", tool_call_id: "live_call", name: "read", content: live_body})
+  messages = messages.push({role: "assistant", content: "The active change is in src/live.rs."})
+  messages = messages.push({role: "user", content: "Continue from the live file finding."})
+  return {transcript: transcript_from_messages(messages), live_result_index: live_result_index}
+}
+
 pipeline default() {
   let transcript = raw_transcript()
   let raw_result = transcript_project(transcript, {policy: "raw"})
@@ -74,4 +136,45 @@ pipeline default() {
   )
   __io_println("bypassed_safety:" + to_string(bypassed.provider_safety_blocked))
   __io_println("bypassed_dropped:" + to_string(bypassed.dropped_count))
+  let gc = transcript_project(gc_transcript(), {policy: "reachability_gc", root_window: 2, min_chars: 100})
+  __io_println("gc_policy:" + gc.policy)
+  __io_println("gc_redacted:" + to_string(gc.redacted_count))
+  __io_println("gc_reclaimed:" + to_string(gc.reclaimed_tokens > 0))
+  __io_println(
+    "gc_old_reclaimed:" + to_string(gc.messages[2].content.contains("reclaimed by reachability_gc")),
+  )
+  __io_println(
+    "gc_live_preserved:" + to_string(gc.messages[4].content.contains("IMPORTANT_LIVE_VALUE")),
+  )
+  __io_println("gc_roots:" + to_string(gc.event.metadata.roots_consulted.contains("last_2_messages")))
+  __io_println("gc_pointer:" + gc.redaction_pointers[0].source)
+  let blocked_gc = transcript_project(
+    gc_transcript(),
+    {policy: "reachability_gc", root_window: 2, min_chars: 100, require_write_barrier: true},
+  )
+  __io_println("gc_barrier_blocked:" + to_string(blocked_gc.redacted_count == 0))
+  let long_case = long_gc_transcript(60)
+  let long_raw = transcript_project(long_case.transcript, {policy: "raw"})
+  let long_gc = transcript_project(
+    long_case.transcript,
+    {policy: "reachability_gc", root_window: 2, min_chars: 100},
+  )
+  let long_barrier_gc = transcript_project(
+    long_case.transcript,
+    {
+      policy: "reachability_gc",
+      root_window: 2,
+      min_chars: 100,
+      require_write_barrier: true,
+      write_barrier_refs: ["scratchpad:live-file-state"],
+    },
+  )
+  __io_println("long_raw_redacted:" + to_string(long_raw.redacted_count))
+  __io_println("long_gc_redacted:" + to_string(long_gc.redacted_count))
+  __io_println("long_gc_reclaimed:" + to_string(long_gc.reclaimed_tokens > 1000))
+  __io_println(
+    "long_gc_live_preserved:"
+      + to_string(long_gc.messages[long_case.live_result_index].content.contains("IMPORTANT_LIVE_VALUE")),
+  )
+  __io_println("long_barrier_gc_redacted:" + to_string(long_barrier_gc.redacted_count))
 }

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -634,6 +634,10 @@ impl AgentEventSink for AcpAgentEventSink {
                 kept_count,
                 dropped_count,
                 provider_safety_blocked,
+                redacted_count,
+                reclaimed_tokens,
+                roots_consulted,
+                redaction_pointers,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "transcript_projected",
@@ -663,6 +667,30 @@ impl AgentEventSink for AcpAgentEventSink {
                     "providerSafetyBlocked".to_string(),
                     serde_json::Value::Bool(*provider_safety_blocked),
                 );
+                if *redacted_count > 0 {
+                    harn_meta.insert(
+                        "redactedCount".to_string(),
+                        serde_json::Value::from(*redacted_count),
+                    );
+                }
+                if *reclaimed_tokens > 0 {
+                    harn_meta.insert(
+                        "reclaimedTokens".to_string(),
+                        serde_json::Value::from(*reclaimed_tokens),
+                    );
+                }
+                if !roots_consulted.is_empty() {
+                    harn_meta.insert(
+                        "rootsConsulted".to_string(),
+                        serde_json::to_value(roots_consulted).unwrap_or_default(),
+                    );
+                }
+                if !redaction_pointers.is_empty() {
+                    harn_meta.insert(
+                        "redactionPointers".to_string(),
+                        serde_json::Value::Array(redaction_pointers.clone()),
+                    );
+                }
                 merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -214,6 +214,10 @@ fn extension_fixture_events() -> Vec<AgentEvent> {
             kept_count: 3,
             dropped_count: 2,
             provider_safety_blocked: false,
+            redacted_count: 0,
+            reclaimed_tokens: 0,
+            roots_consulted: Vec::new(),
+            redaction_pointers: Vec::new(),
         },
         AgentEvent::ReminderEmitted {
             session_id: "session-1".to_string(),
@@ -1141,6 +1145,10 @@ async fn forwarded_agent_events_serialize_as_session_updates() {
             kept_count: 3,
             dropped_count: 2,
             provider_safety_blocked: false,
+            redacted_count: 0,
+            reclaimed_tokens: 0,
+            roots_consulted: Vec::new(),
+            redaction_pointers: Vec::new(),
         },
         AgentEvent::Handoff {
             session_id: "session-1".to_string(),

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -719,16 +719,33 @@ fn __validate_agent_loop_completion_options(opts) {
   }
 }
 
+fn __is_transcript_projection_policy(policy) {
+  return policy == "raw" || policy == "clean_tool_repair" || policy == "squash_failed_calls"
+    || policy == "summary_prefix"
+    || policy == "reachability_gc"
+    || policy == "context_gc"
+    || policy == "tool_result_gc"
+    || policy == "custom"
+}
+
+fn __is_reachability_projection_policy(policy) {
+  return policy == "reachability_gc" || policy == "context_gc" || policy == "tool_result_gc"
+}
+
+fn __validate_non_negative_int_option(label, value) {
+  if value != nil && (type_of(value) != "int" || value < 0) {
+    throw "agent_loop: `" + label + "` must be a non-negative integer"
+  }
+}
+
 fn __validate_transcript_projection(value) {
   if value == nil {
     return
   }
   if type_of(value) == "string" {
     let policy = value
-    if policy != "raw" && policy != "clean_tool_repair" && policy != "squash_failed_calls"
-      && policy != "summary_prefix"
-      && policy != "custom" {
-      throw "agent_loop: `transcript_projection` policy must be one of raw, clean_tool_repair, squash_failed_calls, summary_prefix, custom; got "
+    if !__is_transcript_projection_policy(policy) {
+      throw "agent_loop: `transcript_projection` policy must be one of raw, clean_tool_repair, squash_failed_calls, summary_prefix, reachability_gc, custom; got "
         + policy
     }
     return
@@ -740,10 +757,8 @@ fn __validate_transcript_projection(value) {
   if type_of(policy) != "string" {
     throw "agent_loop: `transcript_projection.policy` must be a string"
   }
-  if policy != "raw" && policy != "clean_tool_repair" && policy != "squash_failed_calls"
-    && policy != "summary_prefix"
-    && policy != "custom" {
-    throw "agent_loop: `transcript_projection.policy` must be one of raw, clean_tool_repair, squash_failed_calls, summary_prefix, custom; got "
+  if !__is_transcript_projection_policy(policy) {
+    throw "agent_loop: `transcript_projection.policy` must be one of raw, clean_tool_repair, squash_failed_calls, summary_prefix, reachability_gc, custom; got "
       + policy
   }
   if policy == "custom" {
@@ -753,9 +768,16 @@ fn __validate_transcript_projection(value) {
     }
   }
   if policy == "summary_prefix" {
-    let keep_last = value?.keep_last
-    if keep_last != nil && (type_of(keep_last) != "int" || keep_last < 0) {
-      throw "agent_loop: `transcript_projection.keep_last` must be a non-negative integer"
+    __validate_non_negative_int_option("transcript_projection.keep_last", value?.keep_last)
+  }
+  if __is_reachability_projection_policy(policy) {
+    let root_window = value?.root_window ?? value?.recent_messages ?? value?.keep_last
+    __validate_non_negative_int_option("transcript_projection.root_window", root_window)
+    let min_chars = value?.min_chars ?? value?.min_reclaim_chars ?? value?.tool_result_min_chars
+    __validate_non_negative_int_option("transcript_projection.min_chars", min_chars)
+    let require_barrier = value?.require_write_barrier ?? value?.require_barrier
+    if require_barrier != nil && type_of(require_barrier) != "bool" {
+      throw "agent_loop: `transcript_projection.require_write_barrier` must be a bool"
     }
   }
 }

--- a/crates/harn-stdlib/src/stdlib/agent/state.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/state.harn
@@ -390,7 +390,7 @@ pub fn agent_record_compaction(session_id, payload) {
  * The persisted message list is never mutated — projection only
  * controls what the next provider request will see. Supported policies:
  * "raw", "clean_tool_repair", "squash_failed_calls", "summary_prefix",
- * and "custom" (with a `projector` closure).
+ * "reachability_gc", and "custom" (with a `projector` closure).
  *
  * @effects: [host]
  * @allocation: heap

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -409,6 +409,14 @@ pub enum AgentEvent {
         kept_count: usize,
         dropped_count: usize,
         provider_safety_blocked: bool,
+        #[serde(default, skip_serializing_if = "is_zero_usize")]
+        redacted_count: usize,
+        #[serde(default, skip_serializing_if = "is_zero_usize")]
+        reclaimed_tokens: usize,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        roots_consulted: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        redaction_pointers: Vec<serde_json::Value>,
     },
     /// Emitted when a pending `system_reminder` is rendered into the
     /// next provider request. ACP clients show these in a reminder lane

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -2163,6 +2163,10 @@ async fn host_agent_session_project_turn(
             kept_count: result.kept_indices.len(),
             dropped_count: result.dropped_indices.len(),
             provider_safety_blocked: result.provider_safety_blocked,
+            redacted_count: result.redaction_pointers.len(),
+            reclaimed_tokens: result.reclaimed_tokens,
+            roots_consulted: result.roots_consulted.clone(),
+            redaction_pointers: result.redaction_pointers.clone(),
         },
     )
     .await;

--- a/crates/harn-vm/src/stdlib/transcript_project.rs
+++ b/crates/harn-vm/src/stdlib/transcript_project.rs
@@ -28,6 +28,8 @@ use crate::vm::{AsyncBuiltinCtx, Vm};
 
 /// Canonical `kind` for the transcript event emitted on each projection.
 pub(crate) const TRANSCRIPT_PROJECTION_EVENT_KIND: &str = "transcript.projection";
+const DEFAULT_REACHABILITY_GC_ROOT_WINDOW: usize = 8;
+const DEFAULT_REACHABILITY_GC_MIN_CHARS: usize = 500;
 
 pub(crate) fn register_transcript_projection_builtins(vm: &mut Vm) {
     vm.register_async_builtin("transcript_project", |ctx, args| async move {
@@ -64,6 +66,18 @@ pub(crate) struct ProjectionPolicy {
     pub summary_text: Option<String>,
     /// For `Custom`: the user closure.
     pub custom: Option<VmValue>,
+    /// For `ReachabilityGc`: number of recent messages treated as roots.
+    pub gc_root_window: usize,
+    /// For `ReachabilityGc`: minimum tool-result body size eligible for reclamation.
+    pub gc_min_chars: usize,
+    /// For `ReachabilityGc`: labels of root sources consulted for audit metadata.
+    pub gc_root_labels: Vec<String>,
+    /// For `ReachabilityGc`: additional caller-supplied root text.
+    pub gc_root_texts: Vec<String>,
+    /// For `ReachabilityGc`: require explicit write-barrier refs before reclaiming.
+    pub gc_require_write_barrier: bool,
+    /// For `ReachabilityGc`: whether explicit write-barrier refs were supplied.
+    pub gc_has_write_barrier: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -72,6 +86,7 @@ pub(crate) enum PolicyKind {
     CleanToolRepair,
     SquashFailedCalls,
     SummaryPrefix,
+    ReachabilityGc,
     Custom,
 }
 
@@ -82,7 +97,28 @@ impl PolicyKind {
             PolicyKind::CleanToolRepair => "clean_tool_repair",
             PolicyKind::SquashFailedCalls => "squash_failed_calls",
             PolicyKind::SummaryPrefix => "summary_prefix",
+            PolicyKind::ReachabilityGc => "reachability_gc",
             PolicyKind::Custom => "custom",
+        }
+    }
+}
+
+impl ProjectionPolicy {
+    #[cfg(test)]
+    fn default_for(kind: PolicyKind) -> Self {
+        Self {
+            kind,
+            respect_provider_signatures: true,
+            reason: None,
+            summary_keep_last: 0,
+            summary_text: None,
+            custom: None,
+            gc_root_window: DEFAULT_REACHABILITY_GC_ROOT_WINDOW,
+            gc_min_chars: DEFAULT_REACHABILITY_GC_MIN_CHARS,
+            gc_root_labels: Vec::new(),
+            gc_root_texts: Vec::new(),
+            gc_require_write_barrier: false,
+            gc_has_write_barrier: false,
         }
     }
 }
@@ -118,10 +154,11 @@ pub(crate) fn parse_projection_options(options: &VmValue) -> Result<ProjectionPo
         "clean_tool_repair" => PolicyKind::CleanToolRepair,
         "squash_failed_calls" => PolicyKind::SquashFailedCalls,
         "summary_prefix" => PolicyKind::SummaryPrefix,
+        "reachability_gc" | "context_gc" | "tool_result_gc" => PolicyKind::ReachabilityGc,
         "custom" => PolicyKind::Custom,
         other => {
             return Err(VmError::Runtime(format!(
-                "transcript_project: unknown policy '{other}' (expected raw, clean_tool_repair, squash_failed_calls, summary_prefix, custom)"
+                "transcript_project: unknown policy '{other}' (expected raw, clean_tool_repair, squash_failed_calls, summary_prefix, reachability_gc, custom)"
             )))
         }
     };
@@ -164,6 +201,52 @@ pub(crate) fn parse_projection_options(options: &VmValue) -> Result<ProjectionPo
             "transcript_project: policy 'custom' requires a projector closure".into(),
         ));
     }
+    let (
+        gc_root_window,
+        gc_min_chars,
+        gc_root_labels,
+        gc_root_texts,
+        gc_require_write_barrier,
+        gc_has_write_barrier,
+    ) = if kind == PolicyKind::ReachabilityGc {
+        let gc_root_window = optional_usize_alias(
+            dict.as_ref(),
+            &["root_window", "recent_messages", "keep_last"],
+            DEFAULT_REACHABILITY_GC_ROOT_WINDOW,
+            "transcript_project",
+        )?;
+        let gc_min_chars = optional_usize_alias(
+            dict.as_ref(),
+            &["min_chars", "min_reclaim_chars", "tool_result_min_chars"],
+            DEFAULT_REACHABILITY_GC_MIN_CHARS,
+            "transcript_project",
+        )?;
+        let gc_require_write_barrier = optional_bool_alias(
+            dict.as_ref(),
+            &["require_write_barrier", "require_barrier"],
+            false,
+            "transcript_project",
+        )?;
+        let (gc_root_labels, gc_root_texts, gc_has_write_barrier) =
+            parse_reachability_gc_roots(dict.as_ref());
+        (
+            gc_root_window,
+            gc_min_chars,
+            gc_root_labels,
+            gc_root_texts,
+            gc_require_write_barrier,
+            gc_has_write_barrier,
+        )
+    } else {
+        (
+            DEFAULT_REACHABILITY_GC_ROOT_WINDOW,
+            DEFAULT_REACHABILITY_GC_MIN_CHARS,
+            Vec::new(),
+            Vec::new(),
+            false,
+            false,
+        )
+    };
     Ok(ProjectionPolicy {
         kind,
         respect_provider_signatures: respect_signatures,
@@ -171,7 +254,133 @@ pub(crate) fn parse_projection_options(options: &VmValue) -> Result<ProjectionPo
         summary_keep_last,
         summary_text,
         custom,
+        gc_root_window,
+        gc_min_chars,
+        gc_root_labels,
+        gc_root_texts,
+        gc_require_write_barrier,
+        gc_has_write_barrier,
     })
+}
+
+fn optional_usize_alias(
+    dict: Option<&BTreeMap<String, VmValue>>,
+    keys: &[&str],
+    default: usize,
+    builtin: &str,
+) -> Result<usize, VmError> {
+    let Some(dict) = dict else {
+        return Ok(default);
+    };
+    for key in keys {
+        match dict.get(*key) {
+            None | Some(VmValue::Nil) => {}
+            Some(value) => {
+                let Some(number) = value.as_int() else {
+                    return Err(VmError::Runtime(format!(
+                        "{builtin}: `{key}` must be a non-negative integer, got {}",
+                        value.type_name()
+                    )));
+                };
+                if number < 0 {
+                    return Err(VmError::Runtime(format!(
+                        "{builtin}: `{key}` must be a non-negative integer"
+                    )));
+                }
+                return Ok(number as usize);
+            }
+        }
+    }
+    Ok(default)
+}
+
+fn optional_bool_alias(
+    dict: Option<&BTreeMap<String, VmValue>>,
+    keys: &[&str],
+    default: bool,
+    builtin: &str,
+) -> Result<bool, VmError> {
+    let Some(dict) = dict else {
+        return Ok(default);
+    };
+    for key in keys {
+        match dict.get(*key) {
+            None | Some(VmValue::Nil) => {}
+            Some(VmValue::Bool(value)) => return Ok(*value),
+            Some(value) => {
+                return Err(VmError::Runtime(format!(
+                    "{builtin}: `{key}` must be a bool, got {}",
+                    value.type_name()
+                )))
+            }
+        }
+    }
+    Ok(default)
+}
+
+fn parse_reachability_gc_roots(
+    dict: Option<&BTreeMap<String, VmValue>>,
+) -> (Vec<String>, Vec<String>, bool) {
+    let Some(dict) = dict else {
+        return (Vec::new(), Vec::new(), false);
+    };
+    let mut labels = Vec::new();
+    let mut texts = Vec::new();
+    let mut has_write_barrier = false;
+    let root_fields = [
+        ("roots", "roots", false),
+        ("active_plan", "active_plan", false),
+        ("scratchpad", "scratchpad", false),
+        ("pending_tool_args", "pending_tool_args", false),
+        ("unresolved_findings", "unresolved_findings", false),
+        ("write_barrier", "write_barrier", true),
+        ("write_barrier_refs", "write_barrier", true),
+        ("barrier_refs", "write_barrier", true),
+    ];
+    for (key, label, is_barrier) in root_fields {
+        let Some(value) = dict.get(key) else {
+            continue;
+        };
+        let before = texts.len();
+        collect_vm_strings(value, &mut texts);
+        if texts.len() > before {
+            push_unique(&mut labels, label.to_string());
+            has_write_barrier |= is_barrier;
+        }
+    }
+    (labels, texts, has_write_barrier)
+}
+
+fn collect_vm_strings(value: &VmValue, out: &mut Vec<String>) {
+    match value {
+        VmValue::String(text) if !text.trim().is_empty() => {
+            out.push(text.to_string());
+        }
+        VmValue::String(_) => {}
+        VmValue::List(items) => {
+            for item in items.iter() {
+                collect_vm_strings(item, out);
+            }
+        }
+        VmValue::Dict(map) => {
+            for value in map.values() {
+                collect_vm_strings(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn push_unique_usize(values: &mut Vec<usize>, value: usize) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
 }
 
 /// Outcome of a single projection.
@@ -190,6 +399,16 @@ pub(crate) struct ProjectionResult {
     /// When `respect_provider_signatures` blocked a drop, this is true
     /// and `messages` is the unchanged raw prefix.
     pub provider_safety_blocked: bool,
+    /// Source indices whose tool-result bodies were replaced by audit pointers.
+    pub redacted_indices: Vec<usize>,
+    /// Approximate token count removed from the projected prefix.
+    pub reclaimed_tokens: usize,
+    /// Character count removed from the projected prefix.
+    pub reclaimed_chars: usize,
+    /// Root source labels consulted by reachability-aware projection.
+    pub roots_consulted: Vec<String>,
+    /// Host/audit pointers for each reclaimed tool result body.
+    pub redaction_pointers: Vec<JsonValue>,
 }
 
 pub(crate) async fn project_transcript(
@@ -218,6 +437,7 @@ pub(crate) async fn project_messages(
             policy.summary_keep_last,
             &policy.summary_text,
         ),
+        PolicyKind::ReachabilityGc => project_reachability_gc(raw, policy),
         PolicyKind::Custom => {
             project_custom(ctx, raw, policy.custom.as_ref().expect("custom validated")).await?
         }
@@ -225,13 +445,23 @@ pub(crate) async fn project_messages(
 
     let mut safety_blocked = false;
     if policy.respect_provider_signatures && policy.kind != PolicyKind::Raw {
-        if let Some(blocked_idx) = first_blocked_signed_drop(raw, &decision.dropped_indices) {
+        let rewritten_indices = decision
+            .dropped_indices
+            .iter()
+            .chain(decision.redacted_indices.iter())
+            .copied()
+            .collect::<Vec<_>>();
+        if let Some(blocked_idx) = first_blocked_signed_drop(raw, &rewritten_indices) {
             safety_blocked = true;
             decision.reason = format!(
                 "{} (blocked: signed reasoning at index {})",
                 decision.reason, blocked_idx
             );
             decision.dropped_indices.clear();
+            decision.redacted_indices.clear();
+            decision.reclaimed_tokens = 0;
+            decision.reclaimed_chars = 0;
+            decision.redaction_pointers.clear();
             decision.kept_indices = (0..raw.len()).collect();
             decision.messages = raw.to_vec();
         }
@@ -251,6 +481,11 @@ pub(crate) async fn project_messages(
         prefix_hash,
         reason,
         provider_safety_blocked: safety_blocked,
+        redacted_indices: decision.redacted_indices,
+        reclaimed_tokens: decision.reclaimed_tokens,
+        reclaimed_chars: decision.reclaimed_chars,
+        roots_consulted: decision.root_labels,
+        redaction_pointers: decision.redaction_pointers,
     })
 }
 
@@ -259,6 +494,11 @@ struct ProjectionDecision {
     messages: Vec<JsonValue>,
     kept_indices: Vec<usize>,
     dropped_indices: Vec<usize>,
+    redacted_indices: Vec<usize>,
+    reclaimed_tokens: usize,
+    reclaimed_chars: usize,
+    redaction_pointers: Vec<JsonValue>,
+    root_labels: Vec<String>,
     reason: String,
 }
 
@@ -267,6 +507,11 @@ fn project_raw(raw: &[JsonValue]) -> ProjectionDecision {
         messages: raw.to_vec(),
         kept_indices: (0..raw.len()).collect(),
         dropped_indices: Vec::new(),
+        redacted_indices: Vec::new(),
+        reclaimed_tokens: 0,
+        reclaimed_chars: 0,
+        redaction_pointers: Vec::new(),
+        root_labels: Vec::new(),
         reason: "raw_passthrough".to_string(),
     }
 }
@@ -408,12 +653,9 @@ fn project_summary_prefix(
     summary_text: &Option<String>,
 ) -> ProjectionDecision {
     if keep_last >= raw.len() {
-        return ProjectionDecision {
-            messages: raw.to_vec(),
-            kept_indices: (0..raw.len()).collect(),
-            dropped_indices: Vec::new(),
-            reason: "summary_prefix_noop_short_history".to_string(),
-        };
+        let mut decision = project_raw(raw);
+        decision.reason = "summary_prefix_noop_short_history".to_string();
+        return decision;
     }
     let drop_count = raw.len() - keep_last;
     let dropped: Vec<usize> = (0..drop_count).collect();
@@ -443,7 +685,69 @@ fn project_summary_prefix(
         messages,
         kept_indices: kept,
         dropped_indices: dropped,
+        redacted_indices: Vec::new(),
+        reclaimed_tokens: 0,
+        reclaimed_chars: 0,
+        redaction_pointers: Vec::new(),
+        root_labels: Vec::new(),
         reason: "summary_prefix".to_string(),
+    }
+}
+
+/// `reachability_gc`: keep the raw transcript intact, but replace stale
+/// model-visible tool-result bodies with compact audit pointers when no
+/// current roots reference their identifiers. Recent messages, explicit
+/// caller roots, and write-barrier refs form the root set.
+fn project_reachability_gc(raw: &[JsonValue], policy: &ProjectionPolicy) -> ProjectionDecision {
+    if policy.gc_require_write_barrier && !policy.gc_has_write_barrier {
+        let mut decision = project_raw(raw);
+        decision.reason = "reachability_gc_write_barrier_missing".to_string();
+        decision.root_labels = reachability_root_labels(raw, policy);
+        return decision;
+    }
+
+    let root_start = raw.len().saturating_sub(policy.gc_root_window);
+    let root_blob = reachability_root_blob(raw, root_start, policy);
+    let root_labels = reachability_root_labels(raw, policy);
+    let mut messages = raw.to_vec();
+    let mut redacted_indices = Vec::new();
+    let mut redaction_pointers = Vec::new();
+    let mut reclaimed_chars = 0usize;
+
+    for idx in 0..root_start {
+        for candidate in tool_result_candidates(idx, &raw[idx]) {
+            let content_chars = candidate.content.chars().count();
+            if content_chars < policy.gc_min_chars || candidate.is_error {
+                continue;
+            }
+            let identifiers = tool_result_reachability_identifiers(raw, &candidate);
+            if identifiers
+                .iter()
+                .any(|identifier| root_blob.contains(identifier))
+            {
+                continue;
+            }
+            let pointer = redaction_pointer(&candidate);
+            let replacement = redacted_tool_result_body(&pointer);
+            messages[idx] =
+                redact_tool_result_message(&messages[idx], &candidate, &replacement, &pointer);
+            reclaimed_chars += content_chars.saturating_sub(replacement.chars().count());
+            push_unique_usize(&mut redacted_indices, idx);
+            redaction_pointers.push(pointer);
+        }
+    }
+
+    let reclaimed_tokens = reclaimed_chars / 4;
+    ProjectionDecision {
+        messages,
+        kept_indices: (0..raw.len()).collect(),
+        dropped_indices: Vec::new(),
+        redacted_indices,
+        reclaimed_tokens,
+        reclaimed_chars,
+        redaction_pointers,
+        root_labels,
+        reason: "reachability_gc".to_string(),
     }
 }
 
@@ -480,6 +784,11 @@ fn parse_custom_projector_result(
                 messages,
                 kept_indices,
                 dropped_indices,
+                redacted_indices: Vec::new(),
+                reclaimed_tokens: 0,
+                reclaimed_chars: 0,
+                redaction_pointers: Vec::new(),
+                root_labels: Vec::new(),
                 reason: "custom".to_string(),
             })
         }
@@ -532,6 +841,11 @@ fn parse_custom_projector_result(
                 messages,
                 kept_indices,
                 dropped_indices,
+                redacted_indices: Vec::new(),
+                reclaimed_tokens: 0,
+                reclaimed_chars: 0,
+                redaction_pointers: Vec::new(),
+                root_labels: Vec::new(),
                 reason,
             })
         }
@@ -584,6 +898,11 @@ fn project_with_drops(raw: &[JsonValue], dropped: &[usize], reason: &str) -> Pro
         messages,
         kept_indices: kept,
         dropped_indices: dropped.to_vec(),
+        redacted_indices: Vec::new(),
+        reclaimed_tokens: 0,
+        reclaimed_chars: 0,
+        redaction_pointers: Vec::new(),
+        root_labels: Vec::new(),
         reason: reason.to_string(),
     }
 }
@@ -592,6 +911,18 @@ fn project_with_drops(raw: &[JsonValue], dropped: &[usize], reason: &str) -> Pro
 struct ToolCallInfo {
     tool_call_id: Option<String>,
     tool_name: Option<String>,
+    node: Option<JsonValue>,
+}
+
+#[derive(Clone, Debug)]
+struct ToolResultCandidate {
+    message_idx: usize,
+    block_idx: Option<usize>,
+    content: String,
+    node: JsonValue,
+    tool_call_id: Option<String>,
+    tool_name: Option<String>,
+    is_error: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -607,6 +938,7 @@ fn extract_tool_calls(message: &JsonValue) -> Vec<ToolCallInfo> {
             calls.push(ToolCallInfo {
                 tool_call_id: extract_tool_call_id(item),
                 tool_name: extract_tool_call_name(item),
+                node: Some(item.clone()),
             });
         }
     }
@@ -622,6 +954,7 @@ fn extract_tool_calls(message: &JsonValue) -> Vec<ToolCallInfo> {
                         .get("name")
                         .and_then(JsonValue::as_str)
                         .map(str::to_string),
+                    node: Some(item.clone()),
                 });
             }
         }
@@ -659,6 +992,27 @@ fn tool_result_matches(message: &JsonValue, call: &ToolCallInfo) -> bool {
     if let (Some(call_id), Some(target_id)) = (call_id, target_id) {
         return call_id == target_id;
     }
+    if message.get("role").and_then(JsonValue::as_str) == Some("user") {
+        if let Some(blocks) = message.get("content").and_then(JsonValue::as_array) {
+            for block in blocks {
+                if block.get("type").and_then(JsonValue::as_str) != Some("tool_result") {
+                    continue;
+                }
+                let target_id = block
+                    .get("tool_use_id")
+                    .or_else(|| block.get("tool_call_id"))
+                    .or_else(|| block.get("id"))
+                    .and_then(JsonValue::as_str);
+                if let (Some(call_id), Some(target_id)) = (call_id, target_id) {
+                    return call_id == target_id;
+                }
+                let target_name = block.get("name").and_then(JsonValue::as_str);
+                if let (Some(name), Some(target_name)) = (call.tool_name.as_deref(), target_name) {
+                    return name == target_name;
+                }
+            }
+        }
+    }
     let tool_name = call.tool_name.as_deref();
     let message_name = message.get("name").and_then(JsonValue::as_str);
     if let (Some(name), Some(msg_name)) = (tool_name, message_name) {
@@ -668,14 +1022,89 @@ fn tool_result_matches(message: &JsonValue, call: &ToolCallInfo) -> bool {
 }
 
 fn tool_result_is_error(message: &JsonValue) -> bool {
-    if message
+    if let Some(candidate) = tool_result_candidates(0, message).into_iter().next() {
+        return candidate.is_error;
+    }
+    tool_result_node_is_error(message)
+}
+
+fn tool_result_candidates(message_idx: usize, message: &JsonValue) -> Vec<ToolResultCandidate> {
+    let role = message
+        .get("role")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("");
+    if matches!(role, "tool" | "tool_result") {
+        return message
+            .get("content")
+            .map(json_text)
+            .map(|content| {
+                vec![ToolResultCandidate {
+                    message_idx,
+                    block_idx: None,
+                    content,
+                    node: message.clone(),
+                    tool_call_id: message
+                        .get("tool_use_id")
+                        .or_else(|| message.get("tool_call_id"))
+                        .and_then(JsonValue::as_str)
+                        .map(str::to_string),
+                    tool_name: message
+                        .get("name")
+                        .and_then(JsonValue::as_str)
+                        .map(str::to_string),
+                    is_error: tool_result_node_is_error(message),
+                }]
+            })
+            .unwrap_or_default();
+    }
+    if role != "user" {
+        return Vec::new();
+    }
+    let Some(blocks) = message.get("content").and_then(JsonValue::as_array) else {
+        return Vec::new();
+    };
+    blocks
+        .iter()
+        .enumerate()
+        .filter_map(|(block_idx, block)| {
+            if block.get("type").and_then(JsonValue::as_str) == Some("tool_result") {
+                return block
+                    .get("content")
+                    .map(json_text)
+                    .map(|content| ToolResultCandidate {
+                        message_idx,
+                        block_idx: Some(block_idx),
+                        content,
+                        node: block.clone(),
+                        tool_call_id: block
+                            .get("tool_use_id")
+                            .or_else(|| block.get("tool_call_id"))
+                            .or_else(|| block.get("id"))
+                            .and_then(JsonValue::as_str)
+                            .map(str::to_string),
+                        tool_name: block
+                            .get("name")
+                            .or_else(|| message.get("name"))
+                            .and_then(JsonValue::as_str)
+                            .map(str::to_string),
+                        is_error: tool_result_node_is_error(block),
+                    });
+            }
+            None
+        })
+        .collect()
+}
+
+fn tool_result_node_is_error(node: &JsonValue) -> bool {
+    if node
         .get("is_error")
+        .or_else(|| node.get("error"))
         .and_then(JsonValue::as_bool)
         .unwrap_or(false)
     {
         return true;
     }
-    if let Some(status) = message.get("status").and_then(JsonValue::as_str) {
+    if let Some(status) = node.get("status").and_then(JsonValue::as_str) {
         if matches!(
             status,
             "error" | "failed" | "rejected" | "exception" | "denied"
@@ -683,15 +1112,264 @@ fn tool_result_is_error(message: &JsonValue) -> bool {
             return true;
         }
     }
-    let content = message
-        .get("content")
-        .and_then(JsonValue::as_str)
-        .unwrap_or("");
+    let content = node.get("content").map(json_text).unwrap_or_default();
     let lowered = content.trim_start().to_ascii_lowercase();
     lowered.starts_with("error:")
         || lowered.starts_with("tool error")
         || lowered.starts_with("failed:")
         || lowered.contains("\"is_error\":true")
+}
+
+fn json_text(value: &JsonValue) -> String {
+    match value {
+        JsonValue::String(text) => text.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn reachability_root_blob(
+    raw: &[JsonValue],
+    root_start: usize,
+    policy: &ProjectionPolicy,
+) -> String {
+    let mut roots = policy.gc_root_texts.join("\n");
+    for message in raw.iter().skip(root_start) {
+        roots.push('\n');
+        roots.push_str(&canonical_json(message));
+    }
+    roots
+}
+
+fn reachability_root_labels(raw: &[JsonValue], policy: &ProjectionPolicy) -> Vec<String> {
+    let mut labels = Vec::new();
+    if policy.gc_root_window > 0 && !raw.is_empty() {
+        push_unique(
+            &mut labels,
+            format!("last_{}_messages", policy.gc_root_window.min(raw.len())),
+        );
+    }
+    for label in &policy.gc_root_labels {
+        push_unique(&mut labels, label.clone());
+    }
+    if policy.gc_require_write_barrier {
+        push_unique(&mut labels, "write_barrier_required".to_string());
+    }
+    labels
+}
+
+fn tool_result_reachability_identifiers(
+    raw: &[JsonValue],
+    candidate: &ToolResultCandidate,
+) -> Vec<String> {
+    let mut identifiers = Vec::new();
+    collect_identifiers_from_str(&candidate.content, &mut identifiers);
+    collect_identifiers_from_json(&candidate.node, &mut identifiers);
+    let result_call = ToolCallInfo {
+        tool_call_id: candidate.tool_call_id.clone(),
+        tool_name: candidate.tool_name.clone(),
+        node: None,
+    };
+    let mut matched_call = false;
+    for previous in raw[..candidate.message_idx].iter().rev() {
+        if previous.get("role").and_then(JsonValue::as_str) != Some("assistant") {
+            continue;
+        }
+        for call in extract_tool_calls(previous) {
+            if !tool_calls_correlate(&call, &result_call) {
+                continue;
+            }
+            if let Some(node) = call.node {
+                collect_identifiers_from_json(&node, &mut identifiers);
+            }
+            matched_call = true;
+            break;
+        }
+        if matched_call {
+            break;
+        }
+    }
+    identifiers.sort();
+    identifiers.dedup();
+    identifiers
+}
+
+fn tool_calls_correlate(call: &ToolCallInfo, result: &ToolCallInfo) -> bool {
+    if let (Some(left), Some(right)) = (&call.tool_call_id, &result.tool_call_id) {
+        return left == right;
+    }
+    if let (Some(left), Some(right)) = (&call.tool_name, &result.tool_name) {
+        return left == right;
+    }
+    false
+}
+
+fn collect_identifiers_from_json(value: &JsonValue, out: &mut Vec<String>) {
+    match value {
+        JsonValue::String(text) => collect_identifiers_from_str(text, out),
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_identifiers_from_json(item, out);
+            }
+        }
+        JsonValue::Object(map) => {
+            for (key, value) in map {
+                if matches!(
+                    key.as_str(),
+                    "id" | "tool_call_id" | "tool_use_id" | "path" | "symbol" | "name"
+                ) {
+                    if let Some(text) = value.as_str() {
+                        collect_identifiers_from_str(text, out);
+                    }
+                }
+                collect_identifiers_from_json(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_identifiers_from_str(text: &str, out: &mut Vec<String>) {
+    for raw in text.split(|ch: char| {
+        ch.is_whitespace()
+            || matches!(
+                ch,
+                '"' | '\'' | '`' | ',' | ';' | '(' | ')' | '[' | ']' | '{' | '}'
+            )
+    }) {
+        let token = raw.trim_matches(|ch: char| {
+            matches!(ch, ':' | '.' | ',' | ';' | '"' | '\'' | '`' | '<' | '>')
+        });
+        if is_reachability_identifier(token) {
+            out.push(token.to_string());
+        }
+    }
+}
+
+fn is_reachability_identifier(token: &str) -> bool {
+    if token.len() < 3 {
+        return false;
+    }
+    if token.contains('/') || token.contains('\\') || token.contains("::") {
+        return true;
+    }
+    if token.rsplit_once('.').is_some_and(|(_, ext)| {
+        (1..=8).contains(&ext.len()) && ext.chars().all(|c| c.is_ascii_alphanumeric())
+    }) {
+        return true;
+    }
+    if token.len() >= 6 && token.contains('_') {
+        return true;
+    }
+    let has_lower = token.chars().any(|c| c.is_ascii_lowercase());
+    let has_upper = token.chars().any(|c| c.is_ascii_uppercase());
+    has_lower && has_upper && token.len() >= 4
+}
+
+fn redact_tool_result_message(
+    message: &JsonValue,
+    candidate: &ToolResultCandidate,
+    replacement: &str,
+    pointer: &JsonValue,
+) -> JsonValue {
+    let mut projected = message.clone();
+    let marker = serde_json::json!({
+        "redacted": true,
+        "policy": "reachability_gc",
+        "redaction_pointer": pointer,
+    });
+    if let Some(map) = projected.as_object_mut() {
+        if let Some(block_idx) = candidate.block_idx {
+            if let Some(blocks) = map.get_mut("content").and_then(JsonValue::as_array_mut) {
+                if let Some(block) = blocks.get_mut(block_idx) {
+                    block["content"] = JsonValue::String(replacement.to_string());
+                    block["_harn_projection"] = marker;
+                }
+            }
+            append_redaction_pointer(map, pointer);
+        } else {
+            map.insert(
+                "content".to_string(),
+                JsonValue::String(replacement.to_string()),
+            );
+            map.insert("_harn_projection".to_string(), marker);
+        }
+    }
+    projected
+}
+
+fn append_redaction_pointer(map: &mut serde_json::Map<String, JsonValue>, pointer: &JsonValue) {
+    let entry = map
+        .entry("_harn_projection".to_string())
+        .or_insert_with(|| {
+            serde_json::json!({
+                "redacted": true,
+                "policy": "reachability_gc",
+                "redaction_pointers": [],
+            })
+        });
+    if !entry.is_object() {
+        *entry = serde_json::json!({
+            "redacted": true,
+            "policy": "reachability_gc",
+            "redaction_pointers": [],
+        });
+    }
+    if let Some(obj) = entry.as_object_mut() {
+        obj.insert("redacted".to_string(), JsonValue::Bool(true));
+        obj.insert(
+            "policy".to_string(),
+            JsonValue::String("reachability_gc".to_string()),
+        );
+        obj.entry("redaction_pointers".to_string())
+            .or_insert_with(|| JsonValue::Array(Vec::new()));
+        if let Some(pointers) = obj
+            .get_mut("redaction_pointers")
+            .and_then(JsonValue::as_array_mut)
+        {
+            pointers.push(pointer.clone());
+        }
+    }
+}
+
+fn redaction_pointer(candidate: &ToolResultCandidate) -> JsonValue {
+    let content_chars = candidate.content.chars().count();
+    let source = match candidate.block_idx {
+        Some(block_idx) => format!(
+            "transcript.messages[{}].content[{block_idx}].content",
+            candidate.message_idx
+        ),
+        None => format!("transcript.messages[{}].content", candidate.message_idx),
+    };
+    serde_json::json!({
+        "policy": "reachability_gc",
+        "source": source,
+        "source_index": candidate.message_idx,
+        "source_block_index": candidate.block_idx,
+        "content_hash": hash_string(&candidate.content),
+        "content_chars": content_chars,
+        "estimated_tokens_reclaimed": content_chars / 4,
+        "tool_call_id": candidate.tool_call_id.clone(),
+        "tool_name": candidate.tool_name.clone(),
+        "reason": "stale_tool_result_unreachable",
+    })
+}
+
+fn redacted_tool_result_body(pointer: &JsonValue) -> String {
+    let source_index = pointer
+        .get("source_index")
+        .and_then(JsonValue::as_u64)
+        .unwrap_or_default();
+    let content_hash = pointer
+        .get("content_hash")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("sha256:");
+    let estimated = pointer
+        .get("estimated_tokens_reclaimed")
+        .and_then(JsonValue::as_u64)
+        .unwrap_or_default();
+    format!(
+        "[tool result reclaimed by reachability_gc; source_index={source_index}; content_hash={content_hash}; estimated_tokens_reclaimed={estimated}. Raw content remains in the transcript audit trail.]"
+    )
 }
 
 fn find_tool_result_idx(
@@ -764,8 +1442,12 @@ fn message_has_signed_reasoning(message: &JsonValue) -> bool {
 
 fn hash_messages(messages: &[JsonValue]) -> String {
     let canonical = canonical_json(&JsonValue::Array(messages.to_vec()));
+    hash_string(&canonical)
+}
+
+fn hash_string(value: &str) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(canonical.as_bytes());
+    hasher.update(value.as_bytes());
     let digest: [u8; 32] = hasher.finalize().into();
     format!("sha256:{}", hex::encode(digest))
 }
@@ -839,6 +1521,48 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
         VmValue::Int(result.dropped_indices.len() as i64),
     );
     dict.insert(
+        "redacted_indices".to_string(),
+        VmValue::List(std::sync::Arc::new(
+            result
+                .redacted_indices
+                .iter()
+                .map(|i| VmValue::Int(*i as i64))
+                .collect(),
+        )),
+    );
+    dict.insert(
+        "redacted_count".to_string(),
+        VmValue::Int(result.redaction_pointers.len() as i64),
+    );
+    dict.insert(
+        "reclaimed_tokens".to_string(),
+        VmValue::Int(result.reclaimed_tokens as i64),
+    );
+    dict.insert(
+        "reclaimed_chars".to_string(),
+        VmValue::Int(result.reclaimed_chars as i64),
+    );
+    dict.insert(
+        "roots_consulted".to_string(),
+        VmValue::List(std::sync::Arc::new(
+            result
+                .roots_consulted
+                .iter()
+                .map(|label| VmValue::String(std::sync::Arc::from(label.clone())))
+                .collect(),
+        )),
+    );
+    dict.insert(
+        "redaction_pointers".to_string(),
+        VmValue::List(std::sync::Arc::new(
+            result
+                .redaction_pointers
+                .iter()
+                .map(json_to_vm_value)
+                .collect(),
+        )),
+    );
+    dict.insert(
         "provider_safety_blocked".to_string(),
         VmValue::Bool(result.provider_safety_blocked),
     );
@@ -869,6 +1593,12 @@ fn projection_event_metadata(result: &ProjectionResult, policy: &ProjectionPolic
         "dropped_indices": result.dropped_indices,
         "kept_count": result.kept_indices.len(),
         "dropped_count": result.dropped_indices.len(),
+        "redacted_indices": result.redacted_indices,
+        "redacted_count": result.redaction_pointers.len(),
+        "reclaimed_tokens": result.reclaimed_tokens,
+        "reclaimed_chars": result.reclaimed_chars,
+        "roots_consulted": result.roots_consulted,
+        "redaction_pointers": result.redaction_pointers,
         "respects_provider_signatures": policy.respect_provider_signatures,
         "provider_safety_blocked": result.provider_safety_blocked,
         "summary_keep_last": match policy.kind {
@@ -915,14 +1645,7 @@ mod tests {
             ],
             None,
         );
-        let policy = ProjectionPolicy {
-            kind: PolicyKind::Raw,
-            respect_provider_signatures: true,
-            reason: None,
-            summary_keep_last: 0,
-            summary_text: None,
-            custom: None,
-        };
+        let policy = ProjectionPolicy::default_for(PolicyKind::Raw);
         let result = project_transcript(None, &transcript, &policy)
             .await
             .unwrap();
@@ -962,14 +1685,7 @@ mod tests {
             ],
             None,
         );
-        let policy = ProjectionPolicy {
-            kind: PolicyKind::CleanToolRepair,
-            respect_provider_signatures: true,
-            reason: None,
-            summary_keep_last: 0,
-            summary_text: None,
-            custom: None,
-        };
+        let policy = ProjectionPolicy::default_for(PolicyKind::CleanToolRepair);
         let result = project_transcript(None, &transcript, &policy)
             .await
             .unwrap();
@@ -1007,14 +1723,7 @@ mod tests {
             ],
             None,
         );
-        let policy = ProjectionPolicy {
-            kind: PolicyKind::SquashFailedCalls,
-            respect_provider_signatures: true,
-            reason: None,
-            summary_keep_last: 0,
-            summary_text: None,
-            custom: None,
-        };
+        let policy = ProjectionPolicy::default_for(PolicyKind::SquashFailedCalls);
         let result = project_transcript(None, &transcript, &policy)
             .await
             .unwrap();
@@ -1035,14 +1744,8 @@ mod tests {
                 .collect(),
             Some("Earlier work boiled down."),
         );
-        let policy = ProjectionPolicy {
-            kind: PolicyKind::SummaryPrefix,
-            respect_provider_signatures: true,
-            reason: None,
-            summary_keep_last: 2,
-            summary_text: None,
-            custom: None,
-        };
+        let mut policy = ProjectionPolicy::default_for(PolicyKind::SummaryPrefix);
+        policy.summary_keep_last = 2;
         let result = project_transcript(None, &transcript, &policy)
             .await
             .unwrap();
@@ -1098,14 +1801,7 @@ mod tests {
             ],
             None,
         );
-        let policy = ProjectionPolicy {
-            kind: PolicyKind::CleanToolRepair,
-            respect_provider_signatures: true,
-            reason: None,
-            summary_keep_last: 0,
-            summary_text: None,
-            custom: None,
-        };
+        let policy = ProjectionPolicy::default_for(PolicyKind::CleanToolRepair);
         let result = project_transcript(None, &transcript, &policy)
             .await
             .unwrap();
@@ -1148,19 +1844,177 @@ mod tests {
             ],
             None,
         );
-        let policy = ProjectionPolicy {
-            kind: PolicyKind::CleanToolRepair,
-            respect_provider_signatures: false,
-            reason: None,
-            summary_keep_last: 0,
-            summary_text: None,
-            custom: None,
-        };
+        let mut policy = ProjectionPolicy::default_for(PolicyKind::CleanToolRepair);
+        policy.respect_provider_signatures = false;
         let result = project_transcript(None, &transcript, &policy)
             .await
             .unwrap();
         assert!(!result.provider_safety_blocked);
         assert!(!result.dropped_indices.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reachability_gc_redacts_only_unrooted_stale_tool_results() {
+        let stale_body = format!("src/old.rs\n{}", "old line\n".repeat(180));
+        let rooted_body = format!(
+            "src/live.rs\nIMPORTANT_LIVE_VALUE\n{}",
+            "live line\n".repeat(180)
+        );
+        let transcript = transcript_with(
+            vec![
+                serde_json::json!({"role": "user", "content": "inspect old and live files"}),
+                serde_json::json!({
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "old_call", "name": "read", "arguments": {"path": "src/old.rs"}}],
+                }),
+                serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": "old_call",
+                    "name": "read",
+                    "content": stale_body,
+                }),
+                serde_json::json!({
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "live_call", "name": "read", "arguments": {"path": "src/live.rs"}}],
+                }),
+                serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": "live_call",
+                    "name": "read",
+                    "content": rooted_body,
+                }),
+                serde_json::json!({"role": "assistant", "content": "The active change is in src/live.rs."}),
+                serde_json::json!({"role": "user", "content": "Continue from the live file finding."}),
+            ],
+            None,
+        );
+        let mut policy = ProjectionPolicy::default_for(PolicyKind::ReachabilityGc);
+        policy.gc_root_window = 2;
+        policy.gc_min_chars = 100;
+
+        let result = project_transcript(None, &transcript, &policy)
+            .await
+            .unwrap();
+
+        assert_eq!(result.dropped_indices.len(), 0);
+        assert_eq!(result.redacted_indices, vec![2]);
+        assert!(result.reclaimed_tokens > 0);
+        assert!(result
+            .roots_consulted
+            .contains(&"last_2_messages".to_string()));
+        assert_eq!(
+            result.redaction_pointers[0]["source"],
+            "transcript.messages[2].content"
+        );
+        assert!(result.messages[2]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("reclaimed by reachability_gc"));
+        assert!(result.messages[4]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("IMPORTANT_LIVE_VALUE"));
+        assert!(result.messages[2]["_harn_projection"]["redacted"]
+            .as_bool()
+            .unwrap_or(false));
+    }
+
+    #[tokio::test]
+    async fn reachability_gc_redacts_only_selected_tool_result_blocks() {
+        let stale_body = format!("src/old.rs\n{}", "old line\n".repeat(180));
+        let rooted_body = format!(
+            "src/live.rs\nIMPORTANT_LIVE_VALUE\n{}",
+            "live line\n".repeat(180)
+        );
+        let transcript = transcript_with(
+            vec![
+                serde_json::json!({"role": "user", "content": "inspect old and live files"}),
+                serde_json::json!({
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "old_call", "name": "read", "input": {"path": "src/old.rs"}},
+                        {"type": "tool_use", "id": "live_call", "name": "read", "input": {"path": "src/live.rs"}}
+                    ],
+                }),
+                serde_json::json!({
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "old_call", "content": stale_body},
+                        {"type": "tool_result", "tool_use_id": "live_call", "content": rooted_body}
+                    ],
+                }),
+                serde_json::json!({"role": "assistant", "content": "The active change is in src/live.rs."}),
+                serde_json::json!({"role": "user", "content": "Continue from the live file finding."}),
+            ],
+            None,
+        );
+        let mut policy = ProjectionPolicy::default_for(PolicyKind::ReachabilityGc);
+        policy.gc_root_window = 2;
+        policy.gc_min_chars = 100;
+
+        let result = project_transcript(None, &transcript, &policy)
+            .await
+            .unwrap();
+
+        assert_eq!(result.redacted_indices, vec![2]);
+        assert_eq!(result.redaction_pointers.len(), 1);
+        assert_eq!(
+            result.redaction_pointers[0]["source"],
+            "transcript.messages[2].content[0].content"
+        );
+        let blocks = result.messages[2]["content"].as_array().unwrap();
+        assert!(blocks[0]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("reclaimed by reachability_gc"));
+        assert!(blocks[1]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("IMPORTANT_LIVE_VALUE"));
+        assert_eq!(
+            result.messages[2]["_harn_projection"]["redaction_pointers"]
+                .as_array()
+                .map(Vec::len),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn reachability_gc_honors_required_write_barrier() {
+        let transcript = transcript_with(
+            vec![
+                serde_json::json!({"role": "user", "content": "read stale"}),
+                serde_json::json!({
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "call", "name": "read", "arguments": {"path": "src/stale.rs"}}],
+                }),
+                serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": "call",
+                    "name": "read",
+                    "content": "src/stale.rs\n".to_string() + &"stale line\n".repeat(180),
+                }),
+                serde_json::json!({"role": "user", "content": "new task"}),
+            ],
+            None,
+        );
+        let mut policy = ProjectionPolicy::default_for(PolicyKind::ReachabilityGc);
+        policy.gc_root_window = 1;
+        policy.gc_min_chars = 100;
+        policy.gc_require_write_barrier = true;
+
+        let result = project_transcript(None, &transcript, &policy)
+            .await
+            .unwrap();
+
+        assert!(result.redacted_indices.is_empty());
+        assert_eq!(result.reason, "reachability_gc_write_barrier_missing");
+        assert!(result
+            .roots_consulted
+            .contains(&"write_barrier_required".to_string()));
     }
 
     #[tokio::test]

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1615,6 +1615,23 @@ Helper policies in `std/agent/autocompact`:
 `compact_preserving_test_failures(...)`, and
 `compact_retaining_current_plan(...)`.
 
+### Transcript projection
+
+`transcript_project(transcript, opts?)` derives a model-visible prefix without
+mutating raw transcript history. `agent_loop(..., {transcript_projection: ...})`
+applies the same projection before each provider turn and records a
+`transcript.projection` event. Built-in policies: `raw`,
+`clean_tool_repair`, `squash_failed_calls`, `summary_prefix`,
+`reachability_gc`, and `custom`.
+
+`reachability_gc` reclaims stale tool-result bodies only in the projected
+prompt. It keeps tool-call metadata and emits `redacted_indices`,
+`reclaimed_tokens`, `roots_consulted`, and `redaction_pointers`; raw
+transcript/audit content stays available by pointer. Useful options:
+`root_window`, `min_chars`, `roots`, `active_plan`, `scratchpad`,
+`pending_tool_args`, `unresolved_findings`, `write_barrier_refs`, and
+`require_write_barrier`.
+
 ## Reminders
 
 System reminders are typed, ephemeral `system_reminder` transcript events

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -110,7 +110,7 @@ that route on it keep working unchanged. Concretely:
 | `fs_watch`             | `subscriptionId`, `events`                                                                                                             |
 | `worker_update`        | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit`                               |
 | `transcript_compacted` | `mode`, `reason`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` |
-| `transcript_projected` | `policy`, `reason`, `prefixHash`, `keptCount`, `droppedCount`, `providerSafetyBlocked`                                                 |
+| `transcript_projected` | `policy`, `reason`, `prefixHash`, `keptCount`, `droppedCount`, `providerSafetyBlocked`, `redactedCount`, `reclaimedTokens`, `rootsConsulted`, `redactionPointers` |
 | `handoff`              | `handoffId`, `artifactId`, `handoff`                                                                                                   |
 | `skill_activated`      | `skillName`, `iteration`, `reason`                                                                                                     |
 | `skill_deactivated`    | `skillName`, `iteration`                                                                                                               |

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -250,6 +250,7 @@ Same as `llm_call`, plus additional options:
 | `compact_keep_first` | int | `0` | Prompt-visible messages to keep verbatim before the compaction summary. The system prompt is always kept separately |
 | `compact_keep_last` | int | strategy default | Prompt-visible messages to keep verbatim after the compaction summary |
 | `auto_compact` | bool/dict | nil | Auto-compaction options. Dict values may include the same compaction policy fields as `compaction` |
+| `transcript_projection` | string/dict | nil | Per-turn model-visible projection over the immutable raw transcript. Policies include `clean_tool_repair`, `squash_failed_calls`, `summary_prefix`, `reachability_gc`, and `custom` |
 | `idle_watchdog_attempts` | int | nil (disabled) | Max consecutive idle-wait ticks that may return no wake reason before the daemon terminates with `status = "watchdog"`. Guards against a misconfigured daemon (e.g. bridge never signals, no timer, no watch paths) hanging the session silently |
 | `context_callback` | closure | nil | Per-turn hook that can rewrite prompt-visible `messages` and/or the effective `system` prompt before the next LLM call |
 | `context_filter` | closure | nil | Alias for `context_callback` |

--- a/docs/src/llm/transcript-projection.md
+++ b/docs/src/llm/transcript-projection.md
@@ -31,6 +31,8 @@ let view = transcript_project(transcript, {policy: "clean_tool_repair"})
 log(view.policy)          // "clean_tool_repair"
 log(view.kept_count)      // messages surviving
 log(view.dropped_count)   // messages hidden from the next request
+log(view.redacted_count)  // tool-result bodies replaced by audit pointers
+log(view.reclaimed_tokens)// estimated prompt tokens reclaimed
 log(view.prefix_hash)     // "sha256:..." of the projected prefix
 log(view.event.kind)      // "transcript.projection" — ready to append to a session
 log(view.messages)        // the model-visible prefix
@@ -47,6 +49,10 @@ log(view.provider_safety_blocked) // true when a signed reasoning block was
 | `reason` | derived | Override the human-readable reason recorded on the projection event. |
 | `keep_last` | `0` | `summary_prefix` only — number of trailing messages kept verbatim. |
 | `summary` | `transcript.summary` | `summary_prefix` only — synthetic summary message body. |
+| `root_window` | `8` | `reachability_gc` only — recent message count treated as roots. `recent_messages` and `keep_last` are aliases. |
+| `min_chars` | `500` | `reachability_gc` only — shortest tool-result body eligible for reclamation. |
+| `roots`, `active_plan`, `scratchpad`, `pending_tool_args`, `unresolved_findings` | `nil` | `reachability_gc` only — additional root material used to keep referenced results visible. |
+| `require_write_barrier` | `false` | `reachability_gc` only — when `true`, reclaim only if `write_barrier`, `write_barrier_refs`, or `barrier_refs` is supplied. |
 | `projector` | _required for `custom`_ | Closure receiving `messages: list`, returning either a list of projected messages or `{messages, reason?, kept_indices?, dropped_indices?}`. |
 
 ## Built-in policies
@@ -84,6 +90,39 @@ let view = transcript_project(transcript, {
   summary: "Earlier turns: investigated repo layout and ran tests.",
 })
 ```
+
+### `reachability_gc`
+
+Keep every transcript message in place, but replace stale, unreachable
+tool-result bodies in the model-visible prefix with compact audit pointers.
+The raw transcript is not changed. Tool-call IDs, tool names, roles, and
+provider message shape are preserved so provider replay stays valid.
+
+Roots are the last `root_window` messages plus optional caller-supplied root
+material such as an active plan, scratchpad, pending tool args, unresolved
+review findings, or explicit `roots`. A tool result whose path, symbol, object
+ID, or call metadata appears in those roots is preserved. Error results are
+preserved by default; they are often still useful repair evidence.
+
+```harn
+let view = transcript_project(transcript, {
+  policy: "reachability_gc",
+  root_window: 6,
+  scratchpad: current_scratchpad,
+  unresolved_findings: review_findings,
+  write_barrier_refs: ["scratchpad:turn-42"],
+  require_write_barrier: true,
+})
+log(view.redacted_count)
+log(view.redaction_pointers[0].source) // transcript.messages[N].content
+```
+
+Redacted tool-result bodies carry `_harn_projection.redaction_pointer`;
+messages containing redacted content also record redaction pointers under
+`_harn_projection`. The projection event records `redacted_indices`,
+`redacted_count`, `reclaimed_tokens`, `reclaimed_chars`, `roots_consulted`, and
+`redaction_pointers`. Hosts can use those pointers to show or recover the raw
+body from the transcript/audit store without sending it to the next model call.
 
 ### `custom`
 
@@ -132,6 +171,8 @@ log(events[0].metadata.policy)                    // "clean_tool_repair"
 log(events[0].metadata.prefix_hash)               // "sha256:..."
 log(events[0].metadata.kept_indices)              // indices kept from raw messages
 log(events[0].metadata.dropped_indices)           // indices hidden from the prefix
+log(events[0].metadata.redacted_indices)          // bodies reclaimed in place
+log(events[0].metadata.reclaimed_tokens)          // estimated prompt-token savings
 log(events[0].metadata.provider_safety_blocked)   // signed-reasoning guardrail state
 ```
 
@@ -162,8 +203,10 @@ The same metadata reaches hosts two ways:
   audit log.
 - **Live** as the typed `TranscriptProjected` agent event, surfaced over ACP as
   a `transcript_projected` `sessionUpdate` carrying `_meta.harn` fields:
-  `policy`, `reason`, `prefixHash`, `keptCount`, `droppedCount`, and
-  `providerSafetyBlocked`. Burin Code and other hosts use this to render a
+  `policy`, `reason`, `prefixHash`, `keptCount`, `droppedCount`,
+  `providerSafetyBlocked`, and when projection reclaims tool-result bodies,
+  `redactedCount`, `reclaimedTokens`, `rootsConsulted`, and
+  `redactionPointers`. Burin Code and other hosts use this to render a
   raw vs. projected side-by-side view without re-parsing the transcript.
 
 Replay can reconstruct both views deterministically: the raw events are

--- a/docs/src/spec/harn-extensions/v1.md
+++ b/docs/src/spec/harn-extensions/v1.md
@@ -106,6 +106,7 @@ Harn extension session updates keep the `sessionUpdate` discriminator at
 | `fs_watch` | `subscriptionId`, `events` | Stable v1 |
 | `worker_update` | `workerId`, `workerName`, `workerTask`, `workerMode`, `event`, `status`, `terminal`, `metadata`, `audit` | Stable v1 |
 | `transcript_compacted` | `mode`, `reason`, `strategy`, `archivedMessages`, `estimatedTokensBefore`, `estimatedTokensAfter`, `snapshotAssetId`, `instructionMode`, `instructionSource`, `compactionPolicy` | Stable v1 |
+| `transcript_projected` | `policy`, `reason`, `prefixHash`, `keptCount`, `droppedCount`, `providerSafetyBlocked`, `redactedCount`, `reclaimedTokens`, `rootsConsulted`, `redactionPointers` | Stable v1 |
 | `handoff` | `handoffId`, `artifactId`, `handoff` | Stable v1 |
 | `skill_activated` | `skillName`, `iteration`, `reason` | Stable v1 |
 | `skill_deactivated` | `skillName`, `iteration` | Stable v1 |


### PR DESCRIPTION
## Summary

- Add the `reachability_gc` transcript projection policy, with `context_gc` and `tool_result_gc` aliases, for model-visible reclamation of stale tool-result bodies while preserving raw transcript/audit/replay data.
- Preserve provider message shape and tool metadata, support explicit roots/write-barrier refs, and emit redaction/reclamation metadata through VM results, agent events, and ACP `_meta.harn`.
- Add deterministic long-horizon conformance coverage with 60 stale tool outputs plus docs and a changelog fragment.

## Verification

- `cargo test -p harn-vm transcript_project --lib`
- `cargo run --quiet --bin harn -- test conformance --filter transcript_projection_policies`
- `cargo test -p harn-serve forwarded_agent_events_serialize_as_session_updates --lib`
- `cargo run --quiet --bin harn -- fmt --check conformance/tests/scenarios/transcript_projection_policies.harn crates/harn-stdlib/src/stdlib/agent/options.harn crates/harn-stdlib/src/stdlib/agent/state.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/scenarios/transcript_projection_policies.harn crates/harn-stdlib/src/stdlib/agent/options.harn crates/harn-stdlib/src/stdlib/agent/state.harn`
- `make lint-test-patterns`
- `make check-docs-snippets`
- `git diff --check origin/main...HEAD`
- pre-commit hook: Rust fmt, Harn fmt/lint, clippy, CI ratchets, generated highlight sync, markdownlint
- pre-push hook: targeted Rust checks, affected Harn fmt/lint, markdownlint, generated highlight check

No live provider eval was run; the repo-native deterministic harness now exercises the long-horizon projection behavior directly.

Closes #2714