### PR TITLE
Allow standard process devices in OS sandboxes

### DIFF
--- a/changelog.d/macos-dev-null-sandbox.fixed.md
+++ b/changelog.d/macos-dev-null-sandbox.fixed.md
@@ -1,2 +1,3 @@
 Allow standard process device files such as `/dev/null` through the macOS and
-Linux process sandboxes without granting broad `/dev` access.
+Linux process sandboxes without granting broad `/dev` access, and mediate Linux
+device ioctls on kernels that support Landlock ABI 5.

--- a/changelog.d/macos-dev-null-sandbox.fixed.md
+++ b/changelog.d/macos-dev-null-sandbox.fixed.md
@@ -1,3 +1,4 @@
 Allow standard process device files such as `/dev/null` through the macOS and
 Linux process sandboxes without granting broad `/dev` access, and mediate Linux
-device ioctls on kernels that support Landlock ABI 5.
+device ioctls on kernels that support Landlock ABI 5. Workflow verifier
+commands also avoid login-shell dotfile reads under those sandboxes.

--- a/changelog.d/macos-dev-null-sandbox.fixed.md
+++ b/changelog.d/macos-dev-null-sandbox.fixed.md
@@ -1,0 +1,2 @@
+Allow standard process device files such as `/dev/null` through the macOS and
+Linux process sandboxes without granting broad `/dev` access.

--- a/conformance/tests/agents/workflow_retry_policy.expected
+++ b/conformance/tests/agents/workflow_retry_policy.expected
@@ -1,9 +1,9 @@
 failed
-error
-error
+verification_failed
+failed
 1
-0
-false
+1
+true
 true
 completed
 1

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1172,7 +1172,10 @@ pub async fn prepare_stage_node(
             let (program, args) = if cfg!(target_os = "windows") {
                 ("cmd", vec!["/C".to_string(), command.to_string()])
             } else {
-                ("/bin/sh", vec!["-lc".to_string(), command.to_string()])
+                // Do not use a login shell here. On macOS, `/bin/sh -l`
+                // reads user dotfiles such as `~/.profile`, which makes
+                // sandboxed verification depend on out-of-worktree state.
+                ("/bin/sh", vec!["-c".to_string(), command.to_string()])
             };
             let mut process_config = crate::stdlib::sandbox::ProcessCommandConfig {
                 stdin_null: true,

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -157,6 +157,9 @@ fn landlock_profile(
         rules: Vec::new(),
         handled_access_fs,
     };
+    for (path, access) in standard_device_rules() {
+        push_rule(&mut profile, path, access, true)?;
+    }
     for path in system_read_roots() {
         push_rule(
             &mut profile,
@@ -187,6 +190,21 @@ fn system_read_roots() -> Vec<PathBuf> {
     ]
     .into_iter()
     .map(PathBuf::from)
+    .collect()
+}
+
+fn standard_device_rules() -> Vec<(PathBuf, u64)> {
+    [
+        (
+            "/dev/null",
+            LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_WRITE_FILE,
+        ),
+        ("/dev/zero", LANDLOCK_ACCESS_FS_READ_FILE),
+        ("/dev/random", LANDLOCK_ACCESS_FS_READ_FILE),
+        ("/dev/urandom", LANDLOCK_ACCESS_FS_READ_FILE),
+    ]
+    .into_iter()
+    .map(|(path, access)| (PathBuf::from(path), access))
     .collect()
 }
 
@@ -521,5 +539,34 @@ mod tests {
             0,
             "read-only roots stay unwritable regardless of workspace write capability",
         );
+    }
+
+    #[test]
+    fn standard_device_rules_allow_common_device_files_only() {
+        let rules = standard_device_rules();
+        assert_eq!(rules.len(), 4);
+        assert!(rules
+            .iter()
+            .any(|(path, access)| path == PathBuf::from("/dev/null")
+                && access & LANDLOCK_ACCESS_FS_READ_FILE != 0
+                && access & LANDLOCK_ACCESS_FS_WRITE_FILE != 0));
+        for device in ["/dev/zero", "/dev/random", "/dev/urandom"] {
+            let Some((_, access)) = rules
+                .iter()
+                .find(|(path, _)| path == &PathBuf::from(device))
+            else {
+                panic!("missing standard device rule for {device}");
+            };
+            assert_ne!(
+                *access & LANDLOCK_ACCESS_FS_READ_FILE,
+                0,
+                "{device} should be readable"
+            );
+            assert_eq!(
+                *access & LANDLOCK_ACCESS_FS_WRITE_FILE,
+                0,
+                "{device} must not be writable"
+            );
+        }
     }
 }

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -7,7 +7,7 @@
 use std::io;
 use std::os::fd::AsRawFd;
 use std::os::unix::process::CommandExt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 use super::{
@@ -545,13 +545,15 @@ mod tests {
     fn standard_device_rules_allow_common_device_files_only() {
         let rules = standard_device_rules();
         assert_eq!(rules.len(), 4);
-        assert!(rules
-            .iter()
-            .any(|(path, access)| path == Path::new("/dev/null")
-                && access & LANDLOCK_ACCESS_FS_READ_FILE != 0
-                && access & LANDLOCK_ACCESS_FS_WRITE_FILE != 0));
+        assert!(rules.iter().any(|(path, access)| path.as_path()
+            == std::path::Path::new("/dev/null")
+            && access & LANDLOCK_ACCESS_FS_READ_FILE != 0
+            && access & LANDLOCK_ACCESS_FS_WRITE_FILE != 0));
         for device in ["/dev/zero", "/dev/random", "/dev/urandom"] {
-            let Some((_, access)) = rules.iter().find(|(path, _)| path == Path::new(device)) else {
+            let Some((_, access)) = rules
+                .iter()
+                .find(|(path, _)| path.as_path() == std::path::Path::new(device))
+            else {
                 panic!("missing standard device rule for {device}");
             };
             assert_ne!(

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -7,7 +7,7 @@
 use std::io;
 use std::os::fd::AsRawFd;
 use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::{
@@ -547,14 +547,11 @@ mod tests {
         assert_eq!(rules.len(), 4);
         assert!(rules
             .iter()
-            .any(|(path, access)| path == PathBuf::from("/dev/null")
+            .any(|(path, access)| path == Path::new("/dev/null")
                 && access & LANDLOCK_ACCESS_FS_READ_FILE != 0
                 && access & LANDLOCK_ACCESS_FS_WRITE_FILE != 0));
         for device in ["/dev/zero", "/dev/random", "/dev/urandom"] {
-            let Some((_, access)) = rules
-                .iter()
-                .find(|(path, _)| path == &PathBuf::from(device))
-            else {
+            let Some((_, access)) = rules.iter().find(|(path, _)| path == Path::new(device)) else {
                 panic!("missing standard device rule for {device}");
             };
             assert_ne!(

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -444,6 +444,9 @@ fn landlock_handled_access(abi: u32) -> u64 {
     if abi >= 3 {
         access |= LANDLOCK_ACCESS_FS_TRUNCATE;
     }
+    if abi >= 5 {
+        access |= LANDLOCK_ACCESS_FS_IOCTL_DEV;
+    }
     access
 }
 
@@ -475,6 +478,7 @@ const LANDLOCK_ACCESS_FS_MAKE_BLOCK: u64 = 1 << 11;
 const LANDLOCK_ACCESS_FS_MAKE_SYM: u64 = 1 << 12;
 const LANDLOCK_ACCESS_FS_REFER: u64 = 1 << 13;
 const LANDLOCK_ACCESS_FS_TRUNCATE: u64 = 1 << 14;
+const LANDLOCK_ACCESS_FS_IOCTL_DEV: u64 = 1 << 15;
 
 #[cfg(test)]
 mod tests {
@@ -548,7 +552,8 @@ mod tests {
         assert!(rules.iter().any(|(path, access)| path.as_path()
             == std::path::Path::new("/dev/null")
             && access & LANDLOCK_ACCESS_FS_READ_FILE != 0
-            && access & LANDLOCK_ACCESS_FS_WRITE_FILE != 0));
+            && access & LANDLOCK_ACCESS_FS_WRITE_FILE != 0
+            && access & LANDLOCK_ACCESS_FS_IOCTL_DEV == 0));
         for device in ["/dev/zero", "/dev/random", "/dev/urandom"] {
             let Some((_, access)) = rules
                 .iter()
@@ -566,6 +571,25 @@ mod tests {
                 0,
                 "{device} must not be writable"
             );
+            assert_eq!(
+                *access & LANDLOCK_ACCESS_FS_IOCTL_DEV,
+                0,
+                "{device} must not receive device ioctl access"
+            );
         }
+    }
+
+    #[test]
+    fn landlock_handled_access_tracks_device_ioctl_abi() {
+        assert_eq!(
+            landlock_handled_access(4) & LANDLOCK_ACCESS_FS_IOCTL_DEV,
+            0,
+            "ABI 4 kernels do not support device ioctl mediation",
+        );
+        assert_ne!(
+            landlock_handled_access(5) & LANDLOCK_ACCESS_FS_IOCTL_DEV,
+            0,
+            "ABI 5+ kernels should explicitly mediate device ioctls",
+        );
     }
 }

--- a/crates/harn-vm/src/stdlib/sandbox/macos.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/macos.rs
@@ -88,11 +88,11 @@ fn render_profile(policy: &CapabilityPolicy) -> String {
          (allow mach-lookup)\n\
          (allow file-read-metadata)\n\
          (allow file-read-data (literal \"/\"))\n\
-         (allow file-write* (subpath \"/dev\"))\n\
          (allow file-read* (subpath \"/private/var/select\"))\n\
          (allow file-read* (subpath \"/var/select\"))\n\
          (allow file-read* (subpath \"/Library/Developer\"))\n",
     );
+    profile.push_str(standard_device_profile_rules());
     for root in system_read_roots() {
         profile.push_str(&format!(
             "(allow file-read* (subpath \"{}\"))\n",
@@ -152,6 +152,26 @@ fn sandbox_profile_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+fn standard_device_profile_rules() -> &'static str {
+    // Keep this aligned with `is_standard_io_device` in `mod.rs`, but include
+    // common read-only entropy/zero devices that language runtimes and test
+    // harnesses legitimately open while still avoiding a broad `/dev` grant.
+    "(allow file-read* \
+       (literal \"/dev/null\") \
+       (literal \"/dev/zero\") \
+       (literal \"/dev/random\") \
+       (literal \"/dev/urandom\") \
+       (literal \"/dev/stdin\") \
+       (literal \"/dev/stdout\") \
+       (literal \"/dev/stderr\") \
+       (subpath \"/dev/fd\"))\n\
+     (allow file-write* \
+       (literal \"/dev/null\") \
+       (literal \"/dev/stdout\") \
+       (literal \"/dev/stderr\") \
+       (subpath \"/dev/fd\"))\n"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -200,6 +220,58 @@ mod tests {
 
         let writable = render_profile(&macos_policy_with_workspace_ops(&["write_text"]));
         assert!(writable.contains("(subpath \"/tmp\") (subpath \"/private/tmp\")"));
+    }
+
+    #[test]
+    fn sandbox_profile_allows_standard_devices_without_broad_dev_write() {
+        let profile = render_profile(&macos_policy_with_workspace_ops(&["read_text"]));
+        for device in ["/dev/null", "/dev/stdin", "/dev/stdout", "/dev/stderr"] {
+            assert!(
+                profile.contains(&format!("(literal \"{device}\")")),
+                "standard device {device} should be explicitly allowed: {profile}"
+            );
+        }
+        for device in ["/dev/zero", "/dev/random", "/dev/urandom"] {
+            assert!(
+                profile.contains(&format!("(literal \"{device}\")")),
+                "common read-only device {device} should be explicitly allowed: {profile}"
+            );
+        }
+        assert!(
+            profile.contains("(subpath \"/dev/fd\")"),
+            "numeric descriptor aliases should be allowed narrowly: {profile}"
+        );
+        assert!(
+            !profile.contains("(allow file-write* (subpath \"/dev\"))"),
+            "profile must not grant broad writes to every device: {profile}"
+        );
+    }
+
+    #[test]
+    fn sandbox_exec_profile_allows_common_device_runtime_access() {
+        if !Path::new(SANDBOX_EXEC_PATH).exists() {
+            return;
+        }
+        let profile = render_profile(&macos_policy_with_workspace_ops(&["read_text"]));
+        let output = Command::new(SANDBOX_EXEC_PATH)
+            .args([
+                "-p",
+                &profile,
+                "--",
+                "/bin/sh",
+                "-c",
+                "cat /dev/null >/dev/null \
+                 && dd if=/dev/zero of=/dev/null bs=1 count=1 2>/dev/null \
+                 && dd if=/dev/urandom of=/dev/null bs=1 count=1 2>/dev/null",
+            ])
+            .output()
+            .expect("run sandbox-exec device smoke");
+        assert!(
+            output.status.success(),
+            "standard device smoke should pass\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -58,10 +58,9 @@ thread_local! {
     static WARNED_KEYS: RefCell<BTreeSet<String>> = const { RefCell::new(BTreeSet::new()) };
 }
 
-/// The kind of filesystem access a path-scope check is guarding. Drives
-/// only the verb rendered in a rejection message — the scope decision
-/// itself is identical for reads, writes, and deletes (a path is either
-/// inside the workspace roots or it is not).
+/// The kind of filesystem access a path-scope check is guarding. This drives
+/// the verb rendered in rejection messages and the narrow standard-device
+/// exception; ordinary files are otherwise scoped by the same workspace roots.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FsAccess {
     Read,
@@ -358,7 +357,7 @@ pub fn check_fs_path_scope(path: &Path, access: FsAccess) -> Result<(), SandboxV
     // rewrites /dev/stdout to a per-process /dev/fd/<…>.output alias that no
     // longer looks like a standard device. Kept deliberately narrow — only
     // the well-known device files, no broader /dev access.
-    if is_standard_io_device(&normalize_io_device_path(path)) {
+    if is_standard_io_device_for_access(&normalize_io_device_path(path), access) {
         return Ok(());
     }
     let candidate = normalize_for_policy(path);
@@ -793,14 +792,25 @@ fn normalize_io_device_path(path: &Path) -> PathBuf {
 }
 
 /// Whether `path` is one of the standard process I/O device files that the
-/// sandbox treats as a stream rather than a workspace mutation: `/dev/stdout`,
-/// `/dev/stderr`, `/dev/null`, or a numeric file-descriptor `/dev/fd/<N>`.
-/// `path` must already be absolute and lexically normalized.
-fn is_standard_io_device(path: &Path) -> bool {
-    matches!(
-        path.to_str(),
-        Some("/dev/stdout" | "/dev/stderr" | "/dev/null")
-    ) || is_dev_fd_descriptor(path)
+/// sandbox treats as a stream rather than a workspace mutation for this access:
+/// stdin is read-only, stdout/stderr/null are read/write, and delete is never a
+/// stream operation. `path` must already be absolute and lexically normalized.
+fn is_standard_io_device_for_access(path: &Path, access: FsAccess) -> bool {
+    match access {
+        FsAccess::Read => {
+            matches!(
+                path.to_str(),
+                Some("/dev/stdin" | "/dev/stdout" | "/dev/stderr" | "/dev/null")
+            ) || is_dev_fd_descriptor(path)
+        }
+        FsAccess::Write => {
+            matches!(
+                path.to_str(),
+                Some("/dev/stdout" | "/dev/stderr" | "/dev/null")
+            ) || is_dev_fd_descriptor(path)
+        }
+        FsAccess::Delete => false,
+    }
 }
 
 /// Whether `path` is exactly `/dev/fd/<N>` for a non-empty run of ASCII
@@ -1028,6 +1038,18 @@ mod tests {
                 "read of standard device {device} must be allowed"
             );
         }
+        assert!(
+            check_fs_path_scope(Path::new("/dev/stdin"), FsAccess::Read).is_ok(),
+            "read of standard device /dev/stdin must be allowed"
+        );
+        assert!(
+            check_fs_path_scope(Path::new("/dev/stdin"), FsAccess::Write).is_err(),
+            "write to /dev/stdin is not a standard output stream"
+        );
+        assert!(
+            check_fs_path_scope(Path::new("/dev/null"), FsAccess::Delete).is_err(),
+            "standard devices must not bypass delete scoping"
+        );
         // Numeric /dev/fd/<N> descriptors are allowed.
         assert!(check_fs_path_scope(Path::new("/dev/fd/1"), FsAccess::Write).is_ok());
         assert!(check_fs_path_scope(Path::new("/dev/fd/2"), FsAccess::Write).is_ok());
@@ -1053,16 +1075,58 @@ mod tests {
 
     #[test]
     fn is_standard_io_device_matches_only_known_streams() {
-        assert!(is_standard_io_device(Path::new("/dev/stdout")));
-        assert!(is_standard_io_device(Path::new("/dev/stderr")));
-        assert!(is_standard_io_device(Path::new("/dev/null")));
-        assert!(is_standard_io_device(Path::new("/dev/fd/0")));
-        assert!(is_standard_io_device(Path::new("/dev/fd/12")));
-        assert!(!is_standard_io_device(Path::new("/dev/fd/")));
-        assert!(!is_standard_io_device(Path::new("/dev/fd/1a")));
-        assert!(!is_standard_io_device(Path::new("/dev/stdoutx")));
-        assert!(!is_standard_io_device(Path::new("/dev/random")));
-        assert!(!is_standard_io_device(Path::new("/tmp/dev/null")));
+        assert!(is_standard_io_device_for_access(
+            Path::new("/dev/stdin"),
+            FsAccess::Read
+        ));
+        assert!(!is_standard_io_device_for_access(
+            Path::new("/dev/stdin"),
+            FsAccess::Write
+        ));
+        assert!(is_standard_io_device_for_access(
+            Path::new("/dev/stdout"),
+            FsAccess::Write
+        ));
+        assert!(is_standard_io_device_for_access(
+            Path::new("/dev/stderr"),
+            FsAccess::Write
+        ));
+        assert!(is_standard_io_device_for_access(
+            Path::new("/dev/null"),
+            FsAccess::Write
+        ));
+        assert!(is_standard_io_device_for_access(
+            Path::new("/dev/fd/0"),
+            FsAccess::Read
+        ));
+        assert!(is_standard_io_device_for_access(
+            Path::new("/dev/fd/12"),
+            FsAccess::Write
+        ));
+        assert!(!is_standard_io_device_for_access(
+            Path::new("/dev/null"),
+            FsAccess::Delete
+        ));
+        assert!(!is_standard_io_device_for_access(
+            Path::new("/dev/fd/"),
+            FsAccess::Write
+        ));
+        assert!(!is_standard_io_device_for_access(
+            Path::new("/dev/fd/1a"),
+            FsAccess::Write
+        ));
+        assert!(!is_standard_io_device_for_access(
+            Path::new("/dev/stdoutx"),
+            FsAccess::Write
+        ));
+        assert!(!is_standard_io_device_for_access(
+            Path::new("/dev/random"),
+            FsAccess::Read
+        ));
+        assert!(!is_standard_io_device_for_access(
+            Path::new("/tmp/dev/null"),
+            FsAccess::Write
+        ));
     }
 
     #[test]

--- a/docs/src/sandboxing.md
+++ b/docs/src/sandboxing.md
@@ -123,6 +123,7 @@ small, named kernel feature, never an open-ended escape hatch.
 | `workspace.write_text` | Landlock `_WRITE_FILE` + `_REMOVE_*` + `_MAKE_*` + (ABI ≥ 2) `_REFER` + (ABI ≥ 3) `_TRUNCATE` | writes scoped to `workspace_roots` |
 | `workspace.delete` | Landlock `_REMOVE_DIR` + `_REMOVE_FILE` | removes scoped to `workspace_roots` |
 | `read_only_roots: [...]` | Landlock `_READ_FILE` + `_READ_DIR` + `_EXECUTE` only | each read-only root is readable but never writable, regardless of the `workspace.*` capabilities |
+| standard process devices | Landlock grants read/write on `/dev/null` and read-only access on `/dev/zero`, `/dev/random`, and `/dev/urandom`; ABI ≥ 5 also handles `_IOCTL_DEV` but does not grant it to these device rules | language runtimes and test harnesses can open the devices they normally need without broad `/dev` access or device ioctl rights |
 | `side_effect_level < network` | seccomp-bpf blocklist on `socket`, `socketpair`, `connect`, `accept`, `accept4`, `bind`, `listen`, `sendto`, `sendmsg`, `recvfrom`, `recvmsg` (return `EPERM`) | network syscalls fail without taking down the process |
 | always | seccomp-bpf blocklist on `bpf`, `mount`, `umount2`, `init_module`, `delete_module`, `finit_module`, `kexec_*`, `ptrace`, `process_vm_readv`/`process_vm_writev`, `perf_event_open`, `swapon`/`swapoff`, `reboot`, `userfaultfd`, `fanotify_init`, `open_by_handle_at` (return `EPERM`) | tier-1 dangerous syscalls are denied unconditionally |
 | always | `prctl(PR_SET_NO_NEW_PRIVS, 1)` | no setuid escalation across `exec` |
@@ -137,7 +138,8 @@ falls back to the warn/enforce decision documented above.
 | Capability / policy | `sandbox-exec` rule | Effect |
 |---|---|---|
 | always | `(deny default)` | every operation requires an explicit allow |
-| always | `(allow process*)` + `(allow sysctl-read)` + `(allow mach-lookup)` + `(allow file-read-data (literal "/"))` + `(allow file-write* (subpath "/dev"))` | minimum surface required to exec a binary and reach `/dev` |
+| always | `(allow process*)` + `(allow sysctl-read)` + `(allow mach-lookup)` + `(allow file-read-data (literal "/"))` | minimum surface required to exec a binary |
+| standard process devices | `(allow file-read* ...)` for `/dev/null`, `/dev/zero`, `/dev/random`, `/dev/urandom`, `/dev/stdin`, `/dev/stdout`, `/dev/stderr`, and `/dev/fd`; `(allow file-write* ...)` only for `/dev/null`, `/dev/stdout`, `/dev/stderr`, and `/dev/fd` | common stdio, entropy, and zero devices work without granting broad `/dev` writes |
 | always | `(allow file-read* (subpath "/bin" \| "/etc" \| "/Library" \| "/opt/homebrew" \| "/private/etc" \| "/System" \| "/usr"))` | read access to the directories the dynamic linker and most CLI tools need |
 | `workspace_roots: [...]` / `read_only_roots: [...]` | `(allow file-read* (subpath "<root>"))` | workspace and read-only roots are readable |
 | `workspace.write_text` / `workspace.delete` (or empty `capabilities`) | `(allow file-write* (subpath "/tmp" \| "/private/tmp" \| "/var/tmp"))` + `(allow file-write* (subpath "<root>"))` + `(deny file-write* (subpath "<read_only_root>"))` | scratch dirs and writable `workspace_roots` are writable; each `read_only_roots` entry is then re-denied write. `sandbox-exec` is last-match-wins, so the trailing deny keeps a read-only root nested under a writable root unwritable even though the two lists are nominally disjoint |


### PR DESCRIPTION
## Summary

- allow standard process device files through the macOS sandbox profile without a broad `/dev` write grant
- add narrow optional Linux Landlock rules for `/dev/null`, `/dev/zero`, `/dev/random`, and `/dev/urandom`
- mediate Linux device ioctls on Landlock ABI 5+ while granting no device ioctl rights to the standard-device allowlist
- tighten Harn's host path gate so `/dev/stdin` is read-only and standard devices never bypass delete scoping
- make workflow verifier commands use non-login shells so sandboxed verification cannot depend on user dotfiles like `~/.profile`
- cover macOS with rendered-profile assertions, a real `sandbox-exec` device smoke test, and the workflow retry conformance fixture

## Platform audit

- macOS: fixed. The profile now explicitly allows standard stdio/null descriptors and read-only entropy/zero devices, and removes the previous broad `(subpath "/dev")` write grant. Workflow verifier subprocesses also avoid login-shell startup files, preventing dotfile sandbox denials from being misclassified as verifier failures.
- Linux: fixed. Landlock now installs optional, narrow device-file rules so common language/test runners can open standard devices when Landlock is enforcing; ABI 5+ kernels also explicitly deny ungranted device ioctls.
- OpenBSD: already covered by the existing `/dev` unveil rule.
- Windows: already covered by inherited stdio handles plus the existing `NUL` stdin handle path; no filesystem-policy change needed.

I intentionally did not add `/dev/tty`, `/dev/ptmx`, or `/dev/pts` because the current process sandbox does not allocate pseudo-terminals for tool subprocesses, and those device classes materially widen the interactive device surface. They should be added only behind a future explicit PTY capability.

## Verification

- `HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance conformance/tests/agents/workflow_retry_policy.harn`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo test -p harn-vm stdlib::sandbox -- --nocapture`
- `CARGO_PROFILE_TEST_DEBUG=0 cargo test -p harn-vm orchestration::workflow -- --nocapture`
- `npx markdownlint-cli2 docs/src/sandboxing.md changelog.d/macos-dev-null-sandbox.fixed.md`
- `cargo fmt --check`
- `git diff --check`
- pre-commit changed-package clippy gate
- pre-push targeted local checks