### PR TITLE
Polish harnlang docs navigation and quickstarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
           make check-provider-support
           make check-connector-matrix
           make check-trigger-examples
+          make check-docs-model-refs
           make check-docs-snippets
           make check-diagnostics-catalog
 
@@ -478,7 +479,7 @@ jobs:
           BEFORE="${{ github.event.before }}"
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$BEFORE" HEAD | grep -q '^docs/'; then
+          elif git diff --name-only "$BEFORE" HEAD | grep -Eq '^(docs/|scripts/build_docs_site\.sh$)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift portal-check
 
 check: all
 
@@ -462,6 +462,10 @@ check-trigger-examples:
 		cargo run --quiet --bin harn -- check "$$dir/lib.harn"; \
 	done
 	@echo "    Trigger examples OK."
+
+check-docs-model-refs:
+	@echo "=== Checking docs model references track provider aliases ==="
+	@./scripts/check_docs_model_refs.sh
 
 # Regenerate the diagnostic-code catalog (markdown page + JSON sidecar)
 # from the in-binary registry in crates/harn-parser/src/diagnostic_codes.rs.

--- a/changelog.d/2749.changed.md
+++ b/changelog.d/2749.changed.md
@@ -1,0 +1,6 @@
+- **Harnlang documentation navigation and first-run guidance.** The mdBook docs
+  now add a top-level section nav, narrow the sidebar to the active
+  documentation mode, clarify LLM provider/model resolution and remote MCP
+  login, stop suggesting Notion MCP OAuth scopes, and publish raw Markdown
+  companions for docs pages during the docs build. CI now also fails when
+  hand-written Sonnet examples drift from the live provider catalog alias.

--- a/crates/harn-vm/src/mcp_presets.rs
+++ b/crates/harn-vm/src/mcp_presets.rs
@@ -165,7 +165,7 @@ const PRESETS: &[McpPreset] = &[
         args: &[],
         url: "https://mcp.notion.com/mcp",
         auth_kind: PresetAuthKind::Oauth,
-        oauth_scopes: Some("read write"),
+        oauth_scopes: None,
         placeholders: NOTION_PLACEHOLDERS,
     },
     McpPreset {
@@ -312,6 +312,10 @@ mod tests {
         assert_eq!(
             notion["url"],
             serde_json::json!("https://mcp.notion.com/mcp")
+        );
+        assert!(
+            notion.get("oauthScopes").is_none(),
+            "Notion MCP does not currently expose configurable OAuth scopes"
         );
     }
 }

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -18,14 +18,12 @@ preferred-dark-theme = "ayu"
 # `harn dump-highlight-keywords` (make gen-highlight); harn-hljs.js
 # consumes it and registers the language with the bundled highlight.js.
 # Order matters — the keyword file must load before the language module.
-additional-js = ["theme/harn-keywords.js", "theme/harn-hljs.js"]
+additional-js = ["theme/harn-keywords.js", "theme/harn-hljs.js", "theme/harn-docs-nav.js"]
 additional-css = ["theme/css/harn-theme.css"]
 
 [output.html.redirect]
 "/docs/prompt-templating/index.html" = "https://harnlang.com/prompt-templating.html"
 "/docs/prompt-templating.html" = "https://harnlang.com/prompt-templating.html"
-"/docs/llm/harn-quickref.md" = "https://harnlang.com/docs/llm/harn-quickref.html"
-"/docs/llm/harn-triggers-quickref.md" = "https://harnlang.com/docs/llm/harn-triggers-quickref.html"
 "/typed-tools.html" = "https://harnlang.com/llm/tools.html"
 "/docs/typed-tools.html" = "https://harnlang.com/llm/tools.html"
 "/providers.html" = "https://harnlang.com/llm/providers.html"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -106,11 +106,11 @@
 - [Context maintenance hooks](./context-maintenance-hooks.md)
 - [Skills](./skills.md)
 - [Personas](./personas.md)
-  - [Persona Prelude](./personas/prelude.md)
+  - [Persona prelude](./personas/prelude.md)
   - [Per-stage tool scoping](./personas/stages.md)
   - [Handoff policy overrides](./personas/handoff.md)
   - [Profile bulletins](./personas/profile-bulletins.md)
-  - [Merge Captain](./personas/merge-captain.md)
+  - [Merge captain](./personas/merge-captain.md)
 - [Skill provenance](./skill-provenance.md)
 - [Sessions](./sessions.md)
 - [Workspace anchor cache contract](./agents/cache_contract.md)
@@ -143,8 +143,8 @@
 - [Harn ACP/MCP extensions v1](./spec/harn-extensions/v1.md)
 - [MCP Apps UI resources](./interop/ui-resource.md)
 - [Agents Protocol v1](./spec/agents-protocol/v1.md)
-- [Agents Protocol Receipt Format](./spec/agents-protocol/receipt-format-v1.md)
-- [Agents Protocol Replay Contract](./spec/agents-protocol/replay-v1.md)
+- [Agents Protocol receipt format](./spec/agents-protocol/receipt-format-v1.md)
+- [Agents Protocol replay contract](./spec/agents-protocol/replay-v1.md)
 
 ## Orchestration
 
@@ -180,10 +180,10 @@
 - [Connector testkit](./connectors/testkit.md)
 - [Triage inbox envelopes](./connectors/triage-inbox.md)
 - [Cron connector](./connectors/cron.md)
-- [GitHub App connector](./connectors/github.md)
+- [GitHub app connector](./connectors/github.md)
 - [Linear connector](./connectors/linear.md)
 - [Notion connector](./connectors/notion.md)
-- [Slack Events connector](./connectors/slack-events.md)
+- [Slack events connector](./connectors/slack-events.md)
 - [Generic webhook connector](./connectors/webhook.md)
 - [A2A push connector](./connectors/a2a-push.md)
 

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1872,7 +1872,7 @@ chat_endpoint = "/v1/chat/completions"
 completion_endpoint = "/v1/completions"
 
 [llm.aliases]
-sonnet = { id = "claude-sonnet-4-20250514", provider = "anthropic" }
+sonnet = { id = "claude-sonnet-4-6", provider = "anthropic" }
 
 [[llm.inference_rules]]
 pattern = "claude-*"

--- a/docs/src/concepts/glossary.md
+++ b/docs/src/concepts/glossary.md
@@ -46,6 +46,16 @@ terminal conditions.
 
 ## Containers and graphs
 
+**VM (virtual machine).** The Harn interpreter state for one running script or
+child task. Most user-facing docs say "interpreter instance" or "child task";
+runtime and ADR pages often use VM because they describe implementation
+boundaries.
+
+**Child VM.** The isolated interpreter instance created for a `spawn` or
+`parallel` child task. Captured values are copied into it. Explicit shared
+handles such as channels, shared cells/maps, mailboxes, and sync permits are
+the way child tasks coordinate with siblings or the parent.
+
 **Stage.** One node in a workflow graph. Kinds: `stage`, `verify`, `join`,
 `condition`, `fork`, `map`, `reduce`, `subagent`, `escalation`.
 

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -1,6 +1,21 @@
 # Concurrency
 
-Harn has built-in concurrency primitives that don't require callbacks, promises, or async/await boilerplate.
+Harn concurrency is structured around child tasks. A child task runs the block
+you give to `spawn` or `parallel` in its own interpreter instance, while the
+parent keeps a handle, result list, stream, or settlement record that joins the
+work back together.
+
+The practical model is:
+
+- normal values are copied into the child task when it starts
+- channels, shared cells/maps, mailboxes, and sync permits are explicit shared
+  handles
+- cancellation and deadlines flow from the parent into children
+- results come back through `await`, `parallel`, `parallel each`,
+  `parallel settle`, or streams
+
+That gives Harn the same shape on the page as the work you are trying to run:
+fan out, wait, collect, and clean up.
 
 ## spawn and await
 
@@ -23,7 +38,9 @@ let handle = spawn { sleep(10s) }
 cancel(handle)
 ```
 
-Each spawned task runs in an isolated interpreter instance.
+Each spawned task runs in an isolated interpreter instance. In runtime and ADR
+pages you may see this called a **child VM**; in day-to-day Harn code, read that
+as "the child task's interpreter."
 
 ## parallel
 
@@ -173,8 +190,14 @@ same `{index, value, channel}` dict.
 
 ## Scoped shared state
 
-Normal values are copied into child VMs. Use shared cells or maps only when
+Normal values are copied into child tasks. Use shared cells or maps only when
 tasks need to coordinate on the same mutable state.
+
+The multithreaded runtime keeps child interpreters isolated, and the shared
+state primitives are the explicit bridge between them. Shared cells/maps,
+mailboxes, mutexes, rwlocks, semaphores, and gates are thread-safe handles
+inherited by `spawn` and `parallel` children. If you do not pass one of those
+handles, the child sees its own copy of the value it captured at start.
 
 ```harn
 let budget = shared_cell({scope: "task_group", key: "tokens", initial: 0})
@@ -303,7 +326,7 @@ Atomic updates mutate the handle and return the previous integer value.
 ## Mutex
 
 `mutex { ... }` is a process-local, fair critical section inherited by
-`spawn` and `parallel` child VMs. It uses the default mutex key
+`spawn` and `parallel` child tasks. It uses the default mutex key
 `"__default__"` and releases automatically when the lexical scope exits,
 including `throw`, `return`, `break`, and caught runtime errors.
 

--- a/docs/src/contributing/preset-hooks.md
+++ b/docs/src/contributing/preset-hooks.md
@@ -101,7 +101,7 @@ prove it out.
    make conformance       # tool_hooks_catalogue_<stack> cases pass
    make lint-md           # docs lint clean
    make check-docs-snippets   # harn,ignore fences only — others must type-check
-   mdbook build docs      # mdBook builds clean
+   ./scripts/build_docs_site.sh  # mdBook builds clean and emits raw .md companions
    ```
 
 ## Adding a new stack catalogue
@@ -204,7 +204,7 @@ Reviewers should check:
 - [ ] Docs updated: shipped-catalogues table, cookbook recipe (when
       the rule unblocks a workflow), CHANGELOG Unreleased entry.
 - [ ] `make conformance`, `make lint-md`, `make check-docs-snippets`,
-      and `mdbook build docs` all pass locally.
+      and `./scripts/build_docs_site.sh` all pass locally.
 
 ## Tracking
 

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -666,8 +666,7 @@ For remote HTTP MCP servers, authorize once with the CLI and reuse the
 stored token:
 
 ```bash
-harn mcp redirect-uri
-harn mcp login https://mcp.notion.com/mcp --scope "read write"
+harn mcp login notion
 ```
 
 ### How to give an agent MCP tools

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -175,14 +175,21 @@ export ANTHROPIC_API_KEY=sk-ant-...
 ```harn
 let response = llm_call(
   "Explain quicksort in two sentences.",
-  "You are a computer science tutor."
+  "You are a computer science tutor.",
+  {provider: "anthropic", model: "claude-sonnet-4-6"}
 )
 log(response)
 ```
 
-No imports, no SDK initialization, no response parsing. Harn ships with
-built-in configs for Anthropic, OpenAI, OpenRouter, Ollama, HuggingFace,
-and local OpenAI-compatible servers.
+The third argument is the model route. You can omit it after `harn quickstart`
+writes defaults, or when environment variables select a provider. With no
+explicit options, Harn checks `HARN_LLM_PROVIDER`, then `HARN_LLM_MODEL`, then
+the default provider from `HARN_DEFAULT_PROVIDER` or provider config. The
+built-in default is Anthropic when its key is available; otherwise Harn can fall
+back to keyless Ollama/local routes. See [LLM providers](./llm/providers.md)
+for the full resolution order, provider table, and `providers.toml` format.
+
+No imports, no SDK initialization, no response parsing.
 
 For production callers, wrap with retry middleware from
 `std/llm/handlers`:
@@ -243,13 +250,42 @@ See [LLM providers](./llm/providers.md) for provider setup.
 
 ## Remote MCP quick start
 
-If you want to use a cloud MCP server such as Notion, authorize it once with
-the CLI and then reference it from `harn.toml`:
+Use a remote MCP server when a Harn program needs tools hosted outside your
+machine. Notion is the common example: the server runs on Notion's side, Harn
+stores your OAuth token locally, and your `.harn` code calls the server through
+the normal MCP builtins.
 
 ```bash
-harn mcp redirect-uri
-harn mcp login https://mcp.notion.com/mcp --scope "read write"
+harn mcp login notion
+harn mcp status notion
 ```
+
+`harn mcp login notion` opens the browser, completes OAuth with PKCE, and
+stores the token in the local OS keychain. `harn mcp redirect-uri` just prints
+the default callback URI (`http://127.0.0.1:9783/oauth/callback`) for servers
+that ask you to pre-register one; you usually do not need it for built-in
+presets such as Notion.
+
+Then declare the server in `harn.toml`:
+
+```toml
+[[mcp]]
+name = "notion"
+transport = "http"
+url = "https://mcp.notion.com/mcp"
+```
+
+And call it from a program:
+
+```harn,ignore
+fn main(harness: Harness) {
+  let pages = mcp_call(mcp.notion, "search", {query: "release notes"})
+  harness.stdio.println(json_stringify_pretty(pages))
+}
+```
+
+For the complete client/server surface, see
+[MCP, ACP, and A2A integration](./mcp-and-acp.md).
 
 ## Next steps
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -3,7 +3,7 @@
 
 # Harn
 
-<p class="tagline">A pipeline-oriented language for AI agent orchestration. LLM calls, tool use, concurrency, retries, and replay are language primitives — not SDK glue.</p>
+<p class="tagline">A pipeline-oriented language for AI agent orchestration. LLM calls, tool use, concurrency, retries, and replay are built into the runtime.</p>
 
 ```harn
 let response = llm_call(
@@ -23,7 +23,7 @@ log(response)
 
 ## What Harn is
 
-Harn is a small language built around one observation: when you write an AI agent, most of your code is *coordination* — calling a model, dispatching a tool, retrying, fanning out work, persisting state, recovering from a crash, replaying a trace for debugging. In Python or TypeScript this becomes a stack of libraries, each with its own configuration surface. In Harn the same patterns are keywords and builtins.
+Harn is a small language built around one observation: when you write an AI agent, most of your code is *coordination* — calling a model, dispatching a tool, retrying, fanning out work, persisting state, recovering from a crash, replaying a trace for debugging. Harn gives those patterns one runtime and one syntax surface.
 
 ```harn
 pipeline review(task) {
@@ -42,7 +42,8 @@ pipeline review(task) {
 }
 ```
 
-No imports. No async annotations. No retry decorators. No HTTP client setup. The orchestration logic *is* the code.
+The orchestration logic is the code: which work fans out, which calls retry,
+where results join, and which effects pass through the harness.
 
 ## Why it exists
 
@@ -58,9 +59,10 @@ No imports. No async annotations. No retry decorators. No HTTP client setup. The
 
 <div class="harn-feature">
 
-### Concurrency without ceremony
+### Concurrency with structure
 
-`parallel each`, `spawn`/`await`, channels, and deadlines are keywords. No promise combinators, no callback chains.
+`parallel each`, `spawn`/`await`, channels, and deadlines keep fan-out, joins,
+and cancellation visible in the program.
 
 </div>
 

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -876,7 +876,7 @@ retry 3 {
       max_iterations: 30,
       max_nudges: 5,
       provider: "anthropic",
-      model: "claude-sonnet-4-20250514"
+      model: "claude-sonnet-4-6"
     }
   )
   log(result.text)

--- a/docs/src/llm/llm_call.md
+++ b/docs/src/llm/llm_call.md
@@ -425,7 +425,7 @@ Harn provides builtins for estimating and controlling LLM costs:
 
 ```harn
 // Estimate cost for a specific call
-let cost = llm_cost("claude-sonnet-4-20250514", 1000, 500)
+let cost = llm_cost("claude-sonnet-4-6", 1000, 500)
 log("Estimated cost: $${cost}")
 
 // Check cumulative session costs

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -31,7 +31,7 @@ family-level guidance, endpoint notes, and downstream JSON support data.
 
 | Provider | Environment variable | Default model |
 |---|---|---|
-| Anthropic (default) | `ANTHROPIC_API_KEY` | `claude-sonnet-4-20250514` |
+| Anthropic (default) | `ANTHROPIC_API_KEY` | `claude-sonnet-4-6` |
 | OpenAI | `OPENAI_API_KEY` | `gpt-4o` |
 | OpenRouter | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4.6` |
 | HuggingFace | `HF_TOKEN` or `HUGGINGFACE_API_KEY` | explicit `model` |
@@ -576,7 +576,7 @@ Set the model explicitly or via environment:
 
 ```harn
 // In code
-llm_call("...", nil, {model: "claude-sonnet-4-5-20241022"})
+llm_call("...", nil, {model: "claude-sonnet-4-6"})
 
 // Or via environment
 // export HARN_LLM_MODEL=gpt-4o

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -167,7 +167,6 @@ args = ["-y", "@modelcontextprotocol/server-github"]
 name = "notion"
 transport = "http"
 url = "https://mcp.notion.com/mcp"
-scopes = "read write"
 
 [[mcp]]
 name = "modern"

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -1381,7 +1381,7 @@ review semantics.
 ### std/personas/prelude
 
 Reusable orchestration primitives for durable persona workflows. See
-[Persona Prelude](./personas/prelude.md) for the complete API.
+[Persona prelude](./personas/prelude.md) for the complete API.
 
 | Function | Description |
 |---|---|

--- a/docs/src/stdlib/llm-handlers.md
+++ b/docs/src/stdlib/llm-handlers.md
@@ -275,7 +275,7 @@ let caller = with_retry(default_llm_caller(), {max_attempts: 3})
 let envelope = caller({
   prompt: "hello",
   system: nil,
-  opts: {provider: "auto", model: "claude-sonnet-4-5"},
+  opts: {provider: "auto", model: "claude-sonnet-4-6"},
   turn: {iteration: 0, session_id: "", attempt: 1},
 })
 if envelope.ok { log(envelope.value.text) }
@@ -391,7 +391,7 @@ import {recommend_max_output_tokens, fits_in_context} from "std/llm/budget"
 let max_out = recommend_max_output_tokens({
   prompt: long_text,
   system: sys,
-  model: "claude-sonnet-4-5",
+  model: "claude-sonnet-4-6",
   task_kind: "summarize",
 })
 
@@ -447,7 +447,7 @@ GPT-5/5.5/4o/4.1, Gemini 2.5 Pro/Flash, Ollama Qwen3/Llama 3.x.
 ```harn,ignore
 import {pack_agent} from "std/llm/defaults"
 
-let opts = pack_agent("claude-sonnet-4-5", {
+let opts = pack_agent("claude-sonnet-4-6", {
   thinking: "medium",
   effort: "quality",
 })

--- a/docs/src/why-harn.md
+++ b/docs/src/why-harn.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD033 -->
+
 # Why Harn?
 
 ## The problem
@@ -85,15 +87,30 @@ mcp_disconnect(client)
 
 ### Concurrency without async/await
 
-`parallel each`, `parallel`, `spawn`/`await`, and channels are keywords,
-not library functions. No callback chains, no promise combinators, no
-`async def` annotations:
+Agent work is mostly waiting: for files, HTTP calls, tool calls, model
+responses, or other workers. Harn makes that waiting explicit in the program
+without asking you to write an event loop.
 
 ```harn
 let results = parallel each files { file ->
   llm_call(read_file(file), "Review this file for security issues")
 }
 ```
+
+<details>
+<summary>How to read this snippet</summary>
+
+For each path in `files`, Harn starts a child task, reads the file inside that
+task, calls the model, and returns the results in input order. If there are `N`
+files and the slowest branch takes `T` seconds, wall-clock time is roughly `T`
+plus scheduling overhead. Memory grows with in-flight tasks and their
+inputs/results, so use `with { max_concurrent: K }` for large file sets or
+provider queues.
+
+Because `parallel each` is part of the language runtime, cancellation, replay,
+trace spans, and host-capability checks stay attached to the whole fan-out.
+
+</details>
 
 ### Retry and error recovery
 
@@ -114,11 +131,22 @@ where they don't. Structural shape types let you describe expected dict
 fields:
 
 ```harn
-fn score(text: string) -> int {
-  let result = llm_call(text, "Rate 1-10. Respond with just the number.")
-  return to_int(result)
+type Review = {
+  path: string,
+  risk: "low" | "medium" | "high",
+  summary?: string,
 }
+
+fn render_review(review: Review) -> string {
+  return "${review.path}: ${review.risk}"
+}
+
+render_review({path: "src/auth.rs", risk: "high", owner: "security"})
 ```
+
+`path` and `risk` are required keys. `summary` is optional. Extra keys such as
+`owner` are allowed, so typed boundaries can describe the fields a function
+actually needs without forcing every caller to erase useful metadata.
 
 ### Embeddable
 
@@ -148,7 +176,7 @@ from langchain_anthropic import ChatAnthropic
 from tenacity import retry, stop_after_attempt
 import aiohttp
 
-llm = ChatAnthropic(model="claude-sonnet-4-20250514")
+llm = ChatAnthropic(model="claude-sonnet-4-6")
 
 @retry(stop=stop_after_attempt(3))
 async def summarize(url):

--- a/docs/theme/css/harn-theme.css
+++ b/docs/theme/css/harn-theme.css
@@ -37,7 +37,7 @@ body,
 .content {
   font-family: var(--harn-font-sans);
   line-height: 1.65;
-  letter-spacing: -0.005em;
+  letter-spacing: 0;
 }
 
 .content h1,
@@ -48,7 +48,7 @@ body,
 .content h6 {
   font-family: var(--harn-font-sans);
   font-weight: 600;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   line-height: 1.25;
 }
 
@@ -184,8 +184,7 @@ pre > code.language-harn {
 .chapter li.part-title {
   font-size: 0.7rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0;
   color: var(--harn-violet);
   margin-top: 1.8em;
   margin-bottom: 0.4em;
@@ -202,7 +201,43 @@ pre > code.language-harn {
 
 .menu-title {
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
+}
+
+.harn-section-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  margin-left: 1rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.harn-section-nav::-webkit-scrollbar {
+  display: none;
+}
+
+.harn-section-nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0 0.55rem;
+  border-radius: var(--harn-radius-sm);
+  color: inherit;
+  font-size: 0.86rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.harn-section-nav a:hover,
+.harn-section-nav a.active {
+  color: var(--harn-violet);
+  background: rgba(91, 77, 255, 0.08);
+}
+
+.harn-sidebar-hidden {
+  display: none !important;
 }
 
 /* ---------- Search ---------- */
@@ -240,7 +275,7 @@ pre > code.language-harn {
   border-bottom: none;
   margin: 0 0 0.4em 0;
   font-size: 2.6rem;
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
   font-weight: 700;
 }
 
@@ -432,6 +467,17 @@ pre > code.language-harn {
 /* ---------- Responsive ---------- */
 
 @media (max-width: 720px) {
+  .harn-section-nav {
+    order: 3;
+    flex-basis: 100%;
+    margin: 0.25rem 0 0 0;
+    padding-bottom: 0.25rem;
+  }
+
+  .harn-section-nav a {
+    font-size: 0.8rem;
+  }
+
   .harn-hero {
     padding: 1.8rem 1.2rem;
   }

--- a/docs/theme/harn-docs-nav.js
+++ b/docs/theme/harn-docs-nav.js
@@ -1,0 +1,90 @@
+(function () {
+  "use strict";
+
+  const sections = [
+    { id: "introduction", title: "Introduction", href: "introduction.html", parts: ["Introduction", "Concepts"] },
+    { id: "tutorials", title: "Tutorials", href: "getting-started.html", parts: ["Tutorials"] },
+    { id: "guides", title: "Guides", href: "common-tasks.html", parts: ["How-to guides"] },
+    { id: "reference", title: "Reference", href: "language-basics.html", parts: ["Reference"] },
+    { id: "explanation", title: "Explanation", href: "host-boundary.html", parts: ["Explanation"] },
+    { id: "operations", title: "Operations", href: "playground.html", parts: ["Operations"] },
+  ];
+
+  function normalizePath(pathname) {
+    return pathname.replace(/^\/+/, "").replace(/\/index\.html$/, "/").replace(/^\.\//, "");
+  }
+
+  function relativeHref(target) {
+    const depth = normalizePath(window.location.pathname)
+      .split("/")
+      .filter(Boolean)
+      .slice(0, -1).length;
+    return "../".repeat(depth) + target;
+  }
+
+  function activePart() {
+    const active = document.querySelector(".chapter li.chapter-item a.active");
+    if (!active) {
+      return "Introduction";
+    }
+
+    let item = active.closest("li");
+    while (item && item.previousElementSibling) {
+      item = item.previousElementSibling;
+      if (item.classList.contains("part-title")) {
+        return item.textContent.trim();
+      }
+    }
+    return "Introduction";
+  }
+
+  function installTopNav(currentSection) {
+    const menu = document.querySelector("#menu-bar");
+    if (!menu || document.querySelector(".harn-section-nav")) {
+      return;
+    }
+
+    const nav = document.createElement("nav");
+    nav.className = "harn-section-nav";
+    nav.setAttribute("aria-label", "Documentation sections");
+
+    for (const section of sections) {
+      const link = document.createElement("a");
+      link.href = relativeHref(section.href);
+      link.textContent = section.title;
+      if (section.id === currentSection.id) {
+        link.className = "active";
+        link.setAttribute("aria-current", "page");
+      }
+      nav.appendChild(link);
+    }
+
+    menu.appendChild(nav);
+  }
+
+  function scopeSidebar(currentSection) {
+    const chapter = document.querySelector(".chapter");
+    if (!chapter) {
+      return;
+    }
+
+    const wanted = new Set(currentSection.parts);
+    let currentPart = "Introduction";
+
+    for (const item of chapter.children) {
+      if (item.classList.contains("part-title")) {
+        currentPart = item.textContent.trim();
+      }
+      item.classList.toggle("harn-sidebar-hidden", !wanted.has(currentPart));
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const part = activePart();
+    const currentSection =
+      sections.find((section) => section.parts.includes(part)) || sections[0];
+    document.body.dataset.harnDocsSection = currentSection.id;
+    installTopNav(currentSection);
+    scopeSidebar(currentSection);
+  });
+})();

--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+mdbook build "$repo_root/docs"
+
+while IFS= read -r -d '' src; do
+  rel="${src#"$repo_root/docs/src/"}"
+  dest="$repo_root/docs/dist/$rel"
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+done < <(find "$repo_root/docs/src" -type f -name '*.md' -print0)
+
+rm -f "$repo_root/docs/dist/SUMMARY.md"
+
+mkdir -p "$repo_root/docs/dist/docs/llm"
+cp "$repo_root/docs/llm/harn-quickref.md" \
+  "$repo_root/docs/dist/docs/llm/harn-quickref.md"
+cp "$repo_root/docs/llm/harn-triggers-quickref.md" \
+  "$repo_root/docs/dist/docs/llm/harn-triggers-quickref.md"

--- a/scripts/check_docs_model_refs.sh
+++ b/scripts/check_docs_model_refs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+providers_toml="$repo_root/crates/harn-vm/src/llm/providers.toml"
+
+alias_id() {
+  local alias="$1"
+  awk -v section="[aliases.${alias}]" '
+    $0 == section { in_section = 1; next }
+    in_section && /^\[/ { exit }
+    in_section && /^[[:space:]]*id[[:space:]]*=/ {
+      line = $0
+      sub(/^[^"]*"/, "", line)
+      sub(/".*$/, "", line)
+      print line
+      exit
+    }
+  ' "$providers_toml"
+}
+
+sonnet_model="$(alias_id sonnet)"
+if [[ -z "$sonnet_model" ]]; then
+  echo "error: could not resolve aliases.sonnet from $providers_toml" >&2
+  exit 1
+fi
+
+mapfile -d '' docs_files < <(
+  find "$repo_root/docs/src" "$repo_root/docs/llm" -type f -name '*.md' -print0
+)
+
+checked_files=()
+for file in "${docs_files[@]}"; do
+  if head -n 5 "$file" | grep -q 'GENERATED'; then
+    continue
+  fi
+  checked_files+=("$file")
+done
+
+pattern='claude-sonnet-4(-[0-9][0-9A-Za-z]*)+'
+failures=0
+while IFS=: read -r file line model; do
+  if [[ "$model" == "$sonnet_model" ]]; then
+    continue
+  fi
+  if sed -n "${line}p" "$file" | grep -q 'harn-doc-model-ref: allow-stale'; then
+    continue
+  fi
+  rel="${file#"$repo_root/"}"
+  echo "error: $rel:$line references $model, but aliases.sonnet is $sonnet_model" >&2
+  echo "       update the docs example or add harn-doc-model-ref: allow-stale if this is intentionally historical." >&2
+  failures=$((failures + 1))
+done < <(rg -n -o "$pattern" "${checked_files[@]}" || true)
+
+if (( failures > 0 )); then
+  exit 1
+fi
+
+echo "docs model refs OK: aliases.sonnet = $sonnet_model"

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -128,10 +128,12 @@ run_docs_audit() {
   time_phase "sync_language_spec" cargo run --quiet --bin harn -- run scripts/sync_language_spec.harn
   time_phase "markdownlint" npx markdownlint-cli2 "**/*.md"
   if command -v mdbook >/dev/null 2>&1; then
-    time_phase "mdbook build" mdbook build docs
+    time_phase "mdbook build" ./scripts/build_docs_site.sh
   else
     echo "warning: mdbook not installed; skipping mdbook build"
   fi
+  time_phase "docs model refs" ./scripts/check_docs_model_refs.sh
+  time_phase "docs snippets" ./scripts/check_docs_snippets.sh
 }
 
 run_grammar_audit() {


### PR DESCRIPTION
## Summary
- Adds a top-level mdBook section nav and scopes the sidebar to the active documentation mode.
- Reworks first-run docs around LLM routing, remote MCP login, concurrency, gradual typing, and child-task/shared-state terminology grounded in the current runtime behavior.
- Publishes raw Markdown companions during docs builds and removes the `.md` redirect that caused the quickref source view to render as redirect HTML.
- Removes Notion MCP OAuth scopes from the preset/docs and adds a docs check so hand-written Sonnet examples track the live `aliases.sonnet` provider catalog entry.

## Verification
- `cargo fmt --check`
- `cargo test -p harn-vm mcp_presets --lib`
- `npx --yes markdownlint-cli2 "**/*.md"`
- `./scripts/build_docs_site.sh`
- `./scripts/check_docs_model_refs.sh`
- `make check-docs-snippets`
- `make check-provider-matrix check-provider-support check-docs-model-refs`
- `make lint-actions`
- `git diff --check`
- pre-commit hook: full workspace clippy, markdown lint, Actions lint
- pre-push hook: targeted local checks and markdown lint

Note: the in-app Browser backend was unavailable in this session, so I verified the built site with a local static server and HTTP checks for the raw `.md` endpoint and generated nav script.