### PR TITLE
Fix release gate flakes

### DIFF
--- a/.github/workflows/release-pr-drift-check.yml
+++ b/.github/workflows/release-pr-drift-check.yml
@@ -1,15 +1,17 @@
 name: Release PR drift check
 
-# Guards `release/v*.*.*` PRs against silent CHANGELOG `## Unreleased`
-# drift absorption. When a release PR sits on a frozen pin SHA and
-# another PR merges to main that appends bullets under `## Unreleased`,
-# GitHub's automatic 3-way merge folds those new bullets into the
-# release section. The merge is textually clean, `mergeable: MERGEABLE`,
-# and auto-merge would happily ship a CHANGELOG that lies about the
-# published artifact.
+# Guards `release/v*.*.*` PRs against stale release pins and silent
+# CHANGELOG `## Unreleased` drift absorption. When a release PR sits on
+# a frozen pin SHA and another PR merges to main, GitHub's automatic
+# 3-way merge can stay textually clean and `mergeable: MERGEABLE` while
+# still omitting the newer main commits from the published artifact. If
+# the newer PR also appends bullets under `## Unreleased`, the merge can
+# fold those bullets into the release section and ship a CHANGELOG that
+# lies about what's in the artifact.
 #
 # This workflow posts a `release-pr-drift-check` check_run on each
-# release PR's head SHA. It fails whenever the pin-time `## Unreleased`
+# release PR's head SHA. It fails whenever the release branch is not
+# parented at current `origin/main`, or when the pin-time `## Unreleased`
 # body (read from the release branch's merge-base with `main`) differs
 # from the current `main` `## Unreleased` body. Remediation: rerun
 # `release_harn.harn` from `burin-labs/harn-bump-fleet` — that re-pins
@@ -152,11 +154,48 @@ jobs:
 
             git fetch origin "$ref" --quiet || true
             pin=$(git merge-base "$sha" origin/main)
+            main_sha=$(git rev-parse origin/main)
+
+            summary_file=$(mktemp)
+            if [ "$pin" != "$main_sha" ]; then
+              new_commits=$(git log --oneline -50 "$pin..origin/main" || true)
+              cat > "$summary_file" <<EOF
+          This release PR is parented at \`$pin\`, but current \`origin/main\` is
+          \`$main_sha\`. Merging this PR would publish \`v$ver\` from a stale
+          main snapshot and omit commits that are already on \`main\`, even if
+          the merge is textually clean.
+
+          **Remediation:** rerun the release harness from \`harn-bump-fleet\`:
+
+          \`\`\`
+          harn run release_harn.harn -- --mode ship-pr --agent --yes-live-release
+          \`\`\`
+
+          The harness re-pins on fresh \`origin/main\`, smart-subtracts the
+          pin-time bullets, and force-pushes a clean release PR.
+
+          - Release branch: \`$ref\`
+          - Pin SHA: \`$pin\`
+          - Current main: \`$main_sha\`
+          - Background: [burin-labs/harn-bump-fleet#39](https://github.com/burin-labs/harn-bump-fleet/issues/39)
+
+          <details><summary>Commits on <code>main</code> after the release pin</summary>
+
+          \`\`\`text
+          $new_commits
+          \`\`\`
+
+          </details>
+          EOF
+              post_check "$sha" failure "Release PR is behind current main" "$summary_file"
+              drift_detected=1
+              echo "::error title=PR #$pr ($ref) — stale release pin::pin $pin is behind origin/main $main_sha; rerun release_harn.harn."
+              continue
+            fi
 
             pin_body=$(git show "$pin:CHANGELOG.md" | extract_unreleased)
             main_body=$(git show origin/main:CHANGELOG.md | extract_unreleased)
 
-            summary_file=$(mktemp)
             if [ "$pin_body" = "$main_body" ]; then
               cat > "$summary_file" <<EOF
           \`main\`'s \`## Unreleased\` matches the pin the release branch is parented at.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "harn-rules-hostlib"
-version = "0.8.60"
+version = "0.8.61"
 dependencies = [
  "harn-hostlib",
  "harn-rules",

--- a/changelog.d/2887.fixed.md
+++ b/changelog.d/2887.fixed.md
@@ -1,0 +1,5 @@
+- **Release gates are more deterministic (#2887).** Unix-socket invalid-JSON
+  tests now avoid client/server write races, hook-session file edit tests use
+  isolated temp files, release PR drift checks reject stale main pins, and the
+  `harn-rules-hostlib` lockfile entry matches the workspace version for locked
+  release checks.

--- a/conformance/tests/hooks_session/file_edited.harn
+++ b/conformance/tests/hooks_session/file_edited.harn
@@ -20,7 +20,7 @@ pipeline default() {
       return nil
     },
   )
-  let tmp = path_join(harness.fs.temp_dir(), "hooks_session_file_edited.txt")
+  let tmp = path_join(harness.fs.temp_dir(), "hooks_session_file_edited-" + uuid() + ".txt")
   harness.fs.write_text(tmp, "hello")
   harness.fs.append(tmp, " world")
   notify_file_edited(tmp, {operation: "append", bytes: 11})
@@ -30,7 +30,9 @@ pipeline default() {
       let result = agent_loop("touch some files", nil, {provider: "mock"})
       __io_println(result.status)
       __io_println(atomic_get(edits_seen))
-      harness.fs.delete(tmp)
+      if harness.fs.exists(tmp) {
+        harness.fs.delete(tmp)
+      }
       clear_session_hooks()
     },
   )

--- a/crates/harn-vm/src/stdlib/net.rs
+++ b/crates/harn-vm/src/stdlib/net.rs
@@ -287,6 +287,7 @@ fn net_unix_socket_json_request_impl(
 #[cfg(all(test, unix))]
 mod tests {
     use std::io::{BufRead, BufReader, Write};
+    use std::net::Shutdown;
 
     use super::*;
 
@@ -347,7 +348,15 @@ mod tests {
         let listener = UnixListener::bind(&socket_path).expect("bind unix listener");
         let server = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().expect("accept");
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().expect("clone stream"))
+                .read_line(&mut request)
+                .expect("read request");
             stream.write_all(b"not-json\n").expect("write response");
+            stream.flush().expect("flush response");
+            stream
+                .shutdown(Shutdown::Write)
+                .expect("shutdown write half");
         });
 
         let result = unix_socket_json_request(


### PR DESCRIPTION
## Summary

- make the Unix-socket invalid-JSON stdlib test deterministic by having the test server read the request before writing the invalid response and shutting down its write half
- isolate the hook-session `file_edited` fixture temp file with a UUID and guard cleanup against already-removed files
- correct the `harn-rules-hostlib` Cargo.lock entry to match the workspace version so locked release/package checks do not drift

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `RUSTFLAGS='-D warnings' CARGO_TARGET_DIR=/tmp/harn-release-gate-fixes-test-target cargo test -p harn-vm stdlib::net::tests::unix_socket_json_request_reports_invalid_json -- --nocapture`
- `cargo run --quiet --bin harn -- fmt --check conformance/tests/hooks_session/file_edited.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/hooks_session/file_edited.harn`
- `cargo run --quiet --bin harn -- test conformance --filter hooks_session/file_edited`
- `TMPDIR=/tmp/harn-release-gate-fixes-tmp CARGO_TARGET_DIR=/tmp/harn-release-gate-fixes-test-target make test` (6436 passed, 2 skipped)
- `TMPDIR=/tmp/harn-release-gate-fixes-tmp CARGO_TARGET_DIR=/tmp/harn-release-gate-fixes-test-target make conformance` (1543 passed)
- `CARGO_TARGET_DIR=/tmp/harn-release-gate-fixes-test-target cargo check --locked -p harn-rules-hostlib`
- pre-push targeted checks passed