### PR TITLE
harn scan: read-only structural search + lint CLI (#2840)

### DIFF
--- a/changelog.d/2840.added.md
+++ b/changelog.d/2840.added.md
@@ -1,0 +1,5 @@
+- Added `harn scan` — read-only structural search and lint over a fileset (Rule Engine Epic B). Run an inline pattern
+  (`harn scan '$X?.$K ?? $D' src --lang typescript`), a saved rule (`--rule rule.toml`), or a directory of rules
+  (`--rule-pack dir`) over files or directories; the walker is gitignore-aware and filters files to each rule's
+  language. Prints grep-style matches with metavar captures, `--report-only` per-file/total counts, and a `--json`
+  envelope. Authored as an embedded `.harn` handler (`std/rules`) behind a thin clap shim.

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -49,6 +49,7 @@ mod quickstart;
 mod routes;
 mod run;
 mod runs;
+mod scan;
 mod serve;
 mod session;
 mod skill;
@@ -173,6 +174,7 @@ pub(crate) use quickstart::QuickstartArgs;
 pub(crate) use routes::RoutesArgs;
 pub(crate) use run::RunArgs;
 pub(crate) use runs::{ReplayArgs, RunsArgs, RunsCommand};
+pub(crate) use scan::ScanArgs;
 pub(crate) use serve::{
     A2aServeArgs, AcpServeTransport, ApiServeArgs, McpServeTransport, ServeAcpArgs, ServeArgs,
     ServeCommand, ServeMcpArgs, ServeObsMode, ServeTlsMode, SiteServeArgs,
@@ -474,6 +476,9 @@ SCRIPTING
     ProviderProbe(ProviderProbeArgs),
     /// Run one-tool provider conformance and classify native/text fallback.
     ProviderToolProbe(ProviderToolProbeArgs),
+    /// Read-only structural search + lint: run a pattern, rule, or rule pack
+    /// over a fileset and report matches or per-file counts (`--report-only`).
+    Scan(ScanArgs),
     /// One-shot agent_loop with a prompt. Routes through the configured
     /// provider (or `HARN_LLM_PROVIDER=mock` for offline use).
     #[command(name = "try")]

--- a/crates/harn-cli/src/cli/scan.rs
+++ b/crates/harn-cli/src/cli/scan.rs
@@ -1,0 +1,32 @@
+use clap::Args;
+
+/// `harn scan` — read-only structural search + lint over a fileset.
+///
+/// Two shapes:
+///   * `harn scan '<pattern>' [paths...] --lang <lang>` — inline pattern.
+///   * `harn scan --rule <file>|--rule-pack <dir> [paths...]` — saved rule(s).
+///
+/// With `--rule`/`--rule-pack` every positional is a path; otherwise the first
+/// positional is the pattern and the rest are paths (the shim disambiguates,
+/// since clap can't tell positionally).
+#[derive(Debug, Args)]
+pub(crate) struct ScanArgs {
+    /// `<pattern> [paths...]`, or just `[paths...]` with `--rule`/`--rule-pack`.
+    #[arg(value_name = "ARGS")]
+    pub args: Vec<String>,
+    /// Target language for an inline pattern (e.g. `typescript`, `rust`).
+    #[arg(long, value_name = "LANG")]
+    pub lang: Option<String>,
+    /// Run a rule from a TOML file instead of an inline pattern.
+    #[arg(long = "rule", value_name = "FILE")]
+    pub rule: Option<String>,
+    /// Run every `*.toml` rule in a directory (a rule pack).
+    #[arg(long = "rule-pack", value_name = "DIR", conflicts_with = "rule")]
+    pub rule_pack: Option<String>,
+    /// Emit a JSON envelope instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
+    /// Report-only: emit per-file/total counts (a data table), not each match.
+    #[arg(long = "report-only")]
+    pub report_only: bool,
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -59,6 +59,7 @@ pub(crate) mod replay;
 pub(crate) mod routes;
 pub mod run;
 pub(crate) mod scaffold_common;
+pub(crate) mod scan;
 pub(crate) mod serve;
 pub(crate) mod session;
 pub(crate) mod skill;

--- a/crates/harn-cli/src/commands/scan.rs
+++ b/crates/harn-cli/src/commands/scan.rs
@@ -1,0 +1,198 @@
+//! `harn scan` dispatches to the embedded `cli/scan.harn` handler. The shim
+//! resolves the rule(s) and the fileset in Rust — where the tree-sitter
+//! `Language` registry and the gitignore-aware walker live — then hands the
+//! `.harn` handler a per-rule *plan* (rule TOML + the matching files). The
+//! handler runs the engine (`std/rules`) and formats the output.
+
+use crate::cli::ScanArgs;
+
+#[cfg(not(feature = "hostlib"))]
+pub(crate) async fn run(_args: ScanArgs) {
+    eprintln!(
+        "`harn scan` requires the `hostlib` feature (default-on); it is unavailable in this build"
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "hostlib")]
+pub(crate) async fn run(args: ScanArgs) {
+    use crate::dispatch;
+    use crate::env_guard::ScopedEnvVar;
+
+    let plan = match build_plan(&args) {
+        Ok(plan) => plan,
+        Err(message) => {
+            eprintln!("scan: {message}");
+            std::process::exit(2);
+        }
+    };
+
+    let _plan = ScopedEnvVar::set("HARN_SCAN_PLAN_JSON", &plan);
+    let _report = ScopedEnvVar::set(
+        "HARN_SCAN_REPORT_ONLY",
+        if args.report_only { "1" } else { "0" },
+    );
+    let exit = dispatch::dispatch_to_embedded_script("scan", Vec::new(), args.json).await;
+    if exit != 0 {
+        std::process::exit(exit);
+    }
+}
+
+#[cfg(feature = "hostlib")]
+fn build_plan(args: &ScanArgs) -> Result<String, String> {
+    use harn_hostlib::ast::Language;
+
+    // With a saved rule/pack every positional is a path; otherwise the first
+    // positional is the inline pattern and the rest are paths.
+    let saved_rule = args.rule.is_some() || args.rule_pack.is_some();
+    let (pattern, paths): (Option<&str>, &[String]) = if saved_rule {
+        (None, &args.args)
+    } else {
+        (
+            args.args.first().map(String::as_str),
+            args.args.get(1..).unwrap_or(&[]),
+        )
+    };
+
+    let specs = resolve_rules(args, pattern)?;
+    let files = collect_files(paths);
+
+    let plan: Vec<serde_json::Value> = specs
+        .into_iter()
+        .map(|spec| {
+            let lang_name = spec.language.name();
+            let matching: Vec<String> = files
+                .iter()
+                .filter(|path| Language::detect(path, None).map(|l| l.name()) == Some(lang_name))
+                .map(|path| path.display().to_string())
+                .collect();
+            serde_json::json!({
+                "rule": spec.toml,
+                "language": lang_name,
+                "files": matching,
+            })
+        })
+        .collect();
+
+    serde_json::to_string(&plan).map_err(|e| format!("serialize plan: {e}"))
+}
+
+#[cfg(feature = "hostlib")]
+struct RuleSpec {
+    toml: String,
+    language: harn_hostlib::ast::Language,
+}
+
+#[cfg(feature = "hostlib")]
+fn resolve_rules(args: &ScanArgs, pattern: Option<&str>) -> Result<Vec<RuleSpec>, String> {
+    use harn_hostlib::ast::Language;
+    use std::fs;
+
+    if let Some(pattern) = pattern {
+        let lang_name = args
+            .lang
+            .as_deref()
+            .ok_or("an inline pattern requires `--lang <language>`")?;
+        let language = Language::from_name(lang_name)
+            .ok_or_else(|| format!("unknown language `{lang_name}`"))?;
+        let toml = format!(
+            "id = \"scan\"\nlanguage = \"{}\"\n[rule]\npattern = \"{}\"\n",
+            toml_escape(lang_name),
+            toml_escape(pattern),
+        );
+        Ok(vec![RuleSpec { toml, language }])
+    } else if let Some(rule_file) = &args.rule {
+        let toml = fs::read_to_string(rule_file).map_err(|e| format!("read `{rule_file}`: {e}"))?;
+        let language = rule_language(&toml)?;
+        Ok(vec![RuleSpec { toml, language }])
+    } else if let Some(dir) = &args.rule_pack {
+        let mut specs = Vec::new();
+        let entries = fs::read_dir(dir).map_err(|e| format!("read rule pack `{dir}`: {e}"))?;
+        let mut paths: Vec<_> = entries
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("toml"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            let toml =
+                fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
+            let language = rule_language(&toml)?;
+            specs.push(RuleSpec { toml, language });
+        }
+        if specs.is_empty() {
+            return Err(format!("rule pack `{dir}` has no `*.toml` rules"));
+        }
+        Ok(specs)
+    } else {
+        Err("provide an inline <pattern>, `--rule <file>`, or `--rule-pack <dir>`".into())
+    }
+}
+
+/// Parse a rule TOML's declared `language` into a [`Language`].
+#[cfg(feature = "hostlib")]
+fn rule_language(src: &str) -> Result<harn_hostlib::ast::Language, String> {
+    use harn_hostlib::ast::Language;
+
+    let value: toml::Value = toml::from_str(src).map_err(|e| format!("invalid rule TOML: {e}"))?;
+    let name = value
+        .get("language")
+        .and_then(|v| v.as_str())
+        .ok_or("rule TOML is missing a top-level `language`")?;
+    Language::from_name(name).ok_or_else(|| format!("unknown language `{name}`"))
+}
+
+/// Collect candidate files from `paths` (default: the current directory),
+/// recursing directories with the gitignore-aware walker.
+#[cfg(feature = "hostlib")]
+fn collect_files(paths: &[String]) -> Vec<std::path::PathBuf> {
+    use ignore::WalkBuilder;
+    use std::path::{Path, PathBuf};
+
+    let roots: Vec<String> = if paths.is_empty() {
+        vec![".".to_string()]
+    } else {
+        paths.to_vec()
+    };
+
+    let mut out: Vec<PathBuf> = Vec::new();
+    for root in &roots {
+        let path = Path::new(root);
+        if path.is_dir() {
+            let mut walker = WalkBuilder::new(path);
+            walker
+                .hidden(false)
+                .git_ignore(true)
+                .git_global(true)
+                .git_exclude(true)
+                .require_git(false);
+            for entry in walker.build().filter_map(Result::ok) {
+                if entry.file_type().is_some_and(|t| t.is_file()) {
+                    out.push(entry.path().to_path_buf());
+                }
+            }
+        } else if path.is_file() {
+            out.push(path.to_path_buf());
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Escape a string for a TOML basic (double-quoted) string.
+#[cfg(feature = "hostlib")]
+fn toml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1007,6 +1007,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
             }
         },
         Command::Provider(args) => commands::provider_capabilities::run_or_exit(args),
+        Command::Scan(args) => commands::scan::run(args).await,
         Command::Try(args) => commands::try_cmd::run(args).await,
         Command::Quickstart(args) => {
             if let Err(error) = commands::quickstart::run_quickstart(&args).await {

--- a/crates/harn-cli/tests/scan_dispatch.rs
+++ b/crates/harn-cli/tests/scan_dispatch.rs
@@ -1,0 +1,131 @@
+//! End-to-end coverage for `harn scan` (#2840): the embedded `.harn` handler
+//! and clap shim run the rule engine over a fileset and emit human / `--json`
+//! output. Spawns the real `harn` binary, like the other `*_dispatch` tests.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Outcome {
+    stdout: String,
+    #[allow(dead_code)]
+    stderr: String,
+    code: i32,
+}
+
+fn fixture_dir(name: &str) -> PathBuf {
+    // A unique-per-test dir under the target tmp area.
+    let dir = std::env::temp_dir().join(format!("harn-scan-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create fixture dir");
+    dir
+}
+
+fn write(dir: &Path, name: &str, contents: &str) {
+    std::fs::write(dir.join(name), contents).expect("write fixture");
+}
+
+fn scan(args: &[&str]) -> Outcome {
+    let output = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .arg("scan")
+        .args(args)
+        .output()
+        .expect("spawn harn scan");
+    Outcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        code: output.status.code().unwrap_or(-1),
+    }
+}
+
+#[test]
+fn inline_pattern_search_reports_matches_and_skips_other_languages() {
+    let dir = fixture_dir("inline");
+    write(
+        &dir,
+        "a.ts",
+        "const a = cfg?.timeout ?? 30;\nconst b = opts?.retries ?? 3;\nconst c = plain;\n",
+    );
+    write(&dir, "b.ts", "let x = o?.count ?? 0;\n");
+    // A Rust file with the same textual shape must be ignored (language filter).
+    write(&dir, "c.rs", "let y = o.count;\n");
+
+    let out = scan(&[
+        "$X?.$K ?? $D",
+        dir.to_str().unwrap(),
+        "--lang",
+        "typescript",
+        "--json",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    let json: serde_json::Value = serde_json::from_str(&out.stdout).expect("valid json envelope");
+    assert_eq!(json["mode"], "search");
+    assert_eq!(json["summary"]["total"], 3);
+    assert_eq!(json["summary"]["files"], 2);
+    let captures = &json["results"][0]["matches"][0]["captures"];
+    assert_eq!(captures["X"], "cfg");
+    assert_eq!(captures["K"], "timeout");
+    assert_eq!(captures["D"], "30");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn report_only_emits_per_file_counts() {
+    let dir = fixture_dir("report");
+    write(&dir, "a.ts", "let p = a?.x ?? 1;\nlet q = b?.y ?? 2;\n");
+    write(&dir, "b.ts", "let r = c?.z ?? 3;\n");
+
+    let out = scan(&[
+        "$X?.$K ?? $D",
+        dir.to_str().unwrap(),
+        "--lang",
+        "typescript",
+        "--report-only",
+        "--json",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let json: serde_json::Value = serde_json::from_str(&out.stdout).expect("valid json");
+    assert_eq!(json["mode"], "report");
+    assert_eq!(json["summary"]["total"], 3);
+    assert_eq!(json["summary"]["files"], 2);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rule_file_runs_a_saved_rule() {
+    let dir = fixture_dir("rulefile");
+    write(&dir, "calls.ts", "foo();\nbar();\nconst keep = 1;\n");
+    write(
+        &dir,
+        "find_calls.toml",
+        "id = \"find-calls\"\nlanguage = \"typescript\"\n[rule]\npattern = \"$FN()\"\n",
+    );
+
+    let out = scan(&[
+        "--rule",
+        dir.join("find_calls.toml").to_str().unwrap(),
+        dir.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let json: serde_json::Value = serde_json::from_str(&out.stdout).expect("valid json");
+    assert_eq!(json["summary"]["total"], 2);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn inline_pattern_without_lang_is_an_error() {
+    let dir = fixture_dir("nolang");
+    write(&dir, "a.ts", "let p = a?.x ?? 1;\n");
+    let out = scan(&["$X?.$K ?? $D", dir.to_str().unwrap()]);
+    assert_ne!(out.code, 0, "missing --lang should fail");
+    assert!(
+        out.stderr.contains("--lang"),
+        "stderr should mention --lang: {}",
+        out.stderr
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -953,6 +953,10 @@ pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
         source: include_str!("stdlib/cli/routes.harn"),
     },
     StdlibCliScript {
+        name: "scan",
+        source: include_str!("stdlib/cli/scan.harn"),
+    },
+    StdlibCliScript {
         name: "scaffold/init",
         source: include_str!("stdlib/cli/scaffold/init.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/scan.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/scan.harn
@@ -1,0 +1,136 @@
+import { rules_report, rules_search } from "std/rules"
+
+/**
+ * `harn scan` — read-only structural search + lint over a fileset.
+ *
+ * The Rust shim (crates/harn-cli/src/commands/scan.rs) resolves the rule(s)
+ * and the matching files (walking directories, filtering by each rule's
+ * language) and hands this handler a *plan*. This handler runs the engine
+ * (`std/rules`) and formats human or `--json` output.
+ *
+ * Inputs:
+ *   HARN_SCAN_PLAN_JSON   — JSON array of {rule, language, files: [...]}.
+ *   HARN_SCAN_REPORT_ONLY — "1" for data-table counts, "0" for each match.
+ *   HARN_OUTPUT_JSON      — "1" for the JSON envelope, else human text.
+ */
+fn join_strs(parts: list, sep: string) -> string {
+  var out = ""
+  var first = true
+  for part in parts {
+    if first {
+      out = part
+      first = false
+    } else {
+      out = out + sep + part
+    }
+  }
+  return out
+}
+
+fn loc(m: dict) -> string {
+  // 1-based row/col, editor-friendly.
+  return to_string(m.start_row + 1) + ":" + to_string(m.start_col + 1)
+}
+
+fn captures_suffix(caps: dict) -> string {
+  let names = keys(caps)
+  if len(names) == 0 {
+    return ""
+  }
+  var parts = []
+  for name in names {
+    parts = parts.push(name + "=" + caps[name])
+  }
+  return "  [" + join_strs(parts, " ") + "]"
+}
+
+fn summary_line(total: int, files: int) -> string {
+  return to_string(total) + " match(es) in " + to_string(files) + " file(s)"
+}
+
+fn run_search(plan: list) -> dict {
+  var lines = []
+  var results = []
+  var total = 0
+  var seen = {}
+  for entry in plan {
+    if len(entry.files) == 0 {
+      continue
+    }
+    let res = rules_search({rule: entry.rule, paths: entry.files})
+    let matches = res.matches ?? []
+    total = total + len(matches)
+    for m in matches {
+      seen = seen.merge({[m.path]: true})
+      lines = lines.push(m.path + ":" + loc(m) + ": " + m.text + captures_suffix(m.captures ?? {}))
+    }
+    results = results.push({language: entry.language, match_count: len(matches), matches: matches})
+  }
+  return {lines: lines, results: results, total: total, files: len(keys(seen))}
+}
+
+fn run_report(plan: list) -> dict {
+  var lines = []
+  var tables = []
+  var total = 0
+  var seen = {}
+  for entry in plan {
+    if len(entry.files) == 0 {
+      continue
+    }
+    let table = rules_report({rule: entry.rule, paths: entry.files})
+    let summary = table.summary ?? {total_rows: 0, files: 0, per_file: {}}
+    total = total + summary.total_rows
+    let per_file = summary.per_file ?? {}
+    for path in keys(per_file) {
+      seen = seen.merge({[path]: true})
+      lines = lines.push(path + ": " + to_string(per_file[path]))
+    }
+    tables = tables.push(table)
+  }
+  return {lines: lines, tables: tables, total: total, files: len(keys(seen))}
+}
+
+fn main(harness: Harness) {
+  let raw = harness.env.get_or("HARN_SCAN_PLAN_JSON", "")
+  if raw == "" {
+    harness.stdio.eprintln("scan: internal error — HARN_SCAN_PLAN_JSON not set by the shim")
+    exit(70)
+  }
+  let plan = json_parse(raw)
+  let report_only = harness.env.get_or("HARN_SCAN_REPORT_ONLY", "0") == "1"
+  let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"
+  if report_only {
+    let out = run_report(plan)
+    if json_mode {
+      let envelope = {
+        schemaVersion: 1,
+        mode: "report",
+        tables: out.tables,
+        summary: {total: out.total, files: out.files},
+      }
+      harness.stdio.println(json_stringify_pretty(envelope))
+    } else {
+      for line in out.lines {
+        harness.stdio.println(line)
+      }
+      harness.stdio.println(summary_line(out.total, out.files))
+    }
+  } else {
+    let out = run_search(plan)
+    if json_mode {
+      let envelope = {
+        schemaVersion: 1,
+        mode: "search",
+        results: out.results,
+        summary: {total: out.total, files: out.files},
+      }
+      harness.stdio.println(json_stringify_pretty(envelope))
+    } else {
+      for line in out.lines {
+        harness.stdio.println(line)
+      }
+      harness.stdio.println(summary_line(out.total, out.files))
+    }
+  }
+}


### PR DESCRIPTION
Closes #2840. Rule Engine Epic B (#2828), program #2826. The first CLI surface over the engine — independent of the rest of the cascade (only needs `std/rules`, already on main via #2879).

## What

`harn scan` runs a pattern, a saved rule, or a rule pack over a fileset, read-only:

```
harn scan '$X?.$K ?? $D' src --lang typescript    # inline pattern
harn scan --rule rule.toml src                      # a saved rule
harn scan --rule-pack rules/ src                    # every *.toml in a dir
harn scan ... --report-only                          # per-file / total counts
harn scan ... --json                                 # JSON envelope
```

Output: grep-style `path:row:col: <text>  [CAPS]` lines + a summary; `--report-only` emits per-file counts; `--json` emits a structured envelope (validated by a dispatch test).

## How

The established embedded-`.harn`-handler + thin-clap-shim pattern:
- **Shim** (`commands/scan.rs`, `#[cfg(feature = "hostlib")]`): resolves the rule(s) (inline pattern → built TOML; `--rule` file; `--rule-pack` dir) and walks the fileset (gitignore-aware `ignore::WalkBuilder`), filtering files to each rule's tree-sitter `Language`. Hands the handler a per-rule plan.
- **Handler** (`cli/scan.harn`): runs `std/rules` (`rules_search` / `rules_report`) per plan entry and formats human / `--json` output.

## Note on the acceptance

The ticket's literal example scans `crates/harn-stdlib` (`.harn` files), but there is **no Harn tree-sitter grammar yet**, so Harn source can't be scanned structurally. This is demonstrated on TypeScript (where the destructuring pattern is valid — the #2824 shape). When a Harn grammar lands, `harn scan` picks it up for free (it is grammar-agnostic).

## Verification

- `cargo test -p harn-cli --test scan_dispatch` — 4 tests green (inline search + language filter, report-only, `--rule` file, missing-`--lang` error), all asserting on the real spawned `harn` binary.
- `cargo fmt` + `harn fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)