### PR TITLE
Add replay counterfactual chains

### DIFF
--- a/changelog.d/2611.added.md
+++ b/changelog.d/2611.added.md
@@ -1,0 +1,4 @@
+- **Replay counterfactual chains.** `harn replay --counterfactual` can now
+  chain repeated plan files into one cumulative dry-run divergence report,
+  evaluates plans only after the requested replay cutoff is valid, and
+  isolates accidental plan-side filesystem writes from the workspace (#2611).

--- a/crates/harn-cli/src/cli/runs.rs
+++ b/crates/harn-cli/src/cli/runs.rs
@@ -45,13 +45,13 @@ pub(crate) struct ReplayArgs {
     #[arg(long, value_name = "EVENT_ID", requires = "session_id")]
     pub at: Option<u64>,
     /// Counterfactual: after rehydrating the session at `--at` (or its full
-    /// state), evaluate this `.harn` plan and report how the workspace
-    /// *would have* diverged — the set of files the plan's edits would
-    /// touch. The plan runs through `edit.dry_run` against a throw-away
+    /// state), evaluate one or more `.harn` plans and report how the workspace
+    /// *would have* diverged — the set of files the chained edits would
+    /// touch. The plans run through `edit.dry_run` against a throw-away
     /// staged-fs overlay (#1722), so the recorded session and the on-disk
     /// tree are never mutated. Requires `--session-id`.
     #[arg(long, value_name = "PLAN", requires = "session_id")]
-    pub counterfactual: Option<String>,
+    pub counterfactual: Vec<String>,
     /// Number of replay reads to compare for deterministic output.
     #[arg(long, default_value_t = 1)]
     pub runs: usize,

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -1005,6 +1005,27 @@ fn test_parses_replay_sources_and_runs() {
     assert_eq!(replay.session_id.as_deref(), Some("session-123"));
     assert_eq!(replay.events_db.as_deref(), Some(".harn/events.sqlite"));
     assert_eq!(replay.runs, 2);
+    assert!(replay.counterfactual.is_empty());
+
+    let cli = Cli::parse_from([
+        "harn",
+        "replay",
+        "--session-id",
+        "session-123",
+        "--events-db",
+        ".harn/events.sqlite",
+        "--at",
+        "7",
+        "--counterfactual",
+        "first.harn",
+        "--counterfactual",
+        "second.harn",
+    ]);
+    let Command::Replay(replay) = cli.command.unwrap() else {
+        panic!("expected replay command");
+    };
+    assert_eq!(replay.at, Some(7));
+    assert_eq!(replay.counterfactual, vec!["first.harn", "second.harn"]);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/counterfactual.rs
+++ b/crates/harn-cli/src/commands/counterfactual.rs
@@ -1,6 +1,6 @@
 //! `harn replay --counterfactual <plan.harn>` — evaluate an alternate edit
-//! plan against the workspace as it stood at a `--at` cutoff and report the
-//! divergent file set without mutating the recorded session or the disk.
+//! plan after replay rehydrates a `--at` cutoff and report the divergent
+//! file set without mutating the recorded session or the workspace.
 //!
 //! This composes two shipped primitives rather than reimplementing any of
 //! their machinery:
@@ -11,20 +11,20 @@
 //! - **#1722 staged-fs** isolates that dry-run inside a throw-away overlay
 //!   so the on-disk tree is byte-identical before and after the call.
 //!
-//! The CLI's only job here is to (1) evaluate the operator's `plan.harn`
-//! into an edit plan, (2) run it through `edit_dry_run`, and (3) project the
-//! dry-run result down to a *divergence* — the set of files that would
-//! differ from the recorded outcome at the cutoff.
+//! The CLI's only job here is to (1) evaluate the operator's plan file(s)
+//! into an edit plan, (2) run the chained ops through `edit_dry_run`, and
+//! (3) project the dry-run result down to a *divergence* — the set of files
+//! that would differ from the recorded outcome at the cutoff.
 //!
 //! ## Plan contract
 //!
-//! The `plan.harn` program `return`s one of (a bare trailing expression
+//! Each `plan.harn` program `return`s one of (a bare trailing expression
 //! returns `nil` in Harn, so the plan must use `return`):
 //!
 //! - a **list** of edit ops — the `plan` argument to `edit_dry_run`
 //!   (`return [{op: "apply_node", path, query, replacement}, ...]`); the CLI
 //!   calls `edit_dry_run` for you, or
-//! - a **dict** that is already an `edit_dry_run` result (carries
+//! - for a single plan only, a **dict** that is already an `edit_dry_run` result (carries
 //!   `per_file_unified_diff`) — for plans that prefer to call `edit_dry_run`
 //!   themselves and shape the result (`return edit_dry_run({plan: [...]})`).
 //!
@@ -32,6 +32,7 @@
 //! `summary` shape, so the CLI never reimplements diffing.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use serde::Serialize;
 use serde_json::Value as JsonValue;
@@ -57,6 +58,10 @@ pub(crate) struct DivergedFile {
 pub(crate) struct CounterfactualReport {
     /// Absolute or workspace-relative path to the evaluated plan.
     pub plan_path: String,
+    /// Every plan in the counterfactual chain, in evaluation order.
+    pub plan_paths: Vec<String>,
+    /// Number of chained plan files evaluated.
+    pub step_count: u64,
     /// `ok`, `partial`, or `no_ops_applied`, straight from `edit.dry_run`.
     pub result: String,
     /// The divergent file set — every file the plan's edits would touch.
@@ -68,25 +73,98 @@ pub(crate) struct CounterfactualReport {
     pub ops_rejected: u64,
 }
 
-/// Evaluate `plan_path` and return its divergence. `Err` carries a
+#[derive(Debug)]
+enum CounterfactualPlan {
+    EditOps(JsonValue),
+    DryRun(JsonValue),
+}
+
+struct CounterfactualSandbox {
+    session_id: String,
+    root: PathBuf,
+}
+
+impl CounterfactualSandbox {
+    fn enter(root: &Path) -> Result<Self, String> {
+        let session_id = format!("harn-counterfactual-{}", uuid::Uuid::now_v7());
+        harn_hostlib::fs::configure_session_root(&session_id, root);
+        harn_hostlib::fs::set_mode(&session_id, harn_hostlib::fs::FsMode::Staged, Some(root))
+            .map_err(|error| format!("failed to isolate counterfactual filesystem: {error}"))?;
+        Ok(Self {
+            session_id,
+            root: root.to_path_buf(),
+        })
+    }
+}
+
+impl Drop for CounterfactualSandbox {
+    fn drop(&mut self) {
+        let _ = harn_hostlib::fs::discard_staged(&self.session_id, &[]);
+        let _ = harn_hostlib::fs::remove_session_state(&self.session_id, Some(&self.root));
+    }
+}
+
+/// Evaluate `plan_paths` and return their cumulative divergence. `Err` carries a
 /// human-readable message suitable for both the `error.message` JSON field
 /// and the human `error:` line.
-pub(crate) fn evaluate(plan_path: &Path) -> Result<CounterfactualReport, String> {
-    let source = std::fs::read_to_string(plan_path).map_err(|error| {
-        format!(
-            "failed to read counterfactual plan {}: {error}",
-            plan_path.display()
-        )
-    })?;
-    let plan_value = run_plan_source(&source, plan_path)?;
-    let dry_run = ensure_dry_run(plan_value, plan_path)?;
-    project_divergence(&dry_run, plan_path)
+pub(crate) fn evaluate(plan_paths: &[PathBuf]) -> Result<CounterfactualReport, String> {
+    if plan_paths.is_empty() {
+        return Err("at least one --counterfactual plan is required".to_string());
+    }
+
+    let mut chained_ops = Vec::new();
+    let mut single_dry_run = None;
+    for plan_path in plan_paths {
+        let source = std::fs::read_to_string(plan_path).map_err(|error| {
+            format!(
+                "failed to read counterfactual plan {}: {error}",
+                plan_path.display()
+            )
+        })?;
+        match normalize_plan_value(run_plan_source(&source, plan_path)?, plan_path)? {
+            CounterfactualPlan::EditOps(JsonValue::Array(ops)) => chained_ops.extend(ops),
+            CounterfactualPlan::EditOps(other) => {
+                return Err(format!(
+                    "counterfactual plan {} must return a list of edit ops, got {}",
+                    plan_path.display(),
+                    json_type_name(&other)
+                ));
+            }
+            CounterfactualPlan::DryRun(dry_run) if plan_paths.len() == 1 => {
+                single_dry_run = Some(dry_run);
+            }
+            CounterfactualPlan::DryRun(_) => {
+                return Err(format!(
+                    "counterfactual plan {} returned an edit_dry_run result, which cannot be \
+                     chained; return the raw edit-op list instead",
+                    plan_path.display()
+                ));
+            }
+        }
+    }
+
+    let dry_run = match single_dry_run {
+        Some(dry_run) => dry_run,
+        None => run_edit_dry_run(JsonValue::Array(chained_ops), &plan_paths[0])?,
+    };
+    project_divergence(&dry_run, plan_paths)
 }
 
 /// Compile and execute `plan.harn`, returning its final value as JSON. The
 /// VM is wired exactly like `harn run`'s — stdlib plus the default hostlib —
 /// so `edit_dry_run` and the staged-fs overlay it relies on are available.
 fn run_plan_source(source: &str, plan_path: &Path) -> Result<JsonValue, String> {
+    let source = source.to_string();
+    let plan_path = plan_path.to_path_buf();
+    std::thread::Builder::new()
+        .name("harn-counterfactual-plan".to_string())
+        .spawn(move || run_plan_source_inner(&source, &plan_path))
+        .map_err(|error| format!("failed to start counterfactual plan runner: {error}"))?
+        .join()
+        .map_err(|_| "counterfactual plan runner panicked".to_string())?
+}
+
+fn run_plan_source_inner(source: &str, plan_path: &Path) -> Result<JsonValue, String> {
     let mut lexer = Lexer::new(source);
     let tokens = lexer
         .tokenize()
@@ -126,9 +204,16 @@ fn run_plan_source(source: &str, plan_path: &Path) -> Result<JsonValue, String> 
     let store_base = project_root
         .clone()
         .unwrap_or_else(|| source_parent.clone());
+    let overlay = Arc::new(harn_vm::testbench::overlay_fs::OverlayFs::rooted_at(
+        &store_base,
+    ));
 
     let local = tokio::task::LocalSet::new();
     futures::executor::block_on(local.run_until(async move {
+        let _overlay_guard = harn_vm::testbench::overlay_fs::install_overlay(overlay);
+        let sandbox = CounterfactualSandbox::enter(&store_base)?;
+        let _session_guard =
+            harn_vm::agent_sessions::enter_current_session(sandbox.session_id.clone());
         let mut vm = harn_vm::Vm::new();
         harn_vm::register_vm_stdlib(&mut vm);
         crate::install_default_hostlib(&mut vm);
@@ -153,15 +238,16 @@ fn run_plan_source(source: &str, plan_path: &Path) -> Result<JsonValue, String> 
     }))
 }
 
-/// Normalize the plan program's final value into an `edit.dry_run` result.
-/// A list is treated as a raw edit plan and run through `edit_dry_run`; a
-/// dict that already carries `per_file_unified_diff` is used as-is.
-fn ensure_dry_run(value: JsonValue, plan_path: &Path) -> Result<JsonValue, String> {
+/// Normalize the plan program's final value into either raw edit ops or an
+/// already-rendered `edit_dry_run` result.
+fn normalize_plan_value(value: JsonValue, plan_path: &Path) -> Result<CounterfactualPlan, String> {
     match value {
-        JsonValue::Array(_) => run_edit_dry_run(value, plan_path),
-        JsonValue::Object(ref map) if map.contains_key("per_file_unified_diff") => Ok(value),
+        JsonValue::Array(_) => Ok(CounterfactualPlan::EditOps(value)),
+        JsonValue::Object(ref map) if map.contains_key("per_file_unified_diff") => {
+            Ok(CounterfactualPlan::DryRun(value))
+        }
         JsonValue::Object(ref map) if map.contains_key("plan") => {
-            run_edit_dry_run(map["plan"].clone(), plan_path)
+            Ok(CounterfactualPlan::EditOps(map["plan"].clone()))
         }
         other => Err(format!(
             "counterfactual plan {} must `return` an edit-op list or an edit_dry_run result, \
@@ -214,7 +300,7 @@ fn run_edit_dry_run(plan: JsonValue, plan_path: &Path) -> Result<JsonValue, Stri
 /// `deleted`, both → `modified`).
 fn project_divergence(
     dry_run: &JsonValue,
-    plan_path: &Path,
+    plan_paths: &[PathBuf],
 ) -> Result<CounterfactualReport, String> {
     let summary = dry_run.get("summary").cloned().unwrap_or(JsonValue::Null);
     let mut diverged = Vec::new();
@@ -252,8 +338,14 @@ fn project_divergence(
         }
     }
 
+    let plan_path_labels = plan_paths
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
     Ok(CounterfactualReport {
-        plan_path: plan_path.to_string_lossy().into_owned(),
+        plan_path: plan_path_labels.join(" -> "),
+        plan_paths: plan_path_labels,
+        step_count: plan_paths.len() as u64,
         result: dry_run
             .get("result")
             .and_then(JsonValue::as_str)
@@ -326,6 +418,10 @@ mod tests {
         Path::new("/tmp/what-if.harn")
     }
 
+    fn plan_paths() -> Vec<PathBuf> {
+        vec![plan_path().to_path_buf()]
+    }
+
     #[test]
     fn projects_diverged_files_and_classifies_status_by_line_deltas() {
         let dry_run = json!({
@@ -343,8 +439,10 @@ mod tests {
                 "ops_rejected": 0,
             },
         });
-        let report = project_divergence(&dry_run, plan_path()).expect("project");
+        let report = project_divergence(&dry_run, &plan_paths()).expect("project");
         assert_eq!(report.result, "ok");
+        assert_eq!(report.step_count, 1);
+        assert_eq!(report.plan_paths, vec!["/tmp/what-if.harn"]);
         assert_eq!(report.files_touched, 3);
         assert_eq!(report.lines_added, 5);
         assert_eq!(report.lines_removed, 6);
@@ -362,14 +460,14 @@ mod tests {
             "per_file_unified_diff": [],
             "summary": {"files_touched": 0, "lines_added": 0, "lines_removed": 0, "ops_applied": 0, "ops_rejected": 0},
         });
-        let report = project_divergence(&dry_run, plan_path()).expect("project");
+        let report = project_divergence(&dry_run, &plan_paths()).expect("project");
         assert!(report.diverged.is_empty());
         assert_eq!(report.result, "no_ops_applied");
     }
 
     #[test]
-    fn ensure_dry_run_rejects_a_nil_plan_with_a_return_hint() {
-        let error = ensure_dry_run(JsonValue::Null, plan_path()).unwrap_err();
+    fn normalize_plan_value_rejects_a_nil_plan_with_a_return_hint() {
+        let error = normalize_plan_value(JsonValue::Null, plan_path()).unwrap_err();
         assert!(error.contains("got nil"), "error: {error}");
         assert!(
             error.contains("return"),
@@ -378,13 +476,27 @@ mod tests {
     }
 
     #[test]
-    fn ensure_dry_run_passes_through_an_existing_dry_run_result() {
+    fn normalize_plan_value_passes_through_an_existing_dry_run_result() {
         let dry_run = json!({
             "result": "ok",
             "per_file_unified_diff": [{"path": "x.rs", "diff": "...", "lines_added": 1, "lines_removed": 0}],
             "summary": {"files_touched": 1},
         });
-        let passed = ensure_dry_run(dry_run.clone(), plan_path()).expect("passthrough");
-        assert_eq!(passed, dry_run);
+        let passed = normalize_plan_value(dry_run.clone(), plan_path()).expect("passthrough");
+        match passed {
+            CounterfactualPlan::DryRun(value) => assert_eq!(value, dry_run),
+            CounterfactualPlan::EditOps(_) => panic!("expected dry-run result"),
+        }
+    }
+
+    #[test]
+    fn normalize_plan_value_reads_plan_field_as_raw_edit_ops() {
+        let value = normalize_plan_value(json!({"plan": [{"op": "safe_text_patch"}]}), plan_path())
+            .expect("normalize");
+        match value {
+            CounterfactualPlan::EditOps(JsonValue::Array(ops)) => assert_eq!(ops.len(), 1),
+            CounterfactualPlan::EditOps(other) => panic!("expected list, got {other:?}"),
+            CounterfactualPlan::DryRun(_) => panic!("expected raw edit ops"),
+        }
     }
 }

--- a/crates/harn-cli/src/commands/replay.rs
+++ b/crates/harn-cli/src/commands/replay.rs
@@ -120,9 +120,9 @@ enum ReplaySource {
         /// at` are rehydrated, replaying the session as it stood at that
         /// point. `None` replays the whole session.
         at: Option<u64>,
-        /// Counterfactual: path to a `.harn` edit plan to evaluate against
+        /// Counterfactual: paths to `.harn` edit plans to evaluate against
         /// the workspace state at the cutoff. `None` for a plain replay.
-        counterfactual: Option<PathBuf>,
+        counterfactual: Vec<PathBuf>,
     },
 }
 
@@ -173,15 +173,12 @@ impl ReplaySource {
         }
     }
 
-    /// Path to the counterfactual `.harn` plan, when `--counterfactual` was
-    /// passed (Session sources only).
-    fn counterfactual_plan(&self) -> Option<&Path> {
+    /// Paths to the counterfactual `.harn` plans, when `--counterfactual`
+    /// was passed (Session sources only).
+    fn counterfactual_plans(&self) -> &[PathBuf] {
         match self {
-            Self::Session {
-                counterfactual: Some(path),
-                ..
-            } => Some(path.as_path()),
-            _ => None,
+            Self::Session { counterfactual, .. } => counterfactual,
+            _ => &[],
         }
     }
 }
@@ -208,40 +205,25 @@ pub(crate) fn run(args: ReplayArgs) -> i32 {
         }
     };
 
-    // The counterfactual is composed *after* the recorded replay is
-    // reconstructed at the `--at` cutoff: the recorded path defines the
-    // baseline, and the plan's dry-run divergence is reported against it.
-    let counterfactual = match source.counterfactual_plan() {
-        Some(plan_path) => match crate::commands::counterfactual::evaluate(plan_path) {
-            Ok(report) => Some(report),
-            Err(error) => {
-                if args.json {
-                    print_json_error("replay_counterfactual_failed", error);
-                } else {
-                    eprintln!("error: {error}");
-                }
-                return 1;
-            }
-        },
-        None => None,
-    };
-
     if args.json {
-        run_json(source, args.runs, counterfactual)
+        run_json(source, args.runs)
     } else {
-        run_human(source, args.runs, counterfactual)
+        run_human(source, args.runs)
     }
 }
 
-fn run_json(
-    source: ReplaySource,
-    runs: usize,
-    counterfactual: Option<crate::commands::counterfactual::CounterfactualReport>,
-) -> i32 {
+fn run_json(source: ReplaySource, runs: usize) -> i32 {
     let mut executions = match execute_runs(&source, runs) {
         Ok(executions) => executions,
         Err(error) => {
             print_json_error(source.load_error_code(), error);
+            return 1;
+        }
+    };
+    let counterfactual = match evaluate_counterfactual(&source) {
+        Ok(report) => report,
+        Err(error) => {
+            print_json_error("replay_counterfactual_failed", error);
             return 1;
         }
     };
@@ -309,13 +291,16 @@ fn run_json(
     exit
 }
 
-fn run_human(
-    source: ReplaySource,
-    runs: usize,
-    counterfactual: Option<crate::commands::counterfactual::CounterfactualReport>,
-) -> i32 {
+fn run_human(source: ReplaySource, runs: usize) -> i32 {
     let executions = match execute_runs(&source, runs) {
         Ok(executions) => executions,
+        Err(error) => {
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    let counterfactual = match evaluate_counterfactual(&source) {
+        Ok(report) => report,
         Err(error) => {
             eprintln!("error: {error}");
             return 1;
@@ -351,6 +336,16 @@ fn run_human(
     i32::from(!executions[0].report.fixture.pass)
 }
 
+fn evaluate_counterfactual(
+    source: &ReplaySource,
+) -> Result<Option<crate::commands::counterfactual::CounterfactualReport>, String> {
+    let plan_paths = source.counterfactual_plans();
+    if plan_paths.is_empty() {
+        return Ok(None);
+    }
+    crate::commands::counterfactual::evaluate(plan_paths).map(Some)
+}
+
 fn resolve_source(args: &ReplayArgs) -> Result<ReplaySource, String> {
     if let Some(session_id) = &args.session_id {
         let events_db = args
@@ -361,7 +356,7 @@ fn resolve_source(args: &ReplayArgs) -> Result<ReplaySource, String> {
             session_id: session_id.clone(),
             events_db: PathBuf::from(events_db),
             at: args.at,
-            counterfactual: args.counterfactual.as_ref().map(PathBuf::from),
+            counterfactual: args.counterfactual.iter().map(PathBuf::from).collect(),
         });
     }
     if let Some(fixture) = &args.fixture {

--- a/crates/harn-cli/tests/replay_session_cli.rs
+++ b/crates/harn-cli/tests/replay_session_cli.rs
@@ -416,6 +416,142 @@ return edit_dry_run({{plan: [
 }
 
 #[test]
+fn replay_counterfactual_chains_plans_cumulatively() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-counterfactual-chain";
+    seed_session_db(&db, session_id);
+
+    let target = temp.path().join("chain.txt");
+    let original = "alpha\n";
+    std::fs::write(&target, original).expect("write target file");
+
+    let first = temp.path().join("first.harn");
+    std::fs::write(
+        &first,
+        format!(
+            r#"return [
+  {{op: "safe_text_patch", path: "{}", old_text: "alpha", new_text: "beta"}},
+]
+"#,
+            target.to_str().unwrap(),
+        ),
+    )
+    .expect("write first plan");
+    let second = temp.path().join("second.harn");
+    std::fs::write(
+        &second,
+        format!(
+            r#"return [
+  {{op: "safe_text_patch", path: "{}", old_text: "beta", new_text: "gamma"}},
+]
+"#,
+            target.to_str().unwrap(),
+        ),
+    )
+    .expect("write second plan");
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--counterfactual",
+            first.to_str().unwrap(),
+            "--counterfactual",
+            second.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --counterfactual chain");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = stdout_json(&out);
+    let counterfactual = &parsed["data"]["counterfactual"];
+    assert_eq!(counterfactual["result"], "ok");
+    assert_eq!(counterfactual["step_count"], 2);
+    assert_eq!(counterfactual["ops_applied"], 2);
+    assert_eq!(counterfactual["files_touched"], 1);
+    assert_eq!(
+        counterfactual["plan_paths"].as_array().unwrap().len(),
+        2,
+        "plan paths should preserve chain order"
+    );
+    let diverged = counterfactual["diverged"].as_array().unwrap();
+    assert_eq!(diverged.len(), 1);
+    assert_eq!(diverged[0]["status"], "modified");
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), original);
+}
+
+#[test]
+fn replay_counterfactual_plan_side_effects_are_isolated() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-counterfactual-isolated";
+    seed_session_db(&db, session_id);
+
+    let target = temp.path().join("isolated.txt");
+    let original = "safe\n";
+    std::fs::write(&target, original).expect("write target file");
+
+    let plan = temp.path().join("plan.harn");
+    std::fs::write(
+        &plan,
+        format!(
+            r#"write_file("{}", "mutated before return\n")
+return [
+  {{op: "safe_text_patch", path: "{}", old_text: "safe", new_text: "preview"}},
+]
+"#,
+            target.to_str().unwrap(),
+            target.to_str().unwrap(),
+        ),
+    )
+    .expect("write plan");
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--counterfactual",
+            plan.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --counterfactual isolated");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = stdout_json(&out);
+    assert_eq!(parsed["data"]["counterfactual"]["result"], "ok");
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), original);
+    let state_dir = temp.path().join(".harn").join("state").join("staged");
+    if state_dir.exists() {
+        let leaked_counterfactual_sessions = std::fs::read_dir(&state_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("harn-counterfactual-")
+            })
+            .count();
+        assert_eq!(leaked_counterfactual_sessions, 0);
+    }
+}
+
+#[test]
 fn replay_counterfactual_rejects_missing_plan() {
     let temp = tempfile::TempDir::new().expect("tempdir");
     let db = temp.path().join("events.sqlite");
@@ -439,6 +575,37 @@ fn replay_counterfactual_rejects_missing_plan() {
     let parsed = stdout_json(&out);
     assert_eq!(parsed["ok"], false);
     assert_eq!(parsed["error"]["code"], "replay_counterfactual_failed");
+}
+
+#[test]
+fn replay_counterfactual_does_not_evaluate_when_cutoff_is_invalid() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let db = temp.path().join("events.sqlite");
+    let session_id = "session-counterfactual-bad-cutoff";
+    seed_session_db(&db, session_id);
+
+    let out = Command::new(binary_path())
+        .args([
+            "replay",
+            "--session-id",
+            session_id,
+            "--events-db",
+            db.to_str().unwrap(),
+            "--at",
+            "0",
+            "--counterfactual",
+            temp.path().join("does-not-exist.harn").to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn harn replay --counterfactual invalid cutoff");
+    assert!(!out.status.success(), "expected invalid cutoff to fail");
+    let parsed = stdout_json(&out);
+    assert_eq!(parsed["error"]["code"], "replay_load_failed");
+    assert!(parsed["error"]["message"]
+        .as_str()
+        .unwrap_or("")
+        .contains("event id 0"));
 }
 
 #[test]

--- a/crates/harn-hostlib/src/ast/dry_run.rs
+++ b/crates/harn-hostlib/src/ast/dry_run.rs
@@ -131,8 +131,10 @@ pub(super) fn run_with_code_index(
         });
     }
 
-    // Always discard the transient session so nothing leaks to disk.
+    // Always discard and remove the transient session so no staged-fs metadata
+    // remains after a preview.
     let _ = crate::fs::discard_staged(&session_id, &[]);
+    let _ = crate::fs::remove_session_state(&session_id, None);
 
     let result_kind = if applied_count == 0 {
         "no_ops_applied"

--- a/crates/harn-hostlib/src/fs.rs
+++ b/crates/harn-hostlib/src/fs.rs
@@ -396,6 +396,37 @@ pub fn discard_staged(session_id: &str, paths: &[String]) -> Result<DiscardResul
     Ok(DiscardResult { discarded_paths })
 }
 
+/// Remove all persisted staged-fs state for a caller-owned throw-away session.
+///
+/// Normal agent sessions keep their manifest after `discard_staged` so hosts can
+/// continue reporting session state. Transient dry-run sessions own their ids,
+/// though, and should remove both the in-memory entry and on-disk overlay after
+/// their preview is rendered.
+pub fn remove_session_state(session_id: &str, root: Option<&Path>) -> Result<(), HostlibError> {
+    validate_session_id(DISCARD_BUILTIN, session_id)?;
+    let mut guard = sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned");
+    let state = match guard.remove(session_id) {
+        Some(state) => state,
+        None => load_state(session_id, root.map(normalize_logical)).map_err(|err| {
+            HostlibError::Backend {
+                builtin: DISCARD_BUILTIN,
+                message: err,
+            }
+        })?,
+    };
+    let dir = session_dir(&state.root, &state.session_id);
+    match stdfs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(HostlibError::Backend {
+            builtin: DISCARD_BUILTIN,
+            message: format!("remove staged session {}: {err}", dir.display()),
+        }),
+    }
+}
+
 pub(crate) fn read(
     path: &Path,
     explicit_session_id: Option<&str>,

--- a/crates/harn-hostlib/tests/fs_staging.rs
+++ b/crates/harn-hostlib/tests/fs_staging.rs
@@ -6,8 +6,9 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use harn_hostlib::fs::{self as host_fs, FsCapability, FsMode};
 use harn_hostlib::tools::permissions;
-use harn_hostlib::{fs::FsCapability, tools::ToolsCapability, BuiltinRegistry, HostlibCapability};
+use harn_hostlib::{tools::ToolsCapability, BuiltinRegistry, HostlibCapability};
 use harn_vm::VmValue;
 use tempfile::TempDir;
 
@@ -104,6 +105,46 @@ fn staged_write_is_read_through_until_commit() {
     };
     assert_eq!(committed.len(), 1);
     assert_eq!(fs::read_to_string(&file).unwrap(), "draft");
+}
+
+#[test]
+fn remove_session_state_deletes_transient_overlay_artifacts() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("transient.txt");
+    let session = unique_session("transient-cleanup");
+    let reg = registry();
+
+    host_fs::set_mode(&session, FsMode::Staged, Some(dir.path())).unwrap();
+    let write = reg.find("hostlib_tools_write_file").unwrap();
+    (write.handler)(&dict_arg(&[
+        ("session_id", vm_string(&session)),
+        ("path", vm_string(&path_str(&file))),
+        ("content", vm_string("preview")),
+    ]))
+    .unwrap();
+
+    let session_dir = dir
+        .path()
+        .join(".harn")
+        .join("state")
+        .join("staged")
+        .join(&session);
+    assert!(
+        session_dir.join("manifest.json").exists(),
+        "staged mode should persist preview metadata before cleanup"
+    );
+
+    host_fs::discard_staged(&session, &[]).unwrap();
+    host_fs::remove_session_state(&session, Some(dir.path())).unwrap();
+
+    assert!(
+        !session_dir.exists(),
+        "transient cleanup should remove the staged-fs session directory"
+    );
+    assert!(
+        !file.exists(),
+        "transient staged writes must never reach the working tree"
+    );
 }
 
 #[test]

--- a/docs/src/cli-json-contract.md
+++ b/docs/src/cli-json-contract.md
@@ -173,12 +173,14 @@ allowlist-stripped replay comparison. `ok: false` with `error.code:
 material diverged after applying the replay allowlist.
 
 `harn replay --session-id <id> --counterfactual <plan.harn>` evaluates an
-alternate edit plan through `edit.dry_run` against the workspace state at
-the `--at` cutoff and attaches the divergence to the single `ReplayReport`
-under `data.counterfactual`: `{ plan_path, result, diverged: [{ path,
-status, lines_added, lines_removed }], files_touched, lines_added,
-lines_removed, ops_applied, ops_rejected }`. The field is omitted for a
-plain replay. A plan that fails to load or evaluate exits non-zero with
+alternate edit plan after the replay source has been rehydrated at the
+`--at` cutoff and attaches the divergence to the single `ReplayReport`
+under `data.counterfactual`: `{ plan_path, plan_paths, step_count, result,
+diverged: [{ path, status, lines_added, lines_removed }], files_touched,
+lines_added, lines_removed, ops_applied, ops_rejected }`. Repeat
+`--counterfactual` to chain plans; the returned edit-op lists are
+concatenated into one cumulative `edit.dry_run`. The field is omitted for
+a plain replay. A plan that fails to load or evaluate exits non-zero with
 `error.code: "replay_counterfactual_failed"`.
 
 ### `harn run --emit-summary-json`

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1458,6 +1458,7 @@ fixture, or an agent session stored in the SQLite EventLog.
 harn replay .harn-runs/<run>.json
 harn replay --fixture conformance/replay-oracle/fixtures/simple_trigger_local_handler.valid.json --runs 3 --json
 harn replay --session-id <id> --events-db .harn/events.sqlite --runs 3 --json
+harn replay --session-id <id> --events-db .harn/events.sqlite --at 7 --counterfactual ./what-if.harn --json
 ```
 
 `--session-id` reads the `observability.agent_events.<sanitized-id>` topic
@@ -1465,6 +1466,9 @@ from `--events-db` in append order, reconstructs a replayable run record,
 and feeds it through the same replay summary path as run-record input.
 When `--runs N` is greater than one, JSON output includes per-run reports
 plus an allowlist-normalized determinism summary.
+`--at <event-id>` rehydrates the session prefix through the inclusive
+event id. Repeat `--counterfactual <plan.harn>` to chain returned edit-op
+lists into one cumulative dry-run divergence report.
 
 ## harn eval
 

--- a/docs/src/cookbooks/replay-time-travel.md
+++ b/docs/src/cookbooks/replay-time-travel.md
@@ -59,9 +59,9 @@ against the full run.
 Rewinding shows you the state the agent saw. The next question is
 *"what if it had edited differently?"* — answer it without mutating the
 recorded session or the workspace. `--counterfactual <plan.harn>`
-evaluates an alternate edit plan against the workspace as it stood at the
-`--at` cutoff and reports the **divergent file set**: the files the plan's
-edits would touch.
+evaluates an alternate edit plan after the session has been rehydrated at
+the `--at` cutoff and reports the **divergent file set**: the files the
+plan's edits would touch.
 
 ```bash
 harn replay --session-id sess_42 --events-db ./.harn/agent-events.db \
@@ -92,13 +92,16 @@ return [
 ]
 ```
 
-(A plan that prefers to call `edit_dry_run` itself works too —
+(A single plan that prefers to call `edit_dry_run` itself works too —
 `return edit_dry_run({plan: [...]})` — the divergence is read off the same
-`per_file_unified_diff` / `summary` shape either way.)
+`per_file_unified_diff` / `summary` shape.)
 
-The plan runs through `edit.dry_run`, which opens and immediately discards
-a throw-away **staged-fs** overlay, so the on-disk tree is byte-identical
-before and after. The human output lists the divergent files:
+The plan runner installs a copy-on-write filesystem overlay while it
+evaluates the `.harn` file, then runs the returned ops through
+`edit.dry_run`, which opens and immediately discards a throw-away
+**staged-fs** overlay. Accidental `write_file(...)` / hostlib writes in the
+plan program do not touch the working tree. The human output lists the
+divergent files:
 
 ```text
 Time-travelled to event 7: replaying the session as it stood at that point.
@@ -117,6 +120,8 @@ In `--json` mode the divergence rides on the replay report under
   "data": {
     "counterfactual": {
       "plan_path": "./what-if.harn",
+      "plan_paths": ["./what-if.harn"],
+      "step_count": 1,
       "result": "ok",
       "diverged": [
         { "path": "src/lib.rs", "status": "modified", "lines_added": 2, "lines_removed": 2 }
@@ -132,10 +137,20 @@ In `--json` mode the divergence rides on the replay report under
 ```
 
 Each file's `status` is `created`, `modified`, or `deleted`, classified
-from its line deltas. **Counterfactual chains** are just a longer plan:
-list every op across the steps you want to compare, and the shared staged
-overlay collapses their cumulative effect into one diff per file — so the
-divergence already reflects the chained edits, not each step in isolation.
+from its line deltas.
+
+**Counterfactual chains** can be one longer plan or repeated
+`--counterfactual` flags. Repeated flags are evaluated in order and their
+returned edit-op lists are concatenated into one `edit_dry_run`, so the
+shared staged overlay collapses the cumulative effect into one diff per
+file:
+
+```bash
+harn replay --session-id sess_42 --events-db ./.harn/agent-events.db \
+  --at 7 \
+  --counterfactual ./rename.harn \
+  --counterfactual ./follow-up.harn
+```
 
 ## Audit a past run, ask what-if, ship the fix
 


### PR DESCRIPTION
## Summary

- Make `harn replay --counterfactual` repeatable so multiple plan files are evaluated in order and their raw edit-op lists are collapsed into one cumulative dry-run divergence report.
- Evaluate counterfactual plans only after session replay and `--at` cutoff validation, and isolate plan-side filesystem writes behind the VM overlay plus staged-fs cleanup.
- Document the JSON fields and cookbook workflow, and add the changelog fragment for #2611.

## Tests

- `cargo test -p harn-cli --test replay_session_cli replay_counterfactual -- --nocapture`
- `cargo test -p harn-cli counterfactual -- --nocapture`
- `cargo test -p harn-cli cli::tests::test_parses_replay_sources_and_runs -- --nocapture`
- `cargo test -p harn-hostlib remove_session_state_deletes_transient_overlay_artifacts -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `make lint-test-patterns`
- `make check-docs-snippets`
- Commit hook: Rust format, changed-package clippy, markdownlint
- Push hook: targeted local checks, markdownlint

Closes #2611.