### PR TITLE
harn-serve: restore persisted sessions on in-process ACP session/load

### DIFF
--- a/changelog.d/2793.fixed.md
+++ b/changelog.d/2793.fixed.md
@@ -1,0 +1,7 @@
+- **In-process ACP `session/load` restores persisted saved sessions (#2793).**
+  A `session/load` for an id the running `harn serve` instance never created now
+  reconstructs it from persisted replay events — registering a live, promptable
+  session and replaying its history — instead of rejecting it as `unknown
+  session`. This is the in-process analogue of the WebSocket hub's persisted
+  fallback and unblocks the Rust TUI saved-session picker and `burin --continue
+  <id>`. Ids with no live session and no persisted events still fail loudly.

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -2976,20 +2976,31 @@ impl AcpServer {
         )
     }
 
+    /// Extract the request's `sessionId`/`session_id` parameter, emitting a
+    /// JSON-RPC error and returning `None` when it is absent or non-string.
+    fn session_id_param<'a>(
+        &self,
+        id: &serde_json::Value,
+        params: &'a serde_json::Value,
+        method: &str,
+    ) -> Option<&'a str> {
+        let session_id = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(serde_json::Value::as_str);
+        if session_id.is_none() {
+            self.send_error(id, -32602, &format!("{method} requires sessionId"));
+        }
+        session_id
+    }
+
     fn restored_session_id<'a>(
         &self,
         id: &serde_json::Value,
         params: &'a serde_json::Value,
         method: &str,
     ) -> Option<&'a str> {
-        let Some(session_id) = params
-            .get("sessionId")
-            .or_else(|| params.get("session_id"))
-            .and_then(serde_json::Value::as_str)
-        else {
-            self.send_error(id, -32602, &format!("{method} requires sessionId"));
-            return None;
-        };
+        let session_id = self.session_id_param(id, params, method)?;
 
         if !self.sessions.contains_key(session_id) {
             self.send_error(id, -32602, &format!("unknown session: {session_id}"));
@@ -3000,13 +3011,38 @@ impl AcpServer {
         Some(session_id)
     }
 
+    /// Register a session the live server never saw so its persisted
+    /// replay history can be restored into an interactive session. Used
+    /// by `session/load` when a client (e.g. the Rust TUI saved-session
+    /// picker) attaches a Burin saved session after a fresh `harn serve`
+    /// start. The in-process channel server spins prompt turns up on
+    /// demand, so the restored session is genuinely live — unlike the
+    /// WebSocket hub's `expired_replay_only` fallback, which has no
+    /// worker to re-attach to.
+    fn register_restored_session(&mut self, session_id: &str, params: &serde_json::Value) {
+        let cwd = params
+            .get("cwd")
+            .and_then(|value| value.as_str())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        self.insert_session(session_id.to_string(), cwd, SessionInfo::default());
+    }
+
     async fn handle_session_load(&mut self, id: &serde_json::Value, params: &serde_json::Value) {
-        let Some(session_id) = self.restored_session_id(id, params, "session/load") else {
+        let Some(session_id) = self
+            .session_id_param(id, params, "session/load")
+            .map(str::to_owned)
+        else {
             return;
         };
 
+        // Replay events are the durable source of truth for the in-process
+        // path, so load them before deciding whether the session is
+        // restorable. This mirrors the WebSocket hub's persisted fallback in
+        // `replay_persisted_acp_events`, but keeps the restored session live
+        // and promptable rather than replay-only.
         let replay_events =
-            match harn_vm::orchestration::load_agent_session_replay_events(session_id).await {
+            match harn_vm::orchestration::load_agent_session_replay_events(&session_id).await {
                 Ok(events) => events,
                 Err(error) => {
                     self.send_error(
@@ -3017,6 +3053,18 @@ impl AcpServer {
                     return;
                 }
             };
+
+        if self.sessions.contains_key(&session_id) {
+            harn_vm::agent_sessions::open_or_create(Some(session_id.clone()));
+        } else if replay_events.is_empty() {
+            // No live session and nothing persisted under this id: fail loudly
+            // so the client can distinguish a typo/stale id from a real load.
+            self.send_error(id, -32602, &format!("unknown session: {session_id}"));
+            return;
+        } else {
+            self.register_restored_session(&session_id, params);
+        }
+
         let replay_sink = AcpAgentEventSink::for_replay(self.output.clone());
         for replay_event in &replay_events {
             replay_sink.handle_event(&replay_event.event);
@@ -3035,7 +3083,7 @@ impl AcpServer {
             .collect();
 
         let mut result = self
-            .session_restore_result(session_id)
+            .session_restore_result(&session_id)
             .expect("validated session should still exist");
         result["replayed"] = serde_json::json!(replayed);
         self.send_response(id, result);

--- a/crates/harn-serve/src/adapters/acp/tests/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/modes.rs
@@ -570,6 +570,114 @@ async fn acp_session_load_replays_persisted_agent_events() {
     harn_vm::event_log::reset_active_event_log();
 }
 
+/// A fresh in-process server (one that never created the id via
+/// `session/new`) must still restore a Burin saved session from
+/// persisted replay events: register it as a live, promptable session,
+/// replay history, and return the normal restore-result shape. This is
+/// the in-process analogue of the WebSocket hub's persisted fallback and
+/// unblocks the Rust TUI saved-session picker.
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_load_restores_persisted_session_unknown_to_server() {
+    harn_vm::event_log::reset_active_event_log();
+    let log = harn_vm::event_log::install_memory_for_current_thread(64);
+
+    // Persist replay history under an id the server has never created.
+    let session_id = "burin-saved-session".to_string();
+    install_test_agent_event_log_sink(&log, &session_id);
+    harn_vm::agent_events::emit_event(&harn_vm::agent_events::AgentEvent::AgentMessageChunk {
+        session_id: session_id.clone(),
+        content: "restored history".to_string(),
+    });
+    wait_for_agent_event_log_entries(&log, &session_id, 1).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/load",
+            "params": {"sessionId": session_id, "cwd": "."},
+        }))
+        .await;
+
+    let replay = recv_json(&mut rx).await;
+    assert_eq!(replay["method"], "session/update");
+    assert_eq!(
+        replay["params"]["update"]["sessionUpdate"],
+        "agent_message_chunk"
+    );
+    assert_eq!(
+        replay["params"]["update"]["content"]["text"],
+        "restored history"
+    );
+    assert_eq!(
+        replay["params"]["update"]["_meta"]["harn"]["replayed"],
+        true
+    );
+
+    let loaded = recv_json(&mut rx).await;
+    assert_eq!(loaded["id"], 1);
+    assert_eq!(loaded["result"]["session"]["sessionId"], session_id);
+    assert_eq!(
+        loaded["result"]["session"]["liveState"], "live",
+        "the in-process server restores to a live, promptable session"
+    );
+    assert_eq!(loaded["result"]["replayed"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        loaded["result"]["replayed"][0]["type"],
+        "agent_message_chunk"
+    );
+
+    // After restore the session is tracked, so a second load takes the
+    // live reload path (and still replays the persisted history).
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/load",
+            "params": {"sessionId": session_id},
+        }))
+        .await;
+    let _second_replay = recv_json(&mut rx).await;
+    let second = recv_json(&mut rx).await;
+    assert_eq!(second["id"], 2);
+    assert_eq!(second["result"]["session"]["sessionId"], session_id);
+
+    harn_vm::agent_events::clear_session_sinks(&session_id);
+    harn_vm::event_log::reset_active_event_log();
+}
+
+/// `session/load` for an id that is neither live nor persisted must fail
+/// loudly so the client can distinguish a stale/typo id from a restore.
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_load_rejects_session_without_persisted_events() {
+    harn_vm::event_log::reset_active_event_log();
+    let _log = harn_vm::event_log::install_memory_for_current_thread(64);
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/load",
+            "params": {"sessionId": "never-existed"},
+        }))
+        .await;
+
+    let response = recv_json(&mut rx).await;
+    assert_eq!(response["id"], 1);
+    assert_eq!(response["error"]["code"], -32602);
+    assert!(response["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("unknown session")));
+
+    harn_vm::event_log::reset_active_event_log();
+}
+
 /// Setting a valid mode ack's with an empty result and emits a
 /// `current_mode_update` notification carrying the new mode id.
 /// Locks the canonical session-modes wire shape so clients depend


### PR DESCRIPTION
Closes #2793

## Problem

The in-process ACP server advertises `agentCapabilities.loadSession = true`, but `handle_session_load` called `restored_session_id` first, which rejected any id missing from the live `self.sessions` map with `unknown session` **before** persisted replay events could be read. A client could therefore only load sessions the current `harn serve` instance already knew — even though the advertised capability and the Burin saved-session UI imply persisted-session attach/restore should work.

The WebSocket ACP hub already had a persisted fallback (`replay_persisted_acp_events`); the in-process/channel path did not.

## Change

`session/load` now loads persisted replay events first, then decides:

- **Live session** → unchanged live reload (`open_or_create` + replay).
- **Not live, but persisted events exist** → register a live, promptable session (mirroring `session/new`'s cwd derivation) and return the normal restore-result shape with replayed history. Because the channel server spins prompt turns up on demand, the restored session is genuinely interactive — so it surfaces `liveState: "live"` rather than the WebSocket hub's `expired_replay_only` (which has no worker to re-attach to).
- **Not live and no persisted events** → still fails loudly with `unknown session` so a typo/stale id is distinguishable from a real restore.

`session/resume` keeps requiring a live session (re-attach without replay); its unknown-session rejection is unchanged. The shared param-extraction was factored into `session_id_param` to keep both paths DRY.

## Tests

- `acp_session_load_restores_persisted_session_unknown_to_server` — a fresh server (no prior `session/new`) restores a saved session from persisted events, replays history, returns `liveState: "live"`, and a second load takes the live path.
- `acp_session_load_rejects_session_without_persisted_events` — an id that is neither live nor persisted fails with `-32602 unknown session`.
- Existing `acp_session_restore_methods_reject_unknown_sessions`, `acp_session_load_replays_persisted_agent_events`, and `acp_session_load_includes_current_mode_state` continue to pass (155/155 ACP adapter tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)