### PR TITLE
rules: curated std seed pack + destructuring codemod (#2844)

### DIFF
--- a/changelog.d/2844.added.md
+++ b/changelog.d/2844.added.md
@@ -1,0 +1,6 @@
+- Added a curated `rules/std` seed rule pack (Rule Engine Epic B) — the engine's reference corpus and dogfood. Ships
+  the flagship **`destructure-defaults`** codemod (`const x = obj?.x ?? d` → `const { x = d } = obj`, the
+  #2824 / burin-code#1629 migration; a `scope-local` suggestion since it assumes a non-nullish object, and only the
+  non-alias case via metavar unification) and a **`no-console-log`** lint. Each rule ships with an annotation fixture
+  (`harn rule test`) and is covered by `crates/harn-rules/tests/seed_pack.rs`. (Ports of the `.harn`-targeting
+  `harn-lint` rules await a Harn tree-sitter grammar, #2888.)

--- a/crates/harn-rules/tests/seed_pack.rs
+++ b/crates/harn-rules/tests/seed_pack.rs
@@ -1,0 +1,61 @@
+//! The curated `rules/std` seed pack (#2844) is part of the engine's
+//! reference corpus — so it ships with tests that fail loudly on a
+//! regression. Each rule is loaded from its shipped `*.toml` and exercised.
+
+use std::path::PathBuf;
+
+use harn_rules::{load_rule_file, CompiledRule};
+
+fn seed(name: &str) -> CompiledRule {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../rules/std")
+        .join(name);
+    let rule = load_rule_file(&path).unwrap_or_else(|e| panic!("load {}: {e}", path.display()));
+    CompiledRule::compile(&rule).unwrap_or_else(|e| panic!("compile {}: {e}", path.display()))
+}
+
+#[test]
+fn destructure_defaults_folds_the_non_alias_case() {
+    let rule = seed("destructure-defaults.toml");
+
+    // The flagship #2824 shape: binding name == property name.
+    let out = rule
+        .apply("const timeout = cfg?.timeout ?? 30;\n")
+        .expect("apply");
+    assert!(out.changed);
+    assert_eq!(out.rewritten, "const { timeout = 30 } = cfg;\n");
+}
+
+#[test]
+fn destructure_defaults_leaves_aliases_alone() {
+    let rule = seed("destructure-defaults.toml");
+    // Binding name (`t`) differs from the property (`timeout`) — `$K` cannot
+    // unify, so the rule must not touch it.
+    let out = rule
+        .apply("const t = cfg?.timeout ?? 30;\n")
+        .expect("apply");
+    assert!(
+        !out.changed,
+        "alias case must be left alone: {}",
+        out.rewritten
+    );
+}
+
+#[test]
+fn destructure_defaults_is_a_suggestion_not_auto_applied() {
+    // The rewrite is unsafe when `$X` is nullish, so it must not auto-apply.
+    let rule = seed("destructure-defaults.toml");
+    assert!(!rule.safety().is_auto_applicable());
+}
+
+#[test]
+fn no_console_log_flags_calls() {
+    let rule = seed("no-console-log.toml");
+    let diags = rule
+        .diagnostics("console.log(x);\nfoo();\nconsole.log(y, z);\n")
+        .expect("diagnostics");
+    assert_eq!(diags.len(), 2);
+    assert_eq!(diags[0].message, "Remove `console.log` before committing");
+    // A lint has no fix.
+    assert!(diags[0].fix.is_none());
+}

--- a/rules/std/README.md
+++ b/rules/std/README.md
@@ -1,0 +1,48 @@
+# `std` rule pack (seed)
+
+A small, curated starter pack of structural rules for the Harn
+[rule engine](../../crates/harn-rules) (#2844) — the engine's reference corpus
+and dogfood. Run them with `harn scan` / `harn codemod`:
+
+```console
+harn scan --rule-pack rules/std src
+harn codemod --rule rules/std/destructure-defaults.toml src      # dry-run
+```
+
+## Rules
+
+| Rule | Kind | Safety | What |
+|------|------|--------|------|
+| `destructure-defaults` | codemod | `scope-local` (suggestion) | Collapse `const x = obj?.x ?? d` into `const { x = d } = obj` |
+| `no-console-log` | lint | — | Flag stray `console.log(...)` calls |
+
+### `destructure-defaults`
+
+The flagship — powers the #2824 / burin-code#1629 migration. The unified `$K`
+means it only rewrites the **non-alias** case (binding name == property name);
+aliases (`const t = cfg?.timeout ?? d`) are left alone.
+
+It is a **suggestion** (`scope-local`, not auto-applied) because the rewrite
+assumes `$X` is non-nullish: `obj?.x ?? d` yields `d` when `obj` is
+null/undefined, but `const { x = d } = obj` throws on a null `obj`. Apply it
+where `$X` is a known-present object, as in the #2824 sites.
+
+## Testing
+
+Each rule ships with an annotation fixture (`<rule>.ts`, the Semgrep
+`// ruleid:` / `// ok:` convention) for `harn rule test` (#2842):
+
+```console
+harn rule test rules/std
+```
+
+The rules are also covered by `crates/harn-rules/tests/seed_pack.rs`, which
+loads each shipped `*.toml` and asserts its behavior (a CI gate today, before
+`harn rule test` lands on `main`).
+
+## Not yet here
+
+Ports of the hardcoded `harn-lint` rules (`optional-shorthand`,
+`redundant-nil-ternary`, `import-order`, …) target **`.harn`** source, which
+needs a Harn tree-sitter grammar — tracked in #2888. Until then this pack
+targets TypeScript/JS and the other grammars the engine already ships.

--- a/rules/std/destructure-defaults.toml
+++ b/rules/std/destructure-defaults.toml
@@ -1,0 +1,18 @@
+# Collapse `const x = obj?.x ?? default` into a destructure with a default.
+#
+# Powers the #2824 / burin-code#1629 migration. The unified `$K` only matches
+# the *non-alias* case (binding name == property name); aliases are left alone.
+#
+# Safety is `scope-local` (a suggestion, not auto-applied): the rewrite assumes
+# `$X` is non-nullish. `obj?.x ?? d` yields `d` when `obj` is null/undefined,
+# but `const { x = d } = obj` throws on a null `obj`. Apply where `$X` is known
+# to be a present object (as in the #2824 sites).
+id = "destructure-defaults"
+language = "typescript"
+severity = "info"
+message = "Collapse `?.x ?? default` into a destructure with a default"
+fix = "const { $K = $D } = $X;"
+safety = "scope-local"
+
+[rule]
+pattern = "const $K = $X?.$K ?? $D"

--- a/rules/std/destructure-defaults.ts
+++ b/rules/std/destructure-defaults.ts
@@ -1,0 +1,11 @@
+// Annotation fixture for `harn rule test` (#2842): a line preceded by a
+// ruleid marker must match the rule; an ok marker means it must not.
+
+// ruleid: destructure-defaults
+const timeout = cfg?.timeout ?? 30;
+
+// ok: destructure-defaults
+const renamed = cfg?.timeout ?? 30;
+
+// ok: destructure-defaults
+const plain = compute();

--- a/rules/std/no-console-log.toml
+++ b/rules/std/no-console-log.toml
@@ -1,0 +1,8 @@
+# Flag stray `console.log` calls (a lint: a message, no rewrite).
+id = "no-console-log"
+language = "typescript"
+severity = "warning"
+message = "Remove `console.log` before committing"
+
+[rule]
+pattern = "console.log($ARG)"

--- a/rules/std/no-console-log.ts
+++ b/rules/std/no-console-log.ts
@@ -1,0 +1,7 @@
+// Annotation fixture for `harn rule test` (#2842).
+
+// ruleid: no-console-log
+console.log(value);
+
+// ok: no-console-log
+logger.info(value);


### PR DESCRIPTION
Closes #2844. Rule Engine Epic B (#2828). Independent off main.

## What

A small, curated `rules/std/` starter pack — the engine's reference corpus and dogfood:

- **`destructure-defaults`** (codemod, flagship): `const x = obj?.x ?? d` → `const { x = d } = obj` — the #2824 / burin-code#1629 migration. Only the **non-alias** case (binding name == property name, via `$K` unification); aliases are left alone. A **`scope-local` suggestion** (not auto-applied) because it assumes a non-nullish object: `obj?.x ?? d` yields `d` on a null `obj`, but destructuring a null `obj` throws. Honest safety tier.
- **`no-console-log`** (lint, no fix): flags stray `console.log(...)`.

Each rule ships with a `harn rule test` annotation fixture (`<rule>.ts`, `// ruleid:` / `// ok:`) and a README documenting the pack + safety rationale.

## Verification

`crates/harn-rules/tests/seed_pack.rs` loads each **shipped** `*.toml` and asserts behavior — green (4 tests): the codemod folds the non-alias case to exactly `const { timeout = 30 } = cfg;`, leaves aliases alone, and is not auto-applicable; the lint flags both calls with no fix. (Once `harn rule test` (#2842) lands, `harn rule test rules/std` becomes the annotation-fixture gate.)

## Note

Ports of the hardcoded `harn-lint` rules (`optional-shorthand`, `redundant-nil-ternary`, …) target `.harn` source, which needs a Harn tree-sitter grammar (#2888). This pack targets TypeScript for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)