### PR TITLE
Fix codemod-overlap corruption, unbounded repeats, dotted session ids, lenient list-match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "harn-rules-hostlib"
-version = "0.8.60"
+version = "0.8.61"
 dependencies = [
  "harn-hostlib",
  "harn-rules",

--- a/changelog.d/codemod-overlap-dedup.fixed.md
+++ b/changelog.d/codemod-overlap-dedup.fixed.md
@@ -1,0 +1,5 @@
+- `harn-rules`: codemod `apply` no longer panics or corrupts a file when a rule's pattern produces
+  nested/overlapping matches (e.g. `$X + $Y` over `a + b + c` matches both the outer and inner
+  binary expression). The engine now keeps the outermost match and rewrites each region exactly once;
+  `fix::splice` additionally skips any overlapping or out-of-range edit instead of panicking
+  `replace_range` on a stale byte offset.

--- a/changelog.d/match-list-exact-length.fixed.md
+++ b/changelog.d/match-list-exact-length.fixed.md
@@ -1,0 +1,3 @@
+- VM: a fixed-arity `match` list pattern is now exact-length. `match xs { [a, b] -> ... }` matches only
+  two-element lists; previously it matched any list of length >= 2 (binding the first two and silently
+  dropping the rest). Use the new `[a, ...rest]` form for at-least-N matching.

--- a/changelog.d/match-list-rest.added.md
+++ b/changelog.d/match-list-rest.added.md
@@ -1,0 +1,4 @@
+- VM: `match` list patterns now support a trailing `...rest` element, mirroring `let`-destructuring.
+  `match xs { [head, ...tail] -> ... }` matches any list with at least one element, binds `head` to the
+  first and `tail` to a new list of the remainder (typed `list<T>`); `[a, ..._]` matches at-least-N and
+  discards the tail.

--- a/changelog.d/repeat-alloc-guard.fixed.md
+++ b/changelog.d/repeat-alloc-guard.fixed.md
@@ -1,0 +1,4 @@
+- VM: a script-controlled string-repeat count no longer crashes the host. `"a" * n`, `s.repeat(n)`,
+  `str_pad`, and `pad_left`/`pad_right` now share one allocation guard (16 MiB) and return a clean
+  runtime error for oversized output instead of exhausting memory or panicking `capacity overflow`
+  (previously only the `repeat()` builtin was guarded).

--- a/changelog.d/session-id-sanitize.fixed.md
+++ b/changelog.d/session-id-sanitize.fixed.md
@@ -1,0 +1,3 @@
+- `harn-hostlib`: `sanitize_component` no longer lets an all-dots session id (`.`, `..`) pass through
+  verbatim, which let staged-filesystem state escape one directory level via `push("..")`. Such ids now
+  fall back to the hashed, traversal-free form like any other unsafe component.

--- a/crates/harn-hostlib/src/fs.rs
+++ b/crates/harn-hostlib/src/fs.rs
@@ -1554,7 +1554,13 @@ fn sanitize_component(input: &str) -> String {
             _ => '_',
         })
         .collect();
-    if sanitized == input {
+    // `.` is allowed inside a name, but a component that is empty or *only*
+    // dots (`.`, `..`, `...`) is a path-traversal / current-dir token, not a
+    // safe single component — `session_dir`'s `dir.push("..")` would escape
+    // the staged-state root. Force the hashed form so the result is always a
+    // genuine, traversal-free directory name.
+    let is_dotted = sanitized.is_empty() || sanitized.bytes().all(|b| b == b'.');
+    if sanitized == input && !is_dotted {
         sanitized
     } else {
         let hash = hex::encode(Sha256::digest(input.as_bytes()));
@@ -1674,4 +1680,48 @@ fn discard_result_to_value(result: DiscardResult) -> VmValue {
                 .collect(),
         )),
     )])
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::{sanitize_component, session_dir, STATE_REL};
+    use std::path::{Component, Path};
+
+    #[test]
+    fn dotted_session_ids_are_never_traversal_tokens() {
+        // `.`, `..`, `...` must not survive verbatim — otherwise
+        // `session_dir`'s `dir.push(..)` escapes the staged-state root.
+        for evil in ["..", ".", "...", ""] {
+            let safe = sanitize_component(evil);
+            assert_ne!(safe, evil, "`{evil}` passed through unsanitized");
+            assert!(
+                !safe.bytes().all(|b| b == b'.'),
+                "`{evil}` -> `{safe}` is still all dots"
+            );
+            // The result is a single normal component (no ParentDir/CurDir).
+            let comps: Vec<_> = Path::new(&safe).components().collect();
+            assert!(
+                comps.iter().all(|c| matches!(c, Component::Normal(_))),
+                "`{safe}` contains a traversal component"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_session_ids_pass_through() {
+        assert_eq!(sanitize_component("abc-123_v2.0"), "abc-123_v2.0");
+    }
+
+    #[test]
+    fn session_dir_stays_under_staged_root() {
+        let dir = session_dir(Path::new("/workspace"), "..");
+        // No path component resolves above the staged dir.
+        assert!(
+            !dir.components().any(|c| matches!(c, Component::ParentDir)),
+            "session_dir({dir:?}) escapes via `..`"
+        );
+        let mut staged = std::path::PathBuf::from("/workspace");
+        staged.extend(STATE_REL);
+        assert!(dir.starts_with(&staged), "{dir:?} not under {staged:?}");
+    }
 }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -203,10 +203,25 @@ impl TypeChecker {
                     _ => None,
                 });
                 for element in elements {
-                    if let Node::Identifier(name) = &element.node {
-                        if name != "_" {
+                    match &element.node {
+                        // Leading element pattern: binds the element type `T`.
+                        Node::Identifier(name) if name != "_" => {
                             scope.define_var(name, item_type.clone());
                         }
+                        // `...rest` collects the tail into a `list<T>` (parity
+                        // with `let`-destructuring rest typing).
+                        Node::Spread(inner) => {
+                            if let Node::Identifier(name) = &inner.node {
+                                if name != "_" {
+                                    let rest_ty = Some(match &item_type {
+                                        Some(t) => TypeExpr::List(Box::new(t.clone())),
+                                        None => TypeExpr::Named("list".into()),
+                                    });
+                                    scope.define_var(name, rest_ty);
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -1643,6 +1643,25 @@ impl TypeChecker {
                             }
                         }
                     }
+                    // Bind the arm's pattern variables (list/dict destructuring,
+                    // including `[a, ...rest]`) with their refined types so the
+                    // guard and body are type-checked against them, not against
+                    // gradual `unknown`. Enum/variant patterns are excluded: a
+                    // variant field can be an unsubstituted generic parameter
+                    // (e.g. the `E` in `Result.Err(e)`), and binding it as a
+                    // concrete type here yields false positives — proper enum
+                    // binding needs type-argument substitution from the matched
+                    // value, which is not wired through this path.
+                    if !matches!(
+                        &arm.pattern.node,
+                        Node::EnumConstruct { .. } | Node::MethodCall { .. }
+                    ) {
+                        self.define_match_pattern_bindings(
+                            &arm.pattern,
+                            value_type.as_ref(),
+                            &mut arm_scope,
+                        );
+                    }
                     if let Some(ref guard) = arm.guard {
                         self.check_node(guard, &mut arm_scope);
                     }

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -24,6 +24,55 @@ fn test_type_mismatch_let() {
 }
 
 #[test]
+fn test_match_list_rest_binds_element_and_list_types() {
+    // `[head, ...rest]` over `list<int>`: head: int, rest: list<int>.
+    let errs = errors(
+        r"pipeline t(task) {
+  let xs: list<int> = [1, 2, 3]
+  match xs {
+    [head, ...rest] -> { let h: int = head
+let r: list<int> = rest }
+    _ -> { }
+  }
+}",
+    );
+    assert!(errs.is_empty(), "expected no errors, got: {errs:?}");
+}
+
+#[test]
+fn test_match_list_rest_type_is_refined_not_gradual() {
+    // Assigning the rest binding to a non-list type must error — proving the
+    // rest var is refined to a `list<…>` (not left untyped/gradual). Likewise
+    // the leading binding is refined to the element type `int`.
+    let errs = errors(
+        r"pipeline t(task) {
+  let xs: list<int> = [1, 2, 3]
+  match xs {
+    [head, ...rest] -> { let r: int = rest }
+    _ -> { }
+  }
+}",
+    );
+    assert_eq!(errs.len(), 1, "expected one mismatch, got: {errs:?}");
+    assert!(errs[0].contains("int"), "{errs:?}");
+
+    let head_errs = errors(
+        r"pipeline t(task) {
+  let xs: list<int> = [1, 2, 3]
+  match xs {
+    [head, ...rest] -> { let h: string = head }
+    _ -> { }
+  }
+}",
+    );
+    assert_eq!(
+        head_errs.len(),
+        1,
+        "expected one mismatch, got: {head_errs:?}"
+    );
+}
+
+#[test]
 fn test_cyclic_type_aliases_do_not_recurse_forever() {
     let errs = errors(
         r"

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -333,7 +333,7 @@ impl CompiledRule {
                 message: "apply requires a `fix` template; this rule has none".into(),
             })?;
 
-        let matches = self.run(source)?;
+        let matches = dedupe_overlapping(self.run(source)?);
         let edits: Vec<AppliedEdit> = matches
             .iter()
             .map(|m| {
@@ -380,6 +380,36 @@ impl CompiledRule {
         }
         matches
     }
+}
+
+/// Drop matches that overlap an already-kept match, keeping the **outermost**
+/// (and, among equal extents, the first). A tree query naturally yields nested
+/// matches — e.g. `$X + $Y` matches both `(a+b)+c` and its inner `a+b` — and
+/// splicing both would apply overlapping byte edits, corrupting the output or
+/// panicking `replace_range` on a stale offset. A codemod must rewrite each
+/// region once, so we keep the enclosing match and discard anything nested in
+/// or straddling it. Matches are returned in document (start-byte) order.
+fn dedupe_overlapping(mut matches: Vec<RuleMatch>) -> Vec<RuleMatch> {
+    // Outermost-first: smallest start, then largest end (widest span wins a tie
+    // on start). After filtering we restore document order.
+    matches.sort_by(|a, b| {
+        a.span
+            .start_byte
+            .cmp(&b.span.start_byte)
+            .then(b.span.end_byte.cmp(&a.span.end_byte))
+    });
+    let mut kept: Vec<RuleMatch> = Vec::with_capacity(matches.len());
+    let mut covered_to = 0usize; // exclusive end of the last kept span
+    for m in matches {
+        // Keep only when this match starts at or after the end of the last kept
+        // one (adjacency is fine; any earlier start means it is nested in, or
+        // straddles, an already-kept span).
+        if m.span.start_byte >= covered_to {
+            covered_to = m.span.end_byte.max(covered_to);
+            kept.push(m);
+        }
+    }
+    kept
 }
 
 /// Compute a [`Span`] for a byte range by counting rows/cols. Used by the
@@ -447,6 +477,55 @@ mod tests {
         assert_eq!(matches[0].text, "cfg?.timeout ?? 30");
         assert_eq!(matches[0].span.start_row, 0);
         assert_eq!(matches[1].span.start_row, 1);
+    }
+
+    #[test]
+    fn nested_matches_do_not_corrupt_or_panic_on_apply() {
+        // `$X + $Y` matches the outer `(a+b)+c` AND the inner `a+b` (distinct
+        // spans). Without overlap resolution, splicing both byte-edits panics
+        // `replace_range` on a stale offset or corrupts the output. The engine
+        // must keep the outermost match and rewrite the region exactly once.
+        let compiled = rule(
+            r#"
+            id = "sum-binop"
+            language = "typescript"
+            fix = "sum($X, $Y)"
+            [rule]
+            pattern = "$X + $Y"
+            "#,
+        );
+        // More than one match exists (outer + inner) before dedup.
+        assert!(compiled.run("const z = a + b + c;\n").unwrap().len() >= 2);
+        let result = compiled.apply("const z = a + b + c;\n").unwrap();
+        // Exactly one outer rewrite; inner `a + b` survives verbatim inside $X.
+        assert_eq!(result.rewritten, "const z = sum(a + b, c);\n");
+        assert_eq!(result.edits.len(), 1);
+        assert!(result.changed);
+    }
+
+    #[test]
+    fn dedupe_overlapping_keeps_outermost_in_document_order() {
+        let span = |s: usize, e: usize| Span {
+            start_byte: s,
+            end_byte: e,
+            start_row: 0,
+            start_col: s,
+            end_row: 0,
+            end_col: e,
+        };
+        let m = |s: usize, e: usize| RuleMatch {
+            rule_id: "r".into(),
+            span: span(s, e),
+            text: String::new(),
+            bindings: BTreeMap::new(),
+        };
+        // outer [0,9) contains inner [0,5); [10,14) is disjoint.
+        let kept = dedupe_overlapping(vec![m(0, 5), m(0, 9), m(10, 14)]);
+        let spans: Vec<_> = kept
+            .iter()
+            .map(|m| (m.span.start_byte, m.span.end_byte))
+            .collect();
+        assert_eq!(spans, vec![(0, 9), (10, 14)]);
     }
 
     #[test]

--- a/crates/harn-rules/src/fix.rs
+++ b/crates/harn-rules/src/fix.rs
@@ -90,12 +90,35 @@ pub struct AppliedEdit {
 /// Apply `edits` to `source` by byte-splice. Edits are spliced in reverse
 /// start order so earlier offsets stay valid; whitespace outside each span
 /// is preserved verbatim.
+///
+/// Edits MUST be non-overlapping — the engine resolves overlaps up front (see
+/// `engine::dedupe_overlapping`) by keeping the outermost match. This function
+/// is a defensive backstop: an out-of-range, mis-aligned, or overlapping span
+/// is skipped rather than allowed to panic `replace_range`, so a buggy rule can
+/// never corrupt a file by splicing a stale offset.
 pub fn splice(source: &str, edits: &[AppliedEdit]) -> String {
     let mut ordered: Vec<&AppliedEdit> = edits.iter().collect();
     ordered.sort_by_key(|e| std::cmp::Reverse(e.span.start_byte));
     let mut out = source.to_string();
+    // Lowest start byte applied so far (we walk highest-start first). An edit
+    // overlaps an already-applied one when its end runs past this boundary.
+    let mut applied_low = usize::MAX;
     for edit in ordered {
-        out.replace_range(edit.span.start_byte..edit.span.end_byte, &edit.replacement);
+        let (start, end) = (edit.span.start_byte, edit.span.end_byte);
+        let in_range = start <= end
+            && end <= out.len()
+            && out.is_char_boundary(start)
+            && out.is_char_boundary(end);
+        let overlaps = end > applied_low;
+        debug_assert!(
+            !overlaps,
+            "splice received overlapping edits; engine should have deduped"
+        );
+        if !in_range || overlaps {
+            continue;
+        }
+        out.replace_range(start..end, &edit.replacement);
+        applied_low = start;
     }
     out
 }

--- a/crates/harn-vm/src/compiler/patterns.rs
+++ b/crates/harn-vm/src/compiler/patterns.rs
@@ -144,6 +144,45 @@ impl Compiler {
         Ok(())
     }
 
+    /// Split a `match` list-pattern's elements into the leading element
+    /// patterns and an optional trailing `...rest` binding name (`None` for a
+    /// `..._` discard). Rejects a spread that is not last, or more than one.
+    fn split_match_list_pattern<'a>(
+        &self,
+        elements: &'a [SNode],
+    ) -> Result<(&'a [SNode], Option<String>), CompileError> {
+        let spread_count = elements
+            .iter()
+            .filter(|e| matches!(e.node, Node::Spread(_)))
+            .count();
+        if spread_count == 0 {
+            return Ok((elements, None));
+        }
+        let last_is_spread = matches!(elements.last().map(|e| &e.node), Some(Node::Spread(_)));
+        if spread_count > 1 || !last_is_spread {
+            return Err(CompileError {
+                message:
+                    "`...rest` must be the last element of a list pattern, and only one is allowed"
+                        .into(),
+                line: self.line,
+            });
+        }
+        let Some(Node::Spread(inner)) = elements.last().map(|e| &e.node) else {
+            unreachable!("checked last is a spread above")
+        };
+        let rest_bind = match &inner.node {
+            Node::Identifier(name) if name == "_" => None,
+            Node::Identifier(name) => Some(name.clone()),
+            _ => {
+                return Err(CompileError {
+                    message: "`...rest` in a list pattern must bind an identifier".into(),
+                    line: self.line,
+                });
+            }
+        };
+        Ok((&elements[..elements.len() - 1], rest_bind))
+    }
+
     /// Compile a `match` expression (`Node::MatchExpr`).
     pub(super) fn compile_match_expr(
         &mut self,
@@ -459,8 +498,14 @@ impl Compiler {
                     self.chunk.patch_jump_to(skip_type, type_fail_target);
                     self.chunk.patch_jump_to(next_arm_jump, next_arm_target);
                 }
-                // List pattern: [literal, binding, ...]
+                // List pattern: `[p0, p1, ...]` matches a list of EXACTLY that
+                // length; `[p0, ...rest]` matches a list of AT LEAST the leading
+                // arity and binds the remainder. The trailing `...rest` is the
+                // only spread allowed, mirroring `let`-destructuring.
                 Node::ListLiteral(elements) => {
+                    let (leading, rest_bind) = self.split_match_list_pattern(elements)?;
+                    let has_rest = leading.len() != elements.len();
+
                     self.chunk.emit(Op::Dup, self.line);
                     let typeof_idx = self.string_constant("type_of");
                     self.chunk.emit_u16(Op::Constant, typeof_idx, self.line);
@@ -477,18 +522,22 @@ impl Compiler {
                     self.chunk.emit_u16(Op::Constant, len_idx, self.line);
                     self.chunk.emit(Op::Swap, self.line);
                     self.chunk.emit_u8(Op::Call, 1, self.line);
-                    let count = self
-                        .chunk
-                        .add_constant(Constant::Int(elements.len() as i64));
+                    let count = self.chunk.add_constant(Constant::Int(leading.len() as i64));
                     self.chunk.emit_u16(Op::Constant, count, self.line);
-                    self.chunk.emit(Op::GreaterEqual, self.line);
+                    // Exact length with no rest; at-least length with `...rest`.
+                    let length_op = if has_rest {
+                        Op::GreaterEqual
+                    } else {
+                        Op::Equal
+                    };
+                    self.chunk.emit(length_op, self.line);
                     let skip_len = self.chunk.emit_jump(Op::JumpIfFalse, self.line);
                     self.chunk.emit(Op::Pop, self.line);
 
                     let mut constraint_skips = Vec::new();
                     let mut bindings = Vec::new();
                     self.begin_scope();
-                    for (i, elem) in elements.iter().enumerate() {
+                    for (i, elem) in leading.iter().enumerate() {
                         match &elem.node {
                             Node::Identifier(name) if name != "_" => {
                                 bindings.push((i, name.clone()));
@@ -514,6 +563,18 @@ impl Compiler {
                         self.chunk.emit_u16(Op::Constant, idx_const, self.line);
                         self.chunk.emit(Op::Subscript, self.line);
                         self.emit_binding_target(name, false);
+                    }
+
+                    // `...rest` binds the tail `list[leading..]`. `Dup` first so
+                    // the match value stays on the stack for the fail/Pop path.
+                    if let Some(rest_name) = &rest_bind {
+                        self.chunk.emit(Op::Dup, self.line);
+                        let start_idx =
+                            self.chunk.add_constant(Constant::Int(leading.len() as i64));
+                        self.chunk.emit_u16(Op::Constant, start_idx, self.line);
+                        self.chunk.emit(Op::Nil, self.line);
+                        self.chunk.emit(Op::Slice, self.line);
+                        self.emit_binding_target(rest_name, false);
                     }
 
                     // Optional guard

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -15,6 +15,36 @@ fn compile_source_with_options(source: &str, options: CompilerOptions) -> Chunk 
     Compiler::with_options(options).compile(&program).unwrap()
 }
 
+fn try_compile(source: &str) -> Result<Chunk, CompileError> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse().unwrap();
+    Compiler::new().compile(&program)
+}
+
+#[test]
+fn match_list_pattern_rest_must_be_last() {
+    let err = try_compile(
+        r"pipeline t(task) { match [1, 2, 3] { [...rest, last] -> { log(last) } _ -> {} } }",
+    )
+    .unwrap_err();
+    assert!(err.message.contains("last element"), "{}", err.message);
+}
+
+#[test]
+fn match_list_pattern_rejects_two_rests() {
+    let err = try_compile(
+        r"pipeline t(task) { match [1, 2, 3] { [a, ...x, ...y] -> { log(a) } _ -> {} } }",
+    )
+    .unwrap_err();
+    assert!(
+        err.message.contains("last element") || err.message.contains("one is allowed"),
+        "{}",
+        err.message
+    );
+}
+
 fn disasm_opcodes(disasm: &str) -> Vec<&str> {
     disasm
         .lines()

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -37,6 +37,7 @@ pub mod harness_system;
 pub mod harness_tenant;
 mod http;
 pub mod jsonrpc;
+pub(crate) mod limits;
 pub mod llm;
 pub mod llm_config;
 pub mod mcp;

--- a/crates/harn-vm/src/limits.rs
+++ b/crates/harn-vm/src/limits.rs
@@ -1,0 +1,50 @@
+//! Shared allocation guards for script-controlled sizes.
+//!
+//! Several builtins and operators repeat a string by a count that comes
+//! straight from a Harn program (`"a" * n`, `s.repeat(n)`, `str_pad`,
+//! `pad_left`/`pad_right`). Without a cap, a large count makes `String::repeat`
+//! either exhaust memory or panic with `capacity overflow` — a script should
+//! never be able to crash the host that way. These helpers centralise the cap
+//! so every site shares one limit and one error.
+
+use crate::value::VmError;
+
+/// Upper bound on the byte length a single repeat/pad expansion may produce
+/// (16 MiB). A typo (`"-" * 1_000_000_000`) errors instead of allocating
+/// gigabytes or panicking.
+pub(crate) const MAX_REPEAT_OUTPUT_BYTES: usize = 1 << 24;
+
+/// Repeat `s` `count` times, refusing to build a string larger than
+/// [`MAX_REPEAT_OUTPUT_BYTES`]. Returns an empty string for non-positive
+/// counts (callers pass `count.max(0)`), and a clean [`VmError::Runtime`]
+/// rather than panicking/OOM-ing when the result would be too large.
+pub(crate) fn checked_repeat(s: &str, count: usize) -> Result<String, VmError> {
+    let total = s.len().saturating_mul(count);
+    if total > MAX_REPEAT_OUTPUT_BYTES {
+        return Err(VmError::Runtime(format!(
+            "repeat: output would be {total} bytes (limit {MAX_REPEAT_OUTPUT_BYTES})"
+        )));
+    }
+    Ok(s.repeat(count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_repeat_ok() {
+        assert_eq!(checked_repeat("ab", 3).unwrap(), "ababab");
+        assert_eq!(checked_repeat("x", 0).unwrap(), "");
+    }
+
+    #[test]
+    fn oversized_repeat_errors_without_panic() {
+        // Would be ~9.2e18 bytes — must error, never allocate or panic.
+        let err = checked_repeat("ab", usize::MAX / 2).unwrap_err();
+        assert!(matches!(err, VmError::Runtime(_)));
+        // Just under vs over the cap.
+        assert!(checked_repeat("a", MAX_REPEAT_OUTPUT_BYTES).is_ok());
+        assert!(checked_repeat("a", MAX_REPEAT_OUTPUT_BYTES + 1).is_err());
+    }
+}

--- a/crates/harn-vm/src/stdlib/strings.rs
+++ b/crates/harn-vm/src/stdlib/strings.rs
@@ -390,9 +390,9 @@ fn str_pad_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError>
     };
     Ok(VmValue::String(std::sync::Arc::from(format!(
         "{}{}{}",
-        fill.repeat(left),
+        crate::limits::checked_repeat(fill, left)?,
         s,
-        fill.repeat(right)
+        crate::limits::checked_repeat(fill, right)?
     ))))
 }
 
@@ -740,17 +740,9 @@ fn repeat_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> 
         return Ok(VmValue::String(std::sync::Arc::from("")));
     }
     // Reject pathological sizes so a typo doesn't try to allocate
-    // multi-gigabyte strings inside a script.
-    const MAX_OUT: usize = 1 << 24;
-    let total = s.len().saturating_mul(count as usize);
-    if total > MAX_OUT {
-        return Err(VmError::Runtime(format!(
-            "repeat: output would be {total} bytes (limit {MAX_OUT})"
-        )));
-    }
-    Ok(VmValue::String(std::sync::Arc::from(
-        s.repeat(count as usize),
-    )))
+    // multi-gigabyte strings (or panic `capacity overflow`) inside a script.
+    let repeated = crate::limits::checked_repeat(&s, count as usize)?;
+    Ok(VmValue::String(std::sync::Arc::from(repeated)))
 }
 
 #[harn_builtin(

--- a/crates/harn-vm/src/vm/methods/string.rs
+++ b/crates/harn-vm/src/vm/methods/string.rs
@@ -57,9 +57,8 @@ impl crate::vm::Vm {
             "chars" => Ok(VmValue::chars_list(s)),
             "repeat" => {
                 let n = args.first().and_then(|a| a.as_int()).unwrap_or(1);
-                Ok(VmValue::String(std::sync::Arc::from(
-                    s.repeat(n.max(0) as usize),
-                )))
+                let repeated = crate::limits::checked_repeat(s, n.max(0) as usize)?;
+                Ok(VmValue::String(std::sync::Arc::from(repeated)))
             }
             "reverse" => Ok(VmValue::String(std::sync::Arc::from(
                 s.chars().rev().collect::<String>(),
@@ -76,8 +75,12 @@ impl crate::vm::Vm {
                 if current_len >= width {
                     Ok(VmValue::String(Arc::clone(s)))
                 } else {
-                    let padding: String =
-                        std::iter::repeat_n(pad_char, width - current_len).collect();
+                    // Cap script-controlled pad widths so a huge `width` errors
+                    // cleanly instead of allocating gigabytes.
+                    let padding = crate::limits::checked_repeat(
+                        pad_char.encode_utf8(&mut [0u8; 4]),
+                        width - current_len,
+                    )?;
                     if left {
                         Ok(VmValue::String(std::sync::Arc::from(format!(
                             "{padding}{s}"

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -472,8 +472,12 @@ impl super::super::Vm {
             (VmValue::Int(x), VmValue::Float(y)) => Ok(VmValue::Float(*x as f64 * y)),
             (VmValue::Float(x), VmValue::Int(y)) => Ok(VmValue::Float(x * *y as f64)),
             (VmValue::String(s), VmValue::Int(n)) | (VmValue::Int(n), VmValue::String(s)) => {
+                // Guard script-controlled repeat counts so `"a" * 1_000_000_000`
+                // errors cleanly instead of OOM-ing / panicking `capacity overflow`.
                 let count = (*n).max(0) as usize;
-                Ok(VmValue::String(s.repeat(count).into()))
+                Ok(VmValue::String(
+                    crate::limits::checked_repeat(s, count)?.into(),
+                ))
             }
             _ => Err(VmError::TypeError(format!(
                 "Cannot multiply {} and {}",

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -500,6 +500,96 @@ log(d.has("z")) }"#,
 }
 
 #[test]
+fn test_string_repeat_operator_rejects_oversized_count() {
+    // `"a" * <huge>` must error cleanly, never OOM / panic `capacity overflow`.
+    let result = run_harn_result(r#"pipeline t(task) { let s = "ab" * 9999999999 }"#);
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("repeat") && err.contains("limit"), "{err}");
+}
+
+#[test]
+fn test_string_repeat_method_rejects_oversized_count() {
+    let result = run_harn_result(r#"pipeline t(task) { let s = "ab".repeat(9999999999) }"#);
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("repeat") && err.contains("limit"), "{err}");
+}
+
+#[test]
+fn test_str_pad_rejects_oversized_width() {
+    let result = run_harn_result(r#"pipeline t(task) { let s = str_pad("x", 9999999999, "-") }"#);
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("repeat") && err.contains("limit"), "{err}");
+}
+
+#[test]
+fn test_string_repeat_operator_small_count_ok() {
+    let out = run_output(r#"pipeline t(task) { log("ab" * 3) }"#);
+    assert_eq!(out, "[harn] ababab");
+}
+
+#[test]
+fn test_match_list_pattern_is_exact_length() {
+    // A fixed-arity list pattern matches ONLY that length: `[a, b]` must NOT
+    // match a 3-element list (previously it did via a `len >= 2` check).
+    let out = run_output(
+        r#"pipeline t(task) {
+match [1, 2, 3] {
+  [a, b] -> { log("two: ${a},${b}") }
+  _ -> { log("other") }
+} }"#,
+    );
+    assert_eq!(out, "[harn] other");
+}
+
+#[test]
+fn test_match_list_pattern_exact_match_binds() {
+    let out = run_output(
+        r#"pipeline t(task) {
+match [10, 20] {
+  [a, b] -> { log("${a},${b}") }
+  _ -> { log("other") }
+} }"#,
+    );
+    assert_eq!(out, "[harn] 10,20");
+}
+
+#[test]
+fn test_match_list_pattern_rest_binds_tail() {
+    let out = run_output(
+        r#"pipeline t(task) {
+match [1, 2, 3] {
+  [head, ...rest] -> { log("${head} :: ${rest}") }
+  _ -> { log("none") }
+} }"#,
+    );
+    assert_eq!(out, "[harn] 1 :: [2, 3]");
+}
+
+#[test]
+fn test_match_list_pattern_rest_empty_tail() {
+    let out = run_output(
+        r#"pipeline t(task) {
+match [42] {
+  [head, ...rest] -> { log("${head} :: ${rest}") }
+  _ -> { log("none") }
+} }"#,
+    );
+    assert_eq!(out, "[harn] 42 :: []");
+}
+
+#[test]
+fn test_match_list_pattern_discard_rest_matches_at_least() {
+    let out = run_output(
+        r#"pipeline t(task) {
+match [1, 2, 3, 4] {
+  [first, ..._] -> { log("first=${first}") }
+  _ -> { log("empty") }
+} }"#,
+    );
+    assert_eq!(out, "[harn] first=1");
+}
+
+#[test]
 fn test_pipe_operator() {
     let out = run_output(
         "pipeline t(task) { fn double(x) { return x * 2 }\nlet r = 5 |> double\nlog(r) }",

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1276,6 +1276,28 @@ let label = match x {
 // label == "big: 5"
 ```
 
+#### List patterns
+
+A list pattern `[p0, p1, …]` matches a list of **exactly** that length and binds
+each identifier element to the value at its position (literals are compared,
+`_` discards). A trailing `...rest` element makes the pattern match a list of
+**at least** the leading arity and binds the remainder as a new list (`..._`
+matches the tail without binding it):
+
+```harn
+match coords {
+  [x, y] -> { "2d: ${x},${y}" }          // matches ONLY length 2
+  [x, y, z] -> { "3d" }                   // matches ONLY length 3
+  [first, ...rest] -> { "${first}+${rest}" } // length >= 1; rest is a list
+  [] -> { "empty" }
+  _ -> { "other" }
+}
+```
+
+When the matched value is a `list<T>`, the leading bindings have type `T` and a
+`...rest` binding has type `list<T>`. Only one `...rest` is allowed and it must
+be last.
+
 ### retry
 
 ```harn

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1274,6 +1274,28 @@ let label = match x {
 // label == "big: 5"
 ```
 
+#### List patterns
+
+A list pattern `[p0, p1, …]` matches a list of **exactly** that length and binds
+each identifier element to the value at its position (literals are compared,
+`_` discards). A trailing `...rest` element makes the pattern match a list of
+**at least** the leading arity and binds the remainder as a new list (`..._`
+matches the tail without binding it):
+
+```harn
+match coords {
+  [x, y] -> { "2d: ${x},${y}" }          // matches ONLY length 2
+  [x, y, z] -> { "3d" }                   // matches ONLY length 3
+  [first, ...rest] -> { "${first}+${rest}" } // length >= 1; rest is a list
+  [] -> { "empty" }
+  _ -> { "other" }
+}
+```
+
+When the matched value is a `list<T>`, the leading bindings have type `T` and a
+`...rest` binding has type `list<T>`. Only one `...rest` is allowed and it must
+be last.
+
 ### retry
 
 ```harn


### PR DESCRIPTION
Adversarial cross-crate bug sweep (recent PRs + older scan/parse/typecheck/VM code). Four confirmed defects survived line-by-line verification; each is fixed at the root with a failing-test-first check. Most agent-surfaced candidates were refuted on verification and deliberately excluded.

## Bugs fixed

**1. harn-rules — codemod corruption/panic on overlapping matches (HIGH)**
A tree query yields nested matches at distinct spans (e.g. `$X + $Y` over `a + b + c` matches outer `(a+b)+c` and inner `a+b`); `evaluator::find` only dedups *exact* spans, so overlapping byte-edits reached `fix::splice` and tripped `replace_range` (panic or corrupted rewrite) — on the `harn codemod --apply` / `ast.batch_apply` path. Now the engine resolves overlaps up front (`dedupe_overlapping`, outermost-wins) and `splice` defensively skips overlapping/out-of-range edits.

**2. harn-vm — unbounded string repeat from script input (MEDIUM, cluster)**
`"a" * n`, `s.repeat(n)`, `str_pad`, and `pad_left`/`pad_right` multiplied by a script-controlled count with no cap → OOM or `capacity overflow` panic. They now share one guard (`limits::checked_repeat`, 16 MiB) returning a clean runtime error; the `repeat()` builtin reuses it (DRY).

**3. harn-hostlib — `sanitize_component` passes `.`/`..` (MEDIUM/LOW)**
An all-dots session id survived verbatim, so staged state escaped one dir level via `push("..")`. Such ids now take the hashed, traversal-free form.

**4. harn-vm + harn-parser — lenient `match` list pattern + new `...rest` (HIGH + feature)**
A fixed-arity `match` list pattern matched any list of length ≥ N (binding the first N, dropping the rest). It is now **exact-length**, and a trailing `...rest` is supported (parity with `let`-destructuring): `[a, ...rest]` matches at-least-N and binds the tail as `list<T>`. The typechecker refines list-pattern bindings (incl. rest) in the **check** path so arm bodies are typed against them; enum/variant patterns are excluded to avoid binding unsubstituted generic params (e.g. `Result.Err`'s `E`).

## Verification
- Full conformance: **1543/1543**
- Full `harn-vm` / `harn-parser` / `harn-rules` / `harn-hostlib` suites green
- New unit/integration tests per fix (overlap dedup + apply, repeat caps, sanitize, exact-length + rest runtime/typecheck/compile-error)
- `clippy -D warnings`, `fmt`, pre-commit + pre-push hooks pass
- Spec updated (`match` list patterns) + 5 changelog fragments

🤖 Generated with [Claude Code](https://claude.com/claude-code)