### PR TITLE
Add read-only roots to harn run sandbox

### DIFF
--- a/changelog.d/2779.added.md
+++ b/changelog.d/2779.added.md
@@ -1,0 +1,5 @@
+- **`harn run` now accepts `--read-only-root`.** CLI now accepts one or
+  more `--read-only-root <path>` arguments to allow read-only access to
+  additional filesystem roots while preserving default run sandbox and
+  network egress guards. This enables maintenance scripts to consume
+  resources outside the workspace without `--no-sandbox`. (#2779)

--- a/crates/harn-cli/src/cli/run.rs
+++ b/crates/harn-cli/src/cli/run.rs
@@ -28,6 +28,14 @@ pub(crate) struct RunArgs {
     /// network egress fail-closed guard for this run.
     #[arg(long = "no-sandbox", action = clap::ArgAction::SetTrue)]
     pub no_sandbox: bool,
+    /// Extra read-only filesystem roots. Repeatable; each path is
+    /// readable but never writable.
+    #[arg(
+        long = "read-only-root",
+        value_name = "PATH",
+        conflicts_with = "no_sandbox"
+    )]
+    pub read_only_root: Vec<PathBuf>,
     /// Evaluate inline Harn code instead of a file.
     #[arg(short = 'e')]
     pub eval: Option<String>,

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -264,6 +264,38 @@ fn test_run_rejects_deny_allow_conflict() {
 }
 
 #[test]
+fn test_run_parses_read_only_roots_and_rejects_no_sandbox_conflict() {
+    let cli = Cli::parse_from([
+        "harn",
+        "run",
+        "--read-only-root",
+        "../shared",
+        "--read-only-root",
+        "/tmp/assets",
+        "main.harn",
+    ]);
+
+    let Command::Run(args) = cli.command.unwrap() else {
+        panic!("expected run command");
+    };
+    assert_eq!(
+        args.read_only_root,
+        vec![PathBuf::from("../shared"), PathBuf::from("/tmp/assets")]
+    );
+
+    let err = Cli::try_parse_from([
+        "harn",
+        "run",
+        "--no-sandbox",
+        "--read-only-root",
+        "../shared",
+        "main.harn",
+    ])
+    .unwrap_err();
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn test_parses_run_llm_mock_flags() {
     let cli = Cli::parse_from(["harn", "run", "--llm-mock", "fixtures.jsonl", "main.harn"]);
 

--- a/crates/harn-cli/src/commands/run/mod.rs
+++ b/crates/harn-cli/src/commands/run/mod.rs
@@ -582,6 +582,9 @@ pub struct RunSandboxOptions {
     /// intended for host-generated scripts whose source file lives outside
     /// the workspace they operate on.
     pub workspace_root: Option<PathBuf>,
+    /// Extra read-only filesystem roots. `path` resolving under one of
+    /// these entries is scoped for reads, but writes still fail.
+    pub read_only_roots: Vec<PathBuf>,
 }
 
 impl Default for RunSandboxOptions {
@@ -589,6 +592,7 @@ impl Default for RunSandboxOptions {
         Self {
             enabled: true,
             workspace_root: None,
+            read_only_roots: Vec::new(),
         }
     }
 }
@@ -599,12 +603,22 @@ impl RunSandboxOptions {
         Self {
             enabled: false,
             workspace_root: None,
+            read_only_roots: Vec::new(),
         }
     }
 
     /// Constrain the default sandbox to an explicit workspace root.
     pub fn with_workspace_root(mut self, workspace_root: impl Into<PathBuf>) -> Self {
         self.workspace_root = Some(workspace_root.into());
+        self
+    }
+
+    /// Add read-only roots to the default sandbox policy.
+    pub fn with_read_only_roots<I>(mut self, read_only_roots: I) -> Self
+    where
+        I: IntoIterator<Item = PathBuf>,
+    {
+        self.read_only_roots = read_only_roots.into_iter().collect();
         self
     }
 }
@@ -925,6 +939,7 @@ fn install_run_sandbox_scope(
     let execution_policy = if harn_vm::orchestration::current_execution_policy().is_none() {
         harn_vm::orchestration::push_execution_policy(default_run_capability_policy(
             workspace_root,
+            &options.read_only_roots,
         ));
         Some(ExecutionPolicyGuard)
     } else {
@@ -940,11 +955,17 @@ fn install_run_sandbox_scope(
 
 fn default_run_capability_policy(
     workspace_root: &Path,
+    read_only_roots: &[PathBuf],
 ) -> harn_vm::orchestration::CapabilityPolicy {
     harn_vm::orchestration::CapabilityPolicy {
         workspace_roots: vec![normalize_run_workspace_root(workspace_root)
             .display()
             .to_string()],
+        read_only_roots: read_only_roots
+            .iter()
+            .map(|path| normalize_run_workspace_root(path.as_path()))
+            .map(|path| path.display().to_string())
+            .collect(),
         side_effect_level: Some("process_exec".to_string()),
         sandbox_profile: harn_vm::orchestration::SandboxProfile::Worktree,
         ..harn_vm::orchestration::CapabilityPolicy::default()
@@ -974,6 +995,10 @@ fn run_sandbox_attestation(sandbox: &RunSandboxOptions) -> serde_json::Value {
         .as_ref()
         .map(|policy| policy.workspace_roots.clone())
         .unwrap_or_default();
+    let read_only_roots = active_policy
+        .as_ref()
+        .map(|policy| policy.read_only_roots.clone())
+        .unwrap_or_default();
     let profile = active_policy
         .as_ref()
         .map(|policy| policy.sandbox_profile.as_str())
@@ -990,6 +1015,7 @@ fn run_sandbox_attestation(sandbox: &RunSandboxOptions) -> serde_json::Value {
         "run_default_enabled": sandbox.enabled,
         "active": active,
         "workspace_roots": workspace_roots,
+        "read_only_roots": read_only_roots,
         "profile": profile,
         "egress": egress,
     })

--- a/crates/harn-cli/src/commands/run/tests.rs
+++ b/crates/harn-cli/src/commands/run/tests.rs
@@ -112,6 +112,7 @@ fn run_sandbox_attestation_reports_effective_policy() {
     harn_vm::reset_thread_local_state();
     let policy = harn_vm::orchestration::CapabilityPolicy {
         workspace_roots: vec!["/tmp/workspace".to_string()],
+        read_only_roots: vec!["/tmp/shared".to_string()],
         sandbox_profile: harn_vm::orchestration::SandboxProfile::OsHardened,
         ..harn_vm::orchestration::CapabilityPolicy::default()
     };
@@ -122,8 +123,154 @@ fn run_sandbox_attestation_reports_effective_policy() {
     assert_eq!(metadata["run_default_enabled"], false);
     assert_eq!(metadata["active"], true);
     assert_eq!(metadata["workspace_roots"][0], "/tmp/workspace");
+    assert_eq!(metadata["read_only_roots"][0], "/tmp/shared");
     assert_eq!(metadata["profile"], "os_hardened");
     assert_eq!(metadata["egress"], "host_policy");
+    harn_vm::reset_thread_local_state();
+}
+
+#[tokio::test]
+async fn execute_run_allows_read_from_explicit_read_only_root_but_denies_write() {
+    harn_vm::reset_thread_local_state();
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let project = temp.path().join("project");
+    let read_only_root = temp.path().join("shared");
+    std::fs::create_dir(&project).expect("create project");
+    std::fs::create_dir(&read_only_root).expect("create read-only root");
+    std::fs::write(project.join("harn.toml"), "").expect("write manifest");
+    let secret = read_only_root.join("payload.txt");
+    let protected = read_only_root.join("prohibited.txt");
+    std::fs::write(&secret, "payload").expect("write payload");
+
+    let script = project.join("main.harn");
+    let secret_literal = secret.to_string_lossy().replace('\\', "\\\\");
+    let prohibited_literal = protected.to_string_lossy().replace('\\', "\\\\");
+    std::fs::write(
+        &script,
+        format!(
+            r#"
+pipeline main() {{
+  __io_println(read_file("{secret_literal}"))
+}}
+"#,
+        ),
+    )
+    .expect("write read script");
+
+    let sandbox_options =
+        || RunSandboxOptions::default().with_read_only_roots(vec![read_only_root.clone()]);
+    let read_outcome = execute_run_with_harnpack_and_sandbox_options(
+        &script.to_string_lossy(),
+        false,
+        HashSet::new(),
+        Vec::new(),
+        Vec::new(),
+        CliLlmMockMode::Off,
+        None,
+        RunProfileOptions::default(),
+        sandbox_options(),
+        HarnpackRunOptions::default(),
+    )
+    .await;
+
+    assert_eq!(
+        read_outcome.exit_code, 0,
+        "stderr:\n{}",
+        read_outcome.stderr
+    );
+    assert_eq!(read_outcome.stdout.trim(), "payload");
+
+    std::fs::write(
+        &script,
+        format!(
+            r#"
+pipeline main() {{
+  write_file("{prohibited_literal}", "should be denied")
+}}
+"#,
+        ),
+    )
+    .expect("write denial script");
+
+    let outcome = execute_run_with_harnpack_and_sandbox_options(
+        &script.to_string_lossy(),
+        false,
+        HashSet::new(),
+        Vec::new(),
+        Vec::new(),
+        CliLlmMockMode::Off,
+        None,
+        RunProfileOptions::default(),
+        sandbox_options(),
+        HarnpackRunOptions::default(),
+    )
+    .await;
+
+    assert_eq!(outcome.exit_code, 1, "stderr:\n{}", outcome.stderr);
+    assert!(
+        outcome.stderr.contains("under a read-only workspace root"),
+        "stderr:\n{}",
+        outcome.stderr
+    );
+    assert!(
+        !protected.exists(),
+        "write under read-only root must be denied"
+    );
+    harn_vm::reset_thread_local_state();
+}
+
+#[cfg(all(feature = "hostlib", unix))]
+#[tokio::test]
+async fn execute_run_allows_command_run_read_from_read_only_root() {
+    harn_vm::reset_thread_local_state();
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let project = temp.path().join("project");
+    let read_only_root = temp.path().join("shared");
+    std::fs::create_dir(&project).expect("create project");
+    std::fs::create_dir(&read_only_root).expect("create read-only root");
+    std::fs::write(project.join("harn.toml"), "").expect("write manifest");
+    let secret = read_only_root.join("payload.txt");
+    std::fs::write(&secret, "payload").expect("write payload");
+
+    let script = project.join("main.harn");
+    let secret_literal = secret.to_string_lossy().replace('\\', "\\\\");
+    std::fs::write(
+        &script,
+        format!(
+            r#"
+import {{ command_run }} from "std/command"
+
+pipeline main() {{
+  let result = command_run(
+    {{argv: ["cat", "{secret_literal}"]}},
+    {{capture: {{max_inline_bytes: 8}}, timeout_ms: 5000}},
+  )
+  if !result.success {{
+    throw "command_run failed: exit_code=${{result.exit_code}} stderr=${{result.stderr}}"
+  }}
+  __io_println(result.stdout)
+}}
+"#
+        ),
+    )
+    .expect("write script");
+
+    let outcome = execute_run_with_harnpack_and_sandbox_options(
+        &script.to_string_lossy(),
+        false,
+        HashSet::new(),
+        Vec::new(),
+        Vec::new(),
+        CliLlmMockMode::Off,
+        None,
+        RunProfileOptions::default(),
+        RunSandboxOptions::default().with_read_only_roots(vec![read_only_root.clone()]),
+        HarnpackRunOptions::default(),
+    )
+    .await;
+
+    assert_eq!(outcome.exit_code, 0, "stderr:\n{}", outcome.stderr);
+    assert_eq!(outcome.stdout.trim(), "payload");
     harn_vm::reset_thread_local_state();
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -253,6 +253,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                 commands::run::RunSandboxOptions::disabled()
             } else {
                 commands::run::RunSandboxOptions::default()
+                    .with_read_only_roots(args.read_only_root.iter().cloned())
             };
             let json_options = args
                 .json

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -19,6 +19,7 @@ harn run -e 'log("hello")'
 harn run --deny shell,exec <file.harn>
 harn run --allow read_file,write_file <file.harn>
 harn run --no-sandbox <file.harn>
+harn run --read-only-root /path/to/other-repo main.harn
 harn run --yes <file.harn>
 harn run --explain-cost <file.harn>
 harn run --attest <file.harn>
@@ -40,6 +41,7 @@ harn run --resume .harn/workers/worker_...json
 | `--deny <builtins>` | Deny specific builtins (comma-separated) |
 | `--allow <builtins>` | Allow only specific builtins (comma-separated) |
 | `--no-sandbox` | Disable the default worktree filesystem/process sandbox and network side-effect ceiling |
+| `--read-only-root <path>` | Read from an extra filesystem root while keeping sandboxing enabled |
 | `--yes` | Accept first-run provider setup prompts, including local Ollama config seeding |
 | `--attest` | Emit a signed provenance receipt after execution |
 | `--receipt-out <path>` | Write the receipt to a specific JSON path |
@@ -186,8 +188,11 @@ the VM. Filesystem and subprocess cwd access are rooted at the nearest
 `harn.toml` project root, or at the invocation working directory when
 no project manifest is present. Network side effects are denied by the
 same default policy. Use `--no-sandbox` only for scripts that need the
-old unrestricted process behavior; the CLI emits a warning when this
-escape hatch is used.
+old unrestricted process behavior; use `--read-only-root` when a script
+needs read access to a sibling or shared directory and should remain in
+the sandboxed profile.
+The CLI emits a warning when `--no-sandbox` is used, and rejects
+`--read-only-root` when `--no-sandbox` is present.
 
 Before starting the VM, `harn run <file>` builds the cross-module
 graph for the entry file. When all imports resolve, unknown call

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -6490,6 +6490,19 @@ network side-effect ceiling for this invocation. The CLI emits a
 warning when this escape hatch is used. `--deny` / `--allow` still
 apply when present.
 
+### --read-only-root
+
+```bash
+harn run --read-only-root /path/to/other-repo main.harn
+```
+
+Permit reads from additional filesystem roots while keeping the default
+`harn run` sandbox policy intact. Paths under each `--read-only-root`
+are allowed for read-style operations but rejected for writes. Use this
+when a script needs to consume files from a sibling checkout or shared
+assets without disabling sandboxing. `--read-only-root` cannot be
+combined with `--no-sandbox`.
+
 ### --deny
 
 ```bash

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -6488,6 +6488,19 @@ network side-effect ceiling for this invocation. The CLI emits a
 warning when this escape hatch is used. `--deny` / `--allow` still
 apply when present.
 
+### --read-only-root
+
+```bash
+harn run --read-only-root /path/to/other-repo main.harn
+```
+
+Permit reads from additional filesystem roots while keeping the default
+`harn run` sandbox policy intact. Paths under each `--read-only-root`
+are allowed for read-style operations but rejected for writes. Use this
+when a script needs to consume files from a sibling checkout or shared
+assets without disabling sandboxing. `--read-only-root` cannot be
+combined with `--no-sandbox`.
+
 ### --deny
 
 ```bash


### PR DESCRIPTION
## Summary

- Add repeatable `harn run --read-only-root <path>` to extend the default run sandbox with explicit read-only filesystem roots.
- Thread the roots through `RunSandboxOptions`, capability policy installation, and sandbox attestation metadata.
- Reject `--read-only-root` together with `--no-sandbox` so the read-only guarantee is not silently disabled.
- Document the new CLI surface in the spec, CLI reference, and changelog.

Closes #2779.

## Verification

- `cargo test -p harn-cli cli::tests::test_run_parses_read_only_roots_and_rejects_no_sandbox_conflict`
- `cargo test -p harn-cli commands::run::tests::execute_run_allows`
- `cargo test -p harn-cli commands::run::tests::run_sandbox_attestation_reports_effective_policy`
- `cargo clippy -p harn-cli --lib -- -D warnings`
- `make check-language-spec`
- `make lint-test-patterns`
- `cargo run --quiet --bin harn -- run --help | rg -- '--read-only-root'`
- Direct smoke: `harn run --read-only-root <tmp>/shared <tmp>/project/main.harn` read a payload from the extra root.
- Pre-commit hook: passed.
- Pre-push hook: passed.