### PR TITLE
Return drained results from command cancellation

### DIFF
--- a/changelog.d/command-cancel-result.changed.md
+++ b/changelog.d/command-cancel-result.changed.md
@@ -1,0 +1,2 @@
+`tools.cancel_handle` can now optionally wait for the background waiter to finish
+draining command artifacts and return the final canceled command result.

--- a/crates/harn-hostlib/schemas/tools/cancel_handle.request.json
+++ b/crates/harn-hostlib/schemas/tools/cancel_handle.request.json
@@ -4,7 +4,9 @@
   "title": "tools.cancel_handle request",
   "type": "object",
   "properties": {
-    "handle_id": { "type": "string" }
+    "handle_id": { "type": "string" },
+    "wait_result_ms": { "type": "integer", "minimum": 0 },
+    "timed_out": { "type": "boolean" }
   },
   "required": ["handle_id"],
   "additionalProperties": false

--- a/crates/harn-hostlib/schemas/tools/cancel_handle.response.json
+++ b/crates/harn-hostlib/schemas/tools/cancel_handle.response.json
@@ -5,7 +5,11 @@
   "type": "object",
   "properties": {
     "handle_id": { "type": "string" },
-    "cancelled": { "type": "boolean" }
+    "cancelled": { "type": "boolean" },
+    "result": {
+      "type": "object",
+      "additionalProperties": true
+    }
   },
   "required": ["handle_id", "cancelled"],
   "additionalProperties": false

--- a/crates/harn-hostlib/src/tools/cancel_handle.rs
+++ b/crates/harn-hostlib/src/tools/cancel_handle.rs
@@ -1,7 +1,7 @@
 //! `tools/cancel_handle` — cancel a specific in-flight long-running tool.
 //!
 //! Accepts `{ handle_id: string }`. Kills the spawned process (SIGKILL) and
-//! removes the entry from the handle store. Returns:
+//! lets the waiter drain artifacts. Returns:
 //!
 //! ```json
 //! { "handle_id": "...", "cancelled": true|false }
@@ -10,23 +10,40 @@
 //! `cancelled: false` means the handle was not found — either it already
 //! completed or the id was invalid.
 
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
 use harn_vm::VmValue;
 
 use crate::error::HostlibError;
-use crate::tools::payload::{require_dict_arg, require_string};
-use crate::tools::response::ResponseBuilder;
+use crate::tools::payload::{optional_bool, optional_u64, require_dict_arg, require_string};
 
 pub(crate) const NAME: &str = "hostlib_tools_cancel_handle";
 
 pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let map = require_dict_arg(NAME, args)?;
     let handle_id = require_string(NAME, &map, "handle_id")?;
+    let wait_result = optional_u64(NAME, &map, "wait_result_ms")?.map(Duration::from_millis);
+    let timed_out = optional_bool(NAME, &map, "timed_out")?.unwrap_or(false);
 
-    let cancelled = super::long_running::cancel_handle(&handle_id)
-        || harn_vm::cancel_long_running_handle(&handle_id);
+    let outcome = super::long_running::cancel_handle_with_options(
+        &handle_id,
+        super::long_running::CancelOptions {
+            timed_out,
+            wait_result,
+        },
+    );
+    let cancelled = outcome.cancelled || harn_vm::cancel_long_running_handle(&handle_id);
 
-    Ok(ResponseBuilder::new()
-        .str("handle_id", handle_id)
-        .bool("cancelled", cancelled)
-        .build())
+    let mut out = BTreeMap::new();
+    out.insert(
+        "handle_id".to_string(),
+        VmValue::String(Arc::from(handle_id)),
+    );
+    out.insert("cancelled".to_string(), VmValue::Bool(cancelled));
+    if let Some(result) = outcome.result {
+        out.insert("result".to_string(), result);
+    }
+    Ok(VmValue::Dict(Arc::new(out)))
 }

--- a/crates/harn-hostlib/src/tools/long_running.rs
+++ b/crates/harn-hostlib/src/tools/long_running.rs
@@ -31,7 +31,9 @@
 //! in the entry and kill by PID when needed. On Unix we call `kill(2)`
 //! directly via an `extern "C"` declaration (no `libc` crate required).
 //! A shared `cancelled` flag suppresses the feedback push when the waiter
-//! sees an exit caused by cancellation.
+//! sees an exit caused by cancellation. Callers that need artifact-stable
+//! cancellation can opt into waiting for the waiter result through
+//! `cancel_handle`.
 
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
@@ -54,6 +56,10 @@ struct CancelState {
     /// Set to `true` when `cancel_handle` / `cancel_session_handles` runs.
     /// The waiter checks this before pushing feedback.
     cancelled: AtomicBool,
+    /// Set by cancellation paths that represent a timeout rather than a
+    /// user-requested kill. The waiter uses this for the returned result
+    /// status while still suppressing inbox feedback.
+    timed_out: AtomicBool,
 }
 
 #[derive(Default)]
@@ -75,6 +81,9 @@ struct HandleEntry {
     /// feedback push is complete. `None` if the test-side hasn't asked
     /// to be notified.
     completion_tx: Option<std::sync::mpsc::SyncSender<()>>,
+    /// Optional one-shot result channel installed by `cancel_handle` when a
+    /// caller wants cancellation to wait until artifacts have been drained.
+    result_tx: Option<std::sync::mpsc::SyncSender<VmValue>>,
 }
 
 #[derive(Default)]
@@ -217,6 +226,7 @@ pub(crate) fn spawn_long_running_with_options(
 
     let cancel_state = Arc::new(CancelState {
         cancelled: AtomicBool::new(false),
+        timed_out: AtomicBool::new(false),
     });
 
     {
@@ -231,6 +241,7 @@ pub(crate) fn spawn_long_running_with_options(
                 session_id: options.session_id.clone(),
                 cancel_state: cancel_state.clone(),
                 completion_tx: None,
+                result_tx: None,
             },
         );
     }
@@ -357,16 +368,17 @@ fn waiter_thread(context: WaiterContext, cancel_state: Arc<CancelState>, capture
         (state.stdout.clone(), state.stderr.clone())
     };
 
-    // Remove our entry from the store, taking the completion notifier on
-    // the way out so we can signal it after the feedback push completes.
-    let completion_tx = {
+    // Remove our entry from the store, taking notifiers on the way out so we
+    // can signal them after the feedback/result path completes.
+    let (completion_tx, result_tx) = {
         let mut store = HANDLE_STORE
             .lock()
             .expect("long-running handle store poisoned");
-        store
+        let entry = store
             .entries
             .remove(&context.handle_id)
-            .and_then(|mut e| e.completion_tx.take())
+            .map(|mut e| (e.completion_tx.take(), e.result_tx.take()));
+        entry.unwrap_or((None, None))
     };
 
     let signal_done = move || {
@@ -375,17 +387,20 @@ fn waiter_thread(context: WaiterContext, cancel_state: Arc<CancelState>, capture
         }
     };
 
-    // If cancellation was requested, don't push feedback — the caller
-    // that cancelled doesn't want to receive a spurious tool_result.
-    if cancel_state.cancelled.load(Ordering::Acquire) {
-        signal_done();
-        return;
-    }
+    let cancelled = cancel_state.cancelled.load(Ordering::Acquire);
+    let timed_out = cancelled && cancel_state.timed_out.load(Ordering::Acquire);
 
     let (exit_code, signal_name) = match status {
         Some(s) => decode_exit_status(s),
         // wait() itself failed — treat as killed (extremely unusual).
         None => (-1, Some("SIGKILL".to_string())),
+    };
+    let command_status = if timed_out {
+        CommandStatus::TimedOut
+    } else if cancelled {
+        CommandStatus::Killed
+    } else {
+        CommandStatus::Completed
     };
     let duration = waiter_start.elapsed();
     let duration_ms = duration.as_millis() as i64;
@@ -407,7 +422,7 @@ fn waiter_thread(context: WaiterContext, cancel_state: Arc<CancelState>, capture
     );
     payload.insert(
         "status".into(),
-        serde_json::Value::String(CommandStatus::Completed.as_str().to_string()),
+        serde_json::Value::String(command_status.as_str().to_string()),
     );
     payload.insert(
         "handle_id".into(),
@@ -433,6 +448,7 @@ fn waiter_thread(context: WaiterContext, cancel_state: Arc<CancelState>, capture
         "exit_code".into(),
         serde_json::Value::Number(exit_code.into()),
     );
+    payload.insert("timed_out".into(), serde_json::Value::Bool(timed_out));
     payload.insert("stdout".into(), serde_json::Value::String(inline_stdout));
     payload.insert("stderr".into(), serde_json::Value::String(inline_stderr));
     payload.insert(
@@ -471,13 +487,19 @@ fn waiter_thread(context: WaiterContext, cancel_state: Arc<CancelState>, capture
         payload.insert("signal".into(), serde_json::Value::Null);
     }
 
-    let content = serde_json::to_string(&payload).unwrap_or_default();
-    harn_vm::orchestration::agent_inbox::push(
-        &context.session_id,
-        "tool_result",
-        &content,
-        "hostlib.long_running.exit",
-    );
+    if let Some(tx) = result_tx {
+        let value = serde_json::Value::Object(payload.clone());
+        let _ = tx.try_send(harn_vm::json_to_vm_value(&value));
+    }
+    if !cancelled {
+        let content = serde_json::to_string(&payload).unwrap_or_default();
+        harn_vm::orchestration::agent_inbox::push(
+            &context.session_id,
+            "tool_result",
+            &content,
+            "hostlib.long_running.exit",
+        );
+    }
     signal_done();
 }
 
@@ -570,47 +592,79 @@ fn spawn_progress_thread(context: ProgressThreadContext) -> std::thread::JoinHan
     })
 }
 
-/// Cancel a specific in-flight long-running handle. Kills the process and
-/// removes the entry. Returns `true` if the handle was found and cancelled.
+pub(crate) struct CancelOptions {
+    pub(crate) timed_out: bool,
+    pub(crate) wait_result: Option<Duration>,
+}
+
+pub(crate) struct CancelOutcome {
+    pub(crate) cancelled: bool,
+    pub(crate) result: Option<VmValue>,
+}
+
+/// Cancel a specific in-flight long-running handle. Kills the process and lets
+/// the waiter drain output/artifacts. Returns `true` if the handle was found
+/// and cancellation was newly requested.
 pub fn cancel_handle(handle_id: &str) -> bool {
-    let (handle_owned, killer, cancel_state, completion_tx) = {
+    cancel_handle_with_options(
+        handle_id,
+        CancelOptions {
+            timed_out: false,
+            wait_result: None,
+        },
+    )
+    .cancelled
+}
+
+pub(crate) fn cancel_handle_with_options(handle_id: &str, options: CancelOptions) -> CancelOutcome {
+    let (killer, cancel_state, result_rx) = {
         let mut store = HANDLE_STORE
             .lock()
             .expect("long-running handle store poisoned");
-        match store.entries.remove(handle_id) {
-            None => return false,
-            Some(mut entry) => (
-                entry.handle.take(),
-                entry.killer.clone(),
-                entry.cancel_state.clone(),
-                entry.completion_tx.take(),
-            ),
+        let Some(entry) = store.entries.get_mut(handle_id) else {
+            return CancelOutcome {
+                cancelled: false,
+                result: None,
+            };
+        };
+        if entry.cancel_state.cancelled.swap(true, Ordering::AcqRel) {
+            return CancelOutcome {
+                cancelled: false,
+                result: None,
+            };
         }
+        entry
+            .cancel_state
+            .timed_out
+            .store(options.timed_out, Ordering::Release);
+        let result_rx = options.wait_result.map(|_| {
+            let (tx, rx) = std::sync::mpsc::sync_channel::<VmValue>(1);
+            entry.result_tx = Some(tx);
+            rx
+        });
+        (entry.killer.clone(), entry.cancel_state.clone(), result_rx)
     };
-    do_kill(handle_owned, killer, cancel_state);
-    // If a test registered a completion notifier, signal it now — the
-    // waiter won't be able to (entry already removed) and we know the
-    // waiter will skip feedback because cancellation is set.
-    if let Some(tx) = completion_tx {
-        let _ = tx.try_send(());
+    do_kill(killer, cancel_state);
+    let result = match (options.wait_result, result_rx) {
+        (Some(timeout), Some(rx)) => rx.recv_timeout(timeout).ok(),
+        _ => None,
+    };
+    CancelOutcome {
+        cancelled: true,
+        result,
     }
-    true
 }
 
 /// Tuple shape used by `cancel_session_handles` to drain entries while
 /// holding the store lock for as little as possible. Boxed-trait fields
 /// make it noisy to inline as an unnamed type.
-type SessionKillEntry = (
-    Option<Box<dyn ProcessHandle>>,
-    Arc<dyn ProcessKiller>,
-    Arc<CancelState>,
-);
+type SessionKillEntry = (Arc<dyn ProcessKiller>, Arc<CancelState>);
 
 /// Cancel all in-flight handles for a given session. Called by the
 /// session-end hook to avoid orphaned processes.
 pub fn cancel_session_handles(session_id: &str) {
     let to_kill: Vec<SessionKillEntry> = {
-        let mut store = HANDLE_STORE
+        let store = HANDLE_STORE
             .lock()
             .expect("long-running handle store poisoned");
         let matching: Vec<String> = store
@@ -622,32 +676,27 @@ pub fn cancel_session_handles(session_id: &str) {
         matching
             .into_iter()
             .filter_map(|id| {
-                store.entries.remove(&id).map(|mut e| {
-                    let handle = e.handle.take();
-                    (handle, e.killer.clone(), e.cancel_state.clone())
-                })
+                let entry = store.entries.get(&id)?;
+                if entry.cancel_state.cancelled.swap(true, Ordering::AcqRel) {
+                    return None;
+                }
+                entry.cancel_state.timed_out.store(false, Ordering::Release);
+                Some((entry.killer.clone(), entry.cancel_state.clone()))
             })
             .collect()
     };
-    for (handle, killer, cancel_state) in to_kill {
-        do_kill(handle, killer, cancel_state);
+    for (killer, cancel_state) in to_kill {
+        do_kill(killer, cancel_state);
     }
 }
 
 /// Set the cancellation flag and kill the process. Used by both `cancel_handle`
 /// and `cancel_session_handles`.
-fn do_kill(
-    handle: Option<Box<dyn ProcessHandle>>,
-    killer: Arc<dyn ProcessKiller>,
-    cancel_state: Arc<CancelState>,
-) {
-    // Signal cancellation so the waiter (if still running) skips feedback.
-    cancel_state.cancelled.store(true, Ordering::Release);
+fn do_kill(killer: Arc<dyn ProcessKiller>, cancel_state: Arc<CancelState>) {
     // Kill via the handle's killer (works whether or not we still own
-    // the handle). If we still hold the handle, drop it after kill so the
-    // OS reaps the child.
+    // the handle). The waiter owns process reaping and artifact finalization.
     killer.kill();
-    drop(handle);
+    cancel_state.cancelled.store(true, Ordering::Release);
 }
 
 /// Register the session-cleanup hook with harn-vm. Uses a `OnceLock` so the

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -90,6 +90,13 @@ fn require_bool(map: &BTreeMap<String, VmValue>, key: &str) -> bool {
     }
 }
 
+fn require_nested_dict(map: &BTreeMap<String, VmValue>, key: &str) -> BTreeMap<String, VmValue> {
+    match map.get(key) {
+        Some(VmValue::Dict(value)) => (**value).clone(),
+        other => panic!("expected dict at {key}, got {other:?}"),
+    }
+}
+
 /// Install a fresh `MockSpawner` for the calling thread and return both the
 /// spawner (for inspection / additional enqueues) and the `SpawnerGuard`
 /// that restores the previous spawner on drop. The guard must be kept
@@ -902,6 +909,55 @@ fn cancel_handle_kills_long_running_process() {
     assert!(
         items.is_empty(),
         "cancelled handle should not push feedback, got {} entries",
+        items.len()
+    );
+}
+
+#[test]
+fn cancel_handle_can_wait_for_timed_out_result() {
+    let session_id = unique_session_id("test-lr-cancel-wait-result");
+    let _session_guard = harn_vm::agent_sessions::enter_current_session(session_id.clone());
+    let _ = harn_vm::orchestration::agent_inbox::drain(&session_id);
+
+    let mut config = MockProcessConfig::running();
+    config.stdout = b"before timeout\n".to_vec();
+    let (_spawner, _controller, _guard) = install_mock_with(config);
+
+    let mut start_req = dict();
+    start_req.insert("argv".into(), vlist_str(&["sleep", "30"]));
+    start_req.insert("background".into(), VmValue::Bool(true));
+    start_req.insert("capture".into(), {
+        let mut capture = BTreeMap::new();
+        capture.insert("max_inline_bytes".into(), VmValue::Int(200));
+        VmValue::Dict(Arc::new(capture))
+    });
+    let start = require_dict(call("hostlib_tools_run_command", start_req).unwrap());
+    let handle_id = require_str(&start, "handle_id");
+
+    let mut cancel_req = dict();
+    cancel_req.insert("handle_id".into(), vstr(&handle_id));
+    cancel_req.insert("wait_result_ms".into(), VmValue::Int(500));
+    cancel_req.insert("timed_out".into(), VmValue::Bool(true));
+    let cancel = require_dict(call("hostlib_tools_cancel_handle", cancel_req).unwrap());
+
+    assert!(require_bool(&cancel, "cancelled"));
+    let result = require_nested_dict(&cancel, "result");
+    assert_eq!(require_str(&result, "handle_id"), handle_id);
+    assert_eq!(require_str(&result, "status"), "timed_out");
+    assert!(require_bool(&result, "timed_out"));
+    assert_eq!(require_int(&result, "exit_code"), -1);
+    assert_eq!(require_str(&result, "stdout"), "before timeout\n");
+    assert!(require_str(&result, "output_path").contains("combined.txt"));
+    assert_eq!(
+        std::fs::read_to_string(require_str(&result, "stdout_path")).unwrap(),
+        "before timeout\n"
+    );
+    assert!(require_int(&result, "byte_count") >= 15);
+
+    let items = harn_vm::orchestration::agent_inbox::drain(&session_id);
+    assert!(
+        items.is_empty(),
+        "cancel result should not also enqueue feedback, got {} entries",
         items.len()
     );
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_command.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_command.harn
@@ -235,9 +235,17 @@ pub fn command_wait(locator, options = nil) -> dict {
  * @api_stability: stable
  * @example: command_cancel(result)
  */
-pub fn command_cancel(locator) -> dict {
+pub fn command_cancel(locator, options = nil) -> dict {
+  let opts = __command_options(options)
   let _enabled = hostlib_enable("tools:deterministic")
-  return hostlib_tools_cancel_handle({handle_id: __command_handle_id(locator, "command_cancel")})
+  var req = {handle_id: __command_handle_id(locator, "command_cancel")}
+  if opts?.wait_result_ms != nil {
+    req = req + {wait_result_ms: opts.wait_result_ms}
+  }
+  if opts?.timed_out != nil {
+    req = req + {timed_out: opts.timed_out}
+  }
+  return hostlib_tools_cancel_handle(req)
 }
 
 fn __command_positive_int(value, fallback: int) -> int {
@@ -334,6 +342,13 @@ fn __command_stream_timeout_result(start, elapsed_ms: int, options) -> dict {
   )
 }
 
+fn __command_stream_cancel_timeout(start, options) {
+  let opts = __command_options(options)
+  let wait_ms = __command_positive_int(opts?.cancel_wait_ms ?? opts?.wait_result_ms, 1000)
+  let cancelled = command_cancel(start, {wait_result_ms: wait_ms, timed_out: true})
+  return cancelled?.result
+}
+
 /**
  * command_run_streaming runs a command in the background, tees new output, and returns the final result.
  *
@@ -357,7 +372,12 @@ pub fn command_run_streaming(spec, options = nil) -> dict {
     stderr_offset = __command_stream_flush(start, "stderr", stderr_offset, read_bytes, opts)
     let elapsed_before_wait = harness.clock.monotonic_ms() - started_ms
     if timeout_ms > 0 && elapsed_before_wait >= timeout_ms {
-      command_cancel(start)
+      let timed_result = __command_stream_cancel_timeout(start, opts)
+      stdout_offset = __command_stream_flush(start, "stdout", stdout_offset, read_bytes, opts)
+      stderr_offset = __command_stream_flush(start, "stderr", stderr_offset, read_bytes, opts)
+      if timed_result != nil {
+        return __command_normalize_result(timed_result)
+      }
       return __command_stream_timeout_result(start, elapsed_before_wait, opts)
     }
     let result = command_wait(start, {timeout_ms: poll_interval_ms})
@@ -368,9 +388,12 @@ pub fn command_run_streaming(spec, options = nil) -> dict {
     }
     let elapsed_after_wait = harness.clock.monotonic_ms() - started_ms
     if timeout_ms > 0 && elapsed_after_wait >= timeout_ms {
-      command_cancel(start)
+      let timed_result = __command_stream_cancel_timeout(start, opts)
       stdout_offset = __command_stream_flush(start, "stdout", stdout_offset, read_bytes, opts)
       stderr_offset = __command_stream_flush(start, "stderr", stderr_offset, read_bytes, opts)
+      if timed_result != nil {
+        return __command_normalize_result(timed_result)
+      }
       return __command_stream_timeout_result(start, elapsed_after_wait, opts)
     }
   }
@@ -707,7 +730,7 @@ pub fn command_step(name: string, spec, options = nil) -> dict {
   let max_attempts = configured_max_attempts < 1 ? 1 : configured_max_attempts
   var attempts = []
   var attempt_number = 1
-  var final_step = nil
+  var final_step = {}
   while attempt_number <= max_attempts {
     let result = __command_invoke_runner(spec, opts)
     var step = __command_step_from_result(name, spec, result, opts, attempts)


### PR DESCRIPTION
## Summary
- let `cancel_handle` optionally wait for and return the drained command result
- keep cancelled command finalization responsible for artifacts and exit payloads
- use the cancellation result path from `std/command.command_run_streaming` timeout handling

## Validation
- `RUSTFLAGS='-D warnings' CARGO_TARGET_DIR=/tmp/harn-command-cancel-result-target cargo test -p harn-hostlib --test process_tools`
- `CARGO_TARGET_DIR=/tmp/harn-command-cancel-result-target cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/stdlib_command.harn`
- `CARGO_TARGET_DIR=/tmp/harn-command-cancel-result-target cargo run --quiet --bin harn -- test conformance --filter command_streaming`
- `RUSTFLAGS='-D warnings' CARGO_TARGET_DIR=/tmp/harn-command-cancel-result-target cargo test -p harn-hostlib --test registration`
- `CARGO_TARGET_DIR=/tmp/harn-command-cancel-result-target cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_command.harn`
- `CARGO_TARGET_DIR=/tmp/harn-command-cancel-result-target cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/stdlib_command.harn`
- `CARGO_TARGET_DIR=/tmp/harn-command-cancel-result-target cargo fmt --all --check`
- `git diff --check`
