### PR TITLE
rules: --rule-pack resolves an installed package by name (#2846)

### DIFF
--- a/changelog.d/2846.added.md
+++ b/changelog.d/2846.added.md
@@ -1,0 +1,5 @@
+- `harn scan` / `harn codemod --rule-pack <name>` now resolves an **installed package** as a rule pack (Rule Engine
+  Epic B) — a pack fetched with `harn add` materializes under `<project>/.harn/packages/<name>`, and `--rule-pack
+  <name>` loads its rules (from the pack's own `[rules] ruleDirs`, falling back to `*.toml` at the pack root). A local
+  directory path still works as before; an unknown name suggests `harn add`. This is the consumption side of the rule
+  registry (#2846); `@scope/name` registry lookup and `harn rule publish`/`search` are the remaining distribution layer.

--- a/crates/harn-cli/src/commands/rules_cli.rs
+++ b/crates/harn-cli/src/commands/rules_cli.rs
@@ -44,23 +44,10 @@ pub(crate) fn resolve_rules(
         let toml = fs::read_to_string(rule_file).map_err(|e| format!("read `{rule_file}`: {e}"))?;
         let language = rule_language(&toml)?;
         Ok(vec![RuleSpec { toml, language }])
-    } else if let Some(dir) = rule_pack {
-        let mut specs = Vec::new();
-        let entries = fs::read_dir(dir).map_err(|e| format!("read rule pack `{dir}`: {e}"))?;
-        let mut paths: Vec<_> = entries
-            .filter_map(Result::ok)
-            .map(|e| e.path())
-            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("toml"))
-            .collect();
-        paths.sort();
-        for path in paths {
-            let toml =
-                fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
-            let language = rule_language(&toml)?;
-            specs.push(RuleSpec { toml, language });
-        }
+    } else if let Some(pack) = rule_pack {
+        let specs = resolve_rule_pack(pack)?;
         if specs.is_empty() {
-            return Err(format!("rule pack `{dir}` has no `*.toml` rules"));
+            return Err(format!("rule pack `{pack}` has no `*.toml` rules"));
         }
         Ok(specs)
     } else {
@@ -97,6 +84,50 @@ fn load_rule_dir_specs(dir: &std::path::Path) -> Result<Vec<RuleSpec>, String> {
         specs.push(RuleSpec { toml, language });
     }
     Ok(specs)
+}
+
+/// Resolve a `--rule-pack` value to its rules. The value is either a local
+/// directory, or the name of an **installed package** (#2846) — a package
+/// fetched with `harn add` and materialized under `<project>/.harn/packages/`.
+fn resolve_rule_pack(pack: &str) -> Result<Vec<RuleSpec>, String> {
+    let local = std::path::Path::new(pack);
+    if local.is_dir() {
+        return load_pack_rules(local);
+    }
+    if let Some(installed) = installed_package_dir(pack) {
+        return load_pack_rules(&installed);
+    }
+    Err(format!(
+        "rule pack `{pack}` is not a directory or an installed package \
+         (run `harn add {pack}` first?)"
+    ))
+}
+
+/// The local directory of an installed package named `name`
+/// (`<project>/.harn/packages/<name>`), if it exists.
+fn installed_package_dir(name: &str) -> Option<std::path::PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let (_, project_dir) = crate::package::find_nearest_manifest(&cwd)?;
+    let dir = project_dir.join(".harn").join("packages").join(name);
+    dir.is_dir().then_some(dir)
+}
+
+/// Load a rule pack's rules: from the pack's own `[rules] ruleDirs` when it
+/// ships a `harn.toml` that declares them, else from `*.toml` at the pack root.
+fn load_pack_rules(dir: &std::path::Path) -> Result<Vec<RuleSpec>, String> {
+    let manifest_path = dir.join("harn.toml");
+    if manifest_path.is_file() {
+        if let Ok(manifest) = crate::package::read_manifest_from_path(&manifest_path) {
+            if !manifest.rules.rule_dirs.is_empty() {
+                let mut specs = Vec::new();
+                for rel in &manifest.rules.rule_dirs {
+                    specs.extend(load_rule_dir_specs(&dir.join(rel))?);
+                }
+                return Ok(specs);
+            }
+        }
+    }
+    load_rule_dir_specs(dir)
 }
 
 /// Discover rules from the nearest project manifest's `[rules] ruleDirs`

--- a/crates/harn-cli/tests/rule_pack_install_dispatch.rs
+++ b/crates/harn-cli/tests/rule_pack_install_dispatch.rs
@@ -1,0 +1,67 @@
+//! End-to-end coverage for installed-package rule packs (#2846): a pack
+//! fetched with `harn add` materializes under `<project>/.harn/packages/<name>`
+//! and is consumed by name via `harn scan/codemod --rule-pack <name>`, reading
+//! the pack's own `[rules] ruleDirs`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn project_with_installed_pack(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("harn-pack-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let pack = dir.join(".harn/packages/my-rules/rules");
+    std::fs::create_dir_all(&pack).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    // The consuming project.
+    std::fs::write(dir.join("harn.toml"), "[package]\nname = \"app\"\n").unwrap();
+    // The installed pack ships its own manifest declaring where its rules live.
+    std::fs::write(
+        dir.join(".harn/packages/my-rules/harn.toml"),
+        "[rules]\nruleDirs = [\"rules\"]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        pack.join("no-foo.toml"),
+        "id = \"no-foo\"\nlanguage = \"typescript\"\nmessage = \"no foo\"\n[rule]\npattern = \"foo()\"\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("spawn harn");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn rule_pack_resolves_an_installed_package_by_name() {
+    let dir = project_with_installed_pack("resolve");
+    std::fs::write(dir.join("src/a.ts"), "foo();\nfoo();\n").unwrap();
+
+    let (stdout, stderr, code) = run(&dir, &["scan", "--rule-pack", "my-rules", "src", "--json"]);
+    assert_eq!(code, 0, "stderr={stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(json["summary"]["total"], 2);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn unknown_pack_name_suggests_harn_add() {
+    let dir = project_with_installed_pack("unknown");
+    std::fs::write(dir.join("src/a.ts"), "foo();\n").unwrap();
+
+    let (_stdout, stderr, code) = run(&dir, &["scan", "--rule-pack", "not-installed", "src"]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("harn add"), "stderr={stderr}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Part of #2846 (the consumption side). Stacked on #2898 (#2843) — the diff here is the single `#2846` commit (it reuses #2843's `[rules] ruleDirs` discovery on the installed pack's own manifest).

## What

`harn scan` / `harn codemod --rule-pack <name>` now resolves the name of a package installed with `harn add` (materialized under `<project>/.harn/packages/<name>`), not just a local directory:

```console
harn add @scope/my-rules
harn scan --rule-pack my-rules src
```

The pack's rules load from **its own** `[rules] ruleDirs` (falling back to `*.toml` at the pack root). A local directory path still works; an unknown name errors with a `harn add` hint. This closes the "installed pack is discoverable" acceptance bullet shared with #2843.

## How

`rules_cli::resolve_rule_pack` tries a local dir first, then `<project>/.harn/packages/<name>` (via `find_nearest_manifest` + the `.harn/packages` convention), then loads the pack's rules with `read_manifest_from_path` + the shared `load_rule_dir_specs`. No pkg-mgr internals touched — purely the materialized-package convention.

## Not in this PR (remaining #2846 distribution layer)

- Direct `@scope/name` **registry** lookup (bypassing the local dependency alias).
- `harn rule publish` / `harn rule search` thin aliases over the existing `harn publish` + CDN registry index.

## Verification

- `cargo test -p harn-cli --test rule_pack_install_dispatch` — 2 green (installed pack resolves by name; unknown name suggests `harn add`).
- `rule_discovery_dispatch` (4) still green; `cargo fmt` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)