### PR TITLE
ci: run release build under bash on Windows

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -304,6 +304,7 @@ jobs:
 
       - name: Build
         timeout-minutes: 90
+        shell: bash
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           # Scope the compile-time optimization tradeoff to release CI only.


### PR DESCRIPTION
## Summary
- force the release binary Build step to use bash on Windows
- fixes v0.8.58 release asset recovery where PowerShell parsed `set -euo pipefail` as `Set-Variable`

## Verification
- `git diff --check`
- `make lint-actions`