### PR TITLE
Add harn-rules crate: rule model + atomic-tier pattern compiler (#2832)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-rules"
+version = "0.8.60"
+dependencies = [
+ "harn-hostlib",
+ "regex",
+ "serde",
+ "serde_json",
+ "streaming-iterator",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml",
+ "tree-sitter",
+]
+
+[[package]]
 name = "harn-serve"
 version = "0.8.60"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/harn-fmt",
     "crates/harn-lint",
     "crates/harn-hostlib",
+    "crates/harn-rules",
     "crates/harn-mcp-rc-compat",
     "perf/llm",
     "perf/vm",

--- a/changelog.d/2832.added.md
+++ b/changelog.d/2832.added.md
@@ -1,0 +1,5 @@
+- Added the `harn-rules` crate — the declarative structural rule engine core (Rule Engine Epic A). It ships the
+  atomic matching tier: a serde rule model (`id` / `language` / `severity` / `message` / `rule` block / `fix`), a
+  pattern compiler that lifts `$VAR` metavariable snippets into tree-sitter queries (operator-precise, with repeated
+  metavars unifying), `kind` and `regex` matchers, and a TOML rule-file / directory loader. Rules run through the same
+  tree-sitter machinery as `ast.search`, producing matches with metavariable bindings.

--- a/crates/harn-rules/Cargo.toml
+++ b/crates/harn-rules/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "harn-rules"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Declarative structural rule engine for Harn — rule model, pattern compiler, and matcher built on the harn-hostlib tree-sitter machinery."
+
+[dependencies]
+harn-hostlib = { path = "../harn-hostlib", default-features = false, features = ["ast"] }
+tree-sitter = "0.26"
+streaming-iterator = "0.1"
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+toml = "1.1"
+thiserror = "2"
+
+[dev-dependencies]
+serde_json = "1"
+streaming-iterator = "0.1"
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/harn-rules/Cargo.toml
+++ b/crates/harn-rules/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 description = "Declarative structural rule engine for Harn — rule model, pattern compiler, and matcher built on the harn-hostlib tree-sitter machinery."
 
 [dependencies]
-harn-hostlib = { path = "../harn-hostlib", default-features = false, features = ["ast"] }
+harn-hostlib = { path = "../harn-hostlib", version = "0.8", default-features = false, features = ["ast"] }
 tree-sitter = "0.26"
 streaming-iterator = "0.1"
 regex = "1"

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -1,0 +1,62 @@
+# harn-rules
+
+The declarative structural rule engine for Harn — the Rust core behind
+`harn rules` / lint / codemod surfaces. Part of the
+[Rule Engine program](https://github.com/burin-labs/harn/issues/2826)
+(Epic A, [harn#2827](https://github.com/burin-labs/harn/issues/2827)).
+
+A **rule** says *what to match* and optionally *how to rewrite* it. The
+engine compiles the rule against the tree-sitter machinery in `harn-hostlib`
+and produces matches with metavariable bindings — the structural complement
+to regex/glob search.
+
+This crate ships the **atomic matching tier**
+([harn#2832](https://github.com/burin-labs/harn/issues/2832)). Relational /
+composite matching (#2833) and `where` / `transform` / `fix` interpolation
+(#2834) build on it.
+
+## Rule shape (TOML)
+
+```toml
+id = "destructure-with-defaults"
+language = "typescript"
+severity = "warning"                 # info | warning (default) | error
+message = "Collapse `?.x ?? default`"
+fix = "{ $KEY: $SRC }"               # presence makes the rule a codemod
+
+[rule]                               # the matcher block — keep it LAST
+pattern = "$SRC?.$KEY ?? $DEFAULT"   # one of: pattern | kind | regex
+```
+
+> **Key ordering:** because `[rule]` opens a TOML table, every scalar field
+> (`id`, `language`, `severity`, `message`, `fix`) must appear **before** it.
+
+A rule's kind is derived from its shape: a `fix` makes it a **codemod**; a
+`message` with no `fix` makes it a **lint**; a bare matcher is a **search**.
+
+### Atomic matcher forms
+
+- `pattern` — a code snippet in the target grammar with `$VAR` metavariable
+  holes. Compiled to a tree-sitter query: each `$VAR` becomes a capture, the
+  snippet's operators/keywords are matched literally (so `??` ≠ `||`), and a
+  repeated `$VAR` unifies (must bind identical text). Variadic `$$$` holes
+  land with the relational tier (#2833).
+- `kind` — a bare tree-sitter node kind (e.g. `"call_expression"`).
+- `regex` — a regular expression over the source text.
+
+## Usage
+
+```rust
+use harn_rules::{Rule, CompiledRule};
+
+let rule = Rule::from_toml_str(/* … */)?;
+let compiled = CompiledRule::compile(&rule)?;
+for m in compiled.run(source)? {
+    println!("{} at {:?}: {}", m.rule_id, m.span, m.text);
+    for (name, binding) in &m.bindings {
+        println!("  ${name} = {}", binding.text);
+    }
+}
+```
+
+Load from disk with `load_rule_file(path)` or `load_rule_dir(dir)`.

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -1,0 +1,387 @@
+//! Compile a [`Rule`] into a runnable matcher and run it against source.
+//!
+//! The atomic tier supports three matcher forms, all reduced to a single
+//! [`RuleMatch`] stream:
+//!
+//! - `pattern` → compiled to a tree-sitter query via [`crate::pattern`].
+//! - `kind` → the trivial query `(<kind>) @__match`.
+//! - `regex` → a text regex over the source, yielding spans with no AST
+//!   metavar bindings.
+
+use std::collections::BTreeMap;
+
+use harn_hostlib::ast::{api, Language};
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Query, QueryCursor};
+
+use crate::error::RulesError;
+use crate::model::{AtomicMatcher, Rule};
+use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+
+/// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
+/// Harn AST wire format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    /// Start byte offset.
+    pub start_byte: usize,
+    /// End byte offset (exclusive).
+    pub end_byte: usize,
+    /// 0-based start row.
+    pub start_row: usize,
+    /// 0-based start column.
+    pub start_col: usize,
+    /// 0-based end row.
+    pub end_row: usize,
+    /// 0-based end column.
+    pub end_col: usize,
+}
+
+impl Span {
+    fn of(node: tree_sitter::Node<'_>) -> Self {
+        let start = node.start_position();
+        let end = node.end_position();
+        Span {
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
+            start_row: start.row,
+            start_col: start.column,
+            end_row: end.row,
+            end_col: end.column,
+        }
+    }
+}
+
+/// A metavariable binding: the captured text plus where it lives.
+#[derive(Debug, Clone)]
+pub struct Binding {
+    /// The captured source text.
+    pub text: String,
+    /// The captured node's span.
+    pub span: Span,
+}
+
+/// One match of a rule against a file.
+#[derive(Debug, Clone)]
+pub struct RuleMatch {
+    /// The rule that produced this match.
+    pub rule_id: String,
+    /// The whole matched range (the pattern root, or the regex span).
+    pub span: Span,
+    /// The matched source text.
+    pub text: String,
+    /// Metavar bindings, keyed by name (without the leading `$`). Empty for
+    /// `kind` and `regex` matchers.
+    pub bindings: BTreeMap<String, Binding>,
+}
+
+/// A rule whose matcher has been compiled and is ready to run.
+pub struct CompiledRule {
+    rule_id: String,
+    language: Language,
+    matcher: CompiledMatcher,
+}
+
+enum CompiledMatcher {
+    /// A tree-sitter query plus the metavar names to extract. Covers both
+    /// `pattern` and `kind` forms.
+    Query { query: Query, metavars: Vec<String> },
+    /// A text regex over the whole source.
+    Regex(regex::Regex),
+}
+
+impl CompiledRule {
+    /// Resolve the rule's language and grammar, then compile its matcher.
+    pub fn compile(rule: &Rule) -> Result<Self, RulesError> {
+        let language =
+            Language::from_name(&rule.language).ok_or_else(|| RulesError::UnknownLanguage {
+                rule: rule.id.clone(),
+                language: rule.language.clone(),
+            })?;
+
+        let matcher = match rule
+            .rule
+            .resolve()
+            .map_err(|message| RulesError::PatternCompile {
+                rule: rule.id.clone(),
+                message,
+            })? {
+            AtomicMatcher::Pattern(snippet) => {
+                let ts_language =
+                    language
+                        .ts_language()
+                        .ok_or_else(|| RulesError::GrammarUnavailable {
+                            rule: rule.id.clone(),
+                            language: language.name().to_string(),
+                        })?;
+                let compiled = compile_pattern(&snippet, language).map_err(|message| {
+                    RulesError::PatternCompile {
+                        rule: rule.id.clone(),
+                        message,
+                    }
+                })?;
+                let query = Query::new(&ts_language, &compiled.query).map_err(|err| {
+                    RulesError::QueryRejected {
+                        rule: rule.id.clone(),
+                        message: err.to_string(),
+                        query: compiled.query.clone(),
+                    }
+                })?;
+                CompiledMatcher::Query {
+                    query,
+                    metavars: compiled.metavars,
+                }
+            }
+            AtomicMatcher::Kind(kind) => {
+                let ts_language =
+                    language
+                        .ts_language()
+                        .ok_or_else(|| RulesError::GrammarUnavailable {
+                            rule: rule.id.clone(),
+                            language: language.name().to_string(),
+                        })?;
+                let query_text = format!("({kind}) @{ROOT_CAPTURE}");
+                let query = Query::new(&ts_language, &query_text).map_err(|err| {
+                    RulesError::QueryRejected {
+                        rule: rule.id.clone(),
+                        message: err.to_string(),
+                        query: query_text.clone(),
+                    }
+                })?;
+                CompiledMatcher::Query {
+                    query,
+                    metavars: Vec::new(),
+                }
+            }
+            AtomicMatcher::Regex(pattern) => {
+                let regex =
+                    regex::Regex::new(&pattern).map_err(|err| RulesError::PatternCompile {
+                        rule: rule.id.clone(),
+                        message: format!("invalid regex `{pattern}`: {err}"),
+                    })?;
+                CompiledMatcher::Regex(regex)
+            }
+        };
+
+        Ok(CompiledRule {
+            rule_id: rule.id.clone(),
+            language,
+            matcher,
+        })
+    }
+
+    /// The language this rule targets.
+    pub fn language(&self) -> Language {
+        self.language
+    }
+
+    /// Run the compiled rule against `source`, returning matches in
+    /// document order.
+    pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {
+        match &self.matcher {
+            CompiledMatcher::Query { query, metavars } => self.run_query(query, metavars, source),
+            CompiledMatcher::Regex(regex) => Ok(self.run_regex(regex, source)),
+        }
+    }
+
+    fn run_query(
+        &self,
+        query: &Query,
+        metavars: &[String],
+        source: &str,
+    ) -> Result<Vec<RuleMatch>, RulesError> {
+        let tree =
+            api::parse_tree(source, self.language).map_err(|err| RulesError::SourceParse {
+                rule: self.rule_id.clone(),
+                message: err.to_string(),
+            })?;
+        let names: Vec<&str> = query.capture_names().to_vec();
+        let bytes = source.as_bytes();
+
+        let mut cursor = QueryCursor::new();
+        let mut it = cursor.matches(query, tree.root_node(), bytes);
+        let mut matches = Vec::new();
+        while let Some(m) = it.next() {
+            let mut root: Option<Span> = None;
+            let mut root_text = String::new();
+            let mut bindings: BTreeMap<String, Binding> = BTreeMap::new();
+            for cap in m.captures {
+                let name = names[cap.index as usize];
+                let span = Span::of(cap.node);
+                let text = source[cap.node.start_byte()..cap.node.end_byte()].to_string();
+                if name == ROOT_CAPTURE {
+                    root = Some(span);
+                    root_text = text;
+                } else if metavars.iter().any(|m| m == name) {
+                    // Canonical metavar capture; unification helpers carry a
+                    // `.` and never appear in `metavars`, so they are skipped.
+                    bindings
+                        .entry(name.to_string())
+                        .or_insert(Binding { text, span });
+                }
+            }
+            if let Some(span) = root {
+                matches.push(RuleMatch {
+                    rule_id: self.rule_id.clone(),
+                    span,
+                    text: root_text,
+                    bindings,
+                });
+            }
+        }
+        // Tree-sitter yields matches in query-eval order; sort to document
+        // order for a stable, intuitive result.
+        matches.sort_by_key(|m| (m.span.start_byte, m.span.end_byte));
+        Ok(matches)
+    }
+
+    fn run_regex(&self, regex: &regex::Regex, source: &str) -> Vec<RuleMatch> {
+        let mut matches = Vec::new();
+        for m in regex.find_iter(source) {
+            let span = byte_span(source, m.start(), m.end());
+            matches.push(RuleMatch {
+                rule_id: self.rule_id.clone(),
+                span,
+                text: m.as_str().to_string(),
+                bindings: BTreeMap::new(),
+            });
+        }
+        matches
+    }
+}
+
+/// Compute a [`Span`] for a byte range by counting rows/cols. Used by the
+/// regex matcher, which has no tree-sitter node to read positions from.
+fn byte_span(source: &str, start: usize, end: usize) -> Span {
+    let (start_row, start_col) = row_col(source, start);
+    let (end_row, end_col) = row_col(source, end);
+    Span {
+        start_byte: start,
+        end_byte: end,
+        start_row,
+        start_col,
+        end_row,
+        end_col,
+    }
+}
+
+fn row_col(source: &str, byte: usize) -> (usize, usize) {
+    let mut row = 0;
+    let mut col = 0;
+    for (i, ch) in source.char_indices() {
+        if i >= byte {
+            break;
+        }
+        if ch == '\n' {
+            row += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    (row, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Rule;
+
+    fn rule(toml: &str) -> CompiledRule {
+        let parsed = Rule::from_toml_str(toml).expect("rule parses");
+        CompiledRule::compile(&parsed).expect("rule compiles")
+    }
+
+    #[test]
+    fn pattern_rule_binds_metavars() {
+        let compiled = rule(
+            r#"
+            id = "destructure-default"
+            language = "typescript"
+            fix = "{ $KEY: $SRC }"
+            [rule]
+            pattern = "$SRC?.$KEY ?? $DEFAULT"
+            "#,
+        );
+        let matches = compiled
+            .run("const a = cfg?.timeout ?? 30;\nconst b = opts?.retries ?? 3;\n")
+            .unwrap();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].bindings["SRC"].text, "cfg");
+        assert_eq!(matches[0].bindings["KEY"].text, "timeout");
+        assert_eq!(matches[0].bindings["DEFAULT"].text, "30");
+        assert_eq!(matches[1].bindings["SRC"].text, "opts");
+        // The match span covers the whole expression.
+        assert_eq!(matches[0].text, "cfg?.timeout ?? 30");
+        assert_eq!(matches[0].span.start_row, 0);
+        assert_eq!(matches[1].span.start_row, 1);
+    }
+
+    #[test]
+    fn kind_rule_matches_node_kind() {
+        let compiled = rule(
+            r#"
+            id = "find-calls"
+            language = "python"
+            [rule]
+            kind = "call"
+            "#,
+        );
+        let matches = compiled.run("print(x)\nlog(y)\n").unwrap();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].text, "print(x)");
+        assert!(matches[0].bindings.is_empty());
+    }
+
+    #[test]
+    fn regex_rule_matches_text() {
+        let compiled = rule(
+            r#"
+            id = "todo"
+            language = "rust"
+            message = "Found a TODO"
+            [rule]
+            regex = "TODO\\(\\w+\\)"
+            "#,
+        );
+        let matches = compiled
+            .run("fn f() {\n    // TODO(ken) fix\n    // todo lower\n}\n")
+            .unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].text, "TODO(ken)");
+        assert_eq!(matches[0].span.start_row, 1);
+    }
+
+    #[test]
+    fn unknown_language_is_an_error() {
+        let parsed = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "cobol"
+            [rule]
+            kind = "foo"
+            "#,
+        )
+        .unwrap();
+        assert!(matches!(
+            CompiledRule::compile(&parsed),
+            Err(RulesError::UnknownLanguage { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_pattern_surfaces_compile_error() {
+        let parsed = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "typescript"
+            [rule]
+            pattern = "foo($$$ARGS)"
+            "#,
+        )
+        .unwrap();
+        assert!(matches!(
+            CompiledRule::compile(&parsed),
+            Err(RulesError::PatternCompile { .. })
+        ));
+    }
+}

--- a/crates/harn-rules/src/error.rs
+++ b/crates/harn-rules/src/error.rs
@@ -1,0 +1,75 @@
+//! Error type for the rule engine.
+
+use thiserror::Error;
+
+/// Anything that can go wrong loading, compiling, or running a rule.
+#[derive(Debug, Error)]
+pub enum RulesError {
+    /// A rule file could not be read.
+    #[error("read rule `{path}`: {source}")]
+    Read {
+        /// The path that failed to read.
+        path: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A rule file could not be parsed as TOML.
+    #[error("parse rule `{path}`: {source}")]
+    Parse {
+        /// The path that failed to parse.
+        path: String,
+        /// The underlying TOML error.
+        source: Box<toml::de::Error>,
+    },
+
+    /// A rule referenced a language the engine does not know.
+    #[error("rule `{rule}`: unknown language `{language}`")]
+    UnknownLanguage {
+        /// The offending rule id.
+        rule: String,
+        /// The language string that did not resolve.
+        language: String,
+    },
+
+    /// A rule's language is known but its grammar was not compiled into
+    /// this build.
+    #[error("rule `{rule}`: grammar for `{language}` is not compiled into this build")]
+    GrammarUnavailable {
+        /// The offending rule id.
+        rule: String,
+        /// The language whose grammar is missing.
+        language: String,
+    },
+
+    /// A `pattern` snippet failed to compile into a tree-sitter query.
+    #[error("rule `{rule}`: {message}")]
+    PatternCompile {
+        /// The offending rule id.
+        rule: String,
+        /// What went wrong compiling the snippet.
+        message: String,
+    },
+
+    /// The compiled query was rejected by tree-sitter. This is an engine
+    /// bug if it happens for a snippet that parsed cleanly, so it carries
+    /// the generated query for debugging.
+    #[error("rule `{rule}`: generated query rejected by tree-sitter: {message}\nquery:\n{query}")]
+    QueryRejected {
+        /// The offending rule id.
+        rule: String,
+        /// The tree-sitter query error.
+        message: String,
+        /// The generated S-expression query.
+        query: String,
+    },
+
+    /// Source text could not be parsed in the rule's grammar.
+    #[error("rule `{rule}`: parse source: {message}")]
+    SourceParse {
+        /// The offending rule id.
+        rule: String,
+        /// The parse failure detail.
+        message: String,
+    },
+}

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -1,0 +1,51 @@
+//! # harn-rules
+//!
+//! The declarative structural rule engine for Harn — the Rust core that
+//! powers `harn rules` / lint / codemod surfaces. A **rule** describes
+//! *what to match* (a pattern snippet, a node kind, or a regex) and
+//! optionally *how to rewrite* it (a `fix`); the engine compiles that rule
+//! against the tree-sitter machinery in [`harn_hostlib::ast`] and produces
+//! [`RuleMatch`]es with metavariable bindings.
+//!
+//! This crate delivers the **atomic matching tier** (issue #2832):
+//!
+//! - [`model`] — the serde rule data model (`id` / `language` / `severity`
+//!   / `message` / `rule` block / `fix`).
+//! - [`pattern`] — the snippet → tree-sitter-query compiler (`$VAR`
+//!   metavariable lifting + unification).
+//! - [`engine`] — compile a [`Rule`] and run it to produce matches.
+//! - [`loader`] — load rules from a TOML file or a directory.
+//!
+//! Relational/composite matching (#2833) and `where` / `transform` / `fix`
+//! interpolation (#2834) layer onto this surface.
+//!
+//! ```
+//! use harn_rules::{Rule, CompiledRule};
+//!
+//! let rule = Rule::from_toml_str(
+//!     r#"
+//!     id = "destructure-default"
+//!     language = "typescript"
+//!     fix = "{ $KEY: $SRC }"
+//!     [rule]
+//!     pattern = "$SRC?.$KEY ?? $DEFAULT"
+//!     "#,
+//! ).unwrap();
+//! let compiled = CompiledRule::compile(&rule).unwrap();
+//! let matches = compiled.run("const a = cfg?.timeout ?? 30;").unwrap();
+//! assert_eq!(matches[0].bindings["KEY"].text, "timeout");
+//! ```
+
+#![forbid(unsafe_code)]
+
+pub mod engine;
+pub mod error;
+pub mod loader;
+pub mod model;
+pub mod pattern;
+
+pub use engine::{Binding, CompiledRule, RuleMatch, Span};
+pub use error::RulesError;
+pub use loader::{load_rule_dir, load_rule_file};
+pub use model::{AtomicMatcher, Matcher, Rule, RuleKind, Severity};
+pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/loader.rs
+++ b/crates/harn-rules/src/loader.rs
@@ -1,0 +1,92 @@
+//! Load rules from disk: a single TOML rule file, or a directory of them.
+
+use std::path::Path;
+
+use crate::error::RulesError;
+use crate::model::Rule;
+
+/// Load a single rule from a `.toml` file.
+pub fn load_rule_file(path: impl AsRef<Path>) -> Result<Rule, RulesError> {
+    let path = path.as_ref();
+    let text = std::fs::read_to_string(path).map_err(|source| RulesError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+    Rule::from_toml_str(&text).map_err(|source| RulesError::Parse {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+/// Load every `.toml` rule directly under `dir`, sorted by filename for a
+/// deterministic order. Non-`.toml` files and subdirectories are ignored.
+pub fn load_rule_dir(dir: impl AsRef<Path>) -> Result<Vec<Rule>, RulesError> {
+    let dir = dir.as_ref();
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .map_err(|source| RulesError::Read {
+            path: dir.display().to_string(),
+            source,
+        })?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.is_file() && p.extension().is_some_and(|ext| ext == "toml"))
+        .collect();
+    entries.sort();
+
+    entries.into_iter().map(load_rule_file).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        let mut f = std::fs::File::create(dir.join(name)).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn loads_a_single_rule_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "r.toml",
+            r#"
+            id = "r"
+            language = "rust"
+            [rule]
+            kind = "macro_invocation"
+            "#,
+        );
+        let rule = load_rule_file(dir.path().join("r.toml")).unwrap();
+        assert_eq!(rule.id, "r");
+    }
+
+    #[test]
+    fn loads_a_directory_in_sorted_order() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "b.toml",
+            "id = \"b\"\nlanguage = \"rust\"\n[rule]\nkind = \"x\"\n",
+        );
+        write(
+            dir.path(),
+            "a.toml",
+            "id = \"a\"\nlanguage = \"rust\"\n[rule]\nkind = \"x\"\n",
+        );
+        write(dir.path(), "ignore.txt", "not a rule");
+        let rules = load_rule_dir(dir.path()).unwrap();
+        let ids: Vec<_> = rules.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn parse_error_names_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "bad.toml", "id = \nthis is not toml");
+        let err = load_rule_file(dir.path().join("bad.toml")).unwrap_err();
+        assert!(matches!(err, RulesError::Parse { .. }));
+    }
+}

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -1,0 +1,236 @@
+//! The declarative rule data model.
+//!
+//! A rule is the atomic unit the engine consumes: an identity (`id`,
+//! `language`, `severity`, `message`), a `rule` block describing *what to
+//! match* (the atomic tier: `pattern` snippet, `kind`, or `regex`), and an
+//! optional `fix` describing *how to rewrite* it. Relational/composite
+//! matching (#2833) and `where`/`transform` (#2834) extend this model;
+//! this module is the atomic-tier surface they build on.
+
+use serde::Deserialize;
+
+/// Diagnostic severity. Mirrors the `harn-lint` vocabulary so findings can
+/// flow into the same reporting surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// Informational; no action required.
+    Info,
+    /// Default — something worth a human's attention.
+    #[default]
+    Warning,
+    /// A problem that should block.
+    Error,
+}
+
+/// What flavor of work a rule performs, derived from its shape rather than
+/// declared: a rule with a `fix` is a codemod; one with a `message` but no
+/// `fix` is a lint; a bare matcher is a search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleKind {
+    /// Find-only: report matches, no diagnostic text, no rewrite.
+    Search,
+    /// Report a diagnostic (`message` + `severity`), no rewrite.
+    Lint,
+    /// Rewrite matches via `fix`.
+    Codemod,
+}
+
+/// The atomic-tier matcher. Exactly one of `pattern` / `kind` / `regex`
+/// must be set; [`Matcher::resolve`] enforces that and yields the typed
+/// [`AtomicMatcher`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Matcher {
+    /// A code snippet in the target grammar with `$VAR` (single-node) and
+    /// `$$$VAR` (variadic) metavariable holes.
+    pub pattern: Option<String>,
+    /// A bare tree-sitter node kind to match (e.g. `"call_expression"`).
+    pub kind: Option<String>,
+    /// A regular expression matched against node text.
+    pub regex: Option<String>,
+}
+
+/// The resolved, exactly-one atomic matcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtomicMatcher {
+    /// A snippet pattern with metavariable holes.
+    Pattern(String),
+    /// A tree-sitter node kind.
+    Kind(String),
+    /// A regex over node text.
+    Regex(String),
+}
+
+impl Matcher {
+    /// Collapse the optional fields into the single atomic form, rejecting
+    /// the zero-or-many cases. Returns `Err` with a human-readable reason.
+    pub fn resolve(&self) -> Result<AtomicMatcher, String> {
+        let set: Vec<&str> = [
+            self.pattern.as_ref().map(|_| "pattern"),
+            self.kind.as_ref().map(|_| "kind"),
+            self.regex.as_ref().map(|_| "regex"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        match set.as_slice() {
+            [] => Err("rule block sets none of `pattern` / `kind` / `regex`".into()),
+            [one] => Ok(match *one {
+                "pattern" => AtomicMatcher::Pattern(self.pattern.clone().unwrap()),
+                "kind" => AtomicMatcher::Kind(self.kind.clone().unwrap()),
+                _ => AtomicMatcher::Regex(self.regex.clone().unwrap()),
+            }),
+            many => Err(format!(
+                "rule block sets multiple matchers ({}); set exactly one",
+                many.join(", ")
+            )),
+        }
+    }
+}
+
+/// A single declarative rule.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Rule {
+    /// Stable identifier (also the diagnostic code).
+    pub id: String,
+    /// Target language name (resolved via `harn_hostlib::ast::Language`).
+    pub language: String,
+    /// Diagnostic severity. Defaults to `warning`.
+    #[serde(default)]
+    pub severity: Severity,
+    /// Human-readable diagnostic message. Empty for search-only rules.
+    #[serde(default)]
+    pub message: String,
+    /// The atomic-tier matcher block.
+    pub rule: Matcher,
+    /// Replacement template. Its presence makes the rule a codemod.
+    #[serde(default)]
+    pub fix: Option<String>,
+}
+
+impl Rule {
+    /// Derive the rule's kind from its shape (see [`RuleKind`]).
+    pub fn kind(&self) -> RuleKind {
+        if self.fix.is_some() {
+            RuleKind::Codemod
+        } else if self.message.is_empty() {
+            RuleKind::Search
+        } else {
+            RuleKind::Lint
+        }
+    }
+
+    /// Parse a single rule from a TOML document.
+    pub fn from_toml_str(text: &str) -> Result<Self, Box<toml::de::Error>> {
+        toml::from_str(text).map_err(Box::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_codemod_rule() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "destructure-default"
+            language = "typescript"
+            severity = "warning"
+            message = "Collapse optional-chain default into a destructuring bind"
+            fix = "{ $KEY: $SRC }"
+
+            [rule]
+            pattern = "$SRC?.$KEY ?? $DEFAULT"
+            "#,
+        )
+        .expect("rule parses");
+        assert_eq!(rule.id, "destructure-default");
+        assert_eq!(rule.language, "typescript");
+        assert_eq!(rule.severity, Severity::Warning);
+        assert_eq!(rule.kind(), RuleKind::Codemod);
+        assert_eq!(
+            rule.rule.resolve().unwrap(),
+            AtomicMatcher::Pattern("$SRC?.$KEY ?? $DEFAULT".into())
+        );
+    }
+
+    #[test]
+    fn severity_defaults_to_warning() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            [rule]
+            kind = "macro_invocation"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(rule.severity, Severity::Warning);
+        // No message, no fix -> a search rule.
+        assert_eq!(rule.kind(), RuleKind::Search);
+    }
+
+    #[test]
+    fn lint_rule_has_message_no_fix() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "todo"
+            language = "rust"
+            message = "Found a TODO"
+            [rule]
+            regex = "TODO"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(rule.kind(), RuleKind::Lint);
+        assert_eq!(
+            rule.rule.resolve().unwrap(),
+            AtomicMatcher::Regex("TODO".into())
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_matchers() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            [rule]
+            kind = "foo"
+            regex = "bar"
+            "#,
+        )
+        .unwrap();
+        assert!(rule.rule.resolve().is_err());
+    }
+
+    #[test]
+    fn rejects_empty_matcher() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            [rule]
+            "#,
+        )
+        .unwrap();
+        assert!(rule.rule.resolve().is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        let err = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            bogus = true
+            [rule]
+            kind = "foo"
+            "#,
+        );
+        assert!(err.is_err());
+    }
+}

--- a/crates/harn-rules/src/pattern.rs
+++ b/crates/harn-rules/src/pattern.rs
@@ -1,0 +1,463 @@
+//! The pattern compiler: a code snippet with metavariable holes → a
+//! tree-sitter query.
+//!
+//! This is the atomic-tier `pattern` form. The idea (from ast-grep) is to
+//! let rule authors write a *snippet of real code* with `$VAR` holes
+//! instead of hand-authoring a tree-sitter S-expression query:
+//!
+//! ```text
+//!   $SRC?.$KEY ?? $DEFAULT
+//! ```
+//!
+//! compiles to
+//!
+//! ```text
+//!   ((binary_expression
+//!      left: (member_expression object: (_) @SRC (optional_chain) property: (_) @KEY)
+//!      "??"
+//!      right: (_) @DEFAULT) @__match)
+//! ```
+//!
+//! ## How it works
+//!
+//! 1. Each `$VAR` is replaced with a unique placeholder identifier so the
+//!    snippet parses as ordinary code in the target grammar.
+//! 2. We parse the substituted snippet — bare, then in a per-language
+//!    wrapper context (e.g. a function body) when the fragment is not a
+//!    valid compilation unit — and locate the snippet's own subtree by its
+//!    byte range in the parsed source.
+//! 3. We walk that subtree and mirror it into a query: every named child is
+//!    emitted with its field name, every anonymous token (operators,
+//!    keywords, punctuation) is emitted as a quoted literal so the structure
+//!    is matched precisely, and every placeholder becomes a `(_) @VAR`
+//!    wildcard capture.
+//! 4. Repeated metavariables unify: the second and later occurrences get
+//!    helper captures plus an `(#eq? …)` predicate so `$X … $X` only matches
+//!    when both holes carry identical text.
+//!
+//! Variadic `$$$` holes are not yet supported (tracked for the relational
+//! tier, #2833); they compile to a clear error.
+
+use std::collections::HashMap;
+
+use harn_hostlib::ast::{api, Language};
+use tree_sitter::Node;
+
+/// The capture name bound to the whole matched pattern, used for range
+/// extraction. Chosen to not collide with a user metavar (which are
+/// uppercase by convention and never start with `__`).
+pub const ROOT_CAPTURE: &str = "__match";
+
+/// Placeholder identifier stem substituted for each `$VAR`. Lowercase +
+/// `__` prefix keeps it a valid identifier across grammars and unlikely to
+/// collide with real snippet text.
+const PLACEHOLDER_STEM: &str = "__harn_hole_";
+
+/// A snippet pattern compiled to a tree-sitter query string.
+#[derive(Debug, Clone)]
+pub struct CompiledPattern {
+    /// The generated S-expression query. Always binds the pattern root to
+    /// `@__match` ([`ROOT_CAPTURE`]).
+    pub query: String,
+    /// Metavar names in first-appearance order (without the leading `$`).
+    pub metavars: Vec<String>,
+}
+
+/// Compile a `pattern` snippet for `language` into a tree-sitter query.
+///
+/// A snippet is often a *fragment* (`a + a`, `foo(bar)`) that is not a
+/// valid compilation unit on its own. We therefore try the snippet bare
+/// first (works for expression-statement languages like TS/JS/Python),
+/// then in a small set of per-language wrapper contexts (e.g. a function
+/// body for Rust/Go), and locate the snippet's own subtree by byte range.
+pub fn compile_pattern(snippet: &str, language: Language) -> Result<CompiledPattern, String> {
+    let sub = substitute(snippet)?;
+    let mut last_err: Option<String> = None;
+
+    for (prefix, suffix) in contexts(language) {
+        let wrapped = format!("{prefix}{}{suffix}", sub.text);
+        let tree = api::parse_tree(&wrapped, language).map_err(|err| err.to_string())?;
+        let root = tree.root_node();
+        if root.has_error() {
+            last_err = Some(format!(
+                "snippet did not parse cleanly in `{}`: `{snippet}`",
+                language.name()
+            ));
+            continue;
+        }
+
+        // The snippet occupies `[start, end)` inside the wrapped source; the
+        // deepest node spanning that range is its own subtree (no need to
+        // descend wrappers — and no risk of over-descending a single-child
+        // node like a unary expression).
+        let start = prefix.len();
+        let end = start + sub.text.len();
+        let Some(pattern_root) = root.descendant_for_byte_range(start, end.saturating_sub(1))
+        else {
+            last_err = Some(format!(
+                "could not locate snippet subtree in `{}`",
+                language.name()
+            ));
+            continue;
+        };
+
+        let bytes = wrapped.as_bytes();
+        let mut builder = QueryBuilder::new(bytes, &sub.placeholder_to_metavar);
+        let body = builder.build(pattern_root);
+        let predicates = builder.predicates();
+        let query = if predicates.is_empty() {
+            format!("({body} @{ROOT_CAPTURE})")
+        } else {
+            format!("({body} @{ROOT_CAPTURE} {predicates})")
+        };
+        return Ok(CompiledPattern {
+            query,
+            metavars: sub.metavar_order,
+        });
+    }
+
+    Err(last_err.unwrap_or_else(|| format!("snippet did not parse in `{}`", language.name())))
+}
+
+/// Candidate parse contexts for a snippet, tried in order. The bare context
+/// (`""`, `""`) comes first; item-required languages add a wrapper that
+/// makes an expression/statement fragment parse. Languages whose top level
+/// already accepts expression statements (TS/JS/Python/Ruby/…) only need
+/// the bare context.
+fn contexts(language: Language) -> Vec<(&'static str, &'static str)> {
+    let mut v = vec![("", "")];
+    let wrapper = match language {
+        Language::Rust => Some(("fn __harn_probe() { ", " }")),
+        Language::Go => Some(("package p\nfunc __harn_probe() { ", " }")),
+        Language::Java | Language::CSharp => {
+            Some(("class __HarnProbe { void __harn_probe() { ", " } }"))
+        }
+        Language::C | Language::Cpp => Some(("void __harn_probe() { ", " }")),
+        Language::Kotlin => Some(("fun __harn_probe() { ", " }")),
+        Language::Swift => Some(("func __harn_probe() { ", " }")),
+        Language::Scala => Some(("def __harn_probe() = { ", " }")),
+        _ => None,
+    };
+    v.extend(wrapper);
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: metavar substitution
+// ---------------------------------------------------------------------------
+
+struct Substituted {
+    /// Snippet with `$VAR` replaced by placeholder identifiers.
+    text: String,
+    /// placeholder identifier → metavar name.
+    placeholder_to_metavar: HashMap<String, String>,
+    /// Metavar names in first-appearance order.
+    metavar_order: Vec<String>,
+}
+
+fn substitute(snippet: &str) -> Result<Substituted, String> {
+    let mut text = String::with_capacity(snippet.len());
+    let mut placeholder_to_metavar = HashMap::new();
+    let mut metavar_to_placeholder: HashMap<String, String> = HashMap::new();
+    let mut metavar_order: Vec<String> = Vec::new();
+
+    let bytes = snippet.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'$' {
+            // Copy this UTF-8 scalar verbatim. Indexing the &str at byte
+            // boundaries is safe because we only special-case ASCII `$`.
+            let ch = snippet[i..].chars().next().unwrap();
+            text.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+        if snippet[i..].starts_with("$$$") {
+            return Err(
+                "variadic `$$$` metavariables are not yet supported (tracked in #2833)".into(),
+            );
+        }
+        // Parse `$NAME` where NAME is `[A-Za-z_][A-Za-z0-9_]*`.
+        let name_start = i + 1;
+        let mut j = name_start;
+        if j < bytes.len() && is_ident_start(bytes[j]) {
+            j += 1;
+            while j < bytes.len() && is_ident_continue(bytes[j]) {
+                j += 1;
+            }
+        }
+        if j == name_start {
+            // A lone `$` that is not a metavar — keep it literal.
+            text.push('$');
+            i += 1;
+            continue;
+        }
+        let name = &snippet[name_start..j];
+        let placeholder = metavar_to_placeholder
+            .entry(name.to_string())
+            .or_insert_with(|| {
+                let placeholder = format!("{PLACEHOLDER_STEM}{}", metavar_order.len());
+                metavar_order.push(name.to_string());
+                placeholder
+            })
+            .clone();
+        placeholder_to_metavar.insert(placeholder.clone(), name.to_string());
+        text.push_str(&placeholder);
+        i = j;
+    }
+
+    if metavar_order.is_empty() {
+        return Err("pattern has no `$VAR` metavariables".into());
+    }
+
+    Ok(Substituted {
+        text,
+        placeholder_to_metavar,
+        metavar_order,
+    })
+}
+
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: walk the located subtree into a query
+// ---------------------------------------------------------------------------
+
+struct QueryBuilder<'a> {
+    src: &'a [u8],
+    placeholder_to_metavar: &'a HashMap<String, String>,
+    /// occurrence count per metavar, to mint unification helper captures.
+    occurrences: HashMap<String, usize>,
+    /// `(#eq? @X @X.2)` predicates for repeated metavars.
+    eq_predicates: Vec<String>,
+}
+
+impl<'a> QueryBuilder<'a> {
+    fn new(src: &'a [u8], placeholder_to_metavar: &'a HashMap<String, String>) -> Self {
+        QueryBuilder {
+            src,
+            placeholder_to_metavar,
+            occurrences: HashMap::new(),
+            eq_predicates: Vec::new(),
+        }
+    }
+
+    fn build(&mut self, node: Node<'_>) -> String {
+        // A placeholder leaf is a metavar hole.
+        if node.child_count() == 0 {
+            let text = self.node_text(node);
+            if let Some(metavar) = self.placeholder_to_metavar.get(text) {
+                return format!("(_) @{}", self.capture_for(metavar));
+            }
+            if node.is_named() {
+                return format!("({})", node.kind());
+            }
+            return quote_literal(text);
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+        let mut cursor = node.walk();
+        for (i, child) in node.children(&mut cursor).enumerate() {
+            let sub = self.build(child);
+            // Field names only attach to named children; an anonymous token
+            // in a field slot is matched positionally as a literal, which
+            // tree-sitter accepts where `field: "literal"` may not.
+            match node.field_name_for_child(i as u32) {
+                Some(field) if child.is_named() => parts.push(format!("{field}: {sub}")),
+                _ => parts.push(sub),
+            }
+        }
+        format!("({} {})", node.kind(), parts.join(" "))
+    }
+
+    /// Mint the capture name for this occurrence of `metavar`. The first
+    /// occurrence is `@NAME`; later ones are `@NAME.k` plus an `(#eq? …)`
+    /// predicate tying them to the first (metavar unification).
+    fn capture_for(&mut self, metavar: &str) -> String {
+        let count = self.occurrences.entry(metavar.to_string()).or_insert(0);
+        *count += 1;
+        if *count == 1 {
+            metavar.to_string()
+        } else {
+            let helper = format!("{metavar}.{count}");
+            self.eq_predicates
+                .push(format!("(#eq? @{metavar} @{helper})"));
+            helper
+        }
+    }
+
+    fn predicates(&self) -> String {
+        self.eq_predicates.join(" ")
+    }
+
+    fn node_text(&self, node: Node<'_>) -> &'a str {
+        std::str::from_utf8(&self.src[node.start_byte()..node.end_byte()]).unwrap_or_default()
+    }
+}
+
+/// Quote an anonymous token as a tree-sitter query literal, escaping `"`
+/// and `\`.
+fn quote_literal(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for ch in text.chars() {
+        if ch == '"' || ch == '\\' {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streaming_iterator::StreamingIterator;
+    use tree_sitter::{Query, QueryCursor};
+
+    /// Compile `snippet`, run the query against `code`, and return the
+    /// captured text for each requested metavar from the first match.
+    fn run(snippet: &str, language: Language, code: &str) -> Vec<(String, Vec<String>)> {
+        let compiled = compile_pattern(snippet, language).expect("compiles");
+        let ts_language = language.ts_language().expect("grammar");
+        let query = Query::new(&ts_language, &compiled.query)
+            .unwrap_or_else(|e| panic!("query rejected: {e}\nquery: {}", compiled.query));
+        let tree = api::parse_tree(code, language).expect("parse code");
+        let names: Vec<&str> = query.capture_names().to_vec();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), code.as_bytes());
+        let mut out = Vec::new();
+        while let Some(m) = matches.next() {
+            let mut per_capture: HashMap<String, Vec<String>> = HashMap::new();
+            for cap in m.captures {
+                let name = names[cap.index as usize].to_string();
+                let text = code[cap.node.start_byte()..cap.node.end_byte()].to_string();
+                per_capture.entry(name).or_default().push(text);
+            }
+            for (name, texts) in per_capture {
+                out.push((name, texts));
+            }
+        }
+        out
+    }
+
+    fn capture<'a>(binds: &'a [(String, Vec<String>)], name: &str) -> &'a [String] {
+        binds
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    #[test]
+    fn compiles_destructuring_default_in_typescript() {
+        // The #2824 / burin-code#1629 codemod shape.
+        let snippet = "$SRC?.$KEY ?? $DEFAULT";
+        let compiled = compile_pattern(snippet, Language::TypeScript).expect("compiles");
+        assert_eq!(compiled.metavars, vec!["SRC", "KEY", "DEFAULT"]);
+        // It captures the optional-chain object/property and the fallback.
+        let binds = run(
+            snippet,
+            Language::TypeScript,
+            "const a = cfg?.timeout ?? 30;",
+        );
+        assert_eq!(capture(&binds, "SRC"), ["cfg".to_string()]);
+        assert_eq!(capture(&binds, "KEY"), ["timeout".to_string()]);
+        assert_eq!(capture(&binds, "DEFAULT"), ["30".to_string()]);
+    }
+
+    #[test]
+    fn operator_is_constrained_not_just_structure() {
+        // The `??` literal in the query must reject a `||` with the same
+        // structural shape — otherwise the codemod would be unsound.
+        let snippet = "$SRC?.$KEY ?? $DEFAULT";
+        let binds = run(
+            snippet,
+            Language::TypeScript,
+            "const a = cfg?.timeout || 30;",
+        );
+        assert!(
+            capture(&binds, "SRC").is_empty(),
+            "|| must not match the ?? pattern"
+        );
+    }
+
+    #[test]
+    fn round_trips_the_assignment_form() {
+        // The literal acceptance pattern: `$NAME = $SRC?.$KEY ?? $DEFAULT`.
+        let snippet = "$NAME = $SRC?.$KEY ?? $DEFAULT";
+        let compiled = compile_pattern(snippet, Language::TypeScript).expect("compiles");
+        assert_eq!(compiled.metavars, vec!["NAME", "SRC", "KEY", "DEFAULT"]);
+        let binds = run(
+            snippet,
+            Language::TypeScript,
+            "x = src?.userId ?? fallback;",
+        );
+        assert_eq!(capture(&binds, "NAME"), ["x".to_string()]);
+        assert_eq!(capture(&binds, "SRC"), ["src".to_string()]);
+        assert_eq!(capture(&binds, "KEY"), ["userId".to_string()]);
+        assert_eq!(capture(&binds, "DEFAULT"), ["fallback".to_string()]);
+    }
+
+    #[test]
+    fn lifts_metavars_in_rust() {
+        let snippet = "let $NAME = $VALUE;";
+        let binds = run(snippet, Language::Rust, "fn f() { let total = compute(); }");
+        assert_eq!(capture(&binds, "NAME"), ["total".to_string()]);
+        assert_eq!(capture(&binds, "VALUE"), ["compute()".to_string()]);
+    }
+
+    #[test]
+    fn lifts_metavars_in_python() {
+        let snippet = "$FN($ARG)";
+        let binds = run(snippet, Language::Python, "print(value)");
+        assert_eq!(capture(&binds, "FN"), ["print".to_string()]);
+        assert_eq!(capture(&binds, "ARG"), ["value".to_string()]);
+    }
+
+    #[test]
+    fn lifts_metavars_in_go() {
+        let snippet = "$FN($ARG)";
+        let binds = run(snippet, Language::Go, "package main\nfunc m() { log(err) }");
+        assert_eq!(capture(&binds, "FN"), ["log".to_string()]);
+        assert_eq!(capture(&binds, "ARG"), ["err".to_string()]);
+    }
+
+    #[test]
+    fn repeated_metavar_unifies() {
+        // `$X + $X` must match `a + a` but not `a + b`.
+        let snippet = "$X + $X";
+        let same = run(snippet, Language::Rust, "fn f() { let _ = a + a; }");
+        assert_eq!(capture(&same, "X"), ["a".to_string()]);
+        let different = run(snippet, Language::Rust, "fn f() { let _ = a + b; }");
+        assert!(
+            capture(&different, "X").is_empty(),
+            "unification must reject `a + b`"
+        );
+    }
+
+    #[test]
+    fn rejects_unparseable_snippet() {
+        let err = compile_pattern("$A ?? ?? $B", Language::TypeScript).unwrap_err();
+        assert!(err.contains("did not parse"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_variadic_for_now() {
+        let err = compile_pattern("foo($$$ARGS)", Language::TypeScript).unwrap_err();
+        assert!(err.contains("variadic"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_pattern_without_metavars() {
+        let err = compile_pattern("foo()", Language::TypeScript).unwrap_err();
+        assert!(err.contains("no `$VAR`"), "got: {err}");
+    }
+}

--- a/crates/harn-rules/tests/atomic_roundtrip.rs
+++ b/crates/harn-rules/tests/atomic_roundtrip.rs
@@ -1,0 +1,55 @@
+//! End-to-end atomic-tier acceptance for #2832: load a rule from a TOML
+//! file, compile its `pattern` snippet into a tree-sitter query, and run it
+//! to produce matches with metavariable bindings — the same path
+//! `ast.search` (#2830) takes, but driven by a declarative rule.
+
+use std::path::PathBuf;
+
+use harn_rules::{load_rule_file, CompiledRule, RuleKind};
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+#[test]
+fn destructuring_rule_round_trips_to_matches() {
+    // 1) Load the declarative rule (the #2824 / burin-code#1629 customer).
+    let rule = load_rule_file(fixture("destructure_default.toml")).expect("rule loads");
+    assert_eq!(rule.id, "destructure-with-defaults");
+    // `fix` present -> codemod.
+    assert_eq!(rule.kind(), RuleKind::Codemod);
+
+    // 2) Compile the `$SRC?.$KEY ?? $DEFAULT` snippet into a query.
+    let compiled = CompiledRule::compile(&rule).expect("rule compiles");
+
+    // 3) Run it over a fixture and read every capture by name.
+    let source = "const a = cfg?.timeout ?? 30;\nconst b = opts?.retries ?? 3;\n";
+    let matches = compiled.run(source).expect("runs");
+    assert_eq!(matches.len(), 2);
+
+    assert_eq!(matches[0].bindings["SRC"].text, "cfg");
+    assert_eq!(matches[0].bindings["KEY"].text, "timeout");
+    assert_eq!(matches[0].bindings["DEFAULT"].text, "30");
+    assert_eq!(matches[0].text, "cfg?.timeout ?? 30");
+
+    assert_eq!(matches[1].bindings["SRC"].text, "opts");
+    assert_eq!(matches[1].bindings["KEY"].text, "retries");
+    assert_eq!(matches[1].bindings["DEFAULT"].text, "3");
+
+    // The bound metavars carry the spans the #2834 `fix` interpolation will
+    // splice from — `{ $KEY: $SRC }` reads `KEY`/`SRC` here.
+    assert_eq!(matches[0].bindings["KEY"].span.start_row, 0);
+    assert_eq!(matches[1].bindings["KEY"].span.start_row, 1);
+}
+
+#[test]
+fn the_pattern_is_operator_precise() {
+    // The compiled query constrains the `??` operator, so the structurally
+    // identical `||` form is left alone — the codemod stays sound.
+    let rule = load_rule_file(fixture("destructure_default.toml")).unwrap();
+    let compiled = CompiledRule::compile(&rule).unwrap();
+    let matches = compiled.run("const a = cfg?.timeout || 30;\n").unwrap();
+    assert!(matches.is_empty(), "`||` must not match the `??` rule");
+}

--- a/crates/harn-rules/tests/fixtures/destructure_default.toml
+++ b/crates/harn-rules/tests/fixtures/destructure_default.toml
@@ -1,0 +1,12 @@
+# The first Rule Engine customer (#2824 / burin-labs/burin-code#1629):
+# find every `src?.key ?? default` shape so the codemod can fold it into a
+# destructuring bind. `fix` makes this a codemod; `transform` + interpolation
+# of the bound metavars into the replacement land in #2834.
+id = "destructure-with-defaults"
+language = "typescript"
+severity = "warning"
+message = "Collapse `?.x ?? default` into a destructuring bind with a default"
+fix = "{ $KEY: $SRC }"
+
+[rule]
+pattern = "$SRC?.$KEY ?? $DEFAULT"


### PR DESCRIPTION
## Summary

Stands up the **`crates/harn-rules`** crate — the declarative structural rule engine core for the [Rule Engine program](https://github.com/burin-labs/harn/issues/2826) (Epic A, [harn#2827](https://github.com/burin-labs/harn/issues/2827)). This PR delivers the **atomic matching tier**.

A **rule** says *what to match* and optionally *how to rewrite* it; the engine compiles it against the existing `harn-hostlib` tree-sitter machinery and produces matches with metavariable bindings — the structural complement to regex/glob search.

## What's in it

- **`model`** — serde rule model: `id` / `language` / `severity` / `message` / `rule` block / `fix`. Rule kind (search | lint | codemod) is derived from shape (presence of `fix` / `message`), not declared.
- **`pattern`** — the snippet → tree-sitter-query compiler. Each `$VAR` metavariable becomes a `(_) @VAR` capture; operators and keywords are matched literally (so `??` ≠ `||` — codemods stay sound); repeated metavars **unify** via `#eq?`; fragment snippets (`a + a`, `foo(bar)`) parse in per-language wrapper contexts and are located by byte range.
- **`engine`** — compile a `Rule` and run it: `pattern` and `kind` go through tree-sitter, `regex` over source text. Yields `RuleMatch`es with named metavar `Binding`s (text + span).
- **`loader`** — load a rule from a TOML file or a directory of them.

## Acceptance ([#2832](https://github.com/burin-labs/harn/issues/2832))

- ✅ Parse + compile an atomic rule and run it through the `ast.search` machinery to produce matches.
- ✅ The destructuring pattern `$SRC?.$KEY ?? $DEFAULT` (the #2824 / burin-code#1629 customer) round-trips into a query that matches the fixture — see `tests/atomic_roundtrip.rs`.
- ✅ Snippet→query lifting tested across **4 grammars** (TypeScript, Python, Rust, Go).

24 unit tests + 2 integration tests + 1 doctest; clippy + fmt clean. New crate triggers no demo-gate (no `pub const BUILTIN_*` / stdlib registration).

Variadic `$$$` holes and relational/composite tiers land in #2833; `where` / `transform` / `fix` interpolation in #2834.

Closes #2832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
