### PR TITLE
Fix Arc-era runtime and ACP edge cases

### DIFF
--- a/changelog.d/arc-dry-bugfix-pass.fixed.md
+++ b/changelog.d/arc-dry-bugfix-pass.fixed.md
@@ -1,0 +1,5 @@
+- **Runtime, ACP, DAP, OAuth, and stdlib edge cases.** Fixed integer
+  division overflow panics, channel-select hangs on closed empty channels,
+  duplicate in-flight ACP request IDs, stale DAP output flushing, OAuth token
+  expiry validation, OAuth error-body secret leakage, and inconsistent
+  duration option coercion across stdlib modules.

--- a/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
+++ b/crates/harn-cli/src/commands/orchestrator/listener/acp_hub.rs
@@ -50,8 +50,7 @@ struct AcpWorker {
     clients: Mutex<BTreeMap<String, AcpClient>>,
     host_owner_client_id: Mutex<Option<String>>,
     pending_client_requests: Mutex<BTreeMap<String, String>>,
-    pending_host_requests: Mutex<BTreeMap<String, AcpHostRequest>>,
-    decided_host_requests: Mutex<BTreeMap<String, AcpHostDecision>>,
+    host_requests: Mutex<AcpHostRequests>,
     sessions: Mutex<BTreeMap<String, AcpSessionSummary>>,
     replay_buffer: Mutex<VecDeque<AcpReplayEvent>>,
     next_event_id: AtomicU64,
@@ -122,10 +121,10 @@ enum AcpClientRequestError {
         request_id: String,
     },
     IdempotentHostDecision {
-        decision: AcpHostDecision,
+        decision: Box<AcpHostDecision>,
     },
     AlreadyDecided {
-        decision: AcpHostDecision,
+        decision: Box<AcpHostDecision>,
         attempted_actor: AcpControlActor,
         attempted_payload: JsonValue,
     },
@@ -145,6 +144,12 @@ enum AcpOutboundRoute {
 struct AcpHostRequest {
     method: String,
     session_id: Option<String>,
+}
+
+#[derive(Default)]
+struct AcpHostRequests {
+    pending: BTreeMap<String, AcpHostRequest>,
+    decided: BTreeMap<String, AcpHostDecision>,
 }
 
 #[derive(Clone, Debug)]
@@ -192,8 +197,7 @@ impl AcpWebSocketHub {
             clients: Mutex::new(BTreeMap::new()),
             host_owner_client_id: Mutex::new(None),
             pending_client_requests: Mutex::new(BTreeMap::new()),
-            pending_host_requests: Mutex::new(BTreeMap::new()),
-            decided_host_requests: Mutex::new(BTreeMap::new()),
+            host_requests: Mutex::new(AcpHostRequests::default()),
             sessions: Mutex::new(BTreeMap::new()),
             replay_buffer: Mutex::new(VecDeque::new()),
             next_event_id: AtomicU64::new(1),
@@ -622,14 +626,6 @@ impl AcpWorker {
         }
     }
 
-    fn pending_host_request(&self, id_key: &str) -> Option<AcpHostRequest> {
-        self.pending_host_requests
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(id_key)
-            .cloned()
-    }
-
     fn annotate_control_actor(&self, value: &mut JsonValue, actor: &AcpControlActor) {
         let Some(params) = value.get_mut("params") else {
             return;
@@ -661,6 +657,69 @@ impl AcpWorker {
         } else {
             json!({"result": value.get("result").cloned().unwrap_or(JsonValue::Null)})
         }
+    }
+
+    fn forward_host_decision(
+        &self,
+        id_key: &str,
+        role: AcpAttachRole,
+        actor: AcpControlActor,
+        value: &JsonValue,
+        sender: &mpsc::UnboundedSender<JsonValue>,
+    ) -> Result<AcpHostDecision, AcpClientRequestError> {
+        let attempted_payload = Self::decision_payload(value);
+        let mut requests = self.host_requests.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(decision) = requests.decided.get(id_key).cloned() {
+            if decision.actor.client_id == actor.client_id && decision.payload == attempted_payload
+            {
+                return Err(AcpClientRequestError::IdempotentHostDecision {
+                    decision: Box::new(decision),
+                });
+            }
+            return Err(AcpClientRequestError::AlreadyDecided {
+                decision: Box::new(decision),
+                attempted_actor: actor,
+                attempted_payload,
+            });
+        }
+
+        let Some(host_request) = requests.pending.get(id_key).cloned() else {
+            return Err(AcpClientRequestError::UnknownHostRequest {
+                request_id: id_key.to_string(),
+            });
+        };
+        if role != AcpAttachRole::HostOwner
+            && !(role == AcpAttachRole::Controller
+                && host_request.method == "session/request_permission")
+        {
+            return Err(AcpClientRequestError::Forbidden {
+                method: host_request.method,
+                role,
+            });
+        }
+
+        let decision = AcpHostDecision {
+            request_id: id_key.to_string(),
+            method: host_request.method,
+            session_id: host_request.session_id,
+            actor,
+            payload: attempted_payload,
+            decided_at_ms: unix_epoch_ms(),
+        };
+        sender
+            .send(value.clone())
+            .map_err(|_| AcpClientRequestError::Disconnected)?;
+        requests.pending.remove(id_key);
+        requests
+            .decided
+            .insert(id_key.to_string(), decision.clone());
+        while requests.decided.len() > ACP_REPLAY_BUFFER_LIMIT {
+            let Some(first_key) = requests.decided.keys().next().cloned() else {
+                break;
+            };
+            requests.decided.remove(&first_key);
+        }
+        Ok(decision)
     }
 
     async fn append_control_outcome(&self, decision: &AcpHostDecision, status: &str, reason: &str) {
@@ -698,72 +757,14 @@ impl AcpWorker {
             }
             self.annotate_control_actor(&mut value, &actor);
         } else if let Some(id_key) = jsonrpc_id_key(&value) {
-            if let Some(decision) = self
-                .decided_host_requests
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .get(&id_key)
-                .cloned()
-            {
-                let attempted_payload = Self::decision_payload(&value);
-                if decision.actor.client_id == actor.client_id
-                    && decision.payload == attempted_payload
-                {
-                    return Err(AcpClientRequestError::IdempotentHostDecision { decision });
-                }
-                return Err(AcpClientRequestError::AlreadyDecided {
-                    decision,
-                    attempted_actor: actor,
-                    attempted_payload,
-                });
-            }
-
-            let Some(host_request) = self.pending_host_request(&id_key) else {
-                return Err(AcpClientRequestError::UnknownHostRequest { request_id: id_key });
-            };
-            if role != AcpAttachRole::HostOwner
-                && !(role == AcpAttachRole::Controller
-                    && host_request.method == "session/request_permission")
-            {
-                return Err(AcpClientRequestError::Forbidden {
-                    method: host_request.method,
-                    role,
-                });
-            }
-
-            self.request_tx
+            let sender = self
+                .request_tx
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
                 .as_ref()
-                .ok_or(AcpClientRequestError::Disconnected)?
-                .send(value.clone())
-                .map_err(|_| AcpClientRequestError::Disconnected)?;
-
-            self.pending_host_requests
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .remove(&id_key);
-            let decision = AcpHostDecision {
-                request_id: id_key.clone(),
-                method: host_request.method,
-                session_id: host_request.session_id,
-                actor,
-                payload: Self::decision_payload(&value),
-                decided_at_ms: unix_epoch_ms(),
-            };
-            {
-                let mut decided = self
-                    .decided_host_requests
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
-                decided.insert(id_key, decision.clone());
-                while decided.len() > ACP_REPLAY_BUFFER_LIMIT {
-                    let Some(first_key) = decided.keys().next().cloned() else {
-                        break;
-                    };
-                    decided.remove(&first_key);
-                }
-            }
+                .cloned()
+                .ok_or(AcpClientRequestError::Disconnected)?;
+            let decision = self.forward_host_decision(&id_key, role, actor, &value, &sender)?;
             self.append_control_outcome(&decision, "accepted", "first_valid_response")
                 .await;
             return Ok(());
@@ -780,10 +781,7 @@ impl AcpWorker {
                     .pending_client_requests
                     .lock()
                     .unwrap_or_else(|e| e.into_inner());
-                if pending
-                    .get(&id_key)
-                    .is_some_and(|pending_client_id| pending_client_id != client_id)
-                {
+                if pending.contains_key(&id_key) {
                     return Err(AcpClientRequestError::DuplicateRequestId);
                 }
                 pending.insert(id_key, client_id.to_string());
@@ -812,14 +810,17 @@ impl AcpWorker {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .take();
-        self.pending_host_requests
+        let mut host_requests = self.host_requests.lock().unwrap_or_else(|e| e.into_inner());
+        host_requests.pending.clear();
+        host_requests.decided.clear();
+    }
+
+    fn register_host_request(&self, id_key: String, method: String, session_id: Option<String>) {
+        self.host_requests
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .clear();
-        self.decided_host_requests
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clear();
+            .pending
+            .insert(id_key, AcpHostRequest { method, session_id });
     }
 
     fn is_expired(&self, retention: Duration) -> bool {
@@ -934,16 +935,7 @@ impl AcpWorker {
         .await;
 
         if let AcpOutboundRoute::HostRequest { id_key, method } = acp_outbound_route(&line) {
-            self.pending_host_requests
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .insert(
-                    id_key,
-                    AcpHostRequest {
-                        method,
-                        session_id: session_id.clone(),
-                    },
-                );
+            self.register_host_request(id_key, method, session_id.clone());
         }
 
         self.deliver_output(&line, annotated);
@@ -2172,8 +2164,7 @@ mod tests {
             ])),
             host_owner_client_id: Mutex::new(Some("owner".to_string())),
             pending_client_requests: Mutex::new(BTreeMap::new()),
-            pending_host_requests: Mutex::new(BTreeMap::new()),
-            decided_host_requests: Mutex::new(BTreeMap::new()),
+            host_requests: Mutex::new(AcpHostRequests::default()),
             sessions: Mutex::new(BTreeMap::new()),
             replay_buffer: Mutex::new(VecDeque::new()),
             next_event_id: AtomicU64::new(1),
@@ -2306,5 +2297,43 @@ mod tests {
                 "source": "websocket",
             })
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn acp_hub_rejects_duplicate_inflight_request_ids_from_same_client() {
+        let (worker, mut request_rx, _owner_rx, _controller_rx, _observer_rx) = test_worker();
+        worker
+            .send_client_request(
+                "controller",
+                AcpAttachRole::Controller,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": "dup",
+                    "method": "session/cancel",
+                    "params": {"sessionId": "session-1"},
+                }),
+            )
+            .await
+            .expect("first request forwards");
+        let forwarded = request_rx.recv().await.expect("forwarded request");
+        assert_eq!(forwarded["id"], "dup");
+
+        let duplicate = worker
+            .send_client_request(
+                "controller",
+                AcpAttachRole::Controller,
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": "dup",
+                    "method": "session/cancel",
+                    "params": {"sessionId": "session-1"},
+                }),
+            )
+            .await
+            .expect_err("same client cannot reuse an in-flight id");
+        assert!(matches!(
+            duplicate,
+            AcpClientRequestError::DuplicateRequestId
+        ));
     }
 }

--- a/crates/harn-dap/src/debugger/events.rs
+++ b/crates/harn-dap/src/debugger/events.rs
@@ -276,7 +276,10 @@ impl Debugger {
     pub(crate) fn flush_output_into(&mut self, responses: &mut Vec<DapResponse>) {
         let output = self.vm.as_ref().unwrap().output().to_string();
         if !output.is_empty() && output != self.output {
-            let new_output = output[self.output.len()..].to_string();
+            let new_output = output
+                .strip_prefix(&self.output)
+                .unwrap_or(&output)
+                .to_string();
             if !new_output.is_empty() {
                 let seq = self.next_seq();
                 responses.push(DapResponse::event(

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -85,6 +85,21 @@ fn stdout_text(responses: &[DapResponse]) -> String {
 }
 
 #[test]
+fn flush_output_recovers_when_cached_output_is_not_a_prefix() {
+    let mut dbg = Debugger::new();
+    let mut vm = Vm::new();
+    vm.append_output("new\n");
+    dbg.vm = Some(vm);
+    dbg.output = "stale and longer".to_string();
+
+    let mut responses = Vec::new();
+    dbg.flush_output_into(&mut responses);
+
+    assert_eq!(stdout_text(&responses), "new\n");
+    assert_eq!(dbg.output, "new\n");
+}
+
+#[test]
 fn test_initialize() {
     let mut dbg = Debugger::new();
     let responses = dbg.handle_message(make_request(1, "initialize", None));

--- a/crates/harn-vm/src/mcp_oauth.rs
+++ b/crates/harn-vm/src/mcp_oauth.rs
@@ -295,9 +295,7 @@ pub async fn complete_authorization(
     let stored = StoredMcpToken {
         access_token: token.access_token,
         refresh_token: token.refresh_token,
-        expires_at_unix: token
-            .expires_in
-            .map(|seconds| current_unix_timestamp().saturating_add(seconds)),
+        expires_at_unix: expires_at_from_expires_in(token.expires_in)?,
         token_endpoint: flow.token_endpoint,
         client_id: flow.client_id,
         client_secret: flow.client_secret,
@@ -475,8 +473,10 @@ async fn dynamic_client_registration(
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "Dynamic client registration failed: {status} {body}"
+        return Err(oauth_http_error(
+            "Dynamic client registration failed",
+            status,
+            &body,
         ));
     }
     response
@@ -521,9 +521,7 @@ async fn refresh_token(
         refresh_token: refreshed
             .refresh_token
             .or_else(|| token.refresh_token.clone()),
-        expires_at_unix: refreshed
-            .expires_in
-            .map(|seconds| current_unix_timestamp().saturating_add(seconds)),
+        expires_at_unix: expires_at_from_expires_in(refreshed.expires_in)?,
         token_endpoint,
         client_id: token.client_id.clone(),
         client_secret: token.client_secret.clone(),
@@ -566,7 +564,7 @@ async fn request_token(
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        return Err(format!("Token request failed: {status} {body}"));
+        return Err(oauth_http_error("Token request failed", status, &body));
     }
     response
         .json::<TokenResponse>()
@@ -580,6 +578,27 @@ fn token_needs_refresh(token: &StoredMcpToken) -> bool {
             expires_at <= current_unix_timestamp().saturating_add(TOKEN_REFRESH_SKEW_SECS)
         }
         None => false,
+    }
+}
+
+fn expires_at_from_expires_in(expires_in: Option<i64>) -> Result<Option<i64>, String> {
+    let Some(seconds) = expires_in else {
+        return Ok(None);
+    };
+    if seconds < 0 {
+        return Err("Token response `expires_in` must be non-negative".to_string());
+    }
+    Ok(Some(current_unix_timestamp().saturating_add(seconds)))
+}
+
+fn oauth_http_error(context: &str, status: reqwest::StatusCode, body: &str) -> String {
+    if body.trim().is_empty() {
+        format!("{context}: {status}")
+    } else {
+        format!(
+            "{context}: {status} ({} byte response body omitted)",
+            body.len()
+        )
     }
 }
 
@@ -950,11 +969,13 @@ fn stored_token_for_import(
     let client_secret = request
         .client_secret
         .as_deref()
+        .map(str::trim)
         .filter(|secret| !secret.is_empty())
         .map(str::to_string);
     let token_endpoint_auth_method = request
         .token_endpoint_auth_method
         .as_deref()
+        .map(str::trim)
         .filter(|method| !method.is_empty())
         .map(str::to_string)
         .unwrap_or_else(|| {
@@ -965,6 +986,13 @@ fn stored_token_for_import(
             }
         });
     validate_token_endpoint_auth_method(&token_endpoint_auth_method)?;
+
+    if request
+        .expires_at_unix
+        .is_some_and(|expires_at| expires_at < 0)
+    {
+        return Err("MCP token import expires_at must be non-negative".to_string());
+    }
 
     Ok(StoredMcpToken {
         access_token: access_token.to_string(),
@@ -977,6 +1005,7 @@ fn stored_token_for_import(
         token_endpoint: request
             .token_endpoint
             .as_deref()
+            .map(str::trim)
             .filter(|endpoint| !endpoint.is_empty())
             .map(str::to_string)
             .unwrap_or_else(|| {
@@ -993,6 +1022,7 @@ fn stored_token_for_import(
         scopes: request
             .scopes
             .as_deref()
+            .map(str::trim)
             .filter(|scopes| !scopes.is_empty())
             .map(str::to_string),
     })
@@ -1079,8 +1109,26 @@ mod tests {
     }
 
     #[test]
-    fn token_import_uses_discovery_binding_and_legacy_auth_defaults() {
-        let discovery = McpOAuthDiscovery {
+    fn token_response_rejects_negative_expiry() {
+        let error = expires_at_from_expires_in(Some(-1)).unwrap_err();
+        assert!(error.contains("expires_in"), "{error}");
+    }
+
+    #[test]
+    fn oauth_http_error_omits_response_body() {
+        let error = oauth_http_error(
+            "Token request failed",
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"access_token":"secret","error_description":"bad"}"#,
+        );
+        assert!(error.contains("400 Bad Request"), "{error}");
+        assert!(error.contains("response body omitted"), "{error}");
+        assert!(!error.contains("secret"), "{error}");
+        assert!(!error.contains("bad"), "{error}");
+    }
+
+    fn test_discovery() -> McpOAuthDiscovery {
+        McpOAuthDiscovery {
             protected_resource_metadata_url: url::Url::parse(
                 "https://mcp.example/.well-known/oauth-protected-resource",
             )
@@ -1107,18 +1155,23 @@ mod tests {
             },
             challenge: None,
             scopes: Vec::new(),
-        };
+        }
+    }
+
+    #[test]
+    fn token_import_uses_discovery_binding_and_legacy_auth_defaults() {
+        let discovery = test_discovery();
         let token = stored_token_for_import(
             &ImportStoredToken {
                 server_url: "https://mcp.example/mcp".to_string(),
                 access_token: "access".to_string(),
                 refresh_token: Some("refresh".to_string()),
                 expires_at_unix: Some(123),
-                token_endpoint: None,
+                token_endpoint: Some("  ".to_string()),
                 client_id: "client".to_string(),
-                client_secret: Some("secret".to_string()),
-                token_endpoint_auth_method: None,
-                scopes: Some("read write".to_string()),
+                client_secret: Some(" secret ".to_string()),
+                token_endpoint_auth_method: Some(" client_secret_post ".to_string()),
+                scopes: Some(" read write ".to_string()),
             },
             &discovery,
         )
@@ -1133,6 +1186,27 @@ mod tests {
         assert_eq!(token.refresh_token.as_deref(), Some("refresh"));
         assert_eq!(token.expires_at_unix, Some(123));
         assert_eq!(token.scopes.as_deref(), Some("read write"));
+    }
+
+    #[test]
+    fn token_import_rejects_negative_expiry() {
+        let discovery = test_discovery();
+        let error = stored_token_for_import(
+            &ImportStoredToken {
+                server_url: "https://mcp.example/mcp".to_string(),
+                access_token: "access".to_string(),
+                refresh_token: None,
+                expires_at_unix: Some(-1),
+                token_endpoint: None,
+                client_id: "client".to_string(),
+                client_secret: None,
+                token_endpoint_auth_method: None,
+                scopes: None,
+            },
+            &discovery,
+        )
+        .unwrap_err();
+        assert!(error.contains("expires_at"), "{error}");
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/stdlib/concurrency.rs
+++ b/crates/harn-vm/src/stdlib/concurrency.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use crate::shared_state::ScopedKey;
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
+use crate::stdlib::options::{non_negative_millis_from_value, ErrorKind};
 use crate::value::{VmAtomicHandle, VmChannelHandle, VmError, VmValue};
 use crate::vm::Vm;
 
@@ -128,7 +129,9 @@ fn try_poll_channels(channels: &[VmValue]) -> (Option<(usize, VmValue, String)>,
                 match rx.try_recv() {
                     Ok(val) => return (Some((i, val, ch.name.to_string())), false),
                     Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
-                        all_closed = false;
+                        if !ch.closed.load(Ordering::SeqCst) {
+                            all_closed = false;
+                        }
                     }
                     Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {}
                 }
@@ -148,17 +151,31 @@ fn cancelled_vm_error() -> VmError {
 
 fn optional_timeout_ms(value: Option<&VmValue>) -> Option<u64> {
     match value {
-        Some(VmValue::Int(n)) => Some((*n).max(0) as u64),
-        Some(VmValue::Duration(ms)) => Some((*ms).max(0) as u64),
+        Some(VmValue::Int(_)) | Some(VmValue::Duration(_)) | Some(VmValue::Float(_)) => {
+            value.and_then(optional_timeout_scalar_ms)
+        }
         Some(VmValue::Dict(dict)) => dict
             .get("timeout_ms")
             .or_else(|| dict.get("max_wait_ms"))
-            .and_then(|v| match v {
-                VmValue::Int(n) => Some((*n).max(0) as u64),
-                VmValue::Duration(ms) => Some((*ms).max(0) as u64),
-                _ => None,
-            }),
+            .and_then(optional_timeout_scalar_ms),
         _ => None,
+    }
+}
+
+fn optional_timeout_scalar_ms(value: &VmValue) -> Option<u64> {
+    match non_negative_millis_from_value(value, "channel_select", "timeout_ms", ErrorKind::Runtime)
+    {
+        Ok(ms) => Some(ms),
+        Err(_) if is_negative_millis_value(value) => Some(0),
+        Err(_) => None,
+    }
+}
+
+fn is_negative_millis_value(value: &VmValue) -> bool {
+    match value {
+        VmValue::Duration(ms) | VmValue::Int(ms) => *ms < 0,
+        VmValue::Float(ms) => ms.is_finite() && *ms < 0.0,
+        _ => false,
     }
 }
 
@@ -1138,8 +1155,8 @@ async fn sleep_builtin(
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     let ms = match args.first() {
-        Some(VmValue::Duration(ms)) => (*ms).max(0) as u64,
-        Some(VmValue::Int(n)) => (*n).max(0) as u64,
+        Some(value) if is_negative_millis_value(value) => 0,
+        Some(value) => non_negative_millis_from_value(value, "sleep", "ms", ErrorKind::Runtime)?,
         _ => 0,
     };
     if ms == 0 {
@@ -1220,7 +1237,7 @@ async fn send_builtin(
     doc = "Receive one value from a channel."
 )]
 async fn receive_builtin(
-    _ctx: crate::vm::AsyncBuiltinCtx,
+    ctx: crate::vm::AsyncBuiltinCtx,
     args: Vec<VmValue>,
 ) -> Result<VmValue, VmError> {
     if args.is_empty() {
@@ -1237,9 +1254,22 @@ async fn receive_builtin(
             };
         }
         let mut rx = ch.receiver.lock().await;
-        match rx.recv().await {
-            Some(val) => Ok(val),
-            None => Ok(VmValue::Nil),
+        let vm = ctx.child_vm();
+        let mut cancel_poll = tokio::time::interval(Duration::from_millis(10));
+        loop {
+            tokio::select! {
+                value = rx.recv() => {
+                    return match value {
+                        Some(val) => Ok(val),
+                        None => Ok(VmValue::Nil),
+                    };
+                }
+                _ = cancel_poll.tick() => {
+                    if vm.is_cancel_requested() {
+                        return Err(cancelled_vm_error());
+                    }
+                }
+            }
         }
     } else {
         Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
@@ -1305,11 +1335,7 @@ async fn select_timeout_builtin(
             ))));
         }
     };
-    let timeout_ms = match &args[1] {
-        VmValue::Int(n) => (*n).max(0) as u64,
-        VmValue::Duration(ms) => (*ms).max(0) as u64,
-        _ => 5000,
-    };
+    let timeout_ms = optional_timeout_scalar_ms(&args[1]).unwrap_or(5000);
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
     loop {
         let (found, all_closed) = try_poll_channels(&channels);
@@ -1651,6 +1677,16 @@ mod tests {
         let err = call(&mut vm, "channel", vec![s("bad_channel"), VmValue::Int(0)])
             .expect_err("zero capacity must fail");
         assert!(err.to_string().contains("capacity"));
+    }
+
+    #[test]
+    fn closed_empty_channel_counts_as_closed_for_select() {
+        let mut vm = vm();
+        let channel = call(&mut vm, "channel", vec![s("done")]).unwrap();
+        call(&mut vm, "close_channel", vec![channel.clone()]).unwrap();
+        let (ready, all_closed) = try_poll_channels(&[channel]);
+        assert!(ready.is_none());
+        assert!(all_closed);
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -19,6 +19,7 @@ use crate::runtime_limits::RuntimeLimits;
 use crate::schema::schema_expect_value;
 use crate::stdlib::host::dispatch_mock_host_call;
 use crate::stdlib::macros::{harn_builtin, BuiltinSignature, Param, VmBuiltinDef, TY_ANY, TY_DICT};
+use crate::stdlib::options::{duration_from_value, ErrorKind};
 use crate::stdlib::waitpoint::{
     cancel_waitpoint_on, complete_waitpoint_on, create_waitpoint_on, inspect_waitpoint_on,
     wait_on_waitpoints, WaitpointRecord, WaitpointStatus, WaitpointWaitFailure,
@@ -1647,14 +1648,7 @@ fn optional_string_list(value: Option<&VmValue>, builtin: &str) -> Result<Vec<St
 }
 
 fn parse_duration_value(value: &VmValue) -> Result<StdDuration, VmError> {
-    match value {
-        VmValue::Duration(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Int(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Float(ms) if *ms >= 0.0 => Ok(StdDuration::from_millis(*ms as u64)),
-        _ => Err(VmError::Runtime(
-            "expected a duration or millisecond count".to_string(),
-        )),
-    }
+    duration_from_value(value, "hitl", "timeout", ErrorKind::Runtime)
 }
 
 fn ensure_hitl_event_log() -> Arc<AnyEventLog> {

--- a/crates/harn-vm/src/stdlib/monitors.rs
+++ b/crates/harn-vm/src/stdlib/monitors.rs
@@ -16,6 +16,7 @@ use crate::event_log::{
 use crate::llm::vm_value_to_json;
 use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::macros::{harn_builtin, BuiltinSignature, Param, VmBuiltinDef, TY_ANY};
+use crate::stdlib::options::{duration_from_value, ErrorKind};
 use crate::triggers::dispatcher::{
     current_dispatch_context, current_dispatch_is_replay, current_dispatch_wait_lease,
 };
@@ -455,15 +456,12 @@ fn parse_required_duration(value: Option<&VmValue>, field: &str) -> Result<StdDu
 }
 
 fn parse_duration_value(value: &VmValue) -> Result<StdDuration, VmError> {
-    match value {
-        VmValue::Duration(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Int(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Float(ms) if *ms >= 0.0 => Ok(StdDuration::from_millis(*ms as u64)),
-        other => Err(VmError::Runtime(format!(
-            "monitor_wait_for_native: expected duration or non-negative millisecond count, got {}",
-            other.type_name()
-        ))),
-    }
+    duration_from_value(
+        value,
+        "monitor_wait_for_native",
+        "timeout",
+        ErrorKind::Runtime,
+    )
 }
 
 fn string_field(map: &BTreeMap<String, VmValue>, field: &str) -> Result<Option<String>, VmError> {

--- a/crates/harn-vm/src/stdlib/options.rs
+++ b/crates/harn-vm/src/stdlib/options.rs
@@ -21,6 +21,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
+use std::time::Duration as StdDuration;
 
 use crate::value::{VmError, VmValue};
 
@@ -156,6 +157,53 @@ pub(crate) fn required_int_arg(
     args.get(idx)
         .and_then(VmValue::as_int)
         .ok_or_else(|| fn_err(fn_name, kind, format_args!("`{arg_name}` must be an int")))
+}
+
+/// Coerce a Harn duration-like value to non-negative milliseconds.
+///
+/// Several stdlib modules accept either a `duration`, an integer millisecond
+/// count, or a finite float millisecond count. Keep the conversion here so the
+/// edge cases stay consistent across waitpoints, monitors, HITL, and storage
+/// connectors.
+pub(crate) fn non_negative_millis_from_value(
+    value: &VmValue,
+    fn_name: &'static str,
+    value_name: &str,
+    kind: ErrorKind,
+) -> Result<u64, VmError> {
+    match value {
+        VmValue::Duration(ms) | VmValue::Int(ms) if *ms >= 0 => Ok(*ms as u64),
+        VmValue::Duration(_) | VmValue::Int(_) => Err(fn_err(
+            fn_name,
+            kind,
+            format_args!("`{value_name}` must be >= 0"),
+        )),
+        VmValue::Float(ms) if ms.is_finite() && *ms >= 0.0 && *ms <= u64::MAX as f64 => {
+            Ok(*ms as u64)
+        }
+        VmValue::Float(_) => Err(fn_err(
+            fn_name,
+            kind,
+            format_args!("`{value_name}` must be a finite non-negative millisecond count"),
+        )),
+        other => Err(fn_err(
+            fn_name,
+            kind,
+            format_args!(
+                "`{value_name}` must be a duration or millisecond count (got {})",
+                other.type_name()
+            ),
+        )),
+    }
+}
+
+pub(crate) fn duration_from_value(
+    value: &VmValue,
+    fn_name: &'static str,
+    value_name: &str,
+    kind: ErrorKind,
+) -> Result<StdDuration, VmError> {
+    non_negative_millis_from_value(value, fn_name, value_name, kind).map(StdDuration::from_millis)
 }
 
 /// Schema-driven parser for an option-bag dict.
@@ -458,6 +506,33 @@ mod tests {
         let d = dict(&[("forwarded", VmValue::Bool(true))]);
         let p = OptionsParser::new("daemon_spawn", &d, ErrorKind::Runtime);
         p.finish_strict(&["forwarded"]).unwrap();
+    }
+
+    #[test]
+    fn duration_coercion_rejects_infinite_float() {
+        let err = non_negative_millis_from_value(
+            &VmValue::Float(f64::INFINITY),
+            "waitpoint_wait",
+            "timeout",
+            ErrorKind::Runtime,
+        )
+        .unwrap_err();
+        match err {
+            VmError::Runtime(msg) => assert!(msg.contains("finite non-negative"), "{msg}"),
+            other => panic!("expected Runtime, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duration_coercion_accepts_finite_float_millis() {
+        let millis = non_negative_millis_from_value(
+            &VmValue::Float(42.9),
+            "waitpoint_wait",
+            "timeout",
+            ErrorKind::Runtime,
+        )
+        .unwrap();
+        assert_eq!(millis, 42);
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -23,6 +23,7 @@ use crate::llm::vm_value_to_json;
 use crate::stdlib::macros::{
     harn_builtin, BuiltinSignature, Param, VmBuiltinDef, TY_ANY, TY_BOOL, TY_DICT, TY_LIST,
 };
+use crate::stdlib::options::{non_negative_millis_from_value, ErrorKind};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -1630,20 +1631,21 @@ fn option_int(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<
         .and_then(|opts| opts.get(key))
         .and_then(|value| match value {
             VmValue::Int(number) => Some(*number),
-            VmValue::Float(number) => Some(*number as i64),
+            VmValue::Float(number)
+                if number.is_finite()
+                    && *number >= i64::MIN as f64
+                    && *number <= i64::MAX as f64 =>
+            {
+                Some(*number as i64)
+            }
             _ => None,
         })
 }
 
 fn option_duration_ms(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<u64> {
-    options
-        .and_then(|opts| opts.get(key))
-        .and_then(|value| match value {
-            VmValue::Duration(ms) if *ms >= 0 => Some(*ms as u64),
-            VmValue::Int(ms) if *ms >= 0 => Some(*ms as u64),
-            VmValue::Float(ms) if *ms >= 0.0 => Some(*ms as u64),
-            _ => None,
-        })
+    options.and_then(|opts| opts.get(key)).and_then(|value| {
+        non_negative_millis_from_value(value, "postgres", key, ErrorKind::Runtime).ok()
+    })
 }
 
 pub(super) fn next_id(prefix: &str) -> String {

--- a/crates/harn-vm/src/stdlib/waitpoint.rs
+++ b/crates/harn-vm/src/stdlib/waitpoint.rs
@@ -15,6 +15,7 @@ use crate::event_log::{
 };
 use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
+use crate::stdlib::options::{duration_from_value, ErrorKind};
 use crate::triggers::dispatcher::{
     current_dispatch_context, current_dispatch_is_replay, DispatchContext,
 };
@@ -1145,14 +1146,7 @@ fn optional_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String
 }
 
 fn parse_duration_value(value: &VmValue) -> Result<StdDuration, VmError> {
-    match value {
-        VmValue::Duration(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Int(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Float(ms) if *ms >= 0.0 => Ok(StdDuration::from_millis(*ms as u64)),
-        _ => Err(VmError::Runtime(
-            "waitpoint.wait: expected a duration or millisecond count".to_string(),
-        )),
-    }
+    duration_from_value(value, "waitpoint.wait", "timeout", ErrorKind::Runtime)
 }
 
 fn waitpoint_suspend_error(wait_id: &str) -> VmError {

--- a/crates/harn-vm/src/stdlib/waitpoints.rs
+++ b/crates/harn-vm/src/stdlib/waitpoints.rs
@@ -14,6 +14,7 @@ use crate::event_log::{
 use crate::llm::vm_value_to_json;
 use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::macros::{harn_builtin, BuiltinSignature, Param, VmBuiltinDef, TY_ANY, TY_DICT};
+use crate::stdlib::options::{duration_from_value, ErrorKind};
 use crate::triggers::dispatcher::{current_dispatch_context, current_dispatch_wait_lease};
 use crate::value::{VmError, VmValue};
 use crate::vm::{AsyncBuiltinCtx, Vm};
@@ -489,14 +490,7 @@ fn string_field(map: &BTreeMap<String, VmValue>, field: &str) -> Result<Option<S
 }
 
 fn parse_duration_value(value: &VmValue) -> Result<StdDuration, VmError> {
-    match value {
-        VmValue::Duration(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Int(ms) if *ms >= 0 => Ok(StdDuration::from_millis(*ms as u64)),
-        VmValue::Float(ms) if *ms >= 0.0 => Ok(StdDuration::from_millis(*ms as u64)),
-        _ => Err(VmError::Runtime(
-            "waitpoint_wait: expected timeout duration or millisecond count".to_string(),
-        )),
-    }
+    duration_from_value(value, "waitpoint_wait", "timeout", ErrorKind::Runtime)
 }
 
 fn default_actor(explicit: Option<String>, dispatch_keys: Option<&DispatchKeys>) -> Option<String> {

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -58,13 +58,12 @@ impl VmClosure {
 /// `Scope::vars` is wrapped in `Arc` so that `VmEnv::clone()` is cheap
 /// (Arc bump per scope) instead of a deep walk of every BTreeMap. The
 /// VM saves and restores `env` snapshots on every function call, and
-/// the call hot path dominates orchestration-heavy workloads (e.g.
-/// burin-code's PreToolUse hooks). With `Arc<BTreeMap<..>>` the
-/// per-scope clone collapses to a refcount bump, and `Arc::make_mut`
-/// only does a deep copy when the scope is still shared
-/// with a saved snapshot — which is exactly the case where the caller
-/// would have needed an isolated copy anyway. Reads still go through
-/// the `BTreeMap` directly via `Deref`.
+/// the call hot path dominates orchestration-heavy workloads. With
+/// `Arc<BTreeMap<..>>`, the per-scope clone collapses to a refcount
+/// bump, and `Arc::make_mut` only does a deep copy when the scope is
+/// still shared with a saved snapshot — which is exactly the case where
+/// the caller would have needed an isolated copy anyway. Reads still go
+/// through the `BTreeMap` directly via `Deref`.
 #[derive(Debug, Clone)]
 pub struct VmEnv {
     pub(crate) scopes: Vec<Scope>,

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -232,10 +232,10 @@ impl super::super::Vm {
             (AdaptiveBinaryOp::Div, BinaryShape::Int, VmValue::Int(_), VmValue::Int(0))
             | (AdaptiveBinaryOp::Mod, BinaryShape::Int, VmValue::Int(_), VmValue::Int(0)) => None,
             (AdaptiveBinaryOp::Div, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
-                Some(VmValue::Int(x / y))
+                Some(VmValue::Int(x.wrapping_div(*y)))
             }
             (AdaptiveBinaryOp::Mod, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
-                Some(VmValue::Int(x % y))
+                Some(VmValue::Int(x.wrapping_rem(*y)))
             }
             (AdaptiveBinaryOp::Add, BinaryShape::Float, VmValue::Float(x), VmValue::Float(y)) => {
                 Some(VmValue::Float(x + y))
@@ -334,7 +334,7 @@ impl super::super::Vm {
         if y == 0 {
             return Err(VmError::DivisionByZero);
         }
-        self.stack.push(VmValue::Int(x / y));
+        self.stack.push(VmValue::Int(x.wrapping_div(y)));
         Ok(())
     }
 
@@ -345,7 +345,7 @@ impl super::super::Vm {
         if y == 0 {
             return Err(VmError::DivisionByZero);
         }
-        self.stack.push(VmValue::Int(x % y));
+        self.stack.push(VmValue::Int(x.wrapping_rem(y)));
         Ok(())
     }
 
@@ -486,7 +486,7 @@ impl super::super::Vm {
     fn div(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
         match (&a, &b) {
             (VmValue::Int(_), VmValue::Int(y)) if *y == 0 => Err(VmError::DivisionByZero),
-            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x / y)),
+            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x.wrapping_div(*y))),
             (VmValue::Float(x), VmValue::Float(y)) => Ok(VmValue::Float(x / y)),
             (VmValue::Int(x), VmValue::Float(y)) => Ok(VmValue::Float(*x as f64 / y)),
             (VmValue::Float(x), VmValue::Int(y)) => Ok(VmValue::Float(x / *y as f64)),
@@ -501,7 +501,7 @@ impl super::super::Vm {
     fn modulo(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
         match (&a, &b) {
             (VmValue::Int(_), VmValue::Int(y)) if *y == 0 => Err(VmError::DivisionByZero),
-            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x % y)),
+            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x.wrapping_rem(*y))),
             (VmValue::Float(_), VmValue::Float(y)) if *y == 0.0 => Err(VmError::DivisionByZero),
             (VmValue::Float(x), VmValue::Float(y)) => Ok(VmValue::Float(x % y)),
             (VmValue::Int(_), VmValue::Float(y)) if *y == 0.0 => Err(VmError::DivisionByZero),

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1362,6 +1362,18 @@ fn test_division_by_zero() {
 }
 
 #[test]
+fn test_int_division_overflow_wraps_instead_of_panicking() {
+    let out = run_output(
+        r"pipeline default(task) {
+  let min = -9223372036854775807 - 1
+  log(min / -1)
+  log(min % -1)
+}",
+    );
+    assert_eq!(out, "[harn] -9223372036854775808\n[harn] 0");
+}
+
+#[test]
 fn test_float_division_by_zero_uses_ieee_values() {
     let out = run_vm(
         "pipeline default(task) { log(is_nan(0.0 / 0.0))\nlog(is_infinite(1.0 / 0.0))\nlog(is_infinite(-1.0 / 0.0)) }",


### PR DESCRIPTION
## Summary
- centralize stdlib duration/millisecond coercion and reject non-finite or negative expiry/timeout edge cases consistently
- fix runtime, DAP, OAuth, and ACP correctness bugs including integer division overflow, closed-channel select hangs, stale DAP output, OAuth secret leakage, and duplicate ACP request IDs
- consolidate ACP host request state so host decisions are atomic and large error payloads stay boxed

## Verification
- cargo test -p harn-vm test_int_division_overflow_wraps_instead_of_panicking --lib
- cargo test -p harn-vm duration_coercion --lib
- cargo test -p harn-vm closed_empty_channel_counts_as_closed_for_select --lib
- cargo test -p harn-vm mcp_oauth::tests --lib
- cargo test -p harn-cli acp_hub_rejects_duplicate_inflight_request_ids_from_same_client --lib
- cargo test -p harn-dap flush_output_recovers_when_cached_output_is_not_a_prefix
- cargo fmt --all --check
- cargo check --workspace --all-targets
- make lint-test-patterns
- cargo clippy -p harn-vm -p harn-cli -p harn-dap --all-targets -- -D warnings
- pre-commit hook
- pre-push hook
