### PR TITLE
Key locks per resource: mutex(resource) {} + per-call-site mutex {}

### DIFF
--- a/changelog.d/keyed-mutex-locks.breaking.md
+++ b/changelog.d/keyed-mutex-locks.breaking.md
@@ -1,0 +1,10 @@
+- **`mutex { ... }` blocks are no longer one process-wide lock.** A bare
+  `mutex { ... }` now keys on its own lexical call-site, so two *distinct*
+  `mutex {}` blocks run concurrently instead of silently serializing against
+  each other. To guard a shared resource, name it: `mutex(resource) { ... }`
+  acquires a lock keyed on the resource's structural value, so every block
+  naming the same resource mutually excludes regardless of where it appears.
+  Code that relied on every `mutex {}` contending on a single global lock must
+  switch to an explicit shared key. Re-acquiring the *same* key on one task
+  still raises `HARN-ORC-011` (self-deadlock), and locks are still released
+  automatically on scope exit and on `throw`.

--- a/conformance/tests/concurrency/mutex_distinct_sites_no_deadlock.expected
+++ b/conformance/tests/concurrency/mutex_distinct_sites_no_deadlock.expected
@@ -1,0 +1,1 @@
+[harn] nested bare blocks are independent locks

--- a/conformance/tests/concurrency/mutex_distinct_sites_no_deadlock.harn
+++ b/conformance/tests/concurrency/mutex_distinct_sites_no_deadlock.harn
@@ -1,0 +1,9 @@
+pipeline test(task) {
+  // Two distinct bare `mutex {}` blocks key on their own lexical call-sites,
+  // so nesting them no longer self-deadlocks (they are independent locks).
+  mutex {
+    mutex {
+      log("nested bare blocks are independent locks")
+    }
+  }
+}

--- a/conformance/tests/concurrency/mutex_keyed_distinct.expected
+++ b/conformance/tests/concurrency/mutex_keyed_distinct.expected
@@ -1,0 +1,1 @@
+[harn] distinct keys do not deadlock

--- a/conformance/tests/concurrency/mutex_keyed_distinct.harn
+++ b/conformance/tests/concurrency/mutex_keyed_distinct.harn
@@ -1,0 +1,9 @@
+pipeline test(task) {
+  // Distinct resource keys are distinct locks, so nesting them does not
+  // deadlock; the same key re-entered would (see mutex_self_reacquire_deadlock).
+  mutex("a") {
+    mutex("b") {
+      log("distinct keys do not deadlock")
+    }
+  }
+}

--- a/conformance/tests/concurrency/mutex_release_on_throw.expected
+++ b/conformance/tests/concurrency/mutex_release_on_throw.expected
@@ -1,2 +1,2 @@
 true
-true
+reacquired

--- a/conformance/tests/concurrency/mutex_release_on_throw.harn
+++ b/conformance/tests/concurrency/mutex_release_on_throw.harn
@@ -1,11 +1,14 @@
 pipeline test(task) {
   let result = try {
-    mutex {
+    mutex("L") {
       throw "boom"
     }
   }
   __io_println(is_err(result))
-  let permit = sync_mutex_acquire("__default__", 0)
-  __io_println(permit != nil)
-  sync_release(permit)
+  // If the throw above failed to release the "L" lock, re-acquiring the same
+  // keyed mutex would self-deadlock (HARN-ORC-011). Reaching the body proves
+  // the guard was released during unwind.
+  mutex("L") {
+    __io_println("reacquired")
+  }
 }

--- a/conformance/tests/concurrency/mutex_self_reacquire_deadlock.harn
+++ b/conformance/tests/concurrency/mutex_self_reacquire_deadlock.harn
@@ -1,7 +1,7 @@
 pipeline test(task) {
-  mutex {
-    mutex {
-      log("unreachable: the inner acquire self-deadlocks")
+  mutex("resource") {
+    mutex("resource") {
+      log("unreachable: re-acquiring the same keyed mutex self-deadlocks")
     }
   }
 }

--- a/crates/harn-cli/src/commands/check/bundle.rs
+++ b/crates/harn-cli/src/commands/check/bundle.rs
@@ -315,7 +315,7 @@ fn node_children_bundle(node: &SNode) -> Vec<&SNode> {
         | Node::Block(body)
         | Node::Closure { body, .. }
         | Node::TryExpr { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::DeferStmt { body } => body.iter().collect(),
         Node::DeadlineBlock { duration, body } => {
             let mut children = vec![duration.as_ref()];

--- a/crates/harn-cli/src/commands/check/mock_host.rs
+++ b/crates/harn-cli/src/commands/check/mock_host.rs
@@ -38,7 +38,7 @@ fn collect_mock_host_capabilities_from_node(
         | Node::ToolDecl { body, .. }
         | Node::SpawnExpr { body }
         | Node::TryExpr { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::DeferStmt { body }
         | Node::Block(body)
         | Node::Closure { body, .. } => {

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -257,7 +257,7 @@ fn spawn_site_children(node: &SNode) -> Vec<&SNode> {
         | Node::Retry { body, .. }
         | Node::TryExpr { body }
         | Node::DeferStmt { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::Block(body)
         | Node::OverrideDecl { body, .. } => children.extend(body.iter()),
         Node::IfElse {
@@ -481,7 +481,7 @@ fn collect_static_tool_surface_from_node(
         | Node::ToolDecl { body, .. }
         | Node::SpawnExpr { body }
         | Node::DeferStmt { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::Block(body)
         | Node::Closure { body, .. }
         | Node::TryExpr { body } => {
@@ -1451,7 +1451,7 @@ fn scan_node_preflight(
         }
         Node::TryExpr { body }
         | Node::SpawnExpr { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::DeferStmt { body } => {
             scan_children(
                 body,

--- a/crates/harn-cli/src/commands/run/explain_cost.rs
+++ b/crates/harn-cli/src/commands/run/explain_cost.rs
@@ -98,7 +98,7 @@ impl CostAnalyzer {
             | Node::Block(body)
             | Node::Closure { body, .. }
             | Node::DeferStmt { body }
-            | Node::MutexBlock { body } => self.walk_nodes(body),
+            | Node::MutexBlock { body, .. } => self.walk_nodes(body),
             Node::SkillDecl { fields, .. } => {
                 for (_, value) in fields {
                     self.walk_node(value);

--- a/crates/harn-cli/src/commands/viz.rs
+++ b/crates/harn-cli/src/commands/viz.rs
@@ -240,7 +240,7 @@ impl MermaidGraph {
             Node::DeadlineBlock { duration, body } => {
                 self.emit_named_block(&format!("deadline {}", inline_label(duration)), body)
             }
-            Node::MutexBlock { body } => self.emit_named_block("mutex", body),
+            Node::MutexBlock { body, .. } => self.emit_named_block("mutex", body),
             Node::Parallel {
                 mode,
                 expr,

--- a/crates/harn-cli/src/provider_bootstrap.rs
+++ b/crates/harn-cli/src/provider_bootstrap.rs
@@ -301,7 +301,7 @@ fn node_uses_provider_llm(node: &SNode, shadows: &HashSet<String>) -> bool {
         | Node::ToolDecl { body, .. }
         | Node::SpawnExpr { body }
         | Node::DeferStmt { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::TryExpr { body }
         | Node::Block(body)
         | Node::Closure { body, .. } => nodes_use_provider_llm(body, shadows),

--- a/crates/harn-fmt/src/formatter/decls.rs
+++ b/crates/harn-fmt/src/formatter/decls.rs
@@ -469,8 +469,14 @@ impl Formatter<'_> {
                 self.dedent();
                 self.writeln("}");
             }
-            Node::MutexBlock { body } => {
-                self.writeln("mutex {");
+            Node::MutexBlock { key, body } => {
+                match key {
+                    Some(key_expr) => {
+                        let k = self.format_expr(key_expr, self.indent);
+                        self.writeln(&format!("mutex({k}) {{"));
+                    }
+                    None => self.writeln("mutex {"),
+                }
                 self.indent();
                 self.format_body(body, node_line);
                 self.dedent();

--- a/crates/harn-fmt/src/formatter/expressions.rs
+++ b/crates/harn-fmt/src/formatter/expressions.rs
@@ -371,7 +371,13 @@ impl Formatter<'_> {
                 let dur = self.format_expr(duration, indent);
                 self.format_block_expr(&format!("deadline {dur} {{"), body, indent)
             }
-            Node::MutexBlock { body } => self.format_block_expr("mutex {", body, indent),
+            Node::MutexBlock { key, body } => match key {
+                Some(key_expr) => {
+                    let k = self.format_expr(key_expr, indent);
+                    self.format_block_expr(&format!("mutex({k}) {{"), body, indent)
+                }
+                None => self.format_block_expr("mutex {", body, indent),
+            },
             Node::IfElse {
                 condition,
                 then_body,

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -24,6 +24,22 @@ fn test_roundtrip_basic() {
 }
 
 #[test]
+fn test_roundtrip_mutex_bare() {
+    assert_roundtrip("pipeline default(task) { mutex { log(1) } }");
+}
+
+#[test]
+fn test_roundtrip_mutex_keyed_preserves_key() {
+    let source = "pipeline default(task) { mutex(\"acct\") { log(1) } }";
+    let formatted = format_source(source).unwrap();
+    assert!(
+        formatted.contains("mutex(\"acct\")"),
+        "keyed mutex must preserve its resource key:\n{formatted}"
+    );
+    assert_roundtrip(source);
+}
+
+#[test]
 fn test_roundtrip_fn_decl() {
     assert_roundtrip("pipeline default(task) { fn add(a, b) { return a + b }\nlog(add(1, 2)) }");
 }

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -1594,7 +1594,7 @@ impl<'a> HandlerIrBuilder<'a> {
             Node::TryExpr { body }
             | Node::SpawnExpr { body }
             | Node::DeferStmt { body }
-            | Node::MutexBlock { body }
+            | Node::MutexBlock { body, .. }
             | Node::Block(body) => self.build_block(body, incoming),
             Node::DeadlineBlock { duration, body } => {
                 let duration_exits = self.build_expr(duration, incoming);

--- a/crates/harn-lint/src/complexity.rs
+++ b/crates/harn-lint/src/complexity.rs
@@ -109,7 +109,7 @@ pub(crate) fn cyclomatic_complexity(nodes: &[SNode]) -> usize {
                 duration: expr,
                 body,
             } => node_complexity(expr) + body_complexity(body),
-            Node::MutexBlock { body }
+            Node::MutexBlock { body, .. }
             | Node::TryExpr { body }
             | Node::DeferStmt { body }
             | Node::Block(body)

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -1602,7 +1602,7 @@ impl<'a> Linter<'a> {
             Node::TryExpr { body }
             | Node::SpawnExpr { body }
             | Node::DeferStmt { body }
-            | Node::MutexBlock { body }
+            | Node::MutexBlock { body, .. }
             | Node::Block(body)
             | Node::Closure { body, .. } => self.collect_persona_calls(persona_name, body),
             Node::DeadlineBlock { duration, body } => {

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -979,7 +979,7 @@ impl<'a> Linter<'a> {
                 self.pop_scope();
             }
 
-            Node::MutexBlock { body } => {
+            Node::MutexBlock { body, .. } => {
                 self.push_scope();
                 self.lint_block(body);
                 self.pop_scope();

--- a/crates/harn-lint/src/rules/deprecated_llm_options.rs
+++ b/crates/harn-lint/src/rules/deprecated_llm_options.rs
@@ -111,7 +111,7 @@ fn visit_node(node: &SNode, diagnostics: &mut Vec<LintDiagnostic>) {
         Node::TryExpr { body }
         | Node::SpawnExpr { body }
         | Node::DeferStmt { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::Block(body)
         | Node::Closure { body, .. } => visit_nodes(body, diagnostics),
         Node::FnDecl { body, .. } | Node::ToolDecl { body, .. } => visit_nodes(body, diagnostics),

--- a/crates/harn-lint/src/rules/optional_shorthand.rs
+++ b/crates/harn-lint/src/rules/optional_shorthand.rs
@@ -178,7 +178,7 @@ impl<'a, 'd> State<'a, 'd> {
             | Node::SpawnExpr { body }
             | Node::Block(body)
             | Node::DeferStmt { body }
-            | Node::MutexBlock { body } => self.visit_block(body),
+            | Node::MutexBlock { body, .. } => self.visit_block(body),
             Node::DeadlineBlock { duration, body } => {
                 self.visit_node(duration);
                 self.visit_block(body);

--- a/crates/harn-lint/src/rules/unnecessary_parentheses.rs
+++ b/crates/harn-lint/src/rules/unnecessary_parentheses.rs
@@ -100,6 +100,9 @@ fn opening_is_required_by_context(tokens: &[Token], open_idx: usize) -> bool {
                 | TokenKind::DualControl
                 | TokenKind::AskUser
                 | TokenKind::EscalateTo
+                // `mutex(resource) { ... }`: the parens delimit the lock's
+                // resource key and are required grammar, not redundant grouping.
+                | TokenKind::Mutex
         )
     })
 }

--- a/crates/harn-lint/src/tests/unnecessary_parentheses.rs
+++ b/crates/harn-lint/src/tests/unnecessary_parentheses.rs
@@ -23,6 +23,23 @@ fn test_unnecessary_parentheses_autofixes_ternary_list_branch() {
 }
 
 #[test]
+fn test_unnecessary_parentheses_ignores_keyed_mutex_parens() {
+    // `mutex(resource)` parens are required grammar (the lock key), not
+    // redundant grouping — stripping them would produce unparseable source.
+    let source = r#"pipeline default(task) {
+  mutex("a") {
+    log(1)
+  }
+}
+"#;
+    let diags = lint_source(source);
+    assert!(
+        !has_rule(&diags, "unnecessary-parentheses"),
+        "keyed mutex parens must not be flagged, got: {diags:?}"
+    );
+}
+
+#[test]
 fn test_unnecessary_parentheses_autofixes_simple_return_value() {
     let source = r"fn repo_arg(repo) {
   return ( repo )

--- a/crates/harn-lsp/src/call_hierarchy.rs
+++ b/crates/harn-lsp/src/call_hierarchy.rs
@@ -307,7 +307,7 @@ fn visit_children_for_callables(node: &SNode, callables: &mut Vec<CallableInfo>)
         | Node::TryExpr { body: stmts }
         | Node::DeferStmt { body: stmts }
         | Node::DeadlineBlock { body: stmts, .. }
-        | Node::MutexBlock { body: stmts }
+        | Node::MutexBlock { body: stmts, .. }
         | Node::Closure { body: stmts, .. } => {
             for stmt in stmts {
                 collect_callables_in_node(stmt, callables);
@@ -416,7 +416,7 @@ fn visit_child_owners(node: &SNode, owner_span: Span, calls: &mut Vec<CallSite>)
         | Node::TryExpr { body }
         | Node::DeferStmt { body }
         | Node::DeadlineBlock { body, .. }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::Closure { body, .. } => body_contains_owner(body, owner_span, calls),
         Node::TryCatch {
             has_catch: _,
@@ -553,7 +553,7 @@ fn collect_calls(node: &SNode, calls: &mut Vec<CallSite>) {
         | Node::TryExpr { body: stmts }
         | Node::DeferStmt { body: stmts }
         | Node::DeadlineBlock { body: stmts, .. }
-        | Node::MutexBlock { body: stmts }
+        | Node::MutexBlock { body: stmts, .. }
         | Node::Closure { body: stmts, .. } => collect_calls_in_body(stmts, calls),
         Node::Parallel {
             expr,

--- a/crates/harn-lsp/src/folding.rs
+++ b/crates/harn-lsp/src/folding.rs
@@ -66,7 +66,7 @@ fn collect_ast_ranges(
         | Node::TryExpr { body }
         | Node::DeferStmt { body }
         | Node::DeadlineBlock { body, .. }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::Closure { body, .. } => {
             push_span_range(ranges, seen, &node.span, Some(FoldingRangeKind::Region));
             collect_body_ranges(body, ranges, seen);

--- a/crates/harn-lsp/src/handlers/completion.rs
+++ b/crates/harn-lsp/src/handlers/completion.rs
@@ -440,7 +440,7 @@ where
         | Node::Closure { body, .. }
         | Node::TryExpr { body }
         | Node::SpawnExpr { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::DeferStmt { body } => visit_nodes(body, visitor),
         Node::MatchExpr { value, arms } => {
             visit_node(value, visitor);

--- a/crates/harn-lsp/src/handlers/definition.rs
+++ b/crates/harn-lsp/src/handlers/definition.rs
@@ -442,7 +442,7 @@ fn node_children(node: &SNode) -> Vec<&SNode> {
         | Node::Block(body)
         | Node::Closure { body, .. }
         | Node::TryExpr { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::DeferStmt { body } => body.iter().collect(),
         Node::FnDecl { body, .. } | Node::ToolDecl { body, .. } => body.iter().collect(),
         Node::IfElse {

--- a/crates/harn-lsp/src/references.rs
+++ b/crates/harn-lsp/src/references.rs
@@ -206,7 +206,7 @@ fn collect_references(snode: &SNode, target_name: &str, refs: &mut Vec<Span>) {
         }
         Node::Block(stmts)
         | Node::SpawnExpr { body: stmts }
-        | Node::MutexBlock { body: stmts }
+        | Node::MutexBlock { body: stmts, .. }
         | Node::DeferStmt { body: stmts } => {
             for s in stmts {
                 collect_references(s, target_name, refs);

--- a/crates/harn-lsp/src/symbols.rs
+++ b/crates/harn-lsp/src/symbols.rs
@@ -866,7 +866,7 @@ fn collect_symbols(
             recurse!(true_expr, scope_span);
             recurse!(false_expr, scope_span);
         }
-        Node::SpawnExpr { body } | Node::MutexBlock { body } | Node::DeferStmt { body } => {
+        Node::SpawnExpr { body } | Node::MutexBlock { body, .. } | Node::DeferStmt { body } => {
             for s in body {
                 recurse!(s, scope_span);
             }

--- a/crates/harn-modules/src/personas.rs
+++ b/crates/harn-modules/src/personas.rs
@@ -633,7 +633,7 @@ fn collect_called_functions_node(node: &SNode, calls: &mut Vec<String>) {
         Node::TryExpr { body }
         | Node::SpawnExpr { body }
         | Node::DeferStmt { body }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::Block(body)
         | Node::Closure { body, .. } => collect_many(body, calls),
         Node::DeadlineBlock { duration, body } => {

--- a/crates/harn-parser/src/ast.rs
+++ b/crates/harn-parser/src/ast.rs
@@ -309,7 +309,14 @@ pub enum Node {
         value: Box<SNode>,
     },
     /// Mutex block: mutual exclusion for concurrent access.
+    ///
+    /// `key` is the optional resource expression in `mutex(resource) { ... }`.
+    /// When present, all blocks acquiring the same structural key value
+    /// mutually exclude; when absent (`mutex { ... }`), the block keys on its
+    /// own lexical call-site, so two distinct `mutex {}` blocks no longer
+    /// serialize against each other.
     MutexBlock {
+        key: Option<Box<SNode>>,
         body: Vec<SNode>,
     },
     /// Break out of a loop.

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -23,6 +23,33 @@ mod tests {
     }
 
     #[test]
+    fn parses_bare_and_keyed_mutex() {
+        fn first_mutex_has_key(source: &str) -> Option<bool> {
+            let program = parse_source(source).unwrap();
+            let mut has_key = None;
+            crate::visit::walk_program(&program, &mut |node| {
+                if has_key.is_none() {
+                    if let Node::MutexBlock { key, .. } = &node.node {
+                        has_key = Some(key.is_some());
+                    }
+                }
+            });
+            has_key
+        }
+
+        assert_eq!(
+            first_mutex_has_key("pipeline default(task) { mutex { log(1) } }"),
+            Some(false),
+            "bare `mutex {{}}` should parse with no key"
+        );
+        assert_eq!(
+            first_mutex_has_key("pipeline default(task) { mutex(\"acct\") { log(1) } }"),
+            Some(true),
+            "`mutex(resource) {{}}` should parse with a key"
+        );
+    }
+
+    #[test]
     fn parser_reports_expression_nesting_depth_limit() {
         let depth = state::MAX_NESTING_DEPTH + 1;
         let source = format!("let x = {}0{}", "(".repeat(depth), ")".repeat(depth));

--- a/crates/harn-parser/src/parser/statements.rs
+++ b/crates/harn-parser/src/parser/statements.rs
@@ -801,11 +801,22 @@ impl Parser {
     pub(super) fn parse_mutex(&mut self) -> Result<SNode, ParserError> {
         let start = self.current_span();
         self.consume(&TokenKind::Mutex, "mutex")?;
+        // Optional resource key: `mutex(resource) { ... }`. Blocks sharing the
+        // same structural key value mutually exclude; a bare `mutex { ... }`
+        // keys on its lexical call-site instead of one process-wide lock.
+        let key = if self.check(&TokenKind::LParen) {
+            self.consume(&TokenKind::LParen, "(")?;
+            let expr = self.parse_expression()?;
+            self.consume(&TokenKind::RParen, ")")?;
+            Some(Box::new(expr))
+        } else {
+            None
+        };
         self.consume(&TokenKind::LBrace, "{")?;
         let body = self.parse_block()?;
         self.consume(&TokenKind::RBrace, "}")?;
         Ok(spanned(
-            Node::MutexBlock { body },
+            Node::MutexBlock { key, body },
             Span::merge(start, self.prev_span()),
         ))
     }

--- a/crates/harn-parser/src/typechecker/exits.rs
+++ b/crates/harn-parser/src/typechecker/exits.rs
@@ -28,7 +28,7 @@ pub fn stmt_definitely_exits(stmt: &SNode) -> bool {
         Node::Block(body)
         | Node::TryExpr { body }
         | Node::CostRoute { body, .. }
-        | Node::MutexBlock { body }
+        | Node::MutexBlock { body, .. }
         | Node::DeadlineBlock { body, .. }
         | Node::Retry { body, .. } => block_definitely_exits(body),
         Node::TryCatch {

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -849,7 +849,7 @@ impl TypeChecker {
             | Node::WhileLoop { body, .. }
             | Node::Retry { body, .. }
             | Node::DeferStmt { body }
-            | Node::MutexBlock { body }
+            | Node::MutexBlock { body, .. }
             | Node::Parallel { body, .. } => {
                 for s in body {
                     self.visit_for_deprecation(s);

--- a/crates/harn-parser/src/typechecker/inference/decls.rs
+++ b/crates/harn-parser/src/typechecker/inference/decls.rs
@@ -52,7 +52,7 @@ impl TypeChecker {
             | Node::Retry { body, .. }
             | Node::CostRoute { body, .. }
             | Node::DeferStmt { body }
-            | Node::MutexBlock { body }
+            | Node::MutexBlock { body, .. }
             | Node::Parallel { body, .. }
             | Node::TryExpr { body } => Self::body_contains_yield(body),
             Node::IfElse {
@@ -309,7 +309,7 @@ impl TypeChecker {
             Node::Block(body)
             | Node::TryExpr { body }
             | Node::CostRoute { body, .. }
-            | Node::MutexBlock { body }
+            | Node::MutexBlock { body, .. }
             | Node::DeadlineBlock { body, .. }
             | Node::Retry { body, .. } => self.body_cannot_fall_through(body, scope),
             Node::TryCatch {
@@ -446,7 +446,7 @@ impl TypeChecker {
             Node::Block(body)
             | Node::TryExpr { body }
             | Node::CostRoute { body, .. }
-            | Node::MutexBlock { body }
+            | Node::MutexBlock { body, .. }
             | Node::DeadlineBlock { body, .. }
             | Node::Retry { body, .. } => {
                 let mut block_scope = scope.child();

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -75,7 +75,7 @@ impl TypeChecker {
                 | Node::CostRoute { body, .. }
                 | Node::WhileLoop { body, .. }
                 | Node::DeferStmt { body }
-                | Node::MutexBlock { body }
+                | Node::MutexBlock { body, .. }
                 | Node::DeadlineBlock { body, .. }
                 | Node::Pipeline { body, .. }
                 | Node::OverrideDecl { body, .. } => {

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -1506,7 +1506,15 @@ impl TypeChecker {
                 self.check_block(body, &mut block_scope);
             }
 
-            Node::MutexBlock { body } | Node::DeferStmt { body } => {
+            Node::MutexBlock { key, body } => {
+                if let Some(key) = key {
+                    self.check_node(key, scope);
+                }
+                let mut block_scope = scope.child();
+                self.check_block(body, &mut block_scope);
+            }
+
+            Node::DeferStmt { body } => {
                 let mut block_scope = scope.child();
                 self.check_block(body, &mut block_scope);
             }

--- a/crates/harn-parser/src/visit.rs
+++ b/crates/harn-parser/src/visit.rs
@@ -151,9 +151,14 @@ fn collect_children<'a>(node: &'a SNode, children: &mut Vec<&'a SNode>) {
         Node::TryExpr { body }
         | Node::SpawnExpr { body }
         | Node::DeferStmt { body }
-        | Node::MutexBlock { body }
         | Node::Block(body)
         | Node::Closure { body, .. } => collect_nodes(body, children),
+        Node::MutexBlock { key, body } => {
+            if let Some(key) = key {
+                children.push(key);
+            }
+            collect_nodes(body, children);
+        }
         Node::FnDecl { body, .. } | Node::ToolDecl { body, .. } => {
             collect_nodes(body, children);
         }

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -618,8 +618,9 @@ fn op_stack_delta(op: Op, count: u16) -> Option<i32> {
         // ops, and variadic ops whose arity isn't the emit argument.
         Jump | JumpIfFalse | JumpIfTrue | IterNext | Return | TailCall | Throw | TryCatchSetup
         | Spawn | Pipe | Parallel | ParallelMap | ParallelMapStream | ParallelSettle
-        | SyncMutexEnter | Import | SelectiveImport | DeadlineSetup | DeadlineEnd | BuildEnum
-        | MatchEnum | Yield | CallSpread | CallBuiltinSpread | MethodCallSpread => return None,
+        | SyncMutexEnter | SyncMutexEnterKeyed | Import | SelectiveImport | DeadlineSetup
+        | DeadlineEnd | BuildEnum | MatchEnum | Yield | CallSpread | CallBuiltinSpread
+        | MethodCallSpread => return None,
     })
 }
 

--- a/crates/harn-vm/src/compiler/mod.rs
+++ b/crates/harn-vm/src/compiler/mod.rs
@@ -451,11 +451,23 @@ impl Compiler {
                 self.compile_scoped_block(body)?;
                 self.chunk.emit(Op::DeadlineEnd, self.line);
             }
-            Node::MutexBlock { body } => {
+            Node::MutexBlock { key, body } => {
                 self.begin_scope();
                 let finally_floor = self.finally_bodies.len();
-                let key_idx = self.string_constant("__default__");
-                self.chunk.emit_u16(Op::SyncMutexEnter, key_idx, self.line);
+                match key {
+                    // `mutex(resource) { ... }`: evaluate the resource and key
+                    // the lock on its structural value at runtime.
+                    Some(key_expr) => {
+                        self.compile_node(key_expr)?;
+                        self.chunk.emit(Op::SyncMutexEnterKeyed, self.line);
+                    }
+                    // `mutex { ... }`: key on the lexical call-site (computed in
+                    // the VM from the chunk + instruction pointer) so distinct
+                    // blocks don't contend on one global lock.
+                    None => {
+                        self.chunk.emit(Op::SyncMutexEnter, self.line);
+                    }
+                }
                 for sn in body {
                     self.compile_discarded_stmt(sn)?;
                 }

--- a/crates/harn-vm/src/orchestration/policy/effects.rs
+++ b/crates/harn-vm/src/orchestration/policy/effects.rs
@@ -494,9 +494,12 @@ fn child_nodes(node: &SNode) -> Vec<&SNode> {
         | Node::Retry { body, .. }
         | Node::TryExpr { body }
         | Node::DeferStmt { body }
-        | Node::MutexBlock { body }
         | Node::Block(body)
         | Node::OverrideDecl { body, .. } => children.extend(body.iter()),
+        Node::MutexBlock { key, body } => {
+            children.extend(key.as_deref());
+            children.extend(body.iter());
+        }
         Node::ImplBlock { methods, .. } => children.extend(methods.iter()),
         Node::IfElse {
             condition,

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -116,7 +116,8 @@ harn_opcode_macros::define_opcodes! {
     ParallelMapStream { async_op(self.execute_parallel_map_stream().await), disasm: bare("PARALLEL_MAP_STREAM") };
     ParallelSettle { async_op(self.execute_parallel_settle().await), disasm: bare("PARALLEL_SETTLE") };
     Spawn { sync(self.execute_spawn()), disasm: bare("SPAWN") };
-    SyncMutexEnter { async_op(self.execute_sync_mutex_enter().await), disasm: const_pool_u16("SYNC_MUTEX_ENTER") };
+    SyncMutexEnter { async_op(self.execute_sync_mutex_enter().await), disasm: bare("SYNC_MUTEX_ENTER") };
+    SyncMutexEnterKeyed { async_op(self.execute_sync_mutex_enter_keyed().await), disasm: bare("SYNC_MUTEX_ENTER_KEYED") };
 
     // === Imports (async) ===
     Import { async_op(self.execute_import_op().await), disasm: const_pool_u16("IMPORT") };

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -6,6 +6,18 @@ use crate::value::{DeadlockError, VmError, VmStream, VmStreamCancel, VmTaskHandl
 
 use super::super::CallArgs;
 
+/// Human-readable rendering of a `mutex(resource)` key for diagnostics
+/// (e.g. the HARN-ORC-011 deadlock message). Scalars render as themselves;
+/// anything structural falls back to the stable structural key.
+fn mutex_resource_display(v: &VmValue) -> String {
+    match v {
+        VmValue::String(s) => s.to_string(),
+        VmValue::Int(n) => n.to_string(),
+        VmValue::Bool(b) => b.to_string(),
+        _ => crate::value::value_structural_hash_key(v),
+    }
+}
+
 /// Decode the `cap_val` stack operand pushed by `parallel ... with
 /// { max_concurrent: N }`. A value of `0` (emitted when no option was
 /// given) and any negative integer both mean "unlimited"; returning
@@ -410,41 +422,64 @@ impl super::super::Vm {
         Ok(())
     }
 
-    // Runtime self-deadlock guard. A lexical `mutex { }` block acquires a
+    /// Bare `mutex { }`: acquire the lock keyed on this block's *lexical
+    /// call-site*. The `(chunk identity, instruction pointer)` pair is stable
+    /// across every execution of this site — including concurrent tasks that
+    /// share the cloned chunk `Arc` — so re-entries of the same block still
+    /// serialize, while two distinct `mutex {}` blocks no longer contend on one
+    /// process-wide lock.
+    pub(super) async fn execute_sync_mutex_enter(&mut self) -> Result<(), VmError> {
+        let frame = self.frames.last().unwrap();
+        let key = format!("@{:x}:{}", Arc::as_ptr(&frame.chunk) as usize, frame.ip);
+        self.sync_mutex_acquire_lexical(key, "<anonymous mutex block>".to_string())
+            .await
+    }
+
+    /// `mutex(resource) { }`: acquire the lock keyed on the resource's
+    /// structural value, so every block naming the same resource mutually
+    /// excludes regardless of where it appears in the source.
+    pub(super) async fn execute_sync_mutex_enter_keyed(&mut self) -> Result<(), VmError> {
+        let resource = self.pop()?;
+        let key = format!("v:{}", crate::value::value_structural_hash_key(&resource));
+        let display = mutex_resource_display(&resource);
+        self.sync_mutex_acquire_lexical(key, display).await
+    }
+
+    // Shared acquire path for both lexical `mutex` forms.
+    //
+    // Runtime self-deadlock guard: a lexical `mutex` block acquires a
     // capacity-1 semaphore with no timeout. If this VM already holds a permit
     // for the same `kind:key`, the acquire can never be granted (the sole
     // permit holder IS the requester, and with no timeout it blocks forever)
     // — a provably-unresolvable self-deadlock with zero false positives.
     //
-    // Deferred follow-ups (not yet covered, to stay false-positive-free):
-    //   * Builtin-path detection (`sync_mutex_acquire`/`sync_rwlock_acquire`):
-    //     those run in a fresh `child_vm()` with an empty held-set and are
-    //     released manually, so a re-acquire is not provably unresolvable
-    //     without threading the parent held-set / holder task ids.
-    //   * Cross-task wait-for-graph cycle detection (A holds L1 waits L2; B
-    //     holds L2 waits L1): needs `VmSyncRuntime` to track per-key holder
-    //     task ids plus per-task "waiting on" edges and a cycle check.
-    pub(super) async fn execute_sync_mutex_enter(&mut self) -> Result<(), VmError> {
-        let (chunk, idx) = {
-            let frame = self.frames.last_mut().unwrap();
-            let idx = frame.chunk.read_u16(frame.ip) as usize;
-            frame.ip += 2;
-            (Arc::clone(&frame.chunk), idx)
-        };
-        let key = Self::const_str(&chunk.constants[idx])?;
-        if self.held_permits_for("mutex", key) >= 1 {
+    // Deferred follow-ups (tracked under the async-safety epic, kept out here to
+    // stay false-positive-free):
+    //   * Cross-context detection across an inline `child_vm()` boundary — the
+    //     child starts with an empty held-set, so a re-acquire from inside an
+    //     async builtin invoked under a held lock is not yet caught. Tracked in
+    //     harn#2803 (propagate the held-set into same-task children).
+    //   * Builtin-path unification (`sync_mutex_acquire`/`sync_rwlock_acquire`):
+    //     harn#2802.
+    //   * Cross-task wait-for-graph cycle detection: harn#2806.
+    async fn sync_mutex_acquire_lexical(
+        &mut self,
+        key: String,
+        display: String,
+    ) -> Result<(), VmError> {
+        if self.held_permits_for("mutex", &key) >= 1 {
             return Err(VmError::Deadlock(Box::new(DeadlockError {
                 kind: "mutex".to_string(),
-                key: key.to_string(),
+                key: display,
                 detail: "re-entrant acquire of a non-reentrant mutex already held by this task"
                     .to_string(),
             })));
         }
         let permit = self
             .sync_runtime
-            .acquire("mutex", key, 1, 1, None, self.cancel_token.clone())
+            .acquire("mutex", &key, 1, 1, None, self.cancel_token.clone())
             .await?
-            .ok_or_else(|| VmError::Runtime(format!("mutex '{key}' timed out")))?;
+            .ok_or_else(|| VmError::Runtime(format!("mutex '{display}' timed out")))?;
         self.held_sync_guards
             .push(crate::synchronization::VmSyncHeldGuard {
                 _permit: permit,

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -326,16 +326,29 @@ Atomic updates mutate the handle and return the previous integer value.
 ## Mutex
 
 `mutex { ... }` is a process-local, fair critical section inherited by
-`spawn` and `parallel` child tasks. It uses the default mutex key
-`"__default__"` and releases automatically when the lexical scope exits,
-including `throw`, `return`, `break`, and caught runtime errors.
+`spawn` and `parallel` child tasks. It releases automatically when the lexical
+scope exits, including `throw`, `return`, `break`, and caught runtime errors.
+
+A bare `mutex { ... }` keys on its own **lexical call-site**, so two distinct
+`mutex {}` blocks are independent locks and do not serialize against each other.
+To guard a shared resource across blocks, name it — `mutex(resource) { ... }`
+keys on the resource expression's structural value, so every block naming the
+same resource mutually excludes regardless of where it appears:
 
 ```harn
 mutex {
-  // only one task executes this block at a time
+  // only one task executes this particular block at a time
   var count = count + 1
 }
+
+mutex(account_id) {
+  // serializes only against other `mutex(account_id)` blocks for the same id
+  apply_charge(account_id)
+}
 ```
+
+Re-acquiring the same key on a single task (e.g. `mutex(x) { mutex(x) { } }`)
+raises `HARN-ORC-011` rather than deadlocking.
 
 Use the named primitives when a workflow needs separate keys, timeouts,
 or observable permits:
@@ -358,7 +371,8 @@ Harn synchronization is intentionally higher-level than OS locks:
 
 | Primitive | Scope | Fairness | Timeout/cancel | Use |
 |---|---|---|---|---|
-| `mutex { ... }` | process-local default key | FIFO | cancellable | Small critical-section updates |
+| `mutex { ... }` | process-local, per-call-site key | FIFO | cancellable | Small critical-section updates |
+| `mutex(resource) { ... }` | process-local, structural-value key | FIFO | cancellable | Guarding a named shared resource |
 | `sync_mutex_acquire(key, timeout?)` | process-local named key | FIFO | returns `nil` on timeout, throws on cancellation | Named critical sections |
 | `sync_rwlock_acquire(key, mode, timeout?)` | process-local named key | FIFO | returns `nil` on timeout, throws on cancellation | Shared readers / exclusive writers |
 | `sync_semaphore_acquire(key, capacity, permits?, timeout?)` | process-local named key | FIFO | returns `nil` on timeout, throws on cancellation | Bounded connector or model work |

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -336,9 +336,17 @@ keys on the resource expression's structural value, so every block naming the
 same resource mutually excludes regardless of where it appears:
 
 ```harn
+fn apply_charge(id) {
+  log(id)
+}
+
+let account_id = "acct-42"
+
+var count = 0
+
 mutex {
   // only one task executes this particular block at a time
-  var count = count + 1
+  count = count + 1
 }
 
 mutex(account_id) {


### PR DESCRIPTION
## Keyed lexical locks — `mutex(resource) { ... }`

First PR of the **async-safety & lock-hardening arc** (#2800). Closes #2801.

### The footgun

Every `mutex { ... }` block in a Harn program keyed on the *same* global
semaphore (`"mutex:__default__"`, capacity 1). Two completely unrelated critical
sections therefore serialized against each other silently — a process-wide lock
masquerading as a local one. This is the single biggest concurrency quirk in the
language and it's invisible at the call-site.

### The change

`mutex` now takes an optional resource key:

```harn
mutex { accounts[a] -= n }        // keyed on THIS call-site
mutex { metrics.hits += 1 }       // keyed on a DIFFERENT call-site — runs concurrently

mutex(account_id) { apply(account_id) }   // keyed on the resource's structural value
// every `mutex(account_id)` for the same id mutually excludes, anywhere in the source
```

- **Bare `mutex { }`** keys on its lexical call-site (chunk identity + instruction
  pointer), computed in the VM. Same block re-entered concurrently still
  serializes; two *distinct* blocks no longer do.
- **`mutex(resource) { }`** keys on the resource expression's structural value
  (`value_structural_hash_key`), so naming the same resource gives mutual
  exclusion regardless of source location.
- Re-acquiring the **same** key on one task still raises `HARN-ORC-011`
  (self-deadlock, shipped in #2797); locks still auto-release on scope exit and
  on `throw`.

### Implementation

- AST: `MutexBlock { key: Option<Box<SNode>>, body }`; parser accepts the
  optional `(expr)`.
- Two no-operand opcodes: `SyncMutexEnter` (call-site key, computed in the VM)
  and new `SyncMutexEnterKeyed` (pops the resource, derives a structural key).
  Both route through one shared acquire path. Replaces the old const-pool
  `"__default__"` key operand.
- Threaded the key expression through the formatter (round-trips losslessly),
  the type-checker (so `mutex(undefined){}` is caught), the effects analysis, and
  the generic AST walker; mechanical `{ body, .. }` everywhere else.
- Bytecode cache auto-invalidates (the front-end fingerprint hashes the parser +
  compiler, both edited).

### Verification

- Conformance (`concurrency/`): updated `mutex_self_reacquire_deadlock` to a
  shared key (nested *bare* blocks are now independent — that's the new
  behavior); rewrote `mutex_release_on_throw` to prove release via lexical
  re-acquire (the old test became vacuous once lexical keys stopped sharing the
  builtin's `"__default__"`); added `mutex_distinct_sites_no_deadlock` and
  `mutex_keyed_distinct`. Full conformance suite green.
- Unit: parser (bare vs keyed parse), formatter (key survives + idempotent),
  `harn-vm` lib.

### Backwards-incompatible

`mutex {}` is no longer one process-wide lock. Code relying on every `mutex {}`
contending on a single global lock must adopt an explicit shared key. Changelog
fragment included (`breaking`).

### Demo gate

No new primitive by the gate's detectors (no `register_builtin` / `host_call` /
new `fn parse_*` — this extends the existing `mutex` construct), and conformance
covers the behavior; carrying `no-demo-needed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
