### PR TITLE
Publish release containers from binary artifacts

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -340,6 +340,9 @@ jobs:
           set -euo pipefail
           start=$SECONDS
           cargo build --release -p harn-cli -p harn-dap -p harn-lsp --target "$HARN_RELEASE_TARGET"
+          if [[ "$HARN_RELEASE_TARGET" == *unknown-linux-gnu ]]; then
+            cargo build --release -p harn-cli --bin harn-container-probe --target "$HARN_RELEASE_TARGET"
+          fi
           duration=$((SECONDS - start))
           {
             echo "### Release binary build"
@@ -466,13 +469,21 @@ jobs:
 
       - name: Package (unix)
         if: runner.os != 'Windows' && needs.setup.outputs.is_release == 'true'
+        env:
+          HARN_RELEASE_TARGET: ${{ matrix.target }}
         run: |
+          set -euo pipefail
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/harn dist/harn
-          cp target/${{ matrix.target }}/release/harn-dap dist/harn-dap
-          cp target/${{ matrix.target }}/release/harn-lsp dist/harn-lsp
+          cp "target/${HARN_RELEASE_TARGET}/release/harn" dist/harn
+          cp "target/${HARN_RELEASE_TARGET}/release/harn-dap" dist/harn-dap
+          cp "target/${HARN_RELEASE_TARGET}/release/harn-lsp" dist/harn-lsp
+          extra_binaries=()
+          if [[ "$HARN_RELEASE_TARGET" == *unknown-linux-gnu ]]; then
+            cp "target/${HARN_RELEASE_TARGET}/release/harn-container-probe" dist/harn-container-probe
+            extra_binaries+=(harn-container-probe)
+          fi
           cd dist
-          tar czf harn-${{ matrix.target }}.tar.gz harn harn-dap harn-lsp
+          tar czf "harn-${HARN_RELEASE_TARGET}.tar.gz" harn harn-dap harn-lsp "${extra_binaries[@]}"
 
       - name: Package (windows)
         if: runner.os == 'Windows' && needs.setup.outputs.is_release == 'true'
@@ -501,9 +512,14 @@ jobs:
 
   container:
     name: Publish container
-    needs: setup
-    if: needs.setup.outputs.should_publish_container == 'true'
+    needs: [setup, release]
+    if: >-
+      always() &&
+      needs.setup.outputs.should_publish_container == 'true' &&
+      (needs.release.result == 'success' ||
+        (needs.release.result == 'skipped' && needs.setup.outputs.should_build_binaries == 'false'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -517,6 +533,36 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Download Linux release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ needs.setup.outputs.ref }}
+        run: |
+          set -euo pipefail
+
+          assets_dir="${RUNNER_TEMP}/harn-release-assets"
+          rm -rf "$assets_dir" release-container
+          mkdir -p "$assets_dir" release-container/amd64 release-container/arm64
+
+          gh release download "$REF" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern harn-x86_64-unknown-linux-gnu.tar.gz \
+            --pattern harn-aarch64-unknown-linux-gnu.tar.gz \
+            --dir "$assets_dir"
+
+          cp "$assets_dir/harn-x86_64-unknown-linux-gnu.tar.gz" release-container/amd64/harn.tar.gz
+          cp "$assets_dir/harn-aarch64-unknown-linux-gnu.tar.gz" release-container/arm64/harn.tar.gz
+
+          for arch in amd64 arm64; do
+            archive="release-container/${arch}/harn.tar.gz"
+            for binary in harn harn-container-probe; do
+              if ! tar tzf "$archive" | grep -Fxq "$binary"; then
+                echo "::error::${archive} is missing ${binary}; container image must be assembled from release artifacts, not a Docker source rebuild."
+                exit 1
+              fi
+            done
+          done
 
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -545,7 +591,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.release
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS unpack
+
+ARG TARGETARCH
+
+WORKDIR /work
+
+COPY release-container/${TARGETARCH}/harn.tar.gz /tmp/harn.tar.gz
+
+RUN set -eux; \
+    mkdir -p /out/usr/local/bin /out/etc/harn /out/var/lib/harn/state; \
+    tar -xzf /tmp/harn.tar.gz -C /out/usr/local/bin harn harn-container-probe; \
+    chmod 0755 /out/usr/local/bin/harn /out/usr/local/bin/harn-container-probe; \
+    printf "# Mount a Harn orchestrator manifest here.\n" > /out/etc/harn/triggers.toml
+
+FROM gcr.io/distroless/cc-debian12
+
+WORKDIR /var/lib/harn
+
+# Inject listener auth and provider secrets at runtime via
+# HARN_ORCHESTRATOR_API_KEYS, HARN_ORCHESTRATOR_HMAC_SECRET,
+# HARN_PROVIDER_*, HARN_SECRET_*,
+# OPENAI_API_KEY, ANTHROPIC_API_KEY, or similar provider-specific env vars.
+#
+# HARN_ORCHESTRATOR_LISTEN intentionally defaults to loopback so a bare
+# `docker run -p 8080:8080 burin-labs/harn` cannot accidentally expose
+# an unauthenticated orchestrator on the host's public interface.
+# Operators that DO want the orchestrator on a public interface must
+# opt in explicitly AND configure auth:
+#
+#   docker run -p 8080:8080 \
+#     -e HARN_ORCHESTRATOR_LISTEN=0.0.0.0:8080 \
+#     -e HARN_ORCHESTRATOR_API_KEYS=<key1,key2> \
+#     burin-labs/harn
+#
+# When HARN_ORCHESTRATOR_LISTEN is non-loopback and no API key/HMAC is
+# configured, the orchestrator refuses to start.
+ENV HARN_SECRET_PROVIDERS=env \
+    HARN_ORCHESTRATOR_API_KEYS= \
+    HARN_ORCHESTRATOR_HMAC_SECRET= \
+    HARN_ORCHESTRATOR_MANIFEST=/etc/harn/triggers.toml \
+    HARN_ORCHESTRATOR_LISTEN=127.0.0.1:8080 \
+    HARN_ORCHESTRATOR_STATE_DIR=/var/lib/harn/state \
+    RUST_LOG=info
+
+COPY --from=unpack --chown=10001:10001 /out/ /
+
+EXPOSE 8080
+
+USER 10001:10001
+
+ENTRYPOINT ["/usr/local/bin/harn", "orchestrator", "serve"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 CMD ["/usr/local/bin/harn-container-probe"]

--- a/changelog.d/2794.fixed.md
+++ b/changelog.d/2794.fixed.md
@@ -1,0 +1,3 @@
+- **Release container publishing now reuses released Linux archives (#2794).**
+  GHCR image assembly no longer recompiles Harn inside Docker after the release
+  binaries already exist, and the container publish leg has its own timeout.

--- a/docs/src/dev/release-assets-manifest.md
+++ b/docs/src/dev/release-assets-manifest.md
@@ -37,6 +37,14 @@ fails the workflow early.
       "size":     12345678,
       "format":   "tar.gz",
       "binaries": ["harn", "harn-dap", "harn-lsp"]
+    },
+    "x86_64-unknown-linux-gnu": {
+      "filename": "harn-x86_64-unknown-linux-gnu.tar.gz",
+      "url":      "...",
+      "sha256":   "...",
+      "size":     12345678,
+      "format":   "tar.gz",
+      "binaries": ["harn", "harn-dap", "harn-lsp", "harn-container-probe"]
     }
   }
 }
@@ -54,6 +62,11 @@ fails the workflow early.
 | `assets[triple].size`              | Archive size in bytes. |
 | `assets[triple].format`            | `"tar.gz"` or `"zip"`. |
 | `assets[triple].binaries`          | List of files unpacked from the archive. |
+
+Linux archives also include `harn-container-probe`, which the release
+container image uses for its distroless health check. Installer scripts
+may ignore that extra binary unless they are assembling the container
+root filesystem.
 
 The currently published target triples are:
 

--- a/scripts/build_release_assets_manifest.py
+++ b/scripts/build_release_assets_manifest.py
@@ -58,12 +58,12 @@ TARGETS: dict[str, dict[str, object]] = {
     "x86_64-unknown-linux-gnu": {
         "filename": "harn-x86_64-unknown-linux-gnu.tar.gz",
         "format": "tar.gz",
-        "binaries": ["harn", "harn-dap", "harn-lsp"],
+        "binaries": ["harn", "harn-dap", "harn-lsp", "harn-container-probe"],
     },
     "aarch64-unknown-linux-gnu": {
         "filename": "harn-aarch64-unknown-linux-gnu.tar.gz",
         "format": "tar.gz",
-        "binaries": ["harn", "harn-dap", "harn-lsp"],
+        "binaries": ["harn", "harn-dap", "harn-lsp", "harn-container-probe"],
     },
     "x86_64-pc-windows-msvc": {
         "filename": "harn-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
## Summary
- package `harn-container-probe` in Linux release archives so release images can reuse published artifacts
- build the GHCR release image from the Linux release tarballs via `Dockerfile.release` instead of recompiling Harn inside Docker/buildx
- make the container publish leg wait for the release asset job and cap it with a 30-minute timeout

Closes #2794

## Verification
- `actionlint .github/workflows/build-release-binaries.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-release-binaries.yml"); puts "yaml ok"'`\n- `python3 scripts/build_release_assets_manifest.py --artifacts-dir "$tmp" --tag v9.9.9 --output "$tmp/release-assets.json"` with fake per-target archives, then `python3 -m json.tool` and grep for `harn-container-probe`\n- `docker build --platform linux/amd64 --target unpack -f Dockerfile.release <tmp-context>` with a dummy release tarball\n- `make lint-actions`\n- `make lint-md`\n- `git diff --check`\n- pre-commit hook\n- pre-push hook