### PR TITLE
Fix harnlang.com docs auto-deploy + homepage rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,17 @@ jobs:
     # Single `curl` to the Render deploy hook; running it on a self-hosted
     # runner adds no value.
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # `always()` is required: without it, this job is skipped whenever ANY job
+    # in the `ci-status` dependency graph is skipped (e2e is label-gated, and
+    # windows/rust-builds are path-filtered), even though `ci-status` itself
+    # succeeds. That GitHub Actions quirk silently disabled docs auto-deploy
+    # for weeks. See actions/runner#2205. We re-assert the success gate
+    # explicitly via `needs.ci-status.result`.
+    if: >-
+      always()
+      && github.ref == 'refs/heads/main'
+      && github.event_name == 'push'
+      && needs.ci-status.result == 'success'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -534,7 +544,9 @@ jobs:
         id: docs-changed
         run: |
           BEFORE="${{ github.event.before }}"
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            # New branch, force-push, or unreachable base — deploy to be safe.
             echo "changed=true" >> "$GITHUB_OUTPUT"
           elif git diff --name-only "$BEFORE" HEAD | grep -Eq '^(docs/|scripts/build_docs_site\.sh$)'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -543,4 +555,13 @@ jobs:
           fi
       - name: Trigger Render deploy
         if: steps.docs-changed.outputs.changed == 'true'
-        run: curl -s "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "${RENDER_DEPLOY_HOOK_URL:-}" ]; then
+            echo "::error::RENDER_DEPLOY_HOOK_URL secret is not set."
+            exit 1
+          fi
+          # `-f` so a rotated/invalid hook fails the job instead of passing
+          # silently (the previous `-s`-only call swallowed every error).
+          curl -fsS --retry 3 --retry-delay 5 "$RENDER_DEPLOY_HOOK_URL"

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 MD033 MD041 -->
 <div class="harn-hero">
 
-# Harn
+<h1 class="harn-hero-title">Harn</h1>
 
 <p class="tagline">A pipeline-oriented language for AI agent orchestration. LLM calls, tool use, concurrency, retries, and replay are built into the runtime.</p>
 
@@ -124,7 +124,7 @@ Read the [Concepts](./concepts/index.md) section: how `llm_call`, `agent_loop`, 
 
 ### Coming from elsewhere
 
-If you're arriving from LangGraph, OpenAI Agents SDK, Anthropic Agent SDK, Inngest, or Mastra, the [terminology cross-reference](./concepts/sota-comparison.md) is the fastest map.
+If you're arriving from agent SDKs or orchestrators like LangGraph, Inngest, or Mastra, use the [terminology reference](./concepts/sota-comparison.md) to get up to speed.
 
 </div>
 

--- a/docs/theme/css/harn-theme.css
+++ b/docs/theme/css/harn-theme.css
@@ -3,6 +3,11 @@
  * Layered on top of the mdbook base themes (light / rust / navy / coal / ayu).
  * Adds Harn brand color, typography, and code-block polish; intentionally
  * conservative so existing pages remain readable across all five themes.
+ *
+ * NOTE ON UNITS: mdBook sets `html { font-size: 62.5% }`, so `1rem == 10px`
+ * and the base body text is `1.6rem == 16px`. Every font-size below is on
+ * that 10px scale. (An earlier version of this file used `1rem`-as-16px
+ * values, which rendered the whole site at ~62.5% of the intended size.)
  */
 
 :root {
@@ -24,6 +29,11 @@
 
   --harn-shadow-soft: 0 1px 2px rgba(26, 21, 48, 0.06),
     0 4px 12px rgba(26, 21, 48, 0.04);
+
+  /* Widen the default 750px column so the rich landing page and reference
+   * tables make better use of horizontal space on desktop. Loaded after
+   * variables.css, so this wins. */
+  --content-max-width: 1000px;
 }
 
 /* ---------- Typography ---------- */
@@ -53,30 +63,30 @@ body,
 }
 
 .content h1 {
-  font-size: 2.25rem;
+  font-size: 3.6rem;
   margin-top: 0;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--sidebar-bg, rgba(0, 0, 0, 0.08));
 }
 
 .content h2 {
-  font-size: 1.6rem;
+  font-size: 2.6rem;
   margin-top: 2.5rem;
 }
 
 .content h3 {
-  font-size: 1.25rem;
+  font-size: 2rem;
   margin-top: 2rem;
 }
 
 .content h4 {
-  font-size: 1.05rem;
+  font-size: 1.7rem;
   margin-top: 1.6rem;
 }
 
 .content p,
 .content li {
-  font-size: 1rem;
+  font-size: 1.6rem;
 }
 
 .content a {
@@ -107,7 +117,7 @@ code {
 pre {
   border-radius: var(--harn-radius);
   padding: 1rem 1.1rem;
-  font-size: 0.88rem;
+  font-size: 1.4rem;
   line-height: 1.55;
   overflow-x: auto;
 }
@@ -131,7 +141,7 @@ pre > code.language-harn {
 /* ---------- Tables ---------- */
 
 .content table {
-  font-size: 0.95rem;
+  font-size: 1.5rem;
   border-collapse: collapse;
   margin: 1.2rem 0;
   width: 100%;
@@ -176,13 +186,13 @@ pre > code.language-harn {
 }
 
 .chapter li.chapter-item {
-  font-size: 0.9rem;
+  font-size: 1.45rem;
   line-height: 1.45;
   padding: 0.18em 0;
 }
 
 .chapter li.part-title {
-  font-size: 0.7rem;
+  font-size: 1.15rem;
   font-weight: 700;
   letter-spacing: 0;
   color: var(--harn-violet);
@@ -224,7 +234,7 @@ pre > code.language-harn {
   padding: 0 0.55rem;
   border-radius: var(--harn-radius-sm);
   color: inherit;
-  font-size: 0.86rem;
+  font-size: 1.4rem;
   font-weight: 600;
   text-decoration: none;
   white-space: nowrap;
@@ -259,7 +269,7 @@ pre > code.language-harn {
 
 .harn-hero {
   margin: 0 0 2.5rem 0;
-  padding: 2.4rem 2rem 2rem 2rem;
+  padding: 2.8rem 2.4rem 2.4rem 2.4rem;
   border-radius: 12px;
   background: linear-gradient(
     135deg,
@@ -270,32 +280,77 @@ pre > code.language-harn {
   box-shadow: var(--harn-shadow-soft);
 }
 
-.harn-hero h1 {
-  color: white;
+/* mdBook colors heading anchors with `.header:link { color: var(--fg) }`
+ * (specificity 0,2,0), which beats `.harn-hero h1`/`.harn-hero a` and turned
+ * the title near-black on the violet hero. Target the anchor at higher
+ * specificity to force it white. */
+.harn-hero h1,
+.harn-hero h1 a,
+.harn-hero h1 a.header,
+.harn-hero .header:link,
+.harn-hero .header:visited {
+  color: #ffffff;
   border-bottom: none;
+}
+
+.harn-hero h1 {
   margin: 0 0 0.4em 0;
-  font-size: 2.6rem;
-  letter-spacing: 0;
+  font-size: 4.2rem;
+  letter-spacing: -0.01em;
   font-weight: 700;
 }
 
 .harn-hero p.tagline {
   color: rgba(255, 255, 255, 0.92);
-  font-size: 1.15rem;
+  font-size: 1.85rem;
   margin: 0 0 1.4rem 0;
-  max-width: 56ch;
+  max-width: 60ch;
   line-height: 1.5;
 }
 
-.harn-hero pre {
-  background: rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  color: #f3f1ff;
-  margin: 0;
+/* Polished dark code card. The default highlight.js light palette is
+ * unreadable on the violet hero, so pin a dark background and a curated
+ * light-on-dark token palette here. */
+.harn-hero pre,
+.harn-hero pre > code,
+.harn-hero pre > code.hljs {
+  background: rgba(13, 10, 30, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #e9e6ff;
 }
 
-.harn-hero pre code {
-  color: #f3f1ff;
+.harn-hero pre > code.language-harn {
+  border-left: none;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.harn-hero pre .hljs-keyword,
+.harn-hero pre .hljs-meta {
+  color: #c9bcff;
+}
+
+.harn-hero pre .hljs-string,
+.harn-hero pre .hljs-regexp {
+  color: #9be7a4;
+}
+
+.harn-hero pre .hljs-built_in,
+.harn-hero pre .hljs-title,
+.harn-hero pre .hljs-title.function_,
+.harn-hero pre .hljs-section {
+  color: #8fd2ff;
+}
+
+.harn-hero pre .hljs-number,
+.harn-hero pre .hljs-literal,
+.harn-hero pre .hljs-symbol {
+  color: #ffc08a;
+}
+
+.harn-hero pre .hljs-comment,
+.harn-hero pre .hljs-punctuation {
+  color: #9a92c0;
 }
 
 .harn-hero a {
@@ -317,10 +372,10 @@ pre > code.language-harn {
 
 .harn-cta {
   display: inline-block;
-  padding: 0.55rem 1.05rem;
+  padding: 0.7rem 1.3rem;
   border-radius: var(--harn-radius);
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 1.5rem;
   text-decoration: none !important;
   transition: transform 80ms ease, background 80ms ease;
 }
@@ -349,7 +404,7 @@ pre > code.language-harn {
 
 .harn-feature-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1rem;
   margin: 1.8rem 0 2.4rem 0;
 }
@@ -369,13 +424,13 @@ pre > code.language-harn {
 
 .harn-feature h3 {
   margin: 0 0 0.4rem 0;
-  font-size: 1rem;
+  font-size: 1.6rem;
   color: var(--harn-violet-dark);
 }
 
 .harn-feature p {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 1.45rem;
   line-height: 1.5;
 }
 
@@ -383,7 +438,7 @@ pre > code.language-harn {
 
 .harn-paths {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 0.9rem;
   margin: 1.6rem 0 2rem 0;
 }
@@ -402,12 +457,12 @@ pre > code.language-harn {
 
 .harn-path-card h3 {
   margin: 0 0 0.35rem 0;
-  font-size: 0.98rem;
+  font-size: 1.55rem;
 }
 
 .harn-path-card p {
   margin: 0;
-  font-size: 0.88rem;
+  font-size: 1.4rem;
   color: inherit;
   opacity: 0.85;
 }
@@ -475,22 +530,22 @@ pre > code.language-harn {
   }
 
   .harn-section-nav a {
-    font-size: 0.8rem;
+    font-size: 1.3rem;
   }
 
   .harn-hero {
-    padding: 1.8rem 1.2rem;
+    padding: 1.8rem 1.4rem;
   }
 
   .harn-hero h1 {
-    font-size: 2rem;
+    font-size: 3.2rem;
   }
 
   .content h1 {
-    font-size: 1.75rem;
+    font-size: 2.8rem;
   }
 
   .content h2 {
-    font-size: 1.35rem;
+    font-size: 2.2rem;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -888,9 +888,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Problem

The harnlang.com docs site had three independent issues keeping it stale and the new landing page looking broken.

### 1. Docs auto-deploy never fired
The `deploy-docs` job in `ci.yml` used `if: github.ref == 'refs/heads/main'` (no `always()`) with `needs: [ci-status]`. Because `ci-status` aggregates jobs that are routinely skipped on a main push (label-gated `e2e`, path-filtered `windows`/`rust-builds`), GitHub's skip-propagation quirk (actions/runner#2205) silently skipped `deploy-docs` on **every** push — **0 fires in the last 60 push-to-main runs**. The Render hook therefore never fired, so the site went stale after early May.

(The separate exit-101 Render build failures in late April were a redirect-vs-chapter conflict in `book.toml`, since resolved on main — current builds are clean.)

### 2. Whole site rendered at ~62.5% size
mdBook sets `html { font-size: 62.5% }` (1rem = 10px) but `harn-theme.css` used `1rem`-as-16px values, so body text was 10px and code 8.8px.

### 3. Homepage hero
- Title was near-black on the violet hero (mdBook's `.header:link { color: var(--fg) }` at specificity 0,2,0 beat the hero rules) and behaved as a clickable heading anchor with a stray chevron.
- Hero code block used the light highlight.js palette on a dark card.

## Fix

- **`ci.yml`:** `if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.ci-status.result == 'success'`, and harden the trigger with `curl -fsS --retry 3` + a secret-present guard so a rotated hook fails loudly instead of passing silently.
- **`harn-theme.css`:** rescale every font-size to mdBook's 10px base, widen the content column 750px → 1000px, force the hero title white at higher specificity, and pin a dark hero code card with a curated light-on-dark token palette.
- **`introduction.md`:** render the hero title as raw `<h1>` (no mdBook anchor/chevron); soften the "Coming from elsewhere" wording.
- **`package-lock.json`:** `npm audit fix` clears the dev-only transitive `brace-expansion` advisory (root now 0 vulns).

## Verification

- Reproduced the historical exit-101 build locally; confirmed current `mdbook build` is clean (exit 0).
- Confirmed `deploy-docs` fired 0/60 recent push runs; new `if` matches the documented actions/runner#2205 workaround.
- `actionlint` clean; markdown lint clean; pre-commit hooks (registry, actions, portal lint) pass.
- Validated the homepage visually with headless-Chrome screenshots against `mdbook serve` (white title, readable dark code card, correct font sizes, wider column).

`no-changelog-needed`: docs-site / CI / lockfile changes only — no harn language or CLI user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)