### PR TITLE
Expose ACP embedding helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,10 @@ jobs:
 
           echo "windows: cargo package args: ${package_args[*]}"
           if command -v cargo-nextest >/dev/null 2>&1; then
-            cargo nextest run "${package_args[@]}" -E "$windows_filter"
+            # Some affected crate sets compile Windows-only surfaces but have
+            # no tests matching the core unit filter; the compile itself is
+            # still the smoke gate for those PRs.
+            cargo nextest run "${package_args[@]}" -E "$windows_filter" --no-tests=warn
           else
             cargo test "${package_args[@]}" --no-run
             cargo test -p harn-lexer -p harn-parser -p harn-stdlib -p harn-vm -p harn-hostlib -p harn-fmt -p harn-lint -p harn-modules

--- a/changelog.d/2636.changed.md
+++ b/changelog.d/2636.changed.md
@@ -1,0 +1,1 @@
+- Expose typed Rust ACP request/result helpers and direct ACP output hooks for in-process embedders.

--- a/crates/harn-serve/src/adapters/acp/bridge.rs
+++ b/crates/harn-serve/src/adapters/acp/bridge.rs
@@ -45,17 +45,37 @@ pub(super) fn suppress_default_info_log(message: &str) -> bool {
 }
 
 #[derive(Clone)]
-pub(super) enum AcpOutput {
+#[non_exhaustive]
+pub enum AcpOutput {
+    /// Write ACP JSON-RPC lines to process stdout, one line per message.
     Stdout(Arc<std::sync::Mutex<()>>),
+    /// Send ACP JSON-RPC lines through an in-process channel.
     Channel(mpsc::UnboundedSender<String>),
+    /// Invoke a host callback for each ACP JSON-RPC line.
+    Callback(Arc<dyn Fn(&str) + Send + Sync + 'static>),
 }
 
 impl AcpOutput {
-    pub(super) fn stdout() -> Self {
+    /// Create an output sink that writes one JSON-RPC line per stdout line.
+    pub fn stdout() -> Self {
         Self::Stdout(Arc::new(std::sync::Mutex::new(())))
     }
 
-    pub(super) fn write_line(&self, line: &str) {
+    /// Create an output sink backed by a Tokio unbounded channel.
+    pub fn channel(tx: mpsc::UnboundedSender<String>) -> Self {
+        Self::Channel(tx)
+    }
+
+    /// Create an output sink backed by a host callback.
+    ///
+    /// The callback receives the serialized JSON-RPC message without a
+    /// trailing newline.
+    pub fn callback(write_line: impl Fn(&str) + Send + Sync + 'static) -> Self {
+        Self::Callback(Arc::new(write_line))
+    }
+
+    /// Write a serialized ACP JSON-RPC message to this sink.
+    pub fn write_line(&self, line: &str) {
         match self {
             Self::Stdout(lock) => {
                 let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
@@ -67,6 +87,7 @@ impl AcpOutput {
             Self::Channel(tx) => {
                 let _ = tx.send(line.to_string());
             }
+            Self::Callback(write_line) => write_line(line),
         }
     }
 }

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -23,9 +23,11 @@ mod sessions;
 #[cfg(test)]
 mod tests;
 mod transport;
+mod types;
 
 use auth::acp_auth_request_for_method;
-use bridge::{AcpBridge, AcpOutput};
+use bridge::AcpBridge;
+pub use bridge::AcpOutput;
 #[cfg(test)]
 use schema::configured_llm_route_for_capabilities;
 use schema::{
@@ -45,6 +47,16 @@ pub(crate) use transport::run_acp_channel_server_with_existing_handle;
 pub use transport::{
     run_acp_channel_server, run_acp_channel_server_with_handle, run_acp_server,
     run_acp_websocket_server, AcpChannelHandle, AcpWebSocketServeOptions,
+};
+pub use types::{
+    AcpContentBlock, AcpEmbeddedResource, AcpHarnMeta, AcpJsonRpcError, AcpJsonRpcErrorResponse,
+    AcpJsonRpcId, AcpJsonRpcRequest, AcpJsonRpcResponse, AcpMeta, AcpSessionCancelToolCallParams,
+    AcpSessionIdParams, AcpSessionInjectContent, AcpSessionInjectMode, AcpSessionInjectParams,
+    AcpSessionMessageIdParams, AcpSessionNewParams, AcpSessionPromptParams, AcpSessionPromptResult,
+    AcpSessionReplaceInjectParams, AcpSessionRestoreResult, ACP_METHOD_INITIALIZE,
+    ACP_METHOD_SESSION_CANCEL, ACP_METHOD_SESSION_CANCEL_TOOL_CALL, ACP_METHOD_SESSION_CLOSE,
+    ACP_METHOD_SESSION_INJECT, ACP_METHOD_SESSION_NEW, ACP_METHOD_SESSION_PENDING_INJECTIONS,
+    ACP_METHOD_SESSION_PROMPT, ACP_METHOD_SESSION_REPLACE_INJECT, ACP_METHOD_SESSION_REVOKE_INJECT,
 };
 
 use std::collections::{BTreeMap, HashMap};
@@ -699,7 +711,13 @@ impl AcpServer {
         Self::new_with_output(config, AcpOutput::stdout())
     }
 
-    fn new_with_output(config: AcpServerConfig, output: AcpOutput) -> Self {
+    /// Create an ACP server that writes responses and notifications to a
+    /// caller-provided output sink.
+    ///
+    /// Prefer [`crate::EmbeddedAgent`] or [`run_acp_channel_server_with_handle`]
+    /// unless the host already owns the compatible current-thread runtime and
+    /// wants to drive incoming JSON-RPC messages directly.
+    pub fn new_with_output(config: AcpServerConfig, output: AcpOutput) -> Self {
         harn_vm::llm_config::set_user_overrides(config.llm_config_overrides.clone());
         harn_vm::llm::capabilities::set_user_overrides(config.llm_capability_overrides.clone());
         let llm_config_overrides = config.llm_config_overrides.clone();
@@ -3531,7 +3549,12 @@ impl AcpServer {
         }
     }
 
-    async fn handle_incoming_message(&mut self, msg: serde_json::Value) {
+    /// Dispatch one incoming ACP JSON-RPC message.
+    ///
+    /// The same router backs stdio, WebSocket, and in-process channel
+    /// transports. `msg` must be either a request/notification with `method`
+    /// or a response with `id` for a pending host callback.
+    pub async fn handle_incoming_message(&mut self, msg: serde_json::Value) {
         if msg.get("method").is_none() && msg.get("id").is_some() {
             if let Some(id) = msg["id"].as_u64() {
                 let mut pending = self.pending.lock().await;

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -123,6 +123,36 @@ async fn start_acp_code_session_with_config(
     (request_tx, response_rx, server, session_id)
 }
 
+#[tokio::test]
+async fn public_acp_output_callback_receives_server_lines() {
+    let lines = Arc::new(Mutex::new(Vec::<String>::new()));
+    let captured = lines.clone();
+    let mut server = AcpServer::new_with_output(
+        AcpServerConfig::new(None),
+        AcpOutput::callback(move |line| {
+            captured
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(line.to_string());
+        }),
+    );
+
+    server
+        .handle_incoming_message(
+            AcpJsonRpcRequest::initialize(1)
+                .into_json_value()
+                .expect("initialize request serializes"),
+        )
+        .await;
+
+    let lines = lines.lock().unwrap_or_else(|error| error.into_inner());
+    let response: serde_json::Value =
+        serde_json::from_str(lines.first().expect("one ACP response line"))
+            .expect("response is JSON");
+    assert_eq!(response["id"], serde_json::json!(1));
+    assert_eq!(response["result"]["agentInfo"]["name"], "harn");
+}
+
 fn attach_test_host_bridge(
     server: &mut AcpServer,
     session_id: &str,

--- a/crates/harn-serve/src/adapters/acp/types.rs
+++ b/crates/harn-serve/src/adapters/acp/types.rs
@@ -1,0 +1,635 @@
+//! Public ACP wire helpers for Rust embedders.
+//!
+//! These types cover the stable request shapes embedders most often send to
+//! `harn serve acp` or [`crate::EmbeddedAgent`]. They intentionally preserve
+//! ACP's JSON field names so callers can serialize them directly onto the wire.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+pub const ACP_METHOD_INITIALIZE: &str = "initialize";
+pub const ACP_METHOD_SESSION_NEW: &str = "session/new";
+pub const ACP_METHOD_SESSION_PROMPT: &str = "session/prompt";
+pub const ACP_METHOD_SESSION_CANCEL: &str = "session/cancel";
+pub const ACP_METHOD_SESSION_CANCEL_TOOL_CALL: &str = "session/cancel_tool_call";
+pub const ACP_METHOD_SESSION_CLOSE: &str = "session/close";
+pub const ACP_METHOD_SESSION_INJECT: &str = "session/inject";
+pub const ACP_METHOD_SESSION_REPLACE_INJECT: &str = "session/replace_inject";
+pub const ACP_METHOD_SESSION_REVOKE_INJECT: &str = "session/revoke_inject";
+pub const ACP_METHOD_SESSION_PENDING_INJECTIONS: &str = "session/pending_injections";
+
+/// JSON-RPC id values accepted by ACP requests and responses.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum AcpJsonRpcId {
+    Number(u64),
+    String(String),
+    Null,
+}
+
+impl From<u64> for AcpJsonRpcId {
+    fn from(value: u64) -> Self {
+        Self::Number(value)
+    }
+}
+
+impl From<&str> for AcpJsonRpcId {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<String> for AcpJsonRpcId {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+/// A typed JSON-RPC request envelope for ACP methods.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpJsonRpcRequest<P = serde_json::Value> {
+    pub jsonrpc: String,
+    pub id: AcpJsonRpcId,
+    pub method: String,
+    pub params: P,
+}
+
+impl<P> AcpJsonRpcRequest<P> {
+    pub fn new(id: impl Into<AcpJsonRpcId>, method: impl Into<String>, params: P) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id: id.into(),
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+impl<P: Serialize> AcpJsonRpcRequest<P> {
+    /// Serialize this request into the `serde_json::Value` expected by the
+    /// in-process ACP channel transport.
+    pub fn into_json_value(self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+
+    /// Serialize this request as one JSON-RPC line for stdio or WebSocket
+    /// text-frame transports.
+    pub fn into_json_line(self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(&self)
+    }
+}
+
+impl AcpJsonRpcRequest<serde_json::Value> {
+    pub fn initialize(id: impl Into<AcpJsonRpcId>) -> Self {
+        Self::new(id, ACP_METHOD_INITIALIZE, serde_json::json!({}))
+    }
+}
+
+impl AcpJsonRpcRequest<AcpSessionNewParams> {
+    pub fn session_new(id: impl Into<AcpJsonRpcId>, params: AcpSessionNewParams) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_NEW, params)
+    }
+}
+
+impl AcpJsonRpcRequest<AcpSessionPromptParams> {
+    pub fn session_prompt(id: impl Into<AcpJsonRpcId>, params: AcpSessionPromptParams) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_PROMPT, params)
+    }
+}
+
+impl AcpJsonRpcRequest<AcpSessionIdParams> {
+    pub fn session_cancel(id: impl Into<AcpJsonRpcId>, params: AcpSessionIdParams) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_CANCEL, params)
+    }
+
+    pub fn session_close(id: impl Into<AcpJsonRpcId>, params: AcpSessionIdParams) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_CLOSE, params)
+    }
+
+    pub fn session_pending_injections(
+        id: impl Into<AcpJsonRpcId>,
+        params: AcpSessionIdParams,
+    ) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_PENDING_INJECTIONS, params)
+    }
+}
+
+impl AcpJsonRpcRequest<AcpSessionInjectParams> {
+    pub fn session_inject(id: impl Into<AcpJsonRpcId>, params: AcpSessionInjectParams) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_INJECT, params)
+    }
+}
+
+impl AcpJsonRpcRequest<AcpSessionReplaceInjectParams> {
+    pub fn session_replace_inject(
+        id: impl Into<AcpJsonRpcId>,
+        params: AcpSessionReplaceInjectParams,
+    ) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_REPLACE_INJECT, params)
+    }
+}
+
+impl AcpJsonRpcRequest<AcpSessionMessageIdParams> {
+    pub fn session_revoke_inject(
+        id: impl Into<AcpJsonRpcId>,
+        params: AcpSessionMessageIdParams,
+    ) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_REVOKE_INJECT, params)
+    }
+}
+
+impl AcpJsonRpcRequest<AcpSessionCancelToolCallParams> {
+    pub fn session_cancel_tool_call(
+        id: impl Into<AcpJsonRpcId>,
+        params: AcpSessionCancelToolCallParams,
+    ) -> Self {
+        Self::new(id, ACP_METHOD_SESSION_CANCEL_TOOL_CALL, params)
+    }
+}
+
+/// Response envelope for successful ACP JSON-RPC calls.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpJsonRpcResponse<R = serde_json::Value> {
+    pub jsonrpc: String,
+    pub id: AcpJsonRpcId,
+    pub result: R,
+}
+
+/// Common JSON-RPC error payload returned by ACP.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpJsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// Response envelope for failed ACP JSON-RPC calls.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpJsonRpcErrorResponse {
+    pub jsonrpc: String,
+    pub id: AcpJsonRpcId,
+    pub error: AcpJsonRpcError,
+}
+
+/// `session/new` params.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionNewParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl AcpSessionNewParams {
+    pub fn cwd(cwd: impl Into<String>) -> Self {
+        Self {
+            cwd: Some(cwd.into()),
+            extra: BTreeMap::new(),
+        }
+    }
+}
+
+/// `session/new`, `session/load`, and `session/resume` result fields Harn
+/// returns for an active ACP session.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionRestoreResult {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modes: Option<serde_json::Value>,
+    #[serde(
+        rename = "configOptions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub config_options: Option<serde_json::Value>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+/// Params containing only an ACP session id.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionIdParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+}
+
+impl AcpSessionIdParams {
+    pub fn new(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+        }
+    }
+}
+
+/// `session/prompt` params.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionPromptParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    pub prompt: Vec<AcpContentBlock>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl AcpSessionPromptParams {
+    pub fn new(session_id: impl Into<String>, prompt: Vec<AcpContentBlock>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            prompt,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    pub fn text(session_id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self::new(session_id, vec![AcpContentBlock::text(text)])
+    }
+}
+
+/// `session/prompt` result.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionPromptResult {
+    #[serde(rename = "stopReason")]
+    pub stop_reason: String,
+}
+
+/// ACP content blocks accepted by Harn prompt and injection requests.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AcpContentBlock {
+    Text {
+        text: String,
+    },
+    Image {
+        #[serde(rename = "mimeType", alias = "media_type")]
+        mime_type: String,
+        #[serde(default, alias = "base64", skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(
+            default,
+            alias = "url",
+            alias = "source_uri",
+            skip_serializing_if = "Option::is_none"
+        )]
+        uri: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+    Audio {
+        #[serde(rename = "mimeType", alias = "media_type")]
+        mime_type: String,
+        #[serde(default, alias = "base64", skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(
+            default,
+            alias = "url",
+            alias = "source_uri",
+            skip_serializing_if = "Option::is_none"
+        )]
+        uri: Option<String>,
+    },
+    Resource {
+        resource: AcpEmbeddedResource,
+    },
+    ResourceLink {
+        uri: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(
+            rename = "mimeType",
+            alias = "media_type",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        mime_type: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        size: Option<u64>,
+    },
+}
+
+impl AcpContentBlock {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text { text: text.into() }
+    }
+
+    pub fn image_data(mime_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Image {
+            mime_type: mime_type.into(),
+            data: Some(data.into()),
+            uri: None,
+            detail: None,
+        }
+    }
+
+    pub fn image_uri(mime_type: impl Into<String>, uri: impl Into<String>) -> Self {
+        Self::Image {
+            mime_type: mime_type.into(),
+            data: None,
+            uri: Some(uri.into()),
+            detail: None,
+        }
+    }
+
+    pub fn audio_data(mime_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Audio {
+            mime_type: mime_type.into(),
+            data: Some(data.into()),
+            uri: None,
+        }
+    }
+
+    pub fn audio_uri(mime_type: impl Into<String>, uri: impl Into<String>) -> Self {
+        Self::Audio {
+            mime_type: mime_type.into(),
+            data: None,
+            uri: Some(uri.into()),
+        }
+    }
+
+    pub fn embedded_text_resource(
+        uri: impl Into<String>,
+        mime_type: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Self {
+        Self::Resource {
+            resource: AcpEmbeddedResource {
+                uri: uri.into(),
+                mime_type: Some(mime_type.into()),
+                text: Some(text.into()),
+                blob: None,
+            },
+        }
+    }
+
+    pub fn resource_link(uri: impl Into<String>) -> Self {
+        Self::ResourceLink {
+            uri: uri.into(),
+            name: None,
+            title: None,
+            description: None,
+            mime_type: None,
+            size: None,
+        }
+    }
+}
+
+/// Embedded resource payload nested under an ACP `resource` content block.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpEmbeddedResource {
+    pub uri: String,
+    #[serde(rename = "mimeType", alias = "media_type")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob: Option<String>,
+}
+
+/// Delivery mode for `session/inject` queued user messages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AcpSessionInjectMode {
+    Queue,
+    Steer,
+}
+
+/// `session/inject` content accepts either a plain string or ACP content blocks.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum AcpSessionInjectContent {
+    Text(String),
+    Blocks(Vec<AcpContentBlock>),
+}
+
+impl From<String> for AcpSessionInjectContent {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for AcpSessionInjectContent {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_string())
+    }
+}
+
+impl From<Vec<AcpContentBlock>> for AcpSessionInjectContent {
+    fn from(value: Vec<AcpContentBlock>) -> Self {
+        Self::Blocks(value)
+    }
+}
+
+/// Standard ACP `_meta` wrapper for Harn-owned extension fields.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpMeta {
+    pub harn: AcpHarnMeta,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl AcpMeta {
+    pub fn actor(actor: serde_json::Value) -> Self {
+        Self {
+            harn: AcpHarnMeta {
+                actor: Some(actor),
+                extra: BTreeMap::new(),
+            },
+            extra: BTreeMap::new(),
+        }
+    }
+}
+
+/// Harn-owned ACP `_meta.harn` extension fields.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpHarnMeta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<serde_json::Value>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+/// `session/inject` params.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionInjectParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    pub mode: AcpSessionInjectMode,
+    pub content: AcpSessionInjectContent,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<AcpMeta>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl AcpSessionInjectParams {
+    pub fn new(
+        session_id: impl Into<String>,
+        mode: AcpSessionInjectMode,
+        content: impl Into<AcpSessionInjectContent>,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            mode,
+            content: content.into(),
+            meta: None,
+            extra: BTreeMap::new(),
+        }
+    }
+}
+
+/// `session/replace_inject` params.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionReplaceInjectParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "messageId")]
+    pub message_id: String,
+    pub content: AcpSessionInjectContent,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<AcpMeta>,
+    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl AcpSessionReplaceInjectParams {
+    pub fn new(
+        session_id: impl Into<String>,
+        message_id: impl Into<String>,
+        content: impl Into<AcpSessionInjectContent>,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            message_id: message_id.into(),
+            content: content.into(),
+            meta: None,
+            extra: BTreeMap::new(),
+        }
+    }
+}
+
+/// Params for pending-message operations such as `session/revoke_inject`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionMessageIdParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "messageId")]
+    pub message_id: String,
+}
+
+impl AcpSessionMessageIdParams {
+    pub fn new(session_id: impl Into<String>, message_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            message_id: message_id.into(),
+        }
+    }
+}
+
+/// `session/cancel_tool_call` params.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcpSessionCancelToolCallParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "toolCallId")]
+    pub tool_call_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(
+        rename = "injectReminder",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub inject_reminder: Option<bool>,
+}
+
+impl AcpSessionCancelToolCallParams {
+    pub fn new(session_id: impl Into<String>, tool_call_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            tool_call_id: tool_call_id.into(),
+            reason: None,
+            inject_reminder: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_prompt_request_serializes_to_acp_wire_shape() {
+        let value =
+            AcpJsonRpcRequest::session_prompt(7, AcpSessionPromptParams::text("sess-1", "hello"))
+                .into_json_value()
+                .expect("request serializes");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": "sess-1",
+                    "prompt": [{"type": "text", "text": "hello"}],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn session_inject_request_serializes_mode_and_content() {
+        let value = AcpJsonRpcRequest::session_inject(
+            "inject-1",
+            AcpSessionInjectParams::new(
+                "sess-1",
+                AcpSessionInjectMode::Steer,
+                vec![AcpContentBlock::text("interrupt after this step")],
+            ),
+        )
+        .into_json_value()
+        .expect("request serializes");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "inject-1",
+                "method": "session/inject",
+                "params": {
+                    "sessionId": "sess-1",
+                    "mode": "steer",
+                    "content": [{"type": "text", "text": "interrupt after this step"}],
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn resource_link_content_serializes_to_acp_wire_shape() {
+        let value = serde_json::to_value(AcpContentBlock::resource_link("file:///tmp/report.md"))
+            .expect("resource link block serializes");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "type": "resource_link",
+                "uri": "file:///tmp/report.md",
+            })
+        );
+    }
+}

--- a/crates/harn-serve/src/embed.rs
+++ b/crates/harn-serve/src/embed.rs
@@ -207,36 +207,18 @@ impl Drop for EmbeddedAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
-    fn recv_json(rx: &mut mpsc::UnboundedReceiver<String>) -> serde_json::Value {
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            match rx.try_recv() {
-                Ok(line) => return serde_json::from_str(&line).expect("valid JSON-RPC line"),
-                Err(mpsc::error::TryRecvError::Empty) => {
-                    assert!(
-                        std::time::Instant::now() < deadline,
-                        "timed out waiting for an ACP response line"
-                    );
-                    thread::sleep(Duration::from_millis(5));
-                }
-                Err(mpsc::error::TryRecvError::Disconnected) => {
-                    panic!("ACP response channel closed before a response arrived")
-                }
-            }
-        }
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
     }
 
-    fn wait_until(deadline: Duration, mut predicate: impl FnMut() -> bool) -> bool {
-        let stop = std::time::Instant::now() + deadline;
-        while std::time::Instant::now() < stop {
-            if predicate() {
-                return true;
-            }
-            thread::sleep(Duration::from_millis(5));
-        }
-        predicate()
+    async fn recv_json(rx: &mut mpsc::UnboundedReceiver<String>) -> serde_json::Value {
+        let line = rx.recv().await.expect("ACP response channel closed");
+        serde_json::from_str(&line).expect("valid JSON-RPC line")
     }
 
     #[test]
@@ -245,10 +227,7 @@ mod tests {
         let requests = agent.requests();
         let mut responses = agent.take_responses().expect("responses receiver");
 
-        assert!(
-            wait_until(Duration::from_secs(5), || agent.handle().is_ready()),
-            "agent never became ready"
-        );
+        block_on(agent.handle().wait_ready());
 
         requests
             .send(serde_json::json!({
@@ -259,7 +238,7 @@ mod tests {
             }))
             .expect("send session/new");
 
-        let created = recv_json(&mut responses);
+        let created = block_on(recv_json(&mut responses));
         assert!(
             created["result"]["sessionId"].as_str().is_some(),
             "session/new should return a sessionId, got: {created}"
@@ -277,19 +256,13 @@ mod tests {
         let agent = EmbeddedAgent::spawn(AcpServerConfig::new(None));
         let handle = agent.handle().clone();
 
-        assert!(
-            wait_until(Duration::from_secs(5), || handle.is_ready()),
-            "agent never became ready"
-        );
+        block_on(handle.wait_ready());
         assert!(!handle.is_terminated());
 
         // A shutdown trigger from a cloned handle (a different owner than the
         // EmbeddedAgent) must stop an otherwise-idle server loop.
         handle.shutdown();
-        assert!(
-            wait_until(Duration::from_secs(5), || handle.is_terminated()),
-            "shutdown() did not terminate the idle agent loop"
-        );
+        block_on(handle.wait_terminated());
 
         drop(agent); // Drop joins the worker; must not hang.
         assert!(handle.is_shutdown());
@@ -304,17 +277,11 @@ mod tests {
         let agent = EmbeddedAgent::spawn(AcpServerConfig::new(None));
         let (requests, _responses, handle) = agent.into_parts();
 
-        assert!(
-            wait_until(Duration::from_secs(5), || handle.is_ready()),
-            "agent never became ready"
-        );
+        block_on(handle.wait_ready());
         assert!(!handle.is_terminated());
 
         drop(requests);
-        assert!(
-            wait_until(Duration::from_secs(5), || handle.is_terminated()),
-            "closing the request channel did not terminate the agent loop"
-        );
+        block_on(handle.wait_terminated());
         assert!(
             !handle.is_shutdown(),
             "EOF teardown must not set the shutdown flag"
@@ -327,10 +294,7 @@ mod tests {
         let (requests, responses, handle) = agent.into_parts();
         let mut responses = responses.expect("responses receiver");
 
-        assert!(
-            wait_until(Duration::from_secs(5), || handle.is_ready()),
-            "agent never became ready"
-        );
+        block_on(handle.wait_ready());
 
         requests
             .send(serde_json::json!({
@@ -340,13 +304,10 @@ mod tests {
                 "params": {"cwd": "."},
             }))
             .expect("send session/new");
-        let created = recv_json(&mut responses);
+        let created = block_on(recv_json(&mut responses));
         assert!(created["result"]["sessionId"].as_str().is_some());
 
         handle.shutdown();
-        assert!(
-            wait_until(Duration::from_secs(5), || handle.is_terminated()),
-            "detached agent did not terminate after shutdown()"
-        );
+        block_on(handle.wait_terminated());
     }
 }

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -34,8 +34,17 @@ pub use adapter::{AdapterDescriptor, TransportAdapter};
 pub use adapters::a2a::{A2aHttpServeOptions, A2aServer, A2aServerConfig, A2A_PROTOCOL_VERSION};
 pub use adapters::acp::{
     run_acp_channel_server, run_acp_channel_server_with_handle, run_acp_server,
-    run_acp_websocket_server, AcpChannelHandle, AcpProfileConfig, AcpRuntimeConfigurator,
-    AcpServer, AcpServerConfig, AcpWebSocketServeOptions, NoopAcpRuntimeConfigurator,
+    run_acp_websocket_server, AcpChannelHandle, AcpContentBlock, AcpEmbeddedResource, AcpHarnMeta,
+    AcpJsonRpcError, AcpJsonRpcErrorResponse, AcpJsonRpcId, AcpJsonRpcRequest, AcpJsonRpcResponse,
+    AcpMeta, AcpOutput, AcpProfileConfig, AcpRuntimeConfigurator, AcpServer, AcpServerConfig,
+    AcpSessionCancelToolCallParams, AcpSessionIdParams, AcpSessionInjectContent,
+    AcpSessionInjectMode, AcpSessionInjectParams, AcpSessionMessageIdParams, AcpSessionNewParams,
+    AcpSessionPromptParams, AcpSessionPromptResult, AcpSessionReplaceInjectParams,
+    AcpSessionRestoreResult, AcpWebSocketServeOptions, NoopAcpRuntimeConfigurator,
+    ACP_METHOD_INITIALIZE, ACP_METHOD_SESSION_CANCEL, ACP_METHOD_SESSION_CANCEL_TOOL_CALL,
+    ACP_METHOD_SESSION_CLOSE, ACP_METHOD_SESSION_INJECT, ACP_METHOD_SESSION_NEW,
+    ACP_METHOD_SESSION_PENDING_INJECTIONS, ACP_METHOD_SESSION_PROMPT,
+    ACP_METHOD_SESSION_REPLACE_INJECT, ACP_METHOD_SESSION_REVOKE_INJECT,
 };
 pub use adapters::api::{ApiHttpServeOptions, ApiServer, ApiServerConfig};
 pub use adapters::mcp::{

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -136,6 +136,7 @@
 - [Protocol support matrix](./protocol-support.md)
 - [MCP, ACP, and A2A integration](./mcp-and-acp.md)
 - [Outbound workflow server](./harn-serve.md)
+- [Embedding Harn in Rust](./embedding-rust.md)
 - [Bridge protocol](./bridge-protocol.md)
 - [Generated protocol artifacts](./protocol-artifacts.md)
 - [Host tools over the bridge](./bridge/host-tools.md)

--- a/docs/src/embedding-rust.md
+++ b/docs/src/embedding-rust.md
@@ -1,0 +1,158 @@
+# Embedding Harn in Rust
+
+`harn-serve` exposes the same ACP agent loop used by `harn serve acp` as a
+Rust API. Use it when a host application wants Harn in-process instead of
+spawning the CLI as a child process.
+
+## Add the crate
+
+Until Harn is published on crates.io, depend on the repository tag you ship
+against:
+
+```toml
+[dependencies]
+harn-serve = { git = "https://github.com/burin-labs/harn", tag = "v0.8.57" }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "sync"] }
+```
+
+Harn uses deep generated and macro-expanded types. Embedders should match the
+crate setting:
+
+```rust
+#![recursion_limit = "256"]
+```
+
+## Start an embedded agent
+
+`EmbeddedAgent` owns the required worker thread and current-thread Tokio
+runtime. It returns typed control handles plus the ACP JSON-RPC channels:
+
+```rust
+#![recursion_limit = "256"]
+
+use harn_serve::{
+    AcpJsonRpcRequest, AcpServerConfig, AcpSessionNewParams, EmbeddedAgent,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut agent = EmbeddedAgent::spawn(AcpServerConfig::new(None));
+    let requests = agent.requests();
+    let _responses = agent
+        .take_responses()
+        .expect("responses are single-consumer");
+
+    let request = AcpJsonRpcRequest::session_new(
+        1,
+        AcpSessionNewParams::cwd("."),
+    )
+    .into_json_value()?;
+    if requests.send(request).is_err() {
+        return Err(std::io::Error::other("ACP worker stopped").into());
+    }
+
+    agent.shutdown();
+    if agent.join().is_err() {
+        return Err(std::io::Error::other("ACP worker panicked").into());
+    }
+    Ok(())
+}
+```
+
+The ACP channel server is `!Send` because it owns a `LocalSet` and uses
+`spawn_local`. `EmbeddedAgent` keeps that detail out of the host: the server
+future is built and driven entirely on the dedicated worker thread, while the
+host keeps `Send` channels and an `AcpChannelHandle`.
+
+## Send typed ACP requests
+
+Use `AcpJsonRpcRequest` plus the request param structs instead of hand-building
+JSON:
+
+```rust
+use harn_serve::{
+    AcpContentBlock, AcpJsonRpcRequest, AcpSessionInjectMode,
+    AcpSessionInjectParams, AcpSessionPromptParams,
+};
+
+let prompt = AcpJsonRpcRequest::session_prompt(
+    2,
+    AcpSessionPromptParams::text("session-id", "Summarize this workspace."),
+)
+.into_json_value()
+.expect("prompt request serializes");
+
+let inject = AcpJsonRpcRequest::session_inject(
+    3,
+    AcpSessionInjectParams::new(
+        "session-id",
+        AcpSessionInjectMode::Steer,
+        vec![AcpContentBlock::text("Stop after the current tool call.")],
+    ),
+)
+.into_json_value()
+.expect("inject request serializes");
+```
+
+The typed helpers preserve ACP wire names such as `sessionId`, `messageId`, and
+`toolCallId`, so serialized values can be sent directly to `EmbeddedAgent`,
+stdio ACP, or ACP WebSocket.
+
+## Own the runtime yourself
+
+Use `run_acp_channel_server_with_handle` when the host already owns a dedicated
+thread and current-thread Tokio runtime:
+
+```rust
+use harn_serve::{run_acp_channel_server_with_handle, AcpServerConfig};
+use tokio::sync::mpsc;
+
+let (request_tx, request_rx) = mpsc::unbounded_channel();
+let (response_tx, response_rx) = mpsc::unbounded_channel();
+let (server, handle) =
+    run_acp_channel_server_with_handle(AcpServerConfig::new(None), request_rx, response_tx);
+
+let runtime = tokio::runtime::Builder::new_current_thread()
+    .enable_all()
+    .build()
+    .expect("start ACP runtime");
+let control = handle.clone();
+control.shutdown();
+runtime.block_on(server);
+```
+
+`AcpChannelHandle::wait_ready()` resolves once the loop can receive requests.
+`shutdown()` asks the loop to drain and stop, and `wait_terminated()` resolves
+after the loop exits.
+
+## Custom output sinks
+
+Advanced embedders that already run on a compatible runtime can drive
+`AcpServer` directly and provide their own output sink:
+
+```rust
+use harn_serve::{AcpOutput, AcpServer, AcpServerConfig};
+
+let output = AcpOutput::callback(|line| {
+    eprintln!("ACP -> host: {line}");
+});
+let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), output);
+```
+
+For most applications, prefer `EmbeddedAgent`; it packages the worker-thread
+lifecycle and prevents accidentally moving the `!Send` server future across
+threads.
+
+## Host callback surface
+
+During `session/prompt`, Harn may call back into the host over ACP JSON-RPC.
+Hosts should be prepared to answer these methods:
+
+- `host/capabilities`
+- `host/call`
+- `session/request_permission`
+- filesystem and process methods advertised through `initialize`
+
+If a host does not support a capability, return an empty capability response or
+the relevant JSON-RPC error. Harn times host callbacks out so an unresponsive
+host cannot block a prompt forever.


### PR DESCRIPTION
## Summary

- Exposes typed Rust ACP JSON-RPC request/response envelopes, request params, content blocks, metadata helpers, and method constants from `harn-serve`.
- Makes direct ACP output routing usable by embedders via public `AcpOutput` constructors, callback sinks, `AcpServer::new_with_output`, and `handle_incoming_message`.
- Adds Rust embedding docs covering `EmbeddedAgent`, typed ACP requests, channel driving, output callbacks, and host callback expectations.
- Replaces the embedded-agent tests' wall-clock polling loop with the existing readiness/termination handle signals.
- Fixes the Windows smoke CI lane so a changed package set that compiles but has no tests matching the narrow Windows unit filter passes instead of failing after a successful compile.

## Why

Issue #2636's transport and `EmbeddedAgent` pieces had already landed on `main`; the remaining Rust embedder gap was a stable typed surface so hosts do not hand-build ACP JSON. This PR fills that gap and pins the public wire shapes with tests.

Closes #2636.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `actionlint .github/workflows/ci.yml`
- `CARGO_TARGET_DIR=/tmp/harn-target-2636 cargo test -p harn-serve --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2636 cargo clippy -p harn-serve --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-2636 cargo doc -p harn-serve --no-deps` (passes with pre-existing rustdoc warnings outside this change)
- `CARGO_TARGET_DIR=/tmp/harn-target-2636 make check-docs-snippets`
- pre-commit hook
- pre-push hook
