### PR TITLE
harn-lint: pluggable Rule trait + registry (#2848)

### DIFF
--- a/crates/harn-cli/src/cli/pg.rs
+++ b/crates/harn-cli/src/cli/pg.rs
@@ -17,7 +17,9 @@ pub(crate) enum PgCommand {
     /// mirroring the live column set. Annotate a query result with the
     /// generated type to type-check field access without a live database:
     ///
-    ///     let receipt: ReceiptRow = pg_query_one(pool, sql, params)
+    /// ```harn
+    /// let receipt: ReceiptRow = pg_query_one(pool, sql, params)
+    /// ```
     ///
     /// Pass `--check` to verify the `--out` file is current (for CI).
     Codegen(PgCodegenArgs),

--- a/crates/harn-cli/tests/persona_cli.rs
+++ b/crates/harn-cli/tests/persona_cli.rs
@@ -268,7 +268,10 @@ fn helper(ctx) {
             .iter()
             .any(|diag| diag.rule == "persona-body-must-call-steps"),
         "expected persona-body-must-call-steps diagnostic, got: {:?}",
-        diagnostics.iter().map(|d| d.rule).collect::<Vec<_>>()
+        diagnostics
+            .iter()
+            .map(|d| d.rule.as_ref())
+            .collect::<Vec<_>>()
     );
 }
 

--- a/crates/harn-lint/src/diagnostic.rs
+++ b/crates/harn-lint/src/diagnostic.rs
@@ -2,6 +2,8 @@
 //! options. Kept separate from the linter's walk state so the public
 //! surface is easy to locate and audit.
 
+use std::borrow::Cow;
+
 use harn_lexer::{FixEdit, Span};
 use harn_parser::{DiagnosticCode as Code, Repair};
 
@@ -9,7 +11,10 @@ use harn_parser::{DiagnosticCode as Code, Repair};
 #[derive(Debug, Clone)]
 pub struct LintDiagnostic {
     pub code: Code,
-    pub rule: &'static str,
+    /// Stable rule identifier. Owned (`Cow`) so dynamically-registered
+    /// rules — engine patterns, `.harn`-authored rules — can carry a
+    /// runtime id, while built-in rules stay zero-cost `Cow::Borrowed`.
+    pub rule: Cow<'static, str>,
     pub message: String,
     pub span: Span,
     pub severity: LintSeverity,

--- a/crates/harn-lint/src/harndoc.rs
+++ b/crates/harn-lint/src/harndoc.rs
@@ -296,7 +296,7 @@ fn check_one_item(
     };
     diagnostics.push(LintDiagnostic {
         code: Code::LintLegacyDocComment,
-        rule: "legacy-doc-comment",
+        rule: "legacy-doc-comment".into(),
         message: format!("{prefix} doc comment(s) above this item should use `/** */` form"),
         span: Span::with_offsets(first.start_byte, last.end_byte, start_line, 1),
         severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/lib.rs
+++ b/crates/harn-lint/src/lib.rs
@@ -17,6 +17,7 @@ mod fixes;
 mod harndoc;
 mod linter;
 mod naming;
+mod rule;
 mod rules;
 
 #[cfg(test)]
@@ -50,7 +51,7 @@ pub fn lint_prompt_template(
         Err(message) => {
             return vec![LintDiagnostic {
                 code: Code::LintTemplateParse,
-                rule: "template-parse",
+                rule: "template-parse".into(),
                 message: format!("template did not parse: {message}"),
                 span: harn_lexer::Span::dummy(),
                 severity: LintSeverity::Error,
@@ -75,7 +76,7 @@ pub fn lint_prompt_template(
     } else {
         diagnostics
             .into_iter()
-            .filter(|d| !rule_disabled(d.rule, disabled_rules))
+            .filter(|d| !rule_disabled(&d.rule, disabled_rules))
             .collect()
     }
 }
@@ -210,7 +211,7 @@ fn lint_full(
         linter
             .diagnostics
             .into_iter()
-            .filter(|d| !rule_disabled(d.rule, disabled_rules))
+            .filter(|d| !rule_disabled(&d.rule, disabled_rules))
             .collect()
     }
 }
@@ -225,7 +226,7 @@ pub fn lint_diagnostics_from_type_diagnostics(
     diagnostics
         .iter()
         .filter_map(type_diagnostic_as_lint)
-        .filter(|diagnostic| !rule_disabled(diagnostic.rule, disabled_rules))
+        .filter(|diagnostic| !rule_disabled(&diagnostic.rule, disabled_rules))
         .collect()
 }
 
@@ -243,7 +244,7 @@ fn type_diagnostic_as_lint(diagnostic: &harn_parser::TypeDiagnostic) -> Option<L
     let span = diagnostic.span?;
     Some(LintDiagnostic {
         code: diagnostic.code,
-        rule,
+        rule: rule.into(),
         message: diagnostic.message.clone(),
         span,
         severity: match diagnostic.severity {

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -20,17 +20,8 @@ use crate::fixes::{
     append_sink_fix, is_pure_expression, remove_method_call_wrapper_fix,
     replace_identifier_text_fix, simple_ident_rename_fix,
 };
-use crate::harndoc::check_legacy_doc_comments;
 use crate::naming::{is_pascal_case, is_snake_case, to_pascal_case, to_snake_case};
-use crate::rules::blank_lines::check_blank_line_between_items;
-use crate::rules::deprecated_llm_options::check_deprecated_llm_options;
-use crate::rules::import_order::check_import_order;
-use crate::rules::optional_shorthand::check_prefer_optional_shorthand;
-use crate::rules::reminder_lifecycle::check_reminder_lifecycle_literals;
-use crate::rules::reminder_provider_count::check_reminder_provider_count;
-use crate::rules::reminder_role_hint::check_reminder_role_hint_capabilities;
-use crate::rules::trailing_comma::check_trailing_comma;
-use crate::rules::unnecessary_parentheses::check_unnecessary_parentheses;
+use crate::rule::{Rule, RuleCtx};
 
 mod walk;
 
@@ -146,10 +137,20 @@ pub(crate) struct Linter<'a> {
     /// suppression gate (which runs per public item) does not re-tokenize
     /// the whole source each time.
     pub(super) cached_comment_toks: Option<Vec<crate::harndoc::LegacyCommentTok>>,
+    /// Pluggable rules driven through the registry. Built-in source- and
+    /// AST-structural rules live here; engine-pattern and `.harn` rules
+    /// join the same list. The intricately-stateful core checks remain
+    /// intrinsic to the walk below.
+    pub(super) rules: Vec<Box<dyn Rule>>,
+    /// Cached `rules.iter().any(Rule::visits_nodes)` so the per-node walk
+    /// skips registry dispatch entirely when no rule opts in.
+    pub(super) rules_visit_nodes: bool,
 }
 
 impl<'a> Linter<'a> {
     pub(crate) fn new(source: Option<&'a str>) -> Self {
+        let rules = crate::rule::builtin_rules();
+        let rules_visit_nodes = rules.iter().any(|rule| rule.visits_nodes());
         Self {
             diagnostics: Vec::new(),
             scopes: vec![HashSet::new()],
@@ -188,7 +189,43 @@ impl<'a> Linter<'a> {
             mcp_registry_missing_annotation_spans: HashMap::new(),
             require_stdlib_metadata: false,
             cached_comment_toks: None,
+            rules,
+            rules_visit_nodes,
         }
+    }
+
+    /// Drive every registered rule through one phase `hook`, in
+    /// registration order. The rule list is moved out for the duration
+    /// so each rule can mutate its own state while still writing into
+    /// `self.diagnostics`.
+    fn run_rule_phase(
+        &mut self,
+        mut hook: impl FnMut(&mut dyn Rule, &RuleCtx<'_>, &mut Vec<LintDiagnostic>),
+    ) {
+        let mut rules = std::mem::take(&mut self.rules);
+        let ctx = RuleCtx {
+            source: self.source,
+        };
+        for rule in &mut rules {
+            hook(rule.as_mut(), &ctx, &mut self.diagnostics);
+        }
+        self.rules = rules;
+    }
+
+    /// Run every rule's whole-program hook, before the AST walk.
+    fn run_program_rules(&mut self, program: &[SNode]) {
+        self.run_rule_phase(|rule, ctx, out| rule.check_program(program, ctx, out));
+    }
+
+    /// Run every rule's per-node hook for `node`. Skipped wholesale
+    /// unless at least one rule opted into the walk phase.
+    pub(super) fn run_node_rules(&mut self, node: &SNode) {
+        self.run_rule_phase(|rule, ctx, out| rule.check_node(node, ctx, out));
+    }
+
+    /// Run every rule's post-walk hook.
+    fn run_finalize_rules(&mut self) {
+        self.run_rule_phase(|rule, ctx, out| rule.finalize(ctx, out));
     }
 
     /// Whether a public item on `item_line` is preceded by a wrong-format
@@ -252,7 +289,7 @@ impl<'a> Linter<'a> {
         };
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintRenamedStdlibSymbol,
-            rule: "renamed-stdlib-symbol",
+            rule: "renamed-stdlib-symbol".into(),
             message: format!("`{name}` was renamed to `{replacement}`"),
             span,
             severity: LintSeverity::Warning,
@@ -392,7 +429,7 @@ impl<'a> Linter<'a> {
         };
         self.diagnostics.push(LintDiagnostic {
             code: lint.code,
-            rule: lint.rule,
+            rule: lint.rule.into(),
             message: format!(
                 "ambient `{}` is deprecated — capabilities now route through `harness.{}.*`",
                 lint.name, lint.sub_handle,
@@ -463,7 +500,7 @@ impl<'a> Linter<'a> {
         };
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintMissingStdlibMetadata,
-            rule: "missing-stdlib-metadata",
+            rule: "missing-stdlib-metadata".into(),
             message,
             span,
             severity: LintSeverity::Warning,
@@ -489,7 +526,7 @@ impl<'a> Linter<'a> {
         }
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintCyclomaticComplexity,
-            rule: "cyclomatic-complexity",
+            rule: "cyclomatic-complexity".into(),
             message: format!(
                 "function `{name}` has cyclomatic complexity {complexity} (> {threshold})"
             ),
@@ -508,7 +545,7 @@ impl<'a> Linter<'a> {
         }
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintNamingConvention,
-            rule: "naming-convention",
+            rule: "naming-convention".into(),
             message: format!("function `{name}` should use snake_case"),
             span,
             severity: LintSeverity::Warning,
@@ -526,7 +563,7 @@ impl<'a> Linter<'a> {
         }
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintNamingConvention,
-            rule: "naming-convention",
+            rule: "naming-convention".into(),
             message: format!("{kind} `{name}` should use PascalCase"),
             span,
             severity: LintSeverity::Warning,
@@ -687,7 +724,7 @@ impl<'a> Linter<'a> {
         let fix = append_sink_fix(value.span, sink);
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintEagerCollectionConversion,
-            rule: "eager-collection-conversion",
+            rule: "eager-collection-conversion".into(),
             message,
             span: value.span,
             severity: LintSeverity::Warning,
@@ -727,7 +764,7 @@ impl<'a> Linter<'a> {
             let fix = remove_method_call_wrapper_fix(self.source, arg.span, receiver.span);
             self.diagnostics.push(LintDiagnostic {
                 code: Code::LintRedundantClone,
-                rule: "redundant-clone",
+                rule: "redundant-clone".into(),
                 message,
                 span: arg.span,
                 severity: LintSeverity::Warning,
@@ -853,7 +890,7 @@ impl<'a> Linter<'a> {
         }
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintLongRunningWithoutCleanup,
-            rule: "long-running-without-cleanup",
+            rule: "long-running-without-cleanup".into(),
             message: format!(
                 "`{name}` starts long-running work without a defer/finally cleanup path"
             ),
@@ -1118,7 +1155,7 @@ impl<'a> Linter<'a> {
     fn warn_missing_mcp_tool_annotations(&mut self, span: Span) {
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintMcpToolAnnotations,
-            rule: "mcp-tool-annotations",
+            rule: "mcp-tool-annotations".into(),
             message: "MCP-exposed `tool_define` registration has no `annotations`".to_string(),
             span,
             severity: LintSeverity::Warning,
@@ -1133,7 +1170,7 @@ impl<'a> Linter<'a> {
     fn warn_missing_secret_scan(&mut self, span: Span) {
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintPrOpenWithoutSecretScan,
-            rule: "pr-open-without-secret-scan",
+            rule: "pr-open-without-secret-scan".into(),
             message: "PR-open flow calls `git::push_pr` without a preceding `secret_scan(...)` in the same handler".to_string(),
             span,
             severity: LintSeverity::Warning,
@@ -1397,7 +1434,7 @@ impl<'a> Linter<'a> {
                 if scope.contains(name) {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintShadowVariable,
-                        rule: "shadow-variable",
+                        rule: "shadow-variable".into(),
                         message: format!(
                             "cannot redeclare immutable variable `{name}` in the same scope"
                         ),
@@ -1417,7 +1454,7 @@ impl<'a> Linter<'a> {
             if outer.iter().any(|s| s.contains(name)) {
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintShadowVariable,
-                    rule: "shadow-variable",
+                    rule: "shadow-variable".into(),
                     message: format!("variable `{name}` shadows a variable in an outer scope"),
                     span,
                     severity: LintSeverity::Warning,
@@ -1451,7 +1488,7 @@ impl<'a> Linter<'a> {
             if outer.iter().any(|s| s.contains(name)) {
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintShadowVariable,
-                    rule: "shadow-variable",
+                    rule: "shadow-variable".into(),
                     message: format!("variable `{name}` shadows a variable in an outer scope"),
                     span,
                     severity: LintSeverity::Warning,
@@ -1473,18 +1510,7 @@ impl<'a> Linter<'a> {
 
     pub(crate) fn lint_program(&mut self, nodes: &[SNode]) {
         self.collect_persona_step_metadata(nodes);
-        if let Some(src) = self.source {
-            check_legacy_doc_comments(src, nodes, &mut self.diagnostics);
-            check_blank_line_between_items(src, nodes, &mut self.diagnostics);
-            check_trailing_comma(src, &mut self.diagnostics);
-            check_import_order(src, nodes, &mut self.diagnostics);
-            check_prefer_optional_shorthand(src, nodes, &mut self.diagnostics);
-            check_unnecessary_parentheses(src, nodes, &mut self.diagnostics);
-        }
-        check_deprecated_llm_options(nodes, &mut self.diagnostics);
-        check_reminder_lifecycle_literals(nodes, &mut self.diagnostics);
-        check_reminder_provider_count(nodes, &mut self.diagnostics);
-        check_reminder_role_hint_capabilities(nodes, &mut self.diagnostics);
+        self.run_program_rules(nodes);
         for node in nodes {
             self.lint_node(node);
         }
@@ -1744,7 +1770,7 @@ impl<'a> Linter<'a> {
         if matching_personas.is_empty() {
             self.diagnostics.push(LintDiagnostic {
                 code: Code::LintPersonaHookTarget,
-                rule: "persona-hook-target",
+                rule: "persona-hook-target".into(),
                 message: format!(
                     "`register_step_hook` pattern `{persona_pattern}` does not match a statically declared `@persona`"
                 ),
@@ -1764,7 +1790,7 @@ impl<'a> Linter<'a> {
         }
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintPersonaHookTarget,
-            rule: "persona-hook-target",
+            rule: "persona-hook-target".into(),
             message: format!(
                 "`register_step_hook` targets step `{step_name}`, but it is not declared by persona(s): {}",
                 missing.join(", ")
@@ -1800,7 +1826,7 @@ impl<'a> Linter<'a> {
             if found_terminator {
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintDeadCodeAfterReturn,
-                    rule: "dead-code-after-return",
+                    rule: "dead-code-after-return".into(),
                     message: "unreachable code after a terminating statement".to_string(),
                     span: node.span,
                     severity: LintSeverity::Warning,
@@ -1864,7 +1890,7 @@ impl<'a> Linter<'a> {
         });
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintLetThenReturn,
-            rule: "let-then-return",
+            rule: "let-then-return".into(),
             message: format!("binding `{name}` is immediately returned"),
             span: Span::with_offsets(
                 node.span.start,
@@ -1897,7 +1923,7 @@ impl<'a> Linter<'a> {
         };
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintUnhandledApprovalResult,
-            rule: "unhandled-approval-result",
+            rule: "unhandled-approval-result".into(),
             message: format!("approval result from `{name}` is discarded"),
             span: node.span,
             severity: LintSeverity::Warning,
@@ -1909,8 +1935,16 @@ impl<'a> Linter<'a> {
         });
     }
 
-    /// Run post-walk analysis and finalize diagnostics.
+    /// Run post-walk analysis and finalize diagnostics. The intrinsic
+    /// core checks (unused/undefined symbols) run first, then every
+    /// registered rule's finalize hook, regardless of the core's
+    /// early exits.
     pub(crate) fn finalize(&mut self) {
+        self.finalize_core();
+        self.run_finalize_rules();
+    }
+
+    fn finalize_core(&mut self) {
         for decl in &self.declarations {
             if decl.name.starts_with('_') {
                 continue;
@@ -1936,7 +1970,7 @@ impl<'a> Linter<'a> {
                 };
                 self.diagnostics.push(LintDiagnostic {
                     code,
-                    rule,
+                    rule: rule.into(),
                     message,
                     span: decl.span,
                     severity: LintSeverity::Warning,
@@ -1953,7 +1987,7 @@ impl<'a> Linter<'a> {
             if !self.references.contains(&decl.name) {
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintUnusedParameter,
-                    rule: "unused-parameter",
+                    rule: "unused-parameter".into(),
                     message: format!("parameter `{}` is declared but never used", decl.name),
                     span: decl.span,
                     severity: LintSeverity::Warning,
@@ -2025,7 +2059,7 @@ impl<'a> Linter<'a> {
                 });
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintUnusedImport,
-                    rule: "unused-import",
+                    rule: "unused-import".into(),
                     message: format!("imported name `{name}` is never used"),
                     span: import.span,
                     severity: LintSeverity::Warning,
@@ -2056,7 +2090,7 @@ impl<'a> Linter<'a> {
                 });
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintMutableNeverReassigned,
-                    rule: "mutable-never-reassigned",
+                    rule: "mutable-never-reassigned".into(),
                     message: format!(
                         "variable `{}` is declared as `var` but never reassigned",
                         decl.name
@@ -2085,7 +2119,7 @@ impl<'a> Linter<'a> {
             if !self.function_references.contains(&decl.name) {
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintUnusedFunction,
-                    rule: "unused-function",
+                    rule: "unused-function".into(),
                     message: format!("function `{}` is declared but never used", decl.name),
                     span: decl.span,
                     severity: LintSeverity::Warning,
@@ -2105,7 +2139,7 @@ impl<'a> Linter<'a> {
             if !self.type_references.contains(&decl.name) {
                 self.diagnostics.push(LintDiagnostic {
                     code: Code::LintUnusedType,
-                    rule: "unused-type",
+                    rule: "unused-type".into(),
                     message: format!(
                         "{} `{}` is declared but never referenced",
                         decl.kind, decl.name
@@ -2136,7 +2170,7 @@ impl<'a> Linter<'a> {
             }
             self.diagnostics.push(LintDiagnostic {
                 code: Code::LintPersonaBodyMustCallSteps,
-                rule: "persona-body-must-call-steps",
+                rule: "persona-body-must-call-steps".into(),
                 message: format!(
                     "`@persona` function `{persona_name}` calls `{name}`, which is not declared `@step`"
                 ),
@@ -2194,7 +2228,7 @@ impl<'a> Linter<'a> {
             };
             self.diagnostics.push(LintDiagnostic {
                 code: Code::LintUndefinedFunction,
-                rule: "undefined-function",
+                rule: "undefined-function".into(),
                 message: format!("function `{name}` is not defined"),
                 span: *span,
                 severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -17,6 +17,9 @@ use crate::naming::simplify_bool_comparison;
 
 impl<'a> Linter<'a> {
     pub(super) fn lint_node(&mut self, snode: &SNode) {
+        if self.rules_visit_nodes {
+            self.run_node_rules(snode);
+        }
         match &snode.node {
             Node::Pipeline {
                 params,
@@ -34,7 +37,7 @@ impl<'a> Linter<'a> {
                 {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintPipelineReturnType,
-                        rule: "pipeline-return-type",
+                        rule: "pipeline-return-type".into(),
                         message: format!(
                             "public pipeline `{name}` has no declared return type; \
                              explicit return types will be required in a future release"
@@ -94,7 +97,7 @@ impl<'a> Linter<'a> {
                 {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintMissingHarndoc,
-                        rule: "missing-harndoc",
+                        rule: "missing-harndoc".into(),
                         message: format!(
                             "public function `{name}` is missing a `/** */` doc comment"
                         ),
@@ -323,7 +326,7 @@ impl<'a> Linter<'a> {
                 if Self::is_assert_builtin(name) && !self.in_test_pipeline() {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintAssertOutsideTest,
-                        rule: "assert-outside-test",
+                        rule: "assert-outside-test".into(),
                         message: format!(
                             "`{name}` is intended for test pipelines, not production control flow"
                         ),
@@ -338,7 +341,7 @@ impl<'a> Linter<'a> {
                 if name == "llm_call" && args.get(1).is_some_and(Self::has_interpolation) {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintPromptInjectionRisk,
-                        rule: "prompt-injection-risk",
+                        rule: "prompt-injection-risk".into(),
                         message:
                             "interpolated data in the `llm_call` system prompt can smuggle untrusted instructions"
                                 .to_string(),
@@ -357,7 +360,7 @@ impl<'a> Linter<'a> {
                     {
                         self.diagnostics.push(LintDiagnostic {
                             code: Code::LintConnectorEffectPolicy,
-                            rule: "connector-effect-policy",
+                            rule: "connector-effect-policy".into(),
                             message: format!(
                                 "connector export `{export}` calls disallowed builtin `{name}`: {reason}"
                             ),
@@ -377,7 +380,7 @@ impl<'a> Linter<'a> {
                     let article = if matches!(target, "int") { "an" } else { "a" };
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintUnnecessaryCast,
-                        rule: "unnecessary-cast",
+                        rule: "unnecessary-cast".into(),
                         message: format!(
                             "`{name}` is a no-op here — its argument is already {article} {target}"
                         ),
@@ -417,7 +420,7 @@ impl<'a> Linter<'a> {
                     if Self::is_boundary_api(name) {
                         self.diagnostics.push(LintDiagnostic {
                             code: Code::LintUntypedDictAccess,
-                            rule: "untyped-dict-access",
+                            rule: "untyped-dict-access".into(),
                             message: format!(
                                 "property access on raw `{name}()` result without schema validation"
                             ),
@@ -440,7 +443,7 @@ impl<'a> Linter<'a> {
                     if Self::is_boundary_api(name) {
                         self.diagnostics.push(LintDiagnostic {
                             code: Code::LintUntypedDictAccess,
-                            rule: "untyped-dict-access",
+                            rule: "untyped-dict-access".into(),
                             message: format!(
                                 "subscript access on raw `{name}()` result without schema validation"
                             ),
@@ -474,7 +477,7 @@ impl<'a> Linter<'a> {
                 {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintConstantLogicalOperand,
-                        rule: "constant-logical-operand",
+                        rule: "constant-logical-operand".into(),
                         message,
                         span: snode.span,
                         severity: LintSeverity::Warning,
@@ -492,7 +495,7 @@ impl<'a> Linter<'a> {
                     let replacement = if op == "==" { "true" } else { "false" };
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintPointlessComparison,
-                        rule: "pointless-comparison",
+                        rule: "pointless-comparison".into(),
                         message: format!("expression is compared to itself with `{op}`"),
                         span: snode.span,
                         severity: LintSeverity::Warning,
@@ -538,7 +541,7 @@ impl<'a> Linter<'a> {
                         });
                         self.diagnostics.push(LintDiagnostic {
                             code: Code::LintComparisonToBool,
-                            rule: "comparison-to-bool",
+                            rule: "comparison-to-bool".into(),
                             message: msg.to_string(),
                             span: snode.span,
                             severity: LintSeverity::Warning,
@@ -583,7 +586,7 @@ impl<'a> Linter<'a> {
                         };
                         self.diagnostics.push(LintDiagnostic {
                             code: Code::LintInvalidBinaryOpLiteral,
-                            rule: "invalid-binary-op-literal",
+                            rule: "invalid-binary-op-literal".into(),
                             message: format!(
                                 "operator '{op}' used with boolean or nil literal — this will cause a runtime error"
                             ),
@@ -632,7 +635,7 @@ impl<'a> Linter<'a> {
                     });
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintRedundantNilTernary,
-                        rule: "redundant-nil-ternary",
+                        rule: "redundant-nil-ternary".into(),
                         message: format!(
                             "ternary nil check over `{ident}` can be replaced with `{ident} ?? <fallback>`"
                         ),
@@ -653,7 +656,7 @@ impl<'a> Linter<'a> {
                 if let Node::BoolLiteral(value) = &condition.node {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintPointlessComparison,
-                        rule: "pointless-comparison",
+                        rule: "pointless-comparison".into(),
                         message: format!("if condition is always `{value}`"),
                         span: condition.span,
                         severity: LintSeverity::Warning,
@@ -675,7 +678,7 @@ impl<'a> Linter<'a> {
                     };
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintEmptyBlock,
-                        rule: "empty-block",
+                        rule: "empty-block".into(),
                         message: "if block has an empty body".to_string(),
                         span: snode.span,
                         severity: LintSeverity::Warning,
@@ -719,7 +722,7 @@ impl<'a> Linter<'a> {
                         });
                         self.diagnostics.push(LintDiagnostic {
                             code: Code::LintUnnecessaryElseReturn,
-                            rule: "unnecessary-else-return",
+                            rule: "unnecessary-else-return".into(),
                             message: "both if and else branches return — else is unnecessary"
                                 .to_string(),
                             span: snode.span,
@@ -756,7 +759,7 @@ impl<'a> Linter<'a> {
                     };
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintEmptyBlock,
-                        rule: "empty-block",
+                        rule: "empty-block".into(),
                         message: "for loop has an empty body".to_string(),
                         span: snode.span,
                         severity: LintSeverity::Warning,
@@ -791,7 +794,7 @@ impl<'a> Linter<'a> {
                 if body.is_empty() {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintEmptyBlock,
-                        rule: "empty-block",
+                        rule: "empty-block".into(),
                         message: "while loop has an empty body".to_string(),
                         span: snode.span,
                         severity: LintSeverity::Warning,
@@ -817,7 +820,7 @@ impl<'a> Linter<'a> {
                 if body.is_empty() {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintEmptyBlock,
-                        rule: "empty-block",
+                        rule: "empty-block".into(),
                         message: "try block has an empty body".to_string(),
                         span: snode.span,
                         severity: LintSeverity::Warning,
@@ -859,7 +862,7 @@ impl<'a> Linter<'a> {
                         if arm.pattern.node == earlier.pattern.node && arm.guard == earlier.guard {
                             self.diagnostics.push(LintDiagnostic {
                                 code: Code::LintDuplicateMatchArm,
-                                rule: "duplicate-match-arm",
+                                rule: "duplicate-match-arm".into(),
                                 message: "duplicate match arm pattern".to_string(),
                                 span: arm.pattern.span,
                                 severity: LintSeverity::Warning,
@@ -954,7 +957,7 @@ impl<'a> Linter<'a> {
                 if self.in_test_pipeline() {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintRequireInTest,
-                        rule: "require-in-test",
+                        rule: "require-in-test".into(),
                         message: "`require` in a test pipeline should usually be an assertion"
                             .to_string(),
                         span: snode.span,
@@ -1217,7 +1220,7 @@ impl<'a> Linter<'a> {
                     };
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintBreakOutsideLoop,
-                        rule: "break-outside-loop",
+                        rule: "break-outside-loop".into(),
                         message: format!("`{keyword}` used outside of a loop"),
                         span: snode.span,
                         severity: LintSeverity::Error,

--- a/crates/harn-lint/src/rule.rs
+++ b/crates/harn-lint/src/rule.rs
@@ -1,0 +1,241 @@
+//! The pluggable lint-rule registry.
+//!
+//! Historically the linter was a hardcoded monolith: every rule was an
+//! inline call in [`Linter::lint_program`][crate::linter::Linter], the
+//! [`lint_node`][crate::linter::Linter] walk, or
+//! [`Linter::finalize`][crate::linter::Linter], with no seam for adding
+//! a rule without editing those sites. This module introduces the
+//! [`Rule`] trait and a registry so built-in, engine-pattern, and
+//! `.harn`-authored rules can all flow through one list.
+//!
+//! A rule observes the program through up to three phases that mirror
+//! the linter's dispatch sites:
+//!
+//! - [`Rule::check_program`] — whole-program pass, before the AST walk.
+//! - [`Rule::check_node`] — per-node pass, interleaved with the walk.
+//! - [`Rule::finalize`] — post-walk pass, once all walk state is known.
+//!
+//! Every hook pushes into an `out` sink rather than returning a `Vec`,
+//! so a rule that fires nothing costs no allocation. All hooks default
+//! to no-ops; a rule implements only the phases it needs. The
+//! intricately-stateful core checks (scope/declaration/reference
+//! tracking) remain intrinsic to the [`Linter`][crate::linter::Linter]
+//! walk; the registry hosts the rules that are pure functions of the
+//! AST and source, which is also the exact shape engine-pattern and
+//! `.harn` rules take.
+
+use harn_parser::SNode;
+
+use crate::diagnostic::LintDiagnostic;
+
+/// Read-only context shared with every rule hook. Carries the inputs a
+/// rule needs beyond the node/program it is handed; today that is just
+/// the original source for source-aware rules.
+pub(crate) struct RuleCtx<'a> {
+    pub source: Option<&'a str>,
+}
+
+/// A single lint rule plugged into the registry.
+pub(crate) trait Rule {
+    /// Stable identifier for this rule. Matches the `rule` field on the
+    /// diagnostics it emits and is the handle used for `disable_rules`
+    /// filtering and per-rule config. A rule that emits several distinct
+    /// diagnostic kinds reports its primary id here.
+    fn id(&self) -> &str;
+
+    /// Whether this rule participates in the per-node walk phase. Lets
+    /// the walk skip [`Rule::check_node`] dispatch entirely when no rule
+    /// opts in, keeping the hot path free for the common case.
+    fn visits_nodes(&self) -> bool {
+        false
+    }
+
+    /// Whole-program pass over the AST (plus optional source), run
+    /// before the node walk.
+    fn check_program(
+        &mut self,
+        _program: &[SNode],
+        _ctx: &RuleCtx<'_>,
+        _out: &mut Vec<LintDiagnostic>,
+    ) {
+    }
+
+    /// Per-node pass, run for each node visited during the walk. Gated
+    /// behind [`Rule::visits_nodes`].
+    fn check_node(&mut self, _node: &SNode, _ctx: &RuleCtx<'_>, _out: &mut Vec<LintDiagnostic>) {}
+
+    /// Post-walk pass, run once after the walk completes.
+    fn finalize(&mut self, _ctx: &RuleCtx<'_>, _out: &mut Vec<LintDiagnostic>) {}
+}
+
+/// Build the registry of built-in rules.
+///
+/// Order is significant: the linter does not sort diagnostics, so
+/// callers see findings in the order the rules run. This preserves the
+/// historical sequence — source-aware formatting rules first, then the
+/// AST-structural rules — so output is byte-identical to the previous
+/// hardcoded dispatch.
+pub(crate) fn builtin_rules() -> Vec<Box<dyn Rule>> {
+    let rules: Vec<Box<dyn Rule>> = vec![
+        Box::new(LegacyDocComments),
+        Box::new(BlankLineBetweenItems),
+        Box::new(TrailingComma),
+        Box::new(ImportOrder),
+        Box::new(PreferOptionalShorthand),
+        Box::new(UnnecessaryParentheses),
+        Box::new(DeprecatedLlmOptions),
+        Box::new(ReminderLifecycle),
+        Box::new(ReminderProviderCount),
+        Box::new(ReminderRoleHint),
+    ];
+    // Ids address rules for per-rule config and `disable_rules`, so they
+    // must be unique. Checked in debug builds so a colliding id surfaces
+    // the moment a new rule is added.
+    if cfg!(debug_assertions) {
+        let mut ids: Vec<&str> = rules.iter().map(|rule| rule.id()).collect();
+        let count = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), count, "built-in lint rule ids must be unique");
+    }
+    rules
+}
+
+/// Declare a built-in rule that is a whole-program check delegating to
+/// an existing free function. The third token selects the delegate's
+/// shape: `src` rules take `(source, program, out)` and no-op without
+/// source; `ast` rules take `(program, out)`; `srconly` rules take
+/// `(source, out)` and no-op without source.
+macro_rules! program_rule {
+    ($name:ident, $id:literal, src, $func:path) => {
+        struct $name;
+        impl Rule for $name {
+            fn id(&self) -> &str {
+                $id
+            }
+            fn check_program(
+                &mut self,
+                program: &[SNode],
+                ctx: &RuleCtx<'_>,
+                out: &mut Vec<LintDiagnostic>,
+            ) {
+                if let Some(src) = ctx.source {
+                    $func(src, program, out);
+                }
+            }
+        }
+    };
+    ($name:ident, $id:literal, ast, $func:path) => {
+        struct $name;
+        impl Rule for $name {
+            fn id(&self) -> &str {
+                $id
+            }
+            fn check_program(
+                &mut self,
+                program: &[SNode],
+                _ctx: &RuleCtx<'_>,
+                out: &mut Vec<LintDiagnostic>,
+            ) {
+                $func(program, out);
+            }
+        }
+    };
+    ($name:ident, $id:literal, srconly, $func:path) => {
+        struct $name;
+        impl Rule for $name {
+            fn id(&self) -> &str {
+                $id
+            }
+            fn check_program(
+                &mut self,
+                _program: &[SNode],
+                ctx: &RuleCtx<'_>,
+                out: &mut Vec<LintDiagnostic>,
+            ) {
+                if let Some(src) = ctx.source {
+                    $func(src, out);
+                }
+            }
+        }
+    };
+}
+
+program_rule!(
+    LegacyDocComments,
+    "legacy-doc-comment",
+    src,
+    crate::harndoc::check_legacy_doc_comments
+);
+program_rule!(
+    BlankLineBetweenItems,
+    "blank-line-between-items",
+    src,
+    crate::rules::blank_lines::check_blank_line_between_items
+);
+program_rule!(
+    ImportOrder,
+    "import-order",
+    src,
+    crate::rules::import_order::check_import_order
+);
+program_rule!(
+    PreferOptionalShorthand,
+    "prefer-optional-shorthand",
+    src,
+    crate::rules::optional_shorthand::check_prefer_optional_shorthand
+);
+program_rule!(
+    UnnecessaryParentheses,
+    "unnecessary-parentheses",
+    src,
+    crate::rules::unnecessary_parentheses::check_unnecessary_parentheses
+);
+program_rule!(
+    DeprecatedLlmOptions,
+    "deprecated_llm_options",
+    ast,
+    crate::rules::deprecated_llm_options::check_deprecated_llm_options
+);
+program_rule!(
+    ReminderLifecycle,
+    "reminder-infinite-discardable",
+    ast,
+    crate::rules::reminder_lifecycle::check_reminder_lifecycle_literals
+);
+program_rule!(
+    ReminderProviderCount,
+    "reminder-provider-count",
+    ast,
+    crate::rules::reminder_provider_count::check_reminder_provider_count
+);
+program_rule!(
+    ReminderRoleHint,
+    "reminder-role-hint-capability",
+    ast,
+    crate::rules::reminder_role_hint::check_reminder_role_hint_capabilities
+);
+
+program_rule!(
+    TrailingComma,
+    "trailing-comma",
+    srconly,
+    crate::rules::trailing_comma::check_trailing_comma
+);
+
+#[cfg(test)]
+mod tests {
+    use super::builtin_rules;
+    use std::collections::HashSet;
+
+    #[test]
+    fn builtin_rule_ids_are_unique_and_nonempty() {
+        let rules = builtin_rules();
+        let mut seen = HashSet::new();
+        for rule in &rules {
+            let id = rule.id();
+            assert!(!id.is_empty(), "rule id must not be empty");
+            assert!(seen.insert(id), "duplicate built-in rule id: {id}");
+        }
+    }
+}

--- a/crates/harn-lint/src/rules/blank_lines.rs
+++ b/crates/harn-lint/src/rules/blank_lines.rs
@@ -69,7 +69,7 @@ pub(crate) fn check_blank_line_between_items(
             let span = Span::with_offsets(insert_offset, insert_offset, insert_line, 1);
             diagnostics.push(LintDiagnostic {
                 code: Code::LintBlankLineBetweenItems,
-                rule: "blank-line-between-items",
+                rule: "blank-line-between-items".into(),
                 message: "top-level items should be separated by a blank line".to_string(),
                 span,
                 severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/rules/deprecated_llm_options.rs
+++ b/crates/harn-lint/src/rules/deprecated_llm_options.rs
@@ -322,7 +322,7 @@ fn make_diagnostic(key: &str, span: Span) -> LintDiagnostic {
     ));
     LintDiagnostic {
         code: Code::LintDeprecatedLlmOptions,
-        rule: RULE_NAME,
+        rule: RULE_NAME.into(),
         message,
         span,
         severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/rules/file_header.rs
+++ b/crates/harn-lint/src/rules/file_header.rs
@@ -28,7 +28,7 @@ pub(crate) fn check_require_file_header(
     let span = Span::with_offsets(0, 0, 1, 1);
     diagnostics.push(LintDiagnostic {
         code: Code::LintRequireFileHeader,
-        rule: "require-file-header",
+        rule: "require-file-header".into(),
         message: "file is missing a `/** */` header doc block".to_string(),
         span,
         severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/rules/import_order.rs
+++ b/crates/harn-lint/src/rules/import_order.rs
@@ -60,7 +60,7 @@ pub(crate) fn check_import_order(
     };
     diagnostics.push(LintDiagnostic {
         code: Code::LintImportOrder,
-        rule: "import-order",
+        rule: "import-order".into(),
         message: "imports are not in canonical order (stdlib first, then alphabetical by path)"
             .to_string(),
         span: replace_span,

--- a/crates/harn-lint/src/rules/mod.rs
+++ b/crates/harn-lint/src/rules/mod.rs
@@ -1,8 +1,8 @@
 //! Source-aware lint rules that operate on raw source plus the AST,
 //! rather than on the stateful [`Linter`][crate::linter::Linter] walk.
-//! Each rule lives in its own submodule so the dispatch list in
-//! [`Linter::lint_program`][crate::linter::Linter::lint_program] stays
-//! legible.
+//! Each rule lives in its own submodule and is wrapped as a registry
+//! entry in [`crate::rule`]; the linter dispatches by iterating the
+//! registry rather than calling each rule by name.
 
 pub(crate) mod ast_walk;
 pub(crate) mod blank_lines;

--- a/crates/harn-lint/src/rules/optional_shorthand.rs
+++ b/crates/harn-lint/src/rules/optional_shorthand.rs
@@ -532,7 +532,7 @@ impl<'a, 'd> State<'a, 'd> {
         let replacement = format!("{inner_text}?");
         self.diagnostics.push(LintDiagnostic {
             code: Code::LintPreferOptionalShorthand,
-            rule: "prefer-optional-shorthand",
+            rule: "prefer-optional-shorthand".into(),
             message: format!("prefer `{inner_text}?` over `{inner_text} | nil`"),
             span,
             severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/rules/reminder_lifecycle.rs
+++ b/crates/harn-lint/src/rules/reminder_lifecycle.rs
@@ -63,7 +63,7 @@ fn key_name(node: &SNode) -> Option<String> {
 fn make_diagnostic(span: Span) -> LintDiagnostic {
     LintDiagnostic {
         code: Code::ReminderInfiniteDiscardable,
-        rule: RULE_NAME,
+        rule: RULE_NAME.into(),
         message:
             "`preserve_on_compact: false` with no finite `ttl_turns` can leave a reminder alive indefinitely until compaction drops it."
                 .to_string(),

--- a/crates/harn-lint/src/rules/reminder_provider_count.rs
+++ b/crates/harn-lint/src/rules/reminder_provider_count.rs
@@ -129,7 +129,7 @@ fn literal_string(node: &SNode) -> Option<String> {
 fn make_diagnostic(count: usize, span: Span) -> LintDiagnostic {
     LintDiagnostic {
         code: Code::ReminderProviderBloat,
-        rule: RULE_NAME,
+        rule: RULE_NAME.into(),
         message: format!(
             "`agent_loop` enables {count} distinct reminder providers; this can add overlapping ambient context."
         ),

--- a/crates/harn-lint/src/rules/reminder_role_hint.rs
+++ b/crates/harn-lint/src/rules/reminder_role_hint.rs
@@ -161,7 +161,7 @@ fn make_diagnostic(route: &LlmRoute, span: Span) -> LintDiagnostic {
     };
     LintDiagnostic {
         code: Code::ReminderUnsupportedUserBlockRoleHint,
-        rule: RULE_NAME,
+        rule: RULE_NAME.into(),
         message: format!(
             "`role_hint: \"user_block\"` is provider-specific, but `{route_label}` cannot render it as an Anthropic user content block or an OpenAI developer message."
         ),

--- a/crates/harn-lint/src/rules/template_provider_identity.rs
+++ b/crates/harn-lint/src/rules/template_provider_identity.rs
@@ -65,7 +65,7 @@ fn make_diagnostic(field: IdentityField, line: usize, col: usize, source: &str) 
     );
     LintDiagnostic {
         code: Code::LintTemplateProviderIdentityBranch,
-        rule: RULE_NAME,
+        rule: RULE_NAME.into(),
         message,
         span,
         severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/rules/template_variant_explosion.rs
+++ b/crates/harn-lint/src/rules/template_variant_explosion.rs
@@ -57,7 +57,7 @@ pub(crate) fn check(
     );
     vec![LintDiagnostic {
         code: Code::LintTemplateVariantExplosion,
-        rule: RULE_NAME,
+        rule: RULE_NAME.into(),
         message,
         span,
         severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/rules/trailing_comma.rs
+++ b/crates/harn-lint/src/rules/trailing_comma.rs
@@ -24,7 +24,7 @@ pub(crate) fn check_trailing_comma(source: &str, diagnostics: &mut Vec<LintDiagn
         };
         diagnostics.push(LintDiagnostic {
             code: Code::LintTrailingComma,
-            rule: "trailing-comma",
+            rule: "trailing-comma".into(),
             message: message.to_string(),
             span: issue.edit.span,
             severity: LintSeverity::Warning,

--- a/crates/harn-lint/src/rules/unnecessary_parentheses.rs
+++ b/crates/harn-lint/src/rules/unnecessary_parentheses.rs
@@ -39,7 +39,7 @@ pub(crate) fn check_unnecessary_parentheses(
                     let open = &tokens[open_idx];
                     diagnostics.push(LintDiagnostic {
                         code: Code::LintUnnecessaryParentheses,
-                        rule: "unnecessary-parentheses",
+                        rule: "unnecessary-parentheses".into(),
                         message: "unnecessary parentheses around a single value".to_string(),
                         span: Span::merge(open.span, token.span),
                         severity: LintSeverity::Warning,

--- a/crates/harn-lsp/src/handlers/formatting.rs
+++ b/crates/harn-lsp/src/handlers/formatting.rs
@@ -102,7 +102,7 @@ fn build_code_actions(
                     })
                     .collect();
 
-                let title = match ld.rule {
+                let title = match ld.rule.as_ref() {
                     "mutable-never-reassigned" => "Change `var` to `let`".to_string(),
                     "comparison-to-bool" => "Simplify boolean comparison".to_string(),
                     "unnecessary-else-return" => "Remove unnecessary else".to_string(),


### PR DESCRIPTION
Closes #2848 (epic #2829, program #2826 — Harn Rule Engine).

## What

Behavior-preserving refactor that converts the hardcoded `harn-lint` dispatch into a pluggable rule **registry**, establishing the seam that engine-pattern (#2849) and `.harn`-authored (#2850) rules plug into, and that the lint VM builtin (#2851) will drive.

- **`trait Rule`** (`crates/harn-lint/src/rule.rs`) with three phase hooks mirroring the linter's dispatch sites: `check_program` (whole-program, pre-walk), `check_node` (per-node, gated by `visits_nodes`), and `finalize` (post-walk). Hooks push into an `out` sink and default to no-ops, so a rule implements only the phases it needs.
- **Registry on `Linter`**: `rules: Vec<Box<dyn Rule>>`, populated by `builtin_rules()`. The 10 separable source/AST rules become registry entries; all three dispatch sites now iterate the registry through one `run_rule_phase` helper. The intricately-stateful core checks (scope/declaration/reference tracking) stay intrinsic to the walk — that is also the exact shape dynamic rules take, so they slot in beside the built-ins rather than re-deriving the walk.
- **Owned rule ids**: `LintDiagnostic.rule` changes from `&'static str` to `Cow<'static, str>` so dynamically-registered rules can carry runtime ids; built-ins stay zero-cost `Cow::Borrowed`. `harn-lsp` / `harn-cli` consumers updated.

## Behavior preservation

Diagnostics, fixes, ordering, `disable_rules` filtering, and `harn.toml` `[lint]`/`[check]` config are all unchanged:

- 259 `harn-lint` unit/integration tests pass (258 prior + 1 new registry-contract test).
- `make lint-harn` produces byte-identical diagnostics across conformance fixtures, scripts, and demo scenarios.
- `harn-cli` (40 test binaries) and `harn-lsp` (42 tests) green; clippy + fmt clean.

## Drive-by fix

A pre-existing `harn-cli` doctest failure: the `harn pg codegen` doc comment's Harn snippet was an indented block that rustdoc compiled as Rust (`pg_query_one not found`). Fenced it as ```harn so it renders as a non-Rust example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)