### PR TITLE
Fix release packaging under strict bash

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -477,13 +477,13 @@ jobs:
           cp "target/${HARN_RELEASE_TARGET}/release/harn" dist/harn
           cp "target/${HARN_RELEASE_TARGET}/release/harn-dap" dist/harn-dap
           cp "target/${HARN_RELEASE_TARGET}/release/harn-lsp" dist/harn-lsp
-          extra_binaries=()
+          package_entries=(harn harn-dap harn-lsp)
           if [[ "$HARN_RELEASE_TARGET" == *unknown-linux-gnu ]]; then
             cp "target/${HARN_RELEASE_TARGET}/release/harn-container-probe" dist/harn-container-probe
-            extra_binaries+=(harn-container-probe)
+            package_entries+=(harn-container-probe)
           fi
           cd dist
-          tar czf "harn-${HARN_RELEASE_TARGET}.tar.gz" harn harn-dap harn-lsp "${extra_binaries[@]}"
+          tar czf "harn-${HARN_RELEASE_TARGET}.tar.gz" "${package_entries[@]}"
 
       - name: Package (windows)
         if: runner.os == 'Windows' && needs.setup.outputs.is_release == 'true'

--- a/changelog.d/release-packaging-bash-nounset.fixed.md
+++ b/changelog.d/release-packaging-bash-nounset.fixed.md
@@ -1,0 +1,3 @@
+- **Release artifact packaging now works on macOS Bash with strict shell mode.**
+  The release binary workflow no longer expands an empty optional-binaries array
+  when packaging non-Linux archives.


### PR DESCRIPTION
## Summary

- fix the release binary workflow's Unix packaging step so macOS Bash with `set -u` never expands an empty optional-binaries array
- keep Linux release archives including `harn-container-probe` via the same package entry list
- add a changelog fragment for the release artifact fix

## Root cause

Release v0.8.61 built and notarized the aarch64 macOS binaries, then failed in `Package (unix)` with:

```text
extra_binaries[@]: unbound variable
```

The step initialized `extra_binaries=()` and expanded `"${extra_binaries[@]}"` under `set -euo pipefail`. On the macOS release runner this is treated as an unbound array when there are no Linux-only extras.

## Verification

- `actionlint .github/workflows/build-release-binaries.yml`
- shell simulation for `aarch64-apple-darwin` and `aarch64-unknown-linux-gnu` package entry lists
- `git diff --check`
- pre-commit and pre-push hooks
