### PR TITLE
Optimize harness dispatch inline caches

### DIFF
--- a/changelog.d/2785.changed.md
+++ b/changelog.d/2785.changed.md
@@ -1,0 +1,4 @@
+- **Harness dispatch hot paths (#2785).** Cached `harness.*` sub-handle reads
+  and cheap synchronous harness method calls now use VM inline-cache fast paths,
+  reducing overhead in tight orchestration loops while preserving mock and null
+  harness audit semantics.

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -7,6 +7,7 @@ use harn_parser::TypeExpr;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
+use crate::harness::HarnessKind;
 use crate::runtime_guards::RuntimeParamGuard;
 
 /// Sentinel value stored in [`Chunk::inline_cache_index`] for code offsets
@@ -189,6 +190,7 @@ impl Eq for DirectCallState {}
 pub(crate) enum PropertyCacheTarget {
     DictField(Arc<str>),
     StructField { field_name: Arc<str>, index: usize },
+    HarnessSubHandle(HarnessKind),
     ListCount,
     ListEmpty,
     ListFirst,
@@ -203,6 +205,7 @@ pub(crate) enum PropertyCacheTarget {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MethodCacheTarget {
+    Harness(HarnessKind),
     ListCount,
     ListEmpty,
     ListContains,

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -879,6 +879,13 @@ impl VmHarness {
             return None;
         }
         let kind = HarnessKind::from_field_name(field)?;
+        self.sub_handle_kind(kind)
+    }
+
+    pub(crate) fn sub_handle_kind(&self, kind: HarnessKind) -> Option<VmHarness> {
+        if self.kind != HarnessKind::Root || kind == HarnessKind::Root {
+            return None;
+        }
         Some(VmHarness {
             inner: Arc::clone(&self.inner),
             kind,
@@ -1135,6 +1142,48 @@ fn main(harness: Harness) {
                 (HarnessKind::Net, "get".to_string()),
                 (HarnessKind::Crypto, "sha256".to_string()),
                 (HarnessKind::Llm, "catalog".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mock_harness_records_repeated_cached_harness_method_calls() {
+        let harness = Harness::mock().env("KEY", "value").build();
+
+        run_harness_source(
+            r#"
+fn main(harness: Harness) {
+  var i = 0
+  while i < 3 {
+    let _ = harness.clock.elapsed()
+    let value = harness.env.get_or("KEY", "")
+    harness.stdio.println(value)
+    i = i + 1
+  }
+}
+"#,
+            harness.clone(),
+        )
+        .expect("mock harness run succeeds");
+
+        assert_eq!(harness.captured_stdio(), "value\nvalue\nvalue\n");
+        let observed: Vec<_> = harness
+            .calls()
+            .into_iter()
+            .map(|call| (call.sub_handle, call.method))
+            .collect();
+        assert_eq!(
+            observed,
+            vec![
+                (HarnessKind::Clock, "elapsed".to_string()),
+                (HarnessKind::Env, "get_or".to_string()),
+                (HarnessKind::Stdio, "println".to_string()),
+                (HarnessKind::Clock, "elapsed".to_string()),
+                (HarnessKind::Env, "get_or".to_string()),
+                (HarnessKind::Stdio, "println".to_string()),
+                (HarnessKind::Clock, "elapsed".to_string()),
+                (HarnessKind::Env, "get_or".to_string()),
+                (HarnessKind::Stdio, "println".to_string()),
             ]
         );
     }

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -1,7 +1,7 @@
 //! Method dispatch for the `Harness` capability handle and its
 //! sub-handles. Every sub-handle (`stdio`, `clock`, `fs`, `env`,
-//! `random`, `net`, `process`, `crypto`, `system`, `llm`) is wired end-to-end in
-//! real, mock, and null modes;
+//! `random`, `net`, `process`, `crypto`, `system`, `llm`, `tenant`, and `obs`)
+//! is wired end-to-end in real, mock, and null modes;
 //! sandbox / egress rejections raised inside a sub-handle method are
 //! tagged with the `HARN-CAP-201` diagnostic code so callers can
 //! attribute the error to the active capability profile rather than an
@@ -57,6 +57,11 @@ impl crate::vm::Vm {
                 category: ErrorCategory::ToolRejected,
             });
         }
+        if let Some(result) =
+            Self::call_harness_method_sync_fast(&mut self.output, handle, method, args)
+        {
+            return result;
+        }
         // Enforce per-harness `NetPolicy` (issue #1913) ahead of mock
         // dispatch so audit_only / quarantine outcomes apply uniformly
         // to real and mock paths.
@@ -90,6 +95,416 @@ impl crate::vm::Vm {
             HarnessKind::Tenant => self.call_harness_tenant_method(handle, method, args),
             HarnessKind::Obs => self.call_harness_obs_method(handle, method, args).await,
         }
+    }
+
+    pub(in crate::vm) fn call_harness_method_sync_fast(
+        output: &mut String,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        if handle.kind() == HarnessKind::Root {
+            return None;
+        }
+        if let HarnessMode::Null(state) = handle.inner().mode() {
+            state.record_deny(handle.kind(), method, args);
+            return Some(Err(VmError::CategorizedError {
+                message: format!("NullHarness denied {}::{method}", handle.kind().type_name()),
+                category: ErrorCategory::ToolRejected,
+            }));
+        }
+        if matches!(handle.inner().mode(), HarnessMode::Mock(_)) {
+            return Self::call_mock_harness_method_sync_fast(handle, method, args);
+        }
+        match handle.kind() {
+            HarnessKind::Stdio => Self::call_harness_stdio_method_sync_fast(output, method, args),
+            HarnessKind::Term => Self::call_harness_term_method_sync_fast(method, args),
+            HarnessKind::Clock => Self::call_harness_clock_method_sync_fast(handle, method),
+            HarnessKind::Env => Self::call_harness_env_method_sync_fast(method, args),
+            HarnessKind::Random => Self::call_harness_random_method_sync_fast(method, args),
+            HarnessKind::Crypto => Self::call_harness_crypto_method_sync_fast(method, args),
+            HarnessKind::Tenant => Self::call_harness_tenant_method_sync_fast(method, args),
+            HarnessKind::Root
+            | HarnessKind::Fs
+            | HarnessKind::Net
+            | HarnessKind::Process
+            | HarnessKind::System
+            | HarnessKind::Llm
+            | HarnessKind::Obs => None,
+        }
+    }
+
+    fn call_harness_clock_method_sync_fast(
+        handle: &VmHarness,
+        method: &str,
+    ) -> Option<Result<VmValue, VmError>> {
+        let clock = handle.inner().clock();
+        match method {
+            "now_ms" => Some(Ok(VmValue::Int(crate::clock::now_wall_ms(clock.as_ref())))),
+            "timestamp" => Some(Ok(VmValue::Float(
+                crate::clock::now_wall_ms(clock.as_ref()) as f64 / 1_000.0,
+            ))),
+            "monotonic_ms" | "elapsed" => Some(Ok(VmValue::Int(clock.monotonic_ms()))),
+            "sleep_ms" => None,
+            _ => None,
+        }
+    }
+
+    fn call_harness_stdio_method_sync_fast(
+        output: &mut String,
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        match method {
+            "println" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stdout(output, &format!("{msg}\n"));
+                Some(Ok(VmValue::Nil))
+            }
+            "print" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stdout(output, &msg);
+                Some(Ok(VmValue::Nil))
+            }
+            "eprintln" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stderr(&format!("{msg}\n"));
+                Some(Ok(VmValue::Nil))
+            }
+            "eprint" => {
+                let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                write_stderr(&msg);
+                Some(Ok(VmValue::Nil))
+            }
+            "read_line" => {
+                if args.is_empty() {
+                    Some(Ok(read_line_legacy_value()))
+                } else {
+                    Some(read_line_structured_value(args))
+                }
+            }
+            "prompt" => Some(prompt_user_value(args, output)),
+            _ => None,
+        }
+    }
+
+    fn call_harness_term_method_sync_fast(
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        match method {
+            "width" => Some(Ok(VmValue::Int(crate::term::width() as i64))),
+            "height" => Some(Ok(VmValue::Int(crate::term::height() as i64))),
+            "read_password" => {
+                let prompt = match optional_string_arg(args, 0, "HarnessTerm.read_password") {
+                    Ok(prompt) => prompt,
+                    Err(err) => return Some(Err(err)),
+                };
+                if args.len() > 1 {
+                    return Some(Err(VmError::TypeError(
+                        "HarnessTerm.read_password expects at most one prompt argument".to_string(),
+                    )));
+                }
+                Some(crate::stdlib::io::read_password_legacy_value(prompt))
+            }
+            _ => None,
+        }
+    }
+
+    fn call_harness_env_method_sync_fast(
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        match method {
+            "get" => {
+                let name = match string_arg(args, 0, "HarnessEnv.get") {
+                    Ok(name) => name,
+                    Err(err) => return Some(Err(err)),
+                };
+                Some(Ok(crate::stdlib::process::read_env_value(name)
+                    .map(vm_string)
+                    .unwrap_or(VmValue::Nil)))
+            }
+            "get_or" => {
+                let name = match string_arg(args, 0, "HarnessEnv.get_or") {
+                    Ok(name) => name,
+                    Err(err) => return Some(Err(err)),
+                };
+                let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
+                Some(Ok(crate::stdlib::process::read_env_value(name)
+                    .map(vm_string)
+                    .unwrap_or(default)))
+            }
+            _ => None,
+        }
+    }
+
+    fn call_harness_random_method_sync_fast(
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        use rand::seq::SliceRandom;
+        use rand::RngExt;
+        match method {
+            "gen_f64" | "f64" | "random" => Some(Ok(VmValue::Float(rand::rng().random()))),
+            "gen_u64" | "u64" => {
+                let value: u64 = rand::rng().random();
+                Some(Ok(VmValue::Int(value.min(i64::MAX as u64) as i64)))
+            }
+            "gen_range" | "range" | "random_int" | "int" => {
+                let min = match args.first().and_then(|v| v.as_int()) {
+                    Some(min) => min,
+                    None => {
+                        return Some(Err(VmError::TypeError(
+                            "HarnessRandom.gen_range expects an integer min argument".to_string(),
+                        )))
+                    }
+                };
+                let max = match args.get(1).and_then(|v| v.as_int()) {
+                    Some(max) => max,
+                    None => {
+                        return Some(Err(VmError::TypeError(
+                            "HarnessRandom.gen_range expects an integer max argument".to_string(),
+                        )))
+                    }
+                };
+                if min > max {
+                    return Some(Ok(VmValue::Nil));
+                }
+                Some(Ok(VmValue::Int(rand::rng().random_range(min..=max))))
+            }
+            "choice" | "random_choice" => {
+                let Some(VmValue::List(items)) = args.first() else {
+                    return Some(Ok(VmValue::Nil));
+                };
+                if items.is_empty() {
+                    return Some(Ok(VmValue::Nil));
+                }
+                let idx = rand::rng().random_range(0..items.len());
+                Some(Ok(items[idx].clone()))
+            }
+            "shuffle" | "random_shuffle" => {
+                let Some(VmValue::List(items)) = args.first() else {
+                    return Some(Ok(VmValue::Nil));
+                };
+                let mut shuffled = items.as_ref().clone();
+                shuffled.shuffle(&mut rand::rng());
+                Some(Ok(VmValue::List(std::sync::Arc::new(shuffled))))
+            }
+            _ => None,
+        }
+    }
+
+    fn call_harness_crypto_method_sync_fast(
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        match method {
+            "sha256" => Some(Ok(crate::harness_crypto::sha256_hex_value(args))),
+            _ => None,
+        }
+    }
+
+    fn call_harness_tenant_method_sync_fast(
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        if !args.is_empty() {
+            return Some(Err(VmError::TypeError(format!(
+                "HarnessTenant.{method} takes no arguments"
+            ))));
+        }
+        match method {
+            "id" => Some(match crate::harness_tenant::current_tenant_id() {
+                Some(tenant) => Ok(vm_string(tenant.0)),
+                None => Err(VmError::CategorizedError {
+                    message: crate::harness_tenant::MISSING_TENANT_MESSAGE.to_string(),
+                    category: ErrorCategory::Auth,
+                }),
+            }),
+            "try_id" => Some(Ok(crate::harness_tenant::current_tenant_id()
+                .map(|tenant| vm_string(tenant.0))
+                .unwrap_or(VmValue::Nil))),
+            _ => None,
+        }
+    }
+
+    fn call_mock_harness_method_sync_fast(
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        let HarnessMode::Mock(state) = handle.inner().mode() else {
+            unreachable!("mock sync fast path is only called for mock harnesses");
+        };
+        let result = match handle.kind() {
+            HarnessKind::Stdio => match method {
+                "println" => {
+                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                    state.push_stdio(&format!("{msg}\n"));
+                    Some(Ok(VmValue::Nil))
+                }
+                "print" => {
+                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                    state.push_stdio(&msg);
+                    Some(Ok(VmValue::Nil))
+                }
+                "eprintln" => {
+                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                    state.push_stderr(&format!("{msg}\n"));
+                    Some(Ok(VmValue::Nil))
+                }
+                "eprint" => {
+                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                    state.push_stderr(&msg);
+                    Some(Ok(VmValue::Nil))
+                }
+                "read_line" => Some(Ok(mock_read_line_value(state, args))),
+                "prompt" => {
+                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
+                    state.push_stdio(&msg);
+                    Some(Ok(mock_read_line_value(state, &[])))
+                }
+                _ => None,
+            },
+            HarnessKind::Term => match method {
+                "width" => Some(Ok(VmValue::Int(
+                    mock_term_dimension(state.env_get("COLUMNS"), 80) as i64,
+                ))),
+                "height" => Some(Ok(VmValue::Int(
+                    mock_term_dimension(state.env_get("LINES"), 24) as i64,
+                ))),
+                "read_password" => {
+                    let prompt = match optional_string_arg(args, 0, "HarnessTerm.read_password") {
+                        Ok(prompt) => prompt,
+                        Err(err) => return Some(Err(err)),
+                    };
+                    if args.len() > 1 {
+                        return Some(Err(VmError::TypeError(
+                            "HarnessTerm.read_password expects at most one prompt argument"
+                                .to_string(),
+                        )));
+                    }
+                    if !prompt.is_empty() {
+                        state.push_stderr(prompt);
+                    }
+                    Some(state.pop_stdin_line().map(vm_string).ok_or_else(|| {
+                        VmError::Runtime("HarnessTerm.read_password: stdin reached EOF".to_string())
+                    }))
+                }
+                _ => None,
+            },
+            HarnessKind::Clock => {
+                let clock = handle.inner().clock();
+                match method {
+                    "now_ms" => Some(Ok(VmValue::Int(crate::clock::now_wall_ms(clock.as_ref())))),
+                    "timestamp" => Some(Ok(VmValue::Float(
+                        crate::clock::now_wall_ms(clock.as_ref()) as f64 / 1_000.0,
+                    ))),
+                    "monotonic_ms" | "elapsed" => Some(Ok(VmValue::Int(clock.monotonic_ms()))),
+                    "sleep_ms" => {
+                        let ms = match sleep_ms_arg(args) {
+                            Ok(ms) => ms,
+                            Err(err) => return Some(Err(err)),
+                        };
+                        if ms > 0 {
+                            state.advance_clock(Duration::from_millis(ms as u64));
+                        }
+                        Some(Ok(VmValue::Nil))
+                    }
+                    _ => None,
+                }
+            }
+            HarnessKind::Env => match method {
+                "get" => {
+                    let key = match string_arg(args, 0, "HarnessEnv.get") {
+                        Ok(key) => key,
+                        Err(err) => return Some(Err(err)),
+                    };
+                    Some(Ok(state
+                        .env_get(key)
+                        .map(vm_string)
+                        .unwrap_or(VmValue::Nil)))
+                }
+                "get_or" => {
+                    let key = match string_arg(args, 0, "HarnessEnv.get_or") {
+                        Ok(key) => key,
+                        Err(err) => return Some(Err(err)),
+                    };
+                    let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
+                    Some(Ok(state.env_get(key).map(vm_string).unwrap_or(default)))
+                }
+                _ => None,
+            },
+            HarnessKind::Random => match method {
+                "u64" | "gen_u64" => Some(
+                    state
+                        .next_random_u64()
+                        .map(|value| VmValue::Int(value.min(i64::MAX as u64) as i64))
+                        .ok_or_else(|| VmError::CategorizedError {
+                            message: "MockHarness has no random_u64 response".to_string(),
+                            category: ErrorCategory::NotFound,
+                        }),
+                ),
+                _ => None,
+            },
+            HarnessKind::Crypto => match method {
+                "sha256" => Some(Ok(crate::harness_crypto::sha256_hex_value(args))),
+                _ => None,
+            },
+            HarnessKind::System => {
+                let json = match method {
+                    "cpu" => serde_json::json!({
+                        "count": 1,
+                        "physical_count": 1,
+                        "model": "mock-cpu",
+                        "frequency_mhz": 0u64,
+                        "usage_pct": 0.0,
+                    }),
+                    "memory" => serde_json::json!({
+                        "total_bytes": 0u64,
+                        "used_bytes": 0u64,
+                        "available_bytes": 0u64,
+                        "total_gb": 0.0,
+                        "used_gb": 0.0,
+                        "available_gb": 0.0,
+                        "pressure": "unknown",
+                    }),
+                    "gpus" | "gpu" => serde_json::Value::Array(Vec::new()),
+                    "temperature" => serde_json::json!({"components": []}),
+                    "platform" => serde_json::json!({
+                        "os": "mock",
+                        "arch": "mock",
+                        "version": "mock",
+                        "kernel": "mock",
+                        "long_os_version": "mock",
+                        "hostname": "mock",
+                    }),
+                    "processes" => serde_json::Value::Array(vec![serde_json::json!({
+                        "pid": 1,
+                        "parent_pid": serde_json::Value::Null,
+                        "name": "harn",
+                        "cpu_pct": 0.0,
+                        "mem_bytes": 0u64,
+                        "is_harn_owned": true,
+                        "is_self": true,
+                    })]),
+                    _ => return None,
+                };
+                Some(Ok(crate::stdlib::json_to_vm_value(&json)))
+            }
+            HarnessKind::Tenant => Self::call_harness_tenant_method_sync_fast(method, args),
+            HarnessKind::Root
+            | HarnessKind::Fs
+            | HarnessKind::Net
+            | HarnessKind::Process
+            | HarnessKind::Llm
+            | HarnessKind::Obs => None,
+        };
+        if result.is_some() {
+            state.record_call(handle.kind(), method, args);
+        }
+        result
     }
 
     /// Root-handle capability methods that bypass the null/mock-mode
@@ -294,24 +709,8 @@ impl crate::vm::Vm {
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
-        if !args.is_empty() {
-            return Err(VmError::TypeError(format!(
-                "HarnessTenant.{method} takes no arguments"
-            )));
-        }
-        match method {
-            "id" => match crate::harness_tenant::current_tenant_id() {
-                Some(tenant) => Ok(vm_string(tenant.0)),
-                None => Err(VmError::CategorizedError {
-                    message: crate::harness_tenant::MISSING_TENANT_MESSAGE.to_string(),
-                    category: ErrorCategory::Auth,
-                }),
-            },
-            "try_id" => Ok(crate::harness_tenant::current_tenant_id()
-                .map(|tenant| vm_string(tenant.0))
-                .unwrap_or(VmValue::Nil)),
-            _ => Err(method_unsupported(handle, method)),
-        }
+        Self::call_harness_tenant_method_sync_fast(method, args)
+            .unwrap_or_else(|| Err(method_unsupported(handle, method)))
     }
 
     async fn call_harness_obs_method(
@@ -508,37 +907,8 @@ impl crate::vm::Vm {
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
-        match method {
-            "println" => {
-                let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                write_stdout(&mut self.output, &format!("{msg}\n"));
-                Ok(VmValue::Nil)
-            }
-            "print" => {
-                let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                write_stdout(&mut self.output, &msg);
-                Ok(VmValue::Nil)
-            }
-            "eprintln" => {
-                let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                write_stderr(&format!("{msg}\n"));
-                Ok(VmValue::Nil)
-            }
-            "eprint" => {
-                let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                write_stderr(&msg);
-                Ok(VmValue::Nil)
-            }
-            "read_line" => {
-                if args.is_empty() {
-                    Ok(read_line_legacy_value())
-                } else {
-                    read_line_structured_value(args)
-                }
-            }
-            "prompt" => prompt_user_value(args, &mut self.output),
-            _ => Err(method_unsupported(handle, method)),
-        }
+        Self::call_harness_stdio_method_sync_fast(&mut self.output, method, args)
+            .unwrap_or_else(|| Err(method_unsupported(handle, method)))
     }
 
     fn call_harness_term_method(
@@ -547,20 +917,8 @@ impl crate::vm::Vm {
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
-        match method {
-            "width" => Ok(VmValue::Int(crate::term::width() as i64)),
-            "height" => Ok(VmValue::Int(crate::term::height() as i64)),
-            "read_password" => {
-                let prompt = optional_string_arg(args, 0, "HarnessTerm.read_password")?;
-                if args.len() > 1 {
-                    return Err(VmError::TypeError(
-                        "HarnessTerm.read_password expects at most one prompt argument".to_string(),
-                    ));
-                }
-                crate::stdlib::io::read_password_legacy_value(prompt)
-            }
-            _ => Err(method_unsupported(handle, method)),
-        }
+        Self::call_harness_term_method_sync_fast(method, args)
+            .unwrap_or_else(|| Err(method_unsupported(handle, method)))
     }
 
     async fn call_harness_clock_method(
@@ -569,13 +927,11 @@ impl crate::vm::Vm {
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
+        if let Some(result) = Self::call_harness_clock_method_sync_fast(handle, method) {
+            return result;
+        }
         let clock = handle.inner().clock();
         match method {
-            "now_ms" => Ok(VmValue::Int(crate::clock::now_wall_ms(clock.as_ref()))),
-            "timestamp" => Ok(VmValue::Float(
-                crate::clock::now_wall_ms(clock.as_ref()) as f64 / 1_000.0,
-            )),
-            "monotonic_ms" | "elapsed" => Ok(VmValue::Int(clock.monotonic_ms())),
             "sleep_ms" => {
                 let ms = sleep_ms_arg(args)?;
                 if ms > 0 {
@@ -619,22 +975,8 @@ impl crate::vm::Vm {
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
-        match method {
-            "get" => {
-                let name = string_arg(args, 0, "HarnessEnv.get")?;
-                Ok(crate::stdlib::process::read_env_value(name)
-                    .map(vm_string)
-                    .unwrap_or(VmValue::Nil))
-            }
-            "get_or" => {
-                let name = string_arg(args, 0, "HarnessEnv.get_or")?;
-                let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
-                Ok(crate::stdlib::process::read_env_value(name)
-                    .map(vm_string)
-                    .unwrap_or(default))
-            }
-            _ => Err(method_unsupported(handle, method)),
-        }
+        Self::call_harness_env_method_sync_fast(method, args)
+            .unwrap_or_else(|| Err(method_unsupported(handle, method)))
     }
 
     /// Dispatch `harness.random.*` in real mode. The handle is intentionally
@@ -647,50 +989,8 @@ impl crate::vm::Vm {
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
-        use rand::seq::SliceRandom;
-        use rand::RngExt;
-        match method {
-            "gen_f64" | "f64" | "random" => Ok(VmValue::Float(rand::rng().random())),
-            "gen_u64" | "u64" => {
-                let value: u64 = rand::rng().random();
-                Ok(VmValue::Int(value.min(i64::MAX as u64) as i64))
-            }
-            "gen_range" | "range" | "random_int" | "int" => {
-                let min = args.first().and_then(|v| v.as_int()).ok_or_else(|| {
-                    VmError::TypeError(
-                        "HarnessRandom.gen_range expects an integer min argument".to_string(),
-                    )
-                })?;
-                let max = args.get(1).and_then(|v| v.as_int()).ok_or_else(|| {
-                    VmError::TypeError(
-                        "HarnessRandom.gen_range expects an integer max argument".to_string(),
-                    )
-                })?;
-                if min > max {
-                    return Ok(VmValue::Nil);
-                }
-                Ok(VmValue::Int(rand::rng().random_range(min..=max)))
-            }
-            "choice" | "random_choice" => {
-                let Some(VmValue::List(items)) = args.first() else {
-                    return Ok(VmValue::Nil);
-                };
-                if items.is_empty() {
-                    return Ok(VmValue::Nil);
-                }
-                let idx = rand::rng().random_range(0..items.len());
-                Ok(items[idx].clone())
-            }
-            "shuffle" | "random_shuffle" => {
-                let Some(VmValue::List(items)) = args.first() else {
-                    return Ok(VmValue::Nil);
-                };
-                let mut shuffled = items.as_ref().clone();
-                shuffled.shuffle(&mut rand::rng());
-                Ok(VmValue::List(std::sync::Arc::new(shuffled)))
-            }
-            _ => Err(method_unsupported(handle, method)),
-        }
+        Self::call_harness_random_method_sync_fast(method, args)
+            .unwrap_or_else(|| Err(method_unsupported(handle, method)))
     }
 
     /// Dispatch `harness.net.*` in real mode through the same egress
@@ -771,10 +1071,8 @@ impl crate::vm::Vm {
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
-        match method {
-            "sha256" => Ok(crate::harness_crypto::sha256_hex_value(args)),
-            _ => Err(method_unsupported(handle, method)),
-        }
+        Self::call_harness_crypto_method_sync_fast(method, args)
+            .unwrap_or_else(|| Err(method_unsupported(handle, method)))
     }
 
     async fn call_mock_harness_method(
@@ -786,80 +1084,20 @@ impl crate::vm::Vm {
         let HarnessMode::Mock(state) = handle.inner().mode() else {
             unreachable!("mock dispatch is only called for mock harnesses");
         };
+        if let Some(result) = Self::call_mock_harness_method_sync_fast(handle, method, args) {
+            return result;
+        }
         state.record_call(handle.kind(), method, args);
         match handle.kind() {
-            HarnessKind::Root => Err(method_unsupported(handle, method)),
-            HarnessKind::Stdio => match method {
-                "println" => {
-                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                    state.push_stdio(&format!("{msg}\n"));
-                    Ok(VmValue::Nil)
-                }
-                "print" => {
-                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                    state.push_stdio(&msg);
-                    Ok(VmValue::Nil)
-                }
-                "eprintln" => {
-                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                    state.push_stderr(&format!("{msg}\n"));
-                    Ok(VmValue::Nil)
-                }
-                "eprint" => {
-                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                    state.push_stderr(&msg);
-                    Ok(VmValue::Nil)
-                }
-                "read_line" => Ok(mock_read_line_value(state, args)),
-                "prompt" => {
-                    let msg = args.first().map(|a| a.display()).unwrap_or_default();
-                    state.push_stdio(&msg);
-                    Ok(mock_read_line_value(state, &[]))
-                }
-                _ => Err(method_unsupported(handle, method)),
-            },
-            HarnessKind::Term => match method {
-                "width" => Ok(VmValue::Int(
-                    mock_term_dimension(state.env_get("COLUMNS"), 80) as i64,
-                )),
-                "height" => Ok(VmValue::Int(
-                    mock_term_dimension(state.env_get("LINES"), 24) as i64,
-                )),
-                "read_password" => {
-                    let prompt = optional_string_arg(args, 0, "HarnessTerm.read_password")?;
-                    if args.len() > 1 {
-                        return Err(VmError::TypeError(
-                            "HarnessTerm.read_password expects at most one prompt argument"
-                                .to_string(),
-                        ));
-                    }
-                    if !prompt.is_empty() {
-                        state.push_stderr(prompt);
-                    }
-                    state.pop_stdin_line().map(vm_string).ok_or_else(|| {
-                        VmError::Runtime("HarnessTerm.read_password: stdin reached EOF".to_string())
-                    })
-                }
-                _ => Err(method_unsupported(handle, method)),
-            },
-            HarnessKind::Clock => {
-                let clock = handle.inner().clock();
-                match method {
-                    "now_ms" => Ok(VmValue::Int(crate::clock::now_wall_ms(clock.as_ref()))),
-                    "timestamp" => Ok(VmValue::Float(
-                        crate::clock::now_wall_ms(clock.as_ref()) as f64 / 1_000.0,
-                    )),
-                    "monotonic_ms" | "elapsed" => Ok(VmValue::Int(clock.monotonic_ms())),
-                    "sleep_ms" => {
-                        let ms = sleep_ms_arg(args)?;
-                        if ms > 0 {
-                            state.advance_clock(Duration::from_millis(ms as u64));
-                        }
-                        Ok(VmValue::Nil)
-                    }
-                    _ => Err(method_unsupported(handle, method)),
-                }
-            }
+            HarnessKind::Root
+            | HarnessKind::Stdio
+            | HarnessKind::Term
+            | HarnessKind::Clock
+            | HarnessKind::Env
+            | HarnessKind::Random
+            | HarnessKind::Crypto
+            | HarnessKind::System
+            | HarnessKind::Tenant => Err(method_unsupported(handle, method)),
             HarnessKind::Fs => match method {
                 "read_file" | "read" => {
                     let path = string_arg(args, 0, "HarnessFs.read_file")?;
@@ -890,28 +1128,6 @@ impl crate::vm::Vm {
                 }
                 _ => Err(method_unsupported(handle, method)),
             },
-            HarnessKind::Env => match method {
-                "get" => {
-                    let key = string_arg(args, 0, "HarnessEnv.get")?;
-                    Ok(state.env_get(key).map(vm_string).unwrap_or(VmValue::Nil))
-                }
-                "get_or" => {
-                    let key = string_arg(args, 0, "HarnessEnv.get_or")?;
-                    let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
-                    Ok(state.env_get(key).map(vm_string).unwrap_or(default))
-                }
-                _ => Err(method_unsupported(handle, method)),
-            },
-            HarnessKind::Random => match method {
-                "u64" | "gen_u64" => state
-                    .next_random_u64()
-                    .map(|value| VmValue::Int(value.min(i64::MAX as u64) as i64))
-                    .ok_or_else(|| VmError::CategorizedError {
-                        message: "MockHarness has no random_u64 response".to_string(),
-                        category: ErrorCategory::NotFound,
-                    }),
-                _ => Err(method_unsupported(handle, method)),
-            },
             HarnessKind::Net => match method {
                 "get" | "http_get" => {
                     let url = string_arg(args, 0, "HarnessNet.get")?;
@@ -931,64 +1147,7 @@ impl crate::vm::Vm {
                 }),
                 _ => Err(method_unsupported(handle, method)),
             },
-            HarnessKind::Crypto => match method {
-                "sha256" => Ok(crate::harness_crypto::sha256_hex_value(args)),
-                _ => Err(method_unsupported(handle, method)),
-            },
-            HarnessKind::System => {
-                // Mock mode returns deterministic synthetic snapshots so
-                // conformance fixtures can exercise the surface without
-                // observing the real host. Methods mirror the real names
-                // exactly, with the same JSON shape, but populated with
-                // fixed placeholder values.
-                let json = match method {
-                    "cpu" => serde_json::json!({
-                        "count": 1,
-                        "physical_count": 1,
-                        "model": "mock-cpu",
-                        "frequency_mhz": 0u64,
-                        "usage_pct": 0.0,
-                    }),
-                    "memory" => serde_json::json!({
-                        "total_bytes": 0u64,
-                        "used_bytes": 0u64,
-                        "available_bytes": 0u64,
-                        "total_gb": 0.0,
-                        "used_gb": 0.0,
-                        "available_gb": 0.0,
-                        "pressure": "unknown",
-                    }),
-                    "gpus" | "gpu" => serde_json::Value::Array(Vec::new()),
-                    "temperature" => serde_json::json!({"components": []}),
-                    "platform" => serde_json::json!({
-                        "os": "mock",
-                        "arch": "mock",
-                        "version": "mock",
-                        "kernel": "mock",
-                        "long_os_version": "mock",
-                        "hostname": "mock",
-                    }),
-                    "processes" => serde_json::Value::Array(vec![serde_json::json!({
-                        "pid": 1,
-                        "parent_pid": serde_json::Value::Null,
-                        "name": "harn",
-                        "cpu_pct": 0.0,
-                        "mem_bytes": 0u64,
-                        "is_harn_owned": true,
-                        "is_self": true,
-                    })]),
-                    _ => return Err(method_unsupported(handle, method)),
-                };
-                Ok(crate::stdlib::json_to_vm_value(&json))
-            }
             HarnessKind::Llm => self.call_harness_llm_method(handle, method, args).await,
-            HarnessKind::Tenant => {
-                // Mock mode shares the same ambient stack as real mode
-                // so conformance fixtures can drive `enter_tenant(...)`
-                // and assert `harness.tenant.id()` returns the pushed
-                // id. No mock-only state is needed.
-                self.call_harness_tenant_method(handle, method, args)
-            }
             HarnessKind::Obs => {
                 // Mock mode shares the same OBS_STATE thread-local as
                 // real mode — fixtures already drive `__obs_*` via

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -423,8 +423,44 @@ impl super::super::Vm {
         }
     }
 
+    fn try_cached_harness_method(
+        cache: Option<(u16, usize, MethodCacheTarget)>,
+        name_idx: u16,
+        argc: usize,
+        obj: &VmValue,
+    ) -> Option<Arc<crate::harness::VmHarness>> {
+        let (cached_name_idx, cached_argc, target) = cache?;
+        if cached_name_idx != name_idx || cached_argc != argc {
+            return None;
+        }
+        let MethodCacheTarget::Harness(kind) = target else {
+            return None;
+        };
+        let VmValue::Harness(handle) = obj else {
+            return None;
+        };
+        if handle.kind() == kind {
+            Some(Arc::clone(handle))
+        } else {
+            None
+        }
+    }
+
+    fn try_harness_method_sync_fast(
+        output: &mut String,
+        obj: &VmValue,
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        let VmValue::Harness(handle) = obj else {
+            return None;
+        };
+        Self::call_harness_method_sync_fast(output, handle, method, args)
+    }
+
     fn method_cache_target(obj: &VmValue, method: &str, argc: usize) -> Option<MethodCacheTarget> {
         match obj {
+            VmValue::Harness(handle) => Self::harness_sync_method_cache_target(handle, method),
             VmValue::List(_) => match (method, argc) {
                 ("count", 0) => Some(MethodCacheTarget::ListCount),
                 ("empty", 0) => Some(MethodCacheTarget::ListEmpty),
@@ -459,6 +495,51 @@ impl super::super::Vm {
             },
             _ => None,
         }
+    }
+
+    fn harness_sync_method_cache_target(
+        handle: &crate::harness::VmHarness,
+        method: &str,
+    ) -> Option<MethodCacheTarget> {
+        let cacheable = match handle.kind() {
+            crate::harness::HarnessKind::Stdio => matches!(
+                method,
+                "print" | "println" | "eprint" | "eprintln" | "read_line" | "prompt"
+            ),
+            crate::harness::HarnessKind::Term => {
+                matches!(method, "width" | "height" | "read_password")
+            }
+            crate::harness::HarnessKind::Clock => {
+                matches!(method, "now_ms" | "timestamp" | "monotonic_ms" | "elapsed")
+            }
+            crate::harness::HarnessKind::Env => matches!(method, "get" | "get_or"),
+            crate::harness::HarnessKind::Random => matches!(
+                method,
+                "gen_f64"
+                    | "f64"
+                    | "random"
+                    | "gen_u64"
+                    | "u64"
+                    | "gen_range"
+                    | "range"
+                    | "random_int"
+                    | "int"
+                    | "choice"
+                    | "random_choice"
+                    | "shuffle"
+                    | "random_shuffle"
+            ),
+            crate::harness::HarnessKind::Crypto => matches!(method, "sha256"),
+            crate::harness::HarnessKind::Tenant => matches!(method, "id" | "try_id"),
+            crate::harness::HarnessKind::Root
+            | crate::harness::HarnessKind::Fs
+            | crate::harness::HarnessKind::Net
+            | crate::harness::HarnessKind::Process
+            | crate::harness::HarnessKind::System
+            | crate::harness::HarnessKind::Llm
+            | crate::harness::HarnessKind::Obs => false,
+        };
+        cacheable.then_some(MethodCacheTarget::Harness(handle.kind()))
     }
 
     fn stack_arg_start(&self, argc: usize) -> Result<usize, VmError> {
@@ -1331,12 +1412,30 @@ impl super::super::Vm {
         ) {
             self.stack.truncate(obj_idx);
             self.stack.push(result);
+        } else if let Some(handle) =
+            Self::try_cached_harness_method(cached_method, name_idx, argc, &obj)
+        {
+            let method = Self::const_str(&chunk.constants[name_idx as usize])?;
+            let args = self.take_stack_args_from(args_start)?;
+            self.stack.truncate(obj_idx);
+            let result = if let Some(result) =
+                Self::call_harness_method_sync_fast(&mut self.output, &handle, method, &args)
+            {
+                result?
+            } else {
+                self.call_method_async(obj, method, &args).await?
+            };
+            self.stack.push(result);
         } else {
             let method = Self::const_str(&chunk.constants[name_idx as usize])?;
             let cache_target = Self::method_cache_target(&obj, method, argc);
+            let args = &self.stack[args_start..];
             let result = if let Some(result) =
-                Self::call_method_sync(&obj, method, &self.stack[args_start..])
+                Self::try_harness_method_sync_fast(&mut self.output, &obj, method, args)
             {
+                self.stack.truncate(obj_idx);
+                result?
+            } else if let Some(result) = Self::call_method_sync(&obj, method, args) {
                 self.stack.truncate(obj_idx);
                 result?
             } else {
@@ -1415,6 +1514,32 @@ impl super::super::Vm {
             ));
         }
 
+        if let Some(handle) = Self::try_cached_harness_method(cached_method, name_idx, argc, obj) {
+            let method = match Self::const_str(&chunk.constants[name_idx as usize]) {
+                Ok(method) => method,
+                Err(err) => {
+                    return Some(self.finish_method_call_sync(
+                        &chunk,
+                        argc,
+                        Err(err),
+                        name_idx,
+                        None,
+                        None,
+                    ))
+                }
+            };
+            if let Some(result) = Self::call_harness_method_sync_fast(
+                &mut self.output,
+                &handle,
+                method,
+                &self.stack[args_start..],
+            ) {
+                return Some(
+                    self.finish_method_call_sync(&chunk, argc, result, name_idx, None, None),
+                );
+            }
+        }
+
         let (result, cache_target) = {
             let method = match Self::const_str(&chunk.constants[name_idx as usize]) {
                 Ok(method) => method,
@@ -1430,7 +1555,13 @@ impl super::super::Vm {
                 }
             };
             let args = &self.stack[args_start..];
-            let result = Self::call_method_sync(obj, method, args)?;
+            let result = if let Some(result) =
+                Self::try_harness_method_sync_fast(&mut self.output, obj, method, args)
+            {
+                result
+            } else {
+                Self::call_method_sync(obj, method, args)?
+            };
             let cache_target = Self::method_cache_target(obj, method, argc);
             (result, cache_target)
         };
@@ -1498,10 +1629,26 @@ impl super::super::Vm {
             Self::try_cached_method(cached_method, name_idx, args.len(), &obj, &args)
         {
             self.stack.push(result);
+        } else if let Some(handle) =
+            Self::try_cached_harness_method(cached_method, name_idx, args.len(), &obj)
+        {
+            let method = Self::const_str(&chunk.constants[name_idx as usize])?;
+            let result = if let Some(result) =
+                Self::call_harness_method_sync_fast(&mut self.output, &handle, method, &args)
+            {
+                result?
+            } else {
+                self.call_method_async(obj, method, &args).await?
+            };
+            self.stack.push(result);
         } else {
             let method = Self::const_str(&chunk.constants[name_idx as usize])?;
             let cache_target = Self::method_cache_target(&obj, method, args.len());
-            let result = if let Some(result) = Self::call_method_sync(&obj, method, &args) {
+            let result = if let Some(result) =
+                Self::try_harness_method_sync_fast(&mut self.output, &obj, method, &args)
+            {
+                result?
+            } else if let Some(result) = Self::call_method_sync(&obj, method, &args) {
                 result?
             } else {
                 self.call_method_async(obj, method, &args).await?

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -124,6 +124,9 @@ impl super::super::Vm {
             (PropertyCacheTarget::EnumFields, VmValue::EnumVariant(enum_variant)) => {
                 Some(VmValue::List(Arc::clone(&enum_variant.fields)))
             }
+            (PropertyCacheTarget::HarnessSubHandle(kind), VmValue::Harness(handle)) => {
+                handle.sub_handle_kind(*kind).map(VmValue::harness)
+            }
             _ => None,
         }
     }
@@ -161,6 +164,11 @@ impl super::super::Vm {
                 "fields" => Some(PropertyCacheTarget::EnumFields),
                 _ => None,
             },
+            VmValue::Harness(handle) if handle.kind() == crate::harness::HarnessKind::Root => {
+                crate::harness::HarnessKind::from_field_name(name)
+                    .map(PropertyCacheTarget::HarnessSubHandle)
+            }
+            VmValue::Harness(_) => None,
             _ => None,
         }
     }

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -91,8 +91,14 @@ fn run_harn_with_inline_cache_entries(source: &str) -> (Vec<InlineCacheEntry>, S
 
                 let mut vm = Vm::new();
                 register_vm_stdlib(&mut vm);
+                vm.set_harness(crate::Harness::real());
                 let result = vm.execute(&chunk).await.unwrap();
-                let inline_cache_entries = vm.inline_cache_entries_for_chunk(&chunk);
+                let mut inline_cache_entries = vm.inline_cache_entries_for_chunk(&chunk);
+                for (cache_id, entries) in &vm.inline_caches {
+                    if *cache_id != chunk.cache_id() {
+                        inline_cache_entries.extend(entries.clone());
+                    }
+                }
                 (inline_cache_entries, vm.output().to_string(), result)
             })
             .await
@@ -736,6 +742,57 @@ log(total)
         MethodCacheTarget::RangeFirst,
         MethodCacheTarget::SetCount,
         MethodCacheTarget::SetContains,
+    ] {
+        assert!(
+            entries.iter().any(|entry| matches!(
+                entry,
+                InlineCacheEntry::Method {
+                    target: cached_target,
+                    ..
+                } if *cached_target == target
+            )),
+            "missing {target:?} in {entries:?}"
+        );
+    }
+}
+
+#[test]
+fn test_inline_cache_warms_harness_property_and_method_sites() {
+    let (entries, out, result) = run_harn_with_inline_cache_entries(
+        r#"fn main(harness: Harness) {
+  var i = 0
+  var hits = 0
+  while i < 3 {
+    if harness.env.get_or("__HARN_TEST_MISSING__", "fallback") == "fallback" {
+      hits = hits + 1
+    }
+    let _ = harness.clock.monotonic_ms()
+    i = i + 1
+  }
+  return hits
+}"#,
+    );
+
+    assert_eq!(out.trim_end(), "");
+    assert!(matches!(result, VmValue::Int(3)));
+    for target in [
+        PropertyCacheTarget::HarnessSubHandle(crate::HarnessKind::Env),
+        PropertyCacheTarget::HarnessSubHandle(crate::HarnessKind::Clock),
+    ] {
+        assert!(
+            entries.iter().any(|entry| matches!(
+                entry,
+                InlineCacheEntry::Property {
+                    target: cached_target,
+                    ..
+                } if *cached_target == target
+            )),
+            "missing {target:?} in {entries:?}"
+        );
+    }
+    for target in [
+        MethodCacheTarget::Harness(crate::HarnessKind::Env),
+        MethodCacheTarget::Harness(crate::HarnessKind::Clock),
     ] {
         assert!(
             entries.iter().any(|entry| matches!(

--- a/perf/vm/README.md
+++ b/perf/vm/README.md
@@ -106,6 +106,7 @@ The microbench suite covers focused VM hot paths:
 - runtime parameter validation for typed user calls
 - property inline-cache hits for dicts, structs, lists, and strings
 - method inline-cache hits for list/string/dict/set helpers
+- harness sub-handle property reads and cached harness method dispatch
 - list callback dispatch through `.filter` and `.map`
 - std/collections dict helper builtins
 - many-part string interpolation and builtin-reference lookup

--- a/perf/vm/bench_vm_fixtures.rs
+++ b/perf/vm/bench_vm_fixtures.rs
@@ -15,6 +15,8 @@ const FIXTURES: &[&str] = &[
     "dict_subscript_assign.harn",
     "filter_nil_loop.harn",
     "function_call_loop.harn",
+    "harness_chained_dispatch.harn",
+    "harness_prebound_dispatch.harn",
     "list_iteration.harn",
     "list_map_filter.harn",
     "local_variable_lookup.harn",
@@ -54,6 +56,7 @@ fn setup_vm(fixture: &Fixture) -> harn_vm::Vm {
     harn_vm::reset_thread_local_state();
     let mut vm = harn_vm::Vm::new();
     harn_vm::register_vm_stdlib(&mut vm);
+    vm.set_harness(harn_vm::Harness::real());
     vm.set_source_info(&fixture.path.to_string_lossy(), &fixture.source);
     if let Some(parent) = fixture.path.parent() {
         vm.set_source_dir(parent);

--- a/perf/vm/bench_vm_hot_paths.rs
+++ b/perf/vm/bench_vm_hot_paths.rs
@@ -17,10 +17,24 @@ struct VmHotPathFixture {
     source: &'static str,
     path: PathBuf,
     chunk: Chunk,
+    uses_real_harness: bool,
 }
 
 impl VmHotPathFixture {
     fn new(name: &'static str, source: &'static str, runtime: &Runtime) -> Self {
+        Self::new_with_real_harness(name, source, runtime, false)
+    }
+
+    fn with_real_harness(name: &'static str, source: &'static str, runtime: &Runtime) -> Self {
+        Self::new_with_real_harness(name, source, runtime, true)
+    }
+
+    fn new_with_real_harness(
+        name: &'static str,
+        source: &'static str,
+        runtime: &Runtime,
+        uses_real_harness: bool,
+    ) -> Self {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("synthetic")
             .join(format!("{name}.harn"));
@@ -30,6 +44,7 @@ impl VmHotPathFixture {
             source,
             path,
             chunk,
+            uses_real_harness,
         };
         fixture.warm_inline_caches(runtime);
         fixture
@@ -39,6 +54,9 @@ impl VmHotPathFixture {
         harn_vm::reset_thread_local_state();
         let mut vm = Vm::new();
         harn_vm::register_vm_stdlib(&mut vm);
+        if self.uses_real_harness {
+            vm.set_harness(harn_vm::Harness::real());
+        }
         vm.set_source_info(&self.path.to_string_lossy(), self.source);
         if let Some(parent) = self.path.parent() {
             vm.set_source_dir(parent);
@@ -272,6 +290,44 @@ pipeline default(task) {
   if total < 0 {
     log("unreachable")
   }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::with_real_harness(
+            "harness_chained_dispatch",
+            r#"
+fn main(harness: Harness) {
+  var i = 0
+  var hits = 0
+  while i < 2500 {
+    if harness.env.get_or("__HARN_VM_BENCH_MISSING__", "fallback") == "fallback" {
+      hits = hits + 1
+    }
+    let _ = harness.clock.monotonic_ms()
+    i = i + 1
+  }
+  return hits
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::with_real_harness(
+            "harness_prebound_dispatch",
+            r#"
+fn main(harness: Harness) {
+  let env = harness.env
+  let clock = harness.clock
+  var i = 0
+  var hits = 0
+  while i < 2500 {
+    if env.get_or("__HARN_VM_BENCH_MISSING__", "fallback") == "fallback" {
+      hits = hits + 1
+    }
+    let _ = clock.monotonic_ms()
+    i = i + 1
+  }
+  return hits
 }
 "#,
             runtime,

--- a/perf/vm/harness_chained_dispatch.harn
+++ b/perf/vm/harness_chained_dispatch.harn
@@ -1,0 +1,12 @@
+fn main(harness: Harness) {
+  var i = 0
+  var hits = 0
+  while i < 25000 {
+    if harness.env.get_or("__HARN_VM_BENCH_MISSING__", "fallback") == "fallback" {
+      hits = hits + 1
+    }
+    let _ = harness.clock.monotonic_ms()
+    i = i + 1
+  }
+  return hits
+}

--- a/perf/vm/harness_prebound_dispatch.harn
+++ b/perf/vm/harness_prebound_dispatch.harn
@@ -1,0 +1,14 @@
+fn main(harness: Harness) {
+  let env = harness.env
+  let clock = harness.clock
+  var i = 0
+  var hits = 0
+  while i < 25000 {
+    if env.get_or("__HARN_VM_BENCH_MISSING__", "fallback") == "fallback" {
+      hits = hits + 1
+    }
+    let _ = clock.monotonic_ms()
+    i = i + 1
+  }
+  return hits
+}

--- a/scripts/ported_handlers.toml
+++ b/scripts/ported_handlers.toml
@@ -55,7 +55,9 @@ path = "crates/harn-cli/src/lib.rs"
 # Re-bumped to 3218: lib.rs reached 3213 on main via #2628 (fast-mode
 # speed/service_tier wiring into the live request path + cost calc) without a
 # matching budget bump, leaving the ratchet stale for every downstream PR.
-max_loc = 3218
+# Re-bumped to 3335: lib.rs reached 3330 on main via #2784 without a matching
+# budget bump, leaving the merge queue ratchet stale for downstream PRs.
+max_loc = 3335
 
 [[handler]]
 path = "crates/harn-cli/src/commands/models/list.rs"


### PR DESCRIPTION
## Summary

- Cache root `harness.*` sub-handle property reads with VM inline-cache targets.
- Cache cheap synchronous harness method calls by receiver kind, method name, and arity.
- Add a synchronous first-hit path for supported real/mock harness surfaces so hot call sites avoid the async trampoline after warm-up.
- Add focused VM perf fixtures plus runtime coverage for harness property/method cache warming and mock call recording semantics.
- Bump the stale `crates/harn-cli/src/lib.rs` ported-handler LOC ratchet to current `main` + slack after #2784 grew that file without the matching budget update, which blocked the merge queue.

## Why

The global `harness` abstraction is useful ergonomically, but tight orchestration loops paid for repeated dynamic sub-handle lookup, method dispatch, and async call setup even on sync-only operations such as `harness.env.get`, `harness.clock.now_ms`, and `harness.crypto.sha256`. This keeps the API surface intact while specializing the hot VM paths.

## Validation

- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `harn check perf/vm/harness_chained_dispatch.harn`
- `harn check perf/vm/harness_prebound_dispatch.harn`
- `harn fmt perf/vm/harness_chained_dispatch.harn perf/vm/harness_prebound_dispatch.harn`
- `harn lint perf/vm/harness_chained_dispatch.harn perf/vm/harness_prebound_dispatch.harn`
- `make lint-no-rust-prompt-prose`
- `make lint-md`
- `make check-ported-handler-loc`
- `CARGO_TARGET_DIR=/tmp/harn-target-harness-dispatch cargo test -p harn-vm test_inline_cache_warms --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-harness-dispatch cargo test -p harn-vm harness --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-harness-dispatch cargo clippy -p harn-vm --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-harness-dispatch cargo test -p harn-vm --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-harness-dispatch cargo check -p harn-vm --tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-harness-dispatch HARN_DEV_TARGET_DIR=/tmp/harn-target-harness-dispatch git push --force-with-lease origin codex/harness-dispatch-specialization` (pre-push hook passed; final ref update reported a stale lease because the remote was already at the amended SHA)
- `CARGO_TARGET_DIR=/tmp/harn-target-harness-dispatch cargo bench -p harn-vm-perf --bench bench_vm_fixtures -- harness_ --noplot`

Benchmark note: `bench_vm_fixtures` completed for the harness fixtures before final cleanup. Later optimized benchmark/perf-crate check attempts were terminated by the local environment during compilation, so I am not treating those as passed local gates.