### PR TITLE
Wire scratchpad roots into reachability GC

### DIFF
--- a/changelog.d/2708.fixed.md
+++ b/changelog.d/2708.fixed.md
@@ -1,0 +1,5 @@
+- **Agent scratchpad + reachability GC integration (#2708).** Agent loops that
+  enable both session scratchpads and reachability-GC transcript projection now
+  pass the live scratchpad as a root and scratchpad-version write barrier, so
+  `require_write_barrier: true` can reclaim stale tool-result bodies only after
+  current working memory has been externalized.

--- a/conformance/tests/scenarios/agent_loop_transcript_projection.expected
+++ b/conformance/tests/scenarios/agent_loop_transcript_projection.expected
@@ -3,3 +3,9 @@ raw_message_count:6
 projection_events:true
 projection_policy:clean_tool_repair
 projection_safety_blocked:false
+gc_status:done
+gc_scratchpad_barrier:true
+gc_has_scratchpad_root:true
+gc_has_write_barrier:true
+gc_projected_reclaimed:true
+gc_live_preserved:true

--- a/conformance/tests/scenarios/agent_loop_transcript_projection.harn
+++ b/conformance/tests/scenarios/agent_loop_transcript_projection.harn
@@ -25,6 +25,41 @@ fn flaky_tool() {
   return tools
 }
 
+fn gc_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "read_stale",
+    "Return a stale observation.",
+    {
+      handler: fn(_args) {
+        var stale = "src/stale.rs\n"
+        for i in range(0, 60) {
+          stale = stale + "stale output line " + to_string(i) + "\n"
+        }
+        return stale
+      },
+      parameters: {},
+    },
+  )
+  tools = tool_define(
+    tools,
+    "read_live",
+    "Return a live observation.",
+    {
+      handler: fn(_args) {
+        var live = "src/live.rs\nLIVE_SENTINEL\n"
+        for i in range(0, 60) {
+          live = live + "live output line " + to_string(i) + "\n"
+        }
+        return live
+      },
+      parameters: {},
+    },
+  )
+  return tools
+}
+
 pipeline default() {
   llm_mock_clear()
   llm_mock({tool_calls: [{id: "call_1", name: "run", arguments: {}}]})
@@ -50,4 +85,64 @@ pipeline default() {
   __io_println("projection_events:" + to_string(len(events) > 0))
   __io_println("projection_policy:" + events[0].metadata.policy)
   __io_println("projection_safety_blocked:" + to_string(events[0].metadata.provider_safety_blocked))
+  llm_mock_clear()
+  llm_mock(
+    {
+      tool_calls: [
+        {id: "read_stale_1", name: "read_stale", arguments: {}},
+        {id: "read_live_1", name: "read_live", arguments: {}},
+      ],
+    },
+  )
+  llm_mock(
+    {
+      text: json_stringify(
+        {
+          schema: "harn.agent_scratchpad.v1",
+          goals: [{text: "complete projection GC task", source_ref: "user:initial"}],
+          open_items: [],
+          facts: [{text: "Continue from src/live.rs and LIVE_SENTINEL", source_ref: "turn:4"}],
+          refs: [
+            {id: "user:initial", kind: "user_input", label: "Initial task"},
+            {id: "turn:4", kind: "tool", label: "read_live returned src/live.rs"},
+          ],
+        },
+      ),
+    },
+  )
+  llm_mock({text: "Done with projection GC. ##DONE##"})
+  let gc_result = agent_loop(
+    "complete projection GC task",
+    "You are a projection test agent.",
+    {
+      provider: "mock",
+      tools: gc_tools(),
+      tool_format: "native",
+      max_iterations: 3,
+      loop_until_done: true,
+      done_sentinel: "##DONE##",
+      transcript_projection: {policy: "reachability_gc", root_window: 1, min_chars: 100, require_write_barrier: true},
+      scratchpad: {enabled: true, reorganize_every: 1, reorganizer: {provider: "mock"}},
+    },
+  )
+  let gc_calls = llm_mock_calls()
+  let projected_stale_body = json_stringify(gc_calls[2].messages[2].content)
+  let projected_live_body = json_stringify(gc_calls[2].messages[3].content)
+  let gc_events = transcript_events_by_kind(gc_result.transcript, "transcript.projection")
+  let gc_projection = gc_events[len(gc_events) - 1]
+  __io_println("gc_status:" + gc_result.status)
+  __io_println("gc_scratchpad_barrier:" + to_string(gc_projection.metadata.redacted_count > 0))
+  __io_println(
+    "gc_has_scratchpad_root:"
+      + to_string(gc_projection.metadata.roots_consulted.contains("scratchpad")),
+  )
+  __io_println(
+    "gc_has_write_barrier:"
+      + to_string(gc_projection.metadata.roots_consulted.contains("write_barrier")),
+  )
+  __io_println(
+    "gc_projected_reclaimed:"
+      + to_string(contains(projected_stale_body, "reclaimed by reachability_gc")),
+  )
+  __io_println("gc_live_preserved:" + to_string(contains(projected_live_body, "LIVE_SENTINEL")))
 }

--- a/crates/harn-stdlib/src/stdlib/agent/preflight.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/preflight.harn
@@ -1,6 +1,9 @@
 import { agent_tool_format } from "std/agent/options"
 import { loop_until_done_system_prompt, render_agent_prompt_id } from "std/agent/prompts"
-import { agent_scratchpad_recitation_fragment } from "std/agent/scratchpad"
+import {
+  agent_scratchpad_options,
+  agent_scratchpad_recitation_fragment,
+} from "std/agent/scratchpad"
 import { agent_session_messages, agent_session_project_turn } from "std/agent/state"
 
 fn __agent_done_sentinel(opts) {
@@ -406,8 +409,38 @@ fn __agent_projection_options(opts) {
   throw "agent_loop: `transcript_projection` must be a string, dict, or nil; got " + type_of(raw)
 }
 
+fn __agent_reachability_projection(policy) {
+  return policy == "reachability_gc" || policy == "context_gc" || policy == "tool_result_gc"
+}
+
+fn __agent_projection_with_scratchpad_barrier(session_id, projection_opts, opts) {
+  let policy_label = projection_opts?.policy ?? "raw"
+  if !__agent_reachability_projection(policy_label) {
+    return projection_opts
+  }
+  let scratchpad_cfg = agent_scratchpad_options(opts)
+  if !scratchpad_cfg.enabled {
+    return projection_opts
+  }
+  let snapshot = agent_session_snapshot(session_id) ?? {}
+  let scratchpad = snapshot?.scratchpad
+  if scratchpad == nil {
+    return projection_opts
+  }
+  let version = snapshot?.scratchpad_version ?? 0
+  return projection_opts
+    + {
+    scratchpad: [projection_opts?.scratchpad, scratchpad],
+    write_barrier_refs: [
+      projection_opts?.write_barrier_refs,
+      projection_opts?.barrier_refs,
+      "agent_scratchpad:v" + to_string(version),
+    ],
+  }
+}
+
 fn __agent_apply_projection(session_id, messages, opts) {
-  let projection_opts = __agent_projection_options(opts)
+  var projection_opts = __agent_projection_options(opts)
   if projection_opts == nil {
     return messages
   }
@@ -415,6 +448,7 @@ fn __agent_apply_projection(session_id, messages, opts) {
   if policy_label == "raw" {
     return messages
   }
+  projection_opts = __agent_projection_with_scratchpad_barrier(session_id, projection_opts, opts)
   let projection = agent_session_project_turn(session_id, projection_opts)
   return projection?.messages ?? messages
 }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1633,7 +1633,9 @@ prompt. It keeps tool-call metadata and emits `redacted_indices`,
 transcript/audit content stays available by pointer. Useful options:
 `root_window`, `min_chars`, `roots`, `active_plan`, `scratchpad`,
 `pending_tool_args`, `unresolved_findings`, `write_barrier_refs`, and
-`require_write_barrier`.
+`require_write_barrier`. In `agent_loop`, enabling both `scratchpad` and a
+reachability-GC projection automatically supplies the current scratchpad as a
+root plus a scratchpad-version write barrier for that turn.
 
 ## Reminders
 

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -320,6 +320,11 @@ synthetic replay message. Updates append compact `agent_scratchpad` transcript
 events with action/version/count metadata; session snapshots and final
 transcripts expose `scratchpad`, `scratchpad_version`, and
 `metadata.agent_scratchpad`.
+When paired with `transcript_projection: {policy: "reachability_gc"}`, the loop
+automatically supplies the current scratchpad as a GC root and
+scratchpad-version write barrier for each provider turn. Referenced tool output
+stays visible; stale, unreferenced tool-result bodies can be reclaimed from the
+model-visible prefix while the raw transcript remains intact.
 
 Scripts can read and write the state directly with
 `agent_session_scratchpad(id)`, `agent_session_set_scratchpad(id, pad, opts?)`,

--- a/docs/src/llm/transcript-projection.md
+++ b/docs/src/llm/transcript-projection.md
@@ -103,6 +103,11 @@ material such as an active plan, scratchpad, pending tool args, unresolved
 review findings, or explicit `roots`. A tool result whose path, symbol, object
 ID, or call metadata appears in those roots is preserved. Error results are
 preserved by default; they are often still useful repair evidence.
+When `agent_loop` runs with both `scratchpad` enabled and a reachability-GC
+projection, the live scratchpad is automatically supplied as a root and
+scratchpad-version write barrier for that turn. This lets
+`require_write_barrier: true` reclaim only after the current working memory has
+been externalized.
 
 ```harn
 let view = transcript_project(transcript, {


### PR DESCRIPTION
## Summary

Closes #2708.

This finishes the cheap-model reliability epic with a cross-primitive integration pass: `agent_loop` now wires the live session scratchpad into reachability-GC transcript projection as both a GC root and a scratchpad-version write barrier. That means `scratchpad` + `transcript_projection: {policy: "reachability_gc", require_write_barrier: true}` can reclaim stale, unreferenced tool-result bodies only after current working memory has been externalized.

Changes in this PR:

- Augment reachability-style agent-loop projection options with the current scratchpad root and `agent_scratchpad:vN` write barrier.
- Add a conformance steel-thread test proving stale tool output is reclaimed while scratchpad-referenced live output survives.
- Document the scratchpad/reachability-GC interaction in the LLM docs and quickref.
- Add a changelog fragment for the epic integration fix.

Epic context already landed before this pass:

- #2711 / #2732: local Ollama grounding smoke for stale-package avoidance; blocked/fake packages dropped from 2/2 baseline to 0/2 in grounded prompts.
- #2712 / #2730: deterministic stall/thrash diagnostics and polling exemption coverage.
- #2713 / #2746: defect-audit calibration with real-defect precision 1.00 and regression rate 0.00.
- #2714 / #2741: deterministic reachability-GC long-horizon projection coverage over 60 stale outputs while preserving replay/audit content.
- #2715 / #2758: scratchpad retention evals covering no scratchpad, append-only recitation, strong periodic reorg, and weak reorg ablation.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo run --quiet --bin harn -- test conformance --filter agent_loop_transcript_projection`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo run --quiet --bin harn -- test conformance --filter transcript_projection_policies`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo run --quiet --bin harn -- test conformance --filter agent_scratchpad_recitation_reorg`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo test -p harn-vm transcript_project --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo test -p harn-vm scratchpad --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo test -p harn-stdlib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo run --quiet --bin harn -- fmt --check conformance/tests/scenarios/agent_loop_transcript_projection.harn crates/harn-stdlib/src/stdlib/agent/preflight.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo run --quiet --bin harn -- check conformance/tests/scenarios/agent_loop_transcript_projection.harn crates/harn-stdlib/src/stdlib/agent/preflight.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo run --quiet --bin harn -- lint conformance/tests/scenarios/agent_loop_transcript_projection.harn crates/harn-stdlib/src/stdlib/agent/preflight.harn`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 make lint-harn`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-2708 make all`
- Post-rebase: `CARGO_TARGET_DIR=/tmp/harn-target-2708 cargo run --quiet --bin harn -- test conformance --filter agent_loop_transcript_projection`
- Pre-push hook: targeted package check, affected Harn fmt/lint, markdown lint, highlight drift check
