### PR TITLE
Recover from invalid await-resumption calls

### DIFF
--- a/changelog.d/agent-await-invalid-feedback.fixed.md
+++ b/changelog.d/agent-await-invalid-feedback.fixed.md
@@ -1,0 +1,4 @@
+- **Agent loop lifecycle calls recover from invalid self-suspension arguments.**
+  Malformed `agent_await_resumption` calls now inject corrective feedback and
+  let the model continue instead of aborting the whole turn with
+  `HARN-SUS-002`.

--- a/conformance/tests/agents/agent_await_resumption_invalid_feedback.expected
+++ b/conformance/tests/agents/agent_await_resumption_invalid_feedback.expected
@@ -1,0 +1,4 @@
+done
+2
+true
+true

--- a/conformance/tests/agents/agent_await_resumption_invalid_feedback.harn
+++ b/conformance/tests/agents/agent_await_resumption_invalid_feedback.harn
@@ -1,0 +1,34 @@
+pipeline main() {
+  llm_mock_clear()
+  llm_mock(
+    {
+      tool_calls: [
+        {
+          id: "bad_await",
+          name: "agent_await_resumption",
+          arguments: {reason: "waiting on review", conditions: {trigger: "review.approved"}},
+        },
+      ],
+      input_tokens: 7,
+      output_tokens: 3,
+    },
+  )
+  llm_mock({text: "Recovered. ##DONE##", input_tokens: 5, output_tokens: 2})
+  let result = agent_loop(
+    "Finish without parking.",
+    nil,
+    {
+      provider: "mock",
+      tool_format: "native",
+      loop_until_done: true,
+      done_sentinel: "##DONE##",
+      max_iterations: 3,
+    },
+  )
+  let calls = llm_mock_calls()
+  let followup = json_stringify(calls[1]?.messages ?? [])
+  __io_println(result.status)
+  __io_println(len(calls))
+  __io_println(contains(followup, "HARN-SUS-002"))
+  __io_println(contains(followup, "conditions.trigger"))
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -594,6 +594,15 @@ fn __agent_loop_await_resumption_top_level(session, iteration, call, parsed, opt
   }
 }
 
+fn __agent_loop_invalid_await_resumption_feedback(error) {
+  return "Invalid agent_await_resumption call: "
+    + to_string(error)
+    + "\n\nThis lifecycle tool is only for parking until external input or a valid resume condition. "
+    + "For ordinary work, continue with the available project tools or finish normally. "
+    + "If you do need a resume condition, `conditions.trigger` must be an object trigger spec; "
+    + "use `conditions.on_event` for an event-topic string."
+}
+
 fn __tool_call_name(call) {
   return to_string(call?.name ?? call?.tool_name ?? "")
 }
@@ -1831,7 +1840,52 @@ fn __agent_loop_run(message, session, initial_opts) {
       agent_session_record_assistant(session.session_id, recorded_assistant)
       let await_call = __agent_await_resumption_call(tool_calls)
       if await_call != nil {
-        suspend_result = __agent_loop_await_resumption(session, iteration, await_call, opts)
+        let await_result = try {
+          __agent_loop_await_resumption(session, iteration, await_call, opts)
+        }
+        if is_err(await_result) {
+          let await_error = unwrap_err(await_result)
+          agent_session_inject_feedback(
+            session.session_id,
+            "agent_await_resumption",
+            __agent_loop_invalid_await_resumption_feedback(await_error),
+          )
+          let await_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+          agent_emit_event(
+            session.session_id,
+            "iteration_end",
+            {
+              iteration: iteration_index + 1,
+              iteration_info: __agent_loop_iteration_info(
+                session.session_id,
+                llm_result,
+                len(tool_calls),
+                visible_text,
+                await_totals,
+                loop_start_ms,
+              )
+                + {dispatch_skipped: true, skip_reason: "invalid_agent_await_resumption"},
+            },
+          )
+          let await_exhaustion = __agent_loop_budget_exhaustion(
+            session.session_id,
+            budget,
+            iteration,
+            await_totals,
+            loop_start_ms,
+            current_max,
+          )
+          if await_exhaustion.exhausted {
+            __agent_loop_emit_budget_exhausted(session.session_id, await_exhaustion)
+            budget_exhausted_emitted = true
+            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, await_exhaustion.kind)
+            final_status = "budget_exhausted"
+            stop_reason = await_exhaustion.kind
+            break
+          }
+          continue
+        }
+        suspend_result = unwrap(await_result)
         let _totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
         agent_emit_event(
           session.session_id,


### PR DESCRIPTION
## Summary
- catch invalid structural `agent_await_resumption` calls inside `agent_loop`
- inject corrective feedback instead of aborting the turn with `HARN-SUS-002`
- add a conformance regression for malformed `conditions.trigger` followed by a successful recovery turn

## Root cause
The lifecycle tool is injected structurally by `agent_loop`, so malformed self-suspension arguments bypass normal tool-result recovery and throw out of the loop. In Rust-headless evals, a model emitted `conditions.trigger` as a string, which turned a recoverable model mistake into a hard runtime abort.

## Verification
- harn test conformance tests/agents/agent_await_resumption_invalid_feedback.harn --timeout 30000 --verbose
- harn test conformance tests/agents/agent_await_resumption.harn --timeout 30000 --verbose
- harn test conformance tests/agents/suspend_diagnostics_trigger_paths.harn --timeout 30000 --verbose
- harn test conformance tests/agents/agent_top_level_await_resumption_cli.harn --timeout 30000 --verbose
- harn fmt --check crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_await_resumption_invalid_feedback.harn
- make lint-harn
- pre-commit and pre-push hooks