### PR TITLE
rules: project-local rule discovery via [rules] ruleDirs (#2843)

### DIFF
--- a/changelog.d/2843.added.md
+++ b/changelog.d/2843.added.md
@@ -1,0 +1,5 @@
+- Added project-local rule discovery (Rule Engine Epic B) — declare `[rules] ruleDirs = ["rules"]` in `harn.toml` and
+  `harn scan` / `harn codemod` load every `*.toml` rule from those directories when no `--rule`/`--rule-pack` is given.
+  `harn scan src` runs the project's rules over `src` (no inline pattern needed — an inline pattern is signalled by
+  `--lang`); `harn codemod src` applies the codemod rules in the pack and silently skips lint/search rules. Resolved
+  relative to the manifest directory; `utilDirs`/`testConfigs` keys are parsed for forward-compat.

--- a/crates/harn-cli/src/commands/codemod.rs
+++ b/crates/harn-cli/src/commands/codemod.rs
@@ -18,11 +18,8 @@ pub(crate) async fn run(args: CodemodArgs) {
     use crate::dispatch;
     use crate::env_guard::ScopedEnvVar;
 
-    if args.rule.is_none() && args.rule_pack.is_none() {
-        eprintln!("codemod: provide `--rule <file>` or `--rule-pack <dir>`");
-        std::process::exit(2);
-    }
-
+    // No early `--rule` check: `resolve` falls back to the project's
+    // `[rules] ruleDirs` (#2843) and errors itself if nothing is found.
     let plan = match resolve(&args) {
         Ok(plan) => plan,
         Err(message) => {
@@ -49,5 +46,21 @@ fn resolve(args: &CodemodArgs) -> Result<String, String> {
 
     let specs =
         rules_cli::resolve_rules(None, None, args.rule.as_deref(), args.rule_pack.as_deref())?;
-    rules_cli::build_plan(specs, &args.paths)
+
+    // A codemod only applies rules that have a `fix`. Discovered packs mix in
+    // lint/search rules, which are silently skipped here; an explicitly given
+    // fix-less rule is a user error and reported as such.
+    let explicit = args.rule.is_some() || args.rule_pack.is_some();
+    let codemod_specs: Vec<_> = specs
+        .into_iter()
+        .filter(|s| rules_cli::rule_has_fix(&s.toml))
+        .collect();
+    if codemod_specs.is_empty() {
+        return Err(if explicit {
+            "the given rule has no `fix` template (it is a lint, not a codemod)".into()
+        } else {
+            "no codemod rules (rules with a `fix`) found in the project `[rules] ruleDirs`".into()
+        });
+    }
+    rules_cli::build_plan(codemod_specs, &args.paths)
 }

--- a/crates/harn-cli/src/commands/rules_cli.rs
+++ b/crates/harn-cli/src/commands/rules_cli.rs
@@ -64,8 +64,63 @@ pub(crate) fn resolve_rules(
         }
         Ok(specs)
     } else {
-        Err("provide an inline <pattern>, `--rule <file>`, or `--rule-pack <dir>`".into())
+        // No explicit rule given: fall back to the project's `[rules] ruleDirs`.
+        let discovered = discover_project_rules()?;
+        if discovered.is_empty() {
+            Err("no rule given: pass an inline `<pattern> --lang <lang>`, \
+                 `--rule <file>`, `--rule-pack <dir>`, or declare \
+                 `[rules] ruleDirs` in harn.toml"
+                .into())
+        } else {
+            Ok(discovered)
+        }
     }
+}
+
+/// Load the `*.toml` rules in `dir` as [`RuleSpec`]s, sorted by path.
+fn load_rule_dir_specs(dir: &std::path::Path) -> Result<Vec<RuleSpec>, String> {
+    use std::fs;
+
+    let mut paths: Vec<_> = fs::read_dir(dir)
+        .map_err(|e| format!("read rule dir `{}`: {e}", dir.display()))?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("toml"))
+        .collect();
+    paths.sort();
+
+    let mut specs = Vec::new();
+    for path in paths {
+        let toml =
+            fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
+        let language = rule_language(&toml)?;
+        specs.push(RuleSpec { toml, language });
+    }
+    Ok(specs)
+}
+
+/// Discover rules from the nearest project manifest's `[rules] ruleDirs`
+/// (resolved relative to the manifest's directory). Returns an empty vec when
+/// there is no manifest or it declares no `ruleDirs`, so callers fall through
+/// to their usual "no rule given" error.
+fn discover_project_rules() -> Result<Vec<RuleSpec>, String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("current dir: {e}"))?;
+    let Some((manifest, manifest_dir)) = crate::package::find_nearest_manifest(&cwd) else {
+        return Ok(Vec::new());
+    };
+
+    let mut specs = Vec::new();
+    for rel in &manifest.rules.rule_dirs {
+        let rule_dir = manifest_dir.join(rel);
+        if !rule_dir.is_dir() {
+            return Err(format!(
+                "`[rules] ruleDirs` entry `{rel}` is not a directory ({})",
+                rule_dir.display()
+            ));
+        }
+        specs.extend(load_rule_dir_specs(&rule_dir)?);
+    }
+    Ok(specs)
 }
 
 /// Build the per-rule plan JSON: each rule paired with the files (recursively
@@ -89,6 +144,15 @@ pub(crate) fn build_plan(specs: Vec<RuleSpec>, paths: &[String]) -> Result<Strin
         })
         .collect();
     serde_json::to_string(&plan).map_err(|e| format!("serialize plan: {e}"))
+}
+
+/// True if a rule TOML declares a top-level `fix` (i.e. it is a codemod, not a
+/// lint/search). Used to filter discovered packs down to applicable rules.
+pub(crate) fn rule_has_fix(src: &str) -> bool {
+    toml::from_str::<toml::Value>(src)
+        .ok()
+        .and_then(|v| v.get("fix").map(toml::Value::is_str))
+        .unwrap_or(false)
 }
 
 /// Parse a rule TOML's declared `language` into a [`Language`].

--- a/crates/harn-cli/src/commands/scan.rs
+++ b/crates/harn-cli/src/commands/scan.rs
@@ -43,16 +43,19 @@ pub(crate) async fn run(args: ScanArgs) {
 fn build_plan(args: &ScanArgs) -> Result<String, String> {
     use crate::commands::rules_cli;
 
-    // With a saved rule/pack every positional is a path; otherwise the first
-    // positional is the inline pattern and the rest are paths.
-    let saved_rule = args.rule.is_some() || args.rule_pack.is_some();
-    let (pattern, paths): (Option<&str>, &[String]) = if saved_rule {
-        (None, &args.args)
-    } else {
+    // The first positional is an inline pattern only in inline mode — i.e.
+    // `--lang` is given and no saved rule (`--rule`/`--rule-pack`) is. With a
+    // saved rule, or in project-discovery mode (`[rules] ruleDirs`, signalled
+    // by no `--lang`), every positional is a path instead. An inline pattern
+    // always needs `--lang`, so its presence is the unambiguous signal.
+    let inline_mode = args.lang.is_some() && args.rule.is_none() && args.rule_pack.is_none();
+    let (pattern, paths): (Option<&str>, &[String]) = if inline_mode {
         (
             args.args.first().map(String::as_str),
             args.args.get(1..).unwrap_or(&[]),
         )
+    } else {
+        (None, &args.args)
     };
 
     let specs = rules_cli::resolve_rules(

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -84,6 +84,34 @@ pub struct Manifest {
     /// manifest-driven ingress surfaces.
     #[serde(default)]
     pub orchestrator: OrchestratorConfig,
+    /// `[rules]` table — `sgconfig`-style structural-rule discovery. Lists the
+    /// directories `harn scan` / `harn codemod` load rules from when no
+    /// explicit `--rule`/`--rule-pack` is given.
+    #[serde(default)]
+    pub rules: RulesConfig,
+}
+
+/// `[rules]` table — project-local structural-rule discovery (#2843).
+///
+/// ```toml
+/// [rules]
+/// ruleDirs = ["rules", "vendor/rules"]
+/// utilDirs = ["rules/util"]
+/// testConfigs = ["rules/tests"]
+/// ```
+///
+/// Paths are resolved relative to the manifest's directory.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RulesConfig {
+    /// Directories of rule `*.toml` files to load.
+    #[serde(default, alias = "rule-dirs", alias = "ruleDirs")]
+    pub rule_dirs: Vec<String>,
+    /// Directories of utility-rule `*.toml` files (referenced via `matches`).
+    #[serde(default, alias = "util-dirs", alias = "utilDirs")]
+    pub util_dirs: Vec<String>,
+    /// Directories holding rule-test fixtures (for `harn rule test`).
+    #[serde(default, alias = "test-configs", alias = "testConfigs")]
+    pub test_configs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1564,6 +1592,22 @@ impl PackageWorkspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rules_table_parses_camel_and_kebab_dir_keys() {
+        // The documented `ruleDirs` camelCase form and the kebab alias both map
+        // to `rule_dirs` (#2843).
+        let camel: Manifest =
+            toml::from_str("[rules]\nruleDirs = [\"rules\", \"vendor/rules\"]\n").unwrap();
+        assert_eq!(camel.rules.rule_dirs, vec!["rules", "vendor/rules"]);
+
+        let kebab: Manifest = toml::from_str("[rules]\nrule-dirs = [\"r\"]\n").unwrap();
+        assert_eq!(kebab.rules.rule_dirs, vec!["r"]);
+
+        // No `[rules]` table → empty discovery, never an error.
+        let none: Manifest = toml::from_str("[package]\nname = \"x\"\n").unwrap();
+        assert!(none.rules.rule_dirs.is_empty());
+    }
 
     #[test]
     fn package_eval_pack_paths_use_package_manifest_entries() {

--- a/crates/harn-cli/tests/rule_discovery_dispatch.rs
+++ b/crates/harn-cli/tests/rule_discovery_dispatch.rs
@@ -1,0 +1,99 @@
+//! End-to-end coverage for project rule discovery (#2843): with a
+//! `[rules] ruleDirs` in `harn.toml`, `harn scan` / `harn codemod` load rules
+//! from those directories when no `--rule`/`--rule-pack` is given. Spawns the
+//! real `harn` binary with its cwd set to the project root.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn project(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("harn-discover-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("rules")).expect("mkdir rules");
+    std::fs::create_dir_all(dir.join("src")).expect("mkdir src");
+    std::fs::write(dir.join("harn.toml"), "[rules]\nruleDirs = [\"rules\"]\n").unwrap();
+    dir
+}
+
+fn write(dir: &Path, rel: &str, contents: &str) {
+    std::fs::write(dir.join(rel), contents).expect("write");
+}
+
+const LINT: &str =
+    "id = \"no-foo\"\nlanguage = \"typescript\"\nmessage = \"no foo\"\n[rule]\npattern = \"foo()\"\n";
+const CODEMOD: &str =
+    "id = \"rename\"\nlanguage = \"typescript\"\nfix = \"bar()\"\n[rule]\npattern = \"foo()\"\n";
+
+fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("spawn harn");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn scan_discovers_rules_from_project_ruledirs() {
+    let dir = project("scan");
+    write(&dir, "rules/no-foo.toml", LINT);
+    write(&dir, "src/a.ts", "foo();\nbar();\nfoo();\n");
+
+    // No --rule and no --lang: discovery mode, `src` is a path.
+    let (stdout, stderr, code) = run(&dir, &["scan", "src", "--json"]);
+    assert_eq!(code, 0, "stderr={stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(json["summary"]["total"], 2);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn codemod_discovery_skips_lints_and_applies_codemods() {
+    let dir = project("codemod");
+    write(&dir, "rules/lint.toml", LINT);
+    write(&dir, "rules/cm.toml", CODEMOD);
+    write(&dir, "src/a.ts", "foo();\n");
+
+    // Mixed pack: the lint rule is skipped, the codemod rule applies.
+    let (stdout, stderr, code) = run(&dir, &["codemod", "src", "--json"]);
+    assert_eq!(code, 0, "stderr={stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(json["summary"]["changed"], 1);
+    assert_eq!(json["files"][0]["preview"], "bar();\n");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn inline_pattern_still_works_with_lang() {
+    let dir = project("inline");
+    write(&dir, "src/a.ts", "let x = a?.b ?? 1;\n");
+
+    // `--lang` present → inline mode: the first positional is the pattern.
+    let (stdout, _stderr, code) = run(
+        &dir,
+        &["scan", "$X?.$K ?? $D", "src", "--lang", "typescript"],
+    );
+    assert_eq!(code, 0);
+    assert!(stdout.contains("1 match"), "stdout={stdout}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_rule_and_no_config_is_a_helpful_error() {
+    let dir = project("noconfig");
+    std::fs::remove_file(dir.join("harn.toml")).unwrap();
+    write(&dir, "src/a.ts", "foo();\n");
+
+    let (_stdout, stderr, code) = run(&dir, &["scan", "src"]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("ruleDirs"), "stderr={stderr}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -84,6 +84,28 @@ rewrote src/config.ts  [safety=BehaviorPreserving]
 Re-running a folded file changes nothing — fixes are checked for idempotency.
 Point `--rule-pack <dir>` at a directory to run every `*.toml` rule in it.
 
+## How do I run my project's rules without naming them?
+
+Declare the rule directories in your `harn.toml` and `harn scan` / `harn codemod`
+discover them automatically:
+
+```toml
+# harn.toml
+[rules]
+ruleDirs = ["rules"]
+```
+
+```console
+$ harn scan src             # runs every rule under rules/ over src/
+$ harn codemod src          # applies the codemod rules; lints are skipped
+```
+
+With `[rules] ruleDirs` set, `harn scan <paths>` needs no inline pattern — a
+pattern is signalled by `--lang`, so its absence means "use the project's
+rules." `harn codemod` applies only the rules that have a `fix`; lint/search
+rules in the same pack are ignored. Paths are resolved relative to the
+`harn.toml` directory.
+
 ## How do I run a rule from `.harn`?
 
 `std/rules` is the same engine, callable inline — an agent can author and run a


### PR DESCRIPTION
Part of #2843 (the project-discovery half). Rule Engine Epic B (#2828). Independent off main.

## What

Declare rule directories in `harn.toml` and `harn scan` / `harn codemod` discover them automatically — no `--rule` needed:

```toml
[rules]
ruleDirs = ["rules"]
```
```console
harn scan src       # runs every rule under rules/ over src/
harn codemod src    # applies the codemod rules; lint/search rules skipped
```

Satisfies the ticket's second acceptance bullet — *"a project-local `ruleDirs` rule is picked up without installation"* — and works **today** for the languages the engine ships (TS/JS/Rust/Go/Python/…).

## How

- **Manifest**: new `[rules]` table (`RulesConfig` — `ruleDirs`/`utilDirs`/`testConfigs`, camelCase + kebab aliases) in `crates/harn-cli/src/package/manifest.rs`, discovered via the existing `find_nearest_manifest` (stops at `.git`), paths resolved relative to the manifest dir.
- **Resolution**: `rules_cli::resolve_rules` gains a discovery fallback in its else branch.
- **Scan disambiguation**: in discovery mode `harn scan <paths>` has no inline pattern — an inline pattern is signalled by `--lang`, so its absence means "use the project's rules." Existing `harn scan '<pat>' src --lang ts` is unchanged.
- **Codemod**: filters discovered rules to those with a `fix` (a mixed pack's lint rules are silently skipped); an explicit fix-less `--rule` stays a clear error.

## Not in this PR (follow-on)

- `harn add <rulepack>` installing a pack **as a package** (the first acceptance bullet) — overlaps #2846 (registry); a rule pack = a package with a `rules` export.
- `utilDirs` cross-referencing (parsed for forward-compat, not yet wired into the engine's `matches`).

## Verification

- `cargo test -p harn-cli --test rule_discovery_dispatch` — 4 green (scan discovery; codemod skips lints + applies codemods; inline still works with `--lang`; helpful no-config error).
- `scan_dispatch` (3) + `codemod_dispatch` (4) still green after the resolution changes; manifest `ruleDirs` alias unit test green.
- `cargo fmt` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)