### PR TITLE
harn-rules-hostlib: expose the rule engine to .harn (#2838 declarative bindings)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ dependencies = [
  "harn-mcp-rc-compat",
  "harn-modules",
  "harn-parser",
+ "harn-rules-hostlib",
  "harn-serve",
  "harn-skills",
  "harn-stdlib",
@@ -2530,6 +2531,16 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "tree-sitter",
+]
+
+[[package]]
+name = "harn-rules-hostlib"
+version = "0.8.60"
+dependencies = [
+ "harn-hostlib",
+ "harn-rules",
+ "harn-vm",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/harn-lint",
     "crates/harn-hostlib",
     "crates/harn-rules",
+    "crates/harn-rules-hostlib",
     "crates/harn-mcp-rc-compat",
     "perf/llm",
     "perf/vm",

--- a/changelog.d/2838.added.md
+++ b/changelog.d/2838.added.md
@@ -1,0 +1,5 @@
+- Added the `harn-rules-hostlib` crate and the `std/rules` stdlib module — the rule engine is now callable from Harn.
+  `rules.search` (read-only) returns matches with capture bindings, `rules.report` (read-only) returns a data table,
+  and `rules.apply` (write-gated, dry-run by default, safety-aware) applies a codemod. A rule is passed as its TOML
+  source, so an agent can author and run a rule entirely in `.harn` without recompiling the binary. The crate lives
+  outside `harn-hostlib` to avoid a dependency cycle, and is wired into the CLI alongside the default capabilities.

--- a/conformance/tests/stdlib/rules_engine.expected
+++ b/conformance/tests/stdlib/rules_engine.expected
@@ -1,0 +1,8 @@
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/stdlib/rules_engine.harn
+++ b/conformance/tests/stdlib/rules_engine.harn
@@ -1,0 +1,27 @@
+import { rules_apply, rules_report, rules_search } from "std/rules"
+
+/**
+ * End-to-end exercise of the `std/rules` surface (#2838): authoring a
+ * declarative rule as TOML *inside Harn* and running it through search,
+ * report-only data tables, and a dry-run codemod — no recompile needed.
+ */
+pipeline default() {
+  hostlib_enable("tools:deterministic")
+  let finder = "id = \"find-calls\"\nlanguage = \"typescript\"\n[rule]\npattern = \"$FN()\"\n"
+  // 1) Search returns matches with capture bindings.
+  let r = rules_search({rule: finder, source: "foo();\nbar();\n", language: "typescript"})
+  __io_println(r.ok && r.match_count == 2)
+  __io_println(r.matches[0].captures.FN == "foo")
+  __io_println(r.matches[1].captures.FN == "bar")
+  // 2) Report-only mode yields a data table with a per-match summary.
+  let rep = rules_report({rule: finder, source: "foo();\nbar();\n", language: "typescript", path: "a.ts"})
+  __io_println(rep.summary.total_rows == 2)
+  __io_println(rep.rule_id == "find-calls")
+  // 3) A codemod in dry-run previews without writing; the
+  //    `behavior-preserving` safety makes it machine-applicable.
+  let codemod = "id = \"rename\"\nlanguage = \"typescript\"\nsafety = \"behavior-preserving\"\nfix = \"bar()\"\n[rule]\npattern = \"foo()\"\n"
+  let ap = rules_apply({rule: codemod, source: "foo();\n", language: "typescript", dry_run: true})
+  __io_println(ap.ok && ap.files[0].changed && !ap.files[0].applied)
+  __io_println(ap.files[0].preview == "bar();\n")
+  __io_println(ap.auto_applicable)
+}

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -38,6 +38,7 @@ harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-ir = { path = "../harn-ir", version = "0.8" }
 harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel", "testbench-wasi"] }
 harn-hostlib = { path = "../harn-hostlib", version = "0.8", optional = true }
+harn-rules-hostlib = { path = "../harn-rules-hostlib", version = "0.8", optional = true }
 harn-lint = { path = "../harn-lint", version = "0.8" }
 harn-modules = { path = "../harn-modules", version = "0.8" }
 harn-fmt = { path = "../harn-fmt", version = "0.8" }
@@ -119,7 +120,12 @@ default = ["hostlib"]
 # server. Default-on so `harn run`-driven scripts that name a hostlib
 # builtin work without extra flags. Disable with `--no-default-features` if
 # you want a slimmer build that doesn't pull tree-sitter/notify/etc.
-hostlib = ["dep:harn-hostlib", "harn-hostlib/full", "harn-serve/hostlib-full"]
+hostlib = [
+    "dep:harn-hostlib",
+    "dep:harn-rules-hostlib",
+    "harn-hostlib/full",
+    "harn-serve/hostlib-full",
+]
 
 [dev-dependencies]
 harn-mcp-rc-compat = { path = "../harn-mcp-rc-compat" }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -62,6 +62,10 @@ pub(crate) fn ensure_builtin_signatures_installed() {
 #[cfg(feature = "hostlib")]
 pub(crate) fn install_default_hostlib(vm: &mut harn_vm::Vm) {
     let _ = harn_hostlib::install_default(vm);
+    // The `rules` capability lives in its own crate (it depends on
+    // `harn-rules`, which depends on `harn-hostlib`, so it can't ship inside
+    // `install_default`). Wire it in alongside the defaults.
+    harn_rules_hostlib::install(vm);
 }
 
 #[cfg(not(feature = "hostlib"))]

--- a/crates/harn-rules-hostlib/Cargo.toml
+++ b/crates/harn-rules-hostlib/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "harn-rules-hostlib"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Host capability exposing the harn-rules declarative rule engine to Harn (`rules.search` / `rules.report` / `rules.apply`)."
+
+[dependencies]
+harn-rules = { path = "../harn-rules", version = "0.8" }
+harn-hostlib = { path = "../harn-hostlib", version = "0.8", default-features = false, features = ["ast"] }
+harn-vm = { path = "../harn-vm", version = "0.8" }
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/harn-rules-hostlib/README.md
+++ b/crates/harn-rules-hostlib/README.md
@@ -1,0 +1,34 @@
+# harn-rules-hostlib
+
+The host capability that exposes the [`harn-rules`](../harn-rules) declarative
+rule engine to the Harn language. Part of the
+[Rule Engine program](https://github.com/burin-labs/harn/issues/2826)
+(Epic A, [harn#2838](https://github.com/burin-labs/harn/issues/2838)).
+
+## Why a separate crate?
+
+`harn-rules` depends on `harn-hostlib` (for the tree-sitter grammars), so the
+`rules` builtins **cannot** live inside `harn-hostlib` — that would be a
+dependency cycle. This crate sits one level up
+(`harn-cli` → `harn-rules-hostlib` → `harn-rules` → `harn-hostlib`) and an
+embedder calls [`install`] next to `harn_hostlib::install_default`.
+
+## Builtins (`std/rules` wraps these)
+
+| Builtin | Gate | What |
+|---|---|---|
+| `rules.search` | read-only | run a rule, return matches with capture bindings |
+| `rules.report` | read-only | run report-only, return a `DataTable` (counts + rows) |
+| `rules.apply`  | write (deterministic-tools) | apply a codemod `fix`; dry-run by default, safety-gated |
+
+A rule is passed as its **TOML source** (`rule`), with either inline `source`
+(+ `language`) or a list of `paths`. So an agent can author and run a rule
+entirely from `.harn` without recompiling the binary.
+
+## Not yet here
+
+The **imperative** rule form — a `.harn` module exporting an
+`on_match($node, ctx)` visitor — needs a synchronous closure-callback from a
+Rust builtin, which the VM does not support today (only async builtins can
+call back into `.harn`). That requires a VM-core prerequisite and is tracked
+separately.

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -1,0 +1,450 @@
+//! Host capability exposing the `harn-rules` declarative rule engine to
+//! Harn as `rules.search` / `rules.report` / `rules.apply`.
+//!
+//! This crate lives outside `harn-hostlib` on purpose: `harn-rules` already
+//! depends on `harn-hostlib` (for the tree-sitter grammars), so the rules
+//! builtins would form a dependency cycle if they lived there. An embedder
+//! (harn-cli, harn-serve) calls [`install`] alongside `harn_hostlib::install_default`.
+//!
+//! ## Builtins
+//!
+//! - `rules.search` (read-only) — run a rule and return its matches.
+//! - `rules.report` (read-only) — run a rule in report-only mode and return
+//!   a [`harn_rules::DataTable`] (counts + per-match rows).
+//! - `rules.apply` (write-gated) — apply a codemod rule's `fix`; writes only
+//!   when `dry_run: false` *and* the rule is safe to auto-apply (or
+//!   `allow_unsafe: true`). Shares the deterministic-tools gate with the
+//!   other mutating builtins.
+//!
+//! A rule is passed as its TOML source (`rule`), so an agent can author and
+//! run a rule entirely from `.harn` without recompiling the binary. The
+//! richer **imperative** `.harn` visitor (`on_match($node, ctx)`) needs a
+//! synchronous closure-callback from a Rust builtin, which the VM does not
+//! support today (only async builtins can call back) — tracked separately.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use harn_hostlib::ast::Language;
+use harn_hostlib::tools::permissions::gated_handler;
+use harn_hostlib::{
+    BuiltinRegistry, HostlibCapability, HostlibError, HostlibRegistry, RegisteredBuiltin,
+};
+use harn_vm::{Vm, VmValue};
+
+use harn_rules::{data_table, CompiledRule, Rule, RuleMatch, SourceFile};
+
+const SEARCH: &str = "hostlib_rules_search";
+const REPORT: &str = "hostlib_rules_report";
+const APPLY: &str = "hostlib_rules_apply";
+
+/// The `rules` host capability.
+#[derive(Default)]
+pub struct RulesCapability;
+
+impl HostlibCapability for RulesCapability {
+    fn module_name(&self) -> &'static str {
+        "rules"
+    }
+
+    fn register_builtins(&self, registry: &mut BuiltinRegistry) {
+        registry.register(RegisteredBuiltin {
+            name: SEARCH,
+            module: "rules",
+            method: "search",
+            handler: Arc::new(search_run),
+        });
+        registry.register(RegisteredBuiltin {
+            name: REPORT,
+            module: "rules",
+            method: "report",
+            handler: Arc::new(report_run),
+        });
+        // `apply` writes files, so it shares the deterministic-tools gate.
+        registry.register(RegisteredBuiltin {
+            name: APPLY,
+            module: "rules",
+            method: "apply",
+            handler: gated_handler(APPLY, apply_run),
+        });
+    }
+}
+
+/// Install the `rules` capability into a VM. Call this alongside
+/// `harn_hostlib::install_default`.
+pub fn install(vm: &mut Vm) {
+    HostlibRegistry::new()
+        .with(RulesCapability)
+        .register_into_vm(vm);
+}
+
+// ---------------------------------------------------------------------------
+// Builtins
+// ---------------------------------------------------------------------------
+
+fn search_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = first_dict(SEARCH, args)?;
+    let rule = compile_rule(SEARCH, &dict)?;
+    let files = load_files(SEARCH, &dict)?;
+
+    let mut matches = Vec::new();
+    for file in &files {
+        for m in rule.run(&file.source).map_err(|e| backend(SEARCH, &e))? {
+            matches.push(match_to_vm(&file.path, &m));
+        }
+    }
+    Ok(dict_vm([
+        ("result", str_vm("ok")),
+        ("match_count", VmValue::Int(matches.len() as i64)),
+        ("matches", VmValue::List(Arc::new(matches))),
+    ]))
+}
+
+fn report_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = first_dict(REPORT, args)?;
+    let rule = compile_rule(REPORT, &dict)?;
+    let files = load_files(REPORT, &dict)?;
+    let table = data_table(&rule, &files).map_err(|e| backend(REPORT, &e))?;
+    Ok(json_to_vm(&table.to_json_value()))
+}
+
+fn apply_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = first_dict(APPLY, args)?;
+    let rule = compile_rule(APPLY, &dict)?;
+    let dry_run = optional_bool(&dict, "dry_run", true);
+    let allow_unsafe = optional_bool(&dict, "allow_unsafe", false);
+    let files = load_files(APPLY, &dict)?;
+
+    let auto_applicable = rule.safety().is_auto_applicable();
+    let mut entries = Vec::new();
+    for file in &files {
+        let outcome = rule.apply(&file.source).map_err(|e| backend(APPLY, &e))?;
+        // Write only on a real apply, when the edit is safe to auto-apply
+        // (or explicitly allowed), and the rule actually changed the file.
+        let applied = !dry_run && outcome.changed && (auto_applicable || allow_unsafe);
+        if applied {
+            std::fs::write(&file.path, &outcome.rewritten).map_err(|e| HostlibError::Backend {
+                builtin: APPLY,
+                message: format!("write `{}`: {e}", file.path.display()),
+            })?;
+        }
+        entries.push(dict_vm([
+            ("path", str_vm(file.path.display().to_string())),
+            ("changed", VmValue::Bool(outcome.changed)),
+            ("applied", VmValue::Bool(applied)),
+            ("idempotent", VmValue::Bool(outcome.idempotent)),
+            ("safety", str_vm(format!("{:?}", outcome.safety))),
+            ("preview", str_vm(outcome.rewritten)),
+        ]));
+    }
+    Ok(dict_vm([
+        ("result", str_vm("ok")),
+        ("dry_run", VmValue::Bool(dry_run)),
+        ("auto_applicable", VmValue::Bool(auto_applicable)),
+        ("files", VmValue::List(Arc::new(entries))),
+    ]))
+}
+
+// ---------------------------------------------------------------------------
+// Shared parsing / conversion
+// ---------------------------------------------------------------------------
+
+fn compile_rule(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+) -> Result<CompiledRule, HostlibError> {
+    let toml = require_string(builtin, dict, "rule")?;
+    let rule = Rule::from_toml_str(&toml).map_err(|e| HostlibError::InvalidParameter {
+        builtin,
+        param: "rule",
+        message: format!("invalid rule TOML: {e}"),
+    })?;
+    CompiledRule::compile(&rule).map_err(|e| HostlibError::InvalidParameter {
+        builtin,
+        param: "rule",
+        message: e.to_string(),
+    })
+}
+
+/// Load the fileset: inline `source` (+ `language`) for a single buffer, or
+/// `paths` read from disk (language inferred per file; undetectable files
+/// are skipped).
+fn load_files(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+) -> Result<Vec<SourceFile>, HostlibError> {
+    if let Some(source) = optional_string(dict, "source") {
+        let language_name = require_string(builtin, dict, "language")?;
+        let language =
+            Language::from_name(&language_name).ok_or_else(|| HostlibError::InvalidParameter {
+                builtin,
+                param: "language",
+                message: format!("unknown language `{language_name}`"),
+            })?;
+        let path = optional_string(dict, "path").unwrap_or_else(|| "<inline>".to_string());
+        return Ok(vec![SourceFile {
+            path: PathBuf::from(path),
+            language,
+            source,
+        }]);
+    }
+
+    let paths = optional_string_list(dict, "paths");
+    if paths.is_empty() {
+        return Err(HostlibError::MissingParameter {
+            builtin,
+            param: "paths",
+        });
+    }
+    let mut files = Vec::new();
+    for path in paths {
+        let contents = std::fs::read_to_string(&path).map_err(|e| HostlibError::Backend {
+            builtin,
+            message: format!("read `{path}`: {e}"),
+        })?;
+        if let Some(file) = SourceFile::detect(&path, contents) {
+            files.push(file);
+        }
+    }
+    Ok(files)
+}
+
+fn match_to_vm(path: &std::path::Path, m: &RuleMatch) -> VmValue {
+    let captures: BTreeMap<String, VmValue> = m
+        .bindings
+        .iter()
+        .map(|(name, b)| (name.clone(), str_vm(&b.text)))
+        .collect();
+    dict_vm([
+        ("path", str_vm(path.display().to_string())),
+        ("text", str_vm(&m.text)),
+        ("start_row", VmValue::Int(m.span.start_row as i64)),
+        ("start_col", VmValue::Int(m.span.start_col as i64)),
+        ("end_row", VmValue::Int(m.span.end_row as i64)),
+        ("end_col", VmValue::Int(m.span.end_col as i64)),
+        ("captures", VmValue::Dict(Arc::new(captures))),
+    ])
+}
+
+fn backend(builtin: &'static str, err: &harn_rules::RulesError) -> HostlibError {
+    HostlibError::Backend {
+        builtin,
+        message: err.to_string(),
+    }
+}
+
+fn json_to_vm(value: &serde_json::Value) -> VmValue {
+    match value {
+        serde_json::Value::Null => VmValue::Nil,
+        serde_json::Value::Bool(b) => VmValue::Bool(*b),
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .map(VmValue::Int)
+            .unwrap_or_else(|| VmValue::Float(n.as_f64().unwrap_or(0.0))),
+        serde_json::Value::String(s) => str_vm(s),
+        serde_json::Value::Array(items) => {
+            VmValue::List(Arc::new(items.iter().map(json_to_vm).collect()))
+        }
+        serde_json::Value::Object(map) => VmValue::Dict(Arc::new(
+            map.iter()
+                .map(|(k, v)| (k.clone(), json_to_vm(v)))
+                .collect(),
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal arg/value helpers (harn-hostlib's `tools::args` is crate-private)
+// ---------------------------------------------------------------------------
+
+fn first_dict(
+    builtin: &'static str,
+    args: &[VmValue],
+) -> Result<Arc<BTreeMap<String, VmValue>>, HostlibError> {
+    match args.first() {
+        Some(VmValue::Dict(dict)) => Ok(dict.clone()),
+        Some(VmValue::Nil) | None => Ok(Arc::new(BTreeMap::new())),
+        Some(_) => Err(HostlibError::InvalidParameter {
+            builtin,
+            param: "params",
+            message: "expected a dict argument".into(),
+        }),
+    }
+}
+
+fn require_string(
+    builtin: &'static str,
+    dict: &BTreeMap<String, VmValue>,
+    key: &'static str,
+) -> Result<String, HostlibError> {
+    match dict.get(key) {
+        Some(VmValue::String(s)) => Ok(s.to_string()),
+        _ => Err(HostlibError::MissingParameter {
+            builtin,
+            param: key,
+        }),
+    }
+}
+
+fn optional_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+    match dict.get(key) {
+        Some(VmValue::String(s)) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+fn optional_string_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<String> {
+    match dict.get(key) {
+        Some(VmValue::List(items)) => items
+            .iter()
+            .filter_map(|v| match v {
+                VmValue::String(s) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn optional_bool(dict: &BTreeMap<String, VmValue>, key: &str, default: bool) -> bool {
+    match dict.get(key) {
+        Some(VmValue::Bool(b)) => *b,
+        _ => default,
+    }
+}
+
+fn str_vm(s: impl AsRef<str>) -> VmValue {
+    VmValue::String(Arc::from(s.as_ref()))
+}
+
+fn dict_vm<const N: usize>(entries: [(&str, VmValue); N]) -> VmValue {
+    let map: BTreeMap<String, VmValue> = entries
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+    VmValue::Dict(Arc::new(map))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
+        let map: BTreeMap<String, VmValue> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect();
+        VmValue::Dict(Arc::new(map))
+    }
+
+    fn get<'a>(v: &'a VmValue, key: &str) -> &'a VmValue {
+        match v {
+            VmValue::Dict(d) => d.get(key).unwrap_or_else(|| panic!("missing {key}")),
+            _ => panic!("not a dict"),
+        }
+    }
+
+    fn int(v: &VmValue) -> i64 {
+        match v {
+            VmValue::Int(i) => *i,
+            other => panic!("not int: {other:?}"),
+        }
+    }
+
+    fn s(v: &VmValue) -> String {
+        match v {
+            VmValue::String(s) => s.to_string(),
+            other => panic!("not string: {other:?}"),
+        }
+    }
+
+    fn b(v: &VmValue) -> bool {
+        match v {
+            VmValue::Bool(b) => *b,
+            other => panic!("not bool: {other:?}"),
+        }
+    }
+
+    const SEARCH_RULE: &str = r#"
+        id = "find-calls"
+        language = "typescript"
+        [rule]
+        pattern = "$FN()"
+    "#;
+
+    #[test]
+    fn search_returns_matches_with_captures() {
+        let result = search_run(&[dict(&[
+            ("rule", str_vm(SEARCH_RULE)),
+            ("source", str_vm("foo();\nbar();\n")),
+            ("language", str_vm("typescript")),
+        ])])
+        .unwrap();
+        assert_eq!(int(get(&result, "match_count")), 2);
+        let matches = match get(&result, "matches") {
+            VmValue::List(l) => l.clone(),
+            _ => panic!(),
+        };
+        assert_eq!(s(get(get(&matches[0], "captures"), "FN")), "foo");
+    }
+
+    #[test]
+    fn report_returns_a_data_table() {
+        let result = report_run(&[dict(&[
+            ("rule", str_vm(SEARCH_RULE)),
+            ("source", str_vm("foo();\nbar();\n")),
+            ("language", str_vm("typescript")),
+            ("path", str_vm("a.ts")),
+        ])])
+        .unwrap();
+        assert_eq!(int(get(get(&result, "summary"), "total_rows")), 2);
+        assert_eq!(s(get(&result, "rule_id")), "find-calls");
+    }
+
+    #[test]
+    fn apply_dry_run_previews_without_writing() {
+        let rule = r#"
+            id = "rename"
+            language = "typescript"
+            safety = "behavior-preserving"
+            fix = "bar()"
+            [rule]
+            pattern = "foo()"
+        "#;
+        let result = apply_run(&[dict(&[
+            ("rule", str_vm(rule)),
+            ("source", str_vm("foo();\n")),
+            ("language", str_vm("typescript")),
+            ("dry_run", VmValue::Bool(true)),
+        ])])
+        .unwrap();
+        let files = match get(&result, "files") {
+            VmValue::List(l) => l.clone(),
+            _ => panic!(),
+        };
+        assert!(b(get(&files[0], "changed")));
+        assert!(!b(get(&files[0], "applied")));
+        assert_eq!(s(get(&files[0], "preview")), "bar();\n");
+    }
+
+    #[test]
+    fn missing_rule_is_an_error() {
+        let err = search_run(&[dict(&[
+            ("source", str_vm("x")),
+            ("language", str_vm("rust")),
+        ])]);
+        assert!(matches!(
+            err,
+            Err(HostlibError::MissingParameter { param: "rule", .. })
+        ));
+    }
+
+    #[test]
+    fn capability_registers_three_builtins() {
+        let mut registry = BuiltinRegistry::new();
+        RulesCapability.register_builtins(&mut registry);
+        let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+        assert_eq!(names, vec![SEARCH, REPORT, APPLY]);
+    }
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -62,6 +62,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_ast.harn"),
     },
     StdlibSource {
+        module: "rules",
+        source: include_str!("stdlib/stdlib_rules.harn"),
+    },
+    StdlibSource {
         module: "artifact/web",
         source: include_str!("stdlib/artifact/web.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/stdlib_rules.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_rules.harn
@@ -1,0 +1,69 @@
+// std/rules - run declarative structural rules (the harn-rules engine) from
+// Harn. A rule is its TOML source, so an agent can author and run a rule
+// inline without recompiling the binary.
+/**
+ * Run a rule and return its matches.
+ *
+ * `params` is a dict:
+ *
+ * - `rule`: the rule's TOML source (id / language / `[rule]` block / `where`
+ *   / `transform` / `fix` / `safety`).
+ * - `source` **or** `paths`: inline text (with `language`) or a list of file
+ *   paths to read.
+ *
+ * On success `result == "ok"` and `matches` is a list of `{path, text,
+ * start_row, start_col, captures}` where `captures` maps each metavar name
+ * to its bound text.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: rules_search({rule: src, source: "foo();", language: "typescript"})
+ */
+pub fn rules_search(params) -> dict {
+  let payload = hostlib_rules_search(params ?? {}) ?? {}
+  return payload
+    .merge(
+    {ok: payload?.result ?? "" == "ok", provenance: {module: "std/rules", helper: "rules_search"}},
+  )
+}
+
+/**
+ * Run a rule in **report-only** mode and return a data table — columnar
+ * findings (`rows`) plus a metrics `summary` (total / files / per-file
+ * counts). Never edits anything.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: rules_report({rule: src, paths: ["a.ts", "b.ts"]})
+ */
+pub fn rules_report(params) -> dict {
+  let payload = hostlib_rules_report(params ?? {}) ?? {}
+  return payload.merge({provenance: {module: "std/rules", helper: "rules_report"}})
+}
+
+/**
+ * Apply a codemod rule's `fix`. **Dry-run by default** — pass `dry_run:
+ * false` to write. Writes only when the rule's `safety` is machine-applicable
+ * (`format-only` / `behavior-preserving`) or `allow_unsafe: true`. Each file
+ * entry reports `{path, changed, applied, idempotent, safety, preview}`.
+ *
+ * Requires the deterministic-tools gate
+ * (`hostlib_enable("tools:deterministic")`).
+ *
+ * @effects: [host, fs]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: rules_apply({rule: src, paths: ["a.ts"], dry_run: false})
+ */
+pub fn rules_apply(params) -> dict {
+  let payload = hostlib_rules_apply(params ?? {}) ?? {}
+  return payload
+    .merge(
+    {ok: payload?.result ?? "" == "ok", provenance: {module: "std/rules", helper: "rules_apply"}},
+  )
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -81,6 +81,8 @@ WORKSPACE_CRATES=(
   harn-serve
   harn-lsp
   harn-hostlib
+  harn-rules
+  harn-rules-hostlib
   harn-cli
 )
 


### PR DESCRIPTION
## Summary

Makes the `harn-rules` declarative rule engine **callable from Harn** (Rule Engine Epic A) — the native escape hatch that needs no separate plugin language.

> **Stacked on #2876** (#2836/#2837). Base retargets to `main` once #2876 merges; auto-merge held until then.

## What's in it

- **New `harn-rules-hostlib` crate** with a `RulesCapability` registering three builtins. It lives outside `harn-hostlib` on purpose — `harn-rules` already depends on `harn-hostlib`, so the builtins would form a dependency cycle there. Dependency chain: `harn-cli` → `harn-rules-hostlib` → `harn-rules` → `harn-hostlib`.
  - `rules.search` (read-only) — run a rule, return matches + capture bindings
  - `rules.report` (read-only) — report-only `DataTable` (counts + per-match rows)
  - `rules.apply` (write-gated, deterministic-tools) — apply a codemod `fix`; dry-run by default, safety-aware (writes only machine-applicable fixes unless `allow_unsafe`)
- **Wired into harn-cli** (`install_default_hostlib`) alongside the default capabilities, behind the existing `hostlib` feature.
- **`std/rules` stdlib module** wrapping the builtins (`rules_search` / `rules_report` / `rules_apply`).
- A rule is passed as its **TOML source**, so an agent can author and run a rule entirely in `.harn` without recompiling the binary.

## Acceptance ([#2838](https://github.com/burin-labs/harn/issues/2838))

- ✅ A declarative rule produces diagnostics/matches, callable from `.harn` — `conformance/tests/stdlib/rules_engine.harn` drives search → report → dry-run apply end-to-end (8 assertions).
- ✅ An agent can author + run a (declarative) rule entirely in `.harn` without recompiling.

## Deferred (filed as #2878)

The **imperative** rule form (`on_match($node, ctx)` visitor) needs a synchronous closure-callback from a Rust builtin, which the VM does not support today (`Vm::call_closure_pub` is async-only; no hostlib builtin invokes a closure). That's a VM-core prerequisite — tracked in #2878. This PR therefore **partially** addresses #2838 (declarative bindings).

5 crate unit tests + conformance; clippy + fmt clean; demo-gate N/A (builtins live outside harn-hostlib). Publish ordering updated.

Refs #2838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
