### PR TITLE
Adopt std/testing helpers across conformance fixtures

### DIFF
--- a/conformance/tests/_common.harn
+++ b/conformance/tests/_common.harn
@@ -1,3 +1,5 @@
+import { poll_until } from "std/poll"
+
 /** Shared conformance helper for fixtures that exec the built `harn` binary. */
 fn first_group(pattern, text) {
   let matches = regex_captures(pattern, text)
@@ -32,17 +34,28 @@ pub fn process_alive(pid) {
 
 /** Poll a subprocess log for a regex match and return the first capture group. */
 pub fn wait_for_log_match(harness: Harness, log_path, pattern) {
-  var attempts = 0
-  while attempts < 300 {
-    if harness.fs.exists(log_path) {
+  return poll_until(
+    { ->
+      if !harness.fs.exists(log_path) {
+        return nil
+      }
       let log = exec("cat", log_path).stdout
       let matches = regex_captures(pattern, log)
       if len(matches) > 0 {
         return matches[0].groups[0]
       }
+      return nil
+    },
+    {timeout_ms: 15000, interval_ms: 50},
+  )
+}
+
+fn log_contains(harness: Harness, log_path, needle) {
+  if harness.fs.exists(log_path) {
+    let log = exec("cat", log_path).stdout
+    if contains(log, needle) {
+      return true
     }
-    sleep(50ms)
-    attempts = attempts + 1
   }
   return nil
 }
@@ -62,18 +75,8 @@ pub fn wait_for_log_match(harness: Harness, log_path, pattern) {
  * signal as a hard prereq should fail with a descriptive `require`.
  */
 pub fn wait_for_log_contains(harness: Harness, log_path, needle) {
-  var attempts = 0
-  while attempts < 600 {
-    if harness.fs.exists(log_path) {
-      let log = exec("cat", log_path).stdout
-      if contains(log, needle) {
-        return true
-      }
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
+  return poll_until({ -> log_contains(harness, log_path, needle) }, {timeout_ms: 30000, interval_ms: 50})
+    ?? false
 }
 
 /** Wait for the orchestrator HTTP listener readiness line and return its URL. */
@@ -98,13 +101,14 @@ pub fn wait_for_a2a_server_url(harness: Harness, log_path) {
  * process gone for subsequent steps should pair this with `kill -KILL`.
  */
 pub fn wait_for_exit(pid) {
-  var attempts = 0
-  while attempts < 600 {
-    if !process_alive(pid) {
-      return true
-    }
-    sleep(50ms)
-    attempts = attempts + 1
-  }
-  return false
+  return poll_until(
+    { ->
+      if !process_alive(pid) {
+        return true
+      }
+      return nil
+    },
+    {timeout_ms: 30000, interval_ms: 50},
+  )
+    ?? false
 }

--- a/conformance/tests/agents/agent_auto_resume_trigger.harn
+++ b/conformance/tests/agents/agent_auto_resume_trigger.harn
@@ -1,41 +1,46 @@
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 import "std/triggers"
 
 pipeline main() {
-  llm_mock(
-    {
-      tool_calls: [
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "park_until_review",
+            name: "agent_await_resumption",
+            arguments: {reason: "waiting on review", conditions: {trigger: {kind: "review.approved", provider: "github"}}},
+          },
+        ],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      llm_text("resumed after review"),
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park until review approval.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      let trigger_handle = suspended?.suspension?.auto_resume_trigger
+      __io_println(suspended?.status)
+      __io_println(trigger_handle?.id != nil)
+      __io_println(trigger_handle?.version != nil)
+      let fired: DispatchHandle = trigger_fire(
+        trigger_handle,
         {
-          id: "park_until_review",
-          name: "agent_await_resumption",
-          arguments: {reason: "waiting on review", conditions: {trigger: {kind: "review.approved", provider: "github"}}},
+          provider: "github",
+          kind: "review.approved",
+          payload: {decision: "approved"},
+          headers: {x_delivery: "auto-resume-conformance"},
         },
-      ],
-      input_tokens: 7,
-      output_tokens: 3,
+      )
+      __io_println(fired.status)
+      let resumed = wait_agent(handle)
+      __io_println(resumed?.status)
+      __io_println(contains(resumed?.task ?? "", "approved"))
     },
   )
-  llm_mock({text: "resumed after review"})
-  let handle = sub_agent_run(
-    "Park until review approval.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  let trigger_handle = suspended?.suspension?.auto_resume_trigger
-  __io_println(suspended?.status)
-  __io_println(trigger_handle?.id != nil)
-  __io_println(trigger_handle?.version != nil)
-  let fired: DispatchHandle = trigger_fire(
-    trigger_handle,
-    {
-      provider: "github",
-      kind: "review.approved",
-      payload: {decision: "approved"},
-      headers: {x_delivery: "auto-resume-conformance"},
-    },
-  )
-  __io_println(fired.status)
-  let resumed = wait_agent(handle)
-  __io_println(resumed?.status)
-  __io_println(contains(resumed?.task ?? "", "approved"))
 }

--- a/conformance/tests/agents/agent_autonomy_budget_exhausts.harn
+++ b/conformance/tests/agents/agent_autonomy_budget_exhausts.harn
@@ -4,51 +4,57 @@
 // approval request before any LLM work fires. Mirrors the trigger-side
 // `daily_autonomy_budget_exceeded` flow added in burin-labs/harn#928.
 import "std/hitl"
+import { with_llm_script } from "std/testing"
 
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "##DONE##", input_tokens: 5, output_tokens: 2, model: "mock-model"})
-  llm_mock({text: "##DONE##", input_tokens: 5, output_tokens: 2, model: "mock-model"})
-  let unique = to_string(to_int(harness.clock.timestamp())) + "-"
-    + to_string(harness.random.gen_range(100000, 999999))
-  let key = "agent.autonomy.budget." + unique
-  // First call burns the quota.
-  let first = agent_loop(
-    "First task",
-    "You are helpful",
-    {
-      provider: "mock",
-      model: "mock-model",
-      max_iterations: 1,
-      max_nudges: 0,
-      autonomy_budget: {per_day: 1, key: key},
+  with_llm_script(
+    [
+      {text: "##DONE##", input_tokens: 5, output_tokens: 2, model: "mock-model"},
+      {text: "##DONE##", input_tokens: 5, output_tokens: 2, model: "mock-model"},
+    ],
+    { ->
+      let unique = to_string(to_int(harness.clock.timestamp())) + "-"
+        + to_string(harness.random.gen_range(100000, 999999))
+      let key = "agent.autonomy.budget." + unique
+      let first = agent_loop(
+        "First task",
+        "You are helpful",
+        {
+          provider: "mock",
+          model: "mock-model",
+          max_iterations: 1,
+          max_nudges: 0,
+          autonomy_budget: {per_day: 1, key: key},
+        },
+      )
+      __io_println(first.status)
+      let second = agent_loop(
+        "Second task",
+        "You are helpful",
+        {
+          provider: "mock",
+          model: "mock-model",
+          max_iterations: 1,
+          max_nudges: 0,
+          autonomy_budget: {per_day: 1, key: key, reviewer: "oncall"},
+        },
+      )
+      __io_println(second.status)
+      __io_println(second.reason)
+      __io_println(second.approval_required)
+      __io_println(second.from_tier)
+      __io_println(second.requested_tier)
+      __io_println(second.reviewers[0])
+      __io_println(type_of(second.request_id) == "string" && len(second.request_id) > 0)
+      let pending = hitl_pending({}).filter({ row -> row.agent == key })
+      __io_println(len(pending) >= 1)
+      __io_println(pending[0].request_kind)
     },
   )
-  // Mock's `##DONE##` exits the loop cleanly -> status "done".
-  __io_println(first.status)
-  // Second call exceeds the daily quota and is routed to approval
-  // before the LLM is touched. The result envelope carries the same
-  // `approval_required` shape the trigger dispatcher emits.
-  let second = agent_loop(
-    "Second task",
-    "You are helpful",
-    {
-      provider: "mock",
-      model: "mock-model",
-      max_iterations: 1,
-      max_nudges: 0,
-      autonomy_budget: {per_day: 1, key: key, reviewer: "oncall"},
-    },
-  )
-  __io_println(second.status)
-  __io_println(second.reason)
-  __io_println(second.approval_required)
-  __io_println(second.from_tier)
-  __io_println(second.requested_tier)
-  __io_println(second.reviewers[0])
-  __io_println(type_of(second.request_id) == "string" && len(second.request_id) > 0)
-  // The approval request landed on hitl.approvals.
-  let pending = hitl_pending({}).filter({ row -> row.agent == key })
-  __io_println(len(pending) >= 1)
-  __io_println(pending[0].request_kind)
 }
+// First call burns the quota.
+// Mock's `##DONE##` exits the loop cleanly -> status "done".
+// Second call exceeds the daily quota and is routed to approval
+// before the LLM is touched. The result envelope carries the same
+// `approval_required` shape the trigger dispatcher emits.
+// The approval request landed on hitl.approvals.

--- a/conformance/tests/agents/agent_await_resumption.harn
+++ b/conformance/tests/agents/agent_await_resumption.harn
@@ -1,53 +1,58 @@
 import { agent_capture_events } from "std/agent/events"
+import { with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock(
-    {
-      tool_calls: [
-        {
-          id: "park_1",
-          name: "agent_await_resumption",
-          arguments: {
-            reason: "waiting on review",
-            conditions: {timeout: {duration_minutes: 5, on_timeout: "resume_with_summary"}},
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "park_1",
+            name: "agent_await_resumption",
+            arguments: {
+              reason: "waiting on review",
+              conditions: {timeout: {duration_minutes: 5, on_timeout: "resume_with_summary"}},
+            },
           },
-        },
-      ],
-      input_tokens: 7,
-      output_tokens: 3,
-    },
-  )
-  let session_id = "await-resumption-" + uuid()
-  let captured = agent_capture_events(
-    session_id,
-    fn() {
-      let handle = sub_agent_run(
-        "Park until a reviewer responds.",
-        {
-          provider: "mock",
-          background: true,
-          session_id: session_id,
-          tool_format: "native",
-          max_iterations: 3,
+        ],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+    ],
+    { ->
+      let session_id = "await-resumption-" + uuid()
+      let captured = agent_capture_events(
+        session_id,
+        fn() {
+          let handle = sub_agent_run(
+            "Park until a reviewer responds.",
+            {
+              provider: "mock",
+              background: true,
+              session_id: session_id,
+              tool_format: "native",
+              max_iterations: 3,
+            },
+          )
+          return wait_agent(handle)
         },
       )
-      return wait_agent(handle)
+      let suspended = captured.result
+      let payload = suspended?.result
+      let audit = captured.events
+        .filter(
+        { event -> event.type == "tool_call_audit" && event.tool_name == "agent_await_resumption" },
+      )
+      __io_println(suspended?.status)
+      __io_println(payload?.status)
+      __io_println(payload?.reason)
+      __io_println(payload?.initiator)
+      __io_println(payload?.conditions?.timeout?.duration_minutes)
+      __io_println(payload?.conditions?.timeout?.on_timeout)
+      __io_println(payload?.handle?.id == suspended?.id)
+      __io_println(len(audit) == 1)
+      __io_println(audit[0]?.audit?.reason)
+      __io_println(audit[0]?.audit?.initiator)
     },
   )
-  let suspended = captured.result
-  let payload = suspended?.result
-  let audit = captured.events
-    .filter(
-    { event -> event.type == "tool_call_audit" && event.tool_name == "agent_await_resumption" },
-  )
-  __io_println(suspended?.status)
-  __io_println(payload?.status)
-  __io_println(payload?.reason)
-  __io_println(payload?.initiator)
-  __io_println(payload?.conditions?.timeout?.duration_minutes)
-  __io_println(payload?.conditions?.timeout?.on_timeout)
-  __io_println(payload?.handle?.id == suspended?.id)
-  __io_println(len(audit) == 1)
-  __io_println(audit[0]?.audit?.reason)
-  __io_println(audit[0]?.audit?.initiator)
 }

--- a/conformance/tests/agents/agent_await_resumption_invalid_feedback.harn
+++ b/conformance/tests/agents/agent_await_resumption_invalid_feedback.harn
@@ -1,34 +1,39 @@
+import { with_llm_script } from "std/testing"
+
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "bad_await",
+            name: "agent_await_resumption",
+            arguments: {reason: "waiting on review", conditions: {trigger: "review.approved"}},
+          },
+        ],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      {text: "Recovered. ##DONE##", input_tokens: 5, output_tokens: 2},
+    ],
+    { ->
+      let result = agent_loop(
+        "Finish without parking.",
+        nil,
         {
-          id: "bad_await",
-          name: "agent_await_resumption",
-          arguments: {reason: "waiting on review", conditions: {trigger: "review.approved"}},
+          provider: "mock",
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_iterations: 3,
         },
-      ],
-      input_tokens: 7,
-      output_tokens: 3,
+      )
+      let calls = llm_mock_calls()
+      let followup = json_stringify(calls[1]?.messages ?? [])
+      __io_println(result.status)
+      __io_println(len(calls))
+      __io_println(contains(followup, "HARN-SUS-002"))
+      __io_println(contains(followup, "conditions.trigger"))
     },
   )
-  llm_mock({text: "Recovered. ##DONE##", input_tokens: 5, output_tokens: 2})
-  let result = agent_loop(
-    "Finish without parking.",
-    nil,
-    {
-      provider: "mock",
-      tool_format: "native",
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_iterations: 3,
-    },
-  )
-  let calls = llm_mock_calls()
-  let followup = json_stringify(calls[1]?.messages ?? [])
-  __io_println(result.status)
-  __io_println(len(calls))
-  __io_println(contains(followup, "HARN-SUS-002"))
-  __io_println(contains(followup, "conditions.trigger"))
 }

--- a/conformance/tests/agents/agent_budget_exhausted.harn
+++ b/conformance/tests/agents/agent_budget_exhausted.harn
@@ -1,22 +1,27 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "still working"})
-  // Run a loop-until-done agent loop against the mock provider with a small
-  // max_iterations budget. The fixture response intentionally omits the
-  // configured ##DONE## sentinel, so the loop exhausts its iteration budget
-  // rather than finishing naturally.
-  let result = agent_loop(
-    "Just keep replying",
-    "You are helpful",
-    {
-      provider: "mock",
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_iterations: 1,
-      max_nudges: 5,
+  with_llm_script(
+    [llm_text("still working")],
+    { ->
+      let result = agent_loop(
+        "Just keep replying",
+        "You are helpful",
+        {
+          provider: "mock",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_iterations: 1,
+          max_nudges: 5,
+        },
+      )
+      __io_println(result.status)
+      assert(result.status == "budget_exhausted", "status should be budget_exhausted")
+      assert(result.llm.iterations >= 1, "should have run at least one iteration")
     },
   )
-  __io_println(result.status)
-  assert(result.status == "budget_exhausted", "status should be budget_exhausted")
-  assert(result.llm.iterations >= 1, "should have run at least one iteration")
 }
+// Run a loop-until-done agent loop against the mock provider with a small
+// max_iterations budget. The fixture response intentionally omits the
+// configured ##DONE## sentinel, so the loop exhausts its iteration budget
+// rather than finishing naturally.

--- a/conformance/tests/agents/agent_chat_loop.harn
+++ b/conformance/tests/agents/agent_chat_loop.harn
@@ -1,56 +1,60 @@
 import { agent_chat_loop, agent_chat_route_input } from "std/agent/chat"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
   let routed = agent_chat_route_input("/help", {}, {"/runs": { _req -> {kind: "handled", message: "runs"} }})
   __io_println(routed.kind)
   __io_println(contains(routed.message, "/runs"))
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "Need more info.",
-      tool_calls: [{id: "wait-1", name: "wait_for_user", arguments: {question: "Which branch?"}}],
+  with_llm_script(
+    [
+      {
+        text: "Need more info.",
+        tool_calls: [{id: "wait-1", name: "wait_for_user", arguments: {question: "Which branch?"}}],
+      },
+      llm_text("Done."),
+    ],
+    { ->
+      let input_count = atomic(0)
+      let model_count = atomic(0)
+      let wait_count = atomic(0)
+      let result = agent_chat_loop(
+        {
+          session_id: "agent-chat-loop-conformance",
+          provider: "mock",
+          tool_format: "native",
+          max_turns: 2,
+          on_user_input: { state ->
+            let n = atomic_add(input_count, 1)
+            if n == 0 {
+              return {kind: "send", message: "start"}
+            }
+            if n == 1 {
+              return {kind: "handled", state: state + {handled_once: true}}
+            }
+            if n == 2 {
+              return {kind: "send", message: "main"}
+            }
+            return {kind: "exit", reason: "operator_exit"}
+          },
+          on_model_turn: { turn, state ->
+            let _ = atomic_add(model_count, 1)
+            if turn.stop_reason == "wait_for_user" {
+              let _ = atomic_add(wait_count, 1)
+            }
+            return {state: state + {last_stop: turn.stop_reason}}
+          },
+        },
+      )
+      __io_println(result.turns)
+      __io_println(result.stop_reason)
+      __io_println(result.last_result?.visible_text)
+      __io_println(result.state.handled_once)
+      __io_println(result.state.last_wait_for_user_question)
+      __io_println(atomic_get(input_count))
+      __io_println(atomic_get(model_count))
+      __io_println(atomic_get(wait_count))
+      __io_println(len(result.transcript.messages))
+      __io_println(agent_session_exists("agent-chat-loop-conformance"))
     },
   )
-  llm_mock({text: "Done."})
-  let input_count = atomic(0)
-  let model_count = atomic(0)
-  let wait_count = atomic(0)
-  let result = agent_chat_loop(
-    {
-      session_id: "agent-chat-loop-conformance",
-      provider: "mock",
-      tool_format: "native",
-      max_turns: 2,
-      on_user_input: { state ->
-        let n = atomic_add(input_count, 1)
-        if n == 0 {
-          return {kind: "send", message: "start"}
-        }
-        if n == 1 {
-          return {kind: "handled", state: state + {handled_once: true}}
-        }
-        if n == 2 {
-          return {kind: "send", message: "main"}
-        }
-        return {kind: "exit", reason: "operator_exit"}
-      },
-      on_model_turn: { turn, state ->
-        let _ = atomic_add(model_count, 1)
-        if turn.stop_reason == "wait_for_user" {
-          let _ = atomic_add(wait_count, 1)
-        }
-        return {state: state + {last_stop: turn.stop_reason}}
-      },
-    },
-  )
-  __io_println(result.turns)
-  __io_println(result.stop_reason)
-  __io_println(result.last_result?.visible_text)
-  __io_println(result.state.handled_once)
-  __io_println(result.state.last_wait_for_user_question)
-  __io_println(atomic_get(input_count))
-  __io_println(atomic_get(model_count))
-  __io_println(atomic_get(wait_count))
-  __io_println(len(result.transcript.messages))
-  __io_println(agent_session_exists("agent-chat-loop-conformance"))
 }

--- a/conformance/tests/agents/agent_daemon_await_resumption.harn
+++ b/conformance/tests/agents/agent_daemon_await_resumption.harn
@@ -1,25 +1,30 @@
 import { agent_capture_events } from "std/agent/events"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
   let session_id = "daemon-await-resumption-" + uuid()
-  llm_mock({text: "daemon idle"})
-  let captured = agent_capture_events(
-    session_id,
-    fn() { return agent_loop(
-      "Poll for background work",
-      nil,
-      {provider: "mock", daemon: true, max_iterations: 1, wake_interval_ms: 1, session_id: session_id},
-    ) },
+  with_llm_script(
+    [llm_text("daemon idle")],
+    { ->
+      let captured = agent_capture_events(
+        session_id,
+        fn() { return agent_loop(
+          "Poll for background work",
+          nil,
+          {provider: "mock", daemon: true, max_iterations: 1, wake_interval_ms: 1, session_id: session_id},
+        ) },
+      )
+      let audit = captured.events
+        .filter(
+        { event -> event.type == "tool_call_audit" && event.tool_name == "agent_await_resumption" },
+      )
+      __io_println(captured.result.status)
+      __io_println(len(audit) == 1)
+      __io_println(audit[0]?.audit?.status)
+      __io_println(audit[0]?.audit?.reason)
+      __io_println(audit[0]?.audit?.initiator)
+      __io_println(audit[0]?.audit?.conditions?.timeout?.duration_minutes)
+      __io_println(audit[0]?.audit?.conditions?.timeout?.on_timeout)
+    },
   )
-  let audit = captured.events
-    .filter(
-    { event -> event.type == "tool_call_audit" && event.tool_name == "agent_await_resumption" },
-  )
-  __io_println(captured.result.status)
-  __io_println(len(audit) == 1)
-  __io_println(audit[0]?.audit?.status)
-  __io_println(audit[0]?.audit?.reason)
-  __io_println(audit[0]?.audit?.initiator)
-  __io_println(audit[0]?.audit?.conditions?.timeout?.duration_minutes)
-  __io_println(audit[0]?.audit?.conditions?.timeout?.on_timeout)
 }

--- a/conformance/tests/agents/agent_event_capture.harn
+++ b/conformance/tests/agents/agent_event_capture.harn
@@ -1,19 +1,23 @@
 import { agent_capture_events } from "std/agent/events"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "Captured."})
-  let session = "capture-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Say captured",
-      nil,
-      {provider: "mock", max_iterations: 1, session_id: session, done_judge: false},
-    ) },
+  with_llm_script(
+    [llm_text("Captured.")],
+    { ->
+      let session = "capture-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Say captured",
+          nil,
+          {provider: "mock", max_iterations: 1, session_id: session, done_judge: false},
+        ) },
+      )
+      let types = captured.events.map({ event -> event.type })
+      __io_println(captured.result.status)
+      __io_println(len(captured.events) > 0)
+      __io_println(contains(types, "iteration_start"))
+    },
   )
-  let types = captured.events.map({ event -> event.type })
-  __io_println(captured.result.status)
-  __io_println(len(captured.events) > 0)
-  __io_println(contains(types, "iteration_start"))
 }

--- a/conformance/tests/agents/agent_host_tools_loop.harn
+++ b/conformance/tests/agents/agent_host_tools_loop.harn
@@ -1,4 +1,5 @@
 import { agent_command_tools } from "std/agent/host_tools"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   let root = path_join(harness.fs.temp_dir(), "harn-host-tools-loop-" + uuid())
@@ -7,39 +8,42 @@ pipeline main() {
     nil,
     {root: root, cwd: root, max_inline_bytes: 4, allow_argv_prefixes: [["sh", "-c"]]},
   )
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "",
-      tool_calls: [
+  with_llm_script(
+    [
+      {
+        text: "",
+        tool_calls: [
+          {
+            id: "run1",
+            name: "run_command",
+            arguments: {argv: ["sh", "-c", "printf toolhistory"], capture: {max_inline_bytes: 4}},
+          },
+        ],
+      },
+      llm_text("Saw the command result."),
+    ],
+    { ->
+      let result = agent_loop(
+        "Run the command and report back.",
+        nil,
         {
-          id: "run1",
-          name: "run_command",
-          arguments: {argv: ["sh", "-c", "printf toolhistory"], capture: {max_inline_bytes: 4}},
+          provider: "mock",
+          tools: tools,
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          done_judge: nil,
         },
-      ],
+      )
+      __io_println(result.status)
+      let calls = llm_mock_calls()
+      __io_println(len(calls) >= 2)
+      __io_println(!contains(calls[0].system, "##DONE##"))
+      __io_println(!contains(calls[1].system, "##DONE##"))
+      __io_println(contains(calls[0].system, "no more tool calls"))
+      let second_turn = json_stringify(calls[1].messages)
+      __io_println(contains(second_turn, "byte_count"))
+      __io_println(contains(second_turn, "tool"))
     },
   )
-  llm_mock({text: "Saw the command result."})
-  let result = agent_loop(
-    "Run the command and report back.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools,
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      done_judge: nil,
-    },
-  )
-  __io_println(result.status)
-  let calls = llm_mock_calls()
-  __io_println(len(calls) >= 2)
-  __io_println(!contains(calls[0].system, "##DONE##"))
-  __io_println(!contains(calls[1].system, "##DONE##"))
-  __io_println(contains(calls[0].system, "no more tool calls"))
-  let second_turn = json_stringify(calls[1].messages)
-  __io_println(contains(second_turn, "byte_count"))
-  __io_println(contains(second_turn, "tool"))
 }

--- a/conformance/tests/agents/agent_loop_adaptive_budget.harn
+++ b/conformance/tests/agents/agent_loop_adaptive_budget.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn lookup_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -16,112 +18,135 @@ fn lookup_tools() {
 
 pipeline default() {
   // Case 1: adaptive budget starts low, ends early on natural completion.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "alpha"}}]})
-  llm_mock({text: "<user_response>All good.</user_response>"})
-  let early = agent_loop(
-    "Inspect alpha",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 3, max: 8, extend_by: 2},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "alpha"}}]},
+      llm_text("<user_response>All good.</user_response>"),
+    ],
+    { ->
+      let early = agent_loop(
+        "Inspect alpha",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 3, max: 8, extend_by: 2},
+        },
+      )
+      __io_println(early.status)
+      __io_println(early.llm.iterations)
+      __io_println(early.adaptive_budget.mode)
+      __io_println(early.adaptive_budget.initial)
+      __io_println(early.adaptive_budget.max)
+      __io_println(early.adaptive_budget.final_limit)
+      __io_println(early.adaptive_budget.extensions_used)
+      __io_println(len(early.adaptive_budget.decisions))
     },
   )
-  __io_println(early.status)
-  __io_println(early.llm.iterations)
-  __io_println(early.adaptive_budget.mode)
-  __io_println(early.adaptive_budget.initial)
-  __io_println(early.adaptive_budget.max)
-  __io_println(early.adaptive_budget.final_limit)
-  __io_println(early.adaptive_budget.extensions_used)
-  __io_println(len(early.adaptive_budget.decisions))
-  // Case 2: cap starts low; tool progress at the cap edge triggers default
-  // policy extension. Three tool turns, then a final natural-completion.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "t1", name: "lookup", arguments: {query: "1"}}]})
-  llm_mock({tool_calls: [{id: "t2", name: "lookup", arguments: {query: "2"}}]})
-  llm_mock({tool_calls: [{id: "t3", name: "lookup", arguments: {query: "3"}}]})
-  llm_mock({text: "<user_response>Done after extension.</user_response>"})
-  let extended = agent_loop(
-    "Inspect everything",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 2, max: 6, extend_by: 2},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "t1", name: "lookup", arguments: {query: "1"}}]},
+      {tool_calls: [{id: "t2", name: "lookup", arguments: {query: "2"}}]},
+      {tool_calls: [{id: "t3", name: "lookup", arguments: {query: "3"}}]},
+      llm_text("<user_response>Done after extension.</user_response>"),
+    ],
+    { ->
+      let extended = agent_loop(
+        "Inspect everything",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 2, max: 6, extend_by: 2},
+        },
+      )
+      __io_println(extended.status)
+      __io_println(extended.llm.iterations)
+      __io_println(extended.adaptive_budget.extensions_used)
+      __io_println(len(extended.adaptive_budget.decisions))
+      __io_println(extended.adaptive_budget.decisions[0].action)
+      __io_println(extended.adaptive_budget.decisions[0].old_limit)
+      __io_println(extended.adaptive_budget.decisions[0].new_limit)
     },
   )
-  __io_println(extended.status)
-  __io_println(extended.llm.iterations)
-  __io_println(extended.adaptive_budget.extensions_used)
-  __io_println(len(extended.adaptive_budget.decisions))
-  __io_println(extended.adaptive_budget.decisions[0].action)
-  __io_println(extended.adaptive_budget.decisions[0].old_limit)
-  __io_println(extended.adaptive_budget.decisions[0].new_limit)
-  // Case 3: max cap is honored. With initial=2, max=4, three tool calls
-  // exhaust the budget after one extension; status becomes budget_exhausted.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "tA", name: "lookup", arguments: {query: "x"}}]})
-  llm_mock({tool_calls: [{id: "tB", name: "lookup", arguments: {query: "y"}}]})
-  llm_mock({tool_calls: [{id: "tC", name: "lookup", arguments: {query: "z"}}]})
-  llm_mock({tool_calls: [{id: "tD", name: "lookup", arguments: {query: "w"}}]})
-  llm_mock({tool_calls: [{id: "tE", name: "lookup", arguments: {query: "q"}}]})
-  let capped = agent_loop(
-    "Keep working",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 2, max: 4, extend_by: 2},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "tA", name: "lookup", arguments: {query: "x"}}]},
+      {tool_calls: [{id: "tB", name: "lookup", arguments: {query: "y"}}]},
+      {tool_calls: [{id: "tC", name: "lookup", arguments: {query: "z"}}]},
+      {tool_calls: [{id: "tD", name: "lookup", arguments: {query: "w"}}]},
+      {tool_calls: [{id: "tE", name: "lookup", arguments: {query: "q"}}]},
+    ],
+    { ->
+      let capped = agent_loop(
+        "Keep working",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 2, max: 4, extend_by: 2},
+        },
+      )
+      __io_println(capped.status)
+      __io_println(capped.adaptive_budget.final_limit)
+      __io_println(capped.adaptive_budget.final_limit <= capped.adaptive_budget.max)
     },
   )
-  __io_println(capped.status)
-  __io_println(capped.adaptive_budget.final_limit)
-  __io_println(capped.adaptive_budget.final_limit <= capped.adaptive_budget.max)
-  // Case 4: caller-supplied loop_control closure stops the loop early.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "early1", name: "lookup", arguments: {query: "stop"}}]})
-  llm_mock({tool_calls: [{id: "early2", name: "lookup", arguments: {query: "now"}}]})
-  let controlled = agent_loop(
-    "Inspect stop",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 5, max: 10, extend_by: 2},
-      loop_control: { state ->
-        if state.iteration >= 2 {
-          {action: "stop", status: "incomplete", reason: "policy stop"}
-        } else {
-          nil
-        }
-      },
+  with_llm_script(
+    [
+      {tool_calls: [{id: "early1", name: "lookup", arguments: {query: "stop"}}]},
+      {tool_calls: [{id: "early2", name: "lookup", arguments: {query: "now"}}]},
+    ],
+    { ->
+      let controlled = agent_loop(
+        "Inspect stop",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 5, max: 10, extend_by: 2},
+          loop_control: { state ->
+            if state.iteration >= 2 {
+              {action: "stop", status: "incomplete", reason: "policy stop"}
+            } else {
+              nil
+            }
+          },
+        },
+      )
+      __io_println(controlled.status)
+      __io_println(controlled.stop_reason)
+      __io_println(controlled.llm.iterations)
+      __io_println(
+        controlled.adaptive_budget.decisions[len(controlled.adaptive_budget.decisions) - 1].action,
+      )
     },
   )
-  __io_println(controlled.status)
-  __io_println(controlled.stop_reason)
-  __io_println(controlled.llm.iterations)
-  __io_println(
-    controlled.adaptive_budget.decisions[len(controlled.adaptive_budget.decisions) - 1].action,
+  with_llm_script(
+    [llm_text("Plain final answer.")],
+    { ->
+      let legacy = agent_loop(
+        "Do nothing fancy.",
+        nil,
+        {provider: "mock", tools: tool_registry(), tool_format: "native", max_iterations: 1},
+      )
+      __io_println(legacy.status)
+      __io_println(legacy.llm.iterations)
+      __io_println(contains(legacy.keys(), "adaptive_budget"))
+    },
   )
-  // Case 5: legacy fixed `max_iterations` still works without adaptive_budget surface.
-  llm_mock_clear()
-  llm_mock({text: "Plain final answer."})
-  let legacy = agent_loop(
-    "Do nothing fancy.",
-    nil,
-    {provider: "mock", tools: tool_registry(), tool_format: "native", max_iterations: 1},
-  )
-  __io_println(legacy.status)
-  __io_println(legacy.llm.iterations)
-  __io_println(contains(legacy.keys(), "adaptive_budget"))
 }
+// Case 2: cap starts low; tool progress at the cap edge triggers default
+// policy extension. Three tool turns, then a final natural-completion.
+// Case 3: max cap is honored. With initial=2, max=4, three tool calls
+// exhaust the budget after one extension; status becomes budget_exhausted.
+// Case 4: caller-supplied loop_control closure stops the loop early.
+// Case 5: legacy fixed `max_iterations` still works without adaptive_budget surface.

--- a/conformance/tests/agents/agent_loop_adaptive_budget_mock_time.harn
+++ b/conformance/tests/agents/agent_loop_adaptive_budget_mock_time.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `iteration_budget` adaptive mode under mock_time. The budget logic
  * is decoupled from wall-clock — it counts turns and tool progress —
@@ -26,30 +28,35 @@ fn lookup_tools() {
 pipeline default() {
   mock_time(1700000000000)
   let start_ms = harness.clock.now_ms()
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "t1", name: "lookup", arguments: {q: "1"}}]})
-  llm_mock({tool_calls: [{id: "t2", name: "lookup", arguments: {q: "2"}}]})
-  llm_mock({tool_calls: [{id: "t3", name: "lookup", arguments: {q: "3"}}]})
-  llm_mock({text: "<user_response>Done.</user_response>"})
-  let result = agent_loop(
-    "Inspect everything.",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 2, max: 8, extend_by: 2},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "t1", name: "lookup", arguments: {q: "1"}}]},
+      {tool_calls: [{id: "t2", name: "lookup", arguments: {q: "2"}}]},
+      {tool_calls: [{id: "t3", name: "lookup", arguments: {q: "3"}}]},
+      llm_text("<user_response>Done.</user_response>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Inspect everything.",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 2, max: 8, extend_by: 2},
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.adaptive_budget.mode)
+      __io_println(result.adaptive_budget.initial)
+      __io_println(result.adaptive_budget.max)
+      __io_println(result.adaptive_budget.extensions_used >= 1)
+      __io_println(result.adaptive_budget.decisions[0].action)
+      __io_println(harness.clock.now_ms() == start_ms)
+      unmock_time()
     },
   )
-  __io_println(result.status)
-  __io_println(result.adaptive_budget.mode)
-  __io_println(result.adaptive_budget.initial)
-  __io_println(result.adaptive_budget.max)
-  __io_println(result.adaptive_budget.extensions_used >= 1)
-  __io_println(result.adaptive_budget.decisions[0].action)
-  // Mock time stayed pinned: no opaque wall-clock observation lurks
-  // in the budget path.
-  __io_println(harness.clock.now_ms() == start_ms)
-  unmock_time()
 }
+// Mock time stayed pinned: no opaque wall-clock observation lurks
+// in the budget path.

--- a/conformance/tests/agents/agent_loop_checkpoint_hook.harn
+++ b/conformance/tests/agents/agent_loop_checkpoint_hook.harn
@@ -6,7 +6,6 @@
  */
 pipeline main() {
   clear_session_hooks()
-  llm_mock_clear()
   let observed = shared_cell({scope: "task_group", key: "checkpoint-kinds", initial: ""})
   register_checkpoint_hook(
     ["iteration_start", "pre_tool_dispatch", "loop_exit"],

--- a/conformance/tests/agents/agent_loop_completion_confirmation_nudge.harn
+++ b/conformance/tests/agents/agent_loop_completion_confirmation_nudge.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Engine-side recovery from the Qwen3 thinking + native tools regression
  * (QwenLM/Qwen3.6 #89): when a model emits prose without any tool_calls
@@ -61,73 +63,85 @@ fn nudge_text_in(calls, idx) {
 
 pipeline main() {
   // Scenario 1: regression-then-recover.
-  llm_mock_clear()
-  llm_mock({text: "Let me look that up for you."})
-  llm_mock({tool_calls: [{id: "l1", name: "lookup", arguments: {query: "release"}}]})
-  llm_mock({text: "Found it: release notes are ready."})
-  let recover = agent_loop(
-    "Look up the release notes.",
-    nil,
-    {
-      provider: "mock",
-      tools: evidence_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 5,
-      max_nudges: 3,
+  with_llm_script(
+    [
+      llm_text("Let me look that up for you."),
+      {tool_calls: [{id: "l1", name: "lookup", arguments: {query: "release"}}]},
+      llm_text("Found it: release notes are ready."),
+    ],
+    { ->
+      let recover = agent_loop(
+        "Look up the release notes.",
+        nil,
+        {
+          provider: "mock",
+          tools: evidence_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 5,
+          max_nudges: 3,
+        },
+      )
+      __io_println("recover.status=" + recover.status)
+      __io_println("recover.iterations=" + to_string(recover.llm.iterations))
+      __io_println("recover.successful=" + json_stringify(recover.tools.successful))
+      let recover_calls = llm_mock_calls()
+      __io_println("recover.nudge_on_turn2=" + to_string(nudge_text_in(recover_calls, 1)))
     },
   )
-  __io_println("recover.status=" + recover.status)
-  __io_println("recover.iterations=" + to_string(recover.llm.iterations))
-  __io_println("recover.successful=" + json_stringify(recover.tools.successful))
-  // The turn-2 request must include the engine-injected nudge text so
-  // the model sees the recovery cue.
-  let recover_calls = llm_mock_calls()
-  __io_println("recover.nudge_on_turn2=" + to_string(nudge_text_in(recover_calls, 1)))
-  // Scenario 2: confirmation path (prose again after the nudge).
-  llm_mock_clear()
-  llm_mock({text: "Direct answer: 42."})
-  llm_mock({text: "Confirmed: 42."})
-  let confirm = agent_loop(
-    "What is the answer?",
-    nil,
-    {
-      provider: "mock",
-      tools: evidence_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 5,
-      max_nudges: 3,
+  with_llm_script(
+    [llm_text("Direct answer: 42."), llm_text("Confirmed: 42.")],
+    { ->
+      let confirm = agent_loop(
+        "What is the answer?",
+        nil,
+        {
+          provider: "mock",
+          tools: evidence_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 5,
+          max_nudges: 3,
+        },
+      )
+      __io_println("confirm.status=" + confirm.status)
+      __io_println("confirm.iterations=" + to_string(confirm.llm.iterations))
+      __io_println("confirm.text=" + confirm.text)
+      let confirm_calls = llm_mock_calls()
+      __io_println("confirm.nudge_on_turn2=" + to_string(nudge_text_in(confirm_calls, 1)))
     },
   )
-  __io_println("confirm.status=" + confirm.status)
-  __io_println("confirm.iterations=" + to_string(confirm.llm.iterations))
-  __io_println("confirm.text=" + confirm.text)
-  let confirm_calls = llm_mock_calls()
-  __io_println("confirm.nudge_on_turn2=" + to_string(nudge_text_in(confirm_calls, 1)))
-  // Scenario 3: rejected-tool then prose. No nudge because the tool
-  // channel was engaged (even though execution failed).
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "bad1", name: "always_fails", arguments: {}}]})
-  llm_mock({text: "Tool blew up, here is what I can say from prior knowledge."})
-  let skip = agent_loop(
-    "Try the tool and report.",
-    nil,
-    {
-      provider: "mock",
-      tools: failing_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 5,
-      max_nudges: 3,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "bad1", name: "always_fails", arguments: {}}]},
+      llm_text("Tool blew up, here is what I can say from prior knowledge."),
+    ],
+    { ->
+      let skip = agent_loop(
+        "Try the tool and report.",
+        nil,
+        {
+          provider: "mock",
+          tools: failing_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 5,
+          max_nudges: 3,
+        },
+      )
+      __io_println("skip.status=" + skip.status)
+      __io_println("skip.iterations=" + to_string(skip.llm.iterations))
+      __io_println(
+        "skip.rejected_has_failure=" + to_string(contains(skip.tools.rejected, "always_fails")),
+      )
+      let skip_calls = llm_mock_calls()
+      __io_println("skip.nudge_on_turn2=" + to_string(nudge_text_in(skip_calls, 1)))
     },
   )
-  __io_println("skip.status=" + skip.status)
-  __io_println("skip.iterations=" + to_string(skip.llm.iterations))
-  __io_println(
-    "skip.rejected_has_failure=" + to_string(contains(skip.tools.rejected, "always_fails")),
-  )
-  let skip_calls = llm_mock_calls()
-  // No nudge on turn 2 — the rejected tool counts as "channel engaged".
-  __io_println("skip.nudge_on_turn2=" + to_string(nudge_text_in(skip_calls, 1)))
 }
+// The turn-2 request must include the engine-injected nudge text so
+// the model sees the recovery cue.
+// Scenario 2: confirmation path (prose again after the nudge).
+// Scenario 3: rejected-tool then prose. No nudge because the tool
+// channel was engaged (even though execution failed).
+// No nudge on turn 2 — the rejected tool counts as "channel engaged".

--- a/conformance/tests/agents/agent_loop_denial_loop.harn
+++ b/conformance/tests/agents/agent_loop_denial_loop.harn
@@ -1,4 +1,5 @@
 import { agent_capture_events } from "std/agent/events"
+import { with_llm_script } from "std/testing"
 
 /**
  * A tool that the capability policy refuses comes back as a structured,
@@ -28,31 +29,36 @@ fn write_tools() {
 
 pipeline default() {
   let tools = write_tools()
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "w1", name: "write_note", arguments: {path: "a"}}]})
-  llm_mock({text: "", tool_calls: [{id: "w2", name: "write_note", arguments: {path: "a"}}]})
-  llm_mock({text: "", tool_calls: [{id: "w3", name: "write_note", arguments: {path: "a"}}]})
-  llm_mock({text: "", tool_calls: [{id: "w4", name: "write_note", arguments: {path: "a"}}]})
-  llm_mock({text: "", tool_calls: [{id: "w5", name: "write_note", arguments: {path: "a"}}]})
-  let session = "denial-loop-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Keep trying to write the note.",
-      nil,
-      {
-        provider: "mock",
-        tools: tools,
-        tool_format: "native",
-        max_iterations: 5,
-        session_id: session,
-        policy: {tools: ["read_only"]},
-        stall_diagnostics: {enabled: true, inject_feedback: false},
-      },
-    ) },
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "w1", name: "write_note", arguments: {path: "a"}}]},
+      {text: "", tool_calls: [{id: "w2", name: "write_note", arguments: {path: "a"}}]},
+      {text: "", tool_calls: [{id: "w3", name: "write_note", arguments: {path: "a"}}]},
+      {text: "", tool_calls: [{id: "w4", name: "write_note", arguments: {path: "a"}}]},
+      {text: "", tool_calls: [{id: "w5", name: "write_note", arguments: {path: "a"}}]},
+    ],
+    { ->
+      let session = "denial-loop-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Keep trying to write the note.",
+          nil,
+          {
+            provider: "mock",
+            tools: tools,
+            tool_format: "native",
+            max_iterations: 5,
+            session_id: session,
+            policy: {tools: ["read_only"]},
+            stall_diagnostics: {enabled: true, inject_feedback: false},
+          },
+        ) },
+      )
+      let stalls = events_of(captured.events, "agent_loop_stall_warning")
+      require len(stalls) >= 1, "repeated terminal denials must trip the loop detector"
+      __io_println(stalls[0].warning.pattern)
+      __io_println(captured.result.suspected_loop)
+    },
   )
-  let stalls = events_of(captured.events, "agent_loop_stall_warning")
-  require len(stalls) >= 1, "repeated terminal denials must trip the loop detector"
-  __io_println(stalls[0].warning.pattern)
-  __io_println(captured.result.suspected_loop)
 }

--- a/conformance/tests/agents/agent_loop_done_judge.harn
+++ b/conformance/tests/agents/agent_loop_done_judge.harn
@@ -1,23 +1,28 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<user_response>Too thin.</user_response>\n<done>##DONE##</done>"})
-  llm_mock(
-    {
-      text: "{\"verdict\":\"continue\",\"reasoning\":\"answer lacks detail\",\"next_step\":\"Answer with the concrete result.\"}",
+  with_llm_script(
+    [
+      llm_text("<user_response>Too thin.</user_response>\n<done>##DONE##</done>"),
+      llm_text(
+        "{\"verdict\":\"continue\",\"reasoning\":\"answer lacks detail\",\"next_step\":\"Answer with the concrete result.\"}",
+      ),
+      llm_text("<user_response>The concrete result is 4.</user_response>\n<done>##DONE##</done>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"the result is explicit\"}"),
+    ],
+    { ->
+      let result = agent_loop(
+        "What is 2 + 2?",
+        nil,
+        {provider: "mock", loop_until_done: true, max_iterations: 4, done_judge: true},
+      )
+      __io_println(result.status)
+      __io_println(result.visible_text)
+      __io_println(result.llm.iterations)
+      let calls = llm_mock_calls()
+      __io_println(len(calls))
+      __io_println(!json_stringify(calls[1].messages).contains("{{"))
+      __io_println(json_stringify(calls[3].messages).contains("The concrete result is 4."))
     },
   )
-  llm_mock({text: "<user_response>The concrete result is 4.</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"the result is explicit\"}"})
-  let result = agent_loop(
-    "What is 2 + 2?",
-    nil,
-    {provider: "mock", loop_until_done: true, max_iterations: 4, done_judge: true},
-  )
-  __io_println(result.status)
-  __io_println(result.visible_text)
-  __io_println(result.llm.iterations)
-  let calls = llm_mock_calls()
-  __io_println(len(calls))
-  __io_println(!json_stringify(calls[1].messages).contains("{{"))
-  __io_println(json_stringify(calls[3].messages).contains("The concrete result is 4."))
 }

--- a/conformance/tests/agents/agent_loop_done_judge_cadence.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_cadence.harn
@@ -1,42 +1,46 @@
 import { agent_capture_events } from "std/agent/events"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn judge_events(events) {
   return events.filter({ event -> event.type == "judge_decision" })
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<user_response>candidate one</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "<user_response>candidate two</user_response>\n<done>##DONE##</done>"})
-  llm_mock(
-    {
-      text: "{\"verdict\":\"continue\",\"reasoning\":\"wait for another candidate\",\"next_step\":\"try again\"}",
+  with_llm_script(
+    [
+      llm_text("<user_response>candidate one</user_response>\n<done>##DONE##</done>"),
+      llm_text("<user_response>candidate two</user_response>\n<done>##DONE##</done>"),
+      llm_text(
+        "{\"verdict\":\"continue\",\"reasoning\":\"wait for another candidate\",\"next_step\":\"try again\"}",
+      ),
+      llm_text("<user_response>candidate three</user_response>\n<done>##DONE##</done>"),
+      llm_text("<user_response>candidate four</user_response>\n<done>##DONE##</done>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"fourth candidate is complete\"}"),
+    ],
+    { ->
+      let session = "done-judge-cadence-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Finish on cadence.",
+          nil,
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 5,
+            max_nudges: 10,
+            session_id: session,
+            done_judge: {cadence: {every: 2}},
+          },
+        ) },
+      )
+      let judges = judge_events(captured.events)
+      require len(judges) == 2, "done_judge cadence should fire on every second completion candidate"
+      __io_println(captured.result.status)
+      __io_println(captured.result.visible_text)
+      __io_println(captured.result.llm.iterations)
+      __io_println(len(llm_mock_calls()))
+      __io_println(len(judges))
     },
   )
-  llm_mock({text: "<user_response>candidate three</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "<user_response>candidate four</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"fourth candidate is complete\"}"})
-  let session = "done-judge-cadence-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Finish on cadence.",
-      nil,
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 5,
-        max_nudges: 10,
-        session_id: session,
-        done_judge: {cadence: {every: 2}},
-      },
-    ) },
-  )
-  let judges = judge_events(captured.events)
-  require len(judges) == 2, "done_judge cadence should fire on every second completion candidate"
-  __io_println(captured.result.status)
-  __io_println(captured.result.visible_text)
-  __io_println(captured.result.llm.iterations)
-  __io_println(len(llm_mock_calls()))
-  __io_println(len(judges))
 }

--- a/conformance/tests/agents/agent_loop_done_judge_cadence_limits.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_cadence_limits.harn
@@ -1,86 +1,100 @@
 import { agent_capture_events } from "std/agent/events"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn judge_events(events) {
   return events.filter({ event -> event.type == "judge_decision" })
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<user_response>healthy one</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "<user_response>healthy two</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "<user_response>healthy three</user_response>\n<done>##DONE##</done>"})
-  let stalled_session = "done-judge-stalled-" + uuid()
-  let stalled = agent_capture_events(
-    stalled_session,
-    fn() { return agent_loop(
-      "Do not judge unless stalled.",
-      nil,
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 3,
-        max_nudges: 10,
-        session_id: stalled_session,
-        done_judge: {cadence: {when: "stalled"}},
-      },
-    ) },
-  )
-  __io_println(stalled.result.status)
-  __io_println(stalled.result.llm.iterations)
-  __io_println(len(judge_events(stalled.events)))
-  __io_println(len(llm_mock_calls()))
-  llm_mock_clear()
-  llm_mock({text: "<user_response>capped one</user_response>\n<done>##DONE##</done>"})
-  llm_mock(
-    {
-      text: "{\"verdict\":\"continue\",\"reasoning\":\"first and only judge fire\",\"next_step\":\"keep going\"}",
+  with_llm_script(
+    [
+      llm_text("<user_response>healthy one</user_response>\n<done>##DONE##</done>"),
+      llm_text("<user_response>healthy two</user_response>\n<done>##DONE##</done>"),
+      llm_text("<user_response>healthy three</user_response>\n<done>##DONE##</done>"),
+    ],
+    { ->
+      let stalled_session = "done-judge-stalled-" + uuid()
+      let stalled = agent_capture_events(
+        stalled_session,
+        fn() { return agent_loop(
+          "Do not judge unless stalled.",
+          nil,
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 3,
+            max_nudges: 10,
+            session_id: stalled_session,
+            done_judge: {cadence: {when: "stalled"}},
+          },
+        ) },
+      )
+      __io_println(stalled.result.status)
+      __io_println(stalled.result.llm.iterations)
+      __io_println(len(judge_events(stalled.events)))
+      __io_println(len(llm_mock_calls()))
     },
   )
-  llm_mock({text: "<user_response>capped two</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "<user_response>capped three</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "<user_response>capped four</user_response>\n<done>##DONE##</done>"})
-  let capped_session = "done-judge-cap-" + uuid()
-  let capped = agent_capture_events(
-    capped_session,
-    fn() { return agent_loop(
-      "Judge once at most.",
-      nil,
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 4,
-        max_nudges: 10,
-        session_id: capped_session,
-        done_judge: {cadence: {every: 1, max_invocations: 1}},
-      },
-    ) },
+  with_llm_script(
+    [
+      llm_text("<user_response>capped one</user_response>\n<done>##DONE##</done>"),
+      llm_text(
+        "{\"verdict\":\"continue\",\"reasoning\":\"first and only judge fire\",\"next_step\":\"keep going\"}",
+      ),
+      llm_text("<user_response>capped two</user_response>\n<done>##DONE##</done>"),
+      llm_text("<user_response>capped three</user_response>\n<done>##DONE##</done>"),
+      llm_text("<user_response>capped four</user_response>\n<done>##DONE##</done>"),
+    ],
+    { ->
+      let capped_session = "done-judge-cap-" + uuid()
+      let capped = agent_capture_events(
+        capped_session,
+        fn() { return agent_loop(
+          "Judge once at most.",
+          nil,
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 4,
+            max_nudges: 10,
+            session_id: capped_session,
+            done_judge: {cadence: {every: 1, max_invocations: 1}},
+          },
+        ) },
+      )
+      __io_println(capped.result.status)
+      __io_println(capped.result.llm.iterations)
+      __io_println(len(judge_events(capped.events)))
+      __io_println(len(llm_mock_calls()))
+    },
   )
-  __io_println(capped.result.status)
-  __io_println(capped.result.llm.iterations)
-  __io_println(len(judge_events(capped.events)))
-  __io_println(len(llm_mock_calls()))
-  llm_mock_clear()
-  llm_mock({text: "<user_response>closure one</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "<user_response>closure two</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"closure accepted on turn two\"}"})
-  let closure_session = "done-judge-closure-" + uuid()
-  let closure = agent_capture_events(
-    closure_session,
-    fn() { return agent_loop(
-      "Judge when the loop-state predicate says so.",
-      nil,
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 3,
-        max_nudges: 10,
-        session_id: closure_session,
-        done_judge: {cadence: {when: { state -> state.iteration == 2 }}},
-      },
-    ) },
+  with_llm_script(
+    [
+      llm_text("<user_response>closure one</user_response>\n<done>##DONE##</done>"),
+      llm_text("<user_response>closure two</user_response>\n<done>##DONE##</done>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"closure accepted on turn two\"}"),
+    ],
+    { ->
+      let closure_session = "done-judge-closure-" + uuid()
+      let closure = agent_capture_events(
+        closure_session,
+        fn() { return agent_loop(
+          "Judge when the loop-state predicate says so.",
+          nil,
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 3,
+            max_nudges: 10,
+            session_id: closure_session,
+            done_judge: {cadence: {when: { state -> state.iteration == 2 }}},
+          },
+        ) },
+      )
+      __io_println(closure.result.status)
+      __io_println(closure.result.llm.iterations)
+      __io_println(len(judge_events(closure.events)))
+      __io_println(len(llm_mock_calls()))
+    },
   )
-  __io_println(closure.result.status)
-  __io_println(closure.result.llm.iterations)
-  __io_println(len(judge_events(closure.events)))
-  __io_println(len(llm_mock_calls()))
 }

--- a/conformance/tests/agents/agent_loop_done_judge_fail_open.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_fail_open.harn
@@ -1,14 +1,21 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<user_response>The answer is 4.</user_response>\n<done>##DONE##</done>"})
-  llm_mock({error: {category: "generic", message: "structured output is unavailable"}})
-  let result = agent_loop(
-    "What is 2 + 2?",
-    nil,
-    {provider: "mock", loop_until_done: true, max_iterations: 2, done_judge: {fail_open_on_error: true}},
+  with_llm_script(
+    [
+      llm_text("<user_response>The answer is 4.</user_response>\n<done>##DONE##</done>"),
+      {error: {category: "generic", message: "structured output is unavailable"}},
+    ],
+    { ->
+      let result = agent_loop(
+        "What is 2 + 2?",
+        nil,
+        {provider: "mock", loop_until_done: true, max_iterations: 2, done_judge: {fail_open_on_error: true}},
+      )
+      __io_println(result.status)
+      __io_println(result.visible_text)
+      __io_println(result.llm.iterations)
+      __io_println(len(llm_mock_calls()))
+    },
   )
-  __io_println(result.status)
-  __io_println(result.visible_text)
-  __io_println(result.llm.iterations)
-  __io_println(len(llm_mock_calls()))
 }

--- a/conformance/tests/agents/agent_loop_done_judge_transcript_isolation.harn
+++ b/conformance/tests/agents/agent_loop_done_judge_transcript_isolation.harn
@@ -1,39 +1,45 @@
 import { agent_capture_events } from "std/agent/events"
 import { agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn judge_events(events) {
   return events.filter({ event -> event.type == "judge_decision" })
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<user_response>isolated final answer</user_response>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"complete\"}"})
-  let session = "done-judge-isolation-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Finish once.",
-      nil,
-      {
-        provider: "mock",
-        tools: tool_registry(),
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 2,
-        session_id: session,
-        done_judge: true,
-      },
-    ) },
+  with_llm_script(
+    [
+      llm_text("<user_response>isolated final answer</user_response>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"complete\"}"),
+    ],
+    { ->
+      let session = "done-judge-isolation-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Finish once.",
+          nil,
+          {
+            provider: "mock",
+            tools: tool_registry(),
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 2,
+            session_id: session,
+            done_judge: true,
+          },
+        ) },
+      )
+      let messages = agent_session_messages(session)
+      let encoded = json_stringify(messages)
+      let judges = judge_events(captured.events)
+      require len(judges) == 1, "done_judge should emit one decision"
+      __io_println(captured.result.status)
+      __io_println(len(messages))
+      __io_println(contains(encoded, "isolated final answer"))
+      __io_println(!contains(encoded, "\"verdict\""))
+      __io_println(!contains(encoded, "complete"))
+      __io_println(len(llm_mock_calls()))
+    },
   )
-  let messages = agent_session_messages(session)
-  let encoded = json_stringify(messages)
-  let judges = judge_events(captured.events)
-  require len(judges) == 1, "done_judge should emit one decision"
-  __io_println(captured.result.status)
-  __io_println(len(messages))
-  __io_println(contains(encoded, "isolated final answer"))
-  __io_println(!contains(encoded, "\"verdict\""))
-  __io_println(!contains(encoded, "complete"))
-  __io_println(len(llm_mock_calls()))
 }

--- a/conformance/tests/agents/agent_loop_failed_tool_result_history.harn
+++ b/conformance/tests/agents/agent_loop_failed_tool_result_history.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn failing_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -18,26 +20,31 @@ fn failing_tools() {
 
 pipeline main() {
   let tools = failing_tools()
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "bad1", name: "explode", arguments: {}}]})
-  llm_mock({text: "I saw the failed tool result."})
-  let result = agent_loop(
-    "Call the failing tool, then summarize the failure.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools,
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      done_judge: nil,
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "bad1", name: "explode", arguments: {}}]},
+      llm_text("I saw the failed tool result."),
+    ],
+    { ->
+      let result = agent_loop(
+        "Call the failing tool, then summarize the failure.",
+        nil,
+        {
+          provider: "mock",
+          tools: tools,
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          done_judge: nil,
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.tools.successful == [])
+      __io_println(contains(result.tools.rejected, "explode"))
+      let calls = llm_mock_calls()
+      let second_turn = json_stringify(calls[1].messages)
+      __io_println(contains(second_turn, "boom from tool handler"))
+      __io_println(contains(second_turn, "error"))
     },
   )
-  __io_println(result.status)
-  __io_println(result.tools.successful == [])
-  __io_println(contains(result.tools.rejected, "explode"))
-  let calls = llm_mock_calls()
-  let second_turn = json_stringify(calls[1].messages)
-  __io_println(contains(second_turn, "boom from tool handler"))
-  __io_println(contains(second_turn, "error"))
 }

--- a/conformance/tests/agents/agent_loop_inline_user_response_placeholder.harn
+++ b/conformance/tests/agents/agent_loop_inline_user_response_placeholder.harn
@@ -1,16 +1,21 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "Remember `<user_response>...</user_response>` is only an example wrapper.\nAudit: actual final answer.",
+  with_llm_script(
+    [
+      llm_text(
+        "Remember `<user_response>...</user_response>` is only an example wrapper.\nAudit: actual final answer.",
+      ),
+    ],
+    { ->
+      let result = agent_loop(
+        "Finish with a visible answer.",
+        nil,
+        {provider: "mock", loop_until_done: false, max_iterations: 1},
+      )
+      __io_println(result.status)
+      __io_println(result.visible_text)
+      __io_println(result.text)
     },
   )
-  let result = agent_loop(
-    "Finish with a visible answer.",
-    nil,
-    {provider: "mock", loop_until_done: false, max_iterations: 1},
-  )
-  __io_println(result.status)
-  __io_println(result.visible_text)
-  __io_println(result.text)
 }

--- a/conformance/tests/agents/agent_loop_loop_control.harn
+++ b/conformance/tests/agents/agent_loop_loop_control.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn lookup_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -27,101 +29,121 @@ fn lookup_tools() {
 
 pipeline default() {
   // Case A: required tool not yet succeeded near cap → default policy extends.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "look_a", name: "lookup", arguments: {query: "first"}}]})
-  llm_mock({tool_calls: [{id: "look_b", name: "lookup", arguments: {query: "second"}}]})
-  llm_mock({tool_calls: [{id: "release_x", name: "release_run", arguments: {}}]})
-  llm_mock({text: "<user_response>Released.</user_response>"})
-  let required_path = agent_loop(
-    "Run the release",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 2, max: 6, extend_by: 2},
-      require_successful_tools: ["release_run"],
+  with_llm_script(
+    [
+      {tool_calls: [{id: "look_a", name: "lookup", arguments: {query: "first"}}]},
+      {tool_calls: [{id: "look_b", name: "lookup", arguments: {query: "second"}}]},
+      {tool_calls: [{id: "release_x", name: "release_run", arguments: {}}]},
+      llm_text("<user_response>Released.</user_response>"),
+    ],
+    { ->
+      let required_path = agent_loop(
+        "Run the release",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 2, max: 6, extend_by: 2},
+          require_successful_tools: ["release_run"],
+        },
+      )
+      __io_println(required_path.status)
+      __io_println(required_path.adaptive_budget.extensions_used)
+      __io_println(required_path.adaptive_budget.final_limit >= 4)
+      __io_println(required_path?.missing_required_tools == nil)
     },
   )
-  __io_println(required_path.status)
-  __io_println(required_path.adaptive_budget.extensions_used)
-  __io_println(required_path.adaptive_budget.final_limit >= 4)
-  __io_println(required_path?.missing_required_tools == nil)
-  // Case B: caller-provided loop_control extends only when remaining=0,
-  // emits a custom reason, and inspects tool progress.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "tk1", name: "lookup", arguments: {query: "a"}}]})
-  llm_mock({tool_calls: [{id: "tk2", name: "lookup", arguments: {query: "b"}}]})
-  llm_mock({tool_calls: [{id: "tk3", name: "lookup", arguments: {query: "c"}}]})
-  llm_mock({text: "<user_response>Done by user.</user_response>"})
-  let custom_policy = agent_loop(
-    "Iterate until policy says stop",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 2, max: 8, extend_by: 1},
-      loop_control: { state ->
-        if state.budget.remaining > 0 {
-          nil
-        } else if state.turn.tool_call_count > 0 {
-          {action: "extend", by: 1, reason: "user-policy: tool progress"}
-        } else {
-          nil
-        }
-      },
+  with_llm_script(
+    [
+      {tool_calls: [{id: "tk1", name: "lookup", arguments: {query: "a"}}]},
+      {tool_calls: [{id: "tk2", name: "lookup", arguments: {query: "b"}}]},
+      {tool_calls: [{id: "tk3", name: "lookup", arguments: {query: "c"}}]},
+      llm_text("<user_response>Done by user.</user_response>"),
+    ],
+    { ->
+      let custom_policy = agent_loop(
+        "Iterate until policy says stop",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 2, max: 8, extend_by: 1},
+          loop_control: { state ->
+            if state.budget.remaining > 0 {
+              nil
+            } else if state.turn.tool_call_count > 0 {
+              {action: "extend", by: 1, reason: "user-policy: tool progress"}
+            } else {
+              nil
+            }
+          },
+        },
+      )
+      __io_println(custom_policy.status)
+      __io_println(custom_policy.adaptive_budget.extensions_used)
+      __io_println(custom_policy.adaptive_budget.decisions[0].reason)
     },
   )
-  __io_println(custom_policy.status)
-  __io_println(custom_policy.adaptive_budget.extensions_used)
-  __io_println(custom_policy.adaptive_budget.decisions[0].reason)
-  // Case C: nil loop_control return after we already converged — natural
-  // completion still wins, no adaptive_budget noise.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "t_nil", name: "lookup", arguments: {query: "noop"}}]})
-  llm_mock({text: "<user_response>quick stop</user_response>"})
-  let no_op_policy = agent_loop(
-    "Stop quickly",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 4, max: 6, extend_by: 1},
-      loop_control: { _state -> nil },
+  with_llm_script(
+    [
+      {tool_calls: [{id: "t_nil", name: "lookup", arguments: {query: "noop"}}]},
+      llm_text("<user_response>quick stop</user_response>"),
+    ],
+    { ->
+      let no_op_policy = agent_loop(
+        "Stop quickly",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 4, max: 6, extend_by: 1},
+          loop_control: { _state -> nil },
+        },
+      )
+      __io_println(no_op_policy.status)
+      __io_println(no_op_policy.adaptive_budget.extensions_used)
+      __io_println(len(no_op_policy.adaptive_budget.decisions))
     },
   )
-  __io_println(no_op_policy.status)
-  __io_println(no_op_policy.adaptive_budget.extensions_used)
-  __io_println(len(no_op_policy.adaptive_budget.decisions))
-  // Case D: until-style extension with explicit target.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "u1", name: "lookup", arguments: {query: "1"}}]})
-  llm_mock({tool_calls: [{id: "u2", name: "lookup", arguments: {query: "2"}}]})
-  llm_mock({tool_calls: [{id: "u3", name: "lookup", arguments: {query: "3"}}]})
-  llm_mock({text: "<user_response>final</user_response>"})
-  let until_policy = agent_loop(
-    "Until-target extension",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      iteration_budget: {mode: "adaptive", initial: 1, max: 10, extend_by: 1},
-      loop_control: { state ->
-        if state.budget.remaining > 0 {
-          nil
-        } else {
-          {action: "extend", until: 6, reason: "lift to 6"}
-        }
-      },
+  with_llm_script(
+    [
+      {tool_calls: [{id: "u1", name: "lookup", arguments: {query: "1"}}]},
+      {tool_calls: [{id: "u2", name: "lookup", arguments: {query: "2"}}]},
+      {tool_calls: [{id: "u3", name: "lookup", arguments: {query: "3"}}]},
+      llm_text("<user_response>final</user_response>"),
+    ],
+    { ->
+      let until_policy = agent_loop(
+        "Until-target extension",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          iteration_budget: {mode: "adaptive", initial: 1, max: 10, extend_by: 1},
+          loop_control: { state ->
+            if state.budget.remaining > 0 {
+              nil
+            } else {
+              {action: "extend", until: 6, reason: "lift to 6"}
+            }
+          },
+        },
+      )
+      __io_println(until_policy.status)
+      __io_println(until_policy.adaptive_budget.decisions[0].new_limit)
     },
   )
-  __io_println(until_policy.status)
-  __io_println(until_policy.adaptive_budget.decisions[0].new_limit)
 }
+// Case B: caller-provided loop_control extends only when remaining=0,
+// emits a custom reason, and inspects tool progress.
+// Case C: nil loop_control return after we already converged — natural
+// completion still wins, no adaptive_budget noise.
+// Case D: until-style extension with explicit target.

--- a/conformance/tests/agents/agent_loop_native_done_sentinel.harn
+++ b/conformance/tests/agents/agent_loop_native_done_sentinel.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn tools() {
   var registry = tool_registry()
   registry = tool_define(
@@ -15,32 +17,37 @@ fn tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "lookup1", name: "lookup", arguments: {}}]})
-  llm_mock({text: "Final answer without sentinel."})
-  llm_mock({text: "##DONE##"})
-  let result = agent_loop(
-    "Use the tool, then finish.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      done_judge: nil,
-      max_iterations: 4,
-      max_nudges: 2,
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "lookup1", name: "lookup", arguments: {}}]},
+      llm_text("Final answer without sentinel."),
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Use the tool, then finish.",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          done_judge: nil,
+          max_iterations: 4,
+          max_nudges: 2,
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.stop_reason)
+      __io_println(result.llm.iterations)
+      __io_println(result.text)
+      __io_println(!contains(result.text, "##DONE##"))
+      let calls = llm_mock_calls()
+      __io_println(contains(calls[0].system, "##DONE##"))
+      __io_println(contains(calls[1].system, "##DONE##"))
+      __io_println(contains(calls[2].system, "##DONE##"))
+      __io_println(!contains(calls[0].system, "<user_response>"))
     },
   )
-  __io_println(result.status)
-  __io_println(result.stop_reason)
-  __io_println(result.llm.iterations)
-  __io_println(result.text)
-  __io_println(!contains(result.text, "##DONE##"))
-  let calls = llm_mock_calls()
-  __io_println(contains(calls[0].system, "##DONE##"))
-  __io_println(contains(calls[1].system, "##DONE##"))
-  __io_println(contains(calls[2].system, "##DONE##"))
-  __io_println(!contains(calls[0].system, "<user_response>"))
 }

--- a/conformance/tests/agents/agent_loop_native_natural_completion.harn
+++ b/conformance/tests/agents/agent_loop_native_natural_completion.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn lookup_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -15,41 +17,49 @@ fn lookup_tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "release"}}]})
-  llm_mock({text: "<user_response>Release notes are ready.</user_response>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"natural final text is complete\"}"})
-  let result = agent_loop(
-    "Inspect evidence and finish.",
-    nil,
-    {
-      provider: "mock",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      done_judge: true,
-      max_iterations: 4,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "release"}}]},
+      llm_text("<user_response>Release notes are ready.</user_response>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"natural final text is complete\"}"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Inspect evidence and finish.",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_judge: true,
+          max_iterations: 4,
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(result.text)
+      __io_println(result.llm.iterations)
+      __io_println(len(calls))
+      __io_println(!contains(calls[0].system, "##DONE##"))
+      __io_println(!contains(calls[1].system, "##DONE##"))
+      __io_println(!contains(calls[0].system, "<user_response>"))
+      __io_println(contains(calls[0].system, "provider's native tool-calling channel"))
+      __io_println(contains(json_stringify(calls[1].messages), "evidence for release"))
     },
   )
-  let calls = llm_mock_calls()
-  __io_println(result.status)
-  __io_println(result.text)
-  __io_println(result.llm.iterations)
-  __io_println(len(calls))
-  __io_println(!contains(calls[0].system, "##DONE##"))
-  __io_println(!contains(calls[1].system, "##DONE##"))
-  __io_println(!contains(calls[0].system, "<user_response>"))
-  __io_println(contains(calls[0].system, "provider's native tool-calling channel"))
-  __io_println(contains(json_stringify(calls[1].messages), "evidence for release"))
-  llm_mock_clear()
-  llm_mock({text: "Plain final answer."})
-  agent_loop(
-    "Finish without tools.",
-    nil,
-    {provider: "mock", tools: tool_registry(), tool_format: "native", max_iterations: 1},
+  with_llm_script(
+    [llm_text("Plain final answer.")],
+    { ->
+      agent_loop(
+        "Finish without tools.",
+        nil,
+        {provider: "mock", tools: tool_registry(), tool_format: "native", max_iterations: 1},
+      )
+      let empty_calls = llm_mock_calls()
+      let empty_system = empty_calls[0].system ?? ""
+      __io_println(!contains(empty_system, "Native tool protocol"))
+      __io_println(!contains(empty_system, "<user_response>"))
+    },
   )
-  let empty_calls = llm_mock_calls()
-  let empty_system = empty_calls[0].system ?? ""
-  __io_println(!contains(empty_system, "Native tool protocol"))
-  __io_println(!contains(empty_system, "<user_response>"))
 }

--- a/conformance/tests/agents/agent_loop_policy_unwind.harn
+++ b/conformance/tests/agents/agent_loop_policy_unwind.harn
@@ -1,4 +1,5 @@
 import { agent_session_finalize } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main(task) {
   let failed = try {
@@ -21,11 +22,15 @@ pipeline main(task) {
     )
   }
   __io_println(is_err(stale_finalize))
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "A later loop should not inherit failed-loop state",
-    nil,
-    {provider: "mock", max_iterations: 1},
+  with_llm_script(
+    [llm_text("<done>##DONE##</done>")],
+    { ->
+      let result = agent_loop(
+        "A later loop should not inherit failed-loop state",
+        nil,
+        {provider: "mock", max_iterations: 1},
+      )
+      __io_println(result.status)
+    },
   )
-  __io_println(result.status)
 }

--- a/conformance/tests/agents/agent_loop_provider_error_structured.harn
+++ b/conformance/tests/agents/agent_loop_provider_error_structured.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 fn lookup_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -15,44 +17,47 @@ fn lookup_tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "release"}}]})
-  llm_mock(
-    {
-      error: {
-        category: "generic",
-        message: "ollama HTTP 400 [invalid_request]: Value looks like object, but can't find closing '}' symbol",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "release"}}]},
+      {
+        error: {
+          category: "generic",
+          message: "ollama HTTP 400 [invalid_request]: Value looks like object, but can't find closing '}' symbol",
+        },
       },
+    ],
+    { ->
+      let transcript_dir = path_join(harness.fs.temp_dir(), "harn-agent-loop-provider-error-" + uuid())
+      let result = agent_loop(
+        "Inspect evidence and finish.",
+        nil,
+        {
+          provider: "mock",
+          model: "qwen-local",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 4,
+          llm_transcript_dir: transcript_dir,
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.stop_reason)
+      __io_println(result.error.category)
+      __io_println(result.error.reason)
+      __io_println(result.error.provider)
+      __io_println(result.error.model)
+      __io_println(result.error.phase)
+      __io_println(result.error.tool_format)
+      __io_println(result.error.after_tool_result)
+      __io_println(result.llm.iterations)
+      __io_println(result.tools.successful[0])
+      __io_println(contains(json_stringify(result.transcript), "agent_loop_terminal_error"))
+      let sidecar = harness.fs.read_text(path_join(transcript_dir, "llm_transcript.jsonl"))
+      __io_println(contains(sidecar, "\"type\":\"provider_call_error\""))
+      __io_println(contains(sidecar, "\"category\":\"generic\""))
+      __io_println(contains(sidecar, "\"reason\":\"invalid_request\""))
     },
   )
-  let transcript_dir = path_join(harness.fs.temp_dir(), "harn-agent-loop-provider-error-" + uuid())
-  let result = agent_loop(
-    "Inspect evidence and finish.",
-    nil,
-    {
-      provider: "mock",
-      model: "qwen-local",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 4,
-      llm_transcript_dir: transcript_dir,
-    },
-  )
-  __io_println(result.status)
-  __io_println(result.stop_reason)
-  __io_println(result.error.category)
-  __io_println(result.error.reason)
-  __io_println(result.error.provider)
-  __io_println(result.error.model)
-  __io_println(result.error.phase)
-  __io_println(result.error.tool_format)
-  __io_println(result.error.after_tool_result)
-  __io_println(result.llm.iterations)
-  __io_println(result.tools.successful[0])
-  __io_println(contains(json_stringify(result.transcript), "agent_loop_terminal_error"))
-  let sidecar = harness.fs.read_text(path_join(transcript_dir, "llm_transcript.jsonl"))
-  __io_println(contains(sidecar, "\"type\":\"provider_call_error\""))
-  __io_println(contains(sidecar, "\"category\":\"generic\""))
-  __io_println(contains(sidecar, "\"reason\":\"invalid_request\""))
 }

--- a/conformance/tests/agents/agent_loop_raw_sentinel_after_user_response.harn
+++ b/conformance/tests/agents/agent_loop_raw_sentinel_after_user_response.harn
@@ -1,12 +1,17 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<user_response>Visible answer.</user_response>##DONE##"})
-  let result = agent_loop(
-    "finish cleanly",
-    nil,
-    {provider: "mock", loop_until_done: true, max_iterations: 3, done_sentinel: "##DONE##"},
+  with_llm_script(
+    [llm_text("<user_response>Visible answer.</user_response>##DONE##")],
+    { ->
+      let result = agent_loop(
+        "finish cleanly",
+        nil,
+        {provider: "mock", loop_until_done: true, max_iterations: 3, done_sentinel: "##DONE##"},
+      )
+      __io_println(result.status)
+      __io_println(result.text)
+      __io_println(result.llm.iterations)
+    },
   )
-  __io_println(result.status)
-  __io_println(result.text)
-  __io_println(result.llm.iterations)
 }

--- a/conformance/tests/agents/agent_loop_require_successful_tools.harn
+++ b/conformance/tests/agents/agent_loop_require_successful_tools.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn tools() {
   var registry = tool_registry()
   registry = tool_define(
@@ -15,59 +17,68 @@ fn tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "x"}}]})
-  llm_mock({text: "Finished."})
-  let failed = agent_loop(
-    "Use one tool.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      require_successful_tools: ["missing_tool"],
+  with_llm_script(
+    [{tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "x"}}]}, llm_text("Finished.")],
+    { ->
+      let failed = agent_loop(
+        "Use one tool.",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          require_successful_tools: ["missing_tool"],
+        },
+      )
+      __io_println(failed.status)
+      __io_println(failed.stop_reason)
+      __io_println(failed.missing_required_tools[0])
     },
   )
-  __io_println(failed.status)
-  __io_println(failed.stop_reason)
-  __io_println(failed.missing_required_tools[0])
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_2", name: "lookup", arguments: {query: "x"}}]})
-  llm_mock({text: "Finished."})
-  let satisfied = agent_loop(
-    "Use one tool.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      require_successful_tools: [["lookup", "alternate_reader"]],
+  with_llm_script(
+    [{tool_calls: [{id: "lookup_2", name: "lookup", arguments: {query: "x"}}]}, llm_text("Finished.")],
+    { ->
+      let satisfied = agent_loop(
+        "Use one tool.",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          require_successful_tools: [["lookup", "alternate_reader"]],
+        },
+      )
+      __io_println(satisfied.status)
+      __io_println(len(satisfied.missing_required_tools ?? []))
     },
   )
-  __io_println(satisfied.status)
-  __io_println(len(satisfied.missing_required_tools ?? []))
-  llm_mock_clear()
-  llm_mock({text: "Finished before using the required tool."})
-  llm_mock({tool_calls: [{id: "lookup_3", name: "lookup", arguments: {query: "x"}}]})
-  llm_mock({text: "Finished after using the required tool."})
-  let gated = agent_loop(
-    "Use one tool.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      max_nudges: 2,
-      require_successful_tools: ["lookup"],
+  with_llm_script(
+    [
+      llm_text("Finished before using the required tool."),
+      {tool_calls: [{id: "lookup_3", name: "lookup", arguments: {query: "x"}}]},
+      llm_text("Finished after using the required tool."),
+    ],
+    { ->
+      let gated = agent_loop(
+        "Use one tool.",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          max_nudges: 2,
+          require_successful_tools: ["lookup"],
+        },
+      )
+      __io_println(gated.status)
+      __io_println(gated.llm.iterations)
+      __io_println(len(gated.missing_required_tools ?? []))
     },
   )
-  __io_println(gated.status)
-  __io_println(gated.llm.iterations)
-  __io_println(len(gated.missing_required_tools ?? []))
 }

--- a/conformance/tests/agents/agent_loop_require_successful_tools_friction.harn
+++ b/conformance/tests/agents/agent_loop_require_successful_tools_friction.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `require_successful_tools` is an active gate: when a required tool
  * never succeeds the agent_loop result carries a structured
@@ -24,58 +26,65 @@ fn tools() {
 
 pipeline main() {
   friction_clear()
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "x"}}]})
-  llm_mock({text: "Finished."})
-  let failed = agent_loop(
-    "Use one tool.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      require_successful_tools: ["missing_tool"],
-      persona: "test_persona",
-      _preset_kind: "test",
+  with_llm_script(
+    [{tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "x"}}]}, llm_text("Finished.")],
+    { ->
+      let failed = agent_loop(
+        "Use one tool.",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          require_successful_tools: ["missing_tool"],
+          persona: "test_persona",
+          _preset_kind: "test",
+        },
+      )
+      __io_println(failed.status)
+      __io_println(failed.stop_reason)
+      __io_println(failed.missing_required_tools[0])
+      __io_println(failed.error_envelope.schema_version)
+      __io_println(failed.error_envelope.kind)
+      __io_println(failed.error_envelope.missing[0])
+      __io_println(contains(failed.error_envelope.successful_tool_names, "lookup"))
+      let events = friction_events()
+      __io_println(len(events))
+      __io_println(events[0].kind)
+      __io_println(events[0].source)
+      __io_println(events[0].actor)
+      __io_println(events[0].metadata.preset_kind)
+      __io_println(contains(events[0].metadata.successful_tool_names, "lookup"))
+      __io_println(events[0].metadata.missing_required_tools[0])
+      friction_clear()
     },
   )
-  __io_println(failed.status)
-  __io_println(failed.stop_reason)
-  __io_println(failed.missing_required_tools[0])
-  // Structured error envelope shape.
-  __io_println(failed.error_envelope.schema_version)
-  __io_println(failed.error_envelope.kind)
-  __io_println(failed.error_envelope.missing[0])
-  __io_println(contains(failed.error_envelope.successful_tool_names, "lookup"))
-  // Friction event was recorded with kind=tool_gap and persona actor.
-  let events = friction_events()
-  __io_println(len(events))
-  __io_println(events[0].kind)
-  __io_println(events[0].source)
-  __io_println(events[0].actor)
-  __io_println(events[0].metadata.preset_kind)
-  __io_println(contains(events[0].metadata.successful_tool_names, "lookup"))
-  __io_println(events[0].metadata.missing_required_tools[0])
-  // No friction event when require_successful_tools is satisfied.
-  friction_clear()
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_2", name: "lookup", arguments: {query: "y"}}]})
-  llm_mock({text: "<user_response>Done.</user_response>"})
-  let satisfied = agent_loop(
-    "Use one tool.",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      require_successful_tools: ["lookup"],
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_2", name: "lookup", arguments: {query: "y"}}]},
+      llm_text("<user_response>Done.</user_response>"),
+    ],
+    { ->
+      let satisfied = agent_loop(
+        "Use one tool.",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          require_successful_tools: ["lookup"],
+        },
+      )
+      __io_println(satisfied.status)
+      __io_println(satisfied?.error_envelope == nil)
+      __io_println(len(friction_events()))
     },
   )
-  __io_println(satisfied.status)
-  __io_println(satisfied?.error_envelope == nil)
-  __io_println(len(friction_events()))
 }
+// Structured error envelope shape.
+// Friction event was recorded with kind=tool_gap and persona actor.
+// No friction event when require_successful_tools is satisfied.

--- a/conformance/tests/agents/agent_loop_stall_judge_continue.harn
+++ b/conformance/tests/agents/agent_loop_stall_judge_continue.harn
@@ -1,5 +1,6 @@
 import { agent_capture_events } from "std/agent/events"
 import { agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
@@ -28,45 +29,48 @@ pipeline default() {
       annotations: {kind: "read"},
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]})
-  llm_mock({text: "", tool_calls: [{id: "noop2", name: "noop", arguments: {}}]})
-  llm_mock({text: "", tool_calls: [{id: "noop3", name: "noop", arguments: {}}]})
-  llm_mock(
-    {
-      text: "{\"verdict\":\"continue\",\"reasoning\":\"needs one more turn\",\"next_step\":\"change approach\"}",
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]},
+      {text: "", tool_calls: [{id: "noop2", name: "noop", arguments: {}}]},
+      {text: "", tool_calls: [{id: "noop3", name: "noop", arguments: {}}]},
+      llm_text(
+        "{\"verdict\":\"continue\",\"reasoning\":\"needs one more turn\",\"next_step\":\"change approach\"}",
+      ),
+      llm_text("still working"),
+    ],
+    { ->
+      let session = "stall-judge-continue-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Continue when the stall judge vetoes.",
+          nil,
+          {
+            provider: "mock",
+            tools: tools,
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 4,
+            session_id: session,
+            stall_diagnostics: {threshold: 3, inject_feedback: true, max_feedback: 1},
+            done_judge: {cadence: {when: "stalled"}},
+          },
+        ) },
+      )
+      let stalls = events_of(captured.events, "agent_loop_stall_warning")
+      let judges = events_of(captured.events, "judge_decision")
+      let messages = json_stringify(agent_session_messages(session))
+      __io_println(captured.result.status)
+      __io_println(len(stalls))
+      __io_println(len(judges))
+      __io_println(judges[0].trigger)
+      __io_println(judges[0].verdict)
+      __io_println(tool_message_count(session))
+      __io_println(contains(messages, "Stall diagnostic"))
+      __io_println(len(llm_mock_calls()))
     },
   )
-  llm_mock({text: "still working"})
-  let session = "stall-judge-continue-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Continue when the stall judge vetoes.",
-      nil,
-      {
-        provider: "mock",
-        tools: tools,
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 4,
-        session_id: session,
-        stall_diagnostics: {threshold: 3, inject_feedback: true, max_feedback: 1},
-        done_judge: {cadence: {when: "stalled"}},
-      },
-    ) },
-  )
-  let stalls = events_of(captured.events, "agent_loop_stall_warning")
-  let judges = events_of(captured.events, "judge_decision")
-  let messages = json_stringify(agent_session_messages(session))
-  __io_println(captured.result.status)
-  __io_println(len(stalls))
-  __io_println(len(judges))
-  __io_println(judges[0].trigger)
-  __io_println(judges[0].verdict)
-  __io_println(tool_message_count(session))
-  __io_println(contains(messages, "Stall diagnostic"))
-  __io_println(len(llm_mock_calls()))
   var other_tools = tool_registry()
   other_tools = tool_define(
     other_tools,
@@ -79,29 +83,34 @@ pipeline default() {
       annotations: {kind: "read"},
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "noopA", name: "noop", arguments: {}}]})
-  llm_mock({text: "", tool_calls: [{id: "noopB", name: "noop", arguments: {}}]})
-  let other_session = "stall-judge-other-" + uuid()
-  let other = agent_capture_events(
-    other_session,
-    fn() { return agent_loop(
-      "Do not run a stall judge for non-stalled cadence.",
-      nil,
-      {
-        provider: "mock",
-        tools: other_tools,
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 2,
-        session_id: other_session,
-        stall_diagnostics: {threshold: 2, inject_feedback: true, max_feedback: 1},
-        done_judge: {cadence: {when: "always"}},
-      },
-    ) },
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "noopA", name: "noop", arguments: {}}]},
+      {text: "", tool_calls: [{id: "noopB", name: "noop", arguments: {}}]},
+    ],
+    { ->
+      let other_session = "stall-judge-other-" + uuid()
+      let other = agent_capture_events(
+        other_session,
+        fn() { return agent_loop(
+          "Do not run a stall judge for non-stalled cadence.",
+          nil,
+          {
+            provider: "mock",
+            tools: other_tools,
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 2,
+            session_id: other_session,
+            stall_diagnostics: {threshold: 2, inject_feedback: true, max_feedback: 1},
+            done_judge: {cadence: {when: "always"}},
+          },
+        ) },
+      )
+      __io_println(other.result.status)
+      __io_println(len(events_of(other.events, "agent_loop_stall_warning")))
+      __io_println(len(events_of(other.events, "judge_decision")))
+      __io_println(tool_message_count(other_session))
+    },
   )
-  __io_println(other.result.status)
-  __io_println(len(events_of(other.events, "agent_loop_stall_warning")))
-  __io_println(len(events_of(other.events, "judge_decision")))
-  __io_println(tool_message_count(other_session))
 }

--- a/conformance/tests/agents/agent_loop_stall_triggers_judge.harn
+++ b/conformance/tests/agents/agent_loop_stall_triggers_judge.harn
@@ -1,5 +1,6 @@
 import { agent_capture_events } from "std/agent/events"
 import { agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
@@ -28,38 +29,43 @@ pipeline default() {
       annotations: {kind: "read"},
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]})
-  llm_mock({text: "", tool_calls: [{id: "noop2", name: "noop", arguments: {}}]})
-  llm_mock({text: "", tool_calls: [{id: "noop3", name: "noop", arguments: {}}]})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"the repeated call is enough\"}"})
-  let session = "stall-judge-done-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Stop when the stall judge accepts.",
-      nil,
-      {
-        provider: "mock",
-        tools: tools,
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 5,
-        session_id: session,
-        stall_diagnostics: {threshold: 3, inject_feedback: true, max_feedback: 1},
-        done_judge: {cadence: {when: "stalled"}},
-      },
-    ) },
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]},
+      {text: "", tool_calls: [{id: "noop2", name: "noop", arguments: {}}]},
+      {text: "", tool_calls: [{id: "noop3", name: "noop", arguments: {}}]},
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"the repeated call is enough\"}"),
+    ],
+    { ->
+      let session = "stall-judge-done-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Stop when the stall judge accepts.",
+          nil,
+          {
+            provider: "mock",
+            tools: tools,
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 5,
+            session_id: session,
+            stall_diagnostics: {threshold: 3, inject_feedback: true, max_feedback: 1},
+            done_judge: {cadence: {when: "stalled"}},
+          },
+        ) },
+      )
+      let stalls = events_of(captured.events, "agent_loop_stall_warning")
+      let judges = events_of(captured.events, "judge_decision")
+      require len(stalls) == 1, "stall warning should fire once"
+      require len(judges) == 1, "stalled done_judge should fire once"
+      __io_println(captured.result.status)
+      __io_println(captured.result.stop_reason)
+      __io_println(judges[0].trigger)
+      __io_println(judges[0].verdict)
+      __io_println(judges[0].iteration == stalls[0].warning.iteration)
+      __io_println(tool_message_count(session))
+      __io_println(len(llm_mock_calls()))
+    },
   )
-  let stalls = events_of(captured.events, "agent_loop_stall_warning")
-  let judges = events_of(captured.events, "judge_decision")
-  require len(stalls) == 1, "stall warning should fire once"
-  require len(judges) == 1, "stalled done_judge should fire once"
-  __io_println(captured.result.status)
-  __io_println(captured.result.stop_reason)
-  __io_println(judges[0].trigger)
-  __io_println(judges[0].verdict)
-  __io_println(judges[0].iteration == stalls[0].warning.iteration)
-  __io_println(tool_message_count(session))
-  __io_println(len(llm_mock_calls()))
 }

--- a/conformance/tests/agents/agent_loop_step_judge.harn
+++ b/conformance/tests/agents/agent_loop_step_judge.harn
@@ -1,36 +1,38 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
   // Turn 1: weak assistant response → judge will veto.
-  llm_mock({text: "<user_response>idk</user_response>\n<done>##DONE##</done>"})
-  // Step judge call 1: revise with critique.
-  llm_mock(
-    {
-      text: "{\"verdict\":\"revise\",\"reasoning\":\"too terse\",\"critique\":\"Show the arithmetic explicitly.\",\"confidence\":0.9}",
+  with_llm_script(
+    [
+      llm_text("<user_response>idk</user_response>\n<done>##DONE##</done>"),
+      llm_text(
+        "{\"verdict\":\"revise\",\"reasoning\":\"too terse\",\"critique\":\"Show the arithmetic explicitly.\",\"confidence\":0.9}",
+      ),
+      llm_text("<user_response>2 + 2 = 4</user_response>\n<done>##DONE##</done>"),
+      llm_text(
+        "{\"verdict\":\"pass\",\"reasoning\":\"shows work\",\"critique\":\"\",\"confidence\":0.95}",
+      ),
+    ],
+    { ->
+      let result = agent_loop(
+        "What is 2 + 2?",
+        nil,
+        {
+          provider: "mock",
+          loop_until_done: true,
+          max_iterations: 4,
+          step_judge: {provider: "mock", on_veto: "replace"},
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.visible_text)
+      __io_println(result.llm.iterations)
+      let calls = llm_mock_calls()
+      __io_println(len(calls))
+      __io_println(!json_stringify(calls[2].messages).contains("idk"))
+      __io_println(json_stringify(calls[2].messages).contains("Show the arithmetic explicitly."))
     },
   )
-  // Turn 2: revised assistant response → judge will pass.
-  llm_mock({text: "<user_response>2 + 2 = 4</user_response>\n<done>##DONE##</done>"})
-  // Step judge call 2: pass.
-  llm_mock(
-    {text: "{\"verdict\":\"pass\",\"reasoning\":\"shows work\",\"critique\":\"\",\"confidence\":0.95}"},
-  )
-  let result = agent_loop(
-    "What is 2 + 2?",
-    nil,
-    {
-      provider: "mock",
-      loop_until_done: true,
-      max_iterations: 4,
-      step_judge: {provider: "mock", on_veto: "replace"},
-    },
-  )
-  __io_println(result.status)
-  __io_println(result.visible_text)
-  __io_println(result.llm.iterations)
-  let calls = llm_mock_calls()
-  __io_println(len(calls))
-  // After replace + regen, the regen turn (calls[2]) should NOT contain the popped weak response.
-  __io_println(!json_stringify(calls[2].messages).contains("idk"))
-  // The regen turn SHOULD contain the injected critique feedback.
-  __io_println(json_stringify(calls[2].messages).contains("Show the arithmetic explicitly."))
 }
+// After replace + regen, the regen turn (calls[2]) should NOT contain the popped weak response.
+// The regen turn SHOULD contain the injected critique feedback.

--- a/conformance/tests/agents/agent_loop_step_judge_low_budget.harn
+++ b/conformance/tests/agents/agent_loop_step_judge_low_budget.harn
@@ -1,37 +1,41 @@
 import { agent_capture_events } from "std/agent/events"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<user_response>safe answer</user_response>\n<done>##DONE##</done>"})
-  llm_mock(
-    {text: "{\"verdict\":\"revise\",\"reasoning\":\"force a regression\",\"critique\":\"try again\"}"},
+  with_llm_script(
+    [
+      llm_text("<user_response>safe answer</user_response>\n<done>##DONE##</done>"),
+      llm_text("{\"verdict\":\"revise\",\"reasoning\":\"force a regression\",\"critique\":\"try again\"}"),
+    ],
+    { ->
+      let session = "step-judge-low-budget-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Answer once.",
+          nil,
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 1,
+            session_id: session,
+            step_judge: {provider: "mock", on_veto: "replace"},
+          },
+        ) },
+      )
+      let decisions = events_of(captured.events, "step_judge_decision")
+      require len(decisions) == 1, "low-budget step_judge skip should emit one decision event"
+      __io_println(captured.result.status)
+      __io_println(captured.result.visible_text)
+      __io_println(len(llm_mock_calls()))
+      __io_println(len(decisions))
+      __io_println(decisions[0].skipped)
+      __io_println(decisions[0].reason)
+      __io_println(decisions[0].vetoed)
+    },
   )
-  let session = "step-judge-low-budget-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Answer once.",
-      nil,
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 1,
-        session_id: session,
-        step_judge: {provider: "mock", on_veto: "replace"},
-      },
-    ) },
-  )
-  let decisions = events_of(captured.events, "step_judge_decision")
-  require len(decisions) == 1, "low-budget step_judge skip should emit one decision event"
-  __io_println(captured.result.status)
-  __io_println(captured.result.visible_text)
-  __io_println(len(llm_mock_calls()))
-  __io_println(len(decisions))
-  __io_println(decisions[0].skipped)
-  __io_println(decisions[0].reason)
-  __io_println(decisions[0].vetoed)
 }

--- a/conformance/tests/agents/agent_loop_structural_validator.harn
+++ b/conformance/tests/agents/agent_loop_structural_validator.harn
@@ -1,5 +1,6 @@
 import { agent_capture_events } from "std/agent/events"
 import { with_structural_validator } from "std/llm/structural_validator"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
@@ -24,317 +25,351 @@ fn write_tools() {
 pipeline default() {
   let tool_text = "<tool_call>\nwrite_note({ path: \"notes.txt\" })\n</tool_call>"
   let malformed_tool_text = "<tool_call>\nwrite_note({ path: })\n</tool_call>"
-  llm_mock_clear()
-  llm_mock({text: "I fixed it already."})
-  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let session = "structural-validator-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Update notes.txt and then finish.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 4,
-        session_id: session,
-        tools: write_tools(),
-        structural_validator: with_structural_validator(),
-      },
-    ) },
-  )
-  let decisions = events_of(captured.events, "structural_validator_decision")
-  require len(decisions) == 1, "validator should emit exactly one decision"
-  __io_println(captured.result.status)
-  __io_println(captured.result.tools.successful[0] == "write_note")
-  __io_println(len(decisions))
-  __io_println(decisions[0].rule)
-  __io_println(decisions[0].vetoed)
-  __io_println(decisions[0].recommended_action.contains("tool call"))
-  let regen_messages = json_stringify(llm_mock_calls()[1].messages)
-  __io_println(!regen_messages.contains("I fixed it already."))
-  __io_println(regen_messages.contains("structural_validator"))
-  __io_println(regen_messages.contains("non_empty_when_writes_expected"))
-  llm_mock_clear()
-  llm_mock({text: "Still done without tools."})
-  try {
-    agent_loop(
-      "Update notes.txt and then finish.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 2,
-        tools: write_tools(),
-        structural_validator: with_structural_validator({on_failure: "raise"}),
-      },
-    )
-    __io_println("no-throw")
-  } catch (e) {
-    __io_println("caught")
-    __io_println(contains(to_string(e), "Assistant emitted no tool calls"))
-  }
-  llm_mock_clear()
-  llm_mock({text: "I fixed it already."})
-  let phantom_session = "structural-validator-phantom-" + uuid()
-  let phantom = agent_capture_events(
-    phantom_session,
-    fn() { return try {
-      agent_loop(
-        "Update notes.txt and then finish.",
-        nil,
-        {
-          provider: "mock",
-          tool_format: "native",
-          loop_until_done: true,
-          max_iterations: 2,
-          tools: write_tools(),
-          session_id: phantom_session,
-          structural_validator: with_structural_validator({on_failure: "raise", rules: ["no_phantom_completion"]}),
-        },
+  with_llm_script(
+    [
+      llm_text("I fixed it already."),
+      {tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let session = "structural-validator-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 4,
+            session_id: session,
+            tools: write_tools(),
+            structural_validator: with_structural_validator(),
+          },
+        ) },
       )
-      "no-throw"
-    } catch (_e) {
-      "caught"
-    } },
+      let decisions = events_of(captured.events, "structural_validator_decision")
+      require len(decisions) == 1, "validator should emit exactly one decision"
+      __io_println(captured.result.status)
+      __io_println(captured.result.tools.successful[0] == "write_note")
+      __io_println(len(decisions))
+      __io_println(decisions[0].rule)
+      __io_println(decisions[0].vetoed)
+      __io_println(decisions[0].recommended_action.contains("tool call"))
+      let regen_messages = json_stringify(llm_mock_calls()[1].messages)
+      __io_println(!regen_messages.contains("I fixed it already."))
+      __io_println(regen_messages.contains("structural_validator"))
+      __io_println(regen_messages.contains("non_empty_when_writes_expected"))
+    },
   )
-  let phantom_decisions = events_of(phantom.events, "structural_validator_decision")
-  __io_println(phantom.result == "caught")
-  __io_println(len(phantom_decisions) == 1)
-  __io_println(phantom_decisions[0].rule == "no_phantom_completion")
-  llm_mock_clear()
-  llm_mock(
-    {text: "", tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]},
+  with_llm_script(
+    [llm_text("Still done without tools.")],
+    { ->
+      try {
+        agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 2,
+            tools: write_tools(),
+            structural_validator: with_structural_validator({on_failure: "raise"}),
+          },
+        )
+        __io_println("no-throw")
+      } catch (e) {
+        __io_println("caught")
+        __io_println(contains(to_string(e), "Assistant emitted no tool calls"))
+      }
+    },
   )
-  llm_mock({text: "I fixed it already.<done>##DONE##</done>"})
-  let post_write_session = "structural-validator-post-write-" + uuid()
-  let post_write = agent_capture_events(
-    post_write_session,
-    fn() { return agent_loop(
-      "Update notes.txt and then finish.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 3,
-        tools: write_tools(),
-        session_id: post_write_session,
-        structural_validator: with_structural_validator({rules: ["no_phantom_completion"]}),
-      },
-    ) },
-  )
-  let post_write_decisions = events_of(post_write.events, "structural_validator_decision")
-  __io_println(post_write.result.status == "done")
-  __io_println(len(post_write_decisions) == 0)
-  llm_mock_clear()
-  llm_mock(
-    {text: "", tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]},
-  )
-  llm_mock({text: "I fixed it already."})
-  let post_write_non_empty_session = "structural-validator-post-write-non-empty-" + uuid()
-  let post_write_non_empty = agent_capture_events(
-    post_write_non_empty_session,
-    fn() { return agent_loop(
-      "Update notes.txt and then summarize.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "native",
-        max_iterations: 3,
-        tools: write_tools(),
-        session_id: post_write_non_empty_session,
-        structural_validator: with_structural_validator(),
-      },
-    ) },
-  )
-  let post_write_non_empty_decisions = events_of(post_write_non_empty.events, "structural_validator_decision")
-  __io_println(post_write_non_empty.result.status == "done")
-  __io_println(len(post_write_non_empty_decisions) == 0)
-  llm_mock_clear()
-  llm_mock({text: "The PATCH_HINT is:\n\n```python\ndef add(a, b): return a + b\n```"})
-  let lifecycle_only_session = "structural-validator-lifecycle-only-" + uuid()
-  let lifecycle_only = agent_capture_events(
-    lifecycle_only_session,
-    fn() { return agent_loop(
-      "No tools are available. State the smallest code change.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "text",
-        max_iterations: 1,
-        session_id: lifecycle_only_session,
-        structural_validator: with_structural_validator(),
-      },
-    ) },
-  )
-  let lifecycle_only_decisions = events_of(lifecycle_only.events, "structural_validator_decision")
-  __io_println(lifecycle_only.result.status == "done")
-  __io_println(len(lifecycle_only_decisions) == 0)
-  llm_mock_clear()
-  llm_mock({text: malformed_tool_text})
-  let malformed_session = "structural-validator-malformed-" + uuid()
-  let malformed = agent_capture_events(
-    malformed_session,
-    fn() { return try {
-      agent_loop(
-        "Update notes.txt and then finish.",
-        nil,
-        {
-          provider: "mock",
-          tool_format: "text",
-          loop_until_done: true,
-          max_iterations: 2,
-          tools: write_tools(),
-          session_id: malformed_session,
-          structural_validator: with_structural_validator({on_failure: "raise", rules: ["tool_calls_well_formed"]}),
-        },
+  with_llm_script(
+    [llm_text("I fixed it already.")],
+    { ->
+      let phantom_session = "structural-validator-phantom-" + uuid()
+      let phantom = agent_capture_events(
+        phantom_session,
+        fn() { return try {
+          agent_loop(
+            "Update notes.txt and then finish.",
+            nil,
+            {
+              provider: "mock",
+              tool_format: "native",
+              loop_until_done: true,
+              max_iterations: 2,
+              tools: write_tools(),
+              session_id: phantom_session,
+              structural_validator: with_structural_validator({on_failure: "raise", rules: ["no_phantom_completion"]}),
+            },
+          )
+          "no-throw"
+        } catch (_e) {
+          "caught"
+        } },
       )
-      "no-throw"
-    } catch (_e) {
-      "caught"
-    } },
+      let phantom_decisions = events_of(phantom.events, "structural_validator_decision")
+      __io_println(phantom.result == "caught")
+      __io_println(len(phantom_decisions) == 1)
+      __io_println(phantom_decisions[0].rule == "no_phantom_completion")
+    },
   )
-  let malformed_decisions = events_of(malformed.events, "structural_validator_decision")
-  __io_println(malformed.result == "caught")
-  __io_println(len(malformed_decisions) == 1)
-  __io_println(malformed_decisions[0].rule == "tool_calls_well_formed")
-  llm_mock_clear()
-  llm_mock({text: tool_text})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let well_formed_session = "structural-validator-well-formed-" + uuid()
-  let well_formed = agent_capture_events(
-    well_formed_session,
-    fn() { return agent_loop(
-      "Update notes.txt and then finish.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "text",
-        loop_until_done: true,
-        max_iterations: 3,
-        tools: write_tools(),
-        session_id: well_formed_session,
-        structural_validator: with_structural_validator({rules: ["tool_calls_well_formed"]}),
-      },
-    ) },
-  )
-  let well_formed_decisions = events_of(well_formed.events, "structural_validator_decision")
-  __io_println(well_formed.result.status == "done")
-  __io_println(len(well_formed_decisions) == 0)
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "write_missing", name: "write_note", arguments: {}}]})
-  llm_mock(
-    {text: "", tool_calls: [{id: "write_2", name: "write_note", arguments: {path: "notes.txt"}}]},
-  )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let missing_arg_session = "structural-validator-native-missing-arg-" + uuid()
-  let missing_arg = agent_capture_events(
-    missing_arg_session,
-    fn() { return agent_loop(
-      "Update notes.txt and then finish.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 3,
-        tools: write_tools(),
-        session_id: missing_arg_session,
-        structural_validator: with_structural_validator({rules: ["tool_calls_well_formed"]}),
-      },
-    ) },
-  )
-  let missing_arg_decisions = events_of(missing_arg.events, "structural_validator_decision")
-  let missing_arg_regen_messages = json_stringify(llm_mock_calls()[1].messages)
-  __io_println(missing_arg.result.status == "done")
-  __io_println(missing_arg.result.tools.successful[0] == "write_note")
-  __io_println(len(missing_arg_decisions) == 1)
-  __io_println(missing_arg_decisions[0].diagnostic.contains("missing required parameter"))
-  __io_println(missing_arg_regen_messages.contains("missing required parameter"))
-  llm_mock_clear()
-  llm_mock({text: "Working on it.", output_tokens: 95})
-  let capped_session = "structural-validator-output-cap-" + uuid()
-  let capped = agent_capture_events(
-    capped_session,
-    fn() { return try {
-      agent_loop(
-        "Update notes.txt and then finish.",
-        nil,
-        {
-          provider: "mock",
-          tool_format: "native",
-          loop_until_done: true,
-          max_iterations: 2,
-          max_tokens: 100,
-          tools: write_tools(),
-          session_id: capped_session,
-          structural_validator: with_structural_validator({on_failure: "raise", rules: ["output_token_cap_with_zero_calls"]}),
-        },
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]},
+      llm_text("I fixed it already.<done>##DONE##</done>"),
+    ],
+    { ->
+      let post_write_session = "structural-validator-post-write-" + uuid()
+      let post_write = agent_capture_events(
+        post_write_session,
+        fn() { return agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 3,
+            tools: write_tools(),
+            session_id: post_write_session,
+            structural_validator: with_structural_validator({rules: ["no_phantom_completion"]}),
+          },
+        ) },
       )
-      "no-throw"
-    } catch (_e) {
-      "caught"
-    } },
+      let post_write_decisions = events_of(post_write.events, "structural_validator_decision")
+      __io_println(post_write.result.status == "done")
+      __io_println(len(post_write_decisions) == 0)
+    },
   )
-  let capped_decisions = events_of(capped.events, "structural_validator_decision")
-  __io_println(capped.result == "caught")
-  __io_println(len(capped_decisions) == 1)
-  __io_println(capped_decisions[0].rule == "output_token_cap_with_zero_calls")
-  llm_mock_clear()
-  llm_mock({text: "Brief update.", output_tokens: 94})
-  llm_mock({text: "<done>##DONE##</done>", output_tokens: 10})
-  let under_cap_session = "structural-validator-output-under-cap-" + uuid()
-  let under_cap = agent_capture_events(
-    under_cap_session,
-    fn() { return agent_loop(
-      "Update notes.txt and then finish.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 3,
-        max_tokens: 100,
-        tools: write_tools(),
-        session_id: under_cap_session,
-        structural_validator: with_structural_validator({rules: ["output_token_cap_with_zero_calls"]}),
-      },
-    ) },
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]},
+      llm_text("I fixed it already."),
+    ],
+    { ->
+      let post_write_non_empty_session = "structural-validator-post-write-non-empty-" + uuid()
+      let post_write_non_empty = agent_capture_events(
+        post_write_non_empty_session,
+        fn() { return agent_loop(
+          "Update notes.txt and then summarize.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "native",
+            max_iterations: 3,
+            tools: write_tools(),
+            session_id: post_write_non_empty_session,
+            structural_validator: with_structural_validator(),
+          },
+        ) },
+      )
+      let post_write_non_empty_decisions = events_of(post_write_non_empty.events, "structural_validator_decision")
+      __io_println(post_write_non_empty.result.status == "done")
+      __io_println(len(post_write_non_empty_decisions) == 0)
+    },
   )
-  let under_cap_decisions = events_of(under_cap.events, "structural_validator_decision")
-  __io_println(under_cap.result.status == "done")
-  __io_println(len(under_cap_decisions) == 0)
-  llm_mock_clear()
-  llm_mock({text: malformed_tool_text})
-  llm_mock({text: tool_text})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let warn_only_session = "structural-validator-warn-only-" + uuid()
-  let warn_only = agent_capture_events(
-    warn_only_session,
-    fn() { return agent_loop(
-      "Update notes.txt and then finish.",
-      nil,
-      {
-        provider: "mock",
-        tool_format: "text",
-        loop_until_done: true,
-        max_iterations: 4,
-        tools: write_tools(),
-        session_id: warn_only_session,
-        structural_validator: with_structural_validator({rules: [{name: "tool_calls_well_formed", warn_only: true}]}),
-      },
-    ) },
+  with_llm_script(
+    [llm_text("The PATCH_HINT is:\n\n```python\ndef add(a, b): return a + b\n```")],
+    { ->
+      let lifecycle_only_session = "structural-validator-lifecycle-only-" + uuid()
+      let lifecycle_only = agent_capture_events(
+        lifecycle_only_session,
+        fn() { return agent_loop(
+          "No tools are available. State the smallest code change.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "text",
+            max_iterations: 1,
+            session_id: lifecycle_only_session,
+            structural_validator: with_structural_validator(),
+          },
+        ) },
+      )
+      let lifecycle_only_decisions = events_of(lifecycle_only.events, "structural_validator_decision")
+      __io_println(lifecycle_only.result.status == "done")
+      __io_println(len(lifecycle_only_decisions) == 0)
+    },
   )
-  let warn_only_decisions = events_of(warn_only.events, "structural_validator_decision")
-  let warn_only_messages = json_stringify(llm_mock_calls()[1].messages)
-  __io_println(warn_only.result.status == "done")
-  __io_println(len(warn_only_decisions) == 1)
-  __io_println(warn_only_decisions[0].rule == "tool_calls_well_formed")
-  __io_println(!(warn_only_decisions[0].vetoed ?? true))
-  __io_println(warn_only_decisions[0].reason == "warn_only")
-  __io_println(!warn_only_messages.contains("structural_validator"))
+  with_llm_script(
+    [llm_text(malformed_tool_text)],
+    { ->
+      let malformed_session = "structural-validator-malformed-" + uuid()
+      let malformed = agent_capture_events(
+        malformed_session,
+        fn() { return try {
+          agent_loop(
+            "Update notes.txt and then finish.",
+            nil,
+            {
+              provider: "mock",
+              tool_format: "text",
+              loop_until_done: true,
+              max_iterations: 2,
+              tools: write_tools(),
+              session_id: malformed_session,
+              structural_validator: with_structural_validator({on_failure: "raise", rules: ["tool_calls_well_formed"]}),
+            },
+          )
+          "no-throw"
+        } catch (_e) {
+          "caught"
+        } },
+      )
+      let malformed_decisions = events_of(malformed.events, "structural_validator_decision")
+      __io_println(malformed.result == "caught")
+      __io_println(len(malformed_decisions) == 1)
+      __io_println(malformed_decisions[0].rule == "tool_calls_well_formed")
+    },
+  )
+  with_llm_script(
+    [llm_text(tool_text), llm_text("<done>##DONE##</done>")],
+    { ->
+      let well_formed_session = "structural-validator-well-formed-" + uuid()
+      let well_formed = agent_capture_events(
+        well_formed_session,
+        fn() { return agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "text",
+            loop_until_done: true,
+            max_iterations: 3,
+            tools: write_tools(),
+            session_id: well_formed_session,
+            structural_validator: with_structural_validator({rules: ["tool_calls_well_formed"]}),
+          },
+        ) },
+      )
+      let well_formed_decisions = events_of(well_formed.events, "structural_validator_decision")
+      __io_println(well_formed.result.status == "done")
+      __io_println(len(well_formed_decisions) == 0)
+    },
+  )
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "write_missing", name: "write_note", arguments: {}}]},
+      {text: "", tool_calls: [{id: "write_2", name: "write_note", arguments: {path: "notes.txt"}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let missing_arg_session = "structural-validator-native-missing-arg-" + uuid()
+      let missing_arg = agent_capture_events(
+        missing_arg_session,
+        fn() { return agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 3,
+            tools: write_tools(),
+            session_id: missing_arg_session,
+            structural_validator: with_structural_validator({rules: ["tool_calls_well_formed"]}),
+          },
+        ) },
+      )
+      let missing_arg_decisions = events_of(missing_arg.events, "structural_validator_decision")
+      let missing_arg_regen_messages = json_stringify(llm_mock_calls()[1].messages)
+      __io_println(missing_arg.result.status == "done")
+      __io_println(missing_arg.result.tools.successful[0] == "write_note")
+      __io_println(len(missing_arg_decisions) == 1)
+      __io_println(missing_arg_decisions[0].diagnostic.contains("missing required parameter"))
+      __io_println(missing_arg_regen_messages.contains("missing required parameter"))
+    },
+  )
+  with_llm_script(
+    [{text: "Working on it.", output_tokens: 95}],
+    { ->
+      let capped_session = "structural-validator-output-cap-" + uuid()
+      let capped = agent_capture_events(
+        capped_session,
+        fn() { return try {
+          agent_loop(
+            "Update notes.txt and then finish.",
+            nil,
+            {
+              provider: "mock",
+              tool_format: "native",
+              loop_until_done: true,
+              max_iterations: 2,
+              max_tokens: 100,
+              tools: write_tools(),
+              session_id: capped_session,
+              structural_validator: with_structural_validator({on_failure: "raise", rules: ["output_token_cap_with_zero_calls"]}),
+            },
+          )
+          "no-throw"
+        } catch (_e) {
+          "caught"
+        } },
+      )
+      let capped_decisions = events_of(capped.events, "structural_validator_decision")
+      __io_println(capped.result == "caught")
+      __io_println(len(capped_decisions) == 1)
+      __io_println(capped_decisions[0].rule == "output_token_cap_with_zero_calls")
+    },
+  )
+  with_llm_script(
+    [{text: "Brief update.", output_tokens: 94}, {text: "<done>##DONE##</done>", output_tokens: 10}],
+    { ->
+      let under_cap_session = "structural-validator-output-under-cap-" + uuid()
+      let under_cap = agent_capture_events(
+        under_cap_session,
+        fn() { return agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 3,
+            max_tokens: 100,
+            tools: write_tools(),
+            session_id: under_cap_session,
+            structural_validator: with_structural_validator({rules: ["output_token_cap_with_zero_calls"]}),
+          },
+        ) },
+      )
+      let under_cap_decisions = events_of(under_cap.events, "structural_validator_decision")
+      __io_println(under_cap.result.status == "done")
+      __io_println(len(under_cap_decisions) == 0)
+    },
+  )
+  with_llm_script(
+    [llm_text(malformed_tool_text), llm_text(tool_text), llm_text("<done>##DONE##</done>")],
+    { ->
+      let warn_only_session = "structural-validator-warn-only-" + uuid()
+      let warn_only = agent_capture_events(
+        warn_only_session,
+        fn() { return agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "text",
+            loop_until_done: true,
+            max_iterations: 4,
+            tools: write_tools(),
+            session_id: warn_only_session,
+            structural_validator: with_structural_validator({rules: [{name: "tool_calls_well_formed", warn_only: true}]}),
+          },
+        ) },
+      )
+      let warn_only_decisions = events_of(warn_only.events, "structural_validator_decision")
+      let warn_only_messages = json_stringify(llm_mock_calls()[1].messages)
+      __io_println(warn_only.result.status == "done")
+      __io_println(len(warn_only_decisions) == 1)
+      __io_println(warn_only_decisions[0].rule == "tool_calls_well_formed")
+      __io_println(!(warn_only_decisions[0].vetoed ?? true))
+      __io_println(warn_only_decisions[0].reason == "warn_only")
+      __io_println(!warn_only_messages.contains("structural_validator"))
+    },
+  )
 }

--- a/conformance/tests/agents/agent_loop_verify_completion_judge_cap.harn
+++ b/conformance/tests/agents/agent_loop_verify_completion_judge_cap.harn
@@ -8,107 +8,119 @@
      `max_verify_attempts` exhaustion path.
    Mocks interleave model turns with the judge's structured-output call. */
 import { agent_capture_events } from "std/agent/events"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
 }
 
 fn run_capped() {
-  llm_mock_clear()
-  llm_mock({text: "Round one. ##DONE##"})
-  llm_mock(
-    {text: "{\"verdict\":\"continue\",\"reasoning\":\"veto one\",\"next_step\":\"keep going\"}"},
+  with_llm_script(
+    [
+      llm_text("Round one. ##DONE##"),
+      llm_text("{\"verdict\":\"continue\",\"reasoning\":\"veto one\",\"next_step\":\"keep going\"}"),
+      llm_text("Round two. ##DONE##"),
+      llm_text("{\"verdict\":\"continue\",\"reasoning\":\"veto two\",\"next_step\":\"keep going\"}"),
+      llm_text("Round three. ##DONE##"),
+    ],
+    { ->
+      let session_id = "verify-judge-cap-" + uuid()
+      let captured = agent_capture_events(
+        session_id,
+        fn() { return agent_loop(
+          "Judge keeps vetoing.",
+          nil,
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 10,
+            max_nudges: 10,
+            session_id: session_id,
+            done_sentinel: "##DONE##",
+            verify_completion_judge: {max_invocations: 2},
+          },
+        ) },
+      )
+      let result = captured.result
+      __io_println("capped.status=${result.status}")
+      __io_println("capped.stop_reason=${result.stop_reason}")
+      __io_println("capped.invocations=${result.completion_judge.invocations}")
+      __io_println("capped.vetoes=${result.completion_judge.vetoes}")
+      __io_println("capped.max_invocations=${result.completion_judge.max_invocations}")
+      __io_println("capped.cap_reached=${result.completion_judge.cap_reached}")
+      __io_println("capped.judge_decisions=${len(events_of(captured.events, "judge_decision"))}")
+      __io_println("capped.calls=${len(llm_mock_calls())}")
+    },
   )
-  llm_mock({text: "Round two. ##DONE##"})
-  llm_mock(
-    {text: "{\"verdict\":\"continue\",\"reasoning\":\"veto two\",\"next_step\":\"keep going\"}"},
-  )
-  llm_mock({text: "Round three. ##DONE##"})
-  let session_id = "verify-judge-cap-" + uuid()
-  let captured = agent_capture_events(
-    session_id,
-    fn() { return agent_loop(
-      "Judge keeps vetoing.",
-      nil,
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 10,
-        max_nudges: 10,
-        session_id: session_id,
-        done_sentinel: "##DONE##",
-        verify_completion_judge: {max_invocations: 2},
-      },
-    ) },
-  )
-  let result = captured.result
-  __io_println("capped.status=${result.status}")
-  __io_println("capped.stop_reason=${result.stop_reason}")
-  __io_println("capped.invocations=${result.completion_judge.invocations}")
-  __io_println("capped.vetoes=${result.completion_judge.vetoes}")
-  __io_println("capped.max_invocations=${result.completion_judge.max_invocations}")
-  __io_println("capped.cap_reached=${result.completion_judge.cap_reached}")
-  __io_println("capped.judge_decisions=${len(events_of(captured.events, "judge_decision"))}")
-  __io_println("capped.calls=${len(llm_mock_calls())}")
 }
 
 fn run_approved() {
-  llm_mock_clear()
-  llm_mock({text: "Final answer. ##DONE##"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"looks complete\"}"})
-  let session_id = "verify-judge-approve-" + uuid()
-  let result = agent_loop(
-    "Judge approves on the first proposal.",
-    nil,
-    {
-      provider: "mock",
-      loop_until_done: true,
-      max_iterations: 10,
-      max_nudges: 10,
-      session_id: session_id,
-      done_sentinel: "##DONE##",
-      verify_completion_judge: true,
+  with_llm_script(
+    [
+      llm_text("Final answer. ##DONE##"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"looks complete\"}"),
+    ],
+    { ->
+      let session_id = "verify-judge-approve-" + uuid()
+      let result = agent_loop(
+        "Judge approves on the first proposal.",
+        nil,
+        {
+          provider: "mock",
+          loop_until_done: true,
+          max_iterations: 10,
+          max_nudges: 10,
+          session_id: session_id,
+          done_sentinel: "##DONE##",
+          verify_completion_judge: true,
+        },
+      )
+      __io_println("approved.status=${result.status}")
+      __io_println("approved.invocations=${result.completion_judge.invocations}")
+      __io_println("approved.vetoes=${result.completion_judge.vetoes}")
+      __io_println("approved.max_invocations=${result.completion_judge.max_invocations}")
+      __io_println("approved.cap_reached=${result.completion_judge.cap_reached}")
+      __io_println("approved.calls=${len(llm_mock_calls())}")
     },
   )
-  __io_println("approved.status=${result.status}")
-  __io_println("approved.invocations=${result.completion_judge.invocations}")
-  __io_println("approved.vetoes=${result.completion_judge.vetoes}")
-  __io_println("approved.max_invocations=${result.completion_judge.max_invocations}")
-  __io_println("approved.cap_reached=${result.completion_judge.cap_reached}")
-  __io_println("approved.calls=${len(llm_mock_calls())}")
 }
 
 fn run_cap_disabled() {
-  llm_mock_clear()
-  llm_mock({text: "Try one. ##DONE##"})
-  llm_mock({text: "{\"verdict\":\"continue\",\"reasoning\":\"veto one\"}"})
-  llm_mock({text: "Try two. ##DONE##"})
-  llm_mock({text: "{\"verdict\":\"continue\",\"reasoning\":\"veto two\"}"})
-  llm_mock({text: "Try three. ##DONE##"})
-  let session_id = "verify-judge-disabled-" + uuid()
-  let captured = agent_capture_events(
-    session_id,
-    fn() { return agent_loop(
-      "Cap disabled; rely on max_verify_attempts.",
-      nil,
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 10,
-        max_nudges: 10,
-        session_id: session_id,
-        done_sentinel: "##DONE##",
-        max_verify_attempts: 2,
-        verify_completion_judge: {max_invocations: 0},
-      },
-    ) },
+  with_llm_script(
+    [
+      llm_text("Try one. ##DONE##"),
+      llm_text("{\"verdict\":\"continue\",\"reasoning\":\"veto one\"}"),
+      llm_text("Try two. ##DONE##"),
+      llm_text("{\"verdict\":\"continue\",\"reasoning\":\"veto two\"}"),
+      llm_text("Try three. ##DONE##"),
+    ],
+    { ->
+      let session_id = "verify-judge-disabled-" + uuid()
+      let captured = agent_capture_events(
+        session_id,
+        fn() { return agent_loop(
+          "Cap disabled; rely on max_verify_attempts.",
+          nil,
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 10,
+            max_nudges: 10,
+            session_id: session_id,
+            done_sentinel: "##DONE##",
+            max_verify_attempts: 2,
+            verify_completion_judge: {max_invocations: 0},
+          },
+        ) },
+      )
+      let result = captured.result
+      __io_println("disabled.status=${result.status}")
+      __io_println("disabled.stop_reason=${result.stop_reason}")
+      __io_println("disabled.invocations=${result.completion_judge.invocations}")
+      __io_println("disabled.cap_reached=${result.completion_judge.cap_reached}")
+      __io_println("disabled.judge_decisions=${len(events_of(captured.events, "judge_decision"))}")
+    },
   )
-  let result = captured.result
-  __io_println("disabled.status=${result.status}")
-  __io_println("disabled.stop_reason=${result.stop_reason}")
-  __io_println("disabled.invocations=${result.completion_judge.invocations}")
-  __io_println("disabled.cap_reached=${result.completion_judge.cap_reached}")
-  __io_println("disabled.judge_decisions=${len(events_of(captured.events, "judge_decision"))}")
 }
 
 pipeline default() {

--- a/conformance/tests/agents/agent_path_scope_guard.harn
+++ b/conformance/tests/agents/agent_path_scope_guard.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn path_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -14,19 +16,19 @@ fn path_tools() {
 }
 
 fn run_read(session, path) {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "call_Read", name: "Read", arguments: {path: path}}]})
-  llm_mock({text: "done"})
-  return agent_loop(
-    "Use Read",
-    nil,
-    {
-      session_id: session,
-      provider: "mock",
-      tools: path_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-    },
+  return with_llm_script(
+    [{tool_calls: [{id: "call_Read", name: "Read", arguments: {path: path}}]}, llm_text("done")],
+    { -> return agent_loop(
+      "Use Read",
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        tools: path_tools(),
+        tool_format: "native",
+        max_iterations: 2,
+      },
+    ) },
   )
 }
 

--- a/conformance/tests/agents/agent_path_scope_permissions.harn
+++ b/conformance/tests/agents/agent_path_scope_permissions.harn
@@ -1,3 +1,4 @@
+import { llm_text, with_llm_script } from "std/testing"
 import { path_scope } from "std/tools"
 
 fn path_tools() {
@@ -26,20 +27,23 @@ fn path_tools() {
 }
 
 fn run_one(session, tool_name, path, permissions) {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "call_" + tool_name, name: tool_name, arguments: {path: path}}]})
-  llm_mock({text: "done"})
-  return agent_loop(
-    "Use " + tool_name,
-    nil,
-    {
-      session_id: session,
-      provider: "mock",
-      tools: path_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      permissions: permissions,
-    },
+  return with_llm_script(
+    [
+      {tool_calls: [{id: "call_" + tool_name, name: tool_name, arguments: {path: path}}]},
+      llm_text("done"),
+    ],
+    { -> return agent_loop(
+      "Use " + tool_name,
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        tools: path_tools(),
+        tool_format: "native",
+        max_iterations: 2,
+        permissions: permissions,
+      },
+    ) },
   )
 }
 

--- a/conformance/tests/agents/agent_preset_audit_summary.harn
+++ b/conformance/tests/agents/agent_preset_audit_summary.harn
@@ -1,4 +1,5 @@
 import { audit_agent, repair_agent, summary_agent } from "std/agent/presets"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn audit_tools() {
   var tools = tool_registry()
@@ -19,42 +20,58 @@ fn audit_tools() {
 pipeline default() {
   // audit_agent: native completion, no done sentinel; must complete on
   // final user_response text.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "i1", name: "inspect", arguments: {what: "release"}}]})
-  llm_mock({text: "<user_response>Audit complete.</user_response>"})
-  let audit = audit_agent("Audit the release", {provider: "mock", tools: audit_tools(), tool_format: "native"})
-  __io_println(audit.status)
-  __io_println(audit.text)
-  __io_println(audit.adaptive_budget.mode)
-  let calls = llm_mock_calls()
-  // No `##DONE##` sentinel should leak into the system prompt.
-  __io_println(!contains(calls[0].system, "##DONE##"))
-  // summary_agent: cheap one-shot, no tools, no looping.
-  llm_mock_clear()
-  llm_mock({text: "Just a summary."})
-  let summary = summary_agent("Summarize.", {provider: "mock"})
-  __io_println(summary.status)
-  __io_println(summary.text)
-  __io_println(summary.llm.iterations)
-  // summary_agent should not inject native-tool options when it has no tools.
-  // This keeps local/Ollama-style providers without native tool support usable.
-  llm_mock_clear()
-  llm_mock({text: "Local summary."})
-  let local_summary = summary_agent("Summarize locally.", {provider: "mock", model: "mystery-model-7b"})
-  __io_println(local_summary.status)
-  __io_println(local_summary.text)
-  let summary_calls = llm_mock_calls()
-  __io_println(summary_calls[0]?.tool_choice == nil)
-  // repair_agent: tool-using with adaptive budget defaults; ends on natural
-  // user_response.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "r1", name: "inspect", arguments: {what: "fix"}}]})
-  llm_mock({text: "<user_response>Fixed.</user_response>"})
-  let repair = repair_agent(
-    "Repair the regression",
-    {provider: "mock", tools: audit_tools(), tool_format: "native"},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "i1", name: "inspect", arguments: {what: "release"}}]},
+      llm_text("<user_response>Audit complete.</user_response>"),
+    ],
+    { ->
+      let audit = audit_agent("Audit the release", {provider: "mock", tools: audit_tools(), tool_format: "native"})
+      __io_println(audit.status)
+      __io_println(audit.text)
+      __io_println(audit.adaptive_budget.mode)
+      let calls = llm_mock_calls()
+      __io_println(!contains(calls[0].system, "##DONE##"))
+    },
   )
-  __io_println(repair.status)
-  __io_println(repair.adaptive_budget.mode)
-  __io_println(repair.adaptive_budget.max >= repair.adaptive_budget.initial)
+  with_llm_script(
+    [llm_text("Just a summary.")],
+    { ->
+      let summary = summary_agent("Summarize.", {provider: "mock"})
+      __io_println(summary.status)
+      __io_println(summary.text)
+      __io_println(summary.llm.iterations)
+    },
+  )
+  with_llm_script(
+    [llm_text("Local summary.")],
+    { ->
+      let local_summary = summary_agent("Summarize locally.", {provider: "mock", model: "mystery-model-7b"})
+      __io_println(local_summary.status)
+      __io_println(local_summary.text)
+      let summary_calls = llm_mock_calls()
+      __io_println(summary_calls[0]?.tool_choice == nil)
+    },
+  )
+  with_llm_script(
+    [
+      {tool_calls: [{id: "r1", name: "inspect", arguments: {what: "fix"}}]},
+      llm_text("<user_response>Fixed.</user_response>"),
+    ],
+    { ->
+      let repair = repair_agent(
+        "Repair the regression",
+        {provider: "mock", tools: audit_tools(), tool_format: "native"},
+      )
+      __io_println(repair.status)
+      __io_println(repair.adaptive_budget.mode)
+      __io_println(repair.adaptive_budget.max >= repair.adaptive_budget.initial)
+    },
+  )
 }
+// No `##DONE##` sentinel should leak into the system prompt.
+// summary_agent: cheap one-shot, no tools, no looping.
+// summary_agent should not inject native-tool options when it has no tools.
+// This keeps local/Ollama-style providers without native tool support usable.
+// repair_agent: tool-using with adaptive budget defaults; ends on natural
+// user_response.

--- a/conformance/tests/agents/agent_preset_captains.harn
+++ b/conformance/tests/agents/agent_preset_captains.harn
@@ -13,6 +13,7 @@ import {
   release_captain_agent,
   review_captain_agent,
 } from "std/agent/presets"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
   // (1) merge_captain — long adaptive budget; tool_using profile;
@@ -79,16 +80,6 @@ pipeline default() {
   // (8) merge_captain default consent ALLOWS read-annotated tools and
   // BLOCKS unannotated/write tools. Drive a real agent_loop through
   // both paths to confirm short-circuit behavior.
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "ok1", name: "lookup", arguments: {q: "x"}},
-        {id: "block1", name: "delete", arguments: {path: "/tmp/y"}},
-      ],
-    },
-  )
-  llm_mock({text: "<user_response>Done.</user_response>"})
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -110,64 +101,83 @@ pipeline default() {
       annotations: {kind: "delete"},
     },
   )
-  let merge_run = merge_captain_agent(
-    "Try one read and one write.",
-    {provider: "mock", tools: registry, tool_format: "native", max_iterations: 3},
-  )
-  __io_println(merge_run.status)
-  // The read tool succeeded; the delete tool was denied by default
-  // consent and never reached the dispatch layer.
-  __io_println(contains(merge_run.tools.successful, "lookup"))
-  __io_println(!contains(merge_run.tools.successful, "delete"))
-  // (9) oncall_captain default rate-limit caps tool calls at 50.
-  // Verify the cap is wired by passing an absurdly small override.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "rl1", name: "lookup", arguments: {q: "1"}}]})
-  llm_mock({tool_calls: [{id: "rl2", name: "lookup", arguments: {q: "2"}}]})
-  llm_mock({tool_calls: [{id: "rl3", name: "lookup", arguments: {q: "3"}}]})
-  llm_mock({text: "<user_response>Stopping.</user_response>"})
-  let oncall_capped = oncall_captain_agent(
-    "Hammer the same tool.",
-    {
-      provider: "mock",
-      tools: registry,
-      tool_format: "native",
-      max_iterations: 5,
-      rate_limit: {max_calls: 1},
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "ok1", name: "lookup", arguments: {q: "x"}},
+          {id: "block1", name: "delete", arguments: {path: "/tmp/y"}},
+        ],
+      },
+      llm_text("<user_response>Done.</user_response>"),
+    ],
+    { ->
+      let merge_run = merge_captain_agent(
+        "Try one read and one write.",
+        {provider: "mock", tools: registry, tool_format: "native", max_iterations: 3},
+      )
+      __io_println(merge_run.status)
+      __io_println(contains(merge_run.tools.successful, "lookup"))
+      __io_println(!contains(merge_run.tools.successful, "delete"))
     },
   )
-  // Status may be done or stuck depending on whether the model
-  // recovers — what matters is that exactly one tool succeeded
-  // and the rest were rejected by the rate-limit layer.
-  __io_println(len(oncall_capped.tools.successful))
-  // (10) release_captain dry_run: opt-in via {dry_run: true}.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "dr1", name: "delete", arguments: {path: "/tmp/preview"}}]})
-  llm_mock({text: "<user_response>Dry run preview.</user_response>"})
-  let release_dry = release_captain_agent(
-    "Preview the action.",
-    {provider: "mock", tools: registry, tool_format: "native", max_iterations: 3, dry_run: true},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "rl1", name: "lookup", arguments: {q: "1"}}]},
+      {tool_calls: [{id: "rl2", name: "lookup", arguments: {q: "2"}}]},
+      {tool_calls: [{id: "rl3", name: "lookup", arguments: {q: "3"}}]},
+      llm_text("<user_response>Stopping.</user_response>"),
+    ],
+    { ->
+      let oncall_capped = oncall_captain_agent(
+        "Hammer the same tool.",
+        {
+          provider: "mock",
+          tools: registry,
+          tool_format: "native",
+          max_iterations: 5,
+          rate_limit: {max_calls: 1},
+        },
+      )
+      __io_println(len(oncall_capped.tools.successful))
+    },
   )
-  __io_println(release_dry.status)
-  // Dry-run reports the tool call as successful (status=dry_run with ok=true).
-  __io_println(contains(release_dry.tools.successful, "delete"))
-  // (11) review_captain_agent runs with tool_using profile and an
-  // adaptive budget — exercise it end-to-end.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "rv1", name: "lookup", arguments: {q: "review"}}]})
-  llm_mock({text: "<user_response>Looks good.</user_response>"})
-  let review_run = review_captain_agent("Review this PR.", {provider: "mock", tools: registry, tool_format: "native"})
-  __io_println(review_run.status)
-  // (12) Explicit `false` opts the caller out of a per-captain default
-  // layer (here: merge_captain's default consent). With consent
-  // disabled the previously-blocked write tool succeeds.
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "ow1", name: "delete", arguments: {path: "/tmp/yes"}}]})
-  llm_mock({text: "<user_response>Done.</user_response>"})
-  let merge_no_consent = merge_captain_agent(
-    "Delete with consent disabled.",
-    {provider: "mock", tools: registry, tool_format: "native", max_iterations: 3, consent: false},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "dr1", name: "delete", arguments: {path: "/tmp/preview"}}]},
+      llm_text("<user_response>Dry run preview.</user_response>"),
+    ],
+    { ->
+      let release_dry = release_captain_agent(
+        "Preview the action.",
+        {provider: "mock", tools: registry, tool_format: "native", max_iterations: 3, dry_run: true},
+      )
+      __io_println(release_dry.status)
+      __io_println(contains(release_dry.tools.successful, "delete"))
+    },
   )
-  __io_println(merge_no_consent.status)
-  __io_println(contains(merge_no_consent.tools.successful, "delete"))
+  with_llm_script(
+    [
+      {tool_calls: [{id: "rv1", name: "lookup", arguments: {q: "review"}}]},
+      llm_text("<user_response>Looks good.</user_response>"),
+    ],
+    { ->
+      let review_run = review_captain_agent("Review this PR.", {provider: "mock", tools: registry, tool_format: "native"})
+      __io_println(review_run.status)
+    },
+  )
+  with_llm_script(
+    [
+      {tool_calls: [{id: "ow1", name: "delete", arguments: {path: "/tmp/yes"}}]},
+      llm_text("<user_response>Done.</user_response>"),
+    ],
+    { ->
+      let merge_no_consent = merge_captain_agent(
+        "Delete with consent disabled.",
+        {provider: "mock", tools: registry, tool_format: "native", max_iterations: 3, consent: false},
+      )
+      __io_println(merge_no_consent.status)
+      __io_println(contains(merge_no_consent.tools.successful, "delete"))
+    },
+  )
 }

--- a/conformance/tests/agents/agent_primitives_one_turn.harn
+++ b/conformance/tests/agents/agent_primitives_one_turn.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 fn calculator_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -32,27 +34,33 @@ fn calculator_tools() {
 
 pipeline main() {
   let tools = calculator_tools()
-  llm_mock({text: "<tool_call>\nadd({ left: 2, right: 3 })\n</tool_call>"})
-  let turn = agent_llm_turn("Calculate 2 + 3", nil, {provider: "mock", tools: tools})
-  let parsed = agent_parse_tool_calls(turn.text, tools)
-  let dispatched = agent_dispatch_tool_call(parsed.tool_calls[0], tools)
-  let batch = agent_dispatch_tool_batch(parsed.tool_calls, tools)
-  let malformed_text = agent_parse_tool_calls("<tool_call>\nadd({ left: })\n</tool_call>", tools)
-  let schema_error = agent_dispatch_tool_call({name: "add", arguments: {left: 2}}, tools)
-  let handler_error = agent_dispatch_tool_call({name: "explode", arguments: {}}, tools)
-  llm_mock({text: "", tool_calls: [{id: "native_add", name: "add", arguments: {left: 4, right: 6}}]})
-  let native_turn = agent_llm_turn("Calculate 4 + 6", nil, {provider: "mock", tools: tools})
-  let native_batch = agent_dispatch_tool_batch(native_turn.tool_calls, tools)
-  __io_println(parsed.tool_calls[0].name)
-  __io_println(dispatched.ok)
-  __io_println(dispatched.rendered_result)
-  __io_println(len(batch))
-  __io_println(batch[0].rendered_result)
-  __io_println(len(malformed_text.tool_parse_errors) > 0)
-  __io_println(schema_error.ok)
-  __io_println(schema_error.error_category)
-  __io_println(handler_error.ok)
-  __io_println(contains(handler_error.error, "boom"))
-  __io_println(native_turn.tool_calls[0].name)
-  __io_println(native_batch[0].rendered_result)
+  with_llm_script(
+    [
+      {text: "<tool_call>\nadd({ left: 2, right: 3 })\n</tool_call>"},
+      {text: "", tool_calls: [{id: "native_add", name: "add", arguments: {left: 4, right: 6}}]},
+    ],
+    { ->
+      let turn = agent_llm_turn("Calculate 2 + 3", nil, {provider: "mock", tools: tools})
+      let parsed = agent_parse_tool_calls(turn.text, tools)
+      let dispatched = agent_dispatch_tool_call(parsed.tool_calls[0], tools)
+      let batch = agent_dispatch_tool_batch(parsed.tool_calls, tools)
+      let malformed_text = agent_parse_tool_calls("<tool_call>\nadd({ left: })\n</tool_call>", tools)
+      let schema_error = agent_dispatch_tool_call({name: "add", arguments: {left: 2}}, tools)
+      let handler_error = agent_dispatch_tool_call({name: "explode", arguments: {}}, tools)
+      let native_turn = agent_llm_turn("Calculate 4 + 6", nil, {provider: "mock", tools: tools})
+      let native_batch = agent_dispatch_tool_batch(native_turn.tool_calls, tools)
+      __io_println(parsed.tool_calls[0].name)
+      __io_println(dispatched.ok)
+      __io_println(dispatched.rendered_result)
+      __io_println(len(batch))
+      __io_println(batch[0].rendered_result)
+      __io_println(len(malformed_text.tool_parse_errors) > 0)
+      __io_println(schema_error.ok)
+      __io_println(schema_error.error_category)
+      __io_println(handler_error.ok)
+      __io_println(contains(handler_error.error, "boom"))
+      __io_println(native_turn.tool_calls[0].name)
+      __io_println(native_batch[0].rendered_result)
+    },
+  )
 }

--- a/conformance/tests/agents/agent_result_shape.harn
+++ b/conformance/tests/agents/agent_result_shape.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Asserts the namespaced `agent_loop` result shape introduced in
  * burin-labs/harn#532. The flat keys (`iterations`, `duration_ms`,
@@ -5,35 +7,38 @@
  * were removed; callers read them via `result.llm.*` and `result.tools.*`.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "still working"})
-  let result = agent_loop(
-    "Just keep replying",
-    "You are helpful",
-    {
-      provider: "mock",
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_iterations: 1,
-      max_nudges: 1,
+  with_llm_script(
+    [llm_text("still working")],
+    { ->
+      let result = agent_loop(
+        "Just keep replying",
+        "You are helpful",
+        {
+          provider: "mock",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_iterations: 1,
+          max_nudges: 1,
+        },
+      )
+      __io_println(result.status == "budget_exhausted")
+      __io_println(type_of(result.llm) == "dict")
+      __io_println(type_of(result.tools) == "dict")
+      __io_println(result.llm.iterations >= 1)
+      __io_println(result.llm.duration_ms >= 0)
+      __io_println(result.llm.input_tokens >= 0)
+      __io_println(result.llm.output_tokens >= 0)
+      __io_println(type_of(result.tools.calls) == "list")
+      __io_println(type_of(result.tools.successful) == "list")
+      __io_println(type_of(result.tools.rejected) == "list")
+      __io_println(type_of(result.tools.mode) == "string")
+      __io_println(result.iterations == nil)
+      __io_println(result.duration_ms == nil)
+      __io_println(result.tools_used == nil)
+      __io_println(result.successful_tools == nil)
+      __io_println(result.rejected_tools == nil)
+      __io_println(result.tool_calling_mode == nil)
     },
   )
-  __io_println(result.status == "budget_exhausted")
-  __io_println(type_of(result.llm) == "dict")
-  __io_println(type_of(result.tools) == "dict")
-  __io_println(result.llm.iterations >= 1)
-  __io_println(result.llm.duration_ms >= 0)
-  __io_println(result.llm.input_tokens >= 0)
-  __io_println(result.llm.output_tokens >= 0)
-  __io_println(type_of(result.tools.calls) == "list")
-  __io_println(type_of(result.tools.successful) == "list")
-  __io_println(type_of(result.tools.rejected) == "list")
-  __io_println(type_of(result.tools.mode) == "string")
-  // The retired flat keys must not resurface as siblings.
-  __io_println(result.iterations == nil)
-  __io_println(result.duration_ms == nil)
-  __io_println(result.tools_used == nil)
-  __io_println(result.successful_tools == nil)
-  __io_println(result.rejected_tools == nil)
-  __io_println(result.tool_calling_mode == nil)
 }
+// The retired flat keys must not resurface as siblings.

--- a/conformance/tests/agents/agent_resume_continuity_reminder.harn
+++ b/conformance/tests/agents/agent_resume_continuity_reminder.harn
@@ -1,4 +1,5 @@
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn resume_tools() {
   var tools = tool_registry()
@@ -12,43 +13,46 @@ fn resume_tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "park_1", name: "agent_await_resumption", arguments: {reason: "waiting on review"}}],
-      input_tokens: 7,
-      output_tokens: 3,
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_1", name: "agent_await_resumption", arguments: {reason: "waiting on review"}}],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      {tool_calls: [{id: "noop_1", name: "noop", arguments: {}}]},
+      llm_text("done"),
+    ],
+    { ->
+      let session_id = "resume-continuity-" + uuid()
+      let handle = sub_agent_run(
+        "Park until an operator resumes you.",
+        {
+          provider: "mock",
+          background: true,
+          session_id: session_id,
+          tools: resume_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+        },
+      )
+      let suspended = wait_agent(handle)
+      let resumed = resume_agent(suspended, "operator says go", true)
+      let completed = wait_agent(handle)
+      let calls = llm_mock_calls()
+      let resumed_system = calls[1].system
+      let next_system = calls[2].system
+      let remaining = transcript_events_by_kind(completed.transcript, "system_reminder")
+        .filter({ event -> event.reminder.dedupe_key == "resume_continuity" })
+      __io_println(suspended.status)
+      __io_println(resumed.status)
+      __io_println(completed.status)
+      __io_println(contains(resumed_system, "You were suspended at turn"))
+      __io_println(contains(resumed_system, "waiting on review"))
+      __io_println(contains(resumed_system, "You have been resumed by the operator"))
+      __io_println(contains(resumed_system, "The resumer provided input: operator says go"))
+      __io_println(!contains(next_system, "You were suspended at turn"))
+      __io_println(len(remaining))
     },
   )
-  let session_id = "resume-continuity-" + uuid()
-  let handle = sub_agent_run(
-    "Park until an operator resumes you.",
-    {
-      provider: "mock",
-      background: true,
-      session_id: session_id,
-      tools: resume_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-    },
-  )
-  let suspended = wait_agent(handle)
-  llm_mock({tool_calls: [{id: "noop_1", name: "noop", arguments: {}}]})
-  llm_mock({text: "done"})
-  let resumed = resume_agent(suspended, "operator says go", true)
-  let completed = wait_agent(handle)
-  let calls = llm_mock_calls()
-  let resumed_system = calls[1].system
-  let next_system = calls[2].system
-  let remaining = transcript_events_by_kind(completed.transcript, "system_reminder")
-    .filter({ event -> event.reminder.dedupe_key == "resume_continuity" })
-  __io_println(suspended.status)
-  __io_println(resumed.status)
-  __io_println(completed.status)
-  __io_println(contains(resumed_system, "You were suspended at turn"))
-  __io_println(contains(resumed_system, "waiting on review"))
-  __io_println(contains(resumed_system, "You have been resumed by the operator"))
-  __io_println(contains(resumed_system, "The resumer provided input: operator says go"))
-  __io_println(!contains(next_system, "You were suspended at turn"))
-  __io_println(len(remaining))
 }

--- a/conformance/tests/agents/agent_runtime_features.harn
+++ b/conformance/tests/agents/agent_runtime_features.harn
@@ -2,6 +2,7 @@ import {
   compact_preserving_test_failures,
   compact_retaining_current_plan,
 } from "std/agent/autocompact"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn list_tools() {
   var tools = tool_registry()
@@ -138,65 +139,75 @@ pipeline test(task) {
     json_stringify(transcript_messages(stopped_after_tool_turn?.transcript))
       .contains("handoff now"),
   )
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "hook_1", name: "list_directory", arguments: {path: "."}}]})
-  llm_mock({text: "Final answer from the model."})
-  let hook_driven_final = agent_loop(
-    "Inspect the workspace",
-    "You are helpful",
-    {
-      provider: "mock",
-      tools: list_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      post_turn_callback: { info ->
-        if len(info?.successful_tool_names ?? []) > 0 {
-          return {
-            message: "finalize now current=${info.successful_tool_names[0]} session=${info.session_successful_tools[0]} rejected=${len(info?.session_rejected_tools ?? [])}",
-            llm_options: {tool_choice: "none"},
-          }
-        }
-        return nil
-      },
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "hook_1", name: "list_directory", arguments: {path: "."}}]},
+      llm_text("Final answer from the model."),
+    ],
+    { ->
+      let hook_driven_final = agent_loop(
+        "Inspect the workspace",
+        "You are helpful",
+        {
+          provider: "mock",
+          tools: list_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          post_turn_callback: { info ->
+            if len(info?.successful_tool_names ?? []) > 0 {
+              return {
+                message: "finalize now current=${info.successful_tool_names[0]} session=${info.session_successful_tools[0]} rejected=${len(info?.session_rejected_tools ?? [])}",
+                llm_options: {tool_choice: "none"},
+              }
+            }
+            return nil
+          },
+        },
+      )
+      let hook_calls = llm_mock_calls()
+      let second_call = json_stringify(hook_calls[1].messages)
+      __io_println(hook_driven_final?.llm?.iterations == 2)
+      __io_println(second_call.contains("current=list_directory"))
+      __io_println(second_call.contains("session=list_directory"))
+      __io_println(second_call.contains("rejected=0"))
+      __io_println(hook_calls[1].tool_choice == "none")
+      __io_println(second_call.contains("finalize now"))
     },
   )
-  let hook_calls = llm_mock_calls()
-  let second_call = json_stringify(hook_calls[1].messages)
-  __io_println(hook_driven_final?.llm?.iterations == 2)
-  __io_println(second_call.contains("current=list_directory"))
-  __io_println(second_call.contains("session=list_directory"))
-  __io_println(second_call.contains("rejected=0"))
-  __io_println(hook_calls[1].tool_choice == "none")
-  __io_println(second_call.contains("finalize now"))
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "hook_2", name: "list_directory", arguments: {path: "."}}]})
-  llm_mock({text: "Final answer after clearing tools."})
-  let final_tools = tool_registry()
-  let cleared_final = agent_loop(
-    "Inspect the workspace",
-    "You are helpful",
-    {
-      provider: "mock",
-      tools: list_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      max_nudges: 0,
-      post_turn_callback: { info ->
-        if len(info?.successful_tool_names ?? []) > 0 {
-          return {
-            message: "finalize without tools",
-            llm_options: {tool_choice: "none", tools: final_tools},
-            next_options: {tools: final_tools, loop_until_done: false, max_nudges: 0},
-          }
-        }
-        return nil
-      },
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "hook_2", name: "list_directory", arguments: {path: "."}}]},
+      llm_text("Final answer after clearing tools."),
+    ],
+    { ->
+      let final_tools = tool_registry()
+      let cleared_final = agent_loop(
+        "Inspect the workspace",
+        "You are helpful",
+        {
+          provider: "mock",
+          tools: list_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          max_nudges: 0,
+          post_turn_callback: { info ->
+            if len(info?.successful_tool_names ?? []) > 0 {
+              return {
+                message: "finalize without tools",
+                llm_options: {tool_choice: "none", tools: final_tools},
+                next_options: {tools: final_tools, loop_until_done: false, max_nudges: 0},
+              }
+            }
+            return nil
+          },
+        },
+      )
+      let cleared_calls = llm_mock_calls()
+      __io_println(cleared_final?.status == "done")
+      __io_println(cleared_final?.llm?.iterations == 2)
+      __io_println(len(cleared_calls[1]?.tools ?? []) == 0)
     },
   )
-  let cleared_calls = llm_mock_calls()
-  __io_println(cleared_final?.status == "done")
-  __io_println(cleared_final?.llm?.iterations == 2)
-  __io_println(len(cleared_calls[1]?.tools ?? []) == 0)
 }

--- a/conformance/tests/agents/agent_session_current_id.harn
+++ b/conformance/tests/agents/agent_session_current_id.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline main(task) {
   assert(
     agent_session_current_id() == nil,
@@ -19,36 +21,40 @@ pipeline main(task) {
       returns: {type: "string"},
     },
   )
-  llm_mock(
-    {text: "Checking the session.", tool_calls: [{id: "sid1", name: "read_current_id", arguments: {}}]},
-  )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Report the current session id",
-    nil,
-    {
-      provider: "mock",
-      tools: tools,
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 4,
-      session_id: session,
+  with_llm_script(
+    [
+      {text: "Checking the session.", tool_calls: [{id: "sid1", name: "read_current_id", arguments: {}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Report the current session id",
+        nil,
+        {
+          provider: "mock",
+          tools: tools,
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 4,
+          session_id: session,
+        },
+      )
+      assert(result?.status == "done", "loop completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) >= 2, "tool call produces a second turn")
+      let turn2_messages = calls[1].messages
+      var saw_session_feedback = false
+      for m in turn2_messages {
+        let content = m?.content
+        if content != nil && contains(content, session) {
+          saw_session_feedback = true
+        }
+      }
+      assert(
+        saw_session_feedback,
+        "next turn includes the tool result returned by agent_session_current_id()",
+      )
+      log("agent_session_current_id tests passed")
     },
   )
-  assert(result?.status == "done", "loop completes")
-  let calls = llm_mock_calls()
-  assert(len(calls) >= 2, "tool call produces a second turn")
-  let turn2_messages = calls[1].messages
-  var saw_session_feedback = false
-  for m in turn2_messages {
-    let content = m?.content
-    if content != nil && contains(content, session) {
-      saw_session_feedback = true
-    }
-  }
-  assert(
-    saw_session_feedback,
-    "next turn includes the tool result returned by agent_session_current_id()",
-  )
-  log("agent_session_current_id tests passed")
 }

--- a/conformance/tests/agents/agent_session_seed_from_jsonl.harn
+++ b/conformance/tests/agents/agent_session_seed_from_jsonl.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline main() {
   let path = path_join(harness.fs.temp_dir(), "harn-seed-" + uuid() + ".jsonl")
   harness.fs
@@ -81,24 +83,27 @@ pipeline main() {
   __io_println(legacy.source_format)
   __io_println(len(legacy_snap.messages))
   __io_println(legacy_snap.messages[1].content)
-  llm_mock_clear()
-  llm_mock({text: "recorded assistant"})
-  let transcript_dir = path_join(harness.fs.temp_dir(), "harn-seed-sidecar-" + uuid())
-  let source_session = agent_session_open()
-  agent_loop(
-    "record this",
-    nil,
-    {
-      provider: "mock",
-      session_id: source_session,
-      max_iterations: 1,
-      llm_transcript_dir: transcript_dir,
+  with_llm_script(
+    [llm_text("recorded assistant")],
+    { ->
+      let transcript_dir = path_join(harness.fs.temp_dir(), "harn-seed-sidecar-" + uuid())
+      let source_session = agent_session_open()
+      agent_loop(
+        "record this",
+        nil,
+        {
+          provider: "mock",
+          session_id: source_session,
+          max_iterations: 1,
+          llm_transcript_dir: transcript_dir,
+        },
+      )
+      let sidecar = path_join(transcript_dir, "llm_transcript.jsonl")
+      __io_println(contains(harness.fs.read_text(sidecar), "\"type\":\"message\""))
+      let imported = agent_session_seed_from_jsonl(sidecar, {provider: "mock"})
+      __io_println(imported.ok)
+      __io_println(imported.source_format)
+      __io_println(imported.turns_loaded >= 2)
     },
   )
-  let sidecar = path_join(transcript_dir, "llm_transcript.jsonl")
-  __io_println(contains(harness.fs.read_text(sidecar), "\"type\":\"message\""))
-  let imported = agent_session_seed_from_jsonl(sidecar, {provider: "mock"})
-  __io_println(imported.ok)
-  __io_println(imported.source_format)
-  __io_println(imported.turns_loaded >= 2)
 }

--- a/conformance/tests/agents/agent_session_tool_format_contract.harn
+++ b/conformance/tests/agents/agent_session_tool_format_contract.harn
@@ -1,27 +1,32 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "first ##DONE##"})
-  let session = agent_session_open("tool-format-contract-conformance")
-  let first = agent_loop(
-    "first turn",
-    nil,
-    {provider: "mock", model: "mock", session_id: session, max_iterations: 1, tool_format: "text"},
+  with_llm_script(
+    [llm_text("first ##DONE##")],
+    { ->
+      let session = agent_session_open("tool-format-contract-conformance")
+      let first = agent_loop(
+        "first turn",
+        nil,
+        {provider: "mock", model: "mock", session_id: session, max_iterations: 1, tool_format: "text"},
+      )
+      require first?.tools?.mode == "text", "first loop uses requested text tool format"
+      require agent_session_tool_format(session) == "text", "session records the tool format contract"
+      let switched = try {
+        agent_loop(
+          "second turn",
+          nil,
+          {provider: "mock", model: "mock", session_id: session, max_iterations: 1, tool_format: "native"},
+        )
+      }
+      require is_err(switched), "same transcript cannot switch tool format"
+      require contains(json_stringify(unwrap_err(switched)), "tool_format"), "error names tool_format"
+      let forked = agent_session_fork(session, "tool-format-contract-fork")
+      require agent_session_tool_format(forked) == "text", "forked transcript inherits the contract"
+      let child = agent_session_open("tool-format-contract-child")
+      agent_session_claim_tool_format(child, "native")
+      require agent_session_tool_format(child) == "native", "new transcripts can choose their contract"
+      __io_println("agent_session_tool_format_contract passed")
+    },
   )
-  require first?.tools?.mode == "text", "first loop uses requested text tool format"
-  require agent_session_tool_format(session) == "text", "session records the tool format contract"
-  let switched = try {
-    agent_loop(
-      "second turn",
-      nil,
-      {provider: "mock", model: "mock", session_id: session, max_iterations: 1, tool_format: "native"},
-    )
-  }
-  require is_err(switched), "same transcript cannot switch tool format"
-  require contains(json_stringify(unwrap_err(switched)), "tool_format"), "error names tool_format"
-  let forked = agent_session_fork(session, "tool-format-contract-fork")
-  require agent_session_tool_format(forked) == "text", "forked transcript inherits the contract"
-  let child = agent_session_open("tool-format-contract-child")
-  agent_session_claim_tool_format(child, "native")
-  require agent_session_tool_format(child) == "native", "new transcripts can choose their contract"
-  __io_println("agent_session_tool_format_contract passed")
 }

--- a/conformance/tests/agents/agent_stop_graceful_handoff.harn
+++ b/conformance/tests/agents/agent_stop_graceful_handoff.harn
@@ -1,4 +1,5 @@
 import { agent_lifecycle_tools, agent_stop, sub_agent_run, wait_agent } from "std/agent/workers"
+import { with_llm_script } from "std/testing"
 
 fn nested_tools() {
   var tools = tool_registry()
@@ -30,72 +31,75 @@ fn nested_tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "spawn_nested_1", name: "spawn_nested", arguments: {}}],
-      input_tokens: 5,
-      output_tokens: 6,
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "spawn_nested_1", name: "spawn_nested", arguments: {}}],
+        input_tokens: 5,
+        output_tokens: 6,
+      },
+      {text: "leaf concluded the migration guard is ready", input_tokens: 2, output_tokens: 3},
+      {
+        tool_calls: [{id: "park_1", name: "agent_await_resumption", arguments: {reason: "waiting for parent stop"}}],
+        input_tokens: 7,
+        output_tokens: 8,
+      },
+    ],
+    { ->
+      let middle = sub_agent_run(
+        "Middle should spawn a leaf then park.",
+        {
+          provider: "mock",
+          background: true,
+          tool_format: "native",
+          max_iterations: 4,
+          token_budget: 50,
+          tools: agent_lifecycle_tools(nested_tools()),
+          allowed_tools: ["spawn_nested", "agent_await_resumption"],
+          session_id: "agent-stop-middle",
+          anchor: {primary: "/workspace/agent-stop-middle"},
+        },
+      )
+      let suspended = wait_agent(middle)
+      let stopped = agent_stop(middle, {graceful: true, reason: "parent takeover"})
+      __io_println("suspended=" + suspended.status)
+      __io_println("stopped=" + stopped.status)
+      __io_println("worker_status=" + stopped.worker.status)
+      __io_println("handoff_type=" + stopped.handoff._type)
+      __io_println("handoff_kind=" + stopped.handoff.kind)
+      __io_println("has_anchor=" + to_string(stopped.handoff.metadata.workspace_anchor.primary != nil))
+      __io_println("has_budget=" + to_string(stopped.handoff.budget_remaining.tokens != nil))
+      __io_println("confidence=" + to_string(stopped.handoff.confidence > 0.0))
+      __io_println("children=" + to_string(len(stopped.children)))
+      __io_println("summary_reason=" + to_string(contains(stopped.summary, "waiting for parent stop")))
+      __io_println(
+        "nested_summary="
+          + to_string(contains(stopped.children[0].handoff.reason, "leaf concluded")),
+      )
+      __io_println("flat_handoffs=" + to_string(len(stopped.handoffs)))
+      __io_println(
+        "outcome="
+          + to_string(contains(stopped.handoff.metadata.outcome, "waiting for parent stop")),
+      )
+      var leaf_status = ""
+      for agent in list_agents() {
+        if agent.result?.session_id == "agent-stop-leaf" {
+          leaf_status = agent.status
+        }
+      }
+      __io_println("leaf_status=" + leaf_status)
+      let hard = sub_agent_run(
+        "Hard cancel stays lossy.",
+        {
+          provider: "mock",
+          background: true,
+          tool_format: "native",
+          max_iterations: 4,
+          session_id: "agent-stop-hard",
+        },
+      )
+      let cancelled = agent_stop(hard, {graceful: false})
+      __io_println("hard=" + cancelled.status)
     },
   )
-  llm_mock({text: "leaf concluded the migration guard is ready", input_tokens: 2, output_tokens: 3})
-  llm_mock(
-    {
-      tool_calls: [{id: "park_1", name: "agent_await_resumption", arguments: {reason: "waiting for parent stop"}}],
-      input_tokens: 7,
-      output_tokens: 8,
-    },
-  )
-  let middle = sub_agent_run(
-    "Middle should spawn a leaf then park.",
-    {
-      provider: "mock",
-      background: true,
-      tool_format: "native",
-      max_iterations: 4,
-      token_budget: 50,
-      tools: agent_lifecycle_tools(nested_tools()),
-      allowed_tools: ["spawn_nested", "agent_await_resumption"],
-      session_id: "agent-stop-middle",
-      anchor: {primary: "/workspace/agent-stop-middle"},
-    },
-  )
-  let suspended = wait_agent(middle)
-  let stopped = agent_stop(middle, {graceful: true, reason: "parent takeover"})
-  __io_println("suspended=" + suspended.status)
-  __io_println("stopped=" + stopped.status)
-  __io_println("worker_status=" + stopped.worker.status)
-  __io_println("handoff_type=" + stopped.handoff._type)
-  __io_println("handoff_kind=" + stopped.handoff.kind)
-  __io_println("has_anchor=" + to_string(stopped.handoff.metadata.workspace_anchor.primary != nil))
-  __io_println("has_budget=" + to_string(stopped.handoff.budget_remaining.tokens != nil))
-  __io_println("confidence=" + to_string(stopped.handoff.confidence > 0.0))
-  __io_println("children=" + to_string(len(stopped.children)))
-  __io_println("summary_reason=" + to_string(contains(stopped.summary, "waiting for parent stop")))
-  __io_println(
-    "nested_summary=" + to_string(contains(stopped.children[0].handoff.reason, "leaf concluded")),
-  )
-  __io_println("flat_handoffs=" + to_string(len(stopped.handoffs)))
-  __io_println(
-    "outcome=" + to_string(contains(stopped.handoff.metadata.outcome, "waiting for parent stop")),
-  )
-  var leaf_status = ""
-  for agent in list_agents() {
-    if agent.result?.session_id == "agent-stop-leaf" {
-      leaf_status = agent.status
-    }
-  }
-  __io_println("leaf_status=" + leaf_status)
-  let hard = sub_agent_run(
-    "Hard cancel stays lossy.",
-    {
-      provider: "mock",
-      background: true,
-      tool_format: "native",
-      max_iterations: 4,
-      session_id: "agent-stop-hard",
-    },
-  )
-  let cancelled = agent_stop(hard, {graceful: false})
-  __io_println("hard=" + cancelled.status)
 }

--- a/conformance/tests/agents/agent_sub_agent_anchor.harn
+++ b/conformance/tests/agents/agent_sub_agent_anchor.harn
@@ -1,20 +1,24 @@
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({text: "child done"})
-  let child = sub_agent_run(
-    "do the work",
-    {
-      provider: "mock",
-      tool_format: "native",
-      max_iterations: 1,
-      session_id: "sub-agent-anchor-child",
-      anchor: {primary: "/workspace/child", anchored_at: "2026-05-24T00:00:01Z"},
+  with_llm_script(
+    [llm_text("child done")],
+    { ->
+      let child = sub_agent_run(
+        "do the work",
+        {
+          provider: "mock",
+          tool_format: "native",
+          max_iterations: 1,
+          session_id: "sub-agent-anchor-child",
+          anchor: {primary: "/workspace/child", anchored_at: "2026-05-24T00:00:01Z"},
+        },
+      )
+      assert(child.ok, "sub_agent_run accepts an anchor option")
+      let child_anchor = agent_session_workspace_anchor("sub-agent-anchor-child")
+      assert(child_anchor?.primary == "/workspace/child", "child session carries the requested anchor")
+      __io_println("agent_sub_agent_anchor tests passed")
     },
   )
-  assert(child.ok, "sub_agent_run accepts an anchor option")
-  let child_anchor = agent_session_workspace_anchor("sub-agent-anchor-child")
-  assert(child_anchor?.primary == "/workspace/child", "child session carries the requested anchor")
-  __io_println("agent_sub_agent_anchor tests passed")
 }

--- a/conformance/tests/agents/agent_turn_native_natural_completion.harn
+++ b/conformance/tests/agents/agent_turn_native_natural_completion.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn tools() {
   var registry = tool_registry()
   registry = tool_define(
@@ -15,20 +17,25 @@ fn tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "native turn"}}]})
-  llm_mock({text: "<user_response>Native turn complete.</user_response>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"answer is complete\"}"})
-  let result = agent_turn(
-    "Use the lookup tool and finish.",
-    {provider: "mock", tools: tools(), tool_format: "native", max_iterations: 3},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "native turn"}}]},
+      llm_text("<user_response>Native turn complete.</user_response>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"answer is complete\"}"),
+    ],
+    { ->
+      let result = agent_turn(
+        "Use the lookup tool and finish.",
+        {provider: "mock", tools: tools(), tool_format: "native", max_iterations: 3},
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(result.visible_text)
+      __io_println(result.llm.iterations)
+      __io_println(len(calls))
+      __io_println(!contains(calls[0].system, "##DONE##"))
+      __io_println(!contains(calls[1].system, "##DONE##"))
+      __io_println(result.judge_decisions[0].verdict)
+    },
   )
-  let calls = llm_mock_calls()
-  __io_println(result.status)
-  __io_println(result.visible_text)
-  __io_println(result.llm.iterations)
-  __io_println(len(calls))
-  __io_println(!contains(calls[0].system, "##DONE##"))
-  __io_println(!contains(calls[1].system, "##DONE##"))
-  __io_println(result.judge_decisions[0].verdict)
 }

--- a/conformance/tests/agents/agent_workspace_anchor_cache_contract.harn
+++ b/conformance/tests/agents/agent_workspace_anchor_cache_contract.harn
@@ -1,70 +1,77 @@
+import { with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "first ##DONE##", input_tokens: 1, output_tokens: 1, model: "o3"})
-  llm_mock({text: "second ##DONE##", input_tokens: 1, output_tokens: 1, model: "o3"})
-  let session_id = "workspace-anchor-cache-" + uuid()
-  let _ = agent_session_open(
-    session_id,
-    {workspace_anchor: {primary: "/workspace/a", anchored_at: "2026-05-24T00:00:00Z"}},
-  )
-  let first = agent_loop(
-    "first",
-    "Base system.",
-    {
-      provider: "mock",
-      model: "o3",
-      session_id: session_id,
-      max_iterations: 1,
-      auto_context_profile: false,
+  with_llm_script(
+    [
+      {text: "first ##DONE##", input_tokens: 1, output_tokens: 1, model: "o3"},
+      {text: "second ##DONE##", input_tokens: 1, output_tokens: 1, model: "o3"},
+    ],
+    { ->
+      let session_id = "workspace-anchor-cache-" + uuid()
+      let _ = agent_session_open(
+        session_id,
+        {workspace_anchor: {primary: "/workspace/a", anchored_at: "2026-05-24T00:00:00Z"}},
+      )
+      let first = agent_loop(
+        "first",
+        "Base system.",
+        {
+          provider: "mock",
+          model: "o3",
+          session_id: session_id,
+          max_iterations: 1,
+          auto_context_profile: false,
+        },
+      )
+      let changed = agent_session_set_workspace_anchor(
+        session_id,
+        {
+          primary: "/workspace/b",
+          additional_roots: [{path: "/workspace/c", mount_mode: "read_only", mounted_at: "2026-05-24T00:00:01Z"}],
+          anchored_at: "2026-05-24T00:00:02Z",
+        },
+      )
+      let second = agent_loop(
+        "second",
+        nil,
+        {
+          provider: "mock",
+          model: "o3",
+          session_id: session_id,
+          max_iterations: 1,
+          auto_context_profile: false,
+        },
+      )
+      let calls = llm_mock_calls()
+      let first_reminders = transcript_events_by_kind(first.transcript, "system_reminder")
+      let second_reminders = transcript_events_by_kind(second.transcript, "system_reminder")
+      let first_body = first_reminders[len(first_reminders) - 1].reminder.body
+      let second_body = second_reminders[len(second_reminders) - 1].reminder.body
+      __io_println(changed)
+      __io_println(len(calls))
+      __io_println(calls[0].system == calls[1].system)
+      __io_println(
+        agent_session_system_prompt(session_id)
+          == first.transcript.metadata.system_prompt.content,
+      )
+      __io_println(calls[0].messages[0].role == "developer")
+      __io_println(contains(calls[0].messages[0].content, "<workspace-anchor>"))
+      __io_println(contains(calls[0].messages[0].content, "primary: /workspace/a"))
+      __io_println(contains(calls[1].messages[0].content, "primary: /workspace/b"))
+      __io_println(
+        contains(
+          calls[1].messages[0].content,
+          "/workspace/c (mount_mode: read_only, mounted_at: 2026-05-24T00:00:01Z)",
+        ),
+      )
+      __io_println(!contains(calls[1].system, "/workspace/a"))
+      __io_println(!contains(calls[1].system, "/workspace/b"))
+      __io_println(
+        first.transcript.metadata.system_prompt.sha256
+          == second.transcript.metadata.system_prompt.sha256,
+      )
+      __io_println(contains(first_body, "primary: /workspace/a"))
+      __io_println(contains(second_body, "primary: /workspace/b"))
     },
   )
-  let changed = agent_session_set_workspace_anchor(
-    session_id,
-    {
-      primary: "/workspace/b",
-      additional_roots: [{path: "/workspace/c", mount_mode: "read_only", mounted_at: "2026-05-24T00:00:01Z"}],
-      anchored_at: "2026-05-24T00:00:02Z",
-    },
-  )
-  let second = agent_loop(
-    "second",
-    nil,
-    {
-      provider: "mock",
-      model: "o3",
-      session_id: session_id,
-      max_iterations: 1,
-      auto_context_profile: false,
-    },
-  )
-  let calls = llm_mock_calls()
-  let first_reminders = transcript_events_by_kind(first.transcript, "system_reminder")
-  let second_reminders = transcript_events_by_kind(second.transcript, "system_reminder")
-  let first_body = first_reminders[len(first_reminders) - 1].reminder.body
-  let second_body = second_reminders[len(second_reminders) - 1].reminder.body
-  __io_println(changed)
-  __io_println(len(calls))
-  __io_println(calls[0].system == calls[1].system)
-  __io_println(
-    agent_session_system_prompt(session_id)
-      == first.transcript.metadata.system_prompt.content,
-  )
-  __io_println(calls[0].messages[0].role == "developer")
-  __io_println(contains(calls[0].messages[0].content, "<workspace-anchor>"))
-  __io_println(contains(calls[0].messages[0].content, "primary: /workspace/a"))
-  __io_println(contains(calls[1].messages[0].content, "primary: /workspace/b"))
-  __io_println(
-    contains(
-      calls[1].messages[0].content,
-      "/workspace/c (mount_mode: read_only, mounted_at: 2026-05-24T00:00:01Z)",
-    ),
-  )
-  __io_println(!contains(calls[1].system, "/workspace/a"))
-  __io_println(!contains(calls[1].system, "/workspace/b"))
-  __io_println(
-    first.transcript.metadata.system_prompt.sha256
-      == second.transcript.metadata.system_prompt.sha256,
-  )
-  __io_println(contains(first_body, "primary: /workspace/a"))
-  __io_println(contains(second_body, "primary: /workspace/b"))
 }

--- a/conformance/tests/agents/agentic_user_model.harn
+++ b/conformance/tests/agents/agentic_user_model.harn
@@ -1,32 +1,34 @@
 import { agentic_user, simulated_user_respond, simulated_user_status } from "std/agent/user"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {text: "{\"action\":\"reply\",\"message\":\"Use node:test.\",\"reason\":\"no extra deps\"}"},
-  )
-  let answerer = agentic_user(
-    {
-      task: "Help a coding agent create a focused test file.",
-      behavior: "Answer clarification questions with plausible project preferences.",
-      provider: "mock",
-      max_replies: 2,
-      max_llm_calls: 2,
+  with_llm_script(
+    [llm_text("{\"action\":\"reply\",\"message\":\"Use node:test.\",\"reason\":\"no extra deps\"}")],
+    { ->
+      let answerer = agentic_user(
+        {
+          task: "Help a coding agent create a focused test file.",
+          behavior: "Answer clarification questions with plausible project preferences.",
+          provider: "mock",
+          max_replies: 2,
+          max_llm_calls: 2,
+        },
+      )
+      let decision = simulated_user_respond(
+        answerer,
+        {
+          question: "Which test runner should I use?",
+          context: "The package has no explicit test framework.",
+        },
+      )
+      let status = simulated_user_status(answerer)
+      let calls = llm_mock_calls()
+      __io_println(decision.action)
+      __io_println(decision.message)
+      __io_println(status.state.replies)
+      __io_println(status.state.llm_calls)
+      __io_println(contains(calls[0].system, "simulating the user"))
+      __io_println(contains(json_stringify(calls[0].messages), "Which test runner"))
     },
   )
-  let decision = simulated_user_respond(
-    answerer,
-    {
-      question: "Which test runner should I use?",
-      context: "The package has no explicit test framework.",
-    },
-  )
-  let status = simulated_user_status(answerer)
-  let calls = llm_mock_calls()
-  __io_println(decision.action)
-  __io_println(decision.message)
-  __io_println(status.state.replies)
-  __io_println(status.state.llm_calls)
-  __io_println(contains(calls[0].system, "simulating the user"))
-  __io_println(contains(json_stringify(calls[0].messages), "Which test runner"))
 }

--- a/conformance/tests/agents/agentic_user_post_turn.harn
+++ b/conformance/tests/agents/agentic_user_post_turn.harn
@@ -1,26 +1,29 @@
 import { scripted_user, simulated_user_post_turn, simulated_user_status } from "std/agent/user"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({text: "Which test runner should I use?"})
-  llm_mock({text: "Done. ##DONE##"})
-  let answerer = scripted_user(["Use Vitest."])
-  let result = agent_loop(
-    "Create index.test.ts with full edge coverage.",
-    nil,
-    {
-      provider: "mock",
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_iterations: 3,
-      post_turn_callback: simulated_user_post_turn(answerer),
+  with_llm_script(
+    [llm_text("Which test runner should I use?"), llm_text("Done. ##DONE##")],
+    { ->
+      let answerer = scripted_user(["Use Vitest."])
+      let result = agent_loop(
+        "Create index.test.ts with full edge coverage.",
+        nil,
+        {
+          provider: "mock",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_iterations: 3,
+          post_turn_callback: simulated_user_post_turn(answerer),
+        },
+      )
+      let calls = llm_mock_calls()
+      let status = simulated_user_status(answerer)
+      __io_println(result.status)
+      __io_println(result.stop_reason)
+      __io_println(result.llm.iterations)
+      __io_println(status.state.replies)
+      __io_println(contains(json_stringify(calls[1].messages), "Use Vitest."))
     },
   )
-  let calls = llm_mock_calls()
-  let status = simulated_user_status(answerer)
-  __io_println(result.status)
-  __io_println(result.stop_reason)
-  __io_println(result.llm.iterations)
-  __io_println(status.state.replies)
-  __io_println(contains(json_stringify(calls[1].messages), "Use Vitest."))
 }

--- a/conformance/tests/agents/agentic_user_scripted_tool.harn
+++ b/conformance/tests/agents/agentic_user_scripted_tool.harn
@@ -1,43 +1,47 @@
 import { agent_capture_events } from "std/agent/events"
 import { scripted_user, simulated_user_status, user_tools } from "std/agent/user"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "ask_1", name: "ask_user", arguments: {question: "Which test runner should I use?"}}],
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "ask_1", name: "ask_user", arguments: {question: "Which test runner should I use?"}}],
+      },
+      llm_text("Created index.test.ts with Vitest edge coverage."),
+    ],
+    { ->
+      let answerer = scripted_user(
+        [{match: "*test runner*", reply: "Use Vitest and cover empty, invalid, and boundary inputs."}],
+        {max_replies: 2},
+      )
+      let session = "agentic-user-scripted-tool"
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Create index.test.ts with edge coverage.",
+          nil,
+          {
+            provider: "mock",
+            tools: user_tools(answerer),
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 3,
+            session_id: session,
+          },
+        ) },
+      )
+      let simulated_audit = captured.events
+        .find(
+        { event -> return event.type == "tool_call_audit" && event.audit.event_type == "simulated_user_reply" },
+      )
+      let calls = llm_mock_calls()
+      let status = simulated_user_status(answerer)
+      __io_println(captured.result.status)
+      __io_println(contains(captured.result.text, "Vitest edge coverage"))
+      __io_println(status.state.replies)
+      __io_println(simulated_audit != nil)
+      __io_println(contains(json_stringify(calls[1].messages), "Use Vitest"))
     },
   )
-  llm_mock({text: "Created index.test.ts with Vitest edge coverage."})
-  let answerer = scripted_user(
-    [{match: "*test runner*", reply: "Use Vitest and cover empty, invalid, and boundary inputs."}],
-    {max_replies: 2},
-  )
-  let session = "agentic-user-scripted-tool"
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Create index.test.ts with edge coverage.",
-      nil,
-      {
-        provider: "mock",
-        tools: user_tools(answerer),
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 3,
-        session_id: session,
-      },
-    ) },
-  )
-  let simulated_audit = captured.events
-    .find(
-    { event -> return event.type == "tool_call_audit" && event.audit.event_type == "simulated_user_reply" },
-  )
-  let calls = llm_mock_calls()
-  let status = simulated_user_status(answerer)
-  __io_println(captured.result.status)
-  __io_println(contains(captured.result.text, "Vitest edge coverage"))
-  __io_println(status.state.replies)
-  __io_println(simulated_audit != nil)
-  __io_println(contains(json_stringify(calls[1].messages), "Use Vitest"))
 }

--- a/conformance/tests/agents/daemon_stdlib_wrappers.harn
+++ b/conformance/tests/agents/daemon_stdlib_wrappers.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn wait_for_iterations(handle, min_iterations) {
   var attempts = 0
   var snap = daemon_snapshot(handle)
@@ -14,42 +16,44 @@ pipeline test(task) {
     + to_string(harness.random.gen_range(100000, 999999))
   let root = path_join(harness.fs.temp_dir(), "harn-daemon-stdlib-" + unique)
   harness.fs.mkdir(root)
-  llm_mock({text: "daemon ready"})
-  llm_mock({text: "handled Foo.swift"})
-  llm_mock({text: "handled Bar.swift"})
-  let daemon = daemon_spawn(
-    {
-      name: "reviewer",
-      task: "Wait for daemon trigger messages and acknowledge the latest file path.",
-      system: "You are a daemon reviewer.",
-      provider: "mock",
-      persist_path: root,
-      wake_interval_ms: 5,
-      max_iterations: 200,
+  with_llm_script(
+    [llm_text("daemon ready"), llm_text("handled Foo.swift"), llm_text("handled Bar.swift")],
+    { ->
+      let daemon = daemon_spawn(
+        {
+          name: "reviewer",
+          task: "Wait for daemon trigger messages and acknowledge the latest file path.",
+          system: "You are a daemon reviewer.",
+          provider: "mock",
+          persist_path: root,
+          wake_interval_ms: 5,
+          max_iterations: 200,
+        },
+      )
+      let first = daemon_snapshot(daemon)
+      __io_println(daemon.status == "running")
+      __io_println(first.daemon_state == "idle")
+      __io_println(first.queued_event_count == 0)
+      daemon_trigger(daemon, {kind: "file_changed", path: "Foo.swift"})
+      let second = wait_for_iterations(daemon, first?.total_iterations ?? 0 + 1)
+      __io_println(second?.total_iterations > first?.total_iterations)
+      __io_println(contains(json_stringify(second?.recorded_messages ?? []), "Foo.swift"))
+      __io_println(second?.queued_event_count == 0)
+      let stopped = daemon_stop(daemon)
+      __io_println(stopped.status == "stopped")
+      let resumed = daemon_resume(root)
+      let resumed_snap = daemon_snapshot(resumed)
+      __io_println(resumed_snap?.total_iterations ?? 0 >= second?.total_iterations ?? 0)
+      __io_println(resumed_snap.queued_event_count == 0)
+      daemon_trigger(resumed, {kind: "file_changed", path: "Bar.swift"})
+      let final_snap = wait_for_iterations(resumed, resumed_snap?.total_iterations ?? 0 + 1)
+      __io_println(final_snap?.total_iterations > resumed_snap?.total_iterations)
+      let recorded = json_stringify(final_snap?.recorded_messages ?? [])
+      __io_println(contains(recorded, "Foo.swift"))
+      __io_println(contains(recorded, "Bar.swift"))
+      __io_println(final_snap?.queued_event_count == 0)
+      daemon_stop(resumed)
+      harness.fs.delete(root)
     },
   )
-  let first = daemon_snapshot(daemon)
-  __io_println(daemon.status == "running")
-  __io_println(first.daemon_state == "idle")
-  __io_println(first.queued_event_count == 0)
-  daemon_trigger(daemon, {kind: "file_changed", path: "Foo.swift"})
-  let second = wait_for_iterations(daemon, first?.total_iterations ?? 0 + 1)
-  __io_println(second?.total_iterations > first?.total_iterations)
-  __io_println(contains(json_stringify(second?.recorded_messages ?? []), "Foo.swift"))
-  __io_println(second?.queued_event_count == 0)
-  let stopped = daemon_stop(daemon)
-  __io_println(stopped.status == "stopped")
-  let resumed = daemon_resume(root)
-  let resumed_snap = daemon_snapshot(resumed)
-  __io_println(resumed_snap?.total_iterations ?? 0 >= second?.total_iterations ?? 0)
-  __io_println(resumed_snap.queued_event_count == 0)
-  daemon_trigger(resumed, {kind: "file_changed", path: "Bar.swift"})
-  let final_snap = wait_for_iterations(resumed, resumed_snap?.total_iterations ?? 0 + 1)
-  __io_println(final_snap?.total_iterations > resumed_snap?.total_iterations)
-  let recorded = json_stringify(final_snap?.recorded_messages ?? [])
-  __io_println(contains(recorded, "Foo.swift"))
-  __io_println(contains(recorded, "Bar.swift"))
-  __io_println(final_snap?.queued_event_count == 0)
-  daemon_stop(resumed)
-  harness.fs.delete(root)
 }

--- a/conformance/tests/agents/nested_execution_budget_depth.harn
+++ b/conformance/tests/agents/nested_execution_budget_depth.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 fn delegated_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -25,44 +27,48 @@ fn delegated_tools() {
 }
 
 pipeline main() {
-  llm_mock({tool_calls: [{id: "delegate_1", name: "delegate", arguments: {}}]})
-  let parent = agent_loop(
-    "Ask the tool to delegate.",
-    nil,
-    {
-      provider: "mock",
-      tools: delegated_tools(),
-      allowed_tools: ["delegate"],
-      tool_format: "native",
-      max_iterations: 1,
-      policy: {recursion_limit: 0},
-    },
-  )
-  __io_println(contains(parent?.tools?.successful ?? [], "delegate"))
-  __io_println(len(parent?.tools?.rejected ?? []) == 0)
-  let flow = workflow_graph(
-    {
-      name: "budgeted_workflow",
-      entry: "act",
-      capability_policy: {recursion_limit: 0},
-      nodes: {
-        act: {
-          kind: "stage",
-          mode: "agent",
-          model_policy: {provider: "mock"},
-          output_contract: {output_kinds: ["summary"]},
+  with_llm_script(
+    [{tool_calls: [{id: "delegate_1", name: "delegate", arguments: {}}]}],
+    { ->
+      let parent = agent_loop(
+        "Ask the tool to delegate.",
+        nil,
+        {
+          provider: "mock",
+          tools: delegated_tools(),
+          allowed_tools: ["delegate"],
+          tool_format: "native",
+          max_iterations: 1,
+          policy: {recursion_limit: 0},
         },
-      },
-      edges: [],
+      )
+      __io_println(contains(parent?.tools?.successful ?? [], "delegate"))
+      __io_println(len(parent?.tools?.rejected ?? []) == 0)
+      let flow = workflow_graph(
+        {
+          name: "budgeted_workflow",
+          entry: "act",
+          capability_policy: {recursion_limit: 0},
+          nodes: {
+            act: {
+              kind: "stage",
+              mode: "agent",
+              model_policy: {provider: "mock"},
+              output_contract: {output_kinds: ["summary"]},
+            },
+          },
+          edges: [],
+        },
+      )
+      let workflow = workflow_execute("Nested workflow stage should be rejected.", flow, [], {max_steps: 1})
+      let stage = workflow?.run?.stages[0]
+      let artifact = stage?.artifacts[0]?.data
+      __io_println(stage?.status == "failed")
+      __io_println(stage?.outcome == "blocked")
+      __io_println(stage?.branch == "failed")
+      __io_println(artifact?.stop_reason == "nested_execution_budget_exhausted")
+      __io_println(artifact?.error?.category == "budget_exceeded")
+      __io_println(contains(artifact?.error?.message ?? "", "workflow_stage: act"))
     },
   )
-  let workflow = workflow_execute("Nested workflow stage should be rejected.", flow, [], {max_steps: 1})
-  let stage = workflow?.run?.stages[0]
-  let artifact = stage?.artifacts[0]?.data
-  __io_println(stage?.status == "failed")
-  __io_println(stage?.outcome == "blocked")
-  __io_println(stage?.branch == "failed")
-  __io_println(artifact?.stop_reason == "nested_execution_budget_exhausted")
-  __io_println(artifact?.error?.category == "budget_exceeded")
-  __io_println(contains(artifact?.error?.message ?? "", "workflow_stage: act"))
 }

--- a/conformance/tests/agents/per_agent_permissions_dynamic.harn
+++ b/conformance/tests/agents/per_agent_permissions_dynamic.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 fn note_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -24,31 +26,35 @@ fn note_tools() {
 }
 
 pipeline main() {
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "read_1", name: "read_note", arguments: {path: "/workspace/a.txt"}},
-        {id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}},
-      ],
-    },
-  )
-  let result = agent_loop(
-    "Read then write.",
-    "Use tools.",
-    {
-      provider: "mock",
-      tools: note_tools(),
-      tool_format: "native",
-      max_iterations: 1,
-      permissions: {
-        allow: {read_note: { args -> args.path.starts_with("/workspace/") }},
-        deny: {write_note: { args -> true }},
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "read_1", name: "read_note", arguments: {path: "/workspace/a.txt"}},
+          {id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}},
+        ],
       },
+    ],
+    { ->
+      let result = agent_loop(
+        "Read then write.",
+        "Use tools.",
+        {
+          provider: "mock",
+          tools: note_tools(),
+          tool_format: "native",
+          max_iterations: 1,
+          permissions: {
+            allow: {read_note: { args -> args.path.starts_with("/workspace/") }},
+            deny: {write_note: { args -> true }},
+          },
+        },
+      )
+      let events = transcript_events(result?.transcript)
+      __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionGrant")) == 1)
+      __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionDeny")) == 1)
+      __io_println(result?.tools?.rejected[0] == "write_note")
+      __io_println(json_stringify(events).contains("/workspace/a.txt"))
     },
   )
-  let events = transcript_events(result?.transcript)
-  __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionGrant")) == 1)
-  __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionDeny")) == 1)
-  __io_println(result?.tools?.rejected[0] == "write_note")
-  __io_println(json_stringify(events).contains("/workspace/a.txt"))
 }

--- a/conformance/tests/agents/per_agent_permissions_escalation.harn
+++ b/conformance/tests/agents/per_agent_permissions_escalation.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 fn write_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -14,35 +16,39 @@ fn write_tools() {
 }
 
 pipeline main() {
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}},
-        {id: "write_2", name: "write_note", arguments: {path: "/workspace/a.txt"}},
-      ],
-    },
-  )
-  let result = agent_loop(
-    "Write twice.",
-    "Use tools.",
-    {
-      provider: "mock",
-      tools: write_tools(),
-      tool_format: "native",
-      max_iterations: 1,
-      permissions: {
-        deny: ["write_note"],
-        on_escalation: { request ->
-          if request.tool == "write_note" && request.args.path.starts_with("/workspace/") {
-            return {grant: "session", approver: "tester", reason: "workspace write approved"}
-          }
-          return false
-        },
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}},
+          {id: "write_2", name: "write_note", arguments: {path: "/workspace/a.txt"}},
+        ],
       },
+    ],
+    { ->
+      let result = agent_loop(
+        "Write twice.",
+        "Use tools.",
+        {
+          provider: "mock",
+          tools: write_tools(),
+          tool_format: "native",
+          max_iterations: 1,
+          permissions: {
+            deny: ["write_note"],
+            on_escalation: { request ->
+              if request.tool == "write_note" && request.args.path.starts_with("/workspace/") {
+                return {grant: "session", approver: "tester", reason: "workspace write approved"}
+              }
+              return false
+            },
+          },
+        },
+      )
+      __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionEscalation")) == 1)
+      __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionGrant")) == 2)
+      __io_println(len(result?.tools?.rejected ?? []) == 0)
+      __io_println(transcript_render_full(result?.transcript).contains("workspace write approved"))
     },
   )
-  __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionEscalation")) == 1)
-  __io_println(len(transcript_events_by_kind(result?.transcript, "PermissionGrant")) == 2)
-  __io_println(len(result?.tools?.rejected ?? []) == 0)
-  __io_println(transcript_render_full(result?.transcript).contains("workspace write approved"))
 }

--- a/conformance/tests/agents/plan_primitives.harn
+++ b/conformance/tests/agents/plan_primitives.harn
@@ -1,5 +1,5 @@
 import "std/plan"
-import { clear_host_mocks, mock_host_response } from "std/testing"
+import { clear_host_mocks, llm_text, mock_host_response, with_llm_script } from "std/testing"
 
 pipeline main() {
   let tools = plan_tools()
@@ -26,38 +26,42 @@ pipeline main() {
   let approved = request_plan_approval(artifact, {reviewers: ["lead"]})
   require approved.approval.state == "approved", "plan approval should use HITL"
   require approved.approval.reviewers[0] == "lead", "reviewer should round-trip"
-  llm_mock(
-    {
-      tool_calls: [
-        {
-          id: "plan1",
-          name: "emit_plan",
-          arguments: {
-            summary: "Implement a small parser change.",
-            steps: [
-              {content: "Read parser tests.", status: "completed"},
-              {content: "Patch parser.", status: "pending"},
-            ],
-            verification_commands: ["cargo test -p harn-parser"],
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "plan1",
+            name: "emit_plan",
+            arguments: {
+              summary: "Implement a small parser change.",
+              steps: [
+                {content: "Read parser tests.", status: "completed"},
+                {content: "Patch parser.", status: "pending"},
+              ],
+              verification_commands: ["cargo test -p harn-parser"],
+            },
           },
-        },
-      ],
+        ],
+      },
+      llm_text("Plan emitted."),
+    ],
+    { ->
+      let result = agent_loop(
+        "Plan a parser change",
+        nil,
+        {provider: "mock", tools: tools, max_iterations: 2, session_id: "plan-conformance"},
+      )
+      let events = transcript_events(result?.transcript)
+      var saw_plan = false
+      for event in events {
+        if event.kind == "plan" {
+          saw_plan = true
+          require event.metadata.plan.schema_version == "harn.plan.v1", "transcript plan metadata should be structured"
+        }
+      }
+      require saw_plan, "agent loop should persist an emitted plan event"
+      log("plan primitives tests passed")
     },
   )
-  llm_mock({text: "Plan emitted."})
-  let result = agent_loop(
-    "Plan a parser change",
-    nil,
-    {provider: "mock", tools: tools, max_iterations: 2, session_id: "plan-conformance"},
-  )
-  let events = transcript_events(result?.transcript)
-  var saw_plan = false
-  for event in events {
-    if event.kind == "plan" {
-      saw_plan = true
-      require event.metadata.plan.schema_version == "harn.plan.v1", "transcript plan metadata should be structured"
-    }
-  }
-  require saw_plan, "agent loop should persist an emitted plan event"
-  log("plan primitives tests passed")
 }

--- a/conformance/tests/agents/spawn_agent_permissions.harn
+++ b/conformance/tests/agents/spawn_agent_permissions.harn
@@ -1,4 +1,5 @@
 import "std/agents"
+import { with_llm_script } from "std/testing"
 
 fn write_tools() {
   var tools = tool_registry()
@@ -16,22 +17,26 @@ fn write_tools() {
 }
 
 pipeline main() {
-  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}}]})
-  let worker = spawn_agent(
-    {
-      name: "permission-worker",
-      task: "Try to write.",
-      wait: true,
-      permissions: {deny: ["write_note"]},
-      node: {
-        kind: "stage",
-        mode: "agent",
-        model_policy: {provider: "mock", tool_format: "native", max_iterations: 1},
-        tools: write_tools(),
-      },
+  with_llm_script(
+    [{tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}}]}],
+    { ->
+      let worker = spawn_agent(
+        {
+          name: "permission-worker",
+          task: "Try to write.",
+          wait: true,
+          permissions: {deny: ["write_note"]},
+          node: {
+            kind: "stage",
+            mode: "agent",
+            model_policy: {provider: "mock", tool_format: "native", max_iterations: 1},
+            tools: write_tools(),
+          },
+        },
+      )
+      __io_println(worker.status == "completed")
+      __io_println(worker.result?.result?.tools?.rejected[0] == "write_note")
+      __io_println(len(transcript_events_by_kind(worker.result?.transcript, "PermissionDeny")) == 1)
     },
   )
-  __io_println(worker.status == "completed")
-  __io_println(worker.result?.result?.tools?.rejected[0] == "write_note")
-  __io_println(len(transcript_events_by_kind(worker.result?.transcript, "PermissionDeny")) == 1)
 }

--- a/conformance/tests/agents/sub_agent_permissions_intersection.harn
+++ b/conformance/tests/agents/sub_agent_permissions_intersection.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 fn write_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -14,20 +16,24 @@ fn write_tools() {
 }
 
 pipeline main() {
-  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}}]})
-  let denied = sub_agent_run(
-    "Try to write.",
-    {
-      provider: "mock",
-      tools: write_tools(),
-      tool_format: "native",
-      max_iterations: 1,
-      policy: {tools: ["read_note"]},
-      permissions: {allow: {write_note: { args -> true }}},
+  with_llm_script(
+    [{tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "/workspace/a.txt"}}]}],
+    { ->
+      let denied = sub_agent_run(
+        "Try to write.",
+        {
+          provider: "mock",
+          tools: write_tools(),
+          tool_format: "native",
+          max_iterations: 1,
+          policy: {tools: ["read_note"]},
+          permissions: {allow: {write_note: { args -> true }}},
+        },
+      )
+      __io_println(!denied?.ok)
+      __io_println(denied.error?.category == "permission_denied")
+      __io_println(denied.error?.tool == "write_note")
+      __io_println(len(transcript_events_by_kind(denied?.transcript, "PermissionDeny")) == 1)
     },
   )
-  __io_println(!denied?.ok)
-  __io_println(denied.error?.category == "permission_denied")
-  __io_println(denied.error?.tool == "write_note")
-  __io_println(len(transcript_events_by_kind(denied?.transcript, "PermissionDeny")) == 1)
 }

--- a/conformance/tests/agents/sub_agent_run_budget_and_background.harn
+++ b/conformance/tests/agents/sub_agent_run_budget_and_background.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn search_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -14,49 +16,63 @@ fn search_tools() {
 }
 
 pipeline main() {
-  llm_mock(
-    {
-      tool_calls: [{id: "budget_1", name: "search", arguments: {query: "token budget"}}],
-      input_tokens: 20,
-      output_tokens: 12,
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "budget_1", name: "search", arguments: {query: "token budget"}}],
+        input_tokens: 20,
+        output_tokens: 12,
+      },
+    ],
+    { ->
+      let budgeted = sub_agent_run(
+        "Investigate under a tiny budget.",
+        {
+          provider: "mock",
+          tools: search_tools(),
+          allowed_tools: ["search"],
+          tool_format: "native",
+          max_iterations: 3,
+          token_budget: 8,
+        },
+      )
+      __io_println(budgeted?.budget_exceeded)
+      __io_println(budgeted?.tokens_used >= 32)
     },
   )
-  let budgeted = sub_agent_run(
-    "Investigate under a tiny budget.",
-    {
-      provider: "mock",
-      tools: search_tools(),
-      allowed_tools: ["search"],
-      tool_format: "native",
-      max_iterations: 3,
-      token_budget: 8,
+  with_llm_script(
+    [llm_text("background summary")],
+    { ->
+      let handle = sub_agent_run("Summarize in the background.", {provider: "mock", background: true})
+      __io_println(handle?.mode == "sub_agent")
+      let done = wait_agent(handle)
+      __io_println(done?.status == "completed")
+      __io_println(done?.result?.ok)
+      __io_println(contains(done?.result?.summary ?? "", "background summary"))
     },
   )
-  __io_println(budgeted?.budget_exceeded)
-  __io_println(budgeted?.tokens_used >= 32)
-  llm_mock({text: "background summary"})
-  let handle = sub_agent_run("Summarize in the background.", {provider: "mock", background: true})
-  __io_println(handle?.mode == "sub_agent")
-  let done = wait_agent(handle)
-  __io_println(done?.status == "completed")
-  __io_println(done?.result?.ok)
-  __io_println(contains(done?.result?.summary ?? "", "background summary"))
-  llm_mock({tool_calls: [{id: "bg_search_1", name: "search", arguments: {query: "background tool"}}]})
-  llm_mock({text: "background tool summary"})
-  let tool_handle = sub_agent_run(
-    "Search in the background with a Harn-owned tool.",
-    {
-      provider: "mock",
-      background: true,
-      tools: search_tools(),
-      allowed_tools: ["search"],
-      tool_format: "native",
-      max_iterations: 3,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "bg_search_1", name: "search", arguments: {query: "background tool"}}]},
+      llm_text("background tool summary"),
+    ],
+    { ->
+      let tool_handle = sub_agent_run(
+        "Search in the background with a Harn-owned tool.",
+        {
+          provider: "mock",
+          background: true,
+          tools: search_tools(),
+          allowed_tools: ["search"],
+          tool_format: "native",
+          max_iterations: 3,
+        },
+      )
+      __io_println(tool_handle?.mode == "sub_agent")
+      let tool_done = wait_agent(tool_handle)
+      __io_println(tool_done?.status == "completed")
+      __io_println(tool_done?.result?.ok)
+      __io_println(contains(tool_done?.result?.summary ?? "", "background tool summary"))
     },
   )
-  __io_println(tool_handle?.mode == "sub_agent")
-  let tool_done = wait_agent(tool_handle)
-  __io_println(tool_done?.status == "completed")
-  __io_println(tool_done?.result?.ok)
-  __io_println(contains(tool_done?.result?.summary ?? "", "background tool summary"))
 }

--- a/conformance/tests/agents/sub_agent_run_clean_transcript.harn
+++ b/conformance/tests/agents/sub_agent_run_clean_transcript.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn child_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -48,25 +50,27 @@ fn parent_tools() {
 }
 
 pipeline main() {
-  llm_mock(
-    {tool_calls: [{id: "parent_1", name: "delegate", arguments: {task: "Find the config path"}}]},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "parent_1", name: "delegate", arguments: {task: "Find the config path"}}]},
+      {tool_calls: [{id: "child_1", name: "search", arguments: {query: "config path"}}]},
+      {tool_calls: [{id: "child_2", name: "read", arguments: {path: "crates/harn-vm/src/lib.rs"}}]},
+      llm_text("The config path is crates/harn-vm/src/lib.rs"),
+      llm_text("Delegation complete."),
+    ],
+    { ->
+      let result = agent_loop(
+        "Investigate the config path",
+        "You are helpful.",
+        {provider: "mock", tools: parent_tools(), tool_format: "native", max_iterations: 2},
+      )
+      let stats = transcript_stats(result?.transcript)
+      let transcript = json_stringify(transcript_messages(result?.transcript))
+      __io_println(stats?.tool_call_count == 1)
+      __io_println(stats?.tool_result_message_count == 1)
+      __io_println(contains(transcript, "delegate"))
+      __io_println(!contains(transcript, "\"search\""))
+      __io_println(!contains(transcript, "\"read\""))
+    },
   )
-  llm_mock({tool_calls: [{id: "child_1", name: "search", arguments: {query: "config path"}}]})
-  llm_mock(
-    {tool_calls: [{id: "child_2", name: "read", arguments: {path: "crates/harn-vm/src/lib.rs"}}]},
-  )
-  llm_mock({text: "The config path is crates/harn-vm/src/lib.rs"})
-  llm_mock({text: "Delegation complete."})
-  let result = agent_loop(
-    "Investigate the config path",
-    "You are helpful.",
-    {provider: "mock", tools: parent_tools(), tool_format: "native", max_iterations: 2},
-  )
-  let stats = transcript_stats(result?.transcript)
-  let transcript = json_stringify(transcript_messages(result?.transcript))
-  __io_println(stats?.tool_call_count == 1)
-  __io_println(stats?.tool_result_message_count == 1)
-  __io_println(contains(transcript, "delegate"))
-  __io_println(!contains(transcript, "\"search\""))
-  __io_println(!contains(transcript, "\"read\""))
 }

--- a/conformance/tests/agents/sub_agent_run_json_mode_data.harn
+++ b/conformance/tests/agents/sub_agent_run_json_mode_data.harn
@@ -1,16 +1,26 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline main() {
-  llm_mock({text: "{\"answer\":\"ok\"}"})
-  let direct = sub_agent_run("Return machine-readable JSON.", {provider: "mock", response_format: "json"})
-  __io_println(direct?.ok)
-  __io_println(direct?.summary == "{\"answer\":\"ok\"}")
-  __io_println(direct?.data?.answer == "ok")
-  llm_mock({text: "{\"answer\":\"background\"}"})
-  let handle = sub_agent_run(
-    "Return machine-readable JSON in the background.",
-    {provider: "mock", response_format: "json", background: true},
+  with_llm_script(
+    [llm_text("{\"answer\":\"ok\"}")],
+    { ->
+      let direct = sub_agent_run("Return machine-readable JSON.", {provider: "mock", response_format: "json"})
+      __io_println(direct?.ok)
+      __io_println(direct?.summary == "{\"answer\":\"ok\"}")
+      __io_println(direct?.data?.answer == "ok")
+    },
   )
-  let done = wait_agent(handle)
-  __io_println(done?.status == "completed")
-  __io_println(done?.result?.summary == "{\"answer\":\"background\"}")
-  __io_println(done?.result?.data?.answer == "background")
+  with_llm_script(
+    [llm_text("{\"answer\":\"background\"}")],
+    { ->
+      let handle = sub_agent_run(
+        "Return machine-readable JSON in the background.",
+        {provider: "mock", response_format: "json", background: true},
+      )
+      let done = wait_agent(handle)
+      __io_println(done?.status == "completed")
+      __io_println(done?.result?.summary == "{\"answer\":\"background\"}")
+      __io_println(done?.result?.data?.answer == "background")
+    },
+  )
 }

--- a/conformance/tests/agents/sub_agent_run_schema_and_permission.harn
+++ b/conformance/tests/agents/sub_agent_run_schema_and_permission.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn write_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -14,34 +16,42 @@ fn write_tools() {
 }
 
 pipeline main() {
-  llm_mock({text: "{\"callers\":[\"crate::parse_config\",\"cli::parse_config\"]}"})
-  let typed = sub_agent_run(
-    "Find all callers of parse_config.",
-    {
-      provider: "mock",
-      returns: {
-        schema: {
-          type: "object",
-          properties: {callers: {type: "array", items: {type: "string"}}},
-          required: ["callers"],
+  with_llm_script(
+    [llm_text("{\"callers\":[\"crate::parse_config\",\"cli::parse_config\"]}")],
+    { ->
+      let typed = sub_agent_run(
+        "Find all callers of parse_config.",
+        {
+          provider: "mock",
+          returns: {
+            schema: {
+              type: "object",
+              properties: {callers: {type: "array", items: {type: "string"}}},
+              required: ["callers"],
+            },
+          },
         },
-      },
+      )
+      __io_println(typed?.ok)
+      __io_println(len(typed?.data?.callers ?? []) == 2)
     },
   )
-  __io_println(typed?.ok)
-  __io_println(len(typed?.data?.callers ?? []) == 2)
-  llm_mock({tool_calls: [{id: "deny_1", name: "write_note", arguments: {path: "notes.txt"}}]})
-  let denied = sub_agent_run(
-    "Try to write a note.",
-    {
-      provider: "mock",
-      tools: write_tools(),
-      allowed_tools: ["read"],
-      tool_format: "native",
-      max_iterations: 1,
+  with_llm_script(
+    [{tool_calls: [{id: "deny_1", name: "write_note", arguments: {path: "notes.txt"}}]}],
+    { ->
+      let denied = sub_agent_run(
+        "Try to write a note.",
+        {
+          provider: "mock",
+          tools: write_tools(),
+          allowed_tools: ["read"],
+          tool_format: "native",
+          max_iterations: 1,
+        },
+      )
+      __io_println(!denied?.ok)
+      __io_println(denied.error?.category == "permission_denied")
+      __io_println(denied.error?.tool == "write_note")
     },
   )
-  __io_println(!denied?.ok)
-  __io_println(denied.error?.category == "permission_denied")
-  __io_println(denied.error?.tool == "write_note")
 }

--- a/conformance/tests/agents/suspend_close_while_suspended.harn
+++ b/conformance/tests/agents/suspend_close_while_suspended.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * S-11 (#1847): closing a suspended worker is terminal. Future resume
  * attempts against the same live handle surface HARN-SUS-010.
@@ -9,30 +11,33 @@
  * cancelled, no panic).
  */
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "park_close", name: "agent_await_resumption", arguments: {reason: "park before close"}}],
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_close", name: "agent_await_resumption", arguments: {reason: "park before close"}}],
+      },
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park, get closed, reject resume.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      __io_println("pre_close_status=" + suspended.status)
+      let closed = close_agent(handle)
+      __io_println("post_close_status=" + closed.status)
+      let resume_attempt = try {
+        resume_agent(handle)
+      }
+      __io_println("resume_failed=" + to_string(is_err(resume_attempt)))
+      __io_println(
+        "resume_err_has_code="
+          + to_string(contains(to_string(unwrap_err(resume_attempt)), "HARN-SUS-010")),
+      )
+      let closed_again = close_agent(handle)
+      __io_println("reclose_status=" + closed_again.status)
     },
   )
-  let handle = sub_agent_run(
-    "Park, get closed, reject resume.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  __io_println("pre_close_status=" + suspended.status)
-  let closed = close_agent(handle)
-  __io_println("post_close_status=" + closed.status)
-  // Resume attempt should reject with HARN-SUS-010.
-  let resume_attempt = try {
-    resume_agent(handle)
-  }
-  __io_println("resume_failed=" + to_string(is_err(resume_attempt)))
-  __io_println(
-    "resume_err_has_code="
-      + to_string(contains(to_string(unwrap_err(resume_attempt)), "HARN-SUS-010")),
-  )
-  // Idempotent re-close — does not panic, returns terminal summary.
-  let closed_again = close_agent(handle)
-  __io_println("reclose_status=" + closed_again.status)
 }
+// Resume attempt should reject with HARN-SUS-010.
+// Idempotent re-close — does not panic, returns terminal summary.

--- a/conformance/tests/agents/suspend_conditioned_trigger.harn
+++ b/conformance/tests/agents/suspend_conditioned_trigger.harn
@@ -18,48 +18,52 @@
  * Conditioned resume).
  */
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 import "std/triggers"
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "park_trigger",
+            name: "agent_await_resumption",
+            arguments: {reason: "waiting on pr.merged", conditions: {trigger: {kind: "pr.merged", provider: "github"}}},
+          },
+        ],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      llm_text("auto-resumed by trigger"),
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park until the PR is merged.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      let trigger_handle = suspended?.suspension?.auto_resume_trigger
+      __io_println("status=" + suspended.status)
+      __io_println("conditions_trigger_kind=" + suspended?.suspension?.conditions?.trigger?.kind ?? "")
+      __io_println(
+        "conditions_trigger_provider="
+          + suspended?.suspension?.conditions?.trigger?.provider ?? "",
+      )
+      __io_println("has_trigger_handle=" + to_string(trigger_handle?.id != nil))
+      let fired: DispatchHandle = trigger_fire(
+        trigger_handle,
         {
-          id: "park_trigger",
-          name: "agent_await_resumption",
-          arguments: {reason: "waiting on pr.merged", conditions: {trigger: {kind: "pr.merged", provider: "github"}}},
+          provider: "github",
+          kind: "pr.merged",
+          payload: {number: 42, merged: true},
+          headers: {x_delivery: "suspend-conditioned-trigger"},
         },
-      ],
-      input_tokens: 7,
-      output_tokens: 3,
+      )
+      __io_println("dispatch_status=" + fired.status)
+      let done = wait_agent(handle)
+      __io_println("final_status=" + done.status)
+      __io_println("has_transcript=" + to_string(done.has_transcript))
     },
   )
-  llm_mock({text: "auto-resumed by trigger"})
-  let handle = sub_agent_run(
-    "Park until the PR is merged.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  let trigger_handle = suspended?.suspension?.auto_resume_trigger
-  __io_println("status=" + suspended.status)
-  __io_println("conditions_trigger_kind=" + suspended?.suspension?.conditions?.trigger?.kind ?? "")
-  __io_println(
-    "conditions_trigger_provider="
-      + suspended?.suspension?.conditions?.trigger?.provider ?? "",
-  )
-  __io_println("has_trigger_handle=" + to_string(trigger_handle?.id != nil))
-  let fired: DispatchHandle = trigger_fire(
-    trigger_handle,
-    {
-      provider: "github",
-      kind: "pr.merged",
-      payload: {number: 42, merged: true},
-      headers: {x_delivery: "suspend-conditioned-trigger"},
-    },
-  )
-  __io_println("dispatch_status=" + fired.status)
-  let done = wait_agent(handle)
-  __io_println("final_status=" + done.status)
-  __io_println("has_transcript=" + to_string(done.has_transcript))
 }

--- a/conformance/tests/agents/suspend_continue_transcript_false.harn
+++ b/conformance/tests/agents/suspend_continue_transcript_false.harn
@@ -8,6 +8,7 @@
  * mode.
  */
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn resume_tools() {
   var tools = tool_registry()
@@ -21,86 +22,86 @@ fn resume_tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
   // First worker: continue_transcript=true (default).
-  llm_mock(
-    {
-      tool_calls: [{id: "park_keep", name: "agent_await_resumption", arguments: {reason: "keep transcript"}}],
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_keep", name: "agent_await_resumption", arguments: {reason: "keep transcript"}}],
+      },
+      llm_text("kept transcript completion"),
+      {
+        tool_calls: [{id: "park_reset", name: "agent_await_resumption", arguments: {reason: "reset transcript"}}],
+      },
+      llm_text("reset transcript completion"),
+    ],
+    { ->
+      let session_keep = "continue-true-" + uuid()
+      let handle_keep = sub_agent_run(
+        "Park then resume with continue_transcript=true.",
+        {
+          provider: "mock",
+          background: true,
+          session_id: session_keep,
+          tools: resume_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+        },
+      )
+      let _suspended_keep = wait_agent(handle_keep)
+      let _resumed_keep = resume_agent(handle_keep, "operator says go", true)
+      let done_keep = wait_agent(handle_keep)
+      let kept_calls = llm_mock_calls()
+      let kept_resumed_system = kept_calls[1].system
+      __io_println("keep_status=" + done_keep.status)
+      __io_println(
+        "keep_resumed_at_turn="
+          + to_string(contains(kept_resumed_system, "You were suspended at turn")),
+      )
+      __io_println(
+        "keep_no_digest_marker="
+          + to_string(!contains(kept_resumed_system, "Prior conversation digest")),
+      )
+      let session_reset = "continue-false-" + uuid()
+      let handle_reset = sub_agent_run(
+        "Park then resume with continue_transcript=false.",
+        {
+          provider: "mock",
+          background: true,
+          session_id: session_reset,
+          tools: resume_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+        },
+      )
+      let _suspended_reset = wait_agent(handle_reset)
+      let _resumed_reset = resume_agent(handle_reset, "operator says reset", false)
+      let done_reset = wait_agent(handle_reset)
+      let reset_calls = llm_mock_calls()
+      let reset_resumed_system = reset_calls[3].system
+      __io_println("reset_status=" + done_reset.status)
+      __io_println(
+        "reset_resumed_at_turn="
+          + to_string(contains(reset_resumed_system, "You were suspended at turn")),
+      )
+      __io_println(
+        "reset_continuity_emitted="
+          + to_string(
+          contains(reset_resumed_system, "Prior conversation")
+            || contains(reset_resumed_system, "You were suspended at turn"),
+        ),
+      )
+      __io_println(
+        "paths_differ_in_input="
+          + to_string(
+          contains(kept_resumed_system, "operator says go")
+            && contains(reset_resumed_system, "operator says reset"),
+        ),
+      )
     },
-  )
-  let session_keep = "continue-true-" + uuid()
-  let handle_keep = sub_agent_run(
-    "Park then resume with continue_transcript=true.",
-    {
-      provider: "mock",
-      background: true,
-      session_id: session_keep,
-      tools: resume_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-    },
-  )
-  let _suspended_keep = wait_agent(handle_keep)
-  llm_mock({text: "kept transcript completion"})
-  let _resumed_keep = resume_agent(handle_keep, "operator says go", true)
-  let done_keep = wait_agent(handle_keep)
-  let kept_calls = llm_mock_calls()
-  let kept_resumed_system = kept_calls[1].system
-  __io_println("keep_status=" + done_keep.status)
-  __io_println(
-    "keep_resumed_at_turn=" + to_string(contains(kept_resumed_system, "You were suspended at turn")),
-  )
-  __io_println(
-    "keep_no_digest_marker="
-      + to_string(!contains(kept_resumed_system, "Prior conversation digest")),
-  )
-  // Second worker: continue_transcript=false.
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "park_reset", name: "agent_await_resumption", arguments: {reason: "reset transcript"}}],
-    },
-  )
-  let session_reset = "continue-false-" + uuid()
-  let handle_reset = sub_agent_run(
-    "Park then resume with continue_transcript=false.",
-    {
-      provider: "mock",
-      background: true,
-      session_id: session_reset,
-      tools: resume_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-    },
-  )
-  let _suspended_reset = wait_agent(handle_reset)
-  llm_mock({text: "reset transcript completion"})
-  let _resumed_reset = resume_agent(handle_reset, "operator says reset", false)
-  let done_reset = wait_agent(handle_reset)
-  let reset_calls = llm_mock_calls()
-  let reset_resumed_system = reset_calls[1].system
-  __io_println("reset_status=" + done_reset.status)
-  __io_println(
-    "reset_resumed_at_turn="
-      + to_string(contains(reset_resumed_system, "You were suspended at turn")),
-  )
-  // The Pre-suspend digest is only attached when the snapshot recorded
-  // a non-empty digest at resume-time. Until S-09's digest provider is
-  // wired into background subagents we assert the reset path differs
-  // observably from the keep path by emitting its own continuity reminder
-  // for the second turn.
-  __io_println(
-    "reset_continuity_emitted="
-      + to_string(
-      contains(reset_resumed_system, "Prior conversation")
-        || contains(reset_resumed_system, "You were suspended at turn"),
-    ),
-  )
-  __io_println(
-    "paths_differ_in_input="
-      + to_string(
-      contains(kept_resumed_system, "operator says go")
-        && contains(reset_resumed_system, "operator says reset"),
-    ),
   )
 }
+// The Pre-suspend digest is only attached when the snapshot recorded
+// a non-empty digest at resume-time. Until S-09's digest provider is
+// wired into background subagents we assert the reset path differs
+// observably from the keep path by emitting its own continuity reminder
+// for the second turn.

--- a/conformance/tests/agents/suspend_daemon_step_parity.harn
+++ b/conformance/tests/agents/suspend_daemon_step_parity.harn
@@ -12,7 +12,6 @@
  * then asserts the snapshot fields directly.
  */
 pipeline main() {
-  llm_mock_clear()
   let unique = to_string(to_int(harness.clock.timestamp())) + "-"
     + to_string(harness.random.gen_range(100000, 999999))
   let dir = path_join(harness.fs.temp_dir(), "harn-daemon-parity-" + unique)

--- a/conformance/tests/agents/suspend_double_resume_race.harn
+++ b/conformance/tests/agents/suspend_double_resume_race.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * S-11 (#1847): a second resume against a worker whose state has
  * already advanced past `suspended` is rejected with a diagnostic
@@ -13,36 +15,39 @@
  * code path is exercised either way — only one resume can win.
  */
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "park_race", name: "agent_await_resumption", arguments: {reason: "park before race"}}],
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_race", name: "agent_await_resumption", arguments: {reason: "park before race"}}],
+      },
+      llm_text("first resume wins"),
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park then race two resumes.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      __io_println("pre_race_status=" + suspended.status)
+      let first = resume_agent(handle)
+      let done = wait_agent(handle)
+      __io_println("first_resume_status=" + first.status)
+      __io_println("post_first_status=" + done.status)
+      let second = try {
+        resume_agent(handle)
+      }
+      __io_println("second_resume_failed=" + to_string(is_err(second)))
+      let err_text = to_string(unwrap_err(second))
+      __io_println(
+        "second_err_has_sus_code="
+          + to_string(contains(err_text, "HARN-SUS-003") || contains(err_text, "HARN-SUS-006")),
+      )
+      __io_println(
+        "second_err_mentions_not_suspended="
+          + to_string(contains(err_text, "not suspended")),
+      )
     },
   )
-  llm_mock({text: "first resume wins"})
-  let handle = sub_agent_run(
-    "Park then race two resumes.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  __io_println("pre_race_status=" + suspended.status)
-  // First resume wins and drives the worker to completion.
-  let first = resume_agent(handle)
-  let done = wait_agent(handle)
-  __io_println("first_resume_status=" + first.status)
-  __io_println("post_first_status=" + done.status)
-  // Second resume sees the worker is no longer suspended and rejects.
-  let second = try {
-    resume_agent(handle)
-  }
-  __io_println("second_resume_failed=" + to_string(is_err(second)))
-  let err_text = to_string(unwrap_err(second))
-  __io_println(
-    "second_err_has_sus_code="
-      + to_string(contains(err_text, "HARN-SUS-003") || contains(err_text, "HARN-SUS-006")),
-  )
-  __io_println(
-    "second_err_mentions_not_suspended="
-      + to_string(contains(err_text, "not suspended")),
-  )
 }
+// First resume wins and drives the worker to completion.
+// Second resume sees the worker is no longer suspended and rejects.

--- a/conformance/tests/agents/suspend_midloop_basic.harn
+++ b/conformance/tests/agents/suspend_midloop_basic.harn
@@ -14,38 +14,42 @@
  *     reminder is consumed on the next turn, not re-applied).
  */
 import { agent_lifecycle_tools } from "std/agent/workers"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "park_1", name: "agent_await_resumption", arguments: {reason: "park for parent"}}],
-      input_tokens: 7,
-      output_tokens: 3,
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_1", name: "agent_await_resumption", arguments: {reason: "park for parent"}}],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      llm_text("child finished after parent resume"),
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park until parent resumes.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 4},
+      )
+      let suspended = wait_agent(handle)
+      let lifecycle = agent_lifecycle_tools(tool_registry(), {subagents: true})
+      let pause_tool = tool_find(lifecycle, "subagent_pause")
+      let resume_tool = tool_find(lifecycle, "subagent_resume")
+      let pause_again = pause_tool.handler({handle: handle.id, reason: "parent re-pauses"})
+      let resumed = resume_tool.handler({handle: handle.id})
+      let done = wait_agent(handle)
+      __io_println("suspended_status=" + suspended.status)
+      __io_println("pause_again_status=" + pause_again.status)
+      __io_println("resume_status=" + resumed.status)
+      __io_println("final_status=" + done.status)
+      __io_println("has_transcript=" + to_string(done.has_transcript))
+      let continuity = transcript_events_by_kind(done.transcript, "system_reminder")
+        .filter({ event -> event.reminder.dedupe_key == "resume_continuity" })
+      __io_println("continuity_left=" + to_string(len(continuity)))
     },
   )
-  llm_mock({text: "child finished after parent resume"})
-  let handle = sub_agent_run(
-    "Park until parent resumes.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 4},
-  )
-  let suspended = wait_agent(handle)
-  let lifecycle = agent_lifecycle_tools(tool_registry(), {subagents: true})
-  let pause_tool = tool_find(lifecycle, "subagent_pause")
-  let resume_tool = tool_find(lifecycle, "subagent_resume")
-  // Idempotent re-pause: already-suspended worker returns same summary.
-  let pause_again = pause_tool.handler({handle: handle.id, reason: "parent re-pauses"})
-  // Parent-driven resume drives the child to completion.
-  let resumed = resume_tool.handler({handle: handle.id})
-  let done = wait_agent(handle)
-  __io_println("suspended_status=" + suspended.status)
-  __io_println("pause_again_status=" + pause_again.status)
-  __io_println("resume_status=" + resumed.status)
-  __io_println("final_status=" + done.status)
-  __io_println("has_transcript=" + to_string(done.has_transcript))
-  // The resume-continuity reminder is single-shot: after the resumed
-  // turn it has been delivered and no longer rides on the transcript.
-  let continuity = transcript_events_by_kind(done.transcript, "system_reminder")
-    .filter({ event -> event.reminder.dedupe_key == "resume_continuity" })
-  __io_println("continuity_left=" + to_string(len(continuity)))
 }
+// Idempotent re-pause: already-suspended worker returns same summary.
+// Parent-driven resume drives the child to completion.
+// The resume-continuity reminder is single-shot: after the resumed
+// turn it has been delivered and no longer rides on the transcript.

--- a/conformance/tests/agents/suspend_nested.harn
+++ b/conformance/tests/agents/suspend_nested.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * S-11 (#1847): nested suspend/resume. Two independent background
  * workers each self-park at turn 1 and can be resumed independently.
@@ -13,47 +15,44 @@
  * `wait_agent` and the first `resume_agent`.
  */
 pipeline main() {
-  llm_mock_clear()
   // Stage worker A: park, then complete.
-  llm_mock(
-    {
-      tool_calls: [{id: "park_a", name: "agent_await_resumption", arguments: {reason: "worker A parks"}}],
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_a", name: "agent_await_resumption", arguments: {reason: "worker A parks"}}],
+      },
+      {
+        tool_calls: [{id: "park_b", name: "agent_await_resumption", arguments: {reason: "worker B parks"}}],
+      },
+      llm_text("worker A completed"),
+      llm_text("worker B completed"),
+    ],
+    { ->
+      let handle_a = sub_agent_run(
+        "Worker A: park until resumed.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended_a = wait_agent(handle_a)
+      let handle_b = sub_agent_run(
+        "Worker B: park until resumed.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended_b = wait_agent(handle_b)
+      __io_println("a_suspended=" + suspended_a.status)
+      __io_println("b_suspended=" + suspended_b.status)
+      __io_println("distinct_ids=" + to_string(suspended_a.id != suspended_b.id))
+      __io_println(
+        "distinct_snapshots=" + to_string(suspended_a.snapshot_path != suspended_b.snapshot_path),
+      )
+      let _resumed_a = resume_agent(handle_a)
+      let done_a = wait_agent(handle_a)
+      let still_b = wait_agent(handle_b)
+      __io_println("a_after_resume=" + done_a.status)
+      __io_println("b_still_suspended=" + still_b.status)
+      let _resumed_b = resume_agent(handle_b)
+      let done_b = wait_agent(handle_b)
+      __io_println("b_after_resume=" + done_b.status)
+      __io_println("a_unchanged=" + done_a.status)
     },
   )
-  let handle_a = sub_agent_run(
-    "Worker A: park until resumed.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended_a = wait_agent(handle_a)
-  // Stage worker B: park, then complete. Queue B's mocks only after
-  // A has reached suspension so the FIFO is unambiguous.
-  llm_mock(
-    {
-      tool_calls: [{id: "park_b", name: "agent_await_resumption", arguments: {reason: "worker B parks"}}],
-    },
-  )
-  let handle_b = sub_agent_run(
-    "Worker B: park until resumed.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended_b = wait_agent(handle_b)
-  __io_println("a_suspended=" + suspended_a.status)
-  __io_println("b_suspended=" + suspended_b.status)
-  __io_println("distinct_ids=" + to_string(suspended_a.id != suspended_b.id))
-  __io_println(
-    "distinct_snapshots=" + to_string(suspended_a.snapshot_path != suspended_b.snapshot_path),
-  )
-  // Resume A first. B must remain suspended.
-  llm_mock({text: "worker A completed"})
-  let _resumed_a = resume_agent(handle_a)
-  let done_a = wait_agent(handle_a)
-  let still_b = wait_agent(handle_b)
-  __io_println("a_after_resume=" + done_a.status)
-  __io_println("b_still_suspended=" + still_b.status)
-  // Resume B independently.
-  llm_mock({text: "worker B completed"})
-  let _resumed_b = resume_agent(handle_b)
-  let done_b = wait_agent(handle_b)
-  __io_println("b_after_resume=" + done_b.status)
-  __io_println("a_unchanged=" + done_a.status)
 }

--- a/conformance/tests/agents/suspend_otel_links.harn
+++ b/conformance/tests/agents/suspend_otel_links.harn
@@ -1,4 +1,5 @@
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 /**
  * S-18 (#1867): the cooperative suspend path ends the in-flight
@@ -26,41 +27,45 @@ import "std/agents"
  */
 pipeline main() {
   enable_tracing(true)
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "park_until_review", name: "agent_await_resumption", arguments: {reason: "waiting on review"}},
-      ],
-      input_tokens: 7,
-      output_tokens: 3,
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "park_until_review", name: "agent_await_resumption", arguments: {reason: "waiting on review"}},
+        ],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      llm_text("resumed and finished"),
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park until review.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      __io_println(suspended?.status)
+      let resumed_handle = resume_agent(handle)
+      __io_println(resumed_handle?.status)
+      let resumed = wait_agent(handle)
+      __io_println(resumed?.status)
+      let spans = trace_spans()
+      let suspension_spans = spans.filter({ s -> s.kind == "suspension" })
+      let resume_spans = spans.filter({ s -> s.kind == "resume" })
+      __io_println(len(suspension_spans) >= 1)
+      __io_println(len(resume_spans) >= 1)
+      let suspension = suspension_spans[0]
+      let resume = resume_spans[0]
+      __io_println(suspension.metadata?.handle != nil)
+      __io_println(suspension.metadata?.reason != nil)
+      __io_println(suspension.metadata?.initiator != nil)
+      __io_println(resume.metadata?.handle != nil)
+      __io_println(resume.metadata?.continue_transcript != nil)
+      __io_println(resume.metadata?.had_resume_input != nil)
+      __io_println(resume.parent_id == nil)
+      __io_println(resume.links != nil)
+      __io_println(len(resume.links) >= 1)
+      enable_tracing(false)
     },
   )
-  llm_mock({text: "resumed and finished"})
-  let handle = sub_agent_run(
-    "Park until review.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  __io_println(suspended?.status)
-  let resumed_handle = resume_agent(handle)
-  __io_println(resumed_handle?.status)
-  let resumed = wait_agent(handle)
-  __io_println(resumed?.status)
-  let spans = trace_spans()
-  let suspension_spans = spans.filter({ s -> s.kind == "suspension" })
-  let resume_spans = spans.filter({ s -> s.kind == "resume" })
-  __io_println(len(suspension_spans) >= 1)
-  __io_println(len(resume_spans) >= 1)
-  let suspension = suspension_spans[0]
-  let resume = resume_spans[0]
-  __io_println(suspension.metadata?.handle != nil)
-  __io_println(suspension.metadata?.reason != nil)
-  __io_println(suspension.metadata?.initiator != nil)
-  __io_println(resume.metadata?.handle != nil)
-  __io_println(resume.metadata?.continue_transcript != nil)
-  __io_println(resume.metadata?.had_resume_input != nil)
-  __io_println(resume.parent_id == nil)
-  __io_println(resume.links != nil)
-  __io_println(len(resume.links) >= 1)
-  enable_tracing(false)
 }

--- a/conformance/tests/agents/suspend_self_park_open.harn
+++ b/conformance/tests/agents/suspend_self_park_open.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * S-11 (#1847): a subagent that self-parks via
  * `agent_await_resumption("blocked")` with no `conditions` enters the
@@ -16,29 +18,32 @@
  *     loop to completion.
  */
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "park_open", name: "agent_await_resumption", arguments: {reason: "blocked"}}],
-      input_tokens: 7,
-      output_tokens: 3,
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_open", name: "agent_await_resumption", arguments: {reason: "blocked"}}],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      llm_text("resumed by operator"),
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park open until an operator resumes.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      __io_println("status=" + suspended.status)
+      __io_println("initiator=" + suspended?.suspension?.initiator ?? "")
+      __io_println("reason=" + suspended?.suspension?.reason ?? "")
+      __io_println("has_conditions=" + to_string(suspended?.suspension?.conditions != nil))
+      __io_println("has_auto_trigger=" + to_string(suspended?.suspension?.auto_resume_trigger != nil))
+      let resumed = resume_agent(handle)
+      let done = wait_agent(handle)
+      __io_println("resume_status=" + resumed.status)
+      __io_println("final_status=" + done.status)
+      __io_println("has_transcript=" + to_string(done.has_transcript))
     },
   )
-  llm_mock({text: "resumed by operator"})
-  let handle = sub_agent_run(
-    "Park open until an operator resumes.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  __io_println("status=" + suspended.status)
-  __io_println("initiator=" + suspended?.suspension?.initiator ?? "")
-  __io_println("reason=" + suspended?.suspension?.reason ?? "")
-  __io_println("has_conditions=" + to_string(suspended?.suspension?.conditions != nil))
-  __io_println("has_auto_trigger=" + to_string(suspended?.suspension?.auto_resume_trigger != nil))
-  // Operator-style resume: no input, default continue_transcript=true.
-  let resumed = resume_agent(handle)
-  let done = wait_agent(handle)
-  __io_println("resume_status=" + resumed.status)
-  __io_println("final_status=" + done.status)
-  __io_println("has_transcript=" + to_string(done.has_transcript))
 }
+// Operator-style resume: no input, default continue_transcript=true.

--- a/conformance/tests/agents/suspend_self_park_with_input.harn
+++ b/conformance/tests/agents/suspend_self_park_with_input.harn
@@ -19,6 +19,7 @@
  *     preserved (default `continue_transcript: true`).
  */
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn resume_tools() {
   var tools = tool_registry()
@@ -32,50 +33,51 @@ fn resume_tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [{id: "park_input", name: "agent_await_resumption", arguments: {reason: "needs operator brief"}}],
-      input_tokens: 7,
-      output_tokens: 3,
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "park_input", name: "agent_await_resumption", arguments: {reason: "needs operator brief"}}],
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+      {tool_calls: [{id: "noop_1", name: "noop", arguments: {}}]},
+      llm_text("operator brief acknowledged"),
+    ],
+    { ->
+      let session_id = "self-park-with-input-" + uuid()
+      let handle = sub_agent_run(
+        "Park then wait for an operator brief.",
+        {
+          provider: "mock",
+          background: true,
+          session_id: session_id,
+          tools: resume_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+        },
+      )
+      let suspended = wait_agent(handle)
+      let resumed = resume_agent(handle, "operator brief: ship the patch", true)
+      let done = wait_agent(handle)
+      let calls = llm_mock_calls()
+      let resumed_system = calls[1].system
+      let next_system = calls[2].system
+      __io_println("suspended_status=" + suspended.status)
+      __io_println("resume_status=" + resumed.status)
+      __io_println("final_status=" + done.status)
+      __io_println(
+        "input_in_reminder="
+          + to_string(contains(resumed_system, "operator brief: ship the patch")),
+      )
+      __io_println("reason_in_reminder=" + to_string(contains(resumed_system, "needs operator brief")))
+      __io_println(
+        "reminder_present_on_resumed_turn="
+          + to_string(contains(resumed_system, "You were suspended at turn")),
+      )
+      __io_println(
+        "reminder_consumed_after_one_turn="
+          + to_string(!contains(next_system, "You were suspended at turn")),
+      )
     },
-  )
-  let session_id = "self-park-with-input-" + uuid()
-  let handle = sub_agent_run(
-    "Park then wait for an operator brief.",
-    {
-      provider: "mock",
-      background: true,
-      session_id: session_id,
-      tools: resume_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-    },
-  )
-  let suspended = wait_agent(handle)
-  // Stage a follow-up tool turn so we can observe the turn-after-resume
-  // system prompt and confirm the continuity reminder is consumed.
-  llm_mock({tool_calls: [{id: "noop_1", name: "noop", arguments: {}}]})
-  llm_mock({text: "operator brief acknowledged"})
-  let resumed = resume_agent(handle, "operator brief: ship the patch", true)
-  let done = wait_agent(handle)
-  let calls = llm_mock_calls()
-  let resumed_system = calls[1].system
-  let next_system = calls[2].system
-  __io_println("suspended_status=" + suspended.status)
-  __io_println("resume_status=" + resumed.status)
-  __io_println("final_status=" + done.status)
-  __io_println(
-    "input_in_reminder="
-      + to_string(contains(resumed_system, "operator brief: ship the patch")),
-  )
-  __io_println("reason_in_reminder=" + to_string(contains(resumed_system, "needs operator brief")))
-  __io_println(
-    "reminder_present_on_resumed_turn="
-      + to_string(contains(resumed_system, "You were suspended at turn")),
-  )
-  __io_println(
-    "reminder_consumed_after_one_turn="
-      + to_string(!contains(next_system, "You were suspended at turn")),
   )
 }

--- a/conformance/tests/agents/suspend_timeout_fail.harn
+++ b/conformance/tests/agents/suspend_timeout_fail.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * S-11 (#1847): a timeout-conditioned suspension with
  * `on_timeout: "fail"` marks the worker as failed when the deadline
@@ -9,50 +11,53 @@
  * `advance_time`.
  */
 pipeline main() {
-  llm_mock_clear()
   let _ = mock_time(1700000100000)
-  llm_mock(
-    {
-      tool_calls: [
-        {
-          id: "park_fail",
-          name: "agent_await_resumption",
-          arguments: {
-            reason: "fail on review timeout",
-            conditions: {
-              trigger: {kind: "review.approved", provider: "github"},
-              timeout: {duration_minutes: 5, on_timeout: "fail"},
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "park_fail",
+            name: "agent_await_resumption",
+            arguments: {
+              reason: "fail on review timeout",
+              conditions: {
+                trigger: {kind: "review.approved", provider: "github"},
+                timeout: {duration_minutes: 5, on_timeout: "fail"},
+              },
             },
           },
-        },
-      ],
+        ],
+      },
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park until the review timeout fails the worker.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      __io_println("status=" + suspended.status)
+      __io_println("has_auto_trigger=" + to_string(suspended?.suspension?.auto_resume_trigger != nil))
+      let _ = advance_time(6 * 60 * 1000)
+      yield_now()
+      yield_now()
+      yield_now()
+      let failed = wait_agent(handle)
+      __io_println("post_timeout_status=" + failed.status)
+      __io_println("has_latest_error=" + to_string(failed?.error != nil))
+      __io_println(
+        "error_mentions_timeout="
+          + to_string(contains(failed?.error ?? "", "timeout")),
+      )
+      let resume_attempt = try {
+        resume_agent(handle)
+      }
+      __io_println("resume_failed=" + to_string(is_err(resume_attempt)))
+      let _ = unmock_time()
     },
   )
-  let handle = sub_agent_run(
-    "Park until the review timeout fails the worker.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  __io_println("status=" + suspended.status)
-  __io_println("has_auto_trigger=" + to_string(suspended?.suspension?.auto_resume_trigger != nil))
-  // Advance past the deadline so the spawned timeout task wakes and
-  // marks the worker failed (no resume attempt).
-  let _ = advance_time(6 * 60 * 1000)
-  yield_now()
-  yield_now()
-  yield_now()
-  let failed = wait_agent(handle)
-  __io_println("post_timeout_status=" + failed.status)
-  __io_println("has_latest_error=" + to_string(failed?.error != nil))
-  __io_println(
-    "error_mentions_timeout="
-      + to_string(contains(failed?.error ?? "", "timeout")),
-  )
-  // A subsequent resume against the failed worker is rejected with
-  // HARN-SUS-001 (worker is not suspended).
-  let resume_attempt = try {
-    resume_agent(handle)
-  }
-  __io_println("resume_failed=" + to_string(is_err(resume_attempt)))
-  let _ = unmock_time()
 }
+// Advance past the deadline so the spawned timeout task wakes and
+// marks the worker failed (no resume attempt).
+// A subsequent resume against the failed worker is rejected with
+// HARN-SUS-001 (worker is not suspended).

--- a/conformance/tests/agents/suspend_timeout_resume_with_summary.harn
+++ b/conformance/tests/agents/suspend_timeout_resume_with_summary.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * S-11 (#1847): a timeout-conditioned suspension auto-resumes when
  * the deadline elapses. With `on_timeout: "resume_with_summary"`
@@ -12,44 +14,47 @@
  * registration (see `register_auto_resume_trigger`).
  */
 pipeline main() {
-  llm_mock_clear()
   let _ = mock_time(1700000000000)
-  llm_mock(
-    {
-      tool_calls: [
-        {
-          id: "park_timeout",
-          name: "agent_await_resumption",
-          arguments: {
-            reason: "waiting on review",
-            conditions: {
-              trigger: {kind: "review.approved", provider: "github"},
-              timeout: {duration_minutes: 5, on_timeout: "resume_with_summary"},
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "park_timeout",
+            name: "agent_await_resumption",
+            arguments: {
+              reason: "waiting on review",
+              conditions: {
+                trigger: {kind: "review.approved", provider: "github"},
+                timeout: {duration_minutes: 5, on_timeout: "resume_with_summary"},
+              },
             },
           },
-        },
-      ],
+        ],
+      },
+      llm_text("resumed after timeout"),
+    ],
+    { ->
+      let handle = sub_agent_run(
+        "Park until the review timeout fires.",
+        {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
+      )
+      let suspended = wait_agent(handle)
+      __io_println("status=" + suspended.status)
+      __io_println("has_auto_trigger=" + to_string(suspended?.suspension?.auto_resume_trigger != nil))
+      let _ = advance_time(6 * 60 * 1000)
+      yield_now()
+      yield_now()
+      yield_now()
+      let resumed = wait_agent(handle)
+      __io_println("post_timeout_status=" + resumed.status)
+      __io_println("has_transcript=" + to_string(resumed.has_transcript))
+      let _ = unmock_time()
     },
   )
-  llm_mock({text: "resumed after timeout"})
-  let handle = sub_agent_run(
-    "Park until the review timeout fires.",
-    {provider: "mock", background: true, tool_format: "native", max_iterations: 3},
-  )
-  let suspended = wait_agent(handle)
-  __io_println("status=" + suspended.status)
-  __io_println("has_auto_trigger=" + to_string(suspended?.suspension?.auto_resume_trigger != nil))
-  // Advance the mock clock past the 5-minute timeout. The spawned
-  // auto-resume timeout task wakes from `clock::sleep`, fires the
-  // synthetic auto_resume.timeout event, and the agent loop resumes.
-  let _ = advance_time(6 * 60 * 1000)
-  // Yield so the timeout task can run, dispatch, and the resumed
-  // worker can complete its next turn.
-  yield_now()
-  yield_now()
-  yield_now()
-  let resumed = wait_agent(handle)
-  __io_println("post_timeout_status=" + resumed.status)
-  __io_println("has_transcript=" + to_string(resumed.has_transcript))
-  let _ = unmock_time()
 }
+// Advance the mock clock past the 5-minute timeout. The spawned
+// auto-resume timeout task wakes from `clock::sleep`, fires the
+// synthetic auto_resume.timeout event, and the agent loop resumes.
+// Yield so the timeout task can run, dispatch, and the resumed
+// worker can complete its next turn.

--- a/conformance/tests/agents/task_plan_budget_workflow_execute.harn
+++ b/conformance/tests/agents/task_plan_budget_workflow_execute.harn
@@ -1,37 +1,41 @@
 import { task_plan_compile } from "std/agent/task_plan"
+import { with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "still working",
-      provider: "openai",
-      model: "gpt-4o-mini",
-      input_tokens: 100000,
-      output_tokens: 100000,
+  with_llm_script(
+    [
+      {
+        text: "still working",
+        provider: "openai",
+        model: "gpt-4o-mini",
+        input_tokens: 100000,
+        output_tokens: 100000,
+      },
+    ],
+    { ->
+      let plan = {
+        schema_version: "1",
+        objective: "Budgeted workflow",
+        entry: "work",
+        nodes: {
+          work: {
+            kind: "agent_loop",
+            purpose: "Run budgeted loop",
+            prompt: "Spend one modeled call",
+            model: {provider: "mock", model: "gpt-4o-mini"},
+            agent_loop: {done_sentinel: "DONE"},
+          },
+        },
+        budgets: {total_cost_usd: 0.000001},
+      }
+      let compiled = task_plan_compile(plan)
+      let result = workflow_execute("Budgeted workflow", compiled.workflow, [], {max_steps: 1})
+      let stage = result.run.stages[0]
+      __io_println(result.status)
+      __io_println(stage.status)
+      __io_println(stage.outcome)
+      __io_println(stage.branch)
+      __io_println(stage.metadata.model_policy.iteration_budget.total_cost_usd == 0.000001)
     },
   )
-  let plan = {
-    schema_version: "1",
-    objective: "Budgeted workflow",
-    entry: "work",
-    nodes: {
-      work: {
-        kind: "agent_loop",
-        purpose: "Run budgeted loop",
-        prompt: "Spend one modeled call",
-        model: {provider: "mock", model: "gpt-4o-mini"},
-        agent_loop: {done_sentinel: "DONE"},
-      },
-    },
-    budgets: {total_cost_usd: 0.000001},
-  }
-  let compiled = task_plan_compile(plan)
-  let result = workflow_execute("Budgeted workflow", compiled.workflow, [], {max_steps: 1})
-  let stage = result.run.stages[0]
-  __io_println(result.status)
-  __io_println(stage.status)
-  __io_println(stage.outcome)
-  __io_println(stage.branch)
-  __io_println(stage.metadata.model_policy.iteration_budget.total_cost_usd == 0.000001)
 }

--- a/conformance/tests/agents/tool_surface_narrowing.harn
+++ b/conformance/tests/agents/tool_surface_narrowing.harn
@@ -1,4 +1,5 @@
 import { agent_capture_events } from "std/agent/events"
+import { with_llm_script } from "std/testing"
 
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
@@ -50,84 +51,94 @@ pipeline default() {
     prompt "Use the run tool when command execution is required."
     allowed_tools ["run"]
   }
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "look-1", name: "look", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "search-1", name: "search", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "look-2", name: "look", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "search-2", name: "search", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "look-3", name: "look", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "done-1", name: "done_sentinel", arguments: {}}]})
-  let session = "tool-surface-narrowing-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Narrow unused tools.",
-      nil,
-      {
-        provider: "mock",
-        tools: narrowing_tools(),
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 6,
-        session_id: session,
-        stop_after_successful_tools: ["done_sentinel"],
-        tool_surface_narrowing: {enabled: true, window_turns: 5},
-      },
-    ) },
-  )
-  let narrow = events_of(captured.events, "skill_narrow")
-  require len(narrow) >= 1, "skill_narrow should be emitted after the configured window"
-  let first = narrow[0]
-  let calls = llm_mock_calls()
-  let sixth_tools = calls[5].tools
-  __io_println(captured.result.status)
-  __io_println(len(narrow) >= 1)
-  __io_println(contains(first.removed_tools, "read_docs"))
-  __io_println(detail_for(first.removed_tool_details, "read_docs").class)
-  __io_println(detail_for(first.kept_tool_details, "run").class)
-  __io_println(detail_for(first.kept_tool_details, "custom_host").class)
-  __io_println(!contains(first.removed_tools, "run"))
-  __io_println(!contains(first.removed_tools, "scaffold"))
-  __io_println(!contains(first.removed_tools, "replace_symbol"))
-  __io_println(!contains(first.removed_tools, "custom_host"))
-  __io_println(!contains(first.remaining_tools, "read_docs"))
-  __io_println(contains(first.remaining_tools, "run"))
-  __io_println(contains(first.remaining_tools, "scaffold"))
-  __io_println(contains(first.remaining_tools, "replace_symbol"))
-  __io_println(!has_tool(sixth_tools, "read_docs"))
-  __io_println(has_tool(sixth_tools, "run"))
-  __io_println(has_tool(sixth_tools, "scaffold"))
-  __io_println(has_tool(sixth_tools, "replace_symbol"))
-  __io_println(has_tool(sixth_tools, "custom_host"))
-  __io_println(has_tool(sixth_tools, "done_sentinel"))
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "rewiden-look-1", name: "look", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "rewiden-search-1", name: "search", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "rewiden-look-2", name: "look", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "rewiden-search-2", name: "search", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "rewiden-look-3", name: "look", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "load-runner", name: "load_skill", arguments: {name: "runner"}}]})
-  llm_mock({tool_calls: [{id: "run-1", name: "run", arguments: {}}]})
-  let rewiden_session = "tool-surface-rewiden-" + uuid()
-  let rewidened = agent_loop(
-    "Narrow unused tools, then load runner.",
-    nil,
-    {
-      provider: "mock",
-      tools: narrowing_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 7,
-      session_id: rewiden_session,
-      stop_after_successful_tools: ["run"],
-      skills: runner,
-      skill_match: {strategy: "manual"},
-      tool_surface_narrowing: {enabled: true, window_turns: 5, mode: "aggressive"},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "look-1", name: "look", arguments: {}}]},
+      {tool_calls: [{id: "search-1", name: "search", arguments: {}}]},
+      {tool_calls: [{id: "look-2", name: "look", arguments: {}}]},
+      {tool_calls: [{id: "search-2", name: "search", arguments: {}}]},
+      {tool_calls: [{id: "look-3", name: "look", arguments: {}}]},
+      {tool_calls: [{id: "done-1", name: "done_sentinel", arguments: {}}]},
+    ],
+    { ->
+      let session = "tool-surface-narrowing-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Narrow unused tools.",
+          nil,
+          {
+            provider: "mock",
+            tools: narrowing_tools(),
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 6,
+            session_id: session,
+            stop_after_successful_tools: ["done_sentinel"],
+            tool_surface_narrowing: {enabled: true, window_turns: 5},
+          },
+        ) },
+      )
+      let narrow = events_of(captured.events, "skill_narrow")
+      require len(narrow) >= 1, "skill_narrow should be emitted after the configured window"
+      let first = narrow[0]
+      let calls = llm_mock_calls()
+      let sixth_tools = calls[5].tools
+      __io_println(captured.result.status)
+      __io_println(len(narrow) >= 1)
+      __io_println(contains(first.removed_tools, "read_docs"))
+      __io_println(detail_for(first.removed_tool_details, "read_docs").class)
+      __io_println(detail_for(first.kept_tool_details, "run").class)
+      __io_println(detail_for(first.kept_tool_details, "custom_host").class)
+      __io_println(!contains(first.removed_tools, "run"))
+      __io_println(!contains(first.removed_tools, "scaffold"))
+      __io_println(!contains(first.removed_tools, "replace_symbol"))
+      __io_println(!contains(first.removed_tools, "custom_host"))
+      __io_println(!contains(first.remaining_tools, "read_docs"))
+      __io_println(contains(first.remaining_tools, "run"))
+      __io_println(contains(first.remaining_tools, "scaffold"))
+      __io_println(contains(first.remaining_tools, "replace_symbol"))
+      __io_println(!has_tool(sixth_tools, "read_docs"))
+      __io_println(has_tool(sixth_tools, "run"))
+      __io_println(has_tool(sixth_tools, "scaffold"))
+      __io_println(has_tool(sixth_tools, "replace_symbol"))
+      __io_println(has_tool(sixth_tools, "custom_host"))
+      __io_println(has_tool(sixth_tools, "done_sentinel"))
     },
   )
-  let rewiden_calls = llm_mock_calls()
-  require rewidened.status == "done", "explicit load_skill rewiden scenario should complete"
-  require !has_tool(rewiden_calls[5].tools, "run"), "run should be narrow before explicit skill load"
-  require has_tool(rewiden_calls[5].tools, "load_skill"), "load_skill should be hard-kept after narrowing"
-  require has_tool(rewiden_calls[6].tools, "run"), "explicit skill activation should reopen skill-scoped run"
+  with_llm_script(
+    [
+      {tool_calls: [{id: "rewiden-look-1", name: "look", arguments: {}}]},
+      {tool_calls: [{id: "rewiden-search-1", name: "search", arguments: {}}]},
+      {tool_calls: [{id: "rewiden-look-2", name: "look", arguments: {}}]},
+      {tool_calls: [{id: "rewiden-search-2", name: "search", arguments: {}}]},
+      {tool_calls: [{id: "rewiden-look-3", name: "look", arguments: {}}]},
+      {tool_calls: [{id: "load-runner", name: "load_skill", arguments: {name: "runner"}}]},
+      {tool_calls: [{id: "run-1", name: "run", arguments: {}}]},
+    ],
+    { ->
+      let rewiden_session = "tool-surface-rewiden-" + uuid()
+      let rewidened = agent_loop(
+        "Narrow unused tools, then load runner.",
+        nil,
+        {
+          provider: "mock",
+          tools: narrowing_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 7,
+          session_id: rewiden_session,
+          stop_after_successful_tools: ["run"],
+          skills: runner,
+          skill_match: {strategy: "manual"},
+          tool_surface_narrowing: {enabled: true, window_turns: 5, mode: "aggressive"},
+        },
+      )
+      let rewiden_calls = llm_mock_calls()
+      require rewidened.status == "done", "explicit load_skill rewiden scenario should complete"
+      require !has_tool(rewiden_calls[5].tools, "run"), "run should be narrow before explicit skill load"
+      require has_tool(rewiden_calls[5].tools, "load_skill"), "load_skill should be hard-kept after narrowing"
+      require has_tool(rewiden_calls[6].tools, "run"), "explicit skill activation should reopen skill-scoped run"
+    },
+  )
 }

--- a/conformance/tests/agents/worker_request_provenance.harn
+++ b/conformance/tests/agents/worker_request_provenance.harn
@@ -1,29 +1,34 @@
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock({text: "background summary"})
-  let handle = sub_agent_run(
-    "Investigate worker provenance",
-    {
-      provider: "mock",
-      background: true,
-      request: {topic: "provenance", owner: "parent"},
-      research_questions: ["Which fields survive wait?"],
-      action_items: [{id: "action_1", title: "Read agents_workers"}],
-      workflow_stages: ["research", "implement"],
-      verification_steps: ["cargo test -p harn-vm agents_workers"],
+  with_llm_script(
+    [llm_text("background summary")],
+    { ->
+      let handle = sub_agent_run(
+        "Investigate worker provenance",
+        {
+          provider: "mock",
+          background: true,
+          request: {topic: "provenance", owner: "parent"},
+          research_questions: ["Which fields survive wait?"],
+          action_items: [{id: "action_1", title: "Read agents_workers"}],
+          workflow_stages: ["research", "implement"],
+          verification_steps: ["cargo test -p harn-vm agents_workers"],
+        },
+      )
+      __io_println(worker_request(handle)?.payload?.topic == "provenance")
+      __io_println(len(worker_research_questions(handle)) == 1)
+      __io_println(worker_action_items(handle)[0]?.id == "action_1")
+      __io_println(worker_workflow_stages(handle)[1] == "implement")
+      __io_println(worker_verification_steps(handle)[0] == "cargo test -p harn-vm agents_workers")
+      let done = wait_agent(handle)
+      __io_println(worker_request(done)?.task == "Investigate worker provenance")
+      __io_println(worker_provenance(done)?.worker_id == done?.id)
+      __io_println(contains(worker_result(done)?.summary ?? "", "background summary"))
+      let continued = send_input(done, "Follow up with implementation details")
+      __io_println(continued?.task == "Follow up with implementation details")
+      __io_println(worker_request(continued)?.task == "Investigate worker provenance")
     },
   )
-  __io_println(worker_request(handle)?.payload?.topic == "provenance")
-  __io_println(len(worker_research_questions(handle)) == 1)
-  __io_println(worker_action_items(handle)[0]?.id == "action_1")
-  __io_println(worker_workflow_stages(handle)[1] == "implement")
-  __io_println(worker_verification_steps(handle)[0] == "cargo test -p harn-vm agents_workers")
-  let done = wait_agent(handle)
-  __io_println(worker_request(done)?.task == "Investigate worker provenance")
-  __io_println(worker_provenance(done)?.worker_id == done?.id)
-  __io_println(contains(worker_result(done)?.summary ?? "", "background summary"))
-  let continued = send_input(done, "Follow up with implementation details")
-  __io_println(continued?.task == "Follow up with implementation details")
-  __io_println(worker_request(continued)?.task == "Investigate worker provenance")
 }

--- a/conformance/tests/agents/worker_retriggerable.harn
+++ b/conformance/tests/agents/worker_retriggerable.harn
@@ -1,4 +1,5 @@
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn current_worker(handle) {
   let worker_id = handle?.id
@@ -32,52 +33,59 @@ fn worker_snapshot_text(harness: Harness, handle) {
 }
 
 pipeline main() {
-  llm_mock({text: "one-shot summary"})
-  let one_shot = sub_agent_run("Answer once.", {provider: "mock", background: true})
-  let one_shot_done = wait_agent(one_shot)
-  __io_println(one_shot_done?.status == "completed")
-  let one_shot_trigger_error = try {
-    worker_trigger(one_shot_done, {follow_up: "again"})
-    false
-  } catch (e) {
-    contains(to_string(e), "not retriggerable")
-  }
-  __io_println(one_shot_trigger_error)
-  llm_mock({text: "first answer"})
-  llm_mock({text: "follow-up answer"})
-  let loop = sub_agent_run(
-    "Answer the first question.",
-    {provider: "mock", background: true, carry: {retriggerable: true}},
+  with_llm_script(
+    [llm_text("one-shot summary")],
+    { ->
+      let one_shot = sub_agent_run("Answer once.", {provider: "mock", background: true})
+      let one_shot_done = wait_agent(one_shot)
+      __io_println(one_shot_done?.status == "completed")
+      let one_shot_trigger_error = try {
+        worker_trigger(one_shot_done, {follow_up: "again"})
+        false
+      } catch (e) {
+        contains(to_string(e), "not retriggerable")
+      }
+      __io_println(one_shot_trigger_error)
+    },
   )
-  let first = wait_for_status(loop, "awaiting")
-  __io_println(first?.status == "awaiting")
-  __io_println(contains(worker_result(first)?.summary ?? "", "first answer"))
-  let first_snapshot = worker_snapshot(harness, loop)
-  let first_snapshot_text = worker_snapshot_text(harness, loop)
-  let first_messages = first_snapshot?.transcript?.messages ?? []
-  __io_println(len(first_messages) >= 2)
-  __io_println(contains(first_snapshot_text, "Answer the first question."))
-  let waiter = channel("waiter")
-  let _wait_task = spawn {
-    let done = wait_agent(loop)
-    send(waiter, done?.status)
-  }
-  sleep(20ms)
-  __io_println(try_receive(waiter) == nil)
-  let retriggered = worker_trigger(loop, {follow_up: "Need one more detail"})
-  __io_println(retriggered?.status == "running")
-  let second = wait_for_status(loop, "awaiting")
-  __io_println(second?.status == "awaiting")
-  __io_println(contains(worker_result(second)?.summary ?? "", "follow-up answer"))
-  __io_println(worker_request(second)?.task == "Answer the first question.")
-  __io_println(worker_provenance(second)?.worker_id == loop?.id)
-  let closed = close_agent(loop)
-  __io_println(closed?.status == "cancelled")
-  let final_snapshot_path = path_join(harness.fs.temp_dir(), "worker-final-" + closed?.id + ".json")
-  harness.fs.copy(closed?.snapshot_path, final_snapshot_path)
-  let final_snapshot_text = harness.fs.read_text(final_snapshot_path)
-  __io_println(len(final_snapshot_text) > len(first_snapshot_text))
-  __io_println(contains(final_snapshot_text, "Answer the first question."))
-  __io_println(contains(final_snapshot_text, "Need one more detail"))
-  __io_println(receive(waiter) == "cancelled")
+  with_llm_script(
+    [llm_text("first answer"), llm_text("follow-up answer")],
+    { ->
+      let loop = sub_agent_run(
+        "Answer the first question.",
+        {provider: "mock", background: true, carry: {retriggerable: true}},
+      )
+      let first = wait_for_status(loop, "awaiting")
+      __io_println(first?.status == "awaiting")
+      __io_println(contains(worker_result(first)?.summary ?? "", "first answer"))
+      let first_snapshot = worker_snapshot(harness, loop)
+      let first_snapshot_text = worker_snapshot_text(harness, loop)
+      let first_messages = first_snapshot?.transcript?.messages ?? []
+      __io_println(len(first_messages) >= 2)
+      __io_println(contains(first_snapshot_text, "Answer the first question."))
+      let waiter = channel("waiter")
+      let _wait_task = spawn {
+        let done = wait_agent(loop)
+        send(waiter, done?.status)
+      }
+      sleep(20ms)
+      __io_println(try_receive(waiter) == nil)
+      let retriggered = worker_trigger(loop, {follow_up: "Need one more detail"})
+      __io_println(retriggered?.status == "running")
+      let second = wait_for_status(loop, "awaiting")
+      __io_println(second?.status == "awaiting")
+      __io_println(contains(worker_result(second)?.summary ?? "", "follow-up answer"))
+      __io_println(worker_request(second)?.task == "Answer the first question.")
+      __io_println(worker_provenance(second)?.worker_id == loop?.id)
+      let closed = close_agent(loop)
+      __io_println(closed?.status == "cancelled")
+      let final_snapshot_path = path_join(harness.fs.temp_dir(), "worker-final-" + closed?.id + ".json")
+      harness.fs.copy(closed?.snapshot_path, final_snapshot_path)
+      let final_snapshot_text = harness.fs.read_text(final_snapshot_path)
+      __io_println(len(final_snapshot_text) > len(first_snapshot_text))
+      __io_println(contains(final_snapshot_text, "Answer the first question."))
+      __io_println(contains(final_snapshot_text, "Need one more detail"))
+      __io_println(receive(waiter) == "cancelled")
+    },
+  )
 }

--- a/conformance/tests/agents/worker_transcript_carry.harn
+++ b/conformance/tests/agents/worker_transcript_carry.harn
@@ -1,20 +1,25 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline main() {
-  llm_mock({text: "first carried answer"})
-  llm_mock({text: "second reset answer"})
-  let worker = sub_agent_run(
-    "Answer the first prompt.",
-    {provider: "mock", background: true, carry: {transcript_mode: "reset"}},
+  with_llm_script(
+    [llm_text("first carried answer"), llm_text("second reset answer")],
+    { ->
+      let worker = sub_agent_run(
+        "Answer the first prompt.",
+        {provider: "mock", background: true, carry: {transcript_mode: "reset"}},
+      )
+      let first = wait_agent(worker)
+      let first_snapshot = json_parse(harness.fs.read_text(first?.snapshot_path))
+      __io_println(first_snapshot?.carry_policy?.transcript_mode == "reset")
+      __io_println(
+        contains(json_stringify(first_snapshot?.transcript?.messages ?? []), "first carried answer"),
+      )
+      let resumed = send_input(first, "Answer the second prompt.")
+      let second = wait_agent(resumed)
+      let second_snapshot = json_parse(harness.fs.read_text(second?.snapshot_path))
+      let second_messages = json_stringify(second_snapshot?.transcript?.messages ?? [])
+      __io_println(contains(second_messages, "second reset answer"))
+      __io_println(!contains(second_messages, "first carried answer"))
+    },
   )
-  let first = wait_agent(worker)
-  let first_snapshot = json_parse(harness.fs.read_text(first?.snapshot_path))
-  __io_println(first_snapshot?.carry_policy?.transcript_mode == "reset")
-  __io_println(
-    contains(json_stringify(first_snapshot?.transcript?.messages ?? []), "first carried answer"),
-  )
-  let resumed = send_input(first, "Answer the second prompt.")
-  let second = wait_agent(resumed)
-  let second_snapshot = json_parse(harness.fs.read_text(second?.snapshot_path))
-  let second_messages = json_stringify(second_snapshot?.transcript?.messages ?? [])
-  __io_println(contains(second_messages, "second reset answer"))
-  __io_println(!contains(second_messages, "first carried answer"))
 }

--- a/conformance/tests/concurrency/with_rate_limit_permit.harn
+++ b/conformance/tests/concurrency/with_rate_limit_permit.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * with_rate_limit acquires a sliding-window permit for the provider and
  * invokes the closure. With a high RPM limit, successive calls return
@@ -5,12 +7,15 @@
  */
 pipeline default(task) {
   llm_rate_limit("mock", {rpm: 1000})
-  llm_mock({text: "one"})
-  llm_mock({text: "two"})
-  let a = with_rate_limit("mock", fn() { llm_call("hello", nil, {provider: "mock"}) })
-  let b = with_rate_limit("mock", fn() { llm_call("hello", nil, {provider: "mock"}) })
-  __io_println(a.text)
-  __io_println(b.text)
-  // Clear the rate limit so other tests aren't affected by it.
-  llm_rate_limit("mock", {rpm: 0})
+  with_llm_script(
+    [llm_text("one"), llm_text("two")],
+    { ->
+      let a = with_rate_limit("mock", fn() { llm_call("hello", nil, {provider: "mock"}) })
+      let b = with_rate_limit("mock", fn() { llm_call("hello", nil, {provider: "mock"}) })
+      __io_println(a.text)
+      __io_println(b.text)
+      llm_rate_limit("mock", {rpm: 0})
+    },
+  )
 }
+// Clear the rate limit so other tests aren't affected by it.

--- a/conformance/tests/concurrency/with_rate_limit_retry.harn
+++ b/conformance/tests/concurrency/with_rate_limit_retry.harn
@@ -1,17 +1,25 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * with_rate_limit retries on rate_limit / overloaded / transient_network /
  * timeout errors with exponential backoff, then returns the successful
  * response. backoff_ms: 1 keeps the test fast.
  */
 pipeline default(task) {
-  llm_mock({error: {category: "rate_limit", message: "429"}})
-  llm_mock({error: {category: "transient_network", message: "connection reset"}})
-  llm_mock({text: "finally"})
-  let r = with_rate_limit(
-    "mock",
-    fn() { llm_call("hello", nil, {provider: "mock", llm_retries: 0}) },
-    {backoff_ms: 1, max_retries: 5},
+  with_llm_script(
+    [
+      {error: {category: "rate_limit", message: "429"}},
+      {error: {category: "transient_network", message: "connection reset"}},
+      llm_text("finally"),
+    ],
+    { ->
+      let r = with_rate_limit(
+        "mock",
+        fn() { llm_call("hello", nil, {provider: "mock", llm_retries: 0}) },
+        {backoff_ms: 1, max_retries: 5},
+      )
+      __io_println(r.text)
+      __io_println(len(llm_mock_calls()))
+    },
   )
-  __io_println(r.text)
-  __io_println(len(llm_mock_calls()))
 }

--- a/conformance/tests/hooks_session/clear_and_unknown_event.harn
+++ b/conformance/tests/hooks_session/clear_and_unknown_event.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `clear_session_hooks()` removes all session-level hooks but leaves
  * tool/persona hooks alone. Unknown event names raise.
@@ -14,12 +16,15 @@ pipeline default() {
     },
   )
   clear_session_hooks()
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  agent_loop("hi", nil, {provider: "mock"})
-  __io_println(atomic_get(observed))
-  let err = try {
-    register_session_hook("PreToolUse", { _ev -> return nil })
-  }
-  __io_println(is_err(err))
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      agent_loop("hi", nil, {provider: "mock"})
+      __io_println(atomic_get(observed))
+      let err = try {
+        register_session_hook("PreToolUse", { _ev -> return nil })
+      }
+      __io_println(is_err(err))
+    },
+  )
 }

--- a/conformance/tests/hooks_session/file_edited.harn
+++ b/conformance/tests/hooks_session/file_edited.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `file_edited` hooks fire when std fs builtins record an edit, plus
  * any explicit `notify_file_edited` calls. They batch through a
@@ -22,11 +24,14 @@ pipeline default() {
   harness.fs.write_text(tmp, "hello")
   harness.fs.append(tmp, " world")
   notify_file_edited(tmp, {operation: "append", bytes: 11})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let result = agent_loop("touch some files", nil, {provider: "mock"})
-  __io_println(result.status)
-  __io_println(atomic_get(edits_seen))
-  harness.fs.delete(tmp)
-  clear_session_hooks()
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let result = agent_loop("touch some files", nil, {provider: "mock"})
+      __io_println(result.status)
+      __io_println(atomic_get(edits_seen))
+      harness.fs.delete(tmp)
+      clear_session_hooks()
+    },
+  )
 }

--- a/conformance/tests/hooks_session/hook_emits_reminder_persona.harn
+++ b/conformance/tests/hooks_session/hook_emits_reminder_persona.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 @persona(name: "hooked_persona")
 fn hooked_persona(input) -> string {
   return persona_work(input)
@@ -30,26 +32,31 @@ pipeline main() {
       return nil
     },
   )
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "persona_1", name: "persona_hook_tool", arguments: {}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "call the persona hook tool",
-    nil,
-    {
-      provider: "mock",
-      tools: persona_hook_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      loop_until_done: true,
-      session_id: "hook-reminder-persona",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "persona_1", name: "persona_hook_tool", arguments: {}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "call the persona hook tool",
+        nil,
+        {
+          provider: "mock",
+          tools: persona_hook_tools(),
+          tool_format: "native",
+          max_iterations: 2,
+          loop_until_done: true,
+          session_id: "hook-reminder-persona",
+        },
+      )
+      let events = transcript_events_by_kind(result.transcript, "system_reminder")
+      __io_println(result.status)
+      __io_println(len(events))
+      __io_println(events[0].reminder.body)
+      __io_println(events[0].reminder.source)
+      __io_println(events[0].reminder.tags[0])
+      clear_persona_hooks()
     },
   )
-  let events = transcript_events_by_kind(result.transcript, "system_reminder")
-  __io_println(result.status)
-  __io_println(len(events))
-  __io_println(events[0].reminder.body)
-  __io_println(events[0].reminder.source)
-  __io_println(events[0].reminder.tags[0])
-  clear_persona_hooks()
 }

--- a/conformance/tests/hooks_session/hook_emits_reminder_session.harn
+++ b/conformance/tests/hooks_session/hook_emits_reminder_session.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline main() {
   clear_session_hooks()
   register_session_hook(
@@ -7,14 +9,17 @@ pipeline main() {
       {reminder: {body: "session reminder fresh", dedupe_key: "session-hook", tags: ["session"]}},
     ] },
   )
-  llm_mock_clear()
-  llm_mock({text: "done"})
-  let result = agent_loop("session hook reminder", nil, {provider: "mock", session_id: "hook-reminder-session"})
-  let events = transcript_events_by_kind(result.transcript, "system_reminder")
-  __io_println(result.status)
-  __io_println(len(events))
-  __io_println(events[0].reminder.body)
-  __io_println(events[0].reminder.source)
-  __io_println(events[0].reminder.tags[0])
-  clear_session_hooks()
+  with_llm_script(
+    [llm_text("done")],
+    { ->
+      let result = agent_loop("session hook reminder", nil, {provider: "mock", session_id: "hook-reminder-session"})
+      let events = transcript_events_by_kind(result.transcript, "system_reminder")
+      __io_println(result.status)
+      __io_println(len(events))
+      __io_println(events[0].reminder.body)
+      __io_println(events[0].reminder.source)
+      __io_println(events[0].reminder.tags[0])
+      clear_session_hooks()
+    },
+  )
 }

--- a/conformance/tests/hooks_session/hook_emits_reminder_step.harn
+++ b/conformance/tests/hooks_session/hook_emits_reminder_step.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 @step(name: "watched_step")
 fn watched_step(input) -> string {
   return "step:" + input
@@ -26,26 +28,31 @@ pipeline main() {
     "PreStep",
     { _ctx -> return {reminder: {body: "step hook reminder", tags: ["step"]}} },
   )
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "step_1", name: "step_hook_tool", arguments: {}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "call the step hook tool",
-    nil,
-    {
-      provider: "mock",
-      tools: step_hook_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      loop_until_done: true,
-      session_id: "hook-reminder-step",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "step_1", name: "step_hook_tool", arguments: {}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "call the step hook tool",
+        nil,
+        {
+          provider: "mock",
+          tools: step_hook_tools(),
+          tool_format: "native",
+          max_iterations: 2,
+          loop_until_done: true,
+          session_id: "hook-reminder-step",
+        },
+      )
+      let events = transcript_events_by_kind(result.transcript, "system_reminder")
+      __io_println(result.status)
+      __io_println(len(events))
+      __io_println(events[0].reminder.body)
+      __io_println(events[0].reminder.source)
+      __io_println(events[0].reminder.tags[0])
+      clear_persona_hooks()
     },
   )
-  let events = transcript_events_by_kind(result.transcript, "system_reminder")
-  __io_println(result.status)
-  __io_println(len(events))
-  __io_println(events[0].reminder.body)
-  __io_println(events[0].reminder.source)
-  __io_println(events[0].reminder.tags[0])
-  clear_persona_hooks()
 }

--- a/conformance/tests/hooks_session/hook_emits_reminder_tool.harn
+++ b/conformance/tests/hooks_session/hook_emits_reminder_tool.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn hook_reminder_tools() {
   let registry = tool_registry()
   return tool_define(
@@ -20,27 +22,32 @@ pipeline main() {
       } },
     },
   )
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "tool_1", name: "hooked_tool", arguments: {}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "call the hooked tool",
-    nil,
-    {
-      provider: "mock",
-      tools: hook_reminder_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      loop_until_done: true,
-      session_id: "hook-reminder-tool",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "tool_1", name: "hooked_tool", arguments: {}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "call the hooked tool",
+        nil,
+        {
+          provider: "mock",
+          tools: hook_reminder_tools(),
+          tool_format: "native",
+          max_iterations: 2,
+          loop_until_done: true,
+          session_id: "hook-reminder-tool",
+        },
+      )
+      let events = transcript_events_by_kind(result.transcript, "system_reminder")
+      __io_println(result.status)
+      __io_println(len(events))
+      __io_println(events[0].reminder.body)
+      __io_println(events[0].reminder.role_hint)
+      __io_println(events[1].reminder.body)
+      __io_println(events[1].reminder.source)
+      clear_tool_hooks()
     },
   )
-  let events = transcript_events_by_kind(result.transcript, "system_reminder")
-  __io_println(result.status)
-  __io_println(len(events))
-  __io_println(events[0].reminder.body)
-  __io_println(events[0].reminder.role_hint)
-  __io_println(events[1].reminder.body)
-  __io_println(events[1].reminder.source)
-  clear_tool_hooks()
 }

--- a/conformance/tests/hooks_session/hook_pre_tool_emits_reminder.harn
+++ b/conformance/tests/hooks_session/hook_pre_tool_emits_reminder.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn pre_hook_tools() {
   let registry = tool_registry()
   return tool_define(
@@ -16,26 +18,31 @@ pipeline main() {
       pre: { _event -> return {reminder: {body: "pre tool reminder", tags: ["pre"], dedupe_key: "pre-hook"}} },
     },
   )
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "pre_tool_1", name: "pre_hook_tool", arguments: {}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "call the pre-hook tool",
-    nil,
-    {
-      provider: "mock",
-      tools: pre_hook_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      loop_until_done: true,
-      session_id: "hook-pre-tool-emits-reminder",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "pre_tool_1", name: "pre_hook_tool", arguments: {}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "call the pre-hook tool",
+        nil,
+        {
+          provider: "mock",
+          tools: pre_hook_tools(),
+          tool_format: "native",
+          max_iterations: 2,
+          loop_until_done: true,
+          session_id: "hook-pre-tool-emits-reminder",
+        },
+      )
+      let events = transcript_events_by_kind(result.transcript, "system_reminder")
+      __io_println(result.status)
+      __io_println(len(events))
+      __io_println(events[0].reminder.body)
+      __io_println(events[0].reminder.tags[0])
+      __io_println(events[0].reminder.source)
+      clear_tool_hooks()
     },
   )
-  let events = transcript_events_by_kind(result.transcript, "system_reminder")
-  __io_println(result.status)
-  __io_println(len(events))
-  __io_println(events[0].reminder.body)
-  __io_println(events[0].reminder.tags[0])
-  __io_println(events[0].reminder.source)
-  clear_tool_hooks()
 }

--- a/conformance/tests/hooks_session/permission_asked_decision.harn
+++ b/conformance/tests/hooks_session/permission_asked_decision.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `permission_asked` hooks can short-circuit the dynamic permission
  * policy by returning a `{decision: "allow"|"deny", reason}` dict.
@@ -35,21 +37,23 @@ pipeline default() {
       return nil
     },
   )
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "call_1", name: "guarded_tool", arguments: {}}]})
-  llm_mock({text: "done"})
-  let result = agent_loop(
-    "use guarded tool",
-    nil,
-    {
-      provider: "mock",
-      tools: make_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      permissions: {deny: ["guarded_tool"], on_escalation: { _req -> return false }},
+  with_llm_script(
+    [{tool_calls: [{id: "call_1", name: "guarded_tool", arguments: {}}]}, llm_text("done")],
+    { ->
+      let result = agent_loop(
+        "use guarded tool",
+        nil,
+        {
+          provider: "mock",
+          tools: make_tools(),
+          tool_format: "native",
+          max_iterations: 2,
+          permissions: {deny: ["guarded_tool"], on_escalation: { _req -> return false }},
+        },
+      )
+      __io_println(result.status)
+      __io_println(atomic_get(replies))
+      clear_session_hooks()
     },
   )
-  __io_println(result.status)
-  __io_println(atomic_get(replies))
-  clear_session_hooks()
 }

--- a/conformance/tests/hooks_session/post_turn.harn
+++ b/conformance/tests/hooks_session/post_turn.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `post_turn` hooks fire after a model/tool turn has been recorded and
  * before post-turn control logic decides whether the loop should continue.
@@ -18,10 +20,13 @@ pipeline default() {
       return nil
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let result = agent_loop("hi", nil, {provider: "mock"})
-  __io_println(result.status)
-  __io_println(atomic_get(post_seen))
-  clear_session_hooks()
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let result = agent_loop("hi", nil, {provider: "mock"})
+      __io_println(result.status)
+      __io_println(atomic_get(post_seen))
+      clear_session_hooks()
+    },
+  )
 }

--- a/conformance/tests/hooks_session/pre_post_compact.harn
+++ b/conformance/tests/hooks_session/pre_post_compact.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `pre_compact` hooks can veto an autocompaction pass with
  * `{block: true}`. `post_compact` hooks observe the archived-message
@@ -33,23 +35,25 @@ pipeline default() {
   )
   // Force compaction with a hostile threshold so the autocompactor
   // tries to compress even with a tiny transcript.
-  llm_mock_clear()
-  llm_mock({text: "round one"})
-  llm_mock({text: "round two"})
-  let result = agent_loop(
-    "compact me",
-    nil,
-    {
-      provider: "mock",
-      loop_until_done: true,
-      max_iterations: 2,
-      compaction: {strategy: "observation_mask"},
-      compact_threshold: 1,
-      compact_keep_last: 0,
+  with_llm_script(
+    [llm_text("round one"), llm_text("round two")],
+    { ->
+      let result = agent_loop(
+        "compact me",
+        nil,
+        {
+          provider: "mock",
+          loop_until_done: true,
+          max_iterations: 2,
+          compaction: {strategy: "observation_mask"},
+          compact_threshold: 1,
+          compact_keep_last: 0,
+        },
+      )
+      __io_println(result.status)
+      __io_println(atomic_get(pre_seen))
+      __io_println(atomic_get(post_seen))
+      clear_session_hooks()
     },
   )
-  __io_println(result.status)
-  __io_println(atomic_get(pre_seen))
-  __io_println(atomic_get(post_seen))
-  clear_session_hooks()
 }

--- a/conformance/tests/hooks_session/session_idle.harn
+++ b/conformance/tests/hooks_session/session_idle.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `session_idle` hooks fire whenever the daemon-mode loop enters an
  * idle wait. Advisory only: the hook can observe iteration count and
@@ -17,15 +19,17 @@ pipeline default() {
       return nil
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "tick"})
-  llm_mock({text: "tock"})
-  let result = agent_loop(
-    "poll background",
-    nil,
-    {provider: "mock", daemon: true, max_iterations: 2, wake_interval_ms: 1},
+  with_llm_script(
+    [llm_text("tick"), llm_text("tock")],
+    { ->
+      let result = agent_loop(
+        "poll background",
+        nil,
+        {provider: "mock", daemon: true, max_iterations: 2, wake_interval_ms: 1},
+      )
+      __io_println(result.status)
+      __io_println(atomic_get(idle_seen) >= 1)
+      clear_session_hooks()
+    },
   )
-  __io_println(result.status)
-  __io_println(atomic_get(idle_seen) >= 1)
-  clear_session_hooks()
 }

--- a/conformance/tests/hooks_session/session_start_end.harn
+++ b/conformance/tests/hooks_session/session_start_end.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * SessionStart and SessionEnd hooks fire around an agent loop, can
  * observe the session id, and run in registration order.
@@ -24,10 +26,13 @@ pipeline default() {
       return nil
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let result = agent_loop("hi", nil, {provider: "mock"})
-  __io_println(result.status)
-  __io_println(atomic_get(observed))
-  clear_session_hooks()
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let result = agent_loop("hi", nil, {provider: "mock"})
+      __io_println(result.status)
+      __io_println(atomic_get(observed))
+      clear_session_hooks()
+    },
+  )
 }

--- a/conformance/tests/hooks_session/tape_capture.harn
+++ b/conformance/tests/hooks_session/tape_capture.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Hook invocations capture deterministic tape entries on the transcript:
  * `hook_call` before the closure runs, `hook_returned` after, and a
@@ -28,13 +30,16 @@ pipeline default() {
     },
   )
   register_session_hook("session_start", { _event -> return nil })
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let result = agent_loop("hello vetome please", nil, {provider: "mock"})
-  let events = transcript_events(result?.transcript)
-  __io_println(result.status)
-  __io_println(count_kind(events, "hook_call") > 0)
-  __io_println(count_kind(events, "hook_returned") > 0)
-  __io_println(count_kind(events, "hook_vetoed") > 0)
-  clear_session_hooks()
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let result = agent_loop("hello vetome please", nil, {provider: "mock"})
+      let events = transcript_events(result?.transcript)
+      __io_println(result.status)
+      __io_println(count_kind(events, "hook_call") > 0)
+      __io_println(count_kind(events, "hook_returned") > 0)
+      __io_println(count_kind(events, "hook_vetoed") > 0)
+      clear_session_hooks()
+    },
+  )
 }

--- a/conformance/tests/hooks_session/user_prompt_submit_veto.harn
+++ b/conformance/tests/hooks_session/user_prompt_submit_veto.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `user_prompt_submit` hooks can veto an agent turn before the agent sees
  * the prompt. A `{block: true, reason}` return short-circuits init and
@@ -15,15 +17,21 @@ pipeline default() {
       return nil
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "should not run"})
-  let blocked = agent_loop("share the secret password", nil, {provider: "mock"})
-  __io_println(blocked.status)
-  __io_println(blocked.stop_reason)
-  __io_println(blocked.error.reason)
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let allowed = agent_loop("hello world", nil, {provider: "mock"})
-  __io_println(allowed.status)
-  clear_session_hooks()
+  with_llm_script(
+    [llm_text("should not run")],
+    { ->
+      let blocked = agent_loop("share the secret password", nil, {provider: "mock"})
+      __io_println(blocked.status)
+      __io_println(blocked.stop_reason)
+      __io_println(blocked.error.reason)
+    },
+  )
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let allowed = agent_loop("hello world", nil, {provider: "mock"})
+      __io_println(allowed.status)
+      clear_session_hooks()
+    },
+  )
 }

--- a/conformance/tests/jsonrpc_batch_validation.harn
+++ b/conformance/tests/jsonrpc_batch_validation.harn
@@ -1,3 +1,5 @@
+import { assert_error_contains } from "std/testing"
+
 /**
  * `jsonrpc_batch` is HTTP-bound, so we can't exercise the round-trip
  * in a hermetic conformance test. Instead this fixture nails down
@@ -8,32 +10,20 @@
  * paths against a synthetic envelope.
  */
 pipeline test(task) {
-  let url_result = try {
-    jsonrpc_batch("", [{method: "ping"}])
-  }
-  assert_eq(is_err(url_result), true, "empty url is rejected")
-  assert_eq(
-    contains(to_string(unwrap_err(url_result)), "url is required"),
-    true,
-    "url-required error surfaces verbatim",
+  assert_error_contains(
+    { -> jsonrpc_batch("", [{method: "ping"}]) },
+    "url is required",
+    "empty url is rejected",
   )
-  let empty_calls = try {
-    jsonrpc_batch("http://example.invalid/rpc", [])
-  }
-  assert_eq(is_err(empty_calls), true, "empty calls is rejected")
-  assert_eq(
-    contains(to_string(unwrap_err(empty_calls)), "calls list cannot be empty"),
-    true,
-    "empty-list error surfaces verbatim",
+  assert_error_contains(
+    { -> jsonrpc_batch("http://example.invalid/rpc", []) },
+    "calls list cannot be empty",
+    "empty calls is rejected",
   )
-  let bad_call = try {
-    jsonrpc_batch("http://example.invalid/rpc", [{params: [1, 2]}])
-  }
-  assert_eq(is_err(bad_call), true, "missing method is rejected")
-  assert_eq(
-    contains(to_string(unwrap_err(bad_call)), "missing 'method'"),
-    true,
-    "missing-method error surfaces verbatim",
+  assert_error_contains(
+    { -> jsonrpc_batch("http://example.invalid/rpc", [{params: [1, 2]}]) },
+    "missing 'method'",
+    "missing method is rejected",
   )
   log("jsonrpc_batch validation: all tests passed")
 }

--- a/conformance/tests/llm_routing/basic.harn
+++ b/conformance/tests/llm_routing/basic.harn
@@ -1,16 +1,21 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Basic routing_policy smoke test: a single-link chain should run
  * through the new executor and surface the routing block on the
  * envelope.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "hello from primary", model: "mock", provider: "mock"})
-  let policy = routing_policy({chain: [{provider: "mock", model: "mock"}], label: "smoke"})
-  let result = llm_call("hi", nil, {routing: policy})
-  __io_println(result.text)
-  __io_println(result.routing.policy)
-  __io_println(result.routing.attempts[0].provider)
-  __io_println(result.routing.attempts[0].status)
-  __io_println(result.routing.selected)
+  with_llm_script(
+    [{text: "hello from primary", model: "mock", provider: "mock"}],
+    { ->
+      let policy = routing_policy({chain: [{provider: "mock", model: "mock"}], label: "smoke"})
+      let result = llm_call("hi", nil, {routing: policy})
+      __io_println(result.text)
+      __io_println(result.routing.policy)
+      __io_println(result.routing.attempts[0].provider)
+      __io_println(result.routing.attempts[0].status)
+      __io_println(result.routing.selected)
+    },
+  )
 }

--- a/conformance/tests/llm_routing/budget_abort.harn
+++ b/conformance/tests/llm_routing/budget_abort.harn
@@ -1,24 +1,29 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Per-call budget cap with on_exceed=abort: the projection sees
  * 100k output tokens at catalog pricing well above the $0.0001 cap,
  * so the chain aborts before any provider call.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "should never reach the provider", model: "gpt-4o-mini", provider: "openai"})
-  let policy = routing_policy(
-    {
-      chain: [{provider: "openai", model: "gpt-4o-mini"}],
-      budget: {per_call_usd: 0.000001, on_exceed: "abort"},
-      label: "tight-budget",
+  with_llm_script(
+    [{text: "should never reach the provider", model: "gpt-4o-mini", provider: "openai"}],
+    { ->
+      let policy = routing_policy(
+        {
+          chain: [{provider: "openai", model: "gpt-4o-mini"}],
+          budget: {per_call_usd: 0.000001, on_exceed: "abort"},
+          label: "tight-budget",
+        },
+      )
+      let result = try {
+        llm_call("hi", nil, {routing: policy, max_tokens: 100000})
+      } catch (e) {
+        {caught: true, category: e.category, limit: e.limit}
+      }
+      __io_println(result.caught)
+      __io_println(result.category)
+      __io_println(result.limit)
     },
   )
-  let result = try {
-    llm_call("hi", nil, {routing: policy, max_tokens: 100000})
-  } catch (e) {
-    {caught: true, category: e.category, limit: e.limit}
-  }
-  __io_println(result.caught)
-  __io_println(result.category)
-  __io_println(result.limit)
 }

--- a/conformance/tests/llm_routing/budget_skip.harn
+++ b/conformance/tests/llm_routing/budget_skip.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Per-call budget with on_exceed=skip: the first (expensive) link
  * is skipped before the provider call, and the chain advances to a
@@ -5,25 +7,28 @@
  * skipped link and the winning attempt.
  */
 pipeline test(task) {
-  llm_mock_clear()
   // Only the cheap link should actually call the mock.
-  llm_mock({text: "cheap won", model: "gpt-4o-mini", provider: "openai"})
-  let policy = routing_policy(
-    {
-      chain: [
-        {provider: "anthropic", model: "claude-opus-4-20250514", label: "expensive"},
-        {provider: "openai", model: "gpt-4o-mini", label: "cheap"},
-      ],
-      budget: {per_call_usd: 0.01, on_exceed: "skip"},
-      label: "skip-expensive",
+  with_llm_script(
+    [{text: "cheap won", model: "gpt-4o-mini", provider: "openai"}],
+    { ->
+      let policy = routing_policy(
+        {
+          chain: [
+            {provider: "anthropic", model: "claude-opus-4-20250514", label: "expensive"},
+            {provider: "openai", model: "gpt-4o-mini", label: "cheap"},
+          ],
+          budget: {per_call_usd: 0.01, on_exceed: "skip"},
+          label: "skip-expensive",
+        },
+      )
+      let result = llm_call("hi", nil, {routing: policy, max_tokens: 2000})
+      __io_println(result.text)
+      let attempts = result.routing.attempts
+      __io_println(len(attempts))
+      __io_println(attempts[0].label)
+      __io_println(attempts[0].status)
+      __io_println(attempts[1].label)
+      __io_println(attempts[1].status)
     },
   )
-  let result = llm_call("hi", nil, {routing: policy, max_tokens: 2000})
-  __io_println(result.text)
-  let attempts = result.routing.attempts
-  __io_println(len(attempts))
-  __io_println(attempts[0].label)
-  __io_println(attempts[0].status)
-  __io_println(attempts[1].label)
-  __io_println(attempts[1].status)
 }

--- a/conformance/tests/llm_routing/failover.harn
+++ b/conformance/tests/llm_routing/failover.harn
@@ -1,37 +1,42 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Failover: the first link returns a 429 rate_limit error, the
  * second link succeeds. The chain should advance and the envelope
  * should surface both attempts.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock(
-    {
-      error: {category: "rate_limit", message: "HTTP 429 rate limit", retry_after_ms: 100},
-      model: "mock",
-      provider: "mock",
+  with_llm_script(
+    [
+      {
+        error: {category: "rate_limit", message: "HTTP 429 rate limit", retry_after_ms: 100},
+        model: "mock",
+        provider: "mock",
+      },
+      {text: "second link won", model: "mock-strong", provider: "mock"},
+    ],
+    { ->
+      let policy = routing_policy(
+        {
+          chain: [
+            {provider: "mock", model: "mock", label: "cheap"},
+            {provider: "mock", model: "mock-strong", label: "frontier"},
+          ],
+          failover: {on_status: [429, 500, 502, 503], max_attempts: 3},
+          label: "cheap-then-frontier",
+        },
+      )
+      let result = llm_call("hi", nil, {routing: policy})
+      __io_println(result.text)
+      __io_println(result.routing.policy)
+      let attempts = result.routing.attempts
+      __io_println(len(attempts))
+      __io_println(attempts[0].label)
+      __io_println(attempts[0].status)
+      __io_println(attempts[0].error.category)
+      __io_println(attempts[1].label)
+      __io_println(attempts[1].status)
+      __io_println(result.routing.selected)
     },
   )
-  llm_mock({text: "second link won", model: "mock-strong", provider: "mock"})
-  let policy = routing_policy(
-    {
-      chain: [
-        {provider: "mock", model: "mock", label: "cheap"},
-        {provider: "mock", model: "mock-strong", label: "frontier"},
-      ],
-      failover: {on_status: [429, 500, 502, 503], max_attempts: 3},
-      label: "cheap-then-frontier",
-    },
-  )
-  let result = llm_call("hi", nil, {routing: policy})
-  __io_println(result.text)
-  __io_println(result.routing.policy)
-  let attempts = result.routing.attempts
-  __io_println(len(attempts))
-  __io_println(attempts[0].label)
-  __io_println(attempts[0].status)
-  __io_println(attempts[0].error.category)
-  __io_println(attempts[1].label)
-  __io_println(attempts[1].status)
-  __io_println(result.routing.selected)
 }

--- a/conformance/tests/llm_routing/non_failover_error_stops_chain.harn
+++ b/conformance/tests/llm_routing/non_failover_error_stops_chain.harn
@@ -1,27 +1,34 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * A non-failover error (e.g. schema_validation) should stop the chain
  * immediately even when later links would succeed — failover rules
  * own the predicate that determines retryable categories.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({error: {category: "auth", message: "missing API key"}, model: "mock", provider: "mock"})
-  llm_mock({text: "would never run", model: "mock", provider: "mock"})
-  let policy = routing_policy(
-    {
-      chain: [
-        {provider: "mock", model: "mock", label: "cheap"},
-        {provider: "mock", model: "mock-strong", label: "frontier"},
-      ],
-      failover: {on_status: [429], on_error_kinds: ["rate_limit"]},
-      label: "narrow-failover",
+  with_llm_script(
+    [
+      {error: {category: "auth", message: "missing API key"}, model: "mock", provider: "mock"},
+      {text: "would never run", model: "mock", provider: "mock"},
+    ],
+    { ->
+      let policy = routing_policy(
+        {
+          chain: [
+            {provider: "mock", model: "mock", label: "cheap"},
+            {provider: "mock", model: "mock-strong", label: "frontier"},
+          ],
+          failover: {on_status: [429], on_error_kinds: ["rate_limit"]},
+          label: "narrow-failover",
+        },
+      )
+      let envelope = try {
+        llm_call("hi", nil, {routing: policy})
+      } catch (e) {
+        {error_caught: true, category: e.category}
+      }
+      __io_println(envelope.error_caught)
+      __io_println(envelope.category)
     },
   )
-  let envelope = try {
-    llm_call("hi", nil, {routing: policy})
-  } catch (e) {
-    {error_caught: true, category: e.category}
-  }
-  __io_println(envelope.error_caught)
-  __io_println(envelope.category)
 }

--- a/conformance/tests/llm_routing/verifier_escalate.harn
+++ b/conformance/tests/llm_routing/verifier_escalate.harn
@@ -1,35 +1,42 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Verifier-signal escalation: the cheap link returns text containing a
  * forbidden pattern, so the lint verifier escalates to the frontier
  * link. The frontier candidate passes verification and is returned.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "answer: TODO finish later", model: "mock", provider: "mock"})
-  llm_mock({text: "answer: 42", model: "mock-strong", provider: "mock"})
-  let policy = routing_policy(
-    {
-      chain: [
-        {provider: "mock", model: "mock", label: "cheap"},
-        {provider: "mock", model: "mock-strong", label: "frontier"},
-      ],
-      escalate_on: [{kind: "lint", forbidden_patterns: ["TODO"], on_fail: "escalate"}],
-      label: "verifier-escalate",
+  with_llm_script(
+    [
+      {text: "answer: TODO finish later", model: "mock", provider: "mock"},
+      {text: "answer: 42", model: "mock-strong", provider: "mock"},
+    ],
+    { ->
+      let policy = routing_policy(
+        {
+          chain: [
+            {provider: "mock", model: "mock", label: "cheap"},
+            {provider: "mock", model: "mock-strong", label: "frontier"},
+          ],
+          escalate_on: [{kind: "lint", forbidden_patterns: ["TODO"], on_fail: "escalate"}],
+          label: "verifier-escalate",
+        },
+      )
+      let result = llm_call("question", nil, {routing: policy})
+      __io_println(result.text)
+      let attempts = result.routing.attempts
+      __io_println(len(attempts))
+      __io_println(attempts[0].label)
+      __io_println(attempts[0].verifier_outcome)
+      __io_println(attempts[0].verifier_signals[0].kind)
+      __io_println(attempts[0].verifier_signals[0].signal)
+      __io_println(attempts[1].label)
+      __io_println(attempts[1].verifier_outcome)
+      __io_println(result.routing.selected)
+      __io_println(to_string(attempts[0].input_tokens > 0))
+      __io_println(to_string(attempts[1].output_tokens > 0))
     },
   )
-  let result = llm_call("question", nil, {routing: policy})
-  __io_println(result.text)
-  let attempts = result.routing.attempts
-  __io_println(len(attempts))
-  __io_println(attempts[0].label)
-  __io_println(attempts[0].verifier_outcome)
-  __io_println(attempts[0].verifier_signals[0].kind)
-  __io_println(attempts[0].verifier_signals[0].signal)
-  __io_println(attempts[1].label)
-  __io_println(attempts[1].verifier_outcome)
-  __io_println(result.routing.selected)
-  // Per-attempt token counts now ride on the trace so downstream graders
-  // can re-cost against alternate pricing tables.
-  __io_println(to_string(attempts[0].input_tokens > 0))
-  __io_println(to_string(attempts[1].output_tokens > 0))
 }
+// Per-attempt token counts now ride on the trace so downstream graders
+// can re-cost against alternate pricing tables.

--- a/conformance/tests/llm_routing/verifier_refine.harn
+++ b/conformance/tests/llm_routing/verifier_refine.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Verifier-signal refine: the first attempt has a forbidden pattern,
  * the lint verifier asks the router to retry the same link with a
@@ -5,21 +7,26 @@
  * Both attempts must show up on the routing trace.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "use unwrap() here", model: "mock", provider: "mock"})
-  llm_mock({text: "use match instead", model: "mock", provider: "mock"})
-  let policy = routing_policy(
-    {
-      chain: [{provider: "mock", model: "mock", label: "cheap"}],
-      escalate_on: [{kind: "lint", forbidden_patterns: ["unwrap"], on_fail: "refine"}],
-      label: "verifier-refine",
+  with_llm_script(
+    [
+      {text: "use unwrap() here", model: "mock", provider: "mock"},
+      {text: "use match instead", model: "mock", provider: "mock"},
+    ],
+    { ->
+      let policy = routing_policy(
+        {
+          chain: [{provider: "mock", model: "mock", label: "cheap"}],
+          escalate_on: [{kind: "lint", forbidden_patterns: ["unwrap"], on_fail: "refine"}],
+          label: "verifier-refine",
+        },
+      )
+      let result = llm_call("question", nil, {routing: policy})
+      __io_println(result.text)
+      let attempts = result.routing.attempts
+      __io_println(len(attempts))
+      __io_println(attempts[0].verifier_outcome)
+      __io_println(attempts[1].verifier_outcome)
+      __io_println(result.routing.selected)
     },
   )
-  let result = llm_call("question", nil, {routing: policy})
-  __io_println(result.text)
-  let attempts = result.routing.attempts
-  __io_println(len(attempts))
-  __io_println(attempts[0].verifier_outcome)
-  __io_println(attempts[1].verifier_outcome)
-  __io_println(result.routing.selected)
 }

--- a/conformance/tests/reminders/reminder_lifecycle_inherited.harn
+++ b/conformance/tests/reminders/reminder_lifecycle_inherited.harn
@@ -1,55 +1,60 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline main() {
   let topic = "transcript.reminder.lifecycle"
   let child = "reminder-lifecycle-inherited-child"
   agent_session_open(child)
   agent_session_reset(child)
   let cursor = event_log.latest(topic)
-  llm_mock_clear()
-  llm_mock({text: "child done"})
-  sub_agent_run(
-    "Child task.",
-    {
-      provider: "mock",
-      model: "mock",
-      session_id: child,
-      max_iterations: 1,
-      done_judge: nil,
-      reminder_propagation: [
+  with_llm_script(
+    [llm_text("child done")],
+    { ->
+      sub_agent_run(
+        "Child task.",
         {
-          id: "inherited-reminder-1",
-          tags: ["handoff"],
-          dedupe_key: "handoff-reminder",
-          ttl_turns: 2,
-          preserve_on_compact: false,
-          propagate: "all",
-          role_hint: "system",
-          source: "inherited",
-          body: "Carry parent context.",
-          fired_at_turn: 0,
-          originating_agent_id: "parent-agent",
+          provider: "mock",
+          model: "mock",
+          session_id: child,
+          max_iterations: 1,
+          done_judge: nil,
+          reminder_propagation: [
+            {
+              id: "inherited-reminder-1",
+              tags: ["handoff"],
+              dedupe_key: "handoff-reminder",
+              ttl_turns: 2,
+              preserve_on_compact: false,
+              propagate: "all",
+              role_hint: "system",
+              source: "inherited",
+              body: "Carry parent context.",
+              fired_at_turn: 0,
+              originating_agent_id: "parent-agent",
+            },
+          ],
         },
-      ],
+      )
+      let stream = event_log
+        .subscribe({topic: topic, from_cursor: cursor, kind_prefix: "transcript.reminder."})
+      fn next_reminder_event(source) {
+        var event = source.next().value
+        while event != nil && event.kind == "transcript.reminder.provider_evaluated" {
+          event = source.next().value
+        }
+        return event
+      }
+      let injected = next_reminder_event(stream)
+      let inherited = next_reminder_event(stream)
+      let fired = next_reminder_event(stream)
+      __io_println(injected.kind)
+      __io_println(injected.payload.reminder_id)
+      __io_println(inherited.kind)
+      __io_println(inherited.payload.originating_agent_id)
+      __io_println(inherited.payload.sub_agent_id)
+      __io_println(inherited.payload.propagate)
+      __io_println(fired.kind)
+      __io_println(fired.payload.session_id == child)
+      __io_println(fired.payload.rendered_role)
     },
   )
-  let stream = event_log
-    .subscribe({topic: topic, from_cursor: cursor, kind_prefix: "transcript.reminder."})
-  fn next_reminder_event(source) {
-    var event = source.next().value
-    while event != nil && event.kind == "transcript.reminder.provider_evaluated" {
-      event = source.next().value
-    }
-    return event
-  }
-  let injected = next_reminder_event(stream)
-  let inherited = next_reminder_event(stream)
-  let fired = next_reminder_event(stream)
-  __io_println(injected.kind)
-  __io_println(injected.payload.reminder_id)
-  __io_println(inherited.kind)
-  __io_println(inherited.payload.originating_agent_id)
-  __io_println(inherited.payload.sub_agent_id)
-  __io_println(inherited.payload.propagate)
-  __io_println(fired.kind)
-  __io_println(fired.payload.session_id == child)
-  __io_println(fired.payload.rendered_role)
 }

--- a/conformance/tests/reminders/reminder_lifecycle_provider_fire_drop.harn
+++ b/conformance/tests/reminders/reminder_lifecycle_provider_fire_drop.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   clear_reminder_providers()
@@ -38,75 +39,76 @@ pipeline main() {
       },
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    nil,
-    {
-      provider: "mock",
-      model: "o3",
-      messages: agent_session_messages(session),
-      session_id: session,
-      _iteration: 4,
+  with_llm_script(
+    [llm_text("ok"), llm_text("ok"), llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        nil,
+        {
+          provider: "mock",
+          model: "o3",
+          messages: agent_session_messages(session),
+          session_id: session,
+          _iteration: 4,
+        },
+      )
+      agent_session_reset(session)
+      agent_session_inject(
+        session,
+        {
+          id: "bad-reminder-event",
+          kind: "system_reminder",
+          role: "system",
+          visibility: "public",
+          text: "bad",
+          reminder: {id: "bad-reminder"},
+        },
+      )
+      llm_call("ignored", nil, {provider: "mock", model: "o3", session_id: session})
+      let after_first_drop = event_log.latest(topic)
+      llm_call("ignored", nil, {provider: "mock", model: "o3", session_id: session})
+      let drop_was_one_shot = event_log.latest(topic) == after_first_drop
+      let validation_session = agent_session_open("reminder-lifecycle-validation-no-fire")
+      agent_session_reset(validation_session)
+      agent_session_inject(validation_session, transcript_reminder_event({body: "do not fire"}))
+      let validation_cursor = event_log.latest(topic)
+      let rejected = try {
+        llm_call(
+          "ignored",
+          nil,
+          {provider: "mock", model: "o3", session_id: validation_session, transcript: {}},
+        )
+        false
+      } catch (e) {
+        contains(json_stringify(e), "transcript")
+      }
+      let validation_did_not_fire = event_log.latest(topic) == validation_cursor
+      let stream = event_log
+        .subscribe({topic: topic, from_cursor: cursor, kind_prefix: "transcript.reminder."})
+      let evaluated = stream.next().value
+      let injected = stream.next().value
+      let fired = stream.next().value
+      let dropped = stream.next().value
+      __io_println(report.fired_count)
+      __io_println(evaluated.kind)
+      __io_println(evaluated.payload.provider_id)
+      __io_println(evaluated.payload.event)
+      __io_println(evaluated.payload.fired)
+      __io_println(injected.kind)
+      __io_println(injected.payload.source)
+      __io_println(fired.kind)
+      __io_println(fired.payload.session_id == session)
+      __io_println(fired.payload.turn_number)
+      __io_println(fired.payload.rendered_role)
+      __io_println(dropped.kind)
+      __io_println(dropped.payload.session_id == session)
+      __io_println(dropped.payload.reminder_id)
+      __io_println(dropped.payload.reason)
+      __io_println(drop_was_one_shot)
+      __io_println(rejected)
+      __io_println(validation_did_not_fire)
+      clear_reminder_providers()
     },
   )
-  agent_session_reset(session)
-  agent_session_inject(
-    session,
-    {
-      id: "bad-reminder-event",
-      kind: "system_reminder",
-      role: "system",
-      visibility: "public",
-      text: "bad",
-      reminder: {id: "bad-reminder"},
-    },
-  )
-  llm_mock({text: "ok"})
-  llm_call("ignored", nil, {provider: "mock", model: "o3", session_id: session})
-  let after_first_drop = event_log.latest(topic)
-  llm_mock({text: "ok"})
-  llm_call("ignored", nil, {provider: "mock", model: "o3", session_id: session})
-  let drop_was_one_shot = event_log.latest(topic) == after_first_drop
-  let validation_session = agent_session_open("reminder-lifecycle-validation-no-fire")
-  agent_session_reset(validation_session)
-  agent_session_inject(validation_session, transcript_reminder_event({body: "do not fire"}))
-  let validation_cursor = event_log.latest(topic)
-  let rejected = try {
-    llm_call(
-      "ignored",
-      nil,
-      {provider: "mock", model: "o3", session_id: validation_session, transcript: {}},
-    )
-    false
-  } catch (e) {
-    contains(json_stringify(e), "transcript")
-  }
-  let validation_did_not_fire = event_log.latest(topic) == validation_cursor
-  let stream = event_log
-    .subscribe({topic: topic, from_cursor: cursor, kind_prefix: "transcript.reminder."})
-  let evaluated = stream.next().value
-  let injected = stream.next().value
-  let fired = stream.next().value
-  let dropped = stream.next().value
-  __io_println(report.fired_count)
-  __io_println(evaluated.kind)
-  __io_println(evaluated.payload.provider_id)
-  __io_println(evaluated.payload.event)
-  __io_println(evaluated.payload.fired)
-  __io_println(injected.kind)
-  __io_println(injected.payload.source)
-  __io_println(fired.kind)
-  __io_println(fired.payload.session_id == session)
-  __io_println(fired.payload.turn_number)
-  __io_println(fired.payload.rendered_role)
-  __io_println(dropped.kind)
-  __io_println(dropped.payload.session_id == session)
-  __io_println(dropped.payload.reminder_id)
-  __io_println(dropped.payload.reason)
-  __io_println(drop_was_one_shot)
-  __io_println(rejected)
-  __io_println(validation_did_not_fire)
-  clear_reminder_providers()
 }

--- a/conformance/tests/reminders/reminder_propagate_all_subagent.harn
+++ b/conformance/tests/reminders/reminder_propagate_all_subagent.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn grandchild_tools() {
   return tool_registry()
 }
@@ -53,7 +55,6 @@ fn parent_tools(child_session, grandchild_session) {
 }
 
 pipeline main() {
-  llm_mock_clear()
   let parent = agent_session_open("reminder-propagate-all-parent")
   let child = "reminder-propagate-all-child"
   let grandchild = "reminder-propagate-all-grandchild"
@@ -68,33 +69,38 @@ pipeline main() {
       {body: "all reminder", tags: ["all"], dedupe_key: "all-key", propagate: "all"},
     ),
   )
-  llm_mock({tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "child_delegate", name: "delegate_grandchild", arguments: {}}]})
-  llm_mock({text: "grandchild done"})
-  llm_mock({text: "child done"})
-  llm_mock({text: "parent done"})
-  agent_loop(
-    "Run child.",
-    nil,
-    {
-      provider: "mock",
-      session_id: parent,
-      tools: parent_tools(child, grandchild),
-      tool_format: "native",
-      max_iterations: 2,
-      done_judge: nil,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]},
+      {tool_calls: [{id: "child_delegate", name: "delegate_grandchild", arguments: {}}]},
+      llm_text("grandchild done"),
+      llm_text("child done"),
+      llm_text("parent done"),
+    ],
+    { ->
+      agent_loop(
+        "Run child.",
+        nil,
+        {
+          provider: "mock",
+          session_id: parent,
+          tools: parent_tools(child, grandchild),
+          tool_format: "native",
+          max_iterations: 2,
+          done_judge: nil,
+        },
+      )
+      let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
+      let grandchild_reminders = transcript_events_by_kind(agent_session_snapshot(grandchild), "system_reminder")
+      __io_println(len(child_reminders))
+      __io_println(child_reminders[0].reminder.body)
+      __io_println(child_reminders[0].reminder.source)
+      __io_println(child_reminders[0].reminder.originating_agent_id == parent)
+      __io_println(len(grandchild_reminders))
+      __io_println(grandchild_reminders[0].reminder.body)
+      __io_println(grandchild_reminders[0].reminder.source)
+      __io_println(grandchild_reminders[0].reminder.originating_agent_id == parent)
+      __io_println(grandchild_reminders[0].reminder.propagate)
     },
   )
-  let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
-  let grandchild_reminders = transcript_events_by_kind(agent_session_snapshot(grandchild), "system_reminder")
-  __io_println(len(child_reminders))
-  __io_println(child_reminders[0].reminder.body)
-  __io_println(child_reminders[0].reminder.source)
-  __io_println(child_reminders[0].reminder.originating_agent_id == parent)
-  __io_println(len(grandchild_reminders))
-  __io_println(grandchild_reminders[0].reminder.body)
-  __io_println(grandchild_reminders[0].reminder.source)
-  __io_println(grandchild_reminders[0].reminder.originating_agent_id == parent)
-  __io_println(grandchild_reminders[0].reminder.propagate)
-  llm_mock_clear()
 }

--- a/conformance/tests/reminders/reminder_propagate_all_to_subagent.harn
+++ b/conformance/tests/reminders/reminder_propagate_all_to_subagent.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn child_tools() {
   return tool_registry()
 }
@@ -28,7 +30,6 @@ fn parent_tools(child_session) {
 }
 
 pipeline main() {
-  llm_mock_clear()
   let parent = agent_session_open("reminder-propagate-all-to-subagent-parent")
   let child = "reminder-propagate-all-to-subagent-child"
   agent_session_open(child)
@@ -40,25 +41,30 @@ pipeline main() {
       {body: "shared with subagent", tags: ["all"], dedupe_key: "all", propagate: "all"},
     ),
   )
-  llm_mock({tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]})
-  llm_mock({text: "child done"})
-  llm_mock({text: "parent done"})
-  agent_loop(
-    "Run child.",
-    nil,
-    {
-      provider: "mock",
-      session_id: parent,
-      tools: parent_tools(child),
-      tool_format: "native",
-      max_iterations: 2,
-      done_judge: nil,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]},
+      llm_text("child done"),
+      llm_text("parent done"),
+    ],
+    { ->
+      agent_loop(
+        "Run child.",
+        nil,
+        {
+          provider: "mock",
+          session_id: parent,
+          tools: parent_tools(child),
+          tool_format: "native",
+          max_iterations: 2,
+          done_judge: nil,
+        },
+      )
+      let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
+      __io_println(len(child_reminders))
+      __io_println(child_reminders[0].reminder.body)
+      __io_println(child_reminders[0].reminder.propagate)
+      __io_println(child_reminders[0].reminder.originating_agent_id == parent)
     },
   )
-  let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
-  __io_println(len(child_reminders))
-  __io_println(child_reminders[0].reminder.body)
-  __io_println(child_reminders[0].reminder.propagate)
-  __io_println(child_reminders[0].reminder.originating_agent_id == parent)
-  llm_mock_clear()
 }

--- a/conformance/tests/reminders/reminder_propagate_handoff.harn
+++ b/conformance/tests/reminders/reminder_propagate_handoff.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn tools() {
   var registry = tool_registry()
   registry = tool_define(
@@ -35,7 +37,6 @@ fn tools() {
 }
 
 pipeline main() {
-  llm_mock_clear()
   let parent = agent_session_open("reminder-propagate-handoff-parent")
   agent_session_reset(parent)
   agent_session_inject(
@@ -56,19 +57,19 @@ pipeline main() {
       {body: "none reminder", tags: ["none"], dedupe_key: "none-key", propagate: "none"},
     ),
   )
-  llm_mock({tool_calls: [{id: "handoff_call", name: "emit_handoff", arguments: {}}]})
-  llm_mock({text: "done"})
-  agent_loop(
-    "Emit a handoff.",
-    nil,
-    {
-      provider: "mock",
-      session_id: parent,
-      tools: tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      done_judge: nil,
-    },
+  with_llm_script(
+    [{tool_calls: [{id: "handoff_call", name: "emit_handoff", arguments: {}}]}, llm_text("done")],
+    { -> agent_loop(
+      "Emit a handoff.",
+      nil,
+      {
+        provider: "mock",
+        session_id: parent,
+        tools: tools(),
+        tool_format: "native",
+        max_iterations: 2,
+        done_judge: nil,
+      },
+    ) },
   )
-  llm_mock_clear()
 }

--- a/conformance/tests/reminders/reminder_propagate_none_dropped_at_handoff.harn
+++ b/conformance/tests/reminders/reminder_propagate_none_dropped_at_handoff.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn tools() {
   var registry = tool_registry()
   registry = tool_define(
@@ -36,7 +38,6 @@ fn tools() {
 pipeline main() {
   // The handoff envelope must omit propagate=none reminders, keeping
   // only the propagate=all entry.
-  llm_mock_clear()
   let parent = agent_session_open("reminder-propagate-none-dropped-at-handoff")
   agent_session_reset(parent)
   agent_session_inject(
@@ -51,19 +52,19 @@ pipeline main() {
       {body: "dropped at handoff", tags: ["none"], dedupe_key: "none-key", propagate: "none"},
     ),
   )
-  llm_mock({tool_calls: [{id: "handoff_call", name: "emit_handoff", arguments: {}}]})
-  llm_mock({text: "done"})
-  agent_loop(
-    "Emit a handoff.",
-    nil,
-    {
-      provider: "mock",
-      session_id: parent,
-      tools: tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      done_judge: nil,
-    },
+  with_llm_script(
+    [{tool_calls: [{id: "handoff_call", name: "emit_handoff", arguments: {}}]}, llm_text("done")],
+    { -> agent_loop(
+      "Emit a handoff.",
+      nil,
+      {
+        provider: "mock",
+        session_id: parent,
+        tools: tools(),
+        tool_format: "native",
+        max_iterations: 2,
+        done_judge: nil,
+      },
+    ) },
   )
-  llm_mock_clear()
 }

--- a/conformance/tests/reminders/reminder_propagate_none_subagent.harn
+++ b/conformance/tests/reminders/reminder_propagate_none_subagent.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn parent_tools(child_session) {
   var tools = tool_registry()
   tools = tool_define(
@@ -17,7 +19,6 @@ fn parent_tools(child_session) {
 }
 
 pipeline main() {
-  llm_mock_clear()
   let parent = agent_session_open("reminder-propagate-none-parent")
   let child = "reminder-propagate-none-child"
   agent_session_open(child)
@@ -29,22 +30,27 @@ pipeline main() {
       {body: "none reminder", tags: ["none"], dedupe_key: "none-key", propagate: "none"},
     ),
   )
-  llm_mock({tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]})
-  llm_mock({text: "child done"})
-  llm_mock({text: "parent done"})
-  agent_loop(
-    "Run child.",
-    nil,
-    {
-      provider: "mock",
-      session_id: parent,
-      tools: parent_tools(child),
-      tool_format: "native",
-      max_iterations: 2,
-      done_judge: nil,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]},
+      llm_text("child done"),
+      llm_text("parent done"),
+    ],
+    { ->
+      agent_loop(
+        "Run child.",
+        nil,
+        {
+          provider: "mock",
+          session_id: parent,
+          tools: parent_tools(child),
+          tool_format: "native",
+          max_iterations: 2,
+          done_judge: nil,
+        },
+      )
+      let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
+      __io_println(len(child_reminders))
     },
   )
-  let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
-  __io_println(len(child_reminders))
-  llm_mock_clear()
 }

--- a/conformance/tests/reminders/reminder_propagate_session_subagent.harn
+++ b/conformance/tests/reminders/reminder_propagate_session_subagent.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn child_tools(grandchild_session) {
   var tools = tool_registry()
   tools = tool_define(
@@ -42,7 +44,6 @@ fn parent_tools(child_session, grandchild_session) {
 }
 
 pipeline main() {
-  llm_mock_clear()
   let parent = agent_session_open("reminder-propagate-session-parent")
   let child = "reminder-propagate-session-child"
   let grandchild = "reminder-propagate-session-grandchild"
@@ -57,29 +58,34 @@ pipeline main() {
       {body: "session reminder", tags: ["session"], dedupe_key: "session-key", propagate: "session"},
     ),
   )
-  llm_mock({tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "child_delegate", name: "delegate_grandchild", arguments: {}}]})
-  llm_mock({text: "grandchild done"})
-  llm_mock({text: "child done"})
-  llm_mock({text: "parent done"})
-  agent_loop(
-    "Run child.",
-    nil,
-    {
-      provider: "mock",
-      session_id: parent,
-      tools: parent_tools(child, grandchild),
-      tool_format: "native",
-      max_iterations: 2,
-      done_judge: nil,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "parent_delegate", name: "delegate_child", arguments: {}}]},
+      {tool_calls: [{id: "child_delegate", name: "delegate_grandchild", arguments: {}}]},
+      llm_text("grandchild done"),
+      llm_text("child done"),
+      llm_text("parent done"),
+    ],
+    { ->
+      agent_loop(
+        "Run child.",
+        nil,
+        {
+          provider: "mock",
+          session_id: parent,
+          tools: parent_tools(child, grandchild),
+          tool_format: "native",
+          max_iterations: 2,
+          done_judge: nil,
+        },
+      )
+      let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
+      let grandchild_reminders = transcript_events_by_kind(agent_session_snapshot(grandchild), "system_reminder")
+      __io_println(len(child_reminders))
+      __io_println(child_reminders[0].reminder.body)
+      __io_println(child_reminders[0].reminder.source)
+      __io_println(child_reminders[0].reminder.originating_agent_id == parent)
+      __io_println(len(grandchild_reminders))
     },
   )
-  let child_reminders = transcript_events_by_kind(agent_session_snapshot(child), "system_reminder")
-  let grandchild_reminders = transcript_events_by_kind(agent_session_snapshot(grandchild), "system_reminder")
-  __io_println(len(child_reminders))
-  __io_println(child_reminders[0].reminder.body)
-  __io_println(child_reminders[0].reminder.source)
-  __io_println(child_reminders[0].reminder.originating_agent_id == parent)
-  __io_println(len(grandchild_reminders))
-  llm_mock_clear()
 }

--- a/conformance/tests/reminders/reminder_provider_agent_loop_defaults.harn
+++ b/conformance/tests/reminders/reminder_provider_agent_loop_defaults.harn
@@ -1,31 +1,37 @@
+import { with_llm_script } from "std/testing"
+
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({text: "done", input_tokens: 80, output_tokens: 0, model: "mock"})
-  let enabled = agent_loop(
-    "token pressure default",
-    nil,
-    {
-      provider: "mock",
-      model: "mock",
-      session_id: "reminder-provider-loop-defaults-enabled",
-      reminders: {config: {token_pressure: {context_window: 100}}},
+  with_llm_script(
+    [
+      {text: "done", input_tokens: 80, output_tokens: 0, model: "mock"},
+      {text: "done", input_tokens: 80, output_tokens: 0, model: "mock"},
+    ],
+    { ->
+      let enabled = agent_loop(
+        "token pressure default",
+        nil,
+        {
+          provider: "mock",
+          model: "mock",
+          session_id: "reminder-provider-loop-defaults-enabled",
+          reminders: {config: {token_pressure: {context_window: 100}}},
+        },
+      )
+      let enabled_reminders = transcript_events_by_kind(enabled.transcript, "system_reminder")
+      let disabled = agent_loop(
+        "token pressure disabled",
+        nil,
+        {
+          provider: "mock",
+          model: "mock",
+          session_id: "reminder-provider-loop-defaults-disabled",
+          reminders: {providers: ["-token_pressure"], config: {token_pressure: {context_window: 100}}},
+        },
+      )
+      let disabled_reminders = transcript_events_by_kind(disabled.transcript, "system_reminder")
+      __io_println(len(enabled_reminders))
+      __io_println(enabled_reminders[0].reminder.tags[0])
+      __io_println(len(disabled_reminders))
     },
   )
-  let enabled_reminders = transcript_events_by_kind(enabled.transcript, "system_reminder")
-  llm_mock_clear()
-  llm_mock({text: "done", input_tokens: 80, output_tokens: 0, model: "mock"})
-  let disabled = agent_loop(
-    "token pressure disabled",
-    nil,
-    {
-      provider: "mock",
-      model: "mock",
-      session_id: "reminder-provider-loop-defaults-disabled",
-      reminders: {providers: ["-token_pressure"], config: {token_pressure: {context_window: 100}}},
-    },
-  )
-  let disabled_reminders = transcript_events_by_kind(disabled.transcript, "system_reminder")
-  __io_println(len(enabled_reminders))
-  __io_println(enabled_reminders[0].reminder.tags[0])
-  __io_println(len(disabled_reminders))
 }

--- a/conformance/tests/reminders/reminder_provider_compass_opt_in.harn
+++ b/conformance/tests/reminders/reminder_provider_compass_opt_in.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * The burin compass (`compass_ast_edits`) is a canonical reminder
  * provider that ships opt-in: it stays silent unless a session enables it
@@ -5,33 +7,34 @@
  * injects its AST-edit steer at session start.
  */
 pipeline main() {
-  llm_mock_clear()
-  llm_mock({text: "done"})
-  let opted_in = agent_loop(
-    "compass opt-in",
-    nil,
-    {
-      provider: "mock",
-      model: "mock",
-      session_id: "reminder-compass-opt-in",
-      reminders: {providers: ["compass_ast_edits"]},
+  with_llm_script(
+    [llm_text("done")],
+    { ->
+      let opted_in = agent_loop(
+        "compass opt-in",
+        nil,
+        {
+          provider: "mock",
+          model: "mock",
+          session_id: "reminder-compass-opt-in",
+          reminders: {providers: ["compass_ast_edits"]},
+        },
+      )
+      let on = transcript_events_by_kind(opted_in.transcript, "system_reminder")
+        .filter({ e -> e.reminder.tags[0] == "compass_ast_edits" })
+      let default_off = agent_loop(
+        "compass default off",
+        nil,
+        {provider: "mock", model: "mock", session_id: "reminder-compass-default-off"},
+      )
+      let off = transcript_events_by_kind(default_off.transcript, "system_reminder")
+        .filter({ e -> e.reminder.tags[0] == "compass_ast_edits" })
+      __io_println(len(on))
+      __io_println(on[0].reminder.tags[0])
+      __io_println(on[0].reminder.source)
+      __io_println(on[0].reminder.body.contains("edit_apply_node"))
+      __io_println(on[0].reminder.preserve_on_compact)
+      __io_println(len(off))
     },
   )
-  let on = transcript_events_by_kind(opted_in.transcript, "system_reminder")
-    .filter({ e -> e.reminder.tags[0] == "compass_ast_edits" })
-  llm_mock_clear()
-  llm_mock({text: "done"})
-  let default_off = agent_loop(
-    "compass default off",
-    nil,
-    {provider: "mock", model: "mock", session_id: "reminder-compass-default-off"},
-  )
-  let off = transcript_events_by_kind(default_off.transcript, "system_reminder")
-    .filter({ e -> e.reminder.tags[0] == "compass_ast_edits" })
-  __io_println(len(on))
-  __io_println(on[0].reminder.tags[0])
-  __io_println(on[0].reminder.source)
-  __io_println(on[0].reminder.body.contains("edit_apply_node"))
-  __io_println(on[0].reminder.preserve_on_compact)
-  __io_println(len(off))
 }

--- a/conformance/tests/reminders/reminder_provider_tool_output_truncated.harn
+++ b/conformance/tests/reminders/reminder_provider_tool_output_truncated.harn
@@ -3,6 +3,7 @@ import {
   agent_reminder_providers_fire,
   agent_session_apply_reminder_post_turn,
 } from "std/agent/state"
+import { with_llm_script } from "std/testing"
 
 fn truncating_tools() {
   var tools = tool_registry()
@@ -57,39 +58,43 @@ pipeline main() {
   __io_println(same_turn_ttl.expired_count)
   __io_println(len(same_turn_reminders))
   __io_println(same_turn_reminders[0].reminder.ttl_turns)
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "large_loop_1", name: "large_output", arguments: {}}]})
-  let loop_enabled = agent_loop(
-    "call a large tool",
-    nil,
-    {
-      provider: "mock",
-      tools: truncating_tools(),
-      tool_format: "native",
-      max_iterations: 1,
-      done_judge: nil,
-      session_id: "reminder-provider-tool-output-loop-enabled",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "large_loop_1", name: "large_output", arguments: {}}]},
+      {tool_calls: [{id: "large_loop_2", name: "large_output", arguments: {}}]},
+    ],
+    { ->
+      let loop_enabled = agent_loop(
+        "call a large tool",
+        nil,
+        {
+          provider: "mock",
+          tools: truncating_tools(),
+          tool_format: "native",
+          max_iterations: 1,
+          done_judge: nil,
+          session_id: "reminder-provider-tool-output-loop-enabled",
+        },
+      )
+      let loop_enabled_reminders = transcript_events_by_kind(loop_enabled.transcript, "system_reminder")
+      let loop_disabled = agent_loop(
+        "call a large tool",
+        nil,
+        {
+          provider: "mock",
+          tools: truncating_tools(),
+          tool_format: "native",
+          max_iterations: 1,
+          done_judge: nil,
+          session_id: "reminder-provider-tool-output-loop-disabled",
+          reminders: {providers: ["-tool_output_truncated"]},
+        },
+      )
+      let loop_disabled_reminders = transcript_events_by_kind(loop_disabled.transcript, "system_reminder")
+      __io_println(len(loop_enabled_reminders))
+      __io_println(loop_enabled_reminders[0].reminder.tags[0])
+      __io_println(len(loop_disabled_reminders))
+      clear_tool_hooks()
     },
   )
-  let loop_enabled_reminders = transcript_events_by_kind(loop_enabled.transcript, "system_reminder")
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "large_loop_2", name: "large_output", arguments: {}}]})
-  let loop_disabled = agent_loop(
-    "call a large tool",
-    nil,
-    {
-      provider: "mock",
-      tools: truncating_tools(),
-      tool_format: "native",
-      max_iterations: 1,
-      done_judge: nil,
-      session_id: "reminder-provider-tool-output-loop-disabled",
-      reminders: {providers: ["-tool_output_truncated"]},
-    },
-  )
-  let loop_disabled_reminders = transcript_events_by_kind(loop_disabled.transcript, "system_reminder")
-  __io_println(len(loop_enabled_reminders))
-  __io_println(loop_enabled_reminders[0].reminder.tags[0])
-  __io_println(len(loop_disabled_reminders))
-  clear_tool_hooks()
 }

--- a/conformance/tests/reminders/reminder_render_anthropic.harn
+++ b/conformance/tests/reminders/reminder_render_anthropic.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   clear_reminder_providers()
@@ -13,23 +14,26 @@ pipeline main() {
   agent_session_reset(session)
   agent_session_inject(session, {role: "user", content: "hello"})
   agent_reminder_providers_fire(session, "session_idle", {session: {id: session}}, {})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    nil,
-    {
-      provider: "mock",
-      model: "claude-sonnet-4-7",
-      messages: agent_session_messages(session),
-      session_id: session,
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        nil,
+        {
+          provider: "mock",
+          model: "claude-sonnet-4-7",
+          messages: agent_session_messages(session),
+          session_id: session,
+        },
+      )
+      let call = llm_mock_calls()[0]
+      __io_println(call.messages[0].role)
+      __io_println(contains(call.messages[0].content[0].text, "<system-reminder>"))
+      __io_println(contains(call.messages[0].content[0].text, "anthropic reminder"))
+      __io_println(call.messages[0].content[0].cache_control.type)
+      __io_println(call.messages[0].content[1].text)
+      clear_reminder_providers()
     },
   )
-  let call = llm_mock_calls()[0]
-  __io_println(call.messages[0].role)
-  __io_println(contains(call.messages[0].content[0].text, "<system-reminder>"))
-  __io_println(contains(call.messages[0].content[0].text, "anthropic reminder"))
-  __io_println(call.messages[0].content[0].cache_control.type)
-  __io_println(call.messages[0].content[1].text)
-  clear_reminder_providers()
 }

--- a/conformance/tests/reminders/reminder_render_anthropic_ephemeral.harn
+++ b/conformance/tests/reminders/reminder_render_anthropic_ephemeral.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   clear_reminder_providers()
@@ -13,23 +14,26 @@ pipeline main() {
   agent_session_reset(session)
   agent_session_inject(session, {role: "user", content: "hello"})
   agent_reminder_providers_fire(session, "session_idle", {session: {id: session}}, {})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    nil,
-    {
-      provider: "mock",
-      model: "claude-sonnet-4-7",
-      messages: agent_session_messages(session),
-      session_id: session,
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        nil,
+        {
+          provider: "mock",
+          model: "claude-sonnet-4-7",
+          messages: agent_session_messages(session),
+          session_id: session,
+        },
+      )
+      let call = llm_mock_calls()[0]
+      __io_println(call.messages[0].role)
+      __io_println(contains(call.messages[0].content[0].text, "<system-reminder>"))
+      __io_println(contains(call.messages[0].content[0].text, "anthropic ephemeral reminder"))
+      __io_println(call.messages[0].content[0].cache_control.type)
+      clear_reminder_providers()
     },
   )
-  let call = llm_mock_calls()[0]
-  __io_println(call.messages[0].role)
-  __io_println(contains(call.messages[0].content[0].text, "<system-reminder>"))
-  __io_println(contains(call.messages[0].content[0].text, "anthropic ephemeral reminder"))
-  // ephemeral_cache hint sets cache_control.type = "ephemeral".
-  __io_println(call.messages[0].content[0].cache_control.type)
-  clear_reminder_providers()
 }
+// ephemeral_cache hint sets cache_control.type = "ephemeral".

--- a/conformance/tests/reminders/reminder_render_anthropic_user_block.harn
+++ b/conformance/tests/reminders/reminder_render_anthropic_user_block.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   clear_reminder_providers()
@@ -13,24 +14,27 @@ pipeline main() {
   agent_session_reset(session)
   agent_session_inject(session, {role: "user", content: "hello"})
   agent_reminder_providers_fire(session, "session_idle", {session: {id: session}}, {})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    nil,
-    {
-      provider: "mock",
-      model: "claude-sonnet-4-7",
-      messages: agent_session_messages(session),
-      session_id: session,
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        nil,
+        {
+          provider: "mock",
+          model: "claude-sonnet-4-7",
+          messages: agent_session_messages(session),
+          session_id: session,
+        },
+      )
+      let call = llm_mock_calls()[0]
+      __io_println(call.messages[0].role)
+      __io_println(contains(call.messages[0].content[0].text, "<system-reminder>"))
+      __io_println(contains(call.messages[0].content[0].text, "anthropic user block reminder"))
+      __io_println(call.messages[0].content[0].cache_control == nil)
+      __io_println(call.messages[0].content[1].text)
+      clear_reminder_providers()
     },
   )
-  let call = llm_mock_calls()[0]
-  __io_println(call.messages[0].role)
-  __io_println(contains(call.messages[0].content[0].text, "<system-reminder>"))
-  __io_println(contains(call.messages[0].content[0].text, "anthropic user block reminder"))
-  // user_block role hint does NOT request ephemeral caching by itself.
-  __io_println(call.messages[0].content[0].cache_control == nil)
-  __io_println(call.messages[0].content[1].text)
-  clear_reminder_providers()
 }
+// user_block role hint does NOT request ephemeral caching by itself.

--- a/conformance/tests/reminders/reminder_render_gemini_xml.harn
+++ b/conformance/tests/reminders/reminder_render_gemini_xml.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   clear_reminder_providers()
@@ -13,22 +14,25 @@ pipeline main() {
   agent_session_reset(session)
   agent_session_inject(session, {role: "user", content: "hello"})
   agent_reminder_providers_fire(session, "session_idle", {session: {id: session}}, {})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    "base system",
-    {
-      provider: "mock",
-      model: "gemini-2.5-flash",
-      messages: agent_session_messages(session),
-      session_id: session,
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        "base system",
+        {
+          provider: "mock",
+          model: "gemini-2.5-flash",
+          messages: agent_session_messages(session),
+          session_id: session,
+        },
+      )
+      let call = llm_mock_calls()[0]
+      __io_println(contains(call.system, "base system"))
+      __io_println(contains(call.system, "<system-reminder>"))
+      __io_println(contains(call.system, "gemini reminder"))
+      __io_println(call.messages[0].role)
+      clear_reminder_providers()
     },
   )
-  let call = llm_mock_calls()[0]
-  __io_println(contains(call.system, "base system"))
-  __io_println(contains(call.system, "<system-reminder>"))
-  __io_println(contains(call.system, "gemini reminder"))
-  __io_println(call.messages[0].role)
-  clear_reminder_providers()
 }

--- a/conformance/tests/reminders/reminder_render_local.harn
+++ b/conformance/tests/reminders/reminder_render_local.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   clear_reminder_providers()
@@ -13,17 +14,20 @@ pipeline main() {
   agent_session_reset(session)
   agent_session_inject(session, {role: "user", content: "hello"})
   agent_reminder_providers_fire(session, "session_idle", {session: {id: session}}, {})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    "base system",
-    {provider: "mock", model: "mock", messages: agent_session_messages(session), session_id: session},
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        "base system",
+        {provider: "mock", model: "mock", messages: agent_session_messages(session), session_id: session},
+      )
+      let call = llm_mock_calls()[0]
+      __io_println(contains(call.system, "System reminder:"))
+      __io_println(contains(call.system, "local reminder"))
+      __io_println(!contains(call.system, "<system-reminder>"))
+      __io_println(call.messages[0].role)
+      clear_reminder_providers()
+    },
   )
-  let call = llm_mock_calls()[0]
-  __io_println(contains(call.system, "System reminder:"))
-  __io_println(contains(call.system, "local reminder"))
-  __io_println(!contains(call.system, "<system-reminder>"))
-  __io_println(call.messages[0].role)
-  clear_reminder_providers()
 }

--- a/conformance/tests/reminders/reminder_render_local_fallback.harn
+++ b/conformance/tests/reminders/reminder_render_local_fallback.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   // Renders the plain-text fallback used for providers without a richer
@@ -17,18 +18,21 @@ pipeline main() {
   agent_session_reset(session)
   agent_session_inject(session, {role: "user", content: "hello"})
   agent_reminder_providers_fire(session, "session_idle", {session: {id: session}}, {})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    "base system",
-    {provider: "mock", model: "mock", messages: agent_session_messages(session), session_id: session},
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        "base system",
+        {provider: "mock", model: "mock", messages: agent_session_messages(session), session_id: session},
+      )
+      let call = llm_mock_calls()[0]
+      __io_println(contains(call.system, "System reminder:"))
+      __io_println(contains(call.system, "local fallback reminder"))
+      __io_println(!contains(call.system, "<system-reminder>"))
+      __io_println(call.messages[0].role)
+      clear_reminder_providers()
+    },
   )
-  let call = llm_mock_calls()[0]
-  __io_println(contains(call.system, "System reminder:"))
-  __io_println(contains(call.system, "local fallback reminder"))
-  // Local fallback uses plain prose, not XML tags.
-  __io_println(!contains(call.system, "<system-reminder>"))
-  __io_println(call.messages[0].role)
-  clear_reminder_providers()
 }
+// Local fallback uses plain prose, not XML tags.

--- a/conformance/tests/reminders/reminder_render_openai_developer.harn
+++ b/conformance/tests/reminders/reminder_render_openai_developer.harn
@@ -1,4 +1,5 @@
 import { agent_reminder_providers_fire, agent_session_messages } from "std/agent/state"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
   clear_reminder_providers()
@@ -13,17 +14,20 @@ pipeline main() {
   agent_session_reset(session)
   agent_session_inject(session, {role: "user", content: "hello"})
   agent_reminder_providers_fire(session, "session_idle", {session: {id: session}}, {})
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "ignored",
-    nil,
-    {provider: "mock", model: "o3", messages: agent_session_messages(session), session_id: session},
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "ignored",
+        nil,
+        {provider: "mock", model: "o3", messages: agent_session_messages(session), session_id: session},
+      )
+      let call = llm_mock_calls()[0]
+      __io_println(call.messages[0].role)
+      __io_println(contains(call.messages[0].content, "openai reminder"))
+      __io_println(call.messages[1].role)
+      __io_println(call.system == nil || !contains(call.system, "openai reminder"))
+      clear_reminder_providers()
+    },
   )
-  let call = llm_mock_calls()[0]
-  __io_println(call.messages[0].role)
-  __io_println(contains(call.messages[0].content, "openai reminder"))
-  __io_println(call.messages[1].role)
-  __io_println(call.system == nil || !contains(call.system, "openai reminder"))
-  clear_reminder_providers()
 }

--- a/conformance/tests/runtime/command_policy_hooks.harn
+++ b/conformance/tests/runtime/command_policy_hooks.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
   let root = path_join(harness.fs.temp_dir(), "harn_command_policy_hooks")
   if harness.fs.exists(root) {
@@ -50,7 +52,6 @@ pipeline default() {
   )
   assert(contains(approval?.stderr ?? "", "requires approval"), "approval reason is surfaced")
   command_policy_pop()
-  llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
     tools,
@@ -62,28 +63,34 @@ pipeline default() {
       handler: { args -> host_call("process.exec", {mode: "argv", argv: ["sh", "-c", args.command], cwd: root}) },
     },
   )
-  llm_mock({tool_calls: [{id: "run_1", name: "run", arguments: {command: "echo agent-policy-deny"}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let loop = agent_loop(
-    "exercise command policy",
-    nil,
-    {
-      provider: "mock",
-      tools: tools,
-      max_iterations: 2,
-      command_policy: command_policy(policy + {deny_patterns: ["*agent-policy-deny*"]}),
-      session_id: "command-policy-hooks",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "run_1", name: "run", arguments: {command: "echo agent-policy-deny"}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let loop = agent_loop(
+        "exercise command policy",
+        nil,
+        {
+          provider: "mock",
+          tools: tools,
+          max_iterations: 2,
+          command_policy: command_policy(policy + {deny_patterns: ["*agent-policy-deny*"]}),
+          session_id: "command-policy-hooks",
+        },
+      )
+      assert(
+        contains(json_stringify(loop), "status: blocked"),
+        "agent_loop scoped command policy applies to run handlers",
+      )
+      let scan = command_llm_risk_scan(
+        {request: {argv: ["curl", "https://example.invalid/secret"]}},
+        {model: "cheap"},
+      )
+      assert(len(scan?.risk_labels ?? []) > 0, "risk scan helper returns structured labels")
+      harness.fs.delete(root)
+      __io_println("command_policy_hooks_ok")
     },
   )
-  assert(
-    contains(json_stringify(loop), "status: blocked"),
-    "agent_loop scoped command policy applies to run handlers",
-  )
-  let scan = command_llm_risk_scan(
-    {request: {argv: ["curl", "https://example.invalid/secret"]}},
-    {model: "cheap"},
-  )
-  assert(len(scan?.risk_labels ?? []) > 0, "risk scan helper returns structured labels")
-  harness.fs.delete(root)
-  __io_println("command_policy_hooks_ok")
 }

--- a/conformance/tests/scenarios/agent_loop_acp_stop_reason.harn
+++ b/conformance/tests/scenarios/agent_loop_acp_stop_reason.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * agent_loop reports a canonical ACP `stopReason` (end_turn / max_tokens
  * / max_turn_requests / refusal) on its result dict via `acp_stop_reason`.
@@ -7,32 +9,46 @@
  */
 pipeline default() {
   // Natural completion → end_turn.
-  llm_mock_clear()
-  llm_mock({text: "all done"})
-  let normal = agent_loop("hi", nil, {provider: "mock"})
-  __io_println(normal.acp_stop_reason)
-  // Provider truncated the response → max_tokens.
-  llm_mock_clear()
-  llm_mock({text: "truncated", stop_reason: "max_tokens"})
-  let truncated = agent_loop("hi", nil, {provider: "mock"})
-  __io_println(truncated.acp_stop_reason)
-  // OpenAI-style finish_reason "length" maps to the same canonical value.
-  llm_mock_clear()
-  llm_mock({text: "truncated", stop_reason: "length"})
-  let length = agent_loop("hi", nil, {provider: "mock"})
-  __io_println(length.acp_stop_reason)
-  // Anthropic refusal → refusal.
-  llm_mock_clear()
-  llm_mock({text: "I cannot assist with that.", stop_reason: "refusal"})
-  let refused = agent_loop("hi", nil, {provider: "mock"})
-  __io_println(refused.acp_stop_reason)
-  // Iteration cap → max_turn_requests. Persistent + text-only keeps the
-  // loop going until max_iterations, which the loop reports as
-  // budget_exhausted; finalize maps that to max_turn_requests when the
-  // iteration count matches the configured cap.
-  llm_mock_clear()
-  llm_mock({text: "still working"})
-  llm_mock({text: "still working"})
-  let capped = agent_loop("hi", nil, {provider: "mock", loop_until_done: true, max_iterations: 1})
-  __io_println(capped.acp_stop_reason)
+  with_llm_script(
+    [llm_text("all done")],
+    { ->
+      let normal = agent_loop("hi", nil, {provider: "mock"})
+      __io_println(normal.acp_stop_reason)
+    },
+  )
+  with_llm_script(
+    [{text: "truncated", stop_reason: "max_tokens"}],
+    { ->
+      let truncated = agent_loop("hi", nil, {provider: "mock"})
+      __io_println(truncated.acp_stop_reason)
+    },
+  )
+  with_llm_script(
+    [{text: "truncated", stop_reason: "length"}],
+    { ->
+      let length = agent_loop("hi", nil, {provider: "mock"})
+      __io_println(length.acp_stop_reason)
+    },
+  )
+  with_llm_script(
+    [{text: "I cannot assist with that.", stop_reason: "refusal"}],
+    { ->
+      let refused = agent_loop("hi", nil, {provider: "mock"})
+      __io_println(refused.acp_stop_reason)
+    },
+  )
+  with_llm_script(
+    [llm_text("still working"), llm_text("still working")],
+    { ->
+      let capped = agent_loop("hi", nil, {provider: "mock", loop_until_done: true, max_iterations: 1})
+      __io_println(capped.acp_stop_reason)
+    },
+  )
 }
+// Provider truncated the response → max_tokens.
+// OpenAI-style finish_reason "length" maps to the same canonical value.
+// Anthropic refusal → refusal.
+// Iteration cap → max_turn_requests. Persistent + text-only keeps the
+// loop going until max_iterations, which the loop reports as
+// budget_exhausted; finalize maps that to max_turn_requests when the
+// iteration count matches the configured cap.

--- a/conformance/tests/scenarios/agent_loop_llm_caller_default.harn
+++ b/conformance/tests/scenarios/agent_loop_llm_caller_default.harn
@@ -1,12 +1,17 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * agent_loop with no llm_caller routes through __default_invoke_llm and
  * preserves existing behavior — golden parity test.
  */
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "all done"})
-  let result = agent_loop("hi", nil, {provider: "mock"})
-  __io_println(result.status)
-  __io_println(result.visible_text)
-  __io_println(len(llm_mock_calls()))
+  with_llm_script(
+    [llm_text("all done")],
+    { ->
+      let result = agent_loop("hi", nil, {provider: "mock"})
+      __io_println(result.status)
+      __io_println(result.visible_text)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
 }

--- a/conformance/tests/scenarios/agent_loop_llm_caller_middleware.harn
+++ b/conformance/tests/scenarios/agent_loop_llm_caller_middleware.harn
@@ -1,27 +1,31 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * A wrapper closure observes per-turn data via `call.turn` before delegating
  * to the underlying llm_call. We println the observed iteration index so the
  * test asserts the wrapper sees per-turn information.
  */
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "Still working."})
-  llm_mock({text: "Finished. ##DONE##"})
-  let observe_caller = { call ->
-    __io_println("turn=" + to_string(call.turn.iteration) + " attempt=" + to_string(call.turn.attempt))
-    let result = try {
-      llm_call(call.prompt, call.system, call.opts)
-    }
-    if !is_err(result) {
-      return {ok: true, value: unwrap(result)}
-    }
-    return {ok: false, status: "exception", error: unwrap_err(result)}
-  }
-  let result = agent_loop(
-    "finish",
-    nil,
-    {provider: "mock", loop_until_done: true, max_iterations: 2, llm_caller: observe_caller},
+  with_llm_script(
+    [llm_text("Still working."), llm_text("Finished. ##DONE##")],
+    { ->
+      let observe_caller = { call ->
+        __io_println("turn=" + to_string(call.turn.iteration) + " attempt=" + to_string(call.turn.attempt))
+        let result = try {
+          llm_call(call.prompt, call.system, call.opts)
+        }
+        if !is_err(result) {
+          return {ok: true, value: unwrap(result)}
+        }
+        return {ok: false, status: "exception", error: unwrap_err(result)}
+      }
+      let result = agent_loop(
+        "finish",
+        nil,
+        {provider: "mock", loop_until_done: true, max_iterations: 2, llm_caller: observe_caller},
+      )
+      __io_println(result.status)
+      __io_println(result.visible_text)
+    },
   )
-  __io_println(result.status)
-  __io_println(result.visible_text)
 }

--- a/conformance/tests/scenarios/agent_loop_llm_retries_default.harn
+++ b/conformance/tests/scenarios/agent_loop_llm_retries_default.harn
@@ -1,13 +1,20 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
   // The default tool_using profile gives agent_loop two transient retries
   // after the first attempt. This succeeds only if the third mock response
   // is reached.
-  llm_mock({error: {category: "rate_limit", message: "429 transient 1"}})
-  llm_mock({error: {category: "rate_limit", message: "429 transient 2"}})
-  llm_mock({text: "Recovered after default retries. ##DONE##"})
-  let result = agent_loop("finish", nil, {provider: "mock", llm_backoff_ms: 0})
-  __io_println(result.status)
-  __io_println(result.visible_text)
-  __io_println(len(llm_mock_calls()))
+  with_llm_script(
+    [
+      {error: {category: "rate_limit", message: "429 transient 1"}},
+      {error: {category: "rate_limit", message: "429 transient 2"}},
+      llm_text("Recovered after default retries. ##DONE##"),
+    ],
+    { ->
+      let result = agent_loop("finish", nil, {provider: "mock", llm_backoff_ms: 0})
+      __io_println(result.status)
+      __io_println(result.visible_text)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
 }

--- a/conformance/tests/scenarios/agent_loop_mcp_http_elicit.harn
+++ b/conformance/tests/scenarios/agent_loop_mcp_http_elicit.harn
@@ -1,4 +1,5 @@
 import { process_shell } from "std/runtime"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn wait_for_file(harness: Harness, path, attempts) {
   var remaining = attempts
@@ -28,34 +29,37 @@ pipeline default() {
   let base = "http://127.0.0.1:" + harness.fs.read_text(port_path).trim()
   host_mock_clear()
   host_mock("mcp", "elicit", {action: "accept", content: {env: "staging", confirm: true}})
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "Calling MCP elicitation tool.",
-      tool_calls: [{id: "mcp-elicit", name: "remote__ask", arguments: {prompt: "Choose deploy target"}}],
+  with_llm_script(
+    [
+      {
+        text: "Calling MCP elicitation tool.",
+        tool_calls: [{id: "mcp-elicit", name: "remote__ask", arguments: {prompt: "Choose deploy target"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Use the remote ask tool",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "native",
+          max_iterations: 3,
+          mcp_servers: [{name: "remote", transport: "http", url: base + "/mcp"}],
+        },
+      )
+      let state = json_parse(harness.net.get(base + "/__state").body)
+      let calls = host_mock_calls()
+      let _stop = harness.net.post(base + "/__shutdown", "")
+      process_shell("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
+      __io_println(result?.tools.successful[0])
+      __io_println(state.tool_calls[0].name)
+      __io_println(state.elicit_response.result.action)
+      __io_println(state.elicit_response.result.content.env)
+      __io_println(state.elicit_response.result.content.confirm)
+      __io_println(calls[0].capability)
+      __io_println(calls[0].operation)
+      __io_println(calls[0].params.server)
     },
   )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Use the remote ask tool",
-    nil,
-    {
-      provider: "mock",
-      tool_format: "native",
-      max_iterations: 3,
-      mcp_servers: [{name: "remote", transport: "http", url: base + "/mcp"}],
-    },
-  )
-  let state = json_parse(harness.net.get(base + "/__state").body)
-  let calls = host_mock_calls()
-  let _stop = harness.net.post(base + "/__shutdown", "")
-  process_shell("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
-  __io_println(result?.tools.successful[0])
-  __io_println(state.tool_calls[0].name)
-  __io_println(state.elicit_response.result.action)
-  __io_println(state.elicit_response.result.content.env)
-  __io_println(state.elicit_response.result.content.confirm)
-  __io_println(calls[0].capability)
-  __io_println(calls[0].operation)
-  __io_println(calls[0].params.server)
 }

--- a/conformance/tests/scenarios/agent_loop_mcp_servers.harn
+++ b/conformance/tests/scenarios/agent_loop_mcp_servers.harn
@@ -1,4 +1,5 @@
 import { process_shell } from "std/runtime"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn wait_for_file(harness: Harness, path, attempts) {
   var remaining = attempts
@@ -27,39 +28,42 @@ pipeline default() {
   require start?.success, "MCP mock server started"
   wait_for_file(harness, port_path, 100)
   let base = "http://127.0.0.1:" + harness.fs.read_text(port_path).trim()
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "Calling MCP tools.",
-      tool_calls: [
-        {id: "mcp1", name: "remote__echo", arguments: {message: "hello from remote"}},
-        {id: "mcp2", name: "mirror__echo", arguments: {message: "hello from mirror"}},
-      ],
+  with_llm_script(
+    [
+      {
+        text: "Calling MCP tools.",
+        tool_calls: [
+          {id: "mcp1", name: "remote__echo", arguments: {message: "hello from remote"}},
+          {id: "mcp2", name: "mirror__echo", arguments: {message: "hello from mirror"}},
+        ],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Use both MCP echo tools",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "native",
+          max_iterations: 3,
+          mcp_servers: [
+            {name: "remote", transport: "http", url: base + "/mcp"},
+            {name: "mirror", transport: "http", url: base + "/mcp"},
+          ],
+        },
+      )
+      let state_response = harness.net.get(base + "/__state")
+      let state = json_parse(state_response.body)
+      let _stop = harness.net.post(base + "/__shutdown", "")
+      process_shell("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
+      __io_println(result?.tools.successful[0])
+      __io_println(result?.tools.successful[1])
+      __io_println(state.list_calls)
+      __io_println(state.tool_calls[0].name)
+      __io_println(state.tool_calls[0].arguments.message)
+      __io_println(state.tool_calls[1].name)
+      __io_println(state.tool_calls[1].arguments.message)
     },
   )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Use both MCP echo tools",
-    nil,
-    {
-      provider: "mock",
-      tool_format: "native",
-      max_iterations: 3,
-      mcp_servers: [
-        {name: "remote", transport: "http", url: base + "/mcp"},
-        {name: "mirror", transport: "http", url: base + "/mcp"},
-      ],
-    },
-  )
-  let state_response = harness.net.get(base + "/__state")
-  let state = json_parse(state_response.body)
-  let _stop = harness.net.post(base + "/__shutdown", "")
-  process_shell("kill $(cat \"" + pid_path + "\") >/dev/null 2>&1 || true")
-  __io_println(result?.tools.successful[0])
-  __io_println(result?.tools.successful[1])
-  __io_println(state.list_calls)
-  __io_println(state.tool_calls[0].name)
-  __io_println(state.tool_calls[0].arguments.message)
-  __io_println(state.tool_calls[1].name)
-  __io_println(state.tool_calls[1].arguments.message)
 }

--- a/conformance/tests/scenarios/agent_loop_parallel_dispatch.harn
+++ b/conformance/tests/scenarios/agent_loop_parallel_dispatch.harn
@@ -13,6 +13,7 @@
  * handler is ever in-flight; with cap=4 all four reach in-flight=4.
  */
 import { compose_tool_callers, with_audit_log, with_required_reason } from "std/llm/tool_middleware"
+import { llm_text, with_llm_script } from "std/testing"
 
 let in_flight = atomic(0)
 
@@ -46,72 +47,78 @@ fn fanout_tools() {
 }
 
 fn run(cap) {
-  llm_mock_clear()
   atomic_set(in_flight, 0)
   atomic_set(peak, 0)
   atomic_set(observed, 0)
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "c1", name: "fanout_echo", arguments: {msg: "alpha", reason: "first"}},
-        {id: "c2", name: "fanout_echo", arguments: {msg: "bravo", reason: "second"}},
-        {id: "c3", name: "fanout_echo", arguments: {msg: "charlie", reason: "third"}},
-        {id: "c4", name: "fanout_echo", arguments: {msg: "delta", reason: "fourth"}},
-      ],
+  return with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "c1", name: "fanout_echo", arguments: {msg: "alpha", reason: "first"}},
+          {id: "c2", name: "fanout_echo", arguments: {msg: "bravo", reason: "second"}},
+          {id: "c3", name: "fanout_echo", arguments: {msg: "charlie", reason: "third"}},
+          {id: "c4", name: "fanout_echo", arguments: {msg: "delta", reason: "fourth"}},
+        ],
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let mw = with_required_reason()
+      let counting_caller = { call, next ->
+        let _ = atomic_add(observed, 1)
+        return mw.caller(call, next)
+      }
+      let result = agent_loop(
+        "fan out",
+        nil,
+        {
+          provider: "mock",
+          tools: fanout_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_concurrent_tools: cap,
+          tool_caller: counting_caller,
+        },
+      )
+      return {status: result.status, observed: atomic_get(observed), peak: atomic_get(peak)}
     },
   )
-  llm_mock({text: "##DONE##"})
-  let mw = with_required_reason()
-  let counting_caller = { call, next ->
-    let _ = atomic_add(observed, 1)
-    return mw.caller(call, next)
-  }
-  let result = agent_loop(
-    "fan out",
-    nil,
-    {
-      provider: "mock",
-      tools: fanout_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_concurrent_tools: cap,
-      tool_caller: counting_caller,
-    },
-  )
-  return {status: result.status, observed: atomic_get(observed), peak: atomic_get(peak)}
 }
 
 fn run_without_middleware(cap) {
-  llm_mock_clear()
   atomic_set(in_flight, 0)
   atomic_set(peak, 0)
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "n1", name: "fanout_echo", arguments: {msg: "one"}},
-        {id: "n2", name: "fanout_echo", arguments: {msg: "two"}},
-        {id: "n3", name: "fanout_echo", arguments: {msg: "three"}},
-        {id: "n4", name: "fanout_echo", arguments: {msg: "four"}},
-      ],
+  return with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "n1", name: "fanout_echo", arguments: {msg: "one"}},
+          {id: "n2", name: "fanout_echo", arguments: {msg: "two"}},
+          {id: "n3", name: "fanout_echo", arguments: {msg: "three"}},
+          {id: "n4", name: "fanout_echo", arguments: {msg: "four"}},
+        ],
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let result = agent_loop(
+        "fan out without middleware",
+        nil,
+        {
+          provider: "mock",
+          tools: fanout_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_concurrent_tools: cap,
+        },
+      )
+      return {status: result.status, peak: atomic_get(peak)}
     },
   )
-  llm_mock({text: "##DONE##"})
-  let result = agent_loop(
-    "fan out without middleware",
-    nil,
-    {
-      provider: "mock",
-      tools: fanout_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_concurrent_tools: cap,
-    },
-  )
-  return {status: result.status, peak: atomic_get(peak)}
 }
 
 let audit_receipt_count = atomic(0)
@@ -119,58 +126,61 @@ let audit_receipt_count = atomic(0)
 let audit_emit_order_bitmask = atomic(0)
 
 fn run_with_audit(cap) {
-  llm_mock_clear()
   atomic_set(in_flight, 0)
   atomic_set(peak, 0)
   atomic_set(observed, 0)
   atomic_set(audit_receipt_count, 0)
   atomic_set(audit_emit_order_bitmask, 0)
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "a1", name: "fanout_echo", arguments: {msg: "first", reason: "r1"}},
-        {id: "a2", name: "fanout_echo", arguments: {msg: "second", reason: "r2"}},
-        {id: "a3", name: "fanout_echo", arguments: {msg: "third", reason: "r3"}},
-      ],
+  return with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "a1", name: "fanout_echo", arguments: {msg: "first", reason: "r1"}},
+          {id: "a2", name: "fanout_echo", arguments: {msg: "second", reason: "r2"}},
+          {id: "a3", name: "fanout_echo", arguments: {msg: "third", reason: "r3"}},
+        ],
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let reason = with_required_reason()
+      let audit_sink = { receipt ->
+        atomic_add(audit_receipt_count, 1)
+        var shifted = 1
+        var n = receipt.emit_order
+        while n > 0 {
+          shifted = shifted * 2
+          n = n - 1
+        }
+        atomic_add(audit_emit_order_bitmask, shifted)
+      }
+      let caller = compose_tool_callers([with_audit_log({sink: audit_sink}), reason.caller])
+      let result = agent_loop(
+        "audit fan-out",
+        nil,
+        {
+          provider: "mock",
+          tools: fanout_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_concurrent_tools: cap,
+          tool_caller: caller,
+        },
+      )
+      return {
+        status: result.status,
+        receipt_count: atomic_get(audit_receipt_count),
+        emit_bitmask: atomic_get(audit_emit_order_bitmask),
+      }
     },
   )
-  llm_mock({text: "##DONE##"})
-  let reason = with_required_reason()
-  // Add each receipt's bit (1 << emit_order) to the bitmask atomic.
-  // For 3 unique calls the bits are disjoint, so atomic_add == OR. The
-  // expected mask for emit_orders {0, 1, 2} is 1+2+4 = 7.
-  let audit_sink = { receipt ->
-    atomic_add(audit_receipt_count, 1)
-    var shifted = 1
-    var n = receipt.emit_order
-    while n > 0 {
-      shifted = shifted * 2
-      n = n - 1
-    }
-    atomic_add(audit_emit_order_bitmask, shifted)
-  }
-  let caller = compose_tool_callers([with_audit_log({sink: audit_sink}), reason.caller])
-  let result = agent_loop(
-    "audit fan-out",
-    nil,
-    {
-      provider: "mock",
-      tools: fanout_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_concurrent_tools: cap,
-      tool_caller: caller,
-    },
-  )
-  return {
-    status: result.status,
-    receipt_count: atomic_get(audit_receipt_count),
-    emit_bitmask: atomic_get(audit_emit_order_bitmask),
-  }
 }
 
+// Add each receipt's bit (1 << emit_order) to the bitmask atomic.
+// For 3 unique calls the bits are disjoint, so atomic_add == OR. The
+// expected mask for emit_orders {0, 1, 2} is 1+2+4 = 7.
 let prefetch_audit_finished = atomic(0)
 
 let prefetch_second_turn_before_audit = atomic(0)

--- a/conformance/tests/scenarios/agent_loop_profiles.harn
+++ b/conformance/tests/scenarios/agent_loop_profiles.harn
@@ -1,36 +1,45 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
   let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
-  llm_mock_clear()
-  llm_mock({text: "{\"note\": \"missing verdict\"}"})
-  llm_mock({text: "{\"verdict\": \"pass\"}"})
-  let structured = agent_loop(
-    "grade this",
-    nil,
-    {provider: "mock", profile: "verifier", output_schema: schema, output_validation: "error"},
+  with_llm_script(
+    [llm_text("{\"note\": \"missing verdict\"}"), llm_text("{\"verdict\": \"pass\"}")],
+    { ->
+      let structured = agent_loop(
+        "grade this",
+        nil,
+        {provider: "mock", profile: "verifier", output_schema: schema, output_validation: "error"},
+      )
+      __io_println(structured.visible_text)
+      __io_println(len(llm_mock_calls()))
+      assert(len(llm_mock_calls()) == 2, "verifier profile should retry schema-invalid output")
+    },
   )
-  __io_println(structured.visible_text)
-  __io_println(len(llm_mock_calls()))
-  assert(len(llm_mock_calls()) == 2, "verifier profile should retry schema-invalid output")
-  llm_mock_clear()
-  llm_mock({text: "Needs another pass."})
-  let verifier = agent_loop("verify this", nil, {provider: "mock", profile: "verifier", loop_until_done: true})
-  __io_println(verifier.status)
-  __io_println(verifier.llm.iterations)
-  assert(verifier.status == "stuck", "verifier max_nudges default should stop immediately")
-  assert(verifier.llm.iterations == 1, "verifier profile should run one text-only turn before stuck")
-  llm_mock_clear()
-  llm_mock({text: "Still working."})
-  llm_mock({text: "Finished. ##DONE##"})
-  let overridden = agent_loop(
-    "finish in two",
-    nil,
-    {provider: "mock", profile: "completer", loop_until_done: true, max_iterations: 2, max_nudges: 2},
+  with_llm_script(
+    [llm_text("Needs another pass.")],
+    { ->
+      let verifier = agent_loop("verify this", nil, {provider: "mock", profile: "verifier", loop_until_done: true})
+      __io_println(verifier.status)
+      __io_println(verifier.llm.iterations)
+      assert(verifier.status == "stuck", "verifier max_nudges default should stop immediately")
+      assert(verifier.llm.iterations == 1, "verifier profile should run one text-only turn before stuck")
+    },
   )
-  __io_println(overridden.status)
-  __io_println(overridden.llm.iterations)
-  assert(overridden.status == "done", "explicit max_iterations/max_nudges should override profile")
-  assert(
-    overridden.llm.iterations == 2,
-    "explicit max_iterations override should allow a second turn",
+  with_llm_script(
+    [llm_text("Still working."), llm_text("Finished. ##DONE##")],
+    { ->
+      let overridden = agent_loop(
+        "finish in two",
+        nil,
+        {provider: "mock", profile: "completer", loop_until_done: true, max_iterations: 2, max_nudges: 2},
+      )
+      __io_println(overridden.status)
+      __io_println(overridden.llm.iterations)
+      assert(overridden.status == "done", "explicit max_iterations/max_nudges should override profile")
+      assert(
+        overridden.llm.iterations == 2,
+        "explicit max_iterations override should allow a second turn",
+      )
+    },
   )
 }

--- a/conformance/tests/scenarios/agent_loop_stall_diagnostics.harn
+++ b/conformance/tests/scenarios/agent_loop_stall_diagnostics.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn tools() {
   var registry = tool_registry()
   registry = tool_define(
@@ -24,75 +26,88 @@ fn tools() {
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "r1", name: "read", arguments: {path: "src/lib.rs"}}]})
-  llm_mock({tool_calls: [{id: "r2", name: "read", arguments: {path: "src/lib.rs"}}]})
-  llm_mock({tool_calls: [{id: "r3", name: "read", arguments: {path: "src/lib.rs"}}]})
-  llm_mock({tool_calls: [{id: "r4", name: "read", arguments: {path: "src/lib.rs"}}]})
-  llm_mock({text: "Done. ##DONE##"})
-  // With the observation-signature detector (#2712) a bare `stall_diagnostics:
-  // true` trips the same-observation condition at its default of 4 byte-
-  // identical (action, observation) repeats.
-  let stalled = agent_loop(
-    "Inspect the file",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 5,
-      stall_diagnostics: true,
+  with_llm_script(
+    [
+      {tool_calls: [{id: "r1", name: "read", arguments: {path: "src/lib.rs"}}]},
+      {tool_calls: [{id: "r2", name: "read", arguments: {path: "src/lib.rs"}}]},
+      {tool_calls: [{id: "r3", name: "read", arguments: {path: "src/lib.rs"}}]},
+      {tool_calls: [{id: "r4", name: "read", arguments: {path: "src/lib.rs"}}]},
+      llm_text("Done. ##DONE##"),
+    ],
+    { ->
+      let stalled = agent_loop(
+        "Inspect the file",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 5,
+          stall_diagnostics: true,
+        },
+      )
+      let warning_events = transcript_events_by_kind(stalled.transcript, "agent_loop_stall_warning")
+      __io_println(stalled.status)
+      __io_println(stalled.repeated_tool_calls)
+      __io_println(stalled.suspected_loop)
+      __io_println(len(stalled.stall_warnings))
+      __io_println(len(warning_events))
+      __io_println(warning_events[0].metadata.tool_name)
+      __io_println(warning_events[0].metadata.repeat_count)
+      __io_println(
+        stalled.stall_warnings[0].arguments_digest == warning_events[0].metadata.arguments_digest,
+      )
     },
   )
-  let warning_events = transcript_events_by_kind(stalled.transcript, "agent_loop_stall_warning")
-  __io_println(stalled.status)
-  __io_println(stalled.repeated_tool_calls)
-  __io_println(stalled.suspected_loop)
-  __io_println(len(stalled.stall_warnings))
-  __io_println(len(warning_events))
-  __io_println(warning_events[0].metadata.tool_name)
-  __io_println(warning_events[0].metadata.repeat_count)
-  __io_println(
-    stalled.stall_warnings[0].arguments_digest == warning_events[0].metadata.arguments_digest,
-  )
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "p1", name: "poll", arguments: {key: "job-1"}}]})
-  llm_mock({tool_calls: [{id: "p2", name: "poll", arguments: {key: "job-1"}}]})
-  llm_mock({tool_calls: [{id: "p3", name: "poll", arguments: {key: "job-1"}}]})
-  llm_mock({text: "Done. ##DONE##"})
-  let polling = agent_loop(
-    "Wait for the job",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 4,
-      stall_diagnostics: {threshold: 3, exempt_tools: ["poll"]},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "p1", name: "poll", arguments: {key: "job-1"}}]},
+      {tool_calls: [{id: "p2", name: "poll", arguments: {key: "job-1"}}]},
+      {tool_calls: [{id: "p3", name: "poll", arguments: {key: "job-1"}}]},
+      llm_text("Done. ##DONE##"),
+    ],
+    { ->
+      let polling = agent_loop(
+        "Wait for the job",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 4,
+          stall_diagnostics: {threshold: 3, exempt_tools: ["poll"]},
+        },
+      )
+      __io_println(polling.status)
+      __io_println(polling.repeated_tool_calls)
+      __io_println(polling.suspected_loop)
+      __io_println(len(polling.stall_warnings))
     },
   )
-  __io_println(polling.status)
-  __io_println(polling.repeated_tool_calls)
-  __io_println(polling.suspected_loop)
-  __io_println(len(polling.stall_warnings))
-  llm_mock_clear()
-  llm_mock({text: "Done. ##DONE##"})
-  let invalid_config = try {
-    agent_loop(
-      "Validate stall config",
-      nil,
-      {
-        provider: "mock",
-        tools: tools(),
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 1,
-        stall_diagnostics: {enabled: "yes"},
-      },
-    )
-  }
-  __io_println(is_err(invalid_config))
-  __io_println(contains(to_string(unwrap_err(invalid_config)), "stall_diagnostics.enabled"))
+  with_llm_script(
+    [llm_text("Done. ##DONE##")],
+    { ->
+      let invalid_config = try {
+        agent_loop(
+          "Validate stall config",
+          nil,
+          {
+            provider: "mock",
+            tools: tools(),
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 1,
+            stall_diagnostics: {enabled: "yes"},
+          },
+        )
+      }
+      __io_println(is_err(invalid_config))
+      __io_println(contains(to_string(unwrap_err(invalid_config)), "stall_diagnostics.enabled"))
+    },
+  )
 }
+// With the observation-signature detector (#2712) a bare `stall_diagnostics:
+// true` trips the same-observation condition at its default of 4 byte-
+// identical (action, observation) repeats.

--- a/conformance/tests/scenarios/agent_loop_thrash_conditions.harn
+++ b/conformance/tests/scenarios/agent_loop_thrash_conditions.harn
@@ -5,8 +5,9 @@
 // is never consulted until a deterministic trip fires.
 import { agent_capture_events } from "std/agent/events"
 import { agent_stall_initial_state, agent_stall_observe_tool_calls } from "std/agent/stall"
+import { llm_text, with_llm_script } from "std/testing"
 
-/* A dispatch result envelope shaped like agent_dispatch_tool_batch output. */
+/** A dispatch result envelope shaped like agent_dispatch_tool_batch output. */
 fn ok_dispatch(name: string, payload) {
   return {results: [{tool_name: name, ok: true, status: "ok", result: payload}]}
 }
@@ -19,7 +20,7 @@ fn call(name: string, args) {
   return [{name: name, arguments: args}]
 }
 
-/*
+/**
  * Feed a sequence of (tool_call, prev_dispatch) steps through the detector and
  * return the pattern of the FIRST warning emitted, or "" if none tripped.
  */
@@ -203,33 +204,35 @@ pipeline default() {
       annotations: {kind: "read"},
     },
   )
-  llm_mock_clear()
-  llm_mock({text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]})
-  llm_mock({text: "Done. ##DONE##"})
-  let session = "thrash-judge-gate-" + uuid()
-  let captured = agent_capture_events(
-    session,
-    fn() { return agent_loop(
-      "Finish without stalling.",
-      nil,
-      {
-        provider: "mock",
-        tools: tools,
-        tool_format: "native",
-        loop_until_done: true,
-        max_iterations: 4,
-        session_id: session,
-        stall_diagnostics: {enabled: true, threshold: 3},
-        done_judge: {cadence: {when: "stalled"}},
-      },
-    ) },
+  with_llm_script(
+    [{text: "", tool_calls: [{id: "noop1", name: "noop", arguments: {}}]}, llm_text("Done. ##DONE##")],
+    { ->
+      let session = "thrash-judge-gate-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Finish without stalling.",
+          nil,
+          {
+            provider: "mock",
+            tools: tools,
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 4,
+            session_id: session,
+            stall_diagnostics: {enabled: true, threshold: 3},
+            done_judge: {cadence: {when: "stalled"}},
+          },
+        ) },
+      )
+      let stalls = captured.events.filter({ event -> event.type == "agent_loop_stall_warning" })
+      let judges = captured.events.filter({ event -> event.type == "judge_decision" })
+      require len(stalls) == 0, "no stall warning should fire below threshold"
+      require len(judges) == 0, "advisory judge must not be consulted without a deterministic trip"
+      __io_println("gate_stalls=" + to_string(len(stalls)))
+      __io_println("gate_judges=" + to_string(len(judges)))
+    },
   )
-  let stalls = captured.events.filter({ event -> event.type == "agent_loop_stall_warning" })
-  let judges = captured.events.filter({ event -> event.type == "judge_decision" })
-  // Invariant: with no deterministic stall warning, the advisory judge must
-  // never be consulted (the gate at loop.harn's `stall_judge_due && stall_warning != nil`).
-  require len(stalls) == 0, "no stall warning should fire below threshold"
-  require len(judges) == 0, "advisory judge must not be consulted without a deterministic trip"
-  __io_println("gate_stalls=" + to_string(len(stalls)))
-  __io_println("gate_judges=" + to_string(len(judges)))
 }
+// Invariant: with no deterministic stall warning, the advisory judge must
+// never be consulted (the gate at loop.harn's `stall_judge_due && stall_warning != nil`).

--- a/conformance/tests/scenarios/agent_loop_tool_caller_observes.harn
+++ b/conformance/tests/scenarios/agent_loop_tool_caller_observes.harn
@@ -6,6 +6,7 @@
  * result that gets recorded into the session.
  */
 import { with_required_reason } from "std/llm/tool_middleware"
+import { llm_text, with_llm_script } from "std/testing"
 
 let observed = atomic(0)
 
@@ -20,35 +21,38 @@ fn tools() {
 }
 
 pipeline default() {
-  llm_mock_clear()
   // Two tool calls in turn 1, then a finishing turn.
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "c1", name: "echo", arguments: {msg: "first", reason: "first call"}},
-        {id: "c2", name: "echo", arguments: {msg: "second", reason: "second call"}},
-      ],
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "c1", name: "echo", arguments: {msg: "first", reason: "first call"}},
+          {id: "c2", name: "echo", arguments: {msg: "second", reason: "second call"}},
+        ],
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let mw = with_required_reason()
+      let counting_caller = { call, next ->
+        let _ = atomic_add(observed, 1)
+        return mw.caller(call, next)
+      }
+      let result = agent_loop(
+        "do it",
+        nil,
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          max_iterations: 3,
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          tool_caller: counting_caller,
+        },
+      )
+      __io_println(result.status)
+      __io_println(atomic_get(observed))
     },
   )
-  llm_mock({text: "##DONE##"})
-  let mw = with_required_reason()
-  let counting_caller = { call, next ->
-    let _ = atomic_add(observed, 1)
-    return mw.caller(call, next)
-  }
-  let result = agent_loop(
-    "do it",
-    nil,
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      max_iterations: 3,
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      tool_caller: counting_caller,
-    },
-  )
-  __io_println(result.status)
-  __io_println(atomic_get(observed))
 }

--- a/conformance/tests/scenarios/agent_loop_transcript_projection.harn
+++ b/conformance/tests/scenarios/agent_loop_transcript_projection.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * agent_loop applies transcript_projection at each turn boundary,
  * emits a transcript.projection event into the immutable raw transcript,
@@ -61,88 +63,94 @@ fn gc_tools() {
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "call_1", name: "run", arguments: {}}]})
-  llm_mock({tool_calls: [{id: "call_2", name: "run", arguments: {}}]})
-  llm_mock({text: "Finished. ##DONE##"})
-  let result = agent_loop(
-    "kick it off",
-    "You are a test agent.",
-    {
-      provider: "mock",
-      tools: flaky_tool(),
-      tool_format: "native",
-      max_iterations: 6,
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      transcript_projection: {policy: "clean_tool_repair"},
-    },
-  )
-  __io_println("status:" + result.status)
-  let raw_messages = transcript_messages(result.transcript)
-  __io_println("raw_message_count:" + to_string(len(raw_messages)))
-  let events = transcript_events_by_kind(result.transcript, "transcript.projection")
-  __io_println("projection_events:" + to_string(len(events) > 0))
-  __io_println("projection_policy:" + events[0].metadata.policy)
-  __io_println("projection_safety_blocked:" + to_string(events[0].metadata.provider_safety_blocked))
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "read_stale_1", name: "read_stale", arguments: {}},
-        {id: "read_live_1", name: "read_live", arguments: {}},
-      ],
-    },
-  )
-  llm_mock(
-    {
-      text: json_stringify(
+  with_llm_script(
+    [
+      {tool_calls: [{id: "call_1", name: "run", arguments: {}}]},
+      {tool_calls: [{id: "call_2", name: "run", arguments: {}}]},
+      llm_text("Finished. ##DONE##"),
+    ],
+    { ->
+      let result = agent_loop(
+        "kick it off",
+        "You are a test agent.",
         {
-          schema: "harn.agent_scratchpad.v1",
-          goals: [{text: "complete projection GC task", source_ref: "user:initial"}],
-          open_items: [],
-          facts: [{text: "Continue from src/live.rs and LIVE_SENTINEL", source_ref: "turn:4"}],
-          refs: [
-            {id: "user:initial", kind: "user_input", label: "Initial task"},
-            {id: "turn:4", kind: "tool", label: "read_live returned src/live.rs"},
-          ],
+          provider: "mock",
+          tools: flaky_tool(),
+          tool_format: "native",
+          max_iterations: 6,
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          transcript_projection: {policy: "clean_tool_repair"},
         },
+      )
+      __io_println("status:" + result.status)
+      let raw_messages = transcript_messages(result.transcript)
+      __io_println("raw_message_count:" + to_string(len(raw_messages)))
+      let events = transcript_events_by_kind(result.transcript, "transcript.projection")
+      __io_println("projection_events:" + to_string(len(events) > 0))
+      __io_println("projection_policy:" + events[0].metadata.policy)
+      __io_println("projection_safety_blocked:" + to_string(events[0].metadata.provider_safety_blocked))
+    },
+  )
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "read_stale_1", name: "read_stale", arguments: {}},
+          {id: "read_live_1", name: "read_live", arguments: {}},
+        ],
+      },
+      llm_text(
+        json_stringify(
+          {
+            schema: "harn.agent_scratchpad.v1",
+            goals: [{text: "complete projection GC task", source_ref: "user:initial"}],
+            open_items: [],
+            facts: [{text: "Continue from src/live.rs and LIVE_SENTINEL", source_ref: "turn:4"}],
+            refs: [
+              {id: "user:initial", kind: "user_input", label: "Initial task"},
+              {id: "turn:4", kind: "tool", label: "read_live returned src/live.rs"},
+            ],
+          },
+        ),
       ),
+      llm_text("Done with projection GC. ##DONE##"),
+    ],
+    { ->
+      let gc_result = agent_loop(
+        "complete projection GC task",
+        "You are a projection test agent.",
+        {
+          provider: "mock",
+          tools: gc_tools(),
+          tool_format: "native",
+          max_iterations: 3,
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          transcript_projection: {policy: "reachability_gc", root_window: 1, min_chars: 100, require_write_barrier: true},
+          scratchpad: {enabled: true, reorganize_every: 1, reorganizer: {provider: "mock"}},
+        },
+      )
+      let gc_calls = llm_mock_calls()
+      let projected_stale_body = json_stringify(gc_calls[2].messages[2].content)
+      let projected_live_body = json_stringify(gc_calls[2].messages[3].content)
+      let gc_events = transcript_events_by_kind(gc_result.transcript, "transcript.projection")
+      let gc_projection = gc_events[len(gc_events) - 1]
+      __io_println("gc_status:" + gc_result.status)
+      __io_println("gc_scratchpad_barrier:" + to_string(gc_projection.metadata.redacted_count > 0))
+      __io_println(
+        "gc_has_scratchpad_root:"
+          + to_string(gc_projection.metadata.roots_consulted.contains("scratchpad")),
+      )
+      __io_println(
+        "gc_has_write_barrier:"
+          + to_string(gc_projection.metadata.roots_consulted.contains("write_barrier")),
+      )
+      __io_println(
+        "gc_projected_reclaimed:"
+          + to_string(contains(projected_stale_body, "reclaimed by reachability_gc")),
+      )
+      __io_println("gc_live_preserved:" + to_string(contains(projected_live_body, "LIVE_SENTINEL")))
     },
   )
-  llm_mock({text: "Done with projection GC. ##DONE##"})
-  let gc_result = agent_loop(
-    "complete projection GC task",
-    "You are a projection test agent.",
-    {
-      provider: "mock",
-      tools: gc_tools(),
-      tool_format: "native",
-      max_iterations: 3,
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      transcript_projection: {policy: "reachability_gc", root_window: 1, min_chars: 100, require_write_barrier: true},
-      scratchpad: {enabled: true, reorganize_every: 1, reorganizer: {provider: "mock"}},
-    },
-  )
-  let gc_calls = llm_mock_calls()
-  let projected_stale_body = json_stringify(gc_calls[2].messages[2].content)
-  let projected_live_body = json_stringify(gc_calls[2].messages[3].content)
-  let gc_events = transcript_events_by_kind(gc_result.transcript, "transcript.projection")
-  let gc_projection = gc_events[len(gc_events) - 1]
-  __io_println("gc_status:" + gc_result.status)
-  __io_println("gc_scratchpad_barrier:" + to_string(gc_projection.metadata.redacted_count > 0))
-  __io_println(
-    "gc_has_scratchpad_root:"
-      + to_string(gc_projection.metadata.roots_consulted.contains("scratchpad")),
-  )
-  __io_println(
-    "gc_has_write_barrier:"
-      + to_string(gc_projection.metadata.roots_consulted.contains("write_barrier")),
-  )
-  __io_println(
-    "gc_projected_reclaimed:"
-      + to_string(contains(projected_stale_body, "reclaimed by reachability_gc")),
-  )
-  __io_println("gc_live_preserved:" + to_string(contains(projected_live_body, "LIVE_SENTINEL")))
 }

--- a/conformance/tests/scenarios/agent_loop_verify_completion.harn
+++ b/conformance/tests/scenarios/agent_loop_verify_completion.harn
@@ -1,79 +1,93 @@
-/* Verifies the `verify_completion` stop-hook contract end-to-end:
-   - the closure fires when the loop is about to yield,
-   - returning a string vetoes the stop and injects feedback,
-   - returning `nil`/`true` confirms the stop and the loop yields,
-   - `max_verify_attempts` caps the veto loop with status `verify_exhausted`,
-   - `done_sentinel: "##DONE##"` keeps sentinel completion explicit for this mock provider.
-   Decisions are keyed on `info.iteration` rather than captured `var` state
-   so the test stays deterministic without depending on closure mutation
-   semantics. */
+import { llm_text, with_llm_script } from "std/testing"
+
+/**
+ * Verifies the `verify_completion` stop-hook contract end-to-end:
+ * - the closure fires when the loop is about to yield,
+ * - returning a string vetoes the stop and injects feedback,
+ * - returning `nil`/`true` confirms the stop and the loop yields,
+ * - `max_verify_attempts` caps the veto loop with status `verify_exhausted`,
+ * - `done_sentinel: "##DONE##"` keeps sentinel completion explicit for this mock provider.
+ * Decisions are keyed on `info.iteration` rather than captured `var` state
+ * so the test stays deterministic without depending on closure mutation
+ * semantics.
+ */
 fn scenario_veto_then_confirm() {
-  llm_mock_clear()
-  llm_mock({text: "Round 1. ##DONE##"})
-  llm_mock({text: "Round 2. ##DONE##"})
-  let cb = { info ->
-    if info.iteration == 0 {
-      return "not yet — try once more"
-    }
-    nil
-  }
-  let result = agent_loop(
-    "do work",
-    "you are an agent.",
-    {
-      provider: "mock",
-      loop_until_done: true,
-      max_iterations: 5,
-      done_sentinel: "##DONE##",
-      verify_completion: cb,
+  with_llm_script(
+    [llm_text("Round 1. ##DONE##"), llm_text("Round 2. ##DONE##")],
+    { ->
+      let cb = { info ->
+        if info.iteration == 0 {
+          return "not yet — try once more"
+        }
+        nil
+      }
+      let result = agent_loop(
+        "do work",
+        "you are an agent.",
+        {
+          provider: "mock",
+          loop_until_done: true,
+          max_iterations: 5,
+          done_sentinel: "##DONE##",
+          verify_completion: cb,
+        },
+      )
+      __io_println("scenario1.status=${result.status}")
+      __io_println("scenario1.iters=${result.llm.iterations}")
+      __io_println("scenario1.calls=${len(llm_mock_calls())}")
     },
   )
-  __io_println("scenario1.status=${result.status}")
-  __io_println("scenario1.iters=${result.llm.iterations}")
-  __io_println("scenario1.calls=${len(llm_mock_calls())}")
 }
 
 fn scenario_max_verify_exhausted() {
-  llm_mock_clear()
-  llm_mock({text: "Trying. ##DONE##"})
-  llm_mock({text: "Trying. ##DONE##"})
-  llm_mock({text: "Trying. ##DONE##"})
-  llm_mock({text: "Trying. ##DONE##"})
-  llm_mock({text: "Trying. ##DONE##"})
-  let always_veto = { _info -> "still not good enough" }
-  let result = agent_loop(
-    "do work",
-    "you are an agent.",
-    {
-      provider: "mock",
-      loop_until_done: true,
-      max_iterations: 10,
-      done_sentinel: "##DONE##",
-      verify_completion: always_veto,
-      max_verify_attempts: 2,
+  with_llm_script(
+    [
+      llm_text("Trying. ##DONE##"),
+      llm_text("Trying. ##DONE##"),
+      llm_text("Trying. ##DONE##"),
+      llm_text("Trying. ##DONE##"),
+      llm_text("Trying. ##DONE##"),
+    ],
+    { ->
+      let always_veto = { _info -> "still not good enough" }
+      let result = agent_loop(
+        "do work",
+        "you are an agent.",
+        {
+          provider: "mock",
+          loop_until_done: true,
+          max_iterations: 10,
+          done_sentinel: "##DONE##",
+          verify_completion: always_veto,
+          max_verify_attempts: 2,
+        },
+      )
+      __io_println("scenario2.status=${result.status}")
+      __io_println("scenario2.calls=${len(llm_mock_calls())}")
     },
   )
-  __io_println("scenario2.status=${result.status}")
-  __io_println("scenario2.calls=${len(llm_mock_calls())}")
 }
 
 fn scenario_confirm_immediately() {
-  llm_mock_clear()
-  llm_mock({text: "First and final. ##DONE##"})
-  let always_confirm = { _info -> nil }
-  let result = agent_loop(
-    "do work",
-    "you are an agent.",
-    {
-      provider: "mock",
-      loop_until_done: true,
-      max_iterations: 5,
-      done_sentinel: "##DONE##",
-      verify_completion: always_confirm,
+  with_llm_script(
+    [llm_text("First and final. ##DONE##")],
+    { ->
+      let always_confirm = { _info -> nil }
+      let result = agent_loop(
+        "do work",
+        "you are an agent.",
+        {
+          provider: "mock",
+          loop_until_done: true,
+          max_iterations: 5,
+          done_sentinel: "##DONE##",
+          verify_completion: always_confirm,
+        },
+      )
+      __io_println("scenario3.status=${result.status}")
+      __io_println("scenario3.iters=${result.llm.iterations}")
     },
   )
-  __io_println("scenario3.status=${result.status}")
-  __io_println("scenario3.iters=${result.llm.iterations}")
 }
 
 pipeline default() {

--- a/conformance/tests/scenarios/agent_progress_tool_mode.harn
+++ b/conformance/tests/scenarios/agent_progress_tool_mode.harn
@@ -1,4 +1,5 @@
 import { agent_capture_events } from "std/agent/events"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn tool_names(tools) {
   var names = []
@@ -10,53 +11,56 @@ fn tool_names(tools) {
 
 pipeline default() {
   let session_id = "agent-progress-tool-" + uuid()
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [
-        {
-          id: "progress-1",
-          name: "report_progress",
-          arguments: {
-            message: "from tool",
-            entries: [{content: "Use progress tool", status: "in_progress", priority: "medium"}],
-            replace: false,
-            metadata: {source: "mock-tool"},
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "progress-1",
+            name: "report_progress",
+            arguments: {
+              message: "from tool",
+              entries: [{content: "Use progress tool", status: "in_progress", priority: "medium"}],
+              replace: false,
+              metadata: {source: "mock-tool"},
+            },
           },
-        },
-      ],
+        ],
+      },
+      llm_text("<user_response>Progress reported.</user_response>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"progress event was emitted\"}"),
+    ],
+    { ->
+      let captured = agent_capture_events(
+        session_id,
+        fn() { return agent_loop(
+          "Report progress with the progress tool.",
+          nil,
+          {
+            provider: "mock",
+            progress_tool: {
+              name: "report_progress",
+              description: "Report structured progress to the host.",
+              system_prompt_nudge: "Use report_progress when reporting status.",
+            },
+            tool_format: "native",
+            loop_until_done: true,
+            done_judge: true,
+            max_iterations: 4,
+            session_id: session_id,
+          },
+        ) },
+      )
+      let calls = llm_mock_calls()
+      let progress_events = captured.events.filter({ event -> event.type == "progress_reported" })
+      require len(progress_events) == 1, "tool-mode progress emits one event"
+      let event = progress_events[0]
+      __io_println("tool_exposed=" + to_string(contains(tool_names(calls[0].tools), "report_progress")))
+      __io_println("progress_events=" + to_string(len(progress_events)))
+      __io_println("event_message=" + event.message)
+      __io_println("entry_status=" + event.entries[0].status)
+      __io_println("replace=" + to_string(event.replace))
+      __io_println("result_status=" + captured.result.status)
     },
   )
-  llm_mock({text: "<user_response>Progress reported.</user_response>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"progress event was emitted\"}"})
-  let captured = agent_capture_events(
-    session_id,
-    fn() { return agent_loop(
-      "Report progress with the progress tool.",
-      nil,
-      {
-        provider: "mock",
-        progress_tool: {
-          name: "report_progress",
-          description: "Report structured progress to the host.",
-          system_prompt_nudge: "Use report_progress when reporting status.",
-        },
-        tool_format: "native",
-        loop_until_done: true,
-        done_judge: true,
-        max_iterations: 4,
-        session_id: session_id,
-      },
-    ) },
-  )
-  let calls = llm_mock_calls()
-  let progress_events = captured.events.filter({ event -> event.type == "progress_reported" })
-  require len(progress_events) == 1, "tool-mode progress emits one event"
-  let event = progress_events[0]
-  __io_println("tool_exposed=" + to_string(contains(tool_names(calls[0].tools), "report_progress")))
-  __io_println("progress_events=" + to_string(len(progress_events)))
-  __io_println("event_message=" + event.message)
-  __io_println("entry_status=" + event.entries[0].status)
-  __io_println("replace=" + to_string(event.replace))
-  __io_println("result_status=" + captured.result.status)
 }

--- a/conformance/tests/scenarios/agent_prompt_overrides_and_timestamps.harn
+++ b/conformance/tests/scenarios/agent_prompt_overrides_and_timestamps.harn
@@ -1,72 +1,83 @@
 import { agent_prompt_overrides } from "std/agent/prompts"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "<done>##DONE##</done>"})
-  agent_loop(
-    "finish quickly",
-    "Base system.",
-    {
-      provider: "mock",
-      loop_until_done: true,
-      max_iterations: 2,
-      timestamp_messages: true,
-      prompts: {"agent.loop_contract": {text: "CUSTOM LOOP CONTRACT {{ done_sentinel }}"}},
+  with_llm_script(
+    [llm_text("<done>##DONE##</done>")],
+    { ->
+      agent_loop(
+        "finish quickly",
+        "Base system.",
+        {
+          provider: "mock",
+          loop_until_done: true,
+          max_iterations: 2,
+          timestamp_messages: true,
+          prompts: {"agent.loop_contract": {text: "CUSTOM LOOP CONTRACT {{ done_sentinel }}"}},
+        },
+      )
+      let calls = llm_mock_calls()
+      assert(contains(calls[0].system, "CUSTOM LOOP CONTRACT ##DONE##"), "prompt override rendered")
+      assert(!contains(calls[0].system, "Keep working until"), "default loop prompt was replaced")
+      assert(contains(calls[0].messages[0].content, "[harn timestamp:"), "message timestamp visible")
+      let bad_override = try {
+        agent_loop(
+          "bad prompt id",
+          "Base system.",
+          {
+            provider: "mock",
+            loop_until_done: true,
+            max_iterations: 1,
+            prompts: {"agent.loop_contractt": {text: "typo"}},
+          },
+        )
+      }
+      assert(is_err(bad_override), "unknown prompt id rejected")
+      assert(
+        contains(to_string(unwrap_err(bad_override)), "unknown prompt id"),
+        "unknown prompt id diagnostic",
+      )
     },
   )
-  let calls = llm_mock_calls()
-  assert(contains(calls[0].system, "CUSTOM LOOP CONTRACT ##DONE##"), "prompt override rendered")
-  assert(!contains(calls[0].system, "Keep working until"), "default loop prompt was replaced")
-  assert(contains(calls[0].messages[0].content, "[harn timestamp:"), "message timestamp visible")
-  let bad_override = try {
-    agent_loop(
-      "bad prompt id",
-      "Base system.",
-      {
-        provider: "mock",
-        loop_until_done: true,
-        max_iterations: 1,
-        prompts: {"agent.loop_contractt": {text: "typo"}},
-      },
-    )
-  }
-  assert(is_err(bad_override), "unknown prompt id rejected")
-  assert(
-    contains(to_string(unwrap_err(bad_override)), "unknown prompt id"),
-    "unknown prompt id diagnostic",
-  )
-  llm_mock_clear()
-  llm_mock({text: "<done>##DONE##</done>"})
-  let typed_prompt_values = {loop_contract: {text: "TYPED LOOP CONTRACT {{ done_sentinel }}"}}
-  let typed_prompt_options = agent_prompt_overrides(typed_prompt_values)
-  agent_loop(
-    "typed override",
-    "Base system.",
-    typed_prompt_options
-      + {provider: "mock", loop_until_done: true, max_iterations: 1},
-  )
-  let typed_calls = llm_mock_calls()
-  assert(
-    contains(typed_calls[0].system, "TYPED LOOP CONTRACT ##DONE##"),
-    "typed prompt helper rendered",
-  )
-  llm_mock_clear()
-  llm_mock({text: "<user_response>turn done</user_response>\n<done>##DONE##</done>"})
-  llm_mock({text: "{\"verdict\":\"done\",\"reasoning\":\"turn complete\"}"})
-  agent_turn(
-    "turn preamble override",
-    {
-      provider: "mock",
-      max_iterations: 2,
-      prompts: {"agent.turn_preamble": {text: "CUSTOM TURN PREAMBLE"}},
+  with_llm_script(
+    [llm_text("<done>##DONE##</done>")],
+    { ->
+      let typed_prompt_values = {loop_contract: {text: "TYPED LOOP CONTRACT {{ done_sentinel }}"}}
+      let typed_prompt_options = agent_prompt_overrides(typed_prompt_values)
+      agent_loop(
+        "typed override",
+        "Base system.",
+        typed_prompt_options
+          + {provider: "mock", loop_until_done: true, max_iterations: 1},
+      )
+      let typed_calls = llm_mock_calls()
+      assert(
+        contains(typed_calls[0].system, "TYPED LOOP CONTRACT ##DONE##"),
+        "typed prompt helper rendered",
+      )
     },
   )
-  let turn_calls = llm_mock_calls()
-  assert(
-    contains(turn_calls[0].system, "CUSTOM TURN PREAMBLE"),
-    "agent_turn preamble override rendered",
+  with_llm_script(
+    [
+      llm_text("<user_response>turn done</user_response>\n<done>##DONE##</done>"),
+      llm_text("{\"verdict\":\"done\",\"reasoning\":\"turn complete\"}"),
+    ],
+    { ->
+      agent_turn(
+        "turn preamble override",
+        {
+          provider: "mock",
+          max_iterations: 2,
+          prompts: {"agent.turn_preamble": {text: "CUSTOM TURN PREAMBLE"}},
+        },
+      )
+      let turn_calls = llm_mock_calls()
+      assert(
+        contains(turn_calls[0].system, "CUSTOM TURN PREAMBLE"),
+        "agent_turn preamble override rendered",
+      )
+    },
   )
-  llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
     tools,
@@ -74,32 +85,36 @@ pipeline test(task) {
     "Say hello.",
     {handler: { args -> "hello " + args.name }, parameters: {name: {type: "string"}}},
   )
-  llm_mock({text: "<user_response>done</user_response>\n<done>##DONE##</done>"})
-  agent_loop(
-    "finish with a tool contract",
-    "Base system.",
-    {
-      provider: "mock",
-      tools: tools,
-      tool_format: "text",
-      loop_until_done: true,
-      max_iterations: 1,
-      done_judge: nil,
-      turn_policy: {require_action_or_yield: true},
-      prompts: {"agent.tool_contract_action_text": {text: "CUSTOM TEXT ACTION {{ done_sentinel }}"}},
+  with_llm_script(
+    [llm_text("<user_response>done</user_response>\n<done>##DONE##</done>")],
+    { ->
+      agent_loop(
+        "finish with a tool contract",
+        "Base system.",
+        {
+          provider: "mock",
+          tools: tools,
+          tool_format: "text",
+          loop_until_done: true,
+          max_iterations: 1,
+          done_judge: nil,
+          turn_policy: {require_action_or_yield: true},
+          prompts: {"agent.tool_contract_action_text": {text: "CUSTOM TEXT ACTION {{ done_sentinel }}"}},
+        },
+      )
+      let text_contract = llm_mock_calls()[0].system
+      assert(contains(text_contract, "name({ key: value })"), "text tool syntax is Harn-call shaped")
+      assert(contains(text_contract, "### greet"), "Harn-rendered tool listing included")
+      assert(
+        contains(text_contract, "CUSTOM TEXT ACTION ##DONE##"),
+        "text tool contract fragment override rendered",
+      )
+      assert(
+        !contains(text_contract, "This turn is action-gated"),
+        "default text action fragment was replaced",
+      )
+      assert(!contains(text_contract, "{\"name\": \"tool_name\""), "legacy JSON tool syntax removed")
+      log("agent_prompt_overrides_and_timestamps tests passed")
     },
   )
-  let text_contract = llm_mock_calls()[0].system
-  assert(contains(text_contract, "name({ key: value })"), "text tool syntax is Harn-call shaped")
-  assert(contains(text_contract, "### greet"), "Harn-rendered tool listing included")
-  assert(
-    contains(text_contract, "CUSTOM TEXT ACTION ##DONE##"),
-    "text tool contract fragment override rendered",
-  )
-  assert(
-    !contains(text_contract, "This turn is action-gated"),
-    "default text action fragment was replaced",
-  )
-  assert(!contains(text_contract, "{\"name\": \"tool_name\""), "legacy JSON tool syntax removed")
-  log("agent_prompt_overrides_and_timestamps tests passed")
 }

--- a/conformance/tests/scenarios/agent_scratchpad_recitation_reorg.harn
+++ b/conformance/tests/scenarios/agent_scratchpad_recitation_reorg.harn
@@ -3,6 +3,7 @@
  * and periodically reorganizes it into cited notes for the next turn.
  */
 import { agent_scratchpad_reorganize } from "std/agent/scratchpad"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn observe_tools() {
   var tools = tool_registry()
@@ -16,43 +17,48 @@ fn observe_tools() {
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "observe_1", name: "observe", arguments: {}}]})
-  llm_mock(
-    {
-      text: "{\"schema\":\"harn.agent_scratchpad.v1\",\"goals\":[{\"text\":\"complete the scratchpad task\",\"source_ref\":\"user:initial\"}],\"open_items\":[],\"facts\":[{\"text\":\"observe returned observed-value-42\",\"source_ref\":\"turn:3\"}],\"refs\":[{\"id\":\"user:initial\",\"kind\":\"user_input\",\"label\":\"Initial task\"},{\"id\":\"turn:3\",\"kind\":\"tool\",\"label\":\"observed-value-42\"}]}",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "observe_1", name: "observe", arguments: {}}]},
+      llm_text(
+        "{\"schema\":\"harn.agent_scratchpad.v1\",\"goals\":[{\"text\":\"complete the scratchpad task\",\"source_ref\":\"user:initial\"}],\"open_items\":[],\"facts\":[{\"text\":\"observe returned observed-value-42\",\"source_ref\":\"turn:3\"}],\"refs\":[{\"id\":\"user:initial\",\"kind\":\"user_input\",\"label\":\"Initial task\"},{\"id\":\"turn:3\",\"kind\":\"tool\",\"label\":\"observed-value-42\"}]}",
+      ),
+      llm_text("Finished with the observation. ##DONE##"),
+    ],
+    { ->
+      let result = agent_loop(
+        "complete the scratchpad task",
+        "You are a test agent.",
+        {
+          provider: "mock",
+          tools: observe_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_iterations: 3,
+          scratchpad: {enabled: true, reorganize_every: 1, reorganizer: {provider: "mock"}},
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println("status:" + result.status)
+      __io_println("calls:" + to_string(len(calls)))
+      __io_println("first_has_scratchpad:" + to_string(contains(calls[0].system, "## Agent scratchpad")))
+      __io_println(
+        "first_tail:"
+          + to_string(ends_with(calls[0].system, "user:initial (user_input): Initial task")),
+      )
+      __io_println(
+        "reorg_prompt:"
+          + to_string(contains(calls[1].messages[0].content, "Reorganize the live agent scratchpad")),
+      )
+      __io_println(
+        "second_has_fact:"
+          + to_string(contains(calls[2].system, "observe returned observed-value-42")),
+      )
+      __io_println("second_has_source:" + to_string(contains(calls[2].system, "[source_ref: turn:3]")))
+      __io_println("snapshot_fact:" + result.transcript.metadata.agent_scratchpad.facts[0].text)
     },
   )
-  llm_mock({text: "Finished with the observation. ##DONE##"})
-  let result = agent_loop(
-    "complete the scratchpad task",
-    "You are a test agent.",
-    {
-      provider: "mock",
-      tools: observe_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_iterations: 3,
-      scratchpad: {enabled: true, reorganize_every: 1, reorganizer: {provider: "mock"}},
-    },
-  )
-  let calls = llm_mock_calls()
-  __io_println("status:" + result.status)
-  __io_println("calls:" + to_string(len(calls)))
-  __io_println("first_has_scratchpad:" + to_string(contains(calls[0].system, "## Agent scratchpad")))
-  __io_println(
-    "first_tail:" + to_string(ends_with(calls[0].system, "user:initial (user_input): Initial task")),
-  )
-  __io_println(
-    "reorg_prompt:"
-      + to_string(contains(calls[1].messages[0].content, "Reorganize the live agent scratchpad")),
-  )
-  __io_println(
-    "second_has_fact:" + to_string(contains(calls[2].system, "observe returned observed-value-42")),
-  )
-  __io_println("second_has_source:" + to_string(contains(calls[2].system, "[source_ref: turn:3]")))
-  __io_println("snapshot_fact:" + result.transcript.metadata.agent_scratchpad.facts[0].text)
   let manual_id = agent_session_open("scratchpad-invalid-source")
   agent_session_set_scratchpad(
     manual_id,
@@ -64,17 +70,20 @@ pipeline default() {
       refs: [{id: "user:initial", kind: "user_input", label: "Initial task"}],
     },
   )
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "{\"schema\":\"harn.agent_scratchpad.v1\",\"goals\":[{\"text\":\"manual task\",\"source_ref\":\"made-up\"}],\"open_items\":[],\"facts\":[{\"text\":\"uncited hallucination\",\"source_ref\":\"made-up\"}],\"refs\":[{\"id\":\"made-up\",\"kind\":\"unknown\",\"label\":\"not allowed\"}]}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"schema\":\"harn.agent_scratchpad.v1\",\"goals\":[{\"text\":\"manual task\",\"source_ref\":\"made-up\"}],\"open_items\":[],\"facts\":[{\"text\":\"uncited hallucination\",\"source_ref\":\"made-up\"}],\"refs\":[{\"id\":\"made-up\",\"kind\":\"unknown\",\"label\":\"not allowed\"}]}",
+      ),
+    ],
+    { ->
+      let rejected = agent_scratchpad_reorganize(
+        {session_id: manual_id, task: "manual task"},
+        {provider: "mock", scratchpad: {enabled: true, reorganizer: {provider: "mock"}}},
+        1,
+      )
+      __io_println("invalid_status:" + rejected.status)
+      __io_println("invalid_preserved:" + agent_session_scratchpad(manual_id).facts[0].text)
     },
   )
-  let rejected = agent_scratchpad_reorganize(
-    {session_id: manual_id, task: "manual task"},
-    {provider: "mock", scratchpad: {enabled: true, reorganizer: {provider: "mock"}}},
-    1,
-  )
-  __io_println("invalid_status:" + rejected.status)
-  __io_println("invalid_preserved:" + agent_session_scratchpad(manual_id).facts[0].text)
 }

--- a/conformance/tests/scenarios/agent_session_system_prompt_parts.harn
+++ b/conformance/tests/scenarios/agent_session_system_prompt_parts.harn
@@ -1,4 +1,5 @@
 import { system_preamble, with_system_prompt_parts } from "std/llm/prompts"
+import { with_llm_script } from "std/testing"
 
 fn occurrences(text, needle) {
   return len(split(text, needle)) - 1
@@ -9,50 +10,58 @@ fn events_by_kind(transcript, kind) {
 }
 
 pipeline default() {
-  llm_mock_clear()
-  let direct = llm_call(
-    "direct prompt",
-    "Direct base.",
-    {provider: "mock", system_preamble: system_preamble("Direct preamble.", {label: "Direct contract"})},
+  with_llm_script(
+    [],
+    { ->
+      let direct = llm_call(
+        "direct prompt",
+        "Direct base.",
+        {provider: "mock", system_preamble: system_preamble("Direct preamble.", {label: "Direct contract"})},
+      )
+      __io_println(len(transcript_messages(direct.transcript)))
+      __io_println(len(events_by_kind(direct.transcript, "system_prompt")))
+      __io_println(transcript_events(direct.transcript)[0].kind == "system_prompt")
+      __io_println(direct.transcript.metadata.system_prompt.content.contains("Direct preamble."))
+      __io_println(occurrences(json_stringify(direct.transcript), "Direct preamble.") == 1)
+    },
   )
-  __io_println(len(transcript_messages(direct.transcript)))
-  __io_println(len(events_by_kind(direct.transcript, "system_prompt")))
-  __io_println(transcript_events(direct.transcript)[0].kind == "system_prompt")
-  __io_println(direct.transcript.metadata.system_prompt.content.contains("Direct preamble."))
-  __io_println(occurrences(json_stringify(direct.transcript), "Direct preamble.") == 1)
-  llm_mock_clear()
-  let sid = "system-prompt-continuation-session"
-  let opts = with_system_prompt_parts(
-    {provider: "mock", session_id: sid, max_iterations: 1, auto_context_profile: false},
-    [
-      system_preamble("Persistent contract.", {label: "Session contract"}),
-      {content: "disabled", enabled: false},
-    ],
-  )
-  let first = agent_loop("hello", "Base system.", opts)
-  let resumed = agent_loop("follow up", "Base system.", opts)
-  let resumed_without_prompt = agent_loop(
-    "resume without prompt options",
-    nil,
-    {provider: "mock", session_id: sid, max_iterations: 1, auto_context_profile: false},
-  )
-  let calls = llm_mock_calls()
-  __io_println(first.status)
-  __io_println(resumed.status)
-  __io_println(resumed_without_prompt.status)
-  __io_println(len(calls))
-  __io_println(occurrences(calls[0].system, "Persistent contract.") == 1)
-  __io_println(occurrences(calls[1].system, "Persistent contract.") == 1)
-  __io_println(occurrences(calls[2].system, "Persistent contract.") == 1)
-  __io_println(!json_stringify(calls[2].messages).contains("Persistent contract."))
-  __io_println(len(transcript_messages(resumed_without_prompt.transcript)))
-  __io_println(len(events_by_kind(resumed_without_prompt.transcript, "system_prompt")))
-  __io_println(transcript_events(resumed_without_prompt.transcript)[0].kind == "system_prompt")
-  __io_println(
-    occurrences(json_stringify(resumed_without_prompt.transcript), "Persistent contract.") == 1,
-  )
-  __io_println(agent_session_system_prompt(sid).contains("Persistent contract."))
-  __io_println(
-    resumed_without_prompt.transcript.metadata.system_prompt.content.contains("Persistent contract."),
+  with_llm_script(
+    [],
+    { ->
+      let sid = "system-prompt-continuation-session"
+      let opts = with_system_prompt_parts(
+        {provider: "mock", session_id: sid, max_iterations: 1, auto_context_profile: false},
+        [
+          system_preamble("Persistent contract.", {label: "Session contract"}),
+          {content: "disabled", enabled: false},
+        ],
+      )
+      let first = agent_loop("hello", "Base system.", opts)
+      let resumed = agent_loop("follow up", "Base system.", opts)
+      let resumed_without_prompt = agent_loop(
+        "resume without prompt options",
+        nil,
+        {provider: "mock", session_id: sid, max_iterations: 1, auto_context_profile: false},
+      )
+      let calls = llm_mock_calls()
+      __io_println(first.status)
+      __io_println(resumed.status)
+      __io_println(resumed_without_prompt.status)
+      __io_println(len(calls))
+      __io_println(occurrences(calls[0].system, "Persistent contract.") == 1)
+      __io_println(occurrences(calls[1].system, "Persistent contract.") == 1)
+      __io_println(occurrences(calls[2].system, "Persistent contract.") == 1)
+      __io_println(!json_stringify(calls[2].messages).contains("Persistent contract."))
+      __io_println(len(transcript_messages(resumed_without_prompt.transcript)))
+      __io_println(len(events_by_kind(resumed_without_prompt.transcript, "system_prompt")))
+      __io_println(transcript_events(resumed_without_prompt.transcript)[0].kind == "system_prompt")
+      __io_println(
+        occurrences(json_stringify(resumed_without_prompt.transcript), "Persistent contract.") == 1,
+      )
+      __io_println(agent_session_system_prompt(sid).contains("Persistent contract."))
+      __io_println(
+        resumed_without_prompt.transcript.metadata.system_prompt.content.contains("Persistent contract."),
+      )
+    },
   )
 }

--- a/conformance/tests/scenarios/approval_policy_rules.harn
+++ b/conformance/tests/scenarios/approval_policy_rules.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 fn policy_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -56,18 +58,20 @@ fn capability_policy() {
 }
 
 fn one_call(name, args, approval_policy) {
-  llm_mock({tool_calls: [{id: "call_1", name: name, arguments: args}]})
-  return agent_loop(
-    "Use the requested tool.",
-    "Use tools.",
-    {
-      provider: "mock",
-      tools: policy_tools(),
-      tool_format: "native",
-      max_iterations: 1,
-      policy: capability_policy(),
-      approval_policy: approval_policy,
-    },
+  return with_llm_script(
+    [{tool_calls: [{id: "call_1", name: name, arguments: args}]}],
+    { -> agent_loop(
+      "Use the requested tool.",
+      "Use tools.",
+      {
+        provider: "mock",
+        tools: policy_tools(),
+        tool_format: "native",
+        max_iterations: 1,
+        policy: capability_policy(),
+        approval_policy: approval_policy,
+      },
+    ) },
   )
 }
 
@@ -111,27 +115,31 @@ pipeline main() {
   let mcp_events = json_stringify(transcript_events_by_kind(mcp?.transcript, "PermissionDeny"))
   __io_println(mcp?.tools?.rejected[0] == "github__create_issue")
   __io_println(mcp_events.contains("mcp_rule"))
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "repeat_1", name: "run_command", arguments: {argv: ["echo", "ok"]}},
-        {id: "repeat_2", name: "run_command", arguments: {argv: ["echo", "ok"]}},
-      ],
+  with_llm_script(
+    [
+      {
+        tool_calls: [
+          {id: "repeat_1", name: "run_command", arguments: {argv: ["echo", "ok"]}},
+          {id: "repeat_2", name: "run_command", arguments: {argv: ["echo", "ok"]}},
+        ],
+      },
+    ],
+    { ->
+      let repeated = agent_loop(
+        "Run twice.",
+        "Use tools.",
+        {
+          provider: "mock",
+          tools: policy_tools(),
+          tool_format: "native",
+          max_iterations: 1,
+          policy: capability_policy(),
+          approval_policy: {allow_sensitive_paths: true, repeat_limit: 1, repeat_action: "deny"},
+        },
+      )
+      let repeat_events = json_stringify(transcript_events_by_kind(repeated?.transcript, "PermissionDeny"))
+      __io_println(repeated?.tools?.rejected[0] == "run_command")
+      __io_println(repeat_events.contains("repeated_call"))
     },
   )
-  let repeated = agent_loop(
-    "Run twice.",
-    "Use tools.",
-    {
-      provider: "mock",
-      tools: policy_tools(),
-      tool_format: "native",
-      max_iterations: 1,
-      policy: capability_policy(),
-      approval_policy: {allow_sensitive_paths: true, repeat_limit: 1, repeat_action: "deny"},
-    },
-  )
-  let repeat_events = json_stringify(transcript_events_by_kind(repeated?.transcript, "PermissionDeny"))
-  __io_println(repeated?.tools?.rejected[0] == "run_command")
-  __io_println(repeat_events.contains("repeated_call"))
 }

--- a/conformance/tests/scenarios/best_of_n_inside_agent_loop.harn
+++ b/conformance/tests/scenarios/best_of_n_inside_agent_loop.harn
@@ -6,37 +6,42 @@
  * visible_text.
  */
 import { best_of_n } from "std/llm/ensemble"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
   // 3 candidate samples consumed in order by best_of_n's sequential sampler.
-  llm_mock({text: "candidate-A"})
-  llm_mock({text: "candidate-B"})
-  llm_mock({text: "candidate-C"})
-  // Structured judge response — picks index 1.
-  llm_mock({text: "{\"best_index\": 1, \"scores\": [0.2, 0.9, 0.3], \"reasoning\": \"B wins\"}"})
-  let bon_caller = { call ->
-    let result = best_of_n(
-      call.prompt,
-      call.system,
-      {n: 3, parallel: false, call_opts: {provider: "mock"}, judge_opts: {provider: "mock"}},
-    )
-    if !(result?.ok ?? false) {
-      return {ok: false, status: "exception", error: "best_of_n failed"}
-    }
-    return {
-      ok: true,
-      value: {
-        text: result.best.text,
-        model: "mock",
-        provider: "mock",
-        input_tokens: 0,
-        output_tokens: 0,
-        usage: {input_tokens: 0, output_tokens: 0},
-      },
-    }
-  }
-  let result = agent_loop("hi", nil, {provider: "mock", llm_caller: bon_caller, max_iterations: 1})
-  __io_println(result.status)
-  __io_println(result.visible_text)
+  with_llm_script(
+    [
+      llm_text("candidate-A"),
+      llm_text("candidate-B"),
+      llm_text("candidate-C"),
+      llm_text("{\"best_index\": 1, \"scores\": [0.2, 0.9, 0.3], \"reasoning\": \"B wins\"}"),
+    ],
+    { ->
+      let bon_caller = { call ->
+        let result = best_of_n(
+          call.prompt,
+          call.system,
+          {n: 3, parallel: false, call_opts: {provider: "mock"}, judge_opts: {provider: "mock"}},
+        )
+        if !(result?.ok ?? false) {
+          return {ok: false, status: "exception", error: "best_of_n failed"}
+        }
+        return {
+          ok: true,
+          value: {
+            text: result.best.text,
+            model: "mock",
+            provider: "mock",
+            input_tokens: 0,
+            output_tokens: 0,
+            usage: {input_tokens: 0, output_tokens: 0},
+          },
+        }
+      }
+      let result = agent_loop("hi", nil, {provider: "mock", llm_caller: bon_caller, max_iterations: 1})
+      __io_println(result.status)
+      __io_println(result.visible_text)
+    },
+  )
 }

--- a/conformance/tests/scenarios/cache_event_receipts.harn
+++ b/conformance/tests/scenarios/cache_event_receipts.harn
@@ -17,6 +17,7 @@
 import { agent_emit_event } from "std/agent/state"
 import { cache_clear, mem_cache } from "std/cache"
 import { with_cache } from "std/llm/handlers"
+import { with_llm_script } from "std/testing"
 
 pipeline default() {
   let session_id = "cache-event-receipts-" + uuid()
@@ -53,20 +54,25 @@ pipeline default() {
   // mock surfaces `input_tokens` + `output_tokens` at the top level
   // (the LLM result then exposes them through `usage` for the metric
   // reader).
-  llm_mock_clear()
-  llm_mock({text: "answer", input_tokens: 11, output_tokens: 7, model: "m", provider: "p"})
-  llm_mock({text: "would-recompute", model: "m", provider: "p"})
-  let store = mem_cache({namespace: "cache-event-receipts-direct-" + uuid()})
-  cache_clear({store: store})
-  let opts = {provider: "p", model: "m", stream: false, store: store, session_id: session_id}
-  let first = with_cache("hello", "sys", opts)
-  let second = with_cache("hello", "sys", opts)
-  __io_println("first.text=" + first.text)
-  __io_println("byte_identical=" + to_string(json_stringify(first) == json_stringify(second)))
-  __io_println("mock_calls=" + to_string(len(llm_mock_calls())))
-  // hits counter started at 1 from the direct emit above, so we expect 2.
-  __io_println("hits=" + to_string(atomic_get(hits)))
-  __io_println("misses=" + to_string(atomic_get(misses)))
-  __io_println("hit.tokens_saved=" + to_string(atomic_get(last_hit_tokens)))
-  __io_println("hit.model_calls_avoided=" + to_string(atomic_get(last_hit_calls_avoided)))
+  with_llm_script(
+    [
+      {text: "answer", input_tokens: 11, output_tokens: 7, model: "m", provider: "p"},
+      {text: "would-recompute", model: "m", provider: "p"},
+    ],
+    { ->
+      let store = mem_cache({namespace: "cache-event-receipts-direct-" + uuid()})
+      cache_clear({store: store})
+      let opts = {provider: "p", model: "m", stream: false, store: store, session_id: session_id}
+      let first = with_cache("hello", "sys", opts)
+      let second = with_cache("hello", "sys", opts)
+      __io_println("first.text=" + first.text)
+      __io_println("byte_identical=" + to_string(json_stringify(first) == json_stringify(second)))
+      __io_println("mock_calls=" + to_string(len(llm_mock_calls())))
+      __io_println("hits=" + to_string(atomic_get(hits)))
+      __io_println("misses=" + to_string(atomic_get(misses)))
+      __io_println("hit.tokens_saved=" + to_string(atomic_get(last_hit_tokens)))
+      __io_println("hit.model_calls_avoided=" + to_string(atomic_get(last_hit_calls_avoided)))
+    },
+  )
 }
+// hits counter started at 1 from the direct emit above, so we expect 2.

--- a/conformance/tests/scenarios/gemini_native_tool_calls_agent_loop.harn
+++ b/conformance/tests/scenarios/gemini_native_tool_calls_agent_loop.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Mocked Gemini-native tool calls should drive normal agent_loop dispatch.
  *
@@ -24,61 +26,64 @@ fn lookup_tools() {
 }
 
 pipeline test(task) {
-  llm_mock_clear()
   atomic_set(lookups, 0)
-  llm_mock(
-    {
-      provider: "mock",
-      model: "gemini-2.5-flash",
-      text: "checking",
-      tool_calls: [
+  with_llm_script(
+    [
+      {
+        provider: "mock",
+        model: "gemini-2.5-flash",
+        text: "checking",
+        tool_calls: [
+          {
+            id: "gemini_call_1",
+            name: "lookup",
+            arguments: {query: "harn"},
+            thought_signature: "opaque-gemini-signature",
+          },
+        ],
+        blocks: [
+          {type: "output_text", text: "checking", visibility: "public"},
+          {
+            type: "tool_call",
+            id: "gemini_call_1",
+            name: "lookup",
+            arguments: {query: "harn"},
+            thought_signature: "opaque-gemini-signature",
+            visibility: "internal",
+          },
+        ],
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Use the lookup tool.",
+        nil,
         {
-          id: "gemini_call_1",
-          name: "lookup",
-          arguments: {query: "harn"},
-          thought_signature: "opaque-gemini-signature",
+          provider: "mock",
+          model: "gemini-2.5-flash",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_iterations: 3,
         },
-      ],
-      blocks: [
-        {type: "output_text", text: "checking", visibility: "public"},
-        {
-          type: "tool_call",
-          id: "gemini_call_1",
-          name: "lookup",
-          arguments: {query: "harn"},
-          thought_signature: "opaque-gemini-signature",
-          visibility: "internal",
-        },
-      ],
+      )
+      assert(result.status == "done", "Gemini mock agent loop finishes")
+      assert(atomic_get(lookups) == 1, "Gemini mock tool call dispatches once")
+      let calls = llm_mock_calls()
+      assert(len(calls) == 2, "agent loop makes a follow-up model turn")
+      let followup = json_stringify(calls[1].messages)
+      assert(contains(followup, "functionCall"), "assistant history preserves Gemini functionCall")
+      assert(
+        contains(followup, "tool_call_id"),
+        "tool result keeps the Gemini call id for adapter lowering",
+      )
+      assert(contains(followup, "thoughtSignature"), "Gemini thought signature is preserved")
+      assert(contains(followup, "opaque-gemini-signature"), "signature bytes are unchanged")
+      __io_println(result.status)
+      __io_println(atomic_get(lookups))
+      __io_println(contains(followup, "functionCall"))
     },
   )
-  llm_mock({text: "##DONE##"})
-  let result = agent_loop(
-    "Use the lookup tool.",
-    nil,
-    {
-      provider: "mock",
-      model: "gemini-2.5-flash",
-      tools: lookup_tools(),
-      tool_format: "native",
-      loop_until_done: true,
-      done_sentinel: "##DONE##",
-      max_iterations: 3,
-    },
-  )
-  assert(result.status == "done", "Gemini mock agent loop finishes")
-  assert(atomic_get(lookups) == 1, "Gemini mock tool call dispatches once")
-  let calls = llm_mock_calls()
-  assert(len(calls) == 2, "agent loop makes a follow-up model turn")
-  let followup = json_stringify(calls[1].messages)
-  assert(contains(followup, "functionCall"), "assistant history preserves Gemini functionCall")
-  assert(
-    contains(followup, "tool_call_id"),
-    "tool result keeps the Gemini call id for adapter lowering",
-  )
-  assert(contains(followup, "thoughtSignature"), "Gemini thought signature is preserved")
-  assert(contains(followup, "opaque-gemini-signature"), "signature bytes are unchanged")
-  __io_println(result.status)
-  __io_println(atomic_get(lookups))
-  __io_println(contains(followup, "functionCall"))
 }

--- a/conformance/tests/scenarios/llm_call_budget_envelope.harn
+++ b/conformance/tests/scenarios/llm_call_budget_envelope.harn
@@ -1,63 +1,71 @@
+import { with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock(
-    {text: "should not be consumed", input_tokens: 1, output_tokens: 1, model: "claude-opus-4-20250514"},
+  with_llm_script(
+    [
+      {text: "should not be consumed", input_tokens: 1, output_tokens: 1, model: "claude-opus-4-20250514"},
+    ],
+    { ->
+      let expensive = try {
+        llm_call(
+          "budget preflight",
+          nil,
+          {
+            provider: "mock",
+            model: "claude-opus-4-20250514",
+            max_tokens: 1024,
+            llm_retries: 0,
+            budget: {max_cost_usd: 0.0001},
+          },
+        )
+      }
+      let expensive_err = unwrap_err(expensive)
+      __io_println(expensive_err.kind)
+      __io_println(expensive_err.reason)
+      __io_println(expensive_err.category)
+      __io_println(expensive_err.projected_cost_usd > 0.0001)
+      __io_println(len(llm_mock_calls()) == 0)
+      let input_limited = try {
+        llm_call(
+          "this prompt is longer than one estimated token",
+          nil,
+          {
+            provider: "mock",
+            model: "gpt-4o-mini",
+            max_tokens: 16,
+            llm_retries: 0,
+            budget: {max_input_tokens: 1},
+          },
+        )
+      }
+      let input_err = unwrap_err(input_limited)
+      __io_println(input_err.limit)
+      __io_println(input_err.projected_input_tokens > 1)
+    },
   )
-  let expensive = try {
-    llm_call(
-      "budget preflight",
-      nil,
+  with_llm_script(
+    [
       {
-        provider: "mock",
+        text: "still should not be consumed",
+        input_tokens: 1,
+        output_tokens: 1,
         model: "claude-opus-4-20250514",
-        max_tokens: 1024,
-        llm_retries: 0,
-        budget: {max_cost_usd: 0.0001},
       },
-    )
-  }
-  let expensive_err = unwrap_err(expensive)
-  __io_println(expensive_err.kind)
-  __io_println(expensive_err.reason)
-  __io_println(expensive_err.category)
-  __io_println(expensive_err.projected_cost_usd > 0.0001)
-  __io_println(len(llm_mock_calls()) == 0)
-  let input_limited = try {
-    llm_call(
-      "this prompt is longer than one estimated token",
-      nil,
-      {
-        provider: "mock",
-        model: "gpt-4o-mini",
-        max_tokens: 16,
-        llm_retries: 0,
-        budget: {max_input_tokens: 1},
-      },
-    )
-  }
-  let input_err = unwrap_err(input_limited)
-  __io_println(input_err.limit)
-  __io_println(input_err.projected_input_tokens > 1)
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "still should not be consumed",
-      input_tokens: 1,
-      output_tokens: 1,
-      model: "claude-opus-4-20250514",
+    ],
+    { ->
+      let loop_result = agent_loop(
+        "agent budget preflight",
+        nil,
+        {
+          provider: "mock",
+          model: "claude-opus-4-20250514",
+          max_tokens: 1024,
+          max_iterations: 2,
+          budget: {total_budget_usd: 0.0001},
+        },
+      )
+      __io_println(loop_result.status)
+      __io_println(len(llm_mock_calls()) == 0)
     },
   )
-  let loop_result = agent_loop(
-    "agent budget preflight",
-    nil,
-    {
-      provider: "mock",
-      model: "claude-opus-4-20250514",
-      max_tokens: 1024,
-      max_iterations: 2,
-      budget: {total_budget_usd: 0.0001},
-    },
-  )
-  __io_println(loop_result.status)
-  __io_println(len(llm_mock_calls()) == 0)
 }

--- a/conformance/tests/scenarios/llm_call_error_categories.harn
+++ b/conformance/tests/scenarios/llm_call_error_categories.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Walk every canonical ErrorCategory string and verify the thrown
  * dict round-trips `category`, `message`, `provider`, and `model` on
@@ -22,21 +24,30 @@ pipeline default(task) {
     "generic",
   ]
   for category in categories {
-    llm_mock({error: {category: category, message: "synthetic-" + category}})
-    try {
-      llm_call("probe", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
-    } catch (e) {
-      __io_println(
-        category + " thrown=" + e.category + " msg=" + e.message + " provider=" + e.provider
-          + " model="
-          + e.model,
-      )
-    }
-    // Parity: llm_call_safe wraps the exact same fields.
-    llm_mock({error: {category: category, message: "safe-" + category}})
-    let r = llm_call_safe("probe", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
-    __io_println(
-      category + " safe=" + r.error.category + " msg=" + r.error.message + " ok=" + to_string(r.ok),
+    with_llm_script(
+      [{error: {category: category, message: "synthetic-" + category}}],
+      { ->
+        try {
+          llm_call("probe", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
+        } catch (e) {
+          __io_println(
+            category + " thrown=" + e.category + " msg=" + e.message + " provider=" + e.provider
+              + " model="
+              + e.model,
+          )
+        }
+      },
+    )
+    with_llm_script(
+      [{error: {category: category, message: "safe-" + category}}],
+      { ->
+        let r = llm_call_safe("probe", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
+        __io_println(
+          category + " safe=" + r.error.category + " msg=" + r.error.message + " ok="
+            + to_string(r.ok),
+        )
+      },
     )
   }
 }
+// Parity: llm_call_safe wraps the exact same fields.

--- a/conformance/tests/scenarios/llm_call_image_content.harn
+++ b/conformance/tests/scenarios/llm_call_image_content.harn
@@ -1,5 +1,6 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
   let png_path = "vision_fixture.png"
   harness.fs
     .write_bytes(
@@ -11,43 +12,47 @@ pipeline test(task) {
   let png = harness.fs.read_bytes(png_path)
   let image_base64 = bytes_to_base64(png)
   harness.fs.delete(png_path)
-  llm_mock({text: "seen"})
-  let result = llm_call(
-    "",
-    nil,
-    {
-      provider: "mock",
-      model: "gpt-4o",
-      vision: true,
-      messages: [
+  with_llm_script(
+    [llm_text("seen")],
+    { ->
+      let result = llm_call(
+        "",
+        nil,
         {
-          role: "user",
-          content: [
-            {type: "text", text: "Caption the image."},
-            {type: "image", base64: image_base64, media_type: "image/png", detail: "low"},
+          provider: "mock",
+          model: "gpt-4o",
+          vision: true,
+          messages: [
+            {
+              role: "user",
+              content: [
+                {type: "text", text: "Caption the image."},
+                {type: "image", base64: image_base64, media_type: "image/png", detail: "low"},
+              ],
+            },
           ],
         },
-      ],
+      )
+      assert_eq(result.text, "seen")
+      let calls = llm_mock_calls()
+      assert_eq(len(calls), 1)
+      let blocks = calls[0].messages[0].content
+      assert_eq(blocks[0].type, "text")
+      assert_eq(blocks[1].type, "image")
+      assert_eq(blocks[1].media_type, "image/png")
+      assert_eq(blocks[1].base64, image_base64)
+      assert_eq(blocks[1].detail, "low")
+      let gate_error = try {
+        llm_call("plain", nil, {provider: "mock", model: "gpt-3.5-turbo", vision: true})
+        "unreachable"
+      } catch (e) {
+        e
+      }
+      assert(
+        contains(gate_error, "option `vision` is not supported"),
+        "vision gate should reject non-vision models",
+      )
+      log("llm_call_image_content tests passed")
     },
   )
-  assert_eq(result.text, "seen")
-  let calls = llm_mock_calls()
-  assert_eq(len(calls), 1)
-  let blocks = calls[0].messages[0].content
-  assert_eq(blocks[0].type, "text")
-  assert_eq(blocks[1].type, "image")
-  assert_eq(blocks[1].media_type, "image/png")
-  assert_eq(blocks[1].base64, image_base64)
-  assert_eq(blocks[1].detail, "low")
-  let gate_error = try {
-    llm_call("plain", nil, {provider: "mock", model: "gpt-3.5-turbo", vision: true})
-    "unreachable"
-  } catch (e) {
-    e
-  }
-  assert(
-    contains(gate_error, "option `vision` is not supported"),
-    "vision gate should reject non-vision models",
-  )
-  log("llm_call_image_content tests passed")
 }

--- a/conformance/tests/scenarios/llm_call_pdf_audio_content.harn
+++ b/conformance/tests/scenarios/llm_call_pdf_audio_content.harn
@@ -1,7 +1,7 @@
 import { upload } from "std/files"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
-  llm_mock_clear()
   let pdf_path = "sample.pdf"
   harness.fs.write_bytes(pdf_path, bytes_from_string("%PDF-1.4\n1 0 obj\n<<>>\nendobj\n"))
   let file_id = upload(pdf_path, "mock")
@@ -9,33 +9,37 @@ pipeline test(task) {
   harness.fs.delete(pdf_path)
   assert_eq(file_id, file_id_again)
   assert(contains(file_id, "mock_file_"), "mock upload should return a stable file_id")
-  llm_mock({text: "summary"})
-  let result = llm_call(
-    "",
-    nil,
-    {
-      provider: "mock",
-      model: "claude-sonnet-4-7",
-      messages: [
+  with_llm_script(
+    [llm_text("summary")],
+    { ->
+      let result = llm_call(
+        "",
+        nil,
         {
-          role: "user",
-          content: [
-            {type: "pdf", file_id: file_id},
-            {type: "audio", base64: "UklGRg==", media_type: "audio/wav"},
-            {type: "text", text: "Summarize the document and audio."},
+          provider: "mock",
+          model: "claude-sonnet-4-7",
+          messages: [
+            {
+              role: "user",
+              content: [
+                {type: "pdf", file_id: file_id},
+                {type: "audio", base64: "UklGRg==", media_type: "audio/wav"},
+                {type: "text", text: "Summarize the document and audio."},
+              ],
+            },
           ],
         },
-      ],
+      )
+      assert_eq(result.text, "summary")
+      let calls = llm_mock_calls()
+      assert_eq(len(calls), 1)
+      let blocks = calls[0].messages[0].content
+      assert_eq(blocks[0].type, "pdf")
+      assert_eq(blocks[0].file_id, file_id)
+      assert_eq(blocks[1].type, "audio")
+      assert_eq(blocks[1].media_type, "audio/wav")
+      assert_eq(blocks[1].base64, "UklGRg==")
+      log("llm_call_pdf_audio_content tests passed")
     },
   )
-  assert_eq(result.text, "summary")
-  let calls = llm_mock_calls()
-  assert_eq(len(calls), 1)
-  let blocks = calls[0].messages[0].content
-  assert_eq(blocks[0].type, "pdf")
-  assert_eq(blocks[0].file_id, file_id)
-  assert_eq(blocks[1].type, "audio")
-  assert_eq(blocks[1].media_type, "audio/wav")
-  assert_eq(blocks[1].base64, "UklGRg==")
-  log("llm_call_pdf_audio_content tests passed")
 }

--- a/conformance/tests/scenarios/llm_call_safe_error.harn
+++ b/conformance/tests/scenarios/llm_call_safe_error.harn
@@ -1,12 +1,18 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * llm_call_safe turns a categorized error into an envelope with
  * {ok: false, response: nil, error: {category, message}}.
  */
 pipeline default(task) {
-  llm_mock({error: {category: "rate_limit", message: "429 Too Many Requests"}})
-  let r = llm_call_safe("hello", nil, {provider: "mock", llm_retries: 0})
-  __io_println(r.ok)
-  __io_println(r.response == nil)
-  __io_println(r.error.category)
-  __io_println(r.error.message.contains("429"))
+  with_llm_script(
+    [{error: {category: "rate_limit", message: "429 Too Many Requests"}}],
+    { ->
+      let r = llm_call_safe("hello", nil, {provider: "mock", llm_retries: 0})
+      __io_println(r.ok)
+      __io_println(r.response == nil)
+      __io_println(r.error.category)
+      __io_println(r.error.message.contains("429"))
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_safe_success.harn
+++ b/conformance/tests/scenarios/llm_call_safe_success.harn
@@ -1,11 +1,17 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * llm_call_safe wraps a successful llm_call in an {ok, response, error}
  * envelope with no throwing.
  */
 pipeline default(task) {
-  llm_mock({text: "ok"})
-  let r = llm_call_safe("hello", nil, {provider: "mock"})
-  __io_println(r.ok)
-  __io_println(r.response.text)
-  __io_println(r.error == nil)
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let r = llm_call_safe("hello", nil, {provider: "mock"})
+      __io_println(r.ok)
+      __io_println(r.response.text)
+      __io_println(r.error == nil)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_structured_result_clean.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_clean.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `llm_call_structured_result` happy path: clean JSON parses on the
  * first attempt, the envelope reports ok=true, attempts=1, and zero
@@ -9,16 +11,20 @@ pipeline default() {
     required: ["name", "age"],
     properties: {name: {type: "string"}, age: {type: "integer"}},
   }
-  llm_mock({text: "{\"name\": \"Ada\", \"age\": 36}"})
-  let r = llm_call_structured_result("Summarize", schema, {provider: "mock"})
-  __io_println(r.ok)
-  __io_println(r.data.name)
-  __io_println(r.data.age)
-  __io_println(r.attempts)
-  __io_println(r.repaired)
-  __io_println(r.extracted_json)
-  __io_println(r.error)
-  __io_println(r.error_category == nil)
-  __io_println(r.usage.input_tokens >= 0)
-  __io_println(r.provider)
+  with_llm_script(
+    [llm_text("{\"name\": \"Ada\", \"age\": 36}")],
+    { ->
+      let r = llm_call_structured_result("Summarize", schema, {provider: "mock"})
+      __io_println(r.ok)
+      __io_println(r.data.name)
+      __io_println(r.data.age)
+      __io_println(r.attempts)
+      __io_println(r.repaired)
+      __io_println(r.extracted_json)
+      __io_println(r.error)
+      __io_println(r.error_category == nil)
+      __io_println(r.usage.input_tokens >= 0)
+      __io_println(r.provider)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_structured_result_fenced.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_fenced.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Fenced JSON inside a markdown code block: the envelope sets
  * extracted_json: true so callers can tell the model wrapped its
@@ -5,11 +7,15 @@
  */
 pipeline default() {
   let schema = {type: "object", required: ["k"], properties: {k: {type: "string"}}}
-  llm_mock({text: "Sure thing!\n```json\n{\"k\": \"v\"}\n```\nDone."})
-  let r = llm_call_structured_result("Q?", schema, {provider: "mock"})
-  __io_println(r.ok)
-  __io_println(r.data.k)
-  __io_println(r.extracted_json)
-  __io_println(r.attempts)
-  __io_println(r.repaired)
+  with_llm_script(
+    [llm_text("Sure thing!\n```json\n{\"k\": \"v\"}\n```\nDone.")],
+    { ->
+      let r = llm_call_structured_result("Q?", schema, {provider: "mock"})
+      __io_println(r.ok)
+      __io_println(r.data.k)
+      __io_println(r.extracted_json)
+      __io_println(r.attempts)
+      __io_println(r.repaired)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_structured_result_prose.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_prose.harn
@@ -1,10 +1,16 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /** JSON embedded in plain prose (no code fence): extracted_json: true. */
 pipeline default() {
   let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
-  llm_mock({text: "Here is my judgment: {\"verdict\": \"PASS\"} — looks good to me."})
-  let r = llm_call_structured_result("Grade", schema, {provider: "mock"})
-  __io_println(r.ok)
-  __io_println(r.data.verdict)
-  __io_println(r.extracted_json)
-  __io_println(r.attempts)
+  with_llm_script(
+    [llm_text("Here is my judgment: {\"verdict\": \"PASS\"} — looks good to me.")],
+    { ->
+      let r = llm_call_structured_result("Grade", schema, {provider: "mock"})
+      __io_println(r.ok)
+      __io_println(r.data.verdict)
+      __io_println(r.extracted_json)
+      __io_println(r.attempts)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_structured_result_repair.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_repair.harn
@@ -1,19 +1,24 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Repair pass success: first call produces malformed-but-salvageable
  * JSON, repair pass returns valid JSON. Envelope marks repaired=true.
  */
 pipeline default() {
   let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
-  // Main call: schema-invalid (missing required key) — burns 1 attempt
-  // (retries: 0 forces immediate repair fallback).
-  llm_mock({text: "{\"note\": \"missing verdict\"}"})
-  // Repair call: produces conforming JSON.
-  llm_mock({text: "{\"verdict\": \"PASS\"}"})
-  let r = llm_call_structured_result("Grade", schema, {provider: "mock", retries: 0, repair: {enabled: true}})
-  __io_println(r.ok)
-  __io_println(r.data.verdict)
-  __io_println(r.repaired)
-  __io_println(r.attempts)
-  // Two underlying LLM calls were made: main (1) + repair (1).
-  __io_println(len(llm_mock_calls()))
+  with_llm_script(
+    [llm_text("{\"note\": \"missing verdict\"}"), llm_text("{\"verdict\": \"PASS\"}")],
+    { ->
+      let r = llm_call_structured_result("Grade", schema, {provider: "mock", retries: 0, repair: {enabled: true}})
+      __io_println(r.ok)
+      __io_println(r.data.verdict)
+      __io_println(r.repaired)
+      __io_println(r.attempts)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
 }
+// Main call: schema-invalid (missing required key) — burns 1 attempt
+// (retries: 0 forces immediate repair fallback).
+// Repair call: produces conforming JSON.
+// Two underlying LLM calls were made: main (1) + repair (1).

--- a/conformance/tests/scenarios/llm_call_structured_result_repair_fail.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_repair_fail.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Repair pass also fails: ok=false with error_category="repair_failed"
  * so callers can distinguish "tried and failed" from a baseline
@@ -5,17 +7,18 @@
  */
 pipeline default() {
   let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
-  // Main call: missing required key.
-  llm_mock({text: "{\"note\": \"nope\"}"})
-  // Repair call: still invalid.
-  llm_mock({text: "{\"note\": \"still nope\"}"})
-  let r = llm_call_structured_result("Grade", schema, {provider: "mock", retries: 0, repair: {enabled: true}})
-  __io_println(r.ok)
-  __io_println(r.data == nil)
-  __io_println(r.error_category)
-  __io_println(r.repaired)
-  // raw_text comes from the main call (the input the repair pass tried
-  // to fix), not the repair output.
-  __io_println(contains(r.raw_text, "nope"))
-  __io_println(len(llm_mock_calls()))
+  with_llm_script(
+    [llm_text("{\"note\": \"nope\"}"), llm_text("{\"note\": \"still nope\"}")],
+    { ->
+      let r = llm_call_structured_result("Grade", schema, {provider: "mock", retries: 0, repair: {enabled: true}})
+      __io_println(r.ok)
+      __io_println(r.data == nil)
+      __io_println(r.error_category)
+      __io_println(r.repaired)
+      __io_println(contains(r.raw_text, "nope"))
+      __io_println(len(llm_mock_calls()))
+    },
+  )
 }
+// Main call: missing required key.
+// Repair call: still invalid.

--- a/conformance/tests/scenarios/llm_call_structured_result_retry.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_retry.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Schema-retry recovery: first response is missing the required key,
  * second response satisfies the schema. The envelope reports
@@ -9,12 +11,15 @@ pipeline default() {
     required: ["verdict"],
     properties: {verdict: {type: "string"}, note: {type: "string"}},
   }
-  llm_mock({text: "{\"note\": \"hmm\"}"})
-  llm_mock({text: "{\"verdict\": \"PASS\", \"note\": \"\"}"})
-  let r = llm_call_structured_result("Grade", schema, {provider: "mock"})
-  __io_println(r.ok)
-  __io_println(r.data.verdict)
-  __io_println(r.attempts)
-  __io_println(r.repaired)
-  __io_println(r.extracted_json)
+  with_llm_script(
+    [llm_text("{\"note\": \"hmm\"}"), llm_text("{\"verdict\": \"PASS\", \"note\": \"\"}")],
+    { ->
+      let r = llm_call_structured_result("Grade", schema, {provider: "mock"})
+      __io_println(r.ok)
+      __io_println(r.data.verdict)
+      __io_println(r.attempts)
+      __io_println(r.repaired)
+      __io_println(r.extracted_json)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_structured_result_schema_fail.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_schema_fail.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Schema-validation failure with no repair: ok=false,
  * error_category="schema_validation", raw_text preserved for
@@ -5,12 +7,16 @@
  */
 pipeline default() {
   let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
-  llm_mock({text: "{\"verdict\": 42}"})
-  let r = llm_call_structured_result("Grade", schema, {provider: "mock", retries: 0})
-  __io_println(r.ok)
-  __io_println(r.data == nil)
-  __io_println(r.error_category)
-  __io_println(contains(r.raw_text, "verdict"))
-  __io_println(r.repaired)
-  __io_println(r.attempts)
+  with_llm_script(
+    [llm_text("{\"verdict\": 42}")],
+    { ->
+      let r = llm_call_structured_result("Grade", schema, {provider: "mock", retries: 0})
+      __io_println(r.ok)
+      __io_println(r.data == nil)
+      __io_println(r.error_category)
+      __io_println(contains(r.raw_text, "verdict"))
+      __io_println(r.repaired)
+      __io_println(r.attempts)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_structured_result_transport.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_transport.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Transport-level failure: the underlying LLM call errors out (e.g.
  * rate limit). The envelope surfaces ok=false, error_category=
@@ -6,13 +8,17 @@
  */
 pipeline default() {
   let schema = {type: "object", required: ["k"], properties: {k: {type: "string"}}}
-  llm_mock({error: {category: "rate_limit", message: "429 slow down"}})
-  let r = llm_call_structured_result("Q", schema, {provider: "mock", llm_retries: 0, repair: {enabled: true}})
-  __io_println(r.ok)
-  __io_println(r.data == nil)
-  __io_println(r.error_category)
-  __io_println(contains(r.error, "429"))
-  __io_println(r.repaired)
-  __io_println(r.attempts)
-  __io_println(r.raw_text)
+  with_llm_script(
+    [{error: {category: "rate_limit", message: "429 slow down"}}],
+    { ->
+      let r = llm_call_structured_result("Q", schema, {provider: "mock", llm_retries: 0, repair: {enabled: true}})
+      __io_println(r.ok)
+      __io_println(r.data == nil)
+      __io_println(r.error_category)
+      __io_println(contains(r.error, "429"))
+      __io_println(r.repaired)
+      __io_println(r.attempts)
+      __io_println(r.raw_text)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_call_structured_result_typed.harn
+++ b/conformance/tests/scenarios/llm_call_structured_result_typed.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Schema-as-type narrowing: when the schema argument is `schema_of(T)`,
  * the envelope's `data` field narrows to `T | nil` so callers dot-walk
@@ -6,15 +8,19 @@
 type Verdict = {verdict: "pass" | "fail", note: string}
 
 pipeline default() {
-  llm_mock({text: "{\"verdict\": \"pass\", \"note\": \"clean\"}"})
-  let r = llm_call_structured_result("Grade", schema_of(Verdict), {provider: "mock"})
-  // Narrow `data` from `Verdict | nil` to `Verdict` via an
-  // explicit nil guard. The result envelope's `data` field
-  // surfaces the schema-derived type.
-  if r.data != nil {
-    __io_println(r.data.verdict)
-    __io_println(r.data.note)
-  } else {
-    __io_println("unexpected failure")
-  }
+  with_llm_script(
+    [llm_text("{\"verdict\": \"pass\", \"note\": \"clean\"}")],
+    { ->
+      let r = llm_call_structured_result("Grade", schema_of(Verdict), {provider: "mock"})
+      if r.data != nil {
+        __io_println(r.data.verdict)
+        __io_println(r.data.note)
+      } else {
+        __io_println("unexpected failure")
+      }
+    },
+  )
 }
+// Narrow `data` from `Verdict | nil` to `Verdict` via an
+// explicit nil guard. The result envelope's `data` field
+// surfaces the schema-derived type.

--- a/conformance/tests/scenarios/llm_call_structured_retry.harn
+++ b/conformance/tests/scenarios/llm_call_structured_retry.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `llm_call_structured` reuses the standard schema-retry loop. First
  * mock: invalid (missing `verdict`). Second mock: valid. One retry
@@ -9,20 +11,29 @@ pipeline default() {
     required: ["verdict"],
     properties: {verdict: {type: "string"}, improvement: {type: "string"}},
   }
-  llm_mock({text: "{\"improvement\": \"try again\"}"})
-  llm_mock({text: "{\"verdict\": \"YES\", \"improvement\": \"\"}"})
-  let result = llm_call_structured("Grade this", schema, {provider: "mock"})
-  __io_println(result.verdict)
-  __io_println(len(llm_mock_calls()))
-  // Exhaust the retry budget by setting `retries: 0` — the helper
-  // throws because `output_validation: "error"` is the forced default.
-  llm_mock_clear()
-  llm_mock({text: "{\"improvement\": \"still broken\"}"})
-  let err = try {
-    llm_call_structured("Grade again", schema, {provider: "mock", retries: 0})
-  }
-  __io_println(is_err(err))
-  // After #534 the thrown value is a {category, message, ...} dict
-  // — dispatch on category instead of string-matching the message.
-  __io_println(unwrap_err(err)?.category == "schema_validation")
+  with_llm_script(
+    [
+      llm_text("{\"improvement\": \"try again\"}"),
+      llm_text("{\"verdict\": \"YES\", \"improvement\": \"\"}"),
+    ],
+    { ->
+      let result = llm_call_structured("Grade this", schema, {provider: "mock"})
+      __io_println(result.verdict)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
+  with_llm_script(
+    [llm_text("{\"improvement\": \"still broken\"}")],
+    { ->
+      let err = try {
+        llm_call_structured("Grade again", schema, {provider: "mock", retries: 0})
+      }
+      __io_println(is_err(err))
+      __io_println(unwrap_err(err)?.category == "schema_validation")
+    },
+  )
 }
+// Exhaust the retry budget by setting `retries: 0` — the helper
+// throws because `output_validation: "error"` is the forced default.
+// After #534 the thrown value is a {category, message, ...} dict
+// — dispatch on category instead of string-matching the message.

--- a/conformance/tests/scenarios/llm_call_structured_safe.harn
+++ b/conformance/tests/scenarios/llm_call_structured_safe.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `llm_call_structured_safe(prompt, schema, options?)` returns the
  * `{ok, data, error}` envelope on both success and failure. Mirrors
@@ -6,25 +8,35 @@
 pipeline default() {
   let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
   // Success path: parsed data surfaces in `.data`, error is nil.
-  llm_mock({text: "{\"verdict\": \"PASS\"}"})
-  let ok = llm_call_structured_safe("Grade", schema, {provider: "mock"})
-  __io_println(ok.ok)
-  __io_println(ok.data.verdict)
-  __io_println(ok.error == nil)
-  // Schema-validation failure: after `retries: 0` the categorized
-  // schema error is captured in the envelope instead of thrown.
-  llm_mock_clear()
-  llm_mock({text: "{\"other\": \"nope\"}"})
-  let bad = llm_call_structured_safe("Grade", schema, {provider: "mock", retries: 0})
-  __io_println(bad.ok)
-  __io_println(bad.data == nil)
-  __io_println(bad.error.category)
-  // Transport-level failure: injected error bubbles up into
-  // `.error.category` / `.error.message`.
-  llm_mock_clear()
-  llm_mock({error: {category: "rate_limit", message: "429 slow down"}})
-  let rate = llm_call_structured_safe("Grade", schema, {provider: "mock", llm_retries: 0})
-  __io_println(rate.ok)
-  __io_println(rate.error.category)
-  __io_println(contains(rate.error.message, "429"))
+  with_llm_script(
+    [llm_text("{\"verdict\": \"PASS\"}")],
+    { ->
+      let ok = llm_call_structured_safe("Grade", schema, {provider: "mock"})
+      __io_println(ok.ok)
+      __io_println(ok.data.verdict)
+      __io_println(ok.error == nil)
+    },
+  )
+  with_llm_script(
+    [llm_text("{\"other\": \"nope\"}")],
+    { ->
+      let bad = llm_call_structured_safe("Grade", schema, {provider: "mock", retries: 0})
+      __io_println(bad.ok)
+      __io_println(bad.data == nil)
+      __io_println(bad.error.category)
+    },
+  )
+  with_llm_script(
+    [{error: {category: "rate_limit", message: "429 slow down"}}],
+    { ->
+      let rate = llm_call_structured_safe("Grade", schema, {provider: "mock", llm_retries: 0})
+      __io_println(rate.ok)
+      __io_println(rate.error.category)
+      __io_println(contains(rate.error.message, "429"))
+    },
+  )
 }
+// Schema-validation failure: after `retries: 0` the categorized
+// schema error is captured in the envelope instead of thrown.
+// Transport-level failure: injected error bubbles up into
+// `.error.category` / `.error.message`.

--- a/conformance/tests/scenarios/llm_call_structured_success.harn
+++ b/conformance/tests/scenarios/llm_call_structured_success.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `llm_call_structured(prompt, schema, options?)` returns the
  * validated data directly — no `.data` unwrap. The helper forces
@@ -10,18 +12,25 @@ pipeline default() {
     required: ["name", "age"],
     properties: {name: {type: "string"}, age: {type: "integer"}},
   }
-  llm_mock({text: "{\"name\": \"Ada\", \"age\": 36}"})
-  let summary = llm_call_structured("Summarize", schema, {provider: "mock"})
-  __io_println(summary.name)
-  __io_println(summary.age)
-  // A single call was made — no schema retry needed.
-  __io_println(len(llm_mock_calls()))
-  // The forced options are applied by the helper, so a user-provided
-  // `system` lands in the standard slot.
-  llm_mock_clear()
-  llm_mock({text: "{\"name\": \"Grace\", \"age\": 42}"})
-  let grace = llm_call_structured("Summarize", schema, {provider: "mock", system: "You are precise."})
-  __io_println(grace.name)
-  let calls = llm_mock_calls()
-  __io_println(calls[0].system)
+  with_llm_script(
+    [llm_text("{\"name\": \"Ada\", \"age\": 36}")],
+    { ->
+      let summary = llm_call_structured("Summarize", schema, {provider: "mock"})
+      __io_println(summary.name)
+      __io_println(summary.age)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
+  with_llm_script(
+    [llm_text("{\"name\": \"Grace\", \"age\": 42}")],
+    { ->
+      let grace = llm_call_structured("Summarize", schema, {provider: "mock", system: "You are precise."})
+      __io_println(grace.name)
+      let calls = llm_mock_calls()
+      __io_println(calls[0].system)
+    },
+  )
 }
+// A single call was made — no schema retry needed.
+// The forced options are applied by the helper, so a user-provided
+// `system` lands in the standard slot.

--- a/conformance/tests/scenarios/llm_call_transport_retries.harn
+++ b/conformance/tests/scenarios/llm_call_transport_retries.harn
@@ -1,66 +1,88 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({error: {category: "server_error", message: "HTTP 503 Service Unavailable"}})
-  llm_mock({text: "ok after retry"})
-  let recovered = llm_call("retry once", nil, {provider: "mock", llm_retries: 2, llm_backoff_ms: 0})
-  __io_println(recovered.prose)
-  __io_println(len(llm_mock_calls()))
-  llm_mock_clear()
-  llm_mock({error: {category: "server_error", message: "HTTP 503 Service Unavailable"}})
-  llm_mock({error: {category: "server_error", message: "HTTP 503 Service Unavailable again"}})
-  llm_mock({text: "unreachable"})
-  let exhausted = try {
-    llm_call("retry budget exhausted", nil, {provider: "mock", llm_retries: 1, llm_backoff_ms: 0})
-  }
-  __io_println(is_err(exhausted))
-  __io_println(unwrap_err(exhausted)?.kind)
-  __io_println(unwrap_err(exhausted)?.reason)
-  __io_println(len(llm_mock_calls()))
-  llm_mock_clear()
-  llm_mock({error: {category: "server_error", message: "HTTP 503 default fail-fast"}})
-  llm_mock({text: "unreachable without explicit retries"})
-  let default_fail_fast = try {
-    llm_call("default retry budget", nil, {provider: "mock", llm_backoff_ms: 0})
-  }
-  __io_println(is_err(default_fail_fast))
-  __io_println(len(llm_mock_calls()))
-  let schema = {type: "object", required: ["answer"], properties: {answer: {type: "string"}}}
-  llm_mock_clear()
-  llm_mock({text: "{\"wrong\": true}"})
-  let schema_failure = try {
-    llm_call(
-      "schema failure is not a transport retry",
-      nil,
-      {
-        provider: "mock",
-        response_format: "json",
-        output_schema: schema,
-        output_validation: "error",
-        schema_retries: 0,
-        llm_retries: 2,
-        llm_backoff_ms: 0,
-      },
-    )
-  }
-  __io_println(is_err(schema_failure))
-  __io_println(unwrap_err(schema_failure)?.category)
-  __io_println(len(llm_mock_calls()))
-  llm_mock_clear()
-  llm_mock({text: "{\"wrong\": true}"})
-  llm_mock({text: "{\"answer\": \"fixed\"}"})
-  let structured = llm_call(
-    "schema retry",
-    nil,
-    {
-      provider: "mock",
-      response_format: "json",
-      output_schema: schema,
-      output_validation: "error",
-      schema_retries: 1,
-      llm_retries: 2,
-      llm_backoff_ms: 0,
+  with_llm_script(
+    [
+      {error: {category: "server_error", message: "HTTP 503 Service Unavailable"}},
+      llm_text("ok after retry"),
+    ],
+    { ->
+      let recovered = llm_call("retry once", nil, {provider: "mock", llm_retries: 2, llm_backoff_ms: 0})
+      __io_println(recovered.prose)
+      __io_println(len(llm_mock_calls()))
     },
   )
-  __io_println(structured.data.answer)
-  __io_println(len(llm_mock_calls()))
+  with_llm_script(
+    [
+      {error: {category: "server_error", message: "HTTP 503 Service Unavailable"}},
+      {error: {category: "server_error", message: "HTTP 503 Service Unavailable again"}},
+      llm_text("unreachable"),
+    ],
+    { ->
+      let exhausted = try {
+        llm_call("retry budget exhausted", nil, {provider: "mock", llm_retries: 1, llm_backoff_ms: 0})
+      }
+      __io_println(is_err(exhausted))
+      __io_println(unwrap_err(exhausted)?.kind)
+      __io_println(unwrap_err(exhausted)?.reason)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
+  with_llm_script(
+    [
+      {error: {category: "server_error", message: "HTTP 503 default fail-fast"}},
+      llm_text("unreachable without explicit retries"),
+    ],
+    { ->
+      let default_fail_fast = try {
+        llm_call("default retry budget", nil, {provider: "mock", llm_backoff_ms: 0})
+      }
+      __io_println(is_err(default_fail_fast))
+      __io_println(len(llm_mock_calls()))
+    },
+  )
+  let schema = {type: "object", required: ["answer"], properties: {answer: {type: "string"}}}
+  with_llm_script(
+    [llm_text("{\"wrong\": true}")],
+    { ->
+      let schema_failure = try {
+        llm_call(
+          "schema failure is not a transport retry",
+          nil,
+          {
+            provider: "mock",
+            response_format: "json",
+            output_schema: schema,
+            output_validation: "error",
+            schema_retries: 0,
+            llm_retries: 2,
+            llm_backoff_ms: 0,
+          },
+        )
+      }
+      __io_println(is_err(schema_failure))
+      __io_println(unwrap_err(schema_failure)?.category)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
+  with_llm_script(
+    [llm_text("{\"wrong\": true}"), llm_text("{\"answer\": \"fixed\"}")],
+    { ->
+      let structured = llm_call(
+        "schema retry",
+        nil,
+        {
+          provider: "mock",
+          response_format: "json",
+          output_schema: schema,
+          output_validation: "error",
+          schema_retries: 1,
+          llm_retries: 2,
+          llm_backoff_ms: 0,
+        },
+      )
+      __io_println(structured.data.answer)
+      __io_println(len(llm_mock_calls()))
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_ensemble_best_of_n.harn
+++ b/conformance/tests/scenarios/llm_ensemble_best_of_n.harn
@@ -1,32 +1,35 @@
 // Conformance test for std/llm/ensemble::best_of_n — structured judge
 // selects the highest-scoring candidate by index.
 import { best_of_n } from "std/llm/ensemble"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "candidate-A"})
-  llm_mock({text: "candidate-B"})
-  llm_mock({text: "candidate-C"})
-  llm_mock({text: "candidate-D"})
-  // Structured judge response.
-  llm_mock(
-    {text: "{\"best_index\": 2, \"scores\": [0.1, 0.2, 0.9, 0.3], \"reasoning\": \"C is best\"}"},
-  )
-  let result = best_of_n(
-    "rate these",
-    "",
-    {
-      n: 4,
-      parallel: false,
-      sampler_opts: {temperature: 1.0, provider: "mock"},
-      call_opts: {provider: "mock"},
-      judge: "structured",
-      judge_opts: {provider: "mock"},
+  with_llm_script(
+    [
+      llm_text("candidate-A"),
+      llm_text("candidate-B"),
+      llm_text("candidate-C"),
+      llm_text("candidate-D"),
+      llm_text("{\"best_index\": 2, \"scores\": [0.1, 0.2, 0.9, 0.3], \"reasoning\": \"C is best\"}"),
+    ],
+    { ->
+      let result = best_of_n(
+        "rate these",
+        "",
+        {
+          n: 4,
+          parallel: false,
+          sampler_opts: {temperature: 1.0, provider: "mock"},
+          call_opts: {provider: "mock"},
+          judge: "structured",
+          judge_opts: {provider: "mock"},
+        },
+      )
+      __io_println(result.ok)
+      __io_println(result.best.index)
+      __io_println(result.best.text)
+      __io_println(result.judge)
+      __io_println(result.reasoning)
     },
   )
-  __io_println(result.ok)
-  __io_println(result.best.index)
-  __io_println(result.best.text)
-  __io_println(result.judge)
-  __io_println(result.reasoning)
 }

--- a/conformance/tests/scenarios/llm_ensemble_self_consistency.harn
+++ b/conformance/tests/scenarios/llm_ensemble_self_consistency.harn
@@ -1,28 +1,28 @@
 // Conformance test for std/llm/ensemble::self_consistency — majority vote
 // across 5 mocked samples picks the answer with 3 votes.
 import { self_consistency } from "std/llm/ensemble"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "A"})
-  llm_mock({text: "B"})
-  llm_mock({text: "A"})
-  llm_mock({text: "C"})
-  llm_mock({text: "A"})
-  let result = self_consistency(
-    "Pick a letter",
-    "",
-    {
-      n: 5,
-      parallel: false,
-      sampler_opts: {temperature: 1.2},
-      call_opts: {provider: "mock"},
-      extract: { text -> text },
+  with_llm_script(
+    [llm_text("A"), llm_text("B"), llm_text("A"), llm_text("C"), llm_text("A")],
+    { ->
+      let result = self_consistency(
+        "Pick a letter",
+        "",
+        {
+          n: 5,
+          parallel: false,
+          sampler_opts: {temperature: 1.2},
+          call_opts: {provider: "mock"},
+          extract: { text -> text },
+        },
+      )
+      __io_println(result.ok)
+      __io_println(result.answer)
+      __io_println(result.answer_count)
+      __io_println(result.total)
+      __io_println(result.entropy > 0.0)
     },
   )
-  __io_println(result.ok)
-  __io_println(result.answer)
-  __io_println(result.answer_count)
-  __io_println(result.total)
-  __io_println(result.entropy > 0.0)
 }

--- a/conformance/tests/scenarios/llm_ensemble_self_consistency_no_extracts.harn
+++ b/conformance/tests/scenarios/llm_ensemble_self_consistency_no_extracts.harn
@@ -2,23 +2,25 @@
 // extract closure returns nil for every sample, the result reports
 // {ok: false, status: "no_extractable_answers"}.
 import { self_consistency } from "std/llm/ensemble"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "noise-1"})
-  llm_mock({text: "noise-2"})
-  llm_mock({text: "noise-3"})
-  let result = self_consistency(
-    "anything",
-    "",
-    {
-      n: 3,
-      parallel: false,
-      sampler_opts: {temperature: 1.2},
-      call_opts: {provider: "mock"},
-      extract: { _text -> nil },
+  with_llm_script(
+    [llm_text("noise-1"), llm_text("noise-2"), llm_text("noise-3")],
+    { ->
+      let result = self_consistency(
+        "anything",
+        "",
+        {
+          n: 3,
+          parallel: false,
+          sampler_opts: {temperature: 1.2},
+          call_opts: {provider: "mock"},
+          extract: { _text -> nil },
+        },
+      )
+      __io_println(result.ok)
+      __io_println(result.status)
     },
   )
-  __io_println(result.ok)
-  __io_println(result.status)
 }

--- a/conformance/tests/scenarios/llm_handlers_circuit_breaker_pool.harn
+++ b/conformance/tests/scenarios/llm_handlers_circuit_breaker_pool.harn
@@ -1,60 +1,66 @@
 import { with_circuit_breaker } from "std/llm/handlers"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
   let raw_handler = fn(call) { return llm_call(call.prompt, call?.system, call.opts) }
   let pooled = with_circuit_breaker(raw_handler, {threshold: 2, reset_ms: 60000})
   let bad_call = {prompt: "bad route", system: nil, opts: {provider: "mock", model: "bad-model", llm_retries: 0}}
   let good_call = {prompt: "good route", system: nil, opts: {provider: "mock", model: "good-model", llm_retries: 0}}
-  llm_mock({error: {category: "server_error", message: "bad model failed once"}})
-  try {
-    pooled(bad_call)
-  } catch (e1) {
-    __io_println(error_category(e1))
-  }
-  __io_println(circuit_check("llm:mock:bad-model"))
-  llm_mock({error: {category: "server_error", message: "bad model failed twice"}})
-  try {
-    pooled(bad_call)
-  } catch (e2) {
-    __io_println(error_category(e2))
-  }
-  __io_println(circuit_check("llm:mock:bad-model"))
-  __io_println(circuit_check("llm:mock:good-model"))
-  llm_mock({text: "healthy"})
-  __io_println(pooled(good_call).text)
-  __io_println(circuit_check("llm:mock:good-model"))
-  try {
-    pooled(bad_call)
-  } catch (e3) {
-    __io_println(e3.category)
-    __io_println(e3.circuit)
-  }
-  __io_println(len(llm_mock_calls()))
-  let shared = with_circuit_breaker(raw_handler, {name: "shared-model-circuit", threshold: 1, reset_ms: 60000})
-  llm_mock({error: {category: "server_error", message: "shared circuit failed"}})
-  try {
-    shared(bad_call)
-  } catch (e4) {
-    __io_println(error_category(e4))
-  }
-  try {
-    shared(good_call)
-  } catch (e5) {
-    __io_println(e5.category)
-    __io_println(e5.circuit)
-  }
-  __io_println(len(llm_mock_calls()))
-  let unset = with_circuit_breaker(
-    fn(_call) {
-      throw "missing route failed"
+  with_llm_script(
+    [
+      {error: {category: "server_error", message: "bad model failed once"}},
+      {error: {category: "server_error", message: "bad model failed twice"}},
+      llm_text("healthy"),
+      {error: {category: "server_error", message: "shared circuit failed"}},
+    ],
+    { ->
+      try {
+        pooled(bad_call)
+      } catch (e1) {
+        __io_println(error_category(e1))
+      }
+      __io_println(circuit_check("llm:mock:bad-model"))
+      try {
+        pooled(bad_call)
+      } catch (e2) {
+        __io_println(error_category(e2))
+      }
+      __io_println(circuit_check("llm:mock:bad-model"))
+      __io_println(circuit_check("llm:mock:good-model"))
+      __io_println(pooled(good_call).text)
+      __io_println(circuit_check("llm:mock:good-model"))
+      try {
+        pooled(bad_call)
+      } catch (e3) {
+        __io_println(e3.category)
+        __io_println(e3.circuit)
+      }
+      __io_println(len(llm_mock_calls()))
+      let shared = with_circuit_breaker(raw_handler, {name: "shared-model-circuit", threshold: 1, reset_ms: 60000})
+      try {
+        shared(bad_call)
+      } catch (e4) {
+        __io_println(error_category(e4))
+      }
+      try {
+        shared(good_call)
+      } catch (e5) {
+        __io_println(e5.category)
+        __io_println(e5.circuit)
+      }
+      __io_println(len(llm_mock_calls()))
+      let unset = with_circuit_breaker(
+        fn(_call) {
+          throw "missing route failed"
+        },
+        {threshold: 1, reset_ms: 60000},
+      )
+      try {
+        unset({prompt: "missing route", opts: {}})
+      } catch (e6) {
+        __io_println(error_category(e6))
+      }
+      __io_println(circuit_check("llm:<unset>:<unset>"))
     },
-    {threshold: 1, reset_ms: 60000},
   )
-  try {
-    unset({prompt: "missing route", opts: {}})
-  } catch (e6) {
-    __io_println(error_category(e6))
-  }
-  __io_println(circuit_check("llm:<unset>:<unset>"))
 }

--- a/conformance/tests/scenarios/llm_handlers_with_cache.harn
+++ b/conformance/tests/scenarios/llm_handlers_with_cache.harn
@@ -1,5 +1,6 @@
 import { cache_clear } from "std/cache"
 import { llm_cache_key, with_cache } from "std/llm/handlers"
+import { with_llm_script } from "std/testing"
 
 pipeline default() {
   let store = {
@@ -8,32 +9,42 @@ pipeline default() {
     path: path_join(harness.fs.temp_dir(), "harn-with-cache-sqlite-" + uuid() + ".sqlite"),
   }
   cache_clear({store: store})
-  llm_mock_clear()
-  llm_mock({text: "cached answer", model: "mock-model", provider: "mock"})
-  llm_mock({text: "fresh answer", model: "mock-model", provider: "mock"})
-  let opts = {provider: "mock", model: "mock-model", store: store, stream: false}
-  __io_println(llm_cache_key("same prompt", "same system", opts).starts_with("sha256:"))
-  let first = with_cache("same prompt", "same system", opts)
-  let second = with_cache("same prompt", "same system", opts)
-  __io_println(first.text)
-  __io_println(second.text)
-  __io_println(json_stringify(first) == json_stringify(second))
-  __io_println(len(llm_mock_calls()) == 1)
-  let skipped = with_cache("same prompt", "same system", opts + {tools: []})
-  __io_println(skipped.text)
-  __io_println(len(llm_mock_calls()) == 2)
+  with_llm_script(
+    [
+      {text: "cached answer", model: "mock-model", provider: "mock"},
+      {text: "fresh answer", model: "mock-model", provider: "mock"},
+    ],
+    { ->
+      let opts = {provider: "mock", model: "mock-model", store: store, stream: false}
+      __io_println(llm_cache_key("same prompt", "same system", opts).starts_with("sha256:"))
+      let first = with_cache("same prompt", "same system", opts)
+      let second = with_cache("same prompt", "same system", opts)
+      __io_println(first.text)
+      __io_println(second.text)
+      __io_println(json_stringify(first) == json_stringify(second))
+      __io_println(len(llm_mock_calls()) == 1)
+      let skipped = with_cache("same prompt", "same system", opts + {tools: []})
+      __io_println(skipped.text)
+      __io_println(len(llm_mock_calls()) == 2)
+    },
+  )
   let fs_store = {
     backend: "fs",
     namespace: "with-cache-fs-" + uuid(),
     path: path_join(harness.fs.temp_dir(), "harn-with-cache-fs-" + uuid()),
   }
-  llm_mock_clear()
-  llm_mock({text: "fs cached", model: "mock-model", provider: "mock"})
-  llm_mock({text: "fs fresh", model: "mock-model", provider: "mock"})
-  let fs_opts = {provider: "mock", model: "mock-model", store: fs_store, stream: false}
-  let fs_first = with_cache("fs prompt", nil, fs_opts)
-  let fs_second = with_cache("fs prompt", nil, fs_opts)
-  __io_println(fs_first.text)
-  __io_println(fs_second.text)
-  __io_println(len(llm_mock_calls()) == 1)
+  with_llm_script(
+    [
+      {text: "fs cached", model: "mock-model", provider: "mock"},
+      {text: "fs fresh", model: "mock-model", provider: "mock"},
+    ],
+    { ->
+      let fs_opts = {provider: "mock", model: "mock-model", store: fs_store, stream: false}
+      let fs_first = with_cache("fs prompt", nil, fs_opts)
+      let fs_second = with_cache("fs prompt", nil, fs_opts)
+      __io_println(fs_first.text)
+      __io_println(fs_second.text)
+      __io_println(len(llm_mock_calls()) == 1)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_mock.harn
+++ b/conformance/tests/scenarios/llm_mock.harn
@@ -1,39 +1,57 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
   // Text mock
-  llm_mock({text: "Paris is the capital."})
-  let r1 = llm_call("What is the capital?", nil, {provider: "mock"})
-  __io_println(r1.text)
-  // Tool call mock
-  llm_mock({tool_calls: [{name: "read_file", arguments: {path: "main.rs"}}]})
-  let r2 = llm_call("Read the file", nil, {provider: "mock"})
-  __io_println(len(r2.tool_calls))
-  __io_println(r2.tool_calls[0].name)
-  // Mixed text + tool calls
-  llm_mock({text: "Checking file.", tool_calls: [{name: "search", arguments: {query: "test"}}]})
-  let r3 = llm_call("Search", nil, {provider: "mock"})
-  __io_println(r3.text)
-  __io_println(r3.tool_calls[0].name)
-  // FIFO ordering
-  llm_mock({text: "first"})
-  llm_mock({text: "second"})
-  __io_println(llm_call("a", nil, {provider: "mock"}).text)
-  __io_println(llm_call("b", nil, {provider: "mock"}).text)
-  // Fallback to default when empty
-  let fb = llm_call("hello world", nil, {provider: "mock"})
-  __io_println(contains(fb.text, "Mock response"))
-  // Pattern matching (not consumed)
-  llm_mock({text: "matched!", match: "*hello*"})
-  __io_println(llm_call("say hello please", nil, {provider: "mock"}).text)
-  __io_println(llm_call("say hello again", nil, {provider: "mock"}).text)
-  // Pattern matching (consumed in match order)
-  llm_mock({text: "first matched", match: "*step*", consume_match: true})
-  llm_mock({text: "second matched", match: "*step*", consume_match: true})
-  __io_println(llm_call("step once", nil, {provider: "mock"}).text)
-  __io_println(llm_call("step twice", nil, {provider: "mock"}).text)
-  // Call inspection
-  let calls = llm_mock_calls()
-  __io_println(len(calls) > 0)
-  // Clear
-  llm_mock_clear()
+  with_llm_script(
+    [llm_text("Paris is the capital.")],
+    { ->
+      let r1 = llm_call("What is the capital?", nil, {provider: "mock"})
+      __io_println(r1.text)
+    },
+  )
+  with_llm_script(
+    [{tool_calls: [{name: "read_file", arguments: {path: "main.rs"}}]}],
+    { ->
+      let r2 = llm_call("Read the file", nil, {provider: "mock"})
+      __io_println(len(r2.tool_calls))
+      __io_println(r2.tool_calls[0].name)
+    },
+  )
+  with_llm_script(
+    [{text: "Checking file.", tool_calls: [{name: "search", arguments: {query: "test"}}]}],
+    { ->
+      let r3 = llm_call("Search", nil, {provider: "mock"})
+      __io_println(r3.text)
+      __io_println(r3.tool_calls[0].name)
+    },
+  )
+  with_llm_script(
+    [llm_text("first"), llm_text("second")],
+    { ->
+      __io_println(llm_call("a", nil, {provider: "mock"}).text)
+      __io_println(llm_call("b", nil, {provider: "mock"}).text)
+      let fb = llm_call("hello world", nil, {provider: "mock"})
+      __io_println(contains(fb.text, "Mock response"))
+    },
+  )
+  with_llm_script(
+    [{text: "matched!", match: "*hello*"}],
+    { ->
+      __io_println(llm_call("say hello please", nil, {provider: "mock"}).text)
+      __io_println(llm_call("say hello again", nil, {provider: "mock"}).text)
+    },
+  )
+  with_llm_script(
+    [
+      {text: "first matched", match: "*step*", consume_match: true},
+      {text: "second matched", match: "*step*", consume_match: true},
+    ],
+    { ->
+      __io_println(llm_call("step once", nil, {provider: "mock"}).text)
+      __io_println(llm_call("step twice", nil, {provider: "mock"}).text)
+      let calls = llm_mock_calls()
+      __io_println(len(calls) > 0)
+    },
+  )
   __io_println(len(llm_mock_calls()))
 }

--- a/conformance/tests/scenarios/llm_mock_error.harn
+++ b/conformance/tests/scenarios/llm_mock_error.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * `llm_call`'s catch value is a dict `{kind, reason, category,
  * message, retry_after_ms?, provider, model}` — the same shape
@@ -8,27 +10,35 @@
 pipeline default(task) {
   // `llm_retries: 0` disables the llm_call-internal transient retry so
   // a single injected error surfaces as a throw on the first attempt.
-  llm_mock({error: {category: "rate_limit", message: "429 Too Many Requests", retry_after_ms: 2500}})
-  try {
-    llm_call("hello", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
-  } catch (e) {
-    __io_println(error_category(e))
-    __io_println(is_rate_limited(e))
-    __io_println(e.kind)
-    __io_println(e.reason)
-    __io_println(e.category)
-    __io_println(e.retry_after_ms)
-    __io_println(e.provider)
-    __io_println(e.model)
-  }
-  llm_mock({error: {category: "overloaded", message: "529 overloaded"}})
-  try {
-    llm_call("hello again", nil, {provider: "mock", llm_retries: 0})
-  } catch (e2) {
-    __io_println(error_category(e2))
-    __io_println(e2.kind)
-    __io_println(e2.reason)
-    // retry_after_ms is omitted when the provider didn't surface one.
-    __io_println(e2.retry_after_ms == nil)
-  }
+  with_llm_script(
+    [{error: {category: "rate_limit", message: "429 Too Many Requests", retry_after_ms: 2500}}],
+    { ->
+      try {
+        llm_call("hello", nil, {provider: "mock", model: "mock-model", llm_retries: 0})
+      } catch (e) {
+        __io_println(error_category(e))
+        __io_println(is_rate_limited(e))
+        __io_println(e.kind)
+        __io_println(e.reason)
+        __io_println(e.category)
+        __io_println(e.retry_after_ms)
+        __io_println(e.provider)
+        __io_println(e.model)
+      }
+    },
+  )
+  with_llm_script(
+    [{error: {category: "overloaded", message: "529 overloaded"}}],
+    { ->
+      try {
+        llm_call("hello again", nil, {provider: "mock", llm_retries: 0})
+      } catch (e2) {
+        __io_println(error_category(e2))
+        __io_println(e2.kind)
+        __io_println(e2.reason)
+        __io_println(e2.retry_after_ms == nil)
+      }
+    },
+  )
 }
+// retry_after_ms is omitted when the provider didn't surface one.

--- a/conformance/tests/scenarios/llm_mock_error_envelope_invalid_kind.harn
+++ b/conformance/tests/scenarios/llm_mock_error_envelope_invalid_kind.harn
@@ -1,3 +1,9 @@
+import { with_llm_script } from "std/testing"
+
 pipeline default(task) {
-  llm_mock({error: {status: 503, kind: "flaky"}})
+  with_llm_script(
+    [{error: {status: 503, kind: "flaky"}}],
+    { ->
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_mock_error_envelopes.harn
+++ b/conformance/tests/scenarios/llm_mock_error_envelopes.harn
@@ -1,27 +1,32 @@
+import { with_llm_script } from "std/testing"
+
 pipeline default(task) {
-  llm_mock_clear()
-  llm_mock(
-    {
-      error: {
-        status: 503,
-        kind: "transient",
-        reason: "upstream_unavailable",
-        message: "upstream unavailable",
-        retry_after_ms: 120,
+  with_llm_script(
+    [
+      {
+        error: {
+          status: 503,
+          kind: "transient",
+          reason: "upstream_unavailable",
+          message: "upstream unavailable",
+          retry_after_ms: 120,
+        },
       },
+      {text: "recovered", tool_calls: []},
+    ],
+    { ->
+      let first = llm_call_safe("first", nil, {provider: "mock", model: "mock-model"})
+      __io_println(first.ok)
+      __io_println(first.response == nil)
+      __io_println(first.error.status)
+      __io_println(first.error.kind)
+      __io_println(first.error.reason)
+      __io_println(first.error.category)
+      __io_println(first.error.provider)
+      __io_println(first.error.model)
+      __io_println(first.error.retry_after_ms)
+      let second = llm_call("second", nil, {provider: "mock", model: "mock-model"})
+      __io_println(second.text)
     },
   )
-  llm_mock({text: "recovered", tool_calls: []})
-  let first = llm_call_safe("first", nil, {provider: "mock", model: "mock-model"})
-  __io_println(first.ok)
-  __io_println(first.response == nil)
-  __io_println(first.error.status)
-  __io_println(first.error.kind)
-  __io_println(first.error.reason)
-  __io_println(first.error.category)
-  __io_println(first.error.provider)
-  __io_println(first.error.model)
-  __io_println(first.error.retry_after_ms)
-  let second = llm_call("second", nil, {provider: "mock", model: "mock-model"})
-  __io_println(second.text)
 }

--- a/conformance/tests/scenarios/llm_optimize_prompt.harn
+++ b/conformance/tests/scenarios/llm_optimize_prompt.harn
@@ -1,6 +1,7 @@
 import { parallel_judge } from "std/llm/judge"
 import { optimize_prompt } from "std/llm/optimize"
 import { propose_instructions } from "std/llm/refine"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
   let judged = parallel_judge("Prompt", [{id: "one"}], { _ctx -> 0.5 })
@@ -8,48 +9,51 @@ pipeline default() {
   let explicit = propose_instructions("Base", {instruction_proposals: "Tighten the answer."})
   __io_println(explicit[0] == "Base")
   __io_println(explicit[1] == "Tighten the answer.")
-  llm_mock_clear()
-  llm_mock({text: "{\"instructions\":[\"Plan first.\",\"Plan first.\"]}"})
-  let proposed = propose_instructions(
-    "Base",
-    {provider: "mock", proposal_count: 2, system: "Proposal sys", schema_retries: 0, repair: false},
-  )
-  __io_println(proposed[0] == "Base")
-  __io_println(proposed[1] == "Plan first.")
-  __io_println(len(proposed) == 2)
-  __io_println(llm_mock_calls()[0].system == "Proposal sys")
-  let result = optimize_prompt(
-    {
-      base_prompt: "Answer the question.",
-      eval_set: [{id: "add", input: "2 + 2", expected: "4"}, {id: "mul", input: "3 * 3", expected: "9"}],
-      metric: { ctx ->
-        var score = 0.0
-        if contains(lowercase(ctx.prompt), "calculate") {
-          score = score + 0.7
-        }
-        if len(ctx.candidate.demos) > 0 {
-          score = score + 0.3
-        }
-        if contains(lowercase(ctx.prompt), "verbose") {
-          score = score - 0.5
-        }
-        return {score: score, reason: ctx.case.id}
-      },
-      trials: 4,
-      budget: {max_concurrent: 2},
-      instruction_proposals: [
-        "Answer the question.",
-        "Calculate carefully and answer only with the result.",
-        "Be verbose and explain every intermediate thought.",
-      ],
-      demos: [[], [{input: "1 + 1", output: "2"}]],
+  with_llm_script(
+    [llm_text("{\"instructions\":[\"Plan first.\",\"Plan first.\"]}")],
+    { ->
+      let proposed = propose_instructions(
+        "Base",
+        {provider: "mock", proposal_count: 2, system: "Proposal sys", schema_retries: 0, repair: false},
+      )
+      __io_println(proposed[0] == "Base")
+      __io_println(proposed[1] == "Plan first.")
+      __io_println(len(proposed) == 2)
+      __io_println(llm_mock_calls()[0].system == "Proposal sys")
+      let result = optimize_prompt(
+        {
+          base_prompt: "Answer the question.",
+          eval_set: [{id: "add", input: "2 + 2", expected: "4"}, {id: "mul", input: "3 * 3", expected: "9"}],
+          metric: { ctx ->
+            var score = 0.0
+            if contains(lowercase(ctx.prompt), "calculate") {
+              score = score + 0.7
+            }
+            if len(ctx.candidate.demos) > 0 {
+              score = score + 0.3
+            }
+            if contains(lowercase(ctx.prompt), "verbose") {
+              score = score - 0.5
+            }
+            return {score: score, reason: ctx.case.id}
+          },
+          trials: 4,
+          budget: {max_concurrent: 2},
+          instruction_proposals: [
+            "Answer the question.",
+            "Calculate carefully and answer only with the result.",
+            "Be verbose and explain every intermediate thought.",
+          ],
+          demos: [[], [{input: "1 + 1", output: "2"}]],
+        },
+      )
+      __io_println(result.best_score == 1.0)
+      __io_println(contains(result.best_prompt, "Calculate carefully"))
+      __io_println(len(result.trace) == 4)
+      __io_println(result.trace[0].candidate.instruction == "Answer the question.")
+      __io_println(result.trace[-1].acquisition.kind == "expected_improvement")
+      __io_println(result.trace[-1].case_scores[0].case_id == "add")
+      __io_println(result.ranked[0].score == 1.0)
     },
   )
-  __io_println(result.best_score == 1.0)
-  __io_println(contains(result.best_prompt, "Calculate carefully"))
-  __io_println(len(result.trace) == 4)
-  __io_println(result.trace[0].candidate.instruction == "Answer the question.")
-  __io_println(result.trace[-1].acquisition.kind == "expected_improvement")
-  __io_println(result.trace[-1].case_scores[0].case_id == "add")
-  __io_println(result.ranked[0].score == 1.0)
 }

--- a/conformance/tests/scenarios/llm_output_format.harn
+++ b/conformance/tests/scenarios/llm_output_format.harn
@@ -1,26 +1,38 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
   let schema = {type: "object", required: ["answer"], properties: {answer: {type: "string"}}}
-  llm_mock({text: "{\"answer\":\"typed\"}"})
-  let typed = llm_call(
-    "Return JSON",
-    nil,
-    {
-      provider: "mock",
-      output_format: {kind: "json_schema", schema: schema, strict: true},
-      output_validation: "error",
+  with_llm_script(
+    [llm_text("{\"answer\":\"typed\"}")],
+    { ->
+      let typed = llm_call(
+        "Return JSON",
+        nil,
+        {
+          provider: "mock",
+          output_format: {kind: "json_schema", schema: schema, strict: true},
+          output_validation: "error",
+        },
+      )
+      __io_println(typed.data.answer)
     },
   )
-  __io_println(typed.data.answer)
-  llm_mock_clear()
-  llm_mock({text: "{\"answer\":\"legacy\"}"})
-  let legacy = llm_call(
-    "Return JSON",
-    nil,
-    {provider: "mock", response_format: "json", json_schema: schema, output_validation: "error"},
+  with_llm_script(
+    [llm_text("{\"answer\":\"legacy\"}")],
+    { ->
+      let legacy = llm_call(
+        "Return JSON",
+        nil,
+        {provider: "mock", response_format: "json", json_schema: schema, output_validation: "error"},
+      )
+      __io_println(legacy.data.answer)
+    },
   )
-  __io_println(legacy.data.answer)
-  llm_mock_clear()
-  llm_mock({text: "{\"answer\":\"loose\"}"})
-  let loose = llm_call("Return JSON", nil, {provider: "mock", output_format: {kind: "json_object"}})
-  __io_println(loose.data.answer)
+  with_llm_script(
+    [llm_text("{\"answer\":\"loose\"}")],
+    { ->
+      let loose = llm_call("Return JSON", nil, {provider: "mock", output_format: {kind: "json_object"}})
+      __io_println(loose.data.answer)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_refine_basic.harn
+++ b/conformance/tests/scenarios/llm_refine_basic.harn
@@ -1,20 +1,24 @@
 // Conformance test for std/llm/refine::refine_prompt — extracts the
 // rewritten prompt and the trailing `DIFF: ...` summary.
 import { refine_prompt } from "std/llm/refine"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "You are an expert.\nDIFF: shortened from 200 to 80 tokens."})
-  let result = refine_prompt(
-    {
-      user_prompt: "Please please please be careful and verbose and ramble about this topic at length",
-      style: "concise",
-      model: "mock-model",
-      provider: "mock",
+  with_llm_script(
+    [llm_text("You are an expert.\nDIFF: shortened from 200 to 80 tokens.")],
+    { ->
+      let result = refine_prompt(
+        {
+          user_prompt: "Please please please be careful and verbose and ramble about this topic at length",
+          style: "concise",
+          model: "mock-model",
+          provider: "mock",
+        },
+      )
+      __io_println(result.ok)
+      __io_println(result.refined)
+      __io_println(result.diff_summary)
+      __io_println(result.style)
     },
   )
-  __io_println(result.ok)
-  __io_println(result.refined)
-  __io_println(result.diff_summary)
-  __io_println(result.style)
 }

--- a/conformance/tests/scenarios/llm_refine_no_diff_marker.harn
+++ b/conformance/tests/scenarios/llm_refine_no_diff_marker.harn
@@ -2,14 +2,18 @@
 // omits the `DIFF: ...` trailer, the entire response becomes the
 // refined prompt and diff_summary is empty.
 import { refine_prompt } from "std/llm/refine"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "A short rewrite without a diff."})
-  let result = refine_prompt(
-    {user_prompt: "ramble ramble ramble", style: "concise", model: "mock-model", provider: "mock"},
+  with_llm_script(
+    [llm_text("A short rewrite without a diff.")],
+    { ->
+      let result = refine_prompt(
+        {user_prompt: "ramble ramble ramble", style: "concise", model: "mock-model", provider: "mock"},
+      )
+      __io_println(result.ok)
+      __io_println(result.refined)
+      __io_println("[" + result.diff_summary + "]")
+    },
   )
-  __io_println(result.ok)
-  __io_println(result.refined)
-  __io_println("[" + result.diff_summary + "]")
 }

--- a/conformance/tests/scenarios/llm_rewrite_supersedes_system_fragments.harn
+++ b/conformance/tests/scenarios/llm_rewrite_supersedes_system_fragments.harn
@@ -6,6 +6,7 @@
  * fragments and silently ignore the rewrite.
  */
 import { default_llm_caller, with_prompt_rewrite } from "std/llm/handlers"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
   // The shape the agent loop hands a caller: a joined `system` string plus the
@@ -20,19 +21,25 @@ pipeline test(task) {
     turn: {iteration: 0, session_id: "", attempt: 1},
   }
   // Rewriting `system` supersedes the decomposed fragments.
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let rewriter = with_prompt_rewrite(
-    default_llm_caller(),
-    fn(prompt, system, opts) { return {system: "REWRITTEN PRIMARY"} },
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let rewriter = with_prompt_rewrite(
+        default_llm_caller(),
+        fn(prompt, system, opts) { return {system: "REWRITTEN PRIMARY"} },
+      )
+      let _ = rewriter(call)
+      assert(llm_mock_calls()[0].system == "REWRITTEN PRIMARY", "system rewrite wins over fragments")
+    },
   )
-  let _ = rewriter(call)
-  assert(llm_mock_calls()[0].system == "REWRITTEN PRIMARY", "system rewrite wins over fragments")
-  // Leaving `system` untouched keeps the decomposed fragments authoritative.
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let passthrough = with_prompt_rewrite(default_llm_caller(), fn(prompt, system, opts) { return {} })
-  let _ = passthrough(call)
-  assert(llm_mock_calls()[0].system == "ORIGINAL JOINED", "fragments retained when system untouched")
-  log("llm_rewrite_supersedes_system_fragments tests passed")
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let passthrough = with_prompt_rewrite(default_llm_caller(), fn(prompt, system, opts) { return {} })
+      let _ = passthrough(call)
+      assert(llm_mock_calls()[0].system == "ORIGINAL JOINED", "fragments retained when system untouched")
+      log("llm_rewrite_supersedes_system_fragments tests passed")
+    },
+  )
 }
+// Leaving `system` untouched keeps the decomposed fragments authoritative.

--- a/conformance/tests/scenarios/llm_safe_safe_call_basic.harn
+++ b/conformance/tests/scenarios/llm_safe_safe_call_basic.harn
@@ -1,11 +1,15 @@
 // std/llm/safe.safe_call wraps a successful llm_call into the canonical
 // envelope shape against the mock provider.
 import { safe_call } from "std/llm/safe"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  let r = safe_call("hi", nil, {provider: "mock", model: "mock-model"})
-  __io_println(r.ok)
-  __io_println(r.value.text)
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      let r = safe_call("hi", nil, {provider: "mock", model: "mock-model"})
+      __io_println(r.ok)
+      __io_println(r.value.text)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_schema_retry.harn
+++ b/conformance/tests/scenarios/llm_schema_retry.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
   let schema = {
     type: "object",
@@ -6,115 +8,131 @@ pipeline default() {
   }
   // First mock: invalid JSON (missing required "verdict" key).
   // Second mock: valid JSON on the nudge retry.
-  llm_mock({text: "{\"improvement\": \"try again\"}"})
-  llm_mock({text: "{\"verdict\": \"YES\", \"improvement\": \"\"}"})
-  let r = llm_call(
-    "Grade this",
-    nil,
-    {
-      provider: "mock",
-      output_schema: schema,
-      output_validation: "error",
-      schema_retries: 2,
-      response_format: "json",
+  with_llm_script(
+    [
+      llm_text("{\"improvement\": \"try again\"}"),
+      llm_text("{\"verdict\": \"YES\", \"improvement\": \"\"}"),
+    ],
+    { ->
+      let r = llm_call(
+        "Grade this",
+        nil,
+        {
+          provider: "mock",
+          output_schema: schema,
+          output_validation: "error",
+          schema_retries: 2,
+          response_format: "json",
+        },
+      )
+      __io_println(r.data.verdict)
+      let calls = llm_mock_calls()
+      __io_println(len(calls))
+      let second_msgs = calls[1].messages
+      let last_msg = second_msgs[len(second_msgs) - 1]
+      __io_println(contains(last_msg.content, "schema"))
+      __io_println(len(second_msgs) == len(calls[0].messages) + 1)
+      var has_assistant = false
+      for msg in second_msgs {
+        if msg.role == "assistant" {
+          has_assistant = true
+        }
+      }
+      __io_println(has_assistant)
+      let trace = agent_trace()
+      var retry_event = nil
+      for ev in trace {
+        if ev.type == "schema_retry" {
+          retry_event = ev
+        }
+      }
+      __io_println(retry_event != nil)
+      __io_println(retry_event.attempt)
+      __io_println(len(retry_event.errors) > 0)
+      __io_println(contains(retry_event.correction_prompt, "schema"))
+      __io_println(retry_event.nudge_used)
     },
   )
-  __io_println(r.data.verdict)
-  // Exactly two calls happened — one initial + one retry.
-  let calls = llm_mock_calls()
-  __io_println(len(calls))
-  // The second call's message list must end with the corrective user
-  // nudge containing the word "schema".
-  let second_msgs = calls[1].messages
-  let last_msg = second_msgs[len(second_msgs) - 1]
-  __io_println(contains(last_msg.content, "schema"))
-  // Issue #533: the invalid response is NOT persisted on retry.
-  // The second call replays the original messages + one correction
-  // user turn, so the message count grows by exactly 1 vs. the first
-  // call, and no "assistant" role appears among the replayed turns.
-  __io_println(len(second_msgs) == len(calls[0].messages) + 1)
-  var has_assistant = false
-  for msg in second_msgs {
-    if msg.role == "assistant" {
-      has_assistant = true
-    }
-  }
-  __io_println(has_assistant)
-  // Issue #533: SchemaRetry trace events carry both the validation
-  // errors AND the correction prompt text, so a transcript reader can
-  // see why a retry happened and what the model received.
-  let trace = agent_trace()
-  var retry_event = nil
-  for ev in trace {
-    if ev.type == "schema_retry" {
-      retry_event = ev
-    }
-  }
-  __io_println(retry_event != nil)
-  __io_println(retry_event.attempt)
-  __io_println(len(retry_event.errors) > 0)
-  __io_println(contains(retry_event.correction_prompt, "schema"))
-  __io_println(retry_event.nudge_used)
-  // schema_retries: 0 — no retry; invalid JSON surfaces as an error.
-  llm_mock_clear()
-  llm_mock({text: "{\"improvement\": \"try again\"}"})
-  let err = try {
-    llm_call(
-      "Grade again",
-      nil,
-      {
-        provider: "mock",
-        output_schema: schema,
-        output_validation: "error",
-        schema_retries: 0,
-        response_format: "json",
-      },
-    )
-  }
-  __io_println(contains(unwrap_err(err).message, "schema"))
-  __io_println(len(llm_mock_calls()))
-  // `schema_retry_nudge: false` still retries; it just omits the
-  // corrective user message.
-  llm_mock_clear()
-  llm_mock({text: "Analyzing the task carefully"})
-  llm_mock({text: "{\"verdict\": \"YES\", \"improvement\": \"\"}"})
-  let bare = llm_call(
-    "Grade with bare retry",
-    nil,
-    {
-      provider: "mock",
-      output_schema: schema,
-      output_validation: "error",
-      schema_retries: 1,
-      schema_retry_nudge: false,
-      response_format: "json",
+  with_llm_script(
+    [llm_text("{\"improvement\": \"try again\"}")],
+    { ->
+      let err = try {
+        llm_call(
+          "Grade again",
+          nil,
+          {
+            provider: "mock",
+            output_schema: schema,
+            output_validation: "error",
+            schema_retries: 0,
+            response_format: "json",
+          },
+        )
+      }
+      __io_println(contains(unwrap_err(err).message, "schema"))
+      __io_println(len(llm_mock_calls()))
     },
   )
-  __io_println(bare.data.verdict)
-  let bare_calls = llm_mock_calls()
-  __io_println(len(bare_calls))
-  let bare_second = bare_calls[1].messages
-  // schema_retry_nudge: false replays the original messages exactly;
-  // the invalid response is NOT persisted as an assistant turn, so
-  // the last role on the retry call is still "user".
-  __io_println(bare_second[len(bare_second) - 1].role)
-  __io_println(len(bare_second) == len(bare_calls[0].messages))
-  // Exhausted prose-only retries surface as hard schema failures.
-  llm_mock_clear()
-  llm_mock({text: "Analyzing the user task"})
-  llm_mock({text: "Examining the failed run"})
-  let prose_err = try {
-    llm_call(
-      "Grade prose-only output",
-      nil,
-      {
-        provider: "mock",
-        output_schema: schema,
-        output_validation: "error",
-        schema_retries: 1,
-        response_format: "json",
-      },
-    )
-  }
-  __io_println(contains(unwrap_err(prose_err).message, "parseable JSON"))
+  with_llm_script(
+    [
+      llm_text("Analyzing the task carefully"),
+      llm_text("{\"verdict\": \"YES\", \"improvement\": \"\"}"),
+    ],
+    { ->
+      let bare = llm_call(
+        "Grade with bare retry",
+        nil,
+        {
+          provider: "mock",
+          output_schema: schema,
+          output_validation: "error",
+          schema_retries: 1,
+          schema_retry_nudge: false,
+          response_format: "json",
+        },
+      )
+      __io_println(bare.data.verdict)
+      let bare_calls = llm_mock_calls()
+      __io_println(len(bare_calls))
+      let bare_second = bare_calls[1].messages
+      __io_println(bare_second[len(bare_second) - 1].role)
+      __io_println(len(bare_second) == len(bare_calls[0].messages))
+    },
+  )
+  with_llm_script(
+    [llm_text("Analyzing the user task"), llm_text("Examining the failed run")],
+    { ->
+      let prose_err = try {
+        llm_call(
+          "Grade prose-only output",
+          nil,
+          {
+            provider: "mock",
+            output_schema: schema,
+            output_validation: "error",
+            schema_retries: 1,
+            response_format: "json",
+          },
+        )
+      }
+      __io_println(contains(unwrap_err(prose_err).message, "parseable JSON"))
+    },
+  )
 }
+// Exactly two calls happened — one initial + one retry.
+// The second call's message list must end with the corrective user
+// nudge containing the word "schema".
+// Issue #533: the invalid response is NOT persisted on retry.
+// The second call replays the original messages + one correction
+// user turn, so the message count grows by exactly 1 vs. the first
+// call, and no "assistant" role appears among the replayed turns.
+// Issue #533: SchemaRetry trace events carry both the validation
+// errors AND the correction prompt text, so a transcript reader can
+// see why a retry happened and what the model received.
+// schema_retries: 0 — no retry; invalid JSON surfaces as an error.
+// `schema_retry_nudge: false` still retries; it just omits the
+// corrective user message.
+// schema_retry_nudge: false replays the original messages exactly;
+// the invalid response is NOT persisted as an assistant turn, so
+// the last role on the retry call is still "user".
+// Exhausted prose-only retries surface as hard schema failures.

--- a/conformance/tests/scenarios/llm_stream_call.harn
+++ b/conformance/tests/scenarios/llm_stream_call.harn
@@ -1,30 +1,45 @@
+import { with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "Visible <think>hidden", stop_reason: "stop"})
-  llm_mock({text: "Visible <think>hidden", stop_reason: "stop"})
-  let chunks = stream
-    .collect(llm_stream_call("stream this", nil, {provider: "mock"}), {max: 4})
-  let direct = llm_call("non-stream this", nil, {provider: "mock"})
-  var raw = ""
-  for chunk in chunks {
-    raw = raw + chunk.delta
-  }
-  let final = chunks[len(chunks) - 1]
-  __io_println(raw == direct.text)
-  __io_println(chunks[0].visible_delta == "Visible")
-  __io_println(chunks[0].partial == "Visible")
-  __io_println(final.finish_reason)
-  __io_println(final.delta == "")
-  llm_mock({text: "early cancel text", stop_reason: "stop"})
-  let first = stream.first(llm_stream_call("cancel early", nil, {provider: "mock"}))
-  __io_println(first.delta == "early cancel text")
-  __io_println(first.finish_reason == nil)
-  llm_mock({text: "break cancel text", stop_reason: "stop"})
-  var broke_before_terminal = false
-  let cancel_stream = llm_stream_call("break early", nil, {provider: "mock"})
-  for chunk in cancel_stream {
-    broke_before_terminal = chunk.finish_reason == nil
-    break
-  }
-  __io_println(broke_before_terminal)
+  with_llm_script(
+    [
+      {text: "Visible <think>hidden", stop_reason: "stop"},
+      {text: "Visible <think>hidden", stop_reason: "stop"},
+    ],
+    { ->
+      let chunks = stream
+        .collect(llm_stream_call("stream this", nil, {provider: "mock"}), {max: 4})
+      let direct = llm_call("non-stream this", nil, {provider: "mock"})
+      var raw = ""
+      for chunk in chunks {
+        raw = raw + chunk.delta
+      }
+      let final = chunks[len(chunks) - 1]
+      __io_println(raw == direct.text)
+      __io_println(chunks[0].visible_delta == "Visible")
+      __io_println(chunks[0].partial == "Visible")
+      __io_println(final.finish_reason)
+      __io_println(final.delta == "")
+    },
+  )
+  with_llm_script(
+    [{text: "early cancel text", stop_reason: "stop"}],
+    { ->
+      let first = stream.first(llm_stream_call("cancel early", nil, {provider: "mock"}))
+      __io_println(first.delta == "early cancel text")
+      __io_println(first.finish_reason == nil)
+    },
+  )
+  with_llm_script(
+    [{text: "break cancel text", stop_reason: "stop"}],
+    { ->
+      var broke_before_terminal = false
+      let cancel_stream = llm_stream_call("break early", nil, {provider: "mock"})
+      for chunk in cancel_stream {
+        broke_before_terminal = chunk.finish_reason == nil
+        break
+      }
+      __io_println(broke_before_terminal)
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_structural_experiments.harn
+++ b/conformance/tests/scenarios/llm_structural_experiments.harn
@@ -1,41 +1,42 @@
 import "std/experiments"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline main() {
-  llm_mock({text: "one"})
-  llm_mock({text: "two"})
-  llm_mock({text: "three"})
-  llm_mock({text: "four"})
-  llm_mock({text: "five"})
-  let custom_exp = custom(
-    "tail_echo",
-    { ctx ->
-      let latest = latest_string_user_message(ctx.messages)
-      let rewritten = replace_message(ctx.messages, latest.index, message("user", latest.message.content + "\n\nTAIL"))
-      return {messages: rewritten, metadata: {kind: "tail_echo"}}
+  with_llm_script(
+    [llm_text("one"), llm_text("two"), llm_text("three"), llm_text("four"), llm_text("five")],
+    { ->
+      let custom_exp = custom(
+        "tail_echo",
+        { ctx ->
+          let latest = latest_string_user_message(ctx.messages)
+          let rewritten = replace_message(ctx.messages, latest.index, message("user", latest.message.content + "\n\nTAIL"))
+          return {messages: rewritten, metadata: {kind: "tail_echo"}}
+        },
+      )
+      llm_call(
+        "alpha\n\nbeta\n\ngamma",
+        nil,
+        {provider: "mock", structural_experiment: "prompt_order_permutation(seed: 42)"},
+      )
+      llm_call("hello", nil, {provider: "mock", structural_experiment: "doubled_prompt"})
+      llm_call(
+        "user prompt",
+        "system prompt",
+        {provider: "mock", structural_experiment: "inverted_system"},
+      )
+      llm_call("final answer", nil, {provider: "mock", structural_experiment: chain_of_draft()})
+      let custom_result = llm_call("custom body", nil, {provider: "mock", structural_experiment: custom_exp})
+      let calls = llm_mock_calls()
+      __io_println(calls[0].messages[0].content != "alpha\n\nbeta\n\ngamma")
+      __io_println(len(calls[1].messages) == 3)
+      __io_println(calls[1].messages[0].content == "hello")
+      __io_println(calls[1].messages[2].content == "hello")
+      __io_println(calls[2].system == "user prompt")
+      __io_println(calls[2].messages[0].content == "system prompt")
+      __io_println(contains(calls[3].messages[0].content, "<draft>"))
+      __io_println(contains(calls[4].messages[0].content, "TAIL"))
+      let provider_events = transcript_events_by_kind(custom_result.transcript, "provider_payload")
+      __io_println(provider_events[0].metadata.structural_experiment.label == "tail_echo")
     },
   )
-  llm_call(
-    "alpha\n\nbeta\n\ngamma",
-    nil,
-    {provider: "mock", structural_experiment: "prompt_order_permutation(seed: 42)"},
-  )
-  llm_call("hello", nil, {provider: "mock", structural_experiment: "doubled_prompt"})
-  llm_call(
-    "user prompt",
-    "system prompt",
-    {provider: "mock", structural_experiment: "inverted_system"},
-  )
-  llm_call("final answer", nil, {provider: "mock", structural_experiment: chain_of_draft()})
-  let custom_result = llm_call("custom body", nil, {provider: "mock", structural_experiment: custom_exp})
-  let calls = llm_mock_calls()
-  __io_println(calls[0].messages[0].content != "alpha\n\nbeta\n\ngamma")
-  __io_println(len(calls[1].messages) == 3)
-  __io_println(calls[1].messages[0].content == "hello")
-  __io_println(calls[1].messages[2].content == "hello")
-  __io_println(calls[2].system == "user prompt")
-  __io_println(calls[2].messages[0].content == "system prompt")
-  __io_println(contains(calls[3].messages[0].content, "<draft>"))
-  __io_println(contains(calls[4].messages[0].content, "TAIL"))
-  let provider_events = transcript_events_by_kind(custom_result.transcript, "provider_payload")
-  __io_println(provider_events[0].metadata.structural_experiment.label == "tail_echo")
 }

--- a/conformance/tests/scenarios/llm_thinking_config.harn
+++ b/conformance/tests/scenarios/llm_thinking_config.harn
@@ -1,41 +1,62 @@
+import { with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
-  llm_call("disabled", nil, {provider: "mock", model: "mock-model", thinking: {mode: "disabled"}})
-  let disabled = llm_mock_calls()[0].thinking
-  assert(disabled.mode == "disabled", "disabled mode reaches mock provider")
-  llm_mock_clear()
-  llm_call(
-    "enabled",
-    nil,
-    {provider: "mock", model: "claude-opus-4-6", thinking: {mode: "enabled", budget_tokens: 8000}},
+  with_llm_script(
+    [],
+    { ->
+      llm_call("disabled", nil, {provider: "mock", model: "mock-model", thinking: {mode: "disabled"}})
+      let disabled = llm_mock_calls()[0].thinking
+      assert(disabled.mode == "disabled", "disabled mode reaches mock provider")
+    },
   )
-  let enabled = llm_mock_calls()[0].thinking
-  assert(enabled.mode == "enabled", "enabled mode reaches mock provider")
-  assert(enabled.budget_tokens == 8000, "enabled budget reaches mock provider")
-  llm_mock_clear()
-  llm_call(
-    "adaptive",
-    nil,
-    {provider: "mock", model: "claude-opus-4-7", thinking: {mode: "adaptive"}},
+  with_llm_script(
+    [],
+    { ->
+      llm_call(
+        "enabled",
+        nil,
+        {provider: "mock", model: "claude-opus-4-6", thinking: {mode: "enabled", budget_tokens: 8000}},
+      )
+      let enabled = llm_mock_calls()[0].thinking
+      assert(enabled.mode == "enabled", "enabled mode reaches mock provider")
+      assert(enabled.budget_tokens == 8000, "enabled budget reaches mock provider")
+    },
   )
-  let adaptive = llm_mock_calls()[0].thinking
-  assert(adaptive.mode == "adaptive", "adaptive mode reaches mock provider")
-  llm_mock_clear()
-  llm_call("effort", nil, {provider: "mock", model: "o3", thinking: {mode: "effort", level: "high"}})
-  let effort = llm_mock_calls()[0].thinking
-  assert(effort.mode == "effort", "effort mode reaches mock provider")
-  assert(effort.level == "high", "effort level reaches mock provider")
-  llm_mock_clear()
-  llm_mock({text: "reasoned answer", thinking_summary: "checked constraints"})
-  let openai_effort = llm_call(
-    "openai reasoning",
-    nil,
-    {provider: "openai", model: "o3", thinking: {mode: "effort", level: "high"}},
+  with_llm_script(
+    [],
+    { ->
+      llm_call(
+        "adaptive",
+        nil,
+        {provider: "mock", model: "claude-opus-4-7", thinking: {mode: "adaptive"}},
+      )
+      let adaptive = llm_mock_calls()[0].thinking
+      assert(adaptive.mode == "adaptive", "adaptive mode reaches mock provider")
+    },
   )
-  let openai_call = llm_mock_calls()[0].thinking
-  assert(openai_call.mode == "effort", "openai effort mode reaches mock transport")
-  assert(openai_call.level == "high", "openai effort level reaches mock transport")
-  assert(openai_effort.text == "reasoned answer", "openai effort call uses mock response")
-  assert(openai_effort.thinking_summary == "checked constraints", "mock summary surfaces on result")
-  log("llm_thinking_config tests passed")
+  with_llm_script(
+    [],
+    { ->
+      llm_call("effort", nil, {provider: "mock", model: "o3", thinking: {mode: "effort", level: "high"}})
+      let effort = llm_mock_calls()[0].thinking
+      assert(effort.mode == "effort", "effort mode reaches mock provider")
+      assert(effort.level == "high", "effort level reaches mock provider")
+    },
+  )
+  with_llm_script(
+    [{text: "reasoned answer", thinking_summary: "checked constraints"}],
+    { ->
+      let openai_effort = llm_call(
+        "openai reasoning",
+        nil,
+        {provider: "openai", model: "o3", thinking: {mode: "effort", level: "high"}},
+      )
+      let openai_call = llm_mock_calls()[0].thinking
+      assert(openai_call.mode == "effort", "openai effort mode reaches mock transport")
+      assert(openai_call.level == "high", "openai effort level reaches mock transport")
+      assert(openai_effort.text == "reasoned answer", "openai effort call uses mock response")
+      assert(openai_effort.thinking_summary == "checked constraints", "mock summary surfaces on result")
+      log("llm_thinking_config tests passed")
+    },
+  )
 }

--- a/conformance/tests/scenarios/llm_thinking_disable_directive.harn
+++ b/conformance/tests/scenarios/llm_thinking_disable_directive.harn
@@ -1,56 +1,72 @@
-/* Verifies that capability-declared `thinking_disable_directive`
-   (e.g. `/no_think` for Qwen3 chat templates) is auto-prepended to the
-   system message when `thinking: false`, and is a no-op otherwise.
-   This is the abstraction that lets script authors say `thinking: false`
-   uniformly without learning per-template prompt directives. */
+import { llm_text, with_llm_script } from "std/testing"
+
+/**
+ * Verifies that capability-declared `thinking_disable_directive`
+ * (e.g. `/no_think` for Qwen3 chat templates) is auto-prepended to the
+ * system message when `thinking: false`, and is a no-op otherwise.
+ * This is the abstraction that lets script authors say `thinking: false`
+ * uniformly without learning per-template prompt directives.
+ */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "say hi",
-    "you are an agent.",
-    {provider: "ollama", model: "qwen3:30b", thinking: {mode: "disabled"}},
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "say hi",
+        "you are an agent.",
+        {provider: "ollama", model: "qwen3:30b", thinking: {mode: "disabled"}},
+      )
+      let qwen_disabled = llm_mock_calls()[0]
+      assert(
+        qwen_disabled.system == "/no_think\nyou are an agent.",
+        "Qwen3-on-Ollama with thinking:false should prepend /no_think to system",
+      )
+    },
   )
-  let qwen_disabled = llm_mock_calls()[0]
-  assert(
-    qwen_disabled.system == "/no_think\nyou are an agent.",
-    "Qwen3-on-Ollama with thinking:false should prepend /no_think to system",
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "say hi",
+        "you are an agent.",
+        {provider: "ollama", model: "qwen3:30b", thinking: {mode: "enabled"}},
+      )
+      let qwen_enabled = llm_mock_calls()[0]
+      assert(
+        qwen_enabled.system == "you are an agent.",
+        "thinking: enabled should leave system untouched",
+      )
+    },
   )
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "say hi",
-    "you are an agent.",
-    {provider: "ollama", model: "qwen3:30b", thinking: {mode: "enabled"}},
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "say hi",
+        "/no_think\nyou are an agent.",
+        {provider: "ollama", model: "qwen3:30b", thinking: {mode: "disabled"}},
+      )
+      let qwen_idempotent = llm_mock_calls()[0]
+      assert(
+        qwen_idempotent.system == "/no_think\nyou are an agent.",
+        "directive injection should be idempotent when already at head of system",
+      )
+    },
   )
-  let qwen_enabled = llm_mock_calls()[0]
-  assert(
-    qwen_enabled.system == "you are an agent.",
-    "thinking: enabled should leave system untouched",
+  with_llm_script(
+    [llm_text("ok")],
+    { ->
+      llm_call(
+        "say hi",
+        "you are an agent.",
+        {provider: "anthropic", model: "claude-haiku-4-7", thinking: {mode: "disabled"}},
+      )
+      let anthropic_call = llm_mock_calls()[0]
+      assert(
+        anthropic_call.system == "you are an agent.",
+        "providers without a directive capability should leave system untouched",
+      )
+      log("llm_thinking_disable_directive tests passed")
+    },
   )
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "say hi",
-    "/no_think\nyou are an agent.",
-    {provider: "ollama", model: "qwen3:30b", thinking: {mode: "disabled"}},
-  )
-  let qwen_idempotent = llm_mock_calls()[0]
-  assert(
-    qwen_idempotent.system == "/no_think\nyou are an agent.",
-    "directive injection should be idempotent when already at head of system",
-  )
-  llm_mock_clear()
-  llm_mock({text: "ok"})
-  llm_call(
-    "say hi",
-    "you are an agent.",
-    {provider: "anthropic", model: "claude-haiku-4-7", thinking: {mode: "disabled"}},
-  )
-  let anthropic_call = llm_mock_calls()[0]
-  assert(
-    anthropic_call.system == "you are an agent.",
-    "providers without a directive capability should leave system untouched",
-  )
-  log("llm_thinking_disable_directive tests passed")
 }

--- a/conformance/tests/scenarios/manifest_hooks_runtime/main.harn
+++ b/conformance/tests/scenarios/manifest_hooks_runtime/main.harn
@@ -1,5 +1,6 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline default() {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -13,38 +14,44 @@ pipeline default() {
     "Read a note from disk",
     {parameters: {path: {type: "string"}}, handler: { args -> "original result " + args.path }},
   )
-  llm_mock({tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]})
-  llm_mock({tool_calls: [{id: "read_1", name: "read_note", arguments: {path: "notes.txt"}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Exercise manifest hooks",
-    nil,
-    {
-      provider: "mock",
-      tools: registry,
-      loop_until_done: true,
-      max_iterations: 4,
-      session_id: "manifest-hooks-runtime",
+  with_llm_script(
+    [
+      {tool_calls: [{id: "write_1", name: "write_note", arguments: {path: "notes.txt"}}]},
+      {tool_calls: [{id: "read_1", name: "read_note", arguments: {path: "notes.txt"}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Exercise manifest hooks",
+        nil,
+        {
+          provider: "mock",
+          tools: registry,
+          loop_until_done: true,
+          max_iterations: 4,
+          session_id: "manifest-hooks-runtime",
+        },
+      )
+      assert(result?.status == "done", "loop completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) == 3, "three model turns happened")
+      var saw_deny = false
+      for message in calls[1].messages {
+        let content = message?.content
+        if content != nil && contains(content, "manifest denied write_note") {
+          saw_deny = true
+        }
+      }
+      assert(saw_deny, "pre-tool hook denied write_note before execution")
+      var saw_post_hook = false
+      for message in calls[2].messages {
+        let content = message?.content
+        if content != nil && contains(content, "HOOKED:original result notes.txt") {
+          saw_post_hook = true
+        }
+      }
+      assert(saw_post_hook, "post-tool hook rewrote the successful result")
+      log("manifest_hooks_runtime tests passed")
     },
   )
-  assert(result?.status == "done", "loop completes")
-  let calls = llm_mock_calls()
-  assert(len(calls) == 3, "three model turns happened")
-  var saw_deny = false
-  for message in calls[1].messages {
-    let content = message?.content
-    if content != nil && contains(content, "manifest denied write_note") {
-      saw_deny = true
-    }
-  }
-  assert(saw_deny, "pre-tool hook denied write_note before execution")
-  var saw_post_hook = false
-  for message in calls[2].messages {
-    let content = message?.content
-    if content != nil && contains(content, "HOOKED:original result notes.txt") {
-      saw_post_hook = true
-    }
-  }
-  assert(saw_post_hook, "post-tool hook rewrote the successful result")
-  log("manifest_hooks_runtime tests passed")
 }

--- a/conformance/tests/scenarios/native_tool_fallback_observability.harn
+++ b/conformance/tests/scenarios/native_tool_fallback_observability.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn tools() {
   var registry = tool_registry()
   registry = tool_define(
@@ -14,41 +16,49 @@ fn tools() {
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "<tool_call>\nread({ path: \"src/lib.rs\" })\n</tool_call>"})
-  llm_mock({text: "<tool_call>\nread({ path: \"src/lib.rs\" })\n</tool_call>"})
-  let fallback = agent_loop(
-    "Inspect the repo",
-    "You are helpful",
-    {
-      provider: "mock",
-      tools: tools(),
-      tool_format: "native",
-      native_tool_fallback: "allow_once",
-      loop_until_done: true,
-      max_iterations: 2,
+  with_llm_script(
+    [
+      llm_text("<tool_call>\nread({ path: \"src/lib.rs\" })\n</tool_call>"),
+      llm_text("<tool_call>\nread({ path: \"src/lib.rs\" })\n</tool_call>"),
+    ],
+    { ->
+      let fallback = agent_loop(
+        "Inspect the repo",
+        "You are helpful",
+        {
+          provider: "mock",
+          tools: tools(),
+          tool_format: "native",
+          native_tool_fallback: "allow_once",
+          loop_until_done: true,
+          max_iterations: 2,
+        },
+      )
+      __io_println(fallback?.trace?.native_text_tool_fallbacks == 2)
+      __io_println(fallback?.trace?.native_text_tool_fallback_rejections == 1)
+      let fallback_events = transcript_events_by_kind(fallback?.transcript, "native_tool_fallback")
+      __io_println(len(fallback_events) == 2)
+      __io_println(fallback_events[0]?.metadata?.accepted)
+      __io_println(!fallback_events[1]?.metadata?.accepted)
     },
   )
-  __io_println(fallback?.trace?.native_text_tool_fallbacks == 2)
-  __io_println(fallback?.trace?.native_text_tool_fallback_rejections == 1)
-  let fallback_events = transcript_events_by_kind(fallback?.transcript, "native_tool_fallback")
-  __io_println(len(fallback_events) == 2)
-  __io_println(fallback_events[0]?.metadata?.accepted)
-  __io_println(!fallback_events[1]?.metadata?.accepted)
-  llm_mock_clear()
-  llm_mock(
-    {
-      error: {
-        category: "server_error",
-        message: "openai-compatible model mock reported completion_tokens=1 but delivered no content, reasoning, or tool calls",
+  with_llm_script(
+    [
+      {
+        error: {
+          category: "server_error",
+          message: "openai-compatible model mock reported completion_tokens=1 but delivered no content, reasoning, or tool calls",
+        },
       },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let retried = agent_loop(
+        "Finish the task",
+        "You are helpful",
+        {provider: "mock", loop_until_done: true, max_iterations: 1, llm_retries: 1},
+      )
+      __io_println(retried?.trace?.empty_completion_retries == 1)
     },
   )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let retried = agent_loop(
-    "Finish the task",
-    "You are helpful",
-    {provider: "mock", loop_until_done: true, max_iterations: 1, llm_retries: 1},
-  )
-  __io_println(retried?.trace?.empty_completion_retries == 1)
 }

--- a/conformance/tests/scenarios/openai_responses_mode_mock.harn
+++ b/conformance/tests/scenarios/openai_responses_mode_mock.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Native OpenAI Responses mode is an explicit llm_call option. The
  * deterministic mock records the normalized request so provider-sensitive
@@ -5,56 +7,59 @@
  * conversation controls survive option extraction without live credentials.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "{\"ok\":true}"})
-  let result = llm_call(
-    "return a structured answer",
-    nil,
-    {
-      provider: "mock",
-      model: "gpt-5.4-preview",
-      api_mode: "responses",
-      output_format: {
-        kind: "json_schema",
-        schema: {type: "object", properties: {ok: {type: "boolean"}}, required: ["ok"]},
-        strict: true,
-      },
-      provider_tools: [
-        {type: "web_search"},
+  with_llm_script(
+    [llm_text("{\"ok\":true}")],
+    { ->
+      let result = llm_call(
+        "return a structured answer",
+        nil,
         {
-          type: "mcp",
-          server_label: "docs",
-          server_url: "https://mcp.example.test",
-          require_approval: "always",
+          provider: "mock",
+          model: "gpt-5.4-preview",
+          api_mode: "responses",
+          output_format: {
+            kind: "json_schema",
+            schema: {type: "object", properties: {ok: {type: "boolean"}}, required: ["ok"]},
+            strict: true,
+          },
+          provider_tools: [
+            {type: "web_search"},
+            {
+              type: "mcp",
+              server_label: "docs",
+              server_url: "https://mcp.example.test",
+              require_approval: "always",
+            },
+          ],
+          previous_response_id: "resp_prev",
+          response_store: false,
+          background: true,
+          truncation: "auto",
+          compact: true,
+          include: ["web_search_call.action"],
+          max_tool_calls: 2,
         },
-      ],
-      previous_response_id: "resp_prev",
-      response_store: false,
-      background: true,
-      truncation: "auto",
-      compact: true,
-      include: ["web_search_call.action"],
-      max_tool_calls: 2,
+      )
+      assert(result.text == "{\"ok\":true}", "mock response returned")
+      let calls = llm_mock_calls()
+      assert(len(calls) == 1, "one LLM call recorded")
+      let call = calls[0]
+      assert(call.api_mode == "responses", "Responses mode recorded")
+      assert(call.output_format.kind == "json_schema", "structured output kind recorded")
+      assert(call.output_format.schema.properties.ok.type == "boolean", "schema recorded")
+      assert(len(call.provider_tools) == 2, "provider tools recorded")
+      assert(call.provider_tools[0].type == "web_search", "hosted tool recorded")
+      assert(call.provider_tools[1].type == "mcp", "remote MCP tool recorded")
+      assert(call.provider_tools[1].server_label == "docs", "remote MCP metadata recorded")
+      assert(call.provider_tools[1].require_approval == "always", "provider approval policy recorded")
+      assert(call.previous_response_id == "resp_prev", "previous response id recorded")
+      assert(!call.store, "store flag recorded")
+      assert(call.background, "background flag recorded")
+      assert(call.truncation == "auto", "truncation policy recorded")
+      assert(call.compact, "standalone compaction flag recorded")
+      assert(call.include[0] == "web_search_call.action", "include list recorded")
+      assert(call.max_tool_calls == 2, "tool-call limit recorded")
+      log("openai_responses_mode_mock tests passed")
     },
   )
-  assert(result.text == "{\"ok\":true}", "mock response returned")
-  let calls = llm_mock_calls()
-  assert(len(calls) == 1, "one LLM call recorded")
-  let call = calls[0]
-  assert(call.api_mode == "responses", "Responses mode recorded")
-  assert(call.output_format.kind == "json_schema", "structured output kind recorded")
-  assert(call.output_format.schema.properties.ok.type == "boolean", "schema recorded")
-  assert(len(call.provider_tools) == 2, "provider tools recorded")
-  assert(call.provider_tools[0].type == "web_search", "hosted tool recorded")
-  assert(call.provider_tools[1].type == "mcp", "remote MCP tool recorded")
-  assert(call.provider_tools[1].server_label == "docs", "remote MCP metadata recorded")
-  assert(call.provider_tools[1].require_approval == "always", "provider approval policy recorded")
-  assert(call.previous_response_id == "resp_prev", "previous response id recorded")
-  assert(!call.store, "store flag recorded")
-  assert(call.background, "background flag recorded")
-  assert(call.truncation == "auto", "truncation policy recorded")
-  assert(call.compact, "standalone compaction flag recorded")
-  assert(call.include[0] == "web_search_call.action", "include list recorded")
-  assert(call.max_tool_calls == 2, "tool-call limit recorded")
-  log("openai_responses_mode_mock tests passed")
 }

--- a/conformance/tests/scenarios/per_step_model_policy.harn
+++ b/conformance/tests/scenarios/per_step_model_policy.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 // `@step(model: ..., budget: ..., error_boundary: ...)` is consumed by
 // the runtime: each step's `llm_call` defaults to the configured model
 // when the call site doesn't override it; per-step token / cost
@@ -45,74 +47,69 @@ fn budget_exhausted_escalate_step(ctx) -> string {
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      match: "classify*",
-      consume_match: false,
-      text: "low_priority",
-      input_tokens: 5,
-      output_tokens: 5,
-      model: "claude-haiku-4-5",
+  with_llm_script(
+    [
+      {
+        match: "classify*",
+        consume_match: false,
+        text: "low_priority",
+        input_tokens: 5,
+        output_tokens: 5,
+        model: "claude-haiku-4-5",
+      },
+      {
+        match: "judge*",
+        consume_match: false,
+        text: "balanced",
+        input_tokens: 12,
+        output_tokens: 18,
+        model: "claude-sonnet-4-6",
+      },
+      {
+        match: "decide*",
+        consume_match: false,
+        text: "merge",
+        input_tokens: 30,
+        output_tokens: 40,
+        model: "claude-opus-4-7",
+      },
+      {
+        match: "explode*",
+        consume_match: false,
+        text: "boom",
+        input_tokens: 50,
+        output_tokens: 100,
+        model: "claude-opus-4-7",
+      },
+      {
+        match: "escalate*",
+        consume_match: false,
+        text: "esc",
+        input_tokens: 50,
+        output_tokens: 100,
+        model: "claude-opus-4-7",
+      },
+    ],
+    { ->
+      let result = triage_captain("PR-42")
+      __io_println(result)
+      __io_println(len(llm_mock_calls()))
+      let escalation_caught = try {
+        budget_exhausted_escalate_step("PR-42")
+      }
+      let err = unwrap_err(escalation_caught)
+      __io_println(err.category)
+      __io_println(err.escalated)
+      __io_println(err.step)
     },
   )
-  llm_mock(
-    {
-      match: "judge*",
-      consume_match: false,
-      text: "balanced",
-      input_tokens: 12,
-      output_tokens: 18,
-      model: "claude-sonnet-4-6",
-    },
-  )
-  llm_mock(
-    {
-      match: "decide*",
-      consume_match: false,
-      text: "merge",
-      input_tokens: 30,
-      output_tokens: 40,
-      model: "claude-opus-4-7",
-    },
-  )
-  llm_mock(
-    {
-      match: "explode*",
-      consume_match: false,
-      text: "boom",
-      input_tokens: 50,
-      output_tokens: 100,
-      model: "claude-opus-4-7",
-    },
-  )
-  llm_mock(
-    {
-      match: "escalate*",
-      consume_match: false,
-      text: "esc",
-      input_tokens: 50,
-      output_tokens: 100,
-      model: "claude-opus-4-7",
-    },
-  )
-  // Routing: each `@step`'s configured model defaults onto its
-  // `llm_call`, the prompt-glob mocks return per-model fixtures, and
-  // the over-budget step is skipped (continue → nil).
-  let result = triage_captain("PR-42")
-  __io_println(result)
-  // 3 calls succeeded; the 4th was rejected pre-flight by the step's
-  // own max_tokens=5 budget.
-  __io_println(len(llm_mock_calls()))
-  // `escalate` re-tags the budget-exhausted error with category
-  // "handoff_escalation" and `escalated: true`, which the persona body
-  // can route on. The step's frame is unwound, so the throw exits the
-  // step function as a typed handoff escalation.
-  let escalation_caught = try {
-    budget_exhausted_escalate_step("PR-42")
-  }
-  let err = unwrap_err(escalation_caught)
-  __io_println(err.category)
-  __io_println(err.escalated)
-  __io_println(err.step)
 }
+// Routing: each `@step`'s configured model defaults onto its
+// `llm_call`, the prompt-glob mocks return per-model fixtures, and
+// the over-budget step is skipped (continue → nil).
+// 3 calls succeeded; the 4th was rejected pre-flight by the step's
+// own max_tokens=5 budget.
+// `escalate` re-tags the budget-exhausted error with category
+// "handoff_escalation" and `escalated: true`, which the persona body
+// can route on. The step's frame is unwound, so the throw exits the
+// step function as a typed handoff escalation.

--- a/conformance/tests/scenarios/persona_hooks.harn
+++ b/conformance/tests/scenarios/persona_hooks.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 let hook_order = atomic(0)
 
 fn audit_tools() {
@@ -18,23 +20,28 @@ fn merge_captain(ctx) -> string {
 
 @step(name: "admin_merge")
 fn admin_merge(ctx) -> string {
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "audit_1", name: "audit_tool", arguments: {}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Run the audit tool",
-    nil,
-    {
-      provider: "mock",
-      tools: audit_tools(),
-      tool_format: "native",
-      max_iterations: 2,
-      loop_until_done: true,
-      session_id: "persona-hooks-composition",
+  return with_llm_script(
+    [
+      {tool_calls: [{id: "audit_1", name: "audit_tool", arguments: {}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Run the audit tool",
+        nil,
+        {
+          provider: "mock",
+          tools: audit_tools(),
+          tool_format: "native",
+          max_iterations: 2,
+          loop_until_done: true,
+          session_id: "persona-hooks-composition",
+        },
+      )
+      let saw_tool_hook = json_stringify(transcript_messages(result?.transcript)).contains("permission_denied")
+      return "merge:" + ctx + ":" + to_string(saw_tool_hook)
     },
   )
-  let saw_tool_hook = json_stringify(transcript_messages(result?.transcript)).contains("permission_denied")
-  return "merge:" + ctx + ":" + to_string(saw_tool_hook)
 }
 
 pipeline default() {

--- a/conformance/tests/scenarios/prompt_fragments_decompose.harn
+++ b/conformance/tests/scenarios/prompt_fragments_decompose.harn
@@ -7,6 +7,7 @@
  * one opaque `primary` block.
  */
 import { agent_build_turn_system, agent_build_turn_system_fragments } from "std/agent/preflight"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn contains_id(items, needle) {
   for item in items {
@@ -57,17 +58,20 @@ pipeline test(task) {
     when_to_use "Use when the user asks to reclaim disk space"
     prompt "Remove disk caches carefully."
   }
-  llm_mock_clear()
-  llm_mock({text: "Cleanup done."})
-  let res = agent_loop(
-    "run disk cleanup please",
-    "You are a careful operator.",
-    {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+  with_llm_script(
+    [llm_text("Cleanup done.")],
+    { ->
+      let res = agent_loop(
+        "run disk cleanup please",
+        "You are a careful operator.",
+        {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+      )
+      assert(res?.status == "done", "live loop completes")
+      let recorded = llm_mock_calls()[0].system
+      assert(contains(recorded, "## Active skills"), "live system surfaces active skills")
+      assert(contains(recorded, "You are a careful operator."), "live system surfaces primary text")
+      assert(!contains(recorded, "\n\n\n"), "no triple-newline runs in composed system")
+      log("prompt_fragments_decompose tests passed")
+    },
   )
-  assert(res?.status == "done", "live loop completes")
-  let recorded = llm_mock_calls()[0].system
-  assert(contains(recorded, "## Active skills"), "live system surfaces active skills")
-  assert(contains(recorded, "You are a careful operator."), "live system surfaces primary text")
-  assert(!contains(recorded, "\n\n\n"), "no triple-newline runs in composed system")
-  log("prompt_fragments_decompose tests passed")
 }

--- a/conformance/tests/scenarios/schema_recover_llm_repair.harn
+++ b/conformance/tests/scenarios/schema_recover_llm_repair.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `schema_recover` falls through to the LLM repair stage when the
  * three deterministic stages can't recover the value, and the mock
@@ -7,13 +9,17 @@
  */
 pipeline default() {
   let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
-  llm_mock({text: "{\"verdict\": \"pass\"}"})
-  let r = schema_recover("model said pass but failed to format it", schema, {provider: "mock"})
-  __io_println(r.ok)
-  __io_println(r.stage)
-  let data = r.data
-  if data != nil {
-    __io_println(data.verdict)
-  }
-  __io_println(r.repaired)
+  with_llm_script(
+    [llm_text("{\"verdict\": \"pass\"}")],
+    { ->
+      let r = schema_recover("model said pass but failed to format it", schema, {provider: "mock"})
+      __io_println(r.ok)
+      __io_println(r.stage)
+      let data = r.data
+      if data != nil {
+        __io_println(data.verdict)
+      }
+      __io_println(r.repaired)
+    },
+  )
 }

--- a/conformance/tests/scenarios/skill_lifecycle_catalog_default.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_catalog_default.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * The default skill path is agentic catalog routing: expose a bounded
  * catalog and `load_skill`, then activate/scoped-load a skill only after
@@ -15,22 +17,27 @@ pipeline test(task) {
     prompt "Beta instructions."
   }
   let registry = skill_define(alpha, "beta", skill_find(beta, "beta") ?? {})
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "load-alpha", name: "load_skill", arguments: {name: "alpha"}}]})
-  llm_mock({text: "Alpha loaded."})
-  let result = agent_loop(
-    "alpha please",
-    nil,
-    {provider: "mock", tool_format: "native", max_iterations: 2, skills: registry},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "load-alpha", name: "load_skill", arguments: {name: "alpha"}}]},
+      llm_text("Alpha loaded."),
+    ],
+    { ->
+      let result = agent_loop(
+        "alpha please",
+        nil,
+        {provider: "mock", tool_format: "native", max_iterations: 2, skills: registry},
+      )
+      assert(result?.status == "done", "catalog-routed loop completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) == 2, "load_skill creates a second model turn")
+      assert(contains(calls[0].system, "## Available skills"), "first turn shows skill catalog")
+      assert(!contains(calls[0].system, "## Active skills"), "catalog does not pre-activate skills")
+      assert(contains(json_stringify(calls[0].tools), "load_skill"), "load_skill is advertised")
+      assert(contains(calls[1].system, "## Active skills"), "loaded skill is active on the next turn")
+      assert(contains(calls[1].system, "Alpha instructions."), "loaded skill prompt is active")
+      assert(!contains(calls[1].system, "## Available skills"), "catalog drops once a skill is active")
+      log("skill_lifecycle_catalog_default tests passed")
+    },
   )
-  assert(result?.status == "done", "catalog-routed loop completes")
-  let calls = llm_mock_calls()
-  assert(len(calls) == 2, "load_skill creates a second model turn")
-  assert(contains(calls[0].system, "## Available skills"), "first turn shows skill catalog")
-  assert(!contains(calls[0].system, "## Active skills"), "catalog does not pre-activate skills")
-  assert(contains(json_stringify(calls[0].tools), "load_skill"), "load_skill is advertised")
-  assert(contains(calls[1].system, "## Active skills"), "loaded skill is active on the next turn")
-  assert(contains(calls[1].system, "Alpha instructions."), "loaded skill prompt is active")
-  assert(!contains(calls[1].system, "## Available skills"), "catalog drops once a skill is active")
-  log("skill_lifecycle_catalog_default tests passed")
 }

--- a/conformance/tests/scenarios/skill_lifecycle_exact_metadata.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_exact_metadata.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Metadata skill matching lives in Harn and uses exact normalized tokens.
  * It should not activate skills from substring matches or stop words.
@@ -13,35 +15,44 @@ pipeline test(task) {
     when_to_use "Use when the user asks to ship or deploy"
     prompt "Ship the release."
   }
-  llm_mock_clear()
-  llm_mock({text: "No skill needed."})
-  let generic = agent_loop(
-    "hey wassup? can you help with this?",
-    nil,
-    {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+  with_llm_script(
+    [llm_text("No skill needed.")],
+    { ->
+      let generic = agent_loop(
+        "hey wassup? can you help with this?",
+        nil,
+        {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+      )
+      assert(generic?.status == "done", "generic prompt completes")
+      assert(
+        !contains(llm_mock_calls()[0].system, "## Active skills"),
+        "generic prompt does not activate cleanup",
+      )
+    },
   )
-  assert(generic?.status == "done", "generic prompt completes")
-  assert(
-    !contains(llm_mock_calls()[0].system, "## Active skills"),
-    "generic prompt does not activate cleanup",
+  with_llm_script(
+    [llm_text("No ship skill needed.")],
+    { ->
+      let substring = agent_loop(
+        "review membership analytics",
+        nil,
+        {provider: "mock", max_iterations: 1, skills: ship, skill_match: {strategy: "metadata"}},
+      )
+      assert(substring?.status == "done", "substring prompt completes")
+      assert(!contains(llm_mock_calls()[0].system, "## Active skills"), "membership does not match ship")
+    },
   )
-  llm_mock_clear()
-  llm_mock({text: "No ship skill needed."})
-  let substring = agent_loop(
-    "review membership analytics",
-    nil,
-    {provider: "mock", max_iterations: 1, skills: ship, skill_match: {strategy: "metadata"}},
+  with_llm_script(
+    [llm_text("Cleanup skill active.")],
+    { ->
+      let explicit_id = agent_loop(
+        "run disk cleanup",
+        nil,
+        {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
+      )
+      assert(explicit_id?.status == "done", "explicit skill-id prompt completes")
+      assert(contains(llm_mock_calls()[0].system, "disk_cleanup"), "explicit id tokens activate cleanup")
+      log("skill_lifecycle_exact_metadata tests passed")
+    },
   )
-  assert(substring?.status == "done", "substring prompt completes")
-  assert(!contains(llm_mock_calls()[0].system, "## Active skills"), "membership does not match ship")
-  llm_mock_clear()
-  llm_mock({text: "Cleanup skill active."})
-  let explicit_id = agent_loop(
-    "run disk cleanup",
-    nil,
-    {provider: "mock", max_iterations: 1, skills: disk_cleanup, skill_match: {strategy: "metadata"}},
-  )
-  assert(explicit_id?.status == "done", "explicit skill-id prompt completes")
-  assert(contains(llm_mock_calls()[0].system, "disk_cleanup"), "explicit id tokens activate cleanup")
-  log("skill_lifecycle_exact_metadata tests passed")
 }

--- a/conformance/tests/scenarios/skill_lifecycle_flags.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_flags.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Skills & Tool Vault phase 3 (harn#74): flag honouring.
  *
@@ -7,7 +9,6 @@
  *   and no activation.
  */
 pipeline test(task) {
-  llm_mock_clear()
   skill private_work {
     description "Rotate database credentials"
     when_to_use "User requests a credential rotation"
@@ -27,27 +28,31 @@ pipeline test(task) {
       "disable-model-invocation": true,
     },
   )
-  llm_mock({text: "Nothing to do."})
-  let result = agent_loop(
-    "Please rotate the staging credentials for me",
-    nil,
-    {provider: "mock", max_iterations: 1, skills: guarded, skill_match: {strategy: "metadata"}},
+  with_llm_script(
+    [llm_text("Nothing to do.")],
+    { ->
+      let result = agent_loop(
+        "Please rotate the staging credentials for me",
+        nil,
+        {provider: "mock", max_iterations: 1, skills: guarded, skill_match: {strategy: "metadata"}},
+      )
+      let events = transcript_events(result?.transcript)
+      var activated = 0
+      var matched_events = 0
+      for ev in events {
+        if ev.kind == "skill_activated" {
+          activated = activated + 1
+        }
+        if ev.kind == "skill_matched" {
+          matched_events = matched_events + 1
+        }
+      }
+      assert(activated == 0, "disable-model-invocation hides the skill from the matcher")
+      assert(matched_events >= 1, "skill_matched event fires even with zero candidates")
+      let calls = llm_mock_calls()
+      assert(!contains(calls[0].system, "## Active skills"), "no active-skill section when no match")
+      log("skill_lifecycle_flags tests passed")
+    },
   )
-  let events = transcript_events(result?.transcript)
-  var activated = 0
-  var matched_events = 0
-  for ev in events {
-    if ev.kind == "skill_activated" {
-      activated = activated + 1
-    }
-    if ev.kind == "skill_matched" {
-      matched_events = matched_events + 1
-    }
-  }
-  assert(activated == 0, "disable-model-invocation hides the skill from the matcher")
-  assert(matched_events >= 1, "skill_matched event fires even with zero candidates")
-  // Active-skill section is omitted when no skill activated.
-  let calls = llm_mock_calls()
-  assert(!contains(calls[0].system, "## Active skills"), "no active-skill section when no match")
-  log("skill_lifecycle_flags tests passed")
 }
+// Active-skill section is omitted when no skill activated.

--- a/conformance/tests/scenarios/skill_lifecycle_manual.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_manual.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * `skill_match: {strategy: "manual"}` lets a host render its own compact
  * skill cards while still giving the model the `load_skill` tool for the
@@ -16,31 +18,36 @@ pipeline test(task) {
     prompt "Beta instructions."
   }
   let registry = skill_define(alpha, "beta", skill_find(beta, "beta") ?? {})
-  llm_mock_clear()
-  llm_mock({tool_calls: [{id: "load-alpha", name: "load_skill", arguments: {name: "alpha"}}]})
-  llm_mock({text: "Alpha loaded."})
-  let result = agent_loop(
-    "alpha please",
-    "Host-rendered cards mention `alpha`.",
-    {
-      provider: "mock",
-      tool_format: "native",
-      max_iterations: 2,
-      skills: registry,
-      skill_match: {strategy: "manual"},
+  with_llm_script(
+    [
+      {tool_calls: [{id: "load-alpha", name: "load_skill", arguments: {name: "alpha"}}]},
+      llm_text("Alpha loaded."),
+    ],
+    { ->
+      let result = agent_loop(
+        "alpha please",
+        "Host-rendered cards mention `alpha`.",
+        {
+          provider: "mock",
+          tool_format: "native",
+          max_iterations: 2,
+          skills: registry,
+          skill_match: {strategy: "manual"},
+        },
+      )
+      assert(result?.status == "done", "manual skill loop completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) == 2, "load_skill creates a second model turn")
+      assert(!contains(calls[0].system, "## Available skills"), "manual strategy suppresses catalog")
+      assert(
+        !contains(calls[0].system, "## Active skills"),
+        "manual strategy does not pre-activate skills",
+      )
+      assert(contains(json_stringify(calls[0].tools), "load_skill"), "load_skill is still advertised")
+      assert(contains(calls[1].system, "## Active skills"), "loaded skill is active on the next turn")
+      assert(contains(calls[1].system, "Alpha instructions."), "loaded skill prompt is active")
+      assert(!contains(calls[1].system, "## Available skills"), "manual strategy never adds the catalog")
+      log("skill_lifecycle_manual tests passed")
     },
   )
-  assert(result?.status == "done", "manual skill loop completes")
-  let calls = llm_mock_calls()
-  assert(len(calls) == 2, "load_skill creates a second model turn")
-  assert(!contains(calls[0].system, "## Available skills"), "manual strategy suppresses catalog")
-  assert(
-    !contains(calls[0].system, "## Active skills"),
-    "manual strategy does not pre-activate skills",
-  )
-  assert(contains(json_stringify(calls[0].tools), "load_skill"), "load_skill is still advertised")
-  assert(contains(calls[1].system, "## Active skills"), "loaded skill is active on the next turn")
-  assert(contains(calls[1].system, "Alpha instructions."), "loaded skill prompt is active")
-  assert(!contains(calls[1].system, "## Available skills"), "manual strategy never adds the catalog")
-  log("skill_lifecycle_manual tests passed")
 }

--- a/conformance/tests/scenarios/skill_lifecycle_metadata.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_metadata.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Skills & Tool Vault phase 3 (harn#74): agent_loop lifecycle
  * integration for the explicit `skill_match: {strategy: "metadata"}`
@@ -15,7 +17,6 @@
  *      carries no keyword overlap.
  */
 pipeline test(task) {
-  llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
     tools,
@@ -45,65 +46,69 @@ pipeline test(task) {
   let registry = skill_define(ship, "inspect", skill_find(inspect, "inspect") ?? {})
   // Single-turn mock so the loop completes naturally; we're only
   // observing the system prompt + tool schema filtering on that turn.
-  llm_mock({text: "On it."})
-  let result = agent_loop(
-    "Ship the new release to production",
-    "You are a staff deploy engineer.",
-    {
-      provider: "mock",
-      tools: tools,
-      tool_format: "native",
-      max_iterations: 1,
-      skills: registry,
-      skill_match: {strategy: "metadata"},
+  with_llm_script(
+    [llm_text("On it.")],
+    { ->
+      let result = agent_loop(
+        "Ship the new release to production",
+        "You are a staff deploy engineer.",
+        {
+          provider: "mock",
+          tools: tools,
+          tool_format: "native",
+          max_iterations: 1,
+          skills: registry,
+          skill_match: {strategy: "metadata"},
+        },
+      )
+      assert(result?.status == "done", "agent loop completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) >= 1, "at least one LLM call happened")
+      let first_system = calls[0].system
+      assert(contains(first_system, "## Active skills"), "system prompt includes active-skill section")
+      assert(contains(first_system, "ship"), "activated skill name surfaces in prompt")
+      assert(contains(first_system, "runbook"), "skill body prompt is woven in")
+      assert(contains(first_system, "Scoped tools: deploy_service"), "allowed_tools listed in prompt")
+      let first_tools = calls[0].tools
+      var seen_deploy = false
+      var seen_metrics = false
+      if first_tools != nil {
+        for t in first_tools {
+          if t?.function?.name == "deploy_service" {
+            seen_deploy = true
+          }
+          if t?.function?.name == "query_metrics" {
+            seen_metrics = true
+          }
+        }
+      }
+      assert(seen_deploy, "scoped tool remained in the schema")
+      assert(!seen_metrics, "out-of-scope tool was filtered")
+      let events = transcript_events(result?.transcript)
+      var matched = 0
+      var activated = 0
+      var scoped = 0
+      for ev in events {
+        if ev.kind == "skill_matched" {
+          matched = matched + 1
+          assert(ev.metadata?.strategy == "metadata", "match phase records strategy")
+        }
+        if ev.kind == "skill_activated" {
+          activated = activated + 1
+          assert(ev.metadata?.name == "ship", "activated the expected skill")
+        }
+        if ev.kind == "skill_scope_tools" {
+          scoped = scoped + 1
+        }
+      }
+      assert(matched >= 1, "at least one skill_matched event fired")
+      assert(activated == 1, "one skill activated")
+      assert(scoped == 1, "tool-scope event fired for the active skill")
+      log("skill_lifecycle_metadata tests passed")
     },
   )
-  assert(result?.status == "done", "agent loop completes")
-  // The system prompt on turn 1 carries the active-skill body.
-  let calls = llm_mock_calls()
-  assert(len(calls) >= 1, "at least one LLM call happened")
-  let first_system = calls[0].system
-  assert(contains(first_system, "## Active skills"), "system prompt includes active-skill section")
-  assert(contains(first_system, "ship"), "activated skill name surfaces in prompt")
-  assert(contains(first_system, "runbook"), "skill body prompt is woven in")
-  assert(contains(first_system, "Scoped tools: deploy_service"), "allowed_tools listed in prompt")
-  // Turn 1 tool schema list: query_metrics has been filtered out by
-  // the allowed_tools scope on the active skill.
-  let first_tools = calls[0].tools
-  var seen_deploy = false
-  var seen_metrics = false
-  if first_tools != nil {
-    for t in first_tools {
-      if t?.function?.name == "deploy_service" {
-        seen_deploy = true
-      }
-      if t?.function?.name == "query_metrics" {
-        seen_metrics = true
-      }
-    }
-  }
-  assert(seen_deploy, "scoped tool remained in the schema")
-  assert(!seen_metrics, "out-of-scope tool was filtered")
-  // Transcript events: skill_matched + skill_activated + skill_scope_tools
-  let events = transcript_events(result?.transcript)
-  var matched = 0
-  var activated = 0
-  var scoped = 0
-  for ev in events {
-    if ev.kind == "skill_matched" {
-      matched = matched + 1
-      assert(ev.metadata?.strategy == "metadata", "match phase records strategy")
-    }
-    if ev.kind == "skill_activated" {
-      activated = activated + 1
-      assert(ev.metadata?.name == "ship", "activated the expected skill")
-    }
-    if ev.kind == "skill_scope_tools" {
-      scoped = scoped + 1
-    }
-  }
-  assert(matched >= 1, "at least one skill_matched event fired")
-  assert(activated == 1, "one skill activated")
-  assert(scoped == 1, "tool-scope event fired for the active skill")
-  log("skill_lifecycle_metadata tests passed")
 }
+// The system prompt on turn 1 carries the active-skill body.
+// Turn 1 tool schema list: query_metrics has been filtered out by
+// the allowed_tools scope on the active skill.
+// Transcript events: skill_matched + skill_activated + skill_scope_tools

--- a/conformance/tests/scenarios/skill_lifecycle_namespace_scope.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_namespace_scope.harn
@@ -1,10 +1,11 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * harn v0.7.20 Gap 3: `namespace:<tag>` entries in a skill's
  * `allowed_tools` list match any tool declared with that namespace,
  * instead of requiring an exact tool-name enumeration.
  */
 pipeline test(task) {
-  llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
     tools,
@@ -37,59 +38,63 @@ pipeline test(task) {
     when_to_use "User wants to investigate code"
     allowed_tools ["namespace:read"]
   }
-  llm_mock({text: "On it."})
-  let result = agent_loop(
-    "Investigate the auth flow",
-    "You are a code explorer.",
-    {
-      provider: "mock",
-      tools: tools,
-      tool_format: "native",
-      max_iterations: 1,
-      skills: explorer,
-      skill_match: {strategy: "metadata"},
+  with_llm_script(
+    [llm_text("On it.")],
+    { ->
+      let result = agent_loop(
+        "Investigate the auth flow",
+        "You are a code explorer.",
+        {
+          provider: "mock",
+          tools: tools,
+          tool_format: "native",
+          max_iterations: 1,
+          skills: explorer,
+          skill_match: {strategy: "metadata"},
+        },
+      )
+      assert(result?.status == "done", "agent loop completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) >= 1, "LLM was called")
+      let first_tools = calls[0].tools
+      var seen_read = false
+      var seen_list = false
+      var seen_write = false
+      if first_tools != nil {
+        for t in first_tools {
+          if t?.function?.name == "read_file" {
+            seen_read = true
+          }
+          if t?.function?.name == "list_files" {
+            seen_list = true
+          }
+          if t?.function?.name == "write_file" {
+            seen_write = true
+          }
+        }
+      }
+      assert(seen_read, "namespace:read matches read_file")
+      assert(seen_list, "namespace:read matches list_files (multiple tools per namespace)")
+      assert(!seen_write, "write-namespace tool filtered out")
+      var threw = false
+      try {
+        var bad = skill_registry()
+        bad = skill_define(bad, "broken", {allowed_tools: ["namespace:"]})
+      } catch (err) {
+        threw = true
+      }
+      assert(threw, "empty namespace tag rejected at skill_define")
+      var threw_typo = false
+      try {
+        var bad = skill_registry()
+        bad = skill_define(bad, "broken", {allowed_tools: ["ns:read"]})
+      } catch (err) {
+        threw_typo = true
+      }
+      assert(threw_typo, "unrecognized colon-prefixed entry rejected")
+      log("skill_lifecycle_namespace_scope tests passed")
     },
   )
-  assert(result?.status == "done", "agent loop completes")
-  let calls = llm_mock_calls()
-  assert(len(calls) >= 1, "LLM was called")
-  let first_tools = calls[0].tools
-  var seen_read = false
-  var seen_list = false
-  var seen_write = false
-  if first_tools != nil {
-    for t in first_tools {
-      if t?.function?.name == "read_file" {
-        seen_read = true
-      }
-      if t?.function?.name == "list_files" {
-        seen_list = true
-      }
-      if t?.function?.name == "write_file" {
-        seen_write = true
-      }
-    }
-  }
-  assert(seen_read, "namespace:read matches read_file")
-  assert(seen_list, "namespace:read matches list_files (multiple tools per namespace)")
-  assert(!seen_write, "write-namespace tool filtered out")
-  // Validation: malformed namespace entry raises at skill_define time.
-  var threw = false
-  try {
-    var bad = skill_registry()
-    bad = skill_define(bad, "broken", {allowed_tools: ["namespace:"]})
-  } catch (err) {
-    threw = true
-  }
-  assert(threw, "empty namespace tag rejected at skill_define")
-  // Validation: non-namespace colon in an entry is a typo.
-  var threw_typo = false
-  try {
-    var bad = skill_registry()
-    bad = skill_define(bad, "broken", {allowed_tools: ["ns:read"]})
-  } catch (err) {
-    threw_typo = true
-  }
-  assert(threw_typo, "unrecognized colon-prefixed entry rejected")
-  log("skill_lifecycle_namespace_scope tests passed")
 }
+// Validation: malformed namespace entry raises at skill_define time.
+// Validation: non-namespace colon in an entry is a typo.

--- a/conformance/tests/scenarios/skill_lifecycle_paths.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_paths.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Skills & Tool Vault phase 3 (harn#74): `paths:` auto-trigger.
  *
@@ -6,7 +8,6 @@
  * path hit alone is enough to activate.
  */
 pipeline test(task) {
-  llm_mock_clear()
   skill infra_touch {
     description "Infrastructure work"
     paths ["infra/**", "Dockerfile"]
@@ -17,39 +18,43 @@ pipeline test(task) {
     paths ["docs/**/*.md"]
   }
   let registry = skill_define(infra_touch, "docs_touch", skill_find(docs_touch, "docs_touch") ?? {})
-  llm_mock({text: "All done."})
-  let result = agent_loop(
-    "fix the edge case",
-    nil,
-    {
-      provider: "mock",
-      max_iterations: 1,
-      skills: registry,
-      skill_match: {strategy: "metadata"},
-      working_files: ["infra/terraform/cluster.tf", "README.md"],
+  with_llm_script(
+    [llm_text("All done.")],
+    { ->
+      let result = agent_loop(
+        "fix the edge case",
+        nil,
+        {
+          provider: "mock",
+          max_iterations: 1,
+          skills: registry,
+          skill_match: {strategy: "metadata"},
+          working_files: ["infra/terraform/cluster.tf", "README.md"],
+        },
+      )
+      assert(result?.status == "done", "loop completes on path-only match")
+      let events = transcript_events(result?.transcript)
+      var infra_activated = false
+      var docs_activated = false
+      for ev in events {
+        if ev.kind == "skill_activated" {
+          if ev.metadata?.name == "infra_touch" {
+            infra_activated = true
+          }
+          if ev.metadata?.name == "docs_touch" {
+            docs_activated = true
+          }
+        }
+      }
+      assert(infra_activated, "path-match alone activates infra_touch")
+      assert(!docs_activated, "non-matching skill stays inactive")
+      let calls = llm_mock_calls()
+      assert(
+        contains(calls[0].system, "infra_touch"),
+        "infra_touch prompt body weaves into system prompt",
+      )
+      log("skill_lifecycle_paths tests passed")
     },
   )
-  assert(result?.status == "done", "loop completes on path-only match")
-  // Exactly one skill should have activated — the infra one.
-  let events = transcript_events(result?.transcript)
-  var infra_activated = false
-  var docs_activated = false
-  for ev in events {
-    if ev.kind == "skill_activated" {
-      if ev.metadata?.name == "infra_touch" {
-        infra_activated = true
-      }
-      if ev.metadata?.name == "docs_touch" {
-        docs_activated = true
-      }
-    }
-  }
-  assert(infra_activated, "path-match alone activates infra_touch")
-  assert(!docs_activated, "non-matching skill stays inactive")
-  let calls = llm_mock_calls()
-  assert(
-    contains(calls[0].system, "infra_touch"),
-    "infra_touch prompt body weaves into system prompt",
-  )
-  log("skill_lifecycle_paths tests passed")
 }
+// Exactly one skill should have activated — the infra one.

--- a/conformance/tests/scenarios/skill_lifecycle_reassess.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_reassess.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Skills & Tool Vault phase 3 (harn#74): `sticky: false` triggers
  * the reassess phase before each turn, swapping skills when later
@@ -11,7 +13,6 @@
  *     scores the pivot, activates `review`, deactivates `draft`.
  */
 pipeline test(task) {
-  llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
     tools,
@@ -30,45 +31,53 @@ pipeline test(task) {
   let registry = skill_define(draft, "review_skill", skill_find(review_skill, "review_skill") ?? {})
   // Turn 0: a tool call forces post_turn_callback to fire, giving
   // us a hook to inject a runtime user message that pivots intent.
-  llm_mock({text: "Drafting.", tool_calls: [{id: "t0", name: "noop", arguments: {}}]})
-  // Turn 1: acknowledge the pivot.
-  llm_mock({text: "Reviewing now."})
-  let result = agent_loop(
-    "Please draft the launch memo",
-    nil,
-    {
-      provider: "mock",
-      tools: tools,
-      tool_format: "native",
-      max_iterations: 2,
-      loop_until_done: true,
-      skills: registry,
-      skill_match: {strategy: "metadata", top_n: 1, sticky: false},
-      post_turn_callback: { info ->
-        if info?.iteration == 0 {
-          return {message: "Actually, please review the existing launch memo."}
-        }
-        return ""
-      },
+  with_llm_script(
+    [{text: "Drafting.", tool_calls: [{id: "t0", name: "noop", arguments: {}}]}],
+    { ->
     },
   )
-  let events = transcript_events(result?.transcript)
-  var draft_activate = false
-  var review_activate = false
-  var draft_deactivate = false
-  for ev in events {
-    if ev.kind == "skill_activated" && ev.metadata?.name == "draft" {
-      draft_activate = true
-    }
-    if ev.kind == "skill_activated" && ev.metadata?.name == "review_skill" {
-      review_activate = true
-    }
-    if ev.kind == "skill_deactivated" && ev.metadata?.name == "draft" {
-      draft_deactivate = true
-    }
-  }
-  assert(draft_activate, "draft activated on turn 0")
-  assert(review_activate, "review activated after reassess on turn 1")
-  assert(draft_deactivate, "draft deactivated before review took over")
-  log("skill_lifecycle_reassess tests passed")
+  with_llm_script(
+    [llm_text("Reviewing now.")],
+    { ->
+      let result = agent_loop(
+        "Please draft the launch memo",
+        nil,
+        {
+          provider: "mock",
+          tools: tools,
+          tool_format: "native",
+          max_iterations: 2,
+          loop_until_done: true,
+          skills: registry,
+          skill_match: {strategy: "metadata", top_n: 1, sticky: false},
+          post_turn_callback: { info ->
+            if info?.iteration == 0 {
+              return {message: "Actually, please review the existing launch memo."}
+            }
+            return ""
+          },
+        },
+      )
+      let events = transcript_events(result?.transcript)
+      var draft_activate = false
+      var review_activate = false
+      var draft_deactivate = false
+      for ev in events {
+        if ev.kind == "skill_activated" && ev.metadata?.name == "draft" {
+          draft_activate = true
+        }
+        if ev.kind == "skill_activated" && ev.metadata?.name == "review_skill" {
+          review_activate = true
+        }
+        if ev.kind == "skill_deactivated" && ev.metadata?.name == "draft" {
+          draft_deactivate = true
+        }
+      }
+      assert(draft_activate, "draft activated on turn 0")
+      assert(review_activate, "review activated after reassess on turn 1")
+      assert(draft_deactivate, "draft deactivated before review took over")
+      log("skill_lifecycle_reassess tests passed")
+    },
+  )
 }
+// Turn 1: acknowledge the pivot.

--- a/conformance/tests/scenarios/skill_lifecycle_session_resume.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_session_resume.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Skills & Tool Vault phase 3 (harn#74): session-resume restores
  * the last active skill when the user re-enters a named session.
@@ -9,45 +11,43 @@
  * re-matching.
  */
 pipeline test(task) {
-  llm_mock_clear()
   skill sticky_skill {
     description "Handle every task"
     prompt "Take a careful, confirmed approach."
   }
-  llm_mock({text: "First turn done."})
-  let sid = "skill-resume-test"
-  let r1 = agent_loop(
-    "please handle this task carefully",
-    nil,
-    {
-      provider: "mock",
-      max_iterations: 1,
-      skills: sticky_skill,
-      session_id: sid,
-      skill_match: {strategy: "metadata"},
+  with_llm_script(
+    [llm_text("First turn done."), llm_text("Resume done.")],
+    { ->
+      let sid = "skill-resume-test"
+      let r1 = agent_loop(
+        "please handle this task carefully",
+        nil,
+        {
+          provider: "mock",
+          max_iterations: 1,
+          skills: sticky_skill,
+          session_id: sid,
+          skill_match: {strategy: "metadata"},
+        },
+      )
+      assert(r1?.status == "done", "first run completes")
+      let r2 = agent_loop(
+        "continue",
+        nil,
+        {
+          provider: "mock",
+          max_iterations: 1,
+          skills: sticky_skill,
+          session_id: sid,
+          skill_match: {strategy: "metadata"},
+        },
+      )
+      assert(r2?.status == "done", "resume run completes")
+      let calls = llm_mock_calls()
+      let last = calls[len(calls) - 1]
+      assert(contains(last.system, "sticky_skill"), "resume turn keeps skill active")
+      log("skill_lifecycle_session_resume tests passed")
     },
   )
-  assert(r1?.status == "done", "first run completes")
-  // Second invocation under the same session id: the matcher still
-  // runs (iteration 0 always re-matches) but the rehydration path
-  // seeded state.active_skills before it ran, so the transcript
-  // carries no extra skill_deactivated event (name didn't change).
-  llm_mock({text: "Resume done."})
-  let r2 = agent_loop(
-    "continue",
-    nil,
-    {
-      provider: "mock",
-      max_iterations: 1,
-      skills: sticky_skill,
-      session_id: sid,
-      skill_match: {strategy: "metadata"},
-    },
-  )
-  assert(r2?.status == "done", "resume run completes")
-  // The second run's system prompt still mentions the skill body.
-  let calls = llm_mock_calls()
-  let last = calls[len(calls) - 1]
-  assert(contains(last.system, "sticky_skill"), "resume turn keeps skill active")
-  log("skill_lifecycle_session_resume tests passed")
 }
+// The second run's system prompt still mentions the skill body.

--- a/conformance/tests/scenarios/skill_lifecycle_workflow.harn
+++ b/conformance/tests/scenarios/skill_lifecycle_workflow.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * harn v0.7.20 Gap 2: `skills:` / `skill_match:` pass through
  * `workflow_execute` to every per-node agent loop. Mirrors
@@ -6,7 +8,6 @@
  * workflow-level skill wiring is no longer silently dropped.
  */
 pipeline test(task) {
-  llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
     tools,
@@ -51,45 +52,48 @@ pipeline test(task) {
   // One-shot mock per stage (2 stages, 2 calls). The execute stage is
   // the only one with tools + skills attached, so only its system
   // prompt carries the active-skill section.
-  llm_mock({text: "Queued up deploy."})
-  llm_mock({text: "Verification ok."})
-  let result = workflow_execute(
-    "Ship the new release to production",
-    flow,
-    [],
-    {max_steps: 4, skills: registry, skill_match: {strategy: "metadata"}},
-  )
-  assert(result?.status == "completed", "workflow completes")
-  // The first LLM call must come from the execute stage. Its system
-  // prompt carries the skill body and its tools list has been
-  // narrowed by `allowed_tools`.
-  let calls = llm_mock_calls()
-  assert(len(calls) >= 1, "at least one LLM call happened")
-  let execute_system = calls[0].system
-  assert(
-    contains(execute_system, "## Active skills"),
-    "skills section surfaces in workflow stage prompt",
-  )
-  assert(contains(execute_system, "ship"), "activated skill name appears")
-  assert(contains(execute_system, "runbook"), "skill body woven into workflow stage prompt")
-  assert(
-    contains(execute_system, "Scoped tools: deploy_service"),
-    "allowed_tools listed in workflow stage prompt",
-  )
-  let execute_tools = calls[0].tools
-  var seen_deploy = false
-  var seen_metrics = false
-  if execute_tools != nil {
-    for t in execute_tools {
-      if t?.function?.name == "deploy_service" {
-        seen_deploy = true
+  with_llm_script(
+    [llm_text("Queued up deploy."), llm_text("Verification ok.")],
+    { ->
+      let result = workflow_execute(
+        "Ship the new release to production",
+        flow,
+        [],
+        {max_steps: 4, skills: registry, skill_match: {strategy: "metadata"}},
+      )
+      assert(result?.status == "completed", "workflow completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) >= 1, "at least one LLM call happened")
+      let execute_system = calls[0].system
+      assert(
+        contains(execute_system, "## Active skills"),
+        "skills section surfaces in workflow stage prompt",
+      )
+      assert(contains(execute_system, "ship"), "activated skill name appears")
+      assert(contains(execute_system, "runbook"), "skill body woven into workflow stage prompt")
+      assert(
+        contains(execute_system, "Scoped tools: deploy_service"),
+        "allowed_tools listed in workflow stage prompt",
+      )
+      let execute_tools = calls[0].tools
+      var seen_deploy = false
+      var seen_metrics = false
+      if execute_tools != nil {
+        for t in execute_tools {
+          if t?.function?.name == "deploy_service" {
+            seen_deploy = true
+          }
+          if t?.function?.name == "query_metrics" {
+            seen_metrics = true
+          }
+        }
       }
-      if t?.function?.name == "query_metrics" {
-        seen_metrics = true
-      }
-    }
-  }
-  assert(seen_deploy, "scoped tool survives into the execute stage's tool schema")
-  assert(!seen_metrics, "out-of-scope tool filtered out on the workflow path")
-  log("skill_lifecycle_workflow tests passed")
+      assert(seen_deploy, "scoped tool survives into the execute stage's tool schema")
+      assert(!seen_metrics, "out-of-scope tool filtered out on the workflow path")
+      log("skill_lifecycle_workflow tests passed")
+    },
+  )
 }
+// The first LLM call must come from the execute stage. Its system
+// prompt carries the skill body and its tools list has been
+// narrowed by `allowed_tools`.

--- a/conformance/tests/scenarios/skills_load_skill_errors/main.harn
+++ b/conformance/tests/scenarios/skills_load_skill_errors/main.harn
@@ -1,41 +1,44 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
   let catalog = render_always_on_catalog(skills_catalog_entries(skills), 2000)
-  llm_mock(
-    {
-      text: "Try the gated skill.",
-      tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "secure-review"}}],
+  with_llm_script(
+    [
+      {
+        text: "Try the gated skill.",
+        tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "secure-review"}}],
+      },
+      {
+        text: "Try a missing skill.",
+        tool_calls: [{id: "ls2", name: "load_skill", arguments: {name: "does-not-exist"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Use the skills catalog",
+        catalog,
+        {
+          provider: "mock",
+          model: "gpt-5.4",
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 5,
+          session_id: "skills-load-skill-errors",
+          skills: skills,
+        },
+      )
+      assert(result?.status == "done", "agent loop completes")
+      let calls = llm_mock_calls()
+      let second_messages = json_stringify(calls[1].messages)
+      assert(
+        contains(second_messages, "skill_model_invocation_disabled"),
+        "gated skill returns a typed error",
+      )
+      assert(!contains(second_messages, "top secret"), "gated skill body does not leak")
+      let third_messages = json_stringify(calls[2].messages)
+      assert(contains(third_messages, "skill_not_found"), "missing skill returns a typed error")
+      log("skills_load_skill_errors passed")
     },
   )
-  llm_mock(
-    {
-      text: "Try a missing skill.",
-      tool_calls: [{id: "ls2", name: "load_skill", arguments: {name: "does-not-exist"}}],
-    },
-  )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Use the skills catalog",
-    catalog,
-    {
-      provider: "mock",
-      model: "gpt-5.4",
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 5,
-      session_id: "skills-load-skill-errors",
-      skills: skills,
-    },
-  )
-  assert(result?.status == "done", "agent loop completes")
-  let calls = llm_mock_calls()
-  let second_messages = json_stringify(calls[1].messages)
-  assert(
-    contains(second_messages, "skill_model_invocation_disabled"),
-    "gated skill returns a typed error",
-  )
-  assert(!contains(second_messages, "top secret"), "gated skill body does not leak")
-  let third_messages = json_stringify(calls[2].messages)
-  assert(contains(third_messages, "skill_not_found"), "missing skill returns a typed error")
-  log("skills_load_skill_errors passed")
 }

--- a/conformance/tests/scenarios/skills_load_skill_roundtrip/main.harn
+++ b/conformance/tests/scenarios/skills_load_skill_roundtrip/main.harn
@@ -1,5 +1,6 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
   var tools = tool_registry()
   tools = tool_define(
     tools,
@@ -15,43 +16,47 @@ pipeline test(task) {
   )
   let catalog = render_always_on_catalog(skills_catalog_entries(skills), 2000)
   assert(contains(catalog, "rust-scripting"), "catalog contains the skill id")
-  llm_mock(
-    {
-      text: "Load the rust instructions.",
-      tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "rust-scripting"}}],
+  with_llm_script(
+    [
+      {
+        text: "Load the rust instructions.",
+        tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "rust-scripting"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Help with rust scripting",
+        catalog,
+        {
+          provider: "mock",
+          model: "gpt-5.4",
+          tools: tools,
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          session_id: "skills-load-skill",
+          skills: skills,
+        },
+      )
+      assert(result?.status == "done", "agent loop finishes")
+      let calls = llm_mock_calls()
+      assert(len(calls) == 2, "two llm calls happened")
+      let first_tools = json_stringify(calls[0].tools)
+      assert(contains(first_tools, "load_skill"), "load_skill is advertised")
+      let second_messages = json_stringify(calls[1].messages)
+      assert(contains(second_messages, "cargo run --bin harn"), "tool result carries the skill body")
+      assert(contains(second_messages, "skills-load-skill"), "session id is substituted")
+      assert(contains(second_messages, "Args: []"), "$ARGUMENTS is substituted")
+      assert(
+        contains(second_messages, ".harn/skills/rust-scripting")
+          || contains(second_messages, ".harn\\\\skills\\\\rust-scripting"),
+        "skill dir is substituted",
+      )
+      let second_tools = json_stringify(calls[1].tools)
+      assert(contains(second_tools, "deploy_service"), "allowed tool remains visible")
+      assert(!contains(second_tools, "query_metrics"), "out-of-scope tool is filtered")
+      log("skills_load_skill_roundtrip passed")
     },
   )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Help with rust scripting",
-    catalog,
-    {
-      provider: "mock",
-      model: "gpt-5.4",
-      tools: tools,
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      session_id: "skills-load-skill",
-      skills: skills,
-    },
-  )
-  assert(result?.status == "done", "agent loop finishes")
-  let calls = llm_mock_calls()
-  assert(len(calls) == 2, "two llm calls happened")
-  let first_tools = json_stringify(calls[0].tools)
-  assert(contains(first_tools, "load_skill"), "load_skill is advertised")
-  let second_messages = json_stringify(calls[1].messages)
-  assert(contains(second_messages, "cargo run --bin harn"), "tool result carries the skill body")
-  assert(contains(second_messages, "skills-load-skill"), "session id is substituted")
-  assert(contains(second_messages, "Args: []"), "$ARGUMENTS is substituted")
-  assert(
-    contains(second_messages, ".harn/skills/rust-scripting")
-      || contains(second_messages, ".harn\\\\skills\\\\rust-scripting"),
-    "skill dir is substituted",
-  )
-  let second_tools = json_stringify(calls[1].tools)
-  assert(contains(second_tools, "deploy_service"), "allowed tool remains visible")
-  assert(!contains(second_tools, "query_metrics"), "out-of-scope tool is filtered")
-  log("skills_load_skill_roundtrip passed")
 }

--- a/conformance/tests/scenarios/tool_call_receipts_local_sink.harn
+++ b/conformance/tests/scenarios/tool_call_receipts_local_sink.harn
@@ -6,6 +6,7 @@ import {
   with_audit_log,
   with_required_reason,
 } from "std/llm/tool_middleware"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn receipt_tools() {
   let registry = tool_registry()
@@ -21,34 +22,37 @@ fn receipt_tools() {
 }
 
 fn run_receipt_agent(session, audit_options) {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [
+  return with_llm_script(
+    [
+      {
+        tool_calls: [
+          {
+            id: "receipt-1",
+            name: "echo_receipt",
+            arguments: {message: "hello", secret: "hide-me", reason: "Need a receipt"},
+          },
+        ],
+      },
+      llm_text("Done. ##DONE##"),
+    ],
+    { ->
+      let reason = with_required_reason({schema_required: false})
+      let tools = tools_use_middleware(receipt_tools(), reason.schema_transform)
+      let caller = compose_tool_callers([with_audit_log(audit_options), reason.caller])
+      return agent_loop(
+        "emit a tool receipt",
+        nil,
         {
-          id: "receipt-1",
-          name: "echo_receipt",
-          arguments: {message: "hello", secret: "hide-me", reason: "Need a receipt"},
+          provider: "mock",
+          model: "mock",
+          session_id: session,
+          tools: tools,
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          tool_caller: caller,
         },
-      ],
-    },
-  )
-  llm_mock({text: "Done. ##DONE##"})
-  let reason = with_required_reason({schema_required: false})
-  let tools = tools_use_middleware(receipt_tools(), reason.schema_transform)
-  let caller = compose_tool_callers([with_audit_log(audit_options), reason.caller])
-  return agent_loop(
-    "emit a tool receipt",
-    nil,
-    {
-      provider: "mock",
-      model: "mock",
-      session_id: session,
-      tools: tools,
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      tool_caller: caller,
+      )
     },
   )
 }

--- a/conformance/tests/scenarios/tool_middleware_captain_recipe.harn
+++ b/conformance/tests/scenarios/tool_middleware_captain_recipe.harn
@@ -16,6 +16,7 @@ import {
   with_summary,
   with_telemetry,
 } from "std/llm/tool_middleware"
+import { llm_text, with_llm_script } from "std/testing"
 
 let audit_records = atomic(0)
 
@@ -73,67 +74,70 @@ fn tools() {
 }
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock(
-    {
-      tool_calls: [
-        {id: "t1", name: "read", arguments: {path: "/tmp/a", reason: "inspect target file"}},
-        {id: "t2", name: "edit", arguments: {path: "/tmp/a", body: "x", reason: "fix typo"}},
-        {id: "t3", name: "escalate", arguments: {task: "Review fix", reason: "needs human eyes"}},
-      ],
-    },
-  )
-  llm_mock({text: "Done. ##DONE##"})
-  let reason_mw = with_required_reason()
-  let stack = compose_tool_callers(
+  with_llm_script(
     [
-      with_audit_log(
-        { _record ->
-          let _ = atomic_add(audit_records, 1)
-        },
-      ),
-      with_telemetry(
-        { _record ->
-          let _ = atomic_add(telemetry_records, 1)
-        },
-      ),
-      with_summary({ call, _result -> return call.tool_name + " ran" }),
-      reason_mw.caller,
-      with_handoff_artifact(
-        {
-          sink: { _record, _call ->
-            let _ = atomic_add(handoff_records, 1)
-          },
-        },
-      ),
-      with_rate_limit({max_calls: 10}),
-      with_dry_run({only: ["edit"], message: "preview"}),
+      {
+        tool_calls: [
+          {id: "t1", name: "read", arguments: {path: "/tmp/a", reason: "inspect target file"}},
+          {id: "t2", name: "edit", arguments: {path: "/tmp/a", body: "x", reason: "fix typo"}},
+          {id: "t3", name: "escalate", arguments: {task: "Review fix", reason: "needs human eyes"}},
+        ],
+      },
+      llm_text("Done. ##DONE##"),
     ],
-  )
-  let registry = tools()
-  let result = agent_loop(
-    "polish + handoff",
-    nil,
-    {
-      provider: "mock",
-      tools: registry,
-      tool_format: "native",
-      max_iterations: 3,
-      loop_until_done: true,
-      tool_caller: stack,
+    { ->
+      let reason_mw = with_required_reason()
+      let stack = compose_tool_callers(
+        [
+          with_audit_log(
+            { _record ->
+              let _ = atomic_add(audit_records, 1)
+            },
+          ),
+          with_telemetry(
+            { _record ->
+              let _ = atomic_add(telemetry_records, 1)
+            },
+          ),
+          with_summary({ call, _result -> return call.tool_name + " ran" }),
+          reason_mw.caller,
+          with_handoff_artifact(
+            {
+              sink: { _record, _call ->
+                let _ = atomic_add(handoff_records, 1)
+              },
+            },
+          ),
+          with_rate_limit({max_calls: 10}),
+          with_dry_run({only: ["edit"], message: "preview"}),
+        ],
+      )
+      let registry = tools()
+      let result = agent_loop(
+        "polish + handoff",
+        nil,
+        {
+          provider: "mock",
+          tools: registry,
+          tool_format: "native",
+          max_iterations: 3,
+          loop_until_done: true,
+          tool_caller: stack,
+        },
+      )
+      __io_println(result.status)
+      __io_println(atomic_get(audit_records))
+      __io_println(atomic_get(telemetry_records))
+      __io_println(atomic_get(handoff_records))
+      __io_println(len(result.tools.successful))
+      __io_println(contains(result.tools.successful, "read"))
+      __io_println(contains(result.tools.successful, "edit"))
+      __io_println(contains(result.tools.successful, "escalate"))
     },
   )
-  __io_println(result.status)
-  // Three tool dispatches: each fired audit + telemetry sinks once.
-  __io_println(atomic_get(audit_records))
-  __io_println(atomic_get(telemetry_records))
-  // Exactly one handoff was emitted (the third call).
-  __io_println(atomic_get(handoff_records))
-  // All three calls succeeded as far as the agent loop is concerned —
-  // the dry-run layer returns ok=true with status="dry_run" instead of
-  // dispatching the underlying handler.
-  __io_println(len(result.tools.successful))
-  __io_println(contains(result.tools.successful, "read"))
-  __io_println(contains(result.tools.successful, "edit"))
-  __io_println(contains(result.tools.successful, "escalate"))
 }
+// Three tool dispatches: each fired audit + telemetry sinks once.
+// Exactly one handoff was emitted (the third call).
+// All three calls succeeded as far as the agent loop is concerned —
+// the dry-run layer returns ok=true with status="dry_run" instead of
+// dispatching the underlying handler.

--- a/conformance/tests/scenarios/tool_search_client_bm25.harn
+++ b/conformance/tests/scenarios/tool_search_client_bm25.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Client-executed `tool_search` fallback with the BM25 strategy,
  * exercised in text-mode (mock provider).
@@ -14,7 +16,6 @@
  *      "client"` so replayers can distinguish path-1 from path-2).
  */
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -43,77 +44,77 @@ pipeline test(task) {
     },
   )
   // Turn 1: model calls the synthetic search tool with "deploy".
-  llm_mock(
-    {
-      text: "Looking up deploy tooling.",
-      tool_calls: [{id: "srv1", name: "__harn_tool_search", arguments: {query: "deploy"}}],
-    },
-  )
-  // Turn 2: model calls the freshly-promoted deploy tool.
-  llm_mock(
-    {
-      text: "Deploying now.",
-      tool_calls: [{id: "tool2", name: "deploy_service", arguments: {env: "prod"}}],
-    },
-  )
-  // Turn 3: signal completion.
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Ship the release",
-    nil,
-    {
-      provider: "mock",
-      tools: registry,
-      tool_search: {variant: "bm25", mode: "client"},
-      loop_until_done: true,
-      max_iterations: 5,
-    },
-  )
-  // Explicit `mode: "client"` — the mock provider now spoofs native
-  // tool_search when its (default) model looks like Claude 4.0+ or
-  // GPT 5.4+, which would otherwise route through the Anthropic
-  // native path. Client-mode tests must opt into the client path.
-  let calls = llm_mock_calls()
-  assert(len(calls) >= 2, "at least two LLM calls happened")
-  // Turn 1 system prompt: synthetic tool visible, deferred tools hidden.
-  let first_system = calls[0].system
-  assert(contains(first_system, "__harn_tool_search"), "synthetic tool advertised on turn 1")
-  assert(contains(first_system, "look"), "non-deferred `look` tool on turn 1")
-  assert(!contains(first_system, "deploy_service"), "deferred `deploy_service` hidden on turn 1")
-  assert(!contains(first_system, "query_metrics"), "deferred `query_metrics` hidden on turn 1")
-  // Turn 2 system prompt: `deploy_service` is now visible because BM25
-  // promoted it. `query_metrics` stays hidden (not a BM25 hit).
-  let second_system = calls[1].system
-  assert(
-    contains(second_system, "deploy_service"),
-    "BM25 must promote `deploy_service` into turn 2's contract prompt",
-  )
-  assert(!contains(second_system, "query_metrics"), "non-matching deferred tools must stay hidden")
-  // Transcript events: mirror the Anthropic shape with mode:"client" tagging.
-  let events = transcript_events(result?.transcript)
-  var query_events = 0
-  var result_events = 0
-  for ev in events {
-    if ev.kind == "tool_search_query" {
-      query_events = query_events + 1
-      assert(ev.metadata?.mode == "client", "query event tagged client mode")
-      assert(ev.metadata?.strategy == "bm25", "query event records strategy")
-      assert(ev.metadata?.query?.query == "deploy", "query event carries the query")
-    }
-    if ev.kind == "tool_search_result" {
-      result_events = result_events + 1
-      assert(ev.metadata?.mode == "client", "result event tagged client mode")
-      let promoted = ev.metadata?.promoted
-      var has_deploy = false
-      for name in promoted {
-        if name == "deploy_service" {
-          has_deploy = true
+  with_llm_script(
+    [
+      {
+        text: "Looking up deploy tooling.",
+        tool_calls: [{id: "srv1", name: "__harn_tool_search", arguments: {query: "deploy"}}],
+      },
+      {
+        text: "Deploying now.",
+        tool_calls: [{id: "tool2", name: "deploy_service", arguments: {env: "prod"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Ship the release",
+        nil,
+        {
+          provider: "mock",
+          tools: registry,
+          tool_search: {variant: "bm25", mode: "client"},
+          loop_until_done: true,
+          max_iterations: 5,
+        },
+      )
+      let calls = llm_mock_calls()
+      assert(len(calls) >= 2, "at least two LLM calls happened")
+      let first_system = calls[0].system
+      assert(contains(first_system, "__harn_tool_search"), "synthetic tool advertised on turn 1")
+      assert(contains(first_system, "look"), "non-deferred `look` tool on turn 1")
+      assert(!contains(first_system, "deploy_service"), "deferred `deploy_service` hidden on turn 1")
+      assert(!contains(first_system, "query_metrics"), "deferred `query_metrics` hidden on turn 1")
+      let second_system = calls[1].system
+      assert(
+        contains(second_system, "deploy_service"),
+        "BM25 must promote `deploy_service` into turn 2's contract prompt",
+      )
+      assert(!contains(second_system, "query_metrics"), "non-matching deferred tools must stay hidden")
+      let events = transcript_events(result?.transcript)
+      var query_events = 0
+      var result_events = 0
+      for ev in events {
+        if ev.kind == "tool_search_query" {
+          query_events = query_events + 1
+          assert(ev.metadata?.mode == "client", "query event tagged client mode")
+          assert(ev.metadata?.strategy == "bm25", "query event records strategy")
+          assert(ev.metadata?.query?.query == "deploy", "query event carries the query")
+        }
+        if ev.kind == "tool_search_result" {
+          result_events = result_events + 1
+          assert(ev.metadata?.mode == "client", "result event tagged client mode")
+          let promoted = ev.metadata?.promoted
+          var has_deploy = false
+          for name in promoted {
+            if name == "deploy_service" {
+              has_deploy = true
+            }
+          }
+          assert(has_deploy, "result event records what was promoted")
         }
       }
-      assert(has_deploy, "result event records what was promoted")
-    }
-  }
-  assert(query_events == 1, "exactly one search query happened")
-  assert(result_events == 1, "exactly one search result event emitted")
-  log("tool_search_client_bm25 tests passed")
+      assert(query_events == 1, "exactly one search query happened")
+      assert(result_events == 1, "exactly one search result event emitted")
+      log("tool_search_client_bm25 tests passed")
+    },
+  )
 }
+// Explicit `mode: "client"` — the mock provider now spoofs native
+// tool_search when its (default) model looks like Claude 4.0+ or
+// GPT 5.4+, which would otherwise route through the Anthropic
+// native path. Client-mode tests must opt into the client path.
+// Turn 1 system prompt: synthetic tool visible, deferred tools hidden.
+// Turn 2 system prompt: `deploy_service` is now visible because BM25
+// promoted it. `query_metrics` stays hidden (not a BM25 hit).
+// Transcript events: mirror the Anthropic shape with mode:"client" tagging.

--- a/conformance/tests/scenarios/tool_search_client_bm25_events.harn
+++ b/conformance/tests/scenarios/tool_search_client_bm25_events.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * harn v0.7.20 Gap 1: promote `tool_search_query` / `tool_search_result`
  * to canonical `AgentEvent` variants so ACP / agent_subscribe consumers
@@ -11,7 +13,6 @@
  * That proves the subscriber fired live (not on post-turn replay).
  */
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -52,81 +53,81 @@ pipeline test(task) {
     },
   )
   // Turn 1: model calls the synthetic search tool with "deploy".
-  llm_mock(
-    {
-      text: "Looking up deploy tooling.",
-      tool_calls: [{id: "srv1", name: "__harn_tool_search", arguments: {query: "deploy"}}],
-    },
-  )
-  // Turn 2: model calls the freshly-promoted deploy tool.
-  llm_mock(
-    {
-      text: "Deploying now.",
-      tool_calls: [{id: "tool2", name: "deploy_service", arguments: {env: "prod"}}],
-    },
-  )
-  // Turn 3: signal completion.
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Ship the release",
-    nil,
-    {
-      provider: "mock",
-      tools: registry,
-      tool_search: {variant: "bm25", mode: "client"},
-      loop_until_done: true,
-      max_iterations: 5,
-      session_id: events_session,
-    },
-  )
-  assert(result?.status == "done", "loop completes")
-  // Turn 2's recorded messages must include the two feedback markers
-  // injected by the subscriber — direct proof the live event fired.
-  // `llm_mock_calls()` captures every inbound call's final message list;
-  // turn 2 is the first call after the tool_search events fired on turn 1.
-  let calls = llm_mock_calls()
-  assert(len(calls) >= 2, "at least two LLM calls happened")
-  let turn2_messages = calls[1].messages
-  var saw_query_marker = false
-  var saw_result_marker = false
-  for m in turn2_messages {
-    let content = m?.content
-    if content != nil {
-      if contains(content, "LIVE_TS_QUERY_FIRED") {
-        saw_query_marker = true
-      }
-      if contains(content, "LIVE_TS_RESULT_FIRED") {
-        saw_result_marker = true
-      }
-    }
-  }
-  assert(saw_query_marker, "subscriber fired for tool_search_query (live, not replayed)")
-  assert(saw_result_marker, "subscriber fired for tool_search_result (live, not replayed)")
-  // Transcript fidelity: the transcript events still match the client-path
-  // shape — same metadata the direct agent-loop subscriber path saw.
-  let events = transcript_events(result?.transcript)
-  var query_events = 0
-  var result_events = 0
-  for ev in events {
-    if ev.kind == "tool_search_query" {
-      query_events = query_events + 1
-      assert(ev.metadata?.mode == "client", "client tag on query")
-      assert(ev.metadata?.strategy == "bm25", "bm25 strategy on query")
-    }
-    if ev.kind == "tool_search_result" {
-      result_events = result_events + 1
-      assert(ev.metadata?.mode == "client", "client tag on result")
-      let promoted = ev.metadata?.promoted
-      var saw_deploy = false
-      for name in promoted {
-        if name == "deploy_service" {
-          saw_deploy = true
+  with_llm_script(
+    [
+      {
+        text: "Looking up deploy tooling.",
+        tool_calls: [{id: "srv1", name: "__harn_tool_search", arguments: {query: "deploy"}}],
+      },
+      {
+        text: "Deploying now.",
+        tool_calls: [{id: "tool2", name: "deploy_service", arguments: {env: "prod"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Ship the release",
+        nil,
+        {
+          provider: "mock",
+          tools: registry,
+          tool_search: {variant: "bm25", mode: "client"},
+          loop_until_done: true,
+          max_iterations: 5,
+          session_id: events_session,
+        },
+      )
+      assert(result?.status == "done", "loop completes")
+      let calls = llm_mock_calls()
+      assert(len(calls) >= 2, "at least two LLM calls happened")
+      let turn2_messages = calls[1].messages
+      var saw_query_marker = false
+      var saw_result_marker = false
+      for m in turn2_messages {
+        let content = m?.content
+        if content != nil {
+          if contains(content, "LIVE_TS_QUERY_FIRED") {
+            saw_query_marker = true
+          }
+          if contains(content, "LIVE_TS_RESULT_FIRED") {
+            saw_result_marker = true
+          }
         }
       }
-      assert(saw_deploy, "promoted list carries the BM25 hit")
-    }
-  }
-  assert(query_events == 1, "one tool_search_query in transcript")
-  assert(result_events == 1, "one tool_search_result in transcript")
-  log("tool_search_client_bm25_events tests passed")
+      assert(saw_query_marker, "subscriber fired for tool_search_query (live, not replayed)")
+      assert(saw_result_marker, "subscriber fired for tool_search_result (live, not replayed)")
+      let events = transcript_events(result?.transcript)
+      var query_events = 0
+      var result_events = 0
+      for ev in events {
+        if ev.kind == "tool_search_query" {
+          query_events = query_events + 1
+          assert(ev.metadata?.mode == "client", "client tag on query")
+          assert(ev.metadata?.strategy == "bm25", "bm25 strategy on query")
+        }
+        if ev.kind == "tool_search_result" {
+          result_events = result_events + 1
+          assert(ev.metadata?.mode == "client", "client tag on result")
+          let promoted = ev.metadata?.promoted
+          var saw_deploy = false
+          for name in promoted {
+            if name == "deploy_service" {
+              saw_deploy = true
+            }
+          }
+          assert(saw_deploy, "promoted list carries the BM25 hit")
+        }
+      }
+      assert(query_events == 1, "one tool_search_query in transcript")
+      assert(result_events == 1, "one tool_search_result in transcript")
+      log("tool_search_client_bm25_events tests passed")
+    },
+  )
 }
+// Turn 2's recorded messages must include the two feedback markers
+// injected by the subscriber — direct proof the live event fired.
+// `llm_mock_calls()` captures every inbound call's final message list;
+// turn 2 is the first call after the tool_search events fired on turn 1.
+// Transcript fidelity: the transcript events still match the client-path
+// shape — same metadata the direct agent-loop subscriber path saw.

--- a/conformance/tests/scenarios/tool_search_client_hybrid.harn
+++ b/conformance/tests/scenarios/tool_search_client_hybrid.harn
@@ -1,5 +1,6 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(registry, "anchor", "Always visible", {parameters: {}, handler: { _ -> "ok" }})
   registry = tool_define(
@@ -14,30 +15,34 @@ pipeline test(task) {
     "Read process output",
     {parameters: {command_id: {type: "string"}}, defer_loading: true, handler: { _ -> "output" }},
   )
-  llm_mock(
-    {
-      text: "searching",
-      tool_calls: [{id: "s1", name: "__harn_tool_search", arguments: {query: "run command"}}],
+  with_llm_script(
+    [
+      {
+        text: "searching",
+        tool_calls: [{id: "s1", name: "__harn_tool_search", arguments: {query: "run command"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "run a command",
+        nil,
+        {provider: "mock", tools: registry, tool_search: "hybrid", loop_until_done: true, max_iterations: 3},
+      )
+      let events = transcript_events(result?.transcript)
+      var saw_hybrid = false
+      var promoted_run = false
+      for ev in events {
+        if ev.kind == "tool_search_query" {
+          saw_hybrid = ev.metadata?.strategy == "hybrid"
+        }
+        if ev.kind == "tool_search_result" {
+          promoted_run = len(ev.metadata?.promoted ?? []) > 0 && ev.metadata.promoted[0] == "run_command"
+        }
+      }
+      assert(saw_hybrid, "query event records hybrid strategy")
+      assert(promoted_run, "hybrid promotes the intended command runner first")
+      log("tool_search_client_hybrid tests passed")
     },
   )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "run a command",
-    nil,
-    {provider: "mock", tools: registry, tool_search: "hybrid", loop_until_done: true, max_iterations: 3},
-  )
-  let events = transcript_events(result?.transcript)
-  var saw_hybrid = false
-  var promoted_run = false
-  for ev in events {
-    if ev.kind == "tool_search_query" {
-      saw_hybrid = ev.metadata?.strategy == "hybrid"
-    }
-    if ev.kind == "tool_search_result" {
-      promoted_run = len(ev.metadata?.promoted ?? []) > 0 && ev.metadata.promoted[0] == "run_command"
-    }
-  }
-  assert(saw_hybrid, "query event records hybrid strategy")
-  assert(promoted_run, "hybrid promotes the intended command runner first")
-  log("tool_search_client_hybrid tests passed")
 }

--- a/conformance/tests/scenarios/tool_search_client_options.harn
+++ b/conformance/tests/scenarios/tool_search_client_options.harn
@@ -1,10 +1,10 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Advanced client-mode options: explicit local fallback, budgeted
  * promotion with oldest-eviction, and a custom synthetic tool name.
  */
 pipeline test(task) {
-  // ---------- Explicit mode:"client" + custom tool name ----------
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -18,42 +18,43 @@ pipeline test(task) {
     "Ship the service",
     {parameters: {env: {type: "string"}}, defer_loading: true, handler: { _ -> "ok" }},
   )
-  // Turn 1: model invokes the renamed search tool.
-  llm_mock(
-    {
-      text: "Searching via the custom name.",
-      tool_calls: [{id: "s1", name: "find_a_tool", arguments: {query: "deploy"}}],
-    },
-  )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "deploy",
-    nil,
-    {
-      provider: "mock",
-      tools: registry,
-      tool_search: {mode: "client", name: "find_a_tool"},
-      loop_until_done: true,
-      max_iterations: 3,
-    },
-  )
-  let calls = llm_mock_calls()
-  assert(contains(calls[0].system, "find_a_tool"), "custom synthetic tool name advertised")
-  assert(!contains(calls[0].system, "__harn_tool_search"), "default name not used when overridden")
-  let events = transcript_events(result?.transcript)
-  var promoted_deploy = false
-  for ev in events {
-    if ev.kind == "tool_search_result" {
-      for n in ev.metadata?.promoted {
-        if n == "deploy_service" {
-          promoted_deploy = true
+  with_llm_script(
+    [
+      {
+        text: "Searching via the custom name.",
+        tool_calls: [{id: "s1", name: "find_a_tool", arguments: {query: "deploy"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "deploy",
+        nil,
+        {
+          provider: "mock",
+          tools: registry,
+          tool_search: {mode: "client", name: "find_a_tool"},
+          loop_until_done: true,
+          max_iterations: 3,
+        },
+      )
+      let calls = llm_mock_calls()
+      assert(contains(calls[0].system, "find_a_tool"), "custom synthetic tool name advertised")
+      assert(!contains(calls[0].system, "__harn_tool_search"), "default name not used when overridden")
+      let events = transcript_events(result?.transcript)
+      var promoted_deploy = false
+      for ev in events {
+        if ev.kind == "tool_search_result" {
+          for n in ev.metadata?.promoted {
+            if n == "deploy_service" {
+              promoted_deploy = true
+            }
+          }
         }
       }
-    }
-  }
-  assert(promoted_deploy, "explicit client mode promotes matches")
-  // ---------- budget_tokens cap with oldest-eviction ----------
-  llm_mock_clear()
+      assert(promoted_deploy, "explicit client mode promotes matches")
+    },
+  )
   var big = tool_registry()
   big = tool_define(
     big,
@@ -61,10 +62,7 @@ pipeline test(task) {
     "Always present",
     {parameters: {op: {type: "string"}}, handler: { _ -> "ok" }},
   )
-  // Three hefty deferred tools. Descriptions padded so each schema
-  // costs ~200+ tokens (≈800 chars) once JSON-serialized. A tiny
-  // `budget_tokens: 150` only fits one at a time.
-  let fat_desc = "A very detailed tool whose description is deliberately long enough \\\n  that its JSON schema runs hundreds of characters, ensuring the \\\n  token-estimator predicts a real budget impact rather than rounding down \\\n  to a trivial cost on the budget accounting path."
+  let fat_desc = "A very detailed tool whose description is deliberately long enough \\\n+  that its JSON schema runs hundreds of characters, ensuring the \\\n+  token-estimator predicts a real budget impact rather than rounding down \\\n+  to a trivial cost on the budget accounting path."
   big = tool_define(
     big,
     "alpha",
@@ -83,37 +81,31 @@ pipeline test(task) {
     fat_desc,
     {parameters: {x: {type: "string"}}, defer_loading: true, handler: { _ -> "c" }},
   )
-  // Turn 1: promote alpha.
-  llm_mock(
-    {text: "alpha", tool_calls: [{id: "q1", name: "__harn_tool_search", arguments: {query: "alpha"}}]},
-  )
-  // Turn 2: promote beta (alpha should be evicted).
-  llm_mock(
-    {text: "beta", tool_calls: [{id: "q2", name: "__harn_tool_search", arguments: {query: "beta"}}]},
-  )
-  // Turn 3: promote gamma (beta should be evicted).
-  llm_mock(
-    {text: "gamma", tool_calls: [{id: "q3", name: "__harn_tool_search", arguments: {query: "gamma"}}]},
-  )
-  llm_mock({text: "<done>##DONE##</done>"})
-  agent_loop(
-    "go",
-    nil,
-    {
-      provider: "mock",
-      tools: big,
-      tool_search: {variant: "bm25", mode: "client", budget_tokens: 150},
-      loop_until_done: true,
-      max_iterations: 5,
+  with_llm_script(
+    [
+      {text: "alpha", tool_calls: [{id: "q1", name: "__harn_tool_search", arguments: {query: "alpha"}}]},
+      {text: "beta", tool_calls: [{id: "q2", name: "__harn_tool_search", arguments: {query: "beta"}}]},
+      {text: "gamma", tool_calls: [{id: "q3", name: "__harn_tool_search", arguments: {query: "gamma"}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      agent_loop(
+        "go",
+        nil,
+        {
+          provider: "mock",
+          tools: big,
+          tool_search: {variant: "bm25", mode: "client", budget_tokens: 150},
+          loop_until_done: true,
+          max_iterations: 5,
+        },
+      )
+      let calls2 = llm_mock_calls()
+      let last_system = calls2[len(calls2) - 1].system
+      assert(contains(last_system, "gamma"), "most-recently-promoted tool is visible")
+      assert(!contains(last_system, "alpha"), "oldest promotion evicted under budget")
+      assert(!contains(last_system, "beta"), "second-oldest promotion evicted under budget")
+      log("tool_search_client_options tests passed")
     },
   )
-  // Explicit `mode: "client"` keeps this test on the local fallback
-  // even when the mock provider uses a native-capable default model.
-  // After three turns: gamma promoted, alpha+beta evicted.
-  let calls2 = llm_mock_calls()
-  let last_system = calls2[len(calls2) - 1].system
-  assert(contains(last_system, "gamma"), "most-recently-promoted tool is visible")
-  assert(!contains(last_system, "alpha"), "oldest promotion evicted under budget")
-  assert(!contains(last_system, "beta"), "second-oldest promotion evicted under budget")
-  log("tool_search_client_options tests passed")
 }

--- a/conformance/tests/scenarios/tool_search_client_regex.harn
+++ b/conformance/tests/scenarios/tool_search_client_regex.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Client-executed `tool_search` fallback with the regex strategy.
  * Variant = regex means the model is shown a regex-flavoured prompt
@@ -5,7 +7,6 @@
  * no backreferences/lookaround).
  */
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -40,64 +41,64 @@ pipeline test(task) {
     {parameters: {cmd: {type: "string"}}, defer_loading: true, handler: { args -> "ran: " + args.cmd }},
   )
   // Turn 1: model runs a regex alternation.
-  llm_mock(
-    {
-      text: "Looking up edit/create tools via regex.",
-      tool_calls: [{id: "rgx1", name: "__harn_tool_search", arguments: {query: "edit|create"}}],
-    },
-  )
-  // Turn 2: call one of the promoted tools.
-  llm_mock(
-    {text: "Editing now.", tool_calls: [{id: "t2", name: "edit_file", arguments: {path: "hello.txt"}}]},
-  )
-  // Turn 3: done.
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Refactor the file",
-    nil,
-    {
-      provider: "mock",
-      tools: registry,
-      tool_search: {variant: "regex", mode: "client"},
-      loop_until_done: true,
-      max_iterations: 5,
-    },
-  )
-  // Explicit `mode: "client"` keeps this test on the local fallback
-  // even when the mock provider uses a native-capable default model.
-  let events = transcript_events(result?.transcript)
-  var found_regex_strategy = false
-  var promoted_edit = false
-  var promoted_create = false
-  var promoted_run = false
-  for ev in events {
-    if ev.kind == "tool_search_query" {
-      assert(ev.metadata?.strategy == "regex", "strategy recorded as regex")
-      found_regex_strategy = true
-    }
-    if ev.kind == "tool_search_result" {
-      for name in ev.metadata?.promoted {
-        if name == "edit_file" {
-          promoted_edit = true
+  with_llm_script(
+    [
+      {
+        text: "Looking up edit/create tools via regex.",
+        tool_calls: [{id: "rgx1", name: "__harn_tool_search", arguments: {query: "edit|create"}}],
+      },
+      {text: "Editing now.", tool_calls: [{id: "t2", name: "edit_file", arguments: {path: "hello.txt"}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Refactor the file",
+        nil,
+        {
+          provider: "mock",
+          tools: registry,
+          tool_search: {variant: "regex", mode: "client"},
+          loop_until_done: true,
+          max_iterations: 5,
+        },
+      )
+      let events = transcript_events(result?.transcript)
+      var found_regex_strategy = false
+      var promoted_edit = false
+      var promoted_create = false
+      var promoted_run = false
+      for ev in events {
+        if ev.kind == "tool_search_query" {
+          assert(ev.metadata?.strategy == "regex", "strategy recorded as regex")
+          found_regex_strategy = true
         }
-        if name == "create_file" {
-          promoted_create = true
-        }
-        if name == "run_shell" {
-          promoted_run = true
+        if ev.kind == "tool_search_result" {
+          for name in ev.metadata?.promoted {
+            if name == "edit_file" {
+              promoted_edit = true
+            }
+            if name == "create_file" {
+              promoted_create = true
+            }
+            if name == "run_shell" {
+              promoted_run = true
+            }
+          }
         }
       }
-    }
-  }
-  assert(found_regex_strategy, "regex strategy tagged in transcript")
-  assert(promoted_edit, "regex `edit|create` matches `edit_file`")
-  assert(promoted_create, "regex `edit|create` matches `create_file`")
-  assert(!promoted_run, "regex `edit|create` must not match `run_shell`")
-  // Second LLM call sees the two edit/create tools but NOT run_shell.
-  let calls = llm_mock_calls()
-  let second_system = calls[1].system
-  assert(contains(second_system, "edit_file"), "edit_file surfaced in turn 2")
-  assert(contains(second_system, "create_file"), "create_file surfaced in turn 2")
-  assert(!contains(second_system, "run_shell"), "run_shell still deferred")
-  log("tool_search_client_regex tests passed")
+      assert(found_regex_strategy, "regex strategy tagged in transcript")
+      assert(promoted_edit, "regex `edit|create` matches `edit_file`")
+      assert(promoted_create, "regex `edit|create` matches `create_file`")
+      assert(!promoted_run, "regex `edit|create` must not match `run_shell`")
+      let calls = llm_mock_calls()
+      let second_system = calls[1].system
+      assert(contains(second_system, "edit_file"), "edit_file surfaced in turn 2")
+      assert(contains(second_system, "create_file"), "create_file surfaced in turn 2")
+      assert(!contains(second_system, "run_shell"), "run_shell still deferred")
+      log("tool_search_client_regex tests passed")
+    },
+  )
 }
+// Explicit `mode: "client"` keeps this test on the local fallback
+// even when the mock provider uses a native-capable default model.
+// Second LLM call sees the two edit/create tools but NOT run_shell.

--- a/conformance/tests/scenarios/tool_search_custom_strategy.harn
+++ b/conformance/tests/scenarios/tool_search_custom_strategy.harn
@@ -1,5 +1,6 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(registry, "anchor", "Always visible", {parameters: {}, handler: { _ -> "anchor" }})
   registry = tool_define(
@@ -8,38 +9,44 @@ pipeline test(task) {
     "Deploy service",
     {parameters: {}, defer_loading: true, handler: { _ -> "deployed" }},
   )
-  llm_mock({text: "search", tool_calls: [{id: "s1", name: "find_tool", arguments: {query: "ship"}}]})
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "ship",
-    nil,
-    {
-      provider: "mock",
-      tools: registry,
-      tool_search: {
-        mode: "client",
-        name: "find_tool",
-        strategy: {
-          handler: { query, _candidates, _state -> {tool_names: ["deploy_tool"], ranked: [{tool_name: "deploy_tool", score: 1.0, snippet: query}]} },
-          name: "fixture",
+  with_llm_script(
+    [
+      {text: "search", tool_calls: [{id: "s1", name: "find_tool", arguments: {query: "ship"}}]},
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "ship",
+        nil,
+        {
+          provider: "mock",
+          tools: registry,
+          tool_search: {
+            mode: "client",
+            name: "find_tool",
+            strategy: {
+              handler: { query, _candidates, _state -> {tool_names: ["deploy_tool"], ranked: [{tool_name: "deploy_tool", score: 1.0, snippet: query}]} },
+              name: "fixture",
+            },
+          },
+          loop_until_done: true,
+          max_iterations: 3,
         },
-      },
-      loop_until_done: true,
-      max_iterations: 3,
+      )
+      let events = transcript_events(result.transcript)
+      var promoted = false
+      var saw_fixture = false
+      for ev in events {
+        if ev.kind == "tool_search_query" {
+          saw_fixture = ev.metadata.strategy == "fixture"
+        }
+        if ev.kind == "tool_search_result" {
+          promoted = len(ev.metadata.promoted ?? []) == 1 && ev.metadata.promoted[0] == "deploy_tool"
+        }
+      }
+      assert(saw_fixture, "custom strategy label recorded")
+      assert(promoted, "custom strategy promoted deploy_tool")
+      log("tool_search_custom_strategy tests passed")
     },
   )
-  let events = transcript_events(result.transcript)
-  var promoted = false
-  var saw_fixture = false
-  for ev in events {
-    if ev.kind == "tool_search_query" {
-      saw_fixture = ev.metadata.strategy == "fixture"
-    }
-    if ev.kind == "tool_search_result" {
-      promoted = len(ev.metadata.promoted ?? []) == 1 && ev.metadata.promoted[0] == "deploy_tool"
-    }
-  }
-  assert(saw_fixture, "custom strategy label recorded")
-  assert(promoted, "custom strategy promoted deploy_tool")
-  log("tool_search_custom_strategy tests passed")
 }

--- a/conformance/tests/scenarios/tool_search_namespace.harn
+++ b/conformance/tests/scenarios/tool_search_namespace.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Tool Vault phase 3 (harn#71): `namespace` field on tool registry
  * entries groups deferred tools for OpenAI's `tool_search` meta-tool.
@@ -6,7 +8,6 @@
  * without another round of schema plumbing.
  */
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -64,50 +65,54 @@ pipeline test(task) {
   // Payload emission: for a supported gpt-5.4+ model with
   // `mode: "native"`, the OpenAI meta-tool collects distinct
   // namespaces into its `namespaces` field.
-  llm_mock({text: "ack"})
-  llm_call(
-    "x",
-    nil,
-    {
-      provider: "mock",
-      model: "gpt-5.4-preview",
-      tools: registry,
-      tool_search: {variant: "bm25", mode: "native"},
+  with_llm_script(
+    [llm_text("ack")],
+    { ->
+      llm_call(
+        "x",
+        nil,
+        {
+          provider: "mock",
+          model: "gpt-5.4-preview",
+          tools: registry,
+          tool_search: {variant: "bm25", mode: "native"},
+        },
+      )
+      let calls = llm_mock_calls()
+      let meta = calls[0].tools[0]
+      assert(meta.type == "tool_search", "meta-tool in slot 0")
+      let ns_list = meta.namespaces
+      assert(ns_list != nil, "meta-tool carries namespaces")
+      assert(len(ns_list) == 2, "two distinct namespaces")
+      assert(ns_list[0] == "crm", "crm sorts first")
+      assert(ns_list[1] == "ops", "ops second")
+      var saw_deploy_api_ns = false
+      for t in calls[0].tools {
+        if t.type == "function" {
+          let fname = t.function?.name
+          if fname == "deploy_api" {
+            assert(t.namespace == "ops", "deploy_api.namespace reaches OpenAI wrapper")
+            saw_deploy_api_ns = true
+          }
+        }
+      }
+      assert(saw_deploy_api_ns, "deploy_api namespace passthrough confirmed")
+      let caught_bad_ns = try {
+        tool_define(
+          tool_registry(),
+          "busted",
+          "bad namespace",
+          {parameters: {}, namespace: 42, handler: { _ -> "ok" }},
+        )
+        false
+      } catch (e) {
+        true
+      }
+      assert(caught_bad_ns, "non-string namespace must be rejected")
+      log("tool_search_namespace tests passed")
     },
   )
-  let calls = llm_mock_calls()
-  let meta = calls[0].tools[0]
-  assert(meta.type == "tool_search", "meta-tool in slot 0")
-  let ns_list = meta.namespaces
-  assert(ns_list != nil, "meta-tool carries namespaces")
-  assert(len(ns_list) == 2, "two distinct namespaces")
-  // `namespaces` is sorted for determinism.
-  assert(ns_list[0] == "crm", "crm sorts first")
-  assert(ns_list[1] == "ops", "ops second")
-  // Individual user tools still carry their namespace.
-  var saw_deploy_api_ns = false
-  for t in calls[0].tools {
-    if t.type == "function" {
-      let fname = t.function?.name
-      if fname == "deploy_api" {
-        assert(t.namespace == "ops", "deploy_api.namespace reaches OpenAI wrapper")
-        saw_deploy_api_ns = true
-      }
-    }
-  }
-  assert(saw_deploy_api_ns, "deploy_api namespace passthrough confirmed")
-  // Type validation: a non-string namespace is rejected by tool_define.
-  let caught_bad_ns = try {
-    tool_define(
-      tool_registry(),
-      "busted",
-      "bad namespace",
-      {parameters: {}, namespace: 42, handler: { _ -> "ok" }},
-    )
-    false
-  } catch (e) {
-    true
-  }
-  assert(caught_bad_ns, "non-string namespace must be rejected")
-  log("tool_search_namespace tests passed")
 }
+// `namespaces` is sorted for determinism.
+// Individual user tools still carry their namespace.
+// Type validation: a non-string namespace is rejected by tool_define.

--- a/conformance/tests/scenarios/tool_search_native_openai.harn
+++ b/conformance/tests/scenarios/tool_search_native_openai.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Tool Vault phase 3 (harn#71): native OpenAI Responses-API
  * `tool_search` payload emission for GPT 5.4+. Verifies that:
@@ -15,7 +17,6 @@
  *      providers.
  */
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -48,65 +49,68 @@ pipeline test(task) {
   // deferred flags. The mock provider won't actually call the tools —
   // we just need a response that lets the call return so we can
   // inspect `llm_mock_calls()`.
-  llm_mock({text: "ack"})
-  llm_call(
-    "do a thing",
-    nil,
-    {
-      provider: "mock",
-      model: "gpt-5.4-preview",
-      tools: registry,
-      tool_search: {variant: "bm25", mode: "native"},
+  with_llm_script(
+    [llm_text("ack")],
+    { ->
+      llm_call(
+        "do a thing",
+        nil,
+        {
+          provider: "mock",
+          model: "gpt-5.4-preview",
+          tools: registry,
+          tool_search: {variant: "bm25", mode: "native"},
+        },
+      )
+      let calls = llm_mock_calls()
+      assert(len(calls) >= 1, "at least one LLM call happened")
+      let tools = calls[0].tools
+      assert(tools != nil, "tools captured")
+      assert(len(tools) == 4, "meta-tool + 3 user tools = 4")
+      let meta = tools[0]
+      assert(meta.type == "tool_search", "OpenAI meta-tool uses the `tool_search` type")
+      assert(meta.mode == "hosted", "native path defaults to hosted mode")
+      assert(meta.name == nil, "OpenAI meta-tool has no `name` field")
+      var saw_deploy_deferred = false
+      var saw_metrics_deferred = false
+      var saw_lookup_eager = false
+      for t in tools {
+        if t.type == "function" {
+          let fname = t.function?.name
+          if fname == "deploy_service" {
+            assert(t.defer_loading, "deploy_service keeps defer_loading: true")
+            saw_deploy_deferred = true
+          }
+          if fname == "query_metrics" {
+            assert(t.defer_loading, "query_metrics keeps defer_loading: true")
+            saw_metrics_deferred = true
+          }
+          if fname == "lookup_account" {
+            assert(t.defer_loading == nil, "eager tool has no defer_loading flag")
+            saw_lookup_eager = true
+          }
+        }
+      }
+      assert(saw_deploy_deferred, "deploy_service present + deferred")
+      assert(saw_metrics_deferred, "query_metrics present + deferred")
+      assert(saw_lookup_eager, "lookup_account present + eager")
+      let pre54_err = try {
+        llm_call(
+          "x",
+          nil,
+          {provider: "mock", model: "gpt-4o", tools: registry, tool_search: {variant: "bm25", mode: "native"}},
+        )
+        nil
+      } catch (e) {
+        e
+      }
+      assert(pre54_err != nil, "pre-5.4 gpt rejects native")
+      assert(pre54_err.contains("does not expose native"), "diagnostic mentions missing native support")
+      log("tool_search_native_openai tests passed")
     },
   )
-  let calls = llm_mock_calls()
-  assert(len(calls) >= 1, "at least one LLM call happened")
-  let tools = calls[0].tools
-  assert(tools != nil, "tools captured")
-  assert(len(tools) == 4, "meta-tool + 3 user tools = 4")
-  // First entry is the OpenAI-shape `tool_search` meta-tool.
-  let meta = tools[0]
-  assert(meta.type == "tool_search", "OpenAI meta-tool uses the `tool_search` type")
-  assert(meta.mode == "hosted", "native path defaults to hosted mode")
-  assert(meta.name == nil, "OpenAI meta-tool has no `name` field")
-  // User tools follow, preserving `defer_loading` on the wrapper.
-  var saw_deploy_deferred = false
-  var saw_metrics_deferred = false
-  var saw_lookup_eager = false
-  for t in tools {
-    if t.type == "function" {
-      let fname = t.function?.name
-      if fname == "deploy_service" {
-        assert(t.defer_loading, "deploy_service keeps defer_loading: true")
-        saw_deploy_deferred = true
-      }
-      if fname == "query_metrics" {
-        assert(t.defer_loading, "query_metrics keeps defer_loading: true")
-        saw_metrics_deferred = true
-      }
-      if fname == "lookup_account" {
-        assert(t.defer_loading == nil, "eager tool has no defer_loading flag")
-        saw_lookup_eager = true
-      }
-    }
-  }
-  assert(saw_deploy_deferred, "deploy_service present + deferred")
-  assert(saw_metrics_deferred, "query_metrics present + deferred")
-  assert(saw_lookup_eager, "lookup_account present + eager")
-  // Negative path: mode:"native" on a pre-5.4 GPT fires the same
-  // diagnostic the unsupported-provider test uses.
-  llm_mock_clear()
-  let pre54_err = try {
-    llm_call(
-      "x",
-      nil,
-      {provider: "mock", model: "gpt-4o", tools: registry, tool_search: {variant: "bm25", mode: "native"}},
-    )
-    nil
-  } catch (e) {
-    e
-  }
-  assert(pre54_err != nil, "pre-5.4 gpt rejects native")
-  assert(pre54_err.contains("does not expose native"), "diagnostic mentions missing native support")
-  log("tool_search_native_openai tests passed")
 }
+// First entry is the OpenAI-shape `tool_search` meta-tool.
+// User tools follow, preserving `defer_loading` on the wrapper.
+// Negative path: mode:"native" on a pre-5.4 GPT fires the same
+// diagnostic the unsupported-provider test uses.

--- a/conformance/tests/scenarios/tool_search_provider_overrides.harn
+++ b/conformance/tests/scenarios/tool_search_provider_overrides.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 /**
  * Tool Vault phase 3 (harn#71): `provider_overrides.<name>.force_native_tool_search`
  * escape hatch for proxied OpenAI-compat endpoints. A self-hosted router
@@ -7,7 +9,6 @@
  * that capability and opt into the native path.
  */
 pipeline test(task) {
-  llm_mock_clear()
   var registry = tool_registry()
   registry = tool_define(
     registry,
@@ -47,22 +48,25 @@ pipeline test(task) {
   // With the override: the same config succeeds and emits the OpenAI
   // meta-tool. `provider_overrides` is keyed by provider name so the
   // same call can pass multiple provider-specific flags.
-  llm_mock_clear()
-  llm_mock({text: "ack"})
-  llm_call(
-    "x",
-    nil,
-    {
-      provider: "mock",
-      model: "my-internal-model",
-      tools: registry,
-      tool_search: {variant: "bm25", mode: "native"},
-      mock: {force_native_tool_search: true},
+  with_llm_script(
+    [llm_text("ack")],
+    { ->
+      llm_call(
+        "x",
+        nil,
+        {
+          provider: "mock",
+          model: "my-internal-model",
+          tools: registry,
+          tool_search: {variant: "bm25", mode: "native"},
+          mock: {force_native_tool_search: true},
+        },
+      )
+      let calls = llm_mock_calls()
+      let meta = calls[0].tools[0]
+      assert(meta.type == "tool_search", "escape hatch emits OpenAI meta-tool")
+      assert(meta.mode == "hosted", "defaults to hosted mode")
+      log("tool_search_provider_overrides tests passed")
     },
   )
-  let calls = llm_mock_calls()
-  let meta = calls[0].tools[0]
-  assert(meta.type == "tool_search", "escape hatch emits OpenAI meta-tool")
-  assert(meta.mode == "hosted", "defaults to hosted mode")
-  log("tool_search_provider_overrides tests passed")
 }

--- a/conformance/tests/scenarios/typed_output_checkpoint_validator_retry.harn
+++ b/conformance/tests/scenarios/typed_output_checkpoint_validator_retry.harn
@@ -1,8 +1,8 @@
 import { agent_capture_events } from "std/agent/events"
 import { typed_output_checkpoint } from "std/checkpoint"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
   let schema = {
     type: "object",
     additionalProperties: false,
@@ -13,48 +13,52 @@ pipeline default() {
       evidence: {type: "array", items: {type: "string"}},
     },
   }
-  llm_mock(
-    {
-      text: "Here is the JSON:\n```json\n{\"decision\":\"merge\",\"confidence\":0.2,\"evidence\":[]}\n```",
+  with_llm_script(
+    [
+      llm_text(
+        "Here is the JSON:\n```json\n{\"decision\":\"merge\",\"confidence\":0.2,\"evidence\":[]}\n```",
+      ),
+      llm_text("{\"decision\":\"wait\",\"confidence\":0.95,\"evidence\":[\"ci still pending\"]}"),
+    ],
+    { ->
+      let session_id = "typed-checkpoint-session"
+      let captured = agent_capture_events(
+        session_id,
+        fn() { typed_output_checkpoint(
+          "merge_captain.next_action",
+          "Choose the next Merge Captain action.",
+          schema,
+          {provider: "mock", session_id: session_id, validator_retries: 1, repair: {enabled: false}},
+          fn(data) {
+            var errors = []
+            if data.confidence < 0.7 {
+              errors = errors.push("confidence must be at least 0.7")
+            }
+            if len(data.evidence) == 0 {
+              errors = errors.push("evidence must cite a deterministic fact")
+            }
+            return {ok: len(errors) == 0, errors: errors}
+          },
+        ) },
+      )
+      let checkpoint = captured.result
+      __io_println(checkpoint.ok)
+      __io_println(checkpoint.data.decision)
+      __io_println(checkpoint.attempts)
+      __io_println(checkpoint.checkpoint_attempts)
+      __io_println(checkpoint.extracted_json)
+      __io_println(len(checkpoint.validator_failures))
+      __io_println(contains(llm_mock_calls()[1].messages[0].content, "confidence must be at least 0.7"))
+      __io_println(captured.events[0].type)
+      __io_println(captured.events[0].checkpoint.final_accepted)
+      let trace = agent_trace()
+      var found = false
+      for event in trace {
+        if event.type == "typed_checkpoint" && event.name == "merge_captain.next_action" {
+          found = event.final_accepted
+        }
+      }
+      __io_println(found)
     },
   )
-  llm_mock({text: "{\"decision\":\"wait\",\"confidence\":0.95,\"evidence\":[\"ci still pending\"]}"})
-  let session_id = "typed-checkpoint-session"
-  let captured = agent_capture_events(
-    session_id,
-    fn() { typed_output_checkpoint(
-      "merge_captain.next_action",
-      "Choose the next Merge Captain action.",
-      schema,
-      {provider: "mock", session_id: session_id, validator_retries: 1, repair: {enabled: false}},
-      fn(data) {
-        var errors = []
-        if data.confidence < 0.7 {
-          errors = errors.push("confidence must be at least 0.7")
-        }
-        if len(data.evidence) == 0 {
-          errors = errors.push("evidence must cite a deterministic fact")
-        }
-        return {ok: len(errors) == 0, errors: errors}
-      },
-    ) },
-  )
-  let checkpoint = captured.result
-  __io_println(checkpoint.ok)
-  __io_println(checkpoint.data.decision)
-  __io_println(checkpoint.attempts)
-  __io_println(checkpoint.checkpoint_attempts)
-  __io_println(checkpoint.extracted_json)
-  __io_println(len(checkpoint.validator_failures))
-  __io_println(contains(llm_mock_calls()[1].messages[0].content, "confidence must be at least 0.7"))
-  __io_println(captured.events[0].type)
-  __io_println(captured.events[0].checkpoint.final_accepted)
-  let trace = agent_trace()
-  var found = false
-  for event in trace {
-    if event.type == "typed_checkpoint" && event.name == "merge_captain.next_action" {
-      found = event.final_accepted
-    }
-  }
-  __io_println(found)
 }

--- a/conformance/tests/scenarios/with_cache_caller_replay.harn
+++ b/conformance/tests/scenarios/with_cache_caller_replay.harn
@@ -13,6 +13,7 @@
  */
 import { cache_clear, mem_cache } from "std/cache"
 import { default_llm_caller, with_cache } from "std/llm/handlers"
+import { with_llm_script } from "std/testing"
 
 pipeline default() {
   let store = mem_cache({namespace: "with-cache-caller-" + uuid()})
@@ -34,32 +35,37 @@ pipeline default() {
       }
     },
   )
-  llm_mock_clear()
   // The mock surfaces input_tokens/output_tokens at the top level; the
   // LLM result wraps them into `usage` so the cache receipt reader sees
   // the right `tokens_saved` figure on hits.
-  llm_mock({text: "answer", input_tokens: 11, output_tokens: 7, model: "m", provider: "p"})
-  llm_mock({text: "fresh-if-uncached", model: "m", provider: "p"})
-  let opts = {provider: "p", model: "m", stream: false}
-  let call_one = {
-    prompt: "hello",
-    system: "sys",
-    opts: opts,
-    turn: {iteration: 0, session_id: session_id, attempt: 1},
-  }
-  let first = caller(call_one)
-  let second = caller(call_one)
-  __io_println("first.ok=" + to_string(first.ok))
-  __io_println("second.ok=" + to_string(second.ok))
-  __io_println(
-    "byte_identical=" + to_string(json_stringify(first.value) == json_stringify(second.value)),
+  with_llm_script(
+    [
+      {text: "answer", input_tokens: 11, output_tokens: 7, model: "m", provider: "p"},
+      {text: "fresh-if-uncached", model: "m", provider: "p"},
+    ],
+    { ->
+      let opts = {provider: "p", model: "m", stream: false}
+      let call_one = {
+        prompt: "hello",
+        system: "sys",
+        opts: opts,
+        turn: {iteration: 0, session_id: session_id, attempt: 1},
+      }
+      let first = caller(call_one)
+      let second = caller(call_one)
+      __io_println("first.ok=" + to_string(first.ok))
+      __io_println("second.ok=" + to_string(second.ok))
+      __io_println(
+        "byte_identical=" + to_string(json_stringify(first.value) == json_stringify(second.value)),
+      )
+      __io_println("mock_calls=" + to_string(len(llm_mock_calls())))
+      let tool_call = call_one + {opts: opts + {tools: []}}
+      let _ = caller(tool_call)
+      __io_println("after_tool_call_mock_calls=" + to_string(len(llm_mock_calls())))
+      __io_println("misses=" + to_string(atomic_get(misses)))
+      __io_println("hits=" + to_string(atomic_get(hits)))
+      __io_println("hit.tokens_saved=" + to_string(atomic_get(last_hit_tokens)))
+    },
   )
-  __io_println("mock_calls=" + to_string(len(llm_mock_calls())))
-  // Calls with tools opt out of the cache by default (skip_when).
-  let tool_call = call_one + {opts: opts + {tools: []}}
-  let _ = caller(tool_call)
-  __io_println("after_tool_call_mock_calls=" + to_string(len(llm_mock_calls())))
-  __io_println("misses=" + to_string(atomic_get(misses)))
-  __io_println("hits=" + to_string(atomic_get(hits)))
-  __io_println("hit.tokens_saved=" + to_string(atomic_get(last_hit_tokens)))
 }
+// Calls with tools opt out of the cache by default (skip_when).

--- a/conformance/tests/skills/load_skill_accepts_valid_signature.harn
+++ b/conformance/tests/skills/load_skill_accepts_valid_signature.harn
@@ -1,67 +1,73 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
   let catalog = render_always_on_catalog(skills_catalog_entries(skills), 2000)
-  llm_mock(
-    {
-      text: "Load the signed instructions.",
-      tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "signed-review"}}],
-    },
-  )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Use the signed skill",
-    catalog,
-    {
-      provider: "mock",
-      model: "gpt-5.4",
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      session_id: "skills-signed-accept",
-      skills: skills,
-    },
-  )
-  assert(result?.status == "done", "agent loop finishes")
-  let chain = skill_who_signed(skills, "signed-review")
-  assert(chain?.trusted, "who-signed query marks chain trusted")
-  assert(
-    chain?.author?.fingerprint == "6eaf8d0aae351c481ddbba5b06012b514f75065ab1e97a325ec65920086b8ccc",
-    "author fingerprint surfaces",
-  )
-  assert(
-    contains(json_stringify(chain), "84878ad03a6518f7bb8f5f4eff29591bb94cafa2ddf37ded6b5bba82cd8ddc60"),
-    "endorsement chain surfaces",
-  )
-  assert(
-    chain?.trust_policy_input?.action == "skill.provenance",
-    "trust-ranking policy input surfaces",
-  )
-  let calls = llm_mock_calls()
-  let second_messages = json_stringify(calls[1].messages)
-  assert(
-    contains(second_messages, "Always verify the signed skill body."),
-    "signed skill body is loaded",
-  )
-  let events = transcript_events(result?.transcript)
-  var saw_record = false
-  for ev in events {
-    if ev?.kind == "skill.loaded" && ev?.metadata?.skill_id == "signed-review" {
-      assert(ev?.metadata?.signed, "trust record marks skill as signed")
-      assert(ev?.metadata?.trusted, "trust record marks skill as trusted")
+  with_llm_script(
+    [
+      {
+        text: "Load the signed instructions.",
+        tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "signed-review"}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Use the signed skill",
+        catalog,
+        {
+          provider: "mock",
+          model: "gpt-5.4",
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          session_id: "skills-signed-accept",
+          skills: skills,
+        },
+      )
+      assert(result?.status == "done", "agent loop finishes")
+      let chain = skill_who_signed(skills, "signed-review")
+      assert(chain?.trusted, "who-signed query marks chain trusted")
       assert(
-        contains(
-          json_stringify(ev?.metadata),
-          "84878ad03a6518f7bb8f5f4eff29591bb94cafa2ddf37ded6b5bba82cd8ddc60",
-        ),
-        "trust record carries endorsements",
+        chain?.author?.fingerprint
+          == "6eaf8d0aae351c481ddbba5b06012b514f75065ab1e97a325ec65920086b8ccc",
+        "author fingerprint surfaces",
       )
       assert(
-        ev?.metadata?.trust_policy_input?.action == "skill.provenance",
-        "trust record carries trust policy input",
+        contains(json_stringify(chain), "84878ad03a6518f7bb8f5f4eff29591bb94cafa2ddf37ded6b5bba82cd8ddc60"),
+        "endorsement chain surfaces",
       )
-      saw_record = true
-    }
-  }
-  assert(saw_record, "skill.loaded trust record emitted")
-  log("load_skill_accepts_valid_signature passed")
+      assert(
+        chain?.trust_policy_input?.action == "skill.provenance",
+        "trust-ranking policy input surfaces",
+      )
+      let calls = llm_mock_calls()
+      let second_messages = json_stringify(calls[1].messages)
+      assert(
+        contains(second_messages, "Always verify the signed skill body."),
+        "signed skill body is loaded",
+      )
+      let events = transcript_events(result?.transcript)
+      var saw_record = false
+      for ev in events {
+        if ev?.kind == "skill.loaded" && ev?.metadata?.skill_id == "signed-review" {
+          assert(ev?.metadata?.signed, "trust record marks skill as signed")
+          assert(ev?.metadata?.trusted, "trust record marks skill as trusted")
+          assert(
+            contains(
+              json_stringify(ev?.metadata),
+              "84878ad03a6518f7bb8f5f4eff29591bb94cafa2ddf37ded6b5bba82cd8ddc60",
+            ),
+            "trust record carries endorsements",
+          )
+          assert(
+            ev?.metadata?.trust_policy_input?.action == "skill.provenance",
+            "trust record carries trust policy input",
+          )
+          saw_record = true
+        }
+      }
+      assert(saw_record, "skill.loaded trust record emitted")
+      log("load_skill_accepts_valid_signature passed")
+    },
+  )
 }

--- a/conformance/tests/skills/load_skill_rejects_unsigned_when_required.harn
+++ b/conformance/tests/skills/load_skill_rejects_unsigned_when_required.harn
@@ -1,46 +1,51 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
-  llm_mock_clear()
   let catalog = render_always_on_catalog(skills_catalog_entries(skills), 2000)
-  llm_mock(
-    {
-      text: "Load the unsigned instructions.",
-      tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "unsigned-review", require_signature: true}}],
+  with_llm_script(
+    [
+      {
+        text: "Load the unsigned instructions.",
+        tool_calls: [{id: "ls1", name: "load_skill", arguments: {name: "unsigned-review", require_signature: true}}],
+      },
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Use the unsigned skill",
+        catalog,
+        {
+          provider: "mock",
+          model: "gpt-5.4",
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          session_id: "skills-unsigned-reject",
+          skills: skills,
+        },
+      )
+      assert(result?.status == "done", "agent loop finishes")
+      let calls = llm_mock_calls()
+      let second_messages = json_stringify(calls[1].messages)
+      assert(
+        contains(second_messages, "UnsignedSkillError"),
+        "unsigned skill load fails with a typed error",
+      )
+      assert(
+        !contains(second_messages, "Unsigned skill body should never load."),
+        "unsigned skill body is not leaked",
+      )
+      let events = transcript_events(result?.transcript)
+      var saw_record = false
+      for ev in events {
+        if ev?.kind == "skill.loaded" && ev?.metadata?.skill_id == "unsigned-review" {
+          assert(!ev?.metadata?.signed, "trust record marks skill as unsigned")
+          assert(!ev?.metadata?.trusted, "unsigned skill is not trusted")
+          saw_record = true
+        }
+      }
+      assert(saw_record, "skill.loaded trust record emitted")
+      log("load_skill_rejects_unsigned_when_required passed")
     },
   )
-  llm_mock({text: "<done>##DONE##</done>"})
-  let result = agent_loop(
-    "Use the unsigned skill",
-    catalog,
-    {
-      provider: "mock",
-      model: "gpt-5.4",
-      tool_format: "native",
-      loop_until_done: true,
-      max_iterations: 3,
-      session_id: "skills-unsigned-reject",
-      skills: skills,
-    },
-  )
-  assert(result?.status == "done", "agent loop finishes")
-  let calls = llm_mock_calls()
-  let second_messages = json_stringify(calls[1].messages)
-  assert(
-    contains(second_messages, "UnsignedSkillError"),
-    "unsigned skill load fails with a typed error",
-  )
-  assert(
-    !contains(second_messages, "Unsigned skill body should never load."),
-    "unsigned skill body is not leaked",
-  )
-  let events = transcript_events(result?.transcript)
-  var saw_record = false
-  for ev in events {
-    if ev?.kind == "skill.loaded" && ev?.metadata?.skill_id == "unsigned-review" {
-      assert(!ev?.metadata?.signed, "trust record marks skill as unsigned")
-      assert(!ev?.metadata?.trusted, "unsigned skill is not trusted")
-      saw_record = true
-    }
-  }
-  assert(saw_record, "skill.loaded trust record emitted")
-  log("load_skill_rejects_unsigned_when_required passed")
 }

--- a/conformance/tests/stdlib/agent_probe.harn
+++ b/conformance/tests/stdlib/agent_probe.harn
@@ -1,5 +1,6 @@
 import { recall_facts } from "std/agent/fact"
 import { probe, probe_eval, probe_typecheck } from "std/agent/probe"
+import { assert_error_contains } from "std/testing"
 import "../_common"
 
 pipeline test_agent_probe(_task) {
@@ -82,21 +83,9 @@ pipeline test_agent_probe(_task) {
   let inspect_stub = probe("Inspect", "anything", opts + {now: "2026-05-23T22:00:07Z"})
   assert_eq(inspect_stub.outcome, "unknown")
   // --- validation errors
-  let bad_kind = try {
-    probe("guess", "echo x", opts)
-  }
-  assert(is_err(bad_kind))
-  assert(contains(to_string(unwrap_err(bad_kind)), "HARN-PROBE-002"))
-  let bad_body = try {
-    probe("eval", "", opts)
-  }
-  assert(is_err(bad_body))
-  assert(contains(to_string(unwrap_err(bad_body)), "HARN-PROBE-004"))
-  let bad_lang = try {
-    probe_eval("echo x", opts + {lang: "python"})
-  }
-  assert(is_err(bad_lang))
-  assert(contains(to_string(unwrap_err(bad_lang)), "HARN-PROBE-003"))
+  assert_error_contains({ -> probe("guess", "echo x", opts) }, "HARN-PROBE-002")
+  assert_error_contains({ -> probe("eval", "", opts) }, "HARN-PROBE-004")
+  assert_error_contains({ -> probe_eval("echo x", opts + {lang: "python"}) }, "HARN-PROBE-003")
   harness.fs.delete(root)
   __io_println("agent probe ok")
 }

--- a/conformance/tests/stdlib/agent_sitrep.harn
+++ b/conformance/tests/stdlib/agent_sitrep.harn
@@ -1,4 +1,5 @@
 import { agent_sitrep, agent_sitrep_append, agent_sitrep_preferred_routes } from "std/agent/sitrep"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
   // Default route list is non-empty and contains anthropic+haiku at the head.
@@ -8,53 +9,54 @@ pipeline test(task) {
   __io_println(routes[0].model == "claude-haiku-4-5-20251001")
   // Mock provider is always available — pin opts.routes to it so the
   // test does not depend on which env keys are present in CI.
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "CURRENT STATE — investigating parser drift.\nWORK DONE — inspected lexer.rs and noted a missing fall-through case.\nNEXT ACTION — patch lexer.rs and re-run the conformance suite.",
-    },
-  )
   let messages = [
     {role: "user", content: "Investigate parser drift."},
     {role: "assistant", content: "Inspected the lexer entrypoint."},
     {role: "user", content: "Focus on diagnostics next."},
   ]
-  let result = agent_sitrep(messages, {routes: [{provider: "mock", model: "mock-sitrep"}]})
-  __io_println(!result.skipped)
-  __io_println(result.provider_used == "mock")
-  __io_println(len(result.lines) == 3)
-  __io_println(result.lines[0].starts_with("CURRENT STATE"))
-  __io_println(result.lines[1].starts_with("WORK DONE"))
-  __io_println(result.lines[2].starts_with("NEXT ACTION"))
-  // Verify the user prompt sent to the LLM contains a formatted
-  // transcript and the prompt template's 3-line contract.
-  let prompt = llm_mock_calls()[0].messages[0].content
-  __io_println(prompt.contains("[USER] Investigate parser drift."))
-  __io_println(prompt.contains("3 short sentences"))
-  // Empty transcript short-circuits without an LLM call.
-  llm_mock_clear()
-  llm_mock({text: "should not be reached"})
-  let empty_result = agent_sitrep([], {routes: [{provider: "mock", model: "mock-sitrep"}]})
-  __io_println(empty_result.skipped)
-  __io_println(empty_result.reason == "empty_transcript")
-  __io_println(len(llm_mock_calls()) == 0)
-  // No-available-provider case: pass a routes list with no mock entry
-  // and rely on the fact that the mock provider is not in the override.
-  llm_mock_clear()
+  with_llm_script(
+    [
+      llm_text(
+        "CURRENT STATE — investigating parser drift.\nWORK DONE — inspected lexer.rs and noted a missing fall-through case.\nNEXT ACTION — patch lexer.rs and re-run the conformance suite.",
+      ),
+    ],
+    { ->
+      let result = agent_sitrep(messages, {routes: [{provider: "mock", model: "mock-sitrep"}]})
+      __io_println(!result.skipped)
+      __io_println(result.provider_used == "mock")
+      __io_println(len(result.lines) == 3)
+      __io_println(result.lines[0].starts_with("CURRENT STATE"))
+      __io_println(result.lines[1].starts_with("WORK DONE"))
+      __io_println(result.lines[2].starts_with("NEXT ACTION"))
+      let prompt = llm_mock_calls()[0].messages[0].content
+      __io_println(prompt.contains("[USER] Investigate parser drift."))
+      __io_println(prompt.contains("3 short sentences"))
+    },
+  )
+  with_llm_script(
+    [llm_text("should not be reached")],
+    { ->
+      let empty_result = agent_sitrep([], {routes: [{provider: "mock", model: "mock-sitrep"}]})
+      __io_println(empty_result.skipped)
+      __io_println(empty_result.reason == "empty_transcript")
+      __io_println(len(llm_mock_calls()) == 0)
+    },
+  )
   let unavailable_result = agent_sitrep(messages, {routes: [{provider: "definitely-not-a-real-provider"}]})
   __io_println(unavailable_result.skipped)
   __io_println(unavailable_result.reason == "no_available_provider")
   // agent_sitrep_append wraps the summary in <sitrep>...</sitrep> and
   // appends as a system-role message.
-  llm_mock_clear()
-  llm_mock({text: "STATE — A.\nWORK — B.\nNEXT — C."})
-  let appended = agent_sitrep_append(messages, {routes: [{provider: "mock", model: "mock-sitrep"}]})
-  __io_println(len(appended) == len(messages) + 1)
-  __io_println(appended[len(appended) - 1].role == "system")
-  __io_println(appended[len(appended) - 1].content.contains("<sitrep>"))
-  __io_println(appended[len(appended) - 1].content.contains("STATE — A."))
-  // Skipped sitrep returns the input unchanged.
-  llm_mock_clear()
+  with_llm_script(
+    [llm_text("STATE — A.\nWORK — B.\nNEXT — C.")],
+    { ->
+      let appended = agent_sitrep_append(messages, {routes: [{provider: "mock", model: "mock-sitrep"}]})
+      __io_println(len(appended) == len(messages) + 1)
+      __io_println(appended[len(appended) - 1].role == "system")
+      __io_println(appended[len(appended) - 1].content.contains("<sitrep>"))
+      __io_println(appended[len(appended) - 1].content.contains("STATE — A."))
+    },
+  )
   let appended_skipped = agent_sitrep_append([], {routes: [{provider: "mock", model: "mock-sitrep"}]})
   __io_println(len(appended_skipped) == 0)
 }

--- a/conformance/tests/stdlib/command_json_helpers.harn
+++ b/conformance/tests/stdlib/command_json_helpers.harn
@@ -5,6 +5,7 @@ import {
   command_result_ok,
   command_try,
 } from "std/command"
+import { assert_error_contains } from "std/testing"
 
 fn json_runner(text) {
   return { _spec, _options -> return command_result_ok(text) }
@@ -43,11 +44,10 @@ pipeline default() {
   assert_eq(malformed.error.category, "invalid_json")
   assert_eq(malformed.step.status, "invalid_json")
   assert(contains(malformed.error.message, "invalid JSON"))
-  let thrown = try {
-    command_json(["bad-json"], {runner: json_runner("{ nope")})
-  }
-  assert_eq(is_err(thrown), true)
-  assert(contains(to_string(unwrap_err(thrown)), "invalid JSON"))
+  assert_error_contains(
+    { -> command_json(["bad-json"], {runner: json_runner("{ nope")}) },
+    "invalid JSON",
+  )
   let step = command_json_step(
     "structured probe",
     ["fake-step"],

--- a/conformance/tests/stdlib/compact_transcript.harn
+++ b/conformance/tests/stdlib/compact_transcript.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 pipeline test(task) {
   let base = transcript_from_messages(
     [
@@ -30,107 +32,110 @@ pipeline test(task) {
   __io_println(
     transcript_events_by_kind(masked, "compaction")[0].metadata?.strategy == "observation_mask",
   )
-  llm_mock_clear()
-  llm_mock({text: "LLM compact summary"})
-  let llm_compacted = transcript_compact(
-    base,
-    {
-      provider: "mock",
-      strategy: "llm",
-      keep_last: 1,
-      summarize_prompt: "compact_transcript_summary.harn.prompt",
-    },
-  )
-  __io_println(transcript_summary(llm_compacted).contains("LLM compact summary"))
-  let llm_calls = llm_mock_calls()
-  let prompt = llm_calls[0].messages[0].content
-  __io_println(prompt.contains("Compact prompt from asset."))
-  __io_println(prompt.contains("Archived count: 2"))
-  llm_mock_clear()
-  llm_mock({text: "policy extension summary"})
-  let policy_extended = transcript_compact(
-    base,
-    {
-      provider: "mock",
-      strategy: "llm",
-      keep_last: 1,
-      instructions: "Preserve parser TODOs.",
-      author: "host",
-    },
-  )
-  let extended_prompt = llm_mock_calls()[0].messages[0].content
-  let extended_event = transcript_events_by_kind(policy_extended, "compaction")[0]
-  __io_println(extended_prompt.contains("Additional compaction instructions"))
-  __io_println(extended_event.metadata?.instruction_mode == "extend")
-  __io_println(extended_event.metadata?.instruction_source == "host")
-  __io_println(extended_event.metadata?.compaction_policy?.instructions == "Preserve parser TODOs.")
-  llm_mock_clear()
-  llm_mock({text: "policy replacement summary"})
-  let policy_replaced = transcript_compact(
-    base,
-    {
-      provider: "mock",
-      strategy: "llm",
-      keep_last: 1,
-      instructions: "Only keep failing verification details.",
-      extend_default_instructions: false,
-    },
-  )
-  let replacement_prompt = llm_mock_calls()[0].messages[0].content
-  __io_println(replacement_prompt.contains("according to these instructions"))
-  __io_println(!replacement_prompt.contains("Preserve goals, constraints"))
-  __io_println(
-    transcript_events_by_kind(policy_replaced, "compaction")[0].metadata?.instruction_mode
-      == "replace",
-  )
-  let stream_session = agent_session_open("compact-stream-session")
-  agent_session_inject(stream_session, {role: "user", content: "one"})
-  agent_session_inject(stream_session, {role: "assistant", content: "two"})
-  agent_session_inject(stream_session, {role: "user", content: "three"})
-  agent_subscribe(
-    stream_session,
-    { ev ->
-      if ev?.type == "transcript_compacted" {
-        agent_session_inject(stream_session, {role: "assistant", content: "LIVE_COMPACTION_EVENT"})
+  with_llm_script(
+    [
+      llm_text("LLM compact summary"),
+      llm_text("policy extension summary"),
+      llm_text("policy replacement summary"),
+    ],
+    { ->
+      let llm_compacted = transcript_compact(
+        base,
+        {
+          provider: "mock",
+          strategy: "llm",
+          keep_last: 1,
+          summarize_prompt: "compact_transcript_summary.harn.prompt",
+        },
+      )
+      __io_println(transcript_summary(llm_compacted).contains("LLM compact summary"))
+      let llm_calls = llm_mock_calls()
+      let prompt = llm_calls[0].messages[0].content
+      __io_println(prompt.contains("Compact prompt from asset."))
+      __io_println(prompt.contains("Archived count: 2"))
+      let policy_extended = transcript_compact(
+        base,
+        {
+          provider: "mock",
+          strategy: "llm",
+          keep_last: 1,
+          instructions: "Preserve parser TODOs.",
+          author: "host",
+        },
+      )
+      let extended_prompt = llm_mock_calls()[1].messages[0].content
+      let extended_event = transcript_events_by_kind(policy_extended, "compaction")[0]
+      __io_println(extended_prompt.contains("Additional compaction instructions"))
+      __io_println(extended_event.metadata?.instruction_mode == "extend")
+      __io_println(extended_event.metadata?.instruction_source == "host")
+      __io_println(extended_event.metadata?.compaction_policy?.instructions == "Preserve parser TODOs.")
+      let policy_replaced = transcript_compact(
+        base,
+        {
+          provider: "mock",
+          strategy: "llm",
+          keep_last: 1,
+          instructions: "Only keep failing verification details.",
+          extend_default_instructions: false,
+        },
+      )
+      let replacement_prompt = llm_mock_calls()[2].messages[0].content
+      __io_println(replacement_prompt.contains("according to these instructions"))
+      __io_println(!replacement_prompt.contains("Preserve goals, constraints"))
+      __io_println(
+        transcript_events_by_kind(policy_replaced, "compaction")[0].metadata?.instruction_mode
+          == "replace",
+      )
+      let stream_session = agent_session_open("compact-stream-session")
+      agent_session_inject(stream_session, {role: "user", content: "one"})
+      agent_session_inject(stream_session, {role: "assistant", content: "two"})
+      agent_session_inject(stream_session, {role: "user", content: "three"})
+      agent_subscribe(
+        stream_session,
+        { ev ->
+          if ev?.type == "transcript_compacted" {
+            agent_session_inject(stream_session, {role: "assistant", content: "LIVE_COMPACTION_EVENT"})
+          }
+        },
+      )
+      let session_snapshot = agent_session_snapshot(stream_session) ?? {}
+      let _ = transcript_compact(session_snapshot, {strategy: "truncate", keep_last: 1, target_tokens: 1})
+      __io_println(
+        json_stringify(transcript_messages(agent_session_snapshot(stream_session) ?? {}))
+          .contains("LIVE_COMPACTION_EVENT"),
+      )
+      let run = run_record(
+        {
+          _type: "run_record",
+          id: "compact-run",
+          workflow_id: "wf",
+          status: "completed",
+          stages: [
+            {id: "stage-truncate", node_id: "truncate", transcript: truncated},
+            {id: "stage-mask", node_id: "mask", transcript: masked},
+            {id: "stage-llm", node_id: "llm", transcript: llm_compacted},
+          ],
+        },
+      )
+      __io_println(run.observability?.schema_version == 4)
+      __io_println(len(run.observability?.compaction_events) == 3)
+      var saw_truncate = false
+      var saw_mask = false
+      var saw_llm = false
+      for ev in run.observability?.compaction_events {
+        if ev.stage_id == "stage-truncate" && ev.strategy == "truncate" && ev.available {
+          saw_truncate = true
+        }
+        if ev.stage_id == "stage-mask" && ev.strategy == "observation_mask" && ev.available {
+          saw_mask = true
+        }
+        if ev.stage_id == "stage-llm" && ev.strategy == "llm" && ev.available {
+          saw_llm = true
+        }
       }
+      __io_println(saw_truncate)
+      __io_println(saw_mask)
+      __io_println(saw_llm)
     },
   )
-  let session_snapshot = agent_session_snapshot(stream_session) ?? {}
-  let _ = transcript_compact(session_snapshot, {strategy: "truncate", keep_last: 1, target_tokens: 1})
-  __io_println(
-    json_stringify(transcript_messages(agent_session_snapshot(stream_session) ?? {}))
-      .contains("LIVE_COMPACTION_EVENT"),
-  )
-  let run = run_record(
-    {
-      _type: "run_record",
-      id: "compact-run",
-      workflow_id: "wf",
-      status: "completed",
-      stages: [
-        {id: "stage-truncate", node_id: "truncate", transcript: truncated},
-        {id: "stage-mask", node_id: "mask", transcript: masked},
-        {id: "stage-llm", node_id: "llm", transcript: llm_compacted},
-      ],
-    },
-  )
-  __io_println(run.observability?.schema_version == 4)
-  __io_println(len(run.observability?.compaction_events) == 3)
-  var saw_truncate = false
-  var saw_mask = false
-  var saw_llm = false
-  for ev in run.observability?.compaction_events {
-    if ev.stage_id == "stage-truncate" && ev.strategy == "truncate" && ev.available {
-      saw_truncate = true
-    }
-    if ev.stage_id == "stage-mask" && ev.strategy == "observation_mask" && ev.available {
-      saw_mask = true
-    }
-    if ev.stage_id == "stage-llm" && ev.strategy == "llm" && ev.available {
-      saw_llm = true
-    }
-  }
-  __io_println(saw_truncate)
-  __io_println(saw_mask)
-  __io_println(saw_llm)
 }

--- a/conformance/tests/stdlib/cost_route.harn
+++ b/conformance/tests/stdlib/cost_route.harn
@@ -1,7 +1,6 @@
 import { llm_call_count } from "std/testing"
 
 pipeline test(task) {
-  llm_mock_clear()
   let routed = cost_route {
     budget_usd: 1.0
     prefer: ["mock:mock"]

--- a/conformance/tests/stdlib/csv_builtins.harn
+++ b/conformance/tests/stdlib/csv_builtins.harn
@@ -1,3 +1,5 @@
+import { assert_error_contains } from "std/testing"
+
 pipeline test(task) {
   let text = "name,age\nalice,30\nbob,25\n"
   // No headers: list of lists
@@ -16,14 +18,6 @@ pipeline test(task) {
   // round-trip list rows
   let listy = csv_stringify([["a", "b"], ["c", "d"]])
   log(listy)
-  let multi_delimiter = try {
-    csv_parse("a||b\n", {delimiter: "||"})
-  }
-  assert(is_err(multi_delimiter))
-  assert(contains(to_string(unwrap_err(multi_delimiter)), "exactly one ASCII"))
-  let unicode_delimiter = try {
-    csv_stringify([["a", "b"]], {delimiter: "é"})
-  }
-  assert(is_err(unicode_delimiter))
-  assert(contains(to_string(unwrap_err(unicode_delimiter)), "exactly one ASCII"))
+  assert_error_contains({ -> csv_parse("a||b\n", {delimiter: "||"}) }, "exactly one ASCII")
+  assert_error_contains({ -> csv_stringify([["a", "b"]], {delimiter: "é"}) }, "exactly one ASCII")
 }

--- a/conformance/tests/stdlib/edit_fast_apply.harn
+++ b/conformance/tests/stdlib/edit_fast_apply.harn
@@ -1,4 +1,5 @@
 import { edit_fast_apply, fast_apply } from "std/edit"
+import { llm_text, with_llm_script } from "std/testing"
 
 fn write_fixture(dir: string, name: string, body: string) -> string {
   let path = path_join(dir, name)
@@ -15,74 +16,73 @@ pipeline default() {
   harness.fs.mkdir(root)
   let path = write_fixture(root, "lib.rs", "fn answer() -> i32 {\n    1\n}\n")
   let before = harness.fs.read_text(path)
-  llm_mock(
-    {text: "{\"content\":\"fn answer() -> i32 {\\n    2\\n}\\n\",\"summary\":\"bump answer\"}"},
-  )
-  let dry = edit_fast_apply(
-    {
-      path: path,
-      intent: "Change answer to return 2.",
-      dry_run: true,
-      llm_options: {provider: "mock", model: "mock"},
+  with_llm_script(
+    [
+      llm_text("{\"content\":\"fn answer() -> i32 {\\n    2\\n}\\n\",\"summary\":\"bump answer\"}"),
+      llm_text("{\"content\":\"fn answer() -> i32 {\\n    3\\n}\\n\"}"),
+      llm_text("{\"content\":\"def answer():\\n    return 4\\n\"}"),
+      llm_text("{\"content\":\"export function answer(): number {\\n  return 5;\\n}\\n\"}"),
+      llm_text("{\"content\":\"fn broken( {\\n\"}"),
+      llm_text("{\"content\":123}"),
+    ],
+    { ->
+      let dry = edit_fast_apply(
+        {
+          path: path,
+          intent: "Change answer to return 2.",
+          dry_run: true,
+          llm_options: {provider: "mock", model: "mock"},
+        },
+      )
+      __io_println(dry.result)
+      __io_println(dry.applied)
+      __io_println(dry.dry_run)
+      __io_println(dry.telemetry.apply_path)
+      __io_println(dry.telemetry.success)
+      __io_println(dry.telemetry.dry_run)
+      __io_println(contains(dry.per_file_unified_diff[0].diff, "    2"))
+      __io_println(harness.fs.read_text(path) == before)
+      let calls = llm_mock_calls()
+      __io_println(contains(calls[0].messages[0].content, "Preimage: sha256:"))
+      let applied = fast_apply(path, "Change answer to return 3.", {llm_options: {provider: "mock", model: "mock"}})
+      __io_println(applied.result)
+      __io_println(applied.applied)
+      __io_println(applied.telemetry.applied)
+      __io_println(applied.safe_text_patch.telemetry.applied)
+      __io_println(contains(harness.fs.read_text(path), "    3"))
+      let py_path = write_fixture(root, "calc.py", "def answer():\n    return 1\n")
+      let py = fast_apply(py_path, "Change answer to return 4.", {llm_options: {provider: "mock", model: "mock"}})
+      __io_println(py.result)
+      __io_println(py.telemetry.apply_path)
+      __io_println(contains(harness.fs.read_text(py_path), "return 4"))
+      let ts_path = write_fixture(root, "widget.ts", "export function answer(): number {\n  return 1;\n}\n")
+      let ts = fast_apply(ts_path, "Change answer to return 5.", {llm_options: {provider: "mock", model: "mock"}})
+      __io_println(ts.result)
+      __io_println(ts.telemetry.apply_path)
+      __io_println(contains(harness.fs.read_text(ts_path), "return 5"))
+      let bad_path = write_fixture(root, "bad.rs", "fn broken() -> i32 {\n    1\n}\n")
+      let bad_before = harness.fs.read_text(bad_path)
+      let rejected = edit_fast_apply(
+        {
+          path: bad_path,
+          intent: "Introduce invalid syntax.",
+          llm_options: {provider: "mock", model: "mock"},
+        },
+      )
+      __io_println(rejected.result)
+      __io_println(rejected.ok)
+      __io_println(rejected.telemetry.validation_rejected)
+      __io_println(harness.fs.read_text(bad_path) == bad_before)
+      let invalid_output = edit_fast_apply(
+        {
+          path: bad_path,
+          intent: "Return a non-string content field.",
+          llm_options: {provider: "mock", model: "mock"},
+        },
+      )
+      __io_println(invalid_output.result)
+      __io_println(invalid_output.errors[0].code)
+      __io_println(harness.fs.read_text(bad_path) == bad_before)
     },
   )
-  __io_println(dry.result)
-  __io_println(dry.applied)
-  __io_println(dry.dry_run)
-  __io_println(dry.telemetry.apply_path)
-  __io_println(dry.telemetry.success)
-  __io_println(dry.telemetry.dry_run)
-  __io_println(contains(dry.per_file_unified_diff[0].diff, "    2"))
-  __io_println(harness.fs.read_text(path) == before)
-  let calls = llm_mock_calls()
-  __io_println(contains(calls[0].messages[0].content, "Preimage: sha256:"))
-  llm_mock_clear()
-  llm_mock({text: "{\"content\":\"fn answer() -> i32 {\\n    3\\n}\\n\"}"})
-  let applied = fast_apply(path, "Change answer to return 3.", {llm_options: {provider: "mock", model: "mock"}})
-  __io_println(applied.result)
-  __io_println(applied.applied)
-  __io_println(applied.telemetry.applied)
-  __io_println(applied.safe_text_patch.telemetry.applied)
-  __io_println(contains(harness.fs.read_text(path), "    3"))
-  let py_path = write_fixture(root, "calc.py", "def answer():\n    return 1\n")
-  llm_mock_clear()
-  llm_mock({text: "{\"content\":\"def answer():\\n    return 4\\n\"}"})
-  let py = fast_apply(py_path, "Change answer to return 4.", {llm_options: {provider: "mock", model: "mock"}})
-  __io_println(py.result)
-  __io_println(py.telemetry.apply_path)
-  __io_println(contains(harness.fs.read_text(py_path), "return 4"))
-  let ts_path = write_fixture(root, "widget.ts", "export function answer(): number {\n  return 1;\n}\n")
-  llm_mock_clear()
-  llm_mock({text: "{\"content\":\"export function answer(): number {\\n  return 5;\\n}\\n\"}"})
-  let ts = fast_apply(ts_path, "Change answer to return 5.", {llm_options: {provider: "mock", model: "mock"}})
-  __io_println(ts.result)
-  __io_println(ts.telemetry.apply_path)
-  __io_println(contains(harness.fs.read_text(ts_path), "return 5"))
-  let bad_path = write_fixture(root, "bad.rs", "fn broken() -> i32 {\n    1\n}\n")
-  let bad_before = harness.fs.read_text(bad_path)
-  llm_mock_clear()
-  llm_mock({text: "{\"content\":\"fn broken( {\\n\"}"})
-  let rejected = edit_fast_apply(
-    {
-      path: bad_path,
-      intent: "Introduce invalid syntax.",
-      llm_options: {provider: "mock", model: "mock"},
-    },
-  )
-  __io_println(rejected.result)
-  __io_println(rejected.ok)
-  __io_println(rejected.telemetry.validation_rejected)
-  __io_println(harness.fs.read_text(bad_path) == bad_before)
-  llm_mock_clear()
-  llm_mock({text: "{\"content\":123}"})
-  let invalid_output = edit_fast_apply(
-    {
-      path: bad_path,
-      intent: "Return a non-string content field.",
-      llm_options: {provider: "mock", model: "mock"},
-    },
-  )
-  __io_println(invalid_output.result)
-  __io_println(invalid_output.errors[0].code)
-  __io_println(harness.fs.read_text(bad_path) == bad_before)
 }

--- a/conformance/tests/stdlib/llm_ensemble_adaptive_stop.harn
+++ b/conformance/tests/stdlib/llm_ensemble_adaptive_stop.harn
@@ -1,8 +1,7 @@
 import { debate } from "std/llm/ensemble"
-import { llm_call_count } from "std/testing"
+import { llm_call_count, llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
   let topic = "llm.ensemble.debate"
   let cursor = event_log.latest(topic)
   let events = if cursor == nil {
@@ -10,32 +9,38 @@ pipeline default() {
   } else {
     event_log.subscribe({topic: topic, from_cursor: cursor})
   }
-  llm_mock({text: "Paris is the capital of France."})
-  llm_mock({text: "The answer is Paris, France."})
-  llm_mock({text: "Paris is the capital of France."})
-  llm_mock({text: "The answer is Paris, France."})
-  llm_mock({text: "Paris is the capital of France."})
-  llm_mock({text: "The answer is Paris, France."})
-  llm_mock({text: "unused round four a"})
-  llm_mock({text: "unused round four b"})
-  let result = debate(
-    {
-      prompt: "What is the capital of France?",
-      debaters: ["alpha", "beta"],
-      n_rounds: 5,
-      adaptive_stop: true,
-      stability_threshold: 0.15,
-      provider: "mock",
+  with_llm_script(
+    [
+      llm_text("Paris is the capital of France."),
+      llm_text("The answer is Paris, France."),
+      llm_text("Paris is the capital of France."),
+      llm_text("The answer is Paris, France."),
+      llm_text("Paris is the capital of France."),
+      llm_text("The answer is Paris, France."),
+      llm_text("unused round four a"),
+      llm_text("unused round four b"),
+    ],
+    { ->
+      let result = debate(
+        {
+          prompt: "What is the capital of France?",
+          debaters: ["alpha", "beta"],
+          n_rounds: 5,
+          adaptive_stop: true,
+          stability_threshold: 0.15,
+          provider: "mock",
+        },
+      )
+      let event = events.next().value
+      __io_println(result.completed_rounds)
+      __io_println(result.stopped_early)
+      __io_println(result.stop_reason)
+      __io_println(llm_call_count())
+      __io_println(event.kind)
+      __io_println(event.payload.round)
+      __io_println(event.payload.requested_rounds)
+      __io_println(event.payload.consecutive_stable_rounds)
+      __io_println(event.payload.max_round_drift < 0.15)
     },
   )
-  let event = events.next().value
-  __io_println(result.completed_rounds)
-  __io_println(result.stopped_early)
-  __io_println(result.stop_reason)
-  __io_println(llm_call_count())
-  __io_println(event.kind)
-  __io_println(event.payload.round)
-  __io_println(event.payload.requested_rounds)
-  __io_println(event.payload.consecutive_stable_rounds)
-  __io_println(event.payload.max_round_drift < 0.15)
 }

--- a/conformance/tests/stdlib/llm_ensemble_fixed_rounds.harn
+++ b/conformance/tests/stdlib/llm_ensemble_fixed_rounds.harn
@@ -1,28 +1,33 @@
 import { debate } from "std/llm/ensemble"
-import { llm_call_count } from "std/testing"
+import { llm_call_count, llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
-  llm_mock_clear()
-  llm_mock({text: "Paris is the capital of France."})
-  llm_mock({text: "The answer is Paris, France."})
-  llm_mock({text: "Paris is the capital of France."})
-  llm_mock({text: "The answer is Paris, France."})
-  llm_mock({text: "Paris is the capital of France."})
-  llm_mock({text: "The answer is Paris, France."})
-  llm_mock({text: "Paris is the capital of France."})
-  llm_mock({text: "The answer is Paris, France."})
-  let result = debate(
-    {
-      prompt: "What is the capital of France?",
-      debaters: ["alpha", "beta"],
-      n_rounds: 4,
-      provider: "mock",
+  with_llm_script(
+    [
+      llm_text("Paris is the capital of France."),
+      llm_text("The answer is Paris, France."),
+      llm_text("Paris is the capital of France."),
+      llm_text("The answer is Paris, France."),
+      llm_text("Paris is the capital of France."),
+      llm_text("The answer is Paris, France."),
+      llm_text("Paris is the capital of France."),
+      llm_text("The answer is Paris, France."),
+    ],
+    { ->
+      let result = debate(
+        {
+          prompt: "What is the capital of France?",
+          debaters: ["alpha", "beta"],
+          n_rounds: 4,
+          provider: "mock",
+        },
+      )
+      __io_println(result.completed_rounds)
+      __io_println(result.stopped_early)
+      __io_println(result.stop_reason == nil)
+      __io_println(llm_call_count())
+      __io_println(len(result.stability))
+      __io_println(result.stability[0].stable)
     },
   )
-  __io_println(result.completed_rounds)
-  __io_println(result.stopped_early)
-  __io_println(result.stop_reason == nil)
-  __io_println(llm_call_count())
-  __io_println(len(result.stability))
-  __io_println(result.stability[0].stable)
 }

--- a/conformance/tests/stdlib/preset_hooks/preset_hooks_llm_classifier_confidence.harn
+++ b/conformance/tests/stdlib/preset_hooks/preset_hooks_llm_classifier_confidence.harn
@@ -1,3 +1,4 @@
+import { llm_text, with_llm_script } from "std/testing"
 import { preset_run_command } from "std/tool_hooks"
 
 /**
@@ -14,50 +15,42 @@ import { preset_run_command } from "std/tool_hooks"
 pipeline default() {
   pipeline_lifecycle_audit_log_take()
   __tool_hooks_classifier_cache_clear()
-  llm_mock_clear()
   /* Above threshold: classifier asks for a rewrite with confidence 0.95;
    * threshold is 0.7 so the rewrite mode fires. */
-  llm_mock(
-    {
-      text: "{\"kind\": \"rewrite\", \"confidence\": 0.95,"
-        + " \"rewritten\": \"echo confident\","
-        + " \"explanation\": \"safe to rewrite\"}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"kind\": \"rewrite\", \"confidence\": 0.95,"
+          + " \"rewritten\": \"echo confident\","
+          + " \"explanation\": \"safe to rewrite\"}",
+      ),
+      llm_text(
+        "{\"kind\": \"rewrite\", \"confidence\": 0.4,"
+          + " \"rewritten\": \"never-applied\","
+          + " \"explanation\": \"low confidence\"}",
+      ),
+    ],
+    { ->
+      let inner = { args -> {ok: true, ran: args.command} }
+      let wrapper = preset_run_command(
+        {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.7}, inner: inner},
+      )
+      let above = wrapper({command: "echo above"})
+      __io_println(above.action)
+      __io_println(above.command)
+      __io_println(above.result.ran)
+      let below = wrapper({command: "echo below"})
+      __io_println(below.ok)
+      __io_println(below.ran)
+      let log = pipeline_lifecycle_audit_log_take()
+      __io_println(log[0].kind)
+      __io_println(log[0].payload.kind)
+      __io_println(log[0].payload.action)
+      __io_println(len(log))
+      let last = log[len(log) - 1]
+      __io_println(last.kind)
+      __io_println(last.payload.action)
+      __io_println(last.payload.kind)
     },
   )
-  let inner = { args -> {ok: true, ran: args.command} }
-  let wrapper = preset_run_command(
-    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.7}, inner: inner},
-  )
-  let above = wrapper({command: "echo above"})
-  __io_println(above.action)
-  __io_println(above.command)
-  __io_println(above.result.ran)
-  /* Below threshold: same kind, confidence 0.4. Wrapper audits the
-   * verdict but runs `inner` with the unaltered command. */
-  llm_mock(
-    {
-      text: "{\"kind\": \"rewrite\", \"confidence\": 0.4,"
-        + " \"rewritten\": \"never-applied\","
-        + " \"explanation\": \"low confidence\"}",
-    },
-  )
-  let below = wrapper({command: "echo below"})
-  __io_println(below.ok)
-  __io_println(below.ran)
-  /* Two classifier verdicts logged, one above-threshold (action="rewrite")
-   * and one below (action="passthrough"). */
-  let log = pipeline_lifecycle_audit_log_take()
-  __io_println(log[0].kind)
-  __io_println(log[0].payload.kind)
-  __io_println(log[0].payload.action)
-  /* The below-threshold call's verdict is the last entry in the log:
-   * passthrough emits no further audit entries. Above-threshold
-   * rewrite emits classifier_verdict + tool_rewrite +
-   * tool_hooks.reminder_injected = 3, then the passthrough adds 1 for
-   * a total of 4. */
-  __io_println(len(log))
-  let last = log[len(log) - 1]
-  __io_println(last.kind)
-  __io_println(last.payload.action)
-  __io_println(last.payload.kind)
 }

--- a/conformance/tests/stdlib/project/project_deep_scan_cache.harn
+++ b/conformance/tests/stdlib/project/project_deep_scan_cache.harn
@@ -1,50 +1,55 @@
 import "std/project"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
   let namespace = "coding-enrichment-${uuid()}"
   let root = path_join(harness.fs.temp_dir(), "project-deep-scan-cache-" + uuid())
   harness.fs.mkdir(root)
   harness.fs.write_text(path_join(root, "README.md"), "# repo\n")
-  llm_mock({text: "{\"purpose\":\"root\"}"})
-  let first = project_deep_scan(
-    root,
-    {
-      namespace: namespace,
-      tiers: ["ambient", "config", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {
-        prompt: "Return valid JSON only.",
-        provider: "mock",
-        schema: {purpose: "string"},
-        budget_tokens_per_dir: 256,
-      },
+  with_llm_script(
+    [llm_text("{\"purpose\":\"root\"}")],
+    { ->
+      let first = project_deep_scan(
+        root,
+        {
+          namespace: namespace,
+          tiers: ["ambient", "config", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {
+            prompt: "Return valid JSON only.",
+            provider: "mock",
+            schema: {purpose: "string"},
+            budget_tokens_per_dir: 256,
+          },
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(len(keys(first)) == 1)
+      __io_println(first["."].enriched.purpose == "root")
+      __io_println(len(calls) == 1)
+      __io_println(contains(calls[0].messages[0].content, "Return valid JSON only."))
+      let second = project_deep_scan(
+        root,
+        {
+          namespace: namespace,
+          tiers: ["ambient", "config", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {
+            prompt: "Return valid JSON only.",
+            provider: "mock",
+            schema: {purpose: "string"},
+            budget_tokens_per_dir: 256,
+          },
+        },
+      )
+      let second_status = project_deep_scan_status(namespace, root)
+      __io_println(second["."].enriched.purpose == "root")
+      __io_println(second_status.total_dirs == 1)
+      __io_println(second_status.cache_hits == 1)
+      __io_println(len(llm_mock_calls()) == 1)
+      harness.fs.delete(root)
     },
   )
-  let calls = llm_mock_calls()
-  __io_println(len(keys(first)) == 1)
-  __io_println(first["."].enriched.purpose == "root")
-  __io_println(len(calls) == 1)
-  __io_println(contains(calls[0].messages[0].content, "Return valid JSON only."))
-  let second = project_deep_scan(
-    root,
-    {
-      namespace: namespace,
-      tiers: ["ambient", "config", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {
-        prompt: "Return valid JSON only.",
-        provider: "mock",
-        schema: {purpose: "string"},
-        budget_tokens_per_dir: 256,
-      },
-    },
-  )
-  let second_status = project_deep_scan_status(namespace, root)
-  __io_println(second["."].enriched.purpose == "root")
-  __io_println(second_status.total_dirs == 1)
-  __io_println(second_status.cache_hits == 1)
-  __io_println(len(llm_mock_calls()) == 1)
-  harness.fs.delete(root)
 }

--- a/conformance/tests/stdlib/project/project_deep_scan_invalidation.harn
+++ b/conformance/tests/stdlib/project/project_deep_scan_invalidation.harn
@@ -1,47 +1,51 @@
 import "std/project"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
   let namespace = "coding-enrichment-${uuid()}"
   let root = path_join(harness.fs.temp_dir(), "project-deep-scan-invalidation-" + uuid())
   harness.fs.mkdir(root)
   harness.fs.write_text(path_join(root, "README.md"), "# repo\n")
-  llm_mock({text: "{\"purpose\":\"root\"}"})
-  let first = project_deep_scan(
-    root,
-    {
-      namespace: namespace,
-      tiers: ["ambient", "config", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {
-        prompt: "Return valid JSON only.",
-        provider: "mock",
-        schema: {purpose: "string"},
-        budget_tokens_per_dir: 256,
-      },
+  with_llm_script(
+    [llm_text("{\"purpose\":\"root\"}"), llm_text("{\"purpose\":\"root changed\"}")],
+    { ->
+      let first = project_deep_scan(
+        root,
+        {
+          namespace: namespace,
+          tiers: ["ambient", "config", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {
+            prompt: "Return valid JSON only.",
+            provider: "mock",
+            schema: {purpose: "string"},
+            budget_tokens_per_dir: 256,
+          },
+        },
+      )
+      harness.fs.write_text(path_join(root, "README.md"), "# repo changed\n")
+      let second = project_deep_scan(
+        root,
+        {
+          namespace: namespace,
+          tiers: ["ambient", "config", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {
+            prompt: "Return valid JSON only.",
+            provider: "mock",
+            schema: {purpose: "string"},
+            budget_tokens_per_dir: 256,
+          },
+        },
+      )
+      let second_status = project_deep_scan_status(namespace, root)
+      __io_println(first["."].enriched.purpose == "root")
+      __io_println(second["."].enriched.purpose == "root changed")
+      __io_println(second_status.cache_hits == 0)
+      __io_println(len(llm_mock_calls()) == 2)
+      harness.fs.delete(root)
     },
   )
-  harness.fs.write_text(path_join(root, "README.md"), "# repo changed\n")
-  llm_mock({text: "{\"purpose\":\"root changed\"}"})
-  let second = project_deep_scan(
-    root,
-    {
-      namespace: namespace,
-      tiers: ["ambient", "config", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {
-        prompt: "Return valid JSON only.",
-        provider: "mock",
-        schema: {purpose: "string"},
-        budget_tokens_per_dir: 256,
-      },
-    },
-  )
-  let second_status = project_deep_scan_status(namespace, root)
-  __io_println(first["."].enriched.purpose == "root")
-  __io_println(second["."].enriched.purpose == "root changed")
-  __io_println(second_status.cache_hits == 0)
-  __io_println(len(llm_mock_calls()) == 2)
-  harness.fs.delete(root)
 }

--- a/conformance/tests/stdlib/project/project_deep_scan_namespaces.harn
+++ b/conformance/tests/stdlib/project/project_deep_scan_namespaces.harn
@@ -1,4 +1,5 @@
 import "std/project"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline test(task) {
   let suffix = uuid()
@@ -7,54 +8,57 @@ pipeline test(task) {
   let root = path_join(harness.fs.temp_dir(), "project-deep-scan-ns-" + suffix)
   harness.fs.mkdir(root)
   harness.fs.write_text(path_join(root, "README.md"), "# repo\n")
-  llm_mock({text: "{\"purpose\":\"alpha root\"}"})
-  let alpha = project_deep_scan(
-    root,
-    {
-      namespace: alpha_namespace,
-      tiers: ["ambient", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
+  with_llm_script(
+    [llm_text("{\"purpose\":\"alpha root\"}"), llm_text("{\"purpose\":\"beta root\"}")],
+    { ->
+      let alpha = project_deep_scan(
+        root,
+        {
+          namespace: alpha_namespace,
+          tiers: ["ambient", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
+        },
+      )
+      let beta = project_deep_scan(
+        root,
+        {
+          namespace: beta_namespace,
+          tiers: ["ambient", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
+        },
+      )
+      let alpha_cached = project_deep_scan(
+        root,
+        {
+          namespace: alpha_namespace,
+          tiers: ["ambient", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
+        },
+      )
+      let beta_cached = project_deep_scan(
+        root,
+        {
+          namespace: beta_namespace,
+          tiers: ["ambient", "enriched"],
+          incremental: true,
+          depth: nil,
+          enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
+        },
+      )
+      __io_println(alpha["."].enriched.purpose == "alpha root")
+      __io_println(beta["."].enriched.purpose == "beta root")
+      __io_println(alpha_cached["."].enriched.purpose == "alpha root")
+      __io_println(beta_cached["."].enriched.purpose == "beta root")
+      __io_println(project_deep_scan_status(alpha_namespace, root).cache_hits == 1)
+      __io_println(project_deep_scan_status(beta_namespace, root).cache_hits == 1)
+      __io_println(len(llm_mock_calls()) == 2)
+      harness.fs.delete(root)
     },
   )
-  llm_mock({text: "{\"purpose\":\"beta root\"}"})
-  let beta = project_deep_scan(
-    root,
-    {
-      namespace: beta_namespace,
-      tiers: ["ambient", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
-    },
-  )
-  let alpha_cached = project_deep_scan(
-    root,
-    {
-      namespace: alpha_namespace,
-      tiers: ["ambient", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
-    },
-  )
-  let beta_cached = project_deep_scan(
-    root,
-    {
-      namespace: beta_namespace,
-      tiers: ["ambient", "enriched"],
-      incremental: true,
-      depth: nil,
-      enrichment: {prompt: "Return valid JSON only.", provider: "mock", schema: {purpose: "string"}},
-    },
-  )
-  __io_println(alpha["."].enriched.purpose == "alpha root")
-  __io_println(beta["."].enriched.purpose == "beta root")
-  __io_println(alpha_cached["."].enriched.purpose == "alpha root")
-  __io_println(beta_cached["."].enriched.purpose == "beta root")
-  __io_println(project_deep_scan_status(alpha_namespace, root).cache_hits == 1)
-  __io_println(project_deep_scan_status(beta_namespace, root).cache_hits == 1)
-  __io_println(len(llm_mock_calls()) == 2)
-  harness.fs.delete(root)
 }

--- a/conformance/tests/stdlib/stdlib_agents_action_graph.harn
+++ b/conformance/tests/stdlib/stdlib_agents_action_graph.harn
@@ -1,4 +1,5 @@
 import "std/agents"
+import { llm_text, with_llm_script } from "std/testing"
 
 pipeline default() {
   let normalized = action_graph(
@@ -45,19 +46,24 @@ pipeline default() {
   let flow = action_graph_flow(execution_plan, config)
   let report = workflow_validate(flow)
   __io_println(report.valid)
-  llm_mock_clear()
-  llm_mock({text: "Research complete."})
-  llm_mock({text: "Implementation batch complete."})
-  llm_mock({text: "Evaluation complete."})
-  let result = action_graph_run(
-    "Fix parser diagnostics",
-    execution_plan,
-    config,
-    {max_steps: 8, persist_path: "/tmp/harn-action-graph-runtime.json"},
+  with_llm_script(
+    [
+      llm_text("Research complete."),
+      llm_text("Implementation batch complete."),
+      llm_text("Evaluation complete."),
+    ],
+    { ->
+      let result = action_graph_run(
+        "Fix parser diagnostics",
+        execution_plan,
+        config,
+        {max_steps: 8, persist_path: "/tmp/harn-action-graph-runtime.json"},
+      )
+      __io_println(result.status == "completed")
+      __io_println(result.run?._type == "run_record")
+      __io_println(len(result.run.stages) == 4)
+      __io_println(result.run.stages[2].kind == "verify")
+      __io_println(result.batches[1].count == 2)
+    },
   )
-  __io_println(result.status == "completed")
-  __io_println(result.run?._type == "run_record")
-  __io_println(len(result.run.stages) == 4)
-  __io_println(result.run.stages[2].kind == "verify")
-  __io_println(result.batches[1].count == 2)
 }

--- a/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_deny.harn
+++ b/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_deny.harn
@@ -1,3 +1,4 @@
+import { llm_text, with_llm_script } from "std/testing"
 import { preset_run_command } from "std/tool_hooks"
 
 /**
@@ -11,32 +12,35 @@ import { preset_run_command } from "std/tool_hooks"
 pipeline default() {
   pipeline_lifecycle_audit_log_take()
   __tool_hooks_classifier_cache_clear()
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "{\"kind\": \"deny\", \"confidence\": 0.95,"
-        + " \"explanation\": \"rm against /etc is dangerous\"}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"kind\": \"deny\", \"confidence\": 0.95,"
+          + " \"explanation\": \"rm against /etc is dangerous\"}",
+      ),
+    ],
+    { ->
+      let inner = { args -> {ok: true, ran: args.command} }
+      let wrapper = preset_run_command(
+        {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.7}, inner: inner},
+      )
+      let result = wrapper({command: "rm -rf /etc/foo"})
+      __io_println(result.action)
+      __io_println(result.catalogue_id)
+      __io_println(result.severity)
+      __io_println(result.explanation)
+      __io_println(result.original_command)
+      __io_println(result.command)
+      __io_println(result?.result == nil)
+      let log = pipeline_lifecycle_audit_log_take()
+      __io_println(len(log))
+      __io_println(log[0].kind)
+      __io_println(log[0].payload.kind)
+      __io_println(log[0].payload.action)
+      __io_println(log[1].kind)
     },
   )
-  /* `inner` would record ran; we expect it to stay silent because the
-   * deny mode never invokes the underlying executor. */
-  let inner = { args -> {ok: true, ran: args.command} }
-  let wrapper = preset_run_command(
-    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.7}, inner: inner},
-  )
-  let result = wrapper({command: "rm -rf /etc/foo"})
-  __io_println(result.action)
-  __io_println(result.catalogue_id)
-  __io_println(result.severity)
-  __io_println(result.explanation)
-  __io_println(result.original_command)
-  __io_println(result.command)
-  /* `result.result` should be absent on deny since `inner` was not run. */
-  __io_println(result?.result == nil)
-  let log = pipeline_lifecycle_audit_log_take()
-  __io_println(len(log))
-  __io_println(log[0].kind)
-  __io_println(log[0].payload.kind)
-  __io_println(log[0].payload.action)
-  __io_println(log[1].kind)
 }
+/* `inner` would record ran; we expect it to stay silent because the
+       * deny mode never invokes the underlying executor. */
+/* `result.result` should be absent on deny since `inner` was not run. */

--- a/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_error_recovery.harn
+++ b/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_error_recovery.harn
@@ -1,3 +1,4 @@
+import { llm_text, with_llm_script } from "std/testing"
 import { preset_run_command } from "std/tool_hooks"
 
 /**
@@ -11,21 +12,24 @@ import { preset_run_command } from "std/tool_hooks"
 pipeline default() {
   pipeline_lifecycle_audit_log_take()
   __tool_hooks_classifier_cache_clear()
-  llm_mock_clear()
   /* Non-JSON model output — the parser should classify as kind=error
    * and the wrapper should passthrough rather than throw. */
-  llm_mock({text: "I am a chatty model and I do not return JSON."})
-  let inner = { args -> {ok: true, ran: args.command} }
-  let wrapper = preset_run_command(
-    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.5}, inner: inner},
+  with_llm_script(
+    [llm_text("I am a chatty model and I do not return JSON.")],
+    { ->
+      let inner = { args -> {ok: true, ran: args.command} }
+      let wrapper = preset_run_command(
+        {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.5}, inner: inner},
+      )
+      let r = wrapper({command: "echo hi"})
+      __io_println(r.ok)
+      __io_println(r.ran)
+      let log = pipeline_lifecycle_audit_log_take()
+      __io_println(len(log))
+      __io_println(log[0].kind)
+      __io_println(log[0].payload.kind)
+      __io_println(log[0].payload.action)
+      __io_println(contains(to_string(log[0].payload.error), "non-JSON"))
+    },
   )
-  let r = wrapper({command: "echo hi"})
-  __io_println(r.ok)
-  __io_println(r.ran)
-  let log = pipeline_lifecycle_audit_log_take()
-  __io_println(len(log))
-  __io_println(log[0].kind)
-  __io_println(log[0].payload.kind)
-  __io_println(log[0].payload.action)
-  __io_println(contains(to_string(log[0].payload.error), "non-JSON"))
 }

--- a/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_passthrough.harn
+++ b/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_passthrough.harn
@@ -1,3 +1,4 @@
+import { llm_text, with_llm_script } from "std/testing"
 import { preset_run_command } from "std/tool_hooks"
 
 /**
@@ -11,51 +12,45 @@ import { preset_run_command } from "std/tool_hooks"
 pipeline default() {
   pipeline_lifecycle_audit_log_take()
   __tool_hooks_classifier_cache_clear()
-  llm_mock_clear()
   /* Scenario 1: below-threshold rewrite. The classifier says rewrite but
    * confidence (0.4) < threshold (0.8) so the wrapper falls through to
    * `inner` with the original command. */
-  llm_mock(
-    {
-      text: "{\"kind\": \"rewrite\", \"confidence\": 0.4,"
-        + " \"rewritten\": \"never-applied\", \"explanation\": \"low confidence\"}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"kind\": \"rewrite\", \"confidence\": 0.4,"
+          + " \"rewritten\": \"never-applied\", \"explanation\": \"low confidence\"}",
+      ),
+      llm_text("{\"kind\": \"allow\", \"confidence\": 0.99, \"explanation\": \"safe\"}"),
+    ],
+    { ->
+      let inner = { args -> {ok: true, ran: args.command} }
+      let wrapper = preset_run_command(
+        {
+          llm_classifier: {model: "haiku", provider: "mock", threshold: 0.8, cache: {ttl_ms: 60000}},
+          inner: inner,
+        },
+      )
+      let r1 = wrapper({command: "echo hello"})
+      __io_println(r1.ok)
+      __io_println(r1.ran)
+      let r2 = wrapper({command: "ls -la"})
+      __io_println(r2.ok)
+      __io_println(r2.ran)
+      let calls_before = len(llm_mock_calls())
+      let r3 = wrapper({command: "echo   hello"})
+      __io_println(r3.ok)
+      __io_println(r3.ran)
+      let calls_after = len(llm_mock_calls())
+      __io_println(calls_after - calls_before)
+      let log = pipeline_lifecycle_audit_log_take()
+      __io_println(len(log))
+      __io_println(log[0].payload.action)
+      __io_println(log[0].payload.cache_hit)
+      __io_println(log[1].payload.action)
+      __io_println(log[1].payload.cache_hit)
+      __io_println(log[2].payload.action)
+      __io_println(log[2].payload.cache_hit)
     },
   )
-  let inner = { args -> {ok: true, ran: args.command} }
-  let wrapper = preset_run_command(
-    {
-      llm_classifier: {model: "haiku", provider: "mock", threshold: 0.8, cache: {ttl_ms: 60000}},
-      inner: inner,
-    },
-  )
-  let r1 = wrapper({command: "echo hello"})
-  __io_println(r1.ok)
-  __io_println(r1.ran)
-  /* Scenario 2: explicit allow verdict — auditing the fact that the
-   * classifier ran and said allow, but no command rewrite. */
-  llm_mock({text: "{\"kind\": \"allow\", \"confidence\": 0.99, \"explanation\": \"safe\"}"})
-  let r2 = wrapper({command: "ls -la"})
-  __io_println(r2.ok)
-  __io_println(r2.ran)
-  /* Scenario 3: cache hit. Repeat scenario 1's command with different
-   * whitespace. The classifier cache should normalize it and return the
-   * prior low-confidence verdict without invoking the model again. */
-  let calls_before = len(llm_mock_calls())
-  let r3 = wrapper({command: "echo   hello"})
-  __io_println(r3.ok)
-  __io_println(r3.ran)
-  let calls_after = len(llm_mock_calls())
-  /* The mock recorder counts every invocation, so the delta must be
-   * zero on a cache hit. */
-  __io_println(calls_after - calls_before)
-  /* Each invocation (cache hit or miss) still audits a classifier
-   * verdict — that's the "audited even on passthrough" contract. */
-  let log = pipeline_lifecycle_audit_log_take()
-  __io_println(len(log))
-  __io_println(log[0].payload.action)
-  __io_println(log[0].payload.cache_hit)
-  __io_println(log[1].payload.action)
-  __io_println(log[1].payload.cache_hit)
-  __io_println(log[2].payload.action)
-  __io_println(log[2].payload.cache_hit)
 }

--- a/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_rewrite.harn
+++ b/conformance/tests/stdlib/tool_hooks/tool_hooks_llm_classifier_rewrite.harn
@@ -1,3 +1,4 @@
+import { llm_text, with_llm_script } from "std/testing"
 import { preset_run_command } from "std/tool_hooks"
 
 /**
@@ -12,41 +13,44 @@ import { preset_run_command } from "std/tool_hooks"
 pipeline default() {
   pipeline_lifecycle_audit_log_take()
   __tool_hooks_classifier_cache_clear()
-  llm_mock_clear()
-  llm_mock(
-    {
-      text: "{\"kind\": \"rewrite\", \"confidence\": 0.92,"
-        + " \"rewritten\": \"npm run lint -- --fix\","
-        + " \"explanation\": \"prefer auto-fix\"}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"kind\": \"rewrite\", \"confidence\": 0.92,"
+          + " \"rewritten\": \"npm run lint -- --fix\","
+          + " \"explanation\": \"prefer auto-fix\"}",
+      ),
+    ],
+    { ->
+      let inner = { args -> {ok: true, ran: args.command} }
+      let wrapper = preset_run_command(
+        {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.8}, inner: inner},
+      )
+      let result = wrapper({command: "npm run lint"})
+      __io_println(result.action)
+      __io_println(result.rule_id)
+      __io_println(result.catalogue_id)
+      __io_println(result.severity)
+      __io_println(result.explanation)
+      __io_println(result.original_command)
+      __io_println(result.command)
+      __io_println(result.result.ok)
+      __io_println(result.result.ran)
+      let calls = llm_mock_calls()
+      __io_println(len(calls))
+      __io_println(contains(to_string(calls[0].system), "shell-command safety reviewer"))
+      let log = pipeline_lifecycle_audit_log_take()
+      __io_println(len(log))
+      __io_println(log[0].kind)
+      __io_println(log[0].payload.kind)
+      __io_println(log[0].payload.action)
+      __io_println(log[1].kind)
+      __io_println(log[2].kind)
     },
   )
-  let inner = { args -> {ok: true, ran: args.command} }
-  let wrapper = preset_run_command(
-    {llm_classifier: {model: "haiku", provider: "mock", threshold: 0.8}, inner: inner},
-  )
-  let result = wrapper({command: "npm run lint"})
-  __io_println(result.action)
-  __io_println(result.rule_id)
-  __io_println(result.catalogue_id)
-  __io_println(result.severity)
-  __io_println(result.explanation)
-  __io_println(result.original_command)
-  __io_println(result.command)
-  __io_println(result.result.ok)
-  __io_println(result.result.ran)
-  /* meta_prompt must have been forwarded to the LLM call as the
-   * `system` channel — verify via the mock recorder. */
-  let calls = llm_mock_calls()
-  __io_println(len(calls))
-  __io_println(contains(to_string(calls[0].system), "shell-command safety reviewer"))
-  /* `tool_hook_classifier_verdict` always fires; the rewrite mode adds
-   * `tool_rewrite` + `tool_hooks.reminder_injected`. Three audit lines
-   * means the classifier verdict + rewrite + reminder all flowed. */
-  let log = pipeline_lifecycle_audit_log_take()
-  __io_println(len(log))
-  __io_println(log[0].kind)
-  __io_println(log[0].payload.kind)
-  __io_println(log[0].payload.action)
-  __io_println(log[1].kind)
-  __io_println(log[2].kind)
 }
+/* meta_prompt must have been forwarded to the LLM call as the
+       * `system` channel — verify via the mock recorder. */
+/* `tool_hook_classifier_verdict` always fires; the rewrite mode adds
+       * `tool_rewrite` + `tool_hooks.reminder_injected`. Three audit lines
+       * means the classifier verdict + rewrite + reminder all flowed. */

--- a/conformance/tests/stdlib/workflow_sub_agent_skill_context.harn
+++ b/conformance/tests/stdlib/workflow_sub_agent_skill_context.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 fn child_tools() {
   var tools = tool_registry()
   tools = tool_define(
@@ -37,7 +39,6 @@ fn workflow_tools() {
 }
 
 pipeline test(task) {
-  llm_mock_clear()
   skill only_look {
     description "Investigate the codebase safely"
     when_to_use "User asks to inspect or read files"
@@ -59,36 +60,40 @@ pipeline test(task) {
       edges: [],
     },
   )
-  llm_mock(
-    {
-      tool_calls: [{id: "stage_1", name: "delegate_readonly", arguments: {task: "Inspect the config file"}}],
+  with_llm_script(
+    [
+      {
+        tool_calls: [{id: "stage_1", name: "delegate_readonly", arguments: {task: "Inspect the config file"}}],
+      },
+      llm_text("I inspected the config path."),
+      llm_text("Delegation finished."),
+    ],
+    { ->
+      let result = workflow_execute(
+        "Inspect the config file",
+        flow,
+        [],
+        {max_steps: 2, skills: only_look, skill_match: {strategy: "metadata"}},
+      )
+      let calls = llm_mock_calls()
+      let child_tool_schemas = calls[1].tools
+      var seen_read = false
+      var seen_write = false
+      if child_tool_schemas != nil {
+        for t in child_tool_schemas {
+          if t?.function?.name == "read_file" {
+            seen_read = true
+          }
+          if t?.function?.name == "write_file" {
+            seen_write = true
+          }
+        }
+      }
+      __io_println(result?.status == "completed")
+      __io_println(len(calls) == 3)
+      __io_println(contains(calls[1].system, "## Active skills"))
+      __io_println(seen_read)
+      __io_println(!seen_write)
     },
   )
-  llm_mock({text: "I inspected the config path."})
-  llm_mock({text: "Delegation finished."})
-  let result = workflow_execute(
-    "Inspect the config file",
-    flow,
-    [],
-    {max_steps: 2, skills: only_look, skill_match: {strategy: "metadata"}},
-  )
-  let calls = llm_mock_calls()
-  let child_tool_schemas = calls[1].tools
-  var seen_read = false
-  var seen_write = false
-  if child_tool_schemas != nil {
-    for t in child_tool_schemas {
-      if t?.function?.name == "read_file" {
-        seen_read = true
-      }
-      if t?.function?.name == "write_file" {
-        seen_write = true
-      }
-    }
-  }
-  __io_println(result?.status == "completed")
-  __io_println(len(calls) == 3)
-  __io_println(contains(calls[1].system, "## Active skills"))
-  __io_println(seen_read)
-  __io_println(!seen_write)
 }

--- a/conformance/tests/testbench/testbench_concurrent_agents_settle.harn
+++ b/conformance/tests/testbench/testbench_concurrent_agents_settle.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * 100 concurrent parallel-each agents each perform a mocked LLM call
  * and return their index. Validates deterministic settlement: every
@@ -7,17 +9,19 @@
  * clock guarantees same-fixture runs produce byte-identical output.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "ok", input_tokens: 1, output_tokens: 1, model: "mock"})
-  let inputs = range(0, 100).to_list()
-  let results = parallel each inputs with { max_concurrent: 10 } { i ->
-    let _resp = llm_call("task " + to_string(i), nil, {provider: "mock", model: "mock"})
-    return i
-  }
-  let sorted = results.sort()
-  __io_println(len(results) == 100)
-  __io_println(sorted[0] == 0)
-  __io_println(sorted[99] == 99)
-  __io_println(len(llm_mock_calls()) == 100)
-  llm_mock_clear()
+  with_llm_script(
+    [{text: "ok", input_tokens: 1, output_tokens: 1, model: "mock"}],
+    { ->
+      let inputs = range(0, 100).to_list()
+      let results = parallel each inputs with { max_concurrent: 10 } { i ->
+        let _resp = llm_call("task " + to_string(i), nil, {provider: "mock", model: "mock"})
+        return i
+      }
+      let sorted = results.sort()
+      __io_println(len(results) == 100)
+      __io_println(sorted[0] == 0)
+      __io_println(sorted[99] == 99)
+      __io_println(len(llm_mock_calls()) == 100)
+    },
+  )
 }

--- a/conformance/tests/testbench/testbench_replay_fidelity.harn
+++ b/conformance/tests/testbench/testbench_replay_fidelity.harn
@@ -1,3 +1,5 @@
+import { with_llm_script } from "std/testing"
+
 /**
  * Script performs deterministic work under a mocked LLM and paused
  * clock. The .testbench-tape sidecar contains the golden tape from the
@@ -23,15 +25,17 @@
  * point — every regen requires explicit review.
  */
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "fidelity-response", input_tokens: 5, output_tokens: 3, model: "mock"})
-  mock_time(1767225600000)
-  let before = harness.clock.now_ms()
-  let resp = llm_call("replay test", nil, {provider: "mock", model: "mock"})
-  advance_time(1000)
-  let after = harness.clock.now_ms()
-  __io_println(resp.text == "fidelity-response")
-  __io_println(after - before == 1000)
-  unmock_time()
-  llm_mock_clear()
+  with_llm_script(
+    [{text: "fidelity-response", input_tokens: 5, output_tokens: 3, model: "mock"}],
+    { ->
+      mock_time(1767225600000)
+      let before = harness.clock.now_ms()
+      let resp = llm_call("replay test", nil, {provider: "mock", model: "mock"})
+      advance_time(1000)
+      let after = harness.clock.now_ms()
+      __io_println(resp.text == "fidelity-response")
+      __io_println(after - before == 1000)
+      unmock_time()
+    },
+  )
 }

--- a/conformance/tests/triggers/llm_predicate_circuit_breaker_opens.harn
+++ b/conformance/tests/triggers/llm_predicate_circuit_breaker_opens.harn
@@ -1,3 +1,4 @@
+import { with_llm_script } from "std/testing"
 import "std/triggers"
 
 fn handler(event: TriggerEvent) -> dict {
@@ -14,53 +15,58 @@ fn classify(event: TriggerEvent) -> bool {
 }
 
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({error: {category: "server_error", message: "503 upstream"}, model: "gpt-4o-mini"})
-  llm_mock({error: {category: "server_error", message: "503 upstream"}, model: "gpt-4o-mini"})
-  llm_mock({error: {category: "server_error", message: "503 upstream"}, model: "gpt-4o-mini"})
-  let unique = to_string(to_int(harness.clock.timestamp())) + "-"
-    + to_string(harness.random.gen_range(100000, 999999))
-  let handle: TriggerHandle = trigger_register(
-    {
-      id: "llm-predicate-breaker-" + unique,
-      kind: "issue.opened",
-      provider: "github",
-      handler: handler,
-      when: classify,
-      when_budget: nil,
-      retry: nil,
-      match: {events: ["issue.opened"]},
-      events: nil,
-      dedupe_key: nil,
-      filter: nil,
-      budget: nil,
-      manifest_path: nil,
-      package_name: nil,
+  with_llm_script(
+    [
+      {error: {category: "server_error", message: "503 upstream"}, model: "gpt-4o-mini"},
+      {error: {category: "server_error", message: "503 upstream"}, model: "gpt-4o-mini"},
+      {error: {category: "server_error", message: "503 upstream"}, model: "gpt-4o-mini"},
+    ],
+    { ->
+      let unique = to_string(to_int(harness.clock.timestamp())) + "-"
+        + to_string(harness.random.gen_range(100000, 999999))
+      let handle: TriggerHandle = trigger_register(
+        {
+          id: "llm-predicate-breaker-" + unique,
+          kind: "issue.opened",
+          provider: "github",
+          handler: handler,
+          when: classify,
+          when_budget: nil,
+          retry: nil,
+          match: {events: ["issue.opened"]},
+          events: nil,
+          dedupe_key: nil,
+          filter: nil,
+          budget: nil,
+          manifest_path: nil,
+          package_name: nil,
+        },
+      )
+      let first: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-1-" + unique}},
+      )
+      let second: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-2-" + unique}},
+      )
+      let third: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-3-" + unique}},
+      )
+      let fourth: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-4-" + unique}},
+      )
+      let evaluated = trigger_inspect_lifecycle("predicate.evaluated")
+        .filter({ entry -> entry?.headers?.trigger_id == handle.id })
+      let last = evaluated[len(evaluated) - 1]
+      __io_println(len(llm_mock_calls()) == 3)
+      __io_println(contains(json_stringify(first.result ?? {}), "\"skipped\":true"))
+      __io_println(contains(json_stringify(second.result ?? {}), "\"skipped\":true"))
+      __io_println(contains(json_stringify(third.result ?? {}), "\"skipped\":true"))
+      __io_println(contains(json_stringify(fourth.result ?? {}), "\"reason\":\"circuit_open\""))
+      __io_println(len(evaluated) == 4 && last?.payload?.reason == "circuit_open")
     },
   )
-  let first: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-1-" + unique}},
-  )
-  let second: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-2-" + unique}},
-  )
-  let third: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-3-" + unique}},
-  )
-  let fourth: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-breaker-4-" + unique}},
-  )
-  let evaluated = trigger_inspect_lifecycle("predicate.evaluated")
-    .filter({ entry -> entry?.headers?.trigger_id == handle.id })
-  let last = evaluated[len(evaluated) - 1]
-  __io_println(len(llm_mock_calls()) == 3)
-  __io_println(contains(json_stringify(first.result ?? {}), "\"skipped\":true"))
-  __io_println(contains(json_stringify(second.result ?? {}), "\"skipped\":true"))
-  __io_println(contains(json_stringify(third.result ?? {}), "\"skipped\":true"))
-  __io_println(contains(json_stringify(fourth.result ?? {}), "\"reason\":\"circuit_open\""))
-  __io_println(len(evaluated) == 4 && last?.payload?.reason == "circuit_open")
 }

--- a/conformance/tests/triggers/llm_predicate_classifies_and_fires.harn
+++ b/conformance/tests/triggers/llm_predicate_classifies_and_fires.harn
@@ -1,3 +1,4 @@
+import { with_llm_script } from "std/testing"
 import "std/triggers"
 
 fn handler(event: TriggerEvent) -> dict {
@@ -14,36 +15,39 @@ fn classify(event: TriggerEvent) -> bool {
 }
 
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "yes", input_tokens: 10, output_tokens: 5, model: "gpt-4o-mini"})
-  let unique = to_string(to_int(harness.clock.timestamp())) + "-"
-    + to_string(harness.random.gen_range(100000, 999999))
-  let handle: TriggerHandle = trigger_register(
-    {
-      id: "llm-predicate-fire-" + unique,
-      kind: "issue.opened",
-      provider: "github",
-      handler: handler,
-      when: classify,
-      when_budget: nil,
-      retry: nil,
-      match: {events: ["issue.opened"]},
-      events: nil,
-      dedupe_key: nil,
-      filter: nil,
-      budget: nil,
-      manifest_path: nil,
-      package_name: nil,
+  with_llm_script(
+    [{text: "yes", input_tokens: 10, output_tokens: 5, model: "gpt-4o-mini"}],
+    { ->
+      let unique = to_string(to_int(harness.clock.timestamp())) + "-"
+        + to_string(harness.random.gen_range(100000, 999999))
+      let handle: TriggerHandle = trigger_register(
+        {
+          id: "llm-predicate-fire-" + unique,
+          kind: "issue.opened",
+          provider: "github",
+          handler: handler,
+          when: classify,
+          when_budget: nil,
+          retry: nil,
+          match: {events: ["issue.opened"]},
+          events: nil,
+          dedupe_key: nil,
+          filter: nil,
+          budget: nil,
+          manifest_path: nil,
+          package_name: nil,
+        },
+      )
+      let fire: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-fire-" + unique}},
+      )
+      let evaluated = trigger_inspect_lifecycle("predicate.evaluated")
+        .filter({ entry -> entry?.headers?.trigger_id == handle.id })
+      __io_println(fire.status == "dispatched")
+      __io_println(contains(json_stringify(fire.result ?? {}), "\"handled\":true"))
+      __io_println(len(evaluated) == 1 && evaluated[0]?.payload?.result)
+      __io_println(len(llm_mock_calls()) == 1)
     },
   )
-  let fire: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-fire-" + unique}},
-  )
-  let evaluated = trigger_inspect_lifecycle("predicate.evaluated")
-    .filter({ entry -> entry?.headers?.trigger_id == handle.id })
-  __io_println(fire.status == "dispatched")
-  __io_println(contains(json_stringify(fire.result ?? {}), "\"handled\":true"))
-  __io_println(len(evaluated) == 1 && evaluated[0]?.payload?.result)
-  __io_println(len(llm_mock_calls()) == 1)
 }

--- a/conformance/tests/triggers/llm_predicate_cost_budget_short_circuits.harn
+++ b/conformance/tests/triggers/llm_predicate_cost_budget_short_circuits.harn
@@ -1,3 +1,4 @@
+import { with_llm_script } from "std/testing"
 import "std/triggers"
 
 fn handler(event: TriggerEvent) -> dict {
@@ -14,38 +15,41 @@ fn classify(event: TriggerEvent) -> bool {
 }
 
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "yes", input_tokens: 3000, output_tokens: 4000, model: "gpt-4o-mini"})
-  let unique = to_string(to_int(harness.clock.timestamp())) + "-"
-    + to_string(harness.random.gen_range(100000, 999999))
-  let handle: TriggerHandle = trigger_register(
-    {
-      id: "llm-predicate-budget-" + unique,
-      kind: "issue.opened",
-      provider: "github",
-      handler: handler,
-      when: classify,
-      when_budget: {max_cost_usd: 0.001, tokens_max: 500, timeout: "5s"},
-      retry: nil,
-      match: {events: ["issue.opened"]},
-      events: nil,
-      dedupe_key: nil,
-      filter: nil,
-      budget: nil,
-      manifest_path: nil,
-      package_name: nil,
+  with_llm_script(
+    [{text: "yes", input_tokens: 3000, output_tokens: 4000, model: "gpt-4o-mini"}],
+    { ->
+      let unique = to_string(to_int(harness.clock.timestamp())) + "-"
+        + to_string(harness.random.gen_range(100000, 999999))
+      let handle: TriggerHandle = trigger_register(
+        {
+          id: "llm-predicate-budget-" + unique,
+          kind: "issue.opened",
+          provider: "github",
+          handler: handler,
+          when: classify,
+          when_budget: {max_cost_usd: 0.001, tokens_max: 500, timeout: "5s"},
+          retry: nil,
+          match: {events: ["issue.opened"]},
+          events: nil,
+          dedupe_key: nil,
+          filter: nil,
+          budget: nil,
+          manifest_path: nil,
+          package_name: nil,
+        },
+      )
+      let fire: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-budget-" + unique}},
+      )
+      let budget_events = trigger_inspect_lifecycle("predicate.budget_exceeded")
+        .filter({ entry -> entry?.headers?.trigger_id == handle.id })
+      let dispatches = trigger_inspect_lifecycle("DispatchStarted")
+        .filter({ entry -> entry?.headers?.trigger_id == handle.id })
+      __io_println(fire.status == "dispatched")
+      __io_println(contains(json_stringify(fire.result ?? {}), "\"reason\":\"budget_exceeded\""))
+      __io_println(len(budget_events) == 1 && budget_events[0]?.payload?.tokens == 7000)
+      __io_println(len(dispatches) == 0)
     },
   )
-  let fire: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-budget-" + unique}},
-  )
-  let budget_events = trigger_inspect_lifecycle("predicate.budget_exceeded")
-    .filter({ entry -> entry?.headers?.trigger_id == handle.id })
-  let dispatches = trigger_inspect_lifecycle("DispatchStarted")
-    .filter({ entry -> entry?.headers?.trigger_id == handle.id })
-  __io_println(fire.status == "dispatched")
-  __io_println(contains(json_stringify(fire.result ?? {}), "\"reason\":\"budget_exceeded\""))
-  __io_println(len(budget_events) == 1 && budget_events[0]?.payload?.tokens == 7000)
-  __io_println(len(dispatches) == 0)
 }

--- a/conformance/tests/triggers/llm_predicate_replay_from_cache.harn
+++ b/conformance/tests/triggers/llm_predicate_replay_from_cache.harn
@@ -1,3 +1,4 @@
+import { with_llm_script } from "std/testing"
 import "std/triggers"
 
 fn handler(event: TriggerEvent) -> dict {
@@ -14,38 +15,41 @@ fn classify(event: TriggerEvent) -> bool {
 }
 
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "yes", input_tokens: 10, output_tokens: 5, model: "gpt-4o-mini"})
-  let unique = to_string(to_int(harness.clock.timestamp())) + "-"
-    + to_string(harness.random.gen_range(100000, 999999))
-  let handle: TriggerHandle = trigger_register(
-    {
-      id: "llm-predicate-replay-" + unique,
-      kind: "issue.opened",
-      provider: "github",
-      handler: handler,
-      when: classify,
-      when_budget: nil,
-      retry: nil,
-      match: {events: ["issue.opened"]},
-      events: nil,
-      dedupe_key: nil,
-      filter: nil,
-      budget: nil,
-      manifest_path: nil,
-      package_name: nil,
+  with_llm_script(
+    [{text: "yes", input_tokens: 10, output_tokens: 5, model: "gpt-4o-mini"}],
+    { ->
+      let unique = to_string(to_int(harness.clock.timestamp())) + "-"
+        + to_string(harness.random.gen_range(100000, 999999))
+      let handle: TriggerHandle = trigger_register(
+        {
+          id: "llm-predicate-replay-" + unique,
+          kind: "issue.opened",
+          provider: "github",
+          handler: handler,
+          when: classify,
+          when_budget: nil,
+          retry: nil,
+          match: {events: ["issue.opened"]},
+          events: nil,
+          dedupe_key: nil,
+          filter: nil,
+          budget: nil,
+          manifest_path: nil,
+          package_name: nil,
+        },
+      )
+      let fire: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-replay-" + unique}},
+      )
+      let replay: DispatchHandle = trigger_replay(fire.event_id)
+      let evaluated = trigger_inspect_lifecycle("predicate.evaluated")
+        .filter({ entry -> entry?.headers?.trigger_id == handle.id })
+      __io_println(fire.status == "dispatched" && replay.status == "dispatched")
+      __io_println(len(llm_mock_calls()) == 1)
+      __io_println(len(evaluated) == 2)
+      __io_println(!evaluated[0]?.payload?.cached && evaluated[1]?.payload?.cached)
+      __io_println(evaluated[1]?.payload?.replay_of_event_id == fire.event_id)
     },
   )
-  let fire: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-replay-" + unique}},
-  )
-  let replay: DispatchHandle = trigger_replay(fire.event_id)
-  let evaluated = trigger_inspect_lifecycle("predicate.evaluated")
-    .filter({ entry -> entry?.headers?.trigger_id == handle.id })
-  __io_println(fire.status == "dispatched" && replay.status == "dispatched")
-  __io_println(len(llm_mock_calls()) == 1)
-  __io_println(len(evaluated) == 2)
-  __io_println(!evaluated[0]?.payload?.cached && evaluated[1]?.payload?.cached)
-  __io_println(evaluated[1]?.payload?.replay_of_event_id == fire.event_id)
 }

--- a/conformance/tests/triggers/llm_predicate_returns_false_short_circuits.harn
+++ b/conformance/tests/triggers/llm_predicate_returns_false_short_circuits.harn
@@ -1,3 +1,4 @@
+import { with_llm_script } from "std/testing"
 import "std/triggers"
 
 fn handler(event: TriggerEvent) -> dict {
@@ -14,36 +15,39 @@ fn classify(event: TriggerEvent) -> bool {
 }
 
 pipeline test(task) {
-  llm_mock_clear()
-  llm_mock({text: "no", input_tokens: 10, output_tokens: 5, model: "gpt-4o-mini"})
-  let unique = to_string(to_int(harness.clock.timestamp())) + "-"
-    + to_string(harness.random.gen_range(100000, 999999))
-  let handle: TriggerHandle = trigger_register(
-    {
-      id: "llm-predicate-false-" + unique,
-      kind: "issue.opened",
-      provider: "github",
-      handler: handler,
-      when: classify,
-      when_budget: nil,
-      retry: nil,
-      match: {events: ["issue.opened"]},
-      events: nil,
-      dedupe_key: nil,
-      filter: nil,
-      budget: nil,
-      manifest_path: nil,
-      package_name: nil,
+  with_llm_script(
+    [{text: "no", input_tokens: 10, output_tokens: 5, model: "gpt-4o-mini"}],
+    { ->
+      let unique = to_string(to_int(harness.clock.timestamp())) + "-"
+        + to_string(harness.random.gen_range(100000, 999999))
+      let handle: TriggerHandle = trigger_register(
+        {
+          id: "llm-predicate-false-" + unique,
+          kind: "issue.opened",
+          provider: "github",
+          handler: handler,
+          when: classify,
+          when_budget: nil,
+          retry: nil,
+          match: {events: ["issue.opened"]},
+          events: nil,
+          dedupe_key: nil,
+          filter: nil,
+          budget: nil,
+          manifest_path: nil,
+          package_name: nil,
+        },
+      )
+      let fire: DispatchHandle = trigger_fire(
+        handle,
+        {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-false-" + unique}},
+      )
+      let dispatches = trigger_inspect_lifecycle("DispatchStarted")
+        .filter({ entry -> entry?.headers?.trigger_id == handle.id })
+      __io_println(fire.status == "dispatched")
+      __io_println(contains(json_stringify(fire.result ?? {}), "\"skipped\":true"))
+      __io_println(contains(json_stringify(fire.result ?? {}), "\"reason\":null"))
+      __io_println(len(dispatches) == 0)
     },
   )
-  let fire: DispatchHandle = trigger_fire(
-    handle,
-    {provider: "github", kind: "issue.opened", headers: {x_delivery: "evt-false-" + unique}},
-  )
-  let dispatches = trigger_inspect_lifecycle("DispatchStarted")
-    .filter({ entry -> entry?.headers?.trigger_id == handle.id })
-  __io_println(fire.status == "dispatched")
-  __io_println(contains(json_stringify(fire.result ?? {}), "\"skipped\":true"))
-  __io_println(contains(json_stringify(fire.result ?? {}), "\"reason\":null"))
-  __io_println(len(dispatches) == 0)
 }

--- a/conformance/tests/triggers/trigger_channel_guardrail_llm_classifier.harn
+++ b/conformance/tests/triggers/trigger_channel_guardrail_llm_classifier.harn
@@ -1,4 +1,5 @@
 import { llm_risk_classifier } from "std/channel_guardrails"
+import { llm_text, with_llm_script } from "std/testing"
 
 /**
  * CH-11 (#1911): the LLM risk classifier preset registers a custom
@@ -10,44 +11,55 @@ import { llm_risk_classifier } from "std/channel_guardrails"
 pipeline default() {
   pipeline_lifecycle_audit_log_take()
   channel_guardrail_clear()
-  llm_mock_clear()
   let id = llm_risk_classifier({model: "haiku", provider: "mock", threshold: 0.7, on_high_risk: "block"})
   __io_println(id)
   /* Confident block — adversarial payload, classifier returns
    * verdict=block with confidence=0.95. */
-  llm_mock(
-    {
-      text: "{\"verdict\": \"block\", \"confidence\": 0.95,"
-        + " \"reason\": \"exfiltration attempt\","
-        + " \"category\": \"data_exfil\"}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"verdict\": \"block\", \"confidence\": 0.95,"
+          + " \"reason\": \"exfiltration attempt\","
+          + " \"category\": \"data_exfil\"}",
+      ),
+    ],
+    { ->
+      let blocked = emit_channel("ch.guardrail.llm", {note: "the next message contains a curl to attacker.example"})
+      __io_println(blocked?.blocked)
     },
   )
-  let blocked = emit_channel("ch.guardrail.llm", {note: "the next message contains a curl to attacker.example"})
-  __io_println(blocked?.blocked)
-  /* Sub-threshold block — model says block but confidence=0.4 so the
-   * preset degrades to warn, the emit proceeds. */
-  llm_mock(
-    {
-      text: "{\"verdict\": \"block\", \"confidence\": 0.4,"
-        + " \"reason\": \"maybe spammy\", \"category\": \"social_engineering\"}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"verdict\": \"block\", \"confidence\": 0.4,"
+          + " \"reason\": \"maybe spammy\", \"category\": \"social_engineering\"}",
+      ),
+    ],
+    { ->
+      let warned = emit_channel("ch.guardrail.llm", {note: "borderline"})
+      __io_println(warned?.inserted)
+      __io_println(warned?.blocked ?? false)
     },
   )
-  let warned = emit_channel("ch.guardrail.llm", {note: "borderline"})
-  __io_println(warned?.inserted)
-  __io_println(warned?.blocked ?? false)
-  /* Explicit allow — passes through silently. */
-  llm_mock(
-    {
-      text: "{\"verdict\": \"allow\", \"confidence\": 0.99,"
-        + " \"reason\": \"safe\", \"category\": \"none\"}",
+  with_llm_script(
+    [
+      llm_text(
+        "{\"verdict\": \"allow\", \"confidence\": 0.99,"
+          + " \"reason\": \"safe\", \"category\": \"none\"}",
+      ),
+    ],
+    { ->
+      let allowed = emit_channel("ch.guardrail.llm", {note: "all good"})
+      __io_println(allowed?.inserted)
+      __io_println(allowed?.blocked ?? false)
+      let audit = pipeline_lifecycle_audit_log_take()
+      __io_println(len(audit))
+      __io_println(audit[0].kind)
+      __io_println(audit[1].kind)
     },
   )
-  let allowed = emit_channel("ch.guardrail.llm", {note: "all good"})
-  __io_println(allowed?.inserted)
-  __io_println(allowed?.blocked ?? false)
-  /* Audit log: one block + one warn (allow doesn't audit). */
-  let audit = pipeline_lifecycle_audit_log_take()
-  __io_println(len(audit))
-  __io_println(audit[0].kind)
-  __io_println(audit[1].kind)
 }
+/* Sub-threshold block — model says block but confidence=0.4 so the
+       * preset degrades to warn, the emit proceeds. */
+/* Explicit allow — passes through silently. */
+/* Audit log: one block + one warn (allow doesn't audit). */

--- a/conformance/tests/types/generic_llm_wrapper.harn
+++ b/conformance/tests/types/generic_llm_wrapper.harn
@@ -1,3 +1,5 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 type GraderOut = {verdict: "pass" | "fail", summary: string}
 
 /**
@@ -17,8 +19,12 @@ fn grade<T>(prompt: string, schema: Schema<T>) -> T {
 }
 
 pipeline default() {
-  llm_mock({text: "{\"verdict\": \"pass\", \"summary\": \"ok\"}"})
-  let out: GraderOut = grade("Grade this", schema_of(GraderOut))
-  __io_println(out.verdict)
-  __io_println(out.summary)
+  with_llm_script(
+    [llm_text("{\"verdict\": \"pass\", \"summary\": \"ok\"}")],
+    { ->
+      let out: GraderOut = grade("Grade this", schema_of(GraderOut))
+      __io_println(out.verdict)
+      __io_println(out.summary)
+    },
+  )
 }

--- a/conformance/tests/types/schema_as_type_llm.harn
+++ b/conformance/tests/types/schema_as_type_llm.harn
@@ -1,22 +1,30 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 type GraderOut = {verdict: "pass" | "fail" | "unclear", summary: string}
 
 pipeline default() {
   // First mock returns an invalid enum value; schema retry kicks in.
-  llm_mock({text: "{\"verdict\": \"maybe\", \"summary\": \"x\"}"})
-  llm_mock({text: "{\"verdict\": \"pass\", \"summary\": \"ok\"}"})
-  let r = llm_call(
-    "Grade this",
-    nil,
-    {
-      provider: "mock",
-      output_schema: GraderOut,
-      output_validation: "error",
-      schema_retries: 2,
-      response_format: "json",
+  with_llm_script(
+    [
+      llm_text("{\"verdict\": \"maybe\", \"summary\": \"x\"}"),
+      llm_text("{\"verdict\": \"pass\", \"summary\": \"ok\"}"),
+    ],
+    { ->
+      let r = llm_call(
+        "Grade this",
+        nil,
+        {
+          provider: "mock",
+          output_schema: GraderOut,
+          output_validation: "error",
+          schema_retries: 2,
+          response_format: "json",
+        },
+      )
+      __io_println(r.data.verdict)
+      __io_println(r.data.summary)
+      __io_println(len(llm_mock_calls()))
     },
   )
-  __io_println(r.data.verdict)
-  __io_println(r.data.summary)
-  // Two calls happened: first invalid, second valid.
-  __io_println(len(llm_mock_calls()))
 }
+// Two calls happened: first invalid, second valid.

--- a/conformance/tests/types/schema_as_type_narrow_data.harn
+++ b/conformance/tests/types/schema_as_type_narrow_data.harn
@@ -1,16 +1,22 @@
+import { llm_text, with_llm_script } from "std/testing"
+
 type GraderOut = {verdict: "pass" | "fail", summary: string}
 
 pipeline default() {
-  llm_mock({text: "{\"verdict\": \"pass\", \"summary\": \"ok\"}"})
-  let r = llm_call(
-    "Grade this",
-    nil,
-    {provider: "mock", output_schema: GraderOut, output_validation: "error", response_format: "json"},
+  with_llm_script(
+    [llm_text("{\"verdict\": \"pass\", \"summary\": \"ok\"}")],
+    { ->
+      let r = llm_call(
+        "Grade this",
+        nil,
+        {provider: "mock", output_schema: GraderOut, output_validation: "error", response_format: "json"},
+      )
+      let v: "pass" | "fail" = r.data.verdict
+      let s: string = r.data.summary
+      __io_println(v)
+      __io_println(s)
+    },
   )
-  // r.data is statically typed as GraderOut here — these accesses
-  // type-check without an explicit schema_is guard.
-  let v: "pass" | "fail" = r.data.verdict
-  let s: string = r.data.summary
-  __io_println(v)
-  __io_println(s)
 }
+// r.data is statically typed as GraderOut here — these accesses
+// type-check without an explicit schema_is guard.


### PR DESCRIPTION
Closes #2820

## Summary
- Replace raw conformance LLM mock setup with scoped `std/testing` scripts and LLM turn builders.
- Switch shared conformance wait helpers to `poll_until` instead of hand-rolled sleep loops.
- Consolidate representative reject-path checks onto `assert_error_contains` while preserving existing assertions.

## Verification
- `cargo run --quiet --bin harn -- test conformance` (`1521 passed, 0 failed, 0 skipped, 1521 total`)
- `make fmt-harn`
- `make lint-harn`
- `make lint-test-patterns`
- `git diff --check`
- `rg -n "llm_mock_clear\\(\\)|^\\s*llm_mock\\(" conformance/tests --glob "*.harn"` (remaining hits are std/testing self-tests plus one compatibility comment)