### PR TITLE
Add generated-artifact registry + close hidden CI drift gaps

### DIFF
--- a/.githooks/lib.sh
+++ b/.githooks/lib.sh
@@ -10,6 +10,11 @@ HOOK_HIGHLIGHT_PATTERN='(^crates/harn-lexer/|^crates/harn-stdlib/src/stdlib/|^cr
 HOOK_LANGSPEC_PATTERN='(^spec/HARN_SPEC\.md$|^docs/src/language-spec\.md$)'
 HOOK_DIAGCATALOG_PATTERN='(^crates/harn-parser/src/diagnostic_codes(\.rs|/)|^docs/src/diagnostics\.md$|^docs/diagnostics-catalog\.json$)'
 HOOK_RATCHET_PATTERN='(^crates/harn-vm/src/(llm/|orchestration/(workflow|artifacts|compaction)\.rs$)|^conformance/|^scripts/(allowed_long_strings\.txt|check_no_rust_prompt_prose\.sh|check_rust_prompt_prose\.py|check_xfail_count\.harn|xfail_threshold\.txt)$|^Makefile$)'
+# Lexer KEYWORDS const <-> tree-sitter keyword mirror.
+HOOK_TREESITTER_PATTERN='(^crates/harn-lexer/src/token\.rs$|^tree-sitter-harn/grammar/keywords\.js$)'
+# The generated-artifact registry and the consumers its audit cross-checks
+# (Makefile target/recipe lists, CI workflows, the hooks themselves).
+HOOK_GENREGISTRY_PATTERN='(^scripts/generated_artifacts\.toml$|^scripts/check_generated_registry\.py$|^Makefile$|^\.github/workflows/|^\.githooks/)'
 HOOK_HARN_FORMAT_SKIP=' semicolon_statements.harn semicolon_if_else_invalid.harn semicolon_try_catch_invalid.harn semicolon_empty_statement_invalid.harn '
 
 hook_paths_match() {

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -128,6 +128,27 @@ else
   echo "=== Pre-commit: skipping language spec sync (no spec changes) ==="
 fi
 
+# Pure-Python, sub-second, no harn build — cheap enough to check (not just
+# at push) so drift in the lexer<->tree-sitter keyword mirror or the
+# generated-artifact registry is caught at the moment it's introduced. We
+# check rather than auto-regenerate so the hand-curated grouping/comments
+# in keywords.js survive; the hint points at `make gen-tree-sitter-keywords`.
+if hook_paths_match "$changed" "$HOOK_TREESITTER_PATTERN"; then
+  echo "=== Pre-commit: checking tree-sitter keyword mirror ==="
+  make -s check-tree-sitter-keywords
+  echo "    Tree-sitter keywords OK."
+else
+  echo "=== Pre-commit: skipping tree-sitter keyword check (no lexer/grammar changes) ==="
+fi
+
+if hook_paths_match "$changed" "$HOOK_GENREGISTRY_PATTERN"; then
+  echo "=== Pre-commit: checking generated-artifact registry ==="
+  make -s check-generated-registry
+  echo "    Generated-artifact registry OK."
+else
+  echo "=== Pre-commit: skipping generated-artifact registry check (no registry/Makefile/workflow/hook changes) ==="
+fi
+
 if hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN" && command -v npx >/dev/null 2>&1; then
   echo "=== Pre-commit: checking markdown ==="
   make lint-md

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -163,6 +163,25 @@ else
   echo "=== Pre-push: skipping highlight check (no lexer/stdlib changes) ==="
 fi
 
+if hook_paths_match "$changed" "$HOOK_TREESITTER_PATTERN"; then
+  echo "=== Pre-push: checking tree-sitter keyword mirror ==="
+  make -s check-tree-sitter-keywords
+  echo "    Tree-sitter keywords OK."
+else
+  echo "=== Pre-push: skipping tree-sitter keyword check (no lexer/grammar changes) ==="
+fi
+
+# Meta-guard: keep scripts/generated_artifacts.toml in agreement with the
+# Makefile `all:` recipe and the CI workflows, so a new gen/check pair
+# can't silently skip CI. Pure-Python; no harn build.
+if hook_paths_match "$changed" "$HOOK_GENREGISTRY_PATTERN"; then
+  echo "=== Pre-push: checking generated-artifact registry ==="
+  make -s check-generated-registry
+  echo "    Generated-artifact registry OK."
+else
+  echo "=== Pre-push: skipping generated-artifact registry check (no registry/Makefile/workflow/hook changes) ==="
+fi
+
 if hook_paths_match "$changed" "$HOOK_DIAGCATALOG_PATTERN"; then
   echo "=== Pre-push: checking diagnostic-code catalog ==="
   if ! make -s check-diagnostics-catalog >/tmp/harn-prepush-diagcatalog.log 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,18 @@ jobs:
           make check-docs-model-refs
           make check-docs-snippets
           make check-diagnostics-catalog
+          # Drift guards that previously existed only in `make all` and so
+          # never ran in any workflow — a contributor could edit
+          # spec/openapi.yaml or the SessionBundle DTO and ship stale
+          # generated artifacts with green CI. The generated-artifact
+          # registry (scripts/generated_artifacts.toml) now forces every
+          # ci = true check to be referenced here. Same warm binary, so
+          # they're effectively free.
+          make check-protocol-artifacts
+          make check-session-bundle-schema
+          make check-provider-catalog
+          make check-provider-catalog-drift
+          make check-docs-workflow-quickstart
           make check-vm-rss-soak
 
   audit-scripts:
@@ -208,6 +220,14 @@ jobs:
       - run: make check-bindings
       - run: make lint-test-patterns
       - run: make lint-diagnostic-codes
+      # Pure-Python sync guards. check-generated-registry is the meta-guard
+      # that keeps scripts/generated_artifacts.toml in agreement with the
+      # Makefile `all:` recipe and the workflows; check-receipt-structs and
+      # check-tree-sitter-keywords are cross-crate sync guards that need no
+      # harn build.
+      - run: make check-receipt-structs
+      - run: make check-tree-sitter-keywords
+      - run: make check-generated-registry
       - run: python3 scripts/verify_release_metadata.py
       - name: Check no retroactive CHANGELOG edits
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,12 @@ polling loops, `SystemTime::now()`, or short `recv_timeout` calls to tests. Use
   and exercise bindings with `make check-bindings`.
 - Generated or local-only paths include `docs/dist/`, `.harn-runs/`, `.harn/`,
   `.harn/receipts/`, `.claude/`, `.burin/`, `target/`, and `node_modules/`.
+- `scripts/generated_artifacts.toml` is the single source of truth for every
+  gen/check drift pair. Adding a generated artifact means adding a `gen-*`/
+  `check-*` Makefile target *and* a registry entry; `make
+  check-generated-registry` fails until the registry, the `all:` recipe, and
+  the CI workflows agree, so a new drift guard can't silently skip CI. See the
+  registry file header for the checklist.
 
 ## Cross-surface changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc
+.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift check-tree-sitter-keywords check-generated-registry portal-check
 
 check: all
 
@@ -537,3 +537,25 @@ lint-no-xfail-regression:
 # add new entries / adjust budgets.
 check-ported-handler-loc:
 	@cargo run --quiet --bin harn -- run scripts/check_ported_handler_loc.harn
+
+# Regenerate tree-sitter-harn/grammar/keywords.js from the lexer's
+# KEYWORDS const (the source of truth for reserved words). Run this
+# whenever a keyword is added, renamed, or retired.
+gen-tree-sitter-keywords:
+	@python3 scripts/sync_tree_sitter_keywords.py --write
+
+# CI guard: fail if the tree-sitter keyword list drifts from the lexer's
+# KEYWORDS const, so the editor grammar and the runtime parser agree on
+# the reserved-word set. `make gen-tree-sitter-keywords` fixes it.
+check-tree-sitter-keywords:
+	@echo "=== Checking tree-sitter keyword list matches the lexer ==="
+	@python3 scripts/sync_tree_sitter_keywords.py
+
+# Meta-guard: fail if scripts/generated_artifacts.toml (the single source
+# of truth for every gen/check drift pair) has drifted from its consumers
+# — the Makefile `all:` recipe, the CI workflows, and the declared output
+# files. Pure-Python; no harn build required. See the registry header for
+# the add-a-new-artifact checklist.
+check-generated-registry:
+	@echo "=== Checking generated-artifact registry is in sync ==="
+	@python3 scripts/check_generated_registry.py

--- a/changelog.d/generated-artifact-registry.added.md
+++ b/changelog.d/generated-artifact-registry.added.md
@@ -1,0 +1,10 @@
+- **Single source of truth for generated-artifact drift checks.**
+  `scripts/generated_artifacts.toml` now registers every "source of truth ->
+  generated file + drift check" pair in one place, and `make
+  check-generated-registry` fails the build when the registry disagrees with
+  the Makefile `all:` recipe, the CI workflows, or the declared output files.
+  A new `gen-*`/`check-*` pair can no longer silently skip CI. Added a
+  cross-crate `make check-tree-sitter-keywords` guard (with `make
+  gen-tree-sitter-keywords`) so the tree-sitter grammar's reserved-word set
+  cannot drift from the lexer `KEYWORDS` const. Both guards run in CI and in
+  the pre-commit / pre-push hooks.

--- a/changelog.d/generated-artifact-registry.fixed.md
+++ b/changelog.d/generated-artifact-registry.fixed.md
@@ -1,0 +1,10 @@
+- **Seven generated-artifact drift guards that never ran in CI now run on
+  every PR.** `check-protocol-artifacts`, `check-session-bundle-schema`,
+  `check-provider-catalog`, `check-provider-catalog-drift`,
+  `check-docs-workflow-quickstart`, `check-receipt-structs`, and the new
+  `check-tree-sitter-keywords` existed only in `make all`, so a contributor
+  could edit `spec/openapi.yaml` or the `SessionBundle` DTO and ship stale
+  bindings with green CI. They are now wired into the appropriate CI lanes.
+  Wiring `check-docs-workflow-quickstart` surfaced a pre-existing stale pin:
+  the workflow-authoring quickstart's `graph_digest` had drifted from the
+  runtime; the docs page and check are re-pinned to the current value.

--- a/docs/src/workflow-authoring-quickstart.md
+++ b/docs/src/workflow-authoring-quickstart.md
@@ -45,7 +45,7 @@ You should see:
   "valid": true,
   "bundle_id": "quickstart-minimal",
   "workflow_id": "quickstart_minimal_workflow",
-  "graph_digest": "sha256:b31130003507343166b74b52792813ae2b56cd1f4a126c11e84c2af06d69c333",
+  "graph_digest": "sha256:d89f161d9fe0739394db76ee48c4e0887b2bc2abba43060cb22826c388b90c2e",
   "errors": [],
   "warnings": []
 }

--- a/scripts/check_docs_workflow_quickstart.sh
+++ b/scripts/check_docs_workflow_quickstart.sh
@@ -95,7 +95,7 @@ expect_json_path "minimal run.graph_digest"       "$RUN_JSON" "graph_digest"    
 
 # Pinned digest in the docs page — bump both together if the canonical
 # graph encoding intentionally changes.
-EXPECTED_MIN_DIGEST='sha256:b31130003507343166b74b52792813ae2b56cd1f4a126c11e84c2af06d69c333'
+EXPECTED_MIN_DIGEST='sha256:d89f161d9fe0739394db76ee48c4e0887b2bc2abba43060cb22826c388b90c2e'
 if [[ "$MIN_DIGEST" != "$EXPECTED_MIN_DIGEST" ]]; then
   echo "FAIL: minimal bundle graph_digest drifted from the value pinned in" >&2
   echo "      docs/src/workflow-authoring-quickstart.md" >&2

--- a/scripts/check_generated_registry.py
+++ b/scripts/check_generated_registry.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Audit that the generated-artifact registry agrees with its consumers.
+
+`scripts/generated_artifacts.toml` is the single source of truth for every
+"source of truth -> generated/mirrored file + drift check" pair in the repo.
+This script (run via `make check-generated-registry`) fails the build when
+the registry and the things that are supposed to track it have drifted:
+
+  * a `gen-*` / `sync-*` Makefile target with no registry entry
+    (someone added a generated artifact but never registered it);
+  * a `check-*` Makefile target that is neither registered nor explicitly
+    exempted (a new drift guard that could silently escape the audit);
+  * a registry entry naming a Makefile target that does not exist;
+  * a registry entry flagged `ci = true` whose check is not referenced in
+    any `.github/workflows/*.yml` (drift would not fail any PR);
+  * a registry entry flagged `make_all = true` whose check is missing from
+    the `all:` recipe (so `make all` would not catch it);
+  * a declared output file that does not exist on disk.
+
+It is intentionally pure-Python with no Rust/`harn` dependency so it runs in
+the fast `audit-scripts` CI lane and in git hooks without a build.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = REPO_ROOT / "scripts" / "generated_artifacts.toml"
+MAKEFILE = REPO_ROOT / "Makefile"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+# Match a Makefile rule definition: `target-name:` at column 0.
+RULE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*):")
+
+
+def whole_target(target: str) -> re.Pattern[str]:
+    """Match `target` not followed by another `-segment` or word char.
+
+    Prevents `check-provider-catalog` from matching inside
+    `check-provider-catalog-drift`.
+    """
+    return re.compile(re.escape(target) + r"(?![\w-])")
+
+
+def makefile_targets(text: str) -> set[str]:
+    targets: set[str] = set()
+    for line in text.splitlines():
+        if line.startswith(("\t", " ")):
+            continue
+        m = RULE_RE.match(line)
+        if m:
+            targets.add(m.group(1))
+    return targets
+
+
+def make_all_recipe(text: str) -> str:
+    """Return the recipe body of the `all:` target (its tab-indented lines)."""
+    lines = text.splitlines()
+    body: list[str] = []
+    in_all = False
+    for line in lines:
+        if line.startswith("all:"):
+            in_all = True
+            continue
+        if in_all:
+            if line.startswith("\t"):
+                body.append(line)
+            elif line.strip() == "":
+                continue
+            else:
+                break
+    return "\n".join(body)
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    with REGISTRY.open("rb") as fh:
+        registry = tomllib.load(fh)
+
+    artifacts = registry.get("artifact", [])
+    exempt = set(registry.get("meta", {}).get("exempt_checks", []))
+
+    make_text = MAKEFILE.read_text(encoding="utf-8")
+    targets = makefile_targets(make_text)
+    all_recipe = make_all_recipe(make_text)
+
+    workflow_text = ""
+    for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        workflow_text += wf.read_text(encoding="utf-8") + "\n"
+
+    # --- Per-entry structural validation -----------------------------------
+    seen_ids: set[str] = set()
+    registered_checks: set[str] = set()
+    registered_gens: set[str] = set()
+
+    for art in artifacts:
+        aid = art.get("id", "<missing id>")
+        if aid in seen_ids:
+            errors.append(f"duplicate artifact id: {aid}")
+        seen_ids.add(aid)
+
+        check = art.get("check", "")
+        gen = art.get("gen", "")
+        if not check:
+            errors.append(f"[{aid}] missing required `check` target")
+        else:
+            registered_checks.add(check)
+            if check not in targets:
+                errors.append(
+                    f"[{aid}] check target `{check}` is not defined in the Makefile"
+                )
+        if gen:
+            registered_gens.add(gen)
+            if gen not in targets:
+                errors.append(
+                    f"[{aid}] gen target `{gen}` is not defined in the Makefile"
+                )
+
+        # ci flag must be honoured by a real workflow reference.
+        if art.get("ci") and check and not whole_target(check).search(workflow_text):
+            errors.append(
+                f"[{aid}] ci = true but `{check}` is not referenced in any "
+                f".github/workflows/*.yml — drift here would not fail a PR. "
+                f"Add `make {check}` to a workflow or set ci = false (with a note)."
+            )
+        # Defensive: a check marked ci=false should not silently be in CI.
+        if art.get("ci") is False and check and whole_target(check).search(workflow_text):
+            errors.append(
+                f"[{aid}] ci = false but `{check}` IS referenced in a workflow. "
+                f"Flip ci = true in the registry to reflect reality."
+            )
+
+        # make_all flag must be honoured by the `all:` recipe.
+        if art.get("make_all") and check and not whole_target(check).search(all_recipe):
+            errors.append(
+                f"[{aid}] make_all = true but `{check}` is missing from the "
+                f"`all:` recipe in the Makefile."
+            )
+
+        # Declared outputs must exist.
+        for out in art.get("outputs", []):
+            if not (REPO_ROOT / out).exists():
+                errors.append(f"[{aid}] declared output does not exist: {out}")
+
+    # --- Completeness: no gen/check pair may escape the registry -----------
+    for target in sorted(targets):
+        if target.startswith(("gen-", "sync-")):
+            if target not in registered_gens:
+                errors.append(
+                    f"Makefile target `{target}` generates an artifact but is not "
+                    f"registered in scripts/generated_artifacts.toml (add an "
+                    f"[[artifact]] block with gen = \"{target}\")."
+                )
+        elif (
+            target.startswith("check-")
+            and target not in registered_checks
+            and target not in exempt
+        ):
+            errors.append(
+                f"Makefile target `{target}` is a check but is neither "
+                f"registered as an [[artifact]].check nor listed in "
+                f"[meta].exempt_checks in scripts/generated_artifacts.toml."
+            )
+
+    # Exempt list hygiene: don't exempt something that is also registered.
+    for ex in sorted(exempt & registered_checks):
+        errors.append(
+            f"`{ex}` is both registered as an artifact check and listed in "
+            f"[meta].exempt_checks — remove it from exempt_checks."
+        )
+
+    if errors:
+        print("error: generated-artifact registry is out of sync:\n", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        print(
+            "\nhint: edit scripts/generated_artifacts.toml (and the Makefile / "
+            "workflows it points at) until they agree. See the header of that "
+            "file for the add-a-new-artifact checklist.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"    Generated-artifact registry OK "
+        f"({len(artifacts)} artifacts, {len(exempt)} exempt checks)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generated_artifacts.toml
+++ b/scripts/generated_artifacts.toml
@@ -1,0 +1,278 @@
+# Generated-artifact registry — single source of truth for every
+# "source of truth -> generated/mirrored file + drift check" pair in the repo.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# The gen/check pairs used to be enumerated independently in FOUR places:
+#   1. the `all:` recipe in the Makefile
+#   2. the audit step(s) in .github/workflows/ci.yml
+#   3. .githooks/pre-commit
+#   4. .githooks/pre-push
+# Nothing forced those four lists to agree, and they drifted: several
+# `check-*` drift guards that exist in the Makefile (and were even
+# advertised in a CI comment as "promoted so a stale artifact fails the
+# PR") never actually ran in any workflow. A contributor could edit
+# spec/openapi.yaml, ship stale bindings, and still get green CI.
+#
+# This registry is the one list. `scripts/check_generated_registry.py`
+# (`make check-generated-registry`) audits the other consumers against
+# it, so a new gen/check pair cannot silently escape CI again, and a
+# generated output cannot lose its drift guard.
+#
+# HOW TO ADD A NEW GENERATED ARTIFACT
+# -----------------------------------
+#   1. Add `gen-<id>` (or `sync-<id>`) and `check-<id>` targets to the Makefile.
+#   2. Add an [[artifact]] block below describing them.
+#   3. Set the stage flags to where the check must run, then wire it:
+#        ci        -> add `make check-<id>` to .github/workflows/ci.yml (or another workflow)
+#        make_all  -> add `check-<id>` to the `all:` recipe in the Makefile
+#        pre_commit/pre_push are informational today (the hooks already
+#        run a curated fast subset); the audit does not force them.
+#   4. Run `make check-generated-registry` — it fails until the registry
+#      and the consumers agree.
+#
+# A `check-*` Makefile target that is NOT a generated-artifact drift guard
+# (a behavioural validator, a perf soak, a LOC ratchet, the registry
+# auditor itself) belongs in `[meta].exempt_checks` instead of an
+# [[artifact]] block, so the completeness audit stays meaningful.
+
+[meta]
+# `check-*` Makefile targets that are intentionally NOT generated-artifact
+# drift guards. Every `^check-*:` target in the Makefile must be either an
+# [[artifact]].check below or listed here, so a newly-added drift guard
+# cannot be forgotten.
+exempt_checks = [
+  "check",                          # the umbrella `check: all` alias
+  "check-vm-rss-soak",              # perf/RSS soak, not a sync guard
+  "check-ported-handler-loc",       # LOC ratchet (epic #2293), not a sync guard
+  "check-trigger-examples",         # validates example projects parse, not a mirror
+  "check-docs-model-refs",          # validates docs track provider aliases, not a mirror
+  "check-docs-snippets",            # validates ```harn blocks parse, not a mirror
+  "check-generated-registry",       # the auditor itself
+]
+
+# ---------------------------------------------------------------------------
+# Fully-wired mirrors (gen + check + CI + make all, several also hooked)
+# ---------------------------------------------------------------------------
+
+[[artifact]]
+id = "highlight"
+description = "mdBook syntax-highlight keyword list, from the live lexer + stdlib builtin names."
+gen = "gen-highlight"
+check = "check-highlight"
+outputs = ["docs/theme/harn-keywords.js"]
+sources = ["crates/harn-lexer/src/", "crates/harn-stdlib/src/stdlib/", "crates/harn-vm/src/stdlib.rs", "crates/harn-vm/src/lib.rs", "crates/harn-modules/"]
+ci = true
+make_all = true
+pre_commit = true
+pre_push = true
+
+[[artifact]]
+id = "language-spec"
+description = "docs/src/language-spec.md is a generated mirror of spec/HARN_SPEC.md (the authoring source)."
+gen = "sync-language-spec"
+check = "check-language-spec"
+outputs = ["docs/src/language-spec.md"]
+sources = ["spec/HARN_SPEC.md"]
+ci = true
+make_all = true
+pre_commit = true
+pre_push = true
+
+[[artifact]]
+id = "diagnostics-catalog"
+description = "Diagnostic-code catalog (markdown page + JSON sidecar) from the in-binary registry."
+gen = "sync-diagnostics-catalog"
+check = "check-diagnostics-catalog"
+outputs = ["docs/src/diagnostics.md", "docs/diagnostics-catalog.json"]
+sources = ["crates/harn-parser/src/diagnostic_codes.rs", "crates/harn-parser/src/diagnostic_codes/"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = true
+
+[[artifact]]
+id = "tree-sitter-keywords"
+description = "tree-sitter-harn keyword list mirrors the harn-lexer KEYWORDS const, so the editor grammar and the runtime parser agree on the reserved word set."
+gen = "gen-tree-sitter-keywords"
+check = "check-tree-sitter-keywords"
+outputs = ["tree-sitter-harn/grammar/keywords.js"]
+sources = ["crates/harn-lexer/src/token.rs"]
+ci = true
+make_all = true
+pre_commit = true
+pre_push = true
+
+# ---------------------------------------------------------------------------
+# Mirrors whose drift guard previously ran ONLY in `make all` (and so never
+# in any CI workflow). Flagged ci = true here; this PR wires them into CI.
+# ---------------------------------------------------------------------------
+
+[[artifact]]
+id = "protocol-artifacts"
+description = "Harn Agents Protocol bindings (Rust/TS/Swift + manifest) generated from spec/openapi.yaml and the wire vocabulary."
+gen = "gen-protocol-artifacts"
+check = "check-protocol-artifacts"
+outputs = [
+  "spec/protocol-artifacts/harn-protocol.rs",
+  "spec/protocol-artifacts/harn-protocol.ts",
+  "spec/protocol-artifacts/HarnProtocol.swift",
+  "spec/protocol-artifacts/manifest.json",
+]
+sources = ["spec/openapi.yaml", "crates/harn-cli/src/commands/"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "session-bundle-schema"
+description = "JSON Schema for the session-bundle DTO, generated from the Rust SessionBundle type."
+gen = "gen-session-bundle-schema"
+check = "check-session-bundle-schema"
+outputs = ["spec/schemas/session-bundle.v1.schema.json"]
+sources = ["crates/harn-vm/src/sessions/", "crates/harn-cli/src/commands/session.rs"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "provider-catalog"
+description = "Checked-in provider/model catalog JSON + schema + downstream TS/Swift bindings, exported from the live ProviderCatalog."
+gen = "gen-provider-catalog"
+check = "check-provider-catalog"
+outputs = [
+  "spec/provider-catalog/provider-catalog.json",
+  "spec/provider-catalog/provider-catalog.schema.json",
+  "spec/provider-catalog/harn-provider-catalog.ts",
+  "spec/provider-catalog/HarnProviderCatalog.swift",
+]
+sources = ["crates/harn-vm/src/llm_config.rs", "crates/harn-vm/src/provider_catalog.rs"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "provider-catalog-drift"
+description = "Replays the provider-catalog refresh workflow against bundled HTTP fixtures and checks the rendered drift report + candidate TOML against committed goldens."
+gen = ""  # regenerate with: harn run scripts/update_provider_catalog.harn -- --check --update
+check = "check-provider-catalog-drift"
+outputs = [
+  "scripts/provider_catalog_fixtures/expected_candidate.toml",
+  "scripts/provider_catalog_fixtures/expected_drift_report.md",
+]
+sources = ["scripts/update_provider_catalog.harn", "scripts/provider_catalog_fixtures/", "crates/harn-vm/src/llm/"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "docs-workflow-quickstart"
+description = "Verifies the workflow-authoring quickstart fixtures still produce the bundle digests, executed-node sequences, and connector-status shapes the docs claim."
+gen = ""  # no generated file; this is a docs<->runtime behavioural guard
+check = "check-docs-workflow-quickstart"
+outputs = ["scripts/check_docs_workflow_quickstart.sh"]
+sources = ["docs/src/", "scripts/check_docs_workflow_quickstart.sh"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "receipt-structs"
+description = "Guards against duplicated/divergent copies of the receipt structs that must stay byte-identical across crates."
+gen = ""  # no generated file; structural duplication guard
+check = "check-receipt-structs"
+outputs = ["scripts/check_receipt_struct_duplication.py"]
+sources = ["crates/harn-vm/src/", "crates/harn-hostlib/src/"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+# ---------------------------------------------------------------------------
+# Already-wired CI checks (verified present in a workflow).
+# ---------------------------------------------------------------------------
+
+[[artifact]]
+id = "protocol-bindings-roundtrip"
+description = "Round-trips the published JSON fixture through the Python and Go protocol bindings to catch wire-vocabulary drift."
+gen = ""  # python/go bindings are emitted by dump-protocol-artifacts; this is the roundtrip validator
+check = "check-bindings"
+outputs = [
+  "spec/protocol-artifacts/python/harn_protocol.py",
+  "spec/protocol-artifacts/go/harnprotocol/harnprotocol.go",
+]
+sources = ["spec/protocol-artifacts/python/", "spec/protocol-artifacts/go/", "scripts/check_protocol_bindings.py"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "trigger-quickref"
+description = "LLM trigger quickref doc generated from the live ProviderCatalog metadata."
+gen = "gen-trigger-quickref"
+check = "check-trigger-quickref"
+outputs = ["docs/llm/harn-triggers-quickref.md"]
+sources = ["crates/harn-vm/src/llm/", "crates/harn-vm/src/provider_catalog.rs"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "provider-matrix"
+description = "Provider/model capability matrix doc generated from capabilities.toml."
+gen = "gen-provider-matrix"
+check = "check-provider-matrix"
+outputs = ["docs/src/provider-matrix.md"]
+sources = ["crates/harn-cli/src/commands/provider_matrix.rs", "crates/harn-vm/src/llm/"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "provider-support"
+description = "Provider support recommendations (markdown + JSON) generated from catalog/capabilities/notes."
+gen = "gen-provider-support"
+check = "check-provider-support"
+outputs = ["docs/src/provider-support.md", "docs/provider-support.json"]
+sources = ["crates/harn-cli/src/cli/providers.rs", "crates/harn-vm/src/llm/"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+[[artifact]]
+id = "connector-matrix"
+description = "Connector capability parity matrix doc generated from package manifests."
+gen = "gen-connector-matrix"
+check = "check-connector-matrix"
+outputs = ["docs/src/connectors/parity-matrix.md"]
+sources = ["crates/harn-cli/portal/", "crates/harn-modules/"]
+ci = true
+make_all = true
+pre_commit = false
+pre_push = false
+
+# ---------------------------------------------------------------------------
+# Cross-repo guard — intentionally NOT in harn CI (needs a sibling
+# burin-code checkout). Runs in release / cross-repo jobs. ci = false.
+# ---------------------------------------------------------------------------
+
+[[artifact]]
+id = "burin-protocol-artifacts"
+description = "Confirms Burin Code's vendored Harn protocol bindings match this checkout. Source of truth is the harn protocol artifacts; the consumer is a sibling repo."
+gen = ""  # regenerate downstream by re-vendoring spec/protocol-artifacts into burin-code
+check = "check-burin-protocol-artifacts"
+outputs = ["spec/protocol-artifacts/HarnProtocol.swift", "spec/protocol-artifacts/harn-protocol.ts"]
+sources = ["spec/protocol-artifacts/"]
+ci = false  # requires BURIN_CODE_ROOT / a sibling burin-code checkout; runs in release + cross-repo jobs only
+make_all = false  # excluded from `make all` for the same reason (no sibling checkout locally)
+pre_commit = false
+pre_push = false

--- a/scripts/sync_tree_sitter_keywords.py
+++ b/scripts/sync_tree_sitter_keywords.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Keep the tree-sitter-harn keyword list in sync with the lexer.
+
+`crates/harn-lexer/src/token.rs` defines `pub const KEYWORDS: &[&str]`, the
+authoritative set of reserved words the runtime parser recognises.
+`tree-sitter-harn/grammar/keywords.js` re-declares the same set so the
+editor grammar (highlighting, structural editing, the LSP fallback parser)
+agrees with the runtime on what is a keyword. Nothing previously checked
+that these two lists stayed equal, so a keyword added to the language could
+silently never reach tree-sitter.
+
+Usage:
+  sync_tree_sitter_keywords.py            # drift check (default); exit 1 on mismatch
+  sync_tree_sitter_keywords.py --write    # rewrite keywords.js from the lexer
+
+The check is intentionally a *set* comparison: the grammar file keeps its
+own hand-curated comments and ordering (keywords are grouped by feature
+there, not alphabetised), so only membership must match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOKEN_RS = REPO_ROOT / "crates" / "harn-lexer" / "src" / "token.rs"
+KEYWORDS_JS = REPO_ROOT / "tree-sitter-harn" / "grammar" / "keywords.js"
+
+STRING_RE = re.compile(r'"([^"\\]*)"')
+
+
+def lexer_keywords() -> set[str]:
+    text = TOKEN_RS.read_text(encoding="utf-8")
+    m = re.search(r"pub const KEYWORDS:\s*&\[&str\]\s*=\s*&\[(.*?)\];", text, re.DOTALL)
+    if not m:
+        raise SystemExit(
+            f"error: could not find `pub const KEYWORDS` in {TOKEN_RS}"
+        )
+    return set(STRING_RE.findall(m.group(1)))
+
+
+def grammar_keywords() -> set[str]:
+    text = KEYWORDS_JS.read_text(encoding="utf-8")
+    m = re.search(r"module\.exports\s*=\s*\[(.*?)\];", text, re.DOTALL)
+    if not m:
+        raise SystemExit(
+            f"error: could not find `module.exports = [ ... ]` in {KEYWORDS_JS}"
+        )
+    # Strip // line comments so commented prose isn't scanned for strings.
+    body = re.sub(r"//[^\n]*", "", m.group(1))
+    return set(STRING_RE.findall(body))
+
+
+def write_keywords_js(keywords: set[str]) -> None:
+    ordered = sorted(keywords)
+    lines = [
+        "// @generated from crates/harn-lexer/src/token.rs (KEYWORDS).",
+        "// Regenerate with `make gen-tree-sitter-keywords`; the lexer is the",
+        "// source of truth. `make check-tree-sitter-keywords` guards drift.",
+        "module.exports = [",
+    ]
+    lines += [f'  "{kw}",' for kw in ordered]
+    lines.append("];")
+    KEYWORDS_JS.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="rewrite keywords.js from the lexer instead of just checking.",
+    )
+    args = parser.parse_args()
+
+    lexer = lexer_keywords()
+    grammar = grammar_keywords()
+
+    if args.write:
+        write_keywords_js(lexer)
+        print(f"    Wrote {len(lexer)} keywords to {KEYWORDS_JS.relative_to(REPO_ROOT)}.")
+        return 0
+
+    missing = lexer - grammar  # in lexer, absent from grammar
+    extra = grammar - lexer  # in grammar, not a real keyword
+
+    if missing or extra:
+        print(
+            "error: tree-sitter keyword list is out of sync with the lexer "
+            "(crates/harn-lexer/src/token.rs KEYWORDS):",
+            file=sys.stderr,
+        )
+        if missing:
+            print(
+                f"  - missing from tree-sitter-harn/grammar/keywords.js: "
+                f"{', '.join(sorted(missing))}",
+                file=sys.stderr,
+            )
+        if extra:
+            print(
+                f"  - present in keywords.js but not a lexer keyword: "
+                f"{', '.join(sorted(extra))}",
+                file=sys.stderr,
+            )
+        print(
+            "\nhint: run `make gen-tree-sitter-keywords` to regenerate from the "
+            "lexer, or reconcile the lists by hand.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"    tree-sitter keyword list OK ({len(lexer)} keywords).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The repo has a mature "source of truth → generated/mirrored file + drift check" pattern — ~15 `gen-*`/`check-*` pairs (highlight keywords, language-spec mirror, protocol bindings, provider catalog, diagnostics catalog, …). But the pairs were enumerated **independently in four places** — the Makefile `all:` recipe, `ci.yml`, `.githooks/pre-commit`, `.githooks/pre-push` — with **nothing forcing them to agree**.

They had already drifted. **Seven `check-*` drift guards existed only in `make all` and ran in zero CI workflows:**

- `check-protocol-artifacts`, `check-session-bundle-schema`, `check-provider-catalog`, `check-provider-catalog-drift`, `check-docs-workflow-quickstart`, `check-receipt-structs`, and (new here) `check-tree-sitter-keywords`.

A contributor could edit `spec/openapi.yaml` or the `SessionBundle` DTO and ship stale generated artifacts with **green CI**. Wiring `check-docs-workflow-quickstart` immediately surfaced a real pre-existing stale pin (see below).

## What this does

**1. A single source of truth — `scripts/generated_artifacts.toml`.** One declarative registry of every gen/check pair: sources, outputs, gen/check targets, and stage flags (`ci`, `make_all`, …).

**2. A meta-audit — `make check-generated-registry`** (`scripts/check_generated_registry.py`, pure-Python, no `harn` build). Fails when the registry disagrees with reality:
- a `gen-*`/`sync-*` or `check-*` Makefile target that isn't registered (or explicitly exempted);
- a registered target that doesn't exist;
- `ci = true` but the check is referenced in no workflow (drift wouldn't fail a PR);
- `make_all = true` but the check is missing from `all:`;
- a declared output file that doesn't exist.

A new gen/check pair can no longer silently skip CI.

**3. Closed the 7 CI gaps.** Cargo-dependent checks → the warm-binary `harn-audit` lane; pure-Python checks → the `audit-scripts` lane.

**4. New cross-crate guard — `make {gen,check}-tree-sitter-keywords`.** Keeps the tree-sitter grammar's reserved-word set equal to the lexer `KEYWORDS` const (set comparison, so the hand-curated grouping in `keywords.js` survives). Previously only loosely checked at release time.

**5. Fixed a pre-existing stale pin.** Wiring `check-docs-workflow-quickstart` revealed the workflow-authoring quickstart's `graph_digest` had drifted from the runtime (last set in #2758). Re-pinned the docs page + check to the current deterministic value.

**6. Wired both pure-Python guards into pre-commit/pre-push** (gated on the relevant paths) and documented the registry in `AGENTS.md`.

## Verification

- `make check-generated-registry` → OK (16 artifacts, 7 exempt checks)
- Full drift-check sweep (all 15 registered checks) → all pass
- `make lint-py` (ruff) → clean; `make lint-md`, `make lint-actions` → clean
- pre-commit (workspace clippy + ratchets + registry + markdown + actions) and pre-push hooks passed on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)