### PR TITLE
codemod: harn fmt post-pass on rewritten .harn output (#2847)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,6 +2539,7 @@ dependencies = [
 name = "harn-rules-hostlib"
 version = "0.8.63"
 dependencies = [
+ "harn-fmt",
  "harn-hostlib",
  "harn-rules",
  "harn-vm",

--- a/changelog.d/2847.added.md
+++ b/changelog.d/2847.added.md
@@ -1,0 +1,7 @@
+- `harn codemod` now runs a **`harn fmt` post-pass** on rewritten `.harn` files (Rule Engine Epic C), so a codemod
+  batch lands fmt-stable — dict-pattern key order, spacing, and trailing commas are normalized and a later `harn fmt`
+  is a no-op. Built into `rules.apply` (on by default; `format: false` opts out; the result reports a `formatted`
+  flag), so the dry-run preview shows the final formatted output and every caller — the CLI and the cloud worker —
+  gets it for free. Only `.harn` is formatted (it is the only language with a bundled formatter). The lint-`--fix`
+  interplay half of #2847 (running the linter after fmt) is tracked as a follow-on now that engine rules are lint
+  rules (#2849).

--- a/crates/harn-rules-hostlib/Cargo.toml
+++ b/crates/harn-rules-hostlib/Cargo.toml
@@ -11,6 +11,9 @@ description = "Host capability exposing the harn-rules declarative rule engine t
 harn-rules = { path = "../harn-rules", version = "0.8" }
 harn-hostlib = { path = "../harn-hostlib", version = "0.8", default-features = false, features = ["ast"] }
 harn-vm = { path = "../harn-vm", version = "0.8" }
+# Formatter for the codemod fmt post-pass (#2847): normalize rewritten .harn so
+# a batch lands fmt-stable. harn-fmt has no harn-rules dep, so no cycle.
+harn-fmt = { path = "../harn-fmt", version = "0.8" }
 serde_json = "1"
 
 [lints]

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -225,17 +225,32 @@ fn apply_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let rule = compile_rule(APPLY, &dict)?;
     let dry_run = optional_bool(&dict, "dry_run", true);
     let allow_unsafe = optional_bool(&dict, "allow_unsafe", false);
+    // fmt post-pass (#2847): normalize rewritten `.harn` so a batch lands
+    // fmt-stable. On by default; `format: false` opts out.
+    let format = optional_bool(&dict, "format", true);
     let files = load_files(APPLY, &dict)?;
 
     let auto_applicable = rule.safety().is_auto_applicable();
     let mut entries = Vec::new();
     for file in &files {
         let outcome = rule.apply(&file.source).map_err(|e| backend(APPLY, &e))?;
+        // Only `.harn` has a formatter; harn_fmt is idempotent, so a later
+        // `harn fmt` is a no-op. A formatter error falls back to the raw
+        // rewrite rather than failing the codemod.
+        let formatted = format && outcome.changed && file.language == Language::Harn;
+        let rewritten = if formatted {
+            match harn_fmt::format_source(&outcome.rewritten) {
+                Ok(canonical) => canonical,
+                Err(_) => outcome.rewritten,
+            }
+        } else {
+            outcome.rewritten
+        };
         // Write only on a real apply, when the edit is safe to auto-apply
         // (or explicitly allowed), and the rule actually changed the file.
         let applied = !dry_run && outcome.changed && (auto_applicable || allow_unsafe);
         if applied {
-            std::fs::write(&file.path, &outcome.rewritten).map_err(|e| HostlibError::Backend {
+            std::fs::write(&file.path, &rewritten).map_err(|e| HostlibError::Backend {
                 builtin: APPLY,
                 message: format!("write `{}`: {e}", file.path.display()),
             })?;
@@ -245,11 +260,12 @@ fn apply_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             ("changed", VmValue::Bool(outcome.changed)),
             ("applied", VmValue::Bool(applied)),
             ("idempotent", VmValue::Bool(outcome.idempotent)),
+            ("formatted", VmValue::Bool(formatted)),
             ("safety", str_vm(format!("{:?}", outcome.safety))),
             // The original source, so callers can render a diff without a
             // (sandboxed) re-read of the file.
             ("before", str_vm(&file.source)),
-            ("preview", str_vm(outcome.rewritten)),
+            ("preview", str_vm(rewritten)),
         ]));
     }
     Ok(dict_vm([
@@ -699,6 +715,61 @@ mod tests {
         assert!(b(get(&files[0], "changed")));
         assert!(!b(get(&files[0], "applied")));
         assert_eq!(s(get(&files[0], "preview")), "bar();\n");
+    }
+
+    const UGLY_HARN_CODEMOD: &str = r#"
+        id = "dd"
+        language = "harn"
+        safety = "scope-local"
+        fix = "let {$K=$D}=$X"
+        [rule]
+        pattern = "let $K = $X?.$K ?? $D"
+    "#;
+
+    #[test]
+    fn apply_formats_harn_output_by_default() {
+        // The fix template is deliberately ugly; the #2847 fmt post-pass
+        // normalizes the rewritten `.harn` (so a batch lands fmt-stable).
+        let result = apply_run(&[dict(&[
+            ("rule", str_vm(UGLY_HARN_CODEMOD)),
+            (
+                "source",
+                str_vm("fn main() {\n  let timeout = cfg?.timeout ?? 30\n}\n"),
+            ),
+            ("language", str_vm("harn")),
+            ("dry_run", VmValue::Bool(true)),
+        ])])
+        .unwrap();
+        let files = match get(&result, "files") {
+            VmValue::List(l) => l.clone(),
+            _ => panic!(),
+        };
+        assert!(b(get(&files[0], "changed")));
+        assert!(b(get(&files[0], "formatted")));
+        let preview = s(get(&files[0], "preview"));
+        assert!(preview.contains("= 30"), "preview not formatted: {preview}");
+    }
+
+    #[test]
+    fn apply_format_false_leaves_raw_output() {
+        let result = apply_run(&[dict(&[
+            ("rule", str_vm(UGLY_HARN_CODEMOD)),
+            (
+                "source",
+                str_vm("fn main() {\n  let timeout = cfg?.timeout ?? 30\n}\n"),
+            ),
+            ("language", str_vm("harn")),
+            ("dry_run", VmValue::Bool(true)),
+            ("format", VmValue::Bool(false)),
+        ])])
+        .unwrap();
+        let files = match get(&result, "files") {
+            VmValue::List(l) => l.clone(),
+            _ => panic!(),
+        };
+        assert!(!b(get(&files[0], "formatted")));
+        let preview = s(get(&files[0], "preview"));
+        assert!(preview.contains("{timeout=30}"), "expected raw: {preview}");
     }
 
     #[test]


### PR DESCRIPTION
Part of #2847. Rule Engine Epic C (#2829). Reachable now that `.harn` codemods exist (grammar #2888).

## What

`harn codemod` runs a **`harn fmt` post-pass** on rewritten `.harn` files, so a batch lands **fmt-stable** — a later `harn fmt` is a no-op:

```console
# fix template "let {$K=$D}=$X" (ugly) →
$ harn codemod --rule dd.toml src --apply
# writes:  let { timeout = 30 } = cfg   (harn_fmt-canonical)
```

## How

- Built into `rules.apply` (`harn-rules-hostlib`): after a rule rewrites a file, if it's `.harn` the output is formatted with `harn_fmt::format_source`. On by default; `format: false` opts out; each file result reports a `formatted` flag.
- The **dry-run preview is formatted too**, so it shows exactly what `--apply` writes.
- Only `.harn` is formatted (the only bundled formatter). harn-rules-hostlib gains a `harn-fmt` dep — **no cycle** (harn-fmt doesn't depend on harn-rules). Reusable by the CLI and the Epic E cloud worker for free.

## Scope note

This is the **fmt** half of #2847 (the headline + the #2824-migration enabler). The lint-`--fix` interplay half ("run the linter after fmt") is tracked as a follow-on — it overlaps #2849 (engine rules are now lint rules), and a well-formed codemod's output is already lint-clean.

## Verification

- `cargo test -p harn-rules-hostlib` (incl. 2 new: formats-by-default with `formatted=true`; `format:false` leaves raw output) green.
- End-to-end: an ugly fix template produces fmt-canonical `.harn` output.
- `cargo fmt` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)