### PR TITLE
harn rule test: inline-annotation rule test harness (#2842)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ dependencies = [
  "harn-mcp-rc-compat",
  "harn-modules",
  "harn-parser",
+ "harn-rules",
  "harn-rules-hostlib",
  "harn-serve",
  "harn-skills",

--- a/changelog.d/2842.added.md
+++ b/changelog.d/2842.added.md
@@ -1,0 +1,5 @@
+- Added `harn rule test` and the `harn_rules::testing` harness (Rule Engine Epic B) — a first-class way to test
+  structural rules with **inline annotations** (the Semgrep convention, made language-agnostic): a fixture line
+  preceded by `// ruleid: <id>` must match the rule, a `// ok: <id>` line must not, and any un-annotated match is a
+  false positive. A rule `foo.toml` pairs with a fixture `foo.<ext>`; `harn rule test <dir>` runs every rule against
+  its fixture, prints per-fixture pass/fail (or a `--json` envelope), and exits non-zero on failure (a CI gate).

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -38,6 +38,7 @@ harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-ir = { path = "../harn-ir", version = "0.8" }
 harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel", "testbench-wasi"] }
 harn-hostlib = { path = "../harn-hostlib", version = "0.8", optional = true }
+harn-rules = { path = "../harn-rules", version = "0.8", optional = true }
 harn-rules-hostlib = { path = "../harn-rules-hostlib", version = "0.8", optional = true }
 harn-lint = { path = "../harn-lint", version = "0.8" }
 harn-modules = { path = "../harn-modules", version = "0.8" }
@@ -122,6 +123,7 @@ default = ["hostlib"]
 # you want a slimmer build that doesn't pull tree-sitter/notify/etc.
 hostlib = [
     "dep:harn-hostlib",
+    "dep:harn-rules",
     "dep:harn-rules-hostlib",
     "harn-hostlib/full",
     "harn-serve/hostlib-full",

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -48,6 +48,7 @@ mod provider;
 mod providers;
 mod quickstart;
 mod routes;
+mod rule;
 mod run;
 mod runs;
 mod scan;
@@ -174,6 +175,7 @@ pub(crate) use providers::{
 };
 pub(crate) use quickstart::QuickstartArgs;
 pub(crate) use routes::RoutesArgs;
+pub(crate) use rule::{RuleArgs, RuleCommand, RuleTestArgs};
 pub(crate) use run::RunArgs;
 pub(crate) use runs::{ReplayArgs, RunsArgs, RunsCommand};
 pub(crate) use scan::ScanArgs;
@@ -484,6 +486,9 @@ SCRIPTING
     /// Apply a codemod rule's `fix` across a fileset. Dry-run by default
     /// (unified diffs); `--apply` writes, safety- and capability-gated.
     Codemod(CodemodArgs),
+    /// Author and test structural rules (`harn rule test` runs a rule's
+    /// inline-annotation fixtures).
+    Rule(RuleArgs),
     /// One-shot agent_loop with a prompt. Routes through the configured
     /// provider (or `HARN_LLM_PROVIDER=mock` for offline use).
     #[command(name = "try")]

--- a/crates/harn-cli/src/cli/rule.rs
+++ b/crates/harn-cli/src/cli/rule.rs
@@ -1,0 +1,25 @@
+use clap::{Args, Subcommand};
+
+/// `harn rule` — author and test structural rules.
+#[derive(Debug, Args)]
+pub(crate) struct RuleArgs {
+    #[command(subcommand)]
+    pub command: RuleCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum RuleCommand {
+    /// Run a rule's inline-annotation tests (`// ruleid:` / `// ok:`).
+    Test(RuleTestArgs),
+}
+
+/// `harn rule test` — check each rule against its annotated fixture.
+#[derive(Debug, Args)]
+pub(crate) struct RuleTestArgs {
+    /// A rule TOML file, or a directory of rules + fixtures (default: `.`).
+    #[arg(value_name = "PATH")]
+    pub path: Option<String>,
+    /// Emit a JSON envelope instead of human-readable output.
+    #[arg(long)]
+    pub json: bool,
+}

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -58,6 +58,7 @@ pub(crate) mod quickstart;
 pub(crate) mod repl;
 pub(crate) mod replay;
 pub(crate) mod routes;
+pub(crate) mod rule;
 pub(crate) mod rules_cli;
 pub mod run;
 pub(crate) mod scaffold_common;

--- a/crates/harn-cli/src/commands/rule.rs
+++ b/crates/harn-cli/src/commands/rule.rs
@@ -1,0 +1,155 @@
+//! `harn rule test` — run each rule's inline-annotation tests.
+//!
+//! A rule `foo.toml` pairs with a fixture `foo.<ext>` (the language's primary
+//! extension) carrying `// ruleid:` / `// ok:` annotations; the harness
+//! (`harn_rules::run_inline_test`) checks that the rule's matches line up.
+
+use crate::cli::RuleArgs;
+
+#[cfg(not(feature = "hostlib"))]
+pub(crate) async fn run(_args: RuleArgs) {
+    eprintln!(
+        "`harn rule` requires the `hostlib` feature (default-on); it is unavailable in this build"
+    );
+    std::process::exit(2);
+}
+
+#[cfg(feature = "hostlib")]
+pub(crate) async fn run(args: RuleArgs) {
+    match args.command {
+        crate::cli::RuleCommand::Test(test) => run_test(test),
+    }
+}
+
+#[cfg(feature = "hostlib")]
+fn run_test(args: crate::cli::RuleTestArgs) {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use harn_rules::{load_rule_file, run_inline_test, CompiledRule, InlineTestReport};
+
+    let root = PathBuf::from(args.path.as_deref().unwrap_or("."));
+    let rule_files = discover_rule_files(&root);
+    if rule_files.is_empty() {
+        eprintln!(
+            "rule test: no `*.toml` rules found under `{}`",
+            root.display()
+        );
+        std::process::exit(2);
+    }
+
+    struct Case {
+        fixture: PathBuf,
+        report: InlineTestReport,
+    }
+    let mut cases: Vec<Case> = Vec::new();
+    let mut missing_fixtures: Vec<PathBuf> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for rule_path in rule_files {
+        let rule = match load_rule_file(&rule_path) {
+            Ok(rule) => rule,
+            // A non-rule `*.toml` in a scanned directory is silently skipped;
+            // an explicit file argument that fails is a hard error.
+            Err(err) => {
+                if root.is_file() {
+                    errors.push(format!("{}: {err}", rule_path.display()));
+                }
+                continue;
+            }
+        };
+        let compiled = match CompiledRule::compile(&rule) {
+            Ok(c) => c,
+            Err(err) => {
+                errors.push(format!("{}: {err}", rule_path.display()));
+                continue;
+            }
+        };
+        let fixture = rule_path.with_extension(compiled.language().primary_extension());
+        let Ok(source) = fs::read_to_string(&fixture) else {
+            missing_fixtures.push(fixture);
+            continue;
+        };
+        match run_inline_test(&compiled, &source) {
+            Ok(report) => cases.push(Case { fixture, report }),
+            Err(err) => errors.push(format!("{}: {err}", fixture.display())),
+        }
+    }
+
+    let failed = cases.iter().filter(|c| !c.report.passed).count();
+
+    if args.json {
+        let cases_json: Vec<serde_json::Value> = cases
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "fixture": c.fixture.display().to_string(),
+                    "rule_id": c.report.rule_id,
+                    "passed": c.report.passed,
+                    "matches": c.report.matches,
+                    "checked": c.report.checked,
+                    "failures": c.report.failures.iter().map(|f| f.describe()).collect::<Vec<_>>(),
+                })
+            })
+            .collect();
+        let envelope = serde_json::json!({
+            "schemaVersion": 1,
+            "passed": failed == 0 && errors.is_empty(),
+            "cases": cases_json,
+            "missing_fixtures": missing_fixtures.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+            "errors": errors,
+        });
+        println!("{}", serde_json::to_string_pretty(&envelope).unwrap());
+    } else {
+        for case in &cases {
+            let tag = if case.report.passed { "PASS" } else { "FAIL" };
+            println!(
+                "{tag}  {} ({})",
+                case.fixture.display(),
+                case.report.rule_id
+            );
+            for failure in &case.report.failures {
+                println!("        {}", failure.describe());
+            }
+        }
+        for path in &missing_fixtures {
+            println!("SKIP  {} (no fixture)", path.display());
+        }
+        for err in &errors {
+            eprintln!("error: {err}");
+        }
+        println!(
+            "{} passed, {failed} failed, {} skipped",
+            cases.len() - failed,
+            missing_fixtures.len()
+        );
+    }
+
+    if failed > 0 || !errors.is_empty() {
+        std::process::exit(1);
+    }
+}
+
+/// Collect rule `*.toml` files: the path itself if it is a file, else every
+/// `*.toml` under it (gitignore-aware).
+#[cfg(feature = "hostlib")]
+fn discover_rule_files(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    use ignore::WalkBuilder;
+
+    if root.is_file() {
+        return vec![root.to_path_buf()];
+    }
+    let mut out = Vec::new();
+    let mut walker = WalkBuilder::new(root);
+    walker.git_ignore(true).require_git(false);
+    for entry in walker.build().filter_map(Result::ok) {
+        let path = entry.path();
+        if entry.file_type().is_some_and(|t| t.is_file())
+            && path.extension().and_then(|e| e.to_str()) == Some("toml")
+        {
+            out.push(path.to_path_buf());
+        }
+    }
+    out.sort();
+    out
+}

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1009,6 +1009,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
         Command::Provider(args) => commands::provider_capabilities::run_or_exit(args),
         Command::Scan(args) => commands::scan::run(args).await,
         Command::Codemod(args) => commands::codemod::run(args).await,
+        Command::Rule(args) => commands::rule::run(args).await,
         Command::Try(args) => commands::try_cmd::run(args).await,
         Command::Quickstart(args) => {
             if let Err(error) = commands::quickstart::run_quickstart(&args).await {

--- a/crates/harn-cli/tests/rule_test_dispatch.rs
+++ b/crates/harn-cli/tests/rule_test_dispatch.rs
@@ -1,0 +1,64 @@
+//! End-to-end coverage for `harn rule test` (#2842): run a rule's annotated
+//! fixture and pass/fail on whether matches line up with `// ruleid:` / `// ok:`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn fixture_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("harn-ruletest-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create fixture dir");
+    dir
+}
+
+fn write(dir: &Path, name: &str, contents: &str) {
+    std::fs::write(dir.join(name), contents).expect("write fixture");
+}
+
+const NO_FOO: &str = "id = \"no-foo\"\nlanguage = \"typescript\"\nmessage = \"no foo\"\n[rule]\npattern = \"foo()\"\n";
+
+fn rule_test(dir: &Path, extra: &[&str]) -> (String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .arg("rule")
+        .arg("test")
+        .arg(dir)
+        .args(extra)
+        .output()
+        .expect("spawn harn rule test");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn passing_fixture_exits_zero() {
+    let dir = fixture_dir("pass");
+    write(&dir, "no-foo.toml", NO_FOO);
+    write(
+        &dir,
+        "no-foo.ts",
+        "// ruleid: no-foo\nfoo();\n// ok: no-foo\nbar();\n",
+    );
+
+    let (stdout, code) = rule_test(&dir, &[]);
+    assert_eq!(code, 0, "stdout={stdout}");
+    assert!(stdout.contains("PASS"), "stdout={stdout}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn false_positive_fails_with_exit_one() {
+    let dir = fixture_dir("fail");
+    write(&dir, "no-foo.toml", NO_FOO);
+    // Two matches but only one annotation → the second is an un-annotated
+    // false positive.
+    write(&dir, "no-foo.ts", "// ruleid: no-foo\nfoo();\nfoo();\n");
+
+    let (stdout, code) = rule_test(&dir, &["--json"]);
+    assert_eq!(code, 1, "stdout={stdout}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["passed"], false);
+    assert_eq!(json["cases"][0]["matches"], 2);
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -65,6 +65,7 @@ pub mod model;
 pub mod pattern;
 pub mod recipe;
 pub mod report;
+pub mod testing;
 pub mod transform;
 
 pub use engine::{Binding, CodemodResult, CompiledRule, Diagnostic, RuleMatch, Span};
@@ -78,3 +79,4 @@ pub use model::{
 pub use pattern::{compile_pattern, CompiledPattern};
 pub use recipe::{run_recipe, FileChange, RecipeRun, RuleRecipe, ScanningRecipe, SourceFile};
 pub use report::{data_table, DataTable, TableRow, TableSummary};
+pub use testing::{run_inline_test, Expectation, FailureKind, InlineTestReport, TestFailure};

--- a/crates/harn-rules/src/testing.rs
+++ b/crates/harn-rules/src/testing.rs
@@ -1,0 +1,239 @@
+//! A small rule-test harness (#2842).
+//!
+//! Run a rule against an **annotated fixture** and check that its matches line
+//! up with inline `// ruleid:` / `// ok:` comments — the Semgrep convention,
+//! adapted to be language-agnostic:
+//!
+//! ```text
+//!   // ruleid: no-foo
+//!   foo();              // <- must match `no-foo`
+//!   // ok: no-foo
+//!   bar();              // <- must NOT match `no-foo`
+//!   baz();              // <- no annotation: must NOT match either
+//! ```
+//!
+//! An annotation comment sits on its **own line** and targets the **next**
+//! line. The check is strict: every match must be covered by a `// ruleid:`
+//! (an un-annotated match is a false positive), and every `// ruleid:` line
+//! must match (a missing match is a false negative).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::engine::CompiledRule;
+use crate::error::RulesError;
+
+/// What an annotation asserts about the line it targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Expectation {
+    /// `// ruleid: <id>` — the targeted line must match the rule.
+    Match,
+    /// `// ok: <id>` — the targeted line must not match.
+    NoMatch,
+}
+
+/// Why a fixture line failed its expectation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureKind {
+    /// `// ruleid:` annotated this line, but the rule did not match.
+    ExpectedMatch,
+    /// `// ok:` annotated this line, but the rule matched it.
+    UnexpectedMatch,
+    /// The rule matched this line, but nothing annotated it (false positive).
+    Unannotated,
+}
+
+/// One failed expectation in a fixture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TestFailure {
+    /// 0-based fixture line.
+    pub line: usize,
+    pub kind: FailureKind,
+}
+
+impl TestFailure {
+    /// A human-readable, 1-based description.
+    pub fn describe(&self) -> String {
+        let what = match self.kind {
+            FailureKind::ExpectedMatch => "expected a match (// ruleid:) but found none",
+            FailureKind::UnexpectedMatch => "matched, but // ok: said it should not",
+            FailureKind::Unannotated => "matched, but no // ruleid: annotated it",
+        };
+        format!("line {}: {what}", self.line + 1)
+    }
+}
+
+/// The outcome of running one rule against one annotated fixture.
+#[derive(Debug, Clone)]
+pub struct InlineTestReport {
+    pub rule_id: String,
+    /// True when there are no failures.
+    pub passed: bool,
+    /// Number of annotations checked.
+    pub checked: usize,
+    /// Number of matches the rule produced.
+    pub matches: usize,
+    pub failures: Vec<TestFailure>,
+}
+
+/// Run `rule` against `source` and compare its matches with the fixture's
+/// inline `// ruleid:` / `// ok:` annotations.
+pub fn run_inline_test(rule: &CompiledRule, source: &str) -> Result<InlineTestReport, RulesError> {
+    let expectations = parse_annotations(source, rule.id());
+
+    let matched_lines: BTreeSet<usize> =
+        rule.run(source)?.iter().map(|m| m.span.start_row).collect();
+
+    let mut failures = Vec::new();
+
+    // Every annotation must hold.
+    for (&line, &expectation) in &expectations {
+        match expectation {
+            Expectation::Match if !matched_lines.contains(&line) => failures.push(TestFailure {
+                line,
+                kind: FailureKind::ExpectedMatch,
+            }),
+            Expectation::NoMatch if matched_lines.contains(&line) => failures.push(TestFailure {
+                line,
+                kind: FailureKind::UnexpectedMatch,
+            }),
+            _ => {}
+        }
+    }
+
+    // Every match must be acknowledged by a `// ruleid:` (no false positives).
+    for &line in &matched_lines {
+        if expectations.get(&line) != Some(&Expectation::Match) {
+            // A `// ok:` match is already reported as UnexpectedMatch above;
+            // only flag the genuinely un-annotated ones here.
+            if !expectations.contains_key(&line) {
+                failures.push(TestFailure {
+                    line,
+                    kind: FailureKind::Unannotated,
+                });
+            }
+        }
+    }
+
+    failures.sort_by_key(|f| (f.line, f.kind as u8));
+
+    Ok(InlineTestReport {
+        rule_id: rule.id().to_string(),
+        passed: failures.is_empty(),
+        checked: expectations.len(),
+        matches: matched_lines.len(),
+        failures,
+    })
+}
+
+/// Parse `// ruleid:` / `// ok:` annotations that apply to `rule_id`. Each
+/// annotation is on its own line and targets the **next** line (0-based). An
+/// id list (`// ruleid: a, b`) applies if `rule_id` is among them.
+fn parse_annotations(source: &str, rule_id: &str) -> BTreeMap<usize, Expectation> {
+    let mut out = BTreeMap::new();
+    for (i, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        // Accept `//` (C-family) or `#` (Python/Ruby/shell) line comments.
+        let Some(rest) = trimmed
+            .strip_prefix("//")
+            .or_else(|| trimmed.strip_prefix('#'))
+        else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let (expectation, ids) = if let Some(ids) = rest.strip_prefix("ruleid:") {
+            (Expectation::Match, ids)
+        } else if let Some(ids) = rest.strip_prefix("ok:") {
+            (Expectation::NoMatch, ids)
+        } else {
+            continue;
+        };
+        if ids.split(',').map(str::trim).any(|id| id == rule_id) {
+            // Targets the next line; a trailing annotation at EOF targets
+            // nothing and is harmless.
+            out.insert(i + 1, expectation);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Rule;
+
+    fn rule(toml: &str) -> CompiledRule {
+        CompiledRule::compile(&Rule::from_toml_str(toml).unwrap()).unwrap()
+    }
+
+    const NO_FOO: &str = r#"
+        id = "no-foo"
+        language = "typescript"
+        message = "no foo"
+        [rule]
+        pattern = "foo()"
+    "#;
+
+    #[test]
+    fn passing_fixture_reports_no_failures() {
+        let r = rule(NO_FOO);
+        let src = "// ruleid: no-foo\nfoo();\n// ok: no-foo\nbar();\n";
+        let report = run_inline_test(&r, src).unwrap();
+        assert!(report.passed, "failures: {:?}", report.failures);
+        assert_eq!(report.checked, 2);
+        assert_eq!(report.matches, 1);
+    }
+
+    #[test]
+    fn false_negative_is_reported() {
+        // `// ruleid:` on a line that does not actually match.
+        let r = rule(NO_FOO);
+        let src = "// ruleid: no-foo\nbar();\n";
+        let report = run_inline_test(&r, src).unwrap();
+        assert!(!report.passed);
+        assert_eq!(report.failures[0].kind, FailureKind::ExpectedMatch);
+    }
+
+    #[test]
+    fn false_positive_on_ok_line_is_reported() {
+        let r = rule(NO_FOO);
+        let src = "// ok: no-foo\nfoo();\n";
+        let report = run_inline_test(&r, src).unwrap();
+        assert!(!report.passed);
+        assert_eq!(report.failures[0].kind, FailureKind::UnexpectedMatch);
+    }
+
+    #[test]
+    fn unannotated_match_is_a_false_positive() {
+        let r = rule(NO_FOO);
+        let src = "foo();\n";
+        let report = run_inline_test(&r, src).unwrap();
+        assert!(!report.passed);
+        assert_eq!(report.failures[0].kind, FailureKind::Unannotated);
+    }
+
+    #[test]
+    fn annotations_for_other_rules_are_ignored() {
+        let r = rule(NO_FOO);
+        // The annotation names a different rule, so it does not apply here;
+        // and the matching line below is annotated for `no-foo`.
+        let src = "// ruleid: other-rule\nbar();\n// ruleid: no-foo\nfoo();\n";
+        let report = run_inline_test(&r, src).unwrap();
+        assert!(report.passed, "failures: {:?}", report.failures);
+        assert_eq!(report.checked, 1);
+    }
+
+    #[test]
+    fn python_hash_comments_work() {
+        let r = rule(
+            r#"
+            id = "call-print"
+            language = "python"
+            [rule]
+            pattern = "print($X)"
+        "#,
+        );
+        let src = "# ruleid: call-print\nprint(x)\n# ok: call-print\ny = 1\n";
+        let report = run_inline_test(&r, src).unwrap();
+        assert!(report.passed, "failures: {:?}", report.failures);
+    }
+}


### PR DESCRIPTION
Closes #2842. Rule Engine Epic B (#2828). Independent off main.

## What

A first-class way to **test structural rules** with inline annotations (the Semgrep convention, made language-agnostic):

```ts
// ruleid: no-foo      // the next line MUST match
foo();
// ok: no-foo          // the next line must NOT match
bar();
baz();                  // un-annotated: must not match either
```

An un-annotated match is a false positive; a `// ruleid:` line with no match is a false negative. `// ok:` tests a near-miss.

- **`harn_rules::testing`** — the reusable harness (`run_inline_test`), 6 unit tests.
- **`harn rule test <dir>`** — a rule `foo.toml` pairs with a fixture `foo.<ext>`; runs every rule against its fixture, prints per-fixture `PASS`/`FAIL` (or `--json`), exits non-zero on failure (a CI gate). Thin Rust shim over the harness; harn-cli gains an optional `harn-rules` dep under `hostlib`.

(Also straightens a pre-existing `Cargo.lock` drift: `harn-rules-hostlib` was pinned 0.8.60 in the lock vs 0.8.61 in the workspace.)

## Verification

- `cargo test -p harn-rules testing::` — 6 green; `cargo test -p harn-cli --test rule_test_dispatch` — green.
- `cargo clippy -p harn-rules -p harn-cli --all-targets` + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)