### PR TITLE
harn-rules: where + transform + fix (#2834)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-rules"
+version = "0.8.60"
+dependencies = [
+ "harn-hostlib",
+ "regex",
+ "serde",
+ "serde_json",
+ "streaming-iterator",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml",
+ "tree-sitter",
+]
+
+[[package]]
 name = "harn-serve"
 version = "0.8.60"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/harn-fmt",
     "crates/harn-lint",
     "crates/harn-hostlib",
+    "crates/harn-rules",
     "crates/harn-mcp-rc-compat",
     "perf/llm",
     "perf/vm",

--- a/changelog.d/2832.added.md
+++ b/changelog.d/2832.added.md
@@ -1,0 +1,5 @@
+- Added the `harn-rules` crate — the declarative structural rule engine core (Rule Engine Epic A). It ships the
+  atomic matching tier: a serde rule model (`id` / `language` / `severity` / `message` / `rule` block / `fix`), a
+  pattern compiler that lifts `$VAR` metavariable snippets into tree-sitter queries (operator-precise, with repeated
+  metavars unifying), `kind` and `regex` matchers, and a TOML rule-file / directory loader. Rules run through the same
+  tree-sitter machinery as `ast.search`, producing matches with metavariable bindings.

--- a/changelog.d/2833.added.md
+++ b/changelog.d/2833.added.md
@@ -1,0 +1,6 @@
+- `harn-rules`: added the relational + composite matching algebra (Rule Engine Epic A). A rule's `[rule]` block is now
+  a recursive node that combines an atomic leaf (`pattern` / `kind` / `regex`) with relational constraints (`inside`,
+  `has`, `follows`, `precedes` — each tuned by `stopBy` and `field`) and composite combinators (`all`, `any`, `not`,
+  and `matches` referencing a `[utils]` utility rule); every key is ANDed. A tree-walking evaluator threads metavar
+  bindings through the relational context. Metavar-free patterns are now valid literal patterns (`foo()` matches calls
+  to `foo`).

--- a/changelog.d/2834.added.md
+++ b/changelog.d/2834.added.md
@@ -1,0 +1,5 @@
+- `harn-rules`: added the predicate + rewrite layer (Rule Engine Epic A). Rules can now narrow matches with `where`
+  constraints (metavar regex, numeric/string comparison, and recursive sub-pattern), synthesize new metavars with a
+  `transform` pipeline (regex `replace`, `substring`, and case `convert`), and rewrite with a `fix` template that
+  interpolates `$VAR` / `${VAR}` from captured and transformed metavars. `CompiledRule::apply` runs a codemod —
+  filtering by constraints and splicing per-match fixes format-preservingly, the same byte-splice as `ast.batch_apply`.

--- a/crates/harn-rules/Cargo.toml
+++ b/crates/harn-rules/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "harn-rules"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Declarative structural rule engine for Harn — rule model, pattern compiler, and matcher built on the harn-hostlib tree-sitter machinery."
+
+[dependencies]
+harn-hostlib = { path = "../harn-hostlib", default-features = false, features = ["ast"] }
+tree-sitter = "0.26"
+streaming-iterator = "0.1"
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+toml = "1.1"
+thiserror = "2"
+
+[dev-dependencies]
+serde_json = "1"
+streaming-iterator = "0.1"
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/harn-rules/Cargo.toml
+++ b/crates/harn-rules/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 description = "Declarative structural rule engine for Harn — rule model, pattern compiler, and matcher built on the harn-hostlib tree-sitter machinery."
 
 [dependencies]
-harn-hostlib = { path = "../harn-hostlib", default-features = false, features = ["ast"] }
+harn-hostlib = { path = "../harn-hostlib", version = "0.8", default-features = false, features = ["ast"] }
 tree-sitter = "0.26"
 streaming-iterator = "0.1"
 regex = "1"

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -11,11 +11,12 @@ and produces matches with metavariable bindings — the structural complement
 to regex/glob search.
 
 This crate ships the **atomic matching tier**
-([harn#2832](https://github.com/burin-labs/harn/issues/2832)) plus the
+([harn#2832](https://github.com/burin-labs/harn/issues/2832)), the
+**relational + composite algebra**
+([harn#2833](https://github.com/burin-labs/harn/issues/2833)), and the
 **predicate + rewrite layer**
-([harn#2834](https://github.com/burin-labs/harn/issues/2834)). Relational /
-composite matching (#2833) and the whole-project scan lifecycle (#2836)
-build on it.
+([harn#2834](https://github.com/burin-labs/harn/issues/2834)). The
+whole-project scan lifecycle (#2836) builds on it.
 
 ## Rule shape (TOML)
 
@@ -45,6 +46,33 @@ A rule's kind is derived from its shape: a `fix` makes it a **codemod**; a
   land with the relational tier (#2833).
 - `kind` — a bare tree-sitter node kind (e.g. `"call_expression"`).
 - `regex` — a regular expression over the source text.
+
+A metavar-free `pattern` is a **literal** pattern: `foo()` matches calls to
+`foo` specifically (every non-metavar identifier/literal is constrained to
+its exact text).
+
+### Relational + composite algebra
+
+Beyond the atomic leaf, a rule node can add relational and composite keys —
+all ANDed. A node matches iff its atomic part matches *and* every other key
+holds:
+
+```toml
+[rule]
+pattern = "let $NAME = $SRC?.$KEY ?? $DEF"
+[rule.inside]                  # ancestor must match this sub-rule
+kind = "statement_block"
+stopBy = "end"                 # neighbor (default) | end | <rule>
+[rule.not.inside]              # composite `not` of a relational `inside`
+kind = "try_statement"
+stopBy = "end"
+```
+
+- **Relational**: `inside` (ancestor), `has` (descendant), `follows` /
+  `precedes` (siblings), each a sub-rule tuned by `stopBy` and `field`
+  (restrict to a tree-sitter field).
+- **Composite**: `all` / `any` (lists of sub-rules), `not` (a sub-rule),
+  and `matches` (reference a `[utils.NAME]` utility rule by id).
 
 ### `where` constraints, `transform`, and `fix`
 

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -1,0 +1,62 @@
+# harn-rules
+
+The declarative structural rule engine for Harn — the Rust core behind
+`harn rules` / lint / codemod surfaces. Part of the
+[Rule Engine program](https://github.com/burin-labs/harn/issues/2826)
+(Epic A, [harn#2827](https://github.com/burin-labs/harn/issues/2827)).
+
+A **rule** says *what to match* and optionally *how to rewrite* it. The
+engine compiles the rule against the tree-sitter machinery in `harn-hostlib`
+and produces matches with metavariable bindings — the structural complement
+to regex/glob search.
+
+This crate ships the **atomic matching tier**
+([harn#2832](https://github.com/burin-labs/harn/issues/2832)). Relational /
+composite matching (#2833) and `where` / `transform` / `fix` interpolation
+(#2834) build on it.
+
+## Rule shape (TOML)
+
+```toml
+id = "destructure-with-defaults"
+language = "typescript"
+severity = "warning"                 # info | warning (default) | error
+message = "Collapse `?.x ?? default`"
+fix = "{ $KEY: $SRC }"               # presence makes the rule a codemod
+
+[rule]                               # the matcher block — keep it LAST
+pattern = "$SRC?.$KEY ?? $DEFAULT"   # one of: pattern | kind | regex
+```
+
+> **Key ordering:** because `[rule]` opens a TOML table, every scalar field
+> (`id`, `language`, `severity`, `message`, `fix`) must appear **before** it.
+
+A rule's kind is derived from its shape: a `fix` makes it a **codemod**; a
+`message` with no `fix` makes it a **lint**; a bare matcher is a **search**.
+
+### Atomic matcher forms
+
+- `pattern` — a code snippet in the target grammar with `$VAR` metavariable
+  holes. Compiled to a tree-sitter query: each `$VAR` becomes a capture, the
+  snippet's operators/keywords are matched literally (so `??` ≠ `||`), and a
+  repeated `$VAR` unifies (must bind identical text). Variadic `$$$` holes
+  land with the relational tier (#2833).
+- `kind` — a bare tree-sitter node kind (e.g. `"call_expression"`).
+- `regex` — a regular expression over the source text.
+
+## Usage
+
+```rust
+use harn_rules::{Rule, CompiledRule};
+
+let rule = Rule::from_toml_str(/* … */)?;
+let compiled = CompiledRule::compile(&rule)?;
+for m in compiled.run(source)? {
+    println!("{} at {:?}: {}", m.rule_id, m.span, m.text);
+    for (name, binding) in &m.bindings {
+        println!("  ${name} = {}", binding.text);
+    }
+}
+```
+
+Load from disk with `load_rule_file(path)` or `load_rule_dir(dir)`.

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -11,9 +11,11 @@ and produces matches with metavariable bindings — the structural complement
 to regex/glob search.
 
 This crate ships the **atomic matching tier**
-([harn#2832](https://github.com/burin-labs/harn/issues/2832)). Relational /
-composite matching (#2833) and `where` / `transform` / `fix` interpolation
-(#2834) build on it.
+([harn#2832](https://github.com/burin-labs/harn/issues/2832)) plus the
+**predicate + rewrite layer**
+([harn#2834](https://github.com/burin-labs/harn/issues/2834)). Relational /
+composite matching (#2833) and the whole-project scan lifecycle (#2836)
+build on it.
 
 ## Rule shape (TOML)
 
@@ -43,6 +45,35 @@ A rule's kind is derived from its shape: a `fix` makes it a **codemod**; a
   land with the relational tier (#2833).
 - `kind` — a bare tree-sitter node kind (e.g. `"call_expression"`).
 - `regex` — a regular expression over the source text.
+
+### `where` constraints, `transform`, and `fix`
+
+A rule can narrow matches with `where` predicates, synthesize new metavars
+with `transform`, and rewrite with `fix`:
+
+```toml
+id = "snakeify-getters"
+language = "typescript"
+fix = "$SNAKE()"                     # interpolates $VAR / ${VAR} (and $$ -> $)
+
+[rule]
+pattern = "$FN()"
+
+[[where]]                            # keep only matches that pass every predicate
+metavar = "FN"
+regex = "^get[A-Z]"                  # or: comparison = { op = ">", value = 100 }
+                                     # or: pattern = "..."  (recursive sub-pattern)
+
+[transform.SNAKE]                    # derive a new metavar before fixing
+source = "FN"
+convert = "snake"                    # or: replace = { regex, by } / substring = { start, end }
+```
+
+`CompiledRule::apply(source)` runs the rule, drops matches that fail any
+constraint, interpolates each match's `fix` (from its captured + transformed
+metavars), and splices the replacements in — format-preserving, the same
+byte-splice guarantee as `ast.batch_apply`. It returns the rewritten source
+plus the per-match edits; the caller decides whether to write.
 
 ## Usage
 

--- a/crates/harn-rules/src/constraint.rs
+++ b/crates/harn-rules/src/constraint.rs
@@ -1,0 +1,256 @@
+//! `where` constraints: predicates on captured metavars (Semgrep
+//! `metavariable-regex` / `metavariable-comparison` / `metavariable-pattern`).
+//!
+//! A match survives only when every constraint holds. Constraints are
+//! compiled once (regex compiled, sub-pattern lowered to a tree-sitter
+//! query) and evaluated against each match's metavar bindings.
+
+use regex::Regex;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Query, QueryCursor};
+
+use harn_hostlib::ast::{api, Language};
+
+use crate::error::RulesError;
+use crate::model::Constraint;
+use crate::pattern::compile_pattern;
+
+/// A compiled `where` constraint bound to one metavar.
+pub struct CompiledConstraint {
+    /// The metavar this constraint filters on (without `$`).
+    pub metavar: String,
+    kind: Kind,
+}
+
+enum Kind {
+    Regex(Regex),
+    Comparison { op: CmpOp, value: toml::Value },
+    SubPattern { language: Language, query: Query },
+}
+
+#[derive(Clone, Copy)]
+enum CmpOp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+impl CmpOp {
+    fn parse(op: &str) -> Option<Self> {
+        Some(match op {
+            "<" => CmpOp::Lt,
+            "<=" => CmpOp::Le,
+            ">" => CmpOp::Gt,
+            ">=" => CmpOp::Ge,
+            "==" => CmpOp::Eq,
+            "!=" => CmpOp::Ne,
+            _ => return None,
+        })
+    }
+}
+
+impl CompiledConstraint {
+    /// Compile a constraint. `default_language` is the rule's language,
+    /// used for a sub-pattern that does not name its own.
+    pub fn compile(
+        rule_id: &str,
+        default_language: Language,
+        constraint: &Constraint,
+    ) -> Result<Self, RulesError> {
+        let err = |message: String| RulesError::PatternCompile {
+            rule: rule_id.to_string(),
+            message,
+        };
+
+        let set = [
+            constraint.regex.is_some(),
+            constraint.comparison.is_some(),
+            constraint.pattern.is_some(),
+        ]
+        .into_iter()
+        .filter(|b| *b)
+        .count();
+        if set != 1 {
+            return Err(err(format!(
+                "where-constraint on `{}` must set exactly one of `regex` / `comparison` / `pattern`",
+                constraint.metavar
+            )));
+        }
+
+        let kind = if let Some(re) = &constraint.regex {
+            Kind::Regex(
+                Regex::new(re)
+                    .map_err(|e| err(format!("constraint regex `{re}` is invalid: {e}")))?,
+            )
+        } else if let Some(cmp) = &constraint.comparison {
+            let op = CmpOp::parse(&cmp.op)
+                .ok_or_else(|| err(format!("unknown comparison operator `{}`", cmp.op)))?;
+            Kind::Comparison {
+                op,
+                value: cmp.value.clone(),
+            }
+        } else {
+            let snippet = constraint.pattern.as_ref().unwrap();
+            let language = match &constraint.language {
+                Some(name) => Language::from_name(name)
+                    .ok_or_else(|| err(format!("unknown sub-pattern language `{name}`")))?,
+                None => default_language,
+            };
+            let ts_language = language
+                .ts_language()
+                .ok_or_else(|| err(format!("grammar for `{}` is unavailable", language.name())))?;
+            let compiled = compile_pattern(snippet, language)
+                .map_err(|m| err(format!("sub-pattern on `{}`: {m}", constraint.metavar)))?;
+            let query = Query::new(&ts_language, &compiled.query)
+                .map_err(|e| err(format!("sub-pattern query rejected: {e}")))?;
+            Kind::SubPattern { language, query }
+        };
+
+        Ok(CompiledConstraint {
+            metavar: constraint.metavar.clone(),
+            kind,
+        })
+    }
+
+    /// Evaluate the constraint against a metavar's captured `text`.
+    pub fn evaluate(&self, text: &str) -> bool {
+        match &self.kind {
+            Kind::Regex(re) => re.is_match(text),
+            Kind::Comparison { op, value } => evaluate_comparison(*op, text, value),
+            Kind::SubPattern { language, query } => {
+                let Ok(tree) = api::parse_tree(text, *language) else {
+                    return false;
+                };
+                let mut cursor = QueryCursor::new();
+                let mut it = cursor.matches(query, tree.root_node(), text.as_bytes());
+                it.next().is_some()
+            }
+        }
+    }
+}
+
+fn evaluate_comparison(op: CmpOp, text: &str, value: &toml::Value) -> bool {
+    // Numeric comparison when the RHS is a number and the captured text
+    // parses as one; otherwise fall back to string equality for `==` / `!=`.
+    if let Some(rhs) = value
+        .as_float()
+        .or_else(|| value.as_integer().map(|i| i as f64))
+    {
+        if let Ok(lhs) = text.trim().parse::<f64>() {
+            return match op {
+                CmpOp::Lt => lhs < rhs,
+                CmpOp::Le => lhs <= rhs,
+                CmpOp::Gt => lhs > rhs,
+                CmpOp::Ge => lhs >= rhs,
+                CmpOp::Eq => (lhs - rhs).abs() < f64::EPSILON,
+                CmpOp::Ne => (lhs - rhs).abs() >= f64::EPSILON,
+            };
+        }
+        // RHS numeric but LHS not a number: only `!=` can be satisfied.
+        return matches!(op, CmpOp::Ne);
+    }
+
+    let rhs = match value {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Boolean(b) => b.to_string(),
+        other => other.to_string(),
+    };
+    match op {
+        CmpOp::Eq => text == rhs,
+        CmpOp::Ne => text != rhs,
+        // Ordering on non-numbers falls back to lexicographic compare.
+        CmpOp::Lt => text < rhs.as_str(),
+        CmpOp::Le => text <= rhs.as_str(),
+        CmpOp::Gt => text > rhs.as_str(),
+        CmpOp::Ge => text >= rhs.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Comparison;
+
+    fn regex_constraint(metavar: &str, re: &str) -> CompiledConstraint {
+        let c = Constraint {
+            metavar: metavar.into(),
+            regex: Some(re.into()),
+            comparison: None,
+            pattern: None,
+            language: None,
+        };
+        CompiledConstraint::compile("r", Language::Rust, &c).unwrap()
+    }
+
+    #[test]
+    fn regex_constraint_matches() {
+        let c = regex_constraint("KEY", "^[a-z][a-zA-Z]*$");
+        assert!(c.evaluate("userId"));
+        assert!(!c.evaluate("0bad"));
+    }
+
+    #[test]
+    fn numeric_comparison() {
+        let c = Constraint {
+            metavar: "N".into(),
+            regex: None,
+            comparison: Some(Comparison {
+                op: ">".into(),
+                value: toml::Value::Integer(0),
+            }),
+            pattern: None,
+            language: None,
+        };
+        let c = CompiledConstraint::compile("r", Language::Rust, &c).unwrap();
+        assert!(c.evaluate("5"));
+        assert!(!c.evaluate("0"));
+        assert!(!c.evaluate("-3"));
+    }
+
+    #[test]
+    fn string_equality_comparison() {
+        let c = Constraint {
+            metavar: "S".into(),
+            regex: None,
+            comparison: Some(Comparison {
+                op: "!=".into(),
+                value: toml::Value::String("nil".into()),
+            }),
+            pattern: None,
+            language: None,
+        };
+        let c = CompiledConstraint::compile("r", Language::Rust, &c).unwrap();
+        assert!(c.evaluate("something"));
+        assert!(!c.evaluate("nil"));
+    }
+
+    #[test]
+    fn sub_pattern_constraint() {
+        // The captured metavar text must itself be a call expression.
+        let c = Constraint {
+            metavar: "VALUE".into(),
+            regex: None,
+            comparison: None,
+            pattern: Some("$FN($ARG)".into()),
+            language: Some("typescript".into()),
+        };
+        let c = CompiledConstraint::compile("r", Language::TypeScript, &c).unwrap();
+        assert!(c.evaluate("compute(x)"));
+        assert!(!c.evaluate("42"));
+    }
+
+    #[test]
+    fn rejects_zero_or_multiple_kinds() {
+        let none = Constraint {
+            metavar: "X".into(),
+            regex: None,
+            comparison: None,
+            pattern: None,
+            language: None,
+        };
+        assert!(CompiledConstraint::compile("r", Language::Rust, &none).is_err());
+    }
+}

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -14,9 +14,12 @@ use harn_hostlib::ast::{api, Language};
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Query, QueryCursor};
 
+use crate::constraint::CompiledConstraint;
 use crate::error::RulesError;
+use crate::fix::{interpolate, splice, AppliedEdit};
 use crate::model::{AtomicMatcher, Rule};
 use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+use crate::transform::CompiledTransform;
 
 /// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
 /// Harn AST wire format.
@@ -74,11 +77,28 @@ pub struct RuleMatch {
     pub bindings: BTreeMap<String, Binding>,
 }
 
+/// The result of applying a codemod rule's `fix` to a source string.
+#[derive(Debug, Clone)]
+pub struct CodemodResult {
+    /// The rewritten source (equals the input when nothing matched).
+    pub rewritten: String,
+    /// The per-match edits that were spliced in, in document order.
+    pub edits: Vec<AppliedEdit>,
+    /// Whether the rewrite changed the source.
+    pub changed: bool,
+}
+
 /// A rule whose matcher has been compiled and is ready to run.
 pub struct CompiledRule {
     rule_id: String,
     language: Language,
     matcher: CompiledMatcher,
+    /// `where` predicates; a match survives only when all hold.
+    constraints: Vec<CompiledConstraint>,
+    /// `transform` definitions: (new metavar name, compiled transform).
+    transforms: Vec<(String, CompiledTransform)>,
+    /// The `fix` replacement template, if this is a codemod.
+    fix: Option<String>,
 }
 
 enum CompiledMatcher {
@@ -162,10 +182,27 @@ impl CompiledRule {
             }
         };
 
+        let constraints = rule
+            .where_constraints
+            .iter()
+            .map(|c| CompiledConstraint::compile(&rule.id, language, c))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let transforms = rule
+            .transform
+            .iter()
+            .map(|(name, t)| {
+                CompiledTransform::compile(&rule.id, name, t).map(|c| (name.clone(), c))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
         Ok(CompiledRule {
             rule_id: rule.id.clone(),
             language,
             matcher,
+            constraints,
+            transforms,
+            fix: rule.fix.clone(),
         })
     }
 
@@ -175,12 +212,82 @@ impl CompiledRule {
     }
 
     /// Run the compiled rule against `source`, returning matches in
-    /// document order.
+    /// document order. Matches that fail any `where` constraint are dropped.
     pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {
-        match &self.matcher {
-            CompiledMatcher::Query { query, metavars } => self.run_query(query, metavars, source),
-            CompiledMatcher::Regex(regex) => Ok(self.run_regex(regex, source)),
+        let mut matches = match &self.matcher {
+            CompiledMatcher::Query { query, metavars } => {
+                self.run_query(query, metavars, source)?
+            }
+            CompiledMatcher::Regex(regex) => self.run_regex(regex, source),
+        };
+        if !self.constraints.is_empty() {
+            matches.retain(|m| self.satisfies_constraints(m));
         }
+        Ok(matches)
+    }
+
+    /// True when every `where` constraint holds for this match. A
+    /// constraint whose metavar is unbound (not captured) fails closed.
+    fn satisfies_constraints(&self, m: &RuleMatch) -> bool {
+        self.constraints.iter().all(|c| {
+            m.bindings
+                .get(&c.metavar)
+                .is_some_and(|b| c.evaluate(&b.text))
+        })
+    }
+
+    /// Apply this codemod rule's `fix` to `source`, returning the rewritten
+    /// text plus the per-match edits. Each match's `fix` template is
+    /// interpolated from its captured metavars plus any `transform`-derived
+    /// ones. Errors if the rule has no `fix`.
+    pub fn apply(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        let template = self
+            .fix
+            .as_ref()
+            .ok_or_else(|| RulesError::PatternCompile {
+                rule: self.rule_id.clone(),
+                message: "apply() requires a `fix` template; this rule has none".into(),
+            })?;
+
+        let matches = self.run(source)?;
+        let edits: Vec<AppliedEdit> = matches
+            .iter()
+            .map(|m| {
+                let vars = self.metavars_for(m);
+                AppliedEdit {
+                    span: m.span,
+                    before: m.text.clone(),
+                    replacement: interpolate(template, &vars),
+                }
+            })
+            .collect();
+
+        let rewritten = splice(source, &edits);
+        let changed = rewritten != source;
+        Ok(CodemodResult {
+            rewritten,
+            edits,
+            changed,
+        })
+    }
+
+    /// Build the full metavar map for a match: captured bindings plus the
+    /// `transform`-synthesized metavars (which may shadow captures).
+    fn metavars_for(&self, m: &RuleMatch) -> BTreeMap<String, String> {
+        let mut vars: BTreeMap<String, String> = m
+            .bindings
+            .iter()
+            .map(|(name, binding)| (name.clone(), binding.text.clone()))
+            .collect();
+        for (name, transform) in &self.transforms {
+            let input = m
+                .bindings
+                .get(&transform.source)
+                .map(|b| b.text.as_str())
+                .unwrap_or("");
+            vars.insert(name.clone(), transform.apply(input));
+        }
+        vars
     }
 
     fn run_query(

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -10,15 +10,13 @@
 
 use std::collections::BTreeMap;
 
-use harn_hostlib::ast::{api, Language};
-use streaming_iterator::StreamingIterator;
-use tree_sitter::{Query, QueryCursor};
+use harn_hostlib::ast::Language;
 
 use crate::constraint::CompiledConstraint;
 use crate::error::RulesError;
+use crate::evaluator::CompiledRuleTree;
 use crate::fix::{interpolate, splice, AppliedEdit};
-use crate::model::{AtomicMatcher, Rule};
-use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+use crate::model::Rule;
 use crate::transform::CompiledTransform;
 
 /// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
@@ -40,7 +38,7 @@ pub struct Span {
 }
 
 impl Span {
-    fn of(node: tree_sitter::Node<'_>) -> Self {
+    pub(crate) fn of(node: tree_sitter::Node<'_>) -> Self {
         let start = node.start_position();
         let end = node.end_position();
         Span {
@@ -92,7 +90,7 @@ pub struct CodemodResult {
 pub struct CompiledRule {
     rule_id: String,
     language: Language,
-    matcher: CompiledMatcher,
+    execution: Execution,
     /// `where` predicates; a match survives only when all hold.
     constraints: Vec<CompiledConstraint>,
     /// `transform` definitions: (new metavar name, compiled transform).
@@ -101,12 +99,12 @@ pub struct CompiledRule {
     fix: Option<String>,
 }
 
-enum CompiledMatcher {
-    /// A tree-sitter query plus the metavar names to extract. Covers both
-    /// `pattern` and `kind` forms.
-    Query { query: Query, metavars: Vec<String> },
-    /// A text regex over the whole source.
-    Regex(regex::Regex),
+enum Execution {
+    /// A top-level pure-`regex` rule: scan the raw source text (grep-style),
+    /// independent of the tree. Its match span is the regex match range.
+    SourceRegex(regex::Regex),
+    /// The full matching algebra (atomic + relational + composite).
+    Tree(Box<CompiledRuleTree>),
 }
 
 impl CompiledRule {
@@ -118,68 +116,24 @@ impl CompiledRule {
                 language: rule.language.clone(),
             })?;
 
-        let matcher = match rule
-            .rule
-            .resolve()
-            .map_err(|message| RulesError::PatternCompile {
-                rule: rule.id.clone(),
-                message,
-            })? {
-            AtomicMatcher::Pattern(snippet) => {
-                let ts_language =
-                    language
-                        .ts_language()
-                        .ok_or_else(|| RulesError::GrammarUnavailable {
-                            rule: rule.id.clone(),
-                            language: language.name().to_string(),
-                        })?;
-                let compiled = compile_pattern(&snippet, language).map_err(|message| {
-                    RulesError::PatternCompile {
-                        rule: rule.id.clone(),
-                        message,
-                    }
-                })?;
-                let query = Query::new(&ts_language, &compiled.query).map_err(|err| {
-                    RulesError::QueryRejected {
-                        rule: rule.id.clone(),
-                        message: err.to_string(),
-                        query: compiled.query.clone(),
-                    }
-                })?;
-                CompiledMatcher::Query {
-                    query,
-                    metavars: compiled.metavars,
+        // A top-level pure-`regex` rule greps the source text directly; any
+        // other shape (pattern / kind / relational / composite) compiles to
+        // the tree-walking algebra.
+        let execution = if rule.rule.is_pure_regex() {
+            let pattern = rule.rule.regex.as_ref().expect("pure regex");
+            Execution::SourceRegex(regex::Regex::new(pattern).map_err(|err| {
+                RulesError::PatternCompile {
+                    rule: rule.id.clone(),
+                    message: format!("invalid regex `{pattern}`: {err}"),
                 }
-            }
-            AtomicMatcher::Kind(kind) => {
-                let ts_language =
-                    language
-                        .ts_language()
-                        .ok_or_else(|| RulesError::GrammarUnavailable {
-                            rule: rule.id.clone(),
-                            language: language.name().to_string(),
-                        })?;
-                let query_text = format!("({kind}) @{ROOT_CAPTURE}");
-                let query = Query::new(&ts_language, &query_text).map_err(|err| {
-                    RulesError::QueryRejected {
-                        rule: rule.id.clone(),
-                        message: err.to_string(),
-                        query: query_text.clone(),
-                    }
-                })?;
-                CompiledMatcher::Query {
-                    query,
-                    metavars: Vec::new(),
-                }
-            }
-            AtomicMatcher::Regex(pattern) => {
-                let regex =
-                    regex::Regex::new(&pattern).map_err(|err| RulesError::PatternCompile {
-                        rule: rule.id.clone(),
-                        message: format!("invalid regex `{pattern}`: {err}"),
-                    })?;
-                CompiledMatcher::Regex(regex)
-            }
+            })?)
+        } else {
+            Execution::Tree(Box::new(CompiledRuleTree::compile(
+                &rule.id,
+                language,
+                &rule.rule,
+                &rule.utils,
+            )?))
         };
 
         let constraints = rule
@@ -199,7 +153,7 @@ impl CompiledRule {
         Ok(CompiledRule {
             rule_id: rule.id.clone(),
             language,
-            matcher,
+            execution,
             constraints,
             transforms,
             fix: rule.fix.clone(),
@@ -214,11 +168,18 @@ impl CompiledRule {
     /// Run the compiled rule against `source`, returning matches in
     /// document order. Matches that fail any `where` constraint are dropped.
     pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {
-        let mut matches = match &self.matcher {
-            CompiledMatcher::Query { query, metavars } => {
-                self.run_query(query, metavars, source)?
-            }
-            CompiledMatcher::Regex(regex) => self.run_regex(regex, source),
+        let mut matches = match &self.execution {
+            Execution::SourceRegex(regex) => self.run_regex(regex, source),
+            Execution::Tree(tree) => tree
+                .find(&self.rule_id, self.language, source)?
+                .into_iter()
+                .map(|m| RuleMatch {
+                    rule_id: self.rule_id.clone(),
+                    span: m.span,
+                    text: m.text,
+                    bindings: m.bindings,
+                })
+                .collect(),
         };
         if !self.constraints.is_empty() {
             matches.retain(|m| self.satisfies_constraints(m));
@@ -288,57 +249,6 @@ impl CompiledRule {
             vars.insert(name.clone(), transform.apply(input));
         }
         vars
-    }
-
-    fn run_query(
-        &self,
-        query: &Query,
-        metavars: &[String],
-        source: &str,
-    ) -> Result<Vec<RuleMatch>, RulesError> {
-        let tree =
-            api::parse_tree(source, self.language).map_err(|err| RulesError::SourceParse {
-                rule: self.rule_id.clone(),
-                message: err.to_string(),
-            })?;
-        let names: Vec<&str> = query.capture_names().to_vec();
-        let bytes = source.as_bytes();
-
-        let mut cursor = QueryCursor::new();
-        let mut it = cursor.matches(query, tree.root_node(), bytes);
-        let mut matches = Vec::new();
-        while let Some(m) = it.next() {
-            let mut root: Option<Span> = None;
-            let mut root_text = String::new();
-            let mut bindings: BTreeMap<String, Binding> = BTreeMap::new();
-            for cap in m.captures {
-                let name = names[cap.index as usize];
-                let span = Span::of(cap.node);
-                let text = source[cap.node.start_byte()..cap.node.end_byte()].to_string();
-                if name == ROOT_CAPTURE {
-                    root = Some(span);
-                    root_text = text;
-                } else if metavars.iter().any(|m| m == name) {
-                    // Canonical metavar capture; unification helpers carry a
-                    // `.` and never appear in `metavars`, so they are skipped.
-                    bindings
-                        .entry(name.to_string())
-                        .or_insert(Binding { text, span });
-                }
-            }
-            if let Some(span) = root {
-                matches.push(RuleMatch {
-                    rule_id: self.rule_id.clone(),
-                    span,
-                    text: root_text,
-                    bindings,
-                });
-            }
-        }
-        // Tree-sitter yields matches in query-eval order; sort to document
-        // order for a stable, intuitive result.
-        matches.sort_by_key(|m| (m.span.start_byte, m.span.end_byte));
-        Ok(matches)
     }
 
     fn run_regex(&self, regex: &regex::Regex, source: &str) -> Vec<RuleMatch> {

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -1,0 +1,387 @@
+//! Compile a [`Rule`] into a runnable matcher and run it against source.
+//!
+//! The atomic tier supports three matcher forms, all reduced to a single
+//! [`RuleMatch`] stream:
+//!
+//! - `pattern` → compiled to a tree-sitter query via [`crate::pattern`].
+//! - `kind` → the trivial query `(<kind>) @__match`.
+//! - `regex` → a text regex over the source, yielding spans with no AST
+//!   metavar bindings.
+
+use std::collections::BTreeMap;
+
+use harn_hostlib::ast::{api, Language};
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Query, QueryCursor};
+
+use crate::error::RulesError;
+use crate::model::{AtomicMatcher, Rule};
+use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+
+/// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
+/// Harn AST wire format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    /// Start byte offset.
+    pub start_byte: usize,
+    /// End byte offset (exclusive).
+    pub end_byte: usize,
+    /// 0-based start row.
+    pub start_row: usize,
+    /// 0-based start column.
+    pub start_col: usize,
+    /// 0-based end row.
+    pub end_row: usize,
+    /// 0-based end column.
+    pub end_col: usize,
+}
+
+impl Span {
+    fn of(node: tree_sitter::Node<'_>) -> Self {
+        let start = node.start_position();
+        let end = node.end_position();
+        Span {
+            start_byte: node.start_byte(),
+            end_byte: node.end_byte(),
+            start_row: start.row,
+            start_col: start.column,
+            end_row: end.row,
+            end_col: end.column,
+        }
+    }
+}
+
+/// A metavariable binding: the captured text plus where it lives.
+#[derive(Debug, Clone)]
+pub struct Binding {
+    /// The captured source text.
+    pub text: String,
+    /// The captured node's span.
+    pub span: Span,
+}
+
+/// One match of a rule against a file.
+#[derive(Debug, Clone)]
+pub struct RuleMatch {
+    /// The rule that produced this match.
+    pub rule_id: String,
+    /// The whole matched range (the pattern root, or the regex span).
+    pub span: Span,
+    /// The matched source text.
+    pub text: String,
+    /// Metavar bindings, keyed by name (without the leading `$`). Empty for
+    /// `kind` and `regex` matchers.
+    pub bindings: BTreeMap<String, Binding>,
+}
+
+/// A rule whose matcher has been compiled and is ready to run.
+pub struct CompiledRule {
+    rule_id: String,
+    language: Language,
+    matcher: CompiledMatcher,
+}
+
+enum CompiledMatcher {
+    /// A tree-sitter query plus the metavar names to extract. Covers both
+    /// `pattern` and `kind` forms.
+    Query { query: Query, metavars: Vec<String> },
+    /// A text regex over the whole source.
+    Regex(regex::Regex),
+}
+
+impl CompiledRule {
+    /// Resolve the rule's language and grammar, then compile its matcher.
+    pub fn compile(rule: &Rule) -> Result<Self, RulesError> {
+        let language =
+            Language::from_name(&rule.language).ok_or_else(|| RulesError::UnknownLanguage {
+                rule: rule.id.clone(),
+                language: rule.language.clone(),
+            })?;
+
+        let matcher = match rule
+            .rule
+            .resolve()
+            .map_err(|message| RulesError::PatternCompile {
+                rule: rule.id.clone(),
+                message,
+            })? {
+            AtomicMatcher::Pattern(snippet) => {
+                let ts_language =
+                    language
+                        .ts_language()
+                        .ok_or_else(|| RulesError::GrammarUnavailable {
+                            rule: rule.id.clone(),
+                            language: language.name().to_string(),
+                        })?;
+                let compiled = compile_pattern(&snippet, language).map_err(|message| {
+                    RulesError::PatternCompile {
+                        rule: rule.id.clone(),
+                        message,
+                    }
+                })?;
+                let query = Query::new(&ts_language, &compiled.query).map_err(|err| {
+                    RulesError::QueryRejected {
+                        rule: rule.id.clone(),
+                        message: err.to_string(),
+                        query: compiled.query.clone(),
+                    }
+                })?;
+                CompiledMatcher::Query {
+                    query,
+                    metavars: compiled.metavars,
+                }
+            }
+            AtomicMatcher::Kind(kind) => {
+                let ts_language =
+                    language
+                        .ts_language()
+                        .ok_or_else(|| RulesError::GrammarUnavailable {
+                            rule: rule.id.clone(),
+                            language: language.name().to_string(),
+                        })?;
+                let query_text = format!("({kind}) @{ROOT_CAPTURE}");
+                let query = Query::new(&ts_language, &query_text).map_err(|err| {
+                    RulesError::QueryRejected {
+                        rule: rule.id.clone(),
+                        message: err.to_string(),
+                        query: query_text.clone(),
+                    }
+                })?;
+                CompiledMatcher::Query {
+                    query,
+                    metavars: Vec::new(),
+                }
+            }
+            AtomicMatcher::Regex(pattern) => {
+                let regex =
+                    regex::Regex::new(&pattern).map_err(|err| RulesError::PatternCompile {
+                        rule: rule.id.clone(),
+                        message: format!("invalid regex `{pattern}`: {err}"),
+                    })?;
+                CompiledMatcher::Regex(regex)
+            }
+        };
+
+        Ok(CompiledRule {
+            rule_id: rule.id.clone(),
+            language,
+            matcher,
+        })
+    }
+
+    /// The language this rule targets.
+    pub fn language(&self) -> Language {
+        self.language
+    }
+
+    /// Run the compiled rule against `source`, returning matches in
+    /// document order.
+    pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {
+        match &self.matcher {
+            CompiledMatcher::Query { query, metavars } => self.run_query(query, metavars, source),
+            CompiledMatcher::Regex(regex) => Ok(self.run_regex(regex, source)),
+        }
+    }
+
+    fn run_query(
+        &self,
+        query: &Query,
+        metavars: &[String],
+        source: &str,
+    ) -> Result<Vec<RuleMatch>, RulesError> {
+        let tree =
+            api::parse_tree(source, self.language).map_err(|err| RulesError::SourceParse {
+                rule: self.rule_id.clone(),
+                message: err.to_string(),
+            })?;
+        let names: Vec<&str> = query.capture_names().to_vec();
+        let bytes = source.as_bytes();
+
+        let mut cursor = QueryCursor::new();
+        let mut it = cursor.matches(query, tree.root_node(), bytes);
+        let mut matches = Vec::new();
+        while let Some(m) = it.next() {
+            let mut root: Option<Span> = None;
+            let mut root_text = String::new();
+            let mut bindings: BTreeMap<String, Binding> = BTreeMap::new();
+            for cap in m.captures {
+                let name = names[cap.index as usize];
+                let span = Span::of(cap.node);
+                let text = source[cap.node.start_byte()..cap.node.end_byte()].to_string();
+                if name == ROOT_CAPTURE {
+                    root = Some(span);
+                    root_text = text;
+                } else if metavars.iter().any(|m| m == name) {
+                    // Canonical metavar capture; unification helpers carry a
+                    // `.` and never appear in `metavars`, so they are skipped.
+                    bindings
+                        .entry(name.to_string())
+                        .or_insert(Binding { text, span });
+                }
+            }
+            if let Some(span) = root {
+                matches.push(RuleMatch {
+                    rule_id: self.rule_id.clone(),
+                    span,
+                    text: root_text,
+                    bindings,
+                });
+            }
+        }
+        // Tree-sitter yields matches in query-eval order; sort to document
+        // order for a stable, intuitive result.
+        matches.sort_by_key(|m| (m.span.start_byte, m.span.end_byte));
+        Ok(matches)
+    }
+
+    fn run_regex(&self, regex: &regex::Regex, source: &str) -> Vec<RuleMatch> {
+        let mut matches = Vec::new();
+        for m in regex.find_iter(source) {
+            let span = byte_span(source, m.start(), m.end());
+            matches.push(RuleMatch {
+                rule_id: self.rule_id.clone(),
+                span,
+                text: m.as_str().to_string(),
+                bindings: BTreeMap::new(),
+            });
+        }
+        matches
+    }
+}
+
+/// Compute a [`Span`] for a byte range by counting rows/cols. Used by the
+/// regex matcher, which has no tree-sitter node to read positions from.
+fn byte_span(source: &str, start: usize, end: usize) -> Span {
+    let (start_row, start_col) = row_col(source, start);
+    let (end_row, end_col) = row_col(source, end);
+    Span {
+        start_byte: start,
+        end_byte: end,
+        start_row,
+        start_col,
+        end_row,
+        end_col,
+    }
+}
+
+fn row_col(source: &str, byte: usize) -> (usize, usize) {
+    let mut row = 0;
+    let mut col = 0;
+    for (i, ch) in source.char_indices() {
+        if i >= byte {
+            break;
+        }
+        if ch == '\n' {
+            row += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    (row, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Rule;
+
+    fn rule(toml: &str) -> CompiledRule {
+        let parsed = Rule::from_toml_str(toml).expect("rule parses");
+        CompiledRule::compile(&parsed).expect("rule compiles")
+    }
+
+    #[test]
+    fn pattern_rule_binds_metavars() {
+        let compiled = rule(
+            r#"
+            id = "destructure-default"
+            language = "typescript"
+            fix = "{ $KEY: $SRC }"
+            [rule]
+            pattern = "$SRC?.$KEY ?? $DEFAULT"
+            "#,
+        );
+        let matches = compiled
+            .run("const a = cfg?.timeout ?? 30;\nconst b = opts?.retries ?? 3;\n")
+            .unwrap();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].bindings["SRC"].text, "cfg");
+        assert_eq!(matches[0].bindings["KEY"].text, "timeout");
+        assert_eq!(matches[0].bindings["DEFAULT"].text, "30");
+        assert_eq!(matches[1].bindings["SRC"].text, "opts");
+        // The match span covers the whole expression.
+        assert_eq!(matches[0].text, "cfg?.timeout ?? 30");
+        assert_eq!(matches[0].span.start_row, 0);
+        assert_eq!(matches[1].span.start_row, 1);
+    }
+
+    #[test]
+    fn kind_rule_matches_node_kind() {
+        let compiled = rule(
+            r#"
+            id = "find-calls"
+            language = "python"
+            [rule]
+            kind = "call"
+            "#,
+        );
+        let matches = compiled.run("print(x)\nlog(y)\n").unwrap();
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].text, "print(x)");
+        assert!(matches[0].bindings.is_empty());
+    }
+
+    #[test]
+    fn regex_rule_matches_text() {
+        let compiled = rule(
+            r#"
+            id = "todo"
+            language = "rust"
+            message = "Found a TODO"
+            [rule]
+            regex = "TODO\\(\\w+\\)"
+            "#,
+        );
+        let matches = compiled
+            .run("fn f() {\n    // TODO(ken) fix\n    // todo lower\n}\n")
+            .unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].text, "TODO(ken)");
+        assert_eq!(matches[0].span.start_row, 1);
+    }
+
+    #[test]
+    fn unknown_language_is_an_error() {
+        let parsed = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "cobol"
+            [rule]
+            kind = "foo"
+            "#,
+        )
+        .unwrap();
+        assert!(matches!(
+            CompiledRule::compile(&parsed),
+            Err(RulesError::UnknownLanguage { .. })
+        ));
+    }
+
+    #[test]
+    fn invalid_pattern_surfaces_compile_error() {
+        let parsed = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "typescript"
+            [rule]
+            pattern = "foo($$$ARGS)"
+            "#,
+        )
+        .unwrap();
+        assert!(matches!(
+            CompiledRule::compile(&parsed),
+            Err(RulesError::PatternCompile { .. })
+        ));
+    }
+}

--- a/crates/harn-rules/src/error.rs
+++ b/crates/harn-rules/src/error.rs
@@ -1,0 +1,75 @@
+//! Error type for the rule engine.
+
+use thiserror::Error;
+
+/// Anything that can go wrong loading, compiling, or running a rule.
+#[derive(Debug, Error)]
+pub enum RulesError {
+    /// A rule file could not be read.
+    #[error("read rule `{path}`: {source}")]
+    Read {
+        /// The path that failed to read.
+        path: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A rule file could not be parsed as TOML.
+    #[error("parse rule `{path}`: {source}")]
+    Parse {
+        /// The path that failed to parse.
+        path: String,
+        /// The underlying TOML error.
+        source: Box<toml::de::Error>,
+    },
+
+    /// A rule referenced a language the engine does not know.
+    #[error("rule `{rule}`: unknown language `{language}`")]
+    UnknownLanguage {
+        /// The offending rule id.
+        rule: String,
+        /// The language string that did not resolve.
+        language: String,
+    },
+
+    /// A rule's language is known but its grammar was not compiled into
+    /// this build.
+    #[error("rule `{rule}`: grammar for `{language}` is not compiled into this build")]
+    GrammarUnavailable {
+        /// The offending rule id.
+        rule: String,
+        /// The language whose grammar is missing.
+        language: String,
+    },
+
+    /// A `pattern` snippet failed to compile into a tree-sitter query.
+    #[error("rule `{rule}`: {message}")]
+    PatternCompile {
+        /// The offending rule id.
+        rule: String,
+        /// What went wrong compiling the snippet.
+        message: String,
+    },
+
+    /// The compiled query was rejected by tree-sitter. This is an engine
+    /// bug if it happens for a snippet that parsed cleanly, so it carries
+    /// the generated query for debugging.
+    #[error("rule `{rule}`: generated query rejected by tree-sitter: {message}\nquery:\n{query}")]
+    QueryRejected {
+        /// The offending rule id.
+        rule: String,
+        /// The tree-sitter query error.
+        message: String,
+        /// The generated S-expression query.
+        query: String,
+    },
+
+    /// Source text could not be parsed in the rule's grammar.
+    #[error("rule `{rule}`: parse source: {message}")]
+    SourceParse {
+        /// The offending rule id.
+        rule: String,
+        /// The parse failure detail.
+        message: String,
+    },
+}

--- a/crates/harn-rules/src/evaluator.rs
+++ b/crates/harn-rules/src/evaluator.rs
@@ -1,0 +1,458 @@
+//! The relational + composite matching algebra (#2833).
+//!
+//! A [`crate::model::RuleNode`] compiles to a [`CompiledNode`] tree, which
+//! the evaluator walks against a parsed source tree. A node matches a
+//! tree-sitter node iff its **atomic** leaf matches *and* every
+//! **relational** (`inside` / `has` / `follows` / `precedes`) and
+//! **composite** (`all` / `any` / `not` / `matches`) part holds — every set
+//! key is ANDed.
+//!
+//! Candidates for the top rule are seeded cheaply (the atomic pattern query
+//! in one pass, or a kind/regex/whole-tree walk); each candidate is then
+//! checked in full. Relational sub-rules run their own atomic match rooted
+//! at the ancestor/descendant/sibling under test.
+
+use std::collections::BTreeMap;
+
+use harn_hostlib::ast::{api, Language};
+use regex::Regex;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Node, Query, QueryCursor};
+
+use crate::engine::{Binding, Span};
+use crate::error::RulesError;
+use crate::model::{AtomicMatcher, RuleNode, StopBy, StopKeyword};
+use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+
+/// Metavar bindings accumulated while matching a node.
+type Bindings = BTreeMap<String, Binding>;
+
+/// One node that matched the top rule, with its bindings.
+pub struct EvalMatch {
+    /// The matched node's span.
+    pub span: Span,
+    /// The matched node's text.
+    pub text: String,
+    /// Metavar bindings (captured + threaded from relational sub-matches).
+    pub bindings: Bindings,
+}
+
+/// A compiled rule tree: the top node plus the utility rules `matches`
+/// references.
+pub struct CompiledRuleTree {
+    top: CompiledNode,
+    utils: BTreeMap<String, CompiledNode>,
+}
+
+struct CompiledNode {
+    atomic: Option<CompiledAtomic>,
+    inside: Option<Box<CompiledRel>>,
+    has: Option<Box<CompiledRel>>,
+    follows: Option<Box<CompiledRel>>,
+    precedes: Option<Box<CompiledRel>>,
+    all: Vec<CompiledNode>,
+    any: Vec<CompiledNode>,
+    not: Option<Box<CompiledNode>>,
+    matches: Option<String>,
+}
+
+struct CompiledRel {
+    node: CompiledNode,
+    stop_by: CompiledStopBy,
+    field: Option<String>,
+}
+
+enum CompiledStopBy {
+    Neighbor,
+    End,
+    Rule(Box<CompiledNode>),
+}
+
+enum CompiledAtomic {
+    Query { query: Query, metavars: Vec<String> },
+    Kind(String),
+    Regex(Regex),
+}
+
+impl CompiledRuleTree {
+    /// Compile a rule's `[rule]` node and its `[utils]` into a runnable
+    /// tree.
+    pub fn compile(
+        rule_id: &str,
+        language: Language,
+        top: &RuleNode,
+        utils: &BTreeMap<String, RuleNode>,
+    ) -> Result<Self, RulesError> {
+        if top.is_empty() {
+            return Err(RulesError::PatternCompile {
+                rule: rule_id.to_string(),
+                message: "rule node is empty (no atomic / relational / composite key)".into(),
+            });
+        }
+        let compiled_utils = utils
+            .iter()
+            .map(|(id, node)| Ok((id.clone(), compile_node(rule_id, language, node)?)))
+            .collect::<Result<BTreeMap<_, _>, RulesError>>()?;
+        Ok(CompiledRuleTree {
+            top: compile_node(rule_id, language, top)?,
+            utils: compiled_utils,
+        })
+    }
+
+    /// Find every node matching the top rule, in document order.
+    pub fn find(
+        &self,
+        rule_id: &str,
+        language: Language,
+        source: &str,
+    ) -> Result<Vec<EvalMatch>, RulesError> {
+        let tree = api::parse_tree(source, language).map_err(|err| RulesError::SourceParse {
+            rule: rule_id.to_string(),
+            message: err.to_string(),
+        })?;
+        let ctx = Ctx {
+            source,
+            utils: &self.utils,
+        };
+        let root = tree.root_node();
+
+        let mut seen: BTreeMap<(usize, usize), EvalMatch> = BTreeMap::new();
+        for node in seed_candidates(&self.top, &ctx, root) {
+            if let Some(bindings) = node_satisfies(&self.top, node, &ctx) {
+                let key = (node.start_byte(), node.end_byte());
+                seen.entry(key).or_insert_with(|| EvalMatch {
+                    span: Span::of(node),
+                    text: ctx.text(node),
+                    bindings,
+                });
+            }
+        }
+        Ok(seen.into_values().collect())
+    }
+}
+
+/// Per-run evaluation context.
+struct Ctx<'a> {
+    source: &'a str,
+    utils: &'a BTreeMap<String, CompiledNode>,
+}
+
+impl Ctx<'_> {
+    fn text(&self, node: Node<'_>) -> String {
+        self.source[node.start_byte()..node.end_byte()].to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compilation
+// ---------------------------------------------------------------------------
+
+fn compile_node(
+    rule_id: &str,
+    language: Language,
+    node: &RuleNode,
+) -> Result<CompiledNode, RulesError> {
+    let mkerr = |message: String| RulesError::PatternCompile {
+        rule: rule_id.to_string(),
+        message,
+    };
+
+    let atomic = match node.atomic().map_err(mkerr)? {
+        None => None,
+        Some(AtomicMatcher::Pattern(snippet)) => {
+            let ts_language = language
+                .ts_language()
+                .ok_or_else(|| mkerr(format!("grammar for `{}` unavailable", language.name())))?;
+            let compiled =
+                compile_pattern(&snippet, language).map_err(|m| mkerr(format!("pattern: {m}")))?;
+            let query = Query::new(&ts_language, &compiled.query).map_err(|e| {
+                RulesError::QueryRejected {
+                    rule: rule_id.to_string(),
+                    message: e.to_string(),
+                    query: compiled.query.clone(),
+                }
+            })?;
+            Some(CompiledAtomic::Query {
+                query,
+                metavars: compiled.metavars,
+            })
+        }
+        Some(AtomicMatcher::Kind(kind)) => Some(CompiledAtomic::Kind(kind)),
+        Some(AtomicMatcher::Regex(re)) => Some(CompiledAtomic::Regex(
+            Regex::new(&re).map_err(|e| mkerr(format!("regex `{re}` invalid: {e}")))?,
+        )),
+    };
+
+    let rel = |sub: &Option<Box<RuleNode>>| -> Result<Option<Box<CompiledRel>>, RulesError> {
+        match sub {
+            None => Ok(None),
+            Some(n) => Ok(Some(Box::new(compile_rel(rule_id, language, n)?))),
+        }
+    };
+
+    let compile_list = |list: &Option<Vec<RuleNode>>| -> Result<Vec<CompiledNode>, RulesError> {
+        list.iter()
+            .flatten()
+            .map(|n| compile_node(rule_id, language, n))
+            .collect()
+    };
+
+    Ok(CompiledNode {
+        atomic,
+        inside: rel(&node.inside)?,
+        has: rel(&node.has)?,
+        follows: rel(&node.follows)?,
+        precedes: rel(&node.precedes)?,
+        all: compile_list(&node.all)?,
+        any: compile_list(&node.any)?,
+        not: match &node.not {
+            None => None,
+            Some(n) => Some(Box::new(compile_node(rule_id, language, n)?)),
+        },
+        matches: node.matches.clone(),
+    })
+}
+
+fn compile_rel(
+    rule_id: &str,
+    language: Language,
+    node: &RuleNode,
+) -> Result<CompiledRel, RulesError> {
+    let stop_by = match &node.stop_by {
+        None | Some(StopBy::Keyword(StopKeyword::Neighbor)) => CompiledStopBy::Neighbor,
+        Some(StopBy::Keyword(StopKeyword::End)) => CompiledStopBy::End,
+        Some(StopBy::Rule(r)) => {
+            CompiledStopBy::Rule(Box::new(compile_node(rule_id, language, r)?))
+        }
+    };
+    Ok(CompiledRel {
+        node: compile_node(rule_id, language, node)?,
+        stop_by,
+        field: node.field.clone(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+/// Seed candidate nodes for the top rule. The atomic pattern query runs in
+/// one pass; kind/regex/composite-only rules fall back to a tree walk.
+fn seed_candidates<'t>(top: &CompiledNode, ctx: &Ctx<'_>, root: Node<'t>) -> Vec<Node<'t>> {
+    match &top.atomic {
+        Some(CompiledAtomic::Query { query, .. }) => {
+            let mut out = Vec::new();
+            let mut seen = std::collections::HashSet::new();
+            let root_index = root_capture_index(query);
+            let mut cursor = QueryCursor::new();
+            let mut it = cursor.matches(query, root, ctx.source.as_bytes());
+            while let Some(m) = it.next() {
+                for cap in m.captures {
+                    if Some(cap.index) == root_index && seen.insert(cap.node.id()) {
+                        out.push(cap.node);
+                    }
+                }
+            }
+            out
+        }
+        Some(CompiledAtomic::Kind(kind)) => {
+            let mut out = Vec::new();
+            for_each_named_descendant(root, &mut |n| {
+                if n.kind() == kind {
+                    out.push(n);
+                }
+            });
+            out
+        }
+        Some(CompiledAtomic::Regex(_)) | None => {
+            let mut out = Vec::new();
+            for_each_named_descendant(root, &mut |n| out.push(n));
+            out
+        }
+    }
+}
+
+/// Full match check for a specific `node`: atomic + relational + composite.
+fn node_satisfies(cnode: &CompiledNode, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    let mut bindings = Bindings::new();
+
+    if let Some(atomic) = &cnode.atomic {
+        merge(&mut bindings, atomic_match(atomic, node, ctx)?);
+    }
+    if let Some(rel) = &cnode.inside {
+        merge(&mut bindings, eval_inside(rel, node, ctx)?);
+    }
+    if let Some(rel) = &cnode.has {
+        merge(&mut bindings, eval_has(rel, node, ctx)?);
+    }
+    if let Some(rel) = &cnode.follows {
+        merge(&mut bindings, eval_sibling(rel, node, ctx, Dir::Before)?);
+    }
+    if let Some(rel) = &cnode.precedes {
+        merge(&mut bindings, eval_sibling(rel, node, ctx, Dir::After)?);
+    }
+    for sub in &cnode.all {
+        merge(&mut bindings, node_satisfies(sub, node, ctx)?);
+    }
+    if !cnode.any.is_empty() {
+        let matched = cnode
+            .any
+            .iter()
+            .find_map(|sub| node_satisfies(sub, node, ctx));
+        merge(&mut bindings, matched?);
+    }
+    if let Some(not) = &cnode.not {
+        if node_satisfies(not, node, ctx).is_some() {
+            return None;
+        }
+    }
+    if let Some(id) = &cnode.matches {
+        let util = ctx.utils.get(id)?;
+        merge(&mut bindings, node_satisfies(util, node, ctx)?);
+    }
+
+    Some(bindings)
+}
+
+fn atomic_match(atomic: &CompiledAtomic, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    match atomic {
+        CompiledAtomic::Kind(kind) => (node.kind() == kind).then(Bindings::new),
+        CompiledAtomic::Regex(re) => re.is_match(&ctx.text(node)).then(Bindings::new),
+        CompiledAtomic::Query { query, metavars } => {
+            let root_index = root_capture_index(query);
+            let names: Vec<&str> = query.capture_names().to_vec();
+            let mut cursor = QueryCursor::new();
+            let mut it = cursor.matches(query, node, ctx.source.as_bytes());
+            while let Some(m) = it.next() {
+                // The pattern must match `node` itself, not a descendant.
+                let roots_here = m
+                    .captures
+                    .iter()
+                    .any(|c| Some(c.index) == root_index && c.node.id() == node.id());
+                if !roots_here {
+                    continue;
+                }
+                let mut bindings = Bindings::new();
+                for cap in m.captures {
+                    let name = names[cap.index as usize];
+                    if metavars.iter().any(|mv| mv == name) {
+                        bindings.entry(name.to_string()).or_insert_with(|| Binding {
+                            text: ctx.text(cap.node),
+                            span: Span::of(cap.node),
+                        });
+                    }
+                }
+                return Some(bindings);
+            }
+            None
+        }
+    }
+}
+
+fn eval_inside(rel: &CompiledRel, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    let mut current = node.parent();
+    let mut child = node;
+    while let Some(ancestor) = current {
+        if let CompiledStopBy::Rule(stop) = &rel.stop_by {
+            if node_satisfies(stop, ancestor, ctx).is_some()
+                && node_satisfies(&rel.node, ancestor, ctx).is_none()
+            {
+                // Hit the stop boundary without matching.
+                return None;
+            }
+        }
+        if let Some(b) = node_satisfies(&rel.node, ancestor, ctx) {
+            if field_ok(rel.field.as_deref(), ancestor, child) {
+                return Some(b);
+            }
+        }
+        if matches!(rel.stop_by, CompiledStopBy::Neighbor) {
+            return None;
+        }
+        child = ancestor;
+        current = ancestor.parent();
+    }
+    None
+}
+
+fn eval_has(rel: &CompiledRel, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    let neighbor = matches!(rel.stop_by, CompiledStopBy::Neighbor);
+    let mut found: Option<Bindings> = None;
+    let mut cursor = node.walk();
+    let children: Vec<Node<'_>> = node.named_children(&mut cursor).collect();
+    for child in children {
+        if let Some(b) = node_satisfies(&rel.node, child, ctx) {
+            if field_ok(rel.field.as_deref(), node, child) {
+                found = Some(b);
+                break;
+            }
+        }
+        if !neighbor {
+            if let Some(b) = eval_has(rel, child, ctx) {
+                found = Some(b);
+                break;
+            }
+        }
+    }
+    found
+}
+
+enum Dir {
+    Before,
+    After,
+}
+
+fn eval_sibling(rel: &CompiledRel, node: Node<'_>, ctx: &Ctx<'_>, dir: Dir) -> Option<Bindings> {
+    let neighbor = matches!(rel.stop_by, CompiledStopBy::Neighbor);
+    let mut sib = match dir {
+        Dir::Before => node.prev_named_sibling(),
+        Dir::After => node.next_named_sibling(),
+    };
+    while let Some(s) = sib {
+        if let Some(b) = node_satisfies(&rel.node, s, ctx) {
+            return Some(b);
+        }
+        if neighbor {
+            return None;
+        }
+        sib = match dir {
+            Dir::Before => s.prev_named_sibling(),
+            Dir::After => s.next_named_sibling(),
+        };
+    }
+    None
+}
+
+/// When a relation names a `field`, the related child must sit in that
+/// field of the parent. `parent` is the ancestor; `child` is the node on
+/// the path toward the matched node.
+fn field_ok(field: Option<&str>, parent: Node<'_>, child: Node<'_>) -> bool {
+    match field {
+        None => true,
+        Some(name) => parent
+            .child_by_field_name(name)
+            .is_some_and(|f| f.id() == child.id()),
+    }
+}
+
+fn merge(into: &mut Bindings, from: Bindings) {
+    for (k, v) in from {
+        into.entry(k).or_insert(v);
+    }
+}
+
+fn root_capture_index(query: &Query) -> Option<u32> {
+    query
+        .capture_names()
+        .iter()
+        .position(|n| *n == ROOT_CAPTURE)
+        .map(|i| i as u32)
+}
+
+fn for_each_named_descendant<'t>(node: Node<'t>, f: &mut impl FnMut(Node<'t>)) {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        f(child);
+        for_each_named_descendant(child, f);
+    }
+}

--- a/crates/harn-rules/src/fix.rs
+++ b/crates/harn-rules/src/fix.rs
@@ -1,0 +1,164 @@
+//! `fix` template interpolation and application.
+//!
+//! A `fix` is a replacement template that interpolates the match's
+//! metavars — both the captured `$VAR`s and any `transform`-synthesized
+//! ones — into replacement text. The engine computes one replacement per
+//! match and splices them into the source (format-preserving byte-splice,
+//! the same guarantee as `ast.batch_apply`).
+
+use std::collections::BTreeMap;
+
+use crate::engine::Span;
+
+/// Interpolate `$VAR` / `${VAR}` references in `template` from `vars`.
+/// An unknown reference is left verbatim (so a literal `$` survives), and
+/// `$$` is an escaped literal dollar sign.
+pub fn interpolate(template: &str, vars: &BTreeMap<String, String>) -> String {
+    let bytes = template.as_bytes();
+    let mut out = String::with_capacity(template.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'$' {
+            let ch = template[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+        // `$$` -> literal `$`.
+        if template[i..].starts_with("$$") {
+            out.push('$');
+            i += 2;
+            continue;
+        }
+        // `${NAME}` braced form.
+        let (name, consumed) = if template[i..].starts_with("${") {
+            match template[i + 2..].find('}') {
+                Some(rel) => (&template[i + 2..i + 2 + rel], 2 + rel + 1),
+                None => {
+                    out.push('$');
+                    i += 1;
+                    continue;
+                }
+            }
+        } else {
+            // `$NAME` bare form.
+            let name_start = i + 1;
+            let mut j = name_start;
+            if j < bytes.len() && is_ident_start(bytes[j]) {
+                j += 1;
+                while j < bytes.len() && is_ident_continue(bytes[j]) {
+                    j += 1;
+                }
+            }
+            (&template[name_start..j], j - i)
+        };
+
+        if name.is_empty() {
+            out.push('$');
+            i += 1;
+            continue;
+        }
+        match vars.get(name) {
+            Some(value) => out.push_str(value),
+            // Unknown metavar: keep the reference literal.
+            None => out.push_str(&template[i..i + consumed]),
+        }
+        i += consumed;
+    }
+    out
+}
+
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// One concrete edit: replace `span`'s bytes (`before`) with `replacement`.
+#[derive(Debug, Clone)]
+pub struct AppliedEdit {
+    /// The replaced span.
+    pub span: Span,
+    /// The original text at the span.
+    pub before: String,
+    /// The interpolated replacement text.
+    pub replacement: String,
+}
+
+/// Apply `edits` to `source` by byte-splice. Edits are spliced in reverse
+/// start order so earlier offsets stay valid; whitespace outside each span
+/// is preserved verbatim.
+pub fn splice(source: &str, edits: &[AppliedEdit]) -> String {
+    let mut ordered: Vec<&AppliedEdit> = edits.iter().collect();
+    ordered.sort_by_key(|e| std::cmp::Reverse(e.span.start_byte));
+    let mut out = source.to_string();
+    for edit in ordered {
+        out.replace_range(edit.span.start_byte..edit.span.end_byte, &edit.replacement);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn interpolates_bare_and_braced() {
+        let v = vars(&[("KEY", "userId"), ("NAME", "id")]);
+        assert_eq!(interpolate("{ $KEY: $NAME }", &v), "{ userId: id }");
+        assert_eq!(interpolate("${KEY}_${NAME}", &v), "userId_id");
+    }
+
+    #[test]
+    fn unknown_metavar_left_literal() {
+        let v = vars(&[("KEY", "x")]);
+        assert_eq!(interpolate("$KEY $UNKNOWN", &v), "x $UNKNOWN");
+    }
+
+    #[test]
+    fn escaped_dollar() {
+        let v = vars(&[]);
+        assert_eq!(interpolate("price is $$5", &v), "price is $5");
+    }
+
+    #[test]
+    fn splices_in_reverse_order() {
+        let source = "aaa bbb ccc";
+        let edits = vec![
+            AppliedEdit {
+                span: Span {
+                    start_byte: 0,
+                    end_byte: 3,
+                    start_row: 0,
+                    start_col: 0,
+                    end_row: 0,
+                    end_col: 3,
+                },
+                before: "aaa".into(),
+                replacement: "X".into(),
+            },
+            AppliedEdit {
+                span: Span {
+                    start_byte: 8,
+                    end_byte: 11,
+                    start_row: 0,
+                    start_col: 8,
+                    end_row: 0,
+                    end_col: 11,
+                },
+                before: "ccc".into(),
+                replacement: "ZZZZ".into(),
+            },
+        ];
+        assert_eq!(splice(source, &edits), "X bbb ZZZZ");
+    }
+}

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -1,0 +1,51 @@
+//! # harn-rules
+//!
+//! The declarative structural rule engine for Harn — the Rust core that
+//! powers `harn rules` / lint / codemod surfaces. A **rule** describes
+//! *what to match* (a pattern snippet, a node kind, or a regex) and
+//! optionally *how to rewrite* it (a `fix`); the engine compiles that rule
+//! against the tree-sitter machinery in [`harn_hostlib::ast`] and produces
+//! [`RuleMatch`]es with metavariable bindings.
+//!
+//! This crate delivers the **atomic matching tier** (issue #2832):
+//!
+//! - [`model`] — the serde rule data model (`id` / `language` / `severity`
+//!   / `message` / `rule` block / `fix`).
+//! - [`pattern`] — the snippet → tree-sitter-query compiler (`$VAR`
+//!   metavariable lifting + unification).
+//! - [`engine`] — compile a [`Rule`] and run it to produce matches.
+//! - [`loader`] — load rules from a TOML file or a directory.
+//!
+//! Relational/composite matching (#2833) and `where` / `transform` / `fix`
+//! interpolation (#2834) layer onto this surface.
+//!
+//! ```
+//! use harn_rules::{Rule, CompiledRule};
+//!
+//! let rule = Rule::from_toml_str(
+//!     r#"
+//!     id = "destructure-default"
+//!     language = "typescript"
+//!     fix = "{ $KEY: $SRC }"
+//!     [rule]
+//!     pattern = "$SRC?.$KEY ?? $DEFAULT"
+//!     "#,
+//! ).unwrap();
+//! let compiled = CompiledRule::compile(&rule).unwrap();
+//! let matches = compiled.run("const a = cfg?.timeout ?? 30;").unwrap();
+//! assert_eq!(matches[0].bindings["KEY"].text, "timeout");
+//! ```
+
+#![forbid(unsafe_code)]
+
+pub mod engine;
+pub mod error;
+pub mod loader;
+pub mod model;
+pub mod pattern;
+
+pub use engine::{Binding, CompiledRule, RuleMatch, Span};
+pub use error::RulesError;
+pub use loader::{load_rule_dir, load_rule_file};
+pub use model::{AtomicMatcher, Matcher, Rule, RuleKind, Severity};
+pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -7,13 +7,18 @@
 //! against the tree-sitter machinery in [`harn_hostlib::ast`] and produces
 //! [`RuleMatch`]es with metavariable bindings.
 //!
-//! This crate delivers the **atomic matching tier** (issue #2832) plus the
-//! **predicate + rewrite layer** (issue #2834):
+//! This crate delivers the **atomic matching tier** (#2832), the
+//! **relational + composite algebra** (#2833), and the **predicate +
+//! rewrite layer** (#2834):
 //!
-//! - [`model`] — the serde rule data model (`id` / `language` / `severity`
-//!   / `message` / `rule` block / `where` / `transform` / `fix`).
+//! - [`model`] — the serde rule data model: the recursive [`RuleNode`]
+//!   (atomic `pattern` / `kind` / `regex`, relational `inside` / `has` /
+//!   `follows` / `precedes`, composite `all` / `any` / `not` / `matches`)
+//!   plus `where` / `transform` / `fix` and `utils`.
 //! - [`pattern`] — the snippet → tree-sitter-query compiler (`$VAR`
-//!   metavariable lifting + unification).
+//!   metavariable lifting, unification, literal patterns).
+//! - [`evaluator`] — the tree-walking match algebra (relational + composite
+//!   + utility-rule reuse).
 //! - [`constraint`] — `where` predicates on captured metavars (regex,
 //!   comparison, recursive sub-pattern).
 //! - [`transform`] — synthesize new metavars (`replace` / `substring` /
@@ -23,8 +28,7 @@
 //!   [`CompiledRule::apply`] a codemod.
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
-//! Relational/composite matching (#2833) and the whole-project scan
-//! lifecycle (#2836) layer onto this surface.
+//! The whole-project scan lifecycle (#2836) layers onto this surface.
 //!
 //! ```
 //! use harn_rules::{Rule, CompiledRule};
@@ -48,6 +52,7 @@
 pub mod constraint;
 pub mod engine;
 pub mod error;
+pub mod evaluator;
 pub mod fix;
 pub mod loader;
 pub mod model;
@@ -59,6 +64,7 @@ pub use error::RulesError;
 pub use fix::{interpolate, AppliedEdit};
 pub use loader::{load_rule_dir, load_rule_file};
 pub use model::{
-    AtomicMatcher, Comparison, Constraint, ConvertOp, Matcher, Rule, RuleKind, Severity, Transform,
+    AtomicMatcher, Comparison, Constraint, ConvertOp, Rule, RuleKind, RuleNode, Severity, StopBy,
+    StopKeyword, Transform,
 };
 pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -7,17 +7,24 @@
 //! against the tree-sitter machinery in [`harn_hostlib::ast`] and produces
 //! [`RuleMatch`]es with metavariable bindings.
 //!
-//! This crate delivers the **atomic matching tier** (issue #2832):
+//! This crate delivers the **atomic matching tier** (issue #2832) plus the
+//! **predicate + rewrite layer** (issue #2834):
 //!
 //! - [`model`] — the serde rule data model (`id` / `language` / `severity`
-//!   / `message` / `rule` block / `fix`).
+//!   / `message` / `rule` block / `where` / `transform` / `fix`).
 //! - [`pattern`] — the snippet → tree-sitter-query compiler (`$VAR`
 //!   metavariable lifting + unification).
-//! - [`engine`] — compile a [`Rule`] and run it to produce matches.
+//! - [`constraint`] — `where` predicates on captured metavars (regex,
+//!   comparison, recursive sub-pattern).
+//! - [`transform`] — synthesize new metavars (`replace` / `substring` /
+//!   `convert`) before fixing.
+//! - [`fix`] — `fix` template interpolation and format-preserving splice.
+//! - [`engine`] — compile a [`Rule`], run it to produce matches, and
+//!   [`CompiledRule::apply`] a codemod.
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
-//! Relational/composite matching (#2833) and `where` / `transform` / `fix`
-//! interpolation (#2834) layer onto this surface.
+//! Relational/composite matching (#2833) and the whole-project scan
+//! lifecycle (#2836) layer onto this surface.
 //!
 //! ```
 //! use harn_rules::{Rule, CompiledRule};
@@ -38,14 +45,20 @@
 
 #![forbid(unsafe_code)]
 
+pub mod constraint;
 pub mod engine;
 pub mod error;
+pub mod fix;
 pub mod loader;
 pub mod model;
 pub mod pattern;
+pub mod transform;
 
-pub use engine::{Binding, CompiledRule, RuleMatch, Span};
+pub use engine::{Binding, CodemodResult, CompiledRule, RuleMatch, Span};
 pub use error::RulesError;
+pub use fix::{interpolate, AppliedEdit};
 pub use loader::{load_rule_dir, load_rule_file};
-pub use model::{AtomicMatcher, Matcher, Rule, RuleKind, Severity};
+pub use model::{
+    AtomicMatcher, Comparison, Constraint, ConvertOp, Matcher, Rule, RuleKind, Severity, Transform,
+};
 pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/loader.rs
+++ b/crates/harn-rules/src/loader.rs
@@ -1,0 +1,92 @@
+//! Load rules from disk: a single TOML rule file, or a directory of them.
+
+use std::path::Path;
+
+use crate::error::RulesError;
+use crate::model::Rule;
+
+/// Load a single rule from a `.toml` file.
+pub fn load_rule_file(path: impl AsRef<Path>) -> Result<Rule, RulesError> {
+    let path = path.as_ref();
+    let text = std::fs::read_to_string(path).map_err(|source| RulesError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+    Rule::from_toml_str(&text).map_err(|source| RulesError::Parse {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+/// Load every `.toml` rule directly under `dir`, sorted by filename for a
+/// deterministic order. Non-`.toml` files and subdirectories are ignored.
+pub fn load_rule_dir(dir: impl AsRef<Path>) -> Result<Vec<Rule>, RulesError> {
+    let dir = dir.as_ref();
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .map_err(|source| RulesError::Read {
+            path: dir.display().to_string(),
+            source,
+        })?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.is_file() && p.extension().is_some_and(|ext| ext == "toml"))
+        .collect();
+    entries.sort();
+
+    entries.into_iter().map(load_rule_file).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        let mut f = std::fs::File::create(dir.join(name)).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn loads_a_single_rule_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "r.toml",
+            r#"
+            id = "r"
+            language = "rust"
+            [rule]
+            kind = "macro_invocation"
+            "#,
+        );
+        let rule = load_rule_file(dir.path().join("r.toml")).unwrap();
+        assert_eq!(rule.id, "r");
+    }
+
+    #[test]
+    fn loads_a_directory_in_sorted_order() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "b.toml",
+            "id = \"b\"\nlanguage = \"rust\"\n[rule]\nkind = \"x\"\n",
+        );
+        write(
+            dir.path(),
+            "a.toml",
+            "id = \"a\"\nlanguage = \"rust\"\n[rule]\nkind = \"x\"\n",
+        );
+        write(dir.path(), "ignore.txt", "not a rule");
+        let rules = load_rule_dir(dir.path()).unwrap();
+        let ids: Vec<_> = rules.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn parse_error_names_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "bad.toml", "id = \nthis is not toml");
+        let err = load_rule_file(dir.path().join("bad.toml")).unwrap_err();
+        assert!(matches!(err, RulesError::Parse { .. }));
+    }
+}

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -39,18 +39,71 @@ pub enum RuleKind {
 }
 
 /// The atomic-tier matcher. Exactly one of `pattern` / `kind` / `regex`
-/// must be set; [`Matcher::resolve`] enforces that and yields the typed
-/// [`AtomicMatcher`].
+/// must be set on a node that carries one; [`RuleNode::atomic`] resolves it.
+///
+/// A `RuleNode` is the recursive matching algebra: an optional **atomic**
+/// leaf (`pattern` / `kind` / `regex`), **relational** constraints
+/// (`inside` / `has` / `follows` / `precedes`, each a sub-node tuned by
+/// `stop_by` / `field`), and **composite** combinators (`all` / `any` /
+/// `not` / `matches`). Every key set on a node is ANDed: the node matches a
+/// tree-sitter node iff its atomic part matches *and* every relational and
+/// composite part holds.
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct Matcher {
-    /// A code snippet in the target grammar with `$VAR` (single-node) and
-    /// `$$$VAR` (variadic) metavariable holes.
+pub struct RuleNode {
+    /// A code snippet in the target grammar with `$VAR` metavariable holes.
     pub pattern: Option<String>,
-    /// A bare tree-sitter node kind to match (e.g. `"call_expression"`).
+    /// A bare tree-sitter node kind (e.g. `"call_expression"`).
     pub kind: Option<String>,
     /// A regular expression matched against node text.
     pub regex: Option<String>,
+
+    /// The node must be **inside** a node matching this sub-rule (ancestor).
+    pub inside: Option<Box<RuleNode>>,
+    /// The node must **have** a descendant matching this sub-rule.
+    pub has: Option<Box<RuleNode>>,
+    /// The node must **follow** a node matching this sub-rule (earlier).
+    pub follows: Option<Box<RuleNode>>,
+    /// The node must **precede** a node matching this sub-rule (later).
+    pub precedes: Option<Box<RuleNode>>,
+
+    /// Relational reach (used when this node is an `inside`/`has`/… target):
+    /// `neighbor` (direct only, default), `end` (transitive), or a rule that
+    /// halts the walk. (TOML `stopBy` or `stop_by`.)
+    #[serde(default, alias = "stopBy")]
+    pub stop_by: Option<StopBy>,
+    /// Restrict an `inside`/`has` relation to a specific tree-sitter field.
+    pub field: Option<String>,
+
+    /// Every sub-rule must match the node.
+    pub all: Option<Vec<RuleNode>>,
+    /// At least one sub-rule must match the node.
+    pub any: Option<Vec<RuleNode>>,
+    /// The sub-rule must NOT match the node.
+    pub not: Option<Box<RuleNode>>,
+    /// Reference a utility rule by id (resolved from `[utils]`).
+    pub matches: Option<String>,
+}
+
+/// How far a relational op (`inside` / `has` / `follows` / `precedes`)
+/// walks the tree looking for a match.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum StopBy {
+    /// `"neighbor"` (direct parent/child/sibling only) or `"end"`
+    /// (transitive — walk to the tree boundary).
+    Keyword(StopKeyword),
+    /// Walk until a node matching this rule is reached, then stop.
+    Rule(Box<RuleNode>),
+}
+
+/// The keyword forms of [`StopBy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StopKeyword {
+    /// Only the immediate neighbor (default).
+    Neighbor,
+    /// Transitive — walk all the way to the tree boundary.
+    End,
 }
 
 /// The resolved, exactly-one atomic matcher.
@@ -64,10 +117,10 @@ pub enum AtomicMatcher {
     Regex(String),
 }
 
-impl Matcher {
-    /// Collapse the optional fields into the single atomic form, rejecting
-    /// the zero-or-many cases. Returns `Err` with a human-readable reason.
-    pub fn resolve(&self) -> Result<AtomicMatcher, String> {
+impl RuleNode {
+    /// Resolve this node's atomic leaf. `Ok(None)` when the node is purely
+    /// relational/composite; `Err` when more than one atomic key is set.
+    pub fn atomic(&self) -> Result<Option<AtomicMatcher>, String> {
         let set: Vec<&str> = [
             self.pattern.as_ref().map(|_| "pattern"),
             self.kind.as_ref().map(|_| "kind"),
@@ -77,17 +130,49 @@ impl Matcher {
         .flatten()
         .collect();
         match set.as_slice() {
-            [] => Err("rule block sets none of `pattern` / `kind` / `regex`".into()),
-            [one] => Ok(match *one {
+            [] => Ok(None),
+            [one] => Ok(Some(match *one {
                 "pattern" => AtomicMatcher::Pattern(self.pattern.clone().unwrap()),
                 "kind" => AtomicMatcher::Kind(self.kind.clone().unwrap()),
                 _ => AtomicMatcher::Regex(self.regex.clone().unwrap()),
-            }),
+            })),
             many => Err(format!(
-                "rule block sets multiple matchers ({}); set exactly one",
+                "rule node sets multiple atomic matchers ({}); set at most one",
                 many.join(", ")
             )),
         }
+    }
+
+    /// True when `regex` is the only key set — a top-level grep-style rule
+    /// that scans source text rather than the tree.
+    pub fn is_pure_regex(&self) -> bool {
+        self.regex.is_some()
+            && self.pattern.is_none()
+            && self.kind.is_none()
+            && self.inside.is_none()
+            && self.has.is_none()
+            && self.follows.is_none()
+            && self.precedes.is_none()
+            && self.all.is_none()
+            && self.any.is_none()
+            && self.not.is_none()
+            && self.matches.is_none()
+    }
+
+    /// True when the node sets no matching keys at all (an empty node, which
+    /// is a rule authoring error).
+    pub fn is_empty(&self) -> bool {
+        self.pattern.is_none()
+            && self.kind.is_none()
+            && self.regex.is_none()
+            && self.inside.is_none()
+            && self.has.is_none()
+            && self.follows.is_none()
+            && self.precedes.is_none()
+            && self.all.is_none()
+            && self.any.is_none()
+            && self.not.is_none()
+            && self.matches.is_none()
     }
 }
 
@@ -105,8 +190,12 @@ pub struct Rule {
     /// Human-readable diagnostic message. Empty for search-only rules.
     #[serde(default)]
     pub message: String,
-    /// The atomic-tier matcher block.
-    pub rule: Matcher,
+    /// The matcher block (atomic / relational / composite algebra).
+    pub rule: RuleNode,
+    /// Local utility rules referenced by `matches`, keyed by id.
+    /// (TOML `[utils.NAME]`.)
+    #[serde(default)]
+    pub utils: BTreeMap<String, RuleNode>,
     /// Predicates on captured metavars; a match survives only when every
     /// constraint holds. (TOML `[[where]]`.)
     #[serde(default, rename = "where")]
@@ -258,8 +347,8 @@ mod tests {
         assert_eq!(rule.severity, Severity::Warning);
         assert_eq!(rule.kind(), RuleKind::Codemod);
         assert_eq!(
-            rule.rule.resolve().unwrap(),
-            AtomicMatcher::Pattern("$SRC?.$KEY ?? $DEFAULT".into())
+            rule.rule.atomic().unwrap(),
+            Some(AtomicMatcher::Pattern("$SRC?.$KEY ?? $DEFAULT".into()))
         );
     }
 
@@ -293,8 +382,8 @@ mod tests {
         .unwrap();
         assert_eq!(rule.kind(), RuleKind::Lint);
         assert_eq!(
-            rule.rule.resolve().unwrap(),
-            AtomicMatcher::Regex("TODO".into())
+            rule.rule.atomic().unwrap(),
+            Some(AtomicMatcher::Regex("TODO".into()))
         );
     }
 
@@ -310,11 +399,11 @@ mod tests {
             "#,
         )
         .unwrap();
-        assert!(rule.rule.resolve().is_err());
+        assert!(rule.rule.atomic().is_err());
     }
 
     #[test]
-    fn rejects_empty_matcher() {
+    fn empty_matcher_is_detectable() {
         let rule = Rule::from_toml_str(
             r#"
             id = "x"
@@ -323,7 +412,31 @@ mod tests {
             "#,
         )
         .unwrap();
-        assert!(rule.rule.resolve().is_err());
+        // An empty node sets no atomic key (Ok(None)) and is flagged empty.
+        assert_eq!(rule.rule.atomic().unwrap(), None);
+        assert!(rule.rule.is_empty());
+    }
+
+    #[test]
+    fn parses_relational_and_composite_keys() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "nested"
+            language = "typescript"
+            [rule]
+            pattern = "let $NAME = $INIT"
+            [rule.inside]
+            kind = "statement_block"
+            stopBy = "end"
+            [rule.not.inside]
+            kind = "try_statement"
+            stopBy = "end"
+            "#,
+        )
+        .expect("parses");
+        assert!(rule.rule.inside.is_some());
+        assert!(rule.rule.not.is_some());
+        assert!(rule.rule.not.as_ref().unwrap().inside.is_some());
     }
 
     #[test]

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -1,0 +1,236 @@
+//! The declarative rule data model.
+//!
+//! A rule is the atomic unit the engine consumes: an identity (`id`,
+//! `language`, `severity`, `message`), a `rule` block describing *what to
+//! match* (the atomic tier: `pattern` snippet, `kind`, or `regex`), and an
+//! optional `fix` describing *how to rewrite* it. Relational/composite
+//! matching (#2833) and `where`/`transform` (#2834) extend this model;
+//! this module is the atomic-tier surface they build on.
+
+use serde::Deserialize;
+
+/// Diagnostic severity. Mirrors the `harn-lint` vocabulary so findings can
+/// flow into the same reporting surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// Informational; no action required.
+    Info,
+    /// Default — something worth a human's attention.
+    #[default]
+    Warning,
+    /// A problem that should block.
+    Error,
+}
+
+/// What flavor of work a rule performs, derived from its shape rather than
+/// declared: a rule with a `fix` is a codemod; one with a `message` but no
+/// `fix` is a lint; a bare matcher is a search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleKind {
+    /// Find-only: report matches, no diagnostic text, no rewrite.
+    Search,
+    /// Report a diagnostic (`message` + `severity`), no rewrite.
+    Lint,
+    /// Rewrite matches via `fix`.
+    Codemod,
+}
+
+/// The atomic-tier matcher. Exactly one of `pattern` / `kind` / `regex`
+/// must be set; [`Matcher::resolve`] enforces that and yields the typed
+/// [`AtomicMatcher`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Matcher {
+    /// A code snippet in the target grammar with `$VAR` (single-node) and
+    /// `$$$VAR` (variadic) metavariable holes.
+    pub pattern: Option<String>,
+    /// A bare tree-sitter node kind to match (e.g. `"call_expression"`).
+    pub kind: Option<String>,
+    /// A regular expression matched against node text.
+    pub regex: Option<String>,
+}
+
+/// The resolved, exactly-one atomic matcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtomicMatcher {
+    /// A snippet pattern with metavariable holes.
+    Pattern(String),
+    /// A tree-sitter node kind.
+    Kind(String),
+    /// A regex over node text.
+    Regex(String),
+}
+
+impl Matcher {
+    /// Collapse the optional fields into the single atomic form, rejecting
+    /// the zero-or-many cases. Returns `Err` with a human-readable reason.
+    pub fn resolve(&self) -> Result<AtomicMatcher, String> {
+        let set: Vec<&str> = [
+            self.pattern.as_ref().map(|_| "pattern"),
+            self.kind.as_ref().map(|_| "kind"),
+            self.regex.as_ref().map(|_| "regex"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        match set.as_slice() {
+            [] => Err("rule block sets none of `pattern` / `kind` / `regex`".into()),
+            [one] => Ok(match *one {
+                "pattern" => AtomicMatcher::Pattern(self.pattern.clone().unwrap()),
+                "kind" => AtomicMatcher::Kind(self.kind.clone().unwrap()),
+                _ => AtomicMatcher::Regex(self.regex.clone().unwrap()),
+            }),
+            many => Err(format!(
+                "rule block sets multiple matchers ({}); set exactly one",
+                many.join(", ")
+            )),
+        }
+    }
+}
+
+/// A single declarative rule.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Rule {
+    /// Stable identifier (also the diagnostic code).
+    pub id: String,
+    /// Target language name (resolved via `harn_hostlib::ast::Language`).
+    pub language: String,
+    /// Diagnostic severity. Defaults to `warning`.
+    #[serde(default)]
+    pub severity: Severity,
+    /// Human-readable diagnostic message. Empty for search-only rules.
+    #[serde(default)]
+    pub message: String,
+    /// The atomic-tier matcher block.
+    pub rule: Matcher,
+    /// Replacement template. Its presence makes the rule a codemod.
+    #[serde(default)]
+    pub fix: Option<String>,
+}
+
+impl Rule {
+    /// Derive the rule's kind from its shape (see [`RuleKind`]).
+    pub fn kind(&self) -> RuleKind {
+        if self.fix.is_some() {
+            RuleKind::Codemod
+        } else if self.message.is_empty() {
+            RuleKind::Search
+        } else {
+            RuleKind::Lint
+        }
+    }
+
+    /// Parse a single rule from a TOML document.
+    pub fn from_toml_str(text: &str) -> Result<Self, Box<toml::de::Error>> {
+        toml::from_str(text).map_err(Box::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_codemod_rule() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "destructure-default"
+            language = "typescript"
+            severity = "warning"
+            message = "Collapse optional-chain default into a destructuring bind"
+            fix = "{ $KEY: $SRC }"
+
+            [rule]
+            pattern = "$SRC?.$KEY ?? $DEFAULT"
+            "#,
+        )
+        .expect("rule parses");
+        assert_eq!(rule.id, "destructure-default");
+        assert_eq!(rule.language, "typescript");
+        assert_eq!(rule.severity, Severity::Warning);
+        assert_eq!(rule.kind(), RuleKind::Codemod);
+        assert_eq!(
+            rule.rule.resolve().unwrap(),
+            AtomicMatcher::Pattern("$SRC?.$KEY ?? $DEFAULT".into())
+        );
+    }
+
+    #[test]
+    fn severity_defaults_to_warning() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            [rule]
+            kind = "macro_invocation"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(rule.severity, Severity::Warning);
+        // No message, no fix -> a search rule.
+        assert_eq!(rule.kind(), RuleKind::Search);
+    }
+
+    #[test]
+    fn lint_rule_has_message_no_fix() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "todo"
+            language = "rust"
+            message = "Found a TODO"
+            [rule]
+            regex = "TODO"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(rule.kind(), RuleKind::Lint);
+        assert_eq!(
+            rule.rule.resolve().unwrap(),
+            AtomicMatcher::Regex("TODO".into())
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_matchers() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            [rule]
+            kind = "foo"
+            regex = "bar"
+            "#,
+        )
+        .unwrap();
+        assert!(rule.rule.resolve().is_err());
+    }
+
+    #[test]
+    fn rejects_empty_matcher() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            [rule]
+            "#,
+        )
+        .unwrap();
+        assert!(rule.rule.resolve().is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        let err = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "rust"
+            bogus = true
+            [rule]
+            kind = "foo"
+            "#,
+        );
+        assert!(err.is_err());
+    }
+}

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -7,6 +7,8 @@
 //! matching (#2833) and `where`/`transform` (#2834) extend this model;
 //! this module is the atomic-tier surface they build on.
 
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 
 /// Diagnostic severity. Mirrors the `harn-lint` vocabulary so findings can
@@ -105,9 +107,113 @@ pub struct Rule {
     pub message: String,
     /// The atomic-tier matcher block.
     pub rule: Matcher,
+    /// Predicates on captured metavars; a match survives only when every
+    /// constraint holds. (TOML `[[where]]`.)
+    #[serde(default, rename = "where")]
+    pub where_constraints: Vec<Constraint>,
+    /// Derived metavars synthesized from captured ones before `fix`
+    /// interpolation, keyed by the new metavar name. (TOML `[transform.X]`.)
+    #[serde(default)]
+    pub transform: BTreeMap<String, Transform>,
     /// Replacement template. Its presence makes the rule a codemod.
     #[serde(default)]
     pub fix: Option<String>,
+}
+
+/// A `where` predicate on a captured metavar. Exactly one of `regex` /
+/// `comparison` / `pattern` is set.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Constraint {
+    /// The metavar this constraint applies to (without the leading `$`).
+    pub metavar: String,
+    /// The metavar's text must match this regex.
+    #[serde(default)]
+    pub regex: Option<String>,
+    /// The metavar's text, parsed as a number, must satisfy this
+    /// comparison (Semgrep `metavariable-comparison`).
+    #[serde(default)]
+    pub comparison: Option<Comparison>,
+    /// A sub-pattern (Semgrep `metavariable-pattern`) run against the
+    /// metavar's captured text; the constraint holds when it matches.
+    #[serde(default)]
+    pub pattern: Option<String>,
+    /// Optional language override for `pattern` — lets a captured string
+    /// literal be matched in a different grammar than the host file.
+    #[serde(default)]
+    pub language: Option<String>,
+}
+
+/// A numeric/string comparison for a [`Constraint`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Comparison {
+    /// One of `<` `<=` `>` `>=` `==` `!=`.
+    pub op: String,
+    /// The right-hand side. Numbers compare numerically; strings/bools
+    /// compare with `==` / `!=` only.
+    pub value: toml::Value,
+}
+
+/// A metavar transform: read `source`, apply exactly one operation, bind
+/// the result under a new metavar name (the map key).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Transform {
+    /// The source metavar name (without `$`) whose text is transformed.
+    pub source: String,
+    /// Regex find/replace.
+    #[serde(default)]
+    pub replace: Option<ReplaceOp>,
+    /// A character-index slice.
+    #[serde(default)]
+    pub substring: Option<SubstringOp>,
+    /// A case conversion.
+    #[serde(default)]
+    pub convert: Option<ConvertOp>,
+}
+
+/// Regex find/replace transform op.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplaceOp {
+    /// The regex to find.
+    pub regex: String,
+    /// The replacement (supports `$1` capture refs).
+    pub by: String,
+}
+
+/// Character-slice transform op. Indices are 0-based char offsets; a
+/// negative or omitted bound clamps to the string end.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubstringOp {
+    /// Inclusive start char index (default 0).
+    #[serde(default)]
+    pub start: Option<i64>,
+    /// Exclusive end char index (default: end of string).
+    #[serde(default)]
+    pub end: Option<i64>,
+}
+
+/// Case-conversion transform op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvertOp {
+    /// `lowerCamelCase`.
+    LowerCamel,
+    /// `UpperCamelCase`.
+    UpperCamel,
+    /// `snake_case`.
+    Snake,
+    /// `SCREAMING_SNAKE_CASE`.
+    ScreamingSnake,
+    /// `kebab-case`.
+    Kebab,
+    /// `lowercase`.
+    Lower,
+    /// `UPPERCASE`.
+    Upper,
 }
 
 impl Rule {

--- a/crates/harn-rules/src/pattern.rs
+++ b/crates/harn-rules/src/pattern.rs
@@ -206,9 +206,8 @@ fn substitute(snippet: &str) -> Result<Substituted, String> {
         i = j;
     }
 
-    if metavar_order.is_empty() {
-        return Err("pattern has no `$VAR` metavariables".into());
-    }
+    // A pattern with no metavars is a valid *literal* pattern (it matches a
+    // fixed structure), so we do not require one.
 
     Ok(Substituted {
         text,
@@ -234,8 +233,10 @@ struct QueryBuilder<'a> {
     placeholder_to_metavar: &'a HashMap<String, String>,
     /// occurrence count per metavar, to mint unification helper captures.
     occurrences: HashMap<String, usize>,
-    /// `(#eq? @X @X.2)` predicates for repeated metavars.
+    /// `(#eq? …)` predicates for repeated metavars and literal leaves.
     eq_predicates: Vec<String>,
+    /// counter for literal-leaf text-constraint captures.
+    literal_count: usize,
 }
 
 impl<'a> QueryBuilder<'a> {
@@ -245,6 +246,7 @@ impl<'a> QueryBuilder<'a> {
             placeholder_to_metavar,
             occurrences: HashMap::new(),
             eq_predicates: Vec::new(),
+            literal_count: 0,
         }
     }
 
@@ -256,7 +258,14 @@ impl<'a> QueryBuilder<'a> {
                 return format!("(_) @{}", self.capture_for(metavar));
             }
             if node.is_named() {
-                return format!("({})", node.kind());
+                // A literal named leaf (a specific identifier / literal in
+                // the snippet): constrain it to its exact text so `foo()`
+                // matches calls to `foo`, not any call.
+                let cap = format!("__lit_{}", self.literal_count);
+                self.literal_count += 1;
+                self.eq_predicates
+                    .push(format!("(#eq? @{cap} {})", quote_literal(text)));
+                return format!("({}) @{cap}", node.kind());
             }
             return quote_literal(text);
         }
@@ -456,8 +465,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_pattern_without_metavars() {
-        let err = compile_pattern("foo()", Language::TypeScript).unwrap_err();
-        assert!(err.contains("no `$VAR`"), "got: {err}");
+    fn literal_pattern_matches_exact_text() {
+        // A metavar-free pattern is a literal pattern: `foo()` matches calls
+        // to `foo`, not to other functions.
+        let snippet = "foo()";
+        let compiled = compile_pattern(snippet, Language::TypeScript).expect("compiles");
+        assert!(compiled.metavars.is_empty());
+        // It matches `foo()` …
+        let hit = run(snippet, Language::TypeScript, "foo();");
+        assert!(!hit.is_empty());
+        // … but not `bar()` (the literal identifier is constrained).
+        let miss = run(snippet, Language::TypeScript, "bar();");
+        assert!(
+            miss.is_empty(),
+            "bar() must not match foo()'s literal pattern: {miss:?}"
+        );
     }
 }

--- a/crates/harn-rules/src/pattern.rs
+++ b/crates/harn-rules/src/pattern.rs
@@ -1,0 +1,463 @@
+//! The pattern compiler: a code snippet with metavariable holes → a
+//! tree-sitter query.
+//!
+//! This is the atomic-tier `pattern` form. The idea (from ast-grep) is to
+//! let rule authors write a *snippet of real code* with `$VAR` holes
+//! instead of hand-authoring a tree-sitter S-expression query:
+//!
+//! ```text
+//!   $SRC?.$KEY ?? $DEFAULT
+//! ```
+//!
+//! compiles to
+//!
+//! ```text
+//!   ((binary_expression
+//!      left: (member_expression object: (_) @SRC (optional_chain) property: (_) @KEY)
+//!      "??"
+//!      right: (_) @DEFAULT) @__match)
+//! ```
+//!
+//! ## How it works
+//!
+//! 1. Each `$VAR` is replaced with a unique placeholder identifier so the
+//!    snippet parses as ordinary code in the target grammar.
+//! 2. We parse the substituted snippet — bare, then in a per-language
+//!    wrapper context (e.g. a function body) when the fragment is not a
+//!    valid compilation unit — and locate the snippet's own subtree by its
+//!    byte range in the parsed source.
+//! 3. We walk that subtree and mirror it into a query: every named child is
+//!    emitted with its field name, every anonymous token (operators,
+//!    keywords, punctuation) is emitted as a quoted literal so the structure
+//!    is matched precisely, and every placeholder becomes a `(_) @VAR`
+//!    wildcard capture.
+//! 4. Repeated metavariables unify: the second and later occurrences get
+//!    helper captures plus an `(#eq? …)` predicate so `$X … $X` only matches
+//!    when both holes carry identical text.
+//!
+//! Variadic `$$$` holes are not yet supported (tracked for the relational
+//! tier, #2833); they compile to a clear error.
+
+use std::collections::HashMap;
+
+use harn_hostlib::ast::{api, Language};
+use tree_sitter::Node;
+
+/// The capture name bound to the whole matched pattern, used for range
+/// extraction. Chosen to not collide with a user metavar (which are
+/// uppercase by convention and never start with `__`).
+pub const ROOT_CAPTURE: &str = "__match";
+
+/// Placeholder identifier stem substituted for each `$VAR`. Lowercase +
+/// `__` prefix keeps it a valid identifier across grammars and unlikely to
+/// collide with real snippet text.
+const PLACEHOLDER_STEM: &str = "__harn_hole_";
+
+/// A snippet pattern compiled to a tree-sitter query string.
+#[derive(Debug, Clone)]
+pub struct CompiledPattern {
+    /// The generated S-expression query. Always binds the pattern root to
+    /// `@__match` ([`ROOT_CAPTURE`]).
+    pub query: String,
+    /// Metavar names in first-appearance order (without the leading `$`).
+    pub metavars: Vec<String>,
+}
+
+/// Compile a `pattern` snippet for `language` into a tree-sitter query.
+///
+/// A snippet is often a *fragment* (`a + a`, `foo(bar)`) that is not a
+/// valid compilation unit on its own. We therefore try the snippet bare
+/// first (works for expression-statement languages like TS/JS/Python),
+/// then in a small set of per-language wrapper contexts (e.g. a function
+/// body for Rust/Go), and locate the snippet's own subtree by byte range.
+pub fn compile_pattern(snippet: &str, language: Language) -> Result<CompiledPattern, String> {
+    let sub = substitute(snippet)?;
+    let mut last_err: Option<String> = None;
+
+    for (prefix, suffix) in contexts(language) {
+        let wrapped = format!("{prefix}{}{suffix}", sub.text);
+        let tree = api::parse_tree(&wrapped, language).map_err(|err| err.to_string())?;
+        let root = tree.root_node();
+        if root.has_error() {
+            last_err = Some(format!(
+                "snippet did not parse cleanly in `{}`: `{snippet}`",
+                language.name()
+            ));
+            continue;
+        }
+
+        // The snippet occupies `[start, end)` inside the wrapped source; the
+        // deepest node spanning that range is its own subtree (no need to
+        // descend wrappers — and no risk of over-descending a single-child
+        // node like a unary expression).
+        let start = prefix.len();
+        let end = start + sub.text.len();
+        let Some(pattern_root) = root.descendant_for_byte_range(start, end.saturating_sub(1))
+        else {
+            last_err = Some(format!(
+                "could not locate snippet subtree in `{}`",
+                language.name()
+            ));
+            continue;
+        };
+
+        let bytes = wrapped.as_bytes();
+        let mut builder = QueryBuilder::new(bytes, &sub.placeholder_to_metavar);
+        let body = builder.build(pattern_root);
+        let predicates = builder.predicates();
+        let query = if predicates.is_empty() {
+            format!("({body} @{ROOT_CAPTURE})")
+        } else {
+            format!("({body} @{ROOT_CAPTURE} {predicates})")
+        };
+        return Ok(CompiledPattern {
+            query,
+            metavars: sub.metavar_order,
+        });
+    }
+
+    Err(last_err.unwrap_or_else(|| format!("snippet did not parse in `{}`", language.name())))
+}
+
+/// Candidate parse contexts for a snippet, tried in order. The bare context
+/// (`""`, `""`) comes first; item-required languages add a wrapper that
+/// makes an expression/statement fragment parse. Languages whose top level
+/// already accepts expression statements (TS/JS/Python/Ruby/…) only need
+/// the bare context.
+fn contexts(language: Language) -> Vec<(&'static str, &'static str)> {
+    let mut v = vec![("", "")];
+    let wrapper = match language {
+        Language::Rust => Some(("fn __harn_probe() { ", " }")),
+        Language::Go => Some(("package p\nfunc __harn_probe() { ", " }")),
+        Language::Java | Language::CSharp => {
+            Some(("class __HarnProbe { void __harn_probe() { ", " } }"))
+        }
+        Language::C | Language::Cpp => Some(("void __harn_probe() { ", " }")),
+        Language::Kotlin => Some(("fun __harn_probe() { ", " }")),
+        Language::Swift => Some(("func __harn_probe() { ", " }")),
+        Language::Scala => Some(("def __harn_probe() = { ", " }")),
+        _ => None,
+    };
+    v.extend(wrapper);
+    v
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: metavar substitution
+// ---------------------------------------------------------------------------
+
+struct Substituted {
+    /// Snippet with `$VAR` replaced by placeholder identifiers.
+    text: String,
+    /// placeholder identifier → metavar name.
+    placeholder_to_metavar: HashMap<String, String>,
+    /// Metavar names in first-appearance order.
+    metavar_order: Vec<String>,
+}
+
+fn substitute(snippet: &str) -> Result<Substituted, String> {
+    let mut text = String::with_capacity(snippet.len());
+    let mut placeholder_to_metavar = HashMap::new();
+    let mut metavar_to_placeholder: HashMap<String, String> = HashMap::new();
+    let mut metavar_order: Vec<String> = Vec::new();
+
+    let bytes = snippet.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'$' {
+            // Copy this UTF-8 scalar verbatim. Indexing the &str at byte
+            // boundaries is safe because we only special-case ASCII `$`.
+            let ch = snippet[i..].chars().next().unwrap();
+            text.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+        if snippet[i..].starts_with("$$$") {
+            return Err(
+                "variadic `$$$` metavariables are not yet supported (tracked in #2833)".into(),
+            );
+        }
+        // Parse `$NAME` where NAME is `[A-Za-z_][A-Za-z0-9_]*`.
+        let name_start = i + 1;
+        let mut j = name_start;
+        if j < bytes.len() && is_ident_start(bytes[j]) {
+            j += 1;
+            while j < bytes.len() && is_ident_continue(bytes[j]) {
+                j += 1;
+            }
+        }
+        if j == name_start {
+            // A lone `$` that is not a metavar — keep it literal.
+            text.push('$');
+            i += 1;
+            continue;
+        }
+        let name = &snippet[name_start..j];
+        let placeholder = metavar_to_placeholder
+            .entry(name.to_string())
+            .or_insert_with(|| {
+                let placeholder = format!("{PLACEHOLDER_STEM}{}", metavar_order.len());
+                metavar_order.push(name.to_string());
+                placeholder
+            })
+            .clone();
+        placeholder_to_metavar.insert(placeholder.clone(), name.to_string());
+        text.push_str(&placeholder);
+        i = j;
+    }
+
+    if metavar_order.is_empty() {
+        return Err("pattern has no `$VAR` metavariables".into());
+    }
+
+    Ok(Substituted {
+        text,
+        placeholder_to_metavar,
+        metavar_order,
+    })
+}
+
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: walk the located subtree into a query
+// ---------------------------------------------------------------------------
+
+struct QueryBuilder<'a> {
+    src: &'a [u8],
+    placeholder_to_metavar: &'a HashMap<String, String>,
+    /// occurrence count per metavar, to mint unification helper captures.
+    occurrences: HashMap<String, usize>,
+    /// `(#eq? @X @X.2)` predicates for repeated metavars.
+    eq_predicates: Vec<String>,
+}
+
+impl<'a> QueryBuilder<'a> {
+    fn new(src: &'a [u8], placeholder_to_metavar: &'a HashMap<String, String>) -> Self {
+        QueryBuilder {
+            src,
+            placeholder_to_metavar,
+            occurrences: HashMap::new(),
+            eq_predicates: Vec::new(),
+        }
+    }
+
+    fn build(&mut self, node: Node<'_>) -> String {
+        // A placeholder leaf is a metavar hole.
+        if node.child_count() == 0 {
+            let text = self.node_text(node);
+            if let Some(metavar) = self.placeholder_to_metavar.get(text) {
+                return format!("(_) @{}", self.capture_for(metavar));
+            }
+            if node.is_named() {
+                return format!("({})", node.kind());
+            }
+            return quote_literal(text);
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+        let mut cursor = node.walk();
+        for (i, child) in node.children(&mut cursor).enumerate() {
+            let sub = self.build(child);
+            // Field names only attach to named children; an anonymous token
+            // in a field slot is matched positionally as a literal, which
+            // tree-sitter accepts where `field: "literal"` may not.
+            match node.field_name_for_child(i as u32) {
+                Some(field) if child.is_named() => parts.push(format!("{field}: {sub}")),
+                _ => parts.push(sub),
+            }
+        }
+        format!("({} {})", node.kind(), parts.join(" "))
+    }
+
+    /// Mint the capture name for this occurrence of `metavar`. The first
+    /// occurrence is `@NAME`; later ones are `@NAME.k` plus an `(#eq? …)`
+    /// predicate tying them to the first (metavar unification).
+    fn capture_for(&mut self, metavar: &str) -> String {
+        let count = self.occurrences.entry(metavar.to_string()).or_insert(0);
+        *count += 1;
+        if *count == 1 {
+            metavar.to_string()
+        } else {
+            let helper = format!("{metavar}.{count}");
+            self.eq_predicates
+                .push(format!("(#eq? @{metavar} @{helper})"));
+            helper
+        }
+    }
+
+    fn predicates(&self) -> String {
+        self.eq_predicates.join(" ")
+    }
+
+    fn node_text(&self, node: Node<'_>) -> &'a str {
+        std::str::from_utf8(&self.src[node.start_byte()..node.end_byte()]).unwrap_or_default()
+    }
+}
+
+/// Quote an anonymous token as a tree-sitter query literal, escaping `"`
+/// and `\`.
+fn quote_literal(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for ch in text.chars() {
+        if ch == '"' || ch == '\\' {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use streaming_iterator::StreamingIterator;
+    use tree_sitter::{Query, QueryCursor};
+
+    /// Compile `snippet`, run the query against `code`, and return the
+    /// captured text for each requested metavar from the first match.
+    fn run(snippet: &str, language: Language, code: &str) -> Vec<(String, Vec<String>)> {
+        let compiled = compile_pattern(snippet, language).expect("compiles");
+        let ts_language = language.ts_language().expect("grammar");
+        let query = Query::new(&ts_language, &compiled.query)
+            .unwrap_or_else(|e| panic!("query rejected: {e}\nquery: {}", compiled.query));
+        let tree = api::parse_tree(code, language).expect("parse code");
+        let names: Vec<&str> = query.capture_names().to_vec();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), code.as_bytes());
+        let mut out = Vec::new();
+        while let Some(m) = matches.next() {
+            let mut per_capture: HashMap<String, Vec<String>> = HashMap::new();
+            for cap in m.captures {
+                let name = names[cap.index as usize].to_string();
+                let text = code[cap.node.start_byte()..cap.node.end_byte()].to_string();
+                per_capture.entry(name).or_default().push(text);
+            }
+            for (name, texts) in per_capture {
+                out.push((name, texts));
+            }
+        }
+        out
+    }
+
+    fn capture<'a>(binds: &'a [(String, Vec<String>)], name: &str) -> &'a [String] {
+        binds
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, v)| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    #[test]
+    fn compiles_destructuring_default_in_typescript() {
+        // The #2824 / burin-code#1629 codemod shape.
+        let snippet = "$SRC?.$KEY ?? $DEFAULT";
+        let compiled = compile_pattern(snippet, Language::TypeScript).expect("compiles");
+        assert_eq!(compiled.metavars, vec!["SRC", "KEY", "DEFAULT"]);
+        // It captures the optional-chain object/property and the fallback.
+        let binds = run(
+            snippet,
+            Language::TypeScript,
+            "const a = cfg?.timeout ?? 30;",
+        );
+        assert_eq!(capture(&binds, "SRC"), ["cfg".to_string()]);
+        assert_eq!(capture(&binds, "KEY"), ["timeout".to_string()]);
+        assert_eq!(capture(&binds, "DEFAULT"), ["30".to_string()]);
+    }
+
+    #[test]
+    fn operator_is_constrained_not_just_structure() {
+        // The `??` literal in the query must reject a `||` with the same
+        // structural shape — otherwise the codemod would be unsound.
+        let snippet = "$SRC?.$KEY ?? $DEFAULT";
+        let binds = run(
+            snippet,
+            Language::TypeScript,
+            "const a = cfg?.timeout || 30;",
+        );
+        assert!(
+            capture(&binds, "SRC").is_empty(),
+            "|| must not match the ?? pattern"
+        );
+    }
+
+    #[test]
+    fn round_trips_the_assignment_form() {
+        // The literal acceptance pattern: `$NAME = $SRC?.$KEY ?? $DEFAULT`.
+        let snippet = "$NAME = $SRC?.$KEY ?? $DEFAULT";
+        let compiled = compile_pattern(snippet, Language::TypeScript).expect("compiles");
+        assert_eq!(compiled.metavars, vec!["NAME", "SRC", "KEY", "DEFAULT"]);
+        let binds = run(
+            snippet,
+            Language::TypeScript,
+            "x = src?.userId ?? fallback;",
+        );
+        assert_eq!(capture(&binds, "NAME"), ["x".to_string()]);
+        assert_eq!(capture(&binds, "SRC"), ["src".to_string()]);
+        assert_eq!(capture(&binds, "KEY"), ["userId".to_string()]);
+        assert_eq!(capture(&binds, "DEFAULT"), ["fallback".to_string()]);
+    }
+
+    #[test]
+    fn lifts_metavars_in_rust() {
+        let snippet = "let $NAME = $VALUE;";
+        let binds = run(snippet, Language::Rust, "fn f() { let total = compute(); }");
+        assert_eq!(capture(&binds, "NAME"), ["total".to_string()]);
+        assert_eq!(capture(&binds, "VALUE"), ["compute()".to_string()]);
+    }
+
+    #[test]
+    fn lifts_metavars_in_python() {
+        let snippet = "$FN($ARG)";
+        let binds = run(snippet, Language::Python, "print(value)");
+        assert_eq!(capture(&binds, "FN"), ["print".to_string()]);
+        assert_eq!(capture(&binds, "ARG"), ["value".to_string()]);
+    }
+
+    #[test]
+    fn lifts_metavars_in_go() {
+        let snippet = "$FN($ARG)";
+        let binds = run(snippet, Language::Go, "package main\nfunc m() { log(err) }");
+        assert_eq!(capture(&binds, "FN"), ["log".to_string()]);
+        assert_eq!(capture(&binds, "ARG"), ["err".to_string()]);
+    }
+
+    #[test]
+    fn repeated_metavar_unifies() {
+        // `$X + $X` must match `a + a` but not `a + b`.
+        let snippet = "$X + $X";
+        let same = run(snippet, Language::Rust, "fn f() { let _ = a + a; }");
+        assert_eq!(capture(&same, "X"), ["a".to_string()]);
+        let different = run(snippet, Language::Rust, "fn f() { let _ = a + b; }");
+        assert!(
+            capture(&different, "X").is_empty(),
+            "unification must reject `a + b`"
+        );
+    }
+
+    #[test]
+    fn rejects_unparseable_snippet() {
+        let err = compile_pattern("$A ?? ?? $B", Language::TypeScript).unwrap_err();
+        assert!(err.contains("did not parse"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_variadic_for_now() {
+        let err = compile_pattern("foo($$$ARGS)", Language::TypeScript).unwrap_err();
+        assert!(err.contains("variadic"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_pattern_without_metavars() {
+        let err = compile_pattern("foo()", Language::TypeScript).unwrap_err();
+        assert!(err.contains("no `$VAR`"), "got: {err}");
+    }
+}

--- a/crates/harn-rules/src/transform.rs
+++ b/crates/harn-rules/src/transform.rs
@@ -1,0 +1,262 @@
+//! The `transform` pipeline: synthesize new metavars from captured ones
+//! before `fix` interpolation (ast-grep `transform:`).
+//!
+//! Each transform reads one `source` metavar and applies exactly one
+//! operation — regex `replace`, a `substring` slice, or a case `convert` —
+//! binding the result under a new metavar name. In v1 transforms read only
+//! the originally-captured metavars (not each other's output).
+
+use regex::Regex;
+
+use crate::error::RulesError;
+use crate::model::{ConvertOp, Transform};
+
+/// A compiled transform: a source metavar plus one operation.
+pub struct CompiledTransform {
+    /// The source metavar name (without `$`).
+    pub source: String,
+    op: Op,
+}
+
+enum Op {
+    Replace {
+        regex: Regex,
+        by: String,
+    },
+    Substring {
+        start: Option<i64>,
+        end: Option<i64>,
+    },
+    Convert(ConvertOp),
+}
+
+impl CompiledTransform {
+    /// Compile a transform, enforcing the exactly-one-operation rule.
+    pub fn compile(rule_id: &str, name: &str, t: &Transform) -> Result<Self, RulesError> {
+        let set = [
+            t.replace.is_some(),
+            t.substring.is_some(),
+            t.convert.is_some(),
+        ]
+        .into_iter()
+        .filter(|b| *b)
+        .count();
+        if set != 1 {
+            return Err(RulesError::PatternCompile {
+                rule: rule_id.to_string(),
+                message: format!(
+                    "transform `{name}` must set exactly one of `replace` / `substring` / `convert`"
+                ),
+            });
+        }
+
+        let op = if let Some(r) = &t.replace {
+            Op::Replace {
+                regex: Regex::new(&r.regex).map_err(|err| RulesError::PatternCompile {
+                    rule: rule_id.to_string(),
+                    message: format!("transform `{name}`: invalid regex `{}`: {err}", r.regex),
+                })?,
+                by: r.by.clone(),
+            }
+        } else if let Some(s) = &t.substring {
+            Op::Substring {
+                start: s.start,
+                end: s.end,
+            }
+        } else {
+            Op::Convert(t.convert.expect("convert is set"))
+        };
+
+        Ok(CompiledTransform {
+            source: t.source.clone(),
+            op,
+        })
+    }
+
+    /// Apply the transform to the source metavar's text.
+    pub fn apply(&self, input: &str) -> String {
+        match &self.op {
+            Op::Replace { regex, by } => regex.replace_all(input, by.as_str()).into_owned(),
+            Op::Substring { start, end } => slice_chars(input, *start, *end),
+            Op::Convert(convert) => convert_case(input, *convert),
+        }
+    }
+}
+
+/// Slice `input` by 0-based char indices. A negative index counts from the
+/// end; out-of-range bounds clamp.
+fn slice_chars(input: &str, start: Option<i64>, end: Option<i64>) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len() as i64;
+    let resolve = |idx: i64| -> usize {
+        let resolved = if idx < 0 { len + idx } else { idx };
+        resolved.clamp(0, len) as usize
+    };
+    let s = resolve(start.unwrap_or(0));
+    let e = resolve(end.unwrap_or(len));
+    if s >= e {
+        return String::new();
+    }
+    chars[s..e].iter().collect()
+}
+
+/// Split an identifier into lowercase words, honoring `_` / `-` / space
+/// separators and camelCase / digit boundaries.
+fn split_words(input: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut prev: Option<char> = None;
+    for ch in input.chars() {
+        if ch == '_' || ch == '-' || ch == ' ' || ch == '/' || ch == '.' {
+            if !current.is_empty() {
+                words.push(std::mem::take(&mut current));
+            }
+            prev = None;
+            continue;
+        }
+        // A lower→upper transition (`fooBar`) or letter→digit starts a word.
+        if let Some(p) = prev {
+            let boundary = (p.is_lowercase() && ch.is_uppercase())
+                || (p.is_alphabetic() && ch.is_ascii_digit())
+                || (p.is_ascii_digit() && ch.is_alphabetic());
+            if boundary && !current.is_empty() {
+                words.push(std::mem::take(&mut current));
+            }
+        }
+        current.push(ch.to_ascii_lowercase());
+        prev = Some(ch);
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+}
+
+fn capitalize(word: &str) -> String {
+    let mut chars = word.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn convert_case(input: &str, convert: ConvertOp) -> String {
+    match convert {
+        ConvertOp::Lower => input.to_lowercase(),
+        ConvertOp::Upper => input.to_uppercase(),
+        ConvertOp::Snake => split_words(input).join("_"),
+        ConvertOp::ScreamingSnake => split_words(input)
+            .iter()
+            .map(|w| w.to_uppercase())
+            .collect::<Vec<_>>()
+            .join("_"),
+        ConvertOp::Kebab => split_words(input).join("-"),
+        ConvertOp::UpperCamel => split_words(input).iter().map(|w| capitalize(w)).collect(),
+        ConvertOp::LowerCamel => {
+            let words = split_words(input);
+            let mut out = String::new();
+            for (i, w) in words.iter().enumerate() {
+                if i == 0 {
+                    out.push_str(w);
+                } else {
+                    out.push_str(&capitalize(w));
+                }
+            }
+            out
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ReplaceOp, SubstringOp};
+
+    fn convert(input: &str, op: ConvertOp) -> String {
+        let t = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: None,
+            convert: Some(op),
+        };
+        CompiledTransform::compile("r", "out", &t)
+            .unwrap()
+            .apply(input)
+    }
+
+    #[test]
+    fn case_conversions() {
+        assert_eq!(convert("user_id", ConvertOp::LowerCamel), "userId");
+        assert_eq!(convert("userId", ConvertOp::Snake), "user_id");
+        assert_eq!(convert("user-id", ConvertOp::UpperCamel), "UserId");
+        assert_eq!(convert("userId", ConvertOp::ScreamingSnake), "USER_ID");
+        assert_eq!(convert("userId", ConvertOp::Kebab), "user-id");
+        assert_eq!(convert("FooBar", ConvertOp::Lower), "foobar");
+    }
+
+    #[test]
+    fn regex_replace() {
+        let t = Transform {
+            source: "X".into(),
+            replace: Some(ReplaceOp {
+                regex: "Controller$".into(),
+                by: String::new(),
+            }),
+            substring: None,
+            convert: None,
+        };
+        let c = CompiledTransform::compile("r", "out", &t).unwrap();
+        assert_eq!(c.apply("UserController"), "User");
+    }
+
+    #[test]
+    fn substring_slice() {
+        let t = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: Some(SubstringOp {
+                start: Some(0),
+                end: Some(3),
+            }),
+            convert: None,
+        };
+        let c = CompiledTransform::compile("r", "out", &t).unwrap();
+        assert_eq!(c.apply("abcdef"), "abc");
+    }
+
+    #[test]
+    fn substring_negative_end() {
+        let t = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: Some(SubstringOp {
+                start: None,
+                end: Some(-1),
+            }),
+            convert: None,
+        };
+        let c = CompiledTransform::compile("r", "out", &t).unwrap();
+        assert_eq!(c.apply("hello"), "hell");
+    }
+
+    #[test]
+    fn rejects_zero_or_multiple_ops() {
+        let none = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: None,
+            convert: None,
+        };
+        assert!(CompiledTransform::compile("r", "out", &none).is_err());
+        let two = Transform {
+            source: "X".into(),
+            replace: Some(ReplaceOp {
+                regex: "a".into(),
+                by: "b".into(),
+            }),
+            substring: None,
+            convert: Some(ConvertOp::Lower),
+        };
+        assert!(CompiledTransform::compile("r", "out", &two).is_err());
+    }
+}

--- a/crates/harn-rules/tests/atomic_roundtrip.rs
+++ b/crates/harn-rules/tests/atomic_roundtrip.rs
@@ -1,0 +1,55 @@
+//! End-to-end atomic-tier acceptance for #2832: load a rule from a TOML
+//! file, compile its `pattern` snippet into a tree-sitter query, and run it
+//! to produce matches with metavariable bindings — the same path
+//! `ast.search` (#2830) takes, but driven by a declarative rule.
+
+use std::path::PathBuf;
+
+use harn_rules::{load_rule_file, CompiledRule, RuleKind};
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+#[test]
+fn destructuring_rule_round_trips_to_matches() {
+    // 1) Load the declarative rule (the #2824 / burin-code#1629 customer).
+    let rule = load_rule_file(fixture("destructure_default.toml")).expect("rule loads");
+    assert_eq!(rule.id, "destructure-with-defaults");
+    // `fix` present -> codemod.
+    assert_eq!(rule.kind(), RuleKind::Codemod);
+
+    // 2) Compile the `$SRC?.$KEY ?? $DEFAULT` snippet into a query.
+    let compiled = CompiledRule::compile(&rule).expect("rule compiles");
+
+    // 3) Run it over a fixture and read every capture by name.
+    let source = "const a = cfg?.timeout ?? 30;\nconst b = opts?.retries ?? 3;\n";
+    let matches = compiled.run(source).expect("runs");
+    assert_eq!(matches.len(), 2);
+
+    assert_eq!(matches[0].bindings["SRC"].text, "cfg");
+    assert_eq!(matches[0].bindings["KEY"].text, "timeout");
+    assert_eq!(matches[0].bindings["DEFAULT"].text, "30");
+    assert_eq!(matches[0].text, "cfg?.timeout ?? 30");
+
+    assert_eq!(matches[1].bindings["SRC"].text, "opts");
+    assert_eq!(matches[1].bindings["KEY"].text, "retries");
+    assert_eq!(matches[1].bindings["DEFAULT"].text, "3");
+
+    // The bound metavars carry the spans the #2834 `fix` interpolation will
+    // splice from — `{ $KEY: $SRC }` reads `KEY`/`SRC` here.
+    assert_eq!(matches[0].bindings["KEY"].span.start_row, 0);
+    assert_eq!(matches[1].bindings["KEY"].span.start_row, 1);
+}
+
+#[test]
+fn the_pattern_is_operator_precise() {
+    // The compiled query constrains the `??` operator, so the structurally
+    // identical `||` form is left alone — the codemod stays sound.
+    let rule = load_rule_file(fixture("destructure_default.toml")).unwrap();
+    let compiled = CompiledRule::compile(&rule).unwrap();
+    let matches = compiled.run("const a = cfg?.timeout || 30;\n").unwrap();
+    assert!(matches.is_empty(), "`||` must not match the `??` rule");
+}

--- a/crates/harn-rules/tests/fixtures/destructure_default.toml
+++ b/crates/harn-rules/tests/fixtures/destructure_default.toml
@@ -1,0 +1,12 @@
+# The first Rule Engine customer (#2824 / burin-labs/burin-code#1629):
+# find every `src?.key ?? default` shape so the codemod can fold it into a
+# destructuring bind. `fix` makes this a codemod; `transform` + interpolation
+# of the bound metavars into the replacement land in #2834.
+id = "destructure-with-defaults"
+language = "typescript"
+severity = "warning"
+message = "Collapse `?.x ?? default` into a destructuring bind with a default"
+fix = "{ $KEY: $SRC }"
+
+[rule]
+pattern = "$SRC?.$KEY ?? $DEFAULT"

--- a/crates/harn-rules/tests/relational_composite.rs
+++ b/crates/harn-rules/tests/relational_composite.rs
@@ -1,0 +1,233 @@
+//! Acceptance for #2833: the relational (`inside` / `has` / `follows` /
+//! `precedes`) and composite (`all` / `any` / `not` / `matches`) algebra,
+//! plus `stopBy` / `field` and utility-rule reuse, across TS and Rust.
+
+use harn_rules::{CompiledRule, Rule};
+
+fn run(toml: &str, source: &str) -> Vec<String> {
+    let rule = Rule::from_toml_str(toml).expect("rule parses");
+    let compiled = CompiledRule::compile(&rule).expect("rule compiles");
+    compiled
+        .run(source)
+        .expect("runs")
+        .into_iter()
+        .map(|m| m.text)
+        .collect()
+}
+
+#[test]
+fn acceptance_inside_function_body_not_inside_try() {
+    // "a `let` binding whose initializer is `$SRC?.$KEY ?? $DEF`, inside a
+    // function body, not inside a try".
+    let toml = r#"
+        id = "let-default-in-fn-not-try"
+        language = "typescript"
+        [rule]
+        pattern = "let $NAME = $SRC?.$KEY ?? $DEF"
+        [rule.inside]
+        kind = "statement_block"
+        stopBy = "end"
+        [rule.not.inside]
+        kind = "try_statement"
+        stopBy = "end"
+    "#;
+    let source = "\
+function ok() {
+  let a = cfg?.x ?? 1;
+}
+function bad() {
+  try {
+    let b = cfg?.y ?? 2;
+  } catch (e) {}
+}
+let c = cfg?.z ?? 3;
+";
+    let matches = run(toml, source);
+    // Only `a` qualifies: `b` is inside a try, `c` is not inside a function.
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("let a = cfg?.x ?? 1"));
+}
+
+#[test]
+fn has_descendant() {
+    // A function that contains a `throw` statement.
+    let toml = r#"
+        id = "fn-that-throws"
+        language = "typescript"
+        [rule]
+        kind = "function_declaration"
+        [rule.has]
+        kind = "throw_statement"
+        stopBy = "end"
+    "#;
+    let source = "\
+function risky() { throw new Error('x'); }
+function safe() { return 1; }
+";
+    let matches = run(toml, source);
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("risky"));
+}
+
+#[test]
+fn follows_and_precedes() {
+    // `follows` / `precedes` are sibling-relative, so match at the statement
+    // level: an expression statement that follows a `let` declaration.
+    let source = "\
+function f() {
+  let x = 1;
+  useIt();
+}
+function g() {
+  useIt();
+}
+";
+    let follows = r#"
+        id = "stmt-after-decl"
+        language = "typescript"
+        [rule]
+        kind = "expression_statement"
+        [rule.follows]
+        kind = "lexical_declaration"
+    "#;
+    // Only the `useIt();` statement that follows `let x = 1;` qualifies.
+    let m = run(follows, source);
+    assert_eq!(m.len(), 1, "follows matches: {m:?}");
+    assert!(m[0].contains("useIt()"));
+
+    // The mirror image: a declaration that precedes an expression statement.
+    let precedes = r#"
+        id = "decl-before-stmt"
+        language = "typescript"
+        [rule]
+        kind = "lexical_declaration"
+        [rule.precedes]
+        kind = "expression_statement"
+    "#;
+    let m = run(precedes, source);
+    assert_eq!(m.len(), 1, "precedes matches: {m:?}");
+    assert!(m[0].contains("let x = 1"));
+}
+
+#[test]
+fn composite_any_and_all() {
+    // `any`: match a call to either `foo` or `bar`.
+    let any_toml = r#"
+        id = "foo-or-bar"
+        language = "typescript"
+        [rule]
+        any = [
+          { pattern = "foo()" },
+          { pattern = "bar()" },
+        ]
+    "#;
+    let matches = run(any_toml, "foo();\nbaz();\nbar();\n");
+    assert_eq!(matches.len(), 2, "matches: {matches:?}");
+
+    // `all`: a call expression that is also inside a function.
+    let all_toml = r#"
+        id = "call-in-fn"
+        language = "typescript"
+        [rule]
+        all = [
+          { kind = "call_expression" },
+          { inside = { kind = "statement_block", stopBy = "end" } },
+        ]
+    "#;
+    let matches = run(all_toml, "function f() { go(); }\ntopLevel();\n");
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("go()"));
+}
+
+#[test]
+fn utility_rule_referenced_by_matches() {
+    // A util rule referenced from `matches`; the same util reused twice
+    // resolves once (compiled into the rule's util map).
+    let toml = r#"
+        id = "uses-util"
+        language = "typescript"
+        [rule]
+        all = [
+          { matches = "is-call" },
+          { inside = { kind = "statement_block", stopBy = "end" } },
+        ]
+        [utils.is-call]
+        kind = "call_expression"
+    "#;
+    let matches = run(toml, "function f() { go(); }\nouter();\n");
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("go()"));
+}
+
+#[test]
+fn stop_by_neighbor_vs_end() {
+    // `neighbor` only checks the direct parent; `end` walks all ancestors.
+    let source = "function f() { { deep(); } }\n";
+
+    let neighbor = r#"
+        id = "n"
+        language = "typescript"
+        [rule]
+        pattern = "deep()"
+        [rule.inside]
+        kind = "function_declaration"
+        stopBy = "neighbor"
+    "#;
+    // `deep()`'s direct ancestors are nested blocks, not the function — so
+    // neighbor-scoped `inside` finds nothing.
+    assert_eq!(run(neighbor, source).len(), 0);
+
+    let end = r#"
+        id = "e"
+        language = "typescript"
+        [rule]
+        pattern = "deep()"
+        [rule.inside]
+        kind = "function_declaration"
+        stopBy = "end"
+    "#;
+    assert_eq!(run(end, source).len(), 1);
+}
+
+#[test]
+fn field_restricts_the_relation() {
+    // `field = "body"` restricts the `inside` relation to the function's
+    // body slot: the function body block matches, a nested block does not.
+    let toml = r#"
+        id = "fn-body-block"
+        language = "typescript"
+        [rule]
+        kind = "statement_block"
+        [rule.inside]
+        kind = "function_declaration"
+        field = "body"
+        stopBy = "neighbor"
+    "#;
+    let matches = run(toml, "function f() { { nested(); } }\n");
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    // The matched block is the function body (it contains the nested block).
+    assert!(matches[0].contains("nested()"));
+}
+
+#[test]
+fn relational_in_rust_grammar() {
+    // Second grammar: a `let` declaration inside a function body.
+    let toml = r#"
+        id = "rust-let-in-fn"
+        language = "rust"
+        [rule]
+        pattern = "let $N = $V;"
+        [rule.inside]
+        kind = "function_item"
+        stopBy = "end"
+    "#;
+    let source = "\
+fn f() {
+    let x = compute();
+}
+const TOP: i32 = 1;
+";
+    let matches = run(toml, source);
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("let x = compute()"));
+}

--- a/crates/harn-rules/tests/where_transform_fix.rs
+++ b/crates/harn-rules/tests/where_transform_fix.rs
@@ -1,0 +1,124 @@
+//! End-to-end acceptance for #2834: `where` constraints, the `transform`
+//! pipeline, and `fix` interpolation, applied as a codemod.
+
+use harn_rules::{CompiledRule, Rule};
+
+fn compile(toml: &str) -> CompiledRule {
+    CompiledRule::compile(&Rule::from_toml_str(toml).expect("rule parses")).expect("rule compiles")
+}
+
+#[test]
+fn destructuring_fix_handles_alias_and_shorthand() {
+    // The #2824 customer's single-binding fold + alias handling:
+    //   `let id = src?.userId`     -> `{ userId: id }`     (aliased)
+    //   `let userId = src?.userId` -> `{ userId: userId }` (shorthand once
+    //                                  `harn fmt` collapses the duplicate key)
+    let rule = compile(
+        r#"
+        id = "fold-optional-bind"
+        language = "typescript"
+        fix = "{ $KEY: $NAME }"
+        [rule]
+        pattern = "let $NAME = $SRC?.$KEY"
+        "#,
+    );
+
+    let aliased = rule.apply("let id = src?.userId;\n").unwrap();
+    assert!(aliased.changed);
+    assert!(
+        aliased.rewritten.contains("{ userId: id }"),
+        "got: {}",
+        aliased.rewritten
+    );
+
+    let shorthand = rule.apply("let userId = src?.userId;\n").unwrap();
+    assert!(
+        shorthand.rewritten.contains("{ userId: userId }"),
+        "got: {}",
+        shorthand.rewritten
+    );
+}
+
+#[test]
+fn fix_uses_a_transform_synthesized_metavar() {
+    // Rename a camelCase call to snake_case using a `convert` transform,
+    // then interpolate the synthesized metavar into the fix.
+    let rule = compile(
+        r#"
+        id = "snakeify-call"
+        language = "typescript"
+        fix = "$SNAKE()"
+        [rule]
+        pattern = "$FN()"
+        [transform.SNAKE]
+        source = "FN"
+        convert = "snake"
+        "#,
+    );
+    let result = rule.apply("getUserId();\n").unwrap();
+    assert!(
+        result.rewritten.contains("get_user_id()"),
+        "got: {}",
+        result.rewritten
+    );
+}
+
+#[test]
+fn where_constraint_filters_matches() {
+    // Only rewrite calls whose callee matches the constraint regex.
+    let rule = compile(
+        r#"
+        id = "guarded-rename"
+        language = "typescript"
+        fix = "renamed()"
+        [rule]
+        pattern = "$FN()"
+        [[where]]
+        metavar = "FN"
+        regex = "^legacy"
+        "#,
+    );
+    let result = rule
+        .apply("legacyInit();\nkeepThis();\nlegacyTeardown();\n")
+        .unwrap();
+    // The two `legacy*` calls are rewritten; `keepThis()` is untouched.
+    assert_eq!(result.edits.len(), 2);
+    assert!(result.rewritten.contains("keepThis()"));
+    assert_eq!(result.rewritten.matches("renamed()").count(), 2);
+}
+
+#[test]
+fn comparison_constraint_filters_numerically() {
+    // Only flag default values greater than 100.
+    let rule = compile(
+        r#"
+        id = "big-default"
+        language = "typescript"
+        fix = "CAPPED"
+        [rule]
+        pattern = "$SRC?.$KEY ?? $N"
+        [[where]]
+        metavar = "N"
+        comparison = { op = ">", value = 100 }
+        "#,
+    );
+    let result = rule
+        .apply("const a = o?.x ?? 5;\nconst b = o?.y ?? 500;\n")
+        .unwrap();
+    assert_eq!(result.edits.len(), 1);
+    assert!(result.rewritten.contains("?? 5"));
+    assert!(result.rewritten.contains("CAPPED"));
+}
+
+#[test]
+fn apply_without_fix_errors() {
+    let rule = compile(
+        r#"
+        id = "search-only"
+        language = "typescript"
+        [rule]
+        pattern = "$FN()"
+        "#,
+    );
+    assert!(rule.apply("foo();").is_err());
+}


### PR DESCRIPTION
## Summary

Adds the **predicate + rewrite layer** to `harn-rules` (Rule Engine Epic A) — the layer that turns matches into fixes. Builds on the atomic tier (#2832).

> Stacked on #2863 (#2832). The diff below is just the #2834 delta; once #2832 merges, this rebases onto `main`.

## What's in it

- **`where` constraints** (`[[where]]`) — filter matches by a captured metavar's text:
  - `regex` (metavariable-regex)
  - `comparison = { op, value }` — numeric or string (metavariable-comparison)
  - `pattern` — a recursive sub-pattern run against the capture's content, optionally in a **different language** for embedded strings (metavariable-pattern)
- **`transform` pipeline** (`[transform.NAME]`) — synthesize new metavars before fixing: regex `replace`, `substring` (char slice, negative indices), and case `convert` (lower/upper-camel, snake, screaming-snake, kebab, lower, upper).
- **`fix` interpolation** — `$VAR` / `${VAR}` (and `$$` → `$`) substituted from captured + transformed metavars.
- **`CompiledRule::apply(source)`** — runs the rule, drops constraint failures, interpolates each match's `fix`, and splices the replacements in. Format-preserving — the same byte-splice guarantee as `ast.batch_apply` (#2831). Returns the rewritten source + per-match edits; the caller decides whether to write. (Per-match interpolated fixes can't use `batch_apply`'s single-replacement model directly; the multi-file driver is the scan lifecycle, #2836.)

## Acceptance ([#2834](https://github.com/burin-labs/harn/issues/2834))

- ✅ The destructuring codemod's alias/shorthand handling expressed as `fix`: `let id = src?.userId` → `{ userId: id }` (aliased), `let userId = src?.userId` → `{ userId: userId }` (which `harn fmt` collapses to shorthand). See `tests/where_transform_fix.rs`.
- ✅ A `fix` that uses a transform-synthesized metavar (camel→snake call rename).
- ✅ Constraint + transform unit tests (regex / numeric comparison / string equality / sub-pattern; replace / substring / convert).

13 new unit tests + 5 new integration tests; clippy + fmt clean.

Relational/composite tiers land in #2833; the whole-project scan lifecycle in #2836.

Closes #2834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
