### PR TITLE
fix(ci): bash 3.2-safe empty-array expansion in release tarball packaging

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -483,7 +483,11 @@ jobs:
             extra_binaries+=(harn-container-probe)
           fi
           cd dist
-          tar czf "harn-${HARN_RELEASE_TARGET}.tar.gz" harn harn-dap harn-lsp "${extra_binaries[@]}"
+          # `${extra_binaries[@]+...}` guards the empty-array case: under
+          # `set -u`, macOS's bash 3.2 treats a plain "${extra_binaries[@]}"
+          # expansion of an empty array as an unbound variable and aborts the
+          # darwin packaging step (only linux-gnu populates the array).
+          tar czf "harn-${HARN_RELEASE_TARGET}.tar.gz" harn harn-dap harn-lsp ${extra_binaries[@]+"${extra_binaries[@]}"}
 
       - name: Package (windows)
         if: runner.os == 'Windows' && needs.setup.outputs.is_release == 'true'


### PR DESCRIPTION
## Problem

`v0.8.61` published to crates.io but produced **no binaries and no GitHub release**. The `Package (unix)` step in `build-release-binaries.yml` runs under `set -euo pipefail` and expanded `"${extra_binaries[@]}"` unconditionally. Only `*-unknown-linux-gnu` populates that array (`harn-container-probe`); macOS/Windows leave it empty. macOS runners use system **bash 3.2**, where expanding an empty array under `set -u` aborts with:

```
extra_binaries[@]: unbound variable
```

That failed `aarch64-apple-darwin`; matrix **fail-fast** then cancelled every other target and skipped `Create GitHub release`.

## Fix

Guard with `${extra_binaries[@]+"${extra_binaries[@]}"}` — expands to nothing when empty, to the quoted elements otherwise.

Verified on bash 3.2.57 (the runner version):
- empty array → no extra arg, no error
- non-empty array → `harn-container-probe` included
- the old form reproduces the unbound-variable abort

## Follow-up

After this merges I'll re-run `build-release-binaries.yml` via `workflow_dispatch` for the existing `v0.8.61` tag (the workflow's documented manual re-release path) to produce the missing binaries + GitHub release. crates.io is already published and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)