### PR TITLE
Fix hostlib payload and process edge cases

### DIFF
--- a/changelog.d/bug-dry-sweep.fixed.md
+++ b/changelog.d/bug-dry-sweep.fixed.md
@@ -1,0 +1,7 @@
+- **Hostlib deterministic tools now reject malformed scalar payloads and report
+  process/file-watch edge cases correctly.** Shared VmValue parsing now rejects
+  non-finite or out-of-range numeric inputs, `run_command` no longer ignores
+  malformed `cwd`/`stdin` fields or wait failures, directory listing reports
+  symlinks without following their targets, inline command output preserves
+  invalid UTF-8 lossily, and file watches can subscribe to `access`/`other`
+  events.

--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -25,6 +25,7 @@ use crate::tools::args::{
     build_dict, dict_arg, optional_bool, optional_int_list, optional_string, optional_string_list,
     require_string, str_value,
 };
+use crate::value_args;
 
 /// Shared, mutable cell carrying the (at most one) live workspace index.
 /// `Mutex` rather than `RwLock` because rebuilds flip the slot wholesale
@@ -1081,18 +1082,12 @@ fn require_non_negative_u64(
     dict: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<u64, HostlibError> {
-    match dict.get(key) {
-        Some(VmValue::Int(n)) if *n >= 0 => Ok(*n as u64),
-        Some(VmValue::Float(f)) if f.fract() == 0.0 && *f >= 0.0 => Ok(*f as u64),
-        Some(VmValue::Int(n)) => Err(HostlibError::InvalidParameter {
+    match value_args::optional_i64_no_default(builtin, dict, key)? {
+        Some(value) if value >= 0 => Ok(value as u64),
+        Some(value) => Err(HostlibError::InvalidParameter {
             builtin,
             param: key,
-            message: format!("must be >= 0, got {n}"),
-        }),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected integer, got {}", other.type_name()),
+            message: format!("must be >= 0, got {value}"),
         }),
         None => Err(HostlibError::MissingParameter {
             builtin,
@@ -1129,19 +1124,13 @@ fn optional_positive_i64(
     dict: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<Option<i64>, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(None),
-        Some(VmValue::Int(n)) if *n >= 1 => Ok(Some(*n)),
-        Some(VmValue::Float(f)) if f.fract() == 0.0 && *f >= 1.0 => Ok(Some(*f as i64)),
-        Some(VmValue::Int(n)) => Err(HostlibError::InvalidParameter {
+    match value_args::optional_i64_no_default(builtin, dict, key)? {
+        None => Ok(None),
+        Some(value) if value >= 1 => Ok(Some(value)),
+        Some(value) => Err(HostlibError::InvalidParameter {
             builtin,
             param: key,
-            message: format!("must be >= 1, got {n}"),
-        }),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected integer, got {}", other.type_name()),
+            message: format!("must be >= 1, got {value}"),
         }),
     }
 }

--- a/crates/harn-hostlib/src/fs_watch/mod.rs
+++ b/crates/harn-hostlib/src/fs_watch/mod.rs
@@ -26,6 +26,8 @@ use crate::tools::args::{
 const SUBSCRIBE_BUILTIN: &str = "hostlib_fs_watch_subscribe";
 const UNSUBSCRIBE_BUILTIN: &str = "hostlib_fs_watch_unsubscribe";
 const DEFAULT_DEBOUNCE_MS: u64 = 50;
+const DEFAULT_KINDS: &[&str] = &["create", "modify", "remove", "rename"];
+const SUPPORTED_KINDS: &[&str] = &["access", "create", "modify", "other", "remove", "rename"];
 
 static NEXT_SUBSCRIPTION_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -447,26 +449,21 @@ fn normalize_kind(kind: &EventKind) -> &'static str {
 
 fn parse_kinds(dict: &BTreeMap<String, VmValue>) -> Result<BTreeSet<String>, HostlibError> {
     let values = optional_string_list(SUBSCRIBE_BUILTIN, dict, "kinds")?.unwrap_or_else(|| {
-        vec![
-            "create".to_string(),
-            "modify".to_string(),
-            "remove".to_string(),
-            "rename".to_string(),
-        ]
+        DEFAULT_KINDS
+            .iter()
+            .map(|kind| (*kind).to_string())
+            .collect()
     });
     let mut kinds = BTreeSet::new();
     for kind in values {
-        match kind.as_str() {
-            "create" | "modify" | "remove" | "rename" => {
-                kinds.insert(kind);
-            }
-            _ => {
-                return Err(HostlibError::InvalidParameter {
-                    builtin: SUBSCRIBE_BUILTIN,
-                    param: "kinds",
-                    message: format!("unsupported event kind `{kind}`"),
-                });
-            }
+        if SUPPORTED_KINDS.contains(&kind.as_str()) {
+            kinds.insert(kind);
+        } else {
+            return Err(HostlibError::InvalidParameter {
+                builtin: SUBSCRIBE_BUILTIN,
+                param: "kinds",
+                message: format!("unsupported event kind `{kind}`"),
+            });
         }
     }
     Ok(kinds)
@@ -668,6 +665,36 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].kind, "remove");
+    }
+
+    #[test]
+    fn kind_filter_allows_access_and_other_events() {
+        let root = std::env::current_dir().unwrap();
+        let mut config = BTreeMap::new();
+        config.insert(
+            "kinds".to_string(),
+            VmValue::List(std::sync::Arc::new(vec![
+                VmValue::String(std::sync::Arc::from("access")),
+                VmValue::String(std::sync::Arc::from("other")),
+            ])),
+        );
+        let mut filter = filter(root.clone(), None);
+        filter.kinds = parse_kinds(&config).unwrap();
+
+        let events = coalesce_events(
+            vec![
+                event(
+                    EventKind::Access(notify::event::AccessKind::Any),
+                    root.join("src/lib.rs"),
+                ),
+                event(EventKind::Other, root.join("README.md")),
+            ],
+            &filter,
+        );
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, "access");
+        assert_eq!(events[1].kind, "other");
     }
 
     #[test]

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -43,6 +43,7 @@ pub mod secret_store;
 pub mod tools;
 
 mod registry;
+mod value_args;
 
 pub use error::HostlibError;
 pub use registry::{BuiltinRegistry, HostlibCapability, HostlibRegistry, RegisteredBuiltin};

--- a/crates/harn-hostlib/src/process/mock.rs
+++ b/crates/harn-hostlib/src/process/mock.rs
@@ -39,6 +39,8 @@ pub struct MockProcessConfig {
     /// error instead of returning a handle. Used to exercise sandbox /
     /// invalid-argv error paths.
     pub spawn_error: Option<ProcessError>,
+    /// If non-`None`, force waits to fail with this I/O error.
+    pub wait_error: Option<String>,
 }
 
 impl Default for MockProcessConfig {
@@ -51,6 +53,7 @@ impl Default for MockProcessConfig {
             exit_status: Some(ExitStatus::from_code(0)),
             force_timeout: false,
             spawn_error: None,
+            wait_error: None,
         }
     }
 }
@@ -249,6 +252,7 @@ struct MockState {
     stderr_cv: Condvar,
     /// Force-timeout config copied from MockProcessConfig.
     force_timeout: bool,
+    wait_error: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -272,6 +276,7 @@ impl MockState {
             stdout_cv: Condvar::new(),
             stderr_cv: Condvar::new(),
             force_timeout: config.force_timeout,
+            wait_error: config.wait_error.clone(),
         }
     }
 
@@ -388,6 +393,9 @@ impl ProcessHandle for MockProcess {
         &mut self,
         timeout: Option<Duration>,
     ) -> io::Result<(Option<ExitStatus>, bool)> {
+        if let Some(error) = self.state.wait_error.as_ref() {
+            return Err(io::Error::other(error.clone()));
+        }
         if self.state.force_timeout {
             self.state.record_kill();
             return Ok((None, true));
@@ -409,6 +417,9 @@ impl ProcessHandle for MockProcess {
     }
 
     fn wait(&mut self) -> io::Result<ExitStatus> {
+        if let Some(error) = self.state.wait_error.as_ref() {
+            return Err(io::Error::other(error.clone()));
+        }
         let outcome = self
             .state
             .wait_for_exit(None)

--- a/crates/harn-hostlib/src/process/real.rs
+++ b/crates/harn-hostlib/src/process/real.rs
@@ -163,19 +163,19 @@ impl ProcessHandle for RealProcess {
             let status = child.wait()?;
             return Ok((Some(decode_status(status)), false));
         };
-        let deadline = Instant::now() + timeout;
+        let start = Instant::now();
         loop {
             match child.try_wait()? {
                 Some(status) => return Ok((Some(decode_status(status)), false)),
                 None => {
-                    if Instant::now() >= deadline {
-                        let _ = child.kill();
+                    let elapsed = start.elapsed();
+                    if elapsed >= timeout {
+                        self.killer.kill();
                         let _ = child.wait();
                         return Ok((None, true));
                     }
-                    // Cheap poll. Real workloads are dominated by spawn cost
-                    // and pipe drain, not this sleep.
-                    thread::sleep(Duration::from_millis(20));
+                    let remaining = timeout.checked_sub(elapsed).unwrap_or_default();
+                    thread::sleep(remaining.min(Duration::from_millis(20)));
                 }
             }
         }

--- a/crates/harn-hostlib/src/tools/args.rs
+++ b/crates/harn-hostlib/src/tools/args.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use harn_vm::VmValue;
 
 use crate::error::HostlibError;
+use crate::value_args;
 
 /// Extract the first argument as a Dict. Tools always receive a single
 /// dict from Harn-side callers; if the caller passed nothing we treat it
@@ -41,18 +42,7 @@ pub fn require_string(
     dict: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<String, HostlibError> {
-    match dict.get(key) {
-        Some(VmValue::String(s)) => Ok(s.to_string()),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected string, got {}", other.type_name()),
-        }),
-        None => Err(HostlibError::MissingParameter {
-            builtin,
-            param: key,
-        }),
-    }
+    value_args::require_string(builtin, dict, key)
 }
 
 /// Optional string field. Missing/`Nil` returns `None`.
@@ -61,15 +51,7 @@ pub fn optional_string(
     dict: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<Option<String>, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(None),
-        Some(VmValue::String(s)) => Ok(Some(s.to_string())),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected string, got {}", other.type_name()),
-        }),
-    }
+    value_args::optional_string(builtin, dict, key)
 }
 
 /// Optional `bool`. Defaults to `default` when missing or `Nil`.
@@ -79,15 +61,7 @@ pub fn optional_bool(
     key: &'static str,
     default: bool,
 ) -> Result<bool, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(default),
-        Some(VmValue::Bool(b)) => Ok(*b),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected bool, got {}", other.type_name()),
-        }),
-    }
+    value_args::optional_bool(builtin, dict, key).map(|value| value.unwrap_or(default))
 }
 
 /// Optional integer. Defaults to `default` when missing or `Nil`.
@@ -100,16 +74,7 @@ pub fn optional_int(
     key: &'static str,
     default: i64,
 ) -> Result<i64, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(default),
-        Some(VmValue::Int(n)) => Ok(*n),
-        Some(VmValue::Float(f)) if f.fract() == 0.0 => Ok(*f as i64),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected integer, got {}", other.type_name()),
-        }),
-    }
+    value_args::optional_i64(builtin, dict, key, default)
 }
 
 /// Optional list of strings. Missing/`Nil` returns `Vec::new()`.
@@ -118,33 +83,7 @@ pub fn optional_string_list(
     dict: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<Vec<String>, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(Vec::new()),
-        Some(VmValue::List(items)) => {
-            let mut out = Vec::with_capacity(items.len());
-            for item in items.iter() {
-                match item {
-                    VmValue::String(s) => out.push(s.to_string()),
-                    other => {
-                        return Err(HostlibError::InvalidParameter {
-                            builtin,
-                            param: key,
-                            message: format!(
-                                "expected list of strings, got element {}",
-                                other.type_name()
-                            ),
-                        });
-                    }
-                }
-            }
-            Ok(out)
-        }
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected list of strings, got {}", other.type_name()),
-        }),
-    }
+    value_args::optional_string_list(builtin, dict, key).map(|value| value.unwrap_or_default())
 }
 
 /// Optional list of integers. Missing/`Nil` returns `Vec::new()`.
@@ -162,27 +101,17 @@ pub fn optional_int_list(
         Some(VmValue::List(items)) => {
             let mut out = Vec::with_capacity(items.len());
             for item in items.iter() {
-                match item {
-                    VmValue::Int(n) => out.push(*n),
-                    VmValue::Float(f) if f.fract() == 0.0 => out.push(*f as i64),
-                    other => {
-                        return Err(HostlibError::InvalidParameter {
-                            builtin,
-                            param: key,
-                            message: format!(
-                                "expected list of integers, got element {}",
-                                other.type_name()
-                            ),
-                        });
-                    }
-                }
+                out.push(value_args::coerce_i64(builtin, key, item)?);
             }
             Ok(out)
         }
         Some(other) => Err(HostlibError::InvalidParameter {
             builtin,
             param: key,
-            message: format!("expected list of integers, got {}", other.type_name()),
+            message: format!(
+                "expected list of integers, got {}",
+                value_args::describe(other)
+            ),
         }),
     }
 }
@@ -204,4 +133,34 @@ where
 /// Convenience constructor for `VmValue::String` from a `&str`.
 pub fn str_value(s: impl AsRef<str>) -> VmValue {
     VmValue::String(Arc::from(s.as_ref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dict(entries: [(&'static str, VmValue); 1]) -> BTreeMap<String, VmValue> {
+        entries
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect()
+    }
+
+    #[test]
+    fn optional_int_rejects_non_finite_float() {
+        let payload = dict([("limit", VmValue::Float(f64::INFINITY))]);
+        assert!(matches!(
+            optional_int("test", &payload, "limit", 0),
+            Err(HostlibError::InvalidParameter { param: "limit", .. })
+        ));
+    }
+
+    #[test]
+    fn optional_int_rejects_out_of_range_float() {
+        let payload = dict([("limit", VmValue::Float(1.0e100))]);
+        assert!(matches!(
+            optional_int("test", &payload, "limit", 0),
+            Err(HostlibError::InvalidParameter { param: "limit", .. })
+        ));
+    }
 }

--- a/crates/harn-hostlib/src/tools/file_io.rs
+++ b/crates/harn-hostlib/src/tools/file_io.rs
@@ -316,7 +316,7 @@ pub(super) fn list_directory(args: &[VmValue]) -> Result<VmValue, HostlibError> 
             if !include_hidden && name.starts_with('.') {
                 continue;
             }
-            let metadata = match entry.metadata() {
+            let metadata = match stdfs::symlink_metadata(entry.path()) {
                 Ok(m) => m,
                 Err(_) => continue,
             };

--- a/crates/harn-hostlib/src/tools/payload.rs
+++ b/crates/harn-hostlib/src/tools/payload.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use harn_vm::VmValue;
 
 use crate::error::HostlibError;
+use crate::value_args;
 
 /// Pull the single dict argument from a builtin call's argv. The dict
 /// itself is the JSON request body; positional args are not used.
@@ -41,18 +42,7 @@ pub(crate) fn optional_string(
     map: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<Option<String>, HostlibError> {
-    let Some(value) = map.get(key) else {
-        return Ok(None);
-    };
-    match value {
-        VmValue::Nil => Ok(None),
-        VmValue::String(s) => Ok(Some(s.to_string())),
-        other => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected string, got {}", describe(other)),
-        }),
-    }
+    value_args::optional_string(builtin, map, key)
 }
 
 /// Optional bool field on a request dict.
@@ -61,18 +51,7 @@ pub(crate) fn optional_bool(
     map: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<Option<bool>, HostlibError> {
-    let Some(value) = map.get(key) else {
-        return Ok(None);
-    };
-    match value {
-        VmValue::Nil => Ok(None),
-        VmValue::Bool(b) => Ok(Some(*b)),
-        other => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected bool, got {}", describe(other)),
-        }),
-    }
+    value_args::optional_bool(builtin, map, key)
 }
 
 /// Optional non-negative integer field on a request dict.
@@ -81,23 +60,7 @@ pub(crate) fn optional_u64(
     map: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<Option<u64>, HostlibError> {
-    let Some(value) = map.get(key) else {
-        return Ok(None);
-    };
-    match value {
-        VmValue::Nil => Ok(None),
-        VmValue::Int(i) if *i >= 0 => Ok(Some(*i as u64)),
-        VmValue::Int(i) => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected non-negative integer, got {i}"),
-        }),
-        other => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected integer, got {}", describe(other)),
-        }),
-    }
+    value_args::optional_u64(builtin, map, key)
 }
 
 /// Convert an optional `timeout_ms` field into a `Duration`, treating zero
@@ -122,31 +85,7 @@ pub(crate) fn optional_string_list(
     map: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<Option<Vec<String>>, HostlibError> {
-    let Some(value) = map.get(key) else {
-        return Ok(None);
-    };
-    match value {
-        VmValue::Nil => Ok(None),
-        VmValue::List(list) => {
-            let mut out = Vec::with_capacity(list.len());
-            for (i, item) in list.iter().enumerate() {
-                let VmValue::String(s) = item else {
-                    return Err(HostlibError::InvalidParameter {
-                        builtin,
-                        param: key,
-                        message: format!("expected string at index {i}, got {}", describe(item)),
-                    });
-                };
-                out.push(s.to_string());
-            }
-            Ok(Some(out))
-        }
-        other => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected list of strings, got {}", describe(other)),
-        }),
-    }
+    value_args::optional_string_list(builtin, map, key)
 }
 
 /// Optional `BTreeMap<String, String>` field on a request dict (e.g. `env`).
@@ -188,10 +127,7 @@ pub(crate) fn require_string(
     map: &BTreeMap<String, VmValue>,
     key: &'static str,
 ) -> Result<String, HostlibError> {
-    optional_string(builtin, map, key)?.ok_or(HostlibError::MissingParameter {
-        builtin,
-        param: key,
-    })
+    value_args::require_string(builtin, map, key)
 }
 
 /// Split an argv list into `(program, remaining_args)`. Errors if the list
@@ -219,16 +155,5 @@ pub(crate) fn parse_argv_program(
 }
 
 fn describe(value: &VmValue) -> &'static str {
-    match value {
-        VmValue::Int(_) => "int",
-        VmValue::Float(_) => "float",
-        VmValue::String(_) => "string",
-        VmValue::Bytes(_) => "bytes",
-        VmValue::Bool(_) => "bool",
-        VmValue::Nil => "nil",
-        VmValue::List(_) => "list",
-        VmValue::Dict(_) => "dict",
-        VmValue::Set(_) => "set",
-        _ => "other",
-    }
+    value_args::describe(value)
 }

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -170,8 +170,10 @@ pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
         })
     });
 
-    let (status, timed_out): (Option<process_handle::ExitStatus>, bool) =
-        handle.wait_with_timeout(req.timeout).unwrap_or_default();
+    let wait_result = handle.wait_with_timeout(req.timeout);
+    if wait_result.is_err() {
+        handle.killer().kill();
+    }
 
     if let Some(t) = stdout_thread {
         let _ = t.join();
@@ -182,6 +184,11 @@ pub(crate) fn run(req: SpawnRequest) -> Result<SpawnOutcome, HostlibError> {
 
     let stdout_bytes: Vec<u8> = out_rx.try_iter().flatten().collect();
     let stderr_bytes: Vec<u8> = err_rx.try_iter().flatten().collect();
+    let (status, timed_out): (Option<process_handle::ExitStatus>, bool) =
+        wait_result.map_err(|error| HostlibError::Backend {
+            builtin: req.builtin,
+            message: format!("wait failed: {error}"),
+        })?;
 
     let ended_at = Some(now_rfc3339());
 
@@ -395,7 +402,10 @@ fn lossy_prefix(bytes: &[u8], max_inline_bytes: usize) -> String {
     let cap = bytes.len().min(max_inline_bytes);
     match std::str::from_utf8(&bytes[..cap]) {
         Ok(text) => text.to_string(),
-        Err(error) => String::from_utf8_lossy(&bytes[..error.valid_up_to()]).into_owned(),
+        Err(error) if error.error_len().is_none() => {
+            String::from_utf8_lossy(&bytes[..error.valid_up_to()]).into_owned()
+        }
+        Err(_) => String::from_utf8_lossy(&bytes[..cap]).into_owned(),
     }
 }
 
@@ -487,6 +497,21 @@ mod tests {
         );
 
         assert_eq!(stdout, "alpha ");
+        assert_eq!(stderr, "");
+    }
+
+    #[test]
+    fn inline_output_preserves_lossy_text_after_invalid_byte() {
+        let (stdout, stderr) = inline_output(
+            b"a\xffb",
+            &[],
+            CaptureConfig {
+                max_inline_bytes: 3,
+                ..CaptureConfig::default()
+            },
+        );
+
+        assert_eq!(stdout, "a\u{fffd}b");
         assert_eq!(stderr, "");
     }
 

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -34,9 +34,10 @@ pub(crate) const NAME: &str = "hostlib_tools_run_command";
 pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let map = require_dict_arg(NAME, args)?;
     let (program, args_tail) = parse_command(&map)?;
-    let cwd = proc::parse_cwd(NAME, payload_str(&map, "cwd").as_deref())?;
+    let cwd_raw = optional_string(NAME, &map, "cwd")?;
+    let cwd = proc::parse_cwd(NAME, cwd_raw.as_deref())?;
     let env = optional_string_map(NAME, &map, "env")?.unwrap_or_default();
-    let stdin = payload_str(&map, "stdin");
+    let stdin = optional_string(NAME, &map, "stdin")?;
     let timeout = optional_timeout(NAME, &map, "timeout_ms")?;
     let capture = parse_capture(&map)?;
     let env_mode = parse_env_mode(&map, !env.is_empty())?;
@@ -195,14 +196,6 @@ fn initial_background_snapshot(
     VmValue::Dict(Arc::new(response))
 }
 
-fn payload_str(map: &std::collections::BTreeMap<String, VmValue>, key: &str) -> Option<String> {
-    match map.get(key)? {
-        VmValue::String(s) => Some(s.to_string()),
-        VmValue::Nil => None,
-        _ => None,
-    }
-}
-
 fn parse_command(
     map: &std::collections::BTreeMap<String, VmValue>,
 ) -> Result<(String, Vec<String>), HostlibError> {
@@ -299,10 +292,10 @@ fn parse_capture(
     if let Some(capture_value) = map.get("capture") {
         match capture_value {
             VmValue::Dict(dict) => {
-                capture.stdout = dict_bool(dict, "stdout")?.unwrap_or(true);
-                capture.stderr = dict_bool(dict, "stderr")?.unwrap_or(true);
-                capture.merge_stderr = dict_bool(dict, "merge_stderr")?.unwrap_or(false);
-                if let Some(bytes) = dict_u64(dict, "max_inline_bytes")? {
+                capture.stdout = optional_bool(NAME, dict, "stdout")?.unwrap_or(true);
+                capture.stderr = optional_bool(NAME, dict, "stderr")?.unwrap_or(true);
+                capture.merge_stderr = optional_bool(NAME, dict, "merge_stderr")?.unwrap_or(false);
+                if let Some(bytes) = optional_u64(NAME, dict, "max_inline_bytes")? {
                     capture.max_inline_bytes = usize::try_from(bytes).unwrap_or(usize::MAX);
                 }
             }
@@ -324,34 +317,4 @@ fn parse_capture(
         capture.max_inline_bytes = usize::try_from(max).unwrap_or(usize::MAX);
     }
     Ok(capture)
-}
-
-fn dict_bool(
-    dict: &std::collections::BTreeMap<String, VmValue>,
-    key: &'static str,
-) -> Result<Option<bool>, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(None),
-        Some(VmValue::Bool(b)) => Ok(Some(*b)),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin: NAME,
-            param: key,
-            message: format!("expected bool, got {}", other.type_name()),
-        }),
-    }
-}
-
-fn dict_u64(
-    dict: &std::collections::BTreeMap<String, VmValue>,
-    key: &'static str,
-) -> Result<Option<u64>, HostlibError> {
-    match dict.get(key) {
-        None | Some(VmValue::Nil) => Ok(None),
-        Some(VmValue::Int(i)) if *i >= 0 => Ok(Some(*i as u64)),
-        Some(other) => Err(HostlibError::InvalidParameter {
-            builtin: NAME,
-            param: key,
-            message: format!("expected non-negative integer, got {}", other.type_name()),
-        }),
-    }
 }

--- a/crates/harn-hostlib/src/value_args.rs
+++ b/crates/harn-hostlib/src/value_args.rs
@@ -1,0 +1,161 @@
+use std::collections::BTreeMap;
+
+use harn_vm::VmValue;
+
+use crate::error::HostlibError;
+
+pub(crate) fn describe(value: &VmValue) -> &'static str {
+    match value {
+        VmValue::Int(_) => "int",
+        VmValue::Float(_) => "float",
+        VmValue::String(_) => "string",
+        VmValue::Bytes(_) => "bytes",
+        VmValue::Bool(_) => "bool",
+        VmValue::Nil => "nil",
+        VmValue::List(_) => "list",
+        VmValue::Dict(_) => "dict",
+        VmValue::Set(_) => "set",
+        _ => "other",
+    }
+}
+
+pub(crate) fn require_string(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<String, HostlibError> {
+    optional_string(builtin, dict, key)?.ok_or(HostlibError::MissingParameter {
+        builtin,
+        param: key,
+    })
+}
+
+pub(crate) fn optional_string(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<String>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::String(s)) => Ok(Some(s.to_string())),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected string, got {}", describe(other)),
+        }),
+    }
+}
+
+pub(crate) fn optional_bool(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<bool>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::Bool(value)) => Ok(Some(*value)),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected bool, got {}", describe(other)),
+        }),
+    }
+}
+
+pub(crate) fn optional_i64(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+    default: i64,
+) -> Result<i64, HostlibError> {
+    match optional_i64_no_default(builtin, dict, key)? {
+        Some(value) => Ok(value),
+        None => Ok(default),
+    }
+}
+
+pub(crate) fn optional_i64_no_default(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<i64>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(value) => coerce_i64(builtin, key, value).map(Some),
+    }
+}
+
+pub(crate) fn optional_u64(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<u64>, HostlibError> {
+    match optional_i64_no_default(builtin, dict, key)? {
+        None => Ok(None),
+        Some(value) if value >= 0 => Ok(Some(value as u64)),
+        Some(value) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected non-negative integer, got {value}"),
+        }),
+    }
+}
+
+pub(crate) fn optional_string_list(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<Option<Vec<String>>, HostlibError> {
+    match dict.get(key) {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(VmValue::List(items)) => items
+            .iter()
+            .enumerate()
+            .map(|(idx, item)| match item {
+                VmValue::String(value) => Ok(value.to_string()),
+                other => Err(HostlibError::InvalidParameter {
+                    builtin,
+                    param: key,
+                    message: format!("expected string at index {idx}, got {}", describe(other)),
+                }),
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(other) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected list of strings, got {}", describe(other)),
+        }),
+    }
+}
+
+pub(crate) fn coerce_i64(
+    builtin: &'static str,
+    key: &'static str,
+    value: &VmValue,
+) -> Result<i64, HostlibError> {
+    match value {
+        VmValue::Int(value) => Ok(*value),
+        VmValue::Float(value) if value.is_finite() && value.fract() == 0.0 => {
+            const I64_MAX_EXCLUSIVE: f64 = 9_223_372_036_854_775_808.0;
+            if *value < i64::MIN as f64 || *value >= I64_MAX_EXCLUSIVE {
+                return Err(HostlibError::InvalidParameter {
+                    builtin,
+                    param: key,
+                    message: format!("integer is outside i64 range: {value}"),
+                });
+            }
+            Ok(*value as i64)
+        }
+        VmValue::Float(value) if !value.is_finite() => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected finite integer, got {value}"),
+        }),
+        other => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: key,
+            message: format!("expected integer, got {}", describe(other)),
+        }),
+    }
+}

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -228,6 +228,22 @@ fn run_command_kills_child_when_timeout_elapses() {
 }
 
 #[test]
+fn run_command_surfaces_wait_errors() {
+    let config = MockProcessConfig {
+        wait_error: Some("wait blew up".to_string()),
+        ..MockProcessConfig::completed(0)
+    };
+    let (_spawner, _controller, _guard) = install_mock_with(config);
+
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["true"]));
+    let err = call("hostlib_tools_run_command", req).unwrap_err();
+    assert!(
+        matches!(err, HostlibError::Backend { message, .. } if message.contains("wait failed"))
+    );
+}
+
+#[test]
 fn run_command_capture_stderr_false_merges_into_stdout() {
     let config = MockProcessConfig {
         stdout: b"out\n".to_vec(),
@@ -387,6 +403,15 @@ fn run_command_rejects_nonexistent_cwd() {
 }
 
 #[test]
+fn run_command_rejects_malformed_cwd() {
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["true"]));
+    req.insert("cwd".into(), VmValue::Bool(true));
+    let err = call("hostlib_tools_run_command", req).unwrap_err();
+    assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "cwd"));
+}
+
+#[test]
 fn run_command_argv_must_be_strings() {
     let mut req = dict();
     req.insert(
@@ -395,6 +420,20 @@ fn run_command_argv_must_be_strings() {
     );
     let err = call("hostlib_tools_run_command", req).unwrap_err();
     assert!(matches!(err, HostlibError::InvalidParameter { param, .. } if param == "argv"));
+}
+
+#[test]
+fn run_command_rejects_out_of_range_capture_limit() {
+    let mut capture = BTreeMap::new();
+    capture.insert("max_inline_bytes".into(), VmValue::Float(1.0e100));
+
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["true"]));
+    req.insert("capture".into(), VmValue::Dict(Arc::new(capture)));
+    let err = call("hostlib_tools_run_command", req).unwrap_err();
+    assert!(
+        matches!(err, HostlibError::InvalidParameter { param, .. } if param == "max_inline_bytes")
+    );
 }
 
 // -------- run_test --------

--- a/crates/harn-hostlib/tests/tools_file_io.rs
+++ b/crates/harn-hostlib/tests/tools_file_io.rs
@@ -279,6 +279,34 @@ fn list_directory_include_hidden_works() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn list_directory_reports_symlink_itself_without_following_target() {
+    use std::os::unix::fs::symlink;
+
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let target = outside.path().join("secret.txt");
+    fs::write(&target, "secret payload").unwrap();
+    let target_size = fs::metadata(&target).unwrap().len() as i64;
+    let link = dir.path().join("link.txt");
+    symlink(&target, &link).unwrap();
+
+    let reg = registry();
+    let entry = reg.find("hostlib_tools_list_directory").unwrap();
+    let result = (entry.handler)(&dict_arg(&[("path", vm_string(&path_str(dir.path())))])).unwrap();
+    let entries = match dict_get(&result, "entries") {
+        VmValue::List(rows) => rows,
+        other => panic!("expected list, got {other:?}"),
+    };
+    assert_eq!(entries.len(), 1);
+    assert!(matches!(
+        dict_get(&entries[0], "is_symlink"),
+        VmValue::Bool(true)
+    ));
+    assert!(matches!(dict_get(&entries[0], "size"), VmValue::Int(size) if *size != target_size));
+}
+
 #[test]
 fn list_directory_respects_max_entries_and_marks_truncated() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- Centralize hostlib `VmValue` scalar parsing so tool argument, payload, and code-index helpers reject bad shapes consistently.
- Harden host process execution: validate malformed `cwd`/`stdin`, surface backend wait errors, use the process killer on timeout, and preserve lossy invalid UTF-8 output safely.
- Tighten host file/watch behavior by reporting symlinks without following target metadata and aligning fs-watch accepted event kinds with normalized output.

## Bugs fixed

- Non-finite and out-of-range numeric payloads are now rejected instead of saturating or silently passing through.
- `run_command` no longer treats wrong-typed `cwd`, `stdin`, or timeout options as absent.
- `proc.run` no longer collapses wait backend failures into a fake killed result.
- Timeout cleanup now uses the same process-killer path as cancellation and avoids overflow-prone deadline arithmetic.
- Inline process output keeps invalid UTF-8 bytes via lossy decoding while still avoiding partial trailing codepoints.
- Directory listing no longer follows symlinks when reporting entry metadata.
- `fs.watch` now accepts the `access` and `other` event kinds that its normalizer can emit.

## DRY / abstraction cleanup

- Added shared `value_args` parsing helpers for strings, booleans, integer payloads, and typed shape descriptions.
- Removed duplicate ad hoc `VmValue` parsing from `tools::args`, `tools::payload`, `tools::run_command`, and code-index helpers.
- Consolidated fs-watch kind defaults/supported values into constants.
- Extended the mock process abstraction to model wait backend failures directly.
- Kept process completion semantics at the backend boundary instead of leaking wait errors as normal killed-process results.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-bug-dry-sweep cargo test -p harn-hostlib --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-bug-dry-sweep cargo test -p harn-hostlib --test process_tools --test tools_file_io`
- `CARGO_TARGET_DIR=/tmp/harn-target-bug-dry-sweep cargo clippy -p harn-hostlib --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/harn-target-bug-dry-sweep cargo test -p harn-hostlib --all-targets`
- `CARGO_TARGET_DIR=/tmp/harn-target-bug-dry-sweep make test`