### PR TITLE
fix(llm/catalog): Cerebras GPT-OSS accepts reasoning_effort="none"

### DIFF
--- a/changelog.d/cerebras-reasoning-none.fixed.md
+++ b/changelog.d/cerebras-reasoning-none.fixed.md
@@ -1,0 +1,8 @@
+- **Cerebras GPT-OSS accepts `reasoning_effort="none"`.**
+  The Cerebras `gpt-oss-*` capability rule advertised `reasoning_effort_supported`
+  without `reasoning_none_supported`, so an "off" reasoning level floored at
+  `minimal` — which Cerebras rejects with `HTTP 400 reasoning_effort: Input
+  should be 'none', 'low', 'medium' or 'high'`. That broke every no-tools /
+  summarize turn on `cerebras/gpt-oss-120b` (e.g. the release-harness
+  audit-finalize turn). The route now advertises `none` as the true
+  reasoning-off value.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -1675,6 +1675,20 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
+    fn cerebras_gpt_oss_supports_reasoning_none() {
+        // Cerebras-hosted GPT-OSS accepts reasoning_effort ∈
+        // {none, low, medium, high} but rejects `minimal`. Advertising
+        // reasoning_none_supported makes the policy resolver materialize an
+        // "off" level as `none` instead of flooring at the rejected
+        // `minimal` (which 400s every no-tools/summarize turn).
+        reset();
+        let caps = lookup("cerebras", "gpt-oss-120b");
+        assert_eq!(caps.thinking_modes, vec!["effort"]);
+        assert!(caps.reasoning_effort_supported);
+        assert!(caps.reasoning_none_supported);
+    }
+
+    #[test]
     fn mock_with_claude_model_routes_to_anthropic() {
         reset();
         let caps = lookup("mock", "claude-sonnet-4-7");

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1931,6 +1931,14 @@ thinking_block_style = "none"
 
 # ---------- Cerebras ----------------------------------------------------------
 
+# Cerebras-hosted GPT-OSS accepts top-level `reasoning_effort` ∈
+# {none, low, medium, high}. It does NOT accept `minimal` — sending it
+# returns `HTTP 400 reasoning_effort: Input should be 'none', 'low',
+# 'medium' or 'high' (wrong_api_format)`. Without `reasoning_none_supported`
+# the policy resolver floors an "off" reasoning level at `minimal`
+# (see thinking_for_reasoning_level), which breaks every no-tools /
+# summarize turn (e.g. the release-harness audit-finalize turn). Cerebras
+# does accept `none`, so advertise it as the true reasoning-off value.
 [[provider.cerebras]]
 model_match = "gpt-oss-*"
 native_tools = true
@@ -1938,6 +1946,7 @@ preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
+reasoning_none_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -197,7 +197,8 @@
         "streaming": true,
         "reasoning_knobs": [
           "effort",
-          "reasoning_effort"
+          "reasoning_effort",
+          "reasoning_none"
         ],
         "prompt_or_context_cache": false,
         "usage_accounting_confidence": "high"

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -14,7 +14,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Anthropic` | Anthropic Messages API | `haiku` | `native` | yes | yes | `tool_use` / `xml_tagged` | `enabled` | yes | `high` | `not_recorded` |
 | `Azure Openai` | OpenAI-compatible chat completions | `azure_openai:gpt-*` | `native` | yes | yes | `none` / `native_json` | none | no | `provider_default` | `not_recorded` |
 | `Bedrock` | AWS Bedrock Converse | `bedrock:anthropic.claude-*` | `native` | yes | yes | `none` / `xml_tagged` | none | no | `provider_default` | `not_recorded` |
-| `Cerebras` | OpenAI-compatible chat completions | `cerebras:gpt-oss-120b` | `native` | yes | yes | `native` / `native_json` | `effort,reasoning_effort` | no | `high` | `not_recorded` |
+| `Cerebras` | OpenAI-compatible chat completions | `cerebras:gpt-oss-120b` | `native` | yes | yes | `native` / `native_json` | `effort,reasoning_effort,reasoning_none` | no | `high` | `not_recorded` |
 | `Dashscope` | OpenAI-compatible chat completions | `dashscope:qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
 | `Deepseek` | OpenAI-compatible chat completions | `deepseek:deepseek-v4-flash` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
 | `Fireworks` | OpenAI-compatible chat completions | `fireworks:*qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -2169,7 +2169,7 @@ public let harnProviderCatalogJSON = #"""
           "effort"
         ],
         "effort_supported": true,
-        "none_supported": false,
+        "none_supported": true,
         "interleaved_supported": false,
         "preserve_thinking": false
       },

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -1990,7 +1990,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
           "effort"
         ],
         "effort_supported": true,
-        "none_supported": false,
+        "none_supported": true,
         "interleaved_supported": false,
         "preserve_thinking": false
       },

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -1813,7 +1813,7 @@
           "effort"
         ],
         "effort_supported": true,
-        "none_supported": false,
+        "none_supported": true,
         "interleaved_supported": false,
         "preserve_thinking": false
       },


### PR DESCRIPTION
## Problem

`cerebras/gpt-oss-120b` returns `HTTP 400 reasoning_effort: Input should be
'none', 'low', 'medium' or 'high' (wrong_api_format)` on no-tools / summarize
turns. The capability rule advertised `reasoning_effort_supported = true`
without `reasoning_none_supported`, so `thinking_for_reasoning_level()` floored
an "off" level at `ReasoningEffort::Minimal` — which Cerebras rejects.

Discovered while routing the release harness planner at Cerebras: with-tools
turns (effort `medium`) succeeded but the audit-finalize turn (effort `off` →
`minimal`) 400'd.

## Fix

Add `reasoning_none_supported = true` to the Cerebras `gpt-oss-*` rule (Cerebras
accepts `none` as the true reasoning-off value) + a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)