### PR TITLE
harn codemod: apply rules across a fileset, dry-run default + gated (#2841)

### DIFF
--- a/changelog.d/2841.added.md
+++ b/changelog.d/2841.added.md
@@ -1,0 +1,7 @@
+- Added `harn codemod` — apply a codemod rule's `fix` across a fileset (Rule Engine Epic B). **Dry-run by default**:
+  prints a unified diff per file that would change, plus its safety tier and whether the fix is idempotent. `--apply`
+  writes the changes (gated by the deterministic-tools capability; a rule above the machine-applicable safety tier also
+  needs `--allow-unsafe`). Run a single rule (`--rule rule.toml`) or a whole directory of them (`--rule-pack dir`) over
+  files or directories. Authored as an embedded `.harn` handler over `std/rules` behind a thin clap shim, sharing the
+  rule/fileset resolution with `harn scan`. `rules.apply` now also returns each file's original `before` source so
+  callers can render a diff without re-reading (sandboxed) files.

--- a/crates/harn-cli/src/cli/codemod.rs
+++ b/crates/harn-cli/src/cli/codemod.rs
@@ -1,0 +1,28 @@
+use clap::Args;
+
+/// `harn codemod` — apply a codemod rule's `fix` across a fileset.
+///
+/// **Dry-run by default** (prints a unified diff per file); pass `--apply` to
+/// write. A rule whose `safety` is above the machine-applicable tier needs
+/// `--allow-unsafe` to apply.
+#[derive(Debug, Args)]
+pub(crate) struct CodemodArgs {
+    /// Files or directories to rewrite (default: the current directory).
+    #[arg(value_name = "PATHS")]
+    pub paths: Vec<String>,
+    /// Run a codemod rule from a TOML file (must declare a `fix`).
+    #[arg(long = "rule", value_name = "FILE")]
+    pub rule: Option<String>,
+    /// Run every `*.toml` rule in a directory (a rule pack).
+    #[arg(long = "rule-pack", value_name = "DIR", conflicts_with = "rule")]
+    pub rule_pack: Option<String>,
+    /// Write the fixes to disk. Without this, codemod is a dry-run preview.
+    #[arg(long)]
+    pub apply: bool,
+    /// Apply even fixes above the machine-applicable safety tier.
+    #[arg(long = "allow-unsafe")]
+    pub allow_unsafe: bool,
+    /// Emit a JSON envelope instead of human-readable diffs.
+    #[arg(long)]
+    pub json: bool,
+}

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -12,6 +12,7 @@
 
 mod bench;
 mod check;
+mod codemod;
 mod completions;
 mod config_cmd;
 mod connect;
@@ -73,6 +74,7 @@ mod workflow;
 
 pub(crate) use bench::{BenchArgs, BenchCommand, BenchReplayArgs};
 pub(crate) use check::{CheckArgs, CheckOutputFormat};
+pub(crate) use codemod::CodemodArgs;
 pub(crate) use completions::{CompletionShell, CompletionsArgs};
 pub(crate) use config_cmd::{ConfigArgs, ConfigCommand, ConfigInspectArgs, ConfigValidateArgs};
 pub(crate) use connect::{
@@ -479,6 +481,9 @@ SCRIPTING
     /// Read-only structural search + lint: run a pattern, rule, or rule pack
     /// over a fileset and report matches or per-file counts (`--report-only`).
     Scan(ScanArgs),
+    /// Apply a codemod rule's `fix` across a fileset. Dry-run by default
+    /// (unified diffs); `--apply` writes, safety- and capability-gated.
+    Codemod(CodemodArgs),
     /// One-shot agent_loop with a prompt. Routes through the configured
     /// provider (or `HARN_LLM_PROVIDER=mock` for offline use).
     #[command(name = "try")]

--- a/crates/harn-cli/src/commands/codemod.rs
+++ b/crates/harn-cli/src/commands/codemod.rs
@@ -1,0 +1,53 @@
+//! `harn codemod` dispatches to the embedded `cli/codemod.harn` handler. Like
+//! `harn scan`, the shim resolves the rule(s) and the fileset in Rust (see
+//! [`crate::commands::rules_cli`]) and hands the handler a per-rule plan; the
+//! handler applies each rule's `fix` via `std/rules` (dry-run by default).
+
+use crate::cli::CodemodArgs;
+
+#[cfg(not(feature = "hostlib"))]
+pub(crate) async fn run(_args: CodemodArgs) {
+    eprintln!(
+        "`harn codemod` requires the `hostlib` feature (default-on); it is unavailable in this build"
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "hostlib")]
+pub(crate) async fn run(args: CodemodArgs) {
+    use crate::dispatch;
+    use crate::env_guard::ScopedEnvVar;
+
+    if args.rule.is_none() && args.rule_pack.is_none() {
+        eprintln!("codemod: provide `--rule <file>` or `--rule-pack <dir>`");
+        std::process::exit(2);
+    }
+
+    let plan = match resolve(&args) {
+        Ok(plan) => plan,
+        Err(message) => {
+            eprintln!("codemod: {message}");
+            std::process::exit(2);
+        }
+    };
+
+    let _plan = ScopedEnvVar::set("HARN_CODEMOD_PLAN_JSON", &plan);
+    let _apply = ScopedEnvVar::set("HARN_CODEMOD_APPLY", if args.apply { "1" } else { "0" });
+    let _unsafe = ScopedEnvVar::set(
+        "HARN_CODEMOD_ALLOW_UNSAFE",
+        if args.allow_unsafe { "1" } else { "0" },
+    );
+    let exit = dispatch::dispatch_to_embedded_script("codemod", Vec::new(), args.json).await;
+    if exit != 0 {
+        std::process::exit(exit);
+    }
+}
+
+#[cfg(feature = "hostlib")]
+fn resolve(args: &CodemodArgs) -> Result<String, String> {
+    use crate::commands::rules_cli;
+
+    let specs =
+        rules_cli::resolve_rules(None, None, args.rule.as_deref(), args.rule_pack.as_deref())?;
+    rules_cli::build_plan(specs, &args.paths)
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod agents_conformance;
 pub(crate) mod bench;
 pub(crate) mod check;
+pub(crate) mod codemod;
 pub(crate) mod config_cmd;
 pub(crate) mod connect;
 pub(crate) mod connector;
@@ -57,6 +58,7 @@ pub(crate) mod quickstart;
 pub(crate) mod repl;
 pub(crate) mod replay;
 pub(crate) mod routes;
+pub(crate) mod rules_cli;
 pub mod run;
 pub(crate) mod scaffold_common;
 pub(crate) mod scan;

--- a/crates/harn-cli/src/commands/rules_cli.rs
+++ b/crates/harn-cli/src/commands/rules_cli.rs
@@ -1,0 +1,155 @@
+//! Shared shim helpers for the rule-engine CLI surfaces (`harn scan`,
+//! `harn codemod`).
+//!
+//! Both surfaces resolve a rule (an inline pattern, a `--rule` TOML file, or a
+//! `--rule-pack` directory) and walk a fileset in Rust — where the tree-sitter
+//! `Language` registry and the gitignore-aware walker live — then hand the
+//! `.harn` handler a per-rule *plan* (the rule TOML plus the files that match
+//! its language). The handler runs `std/rules` over the plan.
+
+#![cfg(feature = "hostlib")]
+
+use std::path::PathBuf;
+
+use harn_hostlib::ast::Language;
+
+/// A resolved rule: its TOML source and the language it targets.
+pub(crate) struct RuleSpec {
+    pub toml: String,
+    pub language: Language,
+}
+
+/// Resolve the rule(s) to run. Exactly one source is used, in priority order:
+/// an inline `pattern` (requires `lang`), a `rule_file`, or a `rule_pack`
+/// directory of `*.toml` rules.
+pub(crate) fn resolve_rules(
+    inline_pattern: Option<&str>,
+    lang: Option<&str>,
+    rule_file: Option<&str>,
+    rule_pack: Option<&str>,
+) -> Result<Vec<RuleSpec>, String> {
+    use std::fs;
+
+    if let Some(pattern) = inline_pattern {
+        let lang_name = lang.ok_or("an inline pattern requires `--lang <language>`")?;
+        let language = Language::from_name(lang_name)
+            .ok_or_else(|| format!("unknown language `{lang_name}`"))?;
+        let toml = format!(
+            "id = \"scan\"\nlanguage = \"{}\"\n[rule]\npattern = \"{}\"\n",
+            toml_escape(lang_name),
+            toml_escape(pattern),
+        );
+        Ok(vec![RuleSpec { toml, language }])
+    } else if let Some(rule_file) = rule_file {
+        let toml = fs::read_to_string(rule_file).map_err(|e| format!("read `{rule_file}`: {e}"))?;
+        let language = rule_language(&toml)?;
+        Ok(vec![RuleSpec { toml, language }])
+    } else if let Some(dir) = rule_pack {
+        let mut specs = Vec::new();
+        let entries = fs::read_dir(dir).map_err(|e| format!("read rule pack `{dir}`: {e}"))?;
+        let mut paths: Vec<_> = entries
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("toml"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            let toml =
+                fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
+            let language = rule_language(&toml)?;
+            specs.push(RuleSpec { toml, language });
+        }
+        if specs.is_empty() {
+            return Err(format!("rule pack `{dir}` has no `*.toml` rules"));
+        }
+        Ok(specs)
+    } else {
+        Err("provide an inline <pattern>, `--rule <file>`, or `--rule-pack <dir>`".into())
+    }
+}
+
+/// Build the per-rule plan JSON: each rule paired with the files (recursively
+/// collected from `paths`, gitignore-aware) that match its language.
+pub(crate) fn build_plan(specs: Vec<RuleSpec>, paths: &[String]) -> Result<String, String> {
+    let files = collect_files(paths);
+    let plan: Vec<serde_json::Value> = specs
+        .into_iter()
+        .map(|spec| {
+            let lang_name = spec.language.name();
+            let matching: Vec<String> = files
+                .iter()
+                .filter(|path| Language::detect(path, None).map(|l| l.name()) == Some(lang_name))
+                .map(|path| path.display().to_string())
+                .collect();
+            serde_json::json!({
+                "rule": spec.toml,
+                "language": lang_name,
+                "files": matching,
+            })
+        })
+        .collect();
+    serde_json::to_string(&plan).map_err(|e| format!("serialize plan: {e}"))
+}
+
+/// Parse a rule TOML's declared `language` into a [`Language`].
+fn rule_language(src: &str) -> Result<Language, String> {
+    let value: toml::Value = toml::from_str(src).map_err(|e| format!("invalid rule TOML: {e}"))?;
+    let name = value
+        .get("language")
+        .and_then(|v| v.as_str())
+        .ok_or("rule TOML is missing a top-level `language`")?;
+    Language::from_name(name).ok_or_else(|| format!("unknown language `{name}`"))
+}
+
+/// Collect candidate files from `paths` (default: the current directory),
+/// recursing directories with the gitignore-aware walker.
+fn collect_files(paths: &[String]) -> Vec<PathBuf> {
+    use ignore::WalkBuilder;
+    use std::path::Path;
+
+    let roots: Vec<String> = if paths.is_empty() {
+        vec![".".to_string()]
+    } else {
+        paths.to_vec()
+    };
+
+    let mut out: Vec<PathBuf> = Vec::new();
+    for root in &roots {
+        let path = Path::new(root);
+        if path.is_dir() {
+            let mut walker = WalkBuilder::new(path);
+            walker
+                .hidden(false)
+                .git_ignore(true)
+                .git_global(true)
+                .git_exclude(true)
+                .require_git(false);
+            for entry in walker.build().filter_map(Result::ok) {
+                if entry.file_type().is_some_and(|t| t.is_file()) {
+                    out.push(entry.path().to_path_buf());
+                }
+            }
+        } else if path.is_file() {
+            out.push(path.to_path_buf());
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Escape a string for a TOML basic (double-quoted) string.
+fn toml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}

--- a/crates/harn-cli/src/commands/scan.rs
+++ b/crates/harn-cli/src/commands/scan.rs
@@ -1,8 +1,9 @@
 //! `harn scan` dispatches to the embedded `cli/scan.harn` handler. The shim
-//! resolves the rule(s) and the fileset in Rust — where the tree-sitter
-//! `Language` registry and the gitignore-aware walker live — then hands the
-//! `.harn` handler a per-rule *plan* (rule TOML + the matching files). The
-//! handler runs the engine (`std/rules`) and formats the output.
+//! resolves the rule(s) and the fileset in Rust (see [`crate::commands::
+//! rules_cli`]) — where the tree-sitter `Language` registry and the
+//! gitignore-aware walker live — then hands the `.harn` handler a per-rule
+//! *plan* (rule TOML + the matching files). The handler runs the engine
+//! (`std/rules`) and formats the output.
 
 use crate::cli::ScanArgs;
 
@@ -40,7 +41,7 @@ pub(crate) async fn run(args: ScanArgs) {
 
 #[cfg(feature = "hostlib")]
 fn build_plan(args: &ScanArgs) -> Result<String, String> {
-    use harn_hostlib::ast::Language;
+    use crate::commands::rules_cli;
 
     // With a saved rule/pack every positional is a path; otherwise the first
     // positional is the inline pattern and the rest are paths.
@@ -54,145 +55,11 @@ fn build_plan(args: &ScanArgs) -> Result<String, String> {
         )
     };
 
-    let specs = resolve_rules(args, pattern)?;
-    let files = collect_files(paths);
-
-    let plan: Vec<serde_json::Value> = specs
-        .into_iter()
-        .map(|spec| {
-            let lang_name = spec.language.name();
-            let matching: Vec<String> = files
-                .iter()
-                .filter(|path| Language::detect(path, None).map(|l| l.name()) == Some(lang_name))
-                .map(|path| path.display().to_string())
-                .collect();
-            serde_json::json!({
-                "rule": spec.toml,
-                "language": lang_name,
-                "files": matching,
-            })
-        })
-        .collect();
-
-    serde_json::to_string(&plan).map_err(|e| format!("serialize plan: {e}"))
-}
-
-#[cfg(feature = "hostlib")]
-struct RuleSpec {
-    toml: String,
-    language: harn_hostlib::ast::Language,
-}
-
-#[cfg(feature = "hostlib")]
-fn resolve_rules(args: &ScanArgs, pattern: Option<&str>) -> Result<Vec<RuleSpec>, String> {
-    use harn_hostlib::ast::Language;
-    use std::fs;
-
-    if let Some(pattern) = pattern {
-        let lang_name = args
-            .lang
-            .as_deref()
-            .ok_or("an inline pattern requires `--lang <language>`")?;
-        let language = Language::from_name(lang_name)
-            .ok_or_else(|| format!("unknown language `{lang_name}`"))?;
-        let toml = format!(
-            "id = \"scan\"\nlanguage = \"{}\"\n[rule]\npattern = \"{}\"\n",
-            toml_escape(lang_name),
-            toml_escape(pattern),
-        );
-        Ok(vec![RuleSpec { toml, language }])
-    } else if let Some(rule_file) = &args.rule {
-        let toml = fs::read_to_string(rule_file).map_err(|e| format!("read `{rule_file}`: {e}"))?;
-        let language = rule_language(&toml)?;
-        Ok(vec![RuleSpec { toml, language }])
-    } else if let Some(dir) = &args.rule_pack {
-        let mut specs = Vec::new();
-        let entries = fs::read_dir(dir).map_err(|e| format!("read rule pack `{dir}`: {e}"))?;
-        let mut paths: Vec<_> = entries
-            .filter_map(Result::ok)
-            .map(|e| e.path())
-            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("toml"))
-            .collect();
-        paths.sort();
-        for path in paths {
-            let toml =
-                fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
-            let language = rule_language(&toml)?;
-            specs.push(RuleSpec { toml, language });
-        }
-        if specs.is_empty() {
-            return Err(format!("rule pack `{dir}` has no `*.toml` rules"));
-        }
-        Ok(specs)
-    } else {
-        Err("provide an inline <pattern>, `--rule <file>`, or `--rule-pack <dir>`".into())
-    }
-}
-
-/// Parse a rule TOML's declared `language` into a [`Language`].
-#[cfg(feature = "hostlib")]
-fn rule_language(src: &str) -> Result<harn_hostlib::ast::Language, String> {
-    use harn_hostlib::ast::Language;
-
-    let value: toml::Value = toml::from_str(src).map_err(|e| format!("invalid rule TOML: {e}"))?;
-    let name = value
-        .get("language")
-        .and_then(|v| v.as_str())
-        .ok_or("rule TOML is missing a top-level `language`")?;
-    Language::from_name(name).ok_or_else(|| format!("unknown language `{name}`"))
-}
-
-/// Collect candidate files from `paths` (default: the current directory),
-/// recursing directories with the gitignore-aware walker.
-#[cfg(feature = "hostlib")]
-fn collect_files(paths: &[String]) -> Vec<std::path::PathBuf> {
-    use ignore::WalkBuilder;
-    use std::path::{Path, PathBuf};
-
-    let roots: Vec<String> = if paths.is_empty() {
-        vec![".".to_string()]
-    } else {
-        paths.to_vec()
-    };
-
-    let mut out: Vec<PathBuf> = Vec::new();
-    for root in &roots {
-        let path = Path::new(root);
-        if path.is_dir() {
-            let mut walker = WalkBuilder::new(path);
-            walker
-                .hidden(false)
-                .git_ignore(true)
-                .git_global(true)
-                .git_exclude(true)
-                .require_git(false);
-            for entry in walker.build().filter_map(Result::ok) {
-                if entry.file_type().is_some_and(|t| t.is_file()) {
-                    out.push(entry.path().to_path_buf());
-                }
-            }
-        } else if path.is_file() {
-            out.push(path.to_path_buf());
-        }
-    }
-    out.sort();
-    out.dedup();
-    out
-}
-
-/// Escape a string for a TOML basic (double-quoted) string.
-#[cfg(feature = "hostlib")]
-fn toml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\t' => out.push_str("\\t"),
-            '\r' => out.push_str("\\r"),
-            _ => out.push(ch),
-        }
-    }
-    out
+    let specs = rules_cli::resolve_rules(
+        pattern,
+        args.lang.as_deref(),
+        args.rule.as_deref(),
+        args.rule_pack.as_deref(),
+    )?;
+    rules_cli::build_plan(specs, paths)
 }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1008,6 +1008,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
         },
         Command::Provider(args) => commands::provider_capabilities::run_or_exit(args),
         Command::Scan(args) => commands::scan::run(args).await,
+        Command::Codemod(args) => commands::codemod::run(args).await,
         Command::Try(args) => commands::try_cmd::run(args).await,
         Command::Quickstart(args) => {
             if let Err(error) = commands::quickstart::run_quickstart(&args).await {

--- a/crates/harn-cli/tests/codemod_dispatch.rs
+++ b/crates/harn-cli/tests/codemod_dispatch.rs
@@ -1,0 +1,99 @@
+//! End-to-end coverage for `harn codemod` (#2841): dry-run by default (a
+//! unified diff per file), `--apply` writes (gated), and re-running a folded
+//! file is idempotent. Spawns the real `harn` binary.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Outcome {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+fn fixture_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("harn-codemod-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create fixture dir");
+    dir
+}
+
+fn write(dir: &Path, name: &str, contents: &str) {
+    std::fs::write(dir.join(name), contents).expect("write fixture");
+}
+
+const RENAME_RULE: &str = "id = \"rename\"\nlanguage = \"typescript\"\nsafety = \"behavior-preserving\"\nfix = \"bar()\"\n[rule]\npattern = \"foo()\"\n";
+
+fn codemod(dir: &Path, extra: &[&str]) -> Outcome {
+    let rule = dir.join("rule.toml");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harn"));
+    cmd.arg("codemod")
+        .arg("--rule")
+        .arg(&rule)
+        .arg(dir)
+        .args(extra);
+    let output = cmd.output().expect("spawn harn codemod");
+    Outcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        code: output.status.code().unwrap_or(-1),
+    }
+}
+
+#[test]
+fn dry_run_previews_without_writing() {
+    let dir = fixture_dir("dry");
+    write(&dir, "a.ts", "foo();\nconst keep = 1;\n");
+    write(&dir, "rule.toml", RENAME_RULE);
+
+    let out = codemod(&dir, &["--json"]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let json: serde_json::Value = serde_json::from_str(&out.stdout).expect("valid json");
+    assert_eq!(json["mode"], "codemod");
+    assert_eq!(json["apply"], false);
+    assert_eq!(json["summary"]["changed"], 1);
+    assert_eq!(json["summary"]["applied"], 0);
+    assert_eq!(json["files"][0]["before"], "foo();\nconst keep = 1;\n");
+    assert_eq!(json["files"][0]["preview"], "bar();\nconst keep = 1;\n");
+
+    // The file on disk is untouched by a dry run.
+    let on_disk = std::fs::read_to_string(dir.join("a.ts")).unwrap();
+    assert_eq!(on_disk, "foo();\nconst keep = 1;\n");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn apply_writes_and_is_idempotent() {
+    let dir = fixture_dir("apply");
+    write(&dir, "a.ts", "foo();\nfoo();\n");
+    write(&dir, "rule.toml", RENAME_RULE);
+
+    let applied = codemod(&dir, &["--apply", "--json"]);
+    assert_eq!(applied.code, 0, "stderr={}", applied.stderr);
+    let json: serde_json::Value = serde_json::from_str(&applied.stdout).expect("valid json");
+    assert_eq!(json["apply"], true);
+    assert_eq!(json["summary"]["applied"], 1);
+
+    let on_disk = std::fs::read_to_string(dir.join("a.ts")).unwrap();
+    assert_eq!(on_disk, "bar();\nbar();\n");
+
+    // Re-running the rule on the folded file changes nothing (idempotent).
+    let again = codemod(&dir, &["--json"]);
+    let json2: serde_json::Value = serde_json::from_str(&again.stdout).expect("valid json");
+    assert_eq!(json2["summary"]["changed"], 0);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_rule_is_an_error() {
+    let dir = fixture_dir("norule");
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .arg("codemod")
+        .arg(&dir)
+        .output()
+        .expect("spawn");
+    assert_ne!(out.status.code().unwrap_or(-1), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -246,6 +246,9 @@ fn apply_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             ("applied", VmValue::Bool(applied)),
             ("idempotent", VmValue::Bool(outcome.idempotent)),
             ("safety", str_vm(format!("{:?}", outcome.safety))),
+            // The original source, so callers can render a diff without a
+            // (sandboxed) re-read of the file.
+            ("before", str_vm(&file.source)),
             ("preview", str_vm(outcome.rewritten)),
         ]));
     }

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -870,6 +870,10 @@ pub struct StdlibCliScript {
 
 pub const STDLIB_CLI_SCRIPTS: &[StdlibCliScript] = &[
     StdlibCliScript {
+        name: "codemod",
+        source: include_str!("stdlib/cli/codemod.harn"),
+    },
+    StdlibCliScript {
         name: "doctor",
         source: include_str!("stdlib/cli/doctor.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/cli/codemod.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/codemod.harn
@@ -1,0 +1,96 @@
+import { unified_diff } from "std/diff"
+import { rules_apply } from "std/rules"
+
+/**
+ * `harn codemod` — apply a codemod rule's `fix` across a fileset.
+ *
+ * **Dry-run by default**: prints a unified diff per file that would change.
+ * `--apply` writes the fixes (gated by the deterministic-tools capability);
+ * a rule above the machine-applicable safety tier additionally needs
+ * `--allow-unsafe`.
+ *
+ * The Rust shim (crates/harn-cli/src/commands/codemod.rs) resolves the rule(s)
+ * and the matching files and passes them as a plan; this handler runs the
+ * engine (`std/rules` `rules_apply`) and formats the diffs / summary.
+ *
+ * Inputs:
+ *   HARN_CODEMOD_PLAN_JSON     — JSON array of {rule, language, files: [...]}.
+ *   HARN_CODEMOD_APPLY         — "1" to write, "0" for a dry-run preview.
+ *   HARN_CODEMOD_ALLOW_UNSAFE  — "1" to apply above machine-applicable safety.
+ *   HARN_OUTPUT_JSON           — "1" for the JSON envelope, else human diffs.
+ */
+fn summary_line(changed: int, applied: int, apply: bool) -> string {
+  if apply {
+    return to_string(applied) + " file(s) rewritten (" + to_string(changed) + " changed)"
+  }
+  return to_string(changed) + " file(s) would change (dry run; pass --apply to write)"
+}
+
+fn run_codemod(plan: list, apply: bool, allow_unsafe: bool) -> dict {
+  var file_results = []
+  var changed = 0
+  var applied = 0
+  for entry in plan {
+    if len(entry.files) == 0 {
+      continue
+    }
+    let res = rules_apply({rule: entry.rule, paths: entry.files, dry_run: !apply, allow_unsafe: allow_unsafe})
+    for f in res.files ?? [] {
+      if f.changed {
+        changed = changed + 1
+        if f.applied {
+          applied = applied + 1
+        }
+        file_results = file_results.push(f)
+      }
+    }
+  }
+  return {files: file_results, changed: changed, applied: applied}
+}
+
+fn main(harness: Harness) {
+  let raw = harness.env.get_or("HARN_CODEMOD_PLAN_JSON", "")
+  if raw == "" {
+    harness.stdio.eprintln("codemod: internal error — HARN_CODEMOD_PLAN_JSON not set by the shim")
+    exit(70)
+  }
+  let plan = json_parse(raw)
+  let apply = harness.env.get_or("HARN_CODEMOD_APPLY", "0") == "1"
+  let allow_unsafe = harness.env.get_or("HARN_CODEMOD_ALLOW_UNSAFE", "0") == "1"
+  let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"
+  // `rules_apply` is a gated deterministic tool, so the capability is required
+  // even for a dry run (which still never writes — the engine's own
+  // `dry_run`/safety checks protect the files). `harn codemod` is a first-party
+  // command the user invoked directly, so enabling it here is the intended use.
+  hostlib_enable("tools:deterministic")
+  let out = run_codemod(plan, apply, allow_unsafe)
+  if json_mode {
+    let envelope = {
+      schemaVersion: 1,
+      mode: "codemod",
+      apply: apply,
+      files: out.files,
+      summary: {changed: out.changed, applied: out.applied},
+    }
+    harness.stdio.println(json_stringify_pretty(envelope))
+  } else {
+    for f in out.files {
+      if apply {
+        harness.stdio.println("rewrote " + f.path + "  [safety=" + f.safety + "]")
+      } else {
+        harness.stdio
+          .println(
+          "would change "
+            + f.path
+            + "  [safety="
+            + f.safety
+            + ", idempotent="
+            + to_string(f.idempotent)
+            + "]",
+        )
+        harness.stdio.println(unified_diff(f.before ?? "", f.preview))
+      }
+    }
+    harness.stdio.println(summary_line(out.changed, out.applied, apply))
+  }
+}


### PR DESCRIPTION
Closes #2841. Rule Engine Epic B (#2828), program #2826. Stacked on #2885 (`harn scan`) — the diff here is the single `#2841` commit (which also extracts the shared `commands::rules_cli` module and refactors scan onto it).

## What

The apply surface — the write counterpart to `harn scan`:

```
harn codemod --rule rule.toml src            # dry-run: a unified diff per file
harn codemod --rule-pack rules/ src          # every *.toml in a dir
harn codemod --rule rule.toml src --apply    # write (capability-gated)
harn codemod ... --apply --allow-unsafe      # apply above machine-applicable safety
harn codemod ... --json                       # JSON envelope
```

**Dry-run by default**: prints a unified diff (`std/diff`) per file that would change, with its safety tier and whether the fix is idempotent. `--apply` writes (gated by the deterministic-tools capability, which the handler enables since the user ran the command directly; the engine's own `dry_run`/safety checks still protect the files). A rule above the machine-applicable safety tier needs `--allow-unsafe`.

## How

Same embedded-`.harn`-handler + thin-clap-shim pattern as `harn scan`, sharing rule + fileset resolution via a new `commands::rules_cli` module (scan refactored onto it — **no duplication**). `rules.apply` now also returns each file's original `before` source, so the handler renders the diff without a (sandboxed) re-read of the file.

## Verification

- `cargo test -p harn-cli --test codemod_dispatch` — 3 tests green (dry-run preview leaves the file untouched; `--apply` writes and a re-run is idempotent; missing-rule error).
- `cargo test -p harn-cli --test scan_dispatch` — 4 green (the `rules_cli` refactor didn't regress scan).
- `cargo test -p harn-rules-hostlib` — green (the `before` field).
- `cargo fmt` + `harn fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)