### PR TITLE
rules: add Harn semantic capture metadata

### DIFF
--- a/changelog.d/2882.added.md
+++ b/changelog.d/2882.added.md
@@ -1,0 +1,3 @@
+- Added Harn-only semantic rule captures with `resolvesTo` / `type` `[[where]]`
+  filters and `capture_metadata` output for resolved binding identity and
+  simple static type labels.

--- a/crates/harn-cli/tests/scan_dispatch.rs
+++ b/crates/harn-cli/tests/scan_dispatch.rs
@@ -120,6 +120,47 @@ fn inline_pattern_search_supports_harn_sources() {
 }
 
 #[test]
+fn saved_harn_rule_surfaces_resolved_capture_metadata() {
+    let dir = fixture_dir("harn-semantic");
+    write(
+        &dir,
+        "calls.harn",
+        "fn target(value: int) -> int {\n  return value\n}\n\nfn call_shadowed(target: fn(int) -> int) {\n  target(1)\n}\n\nfn call_global() {\n  target(2)\n}\n",
+    );
+    write(
+        &dir,
+        "target_call.toml",
+        "id = \"target-call\"\nlanguage = \"harn\"\n[rule]\npattern = \"$FN($ARG)\"\n\n[[where]]\nmetavar = \"FN\"\nresolvesTo = { name = \"target\", kind = \"fn\", line = 1 }\n",
+    );
+
+    let out = scan(&[
+        "--rule",
+        dir.join("target_call.toml").to_str().unwrap(),
+        dir.to_str().unwrap(),
+        "--json",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let json: serde_json::Value = serde_json::from_str(&out.stdout).expect("valid json");
+    assert_eq!(json["summary"]["total"], 1);
+    let matched = &json["results"][0]["matches"][0];
+    assert_eq!(matched["text"], "target(2)");
+    assert_eq!(matched["captures"]["FN"], "target");
+    assert_eq!(matched["capture_metadata"]["FN"]["type"], "fn(int) -> int");
+    assert_eq!(
+        matched["capture_metadata"]["FN"]["resolved"]["name"],
+        "target"
+    );
+    assert_eq!(matched["capture_metadata"]["FN"]["resolved"]["kind"], "fn");
+    assert_eq!(
+        matched["capture_metadata"]["FN"]["resolved"]["start_row"],
+        0
+    );
+    assert_eq!(matched["capture_metadata"]["ARG"]["type"], "int");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn report_only_emits_per_file_counts() {
     let dir = fixture_dir("report");
     write(&dir, "a.ts", "let p = a?.x ?? 1;\nlet q = b?.y ?? 2;\n");

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -56,8 +56,8 @@ use harn_hostlib::{
 use harn_vm::{AsyncBuiltinCtx, Vm, VmError, VmValue};
 
 use harn_rules::{
-    data_table, Applicability, CompiledRule, Diagnostic, Rule, RuleMatch, Safety, Severity,
-    SourceFile, Span,
+    data_table, Applicability, BindingMetadata, CompiledRule, Diagnostic, ResolvedBinding, Rule,
+    RuleMatch, Safety, Severity, SourceFile, Span,
 };
 
 const SEARCH: &str = "hostlib_rules_search";
@@ -330,6 +330,7 @@ fn match_to_vm(path: &std::path::Path, m: &RuleMatch) -> VmValue {
         .iter()
         .map(|(name, b)| (name.clone(), str_vm(&b.text)))
         .collect();
+    let capture_metadata = capture_metadata_vm(m);
     dict_vm([
         ("path", str_vm(path.display().to_string())),
         ("text", str_vm(&m.text)),
@@ -338,6 +339,7 @@ fn match_to_vm(path: &std::path::Path, m: &RuleMatch) -> VmValue {
         ("end_row", VmValue::Int(m.span.end_row as i64)),
         ("end_col", VmValue::Int(m.span.end_col as i64)),
         ("captures", VmValue::Dict(Arc::new(captures))),
+        ("capture_metadata", capture_metadata),
     ])
 }
 
@@ -373,13 +375,48 @@ fn node_vm(m: &RuleMatch) -> VmValue {
         .iter()
         .map(|(name, b)| (name.clone(), str_vm(&b.text)))
         .collect();
+    let capture_metadata = capture_metadata_vm(m);
     dict_vm([
         ("text", str_vm(&m.text)),
         ("captures", VmValue::Dict(Arc::new(captures))),
+        ("capture_metadata", capture_metadata),
         ("start_row", VmValue::Int(m.span.start_row as i64)),
         ("start_col", VmValue::Int(m.span.start_col as i64)),
         ("end_row", VmValue::Int(m.span.end_row as i64)),
         ("end_col", VmValue::Int(m.span.end_col as i64)),
+    ])
+}
+
+fn capture_metadata_vm(m: &RuleMatch) -> VmValue {
+    let metadata: BTreeMap<String, VmValue> = m
+        .bindings
+        .iter()
+        .filter(|(_, binding)| !binding.metadata.is_empty())
+        .map(|(name, binding)| (name.clone(), binding_metadata_vm(&binding.metadata)))
+        .collect();
+    VmValue::Dict(Arc::new(metadata))
+}
+
+fn binding_metadata_vm(metadata: &BindingMetadata) -> VmValue {
+    let mut entries = BTreeMap::new();
+    if let Some(ty) = &metadata.ty {
+        entries.insert("type".into(), str_vm(ty));
+    }
+    if let Some(resolved) = &metadata.resolved {
+        entries.insert("resolved".into(), resolved_binding_vm(resolved));
+    }
+    VmValue::Dict(Arc::new(entries))
+}
+
+fn resolved_binding_vm(resolved: &ResolvedBinding) -> VmValue {
+    dict_vm([
+        ("id", str_vm(&resolved.id)),
+        ("name", str_vm(&resolved.name)),
+        ("kind", str_vm(&resolved.kind)),
+        ("start_row", VmValue::Int(resolved.span.start_row as i64)),
+        ("start_col", VmValue::Int(resolved.span.start_col as i64)),
+        ("end_row", VmValue::Int(resolved.span.end_row as i64)),
+        ("end_col", VmValue::Int(resolved.span.end_col as i64)),
     ])
 }
 
@@ -660,6 +697,33 @@ mod tests {
             _ => panic!(),
         };
         assert_eq!(s(get(get(&matches[0], "captures"), "FN")), "foo");
+    }
+
+    #[test]
+    fn search_returns_harn_capture_metadata() {
+        let rule = r#"
+            id = "int-logs"
+            language = "harn"
+            [rule]
+            pattern = "log($VALUE)"
+        "#;
+        let result = search_run(&[dict(&[
+            ("rule", str_vm(rule)),
+            (
+                "source",
+                str_vm("fn main() {\n  let count: int = 1\n  log(count)\n}\n"),
+            ),
+            ("language", str_vm("harn")),
+        ])])
+        .unwrap();
+        let matches = match get(&result, "matches") {
+            VmValue::List(l) => l.clone(),
+            _ => panic!(),
+        };
+        let metadata = get(get(&matches[0], "capture_metadata"), "VALUE");
+        assert_eq!(s(get(metadata, "type")), "int");
+        assert_eq!(s(get(get(metadata, "resolved"), "name")), "count");
+        assert_eq!(s(get(get(metadata, "resolved"), "kind")), "let");
     }
 
     #[test]

--- a/crates/harn-rules/README.md
+++ b/crates/harn-rules/README.md
@@ -19,7 +19,9 @@ This crate ships the **atomic matching tier**
 **safety + idempotency gate**
 ([harn#2835](https://github.com/burin-labs/harn/issues/2835)), and the
 **whole-project scan lifecycle**
-([harn#2836](https://github.com/burin-labs/harn/issues/2836)).
+([harn#2836](https://github.com/burin-labs/harn/issues/2836)), with
+Harn-only semantic capture metadata for resolved bindings and simple static
+types ([harn#2882](https://github.com/burin-labs/harn/issues/2882)).
 
 ## Rule shape (TOML)
 
@@ -108,6 +110,32 @@ regex = "^get[A-Z]"                  # or: comparison = { op = ">", value = 100 
 source = "FN"
 convert = "snake"                    # or: replace = { regex, by } / substring = { start, end }
 ```
+
+For Harn rules, captures are also enriched with semantic metadata when the
+engine can resolve the node to a local declaration/binding or infer a simple
+type from an annotation/literal. The string captures stay in `captures`; the
+metadata is exposed separately as `capture_metadata`.
+
+```toml
+id = "global-target-call"
+language = "harn"
+
+[rule]
+pattern = "$FN($ARG)"
+
+[[where]]
+metavar = "FN"
+resolvesTo = { name = "target", kind = "fn", line = 1 } # 1-based line
+
+[[where]]
+metavar = "ARG"
+type = "int"
+```
+
+`resolvesTo` accepts any subset of `id`, `name`, `kind`, `line`, and `column`;
+`id` is `<kind>:<name>@<line>:<column>` using 1-based line/column. This is a
+Harn-only first cut: cross-language name/type resolvers are intentionally not
+invented here.
 
 `CompiledRule::apply(source)` runs the rule, drops matches that fail any
 constraint, interpolates each match's `fix` (from its captured + transformed

--- a/crates/harn-rules/src/constraint.rs
+++ b/crates/harn-rules/src/constraint.rs
@@ -11,8 +11,9 @@ use tree_sitter::{Query, QueryCursor};
 
 use harn_hostlib::ast::{api, Language};
 
+use crate::engine::{Binding, ResolvedBinding};
 use crate::error::RulesError;
-use crate::model::Constraint;
+use crate::model::{Constraint, ResolvedBindingConstraint};
 use crate::pattern::compile_pattern;
 
 /// A compiled `where` constraint bound to one metavar.
@@ -26,6 +27,8 @@ enum Kind {
     Regex(Regex),
     Comparison { op: CmpOp, value: toml::Value },
     SubPattern { language: Language, query: Query },
+    ResolvesTo(ResolvedBindingConstraint),
+    Type(String),
 }
 
 #[derive(Clone, Copy)]
@@ -69,13 +72,15 @@ impl CompiledConstraint {
             constraint.regex.is_some(),
             constraint.comparison.is_some(),
             constraint.pattern.is_some(),
+            constraint.resolves_to.is_some(),
+            constraint.type_.is_some(),
         ]
         .into_iter()
         .filter(|b| *b)
         .count();
         if set != 1 {
             return Err(err(format!(
-                "where-constraint on `{}` must set exactly one of `regex` / `comparison` / `pattern`",
+                "where-constraint on `{}` must set exactly one of `regex` / `comparison` / `pattern` / `resolves_to` / `type`",
                 constraint.metavar
             )));
         }
@@ -92,8 +97,7 @@ impl CompiledConstraint {
                 op,
                 value: cmp.value.clone(),
             }
-        } else {
-            let snippet = constraint.pattern.as_ref().unwrap();
+        } else if let Some(snippet) = &constraint.pattern {
             let language = match &constraint.language {
                 Some(name) => Language::from_name(name)
                     .ok_or_else(|| err(format!("unknown sub-pattern language `{name}`")))?,
@@ -107,6 +111,40 @@ impl CompiledConstraint {
             let query = Query::new(&ts_language, &compiled.query)
                 .map_err(|e| err(format!("sub-pattern query rejected: {e}")))?;
             Kind::SubPattern { language, query }
+        } else if let Some(resolves_to) = &constraint.resolves_to {
+            if default_language != Language::Harn {
+                return Err(err(format!(
+                    "`resolves_to` on `{}` is only supported for Harn rules",
+                    constraint.metavar
+                )));
+            }
+            if resolves_to.id.is_none()
+                && resolves_to.name.is_none()
+                && resolves_to.kind.is_none()
+                && resolves_to.line.is_none()
+                && resolves_to.column.is_none()
+            {
+                return Err(err(format!(
+                    "`resolves_to` on `{}` must set at least one identity field",
+                    constraint.metavar
+                )));
+            }
+            Kind::ResolvesTo(resolves_to.clone())
+        } else {
+            if default_language != Language::Harn {
+                return Err(err(format!(
+                    "`type` on `{}` is only supported for Harn rules",
+                    constraint.metavar
+                )));
+            }
+            let expected = constraint.type_.as_ref().unwrap();
+            if expected.trim().is_empty() {
+                return Err(err(format!(
+                    "`type` on `{}` must not be empty",
+                    constraint.metavar
+                )));
+            }
+            Kind::Type(expected.clone())
         };
 
         Ok(CompiledConstraint {
@@ -115,21 +153,49 @@ impl CompiledConstraint {
         })
     }
 
-    /// Evaluate the constraint against a metavar's captured `text`.
-    pub fn evaluate(&self, text: &str) -> bool {
+    /// Evaluate the constraint against a metavar binding.
+    pub fn evaluate(&self, binding: &Binding) -> bool {
         match &self.kind {
-            Kind::Regex(re) => re.is_match(text),
-            Kind::Comparison { op, value } => evaluate_comparison(*op, text, value),
+            Kind::Regex(re) => re.is_match(&binding.text),
+            Kind::Comparison { op, value } => evaluate_comparison(*op, &binding.text, value),
             Kind::SubPattern { language, query } => {
-                let Ok(tree) = api::parse_tree(text, *language) else {
+                let Ok(tree) = api::parse_tree(&binding.text, *language) else {
                     return false;
                 };
                 let mut cursor = QueryCursor::new();
-                let mut it = cursor.matches(query, tree.root_node(), text.as_bytes());
+                let mut it = cursor.matches(query, tree.root_node(), binding.text.as_bytes());
                 it.next().is_some()
             }
+            Kind::ResolvesTo(expected) => binding
+                .metadata
+                .resolved
+                .as_ref()
+                .is_some_and(|actual| resolved_matches(expected, actual)),
+            Kind::Type(expected) => binding
+                .metadata
+                .ty
+                .as_ref()
+                .is_some_and(|actual| actual == expected),
         }
     }
+}
+
+fn resolved_matches(expected: &ResolvedBindingConstraint, actual: &ResolvedBinding) -> bool {
+    expected.id.as_ref().is_none_or(|id| id == &actual.id)
+        && expected
+            .name
+            .as_ref()
+            .is_none_or(|name| name == &actual.name)
+        && expected
+            .kind
+            .as_ref()
+            .is_none_or(|kind| kind == &actual.kind)
+        && expected
+            .line
+            .is_none_or(|line| line == actual.span.start_row + 1)
+        && expected
+            .column
+            .is_none_or(|column| column == actual.span.start_col + 1)
 }
 
 fn evaluate_comparison(op: CmpOp, text: &str, value: &toml::Value) -> bool {
@@ -172,7 +238,23 @@ fn evaluate_comparison(op: CmpOp, text: &str, value: &toml::Value) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::{BindingMetadata, Span};
     use crate::model::Comparison;
+
+    fn binding(text: &str) -> Binding {
+        Binding {
+            text: text.into(),
+            span: Span {
+                start_byte: 0,
+                end_byte: text.len(),
+                start_row: 0,
+                start_col: 0,
+                end_row: 0,
+                end_col: text.len(),
+            },
+            metadata: BindingMetadata::default(),
+        }
+    }
 
     fn regex_constraint(metavar: &str, re: &str) -> CompiledConstraint {
         let c = Constraint {
@@ -180,6 +262,8 @@ mod tests {
             regex: Some(re.into()),
             comparison: None,
             pattern: None,
+            resolves_to: None,
+            type_: None,
             language: None,
         };
         CompiledConstraint::compile("r", Language::Rust, &c).unwrap()
@@ -188,8 +272,8 @@ mod tests {
     #[test]
     fn regex_constraint_matches() {
         let c = regex_constraint("KEY", "^[a-z][a-zA-Z]*$");
-        assert!(c.evaluate("userId"));
-        assert!(!c.evaluate("0bad"));
+        assert!(c.evaluate(&binding("userId")));
+        assert!(!c.evaluate(&binding("0bad")));
     }
 
     #[test]
@@ -202,12 +286,14 @@ mod tests {
                 value: toml::Value::Integer(0),
             }),
             pattern: None,
+            resolves_to: None,
+            type_: None,
             language: None,
         };
         let c = CompiledConstraint::compile("r", Language::Rust, &c).unwrap();
-        assert!(c.evaluate("5"));
-        assert!(!c.evaluate("0"));
-        assert!(!c.evaluate("-3"));
+        assert!(c.evaluate(&binding("5")));
+        assert!(!c.evaluate(&binding("0")));
+        assert!(!c.evaluate(&binding("-3")));
     }
 
     #[test]
@@ -220,11 +306,13 @@ mod tests {
                 value: toml::Value::String("nil".into()),
             }),
             pattern: None,
+            resolves_to: None,
+            type_: None,
             language: None,
         };
         let c = CompiledConstraint::compile("r", Language::Rust, &c).unwrap();
-        assert!(c.evaluate("something"));
-        assert!(!c.evaluate("nil"));
+        assert!(c.evaluate(&binding("something")));
+        assert!(!c.evaluate(&binding("nil")));
     }
 
     #[test]
@@ -235,11 +323,13 @@ mod tests {
             regex: None,
             comparison: None,
             pattern: Some("$FN($ARG)".into()),
+            resolves_to: None,
+            type_: None,
             language: Some("typescript".into()),
         };
         let c = CompiledConstraint::compile("r", Language::TypeScript, &c).unwrap();
-        assert!(c.evaluate("compute(x)"));
-        assert!(!c.evaluate("42"));
+        assert!(c.evaluate(&binding("compute(x)")));
+        assert!(!c.evaluate(&binding("42")));
     }
 
     #[test]
@@ -249,6 +339,8 @@ mod tests {
             regex: None,
             comparison: None,
             pattern: None,
+            resolves_to: None,
+            type_: None,
             language: None,
         };
         assert!(CompiledConstraint::compile("r", Language::Rust, &none).is_err());

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -11,17 +11,19 @@
 use std::collections::BTreeMap;
 
 use harn_hostlib::ast::Language;
+use serde::Serialize;
 
 use crate::constraint::CompiledConstraint;
 use crate::error::RulesError;
 use crate::evaluator::CompiledRuleTree;
 use crate::fix::{interpolate, splice, AppliedEdit};
 use crate::model::{Applicability, Rule, Safety, Severity};
+use crate::semantic::enrich_harn_matches;
 use crate::transform::CompiledTransform;
 
 /// A byte + row/col span. Rows/cols are 0-based, matching the rest of the
 /// Harn AST wire format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct Span {
     /// Start byte offset.
     pub start_byte: usize,
@@ -52,6 +54,41 @@ impl Span {
     }
 }
 
+/// Semantic metadata for a Harn capture. Populated for Harn sources when the
+/// engine can resolve the captured node to a local declaration/binding or infer
+/// a simple static type.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct BindingMetadata {
+    /// Resolved Harn declaration/binding identity for this capture.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved: Option<ResolvedBinding>,
+    /// Static type label for this capture.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub ty: Option<String>,
+}
+
+impl BindingMetadata {
+    /// True when no semantic metadata is available.
+    pub fn is_empty(&self) -> bool {
+        self.resolved.is_none() && self.ty.is_none()
+    }
+}
+
+/// A resolved Harn declaration or binding identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedBinding {
+    /// Stable id: `<kind>:<name>@<line>:<column>` (1-based line/column).
+    pub id: String,
+    /// Binding name.
+    pub name: String,
+    /// Binding kind (`fn`, `pipeline`, `tool`, `struct`, `type`, `let`,
+    /// `var`, `const`, `param`, ...).
+    pub kind: String,
+    /// Span of the declaration/binding name.
+    #[serde(flatten)]
+    pub span: Span,
+}
+
 /// A metavariable binding: the captured text plus where it lives.
 #[derive(Debug, Clone)]
 pub struct Binding {
@@ -59,6 +96,18 @@ pub struct Binding {
     pub text: String,
     /// The captured node's span.
     pub span: Span,
+    /// Optional Harn semantic metadata for this capture.
+    pub metadata: BindingMetadata,
+}
+
+impl Binding {
+    pub(crate) fn new(text: String, span: Span) -> Self {
+        Binding {
+            text,
+            span,
+            metadata: BindingMetadata::default(),
+        }
+    }
 }
 
 /// One match of a rule against a file.
@@ -243,6 +292,14 @@ impl CompiledRule {
                 })
                 .collect(),
         };
+        if self.language == Language::Harn && !matches.is_empty() {
+            enrich_harn_matches(source, &mut matches).map_err(|message| {
+                RulesError::SourceParse {
+                    rule: self.rule_id.clone(),
+                    message,
+                }
+            })?;
+        }
         if !self.constraints.is_empty() {
             matches.retain(|m| self.satisfies_constraints(m));
         }
@@ -252,11 +309,9 @@ impl CompiledRule {
     /// True when every `where` constraint holds for this match. A
     /// constraint whose metavar is unbound (not captured) fails closed.
     fn satisfies_constraints(&self, m: &RuleMatch) -> bool {
-        self.constraints.iter().all(|c| {
-            m.bindings
-                .get(&c.metavar)
-                .is_some_and(|b| c.evaluate(&b.text))
-        })
+        self.constraints
+            .iter()
+            .all(|c| m.bindings.get(&c.metavar).is_some_and(|b| c.evaluate(b)))
     }
 
     /// Apply this codemod rule's `fix` to `source`, returning the rewritten
@@ -606,5 +661,113 @@ mod tests {
             CompiledRule::compile(&parsed),
             Err(RulesError::PatternCompile { .. })
         ));
+    }
+
+    #[test]
+    fn harn_resolves_same_named_call_sites_by_binding_identity() {
+        let compiled = rule(
+            r#"
+            id = "top-level-target"
+            language = "harn"
+            [rule]
+            pattern = "$FN($ARG)"
+
+            [[where]]
+            metavar = "FN"
+            resolvesTo = { name = "target", kind = "fn", line = 1 }
+            "#,
+        );
+        let source = r"fn target(value: int) -> int {
+  return value
+}
+
+fn call_shadowed(target: fn(int) -> int) {
+  target(1)
+}
+
+fn call_global() {
+  target(2)
+}
+";
+        let matches = compiled.run(source).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].text, "target(2)");
+        let binding = &matches[0].bindings["FN"];
+        let resolved = binding.metadata.resolved.as_ref().unwrap();
+        assert_eq!(resolved.name, "target");
+        assert_eq!(resolved.kind, "fn");
+        assert_eq!(resolved.span.start_row, 0);
+        assert_eq!(binding.metadata.ty.as_deref(), Some("fn(int) -> int"));
+    }
+
+    #[test]
+    fn harn_capture_type_constraint_filters_matches() {
+        let compiled = rule(
+            r#"
+            id = "int-logs"
+            language = "harn"
+            [rule]
+            pattern = "log($VALUE)"
+
+            [[where]]
+            metavar = "VALUE"
+            type = "int"
+            "#,
+        );
+        let source = r#"fn main() {
+  let count: int = 1
+  let label: string = "one"
+  log(count)
+  log(label)
+}
+"#;
+        let matches = compiled.run(source).unwrap();
+        assert_eq!(matches.len(), 1);
+        let value = &matches[0].bindings["VALUE"];
+        assert_eq!(value.text, "count");
+        assert_eq!(value.metadata.ty.as_deref(), Some("int"));
+        assert_eq!(
+            value
+                .metadata
+                .resolved
+                .as_ref()
+                .map(|resolved| resolved.kind.as_str()),
+            Some("let")
+        );
+    }
+
+    #[test]
+    fn harn_initializer_uses_outer_binding_scope() {
+        let compiled = rule(
+            r#"
+            id = "outer-initializer"
+            language = "harn"
+            [rule]
+            pattern = "log($VALUE)"
+
+            [[where]]
+            metavar = "VALUE"
+            resolvesTo = { name = "value", kind = "let", line = 2 }
+            "#,
+        );
+        let source = r"fn main() {
+  let value: int = 1
+  if true {
+    let value: string = log(value)
+  }
+}
+";
+        let matches = compiled.run(source).unwrap();
+        assert_eq!(matches.len(), 1);
+        let value = &matches[0].bindings["VALUE"];
+        assert_eq!(value.text, "value");
+        assert_eq!(
+            value
+                .metadata
+                .resolved
+                .as_ref()
+                .map(|resolved| resolved.span.start_row),
+            Some(1)
+        );
     }
 }

--- a/crates/harn-rules/src/evaluator.rs
+++ b/crates/harn-rules/src/evaluator.rs
@@ -336,9 +336,8 @@ fn atomic_match(atomic: &CompiledAtomic, node: Node<'_>, ctx: &Ctx<'_>) -> Optio
                 for cap in m.captures {
                     let name = names[cap.index as usize];
                     if metavars.iter().any(|mv| mv == name) {
-                        bindings.entry(name.to_string()).or_insert_with(|| Binding {
-                            text: ctx.text(cap.node),
-                            span: Span::of(cap.node),
+                        bindings.entry(name.to_string()).or_insert_with(|| {
+                            Binding::new(ctx.text(cap.node), Span::of(cap.node))
                         });
                     }
                 }

--- a/crates/harn-rules/src/lib.rs
+++ b/crates/harn-rules/src/lib.rs
@@ -21,7 +21,7 @@
 //! - [`evaluator`] — the tree-walking match algebra (relational + composite
 //!   + utility-rule reuse).
 //! - [`constraint`] — `where` predicates on captured metavars (regex,
-//!   comparison, recursive sub-pattern).
+//!   comparison, recursive sub-pattern, and Harn-only semantic filters).
 //! - [`transform`] — synthesize new metavars (`replace` / `substring` /
 //!   `convert`) before fixing.
 //! - [`fix`] — `fix` template interpolation and format-preserving splice.
@@ -33,6 +33,8 @@
 //!   with file create/delete ([`ScanningRecipe`], [`run_recipe`]).
 //! - [`report`] — report-only [`DataTable`]s: columnar findings + metrics.
 //! - [`loader`] — load rules from a TOML file or a directory.
+//! - semantic capture metadata — Harn captures gain resolved binding identity
+//!   and simple static type labels when the local syntax provides them.
 //!
 //! The whole-project scan lifecycle (#2836) layers onto this surface.
 //!
@@ -65,16 +67,20 @@ pub mod model;
 pub mod pattern;
 pub mod recipe;
 pub mod report;
+mod semantic;
 pub mod testing;
 pub mod transform;
 
-pub use engine::{Binding, CodemodResult, CompiledRule, Diagnostic, RuleMatch, Span};
+pub use engine::{
+    Binding, BindingMetadata, CodemodResult, CompiledRule, Diagnostic, ResolvedBinding, RuleMatch,
+    Span,
+};
 pub use error::RulesError;
 pub use fix::{interpolate, AppliedEdit};
 pub use loader::{load_rule_dir, load_rule_file};
 pub use model::{
-    Applicability, AtomicMatcher, Comparison, Constraint, ConvertOp, Rule, RuleKind, RuleNode,
-    Safety, Severity, StopBy, StopKeyword, Transform,
+    Applicability, AtomicMatcher, Comparison, Constraint, ConvertOp, ResolvedBindingConstraint,
+    Rule, RuleKind, RuleNode, Safety, Severity, StopBy, StopKeyword, Transform,
 };
 pub use pattern::{compile_pattern, CompiledPattern};
 pub use recipe::{run_recipe, FileChange, RecipeRun, RuleRecipe, ScanningRecipe, SourceFile};

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -299,7 +299,7 @@ pub struct Rule {
 }
 
 /// A `where` predicate on a captured metavar. Exactly one of `regex` /
-/// `comparison` / `pattern` is set.
+/// `comparison` / `pattern` / `resolves_to` / `type` is set.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Constraint {
@@ -316,10 +316,39 @@ pub struct Constraint {
     /// metavar's captured text; the constraint holds when it matches.
     #[serde(default)]
     pub pattern: Option<String>,
+    /// Harn-only semantic filter: the captured node must resolve to a
+    /// declaration/binding matching this identity.
+    #[serde(default, alias = "resolvesTo")]
+    pub resolves_to: Option<ResolvedBindingConstraint>,
+    /// Harn-only semantic filter: the capture's attributed type must equal
+    /// this label.
+    #[serde(default, rename = "type")]
+    pub type_: Option<String>,
     /// Optional language override for `pattern` — lets a captured string
     /// literal be matched in a different grammar than the host file.
     #[serde(default)]
     pub language: Option<String>,
+}
+
+/// A Harn resolved-binding predicate for [`Constraint::resolves_to`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedBindingConstraint {
+    /// Exact resolved id (`<kind>:<name>@<line>:<column>`), if supplied.
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Binding/declaration name.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Binding kind (`fn`, `param`, `let`, ...).
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// 1-based declaration/binding line.
+    #[serde(default)]
+    pub line: Option<usize>,
+    /// 1-based declaration/binding column.
+    #[serde(default)]
+    pub column: Option<usize>,
 }
 
 /// A numeric/string comparison for a [`Constraint`].
@@ -540,5 +569,33 @@ mod tests {
             "#,
         );
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn parses_semantic_where_constraints() {
+        let rule = Rule::from_toml_str(
+            r#"
+            id = "x"
+            language = "harn"
+            [rule]
+            pattern = "$FN($ARG)"
+
+            [[where]]
+            metavar = "FN"
+            resolvesTo = { name = "target", kind = "fn", line = 1, column = 4 }
+
+            [[where]]
+            metavar = "ARG"
+            type = "int"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(rule.where_constraints.len(), 2);
+        let resolved = rule.where_constraints[0].resolves_to.as_ref().unwrap();
+        assert_eq!(resolved.name.as_deref(), Some("target"));
+        assert_eq!(resolved.kind.as_deref(), Some("fn"));
+        assert_eq!(resolved.line, Some(1));
+        assert_eq!(resolved.column, Some(4));
+        assert_eq!(rule.where_constraints[1].type_.as_deref(), Some("int"));
     }
 }

--- a/crates/harn-rules/src/report.rs
+++ b/crates/harn-rules/src/report.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
-use crate::engine::CompiledRule;
+use crate::engine::{BindingMetadata, CompiledRule};
 use crate::error::RulesError;
 use crate::recipe::SourceFile;
 
@@ -42,6 +42,9 @@ pub struct TableRow {
     pub text: String,
     /// The metavar bindings, keyed by name.
     pub bindings: BTreeMap<String, String>,
+    /// Optional semantic metadata for Harn captures, keyed by metavar name.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub capture_metadata: BTreeMap<String, BindingMetadata>,
 }
 
 /// Roll-up metrics for a [`DataTable`].
@@ -85,6 +88,12 @@ pub fn data_table(rule: &CompiledRule, files: &[SourceFile]) -> Result<DataTable
         let path = file.path.display().to_string();
         per_file.insert(path.clone(), matches.len());
         for m in matches {
+            let capture_metadata = m
+                .bindings
+                .iter()
+                .filter(|(_, binding)| !binding.metadata.is_empty())
+                .map(|(name, binding)| (name.clone(), binding.metadata.clone()))
+                .collect();
             rows.push(TableRow {
                 path: path.clone(),
                 start_row: m.span.start_row,
@@ -95,6 +104,7 @@ pub fn data_table(rule: &CompiledRule, files: &[SourceFile]) -> Result<DataTable
                     .into_iter()
                     .map(|(name, binding)| (name, binding.text))
                     .collect(),
+                capture_metadata,
             });
         }
     }
@@ -171,5 +181,31 @@ mod tests {
         assert_eq!(value["rule_id"], "r");
         assert_eq!(value["summary"]["total_rows"], 1);
         assert_eq!(value["rows"][0]["bindings"]["FN"], "go");
+    }
+
+    #[test]
+    fn table_serializes_harn_capture_metadata() {
+        let rule = rule(
+            r#"
+            id = "typed-log"
+            language = "harn"
+            [rule]
+            pattern = "log($VALUE)"
+            "#,
+        );
+        let table = data_table(
+            &rule,
+            &[ts(
+                "a.harn",
+                "fn main() {\n  let count: int = 1\n  log(count)\n}\n",
+            )],
+        )
+        .unwrap();
+        let value = table.to_json_value();
+        let metadata = &value["rows"][0]["capture_metadata"]["VALUE"];
+        assert_eq!(metadata["type"], "int");
+        assert_eq!(metadata["resolved"]["name"], "count");
+        assert_eq!(metadata["resolved"]["start_row"], 1);
+        assert!(metadata["resolved"]["span"].is_null());
     }
 }

--- a/crates/harn-rules/src/semantic.rs
+++ b/crates/harn-rules/src/semantic.rs
@@ -1,0 +1,463 @@
+//! Harn-only semantic capture enrichment.
+//!
+//! The rule engine is grammar-agnostic by default. This module adds a narrow
+//! Harn pass that annotates capture bindings with local declaration identity
+//! and simple type labels where the tree-sitter syntax gives us enough static
+//! information.
+
+use harn_hostlib::ast::{api, Language};
+use tree_sitter::Node;
+
+use crate::engine::{BindingMetadata, ResolvedBinding, RuleMatch, Span};
+
+#[derive(Clone, Copy)]
+struct Scope {
+    start: usize,
+    end: usize,
+}
+
+impl Scope {
+    fn contains(self, byte: usize) -> bool {
+        self.start <= byte && byte <= self.end
+    }
+
+    fn of(node: Node<'_>) -> Self {
+        Scope {
+            start: node.start_byte(),
+            end: node.end_byte(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Decl {
+    name: String,
+    kind: &'static str,
+    name_span: Span,
+    scope: Scope,
+    hoisted: bool,
+    ty: Option<String>,
+    return_ty: Option<String>,
+}
+
+impl Decl {
+    fn resolved(&self) -> ResolvedBinding {
+        ResolvedBinding {
+            id: format!(
+                "{}:{}@{}:{}",
+                self.kind,
+                self.name,
+                self.name_span.start_row + 1,
+                self.name_span.start_col + 1
+            ),
+            name: self.name.clone(),
+            kind: self.kind.to_string(),
+            span: self.name_span,
+        }
+    }
+}
+
+struct HarnSemanticIndex<'src> {
+    source: &'src str,
+    decls: Vec<Decl>,
+}
+
+impl<'src> HarnSemanticIndex<'src> {
+    fn build(source: &'src str, root: Node<'_>) -> Self {
+        let mut index = HarnSemanticIndex {
+            source,
+            decls: Vec::new(),
+        };
+        index.collect(
+            root,
+            Scope {
+                start: 0,
+                end: source.len(),
+            },
+        );
+        index
+    }
+
+    fn enrich_binding(&self, root: Node<'_>, binding: &mut crate::engine::Binding) {
+        let Some(node) = exact_named_node(root, binding.span.start_byte, binding.span.end_byte)
+        else {
+            return;
+        };
+
+        let mut metadata = BindingMetadata::default();
+        if let Some(decl) = self.resolve_capture_node(node) {
+            metadata.resolved = Some(decl.resolved());
+            metadata.ty = match node.kind() {
+                "call_expression" | "generic_call_expression" => decl.return_ty.clone(),
+                _ => decl.ty.clone(),
+            };
+        }
+        if metadata.ty.is_none() {
+            metadata.ty = self.infer_node_type(node);
+        }
+        binding.metadata = metadata;
+    }
+
+    fn resolve_capture_node(&self, node: Node<'_>) -> Option<&Decl> {
+        let ident = resolvable_identifier(node)?;
+        let name = self.text(ident);
+        if let Some(decl) = self.decl_at(ident) {
+            return Some(decl);
+        }
+        self.resolve_name(name, ident.start_byte())
+    }
+
+    fn decl_at(&self, ident: Node<'_>) -> Option<&Decl> {
+        self.decls.iter().find(|decl| {
+            decl.name_span.start_byte == ident.start_byte()
+                && decl.name_span.end_byte == ident.end_byte()
+        })
+    }
+
+    fn resolve_name(&self, name: &str, byte: usize) -> Option<&Decl> {
+        self.decls
+            .iter()
+            .filter(|decl| {
+                decl.name == name
+                    && decl.scope.contains(byte)
+                    && decl.name_span.start_byte != byte
+                    && (decl.hoisted || decl.name_span.start_byte <= byte)
+            })
+            .max_by_key(|decl| (decl.scope.start, decl.name_span.start_byte))
+    }
+
+    fn infer_node_type(&self, node: Node<'_>) -> Option<String> {
+        match node.kind() {
+            "integer_literal" => Some("int".into()),
+            "float_literal" => Some("float".into()),
+            "string_literal"
+            | "raw_string_literal"
+            | "multiline_string_literal"
+            | "interpolated_string" => Some("string".into()),
+            "true" | "false" => Some("bool".into()),
+            "nil" => Some("nil".into()),
+            "list_literal" => Some("list".into()),
+            "dict_literal" => Some("dict".into()),
+            "struct_construct" => node
+                .child_by_field_name("type")
+                .or_else(|| node.child_by_field_name("name"))
+                .map(|name| self.text(name).to_string())
+                .or_else(|| Some("dict".into())),
+            "identifier" => self
+                .resolve_name(self.text(node), node.start_byte())
+                .and_then(|decl| decl.ty.clone()),
+            "call_expression" | "generic_call_expression" => self
+                .resolve_capture_node(node)
+                .and_then(|decl| decl.return_ty.clone()),
+            _ => None,
+        }
+    }
+
+    fn collect(&mut self, node: Node<'_>, scope: Scope) {
+        match node.kind() {
+            "source_file" => self.collect_children(
+                node,
+                Scope {
+                    start: 0,
+                    end: self.source.len(),
+                },
+            ),
+            "block" => {
+                let block_scope = Scope::of(node);
+                self.collect_children(node, block_scope);
+            }
+            "fn_declaration" => self.collect_callable(node, scope, "fn"),
+            "pipeline_declaration" => self.collect_callable(node, scope, "pipeline"),
+            "tool_declaration" => self.collect_callable(node, scope, "tool"),
+            "struct_declaration" => self.add_named_decl(node, scope, "struct", true, None, None),
+            "type_declaration" => {
+                let ty = node
+                    .child_by_field_name("type")
+                    .map(|ty| self.type_text(ty));
+                self.add_named_decl(node, scope, "type", true, ty, None);
+            }
+            "let_binding" | "var_binding" | "const_binding" => self.collect_binding(node, scope),
+            "for_statement" => self.collect_for_statement(node, scope),
+            "select_case" => self.collect_select_case(node, scope),
+            "try_expression" => self.collect_try_expression(node, scope),
+            _ => self.collect_children(node, scope),
+        }
+    }
+
+    fn collect_callable(&mut self, node: Node<'_>, scope: Scope, kind: &'static str) {
+        let body = callable_body(node);
+        let body_scope = body.map(Scope::of).unwrap_or_else(|| Scope::of(node));
+        let (ty, return_ty) = self.callable_types(node);
+        self.add_named_decl(node, scope, kind, true, ty, return_ty);
+        self.collect_params(node, body_scope);
+        if let Some(body) = body {
+            self.collect(body, body_scope);
+        } else {
+            self.collect_children(node, body_scope);
+        }
+    }
+
+    fn collect_binding(&mut self, node: Node<'_>, scope: Scope) {
+        let explicit_ty = node
+            .child_by_field_name("type")
+            .map(|ty| self.type_text(ty));
+        let inferred_ty = explicit_ty.or_else(|| {
+            node.child_by_field_name("value")
+                .and_then(|value| self.infer_node_type(value))
+        });
+        let kind = match node.kind() {
+            "var_binding" => "var",
+            "const_binding" => "const",
+            _ => "let",
+        };
+        let binding_scope = Scope {
+            start: node.end_byte(),
+            end: scope.end,
+        };
+        if let Some(pattern) = node.child_by_field_name("name") {
+            self.add_pattern_decls(pattern, binding_scope, kind, false, inferred_ty);
+        }
+        if let Some(value) = node.child_by_field_name("value") {
+            self.collect(value, scope);
+        }
+    }
+
+    fn collect_for_statement(&mut self, node: Node<'_>, scope: Scope) {
+        if let Some(iterable) = node.child_by_field_name("iterable") {
+            self.collect(iterable, scope);
+        }
+        let body = node.child_by_field_name("body");
+        let body_scope = body.map(Scope::of).unwrap_or(scope);
+        if let Some(pattern) = node.child_by_field_name("variable") {
+            self.add_pattern_decls(pattern, body_scope, "let", false, None);
+        }
+        if let Some(body) = body {
+            self.collect(body, body_scope);
+        }
+    }
+
+    fn collect_select_case(&mut self, node: Node<'_>, scope: Scope) {
+        if let Some(channel) = node.child_by_field_name("channel") {
+            self.collect(channel, scope);
+        }
+        let body = node.child_by_field_name("body");
+        let body_scope = body.map(Scope::of).unwrap_or(scope);
+        if let Some(variable) = node.child_by_field_name("variable") {
+            self.add_identifier_decl(variable, body_scope, "let", false, None, None);
+        }
+        if let Some(body) = body {
+            self.collect(body, body_scope);
+        }
+    }
+
+    fn collect_try_expression(&mut self, node: Node<'_>, scope: Scope) {
+        if let Some(body) = node.child_by_field_name("body") {
+            self.collect(body, Scope::of(body));
+        }
+        let handler = node.child_by_field_name("handler");
+        let handler_scope = handler.map(Scope::of).unwrap_or(scope);
+        if let Some(error_var) = node.child_by_field_name("error_var") {
+            let error_ty = node
+                .child_by_field_name("error_type")
+                .map(|ty| self.type_text(ty));
+            self.add_identifier_decl(error_var, handler_scope, "let", false, error_ty, None);
+        }
+        if let Some(handler) = handler {
+            self.collect(handler, handler_scope);
+        }
+        if let Some(finalizer) = node.child_by_field_name("finalizer") {
+            self.collect(finalizer, Scope::of(finalizer));
+        }
+    }
+
+    fn collect_params(&mut self, callable: Node<'_>, scope: Scope) {
+        let Some(params) = direct_child_kind(callable, "parameter_list") else {
+            return;
+        };
+        let mut cursor = params.walk();
+        for param in params.named_children(&mut cursor) {
+            if param.kind() != "typed_parameter" {
+                continue;
+            }
+            let ty = param
+                .child_by_field_name("type")
+                .map(|ty| self.type_text(ty));
+            if let Some(name) = param.child_by_field_name("name") {
+                self.add_identifier_decl(name, scope, "param", false, ty, None);
+            }
+            if let Some(default) = param.child_by_field_name("default") {
+                self.collect(default, scope);
+            }
+        }
+    }
+
+    fn callable_types(&self, callable: Node<'_>) -> (Option<String>, Option<String>) {
+        let params = direct_child_kind(callable, "parameter_list")
+            .map(|list| {
+                let mut out = Vec::new();
+                let mut cursor = list.walk();
+                for param in list.named_children(&mut cursor) {
+                    if param.kind() == "typed_parameter" {
+                        out.push(
+                            param
+                                .child_by_field_name("type")
+                                .map(|ty| self.type_text(ty))
+                                .unwrap_or_else(|| "_".into()),
+                        );
+                    }
+                }
+                out
+            })
+            .unwrap_or_default();
+        let return_ty = return_type_annotation(callable).map(|ty| self.type_text(ty));
+        let ty = Some(format!(
+            "fn({}) -> {}",
+            params.join(", "),
+            return_ty.clone().unwrap_or_else(|| "unknown".into())
+        ));
+        (ty, return_ty)
+    }
+
+    fn add_named_decl(
+        &mut self,
+        node: Node<'_>,
+        scope: Scope,
+        kind: &'static str,
+        hoisted: bool,
+        ty: Option<String>,
+        return_ty: Option<String>,
+    ) {
+        if let Some(name) = node.child_by_field_name("name") {
+            self.add_identifier_decl(name, scope, kind, hoisted, ty, return_ty);
+        }
+    }
+
+    fn add_pattern_decls(
+        &mut self,
+        pattern: Node<'_>,
+        scope: Scope,
+        kind: &'static str,
+        hoisted: bool,
+        ty: Option<String>,
+    ) {
+        if pattern.kind() == "identifier" {
+            self.add_identifier_decl(pattern, scope, kind, hoisted, ty, None);
+            return;
+        }
+        for_identifier_descendants(pattern, &mut |ident| {
+            self.add_identifier_decl(ident, scope, kind, hoisted, ty.clone(), None);
+        });
+    }
+
+    fn add_identifier_decl(
+        &mut self,
+        ident: Node<'_>,
+        scope: Scope,
+        kind: &'static str,
+        hoisted: bool,
+        ty: Option<String>,
+        return_ty: Option<String>,
+    ) {
+        let name = self.text(ident);
+        if name == "_" {
+            return;
+        }
+        self.decls.push(Decl {
+            name: name.to_string(),
+            kind,
+            name_span: Span::of(ident),
+            scope,
+            hoisted,
+            ty,
+            return_ty,
+        });
+    }
+
+    fn collect_children(&mut self, node: Node<'_>, scope: Scope) {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.collect(child, scope);
+        }
+    }
+
+    fn type_text(&self, node: Node<'_>) -> String {
+        self.text(node).trim().to_string()
+    }
+
+    fn text(&self, node: Node<'_>) -> &'src str {
+        &self.source[node.start_byte()..node.end_byte()]
+    }
+}
+
+pub(crate) fn enrich_harn_matches(source: &str, matches: &mut [RuleMatch]) -> Result<(), String> {
+    let tree = api::parse_tree(source, Language::Harn).map_err(|err| err.to_string())?;
+    let root = tree.root_node();
+    let index = HarnSemanticIndex::build(source, root);
+    for m in matches {
+        for binding in m.bindings.values_mut() {
+            index.enrich_binding(root, binding);
+        }
+    }
+    Ok(())
+}
+
+fn callable_body(node: Node<'_>) -> Option<Node<'_>> {
+    node.child_by_field_name("body")
+        .or_else(|| direct_child_kind(node, "block"))
+}
+
+fn return_type_annotation<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    node.child_by_field_name("return_type").or_else(|| {
+        let mut cursor = node.walk();
+        let found = node
+            .named_children(&mut cursor)
+            .find(|child| child.kind() == "type_annotation");
+        found
+    })
+}
+
+fn resolvable_identifier<'tree>(node: Node<'tree>) -> Option<Node<'tree>> {
+    match node.kind() {
+        "identifier" => Some(node),
+        "call_expression" | "generic_call_expression" => node
+            .child_by_field_name("function")
+            .filter(|function| function.kind() == "identifier"),
+        _ => None,
+    }
+}
+
+fn direct_child_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    let found = node
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == kind);
+    found
+}
+
+fn exact_named_node<'tree>(node: Node<'tree>, start: usize, end: usize) -> Option<Node<'tree>> {
+    if start < node.start_byte() || end > node.end_byte() {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.start_byte() <= start && end <= child.end_byte() {
+            if let Some(found) = exact_named_node(child, start, end) {
+                return Some(found);
+            }
+        }
+    }
+    if node.start_byte() == start && node.end_byte() == end {
+        return Some(node);
+    }
+    None
+}
+
+fn for_identifier_descendants<'tree>(node: Node<'tree>, f: &mut impl FnMut(Node<'tree>)) {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() == "identifier" {
+            f(child);
+        }
+        for_identifier_descendants(child, f);
+    }
+}

--- a/crates/harn-skills/src/corpus/harn-rules/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-rules/SKILL.md
@@ -52,7 +52,10 @@ conformance fixtures.
 ## Predicates, rewrite, and safety
 
 - A `where` predicate narrows matches: `regex`, `comparison = { op, value }`,
-  or a recursive `pattern`.
+  a recursive `pattern`, or Harn-only semantic filters
+  `resolvesTo = { name, kind, line, column, id }` and `type = "int"`.
+  Harn match dictionaries keep text in `captures` and add
+  `capture_metadata` with `resolved` / `type` where available.
 - `[transform.NAME]` synthesizes a metavar before fixing (`convert = "snake"`,
   `replace = { regex, by }`, `substring = { start, end }`).
 - `fix` interpolates `$VAR` / `${VAR}` (`$$` → `$`) and splices

--- a/crates/harn-stdlib/src/stdlib/stdlib_rules.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_rules.harn
@@ -12,8 +12,9 @@
  *   paths to read.
  *
  * On success `result == "ok"` and `matches` is a list of `{path, text,
- * start_row, start_col, captures}` where `captures` maps each metavar name
- * to its bound text.
+ * start_row, start_col, captures, capture_metadata}` where `captures` maps
+ * each metavar name to its bound text. For Harn rules, `capture_metadata`
+ * adds `resolved` and `type` entries when the resolver can supply them.
  *
  * @effects: [host]
  * @allocation: heap
@@ -73,8 +74,8 @@ pub fn rules_diagnostics(params) -> dict {
  * arbitrary conditions). `params` is `{rule, source|paths, language?,
  * on_match}` where `on_match` is `fn(node, ctx)`:
  *
- * - `node`: `{text, captures, start_row, start_col, end_row, end_col}` —
- *   `captures` maps each metavar name to its bound text.
+ * - `node`: `{text, captures, capture_metadata, start_row, start_col,
+ *   end_row, end_col}` — `captures` maps each metavar name to its bound text.
  * - `ctx`: `{path, language, source, rule_id}` (read-only).
  * - returns: `nil`/`false` to skip the match, `true` to flag it with the
  *   rule's defaults, a `{message, fix, safety, severity}` dict, or a list of

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -59,6 +59,29 @@ See `crates/harn-rules/README.md` for the full model: relational keys
 (`inside` / `has` / `follows` / `precedes`), composite keys (`all` / `any` /
 `not` / `matches`), `[[where]]` predicates, and `[transform.NAME]`.
 
+For Harn source, `[[where]]` can also filter by resolved binding identity or
+capture type. This distinguishes two same-named call sites by the declaration
+they actually resolve to:
+
+```toml
+id = "global-target-call"
+language = "harn"
+
+[rule]
+pattern = "$FN($ARG)"
+
+[[where]]
+metavar = "FN"
+resolvesTo = { name = "target", kind = "fn", line = 1 }
+
+[[where]]
+metavar = "ARG"
+type = "int"
+```
+
+The JSON output keeps `captures` as text and adds `capture_metadata` with
+`resolved` and `type` entries when the Harn resolver can supply them.
+
 ## How do I apply a codemod?
 
 `harn codemod` is **dry-run by default** — it prints a unified diff per file


### PR DESCRIPTION
## Summary
- add Harn-only semantic capture enrichment for resolved binding identities and simple static type labels
- add `resolvesTo` / `type` where constraints and expose `capture_metadata` through CLI JSON, report tables, and the Harn hostlib bridge
- document semantic capture filters in the rules README, cookbook, skill corpus, stdlib wrapper docs, and changelog

## Verification
- `make test`
- `cargo test -p harn-rules -p harn-rules-hostlib`
- `cargo test -p harn-cli --test scan_dispatch`
- `cargo clippy -p harn-rules -p harn-rules-hostlib --all-targets -- -D warnings`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_rules.harn`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/stdlib_rules.harn`
- `make fmt-harn`
- `make lint-harn` (passes; prints existing unrelated experiment/demo warnings)
- `make check-docs-snippets`
- `make lint-test-patterns`

Closes #2882.
