### PR TITLE
Add Harn tree-sitter support to rule engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,6 +2376,7 @@ dependencies = [
  "tree-sitter-css",
  "tree-sitter-elixir",
  "tree-sitter-go",
+ "tree-sitter-harn",
  "tree-sitter-haskell",
  "tree-sitter-html",
  "tree-sitter-java",
@@ -6360,6 +6361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-harn"
+version = "0.8.63"
+dependencies = [
+ "cc",
+ "tree-sitter",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/harn-rules",
     "crates/harn-rules-hostlib",
     "crates/harn-mcp-rc-compat",
+    "tree-sitter-harn",
     "perf/llm",
     "perf/vm",
     "perf/orchestration",

--- a/changelog.d/2888.added.md
+++ b/changelog.d/2888.added.md
@@ -1,0 +1,3 @@
+- **Harn structural rule scanning.** The rule engine now ships the Harn
+  tree-sitter grammar through `harn-hostlib`, so `harn scan` and saved TOML
+  rules can structurally match `.harn` source with `language = "harn"` (#2888).

--- a/crates/harn-cli/src/cli/scan.rs
+++ b/crates/harn-cli/src/cli/scan.rs
@@ -14,7 +14,7 @@ pub(crate) struct ScanArgs {
     /// `<pattern> [paths...]`, or just `[paths...]` with `--rule`/`--rule-pack`.
     #[arg(value_name = "ARGS")]
     pub args: Vec<String>,
-    /// Target language for an inline pattern (e.g. `typescript`, `rust`).
+    /// Target language for an inline pattern (e.g. `harn`, `typescript`, `rust`).
     #[arg(long, value_name = "LANG")]
     pub lang: Option<String>,
     /// Run a rule from a TOML file instead of an inline pattern.

--- a/crates/harn-cli/tests/scan_dispatch.rs
+++ b/crates/harn-cli/tests/scan_dispatch.rs
@@ -71,6 +71,55 @@ fn inline_pattern_search_reports_matches_and_skips_other_languages() {
 }
 
 #[test]
+fn inline_pattern_search_supports_harn_sources() {
+    let dir = fixture_dir("harn");
+    write(
+        &dir,
+        "rule_targets.harn",
+        "fn main() {\n  let timeout = cfg?.timeout ?? 30\n  let retries = opts?.retries ?? 3\n}\n",
+    );
+    write(&dir, "other.ts", "const timeout = cfg?.timeout ?? 30;\n");
+
+    let out = scan(&[
+        "$X?.$K ?? $D",
+        dir.to_str().unwrap(),
+        "--lang",
+        "harn",
+        "--json",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    let json: serde_json::Value = serde_json::from_str(&out.stdout).expect("valid json envelope");
+    assert_eq!(json["mode"], "search");
+    assert_eq!(json["summary"]["total"], 2);
+    assert_eq!(json["summary"]["files"], 1);
+    let captures = &json["results"][0]["matches"][0]["captures"];
+    assert_eq!(captures["X"], "cfg");
+    assert_eq!(captures["K"], "timeout");
+    assert_eq!(captures["D"], "30");
+
+    write(
+        &dir,
+        "harn_default_rule.toml",
+        "id = \"harn-defaults\"\nlanguage = \"harn\"\n[rule]\npattern = \"$X?.$K ?? $D\"\n",
+    );
+    let rule_out = scan(&[
+        "--rule",
+        dir.join("harn_default_rule.toml").to_str().unwrap(),
+        dir.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(rule_out.code, 0, "stderr={}", rule_out.stderr);
+    let rule_json: serde_json::Value =
+        serde_json::from_str(&rule_out.stdout).expect("valid rule json envelope");
+    assert_eq!(rule_json["mode"], "search");
+    assert_eq!(rule_json["summary"]["total"], 2);
+    assert_eq!(rule_json["summary"]["files"], 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn report_only_emits_per_file_counts() {
     let dir = fixture_dir("report");
     write(&dir, "a.ts", "let p = a?.x ?? 1;\nlet q = b?.y ?? 2;\n");

--- a/crates/harn-hostlib/Cargo.toml
+++ b/crates/harn-hostlib/Cargo.toml
@@ -45,6 +45,7 @@ ast = [
 # fallback). `grammars-all` is the umbrella the `ast` feature turns on for
 # parity; pick individual families instead for a trimmed grammar set.
 grammars-all = [
+    "grammar-harn",
     "grammar-web",
     "grammar-systems",
     "grammar-scripting",
@@ -52,6 +53,7 @@ grammars-all = [
     "grammar-enterprise",
     "grammar-data",
 ]
+grammar-harn = ["dep:tree-sitter-harn"]
 grammar-web = [
     "dep:tree-sitter-typescript",
     "dep:tree-sitter-javascript",
@@ -176,6 +178,7 @@ tree-sitter-css = { version = "0.25", optional = true }
 tree-sitter-html = { version = "0.23", optional = true }
 tree-sitter-sequel = { version = "0.3", optional = true }
 tree-sitter-md = { version = "0.5", optional = true }
+tree-sitter-harn = { path = "../../tree-sitter-harn", version = "0.8", optional = true }
 
 # Per-OS secret-store backends. The file backend is always compiled in
 # (and is the universal fallback when `HARN_SECRET_STORE_BACKEND=file` is

--- a/crates/harn-hostlib/src/ast/language.rs
+++ b/crates/harn-hostlib/src/ast/language.rs
@@ -35,6 +35,7 @@ use tree_sitter::Language as TsLanguage;
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Language {
+    Harn,
     TypeScript,
     Tsx,
     JavaScript,
@@ -98,6 +99,7 @@ impl Language {
     /// Canonical wire name.
     pub fn name(self) -> &'static str {
         match self {
+            Language::Harn => "harn",
             Language::TypeScript => "typescript",
             Language::Tsx => "tsx",
             Language::JavaScript => "javascript",
@@ -142,6 +144,9 @@ impl Language {
     /// Cheap when present; the underlying `LANGUAGE` constants are static.
     pub fn ts_language(self) -> Option<TsLanguage> {
         Some(match self {
+            #[cfg(feature = "grammar-harn")]
+            Language::Harn => tree_sitter_harn::LANGUAGE.into(),
+
             #[cfg(feature = "grammar-web")]
             Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
             #[cfg(feature = "grammar-web")]
@@ -220,6 +225,7 @@ impl Language {
     pub fn from_name(name: &str) -> Option<Self> {
         let normalized = name.trim().to_ascii_lowercase();
         Some(match normalized.as_str() {
+            "harn" => Language::Harn,
             "typescript" | "ts" => Language::TypeScript,
             "tsx" => Language::Tsx,
             "javascript" | "js" => Language::JavaScript,
@@ -257,6 +263,7 @@ impl Language {
     pub fn from_extension(ext: &str) -> Option<Self> {
         let normalized = ext.trim_start_matches('.').to_ascii_lowercase();
         Some(match normalized.as_str() {
+            "harn" => Language::Harn,
             "ts" => Language::TypeScript,
             "tsx" => Language::Tsx,
             "js" | "mjs" | "cjs" => Language::JavaScript,
@@ -305,6 +312,7 @@ impl Language {
     /// extension [`Language::from_extension`] accepts.
     pub fn primary_extension(self) -> &'static str {
         match self {
+            Language::Harn => "harn",
             Language::TypeScript => "ts",
             Language::Tsx => "tsx",
             Language::JavaScript => "js",
@@ -346,6 +354,7 @@ impl Language {
     /// substrings. `None` means the language has no rename projection yet.
     pub fn rename_identifier_kinds(self) -> Option<&'static [&'static str]> {
         Some(match self {
+            Language::Harn => &["identifier"],
             Language::Rust => &[
                 "identifier",
                 "type_identifier",
@@ -418,6 +427,7 @@ impl Language {
     /// Every language we ship support for. Useful for tests + introspection.
     pub fn all() -> &'static [Language] {
         &[
+            Language::Harn,
             Language::TypeScript,
             Language::Tsx,
             Language::JavaScript,
@@ -473,6 +483,7 @@ mod tests {
     #[test]
     fn extension_detection_round_trips_canonical_extensions() {
         let cases: &[(&str, Language)] = &[
+            ("harn", Language::Harn),
             ("ts", Language::TypeScript),
             ("tsx", Language::Tsx),
             ("js", Language::JavaScript),

--- a/crates/harn-hostlib/src/ast/mod.rs
+++ b/crates/harn-hostlib/src/ast/mod.rs
@@ -18,8 +18,8 @@
 //! ## Languages
 //!
 //! [`language::Language`] covers the general-purpose languages
-//! (TypeScript/TSX, JavaScript/JSX, Python, Go, Rust, Java, C, C++, C#,
-//! Ruby, Kotlin, PHP, Scala, Bash, Swift, Zig, Elixir, Lua, Haskell, R)
+//! (Harn, TypeScript/TSX, JavaScript/JSX, Python, Go, Rust, Java, C, C++,
+//! C#, Ruby, Kotlin, PHP, Scala, Bash, Swift, Zig, Elixir, Lua, Haskell, R)
 //! plus data/markup/config grammars (JSON, YAML, TOML, CSS, HTML, SQL,
 //! Markdown). The latter support the query-driven edit primitives but
 //! carry no symbol-graph projection — see

--- a/crates/harn-hostlib/src/ast/parse_errors.rs
+++ b/crates/harn-hostlib/src/ast/parse_errors.rs
@@ -208,6 +208,23 @@ fn count_top_level_declarations(root: Node<'_>, language: Language) -> u32 {
 #[allow(clippy::type_complexity)]
 fn declaration_kinds(language: Language) -> (&'static [&'static str], &'static [&'static str]) {
     match language {
+        Language::Harn => (
+            &[
+                "pipeline_declaration",
+                "import_declaration",
+                "fn_declaration",
+                "tool_declaration",
+                "skill_declaration",
+                "eval_pack_declaration",
+                "struct_declaration",
+                "enum_declaration",
+                "interface_declaration",
+                "type_declaration",
+                "impl_block",
+                "attributed_declaration",
+            ],
+            &["attributed_declaration"],
+        ),
         Language::TypeScript | Language::Tsx => (
             &[
                 "function_declaration",

--- a/crates/harn-hostlib/src/ast/symbols.rs
+++ b/crates/harn-hostlib/src/ast/symbols.rs
@@ -33,6 +33,7 @@ pub(super) fn extract(tree: &Tree, source: &str, language: Language) -> Vec<Symb
     let mut out: Vec<Symbol> = Vec::new();
 
     match language {
+        Language::Harn => extract_harn(root, source, &mut out),
         Language::TypeScript | Language::Tsx => extract_typescript(root, source, &mut out),
         Language::JavaScript | Language::Jsx => extract_javascript(root, source, &mut out),
         Language::Go => extract_go(root, source, &mut out),
@@ -1526,4 +1527,180 @@ fn extract_r(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
         ));
         None
     });
+}
+
+// ---------------------------------------------------------------------------
+// Harn
+// ---------------------------------------------------------------------------
+
+fn extract_harn(root: Node<'_>, source: &str, out: &mut Vec<Symbol>) {
+    walk_named(root, None, &mut |node, container| {
+        let pos = point_pos(node);
+        match node.kind() {
+            "pipeline_declaration" => {
+                push_harn_callable(
+                    node,
+                    source,
+                    container,
+                    pos,
+                    SymbolKind::Function,
+                    "pipeline",
+                    out,
+                );
+                None
+            }
+            "fn_declaration" => {
+                let kind = if container.is_some() {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                };
+                push_harn_callable(node, source, container, pos, kind, "fn", out);
+                None
+            }
+            "tool_declaration" => {
+                push_harn_callable(
+                    node,
+                    source,
+                    container,
+                    pos,
+                    SymbolKind::Function,
+                    "tool",
+                    out,
+                );
+                None
+            }
+            "override_declaration" | "interface_method" => {
+                push_harn_callable(node, source, container, pos, SymbolKind::Method, "fn", out);
+                None
+            }
+            "skill_declaration" => harn_named_decl(
+                node,
+                source,
+                container,
+                pos,
+                SymbolKind::Other,
+                "skill",
+                out,
+            ),
+            "eval_pack_declaration" => {
+                push_harn_eval_pack(node, source, container, pos, out);
+                None
+            }
+            "struct_declaration" => harn_named_decl(
+                node,
+                source,
+                container,
+                pos,
+                SymbolKind::Struct,
+                "struct",
+                out,
+            ),
+            "enum_declaration" => {
+                harn_named_decl(node, source, container, pos, SymbolKind::Enum, "enum", out)
+            }
+            "interface_declaration" => harn_named_decl(
+                node,
+                source,
+                container,
+                pos,
+                SymbolKind::Interface,
+                "interface",
+                out,
+            ),
+            "type_declaration" | "associated_type_declaration" => {
+                harn_named_decl(node, source, container, pos, SymbolKind::Type, "type", out)
+            }
+            "impl_block" => push_harn_impl(node, source, container, pos, out),
+            _ => None,
+        }
+    });
+}
+
+fn push_harn_callable(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    kind: SymbolKind,
+    keyword: &'static str,
+    out: &mut Vec<Symbol>,
+) {
+    let Some(name) = field_text(node, "name", source) else {
+        return;
+    };
+    let params = harn_parameter_text(node, source);
+    out.push(helpers::sym(
+        &name,
+        kind,
+        container,
+        format!("{keyword} {name}{}", truncate(&params, 80)),
+        pos,
+    ));
+}
+
+fn harn_named_decl(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    kind: SymbolKind,
+    keyword: &'static str,
+    out: &mut Vec<Symbol>,
+) -> Option<String> {
+    let name = field_text(node, "name", source)?;
+    out.push(helpers::sym(
+        &name,
+        kind,
+        container,
+        format!("{keyword} {name}"),
+        pos,
+    ));
+    kind.is_container().then_some(name)
+}
+
+fn push_harn_eval_pack(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) {
+    let name = field_text(node, "name", source)
+        .or_else(|| field_text(node, "id", source).map(|id| id.trim_matches('"').to_string()));
+    let Some(name) = name else {
+        return;
+    };
+    out.push(helpers::sym(
+        &name,
+        SymbolKind::Other,
+        container,
+        format!("eval_pack {name}"),
+        pos,
+    ));
+}
+
+fn push_harn_impl(
+    node: Node<'_>,
+    source: &str,
+    container: Option<&str>,
+    pos: NodePos,
+    out: &mut Vec<Symbol>,
+) -> Option<String> {
+    let name = field_text(node, "type_name", source)?;
+    out.push(helpers::sym(
+        &name,
+        SymbolKind::Module,
+        container,
+        format!("impl {name}"),
+        pos,
+    ));
+    Some(name)
+}
+
+fn harn_parameter_text(node: Node<'_>, source: &str) -> String {
+    helpers::children(node)
+        .find(|child| child.is_named() && child.kind() == "parameter_list")
+        .map(|child| format!("({})", helpers::node_text(child, source)))
+        .unwrap_or_else(|| "()".to_string())
 }

--- a/crates/harn-hostlib/src/code_index/rename.rs
+++ b/crates/harn-hostlib/src/code_index/rename.rs
@@ -1202,6 +1202,33 @@ mod tests {
     }
 
     #[test]
+    fn harn_workspace_rename() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("src/task.harn"),
+            "pub struct Task {\n  title: string\n}\n\nimpl Task {\n  fn summary(task: Task) -> string {\n    return task.title\n  }\n}\n\nfn summarize(task: Task) -> string {\n  return task.title\n}\n",
+        )
+        .unwrap();
+
+        let capability = build_index(root);
+        let symbol_ref = dict(&[
+            ("name", vm_string("Task")),
+            ("path", vm_string("src/task.harn")),
+            ("kind", vm_string("Type")),
+        ]);
+        let result = rename(&capability, symbol_ref, "Job", "workspace");
+        assert_eq!(s(field(&result, "result")), "applied");
+        let source = fs::read_to_string(root.join("src/task.harn")).unwrap();
+        assert!(source.contains("struct Job"));
+        assert!(source.contains("impl Job"));
+        assert!(source.contains("task: Job"));
+        assert!(source.contains("return task.title"));
+        assert!(!source.contains("Task"));
+    }
+
+    #[test]
     fn ambiguous_symbol_without_disambiguator() {
         let dir = tempdir().unwrap();
         let root = dir.path();

--- a/crates/harn-hostlib/tests/ast_language_coverage.rs
+++ b/crates/harn-hostlib/tests/ast_language_coverage.rs
@@ -238,6 +238,8 @@ fn capabilities_matrix_covers_every_language_and_gates_rename() {
     };
     assert!(!b(field(&find("json"), "rename_symbol")));
     assert!(!b(field(&find("json"), "symbols")));
+    assert!(b(field(&find("harn"), "rename_symbol")));
+    assert!(b(field(&find("harn"), "symbols")));
     assert!(b(field(&find("rust"), "rename_symbol")));
     assert!(b(field(&find("rust"), "symbols")));
 }

--- a/crates/harn-hostlib/tests/fixtures/ast/harn/outline.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/harn/outline.golden.json
@@ -1,0 +1,17 @@
+[
+  {"name":"Task", "kind":"struct", "signature":"struct Task", "start_row":0, "end_row":3, "children":[]},
+  {"name":"Runner", "kind":"interface", "signature":"interface Runner", "start_row":5, "end_row":7, "children":
+    [
+      {"name":"run", "kind":"method", "signature":"fn run(task: Task)", "start_row":6, "end_row":6, "children":[]}
+    ]
+  },
+  {"name":"_execute", "kind":"function", "signature":"fn _execute(runner: Runner, task: Task)", "start_row":9, "end_row":11, "children":[]},
+  {"name":"Task", "kind":"module", "signature":"impl Task", "start_row":13, "end_row":17, "children":
+    [
+      {"name":"summary", "kind":"method", "signature":"fn summary(title: string)", "start_row":14, "end_row":16, "children":[]}
+    ]
+  },
+  {"name":"normalize", "kind":"function", "signature":"fn normalize(task)", "start_row":19, "end_row":21, "children":[]},
+  {"name":"review", "kind":"function", "signature":"pipeline review(task)", "start_row":23, "end_row":26, "children":[]},
+  {"name":"_notify", "kind":"function", "signature":"tool _notify(message)", "start_row":28, "end_row":31, "children":[]}
+]

--- a/crates/harn-hostlib/tests/fixtures/ast/harn/source.harn
+++ b/crates/harn-hostlib/tests/fixtures/ast/harn/source.harn
@@ -1,0 +1,32 @@
+pub struct Task {
+  id: string
+  title: string
+}
+
+interface Runner {
+  fn run(task: Task) -> dict
+}
+
+fn _execute(runner: Runner, task: Task) {
+  return runner.run(task)
+}
+
+impl Task {
+  fn summary(title: string) -> string {
+    return title
+  }
+}
+
+fn normalize(task) {
+  return {id: task.id, title: task.title}
+}
+
+pipeline review(task) {
+  let _normalized = normalize(task)
+  return task?.title ?? "untitled"
+}
+
+tool _notify(message) {
+  description "Send a notification"
+  return {ok: true, message: message}
+}

--- a/crates/harn-hostlib/tests/fixtures/ast/harn/symbols.golden.json
+++ b/crates/harn-hostlib/tests/fixtures/ast/harn/symbols.golden.json
@@ -1,0 +1,11 @@
+[
+  {"name":"Task", "kind":"struct", "container":null, "signature":"struct Task", "start_row":0, "start_col":0, "end_row":3, "end_col":1},
+  {"name":"Runner", "kind":"interface", "container":null, "signature":"interface Runner", "start_row":5, "start_col":0, "end_row":7, "end_col":1},
+  {"name":"run", "kind":"method", "container":"Runner", "signature":"fn run(task: Task)", "start_row":6, "start_col":2, "end_row":6, "end_col":28},
+  {"name":"_execute", "kind":"function", "container":null, "signature":"fn _execute(runner: Runner, task: Task)", "start_row":9, "start_col":0, "end_row":11, "end_col":1},
+  {"name":"Task", "kind":"module", "container":null, "signature":"impl Task", "start_row":13, "start_col":0, "end_row":17, "end_col":1},
+  {"name":"summary", "kind":"method", "container":"Task", "signature":"fn summary(title: string)", "start_row":14, "start_col":2, "end_row":16, "end_col":3},
+  {"name":"normalize", "kind":"function", "container":null, "signature":"fn normalize(task)", "start_row":19, "start_col":0, "end_row":21, "end_col":1},
+  {"name":"review", "kind":"function", "container":null, "signature":"pipeline review(task)", "start_row":23, "start_col":0, "end_row":26, "end_col":1},
+  {"name":"_notify", "kind":"function", "container":null, "signature":"tool _notify(message)", "start_row":28, "start_col":0, "end_row":31, "end_col":1}
+]

--- a/crates/harn-rules/src/pattern.rs
+++ b/crates/harn-rules/src/pattern.rs
@@ -492,6 +492,21 @@ mod tests {
     }
 
     #[test]
+    fn compiles_optional_chain_nil_coalescing_in_harn() {
+        let snippet = "$SRC?.$KEY ?? $DEFAULT";
+        let compiled = compile_pattern(snippet, Language::Harn).expect("compiles");
+        assert_eq!(compiled.metavars, vec!["SRC", "KEY", "DEFAULT"]);
+        let binds = run(
+            snippet,
+            Language::Harn,
+            "fn main() {\n  let timeout = cfg?.timeout ?? 30\n}\n",
+        );
+        assert_eq!(capture(&binds, "SRC"), ["cfg".to_string()]);
+        assert_eq!(capture(&binds, "KEY"), ["timeout".to_string()]);
+        assert_eq!(capture(&binds, "DEFAULT"), ["30".to_string()]);
+    }
+
+    #[test]
     fn operator_is_constrained_not_just_structure() {
         // The `??` literal in the query must reject a `||` with the same
         // structural shape — otherwise the codemod would be unsound.

--- a/crates/harn-skills/src/corpus/harn-rules/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-rules/SKILL.md
@@ -84,9 +84,8 @@ conformance fixtures.
 
 ## Gotchas
 
-- There is **no Harn tree-sitter grammar yet**, so `.harn` source can't be
-  scanned structurally — rules target TS/JS/Rust/Go/Python/etc. (tracked in
-  #2888).
+- Harn source is supported: pass `--lang harn`, set `language = "harn"`, or let
+  `.harn` paths resolve from their extension.
 - `rules_apply` is a gated deterministic tool: call
   `hostlib_enable("tools:deterministic")` before it (even for a dry run).
 - Format every rule run / fixture with both `cargo fmt` and `harn fmt`.

--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -528,7 +528,7 @@ pipeline default(task) {
 
 Drop `dry_run` to actually rewrite the files; pair the call with a
 `session_id` for full staged-fs atomicity across the rename plus any
-sibling writes. Supported languages on the first batch: Rust,
+sibling writes. Supported languages on the first batch: Harn, Rust,
 TypeScript/TSX, JavaScript/JSX, Python, Swift, Go.
 
 For the full result shape (`touched_files[*].edits[*]` with byte and

--- a/docs/src/cookbooks/rename-symbol.md
+++ b/docs/src/cookbooks/rename-symbol.md
@@ -12,7 +12,7 @@ touched file lands in the overlay; one `hostlib_fs_commit_staged` flips them
 atomically. Without a session, the host still buffers the full plan in memory
 and only writes after pre-flight passes, so a clean run is all-or-nothing.
 
-Supported languages (first batch): Rust, TypeScript/TSX, JavaScript/JSX,
+Supported languages (first batch): Harn, Rust, TypeScript/TSX, JavaScript/JSX,
 Python, Swift, Go.
 
 ## Recipe — rename a Rust struct across the workspace

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -5,9 +5,8 @@ tree), not by regex. A rule is a small TOML file; you run it read-only with
 `harn scan`, or as a codemod with `harn codemod`. Under the hood it is the
 `harn-rules` crate, exposed to `.harn` as `std/rules`.
 
-> **Languages:** rules target a tree-sitter grammar — TypeScript/JS, Rust, Go,
-> Python, Java, C/C++, Ruby, and more. There is no Harn grammar yet, so `.harn`
-> source can't be scanned structurally ([#2888](https://github.com/burin-labs/harn/issues/2888)).
+> **Languages:** rules target a tree-sitter grammar: Harn, TypeScript/JS, Rust,
+> Go, Python, Java, C/C++, Ruby, and more.
 
 ## How do I search for a code shape?
 
@@ -19,6 +18,12 @@ $ harn scan '$X?.$K ?? $D' src --lang typescript
 src/config.ts:12:18: cfg?.timeout ?? 30   [D=30 K=timeout X=cfg]
 src/config.ts:13:18: cfg?.retries ?? 3    [D=3 K=retries X=cfg]
 2 match(es) in 1 file(s)
+```
+
+The same structural search works over Harn source:
+
+```console
+harn scan '$X?.$K ?? $D' crates/harn-stdlib --lang harn
 ```
 
 - `$X`, `$K`, `$D` are **metavariables** — each binds a sub-tree and is printed
@@ -96,8 +101,8 @@ ruleDirs = ["rules"]
 ```
 
 ```console
-$ harn scan src             # runs every rule under rules/ over src/
-$ harn codemod src          # applies the codemod rules; lints are skipped
+harn scan src             # runs every rule under rules/ over src/
+harn codemod src          # applies the codemod rules; lints are skipped
 ```
 
 With `[rules] ruleDirs` set, `harn scan <paths>` needs no inline pattern — a

--- a/docs/src/stdlib/edit.md
+++ b/docs/src/stdlib/edit.md
@@ -711,7 +711,7 @@ Backed by the `hostlib_code_index_rename_symbol` builtin (issue
 | `dry_run` | no | When `true`, the host validates end-to-end (parse, conflict, syntax) and returns the planned edits without writing. |
 | `validate` | no, default `true` | Re-parse every rewritten file; reject on ERROR / MISSING nodes. |
 
-Supported languages (first batch): Rust, TypeScript/TSX, JavaScript/JSX,
+Supported languages (first batch): Harn, Rust, TypeScript/TSX, JavaScript/JSX,
 Python, Swift, Go. Other languages return `result ==
 "unsupported_language"` instead of silently misrewriting.
 

--- a/scripts/verify_crate_packages.sh
+++ b/scripts/verify_crate_packages.sh
@@ -40,9 +40,9 @@ metadata_file="$tmp/cargo-metadata.json"
 printf '%s\n' "$metadata" >"$metadata_file"
 
 # Verify the candidate workspace as a coherent publish set instead of
-# resolving intra-Harn dependencies to whatever versions are already on
-# crates.io. That catches package-only failures without needing a prior
-# bootstrap publish for newly split crates.
+# resolving workspace-local dependencies to whatever versions are already
+# on crates.io. That catches package-only failures without needing a
+# prior bootstrap publish for newly split crates.
 local_harn_patches=()
 while IFS=$'\t' read -r crate manifest_path; do
   crate_dir="$(cd "$(dirname "$manifest_path")" && pwd)"
@@ -56,11 +56,7 @@ import sys
 metadata = json.loads(pathlib.Path(sys.argv[1]).read_text())
 members = set(metadata["workspace_members"])
 for package in sorted(metadata["packages"], key=lambda p: p["name"]):
-    if (
-        package["id"] in members
-        and package["name"].startswith("harn-")
-        and package.get("publish") != []
-    ):
+    if package["id"] in members and package.get("publish") != []:
         print(f'{package["name"]}\t{package["manifest_path"]}')
 PY
 )

--- a/tree-sitter-harn/Cargo.toml
+++ b/tree-sitter-harn/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "tree-sitter-harn"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Harn grammar for tree-sitter"
+build = "bindings/rust/build.rs"
+include = [
+    "bindings/rust/*",
+    "grammar.js",
+    "grammar/**/*",
+    "queries/*",
+    "src/**/*",
+    "tree-sitter.json",
+]
+
+[lib]
+name = "tree_sitter_harn"
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter-language = "0.1"
+
+[dev-dependencies]
+tree-sitter = "0.26"
+
+[build-dependencies]
+cc = "1.1"
+
+[lints]
+workspace = true

--- a/tree-sitter-harn/bindings/rust/build.rs
+++ b/tree-sitter-harn/bindings/rust/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    let src_dir = std::path::Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.std("c11").include(src_dir);
+
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+
+    c_config.compile("tree-sitter-harn");
+}

--- a/tree-sitter-harn/bindings/rust/lib.rs
+++ b/tree-sitter-harn/bindings/rust/lib.rs
@@ -1,0 +1,27 @@
+//! Harn language support for the tree-sitter parsing library.
+
+use tree_sitter_language::LanguageFn;
+
+extern "C" {
+    fn tree_sitter_harn() -> *const ();
+}
+
+/// The tree-sitter language function for Harn.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_harn) };
+
+/// The content of the generated `node-types.json` file.
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
+
+/// The syntax highlighting query for Harn.
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&super::LANGUAGE.into())
+            .expect("load Harn parser");
+    }
+}


### PR DESCRIPTION
Closes #2888

## Summary
- Package the existing tree-sitter-harn grammar as a workspace Rust crate and wire it into harn-hostlib as Language::Harn.
- Add Harn structural scan coverage for inline patterns and saved TOML rules, plus Harn AST symbols/outline and rename coverage.
- Update rule-engine docs, std/edit language lists, CLI help, and the embedded harn-rules skill now that .harn structural scanning is supported.

## Verification
- cargo test -p tree-sitter-harn
- cargo test -p harn-hostlib --test ast_fixtures
- cargo test -p harn-hostlib --test ast_language_coverage
- cargo test -p harn-hostlib code_index::rename::tests:: --lib
- cargo test -p harn-cli --test scan_dispatch
- cargo test -p harn-rules
- cargo run --quiet --bin harn -- scan `$X?.$K ?? $D` crates/harn-stdlib --lang harn --json
- npm test (tree-sitter-harn)
- make check-docs-snippets
- make lint-test-patterns
- cargo fmt --check
- git diff --check
- pre-commit and pre-push hooks