### PR TITLE
Preserve element/value types in destructured rest patterns

### DIFF
--- a/changelog.d/destructure-rest-element-types.changed.md
+++ b/changelog.d/destructure-rest-element-types.changed.md
@@ -1,0 +1,5 @@
+- **Destructured rest patterns now preserve the source's element/value type.**
+  `let [head, ...rest] = xs` types `rest` as `list<T>` (was the opaque `list`),
+  and `let { a, ...rest } = d` keeps `dict<K, V>` when the source dict is
+  parameterized. Completes the destructuring type inference so iterating or
+  indexing a rest binding recovers a precise element type.

--- a/conformance/errors/types/destructure_rest_inferred_type.error
+++ b/conformance/errors/types/destructure_rest_inferred_type.error
@@ -1,0 +1,1 @@
+expected string, found int

--- a/conformance/errors/types/destructure_rest_inferred_type.harn
+++ b/conformance/errors/types/destructure_rest_inferred_type.harn
@@ -1,0 +1,11 @@
+// Rest patterns preserve the source element type: `rest` here is `list<int>`,
+// so iterating it yields `int` and binding an element to `string` is an error.
+// Before this, the rest binding was the opaque `list` type and slipped through.
+pipeline default() {
+  let [first, ...rest] = [1, 2, 3]
+  __io_println(first)
+  for r in rest {
+    let bad: string = r
+    __io_println(bad)
+  }
+}

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -117,7 +117,12 @@ impl TypeChecker {
                 for field in fields {
                     let name = field.alias.as_deref().unwrap_or(&field.key);
                     let ty = if field.is_rest {
-                        Some(TypeExpr::Named("dict".into()))
+                        // `...rest` collects the un-destructured keys into a new
+                        // dict; a parameterized source keeps its value typing.
+                        match source_ty.as_ref().map(|t| self.resolve_alias(t, scope)) {
+                            Some(TypeExpr::DictType(k, v)) => Some(TypeExpr::DictType(k, v)),
+                            _ => Some(TypeExpr::Named("dict".into())),
+                        }
                     } else {
                         // `source?.key` — optional access mirrors the runtime
                         // "missing key binds nil" semantics.
@@ -143,7 +148,12 @@ impl TypeChecker {
                     .and_then(|t| self.iterable_item_type(t, scope));
                 for elem in elements {
                     let ty = if elem.is_rest {
-                        Some(TypeExpr::Named("list".into()))
+                        // `...rest` collects the remaining elements into a new
+                        // list with the same element type as the source.
+                        match &elem_ty {
+                            Some(inner) => Some(TypeExpr::List(Box::new(inner.clone()))),
+                            None => Some(TypeExpr::Named("list".into())),
+                        }
                     } else {
                         match &elem.default_value {
                             Some(default) => {


### PR DESCRIPTION
## What

Completes the destructuring type inference from #2823. `...rest` bindings carried the opaque `dict`/`list` type, dropping the source's parameter types — the last *recoverable-type-dropped* spot in destructuring.

A rest pattern collects the un-destructured remainder with the **same** shape, so:
- a list rest keeps `list<T>` of the source element type (`let [head, ...rest] = xs`),
- a dict rest over a parameterized source keeps `dict<K, V>` (`let { a, ...rest } = d`).

## Test

`errors/types/destructure_rest_inferred_type.harn` — iterating a list rest now yields the element type, so binding it to `string` is a static error.

Full conformance stays green (**1523 passing, 0 failed**).

## Context

Final piece of the typechecker "recoverable type lost" series: #2823 (destructuring defaults), #2853 (combinators), #2856 (fn returns), and this (rest patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)