### PR TITLE
Detect self-deadlock across inline async-builtin boundaries

### DIFF
--- a/changelog.d/cross-context-deadlock.added.md
+++ b/changelog.d/cross-context-deadlock.added.md
@@ -1,0 +1,8 @@
+- **Self-deadlock detection (`HARN-ORC-011`) now spans inline async-builtin
+  boundaries.** Acquiring a `mutex` that an ancestor already holds — when that
+  ancestor is parked awaiting the async builtin or closure you're running inline
+  — is a provably-unresolvable self-deadlock (the sole holder is blocked waiting
+  on you). The VM now propagates an ancestor's held-lock keys into such inline
+  children and raises `HARN-ORC-011` instead of hanging forever. New concurrent
+  tasks (`spawn`, `parallel`, triggers) deliberately do *not* inherit, since
+  blocking on a parent-held lock there is legitimately resolvable.

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -654,13 +654,17 @@ async fn host_agent_dispatch_tool_call(
     }
 
     let mut permission_grants = permissions::take_session_grants(&session_id);
-    let permission_outcome = permissions::check_dynamic_permission(
+    // Box the permission-check future: this tool-dispatch async fn sits right at
+    // Clippy's `large_stack_frames` threshold, so moving this sizable nested
+    // future to the heap keeps the frame comfortably under it (matches the
+    // `Box::pin` treatment of the reminder-provider futures below).
+    let permission_outcome = Box::pin(permissions::check_dynamic_permission(
         Some(&ctx),
         &mut permission_grants,
         &tool_name,
         &tool_args,
         &session_id,
-    )
+    ))
     .await?;
     permissions::store_session_grants(&session_id, permission_grants);
     if let Some(permission) = permission_outcome {

--- a/crates/harn-vm/src/vm/async_builtin.rs
+++ b/crates/harn-vm/src/vm/async_builtin.rs
@@ -44,8 +44,14 @@ impl AsyncBuiltinCtx {
     /// Clone a fresh child VM from this context. The returned `Vm` shares the
     /// parent's heavy state, so each closure-invoking handler gets its own
     /// cheap execution context.
+    ///
+    /// Uses the *inline* clone: this child runs while the original parent is
+    /// parked awaiting the builtin, so it inherits the parent's held-lock keys
+    /// for cross-context self-deadlock detection (HARN-ORC-011). Long-lived /
+    /// detached contexts use [`AsyncBuiltinCtx::child_ctx`] instead, which does
+    /// not inherit, since the parent keeps running there.
     pub fn child_vm(&self) -> Vm {
-        self.child.lock().child_vm()
+        self.child.lock().child_vm_inline()
     }
 
     /// Pool tasks may execute on any Tokio worker thread, so pool lookup state
@@ -57,8 +63,13 @@ impl AsyncBuiltinCtx {
     /// Create an independent context rooted at a fresh child VM. Long-lived
     /// local tasks use this instead of sharing the parent builtin's output
     /// buffer after the parent future has returned.
+    ///
+    /// This is a *detached* context: the new task runs independently of the
+    /// original parent, so it must NOT inherit the parent's held-lock keys
+    /// (blocking on a parent-held lock is legitimately resolvable here). Uses
+    /// the plain, non-inheriting `child_vm()` rather than `Self::child_vm`.
     pub fn child_ctx(&self) -> Self {
-        Self::new(self.child_vm())
+        Self::new(self.child.lock().child_vm())
     }
 
     /// Forward captured output from a transient child VM (typically created via

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -587,7 +587,7 @@ impl Vm {
                 // into the handler. Drain any output VM-side closures
                 // forwarded into the ctx back to the parent.
                 let (result, captured) =
-                    crate::vm::run_async_builtin_with(self.child_vm(), |ctx| {
+                    crate::vm::run_async_builtin_with(self.child_vm_inline(), |ctx| {
                         async_builtin(ctx, args)
                     })
                     .await;

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -173,6 +173,14 @@ pub struct Vm {
     pub(crate) pool_registry: Arc<crate::stdlib::pool::PoolRegistry>,
     /// Permits acquired by lexical synchronization blocks in this VM.
     pub(crate) held_sync_guards: Vec<crate::synchronization::VmSyncHeldGuard>,
+    /// `(kind, key)` of locks held by an ancestor VM that is *suspended on this
+    /// VM's execution* — i.e. an inline async-builtin child runs while its
+    /// parent is parked mid-instruction still holding these permits. Re-acquiring
+    /// one of them here is a provably-unresolvable self-deadlock (the sole holder
+    /// is blocked awaiting us), so HARN-ORC-011 fires across the child boundary.
+    /// Empty for new concurrent tasks (`spawn`/`parallel`/triggers), where the
+    /// parent keeps running and the block is legitimately resolvable.
+    pub(crate) inherited_held_keys: Arc<Vec<(String, String)>>,
     /// Counter for generating unique task IDs.
     pub(crate) task_counter: u64,
     /// Counter for logical runtime-context task groups.
@@ -321,6 +329,7 @@ impl VmBaseline {
             inline_caches: HashMap::new(),
             pool_registry: crate::stdlib::pool::new_pool_registry(),
             held_sync_guards: Vec::new(),
+            inherited_held_keys: Arc::new(Vec::new()),
             task_counter: 0,
             runtime_context_counter: 0,
             runtime_context: crate::runtime_context::RuntimeContext::root(),
@@ -546,6 +555,7 @@ impl Vm {
             inline_caches: HashMap::new(),
             pool_registry: crate::stdlib::pool::new_pool_registry(),
             held_sync_guards: Vec::new(),
+            inherited_held_keys: Arc::new(Vec::new()),
             task_counter: 0,
             runtime_context_counter: 0,
             runtime_context: crate::runtime_context::RuntimeContext::root(),
@@ -695,6 +705,7 @@ impl Vm {
             inline_caches: HashMap::new(),
             pool_registry: self.pool_registry.clone(),
             held_sync_guards: Vec::new(),
+            inherited_held_keys: Arc::new(Vec::new()),
             task_counter: 0,
             runtime_context_counter: self.runtime_context_counter,
             runtime_context: self.runtime_context.clone(),
@@ -873,11 +884,49 @@ impl Vm {
     /// is cheap and only runs on the rare blocking-acquire path. Used by the
     /// runtime self-deadlock guard.
     pub(crate) fn held_permits_for(&self, kind: &str, key: &str) -> u32 {
-        self.held_sync_guards
+        let own: u32 = self
+            .held_sync_guards
             .iter()
             .filter(|guard| guard._permit.kind() == kind && guard._permit.key() == key)
             .map(|guard| guard._permit.permits())
-            .sum()
+            .sum();
+        // A lock held by a suspended ancestor (inline async-builtin parent)
+        // counts as held by this task: the ancestor cannot release until we
+        // return, so a re-acquire here can never be granted. Count it as one
+        // permit — enough to trip the capacity-1 self-deadlock guard.
+        let inherited = self
+            .inherited_held_keys
+            .iter()
+            .any(|(k, kk)| k == kind && kk == key) as u32;
+        own + inherited
+    }
+
+    /// `(kind, key)` of every lock held by this VM *and* its suspended
+    /// ancestors — the transitive held-set seen by an inline child.
+    pub(crate) fn combined_held_keys(&self) -> Vec<(String, String)> {
+        let mut keys: Vec<(String, String)> = self
+            .held_sync_guards
+            .iter()
+            .map(|guard| {
+                (
+                    guard._permit.kind().to_string(),
+                    guard._permit.key().to_string(),
+                )
+            })
+            .collect();
+        keys.extend(self.inherited_held_keys.iter().cloned());
+        keys
+    }
+
+    /// Clone a child VM for an **inline, same-task** execution (an async builtin
+    /// awaited while this VM is parked, or a user closure that builtin runs and
+    /// awaits). The child inherits this VM's transitive held-lock keys so a
+    /// re-acquire of a parent-held lock is caught as a self-deadlock
+    /// (HARN-ORC-011). Use plain `child_vm()` for new concurrent tasks.
+    pub(crate) fn child_vm_inline(&self) -> Vm {
+        let mut child = self.child_vm();
+        child.inherited_held_keys = Arc::new(self.combined_held_keys());
+        child
     }
 }
 
@@ -940,6 +989,42 @@ mod tests {
             .globals
             .get("stable_global")
             .is_some_and(|value| value.display() == "baseline"));
+    }
+
+    #[tokio::test]
+    async fn inline_child_inherits_held_lock_keys_but_concurrent_child_does_not() {
+        let mut parent = Vm::new();
+        let permit = parent
+            .sync_runtime
+            .acquire("mutex", "v:test", 1, 1, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        parent
+            .held_sync_guards
+            .push(crate::synchronization::VmSyncHeldGuard {
+                _permit: permit,
+                frame_depth: 0,
+                env_scope_depth: 0,
+            });
+        assert_eq!(parent.held_permits_for("mutex", "v:test"), 1);
+
+        // An inline child (async builtin awaited while the parent is parked, or
+        // a closure the builtin runs inline) inherits the held key, so a
+        // re-acquire is caught as a cross-context self-deadlock (HARN-ORC-011)
+        // — even transitively through a further inline child.
+        let inline = parent.child_vm_inline();
+        assert_eq!(inline.held_permits_for("mutex", "v:test"), 1);
+        assert_eq!(
+            inline.child_vm_inline().held_permits_for("mutex", "v:test"),
+            1
+        );
+
+        // A new concurrent task (spawn / parallel / trigger) does NOT inherit:
+        // blocking on a parent-held lock there is legitimately resolvable, so
+        // flagging it would be a false positive.
+        let concurrent = parent.child_vm();
+        assert_eq!(concurrent.held_permits_for("mutex", "v:test"), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Cross-context self-deadlock detection across inline async-builtin boundaries

Second PR of the async-safety arc (#2800). Closes #2803.

### The blind spot

`HARN-ORC-011` (shipped in #2797) catches a task re-acquiring a `mutex` it
already holds. But an **inline async builtin** — or a user closure that builtin
runs and awaits — executes in a `child_vm()` whose `held_sync_guards` start
*empty*, even though the parent is parked mid-instruction still holding its
locks (it shares the same `Arc<VmSyncRuntime>`). So:

```harn
mutex("x") {
  some_builtin_running_a_closure({ -> mutex("x") { ... } })  // hung forever, undetected
}
```

The sole permit holder (the parent) is blocked awaiting the child, so the child
can never acquire `x` — a provably-unresolvable self-deadlock that previously
just hung.

### The fix

The VM now propagates an ancestor's held-lock keys into **inline, same-task**
children (`inherited_held_keys`), and `held_permits_for` counts them — so
`HARN-ORC-011` fires across the boundary instead of hanging.

The propagation is keyed on the existing `child_vm()` (new task) vs.
`child_vm_inline()` (same task) distinction:
- `AsyncBuiltinCtx::child_vm()` (inline closures awaited within a builtin) →
  inherits.
- `child_ctx()` / `spawn` / `parallel` / trigger dispatch (new concurrent tasks)
  → do **not** inherit, because blocking on a parent-held lock there is
  legitimately resolvable. This keeps the guard **false-positive-free**.

Purely additive: working code is unaffected; only a genuine inline self-deadlock
now errors instead of hanging.

### Verification

- New unit test: an inline child (transitively) inherits a held key while a
  concurrent child does not.
- `harn-vm` lib (3119) green; full conformance green (the key false-positive
  safety net — no legitimate inline-closure-with-lock pattern regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
