### PR TITLE
rules: harn rule test discovers project [rules] ruleDirs (#2843)

### DIFF
--- a/changelog.d/2843.changed.md
+++ b/changelog.d/2843.changed.md
@@ -1,0 +1,3 @@
+- `harn rule test` with no path now discovers the project's rules from `[rules] ruleDirs` in `harn.toml` (Rule Engine
+  Epic B) — `harn rule test` becomes a zero-config CI gate for a project's rule pack. Scoped to the declared dirs, so a
+  stray non-rule `*.toml` elsewhere in the tree is not swept up. An explicit `harn rule test <path>` is unchanged.

--- a/crates/harn-cli/src/commands/rule.rs
+++ b/crates/harn-cli/src/commands/rule.rs
@@ -24,19 +24,30 @@ pub(crate) async fn run(args: RuleArgs) {
 #[cfg(feature = "hostlib")]
 fn run_test(args: crate::cli::RuleTestArgs) {
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use harn_rules::{load_rule_file, run_inline_test, CompiledRule, InlineTestReport};
 
-    let root = PathBuf::from(args.path.as_deref().unwrap_or("."));
-    let rule_files = discover_rule_files(&root);
+    // An explicit path wins; otherwise discover the project's `[rules]
+    // ruleDirs` (#2843), falling back to the current directory. This makes
+    // `harn rule test` a zero-config CI gate for a project's rule pack.
+    let (rule_files, source): (Vec<PathBuf>, String) = match args.path.as_deref() {
+        Some(path) => (discover_rule_files(Path::new(path)), path.to_string()),
+        None => match project_rule_dirs() {
+            Some(dirs) => (
+                dirs.iter().flat_map(|d| discover_rule_files(d)).collect(),
+                "[rules] ruleDirs".to_string(),
+            ),
+            None => (discover_rule_files(Path::new(".")), ".".to_string()),
+        },
+    };
     if rule_files.is_empty() {
-        eprintln!(
-            "rule test: no `*.toml` rules found under `{}`",
-            root.display()
-        );
+        eprintln!("rule test: no `*.toml` rules found under `{source}`");
         std::process::exit(2);
     }
+    // A failed load of an explicitly-named rule file is a hard error; a stray
+    // non-rule `*.toml` swept from a directory is silently skipped.
+    let explicit_file = args.path.as_deref().is_some_and(|p| Path::new(p).is_file());
 
     struct Case {
         fixture: PathBuf,
@@ -52,7 +63,7 @@ fn run_test(args: crate::cli::RuleTestArgs) {
             // A non-rule `*.toml` in a scanned directory is silently skipped;
             // an explicit file argument that fails is a hard error.
             Err(err) => {
-                if root.is_file() {
+                if explicit_file {
                     errors.push(format!("{}: {err}", rule_path.display()));
                 }
                 continue;
@@ -152,4 +163,23 @@ fn discover_rule_files(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     }
     out.sort();
     out
+}
+
+/// The project's `[rules] ruleDirs` (resolved relative to the manifest dir),
+/// or `None` when there is no manifest or it declares no `ruleDirs`.
+#[cfg(feature = "hostlib")]
+fn project_rule_dirs() -> Option<Vec<std::path::PathBuf>> {
+    let cwd = std::env::current_dir().ok()?;
+    let (manifest, dir) = crate::package::find_nearest_manifest(&cwd)?;
+    if manifest.rules.rule_dirs.is_empty() {
+        return None;
+    }
+    Some(
+        manifest
+            .rules
+            .rule_dirs
+            .iter()
+            .map(|rel| dir.join(rel))
+            .collect(),
+    )
 }

--- a/crates/harn-cli/tests/rule_test_dispatch.rs
+++ b/crates/harn-cli/tests/rule_test_dispatch.rs
@@ -32,6 +32,36 @@ fn rule_test(dir: &Path, extra: &[&str]) -> (String, i32) {
 }
 
 #[test]
+fn no_path_discovers_project_ruledirs() {
+    // With no path, `harn rule test` uses the project's `[rules] ruleDirs`
+    // (#2843) — scoped to the declared dirs, so a stray non-rule `*.toml`
+    // elsewhere in the project is not swept up.
+    let dir = fixture_dir("discover");
+    std::fs::create_dir_all(dir.join("rules")).unwrap();
+    write(&dir, "harn.toml", "[rules]\nruleDirs = [\"rules\"]\n");
+    write(&dir, "rules/no-foo.toml", NO_FOO);
+    write(
+        &dir,
+        "rules/no-foo.ts",
+        "// ruleid: no-foo\nfoo();\n// ok: no-foo\nbar();\n",
+    );
+    // A non-rule TOML at the project root that must be ignored.
+    write(&dir, "other.toml", "[package]\nname = \"x\"\n");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(&dir)
+        .args(["rule", "test"])
+        .output()
+        .expect("spawn");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code().unwrap_or(-1), 0, "stdout={stdout}");
+    assert!(stdout.contains("1 passed"), "stdout={stdout}");
+    assert!(!stdout.contains("other.toml"), "stray toml swept: {stdout}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn passing_fixture_exits_zero() {
     let dir = fixture_dir("pass");
     write(&dir, "no-foo.toml", NO_FOO);


### PR DESCRIPTION
Part of #2843. Rule Engine Epic B (#2828). Independent off main (builds on #2898's `[rules] ruleDirs`, now on main).

## What

`harn rule test` with no path discovers the project's rules from `[rules] ruleDirs` in `harn.toml` — a zero-config CI gate for a project's rule pack:

```console
harn rule test          # tests every rule in the project's ruleDirs
```

Scoped to the declared dirs (via `find_nearest_manifest`), so a stray non-rule `*.toml` elsewhere in the tree is not swept up — unlike the previous bare-cwd default. An explicit `harn rule test <path>` is unchanged.

## Verification

- `cargo test -p harn-cli --test rule_test_dispatch` — 3 green (incl. the new no-path discovery, which also asserts a root `other.toml` is ignored).
- `cargo fmt` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)