### PR TITLE
harn-rules: where/transform/fix + relational/composite + safety tiers (#2834, #2833, #2835)

### DIFF
--- a/changelog.d/2833.added.md
+++ b/changelog.d/2833.added.md
@@ -1,0 +1,6 @@
+- `harn-rules`: added the relational + composite matching algebra (Rule Engine Epic A). A rule's `[rule]` block is now
+  a recursive node that combines an atomic leaf (`pattern` / `kind` / `regex`) with relational constraints (`inside`,
+  `has`, `follows`, `precedes` — each tuned by `stopBy` and `field`) and composite combinators (`all`, `any`, `not`,
+  and `matches` referencing a `[utils]` utility rule); every key is ANDed. A tree-walking evaluator threads metavar
+  bindings through the relational context. Metavar-free patterns are now valid literal patterns (`foo()` matches calls
+  to `foo`).

--- a/changelog.d/2834.added.md
+++ b/changelog.d/2834.added.md
@@ -1,0 +1,5 @@
+- `harn-rules`: added the predicate + rewrite layer (Rule Engine Epic A). Rules can now narrow matches with `where`
+  constraints (metavar regex, numeric/string comparison, and recursive sub-pattern), synthesize new metavars with a
+  `transform` pipeline (regex `replace`, `substring`, and case `convert`), and rewrite with a `fix` template that
+  interpolates `$VAR` / `${VAR}` from captured and transformed metavars. `CompiledRule::apply` runs a codemod —
+  filtering by constraints and splicing per-match fixes format-preservingly, the same byte-splice as `ast.batch_apply`.

--- a/changelog.d/2835.added.md
+++ b/changelog.d/2835.added.md
@@ -1,0 +1,7 @@
+- `harn-rules`: added fix safety classification and the apply gate (Rule Engine Epic A). A rule declares a `safety`
+  tier (`format-only` → `behavior-preserving` → `scope-local` (default) → `surface-changing` →
+  `capability-changing` → `needs-human`); the two safest are machine-applicable, the rest suggestions. `auto_apply`
+  refuses to silently apply anything riskier than `behavior-preserving`, `apply_checked` additionally asserts the fix
+  is idempotent (re-running it reaches a fixed point), and `diagnostics()` emits per-match diagnostics (message,
+  severity, span, applicability, interpolated fix) — the surface the linter and LSP convert into
+  `LintDiagnostic` / `FixEdit`.

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -11,11 +11,12 @@ and produces matches with metavariable bindings — the structural complement
 to regex/glob search.
 
 This crate ships the **atomic matching tier**
-([harn#2832](https://github.com/burin-labs/harn/issues/2832)) plus the
+([harn#2832](https://github.com/burin-labs/harn/issues/2832)), the
+**relational + composite algebra**
+([harn#2833](https://github.com/burin-labs/harn/issues/2833)), and the
 **predicate + rewrite layer**
-([harn#2834](https://github.com/burin-labs/harn/issues/2834)). Relational /
-composite matching (#2833) and the whole-project scan lifecycle (#2836)
-build on it.
+([harn#2834](https://github.com/burin-labs/harn/issues/2834)). The
+whole-project scan lifecycle (#2836) builds on it.
 
 ## Rule shape (TOML)
 
@@ -45,6 +46,33 @@ A rule's kind is derived from its shape: a `fix` makes it a **codemod**; a
   land with the relational tier (#2833).
 - `kind` — a bare tree-sitter node kind (e.g. `"call_expression"`).
 - `regex` — a regular expression over the source text.
+
+A metavar-free `pattern` is a **literal** pattern: `foo()` matches calls to
+`foo` specifically (every non-metavar identifier/literal is constrained to
+its exact text).
+
+### Relational + composite algebra
+
+Beyond the atomic leaf, a rule node can add relational and composite keys —
+all ANDed. A node matches iff its atomic part matches *and* every other key
+holds:
+
+```toml
+[rule]
+pattern = "let $NAME = $SRC?.$KEY ?? $DEF"
+[rule.inside]                  # ancestor must match this sub-rule
+kind = "statement_block"
+stopBy = "end"                 # neighbor (default) | end | <rule>
+[rule.not.inside]              # composite `not` of a relational `inside`
+kind = "try_statement"
+stopBy = "end"
+```
+
+- **Relational**: `inside` (ancestor), `has` (descendant), `follows` /
+  `precedes` (siblings), each a sub-rule tuned by `stopBy` and `field`
+  (restrict to a tree-sitter field).
+- **Composite**: `all` / `any` (lists of sub-rules), `not` (a sub-rule),
+  and `matches` (reference a `[utils.NAME]` utility rule by id).
 
 ### `where` constraints, `transform`, and `fix`
 

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -103,6 +103,23 @@ metavars), and splices the replacements in — format-preserving, the same
 byte-splice guarantee as `ast.batch_apply`. It returns the rewritten source
 plus the per-match edits; the caller decides whether to write.
 
+### Safety, applicability, and idempotency
+
+A rule declares a `safety` tier — `format-only` → `behavior-preserving` →
+`scope-local` (default) → `surface-changing` → `capability-changing` →
+`needs-human`. The two safest map to **machine-applicable**; the rest are
+**suggestions** (opt-in). The gate:
+
+- `apply` always computes the preview (and reports `safety`,
+  `applicability`, and whether the fix is `idempotent`).
+- `auto_apply` refuses anything above `behavior-preserving` — so the runner
+  never silently applies a risky fix.
+- `apply_checked` additionally fails if the fix is **not idempotent** (re-
+  running it produces further changes — it never reaches a fixed point).
+- `diagnostics(source)` emits one diagnostic per match (message, severity,
+  span, applicability, interpolated fix) — the mapping surface the linter
+  and LSP convert into `LintDiagnostic` / `FixEdit`.
+
 ## Usage
 
 ```rust

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -11,9 +11,11 @@ and produces matches with metavariable bindings — the structural complement
 to regex/glob search.
 
 This crate ships the **atomic matching tier**
-([harn#2832](https://github.com/burin-labs/harn/issues/2832)). Relational /
-composite matching (#2833) and `where` / `transform` / `fix` interpolation
-(#2834) build on it.
+([harn#2832](https://github.com/burin-labs/harn/issues/2832)) plus the
+**predicate + rewrite layer**
+([harn#2834](https://github.com/burin-labs/harn/issues/2834)). Relational /
+composite matching (#2833) and the whole-project scan lifecycle (#2836)
+build on it.
 
 ## Rule shape (TOML)
 
@@ -43,6 +45,35 @@ A rule's kind is derived from its shape: a `fix` makes it a **codemod**; a
   land with the relational tier (#2833).
 - `kind` — a bare tree-sitter node kind (e.g. `"call_expression"`).
 - `regex` — a regular expression over the source text.
+
+### `where` constraints, `transform`, and `fix`
+
+A rule can narrow matches with `where` predicates, synthesize new metavars
+with `transform`, and rewrite with `fix`:
+
+```toml
+id = "snakeify-getters"
+language = "typescript"
+fix = "$SNAKE()"                     # interpolates $VAR / ${VAR} (and $$ -> $)
+
+[rule]
+pattern = "$FN()"
+
+[[where]]                            # keep only matches that pass every predicate
+metavar = "FN"
+regex = "^get[A-Z]"                  # or: comparison = { op = ">", value = 100 }
+                                     # or: pattern = "..."  (recursive sub-pattern)
+
+[transform.SNAKE]                    # derive a new metavar before fixing
+source = "FN"
+convert = "snake"                    # or: replace = { regex, by } / substring = { start, end }
+```
+
+`CompiledRule::apply(source)` runs the rule, drops matches that fail any
+constraint, interpolates each match's `fix` (from its captured + transformed
+metavars), and splices the replacements in — format-preserving, the same
+byte-splice guarantee as `ast.batch_apply`. It returns the rewritten source
+plus the per-match edits; the caller decides whether to write.
 
 ## Usage
 

--- a/crates/harn-rules/src/constraint.rs
+++ b/crates/harn-rules/src/constraint.rs
@@ -1,0 +1,256 @@
+//! `where` constraints: predicates on captured metavars (Semgrep
+//! `metavariable-regex` / `metavariable-comparison` / `metavariable-pattern`).
+//!
+//! A match survives only when every constraint holds. Constraints are
+//! compiled once (regex compiled, sub-pattern lowered to a tree-sitter
+//! query) and evaluated against each match's metavar bindings.
+
+use regex::Regex;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Query, QueryCursor};
+
+use harn_hostlib::ast::{api, Language};
+
+use crate::error::RulesError;
+use crate::model::Constraint;
+use crate::pattern::compile_pattern;
+
+/// A compiled `where` constraint bound to one metavar.
+pub struct CompiledConstraint {
+    /// The metavar this constraint filters on (without `$`).
+    pub metavar: String,
+    kind: Kind,
+}
+
+enum Kind {
+    Regex(Regex),
+    Comparison { op: CmpOp, value: toml::Value },
+    SubPattern { language: Language, query: Query },
+}
+
+#[derive(Clone, Copy)]
+enum CmpOp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+impl CmpOp {
+    fn parse(op: &str) -> Option<Self> {
+        Some(match op {
+            "<" => CmpOp::Lt,
+            "<=" => CmpOp::Le,
+            ">" => CmpOp::Gt,
+            ">=" => CmpOp::Ge,
+            "==" => CmpOp::Eq,
+            "!=" => CmpOp::Ne,
+            _ => return None,
+        })
+    }
+}
+
+impl CompiledConstraint {
+    /// Compile a constraint. `default_language` is the rule's language,
+    /// used for a sub-pattern that does not name its own.
+    pub fn compile(
+        rule_id: &str,
+        default_language: Language,
+        constraint: &Constraint,
+    ) -> Result<Self, RulesError> {
+        let err = |message: String| RulesError::PatternCompile {
+            rule: rule_id.to_string(),
+            message,
+        };
+
+        let set = [
+            constraint.regex.is_some(),
+            constraint.comparison.is_some(),
+            constraint.pattern.is_some(),
+        ]
+        .into_iter()
+        .filter(|b| *b)
+        .count();
+        if set != 1 {
+            return Err(err(format!(
+                "where-constraint on `{}` must set exactly one of `regex` / `comparison` / `pattern`",
+                constraint.metavar
+            )));
+        }
+
+        let kind = if let Some(re) = &constraint.regex {
+            Kind::Regex(
+                Regex::new(re)
+                    .map_err(|e| err(format!("constraint regex `{re}` is invalid: {e}")))?,
+            )
+        } else if let Some(cmp) = &constraint.comparison {
+            let op = CmpOp::parse(&cmp.op)
+                .ok_or_else(|| err(format!("unknown comparison operator `{}`", cmp.op)))?;
+            Kind::Comparison {
+                op,
+                value: cmp.value.clone(),
+            }
+        } else {
+            let snippet = constraint.pattern.as_ref().unwrap();
+            let language = match &constraint.language {
+                Some(name) => Language::from_name(name)
+                    .ok_or_else(|| err(format!("unknown sub-pattern language `{name}`")))?,
+                None => default_language,
+            };
+            let ts_language = language
+                .ts_language()
+                .ok_or_else(|| err(format!("grammar for `{}` is unavailable", language.name())))?;
+            let compiled = compile_pattern(snippet, language)
+                .map_err(|m| err(format!("sub-pattern on `{}`: {m}", constraint.metavar)))?;
+            let query = Query::new(&ts_language, &compiled.query)
+                .map_err(|e| err(format!("sub-pattern query rejected: {e}")))?;
+            Kind::SubPattern { language, query }
+        };
+
+        Ok(CompiledConstraint {
+            metavar: constraint.metavar.clone(),
+            kind,
+        })
+    }
+
+    /// Evaluate the constraint against a metavar's captured `text`.
+    pub fn evaluate(&self, text: &str) -> bool {
+        match &self.kind {
+            Kind::Regex(re) => re.is_match(text),
+            Kind::Comparison { op, value } => evaluate_comparison(*op, text, value),
+            Kind::SubPattern { language, query } => {
+                let Ok(tree) = api::parse_tree(text, *language) else {
+                    return false;
+                };
+                let mut cursor = QueryCursor::new();
+                let mut it = cursor.matches(query, tree.root_node(), text.as_bytes());
+                it.next().is_some()
+            }
+        }
+    }
+}
+
+fn evaluate_comparison(op: CmpOp, text: &str, value: &toml::Value) -> bool {
+    // Numeric comparison when the RHS is a number and the captured text
+    // parses as one; otherwise fall back to string equality for `==` / `!=`.
+    if let Some(rhs) = value
+        .as_float()
+        .or_else(|| value.as_integer().map(|i| i as f64))
+    {
+        if let Ok(lhs) = text.trim().parse::<f64>() {
+            return match op {
+                CmpOp::Lt => lhs < rhs,
+                CmpOp::Le => lhs <= rhs,
+                CmpOp::Gt => lhs > rhs,
+                CmpOp::Ge => lhs >= rhs,
+                CmpOp::Eq => (lhs - rhs).abs() < f64::EPSILON,
+                CmpOp::Ne => (lhs - rhs).abs() >= f64::EPSILON,
+            };
+        }
+        // RHS numeric but LHS not a number: only `!=` can be satisfied.
+        return matches!(op, CmpOp::Ne);
+    }
+
+    let rhs = match value {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Boolean(b) => b.to_string(),
+        other => other.to_string(),
+    };
+    match op {
+        CmpOp::Eq => text == rhs,
+        CmpOp::Ne => text != rhs,
+        // Ordering on non-numbers falls back to lexicographic compare.
+        CmpOp::Lt => text < rhs.as_str(),
+        CmpOp::Le => text <= rhs.as_str(),
+        CmpOp::Gt => text > rhs.as_str(),
+        CmpOp::Ge => text >= rhs.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Comparison;
+
+    fn regex_constraint(metavar: &str, re: &str) -> CompiledConstraint {
+        let c = Constraint {
+            metavar: metavar.into(),
+            regex: Some(re.into()),
+            comparison: None,
+            pattern: None,
+            language: None,
+        };
+        CompiledConstraint::compile("r", Language::Rust, &c).unwrap()
+    }
+
+    #[test]
+    fn regex_constraint_matches() {
+        let c = regex_constraint("KEY", "^[a-z][a-zA-Z]*$");
+        assert!(c.evaluate("userId"));
+        assert!(!c.evaluate("0bad"));
+    }
+
+    #[test]
+    fn numeric_comparison() {
+        let c = Constraint {
+            metavar: "N".into(),
+            regex: None,
+            comparison: Some(Comparison {
+                op: ">".into(),
+                value: toml::Value::Integer(0),
+            }),
+            pattern: None,
+            language: None,
+        };
+        let c = CompiledConstraint::compile("r", Language::Rust, &c).unwrap();
+        assert!(c.evaluate("5"));
+        assert!(!c.evaluate("0"));
+        assert!(!c.evaluate("-3"));
+    }
+
+    #[test]
+    fn string_equality_comparison() {
+        let c = Constraint {
+            metavar: "S".into(),
+            regex: None,
+            comparison: Some(Comparison {
+                op: "!=".into(),
+                value: toml::Value::String("nil".into()),
+            }),
+            pattern: None,
+            language: None,
+        };
+        let c = CompiledConstraint::compile("r", Language::Rust, &c).unwrap();
+        assert!(c.evaluate("something"));
+        assert!(!c.evaluate("nil"));
+    }
+
+    #[test]
+    fn sub_pattern_constraint() {
+        // The captured metavar text must itself be a call expression.
+        let c = Constraint {
+            metavar: "VALUE".into(),
+            regex: None,
+            comparison: None,
+            pattern: Some("$FN($ARG)".into()),
+            language: Some("typescript".into()),
+        };
+        let c = CompiledConstraint::compile("r", Language::TypeScript, &c).unwrap();
+        assert!(c.evaluate("compute(x)"));
+        assert!(!c.evaluate("42"));
+    }
+
+    #[test]
+    fn rejects_zero_or_multiple_kinds() {
+        let none = Constraint {
+            metavar: "X".into(),
+            regex: None,
+            comparison: None,
+            pattern: None,
+            language: None,
+        };
+        assert!(CompiledConstraint::compile("r", Language::Rust, &none).is_err());
+    }
+}

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -14,9 +14,12 @@ use harn_hostlib::ast::{api, Language};
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Query, QueryCursor};
 
+use crate::constraint::CompiledConstraint;
 use crate::error::RulesError;
+use crate::fix::{interpolate, splice, AppliedEdit};
 use crate::model::{AtomicMatcher, Rule};
 use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+use crate::transform::CompiledTransform;
 
 /// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
 /// Harn AST wire format.
@@ -74,11 +77,28 @@ pub struct RuleMatch {
     pub bindings: BTreeMap<String, Binding>,
 }
 
+/// The result of applying a codemod rule's `fix` to a source string.
+#[derive(Debug, Clone)]
+pub struct CodemodResult {
+    /// The rewritten source (equals the input when nothing matched).
+    pub rewritten: String,
+    /// The per-match edits that were spliced in, in document order.
+    pub edits: Vec<AppliedEdit>,
+    /// Whether the rewrite changed the source.
+    pub changed: bool,
+}
+
 /// A rule whose matcher has been compiled and is ready to run.
 pub struct CompiledRule {
     rule_id: String,
     language: Language,
     matcher: CompiledMatcher,
+    /// `where` predicates; a match survives only when all hold.
+    constraints: Vec<CompiledConstraint>,
+    /// `transform` definitions: (new metavar name, compiled transform).
+    transforms: Vec<(String, CompiledTransform)>,
+    /// The `fix` replacement template, if this is a codemod.
+    fix: Option<String>,
 }
 
 enum CompiledMatcher {
@@ -162,10 +182,27 @@ impl CompiledRule {
             }
         };
 
+        let constraints = rule
+            .where_constraints
+            .iter()
+            .map(|c| CompiledConstraint::compile(&rule.id, language, c))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let transforms = rule
+            .transform
+            .iter()
+            .map(|(name, t)| {
+                CompiledTransform::compile(&rule.id, name, t).map(|c| (name.clone(), c))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
         Ok(CompiledRule {
             rule_id: rule.id.clone(),
             language,
             matcher,
+            constraints,
+            transforms,
+            fix: rule.fix.clone(),
         })
     }
 
@@ -175,12 +212,82 @@ impl CompiledRule {
     }
 
     /// Run the compiled rule against `source`, returning matches in
-    /// document order.
+    /// document order. Matches that fail any `where` constraint are dropped.
     pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {
-        match &self.matcher {
-            CompiledMatcher::Query { query, metavars } => self.run_query(query, metavars, source),
-            CompiledMatcher::Regex(regex) => Ok(self.run_regex(regex, source)),
+        let mut matches = match &self.matcher {
+            CompiledMatcher::Query { query, metavars } => {
+                self.run_query(query, metavars, source)?
+            }
+            CompiledMatcher::Regex(regex) => self.run_regex(regex, source),
+        };
+        if !self.constraints.is_empty() {
+            matches.retain(|m| self.satisfies_constraints(m));
         }
+        Ok(matches)
+    }
+
+    /// True when every `where` constraint holds for this match. A
+    /// constraint whose metavar is unbound (not captured) fails closed.
+    fn satisfies_constraints(&self, m: &RuleMatch) -> bool {
+        self.constraints.iter().all(|c| {
+            m.bindings
+                .get(&c.metavar)
+                .is_some_and(|b| c.evaluate(&b.text))
+        })
+    }
+
+    /// Apply this codemod rule's `fix` to `source`, returning the rewritten
+    /// text plus the per-match edits. Each match's `fix` template is
+    /// interpolated from its captured metavars plus any `transform`-derived
+    /// ones. Errors if the rule has no `fix`.
+    pub fn apply(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        let template = self
+            .fix
+            .as_ref()
+            .ok_or_else(|| RulesError::PatternCompile {
+                rule: self.rule_id.clone(),
+                message: "apply() requires a `fix` template; this rule has none".into(),
+            })?;
+
+        let matches = self.run(source)?;
+        let edits: Vec<AppliedEdit> = matches
+            .iter()
+            .map(|m| {
+                let vars = self.metavars_for(m);
+                AppliedEdit {
+                    span: m.span,
+                    before: m.text.clone(),
+                    replacement: interpolate(template, &vars),
+                }
+            })
+            .collect();
+
+        let rewritten = splice(source, &edits);
+        let changed = rewritten != source;
+        Ok(CodemodResult {
+            rewritten,
+            edits,
+            changed,
+        })
+    }
+
+    /// Build the full metavar map for a match: captured bindings plus the
+    /// `transform`-synthesized metavars (which may shadow captures).
+    fn metavars_for(&self, m: &RuleMatch) -> BTreeMap<String, String> {
+        let mut vars: BTreeMap<String, String> = m
+            .bindings
+            .iter()
+            .map(|(name, binding)| (name.clone(), binding.text.clone()))
+            .collect();
+        for (name, transform) in &self.transforms {
+            let input = m
+                .bindings
+                .get(&transform.source)
+                .map(|b| b.text.as_str())
+                .unwrap_or("");
+            vars.insert(name.clone(), transform.apply(input));
+        }
+        vars
     }
 
     fn run_query(

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -10,15 +10,13 @@
 
 use std::collections::BTreeMap;
 
-use harn_hostlib::ast::{api, Language};
-use streaming_iterator::StreamingIterator;
-use tree_sitter::{Query, QueryCursor};
+use harn_hostlib::ast::Language;
 
 use crate::constraint::CompiledConstraint;
 use crate::error::RulesError;
+use crate::evaluator::CompiledRuleTree;
 use crate::fix::{interpolate, splice, AppliedEdit};
-use crate::model::{AtomicMatcher, Rule};
-use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+use crate::model::Rule;
 use crate::transform::CompiledTransform;
 
 /// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
@@ -40,7 +38,7 @@ pub struct Span {
 }
 
 impl Span {
-    fn of(node: tree_sitter::Node<'_>) -> Self {
+    pub(crate) fn of(node: tree_sitter::Node<'_>) -> Self {
         let start = node.start_position();
         let end = node.end_position();
         Span {
@@ -92,7 +90,7 @@ pub struct CodemodResult {
 pub struct CompiledRule {
     rule_id: String,
     language: Language,
-    matcher: CompiledMatcher,
+    execution: Execution,
     /// `where` predicates; a match survives only when all hold.
     constraints: Vec<CompiledConstraint>,
     /// `transform` definitions: (new metavar name, compiled transform).
@@ -101,12 +99,12 @@ pub struct CompiledRule {
     fix: Option<String>,
 }
 
-enum CompiledMatcher {
-    /// A tree-sitter query plus the metavar names to extract. Covers both
-    /// `pattern` and `kind` forms.
-    Query { query: Query, metavars: Vec<String> },
-    /// A text regex over the whole source.
-    Regex(regex::Regex),
+enum Execution {
+    /// A top-level pure-`regex` rule: scan the raw source text (grep-style),
+    /// independent of the tree. Its match span is the regex match range.
+    SourceRegex(regex::Regex),
+    /// The full matching algebra (atomic + relational + composite).
+    Tree(Box<CompiledRuleTree>),
 }
 
 impl CompiledRule {
@@ -118,68 +116,24 @@ impl CompiledRule {
                 language: rule.language.clone(),
             })?;
 
-        let matcher = match rule
-            .rule
-            .resolve()
-            .map_err(|message| RulesError::PatternCompile {
-                rule: rule.id.clone(),
-                message,
-            })? {
-            AtomicMatcher::Pattern(snippet) => {
-                let ts_language =
-                    language
-                        .ts_language()
-                        .ok_or_else(|| RulesError::GrammarUnavailable {
-                            rule: rule.id.clone(),
-                            language: language.name().to_string(),
-                        })?;
-                let compiled = compile_pattern(&snippet, language).map_err(|message| {
-                    RulesError::PatternCompile {
-                        rule: rule.id.clone(),
-                        message,
-                    }
-                })?;
-                let query = Query::new(&ts_language, &compiled.query).map_err(|err| {
-                    RulesError::QueryRejected {
-                        rule: rule.id.clone(),
-                        message: err.to_string(),
-                        query: compiled.query.clone(),
-                    }
-                })?;
-                CompiledMatcher::Query {
-                    query,
-                    metavars: compiled.metavars,
+        // A top-level pure-`regex` rule greps the source text directly; any
+        // other shape (pattern / kind / relational / composite) compiles to
+        // the tree-walking algebra.
+        let execution = if rule.rule.is_pure_regex() {
+            let pattern = rule.rule.regex.as_ref().expect("pure regex");
+            Execution::SourceRegex(regex::Regex::new(pattern).map_err(|err| {
+                RulesError::PatternCompile {
+                    rule: rule.id.clone(),
+                    message: format!("invalid regex `{pattern}`: {err}"),
                 }
-            }
-            AtomicMatcher::Kind(kind) => {
-                let ts_language =
-                    language
-                        .ts_language()
-                        .ok_or_else(|| RulesError::GrammarUnavailable {
-                            rule: rule.id.clone(),
-                            language: language.name().to_string(),
-                        })?;
-                let query_text = format!("({kind}) @{ROOT_CAPTURE}");
-                let query = Query::new(&ts_language, &query_text).map_err(|err| {
-                    RulesError::QueryRejected {
-                        rule: rule.id.clone(),
-                        message: err.to_string(),
-                        query: query_text.clone(),
-                    }
-                })?;
-                CompiledMatcher::Query {
-                    query,
-                    metavars: Vec::new(),
-                }
-            }
-            AtomicMatcher::Regex(pattern) => {
-                let regex =
-                    regex::Regex::new(&pattern).map_err(|err| RulesError::PatternCompile {
-                        rule: rule.id.clone(),
-                        message: format!("invalid regex `{pattern}`: {err}"),
-                    })?;
-                CompiledMatcher::Regex(regex)
-            }
+            })?)
+        } else {
+            Execution::Tree(Box::new(CompiledRuleTree::compile(
+                &rule.id,
+                language,
+                &rule.rule,
+                &rule.utils,
+            )?))
         };
 
         let constraints = rule
@@ -199,7 +153,7 @@ impl CompiledRule {
         Ok(CompiledRule {
             rule_id: rule.id.clone(),
             language,
-            matcher,
+            execution,
             constraints,
             transforms,
             fix: rule.fix.clone(),
@@ -214,11 +168,18 @@ impl CompiledRule {
     /// Run the compiled rule against `source`, returning matches in
     /// document order. Matches that fail any `where` constraint are dropped.
     pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {
-        let mut matches = match &self.matcher {
-            CompiledMatcher::Query { query, metavars } => {
-                self.run_query(query, metavars, source)?
-            }
-            CompiledMatcher::Regex(regex) => self.run_regex(regex, source),
+        let mut matches = match &self.execution {
+            Execution::SourceRegex(regex) => self.run_regex(regex, source),
+            Execution::Tree(tree) => tree
+                .find(&self.rule_id, self.language, source)?
+                .into_iter()
+                .map(|m| RuleMatch {
+                    rule_id: self.rule_id.clone(),
+                    span: m.span,
+                    text: m.text,
+                    bindings: m.bindings,
+                })
+                .collect(),
         };
         if !self.constraints.is_empty() {
             matches.retain(|m| self.satisfies_constraints(m));
@@ -288,57 +249,6 @@ impl CompiledRule {
             vars.insert(name.clone(), transform.apply(input));
         }
         vars
-    }
-
-    fn run_query(
-        &self,
-        query: &Query,
-        metavars: &[String],
-        source: &str,
-    ) -> Result<Vec<RuleMatch>, RulesError> {
-        let tree =
-            api::parse_tree(source, self.language).map_err(|err| RulesError::SourceParse {
-                rule: self.rule_id.clone(),
-                message: err.to_string(),
-            })?;
-        let names: Vec<&str> = query.capture_names().to_vec();
-        let bytes = source.as_bytes();
-
-        let mut cursor = QueryCursor::new();
-        let mut it = cursor.matches(query, tree.root_node(), bytes);
-        let mut matches = Vec::new();
-        while let Some(m) = it.next() {
-            let mut root: Option<Span> = None;
-            let mut root_text = String::new();
-            let mut bindings: BTreeMap<String, Binding> = BTreeMap::new();
-            for cap in m.captures {
-                let name = names[cap.index as usize];
-                let span = Span::of(cap.node);
-                let text = source[cap.node.start_byte()..cap.node.end_byte()].to_string();
-                if name == ROOT_CAPTURE {
-                    root = Some(span);
-                    root_text = text;
-                } else if metavars.iter().any(|m| m == name) {
-                    // Canonical metavar capture; unification helpers carry a
-                    // `.` and never appear in `metavars`, so they are skipped.
-                    bindings
-                        .entry(name.to_string())
-                        .or_insert(Binding { text, span });
-                }
-            }
-            if let Some(span) = root {
-                matches.push(RuleMatch {
-                    rule_id: self.rule_id.clone(),
-                    span,
-                    text: root_text,
-                    bindings,
-                });
-            }
-        }
-        // Tree-sitter yields matches in query-eval order; sort to document
-        // order for a stable, intuitive result.
-        matches.sort_by_key(|m| (m.span.start_byte, m.span.end_byte));
-        Ok(matches)
     }
 
     fn run_regex(&self, regex: &regex::Regex, source: &str) -> Vec<RuleMatch> {

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -16,7 +16,7 @@ use crate::constraint::CompiledConstraint;
 use crate::error::RulesError;
 use crate::evaluator::CompiledRuleTree;
 use crate::fix::{interpolate, splice, AppliedEdit};
-use crate::model::Rule;
+use crate::model::{Applicability, Rule, Safety, Severity};
 use crate::transform::CompiledTransform;
 
 /// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
@@ -84,6 +84,13 @@ pub struct CodemodResult {
     pub edits: Vec<AppliedEdit>,
     /// Whether the rewrite changed the source.
     pub changed: bool,
+    /// The rule's declared safety tier.
+    pub safety: Safety,
+    /// Whether the fix may be auto-applied or is opt-in only.
+    pub applicability: Applicability,
+    /// Whether re-running the fix on `rewritten` yields no further change
+    /// (a fix should reach a fixed point).
+    pub idempotent: bool,
 }
 
 /// A rule whose matcher has been compiled and is ready to run.
@@ -97,6 +104,31 @@ pub struct CompiledRule {
     transforms: Vec<(String, CompiledTransform)>,
     /// The `fix` replacement template, if this is a codemod.
     fix: Option<String>,
+    /// The fix's safety tier (gates auto-apply).
+    safety: Safety,
+    /// The diagnostic message (empty for search-only rules).
+    message: String,
+    /// The diagnostic severity.
+    severity: Severity,
+}
+
+/// A diagnostic produced by running a rule — the mapping surface onto the
+/// linter's `LintDiagnostic` / `FixEdit` (Epic C / the LSP reuse this).
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    /// The rule id (also the diagnostic code).
+    pub rule_id: String,
+    /// The diagnostic message.
+    pub message: String,
+    /// The severity.
+    pub severity: Severity,
+    /// The flagged span.
+    pub span: Span,
+    /// Whether a fix, if present, is auto-applicable or a suggestion.
+    pub applicability: Applicability,
+    /// The interpolated fix replacement for this match, if the rule has a
+    /// `fix`.
+    pub fix: Option<String>,
 }
 
 enum Execution {
@@ -157,12 +189,26 @@ impl CompiledRule {
             constraints,
             transforms,
             fix: rule.fix.clone(),
+            safety: rule.safety,
+            message: rule.message.clone(),
+            severity: rule.severity,
         })
     }
 
     /// The language this rule targets.
     pub fn language(&self) -> Language {
         self.language
+    }
+
+    /// The fix's declared safety tier.
+    pub fn safety(&self) -> Safety {
+        self.safety
+    }
+
+    /// Whether this rule's fix may be auto-applied (machine-applicable) or
+    /// is opt-in only (suggestion).
+    pub fn applicability(&self) -> Applicability {
+        self.safety.applicability()
     }
 
     /// Run the compiled rule against `source`, returning matches in
@@ -201,13 +247,85 @@ impl CompiledRule {
     /// text plus the per-match edits. Each match's `fix` template is
     /// interpolated from its captured metavars plus any `transform`-derived
     /// ones. Errors if the rule has no `fix`.
+    ///
+    /// This computes the preview only — it does not enforce the safety gate.
+    /// Use [`CompiledRule::auto_apply`] to refuse non-machine-applicable
+    /// fixes, or [`CompiledRule::apply_checked`] to also assert idempotency.
     pub fn apply(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        let (rewritten, edits) = self.rewrite(source)?;
+        let changed = rewritten != source;
+        // Idempotency: re-running the fix on its own output must not change
+        // it further (the fix should reach a fixed point).
+        let (twice, _) = self.rewrite(&rewritten)?;
+        let idempotent = twice == rewritten;
+        Ok(CodemodResult {
+            rewritten,
+            edits,
+            changed,
+            safety: self.safety,
+            applicability: self.applicability(),
+            idempotent,
+        })
+    }
+
+    /// Like [`CompiledRule::apply`], but refuses to apply a fix whose
+    /// `safety` is above the machine-applicable threshold (`scope-local` and
+    /// riskier). This is the gate `harn codemod --apply` uses by default.
+    pub fn auto_apply(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        if !self.safety.is_auto_applicable() {
+            return Err(RulesError::NotAutoApplicable {
+                rule: self.rule_id.clone(),
+                safety: format!("{:?}", self.safety),
+            });
+        }
+        self.apply(source)
+    }
+
+    /// Like [`CompiledRule::apply`], but fails if the fix is not idempotent.
+    /// Used by the codemod runner and the rule-test harness to assert a fix
+    /// reaches a fixed point.
+    pub fn apply_checked(&self, source: &str) -> Result<CodemodResult, RulesError> {
+        let result = self.apply(source)?;
+        if !result.idempotent {
+            return Err(RulesError::NotIdempotent {
+                rule: self.rule_id.clone(),
+            });
+        }
+        Ok(result)
+    }
+
+    /// Run the rule and produce one [`Diagnostic`] per match — the surface
+    /// the linter (Epic C) and the LSP convert into `LintDiagnostic` /
+    /// `FixEdit`. Each diagnostic carries the interpolated fix (if any) and
+    /// its applicability tier.
+    pub fn diagnostics(&self, source: &str) -> Result<Vec<Diagnostic>, RulesError> {
+        let applicability = self.applicability();
+        let matches = self.run(source)?;
+        Ok(matches
+            .iter()
+            .map(|m| Diagnostic {
+                rule_id: self.rule_id.clone(),
+                message: self.message.clone(),
+                severity: self.severity,
+                span: m.span,
+                applicability,
+                fix: self.fix.as_ref().map(|template| {
+                    let vars = self.metavars_for(m);
+                    interpolate(template, &vars)
+                }),
+            })
+            .collect())
+    }
+
+    /// The core rewrite: run the rule and splice each match's interpolated
+    /// fix. Returns the rewritten text and the edits.
+    fn rewrite(&self, source: &str) -> Result<(String, Vec<AppliedEdit>), RulesError> {
         let template = self
             .fix
             .as_ref()
             .ok_or_else(|| RulesError::PatternCompile {
                 rule: self.rule_id.clone(),
-                message: "apply() requires a `fix` template; this rule has none".into(),
+                message: "apply requires a `fix` template; this rule has none".into(),
             })?;
 
         let matches = self.run(source)?;
@@ -222,14 +340,7 @@ impl CompiledRule {
                 }
             })
             .collect();
-
-        let rewritten = splice(source, &edits);
-        let changed = rewritten != source;
-        Ok(CodemodResult {
-            rewritten,
-            edits,
-            changed,
-        })
+        Ok((splice(source, &edits), edits))
     }
 
     /// Build the full metavar map for a match: captured bindings plus the

--- a/crates/harn-rules/src/error.rs
+++ b/crates/harn-rules/src/error.rs
@@ -72,4 +72,24 @@ pub enum RulesError {
         /// The parse failure detail.
         message: String,
     },
+
+    /// `auto_apply` was called on a rule whose `safety` is above the
+    /// machine-applicable threshold; it must be applied with explicit opt-in.
+    #[error(
+        "rule `{rule}`: refusing to auto-apply a `{safety}` fix (machine-applicable required)"
+    )]
+    NotAutoApplicable {
+        /// The offending rule id.
+        rule: String,
+        /// The rule's declared safety tier.
+        safety: String,
+    },
+
+    /// A fix did not reach a fixed point: re-running it after applying still
+    /// produced changes.
+    #[error("rule `{rule}`: fix is not idempotent (re-running it produced further changes)")]
+    NotIdempotent {
+        /// The offending rule id.
+        rule: String,
+    },
 }

--- a/crates/harn-rules/src/evaluator.rs
+++ b/crates/harn-rules/src/evaluator.rs
@@ -1,0 +1,458 @@
+//! The relational + composite matching algebra (#2833).
+//!
+//! A [`crate::model::RuleNode`] compiles to a [`CompiledNode`] tree, which
+//! the evaluator walks against a parsed source tree. A node matches a
+//! tree-sitter node iff its **atomic** leaf matches *and* every
+//! **relational** (`inside` / `has` / `follows` / `precedes`) and
+//! **composite** (`all` / `any` / `not` / `matches`) part holds — every set
+//! key is ANDed.
+//!
+//! Candidates for the top rule are seeded cheaply (the atomic pattern query
+//! in one pass, or a kind/regex/whole-tree walk); each candidate is then
+//! checked in full. Relational sub-rules run their own atomic match rooted
+//! at the ancestor/descendant/sibling under test.
+
+use std::collections::BTreeMap;
+
+use harn_hostlib::ast::{api, Language};
+use regex::Regex;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Node, Query, QueryCursor};
+
+use crate::engine::{Binding, Span};
+use crate::error::RulesError;
+use crate::model::{AtomicMatcher, RuleNode, StopBy, StopKeyword};
+use crate::pattern::{compile_pattern, ROOT_CAPTURE};
+
+/// Metavar bindings accumulated while matching a node.
+type Bindings = BTreeMap<String, Binding>;
+
+/// One node that matched the top rule, with its bindings.
+pub struct EvalMatch {
+    /// The matched node's span.
+    pub span: Span,
+    /// The matched node's text.
+    pub text: String,
+    /// Metavar bindings (captured + threaded from relational sub-matches).
+    pub bindings: Bindings,
+}
+
+/// A compiled rule tree: the top node plus the utility rules `matches`
+/// references.
+pub struct CompiledRuleTree {
+    top: CompiledNode,
+    utils: BTreeMap<String, CompiledNode>,
+}
+
+struct CompiledNode {
+    atomic: Option<CompiledAtomic>,
+    inside: Option<Box<CompiledRel>>,
+    has: Option<Box<CompiledRel>>,
+    follows: Option<Box<CompiledRel>>,
+    precedes: Option<Box<CompiledRel>>,
+    all: Vec<CompiledNode>,
+    any: Vec<CompiledNode>,
+    not: Option<Box<CompiledNode>>,
+    matches: Option<String>,
+}
+
+struct CompiledRel {
+    node: CompiledNode,
+    stop_by: CompiledStopBy,
+    field: Option<String>,
+}
+
+enum CompiledStopBy {
+    Neighbor,
+    End,
+    Rule(Box<CompiledNode>),
+}
+
+enum CompiledAtomic {
+    Query { query: Query, metavars: Vec<String> },
+    Kind(String),
+    Regex(Regex),
+}
+
+impl CompiledRuleTree {
+    /// Compile a rule's `[rule]` node and its `[utils]` into a runnable
+    /// tree.
+    pub fn compile(
+        rule_id: &str,
+        language: Language,
+        top: &RuleNode,
+        utils: &BTreeMap<String, RuleNode>,
+    ) -> Result<Self, RulesError> {
+        if top.is_empty() {
+            return Err(RulesError::PatternCompile {
+                rule: rule_id.to_string(),
+                message: "rule node is empty (no atomic / relational / composite key)".into(),
+            });
+        }
+        let compiled_utils = utils
+            .iter()
+            .map(|(id, node)| Ok((id.clone(), compile_node(rule_id, language, node)?)))
+            .collect::<Result<BTreeMap<_, _>, RulesError>>()?;
+        Ok(CompiledRuleTree {
+            top: compile_node(rule_id, language, top)?,
+            utils: compiled_utils,
+        })
+    }
+
+    /// Find every node matching the top rule, in document order.
+    pub fn find(
+        &self,
+        rule_id: &str,
+        language: Language,
+        source: &str,
+    ) -> Result<Vec<EvalMatch>, RulesError> {
+        let tree = api::parse_tree(source, language).map_err(|err| RulesError::SourceParse {
+            rule: rule_id.to_string(),
+            message: err.to_string(),
+        })?;
+        let ctx = Ctx {
+            source,
+            utils: &self.utils,
+        };
+        let root = tree.root_node();
+
+        let mut seen: BTreeMap<(usize, usize), EvalMatch> = BTreeMap::new();
+        for node in seed_candidates(&self.top, &ctx, root) {
+            if let Some(bindings) = node_satisfies(&self.top, node, &ctx) {
+                let key = (node.start_byte(), node.end_byte());
+                seen.entry(key).or_insert_with(|| EvalMatch {
+                    span: Span::of(node),
+                    text: ctx.text(node),
+                    bindings,
+                });
+            }
+        }
+        Ok(seen.into_values().collect())
+    }
+}
+
+/// Per-run evaluation context.
+struct Ctx<'a> {
+    source: &'a str,
+    utils: &'a BTreeMap<String, CompiledNode>,
+}
+
+impl Ctx<'_> {
+    fn text(&self, node: Node<'_>) -> String {
+        self.source[node.start_byte()..node.end_byte()].to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compilation
+// ---------------------------------------------------------------------------
+
+fn compile_node(
+    rule_id: &str,
+    language: Language,
+    node: &RuleNode,
+) -> Result<CompiledNode, RulesError> {
+    let mkerr = |message: String| RulesError::PatternCompile {
+        rule: rule_id.to_string(),
+        message,
+    };
+
+    let atomic = match node.atomic().map_err(mkerr)? {
+        None => None,
+        Some(AtomicMatcher::Pattern(snippet)) => {
+            let ts_language = language
+                .ts_language()
+                .ok_or_else(|| mkerr(format!("grammar for `{}` unavailable", language.name())))?;
+            let compiled =
+                compile_pattern(&snippet, language).map_err(|m| mkerr(format!("pattern: {m}")))?;
+            let query = Query::new(&ts_language, &compiled.query).map_err(|e| {
+                RulesError::QueryRejected {
+                    rule: rule_id.to_string(),
+                    message: e.to_string(),
+                    query: compiled.query.clone(),
+                }
+            })?;
+            Some(CompiledAtomic::Query {
+                query,
+                metavars: compiled.metavars,
+            })
+        }
+        Some(AtomicMatcher::Kind(kind)) => Some(CompiledAtomic::Kind(kind)),
+        Some(AtomicMatcher::Regex(re)) => Some(CompiledAtomic::Regex(
+            Regex::new(&re).map_err(|e| mkerr(format!("regex `{re}` invalid: {e}")))?,
+        )),
+    };
+
+    let rel = |sub: &Option<Box<RuleNode>>| -> Result<Option<Box<CompiledRel>>, RulesError> {
+        match sub {
+            None => Ok(None),
+            Some(n) => Ok(Some(Box::new(compile_rel(rule_id, language, n)?))),
+        }
+    };
+
+    let compile_list = |list: &Option<Vec<RuleNode>>| -> Result<Vec<CompiledNode>, RulesError> {
+        list.iter()
+            .flatten()
+            .map(|n| compile_node(rule_id, language, n))
+            .collect()
+    };
+
+    Ok(CompiledNode {
+        atomic,
+        inside: rel(&node.inside)?,
+        has: rel(&node.has)?,
+        follows: rel(&node.follows)?,
+        precedes: rel(&node.precedes)?,
+        all: compile_list(&node.all)?,
+        any: compile_list(&node.any)?,
+        not: match &node.not {
+            None => None,
+            Some(n) => Some(Box::new(compile_node(rule_id, language, n)?)),
+        },
+        matches: node.matches.clone(),
+    })
+}
+
+fn compile_rel(
+    rule_id: &str,
+    language: Language,
+    node: &RuleNode,
+) -> Result<CompiledRel, RulesError> {
+    let stop_by = match &node.stop_by {
+        None | Some(StopBy::Keyword(StopKeyword::Neighbor)) => CompiledStopBy::Neighbor,
+        Some(StopBy::Keyword(StopKeyword::End)) => CompiledStopBy::End,
+        Some(StopBy::Rule(r)) => {
+            CompiledStopBy::Rule(Box::new(compile_node(rule_id, language, r)?))
+        }
+    };
+    Ok(CompiledRel {
+        node: compile_node(rule_id, language, node)?,
+        stop_by,
+        field: node.field.clone(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+/// Seed candidate nodes for the top rule. The atomic pattern query runs in
+/// one pass; kind/regex/composite-only rules fall back to a tree walk.
+fn seed_candidates<'t>(top: &CompiledNode, ctx: &Ctx<'_>, root: Node<'t>) -> Vec<Node<'t>> {
+    match &top.atomic {
+        Some(CompiledAtomic::Query { query, .. }) => {
+            let mut out = Vec::new();
+            let mut seen = std::collections::HashSet::new();
+            let root_index = root_capture_index(query);
+            let mut cursor = QueryCursor::new();
+            let mut it = cursor.matches(query, root, ctx.source.as_bytes());
+            while let Some(m) = it.next() {
+                for cap in m.captures {
+                    if Some(cap.index) == root_index && seen.insert(cap.node.id()) {
+                        out.push(cap.node);
+                    }
+                }
+            }
+            out
+        }
+        Some(CompiledAtomic::Kind(kind)) => {
+            let mut out = Vec::new();
+            for_each_named_descendant(root, &mut |n| {
+                if n.kind() == kind {
+                    out.push(n);
+                }
+            });
+            out
+        }
+        Some(CompiledAtomic::Regex(_)) | None => {
+            let mut out = Vec::new();
+            for_each_named_descendant(root, &mut |n| out.push(n));
+            out
+        }
+    }
+}
+
+/// Full match check for a specific `node`: atomic + relational + composite.
+fn node_satisfies(cnode: &CompiledNode, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    let mut bindings = Bindings::new();
+
+    if let Some(atomic) = &cnode.atomic {
+        merge(&mut bindings, atomic_match(atomic, node, ctx)?);
+    }
+    if let Some(rel) = &cnode.inside {
+        merge(&mut bindings, eval_inside(rel, node, ctx)?);
+    }
+    if let Some(rel) = &cnode.has {
+        merge(&mut bindings, eval_has(rel, node, ctx)?);
+    }
+    if let Some(rel) = &cnode.follows {
+        merge(&mut bindings, eval_sibling(rel, node, ctx, Dir::Before)?);
+    }
+    if let Some(rel) = &cnode.precedes {
+        merge(&mut bindings, eval_sibling(rel, node, ctx, Dir::After)?);
+    }
+    for sub in &cnode.all {
+        merge(&mut bindings, node_satisfies(sub, node, ctx)?);
+    }
+    if !cnode.any.is_empty() {
+        let matched = cnode
+            .any
+            .iter()
+            .find_map(|sub| node_satisfies(sub, node, ctx));
+        merge(&mut bindings, matched?);
+    }
+    if let Some(not) = &cnode.not {
+        if node_satisfies(not, node, ctx).is_some() {
+            return None;
+        }
+    }
+    if let Some(id) = &cnode.matches {
+        let util = ctx.utils.get(id)?;
+        merge(&mut bindings, node_satisfies(util, node, ctx)?);
+    }
+
+    Some(bindings)
+}
+
+fn atomic_match(atomic: &CompiledAtomic, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    match atomic {
+        CompiledAtomic::Kind(kind) => (node.kind() == kind).then(Bindings::new),
+        CompiledAtomic::Regex(re) => re.is_match(&ctx.text(node)).then(Bindings::new),
+        CompiledAtomic::Query { query, metavars } => {
+            let root_index = root_capture_index(query);
+            let names: Vec<&str> = query.capture_names().to_vec();
+            let mut cursor = QueryCursor::new();
+            let mut it = cursor.matches(query, node, ctx.source.as_bytes());
+            while let Some(m) = it.next() {
+                // The pattern must match `node` itself, not a descendant.
+                let roots_here = m
+                    .captures
+                    .iter()
+                    .any(|c| Some(c.index) == root_index && c.node.id() == node.id());
+                if !roots_here {
+                    continue;
+                }
+                let mut bindings = Bindings::new();
+                for cap in m.captures {
+                    let name = names[cap.index as usize];
+                    if metavars.iter().any(|mv| mv == name) {
+                        bindings.entry(name.to_string()).or_insert_with(|| Binding {
+                            text: ctx.text(cap.node),
+                            span: Span::of(cap.node),
+                        });
+                    }
+                }
+                return Some(bindings);
+            }
+            None
+        }
+    }
+}
+
+fn eval_inside(rel: &CompiledRel, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    let mut current = node.parent();
+    let mut child = node;
+    while let Some(ancestor) = current {
+        if let CompiledStopBy::Rule(stop) = &rel.stop_by {
+            if node_satisfies(stop, ancestor, ctx).is_some()
+                && node_satisfies(&rel.node, ancestor, ctx).is_none()
+            {
+                // Hit the stop boundary without matching.
+                return None;
+            }
+        }
+        if let Some(b) = node_satisfies(&rel.node, ancestor, ctx) {
+            if field_ok(rel.field.as_deref(), ancestor, child) {
+                return Some(b);
+            }
+        }
+        if matches!(rel.stop_by, CompiledStopBy::Neighbor) {
+            return None;
+        }
+        child = ancestor;
+        current = ancestor.parent();
+    }
+    None
+}
+
+fn eval_has(rel: &CompiledRel, node: Node<'_>, ctx: &Ctx<'_>) -> Option<Bindings> {
+    let neighbor = matches!(rel.stop_by, CompiledStopBy::Neighbor);
+    let mut found: Option<Bindings> = None;
+    let mut cursor = node.walk();
+    let children: Vec<Node<'_>> = node.named_children(&mut cursor).collect();
+    for child in children {
+        if let Some(b) = node_satisfies(&rel.node, child, ctx) {
+            if field_ok(rel.field.as_deref(), node, child) {
+                found = Some(b);
+                break;
+            }
+        }
+        if !neighbor {
+            if let Some(b) = eval_has(rel, child, ctx) {
+                found = Some(b);
+                break;
+            }
+        }
+    }
+    found
+}
+
+enum Dir {
+    Before,
+    After,
+}
+
+fn eval_sibling(rel: &CompiledRel, node: Node<'_>, ctx: &Ctx<'_>, dir: Dir) -> Option<Bindings> {
+    let neighbor = matches!(rel.stop_by, CompiledStopBy::Neighbor);
+    let mut sib = match dir {
+        Dir::Before => node.prev_named_sibling(),
+        Dir::After => node.next_named_sibling(),
+    };
+    while let Some(s) = sib {
+        if let Some(b) = node_satisfies(&rel.node, s, ctx) {
+            return Some(b);
+        }
+        if neighbor {
+            return None;
+        }
+        sib = match dir {
+            Dir::Before => s.prev_named_sibling(),
+            Dir::After => s.next_named_sibling(),
+        };
+    }
+    None
+}
+
+/// When a relation names a `field`, the related child must sit in that
+/// field of the parent. `parent` is the ancestor; `child` is the node on
+/// the path toward the matched node.
+fn field_ok(field: Option<&str>, parent: Node<'_>, child: Node<'_>) -> bool {
+    match field {
+        None => true,
+        Some(name) => parent
+            .child_by_field_name(name)
+            .is_some_and(|f| f.id() == child.id()),
+    }
+}
+
+fn merge(into: &mut Bindings, from: Bindings) {
+    for (k, v) in from {
+        into.entry(k).or_insert(v);
+    }
+}
+
+fn root_capture_index(query: &Query) -> Option<u32> {
+    query
+        .capture_names()
+        .iter()
+        .position(|n| *n == ROOT_CAPTURE)
+        .map(|i| i as u32)
+}
+
+fn for_each_named_descendant<'t>(node: Node<'t>, f: &mut impl FnMut(Node<'t>)) {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        f(child);
+        for_each_named_descendant(child, f);
+    }
+}

--- a/crates/harn-rules/src/fix.rs
+++ b/crates/harn-rules/src/fix.rs
@@ -1,0 +1,164 @@
+//! `fix` template interpolation and application.
+//!
+//! A `fix` is a replacement template that interpolates the match's
+//! metavars — both the captured `$VAR`s and any `transform`-synthesized
+//! ones — into replacement text. The engine computes one replacement per
+//! match and splices them into the source (format-preserving byte-splice,
+//! the same guarantee as `ast.batch_apply`).
+
+use std::collections::BTreeMap;
+
+use crate::engine::Span;
+
+/// Interpolate `$VAR` / `${VAR}` references in `template` from `vars`.
+/// An unknown reference is left verbatim (so a literal `$` survives), and
+/// `$$` is an escaped literal dollar sign.
+pub fn interpolate(template: &str, vars: &BTreeMap<String, String>) -> String {
+    let bytes = template.as_bytes();
+    let mut out = String::with_capacity(template.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'$' {
+            let ch = template[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+        // `$$` -> literal `$`.
+        if template[i..].starts_with("$$") {
+            out.push('$');
+            i += 2;
+            continue;
+        }
+        // `${NAME}` braced form.
+        let (name, consumed) = if template[i..].starts_with("${") {
+            match template[i + 2..].find('}') {
+                Some(rel) => (&template[i + 2..i + 2 + rel], 2 + rel + 1),
+                None => {
+                    out.push('$');
+                    i += 1;
+                    continue;
+                }
+            }
+        } else {
+            // `$NAME` bare form.
+            let name_start = i + 1;
+            let mut j = name_start;
+            if j < bytes.len() && is_ident_start(bytes[j]) {
+                j += 1;
+                while j < bytes.len() && is_ident_continue(bytes[j]) {
+                    j += 1;
+                }
+            }
+            (&template[name_start..j], j - i)
+        };
+
+        if name.is_empty() {
+            out.push('$');
+            i += 1;
+            continue;
+        }
+        match vars.get(name) {
+            Some(value) => out.push_str(value),
+            // Unknown metavar: keep the reference literal.
+            None => out.push_str(&template[i..i + consumed]),
+        }
+        i += consumed;
+    }
+    out
+}
+
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// One concrete edit: replace `span`'s bytes (`before`) with `replacement`.
+#[derive(Debug, Clone)]
+pub struct AppliedEdit {
+    /// The replaced span.
+    pub span: Span,
+    /// The original text at the span.
+    pub before: String,
+    /// The interpolated replacement text.
+    pub replacement: String,
+}
+
+/// Apply `edits` to `source` by byte-splice. Edits are spliced in reverse
+/// start order so earlier offsets stay valid; whitespace outside each span
+/// is preserved verbatim.
+pub fn splice(source: &str, edits: &[AppliedEdit]) -> String {
+    let mut ordered: Vec<&AppliedEdit> = edits.iter().collect();
+    ordered.sort_by_key(|e| std::cmp::Reverse(e.span.start_byte));
+    let mut out = source.to_string();
+    for edit in ordered {
+        out.replace_range(edit.span.start_byte..edit.span.end_byte, &edit.replacement);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn interpolates_bare_and_braced() {
+        let v = vars(&[("KEY", "userId"), ("NAME", "id")]);
+        assert_eq!(interpolate("{ $KEY: $NAME }", &v), "{ userId: id }");
+        assert_eq!(interpolate("${KEY}_${NAME}", &v), "userId_id");
+    }
+
+    #[test]
+    fn unknown_metavar_left_literal() {
+        let v = vars(&[("KEY", "x")]);
+        assert_eq!(interpolate("$KEY $UNKNOWN", &v), "x $UNKNOWN");
+    }
+
+    #[test]
+    fn escaped_dollar() {
+        let v = vars(&[]);
+        assert_eq!(interpolate("price is $$5", &v), "price is $5");
+    }
+
+    #[test]
+    fn splices_in_reverse_order() {
+        let source = "aaa bbb ccc";
+        let edits = vec![
+            AppliedEdit {
+                span: Span {
+                    start_byte: 0,
+                    end_byte: 3,
+                    start_row: 0,
+                    start_col: 0,
+                    end_row: 0,
+                    end_col: 3,
+                },
+                before: "aaa".into(),
+                replacement: "X".into(),
+            },
+            AppliedEdit {
+                span: Span {
+                    start_byte: 8,
+                    end_byte: 11,
+                    start_row: 0,
+                    start_col: 8,
+                    end_row: 0,
+                    end_col: 11,
+                },
+                before: "ccc".into(),
+                replacement: "ZZZZ".into(),
+            },
+        ];
+        assert_eq!(splice(source, &edits), "X bbb ZZZZ");
+    }
+}

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -7,13 +7,18 @@
 //! against the tree-sitter machinery in [`harn_hostlib::ast`] and produces
 //! [`RuleMatch`]es with metavariable bindings.
 //!
-//! This crate delivers the **atomic matching tier** (issue #2832) plus the
-//! **predicate + rewrite layer** (issue #2834):
+//! This crate delivers the **atomic matching tier** (#2832), the
+//! **relational + composite algebra** (#2833), and the **predicate +
+//! rewrite layer** (#2834):
 //!
-//! - [`model`] — the serde rule data model (`id` / `language` / `severity`
-//!   / `message` / `rule` block / `where` / `transform` / `fix`).
+//! - [`model`] — the serde rule data model: the recursive [`RuleNode`]
+//!   (atomic `pattern` / `kind` / `regex`, relational `inside` / `has` /
+//!   `follows` / `precedes`, composite `all` / `any` / `not` / `matches`)
+//!   plus `where` / `transform` / `fix` and `utils`.
 //! - [`pattern`] — the snippet → tree-sitter-query compiler (`$VAR`
-//!   metavariable lifting + unification).
+//!   metavariable lifting, unification, literal patterns).
+//! - [`evaluator`] — the tree-walking match algebra (relational + composite
+//!   + utility-rule reuse).
 //! - [`constraint`] — `where` predicates on captured metavars (regex,
 //!   comparison, recursive sub-pattern).
 //! - [`transform`] — synthesize new metavars (`replace` / `substring` /
@@ -23,8 +28,7 @@
 //!   [`CompiledRule::apply`] a codemod.
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
-//! Relational/composite matching (#2833) and the whole-project scan
-//! lifecycle (#2836) layer onto this surface.
+//! The whole-project scan lifecycle (#2836) layers onto this surface.
 //!
 //! ```
 //! use harn_rules::{Rule, CompiledRule};
@@ -48,6 +52,7 @@
 pub mod constraint;
 pub mod engine;
 pub mod error;
+pub mod evaluator;
 pub mod fix;
 pub mod loader;
 pub mod model;
@@ -59,6 +64,7 @@ pub use error::RulesError;
 pub use fix::{interpolate, AppliedEdit};
 pub use loader::{load_rule_dir, load_rule_file};
 pub use model::{
-    AtomicMatcher, Comparison, Constraint, ConvertOp, Matcher, Rule, RuleKind, Severity, Transform,
+    AtomicMatcher, Comparison, Constraint, ConvertOp, Rule, RuleKind, RuleNode, Severity, StopBy,
+    StopKeyword, Transform,
 };
 pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -7,17 +7,24 @@
 //! against the tree-sitter machinery in [`harn_hostlib::ast`] and produces
 //! [`RuleMatch`]es with metavariable bindings.
 //!
-//! This crate delivers the **atomic matching tier** (issue #2832):
+//! This crate delivers the **atomic matching tier** (issue #2832) plus the
+//! **predicate + rewrite layer** (issue #2834):
 //!
 //! - [`model`] — the serde rule data model (`id` / `language` / `severity`
-//!   / `message` / `rule` block / `fix`).
+//!   / `message` / `rule` block / `where` / `transform` / `fix`).
 //! - [`pattern`] — the snippet → tree-sitter-query compiler (`$VAR`
 //!   metavariable lifting + unification).
-//! - [`engine`] — compile a [`Rule`] and run it to produce matches.
+//! - [`constraint`] — `where` predicates on captured metavars (regex,
+//!   comparison, recursive sub-pattern).
+//! - [`transform`] — synthesize new metavars (`replace` / `substring` /
+//!   `convert`) before fixing.
+//! - [`fix`] — `fix` template interpolation and format-preserving splice.
+//! - [`engine`] — compile a [`Rule`], run it to produce matches, and
+//!   [`CompiledRule::apply`] a codemod.
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
-//! Relational/composite matching (#2833) and `where` / `transform` / `fix`
-//! interpolation (#2834) layer onto this surface.
+//! Relational/composite matching (#2833) and the whole-project scan
+//! lifecycle (#2836) layer onto this surface.
 //!
 //! ```
 //! use harn_rules::{Rule, CompiledRule};
@@ -38,14 +45,20 @@
 
 #![forbid(unsafe_code)]
 
+pub mod constraint;
 pub mod engine;
 pub mod error;
+pub mod fix;
 pub mod loader;
 pub mod model;
 pub mod pattern;
+pub mod transform;
 
-pub use engine::{Binding, CompiledRule, RuleMatch, Span};
+pub use engine::{Binding, CodemodResult, CompiledRule, RuleMatch, Span};
 pub use error::RulesError;
+pub use fix::{interpolate, AppliedEdit};
 pub use loader::{load_rule_dir, load_rule_file};
-pub use model::{AtomicMatcher, Matcher, Rule, RuleKind, Severity};
+pub use model::{
+    AtomicMatcher, Comparison, Constraint, ConvertOp, Matcher, Rule, RuleKind, Severity, Transform,
+};
 pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -8,8 +8,8 @@
 //! [`RuleMatch`]es with metavariable bindings.
 //!
 //! This crate delivers the **atomic matching tier** (#2832), the
-//! **relational + composite algebra** (#2833), and the **predicate +
-//! rewrite layer** (#2834):
+//! **relational + composite algebra** (#2833), the **predicate + rewrite
+//! layer** (#2834), and the **safety + idempotency gate** (#2835):
 //!
 //! - [`model`] — the serde rule data model: the recursive [`RuleNode`]
 //!   (atomic `pattern` / `kind` / `regex`, relational `inside` / `has` /
@@ -24,8 +24,10 @@
 //! - [`transform`] — synthesize new metavars (`replace` / `substring` /
 //!   `convert`) before fixing.
 //! - [`fix`] — `fix` template interpolation and format-preserving splice.
-//! - [`engine`] — compile a [`Rule`], run it to produce matches, and
-//!   [`CompiledRule::apply`] a codemod.
+//! - [`engine`] — compile a [`Rule`], run it to produce matches,
+//!   [`CompiledRule::apply`] / [`CompiledRule::auto_apply`] /
+//!   [`CompiledRule::apply_checked`] a codemod (safety-gated, idempotency
+//!   checked), and emit [`Diagnostic`]s.
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
 //! The whole-project scan lifecycle (#2836) layers onto this surface.
@@ -59,12 +61,12 @@ pub mod model;
 pub mod pattern;
 pub mod transform;
 
-pub use engine::{Binding, CodemodResult, CompiledRule, RuleMatch, Span};
+pub use engine::{Binding, CodemodResult, CompiledRule, Diagnostic, RuleMatch, Span};
 pub use error::RulesError;
 pub use fix::{interpolate, AppliedEdit};
 pub use loader::{load_rule_dir, load_rule_file};
 pub use model::{
-    AtomicMatcher, Comparison, Constraint, ConvertOp, Rule, RuleKind, RuleNode, Severity, StopBy,
-    StopKeyword, Transform,
+    Applicability, AtomicMatcher, Comparison, Constraint, ConvertOp, Rule, RuleKind, RuleNode,
+    Safety, Severity, StopBy, StopKeyword, Transform,
 };
 pub use pattern::{compile_pattern, CompiledPattern};

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -39,18 +39,71 @@ pub enum RuleKind {
 }
 
 /// The atomic-tier matcher. Exactly one of `pattern` / `kind` / `regex`
-/// must be set; [`Matcher::resolve`] enforces that and yields the typed
-/// [`AtomicMatcher`].
+/// must be set on a node that carries one; [`RuleNode::atomic`] resolves it.
+///
+/// A `RuleNode` is the recursive matching algebra: an optional **atomic**
+/// leaf (`pattern` / `kind` / `regex`), **relational** constraints
+/// (`inside` / `has` / `follows` / `precedes`, each a sub-node tuned by
+/// `stop_by` / `field`), and **composite** combinators (`all` / `any` /
+/// `not` / `matches`). Every key set on a node is ANDed: the node matches a
+/// tree-sitter node iff its atomic part matches *and* every relational and
+/// composite part holds.
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct Matcher {
-    /// A code snippet in the target grammar with `$VAR` (single-node) and
-    /// `$$$VAR` (variadic) metavariable holes.
+pub struct RuleNode {
+    /// A code snippet in the target grammar with `$VAR` metavariable holes.
     pub pattern: Option<String>,
-    /// A bare tree-sitter node kind to match (e.g. `"call_expression"`).
+    /// A bare tree-sitter node kind (e.g. `"call_expression"`).
     pub kind: Option<String>,
     /// A regular expression matched against node text.
     pub regex: Option<String>,
+
+    /// The node must be **inside** a node matching this sub-rule (ancestor).
+    pub inside: Option<Box<RuleNode>>,
+    /// The node must **have** a descendant matching this sub-rule.
+    pub has: Option<Box<RuleNode>>,
+    /// The node must **follow** a node matching this sub-rule (earlier).
+    pub follows: Option<Box<RuleNode>>,
+    /// The node must **precede** a node matching this sub-rule (later).
+    pub precedes: Option<Box<RuleNode>>,
+
+    /// Relational reach (used when this node is an `inside`/`has`/… target):
+    /// `neighbor` (direct only, default), `end` (transitive), or a rule that
+    /// halts the walk. (TOML `stopBy` or `stop_by`.)
+    #[serde(default, alias = "stopBy")]
+    pub stop_by: Option<StopBy>,
+    /// Restrict an `inside`/`has` relation to a specific tree-sitter field.
+    pub field: Option<String>,
+
+    /// Every sub-rule must match the node.
+    pub all: Option<Vec<RuleNode>>,
+    /// At least one sub-rule must match the node.
+    pub any: Option<Vec<RuleNode>>,
+    /// The sub-rule must NOT match the node.
+    pub not: Option<Box<RuleNode>>,
+    /// Reference a utility rule by id (resolved from `[utils]`).
+    pub matches: Option<String>,
+}
+
+/// How far a relational op (`inside` / `has` / `follows` / `precedes`)
+/// walks the tree looking for a match.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum StopBy {
+    /// `"neighbor"` (direct parent/child/sibling only) or `"end"`
+    /// (transitive — walk to the tree boundary).
+    Keyword(StopKeyword),
+    /// Walk until a node matching this rule is reached, then stop.
+    Rule(Box<RuleNode>),
+}
+
+/// The keyword forms of [`StopBy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StopKeyword {
+    /// Only the immediate neighbor (default).
+    Neighbor,
+    /// Transitive — walk all the way to the tree boundary.
+    End,
 }
 
 /// The resolved, exactly-one atomic matcher.
@@ -64,10 +117,10 @@ pub enum AtomicMatcher {
     Regex(String),
 }
 
-impl Matcher {
-    /// Collapse the optional fields into the single atomic form, rejecting
-    /// the zero-or-many cases. Returns `Err` with a human-readable reason.
-    pub fn resolve(&self) -> Result<AtomicMatcher, String> {
+impl RuleNode {
+    /// Resolve this node's atomic leaf. `Ok(None)` when the node is purely
+    /// relational/composite; `Err` when more than one atomic key is set.
+    pub fn atomic(&self) -> Result<Option<AtomicMatcher>, String> {
         let set: Vec<&str> = [
             self.pattern.as_ref().map(|_| "pattern"),
             self.kind.as_ref().map(|_| "kind"),
@@ -77,17 +130,49 @@ impl Matcher {
         .flatten()
         .collect();
         match set.as_slice() {
-            [] => Err("rule block sets none of `pattern` / `kind` / `regex`".into()),
-            [one] => Ok(match *one {
+            [] => Ok(None),
+            [one] => Ok(Some(match *one {
                 "pattern" => AtomicMatcher::Pattern(self.pattern.clone().unwrap()),
                 "kind" => AtomicMatcher::Kind(self.kind.clone().unwrap()),
                 _ => AtomicMatcher::Regex(self.regex.clone().unwrap()),
-            }),
+            })),
             many => Err(format!(
-                "rule block sets multiple matchers ({}); set exactly one",
+                "rule node sets multiple atomic matchers ({}); set at most one",
                 many.join(", ")
             )),
         }
+    }
+
+    /// True when `regex` is the only key set — a top-level grep-style rule
+    /// that scans source text rather than the tree.
+    pub fn is_pure_regex(&self) -> bool {
+        self.regex.is_some()
+            && self.pattern.is_none()
+            && self.kind.is_none()
+            && self.inside.is_none()
+            && self.has.is_none()
+            && self.follows.is_none()
+            && self.precedes.is_none()
+            && self.all.is_none()
+            && self.any.is_none()
+            && self.not.is_none()
+            && self.matches.is_none()
+    }
+
+    /// True when the node sets no matching keys at all (an empty node, which
+    /// is a rule authoring error).
+    pub fn is_empty(&self) -> bool {
+        self.pattern.is_none()
+            && self.kind.is_none()
+            && self.regex.is_none()
+            && self.inside.is_none()
+            && self.has.is_none()
+            && self.follows.is_none()
+            && self.precedes.is_none()
+            && self.all.is_none()
+            && self.any.is_none()
+            && self.not.is_none()
+            && self.matches.is_none()
     }
 }
 
@@ -105,8 +190,12 @@ pub struct Rule {
     /// Human-readable diagnostic message. Empty for search-only rules.
     #[serde(default)]
     pub message: String,
-    /// The atomic-tier matcher block.
-    pub rule: Matcher,
+    /// The matcher block (atomic / relational / composite algebra).
+    pub rule: RuleNode,
+    /// Local utility rules referenced by `matches`, keyed by id.
+    /// (TOML `[utils.NAME]`.)
+    #[serde(default)]
+    pub utils: BTreeMap<String, RuleNode>,
     /// Predicates on captured metavars; a match survives only when every
     /// constraint holds. (TOML `[[where]]`.)
     #[serde(default, rename = "where")]
@@ -258,8 +347,8 @@ mod tests {
         assert_eq!(rule.severity, Severity::Warning);
         assert_eq!(rule.kind(), RuleKind::Codemod);
         assert_eq!(
-            rule.rule.resolve().unwrap(),
-            AtomicMatcher::Pattern("$SRC?.$KEY ?? $DEFAULT".into())
+            rule.rule.atomic().unwrap(),
+            Some(AtomicMatcher::Pattern("$SRC?.$KEY ?? $DEFAULT".into()))
         );
     }
 
@@ -293,8 +382,8 @@ mod tests {
         .unwrap();
         assert_eq!(rule.kind(), RuleKind::Lint);
         assert_eq!(
-            rule.rule.resolve().unwrap(),
-            AtomicMatcher::Regex("TODO".into())
+            rule.rule.atomic().unwrap(),
+            Some(AtomicMatcher::Regex("TODO".into()))
         );
     }
 
@@ -310,11 +399,11 @@ mod tests {
             "#,
         )
         .unwrap();
-        assert!(rule.rule.resolve().is_err());
+        assert!(rule.rule.atomic().is_err());
     }
 
     #[test]
-    fn rejects_empty_matcher() {
+    fn empty_matcher_is_detectable() {
         let rule = Rule::from_toml_str(
             r#"
             id = "x"
@@ -323,7 +412,31 @@ mod tests {
             "#,
         )
         .unwrap();
-        assert!(rule.rule.resolve().is_err());
+        // An empty node sets no atomic key (Ok(None)) and is flagged empty.
+        assert_eq!(rule.rule.atomic().unwrap(), None);
+        assert!(rule.rule.is_empty());
+    }
+
+    #[test]
+    fn parses_relational_and_composite_keys() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "nested"
+            language = "typescript"
+            [rule]
+            pattern = "let $NAME = $INIT"
+            [rule.inside]
+            kind = "statement_block"
+            stopBy = "end"
+            [rule.not.inside]
+            kind = "try_statement"
+            stopBy = "end"
+            "#,
+        )
+        .expect("parses");
+        assert!(rule.rule.inside.is_some());
+        assert!(rule.rule.not.is_some());
+        assert!(rule.rule.not.as_ref().unwrap().inside.is_some());
     }
 
     #[test]

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -25,6 +25,57 @@ pub enum Severity {
     Error,
 }
 
+/// How risky a rule's `fix` is, mapped onto Burin's edit-safety taxonomy.
+/// Ordered least → most dangerous; the codemod runner auto-applies only the
+/// two safest tiers (see [`Safety::applicability`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Safety {
+    /// Whitespace / formatting only.
+    FormatOnly,
+    /// Semantics-preserving rewrite.
+    BehaviorPreserving,
+    /// Changes behavior, but only within the matched scope. **Default** —
+    /// conservative, so an undeclared codemod does not silently auto-apply.
+    #[default]
+    ScopeLocal,
+    /// Changes an externally-visible surface (a signature, an export).
+    SurfaceChanging,
+    /// Changes capabilities / effects (I/O, permissions).
+    CapabilityChanging,
+    /// Always requires a human in the loop.
+    NeedsHuman,
+}
+
+/// Whether a fix may be auto-applied (clippy/ESLint `machine-applicable`)
+/// or is opt-in only (`suggestion`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Applicability {
+    /// Safe to auto-apply (`format-only` / `behavior-preserving`).
+    MachineApplicable,
+    /// Preview / opt-in only.
+    Suggestion,
+}
+
+impl Safety {
+    /// The applicability tier this safety level maps to. `format-only` and
+    /// `behavior-preserving` are machine-applicable; everything riskier is a
+    /// suggestion.
+    pub fn applicability(self) -> Applicability {
+        if self <= Safety::BehaviorPreserving {
+            Applicability::MachineApplicable
+        } else {
+            Applicability::Suggestion
+        }
+    }
+
+    /// True when the runner may auto-apply this rule's fix without an
+    /// explicit opt-in.
+    pub fn is_auto_applicable(self) -> bool {
+        self.applicability() == Applicability::MachineApplicable
+    }
+}
+
 /// What flavor of work a rule performs, derived from its shape rather than
 /// declared: a rule with a `fix` is a codemod; one with a `message` but no
 /// `fix` is a lint; a bare matcher is a search.
@@ -190,6 +241,9 @@ pub struct Rule {
     /// Human-readable diagnostic message. Empty for search-only rules.
     #[serde(default)]
     pub message: String,
+    /// How risky the `fix` is. Gates auto-apply. Defaults to `scope-local`.
+    #[serde(default)]
+    pub safety: Safety,
     /// The matcher block (atomic / relational / composite algebra).
     pub rule: RuleNode,
     /// Local utility rules referenced by `matches`, keyed by id.

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -7,6 +7,8 @@
 //! matching (#2833) and `where`/`transform` (#2834) extend this model;
 //! this module is the atomic-tier surface they build on.
 
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 
 /// Diagnostic severity. Mirrors the `harn-lint` vocabulary so findings can
@@ -105,9 +107,113 @@ pub struct Rule {
     pub message: String,
     /// The atomic-tier matcher block.
     pub rule: Matcher,
+    /// Predicates on captured metavars; a match survives only when every
+    /// constraint holds. (TOML `[[where]]`.)
+    #[serde(default, rename = "where")]
+    pub where_constraints: Vec<Constraint>,
+    /// Derived metavars synthesized from captured ones before `fix`
+    /// interpolation, keyed by the new metavar name. (TOML `[transform.X]`.)
+    #[serde(default)]
+    pub transform: BTreeMap<String, Transform>,
     /// Replacement template. Its presence makes the rule a codemod.
     #[serde(default)]
     pub fix: Option<String>,
+}
+
+/// A `where` predicate on a captured metavar. Exactly one of `regex` /
+/// `comparison` / `pattern` is set.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Constraint {
+    /// The metavar this constraint applies to (without the leading `$`).
+    pub metavar: String,
+    /// The metavar's text must match this regex.
+    #[serde(default)]
+    pub regex: Option<String>,
+    /// The metavar's text, parsed as a number, must satisfy this
+    /// comparison (Semgrep `metavariable-comparison`).
+    #[serde(default)]
+    pub comparison: Option<Comparison>,
+    /// A sub-pattern (Semgrep `metavariable-pattern`) run against the
+    /// metavar's captured text; the constraint holds when it matches.
+    #[serde(default)]
+    pub pattern: Option<String>,
+    /// Optional language override for `pattern` — lets a captured string
+    /// literal be matched in a different grammar than the host file.
+    #[serde(default)]
+    pub language: Option<String>,
+}
+
+/// A numeric/string comparison for a [`Constraint`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Comparison {
+    /// One of `<` `<=` `>` `>=` `==` `!=`.
+    pub op: String,
+    /// The right-hand side. Numbers compare numerically; strings/bools
+    /// compare with `==` / `!=` only.
+    pub value: toml::Value,
+}
+
+/// A metavar transform: read `source`, apply exactly one operation, bind
+/// the result under a new metavar name (the map key).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Transform {
+    /// The source metavar name (without `$`) whose text is transformed.
+    pub source: String,
+    /// Regex find/replace.
+    #[serde(default)]
+    pub replace: Option<ReplaceOp>,
+    /// A character-index slice.
+    #[serde(default)]
+    pub substring: Option<SubstringOp>,
+    /// A case conversion.
+    #[serde(default)]
+    pub convert: Option<ConvertOp>,
+}
+
+/// Regex find/replace transform op.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplaceOp {
+    /// The regex to find.
+    pub regex: String,
+    /// The replacement (supports `$1` capture refs).
+    pub by: String,
+}
+
+/// Character-slice transform op. Indices are 0-based char offsets; a
+/// negative or omitted bound clamps to the string end.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubstringOp {
+    /// Inclusive start char index (default 0).
+    #[serde(default)]
+    pub start: Option<i64>,
+    /// Exclusive end char index (default: end of string).
+    #[serde(default)]
+    pub end: Option<i64>,
+}
+
+/// Case-conversion transform op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvertOp {
+    /// `lowerCamelCase`.
+    LowerCamel,
+    /// `UpperCamelCase`.
+    UpperCamel,
+    /// `snake_case`.
+    Snake,
+    /// `SCREAMING_SNAKE_CASE`.
+    ScreamingSnake,
+    /// `kebab-case`.
+    Kebab,
+    /// `lowercase`.
+    Lower,
+    /// `UPPERCASE`.
+    Upper,
 }
 
 impl Rule {

--- a/crates/harn-rules/src/pattern.rs
+++ b/crates/harn-rules/src/pattern.rs
@@ -206,9 +206,8 @@ fn substitute(snippet: &str) -> Result<Substituted, String> {
         i = j;
     }
 
-    if metavar_order.is_empty() {
-        return Err("pattern has no `$VAR` metavariables".into());
-    }
+    // A pattern with no metavars is a valid *literal* pattern (it matches a
+    // fixed structure), so we do not require one.
 
     Ok(Substituted {
         text,
@@ -234,8 +233,10 @@ struct QueryBuilder<'a> {
     placeholder_to_metavar: &'a HashMap<String, String>,
     /// occurrence count per metavar, to mint unification helper captures.
     occurrences: HashMap<String, usize>,
-    /// `(#eq? @X @X.2)` predicates for repeated metavars.
+    /// `(#eq? …)` predicates for repeated metavars and literal leaves.
     eq_predicates: Vec<String>,
+    /// counter for literal-leaf text-constraint captures.
+    literal_count: usize,
 }
 
 impl<'a> QueryBuilder<'a> {
@@ -245,6 +246,7 @@ impl<'a> QueryBuilder<'a> {
             placeholder_to_metavar,
             occurrences: HashMap::new(),
             eq_predicates: Vec::new(),
+            literal_count: 0,
         }
     }
 
@@ -256,7 +258,14 @@ impl<'a> QueryBuilder<'a> {
                 return format!("(_) @{}", self.capture_for(metavar));
             }
             if node.is_named() {
-                return format!("({})", node.kind());
+                // A literal named leaf (a specific identifier / literal in
+                // the snippet): constrain it to its exact text so `foo()`
+                // matches calls to `foo`, not any call.
+                let cap = format!("__lit_{}", self.literal_count);
+                self.literal_count += 1;
+                self.eq_predicates
+                    .push(format!("(#eq? @{cap} {})", quote_literal(text)));
+                return format!("({}) @{cap}", node.kind());
             }
             return quote_literal(text);
         }
@@ -456,8 +465,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_pattern_without_metavars() {
-        let err = compile_pattern("foo()", Language::TypeScript).unwrap_err();
-        assert!(err.contains("no `$VAR`"), "got: {err}");
+    fn literal_pattern_matches_exact_text() {
+        // A metavar-free pattern is a literal pattern: `foo()` matches calls
+        // to `foo`, not to other functions.
+        let snippet = "foo()";
+        let compiled = compile_pattern(snippet, Language::TypeScript).expect("compiles");
+        assert!(compiled.metavars.is_empty());
+        // It matches `foo()` …
+        let hit = run(snippet, Language::TypeScript, "foo();");
+        assert!(!hit.is_empty());
+        // … but not `bar()` (the literal identifier is constrained).
+        let miss = run(snippet, Language::TypeScript, "bar();");
+        assert!(
+            miss.is_empty(),
+            "bar() must not match foo()'s literal pattern: {miss:?}"
+        );
     }
 }

--- a/crates/harn-rules/src/transform.rs
+++ b/crates/harn-rules/src/transform.rs
@@ -1,0 +1,262 @@
+//! The `transform` pipeline: synthesize new metavars from captured ones
+//! before `fix` interpolation (ast-grep `transform:`).
+//!
+//! Each transform reads one `source` metavar and applies exactly one
+//! operation — regex `replace`, a `substring` slice, or a case `convert` —
+//! binding the result under a new metavar name. In v1 transforms read only
+//! the originally-captured metavars (not each other's output).
+
+use regex::Regex;
+
+use crate::error::RulesError;
+use crate::model::{ConvertOp, Transform};
+
+/// A compiled transform: a source metavar plus one operation.
+pub struct CompiledTransform {
+    /// The source metavar name (without `$`).
+    pub source: String,
+    op: Op,
+}
+
+enum Op {
+    Replace {
+        regex: Regex,
+        by: String,
+    },
+    Substring {
+        start: Option<i64>,
+        end: Option<i64>,
+    },
+    Convert(ConvertOp),
+}
+
+impl CompiledTransform {
+    /// Compile a transform, enforcing the exactly-one-operation rule.
+    pub fn compile(rule_id: &str, name: &str, t: &Transform) -> Result<Self, RulesError> {
+        let set = [
+            t.replace.is_some(),
+            t.substring.is_some(),
+            t.convert.is_some(),
+        ]
+        .into_iter()
+        .filter(|b| *b)
+        .count();
+        if set != 1 {
+            return Err(RulesError::PatternCompile {
+                rule: rule_id.to_string(),
+                message: format!(
+                    "transform `{name}` must set exactly one of `replace` / `substring` / `convert`"
+                ),
+            });
+        }
+
+        let op = if let Some(r) = &t.replace {
+            Op::Replace {
+                regex: Regex::new(&r.regex).map_err(|err| RulesError::PatternCompile {
+                    rule: rule_id.to_string(),
+                    message: format!("transform `{name}`: invalid regex `{}`: {err}", r.regex),
+                })?,
+                by: r.by.clone(),
+            }
+        } else if let Some(s) = &t.substring {
+            Op::Substring {
+                start: s.start,
+                end: s.end,
+            }
+        } else {
+            Op::Convert(t.convert.expect("convert is set"))
+        };
+
+        Ok(CompiledTransform {
+            source: t.source.clone(),
+            op,
+        })
+    }
+
+    /// Apply the transform to the source metavar's text.
+    pub fn apply(&self, input: &str) -> String {
+        match &self.op {
+            Op::Replace { regex, by } => regex.replace_all(input, by.as_str()).into_owned(),
+            Op::Substring { start, end } => slice_chars(input, *start, *end),
+            Op::Convert(convert) => convert_case(input, *convert),
+        }
+    }
+}
+
+/// Slice `input` by 0-based char indices. A negative index counts from the
+/// end; out-of-range bounds clamp.
+fn slice_chars(input: &str, start: Option<i64>, end: Option<i64>) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len() as i64;
+    let resolve = |idx: i64| -> usize {
+        let resolved = if idx < 0 { len + idx } else { idx };
+        resolved.clamp(0, len) as usize
+    };
+    let s = resolve(start.unwrap_or(0));
+    let e = resolve(end.unwrap_or(len));
+    if s >= e {
+        return String::new();
+    }
+    chars[s..e].iter().collect()
+}
+
+/// Split an identifier into lowercase words, honoring `_` / `-` / space
+/// separators and camelCase / digit boundaries.
+fn split_words(input: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut prev: Option<char> = None;
+    for ch in input.chars() {
+        if ch == '_' || ch == '-' || ch == ' ' || ch == '/' || ch == '.' {
+            if !current.is_empty() {
+                words.push(std::mem::take(&mut current));
+            }
+            prev = None;
+            continue;
+        }
+        // A lower→upper transition (`fooBar`) or letter→digit starts a word.
+        if let Some(p) = prev {
+            let boundary = (p.is_lowercase() && ch.is_uppercase())
+                || (p.is_alphabetic() && ch.is_ascii_digit())
+                || (p.is_ascii_digit() && ch.is_alphabetic());
+            if boundary && !current.is_empty() {
+                words.push(std::mem::take(&mut current));
+            }
+        }
+        current.push(ch.to_ascii_lowercase());
+        prev = Some(ch);
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+}
+
+fn capitalize(word: &str) -> String {
+    let mut chars = word.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn convert_case(input: &str, convert: ConvertOp) -> String {
+    match convert {
+        ConvertOp::Lower => input.to_lowercase(),
+        ConvertOp::Upper => input.to_uppercase(),
+        ConvertOp::Snake => split_words(input).join("_"),
+        ConvertOp::ScreamingSnake => split_words(input)
+            .iter()
+            .map(|w| w.to_uppercase())
+            .collect::<Vec<_>>()
+            .join("_"),
+        ConvertOp::Kebab => split_words(input).join("-"),
+        ConvertOp::UpperCamel => split_words(input).iter().map(|w| capitalize(w)).collect(),
+        ConvertOp::LowerCamel => {
+            let words = split_words(input);
+            let mut out = String::new();
+            for (i, w) in words.iter().enumerate() {
+                if i == 0 {
+                    out.push_str(w);
+                } else {
+                    out.push_str(&capitalize(w));
+                }
+            }
+            out
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ReplaceOp, SubstringOp};
+
+    fn convert(input: &str, op: ConvertOp) -> String {
+        let t = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: None,
+            convert: Some(op),
+        };
+        CompiledTransform::compile("r", "out", &t)
+            .unwrap()
+            .apply(input)
+    }
+
+    #[test]
+    fn case_conversions() {
+        assert_eq!(convert("user_id", ConvertOp::LowerCamel), "userId");
+        assert_eq!(convert("userId", ConvertOp::Snake), "user_id");
+        assert_eq!(convert("user-id", ConvertOp::UpperCamel), "UserId");
+        assert_eq!(convert("userId", ConvertOp::ScreamingSnake), "USER_ID");
+        assert_eq!(convert("userId", ConvertOp::Kebab), "user-id");
+        assert_eq!(convert("FooBar", ConvertOp::Lower), "foobar");
+    }
+
+    #[test]
+    fn regex_replace() {
+        let t = Transform {
+            source: "X".into(),
+            replace: Some(ReplaceOp {
+                regex: "Controller$".into(),
+                by: String::new(),
+            }),
+            substring: None,
+            convert: None,
+        };
+        let c = CompiledTransform::compile("r", "out", &t).unwrap();
+        assert_eq!(c.apply("UserController"), "User");
+    }
+
+    #[test]
+    fn substring_slice() {
+        let t = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: Some(SubstringOp {
+                start: Some(0),
+                end: Some(3),
+            }),
+            convert: None,
+        };
+        let c = CompiledTransform::compile("r", "out", &t).unwrap();
+        assert_eq!(c.apply("abcdef"), "abc");
+    }
+
+    #[test]
+    fn substring_negative_end() {
+        let t = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: Some(SubstringOp {
+                start: None,
+                end: Some(-1),
+            }),
+            convert: None,
+        };
+        let c = CompiledTransform::compile("r", "out", &t).unwrap();
+        assert_eq!(c.apply("hello"), "hell");
+    }
+
+    #[test]
+    fn rejects_zero_or_multiple_ops() {
+        let none = Transform {
+            source: "X".into(),
+            replace: None,
+            substring: None,
+            convert: None,
+        };
+        assert!(CompiledTransform::compile("r", "out", &none).is_err());
+        let two = Transform {
+            source: "X".into(),
+            replace: Some(ReplaceOp {
+                regex: "a".into(),
+                by: "b".into(),
+            }),
+            substring: None,
+            convert: Some(ConvertOp::Lower),
+        };
+        assert!(CompiledTransform::compile("r", "out", &two).is_err());
+    }
+}

--- a/crates/harn-rules/tests/relational_composite.rs
+++ b/crates/harn-rules/tests/relational_composite.rs
@@ -1,0 +1,233 @@
+//! Acceptance for #2833: the relational (`inside` / `has` / `follows` /
+//! `precedes`) and composite (`all` / `any` / `not` / `matches`) algebra,
+//! plus `stopBy` / `field` and utility-rule reuse, across TS and Rust.
+
+use harn_rules::{CompiledRule, Rule};
+
+fn run(toml: &str, source: &str) -> Vec<String> {
+    let rule = Rule::from_toml_str(toml).expect("rule parses");
+    let compiled = CompiledRule::compile(&rule).expect("rule compiles");
+    compiled
+        .run(source)
+        .expect("runs")
+        .into_iter()
+        .map(|m| m.text)
+        .collect()
+}
+
+#[test]
+fn acceptance_inside_function_body_not_inside_try() {
+    // "a `let` binding whose initializer is `$SRC?.$KEY ?? $DEF`, inside a
+    // function body, not inside a try".
+    let toml = r#"
+        id = "let-default-in-fn-not-try"
+        language = "typescript"
+        [rule]
+        pattern = "let $NAME = $SRC?.$KEY ?? $DEF"
+        [rule.inside]
+        kind = "statement_block"
+        stopBy = "end"
+        [rule.not.inside]
+        kind = "try_statement"
+        stopBy = "end"
+    "#;
+    let source = "\
+function ok() {
+  let a = cfg?.x ?? 1;
+}
+function bad() {
+  try {
+    let b = cfg?.y ?? 2;
+  } catch (e) {}
+}
+let c = cfg?.z ?? 3;
+";
+    let matches = run(toml, source);
+    // Only `a` qualifies: `b` is inside a try, `c` is not inside a function.
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("let a = cfg?.x ?? 1"));
+}
+
+#[test]
+fn has_descendant() {
+    // A function that contains a `throw` statement.
+    let toml = r#"
+        id = "fn-that-throws"
+        language = "typescript"
+        [rule]
+        kind = "function_declaration"
+        [rule.has]
+        kind = "throw_statement"
+        stopBy = "end"
+    "#;
+    let source = "\
+function risky() { throw new Error('x'); }
+function safe() { return 1; }
+";
+    let matches = run(toml, source);
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("risky"));
+}
+
+#[test]
+fn follows_and_precedes() {
+    // `follows` / `precedes` are sibling-relative, so match at the statement
+    // level: an expression statement that follows a `let` declaration.
+    let source = "\
+function f() {
+  let x = 1;
+  useIt();
+}
+function g() {
+  useIt();
+}
+";
+    let follows = r#"
+        id = "stmt-after-decl"
+        language = "typescript"
+        [rule]
+        kind = "expression_statement"
+        [rule.follows]
+        kind = "lexical_declaration"
+    "#;
+    // Only the `useIt();` statement that follows `let x = 1;` qualifies.
+    let m = run(follows, source);
+    assert_eq!(m.len(), 1, "follows matches: {m:?}");
+    assert!(m[0].contains("useIt()"));
+
+    // The mirror image: a declaration that precedes an expression statement.
+    let precedes = r#"
+        id = "decl-before-stmt"
+        language = "typescript"
+        [rule]
+        kind = "lexical_declaration"
+        [rule.precedes]
+        kind = "expression_statement"
+    "#;
+    let m = run(precedes, source);
+    assert_eq!(m.len(), 1, "precedes matches: {m:?}");
+    assert!(m[0].contains("let x = 1"));
+}
+
+#[test]
+fn composite_any_and_all() {
+    // `any`: match a call to either `foo` or `bar`.
+    let any_toml = r#"
+        id = "foo-or-bar"
+        language = "typescript"
+        [rule]
+        any = [
+          { pattern = "foo()" },
+          { pattern = "bar()" },
+        ]
+    "#;
+    let matches = run(any_toml, "foo();\nbaz();\nbar();\n");
+    assert_eq!(matches.len(), 2, "matches: {matches:?}");
+
+    // `all`: a call expression that is also inside a function.
+    let all_toml = r#"
+        id = "call-in-fn"
+        language = "typescript"
+        [rule]
+        all = [
+          { kind = "call_expression" },
+          { inside = { kind = "statement_block", stopBy = "end" } },
+        ]
+    "#;
+    let matches = run(all_toml, "function f() { go(); }\ntopLevel();\n");
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("go()"));
+}
+
+#[test]
+fn utility_rule_referenced_by_matches() {
+    // A util rule referenced from `matches`; the same util reused twice
+    // resolves once (compiled into the rule's util map).
+    let toml = r#"
+        id = "uses-util"
+        language = "typescript"
+        [rule]
+        all = [
+          { matches = "is-call" },
+          { inside = { kind = "statement_block", stopBy = "end" } },
+        ]
+        [utils.is-call]
+        kind = "call_expression"
+    "#;
+    let matches = run(toml, "function f() { go(); }\nouter();\n");
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("go()"));
+}
+
+#[test]
+fn stop_by_neighbor_vs_end() {
+    // `neighbor` only checks the direct parent; `end` walks all ancestors.
+    let source = "function f() { { deep(); } }\n";
+
+    let neighbor = r#"
+        id = "n"
+        language = "typescript"
+        [rule]
+        pattern = "deep()"
+        [rule.inside]
+        kind = "function_declaration"
+        stopBy = "neighbor"
+    "#;
+    // `deep()`'s direct ancestors are nested blocks, not the function — so
+    // neighbor-scoped `inside` finds nothing.
+    assert_eq!(run(neighbor, source).len(), 0);
+
+    let end = r#"
+        id = "e"
+        language = "typescript"
+        [rule]
+        pattern = "deep()"
+        [rule.inside]
+        kind = "function_declaration"
+        stopBy = "end"
+    "#;
+    assert_eq!(run(end, source).len(), 1);
+}
+
+#[test]
+fn field_restricts_the_relation() {
+    // `field = "body"` restricts the `inside` relation to the function's
+    // body slot: the function body block matches, a nested block does not.
+    let toml = r#"
+        id = "fn-body-block"
+        language = "typescript"
+        [rule]
+        kind = "statement_block"
+        [rule.inside]
+        kind = "function_declaration"
+        field = "body"
+        stopBy = "neighbor"
+    "#;
+    let matches = run(toml, "function f() { { nested(); } }\n");
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    // The matched block is the function body (it contains the nested block).
+    assert!(matches[0].contains("nested()"));
+}
+
+#[test]
+fn relational_in_rust_grammar() {
+    // Second grammar: a `let` declaration inside a function body.
+    let toml = r#"
+        id = "rust-let-in-fn"
+        language = "rust"
+        [rule]
+        pattern = "let $N = $V;"
+        [rule.inside]
+        kind = "function_item"
+        stopBy = "end"
+    "#;
+    let source = "\
+fn f() {
+    let x = compute();
+}
+const TOP: i32 = 1;
+";
+    let matches = run(toml, source);
+    assert_eq!(matches.len(), 1, "matches: {matches:?}");
+    assert!(matches[0].contains("let x = compute()"));
+}

--- a/crates/harn-rules/tests/safety_idempotency.rs
+++ b/crates/harn-rules/tests/safety_idempotency.rs
@@ -1,0 +1,123 @@
+//! Acceptance for #2835: safety classification, the
+//! machine-applicable/suggestion gate, and the idempotency check.
+
+use harn_rules::{Applicability, CompiledRule, Rule, RulesError, Safety};
+
+fn compile(toml: &str) -> CompiledRule {
+    CompiledRule::compile(&Rule::from_toml_str(toml).expect("parses")).expect("compiles")
+}
+
+fn codemod(safety: &str) -> CompiledRule {
+    compile(&format!(
+        r#"
+        id = "rename"
+        language = "typescript"
+        safety = "{safety}"
+        fix = "bar()"
+        [rule]
+        pattern = "foo()"
+        "#
+    ))
+}
+
+#[test]
+fn default_safety_refuses_auto_apply() {
+    // No `safety` declared -> defaults to scope-local -> a suggestion.
+    let rule = compile(
+        r#"
+        id = "rename"
+        language = "typescript"
+        fix = "bar()"
+        [rule]
+        pattern = "foo()"
+        "#,
+    );
+    assert_eq!(rule.safety(), Safety::ScopeLocal);
+    assert_eq!(rule.applicability(), Applicability::Suggestion);
+    // The preview is still available …
+    let preview = rule.apply("foo();").unwrap();
+    assert!(preview.rewritten.contains("bar()"));
+    // … but auto_apply refuses without an explicit opt-in.
+    assert!(matches!(
+        rule.auto_apply("foo();"),
+        Err(RulesError::NotAutoApplicable { .. })
+    ));
+}
+
+#[test]
+fn machine_applicable_tiers_auto_apply() {
+    for safety in ["format-only", "behavior-preserving"] {
+        let rule = codemod(safety);
+        assert_eq!(rule.applicability(), Applicability::MachineApplicable);
+        let applied = rule.auto_apply("foo();").expect("auto-applies");
+        assert!(applied.rewritten.contains("bar()"));
+        assert_eq!(applied.safety, rule.safety());
+    }
+}
+
+#[test]
+fn risky_tiers_are_suggestions() {
+    for safety in [
+        "scope-local",
+        "surface-changing",
+        "capability-changing",
+        "needs-human",
+    ] {
+        let rule = codemod(safety);
+        assert_eq!(rule.applicability(), Applicability::Suggestion);
+        assert!(rule.auto_apply("foo();").is_err());
+    }
+}
+
+#[test]
+fn idempotent_fix_passes_the_check() {
+    let rule = codemod("format-only");
+    let result = rule.apply("foo();\n").unwrap();
+    assert!(result.idempotent);
+    // `bar()` no longer matches `foo()`, so a second pass is a no-op.
+    assert!(rule.apply_checked("foo();\n").is_ok());
+}
+
+#[test]
+fn non_idempotent_fix_is_rejected() {
+    // `foo()` -> `foo()()` reintroduces a `foo()` match on every pass, so it
+    // never reaches a fixed point.
+    let rule = compile(
+        r#"
+        id = "double-call"
+        language = "typescript"
+        safety = "behavior-preserving"
+        fix = "foo()()"
+        [rule]
+        pattern = "foo()"
+        "#,
+    );
+    let result = rule.apply("foo();\n").unwrap();
+    assert!(!result.idempotent, "fix should be flagged non-idempotent");
+    assert!(matches!(
+        rule.apply_checked("foo();\n"),
+        Err(RulesError::NotIdempotent { .. })
+    ));
+}
+
+#[test]
+fn diagnostics_carry_message_severity_and_applicability() {
+    let rule = compile(
+        r#"
+        id = "no-foo"
+        language = "typescript"
+        severity = "error"
+        message = "Do not call foo()"
+        safety = "behavior-preserving"
+        fix = "bar()"
+        [rule]
+        pattern = "foo()"
+        "#,
+    );
+    let diags = rule.diagnostics("foo();\nfoo();\n").unwrap();
+    assert_eq!(diags.len(), 2);
+    assert_eq!(diags[0].message, "Do not call foo()");
+    assert_eq!(diags[0].rule_id, "no-foo");
+    assert_eq!(diags[0].applicability, Applicability::MachineApplicable);
+    assert_eq!(diags[0].fix.as_deref(), Some("bar()"));
+}

--- a/crates/harn-rules/tests/where_transform_fix.rs
+++ b/crates/harn-rules/tests/where_transform_fix.rs
@@ -1,0 +1,124 @@
+//! End-to-end acceptance for #2834: `where` constraints, the `transform`
+//! pipeline, and `fix` interpolation, applied as a codemod.
+
+use harn_rules::{CompiledRule, Rule};
+
+fn compile(toml: &str) -> CompiledRule {
+    CompiledRule::compile(&Rule::from_toml_str(toml).expect("rule parses")).expect("rule compiles")
+}
+
+#[test]
+fn destructuring_fix_handles_alias_and_shorthand() {
+    // The #2824 customer's single-binding fold + alias handling:
+    //   `let id = src?.userId`     -> `{ userId: id }`     (aliased)
+    //   `let userId = src?.userId` -> `{ userId: userId }` (shorthand once
+    //                                  `harn fmt` collapses the duplicate key)
+    let rule = compile(
+        r#"
+        id = "fold-optional-bind"
+        language = "typescript"
+        fix = "{ $KEY: $NAME }"
+        [rule]
+        pattern = "let $NAME = $SRC?.$KEY"
+        "#,
+    );
+
+    let aliased = rule.apply("let id = src?.userId;\n").unwrap();
+    assert!(aliased.changed);
+    assert!(
+        aliased.rewritten.contains("{ userId: id }"),
+        "got: {}",
+        aliased.rewritten
+    );
+
+    let shorthand = rule.apply("let userId = src?.userId;\n").unwrap();
+    assert!(
+        shorthand.rewritten.contains("{ userId: userId }"),
+        "got: {}",
+        shorthand.rewritten
+    );
+}
+
+#[test]
+fn fix_uses_a_transform_synthesized_metavar() {
+    // Rename a camelCase call to snake_case using a `convert` transform,
+    // then interpolate the synthesized metavar into the fix.
+    let rule = compile(
+        r#"
+        id = "snakeify-call"
+        language = "typescript"
+        fix = "$SNAKE()"
+        [rule]
+        pattern = "$FN()"
+        [transform.SNAKE]
+        source = "FN"
+        convert = "snake"
+        "#,
+    );
+    let result = rule.apply("getUserId();\n").unwrap();
+    assert!(
+        result.rewritten.contains("get_user_id()"),
+        "got: {}",
+        result.rewritten
+    );
+}
+
+#[test]
+fn where_constraint_filters_matches() {
+    // Only rewrite calls whose callee matches the constraint regex.
+    let rule = compile(
+        r#"
+        id = "guarded-rename"
+        language = "typescript"
+        fix = "renamed()"
+        [rule]
+        pattern = "$FN()"
+        [[where]]
+        metavar = "FN"
+        regex = "^legacy"
+        "#,
+    );
+    let result = rule
+        .apply("legacyInit();\nkeepThis();\nlegacyTeardown();\n")
+        .unwrap();
+    // The two `legacy*` calls are rewritten; `keepThis()` is untouched.
+    assert_eq!(result.edits.len(), 2);
+    assert!(result.rewritten.contains("keepThis()"));
+    assert_eq!(result.rewritten.matches("renamed()").count(), 2);
+}
+
+#[test]
+fn comparison_constraint_filters_numerically() {
+    // Only flag default values greater than 100.
+    let rule = compile(
+        r#"
+        id = "big-default"
+        language = "typescript"
+        fix = "CAPPED"
+        [rule]
+        pattern = "$SRC?.$KEY ?? $N"
+        [[where]]
+        metavar = "N"
+        comparison = { op = ">", value = 100 }
+        "#,
+    );
+    let result = rule
+        .apply("const a = o?.x ?? 5;\nconst b = o?.y ?? 500;\n")
+        .unwrap();
+    assert_eq!(result.edits.len(), 1);
+    assert!(result.rewritten.contains("?? 5"));
+    assert!(result.rewritten.contains("CAPPED"));
+}
+
+#[test]
+fn apply_without_fix_errors() {
+    let rule = compile(
+        r#"
+        id = "search-only"
+        language = "typescript"
+        [rule]
+        pattern = "$FN()"
+        "#,
+    );
+    assert!(rule.apply("foo();").is_err());
+}


### PR DESCRIPTION
## Summary

The middle three tiers of the **Harn Rule Engine core** (Epic A, [harn#2827](https://github.com/burin-labs/harn/issues/2827)), landed together as three commits. They build directly on the `harn-rules` atomic tier (#2832, already on `main`).

> **Why consolidated:** these were originally a stacked-PR chain (#2865 → #2866 → #2869). The merge queue + automatic base-branch deletion landed #2866/#2869 into their now-deleted intermediate branches instead of `main`, so the code never reached `main` (the issues stayed open). Rather than rebuild the fragile stack, the three commits are rebased cleanly onto current `main` here. Each commit is self-contained and individually reviewable; `gh pr view --json commits` shows the split. Supersedes #2865.

## Commits

1. **`where` + `transform` + `fix` (#2834)** — the predicate + rewrite layer. `where` constraints (metavar regex / numeric-or-string comparison / recursive sub-pattern), a `transform` pipeline (regex `replace`, `substring`, case `convert`), `fix` template interpolation (`$VAR` / `${VAR}` / `$$`), and `CompiledRule::apply` (format-preserving per-match splice, same guarantee as `ast.batch_apply`).
2. **relational + composite algebra (#2833)** — the `[rule]` block becomes a recursive `RuleNode`: relational `inside` / `has` / `follows` / `precedes` (tuned by `stopBy` + `field`) and composite `all` / `any` / `not` / `matches` (utility rules via `[utils]`), evaluated by a tree-walking evaluator. Metavar-free patterns become literal patterns (`foo()` matches calls to `foo`).
3. **safety tiers + idempotency gate (#2835)** — a per-rule `safety` tier (`format-only` … `needs-human`) mapped to machine-applicable vs suggestion; `auto_apply` refuses anything above `behavior-preserving`; `apply_checked` asserts idempotency; `diagnostics()` is the `LintDiagnostic` / `FixEdit` mapping surface.

## Tests

61 tests across the crate (39 unit + 2 atomic-roundtrip + 8 relational/composite + 5 where/transform/fix + 6 safety/idempotency + 1 doctest); clippy + fmt clean. New crate / no `pub const BUILTIN_*`, so no demo-gate.

Closes #2834. Closes #2833. Closes #2835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
