### PR TITLE
Add MCP token import over ACP

### DIFF
--- a/changelog.d/1430.fixed.md
+++ b/changelog.d/1430.fixed.md
@@ -1,0 +1,2 @@
+ACP MCP clients now resolve Harn-stored OAuth tokens for HTTP servers and can
+import legacy client-owned tokens into Harn's MCP OAuth store.

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -110,6 +110,8 @@ const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.mcp.authorize",
     "mcp/oauth_callback",
     "harn.mcp.oauth_callback",
+    "mcp/import_token",
+    "harn.mcp.import_token",
 ];
 const ACP_AGENT_NOTIFICATIONS: &[&str] = &["session/message", "session/update", "terminal/output"];
 const ACP_CONTENT_BLOCK_TYPES: &[&str] = &["text", "resource_link", "resource", "image", "audio"];

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -118,6 +118,14 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
             .await
             {
                 Ok(Some(token)) => {
+                    if server_ref.json {
+                        print_focused_status_report(&server, "connected", Some(&token), None)
+                            .unwrap_or_else(|error| {
+                                eprintln!("error: {error}");
+                                process::exit(1);
+                            });
+                        return;
+                    }
                     println!("Server: {}", server.name);
                     println!("URL: {}", server.url);
                     println!("Connected: yes");
@@ -134,11 +142,27 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                     println!("Issuer: {}", token.issuer);
                 }
                 Ok(None) => {
+                    if server_ref.json {
+                        print_focused_status_report(&server, "auth_required", None, None)
+                            .unwrap_or_else(|error| {
+                                eprintln!("error: {error}");
+                                process::exit(1);
+                            });
+                        return;
+                    }
                     println!("Server: {}", server.name);
                     println!("URL: {}", server.url);
                     println!("Connected: no");
                 }
                 Err(error) => {
+                    if server_ref.json {
+                        print_focused_status_report(&server, "error", None, Some(error))
+                            .unwrap_or_else(|encode_error| {
+                                eprintln!("error: {encode_error}");
+                                process::exit(1);
+                            });
+                        return;
+                    }
                     eprintln!("error: {error}");
                     process::exit(1);
                 }
@@ -155,7 +179,7 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
 
 /// Schema version for `harn mcp status --json`. Bump when the
 /// `McpStatusReport` shape changes in a way agents must detect.
-pub(crate) const MCP_STATUS_SCHEMA_VERSION: u32 = 1;
+pub(crate) const MCP_STATUS_SCHEMA_VERSION: u32 = 2;
 
 /// Aggregate readiness report for every MCP server declared in the
 /// nearest `harn.toml`. Mirrors the `connect status` report shape: a
@@ -194,6 +218,12 @@ pub(crate) struct McpServerStatus {
     pub prompts: Option<usize>,
     /// Human-readable diagnostic when `state` is `error`, else `None`.
     pub last_error: Option<String>,
+    /// Stored OAuth token expiry as Unix seconds when known.
+    pub token_expires_at_unix: Option<i64>,
+    /// OAuth client id bound to the stored token when known.
+    pub token_client_id: Option<String>,
+    /// OAuth issuer bound to the stored token when known.
+    pub token_issuer: Option<String>,
 }
 
 /// Build and print the all-servers MCP status report.
@@ -298,7 +328,42 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
         resources: None,
         prompts: None,
         last_error,
+        token_expires_at_unix: None,
+        token_client_id: None,
+        token_issuer: None,
     }
+}
+
+fn print_focused_status_report(
+    server: &ResolvedMcpServer,
+    state: &str,
+    token: Option<&mcp_oauth::StoredMcpToken>,
+    last_error: Option<String>,
+) -> Result<(), String> {
+    let report = McpStatusReport {
+        schema_version: MCP_STATUS_SCHEMA_VERSION,
+        manifest: None,
+        servers: vec![McpServerStatus {
+            name: server.name.clone(),
+            transport: "http".to_string(),
+            state: state.to_string(),
+            url: server.url.clone(),
+            lazy: false,
+            tools: None,
+            resources: None,
+            prompts: None,
+            last_error,
+            token_expires_at_unix: token.and_then(|token| token.expires_at_unix),
+            token_client_id: token.map(|token| token.client_id.clone()),
+            token_issuer: token.map(|token| token.issuer.clone()),
+        }],
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report)
+            .map_err(|error| format!("failed to encode JSON output: {error}"))?
+    );
+    Ok(())
 }
 
 pub(crate) async fn resolve_auth_for_server(
@@ -748,10 +813,13 @@ mod tests {
                 resources: None,
                 prompts: None,
                 last_error: None,
+                token_expires_at_unix: None,
+                token_client_id: None,
+                token_issuer: None,
             }],
         };
         let value: serde_json::Value = serde_json::to_value(&report).expect("serialize");
-        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema_version"], 2);
         assert_eq!(value["manifest"], "/repo/harn.toml");
         assert_eq!(value["servers"][0]["name"], "fs");
         assert_eq!(value["servers"][0]["transport"], "stdio");
@@ -759,5 +827,6 @@ mod tests {
         assert_eq!(value["servers"][0]["lazy"], true);
         assert!(value["servers"][0]["tools"].is_null());
         assert!(value["servers"][0]["last_error"].is_null());
+        assert!(value["servers"][0]["token_expires_at_unix"].is_null());
     }
 }

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -70,6 +70,7 @@ use std::time::{Instant, SystemTime};
 use async_trait::async_trait;
 use harn_vm::agent_events::{clear_session_sinks, register_sink, AgentEventSink};
 use harn_vm::visible_text::{sanitize_visible_assistant_text, VisibleTextState};
+use serde::Deserialize;
 use tokio::io::AsyncBufReadExt;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 
@@ -89,6 +90,27 @@ const ACP_AUTH_REQUIRED_CODE: i64 = -32000;
 /// supply one. TUI/headless clients capture this with a loopback listener
 /// (matching `harn mcp login`); GUI clients pass their own URL scheme instead.
 const MCP_DEFAULT_OAUTH_REDIRECT_URI: &str = "http://127.0.0.1:9783/oauth/callback";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct McpImportTokenParams {
+    #[serde(alias = "resource")]
+    url: String,
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    expires_at: Option<i64>,
+    #[serde(default)]
+    token_endpoint: Option<String>,
+    client_id: String,
+    #[serde(default)]
+    client_secret: Option<String>,
+    #[serde(default)]
+    token_endpoint_auth_method: Option<String>,
+    #[serde(default, alias = "scopes")]
+    scope: Option<String>,
+}
 
 /// Parse `state`, `code`, and the optional `iss` issuer out of a captured OAuth
 /// redirect URL (e.g. `burin://oauth/callback?code=…&state=…&iss=…`). Returns
@@ -2657,6 +2679,47 @@ impl AcpServer {
         }
     }
 
+    /// `mcp/import_token`: migrate a token minted by an older client-specific
+    /// OAuth implementation into harn's canonical MCP OAuth store. Discovery,
+    /// issuer binding, resource canonicalization, and keyring layout remain
+    /// harn-owned; clients only hand over the legacy token material once.
+    async fn handle_mcp_import_token(&self, id: &serde_json::Value, params: &serde_json::Value) {
+        let request: McpImportTokenParams = match serde_json::from_value(params.clone()) {
+            Ok(request) => request,
+            Err(error) => {
+                self.send_error(
+                    id,
+                    -32602,
+                    &format!("Invalid mcp/import_token params: {error}"),
+                );
+                return;
+            }
+        };
+        let import = harn_vm::mcp_oauth::ImportStoredToken {
+            server_url: request.url,
+            access_token: request.access_token,
+            refresh_token: request.refresh_token,
+            expires_at_unix: request.expires_at,
+            token_endpoint: request.token_endpoint,
+            client_id: request.client_id,
+            client_secret: request.client_secret,
+            token_endpoint_auth_method: request.token_endpoint_auth_method,
+            scopes: request.scope,
+        };
+        match harn_vm::mcp_oauth::import_stored_token(import).await {
+            Ok(token) => self.send_response(
+                id,
+                serde_json::json!({
+                    "ok": true,
+                    "resource": token.resource,
+                    "issuer": token.issuer,
+                    "expiresAt": token.expires_at_unix,
+                }),
+            ),
+            Err(error) => self.send_error(id, -32000, &error),
+        }
+    }
+
     async fn handle_hitl_respond(&self, id: &serde_json::Value, params: &serde_json::Value) {
         let session_cwd = params
             .get("sessionId")
@@ -3777,6 +3840,12 @@ impl AcpServer {
                     return;
                 }
                 self.handle_mcp_oauth_callback(&id, &params).await;
+            }
+            "mcp/import_token" | "harn.mcp.import_token" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_mcp_import_token(&id, &params).await;
             }
             _ => {
                 if !id.is_null() {

--- a/crates/harn-vm/src/mcp.rs
+++ b/crates/harn-vm/src/mcp.rs
@@ -3,6 +3,7 @@
 //! Supports stdio transport and streamable HTTP-style request/response transport.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -1396,13 +1397,14 @@ async fn mcp_connect_http_impl(spec: &McpServerSpec) -> Result<VmMcpClientHandle
         .protocol_version
         .clone()
         .unwrap_or_else(|| default_protocol_version(protocol_mode).to_string());
+    let auth_token = resolve_http_auth_token(spec).await;
 
     let handle = VmMcpClientHandle {
         name: spec.name.clone(),
         inner: Arc::new(Mutex::new(Some(McpClientInner::Http(HttpMcpClientInner {
             client,
             url: spec.url.clone(),
-            auth_token: spec.auth_token.clone(),
+            auth_token,
             protocol_mode,
             protocol_version,
             session_id: None,
@@ -1418,6 +1420,27 @@ async fn mcp_connect_http_impl(spec: &McpServerSpec) -> Result<VmMcpClientHandle
 
     initialize_client(&handle).await?;
     Ok(handle)
+}
+
+async fn resolve_http_auth_token(spec: &McpServerSpec) -> Option<String> {
+    resolve_http_auth_token_with(spec, |server_url| async move {
+        crate::mcp_oauth::resolve_bearer(&server_url).await
+    })
+    .await
+}
+
+async fn resolve_http_auth_token_with<R, Fut>(spec: &McpServerSpec, resolver: R) -> Option<String>
+where
+    R: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<Option<String>, String>>,
+{
+    if let Some(token) = spec.auth_token.as_deref().filter(|token| !token.is_empty()) {
+        return Some(token.to_string());
+    }
+    if spec.url.is_empty() {
+        return None;
+    }
+    resolver(spec.url.clone()).await.unwrap_or(None)
 }
 
 async fn initialize_client(handle: &VmMcpClientHandle) -> Result<(), VmError> {
@@ -2792,24 +2815,59 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(())).lock().await
     }
 
+    fn http_spec(url: &str, auth_token: Option<&str>) -> McpServerSpec {
+        McpServerSpec {
+            name: "mock-http".to_string(),
+            transport: McpTransport::Http,
+            command: String::new(),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            url: url.to_string(),
+            auth_token: auth_token.map(str::to_string),
+            protocol_version: None,
+            protocol_mode: None,
+            proxy_server_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn http_auth_resolution_prefers_explicit_token() {
+        let spec = http_spec("https://mcp.example/mcp", Some("configured"));
+        let token = resolve_http_auth_token_with(&spec, |_| async {
+            panic!("resolver must not run when the config carries a bearer token")
+        })
+        .await;
+        assert_eq!(token.as_deref(), Some("configured"));
+    }
+
+    #[tokio::test]
+    async fn http_auth_resolution_uses_harn_store_when_config_omits_token() {
+        let spec = http_spec("https://mcp.example/mcp", Some(""));
+        let token = resolve_http_auth_token_with(&spec, |server_url| async move {
+            assert_eq!(server_url, "https://mcp.example/mcp");
+            Ok(Some("stored".to_string()))
+        })
+        .await;
+        assert_eq!(token.as_deref(), Some("stored"));
+    }
+
+    #[tokio::test]
+    async fn http_auth_resolution_leaves_unauthenticated_servers_probeable() {
+        let spec = http_spec("https://mcp.example/mcp", None);
+        let token = resolve_http_auth_token_with(&spec, |_| async {
+            Err("no protected-resource metadata".to_string())
+        })
+        .await;
+        assert_eq!(token, None);
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn http_get_stream_dispatches_inbound_elicitation_response() {
         let _guard = http_mcp_test_guard().await;
         tokio::task::LocalSet::new()
             .run_until(async {
                 let (base_url, mut responses) = spawn_eliciting_http_mcp_server().await;
-                let spec = McpServerSpec {
-                    name: "mock-http".to_string(),
-                    transport: McpTransport::Http,
-                    command: String::new(),
-                    args: Vec::new(),
-                    env: BTreeMap::new(),
-                    url: format!("{base_url}/mcp"),
-                    auth_token: None,
-                    protocol_version: None,
-                    protocol_mode: None,
-                    proxy_server_name: None,
-                };
+                let spec = http_spec(&format!("{base_url}/mcp"), None);
 
                 let handle = connect_mcp_server_from_spec(&spec).await.unwrap();
                 let response = tokio::time::timeout(MCP_TIMEOUT, responses.recv())

--- a/crates/harn-vm/src/mcp_oauth.rs
+++ b/crates/harn-vm/src/mcp_oauth.rs
@@ -114,6 +114,23 @@ pub struct BeginAuthorization {
     pub scopes: Option<String>,
 }
 
+/// A legacy bearer/refresh token that a thin client found in an older
+/// surface-specific store. Discovery and canonical key selection still happen
+/// here so the imported token lands in the same Harn-owned store as a fresh
+/// [`begin_authorization`] / [`complete_authorization`] flow.
+#[derive(Clone, Debug)]
+pub struct ImportStoredToken {
+    pub server_url: String,
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub expires_at_unix: Option<i64>,
+    pub token_endpoint: Option<String>,
+    pub client_id: String,
+    pub client_secret: Option<String>,
+    pub token_endpoint_auth_method: Option<String>,
+    pub scopes: Option<String>,
+}
+
 /// The browser-facing result of [`begin_authorization`]: the URL to open and
 /// the `state` that the matching [`complete_authorization`] call must echo.
 #[derive(Clone, Debug, Serialize)]
@@ -315,6 +332,14 @@ pub async fn resolve_bearer(server_url: &str) -> Result<Option<String>, String> 
         stored = refresh_stored_token_with_store(&store, &stored, &discovery, None).await?;
     }
     Ok(Some(stored.access_token))
+}
+
+/// Import an existing token into the canonical Harn MCP OAuth store.
+pub async fn import_stored_token(request: ImportStoredToken) -> Result<StoredMcpToken, String> {
+    let discovery = discover(&request.server_url).await?;
+    let stored = stored_token_for_import(&request, &discovery)?;
+    save_stored_token(&stored).await?;
+    Ok(stored)
 }
 
 /// Discover the OAuth authorization server protecting an MCP server URL.
@@ -904,6 +929,75 @@ fn validate_token_store_binding(
     Ok(())
 }
 
+fn stored_token_for_import(
+    request: &ImportStoredToken,
+    discovery: &McpOAuthDiscovery,
+) -> Result<StoredMcpToken, String> {
+    let server_url = request.server_url.trim();
+    if server_url.is_empty() {
+        return Err("MCP token import requires server_url".to_string());
+    }
+    let access_token = request.access_token.trim();
+    if access_token.is_empty() {
+        return Err("MCP token import requires access_token".to_string());
+    }
+    let client_id = request.client_id.trim();
+    if client_id.is_empty() {
+        return Err("MCP token import requires client_id".to_string());
+    }
+
+    let resource = canonical_resource_indicator(server_url).map_err(|error| error.to_string())?;
+    let client_secret = request
+        .client_secret
+        .as_deref()
+        .filter(|secret| !secret.is_empty())
+        .map(str::to_string);
+    let token_endpoint_auth_method = request
+        .token_endpoint_auth_method
+        .as_deref()
+        .filter(|method| !method.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            if client_secret.is_some() {
+                "client_secret_post".to_string()
+            } else {
+                "none".to_string()
+            }
+        });
+    validate_token_endpoint_auth_method(&token_endpoint_auth_method)?;
+
+    Ok(StoredMcpToken {
+        access_token: access_token.to_string(),
+        refresh_token: request
+            .refresh_token
+            .as_deref()
+            .filter(|token| !token.is_empty())
+            .map(str::to_string),
+        expires_at_unix: request.expires_at_unix,
+        token_endpoint: request
+            .token_endpoint
+            .as_deref()
+            .filter(|endpoint| !endpoint.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                discovery
+                    .authorization_server_metadata
+                    .token_endpoint
+                    .clone()
+            }),
+        client_id: client_id.to_string(),
+        client_secret,
+        token_endpoint_auth_method,
+        issuer: discovery.authorization_server_issuer.clone(),
+        resource,
+        scopes: request
+            .scopes
+            .as_deref()
+            .filter(|scopes| !scopes.is_empty())
+            .map(str::to_string),
+    })
+}
+
 // --- crypto/util -------------------------------------------------------------
 
 fn generate_pkce_pair() -> (String, String) {
@@ -982,6 +1076,63 @@ mod tests {
         assert!(!token_needs_refresh(&token));
         token.expires_at_unix = Some(current_unix_timestamp() + TOKEN_REFRESH_SKEW_SECS - 1);
         assert!(token_needs_refresh(&token));
+    }
+
+    #[test]
+    fn token_import_uses_discovery_binding_and_legacy_auth_defaults() {
+        let discovery = McpOAuthDiscovery {
+            protected_resource_metadata_url: url::Url::parse(
+                "https://mcp.example/.well-known/oauth-protected-resource",
+            )
+            .unwrap(),
+            protected_resource_metadata: Default::default(),
+            authorization_server_issuer: "https://auth.example".to_string(),
+            authorization_server_metadata_url: url::Url::parse(
+                "https://auth.example/.well-known/oauth-authorization-server",
+            )
+            .unwrap(),
+            authorization_server_metadata_kind:
+                crate::mcp_auth::OAuthAuthorizationServerMetadataKind::OAuthAuthorizationServer,
+            authorization_server_metadata: OAuthAuthorizationServerMetadata {
+                issuer: "https://auth.example".to_string(),
+                authorization_endpoint: "https://auth.example/authorize".to_string(),
+                token_endpoint: "https://auth.example/token".to_string(),
+                registration_endpoint: None,
+                token_endpoint_auth_methods_supported: vec!["none".to_string()],
+                code_challenge_methods_supported: vec!["S256".to_string()],
+                scopes_supported: Vec::new(),
+                client_id_metadata_document_supported: false,
+                authorization_response_iss_parameter_supported: false,
+                extra: Default::default(),
+            },
+            challenge: None,
+            scopes: Vec::new(),
+        };
+        let token = stored_token_for_import(
+            &ImportStoredToken {
+                server_url: "https://mcp.example/mcp".to_string(),
+                access_token: "access".to_string(),
+                refresh_token: Some("refresh".to_string()),
+                expires_at_unix: Some(123),
+                token_endpoint: None,
+                client_id: "client".to_string(),
+                client_secret: Some("secret".to_string()),
+                token_endpoint_auth_method: None,
+                scopes: Some("read write".to_string()),
+            },
+            &discovery,
+        )
+        .unwrap();
+
+        assert_eq!(token.issuer, "https://auth.example");
+        assert_eq!(token.resource, "https://mcp.example/mcp");
+        assert_eq!(token.token_endpoint, "https://auth.example/token");
+        assert_eq!(token.client_id, "client");
+        assert_eq!(token.client_secret.as_deref(), Some("secret"));
+        assert_eq!(token.token_endpoint_auth_method, "client_secret_post");
+        assert_eq!(token.refresh_token.as_deref(), Some("refresh"));
+        assert_eq!(token.expires_at_unix, Some(123));
+        assert_eq!(token.scopes.as_deref(), Some("read write"));
     }
 
     #[tokio::test]

--- a/spec/protocol-artifacts/harn-protocol.rs
+++ b/spec/protocol-artifacts/harn-protocol.rs
@@ -100,6 +100,8 @@ pub const ACP_DISPATCHED_METHOD_MCP_AUTHORIZE: &str = "mcp/authorize";
 pub const ACP_DISPATCHED_METHOD_HARN_MCP_AUTHORIZE: &str = "harn.mcp.authorize";
 pub const ACP_DISPATCHED_METHOD_MCP_OAUTH_CALLBACK: &str = "mcp/oauth_callback";
 pub const ACP_DISPATCHED_METHOD_HARN_MCP_OAUTH_CALLBACK: &str = "harn.mcp.oauth_callback";
+pub const ACP_DISPATCHED_METHOD_MCP_IMPORT_TOKEN: &str = "mcp/import_token";
+pub const ACP_DISPATCHED_METHOD_HARN_MCP_IMPORT_TOKEN: &str = "harn.mcp.import_token";
 
 /// Every JSON-RPC method the ACP adapter actually dispatches, including the workspace-management, workflow-control, and HITL methods the stable bindings do not yet expose as typed enums. Reconciled against the `match` arms in `harn-serve`'s ACP adapter.
 pub const ACP_DISPATCHED_METHODS: &[&str] = &[
@@ -146,6 +148,8 @@ pub const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.mcp.authorize",
     "mcp/oauth_callback",
     "harn.mcp.oauth_callback",
+    "mcp/import_token",
+    "harn.mcp.import_token",
 ];
 
 pub const ACP_CLIENT_METHOD_FS_READ_TEXT_FILE: &str = "fs/read_text_file";


### PR DESCRIPTION
## Summary

- add an ACP `mcp/import_token` method so thin clients can migrate legacy MCP OAuth tokens into Harn-owned storage
- resolve HTTP MCP bearer tokens from the Harn MCP OAuth store when config omits a static token
- expose focused `harn mcp status --url ... --json` output with token metadata for GUI status refreshes

## Validation

- `cargo fmt --check`
- `make check-protocol-artifacts`
- `env CARGO_TARGET_DIR=/tmp/harn-1430-target cargo test -p harn-cli status_report_serializes_with_stable_keys -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-1430-target cargo test -p harn-vm http_auth_resolution_ -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-1430-target cargo test -p harn-vm token_import_uses_discovery_binding_and_legacy_auth_defaults -- --nocapture`
- `env CARGO_TARGET_DIR=/tmp/harn-1430-target cargo test -p harn-serve mcp_oauth --no-fail-fast`
- pre-commit changed-package clippy + markdownlint
- pre-push targeted local checks + markdownlint

Required for burin-labs/burin-code#1430.
