### PR TITLE
dev_setup: GC orphaned per-worktree Cargo target dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "harn-rules-hostlib"
-version = "0.8.60"
+version = "0.8.61"
 dependencies = [
  "harn-hostlib",
  "harn-rules",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
+.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -10,6 +10,12 @@ check: all
 
 setup:
 	./scripts/dev_setup.sh
+
+# Reclaim orphaned per-worktree Cargo target dirs under $TMPDIR/harn-target
+# (left behind when an agent/codex worktree is removed). Add --dry-run to
+# preview: make clean-stale-targets ARGS=--dry-run
+clean-stale-targets:
+	./scripts/prune_stale_targets.sh $(ARGS)
 
 install-hooks:
 	git config core.hooksPath .githooks

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -177,6 +177,12 @@ if [[ -n "${target_dir}" ]]; then
   echo "Configured Cargo target dir -> ${target_dir}"
 fi
 
+# Reclaim per-worktree target dirs left behind by worktrees that have since
+# been removed. Best-effort; never fail setup over housekeeping.
+if [[ -x ./scripts/prune_stale_targets.sh ]]; then
+  ./scripts/prune_stale_targets.sh || true
+fi
+
 if command -v npm >/dev/null 2>&1; then
   echo "Installing repo-local Node tooling..."
   npm install

--- a/scripts/prune_stale_targets.sh
+++ b/scripts/prune_stale_targets.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Prune orphaned per-worktree Cargo target dirs.
+#
+# dev_setup.sh redirects each worktree's CARGO_TARGET_DIR to
+# "$TMPDIR/harn-target/<parent>-<leaf>" so parallel worktree builds don't
+# clobber each other. Nothing reclaimed those dirs when the worktree was
+# removed, so they accumulated (observed: ~1 TB across dozens of deleted
+# agent/codex worktrees). This script deletes any harn-target/* dir that no
+# live git worktree still maps to.
+#
+# Safe by construction: it only removes a dir when (a) no current worktree of
+# any repo under the search roots derives or references that dir, and (b) the
+# dir has not been modified within HARN_TARGET_GC_MIN_AGE_SECS (default 3h),
+# so an in-flight `make setup`/build is never touched.
+#
+# Usage:
+#   scripts/prune_stale_targets.sh [--dry-run]
+# Env:
+#   HARN_TARGET_GC_ROOTS        space-separated repo search roots (default "$HOME/projects")
+#   HARN_TARGET_GC_MIN_AGE_SECS minimum idle age before deletion (default 10800)
+#   TMPDIR                      base for harn-target (default /tmp)
+set -euo pipefail
+
+dry_run=0
+[[ "${1:-}" == "--dry-run" ]] && dry_run=1
+
+target_root="${TMPDIR:-/tmp}/harn-target"
+target_root="${target_root//\/\///}"   # collapse accidental double slash
+[[ -d "$target_root" ]] || { echo "no harn-target dir at $target_root; nothing to prune"; exit 0; }
+
+roots="${HARN_TARGET_GC_ROOTS:-$HOME/projects}"
+min_age="${HARN_TARGET_GC_MIN_AGE_SECS:-10800}"
+cutoff=$(( $(date +%s) - min_age ))
+
+# Build the keep-set: the basename of every harn-target dir that a live
+# worktree still points at. Prefer the authoritative target-dir baked into the
+# worktree's .cargo/config.toml; fall back to the derived <parent>-<leaf> name.
+keep_file="$(mktemp)"
+trap 'rm -f "$keep_file"' EXIT
+for root in $roots; do
+  [ -d "$root" ] || continue
+  for repo in "$root"/*; do
+    [ -d "$repo/.git" ] || [ -f "$repo/.git" ] || continue
+    git -C "$repo" worktree list --porcelain 2>/dev/null \
+      | awk '/^worktree /{print substr($0,10)}'
+  done
+done | sort -u | while read -r wt; do
+  [ -n "$wt" ] || continue
+  cfg="$wt/.cargo/config.toml"
+  if [ -f "$cfg" ]; then
+    td=$(grep -E '^[[:space:]]*target-dir[[:space:]]*=' "$cfg" 2>/dev/null \
+         | head -1 | sed -E 's/^[^"]*"//; s/".*$//' || true)
+    if [ -n "$td" ]; then basename "$td"; fi
+  fi
+  # derived-name fallback (matches dev_setup.sh::derive_target_dir)
+  printf '%s-%s\n' "$(basename "$(dirname "$wt")")" "$(basename "$wt")"
+done | sort -u > "$keep_file"
+
+removed=0; kept=0
+for d in "$target_root"/*; do
+  [ -d "$d" ] || continue
+  name="$(basename "$d")"
+  if grep -qxF "$name" "$keep_file"; then kept=$((kept+1)); continue; fi
+  m=$(stat -f %m "$d" 2>/dev/null || echo 0)
+  if [ "${m:-0}" -ge "$cutoff" ]; then
+    echo "skip (recently active): $name"; kept=$((kept+1)); continue
+  fi
+  sz=$(du -sh "$d" 2>/dev/null | cut -f1 || true)
+  if [ "$dry_run" -eq 1 ]; then
+    echo "would remove orphan: $name (${sz:-?})"
+  else
+    echo "removing orphan: $name (${sz:-?})"
+    rm -rf "$d" || true
+  fi
+  removed=$((removed+1))
+done
+
+echo "harn-target GC: kept=$kept ${dry_run:+would-}removed=$removed (root=$target_root)"


### PR DESCRIPTION
## Problem

`scripts/dev_setup.sh::derive_target_dir()` (run by `make setup` in every worktree) redirects each worktree's `CARGO_TARGET_DIR` to `$TMPDIR/harn-target/<parent>-<leaf>` so parallel worktree builds don't clobber each other. That part is fine — but **nothing ever reclaimed those dirs when a worktree was removed**.

On one machine they had accumulated to **~1.1 TB** across 66 orphaned Rust `target/` dirs from long-deleted agent/codex worktrees (largest single dir 153 GB). `df` showed 96% full with no obvious culprit because it was all hiding in the per-user `$TMPDIR`.

## Fix

- **`scripts/prune_stale_targets.sh`** (new) — removes any `harn-target/*` dir that no live `git worktree` maps to. The keep-set is built from each live worktree's authoritative `.cargo/config.toml` `target-dir`, with the derived `<parent>-<leaf>` name as a fallback. Only deletes dirs idle longer than `HARN_TARGET_GC_MIN_AGE_SECS` (default 3h), so an in-flight `make setup`/build is never touched. Supports `--dry-run`.
- **`scripts/dev_setup.sh`** — invokes the pruner best-effort (`|| true`) after configuring the target dir, so `make setup` self-heals going forward.
- **`Makefile`** — adds `make clean-stale-targets` (preview with `ARGS=--dry-run`).

## Drive-by: Cargo.lock sync

A `cargo` run surfaced that the committed lockfile entry for `harn-rules-hostlib` (`version.workspace = true`) was stale at `0.8.60` while the workspace and every sibling crate are at `0.8.61`, so `cargo build --locked` fails against `main`'s lock. Folded in a one-line sync.

## Validation

- Live dry-run on the affected machine: `kept=1 would-removed=0` (the one live worktree's dir preserved).
- The matching manual sweep removed 66 orphans / kept 1, freeing ~1.05 TB.
- `bash -n` clean on both scripts; pre-commit/pre-push hooks (rustfmt, clippy full workspace, ratchets, generated-artifact registry) pass.

`no-changelog-needed`: dev-tooling only (not part of the shipped `harn` binary/crates), so no user-facing changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)