### PR TITLE
harn-rules: fix safety tiers + apply gate + idempotency (#2835)

### DIFF
--- a/changelog.d/2835.added.md
+++ b/changelog.d/2835.added.md
@@ -1,0 +1,7 @@
+- `harn-rules`: added fix safety classification and the apply gate (Rule Engine Epic A). A rule declares a `safety`
+  tier (`format-only` → `behavior-preserving` → `scope-local` (default) → `surface-changing` →
+  `capability-changing` → `needs-human`); the two safest are machine-applicable, the rest suggestions. `auto_apply`
+  refuses to silently apply anything riskier than `behavior-preserving`, `apply_checked` additionally asserts the fix
+  is idempotent (re-running it reaches a fixed point), and `diagnostics()` emits per-match diagnostics (message,
+  severity, span, applicability, interpolated fix) — the surface the linter and LSP convert into
+  `LintDiagnostic` / `FixEdit`.

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -103,6 +103,23 @@ metavars), and splices the replacements in — format-preserving, the same
 byte-splice guarantee as `ast.batch_apply`. It returns the rewritten source
 plus the per-match edits; the caller decides whether to write.
 
+### Safety, applicability, and idempotency
+
+A rule declares a `safety` tier — `format-only` → `behavior-preserving` →
+`scope-local` (default) → `surface-changing` → `capability-changing` →
+`needs-human`. The two safest map to **machine-applicable**; the rest are
+**suggestions** (opt-in). The gate:
+
+- `apply` always computes the preview (and reports `safety`,
+  `applicability`, and whether the fix is `idempotent`).
+- `auto_apply` refuses anything above `behavior-preserving` — so the runner
+  never silently applies a risky fix.
+- `apply_checked` additionally fails if the fix is **not idempotent** (re-
+  running it produces further changes — it never reaches a fixed point).
+- `diagnostics(source)` emits one diagnostic per match (message, severity,
+  span, applicability, interpolated fix) — the mapping surface the linter
+  and LSP convert into `LintDiagnostic` / `FixEdit`.
+
 ## Usage
 
 ```rust

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -16,7 +16,7 @@ use crate::constraint::CompiledConstraint;
 use crate::error::RulesError;
 use crate::evaluator::CompiledRuleTree;
 use crate::fix::{interpolate, splice, AppliedEdit};
-use crate::model::Rule;
+use crate::model::{Applicability, Rule, Safety, Severity};
 use crate::transform::CompiledTransform;
 
 /// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
@@ -84,6 +84,13 @@ pub struct CodemodResult {
     pub edits: Vec<AppliedEdit>,
     /// Whether the rewrite changed the source.
     pub changed: bool,
+    /// The rule's declared safety tier.
+    pub safety: Safety,
+    /// Whether the fix may be auto-applied or is opt-in only.
+    pub applicability: Applicability,
+    /// Whether re-running the fix on `rewritten` yields no further change
+    /// (a fix should reach a fixed point).
+    pub idempotent: bool,
 }
 
 /// A rule whose matcher has been compiled and is ready to run.
@@ -97,6 +104,31 @@ pub struct CompiledRule {
     transforms: Vec<(String, CompiledTransform)>,
     /// The `fix` replacement template, if this is a codemod.
     fix: Option<String>,
+    /// The fix's safety tier (gates auto-apply).
+    safety: Safety,
+    /// The diagnostic message (empty for search-only rules).
+    message: String,
+    /// The diagnostic severity.
+    severity: Severity,
+}
+
+/// A diagnostic produced by running a rule — the mapping surface onto the
+/// linter's `LintDiagnostic` / `FixEdit` (Epic C / the LSP reuse this).
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    /// The rule id (also the diagnostic code).
+    pub rule_id: String,
+    /// The diagnostic message.
+    pub message: String,
+    /// The severity.
+    pub severity: Severity,
+    /// The flagged span.
+    pub span: Span,
+    /// Whether a fix, if present, is auto-applicable or a suggestion.
+    pub applicability: Applicability,
+    /// The interpolated fix replacement for this match, if the rule has a
+    /// `fix`.
+    pub fix: Option<String>,
 }
 
 enum Execution {
@@ -157,12 +189,26 @@ impl CompiledRule {
             constraints,
             transforms,
             fix: rule.fix.clone(),
+            safety: rule.safety,
+            message: rule.message.clone(),
+            severity: rule.severity,
         })
     }
 
     /// The language this rule targets.
     pub fn language(&self) -> Language {
         self.language
+    }
+
+    /// The fix's declared safety tier.
+    pub fn safety(&self) -> Safety {
+        self.safety
+    }
+
+    /// Whether this rule's fix may be auto-applied (machine-applicable) or
+    /// is opt-in only (suggestion).
+    pub fn applicability(&self) -> Applicability {
+        self.safety.applicability()
     }
 
     /// Run the compiled rule against `source`, returning matches in
@@ -201,13 +247,85 @@ impl CompiledRule {
     /// text plus the per-match edits. Each match's `fix` template is
     /// interpolated from its captured metavars plus any `transform`-derived
     /// ones. Errors if the rule has no `fix`.
+    ///
+    /// This computes the preview only — it does not enforce the safety gate.
+    /// Use [`CompiledRule::auto_apply`] to refuse non-machine-applicable
+    /// fixes, or [`CompiledRule::apply_checked`] to also assert idempotency.
     pub fn apply(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        let (rewritten, edits) = self.rewrite(source)?;
+        let changed = rewritten != source;
+        // Idempotency: re-running the fix on its own output must not change
+        // it further (the fix should reach a fixed point).
+        let (twice, _) = self.rewrite(&rewritten)?;
+        let idempotent = twice == rewritten;
+        Ok(CodemodResult {
+            rewritten,
+            edits,
+            changed,
+            safety: self.safety,
+            applicability: self.applicability(),
+            idempotent,
+        })
+    }
+
+    /// Like [`CompiledRule::apply`], but refuses to apply a fix whose
+    /// `safety` is above the machine-applicable threshold (`scope-local` and
+    /// riskier). This is the gate `harn codemod --apply` uses by default.
+    pub fn auto_apply(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        if !self.safety.is_auto_applicable() {
+            return Err(RulesError::NotAutoApplicable {
+                rule: self.rule_id.clone(),
+                safety: format!("{:?}", self.safety),
+            });
+        }
+        self.apply(source)
+    }
+
+    /// Like [`CompiledRule::apply`], but fails if the fix is not idempotent.
+    /// Used by the codemod runner and the rule-test harness to assert a fix
+    /// reaches a fixed point.
+    pub fn apply_checked(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        let result = self.apply(source)?;
+        if !result.idempotent {
+            return Err(RulesError::NotIdempotent {
+                rule: self.rule_id.clone(),
+            });
+        }
+        Ok(result)
+    }
+
+    /// Run the rule and produce one [`Diagnostic`] per match — the surface
+    /// the linter (Epic C) and the LSP convert into `LintDiagnostic` /
+    /// `FixEdit`. Each diagnostic carries the interpolated fix (if any) and
+    /// its applicability tier.
+    pub fn diagnostics(&self, source: &str) -> Result<Vec<Diagnostic>, RulesError> {
+        let applicability = self.applicability();
+        let matches = self.run(source)?;
+        Ok(matches
+            .iter()
+            .map(|m| Diagnostic {
+                rule_id: self.rule_id.clone(),
+                message: self.message.clone(),
+                severity: self.severity,
+                span: m.span,
+                applicability,
+                fix: self.fix.as_ref().map(|template| {
+                    let vars = self.metavars_for(m);
+                    interpolate(template, &vars)
+                }),
+            })
+            .collect())
+    }
+
+    /// The core rewrite: run the rule and splice each match's interpolated
+    /// fix. Returns the rewritten text and the edits.
+    fn rewrite(&self, source: &str) -> Result<(String, Vec<AppliedEdit>), RulesError> {
         let template = self
             .fix
             .as_ref()
             .ok_or_else(|| RulesError::PatternCompile {
                 rule: self.rule_id.clone(),
-                message: "apply() requires a `fix` template; this rule has none".into(),
+                message: "apply requires a `fix` template; this rule has none".into(),
             })?;
 
         let matches = self.run(source)?;
@@ -222,14 +340,7 @@ impl CompiledRule {
                 }
             })
             .collect();
-
-        let rewritten = splice(source, &edits);
-        let changed = rewritten != source;
-        Ok(CodemodResult {
-            rewritten,
-            edits,
-            changed,
-        })
+        Ok((splice(source, &edits), edits))
     }
 
     /// Build the full metavar map for a match: captured bindings plus the

--- a/crates/harn-rules/src/error.rs
+++ b/crates/harn-rules/src/error.rs
@@ -72,4 +72,24 @@ pub enum RulesError {
         /// The parse failure detail.
         message: String,
     },
+
+    /// `auto_apply` was called on a rule whose `safety` is above the
+    /// machine-applicable threshold; it must be applied with explicit opt-in.
+    #[error(
+        "rule `{rule}`: refusing to auto-apply a `{safety}` fix (machine-applicable required)"
+    )]
+    NotAutoApplicable {
+        /// The offending rule id.
+        rule: String,
+        /// The rule's declared safety tier.
+        safety: String,
+    },
+
+    /// A fix did not reach a fixed point: re-running it after applying still
+    /// produced changes.
+    #[error("rule `{rule}`: fix is not idempotent (re-running it produced further changes)")]
+    NotIdempotent {
+        /// The offending rule id.
+        rule: String,
+    },
 }

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -8,8 +8,8 @@
 //! [`RuleMatch`]es with metavariable bindings.
 //!
 //! This crate delivers the **atomic matching tier** (#2832), the
-//! **relational + composite algebra** (#2833), and the **predicate +
-//! rewrite layer** (#2834):
+//! **relational + composite algebra** (#2833), the **predicate + rewrite
+//! layer** (#2834), and the **safety + idempotency gate** (#2835):
 //!
 //! - [`model`] — the serde rule data model: the recursive [`RuleNode`]
 //!   (atomic `pattern` / `kind` / `regex`, relational `inside` / `has` /
@@ -24,8 +24,10 @@
 //! - [`transform`] — synthesize new metavars (`replace` / `substring` /
 //!   `convert`) before fixing.
 //! - [`fix`] — `fix` template interpolation and format-preserving splice.
-//! - [`engine`] — compile a [`Rule`], run it to produce matches, and
-//!   [`CompiledRule::apply`] a codemod.
+//! - [`engine`] — compile a [`Rule`], run it to produce matches,
+//!   [`CompiledRule::apply`] / [`CompiledRule::auto_apply`] /
+//!   [`CompiledRule::apply_checked`] a codemod (safety-gated, idempotency
+//!   checked), and emit [`Diagnostic`]s.
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
 //! The whole-project scan lifecycle (#2836) layers onto this surface.
@@ -59,12 +61,12 @@ pub mod model;
 pub mod pattern;
 pub mod transform;
 
-pub use engine::{Binding, CodemodResult, CompiledRule, RuleMatch, Span};
+pub use engine::{Binding, CodemodResult, CompiledRule, Diagnostic, RuleMatch, Span};
 pub use error::RulesError;
 pub use fix::{interpolate, AppliedEdit};
 pub use loader::{load_rule_dir, load_rule_file};
 pub use model::{
-    AtomicMatcher, Comparison, Constraint, ConvertOp, Rule, RuleKind, RuleNode, Severity, StopBy,
-    StopKeyword, Transform,
+    Applicability, AtomicMatcher, Comparison, Constraint, ConvertOp, Rule, RuleKind, RuleNode,
+    Safety, Severity, StopBy, StopKeyword, Transform,
 };
 pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -25,6 +25,57 @@ pub enum Severity {
     Error,
 }
 
+/// How risky a rule's `fix` is, mapped onto Burin's edit-safety taxonomy.
+/// Ordered least → most dangerous; the codemod runner auto-applies only the
+/// two safest tiers (see [`Safety::applicability`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Safety {
+    /// Whitespace / formatting only.
+    FormatOnly,
+    /// Semantics-preserving rewrite.
+    BehaviorPreserving,
+    /// Changes behavior, but only within the matched scope. **Default** —
+    /// conservative, so an undeclared codemod does not silently auto-apply.
+    #[default]
+    ScopeLocal,
+    /// Changes an externally-visible surface (a signature, an export).
+    SurfaceChanging,
+    /// Changes capabilities / effects (I/O, permissions).
+    CapabilityChanging,
+    /// Always requires a human in the loop.
+    NeedsHuman,
+}
+
+/// Whether a fix may be auto-applied (clippy/ESLint `machine-applicable`)
+/// or is opt-in only (`suggestion`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Applicability {
+    /// Safe to auto-apply (`format-only` / `behavior-preserving`).
+    MachineApplicable,
+    /// Preview / opt-in only.
+    Suggestion,
+}
+
+impl Safety {
+    /// The applicability tier this safety level maps to. `format-only` and
+    /// `behavior-preserving` are machine-applicable; everything riskier is a
+    /// suggestion.
+    pub fn applicability(self) -> Applicability {
+        if self <= Safety::BehaviorPreserving {
+            Applicability::MachineApplicable
+        } else {
+            Applicability::Suggestion
+        }
+    }
+
+    /// True when the runner may auto-apply this rule's fix without an
+    /// explicit opt-in.
+    pub fn is_auto_applicable(self) -> bool {
+        self.applicability() == Applicability::MachineApplicable
+    }
+}
+
 /// What flavor of work a rule performs, derived from its shape rather than
 /// declared: a rule with a `fix` is a codemod; one with a `message` but no
 /// `fix` is a lint; a bare matcher is a search.
@@ -190,6 +241,9 @@ pub struct Rule {
     /// Human-readable diagnostic message. Empty for search-only rules.
     #[serde(default)]
     pub message: String,
+    /// How risky the `fix` is. Gates auto-apply. Defaults to `scope-local`.
+    #[serde(default)]
+    pub safety: Safety,
     /// The matcher block (atomic / relational / composite algebra).
     pub rule: RuleNode,
     /// Local utility rules referenced by `matches`, keyed by id.

--- a/crates/harn-rules/tests/safety_idempotency.rs
+++ b/crates/harn-rules/tests/safety_idempotency.rs
@@ -1,0 +1,123 @@
+//! Acceptance for #2835: safety classification, the
+//! machine-applicable/suggestion gate, and the idempotency check.
+
+use harn_rules::{Applicability, CompiledRule, Rule, RulesError, Safety};
+
+fn compile(toml: &str) -> CompiledRule {
+    CompiledRule::compile(&Rule::from_toml_str(toml).expect("parses")).expect("compiles")
+}
+
+fn codemod(safety: &str) -> CompiledRule {
+    compile(&format!(
+        r#"
+        id = "rename"
+        language = "typescript"
+        safety = "{safety}"
+        fix = "bar()"
+        [rule]
+        pattern = "foo()"
+        "#
+    ))
+}
+
+#[test]
+fn default_safety_refuses_auto_apply() {
+    // No `safety` declared -> defaults to scope-local -> a suggestion.
+    let rule = compile(
+        r#"
+        id = "rename"
+        language = "typescript"
+        fix = "bar()"
+        [rule]
+        pattern = "foo()"
+        "#,
+    );
+    assert_eq!(rule.safety(), Safety::ScopeLocal);
+    assert_eq!(rule.applicability(), Applicability::Suggestion);
+    // The preview is still available …
+    let preview = rule.apply("foo();").unwrap();
+    assert!(preview.rewritten.contains("bar()"));
+    // … but auto_apply refuses without an explicit opt-in.
+    assert!(matches!(
+        rule.auto_apply("foo();"),
+        Err(RulesError::NotAutoApplicable { .. })
+    ));
+}
+
+#[test]
+fn machine_applicable_tiers_auto_apply() {
+    for safety in ["format-only", "behavior-preserving"] {
+        let rule = codemod(safety);
+        assert_eq!(rule.applicability(), Applicability::MachineApplicable);
+        let applied = rule.auto_apply("foo();").expect("auto-applies");
+        assert!(applied.rewritten.contains("bar()"));
+        assert_eq!(applied.safety, rule.safety());
+    }
+}
+
+#[test]
+fn risky_tiers_are_suggestions() {
+    for safety in [
+        "scope-local",
+        "surface-changing",
+        "capability-changing",
+        "needs-human",
+    ] {
+        let rule = codemod(safety);
+        assert_eq!(rule.applicability(), Applicability::Suggestion);
+        assert!(rule.auto_apply("foo();").is_err());
+    }
+}
+
+#[test]
+fn idempotent_fix_passes_the_check() {
+    let rule = codemod("format-only");
+    let result = rule.apply("foo();\n").unwrap();
+    assert!(result.idempotent);
+    // `bar()` no longer matches `foo()`, so a second pass is a no-op.
+    assert!(rule.apply_checked("foo();\n").is_ok());
+}
+
+#[test]
+fn non_idempotent_fix_is_rejected() {
+    // `foo()` -> `foo()()` reintroduces a `foo()` match on every pass, so it
+    // never reaches a fixed point.
+    let rule = compile(
+        r#"
+        id = "double-call"
+        language = "typescript"
+        safety = "behavior-preserving"
+        fix = "foo()()"
+        [rule]
+        pattern = "foo()"
+        "#,
+    );
+    let result = rule.apply("foo();\n").unwrap();
+    assert!(!result.idempotent, "fix should be flagged non-idempotent");
+    assert!(matches!(
+        rule.apply_checked("foo();\n"),
+        Err(RulesError::NotIdempotent { .. })
+    ));
+}
+
+#[test]
+fn diagnostics_carry_message_severity_and_applicability() {
+    let rule = compile(
+        r#"
+        id = "no-foo"
+        language = "typescript"
+        severity = "error"
+        message = "Do not call foo()"
+        safety = "behavior-preserving"
+        fix = "bar()"
+        [rule]
+        pattern = "foo()"
+        "#,
+    );
+    let diags = rule.diagnostics("foo();\nfoo();\n").unwrap();
+    assert_eq!(diags.len(), 2);
+    assert_eq!(diags[0].message, "Do not call foo()");
+    assert_eq!(diags[0].rule_id, "no-foo");
+    assert_eq!(diags[0].applicability, Applicability::MachineApplicable);
+    assert_eq!(diags[0].fix.as_deref(), Some("bar()"));
+}


### PR DESCRIPTION
## Summary

Makes rule-engine fixes *trustworthy* by classifying them and gating apply (Rule Engine Epic A).

> Stacked on #2866 (#2833) → #2865 (#2834) → #2863 (#2832).

## What's in it

- **`safety` tier** per rule, mapped onto Burin's edit taxonomy: `format-only` → `behavior-preserving` → `scope-local` (**default**) → `surface-changing` → `capability-changing` → `needs-human`. The two safest map to **machine-applicable**; the rest are **suggestions**.
- **`auto_apply`** refuses to apply anything above `behavior-preserving`, so the runner never silently applies a risky fix. `apply` still returns the preview, now reporting `safety` / `applicability` / `idempotent`.
- **`apply_checked`** asserts idempotency — it re-runs the fix on its own output and fails (`NotIdempotent`) if there are further changes, so a fix must reach a fixed point.
- **`diagnostics(source)`** emits one diagnostic per match (message / severity / span / applicability / interpolated fix) — the mapping surface Epic C and the LSP convert into `LintDiagnostic` / `FixEdit`.

## Acceptance ([#2835](https://github.com/burin-labs/harn/issues/2835))

- ✅ Each rule declares safety (defaulting conservatively to `scope-local`); the runner refuses to silently auto-apply anything above `behavior-preserving`.
- ✅ The idempotency assertion (`apply_checked`) catches a non-idempotent fix (`foo()` → `foo()()`) and passes an idempotent one.

6 new integration tests; clippy + fmt clean.

Closes #2835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
