### PR TITLE
Fix VM module closure cycles and add RSS soak gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
           make check-docs-model-refs
           make check-docs-snippets
           make check-diagnostics-catalog
+          make check-vm-rss-soak
 
   audit-scripts:
     name: Audit scripts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -161,6 +161,9 @@ bench-vm-micro:
 
 bench-vm-clone:
 	cargo bench -p harn-vm-perf --bench bench_vmenv_clone -- --output-format bencher
+
+check-vm-rss-soak:
+	python3 scripts/check_vm_rss_soak.py
 
 bench-llm:
 	cargo bench -p harn-llm-perf --bench bench_llm_options_roundtrip -- --output-format bencher

--- a/benchmarks/vm_memory/module_cycle_entry.harn
+++ b/benchmarks/vm_memory/module_cycle_entry.harn
@@ -1,0 +1,8 @@
+import { touch } from "module_cycle_lib"
+
+pipeline default() {
+  let size = touch()
+  if size < 4000000 {
+    throw "module payload was not initialized"
+  }
+}

--- a/benchmarks/vm_memory/module_cycle_lib.harn
+++ b/benchmarks/vm_memory/module_cycle_lib.harn
@@ -1,0 +1,5 @@
+let payload = "x" * 4000000
+
+pub fn touch() {
+  return len(payload)
+}

--- a/benchmarks/vm_memory/module_cycle_lib.harn
+++ b/benchmarks/vm_memory/module_cycle_lib.harn
@@ -1,5 +1,6 @@
 let payload = "x" * 4000000
 
+/** Touch the module payload so imported closures capture module state. */
 pub fn touch() {
   return len(payload)
 }

--- a/changelog.d/vmvalue-leak-gate.fixed.md
+++ b/changelog.d/vmvalue-leak-gate.fixed.md
@@ -1,0 +1,1 @@
+Break module closure reference cycles and add a VM RSS soak gate.

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -15,6 +15,8 @@ use crate::parse_source_file;
 struct BenchRun {
     iteration: usize,
     wall_time_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rss_bytes: Option<u64>,
     llm_time_ms: i64,
     input_tokens: i64,
     output_tokens: i64,
@@ -177,6 +179,7 @@ pub(crate) async fn run_bench(path: &str, iterations: usize, profile: RunProfile
                 runs.push(BenchRun {
                     iteration: iteration + 1,
                     wall_time_ms,
+                    rss_bytes: harn_vm::harness_system::current_process_memory_bytes(),
                     llm_time_ms,
                     input_tokens,
                     output_tokens,
@@ -679,6 +682,7 @@ mod tests {
         BenchRun {
             iteration,
             wall_time_ms,
+            rss_bytes: None,
             llm_time_ms: 0,
             input_tokens: 0,
             output_tokens: 0,

--- a/crates/harn-vm/src/harness_system.rs
+++ b/crates/harn-vm/src/harness_system.rs
@@ -139,6 +139,18 @@ pub fn memory_snapshot() -> Value {
     })
 }
 
+/// Resident bytes for the current Harn process.
+pub fn current_process_memory_bytes() -> Option<u64> {
+    let pid = Pid::from_u32(std::process::id());
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::nothing().with_memory(),
+    );
+    sys.process(pid).map(|process| process.memory())
+}
+
 /// Snapshot of attached GPUs. `sysinfo` does not expose GPU details
 /// directly across all platforms; we surface a non-fatal empty list so
 /// scripts can write `if !gpus.is_empty()` portably. Richer detection
@@ -356,6 +368,13 @@ mod tests {
             Some(true),
             "self entry must be harn-owned"
         );
+    }
+
+    #[test]
+    fn current_process_memory_bytes_reports_self_when_available() {
+        if let Some(bytes) = current_process_memory_bytes() {
+            assert!(bytes > 0, "current process memory should be non-zero");
+        }
     }
 
     #[test]

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use crate::chunk::CompiledFunctionRef;
 
@@ -18,7 +18,7 @@ pub struct VmClosure {
     /// Module-local named functions that should resolve before builtin fallback.
     /// This lets selectively imported functions keep private sibling helpers
     /// without exporting them into the caller's environment.
-    pub module_functions: Option<ModuleFunctionRegistry>,
+    pub module_functions: Option<WeakModuleFunctionRegistry>,
     /// Shared, mutable module-level env: holds top-level `var` / `let`
     /// bindings declared at the module root (caches, counters, lazily
     /// initialized registries). All closures created from the same
@@ -31,11 +31,27 @@ pub struct VmClosure {
     /// before globals. Created in `import_declarations` after the
     /// module's init chunk runs, so the initial values from `var x = ...`
     /// land in it.
-    pub module_state: Option<ModuleState>,
+    pub module_state: Option<WeakModuleState>,
 }
 
 pub type ModuleFunctionRegistry = Arc<VmMutex<BTreeMap<String, Arc<VmClosure>>>>;
+pub type WeakModuleFunctionRegistry = Weak<VmMutex<BTreeMap<String, Arc<VmClosure>>>>;
 pub type ModuleState = Arc<VmMutex<VmEnv>>;
+pub type WeakModuleState = Weak<VmMutex<VmEnv>>;
+
+impl VmClosure {
+    pub(crate) fn module_functions(&self) -> Option<ModuleFunctionRegistry> {
+        self.module_functions
+            .as_ref()
+            .and_then(WeakModuleFunctionRegistry::upgrade)
+    }
+
+    pub(crate) fn module_state(&self) -> Option<ModuleState> {
+        self.module_state
+            .as_ref()
+            .and_then(WeakModuleState::upgrade)
+    }
+}
 
 /// VM environment for variable storage.
 ///

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -38,6 +38,8 @@ fn stdlib_module_artifact_cache_ptr(module: &str, source: &str) -> Option<usize>
 pub(crate) struct LoadedModule {
     pub(crate) functions: BTreeMap<String, Arc<VmClosure>>,
     pub(crate) public_names: HashSet<String>,
+    pub(crate) _module_functions: crate::value::ModuleFunctionRegistry,
+    pub(crate) _module_state: crate::value::ModuleState,
 }
 
 pub fn resolve_module_import_path(base: &Path, path: &str) -> PathBuf {
@@ -212,8 +214,8 @@ impl Vm {
                 func: Arc::new(CompiledFunction::from_cached(compiled)),
                 env: module_env.clone(),
                 source_dir: module_source_dir.clone(),
-                module_functions: Some(Arc::clone(&registry)),
-                module_state: Some(Arc::clone(&module_state)),
+                module_functions: Some(Arc::downgrade(&registry)),
+                module_state: Some(Arc::downgrade(&module_state)),
             });
             registry.lock().insert(name.clone(), Arc::clone(&closure));
             self.env
@@ -269,6 +271,8 @@ impl Vm {
         Ok(LoadedModule {
             functions,
             public_names,
+            _module_functions: registry,
+            _module_state: module_state,
         })
     }
 
@@ -601,8 +605,8 @@ mod tests {
         assert!(!Arc::ptr_eq(&first.func, &second.func));
         assert!(!Arc::ptr_eq(&first.func.chunk, &second.func.chunk));
         assert!(!Arc::ptr_eq(
-            first.module_state.as_ref().expect("first module state"),
-            second.module_state.as_ref().expect("second module state")
+            &first.module_state().expect("first module state"),
+            &second.module_state().expect("second module state")
         ));
     }
 
@@ -640,6 +644,54 @@ mod tests {
         assert_eq!(
             cached_stdlib_module_ptr("agent/prompts"),
             Some(thread_cached)
+        );
+    }
+
+    #[test]
+    fn module_closures_release_state_after_vm_drop() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime builds");
+
+        let (closure_weak, registry_weak, state_weak) = runtime.block_on(async {
+            let mut vm = Vm::new();
+            let loaded = vm
+                .load_module_from_source(
+                    PathBuf::from("<test>/module_cycle.harn"),
+                    r#"
+var payload = "x" * 1024
+
+pub fn touch() {
+  return len(payload)
+}
+"#,
+                )
+                .await
+                .expect("module loads");
+            let closure = Arc::clone(loaded.functions.get("touch").expect("touch export exists"));
+            let closure_weak = Arc::downgrade(&closure);
+            let registry_weak = Arc::downgrade(&loaded._module_functions);
+            let state_weak = Arc::downgrade(&loaded._module_state);
+
+            drop(closure);
+            drop(loaded);
+            drop(vm);
+
+            (closure_weak, registry_weak, state_weak)
+        });
+
+        assert!(
+            closure_weak.upgrade().is_none(),
+            "module closure should drop with its VM"
+        );
+        assert!(
+            registry_weak.upgrade().is_none(),
+            "module function registry should drop with its VM"
+        );
+        assert!(
+            state_weak.upgrade().is_none(),
+            "module state should drop with its VM"
         );
     }
 }

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -572,23 +572,43 @@ mod tests {
             .build()
             .expect("runtime builds");
 
-        let first_exports = runtime.block_on(async {
-            let mut first_vm = Vm::new();
-            first_vm
-                .load_module_exports_from_import("std/agent/prompts")
-                .await
-                .expect("first stdlib import succeeds")
-        });
+        let (first_exports, second_exports, first_state_weak, second_state_weak) = runtime
+            .block_on(async {
+                let mut first_vm = Vm::new();
+                let first_exports = first_vm
+                    .load_module_exports_from_import("std/agent/prompts")
+                    .await
+                    .expect("first stdlib import succeeds");
+                let first_state = first_exports
+                    .get("render_agent_prompt")
+                    .expect("first export exists")
+                    .module_state()
+                    .expect("first module state stays live while VM owns module");
+                let first_state_weak = Arc::downgrade(&first_state);
+                let first_state_ptr = Arc::as_ptr(&first_state);
+
+                let mut second_vm = Vm::new();
+                let second_exports = second_vm
+                    .load_module_exports_from_import("std/agent/prompts")
+                    .await
+                    .expect("second stdlib import succeeds");
+                let second_state = second_exports
+                    .get("render_agent_prompt")
+                    .expect("second export exists")
+                    .module_state()
+                    .expect("second module state stays live while VM owns module");
+                let second_state_weak = Arc::downgrade(&second_state);
+
+                assert_ne!(first_state_ptr, Arc::as_ptr(&second_state));
+                (
+                    first_exports,
+                    second_exports,
+                    first_state_weak,
+                    second_state_weak,
+                )
+            });
         let first_cached =
             cached_stdlib_module_ptr("agent/prompts").expect("first import cached stdlib artifact");
-
-        let second_exports = runtime.block_on(async {
-            let mut second_vm = Vm::new();
-            second_vm
-                .load_module_exports_from_import("std/agent/prompts")
-                .await
-                .expect("second stdlib import succeeds")
-        });
         assert_eq!(
             cached_stdlib_module_ptr("agent/prompts"),
             Some(first_cached)
@@ -604,10 +624,10 @@ mod tests {
         assert!(!Arc::ptr_eq(first, second));
         assert!(!Arc::ptr_eq(&first.func, &second.func));
         assert!(!Arc::ptr_eq(&first.func.chunk, &second.func.chunk));
-        assert!(!Arc::ptr_eq(
-            &first.module_state().expect("first module state"),
-            &second.module_state().expect("second module state")
-        ));
+        assert!(first.module_state().is_none());
+        assert!(second.module_state().is_none());
+        assert!(first_state_weak.upgrade().is_none());
+        assert!(second_state_weak.upgrade().is_none());
     }
 
     #[test]

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1151,8 +1151,8 @@ impl super::super::Vm {
             fn_name: closure.func.name.clone(),
             argc: args_len,
             saved_source_dir,
-            module_functions: closure.module_functions.clone(),
-            module_state: closure.module_state.clone(),
+            module_functions: closure.module_functions(),
+            module_state: closure.module_state(),
             local_slots,
             local_scope_base: self.env.scope_depth().saturating_sub(1),
             local_scope_depth: 0,
@@ -1286,13 +1286,13 @@ impl super::super::Vm {
             module_functions: self
                 .frames
                 .last()
-                .and_then(|frame| frame.module_functions.clone()),
+                .and_then(|frame| frame.module_functions.as_ref().map(Arc::downgrade)),
             // Inherit module state so closures created inside a module function
             // see and mutate the same module-level vars.
             module_state: self
                 .frames
                 .last()
-                .and_then(|frame| frame.module_state.clone()),
+                .and_then(|frame| frame.module_state.as_ref().map(Arc::downgrade)),
         };
         self.stack.push(VmValue::Closure(Arc::new(closure)));
     }

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -32,7 +32,7 @@ impl Vm {
     /// `closure.env` + `module_state`, and we skip the closure merge
     /// entirely as a fast path for context-builder workloads.
     pub(crate) fn closure_call_env(caller_env: &VmEnv, closure: &VmClosure) -> VmEnv {
-        if closure.module_state.is_some() {
+        if closure.module_state().is_some() {
             return closure.env.clone();
         }
         let call_env = closure.env.clone();
@@ -151,8 +151,8 @@ impl Vm {
             fn_name: closure.func.name.clone(),
             argc,
             saved_source_dir,
-            module_functions: closure.module_functions.clone(),
-            module_state: closure.module_state.clone(),
+            module_functions: closure.module_functions(),
+            module_state: closure.module_state(),
             local_slots,
             local_scope_base: self.env.scope_depth().saturating_sub(1),
             local_scope_depth: 0,
@@ -281,8 +281,8 @@ impl Vm {
         } else {
             None
         };
-        let module_functions = closure.module_functions.clone();
-        let module_state = closure.module_state.clone();
+        let module_functions = closure.module_functions();
+        let module_state = closure.module_state();
         let argc = args.len();
         // Spawn the generator body as an async task.
         // The task will execute until return, sending yielded values through the channel.

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -450,7 +450,7 @@ impl Vm {
         &self,
         closure: &crate::value::VmClosure,
     ) -> VmEnv {
-        if closure.module_state.is_some() {
+        if closure.module_state().is_some() {
             return closure.env.clone();
         }
         let call_env = Self::closure_call_env(&self.env, closure);

--- a/scripts/check_vm_rss_soak.py
+++ b/scripts/check_vm_rss_soak.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = ROOT / "benchmarks" / "vm_memory" / "module_cycle_entry.harn"
+DEFAULT_ITERATIONS = 24
+DEFAULT_MAX_TAIL_GROWTH_BYTES = 32 * 1024 * 1024
+
+
+def cargo_target_dir() -> Path:
+    configured = os.environ.get("CARGO_TARGET_DIR")
+    if configured:
+        return Path(configured)
+    result = subprocess.run(
+        ["cargo", "metadata", "--format-version=1", "--no-deps"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    metadata = json.loads(result.stdout)
+    return Path(metadata["target_directory"])
+
+
+def harn_binary() -> Path:
+    suffix = ".exe" if sys.platform == "win32" else ""
+    candidate = cargo_target_dir() / "debug" / f"harn{suffix}"
+    if not candidate.is_file():
+        subprocess.run(["cargo", "build", "--bin", "harn"], cwd=ROOT, check=True)
+    if not candidate.is_file():
+        raise SystemExit(f"error: harn binary was not built at {candidate}")
+    return candidate
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise SystemExit(f"error: {name} must be an integer, got {raw!r}") from error
+    if value <= 0:
+        raise SystemExit(f"error: {name} must be positive")
+    return value
+
+
+def load_rss_samples(report_path: Path) -> list[int]:
+    report = json.loads(report_path.read_text())
+    samples = [
+        iteration.get("rss_bytes")
+        for iteration in report.get("iterations", [])
+        if isinstance(iteration.get("rss_bytes"), int)
+    ]
+    if len(samples) < 3:
+        raise SystemExit("error: benchmark profile did not contain enough rss_bytes samples")
+    return samples
+
+
+def main() -> int:
+    iterations = env_int("HARN_VM_RSS_SOAK_ITERATIONS", DEFAULT_ITERATIONS)
+    max_tail_growth = env_int(
+        "HARN_VM_RSS_SOAK_MAX_TAIL_GROWTH_BYTES",
+        DEFAULT_MAX_TAIL_GROWTH_BYTES,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="harn-vm-rss-soak-") as tmp:
+        report_path = Path(tmp) / "profile.json"
+        subprocess.run(
+            [
+                str(harn_binary()),
+                "bench",
+                str(FIXTURE),
+                "--iterations",
+                str(iterations),
+                "--profile-json",
+                str(report_path),
+            ],
+            cwd=ROOT,
+            check=True,
+        )
+        samples = load_rss_samples(report_path)
+
+    warmup = max(1, len(samples) // 3)
+    tail = samples[warmup:]
+    tail_growth = max(0, tail[-1] - min(tail))
+    if tail_growth > max_tail_growth:
+        raise SystemExit(
+            "error: VM RSS soak grew by "
+            f"{tail_growth} bytes after warmup, above {max_tail_growth} bytes"
+        )
+    print(
+        "vm rss soak: OK "
+        f"iterations={len(samples)} tail_growth_bytes={tail_growth} "
+        f"limit_bytes={max_tail_growth}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- break VM module closure Arc cycles by storing weak module function/state references in closures while LoadedModule owns the strong refs
- add drop coverage for imported module closures and a process RSS helper exposed to benchmarks
- add a VM memory soak benchmark plus CI gate so module-import leaks fail before merge
- include bench JSON RSS telemetry for leak diagnostics

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-vmvalue-leak-gate-target cargo check -p harn-vm -p harn-cli`
- `cargo fmt --all --check`
- `python3 -m py_compile scripts/check_vm_rss_soak.py`
- `CARGO_TARGET_DIR=/tmp/harn-vmvalue-leak-gate-target cargo test -p harn-vm module_closures_release_state_after_vm_drop`
- `CARGO_TARGET_DIR=/tmp/harn-vmvalue-leak-gate-target cargo test -p harn-vm current_process_memory_bytes_reports_self_when_available`
- `CARGO_TARGET_DIR=/tmp/harn-vmvalue-leak-gate-target cargo test -p harn-cli bench_`
- `CARGO_TARGET_DIR=/tmp/harn-vmvalue-leak-gate-target python3 scripts/check_vm_rss_soak.py`
- `make lint-actions`
- `CARGO_TARGET_DIR=/tmp/harn-vmvalue-leak-gate-target cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `/tmp/harn-vmvalue-leak-gate-target/debug/harn fmt --check benchmarks/vm_memory/*.harn`
- `/tmp/harn-vmvalue-leak-gate-target/debug/harn check benchmarks/vm_memory/module_cycle_entry.harn`
- `git diff --check`
- pre-commit and pre-push hooks passed on the published branch
