### PR TITLE
Fix Harn DAP debugger runtime concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           AFFECTED_BASE: origin/${{ github.event.pull_request.base.ref }}
         run: |
-          windows_filter='package(harn-lexer) or package(harn-parser) or package(harn-stdlib) or package(harn-vm) or package(harn-hostlib) or package(harn-fmt) or package(harn-lint) or package(harn-modules)'
+          windows_filter='package(harn-lexer) or package(harn-parser) or package(harn-stdlib) or package(harn-vm) or package(harn-hostlib) or package(harn-fmt) or package(harn-lint) or package(harn-modules) or package(harn-dap)'
           package_args=(--workspace)
 
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,6 +2326,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/changelog.d/dap-runtime-concurrency.fixed.md
+++ b/changelog.d/dap-runtime-concurrency.fixed.md
@@ -1,0 +1,4 @@
+- **Harn DAP now drives debuggee execution on a multi-threaded Tokio runtime with
+  a persistent local task set (#2691).** Debug sessions can run `parallel`
+  blocks and lifecycle pool workers without diverging from the VM concurrency
+  paths used by normal execution.

--- a/changelog.d/dap-runtime-concurrency.fixed.md
+++ b/changelog.d/dap-runtime-concurrency.fixed.md
@@ -2,3 +2,6 @@
   a persistent local task set (#2691).** Debug sessions can run `parallel`
   blocks and lifecycle pool workers without diverging from the VM concurrency
   paths used by normal execution.
+- **DAP source requests now parse `file:` URIs with the standard URL parser.**
+  This keeps source lookup correct for platform-native paths, including Windows
+  drive-letter paths and `localhost` file URIs.

--- a/crates/harn-dap/Cargo.toml
+++ b/crates/harn-dap/Cargo.toml
@@ -18,6 +18,7 @@ harn-vm = { path = "../harn-vm", version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt"] }
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/harn-dap/src/debugger/breakpoints.rs
+++ b/crates/harn-dap/src/debugger/breakpoints.rs
@@ -256,11 +256,9 @@ impl Debugger {
                 self.ensure_runtime();
                 if let Some(vm) = self.vm.as_mut() {
                     let runtime = self.runtime.as_ref().unwrap();
+                    let local_set = self.local_set.as_ref().unwrap();
                     runtime
-                        .block_on(async {
-                            let local = tokio::task::LocalSet::new();
-                            local.run_until(vm.evaluate_in_frame(&expr, 0)).await
-                        })
+                        .block_on(local_set.run_until(vm.evaluate_in_frame(&expr, 0)))
                         .map(|v| v.is_truthy())
                         .unwrap_or(true)
                 } else {

--- a/crates/harn-dap/src/debugger/sources.rs
+++ b/crates/harn-dap/src/debugger/sources.rs
@@ -103,51 +103,11 @@ impl Debugger {
 }
 
 fn file_uri_to_path(uri: &str) -> Option<std::path::PathBuf> {
-    let rest = uri.strip_prefix("file://")?;
-    let local = if rest == "localhost" {
-        ""
-    } else if rest.starts_with("localhost/") {
-        &rest["localhost".len()..]
-    } else {
-        rest
-    };
-    let decoded = percent_decode(local)?;
-    #[cfg(windows)]
-    {
-        let path = decoded.strip_prefix('/').unwrap_or(&decoded);
-        Some(std::path::PathBuf::from(path))
+    let parsed = url::Url::parse(uri).ok()?;
+    if parsed.scheme() != "file" {
+        return None;
     }
-    #[cfg(not(windows))]
-    {
-        Some(std::path::PathBuf::from(decoded))
-    }
-}
-
-fn percent_decode(input: &str) -> Option<String> {
-    let bytes = input.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' {
-            let hi = *bytes.get(i + 1)?;
-            let lo = *bytes.get(i + 2)?;
-            out.push((hex_value(hi)? << 4) | hex_value(lo)?);
-            i += 3;
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8(out).ok()
-}
-
-fn hex_value(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
-    }
+    parsed.to_file_path().ok()
 }
 
 fn stdlib_source(path: &str) -> Option<&'static str> {

--- a/crates/harn-dap/src/debugger/state.rs
+++ b/crates/harn-dap/src/debugger/state.rs
@@ -71,6 +71,11 @@ pub struct Debugger {
     /// Built lazily so protocol-only debugger sessions and unit tests do
     /// not open runtime I/O/timer descriptors they never use.
     pub(crate) runtime: Option<tokio::runtime::Runtime>,
+    /// Persistent local task set for VM paths that still use
+    /// `spawn_local` (`parallel`, `spawn`, streams) while the owning
+    /// runtime can also execute `tokio::spawn` pool workers on OS
+    /// threads.
+    pub(crate) local_set: Option<tokio::task::LocalSet>,
     /// Next variable reference ID (start at 100 to avoid conflict with scope refs).
     pub(crate) next_var_ref: i64,
     /// Whether to break on thrown exceptions.
@@ -200,6 +205,7 @@ impl Debugger {
             var_refs: BTreeMap::new(),
             next_var_ref: 100,
             runtime: None,
+            local_set: None,
             break_on_exceptions: false,
             exception_filters: BTreeMap::new(),
             latest_debug_state: Arc::new(Mutex::new(None)),
@@ -309,11 +315,14 @@ impl Debugger {
     pub(crate) fn ensure_runtime(&mut self) {
         if self.runtime.is_none() {
             self.runtime = Some(
-                tokio::runtime::Builder::new_current_thread()
+                tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
                     .build()
                     .unwrap(),
             );
+        }
+        if self.local_set.is_none() {
+            self.local_set = Some(tokio::task::LocalSet::new());
         }
     }
 
@@ -352,6 +361,7 @@ impl Drop for Debugger {
             vm.signal_cancel();
         }
         self.vm = None;
+        self.local_set = None;
         if let Some(runtime) = self.runtime.take() {
             runtime.shutdown_timeout(Duration::ZERO);
         }

--- a/crates/harn-dap/src/debugger/stepping.rs
+++ b/crates/harn-dap/src/debugger/stepping.rs
@@ -382,8 +382,9 @@ impl Debugger {
         self.ensure_runtime();
         let step_result = {
             let runtime = self.runtime.as_ref().unwrap();
+            let local_set = self.local_set.as_ref().unwrap();
             let vm = self.vm.as_mut().unwrap();
-            runtime.block_on(async { vm.step_execute().await })
+            runtime.block_on(local_set.run_until(vm.step_execute()))
         };
 
         for tele in self.drain_telemetry_events() {
@@ -444,11 +445,11 @@ impl Debugger {
                                     self.ensure_runtime();
                                     if let Some(vm) = self.vm.as_mut() {
                                         let runtime = self.runtime.as_ref().unwrap();
+                                        let local_set = self.local_set.as_ref().unwrap();
                                         let truthy = runtime
-                                            .block_on(async {
-                                                let local = tokio::task::LocalSet::new();
-                                                local.run_until(vm.evaluate_in_frame(cond, 0)).await
-                                            })
+                                            .block_on(
+                                                local_set.run_until(vm.evaluate_in_frame(cond, 0)),
+                                            )
                                             .map(|v| v.is_truthy())
                                             .unwrap_or(true);
                                         if !truthy {

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use super::state::{Debugger, StepMode};
-use crate::protocol::DapMessage;
+use crate::protocol::{DapMessage, DapResponse};
 
 fn make_request(seq: i64, command: &str, args: Option<serde_json::Value>) -> DapMessage {
     DapMessage {
@@ -26,6 +26,46 @@ fn write_temp_program(file_name: &str, source: &str) -> (TempDir, PathBuf) {
     let file = dir.path().join(file_name);
     std::fs::write(&file, source).expect("write temp Harn program");
     (dir, file)
+}
+
+fn run_debug_program(file_name: &str, source: &str) -> Vec<DapResponse> {
+    let mut dbg = Debugger::new();
+    let (_dir, file) = write_temp_program(file_name, source);
+
+    dbg.handle_message(make_request(1, "initialize", None));
+    dbg.handle_message(make_request(
+        2,
+        "launch",
+        Some(json!({"program": file.to_string_lossy()})),
+    ));
+
+    let mut responses = dbg.handle_message(make_request(3, "configurationDone", None));
+    let mut steps = 0usize;
+    while dbg.is_running() {
+        responses.extend(dbg.step_running_vm());
+        steps += 1;
+        assert!(steps < 20_000, "debug program did not terminate");
+    }
+    responses
+}
+
+fn stdout_text(responses: &[DapResponse]) -> String {
+    responses
+        .iter()
+        .filter(|r| {
+            r.event.as_deref() == Some("output")
+                && r.body
+                    .as_ref()
+                    .map(|b| b["category"] == "stdout")
+                    .unwrap_or(false)
+        })
+        .filter_map(|r| {
+            r.body
+                .as_ref()
+                .and_then(|body| body["output"].as_str())
+                .map(str::to_string)
+        })
+        .collect::<String>()
 }
 
 #[test]
@@ -186,6 +226,68 @@ fn test_launch_and_run() {
         .find(|r| r.event.as_deref() == Some("terminated"));
     assert!(terminated.is_some());
     drop(dbg);
+}
+
+#[test]
+fn test_parallel_runs_under_debugger_runtime() {
+    let responses = run_debug_program(
+        "parallel_debugger_runtime.harn",
+        r"
+pipeline test(task) {
+  let results = parallel 3 { i -> i * 10 }
+  log(results)
+}
+",
+    );
+    assert!(
+        responses
+            .iter()
+            .any(|r| r.event.as_deref() == Some("terminated")),
+        "parallel debug run should terminate: {responses:?}"
+    );
+    let output = stdout_text(&responses);
+    assert!(
+        output.contains("[harn] [0, 10, 20]"),
+        "parallel output missing from debugger stdout: {output:?}"
+    );
+}
+
+#[test]
+fn test_pool_workers_run_under_debugger_runtime() {
+    let responses = run_debug_program(
+        "pool_debugger_runtime.harn",
+        r#"
+import { pool_create, pool_wait } from "std/lifecycle/pool"
+
+pipeline test(task) {
+  let pool = pool_create({name: "dap-pool-runtime", max_concurrent: 4})
+  var handles = []
+  for i in 0 to 8 exclusive {
+    let seed = i
+    handles = handles.push(pool.submit({ -> seed + 10 }))
+  }
+  let results = pool_wait(handles)
+  var completed = 0
+  for result in results {
+    if result.status == "completed" && result.result >= 10 {
+      completed = completed + 1
+    }
+  }
+  log(completed)
+}
+"#,
+    );
+    assert!(
+        responses
+            .iter()
+            .any(|r| r.event.as_deref() == Some("terminated")),
+        "pool debug run should terminate: {responses:?}"
+    );
+    let output = stdout_text(&responses);
+    assert!(
+        output.contains("[harn] 8"),
+        "pool output missing from debugger stdout: {output:?}"
+    );
 }
 
 #[test]

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::path::PathBuf;
 
 use harn_vm::{Vm, VmValue};
@@ -26,6 +27,21 @@ fn write_temp_program(file_name: &str, source: &str) -> (TempDir, PathBuf) {
     let file = dir.path().join(file_name);
     std::fs::write(&file, source).expect("write temp Harn program");
     (dir, file)
+}
+
+fn file_uri(path: &Path) -> String {
+    url::Url::from_file_path(path)
+        .expect("absolute temporary path should convert to a file URI")
+        .to_string()
+}
+
+fn localhost_file_uri(path: &Path) -> String {
+    let uri = file_uri(path);
+    format!(
+        "file://localhost{}",
+        uri.strip_prefix("file://")
+            .expect("file_uri should produce a file scheme URI")
+    )
 }
 
 fn run_debug_program(file_name: &str, source: &str) -> Vec<DapResponse> {
@@ -458,14 +474,10 @@ fn test_source_reads_prompt_template_from_disk() {
 #[test]
 fn test_source_decodes_file_uri_paths() {
     let (dir, file) = write_temp_program("space name.harn", "pipeline test(task) {}\n");
-    let encoded = file.to_string_lossy().replace(' ', "%20");
 
-    for (seq, uri) in [
-        format!("file://{encoded}"),
-        format!("file://localhost{encoded}"),
-    ]
-    .into_iter()
-    .enumerate()
+    for (seq, uri) in [file_uri(&file), localhost_file_uri(&file)]
+        .into_iter()
+        .enumerate()
     {
         let responses = Debugger::new().handle_message(make_request(
             seq as i64 + 1,

--- a/crates/harn-dap/src/debugger/variables.rs
+++ b/crates/harn-dap/src/debugger/variables.rs
@@ -402,10 +402,10 @@ impl Debugger {
         };
         let name = name.to_string();
         let value_expr = value_expr.to_string();
-        self.runtime
-            .as_ref()
-            .unwrap()
-            .block_on(async { vm.set_variable_in_frame(&name, &value_expr, 0).await })
+        let runtime = self.runtime.as_ref().unwrap();
+        let local_set = self.local_set.as_ref().unwrap();
+        runtime
+            .block_on(local_set.run_until(vm.set_variable_in_frame(&name, &value_expr, 0)))
             .map_err(|e| format!("setVariable: {e}"))
     }
 
@@ -438,10 +438,10 @@ impl Debugger {
             ));
         };
         let expression_owned = expression.to_string();
-        self.runtime
-            .as_ref()
-            .unwrap()
-            .block_on(async { vm.evaluate_in_frame(&expression_owned, 0).await })
+        let runtime = self.runtime.as_ref().unwrap();
+        let local_set = self.local_set.as_ref().unwrap();
+        runtime
+            .block_on(local_set.run_until(vm.evaluate_in_frame(&expression_owned, 0)))
             .map_err(|e| format!("Cannot evaluate '{expression}': {e}"))
     }
 


### PR DESCRIPTION
## Summary
- run Harn DAP debuggee execution on a multi-threaded Tokio runtime with a persistent LocalSet
- route debugger expression, breakpoint-condition, and set-variable VM calls through that same LocalSet
- add DAP regression coverage for parallel blocks and lifecycle pool workers

## Verification
- CARGO_TARGET_DIR=/tmp/harn-dap-concurrency-target cargo test -p harn-dap test_parallel_runs_under_debugger_runtime -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-dap-concurrency-target cargo test -p harn-dap test_pool_workers_run_under_debugger_runtime -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-dap-concurrency-target cargo test -p harn-dap
- git commit hook: cargo fmt, changed-package clippy, markdownlint
- git push hook: targeted local checks, markdownlint