### PR TITLE
Fix return-expression throws under try handlers

### DIFF
--- a/changelog.d/2821.fixed.md
+++ b/changelog.d/2821.fixed.md
@@ -1,0 +1,4 @@
+- **VM try/catch now observes throws from return expressions (#2821).**
+  `return f()` and `return value |> f` inside a `try` block no longer elide
+  the handler frame, so local catches run and typed-catch mismatches still
+  propagate correctly.

--- a/conformance/tests/errors_by_feature/return_expr_throw_try_catch.expected
+++ b/conformance/tests/errors_by_feature/return_expr_throw_try_catch.expected
@@ -1,0 +1,3 @@
+direct:body
+pipe:pipe
+outer:OtherError.Remote(body)

--- a/conformance/tests/errors_by_feature/return_expr_throw_try_catch.harn
+++ b/conformance/tests/errors_by_feature/return_expr_throw_try_catch.harn
@@ -1,0 +1,62 @@
+enum AppError {
+  Local(msg)
+}
+
+enum OtherError {
+  Remote(msg)
+}
+
+fn direct_return_catches(body) {
+  try {
+    return body()
+  } catch (e) {
+    return "direct:" + to_string(e)
+  }
+}
+
+fn pipe_fail(_value) {
+  throw "pipe"
+}
+
+fn pipe_return_catches() {
+  try {
+    return 1 |> pipe_fail
+  } catch (e) {
+    return "pipe:" + to_string(e)
+  }
+}
+
+fn other_error() -> OtherError {
+  return OtherError.Remote("body")
+}
+
+fn typed_catch_mismatch_propagates(body, _sample: AppError) {
+  try {
+    return body()
+  } catch (e: AppError) {
+    return "local:" + to_string(e)
+  }
+}
+
+pipeline default() {
+  __io_println(
+    direct_return_catches(
+      { ->
+        throw "body"
+      },
+    ),
+  )
+  __io_println(pipe_return_catches())
+  let propagated = try {
+    typed_catch_mismatch_propagates(
+      { ->
+        throw other_error()
+      },
+      AppError.Local("sample"),
+    )
+    "not propagated"
+  } catch (e) {
+    "outer:" + to_string(e)
+  }
+  __io_println(propagated)
+}

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -1197,6 +1197,18 @@ pub(crate) fn disasm_u16(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
     format!("{label} {arg:>4}")
 }
 
+pub(crate) fn disasm_try_catch_setup(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let catch_offset = chunk.read_u16(*ip);
+    *ip += 2;
+    let type_idx = chunk.read_u16(*ip);
+    *ip += 2;
+    if let Some(type_name) = chunk.constants.get(type_idx as usize) {
+        format!("{label} {catch_offset:>4} type {type_idx:>4} ({type_name})")
+    } else {
+        format!("{label} {catch_offset:>4} type {type_idx:>4}")
+    }
+}
+
 pub(crate) fn disasm_const_pool_u16(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
     let idx = chunk.read_u16(*ip);
     *ip += 2;

--- a/crates/harn-vm/src/compiler/error_handling.rs
+++ b/crates/harn-vm/src/compiler/error_handling.rs
@@ -255,6 +255,7 @@ impl Compiler {
 
         let loop_start = self.chunk.current_offset();
 
+        self.handler_depth += 1;
         let catch_jump = self.chunk.emit_jump(Op::TryCatchSetup, self.line);
         // Empty type name → untyped catch.
         let empty_type = self.string_constant("");
@@ -269,6 +270,7 @@ impl Compiler {
 
         self.compile_block(body)?;
 
+        self.handler_depth -= 1;
         self.chunk.emit(Op::PopHandler, self.line);
         let end_jump = self.chunk.emit_jump(Op::Jump, self.line);
 

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -212,20 +212,27 @@ impl Compiler {
         } else {
             // No pending finally — use tail-call optimization when possible.
             if let Some(val) = value {
-                if let Node::FunctionCall { name, args, .. } = &val.node {
-                    let name_idx = self.string_constant(name);
-                    self.chunk.emit_u16(Op::Constant, name_idx, self.line);
-                    for arg in args {
-                        self.compile_node(arg)?;
-                    }
-                    self.chunk
-                        .emit_u8(Op::TailCall, args.len() as u8, self.line);
-                } else if let Node::BinaryOp { op, left, right } = &val.node {
-                    if op == "|>" && !contains_pipe_placeholder(right) {
-                        self.compile_node(left)?;
-                        self.compile_node(right)?;
-                        self.chunk.emit(Op::Swap, self.line);
-                        self.chunk.emit_u8(Op::TailCall, 1, self.line);
+                // Active handlers store catch offsets into this frame. Keep
+                // the frame explicit until the return expression succeeds.
+                let allow_tail_call = self.handler_depth == 0;
+                if allow_tail_call {
+                    if let Node::FunctionCall { name, args, .. } = &val.node {
+                        let name_idx = self.string_constant(name);
+                        self.chunk.emit_u16(Op::Constant, name_idx, self.line);
+                        for arg in args {
+                            self.compile_node(arg)?;
+                        }
+                        self.chunk
+                            .emit_u8(Op::TailCall, args.len() as u8, self.line);
+                    } else if let Node::BinaryOp { op, left, right } = &val.node {
+                        if op == "|>" && !contains_pipe_placeholder(right) {
+                            self.compile_node(left)?;
+                            self.compile_node(right)?;
+                            self.chunk.emit(Op::Swap, self.line);
+                            self.chunk.emit_u8(Op::TailCall, 1, self.line);
+                        } else {
+                            self.compile_node(val)?;
+                        }
                     } else {
                         self.compile_node(val)?;
                     }

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -439,3 +439,67 @@ fn miswired_produces_value_trips_balance_assertion() {
          must trip the #2622 stack-balance assertion",
     );
 }
+
+#[test]
+fn return_call_inside_handler_does_not_tail_call() {
+    let chunk = compile_source(
+        r"
+fn plain(body) {
+  return body()
+}
+
+fn guarded(body) {
+  try {
+    return body()
+  } catch (e) {
+    return nil
+  }
+}
+
+fn guarded_retry(body) {
+  retry(1) {
+    return body()
+  }
+}
+
+pipeline default() {}
+",
+    );
+
+    let plain = chunk
+        .functions
+        .iter()
+        .find(|func| func.name == "plain")
+        .expect("plain function compiled");
+    let plain_disasm = plain.chunk.disassemble("plain");
+    assert!(
+        plain_disasm.contains("TAIL_CALL"),
+        "plain return call should keep the tail-call optimization",
+    );
+
+    let guarded = chunk
+        .functions
+        .iter()
+        .find(|func| func.name == "guarded")
+        .expect("guarded function compiled");
+    let guarded_disasm = guarded.chunk.disassemble("guarded");
+    assert!(
+        !guarded_disasm.contains("TAIL_CALL"),
+        "active try/catch handlers must keep their owning frame alive",
+    );
+    assert!(
+        guarded_disasm.contains("CALL_BUILTIN"),
+        "the guarded return expression should still call the callee normally",
+    );
+
+    let guarded_retry = chunk
+        .functions
+        .iter()
+        .find(|func| func.name == "guarded_retry")
+        .expect("guarded_retry function compiled");
+    let guarded_retry_disasm = guarded_retry.chunk.disassemble("guarded_retry");
+    assert!(
+        !guarded_retry_disasm.contains("TAIL_CALL"),
+        "retry handlers must also keep their owning frame alive",
+    );
+}

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1255,6 +1255,13 @@ impl super::super::Vm {
         Ok(())
     }
 
+    fn current_frame_has_exception_handler(&self) -> bool {
+        let current_depth = self.frames.len();
+        self.exception_handlers
+            .iter()
+            .any(|handler| handler.frame_depth == current_depth)
+    }
+
     /// Sync fast path for `Op::TailCall`. Peeks the callee on the stack
     /// **before** touching `ip`; if it resolves to a non-generator user
     /// closure and neither the current frame nor the callee is tracked
@@ -1279,6 +1286,9 @@ impl super::super::Vm {
     pub(super) fn execute_tail_call_sync(&mut self) -> Option<Result<(), VmError>> {
         let frame = self.frames.last().unwrap();
         if crate::step_runtime::is_tracked_function(&frame.fn_name) {
+            return None;
+        }
+        if self.current_frame_has_exception_handler() {
             return None;
         }
         let argc = frame.chunk.code[frame.ip] as usize;
@@ -1336,10 +1346,13 @@ impl super::super::Vm {
                 .unwrap_or_default();
             if crate::step_runtime::is_tracked_function(&current_fn_name)
                 || crate::step_runtime::is_tracked_function(&closure.func.name)
+                || self.current_frame_has_exception_handler()
             {
                 // Persona/step lifecycle state is frame-owned. Keep those
                 // frames explicit so PreStep/PostStep hooks see the same
-                // boundaries as a non-tail call.
+                // boundaries as a non-tail call. Exception handlers also
+                // store instruction pointers into their owning frame, so
+                // that frame cannot be elided while a handler is active.
                 let args = self.take_stack_args_from(args_start)?;
                 self.stack.truncate(callee_idx);
                 self.call_user_closure(closure, args).await?;

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -107,7 +107,7 @@ harn_opcode_macros::define_opcodes! {
 
     // === Error handling ===
     Throw { sync(self.execute_throw()), disasm: bare("THROW") };
-    TryCatchSetup { sync_void(self.execute_try_catch_setup()), disasm: u16("TRY_CATCH_SETUP") };
+    TryCatchSetup { sync_void(self.execute_try_catch_setup()), disasm: try_catch_setup("TRY_CATCH_SETUP") };
     PopHandler { sync_void(self.execute_pop_handler()), disasm: bare("POP_HANDLER") };
 
     // === Concurrency ===


### PR DESCRIPTION
## Summary

- Fix tail-call lowering/runtime TCO so `return f()` and `return value |> f` keep the owning frame alive while a try/catch handler is active.
- Keep retry handler depth aligned with other handler setup paths.
- Add conformance coverage for direct return calls, pipe return calls, and typed-catch mismatch propagation.
- Fix `TRY_CATCH_SETUP` disassembly to consume its typed-catch operand.

Fixes #2821

## Verification

- `cargo run --quiet --bin harn -- test conformance --filter return_expr_throw_try_catch`
- `cargo run --quiet --bin harn -- lint conformance/tests/errors_by_feature/return_expr_throw_try_catch.harn`
- `cargo test -p harn-vm return_call_inside_handler_does_not_tail_call`
- `cargo test -p harn-vm --lib compiler::tests`
- `cargo test -p harn-vm --lib chunk::tests::disassemble_covers_every_opcode_variant`
- `cargo run --quiet --bin harn -- test conformance --filter errors_by_feature`
- `make lint-test-patterns`
- `make test`
- pre-commit and pre-push hooks