### PR TITLE
Surface tool-policy and permission denials as structured runtime events

### DIFF
--- a/changelog.d/2780.added.md
+++ b/changelog.d/2780.added.md
@@ -1,0 +1,12 @@
+- **Tool-policy and permission denials now carry a structured `denial`
+  record (#2780).** When a capability/policy ceiling, argument allow-list,
+  dynamic permission rule, approval decision, or pre-tool hook refuses an
+  agent tool call, the denied `tool_result` and the `PermissionDeny`
+  transcript event now include a `denial` object with the refusing `gate`
+  (`tool_ceiling`, `capability_ceiling`, `side_effect_ceiling`,
+  `arg_constraint`, `dynamic_permission`, `approval_policy`,
+  `approval_unavailable`, `host_rejected`, `hook_deny`), the exceeded
+  `capability`, any `denied_paths`, and a `retryable` flag (always `false`
+  today — these gates are terminal). Host harnesses can fail or pivot on a
+  terminal denial without spending another model call re-parsing prose, and
+  the loop's stall detector counts repeated terminal denials as a loop.

--- a/conformance/tests/agents/agent_loop_denial_loop.expected
+++ b/conformance/tests/agents/agent_loop_denial_loop.expected
@@ -1,0 +1,2 @@
+repeated_error
+true

--- a/conformance/tests/agents/agent_loop_denial_loop.harn
+++ b/conformance/tests/agents/agent_loop_denial_loop.harn
@@ -1,0 +1,58 @@
+import { agent_capture_events } from "std/agent/events"
+
+/**
+ * A tool that the capability policy refuses comes back as a structured,
+ * terminal denial (ok: false, error_category "permission_denied", with a
+ * `denial` record). Re-issuing it can never succeed, so the stall detector
+ * must count the repeats as a loop instead of letting the agent burn turns
+ * retrying a denied call (#2780).
+ */
+fn events_of(events, kind) {
+  return events.filter({ event -> event.type == kind })
+}
+
+fn write_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note",
+    {
+      handler: { _args -> "" },
+      parameters: {path: {type: "string", description: "Path to write"}},
+      returns: {type: "string"},
+    },
+  )
+  return tools
+}
+
+pipeline default() {
+  let tools = write_tools()
+  llm_mock_clear()
+  llm_mock({text: "", tool_calls: [{id: "w1", name: "write_note", arguments: {path: "a"}}]})
+  llm_mock({text: "", tool_calls: [{id: "w2", name: "write_note", arguments: {path: "a"}}]})
+  llm_mock({text: "", tool_calls: [{id: "w3", name: "write_note", arguments: {path: "a"}}]})
+  llm_mock({text: "", tool_calls: [{id: "w4", name: "write_note", arguments: {path: "a"}}]})
+  llm_mock({text: "", tool_calls: [{id: "w5", name: "write_note", arguments: {path: "a"}}]})
+  let session = "denial-loop-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "Keep trying to write the note.",
+      nil,
+      {
+        provider: "mock",
+        tools: tools,
+        tool_format: "native",
+        max_iterations: 5,
+        session_id: session,
+        policy: {tools: ["read_only"]},
+        stall_diagnostics: {enabled: true, inject_feedback: false},
+      },
+    ) },
+  )
+  let stalls = events_of(captured.events, "agent_loop_stall_warning")
+  require len(stalls) >= 1, "repeated terminal denials must trip the loop detector"
+  __io_println(stalls[0].warning.pattern)
+  __io_println(captured.result.suspected_loop)
+}

--- a/conformance/tests/agents/agent_worker_policy.expected
+++ b/conformance/tests/agents/agent_worker_policy.expected
@@ -4,3 +4,5 @@ true
 true
 true
 true
+true
+true

--- a/conformance/tests/agents/agent_worker_policy.harn
+++ b/conformance/tests/agents/agent_worker_policy.harn
@@ -29,6 +29,11 @@ pipeline main() {
   let transcript = json_stringify(transcript_messages(denied?.transcript))
   __io_println(transcript.contains("permission_denied"))
   __io_println(transcript.contains("write_note"))
+  // The denial is structured: the gate that refused the call and a
+  // terminal `retryable: false` ride along so a host harness can fail or
+  // pivot without re-parsing the reason prose (#2780).
+  __io_println(transcript.contains("tool_ceiling"))
+  __io_println(transcript.contains("retryable"))
   let read_only_denied = agent_loop(
     "Try to write a note",
     "You are helpful",

--- a/crates/harn-vm/src/agent_events/mod.rs
+++ b/crates/harn-vm/src/agent_events/mod.rs
@@ -42,5 +42,5 @@ pub use registry::{
     unregister_wildcard_sink, WildcardSinkHandle,
 };
 pub use sinks::{AgentEventSink, EventLogSink, JsonlEventSink, MultiSink, PersistedAgentEvent};
-pub use tool::{ToolCallErrorCategory, ToolCallStatus, ToolExecutor};
+pub use tool::{DenialGate, ToolCallErrorCategory, ToolCallStatus, ToolDenial, ToolExecutor};
 pub use worker::{FsWatchEvent, WorkerEvent};

--- a/crates/harn-vm/src/agent_events/tests.rs
+++ b/crates/harn-vm/src/agent_events/tests.rs
@@ -419,6 +419,59 @@ fn tool_call_error_category_serializes_as_snake_case() {
 }
 
 #[test]
+fn denial_gate_serializes_as_snake_case() {
+    use crate::agent_events::DenialGate;
+    let pairs = [
+        (DenialGate::ToolCeiling, "tool_ceiling"),
+        (DenialGate::CapabilityCeiling, "capability_ceiling"),
+        (DenialGate::SideEffectCeiling, "side_effect_ceiling"),
+        (DenialGate::ArgConstraint, "arg_constraint"),
+        (DenialGate::DynamicPermission, "dynamic_permission"),
+        (DenialGate::ApprovalPolicy, "approval_policy"),
+        (DenialGate::ApprovalUnavailable, "approval_unavailable"),
+        (DenialGate::HostRejected, "host_rejected"),
+        (DenialGate::HookDeny, "hook_deny"),
+        (DenialGate::Unknown, "unknown"),
+    ];
+    // Keep ALL exhaustive so a new gate forces a wire-string decision.
+    assert_eq!(pairs.len(), DenialGate::ALL.len());
+    for (variant, wire) in pairs {
+        let encoded = serde_json::to_string(&variant).unwrap();
+        assert_eq!(encoded, format!("\"{wire}\""));
+        assert_eq!(variant.as_str(), wire);
+        let decoded: DenialGate = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, variant);
+    }
+}
+
+#[test]
+fn tool_denial_serializes_terminal_record_and_skips_empty_fields() {
+    use crate::agent_events::{DenialGate, ToolDenial};
+    // A capability ceiling: gate + capability present, no declared paths.
+    let denial = ToolDenial::terminal(
+        DenialGate::CapabilityCeiling,
+        Some("workspace.write_text".to_string()),
+        "tool 'edit' exceeds capability ceiling: workspace.write_text",
+    );
+    let json = denial.to_json();
+    assert_eq!(json["gate"], "capability_ceiling");
+    assert_eq!(json["capability"], "workspace.write_text");
+    assert_eq!(json["retryable"], false);
+    assert!(json["reason"]
+        .as_str()
+        .unwrap()
+        .contains("capability ceiling"));
+    // Empty `denied_paths` and absent `capability` are omitted from the wire.
+    let bare = ToolDenial::terminal(DenialGate::ToolCeiling, None, "exceeds tool ceiling");
+    let bare_json = bare.to_json();
+    assert!(bare_json.get("denied_paths").is_none());
+    assert!(bare_json.get("capability").is_none());
+    // Round-trips back to an equal value.
+    let recovered: ToolDenial = serde_json::from_value(denial.to_json()).unwrap();
+    assert_eq!(recovered, denial);
+}
+
+#[test]
 fn tool_executor_round_trips_with_adjacent_tag() {
     // Adjacent tagging keeps the wire shape uniform — every variant
     // is a JSON object with a `kind` discriminator. The ACP adapter

--- a/crates/harn-vm/src/agent_events/tool.rs
+++ b/crates/harn-vm/src/agent_events/tool.rs
@@ -134,6 +134,128 @@ impl ToolCallErrorCategory {
     }
 }
 
+/// Which gate refused a tool call. Pairs with [`ToolDenial`] so host
+/// harnesses can distinguish a hard capability/policy ceiling (terminal —
+/// retrying the identical call can never succeed) from a user/host
+/// approval rejection, without re-parsing the human-readable reason
+/// string (harn#2780).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenialGate {
+    /// The tool is not in the policy's allowed-tool list.
+    ToolCeiling,
+    /// The tool requires a capability/operation the policy does not grant
+    /// (e.g. `workspace.write_text`, `process.exec`).
+    CapabilityCeiling,
+    /// The tool's side-effect level exceeds the policy ceiling
+    /// (e.g. a `process_exec` tool under a `read_only` policy).
+    SideEffectCeiling,
+    /// A `tool_arg_constraint` allow-list rejected the resolved argument
+    /// value (e.g. a `command` that does not match `cargo *`).
+    ArgConstraint,
+    /// A dynamic permission rule (`when`/`unless` predicate) denied the
+    /// call.
+    DynamicPermission,
+    /// A static approval policy decided `deny`.
+    ApprovalPolicy,
+    /// Approval was required (`ask`) but could not be requested because no
+    /// host bridge was available or the request transport failed.
+    ApprovalUnavailable,
+    /// The host/user rejected an approval request (`session/request_permission`).
+    HostRejected,
+    /// A registered pre-tool hook returned `deny`.
+    HookDeny,
+    /// Gate could not be classified.
+    #[default]
+    Unknown,
+}
+
+impl DenialGate {
+    pub const ALL: [Self; 10] = [
+        Self::ToolCeiling,
+        Self::CapabilityCeiling,
+        Self::SideEffectCeiling,
+        Self::ArgConstraint,
+        Self::DynamicPermission,
+        Self::ApprovalPolicy,
+        Self::ApprovalUnavailable,
+        Self::HostRejected,
+        Self::HookDeny,
+        Self::Unknown,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ToolCeiling => "tool_ceiling",
+            Self::CapabilityCeiling => "capability_ceiling",
+            Self::SideEffectCeiling => "side_effect_ceiling",
+            Self::ArgConstraint => "arg_constraint",
+            Self::DynamicPermission => "dynamic_permission",
+            Self::ApprovalPolicy => "approval_policy",
+            Self::ApprovalUnavailable => "approval_unavailable",
+            Self::HostRejected => "host_rejected",
+            Self::HookDeny => "hook_deny",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Structured record of a tool call refused at the dispatch boundary —
+/// by a capability/policy ceiling, an argument allow-list, a permission
+/// rule, an approval decision, or a pre-tool hook. Carried on the denied
+/// `tool_result` and the `PermissionDeny` transcript event so host
+/// harnesses (and the loop's own stall detector) can fail or pivot early
+/// without re-parsing human-readable command output (harn#2780). The
+/// `denied_paths` field captures any workspace paths the refused call
+/// declared, so a path-scoped denial names the offending path.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolDenial {
+    /// Which gate refused the call.
+    pub gate: DenialGate,
+    /// Capability/operation that was exceeded, e.g. `workspace.read_text`
+    /// or `process.exec`, when the gate identified one.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub capability: Option<String>,
+    /// Workspace paths the denied call declared, when the tool annotates
+    /// path arguments. Empty for tools that declare no paths.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub denied_paths: Vec<String>,
+    /// Whether re-issuing the identical call could ever succeed. Capability
+    /// and side-effect ceilings, argument allow-lists, and policy/approval
+    /// denials are terminal (`false`); a host harness should fail or pivot
+    /// rather than spend another model call retrying.
+    pub retryable: bool,
+    /// Human-readable explanation — the same text the model sees in the
+    /// tool result.
+    pub reason: String,
+}
+
+impl ToolDenial {
+    /// Build a terminal denial (`retryable: false`) with no declared paths
+    /// attached yet. Every gate Harn currently enforces is terminal —
+    /// re-issuing the identical call can never succeed — so the constructor
+    /// hard-codes `retryable: false`; the field exists so a future soft
+    /// denial can set it `true`. Callers at the dispatch boundary enrich
+    /// `denied_paths` from the tool's annotated path arguments.
+    pub fn terminal(
+        gate: DenialGate,
+        capability: Option<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            gate,
+            capability,
+            denied_paths: Vec::new(),
+            retryable: false,
+            reason: reason.into(),
+        }
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+}
+
 /// Where a tool actually ran. Tags `ToolCallUpdate` so clients can render
 /// "via mcp:linear" / "via host bridge" badges, attribute latency by
 /// transport, and route errors to the right surface (harn#691).

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -210,9 +210,19 @@ fn agent_primitive_denied_tool(
     tool_args: &serde_json::Value,
     reason: impl Into<String>,
     category: crate::agent_events::ToolCallErrorCategory,
+    denial: Option<&crate::agent_events::ToolDenial>,
 ) -> serde_json::Value {
     let reason = reason.into();
-    let result = agent_tools::denied_tool_result(tool_name, reason.clone());
+    let mut result = agent_tools::denied_tool_result(tool_name, reason.clone());
+    // Mirror the structured denial onto the inner tool result so it rides
+    // along in the transcript the model sees, and onto the envelope so a
+    // host harness reading the dispatch outcome can fail or pivot early
+    // without re-parsing the rendered reason (harn#2780).
+    if let Some(denial) = denial {
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("denial".to_string(), denial.to_json());
+        }
+    }
     serde_json::json!({
         "ok": false,
         "status": "error",
@@ -223,8 +233,95 @@ fn agent_primitive_denied_tool(
         "rendered_result": agent_tools::render_tool_result(&result),
         "error": reason,
         "error_category": category.as_str(),
+        "denial": denial.map(crate::agent_events::ToolDenial::to_json),
         "executor": null,
     })
+}
+
+/// Append a `PermissionDeny` transcript event that carries the structured
+/// [`crate::agent_events::ToolDenial`] alongside the human-readable reason.
+/// Silent no-op for sessions that were never opened.
+fn emit_permission_deny_event(
+    session_id: &str,
+    tool_name: &str,
+    tool_args: &serde_json::Value,
+    denial: &crate::agent_events::ToolDenial,
+    escalated: bool,
+    policy_decision: Option<serde_json::Value>,
+) {
+    if !crate::agent_sessions::exists(session_id) {
+        return;
+    }
+    let event = permissions::permission_deny_transcript_event(
+        tool_name,
+        tool_args,
+        denial,
+        escalated,
+        policy_decision,
+    );
+    let _ = crate::agent_sessions::append_event(session_id, event);
+}
+
+/// Emit the `PermissionDeny` event and build the denied `tool_result` for a
+/// refused agent tool call. Centralizes the structured-denial plumbing so
+/// every gate (capability ceiling, argument allow-list, dynamic permission,
+/// approval policy, host rejection, pre-tool hook) produces an identical
+/// shape. Fills `denied_paths` from the tool's annotated path arguments when
+/// the caller left them empty. Returns the raw `serde_json::Value` so callers
+/// that need to enrich it further (e.g. attach hook-reminder audit) can do so
+/// before converting to a `VmValue`.
+fn deny_tool_call(
+    session_id: &str,
+    tool_name: &str,
+    tool_call_id: &str,
+    tool_args: &serde_json::Value,
+    mut denial: crate::agent_events::ToolDenial,
+    escalated: bool,
+    policy_decision: Option<serde_json::Value>,
+) -> serde_json::Value {
+    if denial.denied_paths.is_empty() {
+        denial.denied_paths =
+            crate::orchestration::current_tool_declared_paths(tool_name, tool_args);
+    }
+    emit_permission_deny_event(
+        session_id,
+        tool_name,
+        tool_args,
+        &denial,
+        escalated,
+        policy_decision,
+    );
+    agent_primitive_denied_tool(
+        tool_name,
+        tool_call_id,
+        tool_args,
+        denial.reason.clone(),
+        crate::agent_events::ToolCallErrorCategory::PermissionDenied,
+        Some(&denial),
+    )
+}
+
+/// `deny_tool_call` for the common case where no further enrichment is
+/// needed — emits the event, builds the denied result, and converts to a
+/// `VmValue` ready to return from the dispatch primitive.
+fn deny_tool_call_value(
+    session_id: &str,
+    tool_name: &str,
+    tool_call_id: &str,
+    tool_args: &serde_json::Value,
+    denial: crate::agent_events::ToolDenial,
+    escalated: bool,
+    policy_decision: Option<serde_json::Value>,
+) -> VmValue {
+    json_to_vm_value(&deny_tool_call(
+        session_id,
+        tool_name,
+        tool_call_id,
+        tool_args,
+        denial,
+        escalated,
+        policy_decision,
+    ))
 }
 
 /// Build the `tool_result` shape used when a call was preempted by
@@ -531,8 +628,8 @@ async fn host_agent_dispatch_tool_call(
     let bridge = current_host_bridge();
     let _policy_guard = agent_session_host::install_session_policy_guard(options)?;
 
-    if let Err(error) =
-        crate::orchestration::enforce_current_policy_for_tool(&tool_name).and_then(|_| {
+    if let Err(policy_denial) = crate::orchestration::enforce_current_policy_for_tool(&tool_name)
+        .and_then(|_| {
             crate::orchestration::enforce_tool_arg_constraints(
                 &crate::orchestration::current_execution_policy().unwrap_or_default(),
                 &tool_name,
@@ -540,22 +637,20 @@ async fn host_agent_dispatch_tool_call(
             )
         })
     {
-        let reason = error.to_string();
-        emit_permission_event(
-            &session_id,
-            "PermissionDeny",
-            &tool_name,
-            &tool_args,
-            &reason,
-            false,
+        let denial = crate::agent_events::ToolDenial::terminal(
+            policy_denial.gate,
+            policy_denial.capability,
+            policy_denial.reason,
         );
-        return Ok(json_to_vm_value(&agent_primitive_denied_tool(
+        return Ok(deny_tool_call_value(
+            &session_id,
             &tool_name,
             &tool_id,
             &tool_args,
-            reason,
-            crate::agent_events::ToolCallErrorCategory::PermissionDenied,
-        )));
+            denial,
+            false,
+            None,
+        ));
     }
 
     let mut permission_grants = permissions::take_session_grants(&session_id);
@@ -601,21 +696,20 @@ async fn host_agent_dispatch_tool_call(
                         true,
                     );
                 }
-                emit_permission_event(
-                    &session_id,
-                    "PermissionDeny",
-                    &tool_name,
-                    &tool_args,
-                    &reason,
-                    escalated,
+                let denial = crate::agent_events::ToolDenial::terminal(
+                    crate::agent_events::DenialGate::DynamicPermission,
+                    None,
+                    reason,
                 );
-                return Ok(json_to_vm_value(&agent_primitive_denied_tool(
+                return Ok(deny_tool_call_value(
+                    &session_id,
                     &tool_name,
                     &tool_id,
                     &tool_args,
-                    reason,
-                    crate::agent_events::ToolCallErrorCategory::PermissionDenied,
-                )));
+                    denial,
+                    escalated,
+                    None,
+                ));
             }
         }
     }
@@ -643,42 +737,37 @@ async fn host_agent_dispatch_tool_call(
             );
         }
         Some(decision) if decision.is_deny() => {
-            emit_permission_event_with_policy(
-                &session_id,
-                "PermissionDeny",
-                &tool_name,
-                &tool_args,
-                &decision.reason,
-                false,
-                Some(decision.receipt.clone()),
+            let denial = crate::agent_events::ToolDenial::terminal(
+                crate::agent_events::DenialGate::ApprovalPolicy,
+                None,
+                decision.reason,
             );
-            return Ok(json_to_vm_value(&agent_primitive_denied_tool(
+            return Ok(deny_tool_call_value(
+                &session_id,
                 &tool_name,
                 &tool_id,
                 &tool_args,
-                decision.reason,
-                crate::agent_events::ToolCallErrorCategory::PermissionDenied,
-            )));
+                denial,
+                false,
+                Some(decision.receipt),
+            ));
         }
         Some(decision) if decision.is_ask() => {
             let Some(bridge) = bridge.as_ref() else {
-                let reason = "approval required but no host bridge is available";
-                emit_permission_event_with_policy(
-                    &session_id,
-                    "PermissionDeny",
-                    &tool_name,
-                    &tool_args,
-                    reason,
-                    false,
-                    Some(decision.receipt.clone()),
+                let denial = crate::agent_events::ToolDenial::terminal(
+                    crate::agent_events::DenialGate::ApprovalUnavailable,
+                    None,
+                    "approval required but no host bridge is available",
                 );
-                return Ok(json_to_vm_value(&agent_primitive_denied_tool(
+                return Ok(deny_tool_call_value(
+                    &session_id,
                     &tool_name,
                     &tool_id,
                     &tool_args,
-                    reason,
-                    crate::agent_events::ToolCallErrorCategory::PermissionDenied,
-                )));
+                    denial,
+                    false,
+                    Some(decision.receipt.clone()),
+                ));
             };
             let approval_id = if tool_id.is_empty() {
                 format!("tool_call_{}", uuid::Uuid::now_v7())
@@ -727,43 +816,37 @@ async fn host_agent_dispatch_tool_call(
                         );
                     }
                     crate::llm::acp_permission::WireOutcome::Rejected { reason } => {
-                        emit_permission_event_with_policy(
-                            &session_id,
-                            "PermissionDeny",
-                            &tool_name,
-                            &tool_args,
-                            &reason,
-                            true,
-                            Some(decision.receipt.clone()),
+                        let denial = crate::agent_events::ToolDenial::terminal(
+                            crate::agent_events::DenialGate::HostRejected,
+                            None,
+                            reason,
                         );
-                        return Ok(json_to_vm_value(&agent_primitive_denied_tool(
+                        return Ok(deny_tool_call_value(
+                            &session_id,
                             &tool_name,
                             &tool_id,
                             &tool_args,
-                            reason,
-                            crate::agent_events::ToolCallErrorCategory::PermissionDenied,
-                        )));
+                            denial,
+                            true,
+                            Some(decision.receipt.clone()),
+                        ));
                     }
                 },
                 Err(_) => {
-                    let reason =
-                        "approval request failed or host does not implement session/request_permission";
-                    emit_permission_event_with_policy(
-                        &session_id,
-                        "PermissionDeny",
-                        &tool_name,
-                        &tool_args,
-                        reason,
-                        true,
-                        Some(decision.receipt.clone()),
+                    let denial = crate::agent_events::ToolDenial::terminal(
+                        crate::agent_events::DenialGate::ApprovalUnavailable,
+                        None,
+                        "approval request failed or host does not implement session/request_permission",
                     );
-                    return Ok(json_to_vm_value(&agent_primitive_denied_tool(
+                    return Ok(deny_tool_call_value(
+                        &session_id,
                         &tool_name,
                         &tool_id,
                         &tool_args,
-                        reason,
-                        crate::agent_events::ToolCallErrorCategory::PermissionDenied,
-                    )));
+                        denial,
+                        true,
+                        Some(decision.receipt.clone()),
+                    ));
                 }
             }
         }
@@ -788,12 +871,19 @@ async fn host_agent_dispatch_tool_call(
     .await;
     hook_reminder_reports.extend(reports);
     if let Some(reason) = pre_tool_result? {
-        let denied = agent_primitive_denied_tool(
+        let denial = crate::agent_events::ToolDenial::terminal(
+            crate::agent_events::DenialGate::HookDeny,
+            None,
+            reason,
+        );
+        let denied = deny_tool_call(
+            &session_id,
             &tool_name,
             &tool_id,
             &tool_args,
-            reason,
-            crate::agent_events::ToolCallErrorCategory::PermissionDenied,
+            denial,
+            false,
+            None,
         );
         let denied = attach_hook_reminder_audit(denied, hook_reminder_reports);
         return Ok(json_to_vm_value(&denied));
@@ -873,12 +963,15 @@ async fn host_agent_dispatch_tool_call(
 
     let tool_schemas = tools::collect_tool_schemas(tools, None);
     if let Err(message) = tools::validate_tool_args(&tool_name, &tool_args, &tool_schemas) {
+        // Schema validation is not a policy denial — the model can fix the
+        // arguments and retry — so no structured `ToolDenial` is attached.
         let denied = agent_primitive_denied_tool(
             &tool_name,
             &tool_id,
             &tool_args,
             message,
             crate::agent_events::ToolCallErrorCategory::SchemaValidation,
+            None,
         );
         let denied = attach_hook_reminder_audit(denied, hook_reminder_reports);
         return Ok(json_to_vm_value(&denied));

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -114,6 +114,36 @@ pub(crate) fn permission_transcript_event_with_policy(
     crate::llm::helpers::transcript_event(kind, "tool", "internal", reason, Some(metadata))
 }
 
+/// Build a `PermissionDeny` transcript event that carries the structured
+/// [`crate::agent_events::ToolDenial`] alongside the human-readable reason,
+/// so host harnesses reading the event log can fail or pivot on a terminal
+/// denial without re-parsing prose (harn#2780).
+pub(crate) fn permission_deny_transcript_event(
+    tool_name: &str,
+    args: &serde_json::Value,
+    denial: &crate::agent_events::ToolDenial,
+    escalated: bool,
+    policy_decision: Option<serde_json::Value>,
+) -> VmValue {
+    let mut metadata = serde_json::json!({
+        "tool_name": tool_name,
+        "arguments": args,
+        "reason": denial.reason,
+        "escalated": escalated,
+        "denial": denial.to_json(),
+    });
+    if let Some(policy_decision) = policy_decision {
+        metadata["policy_decision"] = policy_decision;
+    }
+    crate::llm::helpers::transcript_event(
+        "PermissionDeny",
+        "tool",
+        "internal",
+        &denial.reason,
+        Some(metadata),
+    )
+}
+
 thread_local! {
     static DYNAMIC_PERMISSION_STACK: RefCell<Vec<DynamicPermissionPolicy>> = const { RefCell::new(Vec::new()) };
     static SESSION_PERMISSION_GRANTS: RefCell<BTreeMap<String, BTreeSet<String>>> = const {

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -142,6 +142,40 @@ pub(super) fn reject_policy(reason: String) -> Result<(), VmError> {
     })
 }
 
+/// Structured refusal produced by the agent-tool capability gates
+/// (`enforce_current_policy_for_tool`, `enforce_tool_arg_constraints`).
+/// Records the gate identity and the exceeded capability so the dispatch
+/// boundary can build a full [`crate::agent_events::ToolDenial`] for the
+/// model and host. `From<PolicyDenial> for VmError` keeps the legacy
+/// `?`-using callers — which only need the categorized error — unchanged.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PolicyDenial {
+    pub gate: crate::agent_events::DenialGate,
+    pub capability: Option<String>,
+    pub reason: String,
+}
+
+impl From<PolicyDenial> for VmError {
+    fn from(denial: PolicyDenial) -> Self {
+        VmError::CategorizedError {
+            message: denial.reason,
+            category: crate::value::ErrorCategory::ToolRejected,
+        }
+    }
+}
+
+pub(super) fn reject_tool(
+    gate: crate::agent_events::DenialGate,
+    capability: Option<String>,
+    reason: String,
+) -> Result<(), PolicyDenial> {
+    Err(PolicyDenial {
+        gate,
+        capability,
+        reason,
+    })
+}
+
 /// Mutation classification for a tool, derived from the pipeline's
 /// declared `ToolKind`. Used in telemetry and pre/post-bridge payloads
 /// while those methods still exist. Returns `"other"` for unannotated
@@ -413,20 +447,27 @@ pub fn enforce_current_policy_for_bridge_builtin(name: &str) -> Result<(), VmErr
     Ok(())
 }
 
-pub fn enforce_current_policy_for_tool(tool_name: &str) -> Result<(), VmError> {
+pub fn enforce_current_policy_for_tool(tool_name: &str) -> Result<(), PolicyDenial> {
+    use crate::agent_events::DenialGate;
     let Some(policy) = current_execution_policy() else {
         return Ok(());
     };
     if !policy_allows_tool(&policy, tool_name) {
-        return reject_policy(format!("tool '{tool_name}' exceeds tool ceiling"));
+        return reject_tool(
+            DenialGate::ToolCeiling,
+            None,
+            format!("tool '{tool_name}' exceeds tool ceiling"),
+        );
     }
     if let Some(annotations) = policy.tool_annotations.get(tool_name) {
         for (capability, ops) in &annotations.capabilities {
             for op in ops {
                 if !policy_allows_capability(&policy, capability, op) {
-                    return reject_policy(format!(
-                        "tool '{tool_name}' exceeds capability ceiling: {capability}.{op}"
-                    ));
+                    return reject_tool(
+                        DenialGate::CapabilityCeiling,
+                        Some(format!("{capability}.{op}")),
+                        format!("tool '{tool_name}' exceeds capability ceiling: {capability}.{op}"),
+                    );
                 }
             }
         }
@@ -434,10 +475,14 @@ pub fn enforce_current_policy_for_tool(tool_name: &str) -> Result<(), VmError> {
         if requested_level != SideEffectLevel::None
             && !policy_allows_side_effect(&policy, requested_level.as_str())
         {
-            return reject_policy(format!(
-                "tool '{tool_name}' exceeds side-effect ceiling: {}",
-                requested_level.as_str()
-            ));
+            return reject_tool(
+                DenialGate::SideEffectCeiling,
+                None,
+                format!(
+                    "tool '{tool_name}' exceeds side-effect ceiling: {}",
+                    requested_level.as_str()
+                ),
+            );
         }
     }
     Ok(())

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -8,9 +8,10 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use super::super::glob_match;
-use super::reject_policy;
+use super::{reject_tool, PolicyDenial};
+use crate::agent_events::DenialGate;
 use crate::tool_annotations::ToolAnnotations;
-use crate::value::{VmError, VmValue};
+use crate::value::VmValue;
 
 /// Extended policy that supports argument-level constraints.
 ///
@@ -47,7 +48,7 @@ pub fn enforce_tool_arg_constraints(
     policy: &CapabilityPolicy,
     tool_name: &str,
     args: &serde_json::Value,
-) -> Result<(), VmError> {
+) -> Result<(), PolicyDenial> {
     for constraint in &policy.tool_arg_constraints {
         if !glob_match(&constraint.tool, tool_name) {
             continue;
@@ -101,12 +102,16 @@ pub fn enforce_tool_arg_constraints(
             .iter()
             .any(|pattern| glob_match(pattern, &candidate));
         if !matches {
-            return reject_policy(format!(
-                "tool '{tool_name}' {arg_key} '{candidate}' does not match allowed patterns: {:?}. \
-                 Only the {arg_key} argument is checked against this allow-list — other argument \
-                 values are not.",
-                constraint.arg_patterns
-            ));
+            return reject_tool(
+                DenialGate::ArgConstraint,
+                None,
+                format!(
+                    "tool '{tool_name}' {arg_key} '{candidate}' does not match allowed patterns: {:?}. \
+                     Only the {arg_key} argument is checked against this allow-list — other argument \
+                     values are not.",
+                    constraint.arg_patterns
+                ),
+            );
         }
     }
     Ok(())

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -1232,13 +1232,62 @@ fn reset_thread_local_state_clears_execution_policy_stack() {
 
 #[test]
 fn execution_policy_rejects_unlisted_tool() {
+    use crate::agent_events::DenialGate;
     push_execution_policy(CapabilityPolicy {
         tools: vec!["read".to_string()],
         ..Default::default()
     });
-    let result = enforce_current_policy_for_tool("edit");
+    let denial = enforce_current_policy_for_tool("edit").unwrap_err();
     pop_execution_policy();
-    assert!(result.is_err());
+    // The refusal is structured: gate identifies the tool ceiling and the
+    // reason carries the same text the model sees (#2780).
+    assert_eq!(denial.gate, DenialGate::ToolCeiling);
+    assert!(denial.capability.is_none());
+    assert!(denial.reason.contains("tool ceiling"));
+}
+
+#[test]
+fn execution_policy_capability_ceiling_records_gate_and_capability() {
+    use crate::agent_events::DenialGate;
+    let mut tool_annotations = BTreeMap::new();
+    tool_annotations.insert(
+        "edit".to_string(),
+        crate::tool_annotations::ToolAnnotations {
+            kind: crate::tool_annotations::ToolKind::Edit,
+            capabilities: BTreeMap::from([(
+                "workspace".to_string(),
+                vec!["write_text".to_string()],
+            )]),
+            ..Default::default()
+        },
+    );
+    push_execution_policy(CapabilityPolicy {
+        tools: vec!["edit".to_string()],
+        capabilities: BTreeMap::from([("workspace".to_string(), vec!["read_text".to_string()])]),
+        tool_annotations,
+        ..Default::default()
+    });
+    let denial = enforce_current_policy_for_tool("edit").unwrap_err();
+    pop_execution_policy();
+    assert_eq!(denial.gate, DenialGate::CapabilityCeiling);
+    assert_eq!(denial.capability.as_deref(), Some("workspace.write_text"));
+}
+
+#[test]
+fn arg_constraint_denial_records_arg_constraint_gate() {
+    use crate::agent_events::DenialGate;
+    let policy = CapabilityPolicy {
+        tool_arg_constraints: vec![ToolArgConstraint {
+            tool: "exec".to_string(),
+            arg_patterns: vec!["cargo *".to_string()],
+            arg_key: Some("command".to_string()),
+        }],
+        ..Default::default()
+    };
+    let denial =
+        enforce_tool_arg_constraints(&policy, "exec", &serde_json::json!({"command": "rm -rf /"}))
+            .unwrap_err();
+    assert_eq!(denial.gate, DenialGate::ArgConstraint);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

A Burin `cpp-test` eval on Harn v0.8.58 (#2780) burned ~50 provider calls and 40 `run` calls before hitting `max_turn_requests` because verifier/tool-policy problems looked to the agent like ordinary command failures. Harn surfaced denials only as human-readable command output, so a host harness had no structured signal to fail or pivot early.

## What this does

When a tool call is refused **at the dispatch boundary**, the denied `tool_result` and the `PermissionDeny` transcript event now carry a structured `denial` record:

```json
{
  "gate": "capability_ceiling",
  "capability": "workspace.write_text",
  "denied_paths": ["src/main.rs"],
  "retryable": false,
  "reason": "tool 'edit' exceeds capability ceiling: workspace.write_text"
}
```

- **`gate`** — which gate refused: `tool_ceiling`, `capability_ceiling`, `side_effect_ceiling`, `arg_constraint`, `dynamic_permission`, `approval_policy`, `approval_unavailable`, `host_rejected`, `hook_deny`.
- **`capability`** — the exceeded capability/operation, when the gate names one.
- **`denied_paths`** — workspace paths the refused call declared (a path-scoped denial names the offending path).
- **`retryable`** — `false` for every gate Harn enforces today (they're terminal); the field exists so a future soft denial can set it `true`.

This rides on both the inner result (so the model sees it in the transcript) and the dispatch envelope (so a host harness reads it without re-parsing prose).

### Desired behaviors from #2780

- ✅ Runtime emits **structured** denial records, not just command output.
- ✅ Includes tool name, attempted args, gate/ceiling name, denied capability/path, and a terminal-vs-retryable flag.
- ✅ Host harnesses can convert non-retryable denials into early failures **without another LLM call** — read `denial.retryable == false`.
- ✅ The loop's stall detector already counts repeated terminal denials as a loop: denials are `ok: false`, so they flow through the existing same-error condition. New conformance test `agent_loop_denial_loop` proves repeated policy denials trip `repeated_error` / `suspected_loop`.

## Implementation

- New `DenialGate` enum + `ToolDenial` record in `agent_events` (wire-stable, snake_case).
- Policy gates (`enforce_current_policy_for_tool`, `enforce_tool_arg_constraints`) now return a structured `PolicyDenial` (gate + capability + reason). `From<PolicyDenial> for VmError` keeps the legacy `?`-using callers unchanged.
- `deny_tool_call` centralizes the emit-event + build-result plumbing so every gate produces an identical shape and fills `denied_paths` from the tool's annotated path args.

## Tests

- Unit: `denial_gate_serializes_as_snake_case`, `tool_denial_serializes_terminal_record_and_skips_empty_fields`, `execution_policy_capability_ceiling_records_gate_and_capability`, `arg_constraint_denial_records_arg_constraint_gate`, plus the updated unlisted-tool test.
- Conformance: `agent_worker_policy` (asserts the structured `denial` rides the transcript) and new `agent_loop_denial_loop` (repeated terminal denials trip the loop detector).
- Full `agents` conformance suite green (the only 2 non-passes spawn an external `harn` binary that isn't under the isolated build dir — environmental, pass with the correct binary path).

Closes #2780

🤖 Generated with [Claude Code](https://claude.com/claude-code)