### PR TITLE
harn-rules: imperative on_match visitor + declarative diagnostics (#2878)

### DIFF
--- a/changelog.d/2878.added.md
+++ b/changelog.d/2878.added.md
@@ -1,0 +1,7 @@
+- `std/rules` gained the **imperative** rule visitor `rules.visit` (Rule Engine Epic A) — the native escape hatch for
+  logic a declarative rule cannot express. It runs a rule's matcher and calls a `.harn` `on_match(node, ctx)` visitor
+  once per match; the visitor returns its report(s) (`nil`/`false` to skip, `true` to flag, a `{message, fix, safety,
+  severity}` dict, or a list of them), which become diagnostics in the same shape as the new `rules.diagnostics`. The
+  visitor can compute a message or fix from the captured metavars, which the declarative form cannot. `rules.visit` is
+  an async builtin (a sync builtin cannot call a `.harn` closure) and is read-only. Also added `rules.diagnostics`,
+  which runs a declarative rule and returns its diagnostics.

--- a/conformance/tests/stdlib/rules_engine.expected
+++ b/conformance/tests/stdlib/rules_engine.expected
@@ -6,3 +6,15 @@ true
 true
 true
 true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/stdlib/rules_engine.harn
+++ b/conformance/tests/stdlib/rules_engine.harn
@@ -1,20 +1,22 @@
-import { rules_apply, rules_report, rules_search } from "std/rules"
+import { rules_apply, rules_diagnostics, rules_report, rules_search, rules_visit } from "std/rules"
 
 /**
- * End-to-end exercise of the `std/rules` surface (#2838): authoring a
- * declarative rule as TOML *inside Harn* and running it through search,
- * report-only data tables, and a dry-run codemod — no recompile needed.
+ * End-to-end exercise of the `std/rules` surface (#2838 + #2878): authoring a
+ * rule as TOML *inside Harn* and running it through search, report-only data
+ * tables, declarative diagnostics, an imperative `on_match` visitor, and a
+ * dry-run codemod — no recompile needed.
  */
 pipeline default() {
   hostlib_enable("tools:deterministic")
   let finder = "id = \"find-calls\"\nlanguage = \"typescript\"\n[rule]\npattern = \"$FN()\"\n"
+  let src = "foo();\nbar();\n"
   // 1) Search returns matches with capture bindings.
-  let r = rules_search({rule: finder, source: "foo();\nbar();\n", language: "typescript"})
+  let r = rules_search({rule: finder, source: src, language: "typescript"})
   __io_println(r.ok && r.match_count == 2)
   __io_println(r.matches[0].captures.FN == "foo")
   __io_println(r.matches[1].captures.FN == "bar")
   // 2) Report-only mode yields a data table with a per-match summary.
-  let rep = rules_report({rule: finder, source: "foo();\nbar();\n", language: "typescript", path: "a.ts"})
+  let rep = rules_report({rule: finder, source: src, language: "typescript", path: "a.ts"})
   __io_println(rep.summary.total_rows == 2)
   __io_println(rep.rule_id == "find-calls")
   // 3) A codemod in dry-run previews without writing; the
@@ -24,4 +26,55 @@ pipeline default() {
   __io_println(ap.ok && ap.files[0].changed && !ap.files[0].applied)
   __io_println(ap.files[0].preview == "bar();\n")
   __io_println(ap.auto_applicable)
+  // 4) A declarative lint rule (a `message`, no `fix`) emits diagnostics.
+  let lint = "id = \"calls\"\nlanguage = \"typescript\"\nmessage = \"function call\"\n[rule]\npattern = \"$FN()\"\n"
+  let decl = rules_diagnostics({rule: lint, source: src, language: "typescript", path: "a.ts"})
+  __io_println(decl.ok && decl.diagnostic_count == 2)
+  __io_println(decl.diagnostics[0].message == "function call")
+  // 5) An imperative visitor over the *same matcher* returning the *same*
+  //    static message produces IDENTICAL diagnostics (the #2878 acceptance):
+  //    same message, severity, applicability, and spans.
+  let imp = rules_visit(
+    {
+      rule: finder,
+      source: src,
+      language: "typescript",
+      path: "a.ts",
+      on_match: fn(node, ctx) { return {message: "function call"} },
+    },
+  )
+  __io_println(imp.ok && imp.diagnostic_count == 2)
+  __io_println(imp.diagnostics[0].message == decl.diagnostics[0].message)
+  __io_println(imp.diagnostics[0].severity == decl.diagnostics[0].severity)
+  __io_println(imp.diagnostics[0].applicability == decl.diagnostics[0].applicability)
+  __io_println(imp.diagnostics[0].start_row == decl.diagnostics[0].start_row)
+  __io_println(imp.diagnostics[1].start_row == decl.diagnostics[1].start_row)
+  // 6) Imperative-only power: compute a message from the captured metavar —
+  //    something a declarative rule (with only a static message) cannot.
+  let computed = rules_visit(
+    {
+      rule: finder,
+      source: src,
+      language: "typescript",
+      on_match: fn(node, ctx) { return {message: "call to " + node.captures.FN} },
+    },
+  )
+  __io_println(computed.diagnostics[0].message == "call to foo")
+  __io_println(computed.diagnostics[1].message == "call to bar")
+  // 7) The visitor controls flow: returning nil skips a match.
+  let filtered = rules_visit(
+    {
+      rule: finder,
+      source: src,
+      language: "typescript",
+      on_match: fn(node, ctx) {
+        if node.captures.FN == "foo" {
+          return {message: "kept"}
+        }
+        return nil
+      },
+    },
+  )
+  __io_println(filtered.diagnostic_count == 1)
+  __io_println(filtered.diagnostics[0].message == "kept")
 }

--- a/crates/harn-rules-hostlib/README.md
+++ b/crates/harn-rules-hostlib/README.md
@@ -19,16 +19,33 @@ embedder calls [`install`] next to `harn_hostlib::install_default`.
 |---|---|---|
 | `rules.search` | read-only | run a rule, return matches with capture bindings |
 | `rules.report` | read-only | run report-only, return a `DataTable` (counts + rows) |
+| `rules.diagnostics` | read-only | run a declarative rule, return its diagnostics |
+| `rules.visit` | read-only (async) | imperative `on_match($node, ctx)` visitor |
 | `rules.apply`  | write (deterministic-tools) | apply a codemod `fix`; dry-run by default, safety-gated |
 
 A rule is passed as its **TOML source** (`rule`), with either inline `source`
 (+ `language`) or a list of `paths`. So an agent can author and run a rule
 entirely from `.harn` without recompiling the binary.
 
-## Not yet here
+## The imperative visitor (`rules.visit`)
 
-The **imperative** rule form — a `.harn` module exporting an
-`on_match($node, ctx)` visitor — needs a synchronous closure-callback from a
-Rust builtin, which the VM does not support today (only async builtins can
-call back into `.harn`). That requires a VM-core prerequisite and is tracked
-separately.
+[harn#2878](https://github.com/burin-labs/harn/issues/2878) — the native
+escape hatch. `rules.visit` runs a rule's matcher and calls a `.harn` visitor
+`on_match($node, $ctx)` once per match. The visitor **returns** its report(s)
+— `nil`/`false` to skip, `true` to flag with rule defaults, a
+`{message, fix, safety, severity}` dict, or a list of them — which become
+diagnostics in the same shape `rules.diagnostics` emits. It can compute a
+message or fix from the captured metavars, which the declarative form cannot.
+
+Two design points worth knowing:
+
+- **Async, registered directly on the VM.** A *synchronous* hostlib builtin
+  cannot call a `.harn` closure (`Vm::call_closure_pub` is async-only), so
+  `rules.visit` is an **async** builtin installed via
+  `Vm::register_async_builtin` in [`install`] rather than through the sync
+  `HostlibRegistry`. It obtains a child VM from its `AsyncBuiltinCtx` and calls
+  back per match.
+- **Returns rather than mutates.** Harn closures capture by value and
+  `VmValue` has no callable variant carrying captured Rust state, so a
+  mutating `ctx.report(...)` could not accumulate soundly. Returning the
+  report is both the correct option and the simpler one.

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -11,19 +11,41 @@
 //! - `rules.search` (read-only) — run a rule and return its matches.
 //! - `rules.report` (read-only) — run a rule in report-only mode and return
 //!   a [`harn_rules::DataTable`] (counts + per-match rows).
+//! - `rules.diagnostics` (read-only) — run a **declarative** rule and return
+//!   its [`harn_rules::Diagnostic`]s (message + severity + span + fix).
+//! - `rules.visit` (read-only, **async**) — the **imperative** escape hatch:
+//!   run a rule's matcher, then invoke a `.harn` visitor
+//!   `on_match($node, $ctx)` once per match. The visitor returns its
+//!   report(s) — `nil`/`false` to skip, a `{message, fix, safety}` dict, or
+//!   a list of them — which the engine turns into diagnostics of the same
+//!   shape `rules.diagnostics` emits. The visitor has full programmatic
+//!   control (compute a message/fix from the captured metavars), which the
+//!   declarative form cannot.
 //! - `rules.apply` (write-gated) — apply a codemod rule's `fix`; writes only
 //!   when `dry_run: false` *and* the rule is safe to auto-apply (or
 //!   `allow_unsafe: true`). Shares the deterministic-tools gate with the
 //!   other mutating builtins.
 //!
 //! A rule is passed as its TOML source (`rule`), so an agent can author and
-//! run a rule entirely from `.harn` without recompiling the binary. The
-//! richer **imperative** `.harn` visitor (`on_match($node, ctx)`) needs a
-//! synchronous closure-callback from a Rust builtin, which the VM does not
-//! support today (only async builtins can call back) — tracked separately.
+//! run a rule — declarative *or* imperative — entirely from `.harn` without
+//! recompiling the binary.
+//!
+//! ### Why `rules.visit` is async, and why it returns rather than mutates
+//!
+//! A *synchronous* hostlib builtin cannot call a `.harn` closure: the VM's
+//! [`Vm::call_closure_pub`] is async-only. So the visitor is registered as an
+//! **async** builtin (directly on the VM via [`Vm::register_async_builtin`],
+//! bypassing the sync [`HostlibRegistry`]), which can obtain a child VM from
+//! its [`AsyncBuiltinCtx`] and call back per match.
+//!
+//! The visitor **returns** its reports instead of calling a mutating
+//! `ctx.report(...)`: Harn closures capture by value, so a Harn-side
+//! accumulator could not collect across calls, and `VmValue` has no callable
+//! variant that carries captured Rust state to embed a stateful `report`
+//! method in `ctx`. Returning is both the sound option and the simpler one.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use harn_hostlib::ast::Language;
@@ -31,12 +53,17 @@ use harn_hostlib::tools::permissions::gated_handler;
 use harn_hostlib::{
     BuiltinRegistry, HostlibCapability, HostlibError, HostlibRegistry, RegisteredBuiltin,
 };
-use harn_vm::{Vm, VmValue};
+use harn_vm::{AsyncBuiltinCtx, Vm, VmError, VmValue};
 
-use harn_rules::{data_table, CompiledRule, Rule, RuleMatch, SourceFile};
+use harn_rules::{
+    data_table, Applicability, CompiledRule, Diagnostic, Rule, RuleMatch, Safety, Severity,
+    SourceFile, Span,
+};
 
 const SEARCH: &str = "hostlib_rules_search";
 const REPORT: &str = "hostlib_rules_report";
+const DIAGNOSTICS: &str = "hostlib_rules_diagnostics";
+const VISIT: &str = "hostlib_rules_visit";
 const APPLY: &str = "hostlib_rules_apply";
 
 /// The `rules` host capability.
@@ -61,6 +88,12 @@ impl HostlibCapability for RulesCapability {
             method: "report",
             handler: Arc::new(report_run),
         });
+        registry.register(RegisteredBuiltin {
+            name: DIAGNOSTICS,
+            module: "rules",
+            method: "diagnostics",
+            handler: Arc::new(diagnostics_run),
+        });
         // `apply` writes files, so it shares the deterministic-tools gate.
         registry.register(RegisteredBuiltin {
             name: APPLY,
@@ -77,6 +110,10 @@ pub fn install(vm: &mut Vm) {
     HostlibRegistry::new()
         .with(RulesCapability)
         .register_into_vm(vm);
+    // `rules.visit` invokes a `.harn` closure per match, which only an async
+    // builtin can do (`call_closure_pub` is async). It is therefore registered
+    // directly on the VM rather than through the sync `HostlibRegistry`.
+    vm.register_async_builtin(VISIT, visit_run);
 }
 
 // ---------------------------------------------------------------------------
@@ -107,6 +144,80 @@ fn report_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let files = load_files(REPORT, &dict)?;
     let table = data_table(&rule, &files).map_err(|e| backend(REPORT, &e))?;
     Ok(json_to_vm(&table.to_json_value()))
+}
+
+fn diagnostics_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let dict = first_dict(DIAGNOSTICS, args)?;
+    let rule = compile_rule(DIAGNOSTICS, &dict)?;
+    let files = load_files(DIAGNOSTICS, &dict)?;
+
+    let mut diagnostics = Vec::new();
+    for file in &files {
+        for d in rule
+            .diagnostics(&file.source)
+            .map_err(|e| backend(DIAGNOSTICS, &e))?
+        {
+            diagnostics.push(diagnostic_vm(&file.path, &d));
+        }
+    }
+    Ok(dict_vm([
+        ("result", str_vm("ok")),
+        ("diagnostic_count", VmValue::Int(diagnostics.len() as i64)),
+        ("diagnostics", VmValue::List(Arc::new(diagnostics))),
+    ]))
+}
+
+/// The imperative escape hatch (#2878): run the rule's matcher, then call the
+/// `.harn` visitor `on_match($node, $ctx)` once per match. The visitor's
+/// return value becomes diagnostics of the same shape `rules.diagnostics`
+/// emits. Read-only — it never writes; the agent applies fixes itself.
+async fn visit_run(ctx: AsyncBuiltinCtx, args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let dict = first_dict(VISIT, &args).map_err(host_err)?;
+    let rule = compile_rule(VISIT, &dict).map_err(host_err)?;
+    let files = load_files(VISIT, &dict).map_err(host_err)?;
+    let visitor = match dict.get("on_match") {
+        Some(VmValue::Closure(c)) => c.clone(),
+        _ => {
+            return Err(VmError::Runtime(format!(
+                "{VISIT}: `on_match` must be a function `fn(node, ctx)`"
+            )))
+        }
+    };
+
+    let default_severity = rule.severity();
+    let default_safety = rule.safety();
+    let rule_id = rule.id().to_string();
+
+    let mut vm = ctx.child_vm();
+    let mut diagnostics = Vec::new();
+    for file in &files {
+        let matches = rule
+            .run(&file.source)
+            .map_err(|e| host_err(backend(VISIT, &e)))?;
+        let file_ctx = ctx_vm(&file.path, file.language, &file.source, &rule_id);
+        for m in &matches {
+            let node = node_vm(m);
+            let ret = vm
+                .call_closure_pub(&visitor, &[node, file_ctx.clone()])
+                .await?;
+            ctx.forward_output(&vm.take_output());
+            for report in reports_from_return(ret) {
+                diagnostics.push(report_to_diagnostic_vm(
+                    &file.path,
+                    &rule_id,
+                    m.span,
+                    report,
+                    default_severity,
+                    default_safety,
+                ));
+            }
+        }
+    }
+    Ok(dict_vm([
+        ("result", str_vm("ok")),
+        ("diagnostic_count", VmValue::Int(diagnostics.len() as i64)),
+        ("diagnostics", VmValue::List(Arc::new(diagnostics))),
+    ]))
 }
 
 fn apply_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
@@ -231,6 +342,165 @@ fn backend(builtin: &'static str, err: &harn_rules::RulesError) -> HostlibError 
     HostlibError::Backend {
         builtin,
         message: err.to_string(),
+    }
+}
+
+/// Lower a `HostlibError` into a `VmError` for the async `rules.visit` path
+/// (which must return `VmError`, not `HostlibError`).
+fn host_err(err: HostlibError) -> VmError {
+    VmError::Runtime(err.to_string())
+}
+
+/// One report a `.harn` visitor returned for a single match. Every field is
+/// optional: an empty report (e.g. the visitor returned `true`) flags the
+/// match using the rule's own defaults.
+#[derive(Default)]
+struct ReportSpec {
+    message: Option<String>,
+    fix: Option<String>,
+    safety: Option<Safety>,
+    severity: Option<Severity>,
+}
+
+/// The `node` value handed to a visitor: the matched text, its metavar
+/// captures, and its span.
+fn node_vm(m: &RuleMatch) -> VmValue {
+    let captures: BTreeMap<String, VmValue> = m
+        .bindings
+        .iter()
+        .map(|(name, b)| (name.clone(), str_vm(&b.text)))
+        .collect();
+    dict_vm([
+        ("text", str_vm(&m.text)),
+        ("captures", VmValue::Dict(Arc::new(captures))),
+        ("start_row", VmValue::Int(m.span.start_row as i64)),
+        ("start_col", VmValue::Int(m.span.start_col as i64)),
+        ("end_row", VmValue::Int(m.span.end_row as i64)),
+        ("end_col", VmValue::Int(m.span.end_col as i64)),
+    ])
+}
+
+/// The read-only `ctx` value handed to a visitor: where the match lives and
+/// what produced it.
+fn ctx_vm(path: &Path, language: Language, source: &str, rule_id: &str) -> VmValue {
+    dict_vm([
+        ("path", str_vm(path.display().to_string())),
+        ("language", str_vm(language.name())),
+        ("source", str_vm(source)),
+        ("rule_id", str_vm(rule_id)),
+    ])
+}
+
+/// Build a diagnostic dict — the one shape both `rules.diagnostics` and
+/// `rules.visit` emit, so an equivalent declarative and imperative rule
+/// produce identical output.
+fn diagnostic_dict(
+    path: &Path,
+    rule_id: &str,
+    message: &str,
+    severity: Severity,
+    span: Span,
+    fix: Option<String>,
+    applicability: Applicability,
+) -> VmValue {
+    dict_vm([
+        ("path", str_vm(path.display().to_string())),
+        ("rule_id", str_vm(rule_id)),
+        ("message", str_vm(message)),
+        ("severity", str_vm(severity.as_str())),
+        ("start_row", VmValue::Int(span.start_row as i64)),
+        ("start_col", VmValue::Int(span.start_col as i64)),
+        ("end_row", VmValue::Int(span.end_row as i64)),
+        ("end_col", VmValue::Int(span.end_col as i64)),
+        ("applicability", str_vm(applicability.as_str())),
+        ("fix", fix.map(str_vm).unwrap_or(VmValue::Nil)),
+    ])
+}
+
+fn diagnostic_vm(path: &Path, d: &Diagnostic) -> VmValue {
+    diagnostic_dict(
+        path,
+        &d.rule_id,
+        &d.message,
+        d.severity,
+        d.span,
+        d.fix.clone(),
+        d.applicability,
+    )
+}
+
+/// Turn a visitor's [`ReportSpec`] into the same diagnostic dict, located at
+/// the match's span and falling back to the rule's defaults.
+fn report_to_diagnostic_vm(
+    path: &Path,
+    rule_id: &str,
+    span: Span,
+    report: ReportSpec,
+    default_severity: Severity,
+    default_safety: Safety,
+) -> VmValue {
+    let severity = report.severity.unwrap_or(default_severity);
+    let safety = report.safety.unwrap_or(default_safety);
+    diagnostic_dict(
+        path,
+        rule_id,
+        report.message.as_deref().unwrap_or(""),
+        severity,
+        span,
+        report.fix,
+        safety.applicability(),
+    )
+}
+
+/// Interpret a visitor's return value: `nil`/`false` skips, `true` flags with
+/// rule defaults, a dict is one report, a list is many (skipping `nil`/`false`
+/// entries).
+fn reports_from_return(ret: VmValue) -> Vec<ReportSpec> {
+    match ret {
+        VmValue::Nil | VmValue::Bool(false) => Vec::new(),
+        VmValue::Bool(true) => vec![ReportSpec::default()],
+        VmValue::Dict(d) => vec![report_from_dict(&d)],
+        VmValue::List(items) => items.iter().filter_map(report_from_item).collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn report_from_item(v: &VmValue) -> Option<ReportSpec> {
+    match v {
+        VmValue::Nil | VmValue::Bool(false) => None,
+        VmValue::Bool(true) => Some(ReportSpec::default()),
+        VmValue::Dict(d) => Some(report_from_dict(d)),
+        _ => None,
+    }
+}
+
+fn report_from_dict(d: &BTreeMap<String, VmValue>) -> ReportSpec {
+    ReportSpec {
+        message: optional_string(d, "message"),
+        fix: optional_string(d, "fix"),
+        safety: optional_string(d, "safety").and_then(|s| parse_safety(&s)),
+        severity: optional_string(d, "severity").and_then(|s| parse_severity(&s)),
+    }
+}
+
+fn parse_severity(s: &str) -> Option<Severity> {
+    match s {
+        "info" => Some(Severity::Info),
+        "warning" => Some(Severity::Warning),
+        "error" => Some(Severity::Error),
+        _ => None,
+    }
+}
+
+fn parse_safety(s: &str) -> Option<Safety> {
+    match s {
+        "format-only" => Some(Safety::FormatOnly),
+        "behavior-preserving" => Some(Safety::BehaviorPreserving),
+        "scope-local" => Some(Safety::ScopeLocal),
+        "surface-changing" => Some(Safety::SurfaceChanging),
+        "capability-changing" => Some(Safety::CapabilityChanging),
+        "needs-human" => Some(Safety::NeedsHuman),
+        _ => None,
     }
 }
 
@@ -429,6 +699,66 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_returns_lint_findings() {
+        let lint = r#"
+            id = "calls"
+            language = "typescript"
+            message = "function call"
+            [rule]
+            pattern = "$FN()"
+        "#;
+        let result = diagnostics_run(&[dict(&[
+            ("rule", str_vm(lint)),
+            ("source", str_vm("foo();\nbar();\n")),
+            ("language", str_vm("typescript")),
+            ("path", str_vm("a.ts")),
+        ])])
+        .unwrap();
+        assert_eq!(int(get(&result, "diagnostic_count")), 2);
+        let diags = match get(&result, "diagnostics") {
+            VmValue::List(l) => l.clone(),
+            _ => panic!(),
+        };
+        assert_eq!(s(get(&diags[0], "message")), "function call");
+        assert_eq!(s(get(&diags[0], "severity")), "warning");
+        // No `fix` and default safety → a suggestion, not machine-applicable.
+        assert_eq!(s(get(&diags[0], "applicability")), "suggestion");
+        assert_eq!(int(get(&diags[1], "start_row")), 1);
+        assert!(matches!(get(&diags[0], "fix"), VmValue::Nil));
+    }
+
+    #[test]
+    fn report_helpers_round_trip_severity_and_safety() {
+        // The string<->enum mapping used by `rules.visit` reports.
+        assert_eq!(parse_severity("error"), Some(Severity::Error));
+        assert_eq!(parse_severity("bogus"), None);
+        assert_eq!(parse_safety("format-only"), Some(Safety::FormatOnly));
+        assert_eq!(parse_safety("needs-human"), Some(Safety::NeedsHuman));
+        assert_eq!(parse_safety("nope"), None);
+        // `true` flags with defaults; nil/false skip; a dict carries fields.
+        assert_eq!(reports_from_return(VmValue::Bool(true)).len(), 1);
+        assert_eq!(reports_from_return(VmValue::Nil).len(), 0);
+        assert_eq!(reports_from_return(VmValue::Bool(false)).len(), 0);
+        let list = VmValue::List(Arc::new(vec![
+            dict(&[("message", str_vm("a"))]),
+            VmValue::Nil,
+            dict(&[("message", str_vm("b"))]),
+        ]));
+        assert_eq!(reports_from_return(list).len(), 2);
+    }
+
+    #[test]
+    fn capability_does_not_register_the_async_visitor() {
+        // `rules.visit` is async, so it is installed directly on the VM in
+        // `install`, not through the sync capability registry.
+        let mut registry = BuiltinRegistry::new();
+        RulesCapability.register_builtins(&mut registry);
+        let names: Vec<_> = registry.iter().map(|b| b.name).collect();
+        assert!(!names.contains(&VISIT));
+        assert!(names.contains(&DIAGNOSTICS));
+    }
+
+    #[test]
     fn missing_rule_is_an_error() {
         let err = search_run(&[dict(&[
             ("source", str_vm("x")),
@@ -441,10 +771,10 @@ mod tests {
     }
 
     #[test]
-    fn capability_registers_three_builtins() {
+    fn capability_registers_the_sync_builtins() {
         let mut registry = BuiltinRegistry::new();
         RulesCapability.register_builtins(&mut registry);
         let names: Vec<_> = registry.iter().map(|b| b.name).collect();
-        assert_eq!(names, vec![SEARCH, REPORT, APPLY]);
+        assert_eq!(names, vec![SEARCH, REPORT, DIAGNOSTICS, APPLY]);
     }
 }

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -216,6 +216,17 @@ impl CompiledRule {
         &self.rule_id
     }
 
+    /// The rule's diagnostic severity (the default for any diagnostic the
+    /// rule produces).
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    /// The rule's static diagnostic message (empty for a search-only rule).
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
     /// Run the compiled rule against `source`, returning matches in
     /// document order. Matches that fail any `where` constraint are dropped.
     pub fn run(&self, source: &str) -> Result<Vec<RuleMatch>, RulesError> {

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -25,6 +25,18 @@ pub enum Severity {
     Error,
 }
 
+impl Severity {
+    /// The stable lowercase name (the inverse of the `Deserialize` rename),
+    /// used for diagnostics and JSON surfaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Severity::Info => "info",
+            Severity::Warning => "warning",
+            Severity::Error => "error",
+        }
+    }
+}
+
 /// How risky a rule's `fix` is, mapped onto Burin's edit-safety taxonomy.
 /// Ordered least → most dangerous; the codemod runner auto-applies only the
 /// two safest tiers (see [`Safety::applicability`]).
@@ -57,7 +69,30 @@ pub enum Applicability {
     Suggestion,
 }
 
+impl Applicability {
+    /// The stable name used for diagnostics and JSON surfaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Applicability::MachineApplicable => "machine-applicable",
+            Applicability::Suggestion => "suggestion",
+        }
+    }
+}
+
 impl Safety {
+    /// The stable kebab-case name (the inverse of the `Deserialize` rename),
+    /// used for diagnostics and JSON surfaces.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Safety::FormatOnly => "format-only",
+            Safety::BehaviorPreserving => "behavior-preserving",
+            Safety::ScopeLocal => "scope-local",
+            Safety::SurfaceChanging => "surface-changing",
+            Safety::CapabilityChanging => "capability-changing",
+            Safety::NeedsHuman => "needs-human",
+        }
+    }
+
     /// The applicability tier this safety level maps to. `format-only` and
     /// `behavior-preserving` are machine-applicable; everything riskier is a
     /// suggestion.

--- a/crates/harn-stdlib/src/stdlib/stdlib_rules.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_rules.harn
@@ -46,6 +46,60 @@ pub fn rules_report(params) -> dict {
 }
 
 /**
+ * Run a declarative rule and return its **diagnostics** — the lint surface of
+ * a rule that carries a `message`. On success `result == "ok"` and
+ * `diagnostics` is a list of `{path, rule_id, message, severity, start_row,
+ * start_col, end_row, end_col, applicability, fix}` (one per match; `fix` is
+ * `nil` unless the rule has a `fix` template).
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: rules_diagnostics({rule: src, source: "foo();", language: "typescript"})
+ */
+pub fn rules_diagnostics(params) -> dict {
+  let payload = hostlib_rules_diagnostics(params ?? {}) ?? {}
+  return payload
+    .merge(
+    {ok: payload?.result ?? "" == "ok", provenance: {module: "std/rules", helper: "rules_diagnostics"}},
+  )
+}
+
+/**
+ * Run a rule's matcher, then call an **imperative** visitor `on_match(node,
+ * ctx)` once per match — the escape hatch for logic a declarative rule cannot
+ * express (compute a message or fix from the captured metavars, filter on
+ * arbitrary conditions). `params` is `{rule, source|paths, language?,
+ * on_match}` where `on_match` is `fn(node, ctx)`:
+ *
+ * - `node`: `{text, captures, start_row, start_col, end_row, end_col}` —
+ *   `captures` maps each metavar name to its bound text.
+ * - `ctx`: `{path, language, source, rule_id}` (read-only).
+ * - returns: `nil`/`false` to skip the match, `true` to flag it with the
+ *   rule's defaults, a `{message, fix, safety, severity}` dict, or a list of
+ *   such dicts (to report several findings on one node).
+ *
+ * Read-only — `visit` never writes; apply fixes with `rules_apply` or your own
+ * write. On success `result == "ok"` and `diagnostics` is a list in the same
+ * shape `rules_diagnostics` emits, so an imperative rule and its declarative
+ * equivalent produce identical diagnostics.
+ *
+ * @effects: [host]
+ * @allocation: heap
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: rules_visit({rule: src, source: "f();", language: "typescript", on_match: fn(node, ctx) { return {message: "call"} }})
+ */
+pub fn rules_visit(params) -> dict {
+  let payload = hostlib_rules_visit(params ?? {}) ?? {}
+  return payload
+    .merge(
+    {ok: payload?.result ?? "" == "ok", provenance: {module: "std/rules", helper: "rules_visit"}},
+  )
+}
+
+/**
  * Apply a codemod rule's `fix`. **Dry-run by default** — pass `dry_run:
  * false` to write. Writes only when the rule's `safety` is machine-applicable
  * (`format-only` / `behavior-preserving`) or `allow_unsafe: true`. Each file


### PR DESCRIPTION
Closes #2878. Part of Rule Engine Epic A (#2827), program #2826. Stacked on #2879 (#2838) — the diff here is the single `#2878` commit.

## What

The **imperative** rule form — the native escape hatch (the JSSG / codemod.com insight). `rules.visit` runs a rule's matcher and calls a `.harn` visitor `on_match(node, ctx)` once per match. The visitor **returns** its report(s), which become diagnostics in the same shape as the new `rules.diagnostics`:

- `node`: `{text, captures, start_row, start_col, end_row, end_col}`
- `ctx`: `{path, language, source, rule_id}` (read-only)
- returns: `nil`/`false` to skip · `true` to flag with rule defaults · a `{message, fix, safety, severity}` dict · or a list of them

The visitor can compute a message or fix from the captured metavars — which the declarative form cannot.

Also adds `rules.diagnostics` (declarative diagnostics), `Severity`/`Safety`/`Applicability::as_str`, and `CompiledRule::severity`/`message`.

## Design (the #2878 blocker, resolved)

- **Async, registered directly on the VM.** A *synchronous* hostlib builtin cannot call a `.harn` closure (`Vm::call_closure_pub` is async-only). So `rules.visit` is an **async** builtin installed via `Vm::register_async_builtin` in `install()`, bypassing the sync `HostlibRegistry`; it takes a child VM from its `AsyncBuiltinCtx` and calls back per match. No VM-core change was needed — async-builtin support already existed.
- **Returns rather than mutates.** Harn closures capture by value, and `VmValue` has no callable variant carrying captured Rust state, so a mutating `ctx.report(...)` could not accumulate soundly. Returning the report is the sound option and the simpler one (`SIMPLER and DUMBER`).
- **Read-only:** `visit` never writes; the agent applies fixes via `rules.apply`.

## Verification

- `cargo test -p harn-rules -p harn-rules-hostlib` — green (incl. new `diagnostics_returns_lint_findings`, `report_helpers_round_trip_severity_and_safety`, capability-registration tests).
- `cargo clippy -p harn-rules -p harn-rules-hostlib --all-targets` — clean.
- `harn test conformance --filter rules_engine` — **PASS** (20 assertions). The conformance test proves the acceptance:
  - an imperative rule and its declarative equivalent produce **identical** diagnostics (message, severity, applicability, spans);
  - the visitor computes a per-match message (`call to foo` / `call to bar`) — declarative cannot;
  - returning `nil` filters a match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)