### PR TITLE
Speed up repo-scale text scans: share compiled regexes via Rc (#2796)

### DIFF
--- a/changelog.d/2796.changed.md
+++ b/changelog.d/2796.changed.md
@@ -1,0 +1,12 @@
+- **Much faster repo-scale text scans (#2796).** The regex builtins cached the
+  compiled pattern but handed each call a *deep clone* of `regex::Regex`, which
+  re-copies the compiled program and its match-cache pool (~3.5us/call) — the
+  dominant cost when running `regex_match` over every line of a source tree.
+  The cache now shares each compiled pattern via `Rc`, so a repeated lookup is
+  a refcount bump, and a single-slot memo skips the cache-key allocation when
+  the same pattern is reused in a loop. `regex_match` / `regex_replace` /
+  `regex_captures` / `regex_split` and the `contains` / `starts_with` /
+  `ends_with` / `split` / `replace` / `index_of` string methods also borrow
+  their subject/needle instead of cloning it. A line-oriented scan of the
+  repository (~740k `regex_match` calls) drops from ~4.0s to ~1.2s, making
+  TypeScript-style source-tree scanners practical to port to Harn.

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -381,6 +381,10 @@ fn attributed_top_level_fn_does_not_emit_spurious_pop() {
 /// exactly. A bare `Op::Closure` leaves one value (`Some(1)`); pairing it
 /// with the matching bind (`Op::DefVar`) nets zero (`Some(0)`); and emitting
 /// a branch taints the span so the model declines to judge it (`None`).
+///
+/// The balance model and its assertion are `#[cfg(debug_assertions)]`, so this
+/// test (and the miswiring test below) only compile and run in debug builds.
+#[cfg(debug_assertions)]
 #[test]
 fn balance_model_tracks_straight_line_and_declines_branches() {
     let mut chunk = Chunk::new();
@@ -408,6 +412,7 @@ fn balance_model_tracks_straight_line_and_declines_branches() {
 /// which emits a balanced `Closure; DefVar` and leaves nothing to pop) and
 /// confirm the balance assertion panics instead of letting the compiler emit
 /// the unbalanced `Op::Pop` that #2610 only caught as a runtime underflow.
+#[cfg(debug_assertions)]
 #[test]
 fn miswired_produces_value_trips_balance_assertion() {
     struct ResetGuard;

--- a/crates/harn-vm/src/stdlib/regex.rs
+++ b/crates/harn-vm/src/stdlib/regex.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
+use std::rc::Rc;
 
 use crate::runtime_limits::RuntimeLimits;
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
@@ -9,27 +10,51 @@ use crate::vm::Vm;
 const REGEX_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_regex_cache_entries;
 
 thread_local! {
-    static REGEX_CACHE: RefCell<HashMap<String, regex::Regex>> = RefCell::new(HashMap::new());
+    // `regex::Regex` is stored behind an `Rc` because `Regex::clone` deep-copies
+    // the compiled program and its match-cache pool — ~3.5us per call, which
+    // dominated repeated `regex_match` over a file's lines. Handing callers an
+    // `Rc<Regex>` makes each lookup a refcount bump instead.
+    static REGEX_CACHE: RefCell<HashMap<String, Rc<regex::Regex>>> = RefCell::new(HashMap::new());
+    // Scan loops almost always reuse the same pattern (e.g. `regex_match(p, line)`
+    // across every line of a file). This single-slot memo short-circuits those
+    // calls before the cache-key allocation and the HashMap hash, leaving only a
+    // string compare plus the `Rc` bump.
+    static LAST_REGEX: RefCell<Option<(String, String, Rc<regex::Regex>)>> =
+        const { RefCell::new(None) };
 }
 
-fn get_cached_regex(pattern: &str, flags: &str) -> Result<regex::Regex, VmError> {
-    let cache_key = format!("{flags}\0{pattern}");
-    REGEX_CACHE.with(|cache| {
+fn get_cached_regex(pattern: &str, flags: &str) -> Result<Rc<regex::Regex>, VmError> {
+    if let Some(re) = LAST_REGEX.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .filter(|(p, f, _)| p == pattern && f == flags)
+            .map(|(_, _, re)| Rc::clone(re))
+    }) {
+        return Ok(re);
+    }
+
+    let re = REGEX_CACHE.with(|cache| -> Result<Rc<regex::Regex>, VmError> {
+        let cache_key = format!("{flags}\0{pattern}");
         let mut cache = cache.borrow_mut();
         if let Some(re) = cache.get(&cache_key) {
-            return Ok(re.clone());
+            return Ok(Rc::clone(re));
         }
-        let re = build_regex(pattern, flags).map_err(|e| {
+        let re = Rc::new(build_regex(pattern, flags).map_err(|e| {
             VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
                 "Invalid regex: {e}"
             ))))
-        })?;
+        })?);
         if cache.len() >= REGEX_CACHE_LIMIT {
             cache.clear();
         }
-        cache.insert(cache_key, re.clone());
+        cache.insert(cache_key, Rc::clone(&re));
         Ok(re)
-    })
+    })?;
+
+    LAST_REGEX.with(|slot| {
+        *slot.borrow_mut() = Some((pattern.to_string(), flags.to_string(), Rc::clone(&re)));
+    });
+    Ok(re)
 }
 
 fn build_regex(pattern: &str, flags: &str) -> Result<regex::Regex, String> {
@@ -69,9 +94,9 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
 )]
 fn regex_match_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     if args.len() >= 2 {
-        let pattern = args[0].display();
-        let text = args[1].display();
-        let flags = args.get(2).map(VmValue::display).unwrap_or_default();
+        let pattern = args[0].as_str_cow();
+        let text = args[1].as_str_cow();
+        let flags = args.get(2).map(VmValue::as_str_cow).unwrap_or_default();
         let re = get_cached_regex(&pattern, &flags)?;
         let matches: Vec<VmValue> = re
             .find_iter(&text)
@@ -95,13 +120,13 @@ fn regex_match_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 )]
 fn regex_replace_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     if args.len() >= 3 {
-        let pattern = args[0].display();
-        let replacement = args[1].display();
-        let text = args[2].display();
-        let flags = args.get(3).map(VmValue::display).unwrap_or_default();
+        let pattern = args[0].as_str_cow();
+        let replacement = args[1].as_str_cow();
+        let text = args[2].as_str_cow();
+        let flags = args.get(3).map(VmValue::as_str_cow).unwrap_or_default();
         let re = get_cached_regex(&pattern, &flags)?;
         return Ok(VmValue::String(std::sync::Arc::from(
-            re.replace_all(&text, replacement.as_str()).into_owned(),
+            re.replace_all(&text, replacement.as_ref()).into_owned(),
         )));
     }
     Ok(VmValue::Nil)
@@ -115,8 +140,8 @@ fn regex_captures_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     if args.len() < 2 {
         return Ok(VmValue::List(std::sync::Arc::new(Vec::new())));
     }
-    let pattern = args[0].display();
-    let text = args[1].display();
+    let pattern = args[0].as_str_cow();
+    let text = args[1].as_str_cow();
     let re = get_cached_regex(&pattern, "")?;
 
     let mut results: Vec<VmValue> = Vec::new();
@@ -161,9 +186,9 @@ fn regex_split_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     if args.len() < 2 {
         return Ok(VmValue::Nil);
     }
-    let text = args[0].display();
-    let pattern = args[1].display();
-    let flags = args.get(2).map(VmValue::display).unwrap_or_default();
+    let text = args[0].as_str_cow();
+    let pattern = args[1].as_str_cow();
+    let flags = args.get(2).map(VmValue::as_str_cow).unwrap_or_default();
     let re = get_cached_regex(&pattern, &flags)?;
     Ok(VmValue::List(std::sync::Arc::new(
         re.split(&text)
@@ -384,5 +409,17 @@ mod tests {
         }
         let re = get_cached_regex("pat0", "").unwrap();
         assert!(re.is_match("pat0"));
+    }
+
+    // A repeated lookup must hand back the *same* compiled regex, not a deep
+    // clone. `regex::Regex::clone` re-copies the compiled program and match
+    // cache (~3.5us/call), so cloning per call is what made line-oriented
+    // scans slow (#2796). Sharing via `Rc` keeps the hot path a refcount bump;
+    // this guards against a regression back to per-call cloning.
+    #[test]
+    fn cache_returns_shared_instance() {
+        let first = get_cached_regex("shared_pattern", "").unwrap();
+        let second = get_cached_regex("shared_pattern", "").unwrap();
+        assert!(Rc::ptr_eq(&first, &second));
     }
 }

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -320,6 +320,18 @@ impl VmValue {
         }
     }
 
+    /// Borrows the string contents without allocating when the value is
+    /// already a string. Non-string values are rendered with `display()`,
+    /// matching the coercion callers apply at string boundaries. Hot string
+    /// builtins (regex, split, contains) use this to avoid cloning the
+    /// subject text on every call.
+    pub fn as_str_cow(&self) -> std::borrow::Cow<'_, str> {
+        match self {
+            VmValue::String(s) => std::borrow::Cow::Borrowed(s),
+            other => std::borrow::Cow::Owned(other.display()),
+        }
+    }
+
     pub fn struct_name(&self) -> Option<&str> {
         match self {
             VmValue::StructInstance { layout, .. } => Some(layout.struct_name()),

--- a/crates/harn-vm/src/vm/methods/string.rs
+++ b/crates/harn-vm/src/vm/methods/string.rs
@@ -12,13 +12,16 @@ impl crate::vm::Vm {
             "count" => Ok(VmValue::Int(s.chars().count() as i64)),
             "empty" => Ok(VmValue::Bool(s.is_empty())),
             "contains" => Ok(VmValue::Bool(
-                s.contains(&*args.first().map(|a| a.display()).unwrap_or_default()),
+                s.contains(&*args.first().map(|a| a.as_str_cow()).unwrap_or_default()),
             )),
             "replace" if args.len() >= 2 => Ok(VmValue::String(std::sync::Arc::from(
-                s.replace(&args[0].display(), &args[1].display()),
+                s.replace(&*args[0].as_str_cow(), &args[1].as_str_cow()),
             ))),
             "split" => {
-                let sep = args.first().map(|a| a.display()).unwrap_or(",".into());
+                let sep = args
+                    .first()
+                    .map(|a| a.as_str_cow())
+                    .unwrap_or(std::borrow::Cow::Borrowed(","));
                 Ok(VmValue::List(std::sync::Arc::new(
                     s.split(&*sep)
                         .map(|p| VmValue::String(std::sync::Arc::from(p)))
@@ -27,10 +30,10 @@ impl crate::vm::Vm {
             }
             "trim" => Ok(VmValue::String(std::sync::Arc::from(s.trim()))),
             "starts_with" => Ok(VmValue::Bool(
-                s.starts_with(&*args.first().map(|a| a.display()).unwrap_or_default()),
+                s.starts_with(&*args.first().map(|a| a.as_str_cow()).unwrap_or_default()),
             )),
             "ends_with" => Ok(VmValue::Bool(
-                s.ends_with(&*args.first().map(|a| a.display()).unwrap_or_default()),
+                s.ends_with(&*args.first().map(|a| a.as_str_cow()).unwrap_or_default()),
             )),
             "lowercase" => Ok(VmValue::String(std::sync::Arc::from(s.to_lowercase()))),
             "uppercase" => Ok(VmValue::String(std::sync::Arc::from(s.to_uppercase()))),
@@ -45,9 +48,9 @@ impl crate::vm::Vm {
                 Ok(VmValue::String(std::sync::Arc::from(substr)))
             }
             "index_of" => {
-                let needle = args.first().map(|a| a.display()).unwrap_or_default();
+                let needle = args.first().map(|a| a.as_str_cow()).unwrap_or_default();
                 let idx = s
-                    .find(&needle)
+                    .find(&*needle)
                     .map(|byte_pos| s[..byte_pos].chars().count() as i64);
                 Ok(VmValue::Int(idx.unwrap_or(-1)))
             }

--- a/crates/harn-vm/thread_local_audit.toml
+++ b/crates/harn-vm/thread_local_audit.toml
@@ -508,7 +508,7 @@ plan = "task_local_or_explicit"
 
 [[thread_local]]
 path = "src/stdlib/regex.rs"
-statics = ["REGEX_CACHE"]
+statics = ["REGEX_CACHE", "LAST_REGEX"]
 category = "thread_private"
 plan = "thread_private_cache"
 

--- a/docs/src/dev/vm-stdlib-perf-notes.md
+++ b/docs/src/dev/vm-stdlib-perf-notes.md
@@ -85,6 +85,40 @@ canonical connector option-builder shape):
 Conformance was unchanged (`stdlib_collections`, `stdlib_json`, and the
 broader 933-test suite all pass).
 
+### 3. Regex builtins share compiled patterns via `Rc` instead of cloning
+
+Issue #2796 surfaced this while porting a TypeScript repo-audit script:
+a line-oriented scan of the repository was ~3.4× slower in Harn than the
+Node baseline. Decomposing the scan (file walk / `read_text` / line split
+/ `contains` / `regex_match`, each timed separately over ~740k lines)
+isolated the cost entirely to `regex_match` at ~4.4 µs/call — file I/O,
+splitting, and `contains` were all already cheap.
+
+The pattern was cached, but `get_cached_regex` returned `regex::Regex::clone`
+on every hit, and `regex::Regex::clone` deep-copies the compiled program and
+its lazy-DFA match-cache pool. A standalone Rust probe confirmed the cost:
+134k `find_iter` calls over a real file took 3.3 ms reusing one `Regex`,
+466 ms cloning the `Regex` per call, and 2.7 ms cloning an `Rc<Regex>` per
+call — i.e. the deep clone, not the match, was ~99% of the time.
+
+The fix stores `Rc<regex::Regex>` in the thread-local cache so a hit is a
+refcount bump, adds a single-slot "last pattern" memo that skips the
+cache-key `format!` and HashMap hash when a scan loop reuses one pattern,
+and switches the regex/`contains`/`split` family to borrow their subject and
+needle (`VmValue::as_str_cow`) instead of `display()`-cloning per call.
+
+Effect on `regex_scan_loop` (4,000 iterations × 10 lines of two `contains`
+plus one `regex_match` — the canonical line scan shape):
+
+| metric                    | baseline (Harn 0.8.60) | post-#2796 | delta  |
+|---------------------------|-----------------------:|-----------:|-------:|
+| `harn bench` 10-iter mean |                 367.9 ms |    36.6 ms | −90 %  |
+
+A full-repository scan (~740k `regex_match` calls over 1,409 files) drops
+its regex phase from ~4.0 s to ~1.2 s; the remaining cost is VM call
+dispatch and result-list construction, not the regex engine. Conformance
+(`regex*`, `string*`) was unchanged.
+
 ## Post-#2095 performance wave
 
 The #1426 profile left a second wave of runtime and typechecker work.

--- a/perf/vm/README.md
+++ b/perf/vm/README.md
@@ -57,8 +57,10 @@ operations and allocated bytes per fixture run.
 The fixture set covers core interpreter ops (arithmetic, function calls,
 struct/dict/list reads), the option-builder pipelines that connector
 helpers and `agent_dispatch_tool_batch` exercise on every call
-(`dict_merge_loop`, `dict_subscript_assign`, `filter_nil_loop`), and a
-representative agent-tool dispatch loop (`agent_tool_dispatch`).
+(`dict_merge_loop`, `dict_subscript_assign`, `filter_nil_loop`), a
+representative agent-tool dispatch loop (`agent_tool_dispatch`), and a
+line-oriented source scan (`regex_scan_loop`) that mirrors the per-line
+`contains` + `regex_match` shape of repo-scale audit scripts (#2796).
 [`docs/src/dev/vm-stdlib-perf-notes.md`](../../docs/src/dev/vm-stdlib-perf-notes.md)
 captures the analysis behind the current allocation budget.
 

--- a/perf/vm/bench_vm_fixtures.rs
+++ b/perf/vm/bench_vm_fixtures.rs
@@ -22,6 +22,7 @@ const FIXTURES: &[&str] = &[
     "local_variable_lookup.harn",
     "method_call_dispatch.harn",
     "recursive_countdown.harn",
+    "regex_scan_loop.harn",
     "string_interpolation_loop.harn",
     "struct_field_read.harn",
 ];

--- a/perf/vm/regex_scan_loop.harn
+++ b/perf/vm/regex_scan_loop.harn
@@ -1,0 +1,41 @@
+/**
+ * Line-oriented source scan: the shape of repo-scale audit scripts that walk
+ * files, split them into lines, and run string + regex predicates over every
+ * line. Exercises the hot per-call path of `contains` and `regex_match`
+ * (subject borrowing + the shared compiled-regex cache) without touching the
+ * filesystem, so the fixture measures VM/builtin work only.
+ */
+pipeline default(task) {
+  let lines = [
+    "fn parse_config(path: string) -> Config {",
+    "    let raw = read_text(path)  // TODO: cache reads",
+    "    return raw.unwrap()",
+    "}",
+    "pub fn render(items: list) -> string {",
+    "    items.map({ it -> it.name }).join(\", \")",
+    "}",
+    "// FIXME: handle the empty case",
+    "let x = compute(42)",
+    "struct Widget { id: int, label: string }",
+  ]
+  var hits = 0
+  var iteration = 0
+  while iteration < 4000 {
+    for line in lines {
+      if line.contains("unwrap()") {
+        hits = hits + 1
+      }
+      if line.contains("TODO") {
+        hits = hits + 1
+      }
+      let m = regex_match("fn\\s+\\w+", line)
+      if m != nil {
+        hits = hits + 1
+      }
+    }
+    iteration = iteration + 1
+  }
+  if hits < 0 {
+    log("unreachable")
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2796.

Porting a TypeScript repo-audit script to Harn was abandoned because a line-oriented source scan ran ~3.4× slower than the Node baseline. This makes that class of workload practical.

### Investigation

Decomposing a full-repo scan (file walk → `read_text` → line split → `contains` → `regex_match`, each timed separately over ~740k lines across 1,409 files) pinned the entire gap on `regex_match` at ~4.4 µs/call. File I/O, line splitting, and `contains` were all already cheap.

A standalone Rust probe over a real file (134k `find_iter` calls) isolated the cause:

| path | time |
|---|---|
| reuse one `Regex` | **3.3 ms** |
| **clone the `Regex` per call** | **466 ms** |
| clone an `Rc<Regex>` per call | 2.7 ms |

`get_cached_regex` cached the compiled pattern but returned `regex::Regex::clone` on every hit — and `Regex::clone` deep-copies the compiled program and its lazy-DFA match-cache pool. The deep clone, not the match, was ~99% of the time.

### Fix

- Store `Rc<regex::Regex>` in the thread-local cache so a hit is a refcount bump (`regex_match` / `regex_replace` / `regex_captures` / `regex_split`).
- Add a single-slot "last pattern" memo that skips the cache-key `format!` and the HashMap hash when a scan loop reuses one pattern.
- Add `VmValue::as_str_cow` and switch the regex builtins plus the `contains` / `starts_with` / `ends_with` / `split` / `replace` / `index_of` string methods to borrow their subject/needle instead of `display()`-cloning per call.

### Results

| workload | before (0.8.60) | after | delta |
|---|---|---|---|
| `regex_scan_loop` fixture (`harn bench`, 10 iter) | 367.9 ms | 36.6 ms | **−90%** |
| full-repo regex phase (~740k calls) | ~4.0 s | ~1.2 s | **−70%** |
| end-to-end single-dir scan | 2.76 s | 1.25 s | −55% |

The residual regex cost is now VM call dispatch + result-list construction, not the regex engine.

### Regression guards

- `perf/vm/regex_scan_loop.harn` fixture (auto-discovered by `bench_vm.sh`, registered in the Criterion `bench_vm_fixtures` list) mirrors the per-line `contains` + `regex_match` shape.
- A `cache_returns_shared_instance` unit test asserts the cache hands back a shared `Rc`, catching a regression back to per-call cloning.

### Drive-by

Gated two debug-only stack-balance compiler tests behind `#[cfg(debug_assertions)]` — they call `Chunk::balance_probe` / `balance_delta_since`, which are themselves `#[cfg(debug_assertions)]`, so `cargo test --release -p harn-vm` failed to compile before this (pre-existing on `main`; CI runs tests in debug so it was latent).

### Relationship to #2812

Complements #2812 (issue #2790), which attacked the *cursor/char-access* angle of the same dogfooding goal (O(n²) `substring` cursors → `chars()` materialization + ASCII interning). This PR is the *regex/line-scan* angle. Rebased on top of it; no overlap.

### Verification

- Conformance `regex*` (6) and `string*` (23) suites pass with the new binary.
- `harn-vm` regex unit tests (18) pass, including the new shared-instance guard.
- `make`/pre-commit hooks (fmt, harn lint, clippy on harn-vm) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)