### PR TITLE
Fix single-trace skill induction heldout gate

### DIFF
--- a/changelog.d/2709.fixed.md
+++ b/changelog.d/2709.fixed.md
@@ -1,0 +1,3 @@
+- Fixed `skill_induce(...)` so a single source trace with held-out sibling
+  traces can pass the replay-gated skill induction path instead of falling
+  through to repeated-trace mining.

--- a/crates/harn-vm/src/orchestration/crystallize/api.rs
+++ b/crates/harn-vm/src/orchestration/crystallize/api.rs
@@ -147,10 +147,11 @@ pub fn crystallize_traces(
 /// (`build_crystallization_bundle`) and validates with the existing
 /// validator.
 ///
-/// `extra_parameters` and `extra_metadata` let callers seed parameters
-/// (e.g., release identity fields like `current_version` /
-/// `next_version`) and metadata (segment / recovery summaries) that the
-/// trace alone does not surface.
+/// The trace is treated as the source example and `options.shadow_traces`
+/// supply held-out siblings for replay/shadow gating. `extra_parameters`
+/// and `extra_metadata` let callers seed parameters (e.g., release identity
+/// fields like `current_version` / `next_version`) and metadata (segment /
+/// recovery summaries) that the trace alone does not surface.
 pub fn synthesize_candidate_from_trace(
     trace: CrystallizationTrace,
     options: CrystallizeOptions,
@@ -164,8 +165,20 @@ pub fn synthesize_candidate_from_trace(
         ));
     }
     let normalized = normalize_trace(trace);
+    let (shadow_traces, excluded_shadow) = partition_mineable_traces(
+        options
+            .shadow_traces
+            .iter()
+            .cloned()
+            .map(normalize_trace)
+            .collect(),
+    );
+    let mut shadow_pool = Vec::with_capacity(1 + shadow_traces.len());
+    shadow_pool.push(normalized.clone());
+    shadow_pool.extend(shadow_traces);
+
     let mut candidate = build_single_trace_candidate(&normalized, &options, extra_parameters);
-    candidate.shadow = shadow_candidate(&candidate, std::slice::from_ref(&normalized));
+    candidate.shadow = shadow_candidate(&candidate, &shadow_pool);
     if !candidate.shadow.pass {
         candidate
             .rejection_reasons
@@ -189,7 +202,7 @@ pub fn synthesize_candidate_from_trace(
         version: 1,
         generated_at: now_rfc3339(),
         source_trace_count: 1,
-        excluded_trace_count: 0,
+        excluded_trace_count: excluded_shadow.len(),
         selected_candidate_id: selected_id,
         candidates: accepted,
         rejected_candidates: rejected,
@@ -215,7 +228,7 @@ pub fn synthesize_candidate_from_trace(
         segment_summary,
         recovery_summary,
     };
-    refresh_skill_candidates(&mut report, std::slice::from_ref(&normalized));
+    refresh_skill_candidates(&mut report, &shadow_pool);
 
     Ok(CrystallizationArtifacts {
         report,

--- a/crates/harn-vm/src/orchestration/crystallize_tests.rs
+++ b/crates/harn-vm/src/orchestration/crystallize_tests.rs
@@ -672,6 +672,43 @@ fn plan_only_fixture_yields_plan_only_kind() {
 }
 
 #[test]
+fn single_trace_synthesis_uses_shadow_traces_for_skill_induction() {
+    let source = version_trace("trace_source", "0.9.1", "release-branch", false);
+    let heldout = version_trace("trace_heldout", "0.9.2", "release-branch", false);
+
+    let artifacts = synthesize_candidate_from_trace(
+        source,
+        CrystallizeOptions {
+            shadow_traces: vec![heldout],
+            workflow_name: Some("release_package_maintenance".to_string()),
+            package_name: Some("release-workflows".to_string()),
+            ..CrystallizeOptions::default()
+        },
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("single-trace synthesis");
+
+    let candidate = artifacts.report.candidates.first().expect("candidate");
+    assert!(candidate.shadow.pass);
+    assert_eq!(candidate.shadow.compared_traces, 2);
+
+    let skill = artifacts
+        .report
+        .skill_candidates
+        .first()
+        .expect("accepted skill candidate");
+    assert!(skill.replay_gate.receipt.accepted);
+    assert_eq!(skill.replay_gate.original_trace_count, 1);
+    assert_eq!(skill.replay_gate.heldout_trace_count, 1);
+    assert!(skill
+        .evidence_refs
+        .iter()
+        .any(|evidence| evidence.role == SkillCandidateEvidenceRole::HeldOut));
+}
+
+#[test]
 fn rejected_bundle_has_rejected_kind() {
     let traces = vec![
         version_trace("trace_a", "0.7.1", "release-branch", false),

--- a/crates/harn-vm/src/stdlib/records.rs
+++ b/crates/harn-vm/src/stdlib/records.rs
@@ -926,7 +926,7 @@ fn skill_induce_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         .ok_or_else(|| VmError::Runtime("skill_induce: payload must be a dict".to_string()))?;
     let traces = parse_skill_induce_traces(payload)?;
     let options = parse_skill_induce_options(payload)?;
-    let artifacts = if traces.len() == 1 && options.shadow_traces.is_empty() {
+    let artifacts = if traces.len() == 1 {
         synthesize_candidate_from_trace(
             traces.into_iter().next().expect("len checked"),
             options,
@@ -1346,3 +1346,100 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     &EVAL_METRIC_IMPL_DEF,
     &EVAL_METRICS_IMPL_DEF,
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn skill_induce_trace(id: &str, version: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "source_hash": format!("sha256:{id}"),
+            "actions": [
+                {
+                    "id": format!("{id}-branch"),
+                    "kind": "tool_call",
+                    "name": "git.checkout_branch",
+                    "parameters": {
+                        "branch_name": format!("release-{version}")
+                    },
+                    "side_effects": [
+                        {
+                            "kind": "git_ref",
+                            "target": "release-branch",
+                            "capability": "git.write"
+                        }
+                    ],
+                    "capabilities": ["git.write"],
+                    "deterministic": true
+                },
+                {
+                    "id": format!("{id}-manifest"),
+                    "kind": "file_mutation",
+                    "name": "update_manifest_version",
+                    "parameters": {
+                        "version": version
+                    },
+                    "side_effects": [
+                        {
+                            "kind": "file_write",
+                            "target": "harn.toml",
+                            "capability": "fs.write"
+                        }
+                    ],
+                    "capabilities": ["fs.write"],
+                    "deterministic": true
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn skill_induce_accepts_single_trace_with_heldout_sibling() {
+        let payload = serde_json::json!({
+            "trace": skill_induce_trace("source_trace", "0.9.1"),
+            "heldout_traces": [skill_induce_trace("heldout_trace", "0.9.2")],
+            "options": {
+                "workflow_name": "release_package_maintenance",
+                "package_name": "release-workflows"
+            }
+        });
+
+        let result = skill_induce_impl(
+            &[crate::stdlib::json_to_vm_value(&payload)],
+            &mut String::new(),
+        )
+        .expect("skill_induce");
+        let result = result.as_dict().expect("skill_induce result dict");
+        assert!(matches!(result.get("accepted"), Some(VmValue::Bool(true))));
+
+        let Some(VmValue::List(skills)) = result.get("skill_candidates") else {
+            panic!("skill_candidates should be a list");
+        };
+        assert_eq!(skills.len(), 1);
+
+        let skill = skills[0].as_dict().expect("skill candidate dict");
+        let replay_gate = skill
+            .get("replay_gate")
+            .and_then(VmValue::as_dict)
+            .expect("replay_gate dict");
+        assert_eq!(
+            replay_gate
+                .get("original_trace_count")
+                .and_then(VmValue::as_int),
+            Some(1)
+        );
+        assert_eq!(
+            replay_gate
+                .get("heldout_trace_count")
+                .and_then(VmValue::as_int),
+            Some(1)
+        );
+
+        let receipt = replay_gate
+            .get("receipt")
+            .and_then(VmValue::as_dict)
+            .expect("receipt dict");
+        assert!(matches!(receipt.get("accepted"), Some(VmValue::Bool(true))));
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `skill_induce(...)` so a single source trace with held-out sibling traces uses the single-trace synthesis path instead of repeated-trace mining.
- Feed `CrystallizeOptions::shadow_traces` into single-trace synthesis shadow replay and skill evidence, allowing replay-gated skill acceptance when the held-out sibling passes.
- Add regression coverage for both the core synthesis API and the stdlib facade, plus a changelog fragment.

## Root Cause

The `skill_induce` facade accepted `trace`/`trajectory` plus `heldout_traces`, but routed any single source trace with held-outs into `crystallize_traces`. That path requires at least two source examples and failed before the replay gate could evaluate the held-out sibling.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo check -p harn-vm --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo test -p harn-vm skill_induce_accepts_single_trace_with_heldout_sibling`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo test -p harn-vm single_trace_synthesis_uses_shadow_traces_for_skill_induction`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo test -p harn-vm crystallize`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo test -p harn-vm --test trajectory_tap`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo test -p harn-cli --test crystallize_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo test -p harn-cli --test eval_skill_gate_cli`
- `CARGO_TARGET_DIR=/tmp/harn-target-2709 cargo run --quiet --bin harn -- eval skill-gate examples/evals/skill-gate/smoke/manifest.json --output /tmp/harn-skill-gate-2709 --json`
- `make lint-test-patterns`
- pre-commit hook passed
- pre-push hook passed

Closes #2709