### PR TITLE
[codex] Require tag-first Harn releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,13 +11,12 @@ name: Publish release
 #      The tag push (under the harn-release-bot App identity) also
 #      cascades to build-release-binaries.yml for tarballs + container.
 #
-#   2. push to main — legacy/recovery drift path. If Cargo.toml's
-#      workspace version is ahead of the latest `vX.Y.Z` tag the
-#      workflow tags HEAD and publishes from there. Under the new
-#      tag-first flow this trigger usually no-ops (the tag was pushed
-#      pre-merge so post-merge main's Cargo.toml already matches the
-#      tag); it remains as the safety net for releases authored without
-#      release_harn.harn (or for an old client that doesn't push tags).
+#   2. push to main — no-op/self-heal only. A release whose Cargo.toml
+#      version is ahead of the latest `vX.Y.Z` tag must already have a
+#      matching `vX.Y.Z` tag at the bumping commit. If not, this
+#      workflow fails loudly instead of tagging main HEAD. That makes
+#      tag-first publishing mandatory: concurrent merge-queue entries
+#      cannot leak into the published artifact.
 #
 #   3. workflow_dispatch — manual recovery for the partial-failure case
 #      (tag pushed but crates.io publish was incomplete). With no
@@ -124,10 +123,33 @@ jobs:
           CARGO_VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
           LATEST_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)"
           LATEST_VERSION="${LATEST_TAG#v}"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          MATCHING_TAG="v$CARGO_VERSION"
+          MAIN_DRIFT_PUBLISH_REF=""
           version_gt() {
             local left="$1"
             local right="$2"
             [[ "$left" != "$right" ]] && [[ "$(printf '%s\n%s\n' "$right" "$left" | sort -V | tail -n 1)" == "$left" ]]
+          }
+          resolve_tag_commit() {
+            git rev-list -n 1 "$1" 2>/dev/null || true
+          }
+          require_tag_first_main_publish() {
+            if [[ "$EVENT_NAME" != "push" || "$REF_TYPE" != "branch" || "$REF_NAME" != "main" ]]; then
+              return 0
+            fi
+            local matching_tag_commit
+            matching_tag_commit="$(resolve_tag_commit "$MATCHING_TAG")"
+            if [[ -z "$matching_tag_commit" ]]; then
+              echo "::error::Cargo.toml=$CARGO_VERSION is ahead of latest tag ${LATEST_TAG:-<none>}, but $MATCHING_TAG does not exist. Push $MATCHING_TAG at the release commit before merging; publish-release.yml will not tag main HEAD."
+              exit 1
+            fi
+            if [[ "$matching_tag_commit" != "$HEAD_SHA" ]]; then
+              echo "::error::$MATCHING_TAG points at $matching_tag_commit, but main push is $HEAD_SHA. Refusing to publish from main HEAD; re-run the tag-first release flow from the intended commit."
+              exit 1
+            fi
+            MAIN_DRIFT_PUBLISH_REF="$MATCHING_TAG"
+            echo "::notice::$MATCHING_TAG already points at this main commit; any publish recovery will use the tag, not main HEAD."
           }
 
           # Tag-push trigger ("tag is truth"). The release harness pushed
@@ -152,9 +174,11 @@ jobs:
           fi
 
           if [[ -z "$LATEST_TAG" ]]; then
+            require_tag_first_main_publish
             DRIFT=true
             echo "::notice::No vX.Y.Z tags exist yet; treating Cargo.toml=$CARGO_VERSION as drift (first release)."
           elif version_gt "$CARGO_VERSION" "$LATEST_VERSION"; then
+            require_tag_first_main_publish
             DRIFT=true
             echo "::notice::Cargo.toml=$CARGO_VERSION ahead of latest tag $LATEST_TAG → finalize needed."
           elif [[ "$CARGO_VERSION" != "$LATEST_VERSION" ]]; then
@@ -187,6 +211,10 @@ jobs:
             fi
           fi
           PUBLISH_REF=main
+          if [[ -n "$MAIN_DRIFT_PUBLISH_REF" ]]; then
+            PUBLISH_REF="$MAIN_DRIFT_PUBLISH_REF"
+            echo "::notice::Tag-first main-push recovery: publishing from $PUBLISH_REF instead of main."
+          fi
           if [[ "$EVENT_NAME" == "workflow_dispatch" && "$DRIFT" == "false" && -n "$LATEST_TAG" ]]; then
             PUBLISH_REF="$LATEST_TAG"
             echo "::notice::Manual recovery has no tag drift; publishing from existing tag $LATEST_TAG instead of current main."

--- a/changelog.d/tag-first-release-guard.fixed.md
+++ b/changelog.d/tag-first-release-guard.fixed.md
@@ -1,0 +1,4 @@
+- **Release publishing now fails closed without a pre-pushed tag.** The
+  push-to-main release workflow refuses to tag main HEAD when Cargo.toml is
+  ahead of the latest release tag, and `release_ship.sh --prepare` now routes
+  through the tag-first release harness.

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -59,7 +59,7 @@ log_step() {
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/release_ship.sh --prepare --bump patch|minor|major [--skip-audit] [--skip-dry-run]
+  ./scripts/release_ship.sh --prepare --bump patch|minor|major [--skip-audit] [--skip-dry-run]  # release_harn.harn only
   ./scripts/release_ship.sh --bump patch|minor|major [--skip-dry-run] [--base main]   # recovery
   ./scripts/release_ship.sh --finalize [--skip-dry-run] [--reaudit] [--notes-output path] [--skip-github-release] [--base main]
 
@@ -80,11 +80,11 @@ DEFAULT FLOW (one human PR, then bot finalizes)
   3. Run prepare-here, which audits, dry-run-publishes, bumps
      Cargo.toml/Cargo.lock, regenerates derived files, and stages
      everything ready for a single commit:
-       ./scripts/release_ship.sh --prepare --bump patch
+       harn run --no-sandbox ~/projects/harn-bump-fleet/release_harn.harn -- --mode ship-pr --agent --yes-live-release
 
-  4. Commit + push + tag + push tag + open PR. The release_harn.harn
-     harness orchestrates these in order so the tag is on origin BEFORE
-     the PR is opened:
+  4. The release_harn.harn harness commits, pushes, tags, pushes the tag,
+     and opens the PR in that order so the tag is on origin BEFORE the PR
+     is opened:
        git commit -m "Release vX.Y.Z"
        git push -u origin release/vX.Y.Z
        git tag -a vX.Y.Z -m "Release vX.Y.Z"
@@ -103,6 +103,9 @@ DEFAULT FLOW (one human PR, then bot finalizes)
 PREPARE MODE
 ==============================================================================
 
+  - Implementation detail used by release_harn.harn. Standalone prepare is
+    rejected because the tag must be pushed before the Release PR enters the
+    merge queue.
   - Runs from a non-main branch with the release content already authored.
   - Detects bump type via --bump and confirms it matches the CHANGELOG
     top entry (CHANGELOG must be at the next vX.Y.Z heading already).
@@ -181,6 +184,10 @@ ENVIRONMENT VARIABLES
     Force --finalize to re-run the full release-gate audit. Defaults
     off — merge-queue CI already proved the same gates a few minutes
     ago. Use when finalizing locally after edits.
+
+  HARN_RELEASE_HARNESS=1
+    Required for --prepare. Set by harn-bump-fleet/release_harn.harn after
+    it pins the release commit and before it pushes the vX.Y.Z tag.
 EOF
 }
 
@@ -322,6 +329,16 @@ require_release_branch() {
     echo "hint: git checkout -b release/vX.Y.Z"
     exit 1
   fi
+}
+
+require_release_harness_prepare() {
+  if [[ "${HARN_RELEASE_HARNESS:-0}" == "1" ]]; then
+    return 0
+  fi
+  echo "error: release_ship.sh --prepare is only supported through release_harn.harn"
+  echo "hint: run: harn run --no-sandbox ~/projects/harn-bump-fleet/release_harn.harn -- --mode ship-pr --agent --yes-live-release"
+  echo "hint: tag-first is mandatory; standalone prepare can open a racy Release PR without a pre-pushed tag"
+  exit 1
 }
 
 # Verify the top CHANGELOG.md heading matches the expected next version.
@@ -661,6 +678,7 @@ esac
 #   bump-pr:      clean main, opens recovery release branch
 #   finalize:     clean main with Cargo.toml ahead of latest tag
 if [[ "$MODE" == "prepare-here" ]]; then
+  require_release_harness_prepare
   require_release_branch "$BASE_BRANCH"
 elif [[ "$MODE" == "finalize" ]]; then
   require_clean_tree


### PR DESCRIPTION
## Summary
- make push-to-main release publishing fail closed when Cargo.toml is ahead without a matching tag at the bumping commit
- publish main-push recovery from the matching tag instead of main HEAD
- require release_ship.sh --prepare to run through release_harn.harn so the tag-first harness owns the race-prone path

## Verification
- make lint-actions
- bash -n scripts/release_ship.sh
- bash scripts/release_ship.sh --prepare --bump patch (expected fail-fast guard)
