### PR TITLE
Keep write tools during safe tool narrowing

### DIFF
--- a/changelog.d/2773.fixed.md
+++ b/changelog.d/2773.fixed.md
@@ -1,0 +1,5 @@
+- **Agent tool-surface narrowing now keeps write/control tools safe by default
+  (#2773).** The default policy only prunes unused read-only tools, keeps
+  mutating, approval, session-control, progress, result-polling, and unknown
+  host tools visible through long discovery windows, and adds an explicit
+  aggressive mode for callers that want usage-only pruning.

--- a/conformance/tests/agents/tool_surface_narrowing.expected
+++ b/conformance/tests/agents/tool_surface_narrowing.expected
@@ -1,6 +1,17 @@
 done
 true
 true
+read_only
+mutating
+unknown
+true
+true
+true
+true
+true
+true
+true
+true
 true
 true
 true

--- a/conformance/tests/agents/tool_surface_narrowing.harn
+++ b/conformance/tests/agents/tool_surface_narrowing.harn
@@ -13,11 +13,33 @@ fn has_tool(tools, name) {
   return false
 }
 
+fn detail_for(details, name) {
+  for detail in details ?? [] {
+    if detail?.name == name {
+      return detail
+    }
+  }
+  return nil
+}
+
+fn add_narrowing_tool(tools, name, annotations = nil) {
+  var config = {parameters: {}, handler: { _args -> "ok" }}
+  if annotations != nil {
+    config = config + {annotations: annotations}
+  }
+  return tool_define(tools, name, "test tool " + name, config)
+}
+
 fn narrowing_tools() {
   var tools = tool_registry()
-  for name in ["look", "search", "run", "replace_symbol", "done_sentinel"] {
-    tools = tool_define(tools, name, "test tool " + name, {parameters: {}, handler: { _args -> "ok" }})
-  }
+  tools = add_narrowing_tool(tools, "look", {kind: "read", side_effect_level: "read_only"})
+  tools = add_narrowing_tool(tools, "search", {kind: "search", side_effect_level: "read_only"})
+  tools = add_narrowing_tool(tools, "read_docs", {kind: "read", side_effect_level: "read_only"})
+  tools = add_narrowing_tool(tools, "run", {kind: "execute", side_effect_level: "process_exec"})
+  tools = add_narrowing_tool(tools, "scaffold", {kind: "scaffold", side_effect_level: "workspace_write"})
+  tools = add_narrowing_tool(tools, "replace_symbol", {kind: "edit", side_effect_level: "workspace_write"})
+  tools = add_narrowing_tool(tools, "custom_host")
+  tools = add_narrowing_tool(tools, "done_sentinel", {kind: "session_control"})
   return tools
 }
 
@@ -60,12 +82,23 @@ pipeline default() {
   let sixth_tools = calls[5].tools
   __io_println(captured.result.status)
   __io_println(len(narrow) >= 1)
-  __io_println(contains(first.removed_tools, "run"))
+  __io_println(contains(first.removed_tools, "read_docs"))
+  __io_println(detail_for(first.removed_tool_details, "read_docs").class)
+  __io_println(detail_for(first.kept_tool_details, "run").class)
+  __io_println(detail_for(first.kept_tool_details, "custom_host").class)
+  __io_println(!contains(first.removed_tools, "run"))
+  __io_println(!contains(first.removed_tools, "scaffold"))
   __io_println(!contains(first.removed_tools, "replace_symbol"))
-  __io_println(!contains(first.remaining_tools, "run"))
+  __io_println(!contains(first.removed_tools, "custom_host"))
+  __io_println(!contains(first.remaining_tools, "read_docs"))
+  __io_println(contains(first.remaining_tools, "run"))
+  __io_println(contains(first.remaining_tools, "scaffold"))
   __io_println(contains(first.remaining_tools, "replace_symbol"))
-  __io_println(!has_tool(sixth_tools, "run"))
+  __io_println(!has_tool(sixth_tools, "read_docs"))
+  __io_println(has_tool(sixth_tools, "run"))
+  __io_println(has_tool(sixth_tools, "scaffold"))
   __io_println(has_tool(sixth_tools, "replace_symbol"))
+  __io_println(has_tool(sixth_tools, "custom_host"))
   __io_println(has_tool(sixth_tools, "done_sentinel"))
   llm_mock_clear()
   llm_mock({tool_calls: [{id: "rewiden-look-1", name: "look", arguments: {}}]})
@@ -89,7 +122,7 @@ pipeline default() {
       stop_after_successful_tools: ["run"],
       skills: runner,
       skill_match: {strategy: "manual"},
-      tool_surface_narrowing: {enabled: true, window_turns: 5},
+      tool_surface_narrowing: {enabled: true, window_turns: 5, mode: "aggressive"},
     },
   )
   let rewiden_calls = llm_mock_calls()

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -477,6 +477,9 @@ impl AgentEventSink for AcpAgentEventSink {
                 reason,
                 removed_tools,
                 remaining_tools,
+                policy,
+                removed_tool_details,
+                kept_tool_details,
             } => {
                 let mut update = serde_json::json!({
                     "sessionUpdate": "skill_narrow",
@@ -494,6 +497,18 @@ impl AgentEventSink for AcpAgentEventSink {
                     "remainingTools".to_string(),
                     serde_json::to_value(remaining_tools).unwrap_or_default(),
                 );
+                if !policy.is_null() {
+                    harn_meta.insert("policy".to_string(), policy.clone());
+                }
+                if !removed_tool_details.is_null() {
+                    harn_meta.insert(
+                        "removedToolDetails".to_string(),
+                        removed_tool_details.clone(),
+                    );
+                }
+                if !kept_tool_details.is_null() {
+                    harn_meta.insert("keptToolDetails".to_string(), kept_tool_details.clone());
+                }
                 merge_harn_meta(&mut update, harn_meta);
                 self.write_notification(serde_json::json!({
                     "sessionId": session_id,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -173,6 +173,9 @@ fn extension_fixture_events() -> Vec<AgentEvent> {
             reason: "unused across 5 turns".to_string(),
             removed_tools: vec!["write".to_string()],
             remaining_tools: vec!["read".to_string()],
+            policy: serde_json::Value::Null,
+            removed_tool_details: serde_json::Value::Null,
+            kept_tool_details: serde_json::Value::Null,
         },
         AgentEvent::ToolSearchQuery {
             session_id: "session-1".to_string(),
@@ -1153,6 +1156,9 @@ async fn forwarded_agent_events_serialize_as_session_updates() {
             reason: "unused across 5 turns".to_string(),
             removed_tools: vec!["write".to_string()],
             remaining_tools: vec!["read".to_string()],
+            policy: serde_json::Value::Null,
+            removed_tool_details: serde_json::Value::Null,
+            kept_tool_details: serde_json::Value::Null,
         },
         AgentEvent::ToolSearchQuery {
             session_id: "session-1".to_string(),
@@ -1241,6 +1247,32 @@ async fn forwarded_agent_events_serialize_as_session_updates() {
         assert_eq!(payload["params"]["sessionId"], "session-1");
         assert_eq!(payload["params"]["update"]["sessionUpdate"], expected);
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn skill_narrow_serializes_policy_details_under_harn_meta() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let sink = AcpAgentEventSink::new(AcpOutput::Channel(tx));
+    sink.handle_event(&AgentEvent::SkillNarrow {
+        session_id: "session-1".to_string(),
+        reason: "unused across 5 turns".to_string(),
+        removed_tools: vec!["read_docs".to_string()],
+        remaining_tools: vec!["run".to_string()],
+        policy: serde_json::json!({"mode": "safe", "prune_classes": ["read_only"]}),
+        removed_tool_details: serde_json::json!([
+            {"name": "read_docs", "class": "read_only", "reason": "unused_prunable_class"}
+        ]),
+        kept_tool_details: serde_json::json!([
+            {"name": "run", "class": "mutating", "reason": "class_kept"}
+        ]),
+    });
+
+    let line = rx.recv().await.expect("ACP event notification");
+    let payload: serde_json::Value = serde_json::from_str(&line).expect("json");
+    let harn_meta = update_harn_meta(&payload);
+    assert_eq!(harn_meta["policy"]["mode"], "safe");
+    assert_eq!(harn_meta["removedToolDetails"][0]["name"], "read_docs");
+    assert_eq!(harn_meta["keptToolDetails"][0]["class"], "mutating");
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -706,16 +706,61 @@ fn __default_tool_surface_hard_keep() {
   ]
 }
 
+fn __tool_surface_safe_defaults() {
+  return {
+    enabled: true,
+    window_turns: 5,
+    mode: "safe",
+    hard_keep: __default_tool_surface_hard_keep(),
+    prune_classes: ["read_only"],
+    keep_classes: ["mutating", "approval", "session_control", "progress", "result_polling", "unknown"],
+    unknown_tool_policy: "keep",
+  }
+}
+
+fn __tool_surface_aggressive_defaults() {
+  return {
+    enabled: true,
+    window_turns: 5,
+    mode: "aggressive",
+    hard_keep: __default_tool_surface_hard_keep(),
+    prune_classes: ["read_only", "mutating", "approval", "session_control", "progress", "result_polling", "unknown"],
+    keep_classes: [],
+    unknown_tool_policy: "prune",
+  }
+}
+
+fn __validate_tool_surface_mode(mode) {
+  if mode == "safe" || mode == "aggressive" {
+    return
+  }
+  throw "agent_loop: `tool_surface_narrowing.mode` must be \"safe\" or \"aggressive\""
+}
+
+fn __validate_tool_surface_unknown_policy(policy) {
+  if policy == "keep" || policy == "prune" {
+    return
+  }
+  throw "agent_loop: `tool_surface_narrowing.unknown_tool_policy` must be \"keep\" or \"prune\""
+}
+
 fn __normalize_tool_surface_narrowing(value) {
-  let defaults = {enabled: true, window_turns: 5, hard_keep: __default_tool_surface_hard_keep()}
+  let safe_defaults = __tool_surface_safe_defaults()
   if value == nil {
-    return defaults
+    return safe_defaults
   }
   if type_of(value) == "bool" {
-    return defaults + {enabled: value}
+    return safe_defaults + {enabled: value}
   }
   if type_of(value) != "dict" {
     throw "agent_loop: `tool_surface_narrowing` must be a dict, bool, or nil; got " + type_of(value)
+  }
+  let requested_mode = value?.mode ?? safe_defaults.mode
+  __validate_tool_surface_mode(requested_mode)
+  let defaults = if requested_mode == "aggressive" {
+    __tool_surface_aggressive_defaults()
+  } else {
+    safe_defaults
   }
   let enabled = value?.enabled ?? defaults.enabled
   if type_of(enabled) != "bool" {
@@ -730,7 +775,23 @@ fn __normalize_tool_surface_narrowing(value) {
   }
   let hard_keep = value?.hard_keep ?? defaults.hard_keep
   __validate_string_list("agent_loop: `tool_surface_narrowing.hard_keep`", hard_keep)
-  return defaults + value + {enabled: enabled, window_turns: window_turns, hard_keep: hard_keep}
+  let prune_classes = value?.prune_classes ?? defaults.prune_classes
+  __validate_string_list("agent_loop: `tool_surface_narrowing.prune_classes`", prune_classes)
+  let keep_classes = value?.keep_classes ?? defaults.keep_classes
+  __validate_string_list("agent_loop: `tool_surface_narrowing.keep_classes`", keep_classes)
+  let unknown_tool_policy = value?.unknown_tool_policy ?? defaults.unknown_tool_policy
+  __validate_tool_surface_unknown_policy(unknown_tool_policy)
+  return defaults
+    + value
+    + {
+    enabled: enabled,
+    window_turns: window_turns,
+    mode: requested_mode,
+    hard_keep: hard_keep,
+    prune_classes: prune_classes,
+    keep_classes: keep_classes,
+    unknown_tool_policy: unknown_tool_policy,
+  }
 }
 
 fn __validate_removed_agent_loop_options(opts) {

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -355,7 +355,7 @@ fn __tool_surface_name(entry) {
   return entry?.name ?? entry?.function?.name ?? ""
 }
 
-fn __tool_surface_current_names(opts) {
+fn __tool_surface_current_entries(opts) {
   let registry = opts?.tools
   let entries = if type_of(registry) == "dict" {
     registry?.tools ?? []
@@ -364,12 +364,22 @@ fn __tool_surface_current_names(opts) {
   } else {
     []
   }
+  var selected = []
   var names = []
   for entry in entries {
     let name = __tool_surface_name(entry)
     if name != "" && !contains(names, name) {
       names = names.push(name)
+      selected = selected.push(entry)
     }
+  }
+  return selected
+}
+
+fn __tool_surface_current_names(opts) {
+  var names = []
+  for entry in __tool_surface_current_entries(opts) {
+    names = names.push(__tool_surface_name(entry))
   }
   return names
 }
@@ -415,14 +425,169 @@ fn __tool_surface_window_used(history) {
   return used
 }
 
-fn __tool_surface_removed(candidates, used, hard_keep) {
+fn __tool_surface_annotations(entry) {
+  let direct = entry?.annotations
+  if type_of(direct) == "dict" {
+    return direct
+  }
+  let func = entry?.function
+  if type_of(func) == "dict" && type_of(func?.annotations) == "dict" {
+    return func.annotations
+  }
+  return {}
+}
+
+fn __tool_surface_text(value) {
+  if value == nil {
+    return ""
+  }
+  return lowercase(trim(to_string(value)))
+}
+
+fn __tool_surface_enabled(value) {
+  return type_of(value) == "bool" && value
+}
+
+fn __tool_surface_entry_class(entry) {
+  let annotations = __tool_surface_annotations(entry)
+  let side_effect = __tool_surface_text(
+    annotations?.side_effect_level ?? annotations?.sideEffectLevel ?? annotations?.side_effect
+      ?? annotations?.sideEffect,
+  )
+  let kind = __tool_surface_text(annotations?.kind ?? annotations?.tool_kind ?? annotations?.toolKind)
+  let name = __tool_surface_text(__tool_surface_name(entry))
+  if __tool_surface_enabled(annotations?.agent_lifecycle)
+    || __tool_surface_enabled(annotations?.structural)
+    || contains(["session_control", "lifecycle", "suspend", "resume"], kind)
+    || contains(
+    ["load_skill", "agent_await_resumption", "subagent_pause", "subagent_resume", "wait_for_user"],
+    name,
+  ) {
+    return "session_control"
+  }
+  if __tool_surface_enabled(annotations?.approval)
+    || __tool_surface_enabled(annotations?.requires_approval)
+    || contains(["approval", "human_gate"], kind) {
+    return "approval"
+  }
+  if __tool_surface_enabled(annotations?.progress) || kind == "progress" {
+    return "progress"
+  }
+  if __tool_surface_enabled(annotations?.result_reader)
+    || __tool_surface_enabled(annotations?.result_polling)
+    || kind == "result_polling"
+    || starts_with(name, "read_command_output") {
+    return "result_polling"
+  }
+  if side_effect != "" && side_effect != "none" && side_effect != "read_only" && side_effect != "read" {
+    return "mutating"
+  }
+  if contains(
+    [
+      "edit",
+      "write",
+      "execute",
+      "run",
+      "command",
+      "scaffold",
+      "delete",
+      "mutation",
+      "mutate",
+      "network",
+    ],
+    kind,
+  ) {
+    return "mutating"
+  }
+  if side_effect == "none" || side_effect == "read_only" || side_effect == "read" {
+    return "read_only"
+  }
+  if contains(["read", "search", "fetch", "think", "lookup", "inspect"], kind) {
+    return "read_only"
+  }
+  if __tool_surface_enabled(annotations?.readOnlyHint)
+    && !__tool_surface_enabled(annotations?.destructiveHint) {
+    return "read_only"
+  }
+  return "unknown"
+}
+
+fn __tool_surface_entry_detail(entry, class, reason) {
+  let annotations = __tool_surface_annotations(entry)
+  return {
+    name: __tool_surface_name(entry),
+    class: class,
+    kind: __tool_surface_text(annotations?.kind ?? annotations?.tool_kind ?? annotations?.toolKind),
+    side_effect_level: __tool_surface_text(
+      annotations?.side_effect_level ?? annotations?.sideEffectLevel ?? annotations?.side_effect
+        ?? annotations?.sideEffect,
+    ),
+    reason: reason,
+  }
+}
+
+fn __tool_surface_entry_prunable(entry, config) {
+  let class = __tool_surface_entry_class(entry)
+  let keep_classes = config?.keep_classes ?? []
+  if contains(keep_classes, class) {
+    return false
+  }
+  if class == "unknown" {
+    let unknown_tool_policy = config?.unknown_tool_policy ?? "keep"
+    return unknown_tool_policy == "prune"
+  }
+  let mode = config?.mode ?? "safe"
+  if mode == "aggressive" {
+    return true
+  }
+  return contains(config?.prune_classes ?? ["read_only"], class)
+}
+
+fn __tool_surface_removed(candidates, used, config) {
+  let hard_keep = config?.hard_keep ?? []
   var removed = []
-  for name in candidates {
-    if !contains(used, name) && !contains(hard_keep, name) {
-      removed = removed.push(name)
+  for entry in candidates {
+    let name = __tool_surface_name(entry)
+    if name == "" || contains(used, name) || contains(hard_keep, name) {
+      continue
+    }
+    let class = __tool_surface_entry_class(entry)
+    if __tool_surface_entry_prunable(entry, config) {
+      removed = removed.push(__tool_surface_entry_detail(entry, class, "unused_prunable_class"))
     }
   }
   return removed
+}
+
+fn __tool_surface_removed_names(details) {
+  var names = []
+  for detail in details {
+    let name = detail?.name ?? ""
+    if name != "" && !contains(names, name) {
+      names = names.push(name)
+    }
+  }
+  return names
+}
+
+fn __tool_surface_keep_details(candidates, removed, used, hard_keep) {
+  var details = []
+  for entry in candidates {
+    let name = __tool_surface_name(entry)
+    if name == "" || contains(removed, name) {
+      continue
+    }
+    let class = __tool_surface_entry_class(entry)
+    let reason = if contains(used, name) {
+      "used_in_window"
+    } else if contains(hard_keep, name) {
+      "hard_keep"
+    } else {
+      "class_kept"
+    }
+    details = details.push(__tool_surface_entry_detail(entry, class, reason))
+  }
+  return details
 }
 
 fn __tool_surface_remaining(candidates, removed) {
@@ -443,22 +608,39 @@ fn __tool_surface_narrowing_post_turn(session, llm_result, dispatch_results, opt
   let window_turns = config?.window_turns ?? 5
   let attempted = __tool_surface_attempted_names(llm_result, dispatch_results)
   let history = __tool_surface_append_history(opts?._tool_surface_narrowing_history ?? [], attempted, window_turns)
+  let candidate_entries = __tool_surface_current_entries(opts)
   let candidates = __tool_surface_current_names(opts)
   if len(candidates) == 0 || len(history) < window_turns {
     return {history: history, narrowed_tools: opts?._tool_surface_narrowed_tools, changed: false}
   }
   let used = __tool_surface_window_used(history)
   let hard_keep = config?.hard_keep ?? []
-  let removed = __tool_surface_removed(candidates, used, hard_keep)
+  let removed_details = __tool_surface_removed(candidate_entries, used, config)
+  let removed = __tool_surface_removed_names(removed_details)
   if len(removed) == 0 {
     return {history: history, narrowed_tools: opts?._tool_surface_narrowed_tools, changed: false}
   }
   let remaining = __tool_surface_remaining(candidates, removed)
+  let kept_details = __tool_surface_keep_details(candidate_entries, removed, used, hard_keep)
   let reason = "unused across last " + to_string(window_turns) + " turns"
   agent_session_record_skill_event(
     session.session_id,
     "skill_narrow",
-    {reason: reason, removed_tools: removed, remaining_tools: remaining, window_turns: window_turns},
+    {
+      reason: reason,
+      removed_tools: removed,
+      remaining_tools: remaining,
+      window_turns: window_turns,
+      policy: {
+        mode: config?.mode ?? "safe",
+        prune_classes: config?.prune_classes ?? ["read_only"],
+        keep_classes: config?.keep_classes ?? [],
+        unknown_tool_policy: config?.unknown_tool_policy ?? "keep",
+        hard_keep: hard_keep,
+      },
+      removed_tool_details: removed_details,
+      kept_tool_details: kept_details,
+    },
   )
   return {
     history: history,
@@ -466,6 +648,8 @@ fn __tool_surface_narrowing_post_turn(session, llm_result, dispatch_results, opt
     changed: true,
     removed_tools: removed,
     remaining_tools: remaining,
+    removed_tool_details: removed_details,
+    kept_tool_details: kept_details,
     reason: reason,
   }
 }

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -378,6 +378,12 @@ pub enum AgentEvent {
         reason: String,
         removed_tools: Vec<String>,
         remaining_tools: Vec<String>,
+        #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+        policy: serde_json::Value,
+        #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+        removed_tool_details: serde_json::Value,
+        #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+        kept_tool_details: serde_json::Value,
     },
     /// Emitted when a `tool_search` query is issued by the model. Carries
     /// the raw query args, the configured strategy, and a `mode` tag

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1468,6 +1468,18 @@ fn host_agent_session_record_skill_event_builtin(
                 reason,
                 removed_tools: string_list("removed_tools"),
                 remaining_tools: string_list("remaining_tools"),
+                policy: metadata_json
+                    .get("policy")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                removed_tool_details: metadata_json
+                    .get("removed_tool_details")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                kept_tool_details: metadata_json
+                    .get("kept_tool_details")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
             });
         }
         _ => {}
@@ -1873,6 +1885,18 @@ fn build_agent_event(
                 reason: get_string("reason"),
                 removed_tools: string_list("removed_tools"),
                 remaining_tools: string_list("remaining_tools"),
+                policy: payload_obj
+                    .and_then(|m| m.get("policy"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                removed_tool_details: payload_obj
+                    .and_then(|m| m.get("removed_tool_details"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                kept_tool_details: payload_obj
+                    .and_then(|m| m.get("kept_tool_details"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
             })
         }
         "loop_control_decision" => Ok(AgentEvent::LoopControlDecision {

--- a/docs/src/bridge-protocol.md
+++ b/docs/src/bridge-protocol.md
@@ -918,7 +918,8 @@ variants into:
 - `sessionUpdate: "skill_activated"` — `{skillName, iteration, reason}`
 - `sessionUpdate: "skill_deactivated"` — `{skillName, iteration}`
 - `sessionUpdate: "skill_scope_tools"` — `{skillName, allowedTools}`
-- `sessionUpdate: "skill_narrow"` — `{reason, removedTools, remainingTools}`
+- `sessionUpdate: "skill_narrow"` — `{reason, removedTools, remainingTools,
+  policy, removedToolDetails, keptToolDetails}`
 
 `skill_matched` stays internal to the VM transcript — the candidate
 list can be large and host UIs typically only care about activation

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -2727,16 +2727,30 @@ diagnostics for workflow and stage surfaces.
 
 `agent_loop` narrows the model-visible tool surface between turns by
 default. The `tool_surface_narrowing` option accepts `false` to disable,
-`true` to use defaults, or a dict with `enabled`, `window_turns`, and
-`hard_keep`. After `window_turns` observed turns, tools that were not
-attempted in that rolling window are removed from the next model call
-unless listed in `hard_keep`. The default window is five turns.
+`true` to use defaults, or a dict with `enabled`, `window_turns`,
+`hard_keep`, `mode`, `prune_classes`, `keep_classes`, and
+`unknown_tool_policy`. After `window_turns` observed turns, tools in
+prunable classes that were not attempted in that rolling window are removed
+from the next model call unless listed in `hard_keep`. The default window
+is five turns.
 
 Narrowing is usage-based only; it does not inspect file extensions,
-languages, or project metadata. Explicit skill activation widens back to
-the skill-scoped surface, after which narrowing may run again. Every
-narrowing step emits a `skill_narrow` agent event with `reason`,
-`removed_tools`, and `remaining_tools`.
+languages, or project metadata. The default `mode: "safe"` prunes only
+`read_only` tools and keeps `mutating`, `approval`, `session_control`,
+`progress`, `result_polling`, and `unknown` tools by class. Host/custom
+tools with missing side-effect annotations are therefore kept by default.
+Set `mode: "aggressive"` to opt into usage-only pruning across tool classes,
+or override `prune_classes`, `keep_classes`, and `unknown_tool_policy` for a
+custom policy. Host surfaces should annotate tools with
+`annotations.side_effect_level` (`none`, `read_only`, `workspace_write`,
+`process_exec`, or `network`) and `annotations.kind` so narrowing can classify
+them intentionally.
+
+Explicit skill activation widens back to the skill-scoped surface, after
+which narrowing may run again. Every narrowing step emits a `skill_narrow`
+agent event with `reason`, `removed_tools`, `remaining_tools`, `policy`,
+`removed_tool_details`, and `kept_tool_details` so replayers and hosts can
+explain why a tool did or did not remain visible.
 
 #### Agent loop completion gates
 

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -236,7 +236,7 @@ Same as `llm_call`, plus additional options:
 | `tool_backoff_ms` | int | `1000` | Base backoff delay in ms for tool retries (doubles each attempt) |
 | `max_concurrent_tools` | int | `1` | Maximum in-flight tool calls from one planner turn. Results are recorded in emitted order even when calls complete out of order |
 | `prefetch_next_turn` | bool | `false` | Start the next planner turn after tool results are recorded while local/custom audit receipt sinks flush in the background. The loop drains those flushes before returning |
-| `tool_surface_narrowing` | bool/dict | `{enabled: true, window_turns: 5}` | Between turns, remove model-visible tools that were unused across the rolling window. Dict configs may set `enabled`, `window_turns`, and `hard_keep`; explicit skill activation widens back to the skill-scoped surface |
+| `tool_surface_narrowing` | bool/dict | `{enabled: true, window_turns: 5, mode: "safe"}` | Between turns, remove model-visible tools that were unused across the rolling window. Safe mode narrows unused `read_only` tools while keeping mutating/control/unknown tools by class; dict configs may also set `mode: "aggressive"`, `hard_keep`, `prune_classes`, `keep_classes`, and `unknown_tool_policy` |
 | `progress_tool` | bool/dict | `false` | Opt in to a model-facing progress tool that emits `progress_reported` agent events. `true` exposes `agent_progress`; a dict may set `name`, `description`, and `system_prompt_nudge`. ACP clients receive task-list entries as canonical `plan` updates and message-only reports as Harn `progress` narration |
 | `policy` | dict | nil | Capability ceiling applied to this agent loop |
 | `daemon` | bool | `false` | Idle instead of terminating after text-only turns |
@@ -1030,8 +1030,21 @@ zero-candidate passes so replayers see the boundary), one
 `skill_activated` per activated skill, and one `skill_scope_tools`
 event per activation whose `allowed_tools` narrowed the surface. When
 `tool_surface_narrowing` removes unused tools between turns, the loop
-also emits `skill_narrow` with `removed_tools`, `remaining_tools`, and
-the narrowing reason.
+also emits `skill_narrow` with `removed_tools`, `remaining_tools`, the
+narrowing reason, policy details, removed-tool details, and kept-tool
+details.
+
+The default narrowing policy is safe by class: only tools classified as
+`read_only` are prunable. Tools classified as `mutating`, `approval`,
+`session_control`, `progress`, or `result_polling` remain visible even after
+long discovery windows, and host/custom tools with missing annotations are
+classified as `unknown` and kept. Host surfaces should annotate each tool with
+`annotations.side_effect_level` (`none`, `read_only`, `workspace_write`,
+`process_exec`, or `network`) plus a `kind` such as `read`, `search`, `edit`,
+or `execute`. Use `tool_surface_narrowing: {mode: "aggressive"}` only when a
+session intentionally wants usage-only pruning across all classes; callers can
+still override `prune_classes`, `keep_classes`, `unknown_tool_policy`, and
+`hard_keep` for narrower policies.
 
 ## Delegated workers
 

--- a/docs/src/spec/harn-extensions/v1.md
+++ b/docs/src/spec/harn-extensions/v1.md
@@ -147,7 +147,7 @@ Harn extension session updates keep the `sessionUpdate` discriminator at
 | `handoff` | `handoffId`, `artifactId`, `handoff` | Stable v1 |
 | `skill_activated` | `skillName`, `iteration`, `reason` | Stable v1 |
 | `skill_deactivated` | `skillName`, `iteration` | Stable v1 |
-| `skill_narrow` | `reason`, `removedTools`, `remainingTools` | Stable v1 |
+| `skill_narrow` | `reason`, `removedTools`, `remainingTools`, `policy`, `removedToolDetails`, `keptToolDetails` | Stable v1 |
 | `skill_scope_tools` | `skillName`, `allowedTools` | Stable v1 |
 | `tool_search_query` | `toolUseId`, `name`, `query`, `strategy`, `mode` | Stable v1 |
 | `tool_search_result` | `toolUseId`, `promoted`, `strategy`, `mode` | Stable v1 |

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -2725,16 +2725,30 @@ diagnostics for workflow and stage surfaces.
 
 `agent_loop` narrows the model-visible tool surface between turns by
 default. The `tool_surface_narrowing` option accepts `false` to disable,
-`true` to use defaults, or a dict with `enabled`, `window_turns`, and
-`hard_keep`. After `window_turns` observed turns, tools that were not
-attempted in that rolling window are removed from the next model call
-unless listed in `hard_keep`. The default window is five turns.
+`true` to use defaults, or a dict with `enabled`, `window_turns`,
+`hard_keep`, `mode`, `prune_classes`, `keep_classes`, and
+`unknown_tool_policy`. After `window_turns` observed turns, tools in
+prunable classes that were not attempted in that rolling window are removed
+from the next model call unless listed in `hard_keep`. The default window
+is five turns.
 
 Narrowing is usage-based only; it does not inspect file extensions,
-languages, or project metadata. Explicit skill activation widens back to
-the skill-scoped surface, after which narrowing may run again. Every
-narrowing step emits a `skill_narrow` agent event with `reason`,
-`removed_tools`, and `remaining_tools`.
+languages, or project metadata. The default `mode: "safe"` prunes only
+`read_only` tools and keeps `mutating`, `approval`, `session_control`,
+`progress`, `result_polling`, and `unknown` tools by class. Host/custom
+tools with missing side-effect annotations are therefore kept by default.
+Set `mode: "aggressive"` to opt into usage-only pruning across tool classes,
+or override `prune_classes`, `keep_classes`, and `unknown_tool_policy` for a
+custom policy. Host surfaces should annotate tools with
+`annotations.side_effect_level` (`none`, `read_only`, `workspace_write`,
+`process_exec`, or `network`) and `annotations.kind` so narrowing can classify
+them intentionally.
+
+Explicit skill activation widens back to the skill-scoped surface, after
+which narrowing may run again. Every narrowing step emits a `skill_narrow`
+agent event with `reason`, `removed_tools`, `remaining_tools`, `policy`,
+`removed_tool_details`, and `kept_tool_details` so replayers and hosts can
+explain why a tool did or did not remain visible.
 
 #### Agent loop completion gates
 


### PR DESCRIPTION
## Summary
- make default tool-surface narrowing class-aware so only unused read-only tools are prunable
- keep mutating, approval/session-control, progress/result-polling, and unknown host tools visible by default; add explicit aggressive mode for usage-only pruning
- carry narrowing policy/details through AgentEvent and ACP _meta.harn diagnostics
- update regression coverage and docs/spec/changelog

Fixes #2773.

## Verification
- cargo run --quiet --bin harn -- test conformance --filter tool_surface_narrowing
- cargo test -p harn-serve adapters::acp::events
- cargo test -p harn-vm agent_session_host
- make fmt-harn
- make lint-harn
- make lint-test-patterns
- make check-docs-snippets
- make check-protocol-artifacts
- make test
- post-rebase: cargo run --quiet --bin harn -- test conformance --filter tool_surface_narrowing
- post-rebase: cargo test -p harn-serve skill_narrow_serializes_policy_details_under_harn_meta
