### PR TITLE
Fix release container archive verification

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -556,8 +556,10 @@ jobs:
 
           for arch in amd64 arm64; do
             archive="release-container/${arch}/harn.tar.gz"
+            archive_list="${assets_dir}/${arch}.lst"
+            tar tzf "$archive" > "$archive_list"
             for binary in harn harn-container-probe; do
-              if ! tar tzf "$archive" | grep -Fxq "$binary"; then
+              if ! grep -Fxq "$binary" "$archive_list"; then
                 echo "::error::${archive} is missing ${binary}; container image must be assembled from release artifacts, not a Docker source rebuild."
                 exit 1
               fi

--- a/changelog.d/release-container-tar-list.fixed.md
+++ b/changelog.d/release-container-tar-list.fixed.md
@@ -1,0 +1,1 @@
+- Release container publishing now verifies packaged Linux archives without `pipefail` false negatives.


### PR DESCRIPTION
## Summary
- materialize each Linux release archive listing once before checking required binaries
- avoid `set -euo pipefail` false negatives from `tar tzf | grep -q` SIGPIPE
- add a release-note fragment for the container publish recovery path

## Verification
- `actionlint .github/workflows/build-release-binaries.yml`
- local `bash -euo pipefail` tarball simulation for amd64/arm64 archives
- `git diff --check`
- repo pre-commit hook
- repo pre-push hook
