### PR TITLE
harn-rules: whole-project lifecycle + report-only data tables (#2836, #2837)

### DIFF
--- a/changelog.d/2836.added.md
+++ b/changelog.d/2836.added.md
@@ -1,0 +1,5 @@
+- `harn-rules`: added the whole-project scan → accumulate → edit lifecycle (Rule Engine Epic A), adapted from
+  OpenRewrite's `ScanningRecipe`. A `ScanningRecipe` reads the entire fileset into a typed accumulator in a `scan`
+  pass (deterministic, path-sorted), then a `generate` pass turns that state into `FileChange`s — edit, **create**, or
+  **delete** — so rules can act on a whole-project view (import insertion, codegen, cross-file dead-code removal), not
+  just in-place edits. Per-file declarative codemods plug in via the `RuleRecipe` adapter.

--- a/changelog.d/2837.added.md
+++ b/changelog.d/2837.added.md
@@ -1,0 +1,6 @@
+- `harn-rules`: added report-only data tables (Rule Engine Epic A), adapted from OpenRewrite's first-class data
+  tables. `data_table(rule, files)` runs a rule across a project without editing and returns a columnar `DataTable` —
+  one row per match (path, position, matched text, metavar bindings) plus a metrics summary (total findings, files
+  touched, per-file counts). The envelope serializes to JSON (`to_json` / `to_json_value`) for inventory, impact
+  analysis, and audit — e.g. the destructuring rule's "sites / files / alias-count" measurement, produced
+  automatically.

--- a/crates/harn-rules/Cargo.toml
+++ b/crates/harn-rules/Cargo.toml
@@ -13,11 +13,11 @@ tree-sitter = "0.26"
 streaming-iterator = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "1.1"
 thiserror = "2"
 
 [dev-dependencies]
-serde_json = "1"
 streaming-iterator = "0.1"
 tempfile = "3"
 

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -158,3 +158,15 @@ for change in &run.changes { /* the caller writes / formats them */ }
 
 `run_recipe` returns the changes; the caller (a CLI, the staged filesystem)
 decides whether to write and `harn fmt` them.
+
+### Data tables (report-only)
+
+`data_table(rule, files)` runs a rule across a project **without editing** and
+returns a columnar `DataTable` — one row per match (path, position, text,
+metavar bindings) plus a metrics summary (total findings, files, per-file
+counts). It serializes to JSON for inventory / impact analysis / audit:
+
+```rust
+let table = harn_rules::data_table(&compiled, &source_files)?;
+println!("{}", table.to_json());   // { rule_id, columns, rows, summary }
+```

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -13,10 +13,13 @@ to regex/glob search.
 This crate ships the **atomic matching tier**
 ([harn#2832](https://github.com/burin-labs/harn/issues/2832)), the
 **relational + composite algebra**
-([harn#2833](https://github.com/burin-labs/harn/issues/2833)), and the
+([harn#2833](https://github.com/burin-labs/harn/issues/2833)), the
 **predicate + rewrite layer**
-([harn#2834](https://github.com/burin-labs/harn/issues/2834)). The
-whole-project scan lifecycle (#2836) builds on it.
+([harn#2834](https://github.com/burin-labs/harn/issues/2834)), the
+**safety + idempotency gate**
+([harn#2835](https://github.com/burin-labs/harn/issues/2835)), and the
+**whole-project scan lifecycle**
+([harn#2836](https://github.com/burin-labs/harn/issues/2836)).
 
 ## Rule shape (TOML)
 
@@ -136,3 +139,22 @@ for m in compiled.run(source)? {
 ```
 
 Load from disk with `load_rule_file(path)` or `load_rule_dir(dir)`.
+
+### Whole-project lifecycle
+
+For rules that must see the whole repo before editing — or that create /
+delete files (import insertion, codegen, dead-code removal) — implement a
+`ScanningRecipe` (OpenRewrite-style): a deterministic, path-sorted `scan`
+pass folds every file into a typed accumulator, then a `generate` pass turns
+that state into a set of `FileChange`s (`Edit` / `Create` / `Delete`).
+
+```rust
+use harn_rules::{run_recipe, RuleRecipe};
+
+// Run a declarative codemod across a project (per-file, no scan state):
+let run = run_recipe(&RuleRecipe { rule: &compiled }, source_files)?;
+for change in &run.changes { /* the caller writes / formats them */ }
+```
+
+`run_recipe` returns the changes; the caller (a CLI, the staged filesystem)
+decides whether to write and `harn fmt` them.

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -211,6 +211,11 @@ impl CompiledRule {
         self.safety.applicability()
     }
 
+    /// The rule's id.
+    pub fn id(&self) -> &str {
+        &self.rule_id
+    }
+
     /// Run the compiled rule against `source`, returning matches in
     /// document order. Matches that fail any `where` constraint are dropped.
     pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -30,6 +30,7 @@
 //!   checked), and emit [`Diagnostic`]s.
 //! - [`recipe`] — the whole-project scan → accumulate → edit lifecycle,
 //!   with file create/delete ([`ScanningRecipe`], [`run_recipe`]).
+//! - [`report`] — report-only [`DataTable`]s: columnar findings + metrics.
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
 //! The whole-project scan lifecycle (#2836) layers onto this surface.
@@ -62,6 +63,7 @@ pub mod loader;
 pub mod model;
 pub mod pattern;
 pub mod recipe;
+pub mod report;
 pub mod transform;
 
 pub use engine::{Binding, CodemodResult, CompiledRule, Diagnostic, RuleMatch, Span};
@@ -74,3 +76,4 @@ pub use model::{
 };
 pub use pattern::{compile_pattern, CompiledPattern};
 pub use recipe::{run_recipe, FileChange, RecipeRun, RuleRecipe, ScanningRecipe, SourceFile};
+pub use report::{data_table, DataTable, TableRow, TableSummary};

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -28,6 +28,8 @@
 //!   [`CompiledRule::apply`] / [`CompiledRule::auto_apply`] /
 //!   [`CompiledRule::apply_checked`] a codemod (safety-gated, idempotency
 //!   checked), and emit [`Diagnostic`]s.
+//! - [`recipe`] — the whole-project scan → accumulate → edit lifecycle,
+//!   with file create/delete ([`ScanningRecipe`], [`run_recipe`]).
 //! - [`loader`] — load rules from a TOML file or a directory.
 //!
 //! The whole-project scan lifecycle (#2836) layers onto this surface.
@@ -59,6 +61,7 @@ pub mod fix;
 pub mod loader;
 pub mod model;
 pub mod pattern;
+pub mod recipe;
 pub mod transform;
 
 pub use engine::{Binding, CodemodResult, CompiledRule, Diagnostic, RuleMatch, Span};
@@ -70,3 +73,4 @@ pub use model::{
     Safety, Severity, StopBy, StopKeyword, Transform,
 };
 pub use pattern::{compile_pattern, CompiledPattern};
+pub use recipe::{run_recipe, FileChange, RecipeRun, RuleRecipe, ScanningRecipe, SourceFile};

--- a/crates/harn-rules/src/recipe.rs
+++ b/crates/harn-rules/src/recipe.rs
@@ -1,0 +1,290 @@
+//! Whole-project scan → accumulate → edit lifecycle (#2836).
+//!
+//! Adapted from OpenRewrite's `ScanningRecipe`: a rule can read the *whole*
+//! fileset into a typed accumulator before it edits, and can emit new files
+//! or delete existing ones — not just edit in place. That whole-project view
+//! is what import insertion, codegen, and cross-file dead-code removal need.
+//!
+//! A run is two deterministic passes over the (path-sorted) files:
+//!
+//! 1. **scan** — each file updates a typed accumulator; no edits.
+//! 2. **generate** — the accumulator + the files produce a set of
+//!    [`FileChange`]s (edit / create / delete).
+//!
+//! Per-file declarative codemods plug in via [`RuleRecipe`], which needs no
+//! scan state; richer recipes implement [`ScanningRecipe`] directly.
+
+use std::path::{Path, PathBuf};
+
+use harn_hostlib::ast::Language;
+
+use crate::engine::CompiledRule;
+use crate::error::RulesError;
+
+/// One source file handed to a recipe.
+#[derive(Debug, Clone)]
+pub struct SourceFile {
+    /// The file's path (used for ordering and change attribution).
+    pub path: PathBuf,
+    /// The file's language.
+    pub language: Language,
+    /// The file's contents.
+    pub source: String,
+}
+
+impl SourceFile {
+    /// Construct a source file, detecting the language from the path's
+    /// extension. Returns `None` if no grammar matches.
+    pub fn detect(path: impl Into<PathBuf>, source: impl Into<String>) -> Option<Self> {
+        let path = path.into();
+        let language = Language::detect(&path, None)?;
+        Some(SourceFile {
+            path,
+            language,
+            source: source.into(),
+        })
+    }
+}
+
+/// A change a recipe wants to make to the project. The runner returns these;
+/// the caller (a CLI / the staged filesystem) decides whether to write them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileChange {
+    /// Replace an existing file's contents.
+    Edit {
+        /// The file to rewrite.
+        path: PathBuf,
+        /// The new contents.
+        contents: String,
+    },
+    /// Create a new file.
+    Create {
+        /// The path to create.
+        path: PathBuf,
+        /// The new file's contents.
+        contents: String,
+    },
+    /// Delete an existing file.
+    Delete {
+        /// The path to delete.
+        path: PathBuf,
+    },
+}
+
+impl FileChange {
+    /// The path this change targets.
+    pub fn path(&self) -> &Path {
+        match self {
+            FileChange::Edit { path, .. }
+            | FileChange::Create { path, .. }
+            | FileChange::Delete { path } => path,
+        }
+    }
+}
+
+/// A two-phase, whole-project rule.
+pub trait ScanningRecipe {
+    /// The typed accumulator threaded from `scan` into `generate`.
+    type Acc: Default;
+
+    /// Read one file and update the accumulator. Called once per file, in
+    /// path-sorted order, before any `generate`.
+    fn scan(&self, file: &SourceFile, acc: &mut Self::Acc) -> Result<(), RulesError>;
+
+    /// Produce the project's changes from the accumulated state and the
+    /// (path-sorted) files.
+    fn generate(
+        &self,
+        files: &[SourceFile],
+        acc: &Self::Acc,
+    ) -> Result<Vec<FileChange>, RulesError>;
+}
+
+/// The result of running a recipe over a project.
+#[derive(Debug, Clone)]
+pub struct RecipeRun {
+    /// The changes the recipe produced, sorted by path for determinism.
+    pub changes: Vec<FileChange>,
+}
+
+impl RecipeRun {
+    /// Files this run edits.
+    pub fn edits(&self) -> impl Iterator<Item = &FileChange> {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, FileChange::Edit { .. }))
+    }
+
+    /// Files this run creates.
+    pub fn creations(&self) -> impl Iterator<Item = &FileChange> {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, FileChange::Create { .. }))
+    }
+}
+
+/// Run `recipe` over `files`: a `scan` pass (path-sorted) followed by a
+/// `generate` pass. The returned changes are path-sorted for a stable,
+/// reproducible result.
+pub fn run_recipe<R: ScanningRecipe>(
+    recipe: &R,
+    mut files: Vec<SourceFile>,
+) -> Result<RecipeRun, RulesError> {
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let mut acc = R::Acc::default();
+    for file in &files {
+        recipe.scan(file, &mut acc)?;
+    }
+
+    let mut changes = recipe.generate(&files, &acc)?;
+    changes.sort_by(|a, b| a.path().cmp(b.path()));
+    Ok(RecipeRun { changes })
+}
+
+/// Adapter that runs a declarative [`CompiledRule`] as a recipe: a per-file
+/// codemod with no scan state. Each file matching the rule's language is
+/// rewritten via [`CompiledRule::apply`]; only changed files yield an edit.
+pub struct RuleRecipe<'a> {
+    /// The compiled codemod rule.
+    pub rule: &'a CompiledRule,
+}
+
+impl ScanningRecipe for RuleRecipe<'_> {
+    type Acc = ();
+
+    fn scan(&self, _file: &SourceFile, _acc: &mut ()) -> Result<(), RulesError> {
+        Ok(())
+    }
+
+    fn generate(&self, files: &[SourceFile], _acc: &()) -> Result<Vec<FileChange>, RulesError> {
+        let mut changes = Vec::new();
+        for file in files {
+            if file.language != self.rule.language() {
+                continue;
+            }
+            let result = self.rule.apply(&file.source)?;
+            if result.changed {
+                changes.push(FileChange::Edit {
+                    path: file.path.clone(),
+                    contents: result.rewritten,
+                });
+            }
+        }
+        Ok(changes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Rule;
+
+    fn ts(path: &str, source: &str) -> SourceFile {
+        SourceFile {
+            path: PathBuf::from(path),
+            language: Language::TypeScript,
+            source: source.to_string(),
+        }
+    }
+
+    /// A recipe that counts call expressions across the project and, if any
+    /// exist, emits a single generated report file — exercising both the
+    /// accumulator and `FileChange::Create`.
+    struct CallCounter;
+    impl ScanningRecipe for CallCounter {
+        type Acc = usize;
+        fn scan(&self, file: &SourceFile, acc: &mut usize) -> Result<(), RulesError> {
+            *acc += file.source.matches("()").count();
+            Ok(())
+        }
+        fn generate(
+            &self,
+            _files: &[SourceFile],
+            acc: &usize,
+        ) -> Result<Vec<FileChange>, RulesError> {
+            if *acc == 0 {
+                return Ok(vec![]);
+            }
+            Ok(vec![FileChange::Create {
+                path: PathBuf::from("report.txt"),
+                contents: format!("calls: {acc}\n"),
+            }])
+        }
+    }
+
+    #[test]
+    fn recipe_accumulates_then_generates_a_new_file() {
+        let files = vec![ts("a.ts", "foo();\n"), ts("b.ts", "bar(); baz();\n")];
+        let run = run_recipe(&CallCounter, files).unwrap();
+        assert_eq!(run.changes.len(), 1);
+        assert_eq!(
+            run.changes[0],
+            FileChange::Create {
+                path: PathBuf::from("report.txt"),
+                contents: "calls: 3\n".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn scan_runs_in_path_sorted_order() {
+        // The accumulator records the order files are scanned in; the runner
+        // must sort by path regardless of input order.
+        struct OrderRecorder;
+        impl ScanningRecipe for OrderRecorder {
+            type Acc = Vec<String>;
+            fn scan(&self, file: &SourceFile, acc: &mut Vec<String>) -> Result<(), RulesError> {
+                acc.push(file.path.to_string_lossy().to_string());
+                Ok(())
+            }
+            fn generate(
+                &self,
+                _f: &[SourceFile],
+                acc: &Vec<String>,
+            ) -> Result<Vec<FileChange>, RulesError> {
+                Ok(vec![FileChange::Create {
+                    path: PathBuf::from("order.txt"),
+                    contents: acc.join(","),
+                }])
+            }
+        }
+        let files = vec![ts("z.ts", ""), ts("a.ts", ""), ts("m.ts", "")];
+        let run = run_recipe(&OrderRecorder, files).unwrap();
+        match &run.changes[0] {
+            FileChange::Create { contents, .. } => assert_eq!(contents, "a.ts,m.ts,z.ts"),
+            other => panic!("expected create, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rule_recipe_edits_matching_files_only() {
+        let rule = crate::engine::CompiledRule::compile(
+            &Rule::from_toml_str(
+                r#"
+                id = "rename-foo"
+                language = "typescript"
+                safety = "behavior-preserving"
+                fix = "bar()"
+                [rule]
+                pattern = "foo()"
+                "#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let files = vec![
+            ts("a.ts", "foo();\n"),
+            ts("b.ts", "noMatch();\n"),
+            SourceFile {
+                path: PathBuf::from("c.rs"),
+                language: Language::Rust,
+                source: "fn f() { foo(); }".into(),
+            },
+        ];
+        let run = run_recipe(&RuleRecipe { rule: &rule }, files).unwrap();
+        // Only a.ts changes: b.ts has no match, c.rs is a different language.
+        assert_eq!(run.changes.len(), 1);
+        assert_eq!(run.changes[0].path(), Path::new("a.ts"));
+    }
+}

--- a/crates/harn-rules/src/report.rs
+++ b/crates/harn-rules/src/report.rs
@@ -1,0 +1,175 @@
+//! Data tables — rules emit structured findings/metrics (#2837).
+//!
+//! Adopted from OpenRewrite's first-class data tables: a rule run can emit
+//! columnar findings + a metrics summary alongside (or instead of) diffs.
+//! This is **report-only** — building a table never edits anything — which
+//! is what inventory, impact analysis, and audit need.
+//!
+//! The envelope is plain `serde` (`Serialize`), consistent with the rest of
+//! the `--json` surfaces; [`DataTable::to_json`] renders it.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use crate::engine::CompiledRule;
+use crate::error::RulesError;
+use crate::recipe::SourceFile;
+
+/// A columnar table of a rule's findings across a project.
+#[derive(Debug, Clone, Serialize)]
+pub struct DataTable {
+    /// The rule that produced the table.
+    pub rule_id: String,
+    /// The metavar column names present across all rows (sorted, stable).
+    pub columns: Vec<String>,
+    /// One row per match.
+    pub rows: Vec<TableRow>,
+    /// Roll-up metrics.
+    pub summary: TableSummary,
+}
+
+/// One finding: where it is, the matched text, and the metavar bindings.
+#[derive(Debug, Clone, Serialize)]
+pub struct TableRow {
+    /// The file the match is in.
+    pub path: String,
+    /// 0-based start row.
+    pub start_row: usize,
+    /// 0-based start column.
+    pub start_col: usize,
+    /// The matched text.
+    pub text: String,
+    /// The metavar bindings, keyed by name.
+    pub bindings: BTreeMap<String, String>,
+}
+
+/// Roll-up metrics for a [`DataTable`].
+#[derive(Debug, Clone, Serialize)]
+pub struct TableSummary {
+    /// Total number of findings (rows).
+    pub total_rows: usize,
+    /// Number of files with at least one finding.
+    pub files: usize,
+    /// Per-file finding counts (the #2824 "sites / files" measurement).
+    pub per_file: BTreeMap<String, usize>,
+}
+
+impl DataTable {
+    /// Render the table as a JSON string.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("DataTable serializes")
+    }
+
+    /// Render the table as a `serde_json::Value`.
+    pub fn to_json_value(&self) -> serde_json::Value {
+        serde_json::to_value(self).expect("DataTable serializes")
+    }
+}
+
+/// Run `rule` over `files` in **report-only** mode and collect a
+/// [`DataTable`] — one row per match, with per-file and total counts. No
+/// edits are made.
+pub fn data_table(rule: &CompiledRule, files: &[SourceFile]) -> Result<DataTable, RulesError> {
+    let mut rows: Vec<TableRow> = Vec::new();
+    let mut per_file: BTreeMap<String, usize> = BTreeMap::new();
+
+    for file in files {
+        if file.language != rule.language() {
+            continue;
+        }
+        let matches = rule.run(&file.source)?;
+        if matches.is_empty() {
+            continue;
+        }
+        let path = file.path.display().to_string();
+        per_file.insert(path.clone(), matches.len());
+        for m in matches {
+            rows.push(TableRow {
+                path: path.clone(),
+                start_row: m.span.start_row,
+                start_col: m.span.start_col,
+                text: m.text,
+                bindings: m
+                    .bindings
+                    .into_iter()
+                    .map(|(name, binding)| (name, binding.text))
+                    .collect(),
+            });
+        }
+    }
+
+    let columns: BTreeSet<String> = rows
+        .iter()
+        .flat_map(|r| r.bindings.keys().cloned())
+        .collect();
+
+    let summary = TableSummary {
+        total_rows: rows.len(),
+        files: per_file.len(),
+        per_file,
+    };
+
+    Ok(DataTable {
+        rule_id: rule.id().to_string(),
+        columns: columns.into_iter().collect(),
+        rows,
+        summary,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Rule;
+
+    fn rule(toml: &str) -> CompiledRule {
+        CompiledRule::compile(&Rule::from_toml_str(toml).unwrap()).unwrap()
+    }
+
+    fn ts(path: &str, source: &str) -> SourceFile {
+        SourceFile::detect(path, source).unwrap()
+    }
+
+    #[test]
+    fn report_only_table_counts_sites_per_file() {
+        let rule = rule(
+            r#"
+            id = "find-calls"
+            language = "typescript"
+            [rule]
+            pattern = "$FN()"
+            "#,
+        );
+        let files = vec![
+            ts("a.ts", "foo();\nbar();\n"),
+            ts("b.ts", "baz();\n"),
+            ts("c.ts", "const x = 1;\n"),
+        ];
+        let table = data_table(&rule, &files).unwrap();
+        assert_eq!(table.summary.total_rows, 3);
+        assert_eq!(table.summary.files, 2);
+        assert_eq!(table.summary.per_file["a.ts"], 2);
+        assert_eq!(table.summary.per_file["b.ts"], 1);
+        assert!(!table.summary.per_file.contains_key("c.ts"));
+        assert_eq!(table.columns, vec!["FN"]);
+        assert_eq!(table.rows[0].bindings["FN"], "foo");
+    }
+
+    #[test]
+    fn table_serializes_to_json() {
+        let rule = rule(
+            r#"
+            id = "r"
+            language = "typescript"
+            [rule]
+            pattern = "$FN()"
+            "#,
+        );
+        let table = data_table(&rule, &[ts("a.ts", "go();\n")]).unwrap();
+        let value = table.to_json_value();
+        assert_eq!(value["rule_id"], "r");
+        assert_eq!(value["summary"]["total_rows"], 1);
+        assert_eq!(value["rows"][0]["bindings"]["FN"], "go");
+    }
+}

--- a/crates/harn-rules/tests/data_tables.rs
+++ b/crates/harn-rules/tests/data_tables.rs
@@ -1,0 +1,63 @@
+//! Acceptance for #2837: report-only data tables. Running the destructuring
+//! rule yields a table with per-file site counts, a total, and enough
+//! structure to derive the alias count — the #2824 "~2,576 sites / 109
+//! files" measurement, produced automatically.
+
+use harn_rules::{data_table, CompiledRule, Rule, SourceFile};
+
+fn ts(path: &str, source: &str) -> SourceFile {
+    SourceFile::detect(path, source).unwrap()
+}
+
+#[test]
+fn destructuring_report_only_table_matches_measurement_style() {
+    let rule = CompiledRule::compile(
+        &Rule::from_toml_str(
+            r#"
+            id = "destructure-sites"
+            language = "typescript"
+            [rule]
+            pattern = "let $NAME = $SRC?.$KEY ?? $DEFAULT"
+            "#,
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    let files = vec![
+        ts(
+            "config.ts",
+            "let id = src?.userId ?? 0;\nlet name = src?.name ?? \"\";\n",
+        ),
+        ts("opts.ts", "let count = o?.count ?? 0;\n"),
+        ts("empty.ts", "const x = 1;\n"),
+    ];
+
+    let table = data_table(&rule, &files).unwrap();
+
+    // Total foldable runs (sites) and per-file counts, OpenRewrite-style.
+    assert_eq!(table.summary.total_rows, 3);
+    assert_eq!(table.summary.files, 2);
+    assert_eq!(table.summary.per_file["config.ts"], 2);
+    assert_eq!(table.summary.per_file["opts.ts"], 1);
+    assert!(!table.summary.per_file.contains_key("empty.ts"));
+
+    // The metavar columns are present for downstream analysis.
+    assert!(table.columns.contains(&"NAME".to_string()));
+    assert!(table.columns.contains(&"KEY".to_string()));
+
+    // Alias count = sites where the binding name differs from the key
+    // (`let id = src?.userId` is an alias; `let name = src?.name` is not).
+    let aliases = table
+        .rows
+        .iter()
+        .filter(|r| r.bindings["NAME"] != r.bindings["KEY"])
+        .count();
+    assert_eq!(aliases, 1);
+
+    // Report-only: the table is the whole output; nothing was edited.
+    // (data_table never calls apply — it only runs the matcher.)
+    let json = table.to_json_value();
+    assert_eq!(json["summary"]["total_rows"], 3);
+    assert_eq!(json["rule_id"], "destructure-sites");
+}

--- a/crates/harn-rules/tests/lifecycle.rs
+++ b/crates/harn-rules/tests/lifecycle.rs
@@ -1,0 +1,187 @@
+//! Acceptance for #2836: the whole-project scan → accumulate → edit
+//! lifecycle, including a decision that needs the whole-project view and
+//! new-file generation.
+
+use std::path::{Path, PathBuf};
+
+use harn_rules::{run_recipe, FileChange, RulesError, ScanningRecipe, SourceFile};
+use regex::Regex;
+
+fn ts(path: &str, source: &str) -> SourceFile {
+    SourceFile::detect(path, source).expect("ts file")
+}
+
+/// Insert a missing import for `symbol` at the top of every file that
+/// references it but does not import it — pointing at the module that
+/// *exports* it (discovered by scanning the whole project). This decision
+/// is impossible per-file: the target module is only known after scanning.
+struct EnsureImport {
+    symbol: String,
+}
+
+#[derive(Default)]
+struct ImportAcc {
+    /// Module specifier (e.g. `./logger`) of the file that exports `symbol`.
+    exporting_module: Option<String>,
+    /// Files that reference `symbol` without importing it.
+    needs_import: Vec<PathBuf>,
+}
+
+impl EnsureImport {
+    fn references(&self, src: &str) -> bool {
+        Regex::new(&format!(r"\b{}\b", regex::escape(&self.symbol)))
+            .unwrap()
+            .is_match(src)
+    }
+    fn exports(&self, src: &str) -> bool {
+        Regex::new(&format!(
+            r"export\s+(function|class|const)\s+{}\b",
+            regex::escape(&self.symbol)
+        ))
+        .unwrap()
+        .is_match(src)
+    }
+    fn imports(&self, src: &str) -> bool {
+        src.lines()
+            .any(|l| l.contains("import") && l.contains(&self.symbol) && l.contains("from"))
+    }
+}
+
+impl ScanningRecipe for EnsureImport {
+    type Acc = ImportAcc;
+
+    fn scan(&self, file: &SourceFile, acc: &mut ImportAcc) -> Result<(), RulesError> {
+        if self.exports(&file.source) {
+            let stem = file.path.file_stem().unwrap().to_string_lossy();
+            acc.exporting_module = Some(format!("./{stem}"));
+            return Ok(());
+        }
+        if self.references(&file.source) && !self.imports(&file.source) {
+            acc.needs_import.push(file.path.clone());
+        }
+        Ok(())
+    }
+
+    fn generate(
+        &self,
+        files: &[SourceFile],
+        acc: &ImportAcc,
+    ) -> Result<Vec<FileChange>, RulesError> {
+        let Some(module) = &acc.exporting_module else {
+            return Ok(vec![]); // symbol not exported anywhere → nothing to do
+        };
+        let mut changes = Vec::new();
+        for path in &acc.needs_import {
+            let file = files.iter().find(|f| &f.path == path).unwrap();
+            let import = format!("import {{ {} }} from \"{module}\";\n", self.symbol);
+            changes.push(FileChange::Edit {
+                path: path.clone(),
+                contents: format!("{import}{}", file.source),
+            });
+        }
+        Ok(changes)
+    }
+}
+
+#[test]
+fn inserts_missing_import_using_whole_project_view() {
+    let files = vec![
+        ts("logger.ts", "export function Logger() {}\n"),
+        ts("a.ts", "Logger();\n"), // needs import
+        ts("b.ts", "import { Logger } from \"./logger\";\nLogger();\n"), // already imports
+        ts("c.ts", "noRef();\n"),  // no reference
+    ];
+    let run = run_recipe(
+        &EnsureImport {
+            symbol: "Logger".into(),
+        },
+        files,
+    )
+    .unwrap();
+
+    // Exactly one file (`a.ts`) gets the import; the module specifier comes
+    // from scanning `logger.ts`.
+    assert_eq!(run.changes.len(), 1, "changes: {:?}", run.changes);
+    match &run.changes[0] {
+        FileChange::Edit { path, contents } => {
+            assert_eq!(path, Path::new("a.ts"));
+            assert_eq!(
+                contents,
+                "import { Logger } from \"./logger\";\nLogger();\n"
+            );
+        }
+        other => panic!("expected edit, got {other:?}"),
+    }
+}
+
+#[test]
+fn no_import_inserted_when_symbol_is_not_exported_anywhere() {
+    // Without a defining module, the recipe cannot know what to import.
+    let files = vec![ts("a.ts", "Logger();\n")];
+    let run = run_recipe(
+        &EnsureImport {
+            symbol: "Logger".into(),
+        },
+        files,
+    )
+    .unwrap();
+    assert!(run.changes.is_empty());
+}
+
+/// Generate a barrel file re-exporting every module that exports something —
+/// a new-file-generation recipe.
+struct Barrel;
+
+impl ScanningRecipe for Barrel {
+    type Acc = Vec<String>;
+
+    fn scan(&self, file: &SourceFile, acc: &mut Vec<String>) -> Result<(), RulesError> {
+        if file.source.contains("export ") {
+            let stem = file.path.file_stem().unwrap().to_string_lossy();
+            acc.push(format!("./{stem}"));
+        }
+        Ok(())
+    }
+
+    fn generate(
+        &self,
+        _files: &[SourceFile],
+        modules: &Vec<String>,
+    ) -> Result<Vec<FileChange>, RulesError> {
+        if modules.is_empty() {
+            return Ok(vec![]);
+        }
+        let body = modules
+            .iter()
+            .map(|m| format!("export * from \"{m}\";"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(vec![FileChange::Create {
+            path: PathBuf::from("index.ts"),
+            contents: format!("{body}\n"),
+        }])
+    }
+}
+
+#[test]
+fn emits_a_new_barrel_file() {
+    let files = vec![
+        ts("alpha.ts", "export const a = 1;\n"),
+        ts("beta.ts", "export const b = 2;\n"),
+        ts("internal.ts", "const x = 3;\n"),
+    ];
+    let run = run_recipe(&Barrel, files).unwrap();
+    let creations: Vec<_> = run.creations().collect();
+    assert_eq!(creations.len(), 1);
+    match creations[0] {
+        FileChange::Create { path, contents } => {
+            assert_eq!(path, Path::new("index.ts"));
+            // Path-sorted scan → alpha before beta; internal.ts has no export.
+            assert_eq!(
+                contents,
+                "export * from \"./alpha\";\nexport * from \"./beta\";\n"
+            );
+        }
+        other => panic!("expected create, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

The whole-project + reporting layers of the **Harn Rule Engine core** (Epic A), as two clean commits.

> **Stacked on #2873** (which lands #2834/#2833/#2835). Base will retarget to `main` once #2873 merges; **auto-merge intentionally not enabled yet** to avoid the merge-queue/branch-deletion interaction that tangled the earlier stack. `gh pr view --json commits` shows the per-issue split.

## Commits

1. **whole-project lifecycle (#2836)** — an OpenRewrite-style `ScanningRecipe`: a deterministic path-sorted `scan` pass folds every file into a typed accumulator, then a `generate` pass emits `FileChange`s (`Edit` / **`Create`** / **`Delete`**) — the whole-project view + file create/delete that import insertion, codegen, and cross-file dead-code removal need. `RuleRecipe` adapts a declarative `CompiledRule` into a per-file codemod recipe.
2. **report-only data tables (#2837)** — `data_table(rule, files)` runs a rule across a project without editing and returns a columnar `DataTable` (one row per match: path, position, text, metavar bindings) + a metrics summary (total / files / per-file counts), serializable to a JSON envelope.

## Acceptance

- **#2836:** a recipe inserts a missing import using the whole-project view (the exporting module is only known after scanning) and a recipe emits a new barrel file via `FileChange::Create` — `tests/lifecycle.rs`.
- **#2837:** the destructuring rule in report-only mode yields per-file site counts, a total, and the derivable alias count — the #2824 "sites / files" measurement, automatically — `tests/data_tables.rs`.

68 tests across the crate; clippy + fmt clean.

Closes #2836. Closes #2837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
