### PR TITLE
Add bounded MCP Code Mode retries

### DIFF
--- a/changelog.d/2718.added.md
+++ b/changelog.d/2718.added.md
@@ -1,0 +1,2 @@
+- Add bounded MCP Code Mode fan-out with trusted retry gates,
+  idempotency-key replay, per-server bulkheads, and outputSchema validation.

--- a/conformance/tests/scenarios/composition_mcp_code_mode.expected
+++ b/conformance/tests/scenarios/composition_mcp_code_mode.expected
@@ -12,3 +12,6 @@ Harn docs
 1
 docs__search
 true
+true
+2
+0

--- a/conformance/tests/scenarios/composition_mcp_code_mode.harn
+++ b/conformance/tests/scenarios/composition_mcp_code_mode.harn
@@ -58,4 +58,18 @@ pipeline main() {
   )
   __io_println(full_report.child_calls[0].tool_name)
   __io_println(contains(full_report.child_results[0].raw_output, "Harn docs"))
+  let settled = composition_mcp_execute(
+    "let result = map_bounded([\"runtime\", \"stdlib\"], { q -> docs_search({query: q}) }, {concurrency: 2})\nreturn {succeeded: result.succeeded, failed: result.failed}",
+    tools,
+    {
+      run_id: "mcp-code-mode-bounded",
+      max_concurrent: 2,
+      max_concurrent_per_server: 1,
+      trusted_servers: ["docs"],
+      retry: {max_attempts: 2, base_delay_ms: 0, max_delay_ms: 0},
+    },
+  )
+  __io_println(settled.ok)
+  __io_println(settled.result.succeeded)
+  __io_println(settled.result.failed)
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_composition.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_composition.harn
@@ -79,7 +79,23 @@ fn __composition_mcp_servers(manifest) {
 
 fn __composition_execute_options(opts, dispatcher) {
   var out = {dispatcher: dispatcher}
-  for key in ["session_id", "run_id", "max_operations", "timeout_ms", "max_output_bytes"] {
+  for key in [
+    "session_id",
+    "run_id",
+    "max_operations",
+    "timeout_ms",
+    "max_output_bytes",
+    "max_concurrent_operations",
+    "max_concurrent",
+    "max_concurrent_per_server",
+    "per_server_concurrency",
+    "trusted_servers",
+    "trusted_mcp_servers",
+    "trust_annotations",
+    "trust_mcp_annotations",
+    "call_timeout_ms",
+    "retry",
+  ] {
     if opts?[key] != nil {
       out = out + {[key]: opts[key]}
     }
@@ -251,6 +267,12 @@ pub fn composition_mcp_tools(registry = nil, options = nil) {
         max_operations: {type: "integer", required: false},
         timeout_ms: {type: "integer", required: false},
         max_output_bytes: {type: "integer", required: false},
+        max_concurrent: {type: "integer", required: false},
+        max_concurrent_per_server: {type: "integer", required: false},
+        trusted_servers: {type: "array", required: false},
+        trust_annotations: {type: "boolean", required: false},
+        call_timeout_ms: {type: "integer", required: false},
+        retry: {type: "object", required: false},
         tools: {type: "array", required: false},
         include_report: {type: "boolean", required: false},
       },

--- a/crates/harn-vm/src/composition/harn_api.rs
+++ b/crates/harn-vm/src/composition/harn_api.rs
@@ -5,7 +5,10 @@ use serde_json::Value;
 use super::manifest::{BindingManifest, BindingPolicyDisposition};
 
 pub fn composition_harn_api(manifest: &BindingManifest) -> String {
-    let mut out = String::from("// Harn Code Mode API. Snippets call these bindings; the executor supplies __composition_call.\n");
+    let mut out = String::from(
+        "// Harn Code Mode API. Snippets call these bindings; the executor supplies __composition_call.\n\
+         // Use map_bounded(items, { item -> ... }, {concurrency: N}) for settled fan-out.\n",
+    );
     out.push_str("type JsonValue = unknown\n\n");
     for binding in &manifest.bindings {
         if binding.policy.disposition != BindingPolicyDisposition::Allowed {

--- a/crates/harn-vm/src/composition/mod.rs
+++ b/crates/harn-vm/src/composition/mod.rs
@@ -5,11 +5,14 @@
 //! opaque "execute code" blob, so policy, transcript, replay, and host approval
 //! surfaces can keep reasoning about each child call normally.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
+use std::time::Duration;
 
+use futures::stream::{FuturesUnordered, StreamExt};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::agent_events::{ToolCallErrorCategory, ToolCallStatus};
 use crate::tool_annotations::SideEffectLevel;
@@ -39,8 +42,8 @@ pub use manifest::{
 pub use types::{
     CompositionChildCall, CompositionChildResult, CompositionExecutionLimits,
     CompositionExecutionReport, CompositionExecutionRequest, CompositionFailureCategory,
-    CompositionRunEnvelope, CompositionToolHost, CompositionToolOutput,
-    COMPOSITION_EXECUTION_SCHEMA_VERSION,
+    CompositionMcpPolicy, CompositionRetryPolicy, CompositionRunEnvelope, CompositionToolHost,
+    CompositionToolOutput, COMPOSITION_EXECUTION_SCHEMA_VERSION,
 };
 pub use typescript::composition_typescript_declarations;
 
@@ -164,13 +167,17 @@ impl ExecutionState {
             executor: Some(crate::agent_events::ToolExecutor::HarnBuiltin),
             duration_ms: Some(0),
             execution_duration_ms: Some(0),
+            attempt: 1,
+            retry_attempts: 0,
+            retry_errors: Vec::new(),
+            retry_delays_ms: Vec::new(),
         });
     }
 
     fn push_result(
         &mut self,
         call: &CompositionChildCall,
-        output: &CompositionToolOutput,
+        outcome: &CompositionDispatchOutcome,
         elapsed_ms: u64,
     ) {
         if self
@@ -185,19 +192,89 @@ impl ExecutionState {
             tool_call_id: call.tool_call_id.clone(),
             tool_name: call.tool_name.clone(),
             operation_index: call.operation_index,
-            status: if output.error.is_some() {
+            status: if outcome.output.error.is_some() {
                 ToolCallStatus::Failed
             } else {
                 ToolCallStatus::Completed
             },
-            raw_output: output.value.clone(),
-            error: output.error.clone(),
-            error_category: output.error_category,
-            executor: output.executor.clone(),
+            raw_output: outcome.output.value.clone(),
+            error: outcome.output.error.clone(),
+            error_category: outcome.output.error_category,
+            executor: outcome.output.executor.clone(),
             duration_ms: Some(elapsed_ms),
             execution_duration_ms: Some(elapsed_ms),
+            attempt: outcome.attempt,
+            retry_attempts: outcome.retry_attempts,
+            retry_errors: outcome.retry_errors.clone(),
+            retry_delays_ms: outcome.retry_delays_ms.clone(),
         });
     }
+}
+
+#[derive(Clone)]
+struct CompositionRuntime {
+    state: Arc<parking_lot::Mutex<ExecutionState>>,
+    host: Arc<dyn CompositionToolHost>,
+    bulkheads: Arc<CompositionBulkheads>,
+}
+
+struct CompositionBulkheads {
+    global: Arc<Semaphore>,
+    per_server: parking_lot::Mutex<HashMap<String, Arc<Semaphore>>>,
+    per_server_limit: usize,
+}
+
+impl CompositionBulkheads {
+    fn new(limits: &CompositionExecutionLimits) -> Self {
+        Self {
+            global: Arc::new(Semaphore::new(
+                limits
+                    .max_concurrent_operations
+                    .clamp(1, Semaphore::MAX_PERMITS),
+            )),
+            per_server: parking_lot::Mutex::new(HashMap::new()),
+            per_server_limit: limits
+                .max_concurrent_per_server
+                .clamp(1, Semaphore::MAX_PERMITS),
+        }
+    }
+
+    async fn acquire(
+        &self,
+        binding: &BindingManifestEntry,
+    ) -> Result<(OwnedSemaphorePermit, Option<OwnedSemaphorePermit>), VmError> {
+        let global = self
+            .global
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| VmError::Runtime("composition bulkhead closed".to_string()))?;
+        let server = mcp_server_name(binding);
+        let per_server = match server {
+            Some(server) => {
+                let semaphore = {
+                    let mut semaphores = self.per_server.lock();
+                    semaphores
+                        .entry(server)
+                        .or_insert_with(|| Arc::new(Semaphore::new(self.per_server_limit)))
+                        .clone()
+                };
+                Some(semaphore.acquire_owned().await.map_err(|_| {
+                    VmError::Runtime("composition per-server bulkhead closed".to_string())
+                })?)
+            }
+            None => None,
+        };
+        Ok((global, per_server))
+    }
+}
+
+struct CompositionDispatchOutcome {
+    output: CompositionToolOutput,
+    attempt: u32,
+    retry_attempts: u32,
+    retry_errors: Vec<String>,
+    retry_delays_ms: Vec<u64>,
 }
 
 /// Execute a read-only Harn-native composition snippet against a manifest.
@@ -356,7 +433,14 @@ async fn execute_harn_composition_inner(
     }));
     let mut vm = Vm::new();
     crate::register_core_stdlib(&mut vm);
-    register_composition_call_builtin(&mut vm, state.clone(), host);
+    let limits = state.lock().request.limits.clone();
+    let runtime = CompositionRuntime {
+        state: state.clone(),
+        host,
+        bulkheads: Arc::new(CompositionBulkheads::new(&limits)),
+    };
+    register_composition_call_builtin(&mut vm, runtime.clone());
+    register_composition_map_bounded_builtin(&mut vm, runtime);
     if let Some(timeout_ms) = state.lock().request.limits.timeout_ms {
         vm.push_deadline_after(std::time::Duration::from_millis(timeout_ms));
     }
@@ -415,14 +499,9 @@ async fn execute_harn_composition_inner(
     }
 }
 
-fn register_composition_call_builtin(
-    vm: &mut Vm,
-    state: Arc<parking_lot::Mutex<ExecutionState>>,
-    host: Arc<dyn CompositionToolHost>,
-) {
+fn register_composition_call_builtin(vm: &mut Vm, runtime: CompositionRuntime) {
     vm.register_async_builtin("__composition_call", move |_ctx, args| {
-        let state = state.clone();
-        let host = host.clone();
+        let runtime = runtime.clone();
         async move {
             let tool_name = args
                 .first()
@@ -433,24 +512,389 @@ fn register_composition_call_builtin(
                 .map(crate::llm::vm_value_to_json)
                 .unwrap_or_else(|| serde_json::json!({}));
             let (binding, call, clock) = {
-                let mut state = state.lock();
+                let mut state = runtime.state.lock();
                 let (binding, call) = state.next_call(&tool_name, input.clone())?;
                 (binding, call, state.clock.clone())
             };
             let started_ms = clock.monotonic_ms();
-            let output = host.call(&binding, input).await;
+            let outcome = dispatch_binding_with_policy(&runtime, &binding, input).await?;
             {
-                let mut state = state.lock();
-                state.push_result(&call, &output, elapsed_ms(&*clock, started_ms));
+                let mut state = runtime.state.lock();
+                state.push_result(&call, &outcome, elapsed_ms(&*clock, started_ms));
             }
-            if let Some(error) = output.error {
+            if let Some(error) = outcome.output.error {
                 return Err(VmError::Runtime(error));
             }
             Ok(crate::json_to_vm_value(
-                &output.value.unwrap_or(Value::Null),
+                &outcome.output.value.unwrap_or(Value::Null),
             ))
         }
     });
+}
+
+async fn dispatch_binding_with_policy(
+    runtime: &CompositionRuntime,
+    binding: &BindingManifestEntry,
+    input: Value,
+) -> Result<CompositionDispatchOutcome, VmError> {
+    let policy = runtime.state.lock().request.mcp_policy.clone();
+    let retry = policy.retry.clone();
+    let max_attempts = retry.max_attempts.max(1);
+    let can_retry = retry_allowed(binding, &input, &policy);
+    let mut attempt = 1u32;
+    let mut retry_errors = Vec::new();
+    let mut retry_delays_ms = Vec::new();
+
+    loop {
+        let (_global_permit, _server_permit) = runtime.bulkheads.acquire(binding).await?;
+        let call = runtime.host.call(binding, input.clone());
+        let mut output = if let Some(timeout_ms) = policy.call_timeout_ms.filter(|ms| *ms > 0) {
+            match tokio::time::timeout(Duration::from_millis(timeout_ms), call).await {
+                Ok(output) => output,
+                Err(_) => CompositionToolOutput::error(
+                    format!(
+                        "composition binding '{}' timed out after {timeout_ms}ms",
+                        binding.name
+                    ),
+                    ToolCallErrorCategory::Timeout,
+                ),
+            }
+        } else {
+            call.await
+        };
+        drop((_global_permit, _server_permit));
+
+        if output.error.is_none() {
+            if let Some(value) = output.value.take() {
+                match validate_binding_output(binding, value) {
+                    Ok(value) => output.value = Some(value),
+                    Err(message) => {
+                        output = CompositionToolOutput::error(
+                            message,
+                            ToolCallErrorCategory::SchemaValidation,
+                        );
+                    }
+                }
+            }
+        }
+
+        if output.error.is_none()
+            || attempt >= max_attempts
+            || !can_retry
+            || !is_retryable_child_error(&output)
+        {
+            return Ok(CompositionDispatchOutcome {
+                output,
+                attempt,
+                retry_attempts: attempt.saturating_sub(1),
+                retry_errors,
+                retry_delays_ms,
+            });
+        }
+
+        let error = output
+            .error
+            .clone()
+            .unwrap_or_else(|| "composition child call failed".to_string());
+        let delay_ms = compute_retry_delay_ms(binding, &input, attempt, &retry, &error);
+        retry_errors.push(error);
+        retry_delays_ms.push(delay_ms);
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
+        attempt = attempt.saturating_add(1);
+    }
+}
+
+fn validate_binding_output(binding: &BindingManifestEntry, value: Value) -> Result<Value, String> {
+    let Some(schema) = &binding.output_schema else {
+        return Ok(value);
+    };
+    let value_vm = crate::json_to_vm_value(&value);
+    let schema_vm = crate::json_to_vm_value(schema);
+    crate::schema::schema_expect_value(&value_vm, &schema_vm, false)
+        .map(|value| crate::llm::vm_value_to_json(&value))
+        .map_err(|error| {
+            format!(
+                "composition binding '{}' outputSchema validation failed: {error}",
+                binding.name
+            )
+        })
+}
+
+fn retry_allowed(
+    binding: &BindingManifestEntry,
+    input: &Value,
+    policy: &CompositionMcpPolicy,
+) -> bool {
+    if idempotency_key_present(input) {
+        return true;
+    }
+    if binding.source == "mcp_server" {
+        if !mcp_binding_trusted(binding, policy) {
+            return false;
+        }
+        return binding.annotations.destructive_hint != Some(true)
+            && (binding.annotations.read_only_hint == Some(true)
+                || binding.annotations.idempotent_hint == Some(true));
+    }
+    binding.side_effect_level == SideEffectLevel::ReadOnly
+        && binding.annotations.kind.is_read_only()
+}
+
+fn mcp_binding_trusted(binding: &BindingManifestEntry, policy: &CompositionMcpPolicy) -> bool {
+    policy.trust_annotations
+        || mcp_server_name(binding)
+            .as_ref()
+            .is_some_and(|server| policy.trusted_servers.contains(server))
+}
+
+fn mcp_server_name(binding: &BindingManifestEntry) -> Option<String> {
+    binding
+        .metadata
+        .get("_mcp_server")
+        .or_else(|| binding.metadata.get("mcp_server"))
+        .or_else(|| binding.metadata.pointer("/server/name"))
+        .and_then(Value::as_str)
+        .filter(|server| !server.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn idempotency_key_present(input: &Value) -> bool {
+    for pointer in [
+        "/idempotency_key",
+        "/idempotencyKey",
+        "/_idempotency_key",
+        "/_meta/idempotencyKey",
+        "/_meta/harn/idempotencyKey",
+    ] {
+        if input.pointer(pointer).is_some_and(|value| match value {
+            Value::String(value) => !value.trim().is_empty(),
+            Value::Null => false,
+            _ => true,
+        }) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_retryable_child_error(output: &CompositionToolOutput) -> bool {
+    if matches!(
+        output.error_category,
+        Some(
+            ToolCallErrorCategory::Network
+                | ToolCallErrorCategory::Timeout
+                | ToolCallErrorCategory::McpServerError
+        )
+    ) {
+        return true;
+    }
+    let Some(error) = &output.error else {
+        return false;
+    };
+    let error = error.to_ascii_lowercase();
+    [
+        "429",
+        "503",
+        "retry-after",
+        "rate limit",
+        "rate-limit",
+        "timeout",
+        "timed out",
+        "transient",
+        "overloaded",
+        "server closed connection",
+        "disconnected",
+        "mcp read error",
+        "mcp write error",
+        "connection reset",
+    ]
+    .iter()
+    .any(|needle| error.contains(needle))
+}
+
+fn compute_retry_delay_ms(
+    binding: &BindingManifestEntry,
+    input: &Value,
+    attempt: u32,
+    retry: &CompositionRetryPolicy,
+    error: &str,
+) -> u64 {
+    if retry.max_delay_ms == 0 {
+        return 0;
+    }
+    if retry.honor_retry_after {
+        if let Some(delay) = retry_after_ms_from_error(error) {
+            return delay.min(retry.max_delay_ms);
+        }
+    }
+    let shift = attempt.saturating_sub(1).min(20);
+    let multiplier = 1u64.checked_shl(shift).unwrap_or(u64::MAX);
+    let base = retry.base_delay_ms.saturating_mul(multiplier);
+    if base == 0 {
+        return 0;
+    }
+    let jitter_span = (base / 2).max(1);
+    let mut hasher = Sha256::new();
+    hasher.update(binding.name.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(attempt.to_le_bytes());
+    hasher.update(b"\0");
+    if let Ok(bytes) = serde_json::to_vec(input) {
+        hasher.update(bytes);
+    }
+    let digest = hasher.finalize();
+    let jitter = u64::from_le_bytes(digest[..8].try_into().unwrap_or([0; 8])) % (jitter_span + 1);
+    base.saturating_add(jitter).min(retry.max_delay_ms)
+}
+
+fn retry_after_ms_from_error(error: &str) -> Option<u64> {
+    let lower = error.to_ascii_lowercase();
+    let (_, tail) = lower.split_once("retry-after")?;
+    let value = tail
+        .trim_start_matches(|c: char| c == ':' || c == '=' || c.is_whitespace())
+        .split(|c: char| !c.is_ascii_digit())
+        .next()
+        .filter(|value| !value.is_empty())?;
+    value
+        .parse::<u64>()
+        .ok()
+        .map(|seconds| seconds.saturating_mul(1000))
+}
+
+fn register_composition_map_bounded_builtin(vm: &mut Vm, runtime: CompositionRuntime) {
+    vm.register_async_builtin("map_bounded", move |ctx, args| {
+        let runtime = runtime.clone();
+        async move {
+            let items = match args.first() {
+                Some(VmValue::List(items)) => items.as_ref().clone(),
+                Some(other) => {
+                    return Err(VmError::TypeError(format!(
+                        "map_bounded: first argument must be a list, got {}",
+                        other.type_name()
+                    )))
+                }
+                None => {
+                    return Err(VmError::Runtime(
+                        "map_bounded: first argument must be a list".to_string(),
+                    ))
+                }
+            };
+            let closure = match args.get(1) {
+                Some(VmValue::Closure(closure)) => closure.clone(),
+                Some(other) => {
+                    return Err(VmError::TypeError(format!(
+                        "map_bounded: second argument must be a closure, got {}",
+                        other.type_name()
+                    )))
+                }
+                None => {
+                    return Err(VmError::Runtime(
+                        "map_bounded: second argument must be a closure".to_string(),
+                    ))
+                }
+            };
+            let options = args
+                .get(2)
+                .map(crate::llm::vm_value_to_json)
+                .unwrap_or_else(|| serde_json::json!({}));
+            let default_cap = runtime
+                .state
+                .lock()
+                .request
+                .limits
+                .max_concurrent_operations
+                .max(1);
+            let cap = options
+                .get("concurrency")
+                .or_else(|| options.get("max_concurrent"))
+                .and_then(Value::as_u64)
+                .map(|value| value.max(1) as usize)
+                .unwrap_or(default_cap)
+                .min(items.len().max(1));
+
+            let total = items.len();
+            let mut pending = items.into_iter().enumerate();
+            let mut in_flight = FuturesUnordered::new();
+            let mut results: Vec<Option<VmValue>> = vec![None; total];
+            let mut succeeded = 0i64;
+            let mut failed = 0i64;
+
+            while in_flight.len() < cap {
+                let Some((index, item)) = pending.next() else {
+                    break;
+                };
+                in_flight.push(run_map_bounded_item(
+                    ctx.clone(),
+                    closure.clone(),
+                    index,
+                    item,
+                ));
+            }
+            while let Some((index, output, result)) = in_flight.next().await {
+                ctx.forward_output(&output);
+                match result {
+                    Ok(value) => {
+                        succeeded += 1;
+                        results[index] = Some(VmValue::enum_variant("Result", "Ok", vec![value]));
+                    }
+                    Err(error) => {
+                        failed += 1;
+                        results[index] = Some(VmValue::enum_variant(
+                            "Result",
+                            "Err",
+                            vec![VmValue::String(std::sync::Arc::from(error.to_string()))],
+                        ));
+                    }
+                }
+                if let Some((next_index, next_item)) = pending.next() {
+                    in_flight.push(run_map_bounded_item(
+                        ctx.clone(),
+                        closure.clone(),
+                        next_index,
+                        next_item,
+                    ));
+                }
+            }
+
+            let mut dict = BTreeMap::new();
+            dict.insert(
+                "results".to_string(),
+                VmValue::List(std::sync::Arc::new(
+                    results
+                        .into_iter()
+                        .map(|value| {
+                            value.unwrap_or_else(|| {
+                                VmValue::enum_variant(
+                                    "Result",
+                                    "Err",
+                                    vec![VmValue::String(std::sync::Arc::from(
+                                        "map_bounded: task did not produce a result",
+                                    ))],
+                                )
+                            })
+                        })
+                        .collect(),
+                )),
+            );
+            dict.insert("succeeded".to_string(), VmValue::Int(succeeded));
+            dict.insert("failed".to_string(), VmValue::Int(failed));
+            Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+        }
+    });
+}
+
+async fn run_map_bounded_item(
+    ctx: crate::vm::AsyncBuiltinCtx,
+    closure: std::sync::Arc<crate::VmClosure>,
+    index: usize,
+    item: VmValue,
+) -> (usize, String, Result<VmValue, VmError>) {
+    let mut vm = ctx.child_vm();
+    let result = vm.call_closure_pub(&closure, &[item]).await;
+    let output = vm.take_output();
+    (index, output, result)
 }
 
 fn elapsed_ms(clock: &dyn harn_clock::Clock, started_ms: i64) -> u64 {
@@ -608,6 +1052,7 @@ const PURE_COMPOSITION_CALLS: &[&str] = &[
     "keys",
     "len",
     "lower",
+    "map_bounded",
     "parse_float_or",
     "parse_int_or",
     "split",
@@ -791,6 +1236,64 @@ pub fn register_composition_builtins(vm: &mut Vm) {
             if let Some(max_output_bytes) = options.get("max_output_bytes").and_then(Value::as_u64)
             {
                 request.limits.max_output_bytes = max_output_bytes;
+            }
+            if let Some(max_concurrent) = options
+                .get("max_concurrent_operations")
+                .or_else(|| options.get("max_concurrent"))
+                .and_then(Value::as_u64)
+            {
+                request.limits.max_concurrent_operations =
+                    usize::try_from(max_concurrent).unwrap_or(usize::MAX).max(1);
+            }
+            if let Some(per_server) = options
+                .get("max_concurrent_per_server")
+                .or_else(|| options.get("per_server_concurrency"))
+                .and_then(Value::as_u64)
+            {
+                request.limits.max_concurrent_per_server =
+                    usize::try_from(per_server).unwrap_or(usize::MAX).max(1);
+            }
+            let trusted_servers = string_set_option(&options, "trusted_servers");
+            let trusted_mcp_servers = string_set_option(&options, "trusted_mcp_servers");
+            if !trusted_servers.is_empty() || !trusted_mcp_servers.is_empty() {
+                request
+                    .mcp_policy
+                    .trusted_servers
+                    .extend(trusted_servers.into_iter().chain(trusted_mcp_servers));
+            }
+            if let Some(trust_annotations) = options
+                .get("trust_annotations")
+                .or_else(|| options.get("trust_mcp_annotations"))
+                .and_then(Value::as_bool)
+            {
+                request.mcp_policy.trust_annotations = trust_annotations;
+            }
+            if let Some(call_timeout_ms) = options.get("call_timeout_ms").and_then(Value::as_u64) {
+                request.mcp_policy.call_timeout_ms = Some(call_timeout_ms);
+            }
+            if let Some(retry_options) = options.get("retry") {
+                if let Some(max_attempts) =
+                    retry_options.get("max_attempts").and_then(Value::as_u64)
+                {
+                    request.mcp_policy.retry.max_attempts =
+                        u32::try_from(max_attempts).unwrap_or(u32::MAX).max(1);
+                }
+                if let Some(base_delay_ms) =
+                    retry_options.get("base_delay_ms").and_then(Value::as_u64)
+                {
+                    request.mcp_policy.retry.base_delay_ms = base_delay_ms;
+                }
+                if let Some(max_delay_ms) =
+                    retry_options.get("max_delay_ms").and_then(Value::as_u64)
+                {
+                    request.mcp_policy.retry.max_delay_ms = max_delay_ms;
+                }
+                if let Some(honor_retry_after) = retry_options
+                    .get("honor_retry_after")
+                    .and_then(Value::as_bool)
+                {
+                    request.mcp_policy.retry.honor_retry_after = honor_retry_after;
+                }
             }
         }
         let host: Arc<dyn CompositionToolHost> = match dispatcher {

--- a/crates/harn-vm/src/composition/tests.rs
+++ b/crates/harn-vm/src/composition/tests.rs
@@ -1,10 +1,15 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use serde_json::Value;
 
 use super::*;
 use crate::agent_events::{AgentEvent, ToolCallErrorCategory, ToolCallStatus};
+use crate::testbench::mcp_mock::{
+    McpWorldFault, McpWorldFaultSpec, McpWorldOperation, McpWorldRuntime, McpWorldSpec,
+    McpWorldToolSpec,
+};
 use crate::tool_annotations::{SideEffectLevel, ToolAnnotations};
 
 #[test]
@@ -390,6 +395,453 @@ async fn harn_composition_dispatcher_closure_receives_real_inputs_and_returns_ou
         report.run.result.as_ref().and_then(Value::as_str),
         Some("real-file-bytes")
     );
+}
+
+struct WorldCompositionHost {
+    runtime: Arc<parking_lot::Mutex<McpWorldRuntime>>,
+    attempts: Arc<AtomicU64>,
+    active: Arc<AtomicUsize>,
+    peak: Arc<AtomicUsize>,
+}
+
+impl WorldCompositionHost {
+    fn new(spec: McpWorldSpec) -> Self {
+        Self {
+            runtime: Arc::new(parking_lot::Mutex::new(McpWorldRuntime::new(spec))),
+            attempts: Arc::new(AtomicU64::new(0)),
+            active: Arc::new(AtomicUsize::new(0)),
+            peak: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn attempts(&self) -> u64 {
+        self.attempts.load(Ordering::SeqCst)
+    }
+
+    fn peak(&self) -> usize {
+        self.peak.load(Ordering::SeqCst)
+    }
+
+    fn update_peak(&self, active: usize) {
+        let mut observed = self.peak.load(Ordering::SeqCst);
+        while active > observed {
+            match self
+                .peak
+                .compare_exchange(observed, active, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(next) => observed = next,
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CompositionToolHost for WorldCompositionHost {
+    async fn call(&self, binding: &BindingManifestEntry, input: Value) -> CompositionToolOutput {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.update_peak(active);
+        tokio::task::yield_now().await;
+        let tool_name = binding
+            .metadata
+            .get("_mcp_tool_name")
+            .or_else(|| binding.metadata.get("mcp_tool_name"))
+            .and_then(Value::as_str)
+            .unwrap_or(&binding.name);
+        let response = self
+            .runtime
+            .lock()
+            .handle_json_rpc(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": tool_name,
+                    "arguments": input,
+                },
+            }))
+            .unwrap_or_else(|| {
+                serde_json::json!({
+                    "error": {"message": "simulated MCP world returned no response"}
+                })
+            });
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        if let Some(error) = response.get("error") {
+            let message = error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("MCP server error");
+            return CompositionToolOutput::error(
+                format!("MCP server error: {message}; data={}", error["data"]),
+                ToolCallErrorCategory::McpServerError,
+            );
+        }
+        let result = response.get("result").cloned().unwrap_or(Value::Null);
+        if result.get("isError").and_then(Value::as_bool) == Some(true) {
+            let message = result
+                .get("content")
+                .and_then(Value::as_array)
+                .and_then(|items| items.first())
+                .and_then(|item| item.get("text"))
+                .and_then(Value::as_str)
+                .unwrap_or("MCP tool error");
+            return CompositionToolOutput::error(message, ToolCallErrorCategory::ToolError);
+        }
+        CompositionToolOutput::ok(
+            result
+                .get("structuredContent")
+                .cloned()
+                .unwrap_or(Value::Null),
+        )
+    }
+}
+
+fn mcp_world_manifest(tool: &McpWorldToolSpec) -> BindingManifest {
+    let mut entry = serde_json::json!({
+        "name": format!("docs__{}", tool.name),
+        "description": tool.description.clone(),
+        "inputSchema": tool.input_schema.clone(),
+        "executor": "mcp_server",
+        "_mcp_server": "docs",
+        "_mcp_tool_name": tool.name.clone(),
+        "defer_loading": true,
+    });
+    if let Some(output_schema) = &tool.output_schema {
+        entry["outputSchema"] = output_schema.clone();
+    }
+    if let Some(annotations) = &tool.annotations {
+        entry["annotations"] = annotations.clone();
+    }
+    binding_manifest_from_tool_surface(
+        &Value::Array(vec![entry]),
+        BindingManifestOptions::default(),
+    )
+}
+
+fn retry_test_policy() -> CompositionMcpPolicy {
+    CompositionMcpPolicy {
+        trusted_servers: BTreeSet::from(["docs".to_string()]),
+        retry: CompositionRetryPolicy {
+            max_attempts: 3,
+            base_delay_ms: 0,
+            max_delay_ms: 0,
+            honor_retry_after: true,
+        },
+        ..CompositionMcpPolicy::default()
+    }
+}
+
+fn retry_gate_binding() -> BindingManifestEntry {
+    BindingManifestEntry {
+        name: "docs__search".to_string(),
+        binding: "docs_search".to_string(),
+        annotations: ToolAnnotations {
+            read_only_hint: Some(true),
+            destructive_hint: Some(false),
+            ..ToolAnnotations::default()
+        },
+        side_effect_level: SideEffectLevel::ReadOnly,
+        source: "mcp_server".to_string(),
+        metadata: serde_json::json!({"_mcp_server": "docs"}),
+        ..BindingManifestEntry::default()
+    }
+}
+
+#[test]
+fn retry_gate_trusts_mcp_annotations_only_for_trusted_servers() {
+    let binding = retry_gate_binding();
+    assert!(!retry_allowed(
+        &binding,
+        &serde_json::json!({}),
+        &CompositionMcpPolicy::default()
+    ));
+    assert!(retry_allowed(
+        &binding,
+        &serde_json::json!({}),
+        &retry_test_policy()
+    ));
+
+    let destructive = BindingManifestEntry {
+        annotations: ToolAnnotations {
+            read_only_hint: Some(false),
+            destructive_hint: Some(true),
+            idempotent_hint: Some(false),
+            ..ToolAnnotations::default()
+        },
+        ..binding
+    };
+    assert!(!retry_allowed(
+        &destructive,
+        &serde_json::json!({}),
+        &retry_test_policy()
+    ));
+    assert!(retry_allowed(
+        &destructive,
+        &serde_json::json!({"idempotency_key": "row-1"}),
+        &retry_test_policy()
+    ));
+}
+
+#[test]
+fn retry_delay_honors_retry_after_caps_and_deterministic_jitter() {
+    let binding = retry_gate_binding();
+    let policy = CompositionRetryPolicy {
+        max_attempts: 4,
+        base_delay_ms: 100,
+        max_delay_ms: 250,
+        honor_retry_after: true,
+    };
+    assert_eq!(
+        compute_retry_delay_ms(
+            &binding,
+            &serde_json::json!({"query": "runtime"}),
+            1,
+            &policy,
+            "HTTP 503\nRetry-After: 7",
+        ),
+        250
+    );
+
+    let jitter_policy = CompositionRetryPolicy {
+        max_delay_ms: 1_000,
+        ..policy
+    };
+    let input = serde_json::json!({"query": "runtime"});
+    let first = compute_retry_delay_ms(&binding, &input, 2, &jitter_policy, "HTTP 503");
+    let second = compute_retry_delay_ms(&binding, &input, 2, &jitter_policy, "HTTP 503");
+    assert_eq!(first, second);
+    assert!((200..=300).contains(&first), "delay was {first}");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn harn_composition_retries_trusted_read_only_mcp_faults() {
+    let tool = McpWorldToolSpec {
+        name: "search".to_string(),
+        description: "Search docs".to_string(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        }),
+        output_schema: Some(serde_json::json!({
+            "type": "object",
+            "required": ["ok"],
+            "properties": {"ok": {"type": "boolean"}},
+        })),
+        annotations: Some(serde_json::json!({
+            "readOnlyHint": true,
+            "destructiveHint": false,
+        })),
+        operation: McpWorldOperation::Noop {
+            result: serde_json::json!({"ok": true}),
+        },
+    };
+    let host = Arc::new(WorldCompositionHost::new(McpWorldSpec {
+        tools: vec![tool.clone()],
+        faults: vec![McpWorldFaultSpec {
+            tool: "search".to_string(),
+            at_call: Some(1),
+            every: None,
+            fault: McpWorldFault::JsonRpcError {
+                code: -32000,
+                message: "HTTP 503 Service Unavailable\nRetry-After: 0".to_string(),
+                data: Some(serde_json::json!({"status": 503})),
+            },
+        }],
+        ..McpWorldSpec::default()
+    }));
+    let report = execute_harn_composition(
+        CompositionExecutionRequest {
+            run_id: "run-retry".to_string(),
+            snippet: "return docs_search({query: \"runtime\"})".to_string(),
+            manifest: mcp_world_manifest(&tool),
+            mcp_policy: retry_test_policy(),
+            ..CompositionExecutionRequest::default()
+        },
+        host.clone(),
+    )
+    .await;
+    assert!(report.ok, "{}", report.summary);
+    assert_eq!(host.attempts(), 2);
+    assert_eq!(report.child_results[0].retry_attempts, 1);
+    assert_eq!(report.child_results[0].retry_delays_ms, vec![0]);
+    assert_eq!(report.run.result.unwrap()["ok"], true);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn harn_composition_does_not_retry_untrusted_mcp_annotations() {
+    let tool = McpWorldToolSpec {
+        name: "search".to_string(),
+        description: "Search docs".to_string(),
+        input_schema: serde_json::json!({"type": "object"}),
+        output_schema: None,
+        annotations: Some(serde_json::json!({"readOnlyHint": true})),
+        operation: McpWorldOperation::Noop {
+            result: serde_json::json!({"ok": true}),
+        },
+    };
+    let host = Arc::new(WorldCompositionHost::new(McpWorldSpec {
+        tools: vec![tool.clone()],
+        faults: vec![McpWorldFaultSpec {
+            tool: "search".to_string(),
+            at_call: Some(1),
+            every: None,
+            fault: McpWorldFault::JsonRpcError {
+                code: -32000,
+                message: "HTTP 503 Service Unavailable".to_string(),
+                data: None,
+            },
+        }],
+        ..McpWorldSpec::default()
+    }));
+    let report = execute_harn_composition(
+        CompositionExecutionRequest {
+            run_id: "run-untrusted".to_string(),
+            snippet: "return docs_search({query: \"runtime\"})".to_string(),
+            manifest: mcp_world_manifest(&tool),
+            ..CompositionExecutionRequest::default()
+        },
+        host.clone(),
+    )
+    .await;
+    assert!(!report.ok);
+    assert_eq!(host.attempts(), 1);
+    assert_eq!(report.child_results[0].retry_attempts, 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn map_bounded_respects_per_server_bulkhead() {
+    let tool = McpWorldToolSpec {
+        name: "search".to_string(),
+        description: "Search docs".to_string(),
+        input_schema: serde_json::json!({"type": "object"}),
+        output_schema: None,
+        annotations: Some(serde_json::json!({"readOnlyHint": true})),
+        operation: McpWorldOperation::Noop {
+            result: serde_json::json!({"ok": true}),
+        },
+    };
+    let host = Arc::new(WorldCompositionHost::new(McpWorldSpec {
+        tools: vec![tool.clone()],
+        ..McpWorldSpec::default()
+    }));
+    let report = execute_harn_composition(
+        CompositionExecutionRequest {
+            run_id: "run-map-bounded".to_string(),
+            snippet: "let settled = map_bounded([1, 2, 3, 4, 5], { item -> docs_search({query: to_string(item)}) }, {concurrency: 5})\nreturn {succeeded: settled.succeeded, failed: settled.failed}".to_string(),
+            manifest: mcp_world_manifest(&tool),
+            limits: CompositionExecutionLimits {
+                max_concurrent_operations: 8,
+                max_concurrent_per_server: 2,
+                ..CompositionExecutionLimits::default()
+            },
+            mcp_policy: retry_test_policy(),
+            ..CompositionExecutionRequest::default()
+        },
+        host.clone(),
+    )
+    .await;
+    assert!(report.ok, "{}", report.summary);
+    assert_eq!(host.attempts(), 5);
+    assert!(host.peak() <= 2, "peak was {}", host.peak());
+    let result = report.run.result.unwrap();
+    assert_eq!(result["succeeded"], 5);
+    assert_eq!(result["failed"], 0);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn harn_composition_rejects_invalid_mcp_structured_content() {
+    let tool = McpWorldToolSpec {
+        name: "count".to_string(),
+        description: "Count rows".to_string(),
+        input_schema: serde_json::json!({"type": "object"}),
+        output_schema: Some(serde_json::json!({
+            "type": "object",
+            "required": ["count"],
+            "properties": {"count": {"type": "integer"}},
+        })),
+        annotations: Some(serde_json::json!({"readOnlyHint": true})),
+        operation: McpWorldOperation::Noop {
+            result: serde_json::json!({"count": "bad"}),
+        },
+    };
+    let report = execute_harn_composition(
+        CompositionExecutionRequest {
+            run_id: "run-schema".to_string(),
+            snippet: "return docs_count({})".to_string(),
+            manifest: mcp_world_manifest(&tool),
+            mcp_policy: retry_test_policy(),
+            ..CompositionExecutionRequest::default()
+        },
+        Arc::new(WorldCompositionHost::new(McpWorldSpec {
+            tools: vec![tool.clone()],
+            ..McpWorldSpec::default()
+        })),
+    )
+    .await;
+    assert!(!report.ok);
+    assert_eq!(
+        report.child_results[0].error_category,
+        Some(ToolCallErrorCategory::SchemaValidation)
+    );
+    assert!(report.child_results[0]
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("outputSchema"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn harn_composition_retries_destructive_mcp_only_with_idempotency_key() {
+    let tool = McpWorldToolSpec {
+        name: "append_row".to_string(),
+        description: "Append a row".to_string(),
+        input_schema: serde_json::json!({"type": "object"}),
+        output_schema: Some(serde_json::json!({"type": "object"})),
+        annotations: Some(serde_json::json!({
+            "readOnlyHint": false,
+            "destructiveHint": true,
+            "idempotentHint": false,
+        })),
+        operation: McpWorldOperation::Append {
+            path: "/rows".to_string(),
+            value_arg: "row".to_string(),
+            id_field: None,
+            id_prefix: None,
+        },
+    };
+    let host = Arc::new(WorldCompositionHost::new(McpWorldSpec {
+        initial_state: serde_json::json!({"rows": []}),
+        tools: vec![tool.clone()],
+        faults: vec![McpWorldFaultSpec {
+            tool: "append_row".to_string(),
+            at_call: Some(1),
+            every: None,
+            fault: McpWorldFault::PartialWrite {
+                path: "/rows".to_string(),
+                value: serde_json::json!([{"id": "r1"}]),
+                message: "HTTP 503 Service Unavailable\nRetry-After: 0".to_string(),
+            },
+        }],
+        ..McpWorldSpec::default()
+    }));
+    let report = execute_harn_composition(
+        CompositionExecutionRequest {
+            run_id: "run-idempotency".to_string(),
+            snippet: "return docs_append_row({row: {id: \"r1\"}, idempotency_key: \"row-r1\"})"
+                .to_string(),
+            manifest: mcp_world_manifest(&tool),
+            mcp_policy: retry_test_policy(),
+            ..CompositionExecutionRequest::default()
+        },
+        host.clone(),
+    )
+    .await;
+    assert!(report.ok, "{}", report.summary);
+    assert_eq!(host.attempts(), 2);
+    assert_eq!(report.child_results[0].retry_attempts, 1);
+    let state = host.runtime.lock().state().clone();
+    assert_eq!(state["rows"], serde_json::json!([{"id": "r1"}]));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/composition/types.rs
+++ b/crates/harn-vm/src/composition/types.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeSet;
 
 use crate::agent_events::{ToolCallErrorCategory, ToolCallStatus, ToolExecutor};
 use crate::tool_annotations::{SideEffectLevel, ToolAnnotations};
@@ -178,6 +179,10 @@ pub struct CompositionChildResult {
     pub executor: Option<ToolExecutor>,
     pub duration_ms: Option<u64>,
     pub execution_duration_ms: Option<u64>,
+    pub attempt: u32,
+    pub retry_attempts: u32,
+    pub retry_errors: Vec<String>,
+    pub retry_delays_ms: Vec<u64>,
 }
 
 impl Default for CompositionChildResult {
@@ -194,6 +199,10 @@ impl Default for CompositionChildResult {
             executor: None,
             duration_ms: None,
             execution_duration_ms: None,
+            attempt: 1,
+            retry_attempts: 0,
+            retry_errors: Vec::new(),
+            retry_delays_ms: Vec::new(),
         }
     }
 }
@@ -204,6 +213,8 @@ pub struct CompositionExecutionLimits {
     pub max_operations: u64,
     pub timeout_ms: Option<u64>,
     pub max_output_bytes: u64,
+    pub max_concurrent_operations: usize,
+    pub max_concurrent_per_server: usize,
 }
 
 impl Default for CompositionExecutionLimits {
@@ -212,8 +223,39 @@ impl Default for CompositionExecutionLimits {
             max_operations: 64,
             timeout_ms: Some(10_000),
             max_output_bytes: 64 * 1024,
+            max_concurrent_operations: 16,
+            max_concurrent_per_server: 4,
         }
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompositionRetryPolicy {
+    pub max_attempts: u32,
+    pub base_delay_ms: u64,
+    pub max_delay_ms: u64,
+    pub honor_retry_after: bool,
+}
+
+impl Default for CompositionRetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_delay_ms: 100,
+            max_delay_ms: 2_000,
+            honor_retry_after: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompositionMcpPolicy {
+    pub trusted_servers: BTreeSet<String>,
+    pub trust_annotations: bool,
+    pub retry: CompositionRetryPolicy,
+    pub call_timeout_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -226,6 +268,7 @@ pub struct CompositionExecutionRequest {
     pub manifest: BindingManifest,
     pub requested_side_effect_ceiling: SideEffectLevel,
     pub limits: CompositionExecutionLimits,
+    pub mcp_policy: CompositionMcpPolicy,
     pub metadata: Value,
 }
 
@@ -239,6 +282,7 @@ impl Default for CompositionExecutionRequest {
             manifest: BindingManifest::default(),
             requested_side_effect_ceiling: SideEffectLevel::ReadOnly,
             limits: CompositionExecutionLimits::default(),
+            mcp_policy: CompositionMcpPolicy::default(),
             metadata: Value::Object(serde_json::Map::new()),
         }
     }

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -1946,6 +1946,9 @@ pub(crate) async fn call_mcp_tool_with_hint(
     }
 
     let cache_hint = McpCacheHint::from_result(&result);
+    if let Some(structured) = result.get("structuredContent") {
+        return Ok((structured.clone(), cache_hint));
+    }
     let content = result
         .get("content")
         .and_then(|c| c.as_array())

--- a/crates/harn-vm/src/orchestration/safe_function_tools.rs
+++ b/crates/harn-vm/src/orchestration/safe_function_tools.rs
@@ -161,6 +161,7 @@ fn read_only_annotations(capability: &str, ops: &[&str]) -> ToolAnnotations {
         emits_artifacts: false,
         result_readers: Vec::new(),
         inline_result: true,
+        ..ToolAnnotations::default()
     }
 }
 
@@ -176,6 +177,7 @@ fn think_annotations() -> ToolAnnotations {
         emits_artifacts: false,
         result_readers: Vec::new(),
         inline_result: true,
+        ..ToolAnnotations::default()
     }
 }
 

--- a/crates/harn-vm/src/testbench/mcp_mock.rs
+++ b/crates/harn-vm/src/testbench/mcp_mock.rs
@@ -539,6 +539,12 @@ pub enum McpWorldFault {
     },
 }
 
+impl McpWorldFault {
+    fn has_effect(&self) -> bool {
+        matches!(self, Self::PartialWrite { .. })
+    }
+}
+
 fn default_partial_write_message() -> String {
     "simulated partial write".to_string()
 }
@@ -548,6 +554,7 @@ pub struct McpWorldRuntime {
     spec: McpWorldSpec,
     state: JsonValue,
     tool_calls: BTreeMap<String, u64>,
+    idempotency_results: BTreeMap<String, JsonValue>,
     total_tool_calls: u64,
 }
 
@@ -558,6 +565,7 @@ impl McpWorldRuntime {
             spec,
             state,
             tool_calls: BTreeMap::new(),
+            idempotency_results: BTreeMap::new(),
             total_tool_calls: 0,
         }
     }
@@ -665,6 +673,13 @@ impl McpWorldRuntime {
             .get("arguments")
             .cloned()
             .unwrap_or_else(|| json!({}));
+        let idempotency_key =
+            idempotency_key_from_arguments(&arguments).map(|key| format!("{name}:{key}"));
+        if let Some(key) = &idempotency_key {
+            if let Some(structured) = self.idempotency_results.get(key) {
+                return successful_tool_response(id, structured.clone());
+            }
+        }
         let Some(tool) = self
             .spec
             .tools
@@ -692,11 +707,28 @@ impl McpWorldRuntime {
             .find(|fault| fault.applies_to(name, call_number))
             .cloned()
         {
-            return self.apply_fault(id, &fault.fault, &arguments);
+            let response = self.apply_fault(id, &fault.fault, &arguments);
+            if fault.fault.has_effect() {
+                if let Some(key) = idempotency_key {
+                    self.idempotency_results.insert(
+                        key,
+                        json!({
+                            "ok": true,
+                            "idempotentReplay": true,
+                        }),
+                    );
+                }
+            }
+            return response;
         }
 
         match self.apply_operation(&tool.operation, &arguments) {
-            Ok(structured) => successful_tool_response(id, structured),
+            Ok(structured) => {
+                if let Some(key) = idempotency_key {
+                    self.idempotency_results.insert(key, structured.clone());
+                }
+                successful_tool_response(id, structured)
+            }
             Err(message) => tool_error_response(id, message, None),
         }
     }
@@ -985,6 +1017,23 @@ fn argument_value(arguments: &JsonValue, name: &str) -> Result<JsonValue, String
         .get(name)
         .cloned()
         .ok_or_else(|| format!("missing argument `{name}`"))
+}
+
+fn idempotency_key_from_arguments(arguments: &JsonValue) -> Option<String> {
+    [
+        "/idempotency_key",
+        "/idempotencyKey",
+        "/_idempotency_key",
+        "/_meta/idempotencyKey",
+        "/_meta/harn/idempotencyKey",
+    ]
+    .iter()
+    .find_map(|pointer| match arguments.pointer(pointer) {
+        Some(JsonValue::String(value)) if !value.trim().is_empty() => Some(value.clone()),
+        Some(JsonValue::Number(value)) => Some(value.to_string()),
+        Some(JsonValue::Bool(value)) => Some(value.to_string()),
+        _ => None,
+    })
 }
 
 fn render_state_path(path: &str, arguments: &JsonValue) -> Result<String, String> {
@@ -1421,5 +1470,62 @@ mod tests {
             .expect("response");
         assert_eq!(response["result"]["isError"], true);
         assert_eq!(runtime.state().pointer("/rows/a/count"), Some(&json!(1)));
+    }
+
+    #[test]
+    fn world_idempotency_key_replays_after_partial_write_fault() {
+        let spec = McpWorldSpec {
+            initial_state: json!({ "rows": [] }),
+            tools: vec![McpWorldToolSpec {
+                name: "append".to_string(),
+                description: String::new(),
+                input_schema: default_input_schema(),
+                output_schema: None,
+                annotations: None,
+                operation: McpWorldOperation::Append {
+                    path: "/rows".to_string(),
+                    value_arg: "row".to_string(),
+                    id_field: None,
+                    id_prefix: None,
+                },
+            }],
+            faults: vec![McpWorldFaultSpec {
+                tool: "append".to_string(),
+                at_call: Some(1),
+                every: None,
+                fault: McpWorldFault::PartialWrite {
+                    path: "/rows".to_string(),
+                    value: json!([{ "id": "r1" }]),
+                    message: "write failed after commit".to_string(),
+                },
+            }],
+            ..McpWorldSpec::default()
+        };
+        let mut runtime = McpWorldRuntime::new(spec);
+        let request = |id| {
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": {
+                    "name": "append",
+                    "arguments": {
+                        "row": {"id": "r1"},
+                        "idempotency_key": "append-r1"
+                    }
+                }
+            })
+        };
+
+        let first = runtime.handle_json_rpc(request(1)).expect("first response");
+        assert_eq!(first["result"]["isError"], true);
+        let second = runtime
+            .handle_json_rpc(request(2))
+            .expect("second response");
+        assert_eq!(second["result"]["isError"], false);
+        assert_eq!(
+            runtime.state().pointer("/rows"),
+            Some(&json!([{ "id": "r1" }]))
+        );
     }
 }

--- a/crates/harn-vm/src/tool_annotations.rs
+++ b/crates/harn-vm/src/tool_annotations.rs
@@ -194,6 +194,22 @@ pub struct ToolAnnotations {
     /// Explicit escape hatch for tools whose results are always complete
     /// inline, even though they are execute-like.
     pub inline_result: bool,
+    /// MCP `readOnlyHint`. This remains advisory; policy decides whether
+    /// the server that supplied it is trusted enough to rely on it.
+    #[serde(rename = "readOnlyHint", skip_serializing_if = "Option::is_none")]
+    pub read_only_hint: Option<bool>,
+    /// MCP `destructiveHint`. This remains advisory; policy decides whether
+    /// the server that supplied it is trusted enough to rely on it.
+    #[serde(rename = "destructiveHint", skip_serializing_if = "Option::is_none")]
+    pub destructive_hint: Option<bool>,
+    /// MCP `idempotentHint`. This remains advisory; policy decides whether
+    /// the server that supplied it is trusted enough to rely on it.
+    #[serde(rename = "idempotentHint", skip_serializing_if = "Option::is_none")]
+    pub idempotent_hint: Option<bool>,
+    /// MCP `openWorldHint`. This remains advisory; policy decides whether
+    /// the server that supplied it is trusted enough to rely on it.
+    #[serde(rename = "openWorldHint", skip_serializing_if = "Option::is_none")]
+    pub open_world_hint: Option<bool>,
 }
 
 #[cfg(test)]
@@ -283,5 +299,24 @@ mod tests {
         assert!(!annotations.emits_artifacts);
         assert!(annotations.result_readers.is_empty());
         assert!(!annotations.inline_result);
+    }
+
+    #[test]
+    fn mcp_annotation_hints_round_trip() {
+        let annotations: ToolAnnotations = serde_json::from_value(serde_json::json!({
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false
+        }))
+        .expect("MCP hints should deserialize");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
+
+        let encoded = serde_json::to_value(&annotations).expect("serialize annotations");
+        assert_eq!(encoded["readOnlyHint"], true);
+        assert_eq!(encoded["idempotentHint"], true);
     }
 }

--- a/crates/harn-vm/src/tool_surface.rs
+++ b/crates/harn-vm/src/tool_surface.rs
@@ -233,6 +233,22 @@ fn parse_tool_annotations(map: &serde_json::Map<String, serde_json::Value>) -> T
             .get("inline_result")
             .and_then(|value| value.as_bool())
             .unwrap_or(false),
+        read_only_hint: map
+            .get("readOnlyHint")
+            .or_else(|| policy.get("readOnlyHint"))
+            .and_then(|value| value.as_bool()),
+        destructive_hint: map
+            .get("destructiveHint")
+            .or_else(|| policy.get("destructiveHint"))
+            .and_then(|value| value.as_bool()),
+        idempotent_hint: map
+            .get("idempotentHint")
+            .or_else(|| policy.get("idempotentHint"))
+            .and_then(|value| value.as_bool()),
+        open_world_hint: map
+            .get("openWorldHint")
+            .or_else(|| policy.get("openWorldHint"))
+            .and_then(|value| value.as_bool()),
     }
 }
 

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -2309,7 +2309,10 @@ tool registry dict.
 The `composition_*` builtins back [Governed Code Mode](./code-mode.md). The
 executor is read-only: it rejects imports, writes, process execution, network
 access, direct HITL, parallel/spawn, and calls outside the manifest bindings and
-pure data helpers. `std/composition` adds MCP-focused helpers including
+pure data helpers. Composition snippets may use `map_bounded(...)` for settled
+fan-out; child binding calls still honor global and per-MCP-server concurrency
+caps, retry policy, trusted MCP annotation gates, idempotency keys, and
+`outputSchema` validation. `std/composition` adds MCP-focused helpers including
 `composition_mcp_api(...)`, `composition_mcp_execute(...)`, and
 `composition_mcp_tools(...)`, which registers the compact MCP profile tools
 `harn.code.search_examples`, `harn.code.generate_harn_api`, and

--- a/docs/src/code-mode.md
+++ b/docs/src/code-mode.md
@@ -110,7 +110,22 @@ The report contains:
 - `child_results`: ordered child statuses with raw output or error.
 
 The current executor is intentionally read-only. It enforces child-call,
-timeout, and output-size limits. Pass `session_id` in the execute options when
+timeout, output-size, global concurrency, and per-MCP-server concurrency limits.
+`map_bounded(items, { item -> ... }, {concurrency: N})` is available inside
+snippets for settled fan-out; each item returns a `Result.Ok` or `Result.Err`
+entry plus `succeeded` and `failed` counts, while child calls still pass through
+the same audit and policy path.
+
+MCP binding calls are wrapped with per-call timeout, retry, and bulkhead policy.
+Retries are only automatic when a server is trusted and its MCP annotations mark
+the tool as `readOnlyHint` or `idempotentHint`; destructive, non-idempotent, or
+untrusted tools are not retried unless the call input carries an idempotency key
+(`idempotency_key`, `idempotencyKey`, or `_meta.idempotencyKey`). Backoff honors
+`Retry-After` on retryable 429/503-style failures and caps attempts and delay.
+When a binding declares `outputSchema`, the executor validates the structured
+child output before returning it to the snippet.
+
+Pass `session_id` in the execute options when
 the caller wants Harn to emit the corresponding `composition_start`,
 `composition_child_call`, `composition_child_result`, and terminal composition
 events to the live agent event sinks. Future frontends must route every binding
@@ -176,7 +191,14 @@ let api = composition_mcp_api(tool_registry, {query: "issues", limit: 5})
 let output = composition_mcp_execute(
   "let hits = github_search_issues({query: \"is:open label:bug\"})\nreturn hits",
   tool_registry,
-  {manifest: api.manifest, max_operations: 4},
+  {
+    manifest: api.manifest,
+    max_operations: 16,
+    max_concurrent: 8,
+    max_concurrent_per_server: 4,
+    trusted_servers: api.servers,
+    retry: {max_attempts: 3, base_delay_ms: 100, max_delay_ms: 2000},
+  },
 )
 ```
 


### PR DESCRIPTION
Summary
- Add Code Mode MCP bulkheads, per-call timeout, trusted retry/backoff policy, idempotency-key retry gates, and outputSchema validation.
- Add `map_bounded(...)` settled fan-out for Harn composition snippets and thread concurrency/retry options through `std/composition`.
- Preserve MCP `structuredContent`, extend MCP annotation parsing, and teach the #2710-style mock idempotency-key replay for partial-write retries.
- Cover the behavior in Rust tests, conformance, docs, and a changelog fragment.

Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-2718 cargo check --workspace`
- `CARGO_TARGET_DIR=/tmp/harn-target-2718 cargo test -p harn-vm composition::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-2718 cargo run --quiet --bin harn -- test conformance --filter composition_mcp_code_mode`
- `CARGO_TARGET_DIR=/tmp/harn-target-2718 cargo clippy -p harn-vm -p harn-stdlib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-2718 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-2718 make fmt-harn`
- `make lint-test-patterns`
- pre-commit and pre-push hooks passed

A/B notes
- The deterministic MCP mock uses no LLM calls, so token delta is 0 for both sequential and bounded paths.
- The conformance steel thread verifies a 2-call `map_bounded` run with `succeeded=2`, `failed=0`; Rust coverage verifies 5 child calls under a per-server peak cap of 2, trusted read-only retry count/delay recording, untrusted no-retry behavior, destructive retry only with idempotency key, and invalid `structuredContent` rejection.

Closes #2718