### PR TITLE
Keep the system prompt cache-stable: append reminders as a trailing message

### DIFF
--- a/changelog.d/2903.changed.md
+++ b/changelog.d/2903.changed.md
@@ -1,0 +1,4 @@
+- **Reminder prompts now preserve local model prefix-cache stability (#2903).**
+  Non-Anthropic reminder text is appended after the message history instead of
+  mutating the leading system prompt, so llama.cpp-style prefix caches stay warm
+  when reminder sets change.

--- a/conformance/tests/agents/agent_resume_continuity_reminder.harn
+++ b/conformance/tests/agents/agent_resume_continuity_reminder.harn
@@ -40,19 +40,25 @@ pipeline main() {
       let resumed = resume_agent(suspended, "operator says go", true)
       let completed = wait_agent(handle)
       let calls = llm_mock_calls()
-      let resumed_system = calls[1].system
-      let next_system = calls[2].system
+      let resumed_msgs = calls[1].messages
+      let resumed_tail = resumed_msgs[len(resumed_msgs) - 1].content
+      let next_msgs = calls[2].messages
+      let next_tail = next_msgs[len(next_msgs) - 1].content
       let remaining = transcript_events_by_kind(completed.transcript, "system_reminder")
         .filter({ event -> event.reminder.dedupe_key == "resume_continuity" })
       __io_println(suspended.status)
       __io_println(resumed.status)
       __io_println(completed.status)
-      __io_println(contains(resumed_system, "You were suspended at turn"))
-      __io_println(contains(resumed_system, "waiting on review"))
-      __io_println(contains(resumed_system, "You have been resumed by the operator"))
-      __io_println(contains(resumed_system, "The resumer provided input: operator says go"))
-      __io_println(!contains(next_system, "You were suspended at turn"))
+      __io_println(contains(resumed_tail, "You were suspended at turn"))
+      __io_println(contains(resumed_tail, "waiting on review"))
+      __io_println(contains(resumed_tail, "You have been resumed by the operator"))
+      __io_println(contains(resumed_tail, "The resumer provided input: operator says go"))
+      __io_println(!contains(next_tail, "You were suspended at turn"))
       __io_println(len(remaining))
     },
   )
 }
+// The resume-continuity reminder is a SystemText reminder, now delivered
+// as the trailing user message rather than folded into the system string,
+// so the system string stays byte-stable across turns. Its body is
+// unchanged at the new position.

--- a/conformance/tests/agents/suspend_continue_transcript_false.harn
+++ b/conformance/tests/agents/suspend_continue_transcript_false.harn
@@ -51,15 +51,16 @@ pipeline main() {
       let _resumed_keep = resume_agent(handle_keep, "operator says go", true)
       let done_keep = wait_agent(handle_keep)
       let kept_calls = llm_mock_calls()
-      let kept_resumed_system = kept_calls[1].system
+      let kept_msgs = kept_calls[1].messages
+      let kept_resumed_tail = kept_msgs[len(kept_msgs) - 1].content
       __io_println("keep_status=" + done_keep.status)
       __io_println(
         "keep_resumed_at_turn="
-          + to_string(contains(kept_resumed_system, "You were suspended at turn")),
+          + to_string(contains(kept_resumed_tail, "You were suspended at turn")),
       )
       __io_println(
         "keep_no_digest_marker="
-          + to_string(!contains(kept_resumed_system, "Prior conversation digest")),
+          + to_string(!contains(kept_resumed_tail, "Prior conversation digest")),
       )
       let session_reset = "continue-false-" + uuid()
       let handle_reset = sub_agent_run(
@@ -77,29 +78,33 @@ pipeline main() {
       let _resumed_reset = resume_agent(handle_reset, "operator says reset", false)
       let done_reset = wait_agent(handle_reset)
       let reset_calls = llm_mock_calls()
-      let reset_resumed_system = reset_calls[3].system
+      let reset_msgs = reset_calls[3].messages
+      let reset_resumed_tail = reset_msgs[len(reset_msgs) - 1].content
       __io_println("reset_status=" + done_reset.status)
       __io_println(
         "reset_resumed_at_turn="
-          + to_string(contains(reset_resumed_system, "You were suspended at turn")),
+          + to_string(contains(reset_resumed_tail, "You were suspended at turn")),
       )
       __io_println(
         "reset_continuity_emitted="
           + to_string(
-          contains(reset_resumed_system, "Prior conversation")
-            || contains(reset_resumed_system, "You were suspended at turn"),
+          contains(reset_resumed_tail, "Prior conversation")
+            || contains(reset_resumed_tail, "You were suspended at turn"),
         ),
       )
       __io_println(
         "paths_differ_in_input="
           + to_string(
-          contains(kept_resumed_system, "operator says go")
-            && contains(reset_resumed_system, "operator says reset"),
+          contains(kept_resumed_tail, "operator says go")
+            && contains(reset_resumed_tail, "operator says reset"),
         ),
       )
     },
   )
 }
+// The resume-continuity reminder is a SystemText reminder, now delivered
+// as the trailing user message instead of folded into the system string
+// (keeps the system string byte-stable across turns).
 // The Pre-suspend digest is only attached when the snapshot recorded
 // a non-empty digest at resume-time. Until S-09's digest provider is
 // wired into background subagents we assert the reset path differs

--- a/conformance/tests/agents/suspend_self_park_with_input.harn
+++ b/conformance/tests/agents/suspend_self_park_with_input.harn
@@ -60,24 +60,30 @@ pipeline main() {
       let resumed = resume_agent(handle, "operator brief: ship the patch", true)
       let done = wait_agent(handle)
       let calls = llm_mock_calls()
-      let resumed_system = calls[1].system
-      let next_system = calls[2].system
+      let resumed_msgs = calls[1].messages
+      let resumed_tail = resumed_msgs[len(resumed_msgs) - 1].content
+      let next_msgs = calls[2].messages
+      let next_tail = next_msgs[len(next_msgs) - 1].content
       __io_println("suspended_status=" + suspended.status)
       __io_println("resume_status=" + resumed.status)
       __io_println("final_status=" + done.status)
       __io_println(
         "input_in_reminder="
-          + to_string(contains(resumed_system, "operator brief: ship the patch")),
+          + to_string(contains(resumed_tail, "operator brief: ship the patch")),
       )
-      __io_println("reason_in_reminder=" + to_string(contains(resumed_system, "needs operator brief")))
+      __io_println("reason_in_reminder=" + to_string(contains(resumed_tail, "needs operator brief")))
       __io_println(
         "reminder_present_on_resumed_turn="
-          + to_string(contains(resumed_system, "You were suspended at turn")),
+          + to_string(contains(resumed_tail, "You were suspended at turn")),
       )
       __io_println(
         "reminder_consumed_after_one_turn="
-          + to_string(!contains(next_system, "You were suspended at turn")),
+          + to_string(!contains(next_tail, "You were suspended at turn")),
       )
     },
   )
 }
+// The resume-continuity reminder is a SystemText reminder, now delivered
+// as the trailing user message rather than folded into the system string
+// (keeps the system string byte-stable across turns). Its body and
+// single-shot lifecycle are unchanged at the new position.

--- a/conformance/tests/reminders/reminder_render_gemini_xml.expected
+++ b/conformance/tests/reminders/reminder_render_gemini_xml.expected
@@ -1,4 +1,5 @@
 true
 true
 true
+true
 user

--- a/conformance/tests/reminders/reminder_render_gemini_xml.harn
+++ b/conformance/tests/reminders/reminder_render_gemini_xml.harn
@@ -28,11 +28,16 @@ pipeline main() {
         },
       )
       let call = llm_mock_calls()[0]
+      let last = call.messages[len(call.messages) - 1]
       __io_println(contains(call.system, "base system"))
-      __io_println(contains(call.system, "<system-reminder>"))
-      __io_println(contains(call.system, "gemini reminder"))
-      __io_println(call.messages[0].role)
+      __io_println(!contains(call.system, "<system-reminder>"))
+      __io_println(contains(last.content, "<system-reminder>"))
+      __io_println(contains(last.content, "gemini reminder"))
+      __io_println(last.role)
       clear_reminder_providers()
     },
   )
 }
+// The stable primary ("base system") stays in the system string, but the
+// XML-scaffolded reminder is moved to the trailing user message so the
+// system string is byte-stable across turns for the prefix cache.

--- a/conformance/tests/reminders/reminder_render_local.expected
+++ b/conformance/tests/reminders/reminder_render_local.expected
@@ -1,4 +1,5 @@
 true
 true
 true
+true
 user

--- a/conformance/tests/reminders/reminder_render_local.harn
+++ b/conformance/tests/reminders/reminder_render_local.harn
@@ -23,11 +23,15 @@ pipeline main() {
         {provider: "mock", model: "mock", messages: agent_session_messages(session), session_id: session},
       )
       let call = llm_mock_calls()[0]
-      __io_println(contains(call.system, "System reminder:"))
-      __io_println(contains(call.system, "local reminder"))
-      __io_println(!contains(call.system, "<system-reminder>"))
-      __io_println(call.messages[0].role)
+      let last = call.messages[len(call.messages) - 1]
+      __io_println(!contains(call.system, "System reminder:"))
+      __io_println(contains(last.content, "System reminder:"))
+      __io_println(contains(last.content, "local reminder"))
+      __io_println(!contains(last.content, "<system-reminder>"))
+      __io_println(last.role)
       clear_reminder_providers()
     },
   )
 }
+// SystemText reminders move out of the system string into the trailing
+// user message; the plain-prose body is preserved at the new position.

--- a/conformance/tests/reminders/reminder_render_local_fallback.expected
+++ b/conformance/tests/reminders/reminder_render_local_fallback.expected
@@ -1,4 +1,5 @@
 true
 true
 true
+true
 user

--- a/conformance/tests/reminders/reminder_render_local_fallback.harn
+++ b/conformance/tests/reminders/reminder_render_local_fallback.harn
@@ -27,12 +27,18 @@ pipeline main() {
         {provider: "mock", model: "mock", messages: agent_session_messages(session), session_id: session},
       )
       let call = llm_mock_calls()[0]
-      __io_println(contains(call.system, "System reminder:"))
-      __io_println(contains(call.system, "local fallback reminder"))
-      __io_println(!contains(call.system, "<system-reminder>"))
-      __io_println(call.messages[0].role)
+      let last = call.messages[len(call.messages) - 1]
+      __io_println(!contains(call.system, "System reminder:"))
+      __io_println(contains(last.content, "System reminder:"))
+      __io_println(contains(last.content, "local fallback reminder"))
+      __io_println(!contains(last.content, "<system-reminder>"))
+      __io_println(last.role)
       clear_reminder_providers()
     },
   )
 }
-// Local fallback uses plain prose, not XML tags.
+// SystemText reminders are kept OUT of the system string (so it stays
+// byte-stable across turns for the non-Anthropic prefix cache) and
+// folded into the trailing user message instead. The plain-prose body
+// and "no XML scaffolding" invariants are preserved at the new position.
+// Local fallback uses plain prose, not XML tags, now in the trailing message.

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -1207,21 +1207,82 @@ fn try_prepend_user_reminder(
     true
 }
 
+/// Append `text` to a message's `content`, preserving whatever shape the
+/// content already uses (string or array of content blocks). Mirrors the tail
+/// counterpart of [`prepend_content_blocks`].
+fn append_text_to_message_content(content: &mut serde_json::Value, text: &str) {
+    if let serde_json::Value::Array(existing) = content {
+        existing.push(serde_json::json!({"type": "text", "text": text}));
+        return;
+    }
+    if let serde_json::Value::String(existing) = content {
+        *existing = format!("{existing}\n\n{text}");
+        return;
+    }
+    if content.is_null() {
+        *content = serde_json::Value::String(text.to_string());
+        return;
+    }
+    *content = serde_json::Value::Array(vec![
+        std::mem::take(content),
+        serde_json::json!({"type": "text", "text": text}),
+    ]);
+}
+
+/// Fold the coalesced `SystemText` reminder block into the trailing message
+/// when that message is already a `user` turn, mirroring
+/// [`try_prepend_user_reminder`] but appending to the tail. Returns `false`
+/// when the last message is absent or not a `user` turn, so the caller can
+/// instead append a fresh trailing `user` message. Appending strictly after
+/// the final message also guarantees we never split a tool_call/tool_result
+/// pair.
+fn try_append_user_reminder_text(messages: &mut [serde_json::Value], text: &str) -> bool {
+    let Some(last) = messages.last_mut() else {
+        return false;
+    };
+    let Some(last_obj) = last.as_object_mut() else {
+        return false;
+    };
+    if last_obj.get("role").and_then(|role| role.as_str()) != Some("user") {
+        return false;
+    }
+    let content = last_obj
+        .entry("content".to_string())
+        .or_insert(serde_json::Value::Null);
+    append_text_to_message_content(content, text);
+    true
+}
+
 fn apply_rendered_reminder_messages(
     messages: Vec<serde_json::Value>,
     rendered: &[RenderedReminder],
 ) -> Vec<serde_json::Value> {
     let mut messages = messages;
     let mut prefix = Vec::new();
+    let mut system_text_blocks: Vec<&str> = Vec::new();
     for reminder in rendered {
-        let RenderedReminder::Message(message) = reminder else {
-            continue;
-        };
-        if !try_prepend_user_reminder(&mut messages, message) {
-            prefix.push(message.clone());
+        match reminder {
+            RenderedReminder::Message(message) => {
+                if !try_prepend_user_reminder(&mut messages, message) {
+                    prefix.push(message.clone());
+                }
+            }
+            // `SystemText` reminders used to be folded into the `system`
+            // string. They are now coalesced into a single trailing `user`
+            // message so the `system` string stays byte-identical across turns
+            // (keeping the llama.cpp / non-Anthropic KV prefix cache warm). The
+            // text is unchanged — `reminder_system_text` already wrapped each
+            // body in its `<system-reminder>` scaffolding.
+            RenderedReminder::SystemText(text) => system_text_blocks.push(text),
         }
     }
     prefix.extend(messages);
+    if !system_text_blocks.is_empty() {
+        let coalesced = system_text_blocks.join("\n\n");
+        if !try_append_user_reminder_text(&mut prefix, &coalesced) {
+            prefix.push(serde_json::json!({"role": "user", "content": coalesced}));
+        }
+    }
     prefix
 }
 
@@ -1329,16 +1390,15 @@ pub(crate) fn assemble_system_prompt(
     // cannot drift. Dormant until a tool actually carries `guidance`.
     append_tool_guidance_fragments(&mut fragments, options);
 
-    for reminder in rendered_reminders {
-        if let RenderedReminder::SystemText(text) = reminder {
-            fragments.push(PromptFragment::new(
-                "reminder",
-                "reminder",
-                FragmentBucket::Before,
-                text.clone(),
-            ));
-        }
-    }
+    // NB: `RenderedReminder::SystemText` reminders are intentionally NOT folded
+    // into the system fragments here. They are appended as a trailing `user`
+    // message in `apply_rendered_reminder_messages` so the assembled `system`
+    // string stays byte-identical across turns even as the live reminder set
+    // changes (token-pressure %, idle nudge, recap TTL), keeping the
+    // non-Anthropic prefix cache warm. `RenderedReminder::Message` reminders
+    // (Anthropic user blocks / OpenAI developer messages) are likewise handled
+    // on the message path with their `cache_control`, never here.
+    let _ = rendered_reminders;
 
     let ctx = assemble_ctx(options);
     Ok(assemble(&fragments, &ctx))
@@ -2889,7 +2949,7 @@ mod reminder_render_tests {
     }
 
     #[test]
-    fn compose_system_prompt_places_reminders_before_appendix() {
+    fn system_text_reminders_are_excluded_from_system_string() {
         let options = BTreeMap::from([
             (
                 "system_prompt_parts".to_string(),
@@ -2900,6 +2960,9 @@ mod reminder_render_tests {
                 VmValue::String(std::sync::Arc::from("appendix")),
             ),
         ]);
+        // A `SystemText` reminder must NOT appear in the assembled `system`
+        // string — it is routed to a trailing message instead so the system
+        // string stays cache-stable across turns.
         let prompt = compose_system_prompt_with_reminders(
             Some("base".to_string()),
             Some(&options),
@@ -2907,8 +2970,16 @@ mod reminder_render_tests {
         )
         .expect("system prompt")
         .expect("non-empty prompt");
+        assert_eq!(prompt, "parts\n\nbase\n\nappendix");
 
-        assert_eq!(prompt, "parts\n\nbase\n\nreminder\n\nappendix");
+        // The reminder text instead lands as the trailing user message.
+        let messages = apply_rendered_reminder_messages(
+            vec![serde_json::json!({"role": "assistant", "content": "ok"})],
+            &[RenderedReminder::SystemText("reminder".to_string())],
+        );
+        let last = messages.last().expect("trailing message");
+        assert_eq!(last["role"], "user");
+        assert_eq!(last["content"], "reminder");
     }
 
     fn s(text: &str) -> VmValue {
@@ -2946,8 +3017,121 @@ mod reminder_render_tests {
         .expect("system prompt")
         .expect("non-empty prompt");
         // Before bucket in declaration order (preamble, prefix, context,
-        // parts, primary, reminder), then After bucket (appendix, suffix).
-        assert_eq!(prompt, "P\n\nX\n\nC\n\nparts\n\nbase\n\nR\n\nA\n\nS");
+        // parts, primary), then After bucket (appendix, suffix). The
+        // `SystemText` reminder ("R") is no longer folded into the system
+        // string — it is appended as a trailing message instead.
+        assert_eq!(prompt, "P\n\nX\n\nC\n\nparts\n\nbase\n\nA\n\nS");
+        assert!(!prompt.contains('R'));
+    }
+
+    #[test]
+    fn system_string_is_byte_stable_across_changing_reminder_sets() {
+        // Same stable system fragments on both turns; the only difference is
+        // the live reminder set. Turn N has no reminders; turn N+1 fires a
+        // token-pressure reminder. The assembled `system` string must be
+        // byte-identical so the non-Anthropic prefix cache stays warm.
+        let options = BTreeMap::from([
+            ("system_prompt_parts".to_string(), s("parts")),
+            ("system_appendix".to_string(), s("appendix")),
+        ]);
+
+        let turn_n =
+            compose_system_prompt_with_reminders(Some("base".to_string()), Some(&options), &[])
+                .expect("system prompt")
+                .expect("non-empty prompt");
+
+        let pressure = "<system-reminder>\nContext is 82% full; wrap up.\n</system-reminder>";
+        let turn_n_plus_1 = compose_system_prompt_with_reminders(
+            Some("base".to_string()),
+            Some(&options),
+            &[RenderedReminder::SystemText(pressure.to_string())],
+        )
+        .expect("system prompt")
+        .expect("non-empty prompt");
+
+        assert_eq!(
+            turn_n, turn_n_plus_1,
+            "system string must not change when the reminder set changes"
+        );
+        assert!(!turn_n.contains("system-reminder"));
+
+        // The reminder is present on turn N+1 — as the trailing user message,
+        // not in the system string.
+        let base_messages = || vec![serde_json::json!({"role": "user", "content": "hello"})];
+        let msgs_n = apply_rendered_reminder_messages(base_messages(), &[]);
+        let msgs_n_plus_1 = apply_rendered_reminder_messages(
+            base_messages(),
+            &[RenderedReminder::SystemText(pressure.to_string())],
+        );
+        // Turn N: no reminder anywhere in the message array.
+        assert!(!serde_json::to_string(&msgs_n)
+            .unwrap()
+            .contains("system-reminder"));
+        // Turn N+1: reminder folded into the trailing user turn (merged with
+        // the existing user message rather than appended as a second user msg).
+        assert_eq!(msgs_n_plus_1.len(), 1);
+        let last = msgs_n_plus_1.last().expect("trailing message");
+        assert_eq!(last["role"], "user");
+        assert_eq!(last["content"], format!("hello\n\n{pressure}"));
+    }
+
+    #[test]
+    fn system_text_reminder_appends_new_user_message_after_assistant_tail() {
+        // When the conversation tail is an assistant turn (e.g. a tool_call),
+        // the reminder must be appended as a fresh trailing user message —
+        // never merged into the assistant turn and never inserted before it.
+        let messages = vec![
+            serde_json::json!({"role": "user", "content": "do it"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{"id": "c1", "type": "function"}],
+            }),
+            serde_json::json!({"role": "tool", "tool_call_id": "c1", "content": "result"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{"id": "c2", "type": "function"}],
+            }),
+        ];
+        let out = apply_rendered_reminder_messages(
+            messages,
+            &[RenderedReminder::SystemText(
+                "<system-reminder>\nR\n</system-reminder>".to_string(),
+            )],
+        );
+        assert_eq!(out.len(), 5);
+        // The original assistant tool_call/tool_result ordering is preserved.
+        assert_eq!(out[1]["role"], "assistant");
+        assert_eq!(out[2]["role"], "tool");
+        assert_eq!(out[3]["role"], "assistant");
+        // The reminder is a brand-new trailing user message.
+        assert_eq!(out[4]["role"], "user");
+        assert_eq!(
+            out[4]["content"],
+            "<system-reminder>\nR\n</system-reminder>"
+        );
+    }
+
+    #[test]
+    fn multiple_system_text_reminders_coalesce_into_one_trailing_message() {
+        let out = apply_rendered_reminder_messages(
+            vec![serde_json::json!({"role": "assistant", "content": "ok"})],
+            &[
+                RenderedReminder::SystemText(
+                    "<system-reminder>\nA\n</system-reminder>".to_string(),
+                ),
+                RenderedReminder::SystemText(
+                    "<system-reminder>\nB\n</system-reminder>".to_string(),
+                ),
+            ],
+        );
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[1]["role"], "user");
+        assert_eq!(
+            out[1]["content"],
+            "<system-reminder>\nA\n</system-reminder>\n\n<system-reminder>\nB\n</system-reminder>"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
On local llama.cpp (and any non-Anthropic / non-developer-role provider), reminders rendered as `SystemText` were folded into the `system` string — which serializes as the **first** message. Reminders are sticky and re-scanned every turn, so whenever the live set changed (token-pressure %, idle nudge, recap TTL expiry) the `system` string mutated at **byte offset 0**, collapsing llama.cpp's longest-common-prefix KV cache.

Measured impact (py-smoke, qwen3.6-35B-A3B on llama.cpp): 19 turns, **prompt-eval 46.4s (63% of wall-clock), ~33k tokens re-processed**, `sim_best ≈ 0.70`. Generation itself was healthy (~42 tok/s).

## Fix
Move `SystemText` reminders out of the `system` string and append them as a single coalesced trailing **`user`** message (merged into the tail user turn if present, else a fresh one; always strictly after the last message, so `tool_call`/`tool_result` pairs are never split). Text is **byte-for-byte unchanged** — `reminder_system_text`'s `<system-reminder>` scaffolding is reused; only the position moves. The `system` string is now byte-identical across turns, so the KV prefix stays warm and only the short suffix is re-evaluated.

The Anthropic (`message_wire_format == "anthropic"`) and `prefers_role_developer` paths are **untouched** — those still route reminders as `Message` / `cache_control: ephemeral`.

## Verification
- `cargo test -p harn-vm --lib llm` — **815 passed**
- `harn test conformance` — **1548 passed** (6 reminder/agent fixtures updated to assert the new tail position; reminders still present verbatim, single-shot TTL lifecycle intact — not regressions)
- New `system_string_is_byte_stable_across_changing_reminder_sets` proves the invariant (same fragments + different reminder sets → byte-identical `system`).
- `cargo fmt` clean.

Expected effect: on a turn where only reminders change, `sim_best` should rise from ~0.70 toward ~0.99 and prompt-eval tokens drop to roughly the appended reminder block — recovering most of that 46s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)