### PR TITLE
Fix portal and fs edge cases

### DIFF
--- a/changelog.d/bug-dry-pass-20260531.fixed.md
+++ b/changelog.d/bug-dry-pass-20260531.fixed.md
@@ -1,0 +1,5 @@
+- **Portal and filesystem helpers are more robust.** Portal launches now use
+  collision-resistant IDs and real RFC 3339 timestamps, portal run analysis
+  handles case-insensitive search and large duration values safely, and
+  stdlib filesystem copy/move/delete/mkdir operations now honor the
+  testbench overlay and mutation notifications consistently.

--- a/crates/harn-cli/src/commands/portal/launch.rs
+++ b/crates/harn-cli/src/commands/portal/launch.rs
@@ -14,7 +14,7 @@ use super::errors::{bad_request_error, internal_error};
 use super::query::ErrorResponse;
 use super::run_analysis::scan_runs;
 use super::state::PortalState;
-use super::util::{portal_timestamp_id, redacted_string};
+use super::util::{portal_now_rfc3339, portal_unique_id, redacted_string};
 
 const MAX_LAUNCH_JOB_LOG_BYTES: usize = 256 * 1024;
 const MAX_COMPLETED_LAUNCH_JOBS: usize = 200;
@@ -25,8 +25,8 @@ pub(super) async fn create_launch_job(
 ) -> Result<PortalLaunchJob, (StatusCode, Json<ErrorResponse>)> {
     validate_launch_request(&request)?;
 
-    let job_id = portal_timestamp_id("job");
-    let started_at = portal_timestamp_id("started");
+    let job_id = portal_unique_id("job");
+    let started_at = portal_now_rfc3339();
     let before_paths = known_run_paths(&state.run_dir).map_err(internal_error)?;
     let launch_env = validated_env_overrides(request.env.as_ref())?;
     let materialized =
@@ -88,13 +88,13 @@ pub(super) async fn create_launch_job(
                     } else {
                         "failed".to_string()
                     };
-                    job.finished_at = Some(portal_timestamp_id("finished"));
+                    job.finished_at = Some(portal_now_rfc3339());
                     job.discovered_run_paths =
                         discovered_run_paths(&run_dir, &before_paths).unwrap_or_default();
                 }
                 Err(error) => {
                     job.status = "failed".to_string();
-                    job.finished_at = Some(portal_timestamp_id("finished"));
+                    job.finished_at = Some(portal_now_rfc3339());
                     job.logs = format!("failed to start harn run: {error}");
                 }
             }
@@ -114,8 +114,8 @@ pub(super) async fn create_trigger_replay_job(
         return Err(bad_request_error("event_id is required"));
     }
 
-    let job_id = portal_timestamp_id("job");
-    let started_at = portal_timestamp_id("started");
+    let job_id = portal_unique_id("job");
+    let started_at = portal_now_rfc3339();
     let before_paths = known_run_paths(&state.run_dir).map_err(internal_error)?;
     let job = PortalLaunchJob {
         id: job_id.clone(),
@@ -161,13 +161,13 @@ pub(super) async fn create_trigger_replay_job(
                     } else {
                         "failed".to_string()
                     };
-                    job.finished_at = Some(portal_timestamp_id("finished"));
+                    job.finished_at = Some(portal_now_rfc3339());
                     job.discovered_run_paths =
                         discovered_run_paths(&run_dir, &before_paths).unwrap_or_default();
                 }
                 Err(error) => {
                     job.status = "failed".to_string();
-                    job.finished_at = Some(portal_timestamp_id("finished"));
+                    job.finished_at = Some(portal_now_rfc3339());
                     job.logs = format!("failed to start trigger replay: {error}");
                 }
             }
@@ -257,13 +257,14 @@ pub(super) fn validated_env_overrides(
     let mut validated = BTreeMap::new();
     if let Some(env) = env {
         for (key, value) in env {
-            if key.is_empty()
-                || !key
-                    .chars()
-                    .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_')
-            {
+            if !valid_env_key(key) {
                 return Err(bad_request_error(format!(
-                    "invalid env key '{key}'; use uppercase shell-style names only"
+                    "invalid env key '{key}'; use uppercase shell-style names that start with a letter or underscore"
+                )));
+            }
+            if value.contains('\0') {
+                return Err(bad_request_error(format!(
+                    "env value for '{key}' contains a NUL byte"
                 )));
             }
             if value.len() > 16_384 {
@@ -275,6 +276,15 @@ pub(super) fn validated_env_overrides(
         }
     }
     Ok(validated)
+}
+
+fn valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_uppercase() || first == '_')
+        && chars.all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_')
 }
 
 pub(super) fn build_launch_env(
@@ -400,7 +410,16 @@ fn resolve_workspace_file(workspace_root: &Path, relative_path: &str) -> Result<
     if !resolved.exists() {
         return Err(format!("file not found: {relative_path}"));
     }
-    Ok(resolved)
+    let canonical_root = workspace_root
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve workspace root: {error}"))?;
+    let canonical_resolved = resolved
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve file path: {error}"))?;
+    if !canonical_resolved.starts_with(&canonical_root) {
+        return Err("file_path must stay inside the current workspace".to_string());
+    }
+    Ok(canonical_resolved)
 }
 
 fn build_playground_source(

--- a/crates/harn-cli/src/commands/portal/run_analysis.rs
+++ b/crates/harn-cli/src/commands/portal/run_analysis.rs
@@ -268,6 +268,10 @@ fn matches_run_search(run: &PortalRunSummary, needle: &str) -> bool {
     .contains(needle)
 }
 
+fn trace_span_end_ms(span: &harn_vm::orchestration::RunTraceSpanRecord) -> u64 {
+    span.start_ms.saturating_add(span.duration_ms)
+}
+
 fn collect_run_files(
     root: &Path,
     current: &Path,
@@ -420,7 +424,11 @@ pub(super) fn summarize_runs(runs: &[PortalRunSummary]) -> PortalStats {
     let avg_duration_ms = if durations.is_empty() {
         0
     } else {
-        durations.iter().sum::<u64>() / durations.len() as u64
+        let total = durations
+            .iter()
+            .map(|duration| u128::from(*duration))
+            .sum::<u128>();
+        u64::try_from(total / durations.len() as u128).unwrap_or(u64::MAX)
     };
     PortalStats {
         total_runs,
@@ -634,11 +642,11 @@ fn build_spans(run: &harn_vm::orchestration::RunRecord) -> Vec<PortalSpan> {
             let depth = span_depth(&span, &by_id);
             let lane = match lane_ends.iter().position(|end| *end <= span.start_ms) {
                 Some(index) => {
-                    lane_ends[index] = span.start_ms + span.duration_ms;
+                    lane_ends[index] = trace_span_end_ms(&span);
                     index
                 }
                 None => {
-                    lane_ends.push(span.start_ms + span.duration_ms);
+                    lane_ends.push(trace_span_end_ms(&span));
                     lane_ends.len() - 1
                 }
             };
@@ -650,7 +658,7 @@ fn build_spans(run: &harn_vm::orchestration::RunRecord) -> Vec<PortalSpan> {
                 name: span.name.clone(),
                 start_ms: span.start_ms,
                 duration_ms: span.duration_ms,
-                end_ms: span.start_ms + span.duration_ms,
+                end_ms: trace_span_end_ms(&span),
                 label: span_label(&span),
                 lane,
                 depth,
@@ -1029,17 +1037,16 @@ fn run_duration_ms(run: &harn_vm::orchestration::RunRecord) -> Option<u64> {
             return Some(duration);
         }
     }
-    if let Some(max_end) = run
-        .trace_spans
-        .iter()
-        .map(|span| span.start_ms + span.duration_ms)
-        .max()
-    {
+    if let Some(max_end) = run.trace_spans.iter().map(trace_span_end_ms).max() {
         if max_end > 0 {
             return Some(max_end);
         }
     }
-    let stage_total = run.stages.iter().filter_map(stage_duration_ms).sum::<u64>();
+    let stage_total = run
+        .stages
+        .iter()
+        .filter_map(stage_duration_ms)
+        .fold(0u64, u64::saturating_add);
     if stage_total > 0 {
         return Some(stage_total);
     }

--- a/crates/harn-cli/src/commands/portal/tests.rs
+++ b/crates/harn-cli/src/commands/portal/tests.rs
@@ -11,7 +11,9 @@ use tower::util::ServiceExt;
 
 use crate::commands::persona;
 
-use super::dto::{PortalLaunchRequest, PortalRunDiff, PortalRunSummary};
+use super::dto::{
+    PortalLaunchRequest, PortalRunDiff, PortalRunSummary, PortalSpan, PortalStage, PortalStageDebug,
+};
 use super::launch::{
     build_launch_env, launch_output_logs, materialize_launch_target, prune_completed_launch_jobs,
     scan_launch_targets, validate_launch_request, validated_env_overrides,
@@ -20,10 +22,11 @@ use super::query::ListRunsQuery;
 use super::router::build_router;
 use super::run_analysis::{
     build_policy_summary, build_replay_summary, build_run_detail, build_run_summary,
-    filter_and_sort_runs, resolve_run_path, scan_runs,
+    filter_and_sort_runs, resolve_run_path, scan_runs, summarize_runs,
 };
 use super::state::PortalState;
 use super::transcript::discover_transcript_steps;
+use super::util::{date_ms, owning_stage, portal_now_rfc3339, portal_unique_id, preview_text};
 
 fn test_portal_state(run_dir: &Path) -> Arc<PortalState> {
     test_portal_state_with_mutations(run_dir, true)
@@ -78,11 +81,132 @@ fn test_portal_state_with_personas(
     })
 }
 
+fn empty_stage_debug() -> PortalStageDebug {
+    PortalStageDebug {
+        call_count: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        consumed_artifact_ids: Vec::new(),
+        produced_artifact_ids: Vec::new(),
+        selected_artifact_ids: Vec::new(),
+        worker_id: None,
+        error: None,
+        model_policy: None,
+        auto_compact: None,
+        output_visibility: None,
+        context_policy: None,
+        retry_policy: None,
+        capability_policy: None,
+        input_contract: None,
+        output_contract: None,
+        prompt: None,
+        system_prompt: None,
+        rendered_context: None,
+    }
+}
+
+fn run_summary_with_duration(id: &str, duration_ms: Option<u64>) -> PortalRunSummary {
+    PortalRunSummary {
+        path: format!("{id}.json"),
+        id: id.to_string(),
+        workflow_name: "workflow".to_string(),
+        status: "complete".to_string(),
+        last_stage_node_id: None,
+        failure_summary: None,
+        started_at: String::new(),
+        finished_at: None,
+        duration_ms,
+        stage_count: 0,
+        child_run_count: 0,
+        call_count: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        models: Vec::new(),
+        updated_at_ms: 0,
+        skills: Vec::new(),
+    }
+}
+
 #[test]
 fn resolve_run_path_rejects_parent_segments() {
     let temp = tempfile::tempdir().unwrap();
     let error = resolve_run_path(temp.path(), "../outside.json").unwrap_err();
     assert_eq!(error.0, StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn date_ms_rejects_pre_epoch_dates() {
+    assert_eq!(date_ms("1969-12-31T23:59:59Z"), None);
+    assert_eq!(date_ms("1970-01-01T00:00:00Z"), Some(0));
+}
+
+#[test]
+fn portal_launch_ids_are_unique_and_timestamps_are_rfc3339() {
+    let mut ids = std::collections::BTreeSet::new();
+    for _ in 0..128 {
+        let id = portal_unique_id("job");
+        assert!(id.starts_with("job-"));
+        assert!(ids.insert(id));
+    }
+    assert!(time::OffsetDateTime::parse(
+        &portal_now_rfc3339(),
+        &time::format_description::well_known::Rfc3339
+    )
+    .is_ok());
+}
+
+#[test]
+fn preview_text_truncates_on_character_boundaries() {
+    let line = "é".repeat(181);
+    let preview = preview_text(&line);
+    assert_eq!(preview, format!("{}...", "é".repeat(180)));
+}
+
+#[test]
+fn owning_stage_saturates_stage_boundaries() {
+    let stages = vec![PortalStage {
+        id: "stage-1".to_string(),
+        node_id: "huge".to_string(),
+        kind: "stage".to_string(),
+        status: "running".to_string(),
+        outcome: String::new(),
+        branch: None,
+        started_at: String::new(),
+        finished_at: None,
+        duration_ms: Some(u64::MAX),
+        artifact_count: 0,
+        attempt_count: 0,
+        verification_summary: None,
+        debug: empty_stage_debug(),
+    }];
+    let span = PortalSpan {
+        span_id: 1,
+        parent_id: None,
+        kind: "llm_call".to_string(),
+        name: "call".to_string(),
+        start_ms: u64::MAX - 1,
+        duration_ms: 1,
+        end_ms: u64::MAX,
+        label: "call".to_string(),
+        lane: 0,
+        depth: 0,
+        metadata: BTreeMap::new(),
+    };
+
+    assert_eq!(
+        owning_stage(&span, &stages).map(|stage| stage.node_id.as_str()),
+        Some("huge")
+    );
+}
+
+#[test]
+fn summarize_runs_averages_large_durations_without_overflow() {
+    let stats = summarize_runs(&[
+        run_summary_with_duration("run-1", Some(u64::MAX)),
+        run_summary_with_duration("run-2", Some(u64::MAX)),
+    ]);
+
+    assert_eq!(stats.avg_duration_ms, u64::MAX);
 }
 
 #[test]
@@ -243,6 +367,30 @@ fn build_run_detail_exposes_observability_summary() {
         .transcript_pointers
         .iter()
         .any(|pointer| pointer.kind == "llm_jsonl"));
+}
+
+#[test]
+fn build_run_detail_saturates_trace_span_end_times() {
+    let temp = tempfile::tempdir().unwrap();
+    let run = harn_vm::orchestration::RunRecord {
+        id: "run-overflow".to_string(),
+        workflow_id: "wf".to_string(),
+        workflow_name: Some("demo".to_string()),
+        status: "complete".to_string(),
+        trace_spans: vec![harn_vm::orchestration::RunTraceSpanRecord {
+            span_id: 1,
+            kind: "tool_call".to_string(),
+            name: "huge-span".to_string(),
+            start_ms: u64::MAX - 1,
+            duration_ms: 10,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let detail = build_run_detail(temp.path(), "run.json", &run);
+    assert_eq!(detail.summary.duration_ms, Some(u64::MAX));
+    assert_eq!(detail.spans[0].end_ms, u64::MAX);
 }
 
 #[test]
@@ -412,6 +560,15 @@ fn validated_env_overrides_rejects_non_shell_style_names() {
         ("bad-key".to_string(), "oops".to_string()),
     ]);
     assert!(validated_env_overrides(Some(&env)).is_err());
+
+    let starts_with_digit = BTreeMap::from([("1BAD".to_string(), "oops".to_string())]);
+    assert!(validated_env_overrides(Some(&starts_with_digit)).is_err());
+}
+
+#[test]
+fn validated_env_overrides_rejects_nul_values() {
+    let env = BTreeMap::from([("GOOD_KEY".to_string(), "before\0after".to_string())]);
+    assert!(validated_env_overrides(Some(&env)).is_err());
 }
 
 #[test]
@@ -511,6 +668,35 @@ fn materialize_playground_target_creates_workspace_files() {
     let source = fs::read_to_string(workspace_dir.join("workflow.harn")).unwrap();
     assert!(source.contains("workspace_file"));
     assert!(source.contains("persist_path"));
+    assert_eq!(source.matches("kind: \"stage\"").count(), 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn materialize_file_target_rejects_symlink_escape() {
+    let temp = tempfile::tempdir().unwrap();
+    let workspace = temp.path().join("workspace");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(outside.join("secret.harn"), "pipeline main() {}\n").unwrap();
+    std::os::unix::fs::symlink(outside.join("secret.harn"), workspace.join("link.harn")).unwrap();
+
+    let error = materialize_launch_target(
+        temp.path(),
+        &workspace,
+        "job-1",
+        PortalLaunchRequest {
+            file_path: Some("link.harn".to_string()),
+            source: None,
+            task: None,
+            provider: None,
+            model: None,
+            env: None,
+        },
+    )
+    .unwrap_err();
+    assert!(error.contains("stay inside"));
 }
 
 #[tokio::test]
@@ -874,7 +1060,7 @@ fn filter_and_sort_runs_applies_search_status_and_ordering() {
     ];
 
     let query = ListRunsQuery {
-        q: Some("assertion".to_string()),
+        q: Some("ASSERTION".to_string()),
         workflow: None,
         status: Some("failed".to_string()),
         sort: Some("duration".to_string()),

--- a/crates/harn-cli/src/commands/portal/util.rs
+++ b/crates/harn-cli/src/commands/portal/util.rs
@@ -7,15 +7,21 @@ pub(super) fn system_time_ms(time: SystemTime) -> Option<u128> {
     time.duration_since(UNIX_EPOCH).ok().map(|d| d.as_millis())
 }
 
-pub(super) fn portal_timestamp_id(prefix: &str) -> String {
+pub(super) fn portal_unique_id(prefix: &str) -> String {
     let millis = system_time_ms(SystemTime::now()).unwrap_or_default();
-    format!("{prefix}-{millis}")
+    format!("{prefix}-{millis}-{}", uuid::Uuid::now_v7().simple())
+}
+
+pub(super) fn portal_now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
 }
 
 pub(super) fn date_ms(value: &str) -> Option<u64> {
     let parsed =
         time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339).ok()?;
-    Some(parsed.unix_timestamp_nanos() as u64 / 1_000_000)
+    u64::try_from(parsed.unix_timestamp_nanos() / 1_000_000).ok()
 }
 
 pub(super) fn compact_metadata(metadata: &BTreeMap<String, serde_json::Value>) -> String {
@@ -119,7 +125,10 @@ pub(super) fn string_array_value(
 pub(super) fn span_kind_totals(spans: &[PortalSpan]) -> Vec<(String, u64)> {
     let mut totals = HashMap::<String, u64>::new();
     for span in spans {
-        *totals.entry(span.kind.clone()).or_default() += span.duration_ms;
+        totals
+            .entry(span.kind.clone())
+            .and_modify(|total| *total = total.saturating_add(span.duration_ms))
+            .or_insert(span.duration_ms);
     }
     let mut values = totals.into_iter().collect::<Vec<_>>();
     values.sort_by_key(|entry| std::cmp::Reverse(entry.1));
@@ -140,7 +149,7 @@ pub(super) fn owning_stage<'a>(
     let mut cursor = 0u64;
     for (stage, duration) in offsets {
         let start = cursor;
-        let end = cursor + duration;
+        let end = cursor.saturating_add(duration);
         if span.start_ms >= start && span.end_ms <= end {
             return Some(stage);
         }
@@ -156,10 +165,13 @@ pub(super) fn preview_text(text: &str) -> String {
         .find(|line| !line.trim().is_empty())
         .unwrap_or("")
         .trim();
-    if line.len() > 180 {
-        format!("{}...", &line[..180])
+    const MAX_PREVIEW_CHARS: usize = 180;
+    let mut chars = line.chars();
+    let preview = chars.by_ref().take(MAX_PREVIEW_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{preview}...")
     } else {
-        line.to_string()
+        preview
     }
 }
 

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -1663,6 +1663,16 @@ mod tests {
     }
 
     #[test]
+    fn toml_string_literal_escapes_all_basic_control_characters() {
+        let literal = toml_string_literal("a\u{08}\t\n\u{0C}\r\"\\\u{07}z").unwrap();
+        let parsed: toml::Value = toml::from_str(&format!("value = {literal}\n")).unwrap();
+        assert_eq!(
+            parsed.get("value").and_then(toml::Value::as_str),
+            Some("a\u{08}\t\n\u{0C}\r\"\\\u{07}z")
+        );
+    }
+
+    #[test]
     fn orchestrator_drain_config_parses_defaults_and_overrides() {
         let default_manifest: Manifest = toml::from_str(
             r#"

--- a/crates/harn-cli/src/package/package_ops.rs
+++ b/crates/harn-cli/src/package/package_ops.rs
@@ -1380,26 +1380,6 @@ fn push_toml_string_field(out: &mut String, key: &str, value: &str) -> Result<()
     Ok(())
 }
 
-fn toml_string_literal(value: &str) -> Result<String, PackageError> {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('"');
-    for ch in value.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            ch if ch.is_control() => {
-                out.push_str(&format!("\\u{:04X}", ch as u32));
-            }
-            ch => out.push(ch),
-        }
-    }
-    out.push('"');
-    Ok(out)
-}
-
 fn render_unified_diff(old: &str, new: &str, label: &str) -> Result<String, PackageError> {
     let temp = tempfile::tempdir()
         .map_err(|error| PackageError::Ops(format!("failed to create temp dir: {error}")))?;

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -455,6 +455,10 @@ fn queue_file_edited_for(resolved: &std::path::Path, operation: &str, bytes: usi
     );
 }
 
+fn edited_byte_count(bytes: u64) -> usize {
+    usize::try_from(bytes).unwrap_or(usize::MAX)
+}
+
 #[harn_builtin(
     sig = "file_exists(path: string) -> bool",
     category = "fs",
@@ -510,6 +514,7 @@ fn delete_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     FILE_TEXT_CACHE.with(|cache| {
         cache.borrow_mut().remove(&resolved);
     });
+    queue_file_edited_for(&resolved, "delete", 0);
     Ok(VmValue::Nil)
 }
 
@@ -596,6 +601,7 @@ fn mkdir_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
             resolved.display()
         ))))
     })?;
+    queue_file_edited_for(&resolved, "mkdir", 0);
     Ok(VmValue::Nil)
 }
 
@@ -635,7 +641,7 @@ fn copy_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
             &resolved_dst,
             crate::stdlib::sandbox::FsAccess::Write,
         )?;
-        std::fs::copy(&resolved_src, &resolved_dst).map_err(|e| {
+        let bytes = overlay::copy(&resolved_src, &resolved_dst).map_err(|e| {
             VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
                 "Failed to copy {} to {}: {e}",
                 resolved_src.display(),
@@ -645,6 +651,7 @@ fn copy_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         FILE_TEXT_CACHE.with(|cache| {
             cache.borrow_mut().remove(&resolved_dst);
         });
+        queue_file_edited_for(&resolved_dst, "copy", edited_byte_count(bytes));
     }
     Ok(VmValue::Nil)
 }
@@ -754,27 +761,34 @@ fn move_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     crate::stdlib::sandbox::enforce_fs_path(
         "move_file",
         &src,
-        crate::stdlib::sandbox::FsAccess::Write,
+        crate::stdlib::sandbox::FsAccess::Read,
+    )?;
+    crate::stdlib::sandbox::enforce_fs_path(
+        "move_file",
+        &src,
+        crate::stdlib::sandbox::FsAccess::Delete,
     )?;
     crate::stdlib::sandbox::enforce_fs_path(
         "move_file",
         &dst,
         crate::stdlib::sandbox::FsAccess::Write,
     )?;
-    if std::fs::rename(&src, &dst).is_ok() {
+    if let Ok(bytes) = overlay::rename(&src, &dst) {
         FILE_TEXT_CACHE.with(|c| {
             let mut c = c.borrow_mut();
             c.remove(&src);
             c.remove(&dst);
         });
+        queue_file_edited_for(&src, "move_from", 0);
+        queue_file_edited_for(&dst, "move", edited_byte_count(bytes));
         return Ok(VmValue::Nil);
     }
-    std::fs::copy(&src, &dst).map_err(|e| {
+    let bytes = overlay::copy(&src, &dst).map_err(|e| {
         VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
             "move_file: copy failed: {e}"
         ))))
     })?;
-    std::fs::remove_file(&src).map_err(|e| {
+    overlay::remove_file(&src).map_err(|e| {
         VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
             "move_file: remove src failed: {e}"
         ))))
@@ -784,6 +798,8 @@ fn move_file_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         c.remove(&src);
         c.remove(&dst);
     });
+    queue_file_edited_for(&src, "move_from", 0);
+    queue_file_edited_for(&dst, "move", edited_byte_count(bytes));
     Ok(VmValue::Nil)
 }
 
@@ -1077,6 +1093,121 @@ mod tests {
             !path.exists(),
             "overlay write should not materialize on the underlying fs"
         );
+    }
+
+    #[test]
+    fn copy_file_observes_active_overlay_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let overlay = std::sync::Arc::new(crate::testbench::overlay_fs::OverlayFs::rooted_at(
+            dir.path(),
+        ));
+        let _guard = crate::testbench::overlay_fs::install_overlay(overlay);
+        let mut vm = vm();
+        let src = dir.path().join("src.txt");
+        let dst = dir.path().join("dst.txt");
+
+        call(
+            &mut vm,
+            "write_file",
+            vec![s(&src.to_string_lossy()), s("overlay only")],
+        )
+        .unwrap();
+        call(
+            &mut vm,
+            "copy_file",
+            vec![s(&src.to_string_lossy()), s(&dst.to_string_lossy())],
+        )
+        .unwrap();
+
+        assert_eq!(
+            call(&mut vm, "read_file", vec![s(&dst.to_string_lossy())])
+                .unwrap()
+                .display(),
+            "overlay only"
+        );
+        assert!(!dst.exists(), "overlay copy should not touch real disk");
+    }
+
+    #[test]
+    fn move_file_observes_active_overlay_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let overlay = std::sync::Arc::new(crate::testbench::overlay_fs::OverlayFs::rooted_at(
+            dir.path(),
+        ));
+        let _guard = crate::testbench::overlay_fs::install_overlay(overlay);
+        let mut vm = vm();
+        let src = dir.path().join("src.txt");
+        let dst = dir.path().join("dst.txt");
+
+        call(
+            &mut vm,
+            "write_file",
+            vec![s(&src.to_string_lossy()), s("overlay only")],
+        )
+        .unwrap();
+        call(
+            &mut vm,
+            "move_file",
+            vec![s(&src.to_string_lossy()), s(&dst.to_string_lossy())],
+        )
+        .unwrap();
+
+        assert_eq!(
+            call(&mut vm, "read_file", vec![s(&dst.to_string_lossy())])
+                .unwrap()
+                .display(),
+            "overlay only"
+        );
+        assert!(call(&mut vm, "read_file", vec![s(&src.to_string_lossy())]).is_err());
+        assert!(!dst.exists(), "overlay move should not touch real disk");
+    }
+
+    #[test]
+    fn fs_mutations_emit_file_edited_notifications() {
+        crate::orchestration::clear_file_edit_queue();
+        let dir = tempfile::tempdir().unwrap();
+        let mut vm = vm();
+        let src = dir.path().join("src.txt");
+        let dst = dir.path().join("dst.txt");
+        let moved = dir.path().join("moved.txt");
+        let subdir = dir.path().join("subdir");
+
+        call(
+            &mut vm,
+            "write_file",
+            vec![s(&src.to_string_lossy()), s("hi")],
+        )
+        .unwrap();
+        call(
+            &mut vm,
+            "copy_file",
+            vec![s(&src.to_string_lossy()), s(&dst.to_string_lossy())],
+        )
+        .unwrap();
+        call(
+            &mut vm,
+            "move_file",
+            vec![s(&dst.to_string_lossy()), s(&moved.to_string_lossy())],
+        )
+        .unwrap();
+        call(&mut vm, "mkdir", vec![s(&subdir.to_string_lossy())]).unwrap();
+        call(&mut vm, "delete_file", vec![s(&moved.to_string_lossy())]).unwrap();
+
+        let operations = crate::orchestration::drain_file_edits()
+            .into_iter()
+            .filter_map(|entry| {
+                entry
+                    .metadata
+                    .get("operation")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>();
+        assert!(operations.contains(&"write".to_string()));
+        assert!(operations.contains(&"copy".to_string()));
+        assert!(operations.contains(&"move".to_string()));
+        assert!(operations.contains(&"mkdir".to_string()));
+        assert!(operations.contains(&"delete".to_string()));
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/path.rs
+++ b/crates/harn-vm/src/stdlib/path.rs
@@ -18,6 +18,15 @@ fn to_posix(s: &str) -> String {
     s.replace('\\', "/")
 }
 
+fn to_native(s: &str) -> String {
+    let posix = to_posix(s);
+    if cfg!(windows) {
+        posix.replace('/', "\\")
+    } else {
+        posix
+    }
+}
+
 /// Returns true if the path is absolute (leading `/` on posix or `X:/` drive
 /// root on windows). `X:foo` is drive-relative, not absolute.
 fn is_absolute_str(p: &str) -> bool {
@@ -364,10 +373,8 @@ fn path_to_posix_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
 
 #[harn_builtin(sig = "path_to_native(path: string?) -> string", category = "path")]
 fn path_to_native_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    // Harn normalises on `/` regardless of OS, so this currently mirrors
-    // path_to_posix. Reserved for future Windows-host specialisation.
     let p = args.first().map(|a| a.display()).unwrap_or_default();
-    Ok(VmValue::String(std::sync::Arc::from(to_posix(&p))))
+    Ok(VmValue::String(std::sync::Arc::from(to_native(&p))))
 }
 
 #[harn_builtin(
@@ -496,6 +503,16 @@ mod tests {
         assert!(!is_absolute_str("a/b"));
         assert!(!is_absolute_str("./a"));
         assert!(!is_absolute_str(""));
+    }
+
+    #[test]
+    fn native_path_conversion_matches_host_separator() {
+        let native = to_native("a\\b/c");
+        if cfg!(windows) {
+            assert_eq!(native, "a\\b\\c");
+        } else {
+            assert_eq!(native, "a/b/c");
+        }
     }
 
     #[test]

--- a/crates/harn-vm/src/testbench/overlay_fs.rs
+++ b/crates/harn-vm/src/testbench/overlay_fs.rs
@@ -8,10 +8,8 @@
 //! it back with `git apply`, or discard it.
 //!
 //! Only the surface that stdlib `fs.*` builtins exercise is intercepted:
-//! read/write text and bytes, append, exists, remove, list, create_dir.
-//! `rename`, `copy`, and `metadata` fall through to the underlying fs
-//! (they're mostly useful only for production-style checks the testbench
-//! doesn't replace).
+//! read/write text and bytes, append, exists, remove, copy, rename, list,
+//! and create_dir. Metadata still falls through to the underlying fs.
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -136,6 +134,19 @@ impl OverlayFs {
         self.write(path, &combined)
     }
 
+    pub fn copy(&self, src: &Path, dst: &Path) -> std::io::Result<u64> {
+        let bytes = self.read(src)?;
+        let len = bytes.len() as u64;
+        self.write(dst, &bytes)?;
+        Ok(len)
+    }
+
+    pub fn rename(&self, src: &Path, dst: &Path) -> std::io::Result<u64> {
+        let len = self.copy(src, dst)?;
+        self.remove_file(src)?;
+        Ok(len)
+    }
+
     pub fn exists(&self, path: &Path) -> bool {
         if !self.within_root(path) {
             return path.exists();
@@ -164,6 +175,7 @@ impl OverlayFs {
                 format!("overlay: {} already deleted", key.display()),
             )),
             _ => {
+                layer.retain(|entry_path, _| !entry_path.starts_with(&key) || entry_path == &key);
                 if underlying_present {
                     layer.insert(key, OverlayEntry::Deleted);
                 } else {
@@ -180,7 +192,25 @@ impl OverlayFs {
         }
         let key = self.key(path);
         let mut layer = self.layer.lock().expect("overlay layer poisoned");
-        layer.insert(key, OverlayEntry::Directory);
+        if key == self.root {
+            layer.insert(key, OverlayEntry::Directory);
+            return Ok(());
+        }
+        let relative = key.strip_prefix(&self.root).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "overlay: {} is outside {}",
+                    key.display(),
+                    self.root.display()
+                ),
+            )
+        })?;
+        let mut current = self.root.clone();
+        for component in relative.components() {
+            current.push(component.as_os_str());
+            layer.insert(current.clone(), OverlayEntry::Directory);
+        }
         Ok(())
     }
 
@@ -198,8 +228,33 @@ impl OverlayFs {
             return Ok(entries);
         }
         let dir_key = self.key(path);
+        let virtual_dir_exists;
+        {
+            let layer = self.layer.lock().expect("overlay layer poisoned");
+            match layer.get(&dir_key) {
+                Some(OverlayEntry::Deleted) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("overlay: {} was deleted", dir_key.display()),
+                    ));
+                }
+                Some(OverlayEntry::File(_)) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotADirectory,
+                        format!("overlay: {} is a file", dir_key.display()),
+                    ));
+                }
+                Some(OverlayEntry::Directory) => {
+                    virtual_dir_exists = true;
+                }
+                None => {
+                    virtual_dir_exists = false;
+                }
+            }
+        }
+        let disk_dir_exists = path.exists();
         let mut entries: BTreeMap<PathBuf, OverlayDirEntry> = BTreeMap::new();
-        if path.exists() {
+        if disk_dir_exists {
             for entry in std::fs::read_dir(path)? {
                 let entry = entry?;
                 let p = entry.path();
@@ -243,6 +298,12 @@ impl OverlayFs {
                     entries.remove(key);
                 }
             }
+        }
+        if entries.is_empty() && !disk_dir_exists && !virtual_dir_exists {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("overlay: {} was not found", dir_key.display()),
+            ));
         }
         Ok(entries.into_values().collect())
     }
@@ -529,6 +590,65 @@ pub mod helpers {
         result
     }
 
+    pub fn copy(src: &Path, dst: &Path) -> std::io::Result<u64> {
+        match active_overlay() {
+            Some(overlay) => {
+                let result = overlay.copy(src, dst);
+                if let Ok(bytes) = overlay.read(src) {
+                    record_file_read(src, &bytes);
+                    if result.is_ok() {
+                        record_file_write(dst, &bytes);
+                    }
+                }
+                result
+            }
+            None => {
+                let copied = std::fs::copy(src, dst)?;
+                if tape::active_recorder().is_some() {
+                    let bytes = std::fs::read(dst)?;
+                    record_file_read(src, &bytes);
+                    record_file_write(dst, &bytes);
+                }
+                Ok(copied)
+            }
+        }
+    }
+
+    pub fn rename(src: &Path, dst: &Path) -> std::io::Result<u64> {
+        match active_overlay() {
+            Some(overlay) => {
+                let bytes_for_record = overlay.read(src).ok();
+                let result = overlay.rename(src, dst);
+                if result.is_ok() {
+                    if let Some(bytes) = bytes_for_record.as_deref() {
+                        record_file_read(src, bytes);
+                        record_file_write(dst, bytes);
+                        record_file_delete(src);
+                    }
+                }
+                result
+            }
+            None => {
+                let bytes = tape::active_recorder()
+                    .is_some()
+                    .then(|| std::fs::read(src))
+                    .transpose()?;
+                let len = bytes
+                    .as_ref()
+                    .map(|bytes| bytes.len() as u64)
+                    .or_else(|| std::fs::metadata(src).ok().map(|metadata| metadata.len()))
+                    .unwrap_or(0);
+                std::fs::rename(src, dst)?;
+                if let Some(bytes) = bytes.as_deref() {
+                    record_file_read(src, bytes);
+                    record_file_write(dst, bytes);
+                    record_file_delete(src);
+                }
+                Ok(len)
+            }
+        }
+    }
+
     pub fn exists(path: &Path) -> bool {
         match active_overlay() {
             Some(overlay) => overlay.exists(path),
@@ -619,6 +739,58 @@ mod tests {
         let diff = overlay.diff();
         assert_eq!(diff.len(), 1);
         assert!(matches!(diff[0].kind, DiffKind::Deleted));
+    }
+
+    #[test]
+    fn delete_masks_underlying_directory_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("doomed");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("secret.txt"), "x").unwrap();
+        let overlay = OverlayFs::rooted_at(dir.path());
+
+        overlay.remove_file(&nested).unwrap();
+
+        assert!(!overlay.exists(&nested));
+        assert_eq!(
+            overlay.read_dir(&nested).unwrap_err().kind(),
+            std::io::ErrorKind::NotFound
+        );
+        assert!(nested.join("secret.txt").exists());
+    }
+
+    #[test]
+    fn recursive_mkdir_creates_visible_overlay_ancestors() {
+        let dir = tempfile::tempdir().unwrap();
+        let overlay = OverlayFs::rooted_at(dir.path());
+        overlay
+            .create_dir_all(&dir.path().join("alpha/beta/gamma"))
+            .unwrap();
+
+        let root_entries = overlay.read_dir(&dir.path().join("alpha")).unwrap();
+        assert_eq!(root_entries.len(), 1);
+        assert_eq!(
+            root_entries[0]
+                .path
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("beta")
+        );
+        assert!(root_entries[0].is_dir);
+    }
+
+    #[test]
+    fn read_dir_reports_missing_empty_overlay_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let overlay = OverlayFs::rooted_at(dir.path());
+
+        assert_eq!(
+            overlay
+                .read_dir(&dir.path().join("missing"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotFound
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- harden portal launch/run analysis around unique job IDs, RFC3339 timestamps, symlink escapes, env validation, Unicode previews, case-insensitive search, and large duration arithmetic
- route stdlib fs copy/move/delete/mkdir through the overlay/notification path and tighten overlay directory semantics
- consolidate package TOML string escaping and add focused regression coverage plus a changelog fragment

## Validation
- `cargo fmt --check && git diff --check`
- `npm run portal:lint`
- `npm run portal:test`
- `npm run portal:build`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry cargo test -p harn-vm testbench::overlay_fs::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry cargo test -p harn-vm stdlib::fs::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry cargo test -p harn-vm stdlib::path::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry cargo test -p harn-cli commands::portal::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry cargo test -p harn-cli package::manifest::tests::toml_string_literal_escapes_all_basic_control_characters -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry cargo test -p harn-cli package::lockfile::tests::rendered_dependency_values_are_toml_escaped -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry make test`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry make lint`
- `CARGO_TARGET_DIR=/tmp/harn-target-4ab5-bugdry make conformance`