### PR TITLE
lint: per-rule severity overrides via [lint.severity] (#2851 part A)

### DIFF
--- a/changelog.d/2851.added.md
+++ b/changelog.d/2851.added.md
@@ -1,0 +1,5 @@
+- Added `[lint.severity]` per-rule severity overrides (Rule Engine Epic C): a project can promote a rule to an error
+  or demote one to `info` from `harn.toml`, e.g. `[lint.severity]` + `unnecessary-parentheses = "error"`. Applied
+  after `disable_rules` filtering, by rule id (works for built-in and engine rules alike), reflected in `harn lint`,
+  `harn lint --fix`, `harn fix`, and the JSON report. (Part of #2851; the `lint.run` VM builtin — exposing the linter
+  to agents/IDEs without shelling out — is the remaining half.)

--- a/crates/harn-cli/src/commands/check/config.rs
+++ b/crates/harn-cli/src/commands/check/config.rs
@@ -84,6 +84,34 @@ pub(crate) fn harn_lint_persona_step_allowlist(path: &Path) -> Vec<String> {
     }
 }
 
+/// Per-rule severity overrides from `[lint.severity]` (#2851), parsed to
+/// [`harn_lint::LintSeverity`]. An unrecognized severity string is dropped
+/// with a warning rather than failing the run.
+pub(crate) fn harn_lint_severity_overrides(
+    path: &Path,
+) -> std::collections::HashMap<String, harn_lint::LintSeverity> {
+    let raw = match harn_config::load_for_path(path) {
+        Ok(cfg) => cfg.lint.severity,
+        Err(e) => {
+            eprintln!("warning: {e}");
+            return std::collections::HashMap::new();
+        }
+    };
+    raw.into_iter()
+        .filter_map(
+            |(rule, severity)| match severity.to_ascii_lowercase().as_str() {
+                "error" => Some((rule, harn_lint::LintSeverity::Error)),
+                "warning" | "warn" => Some((rule, harn_lint::LintSeverity::Warning)),
+                "info" => Some((rule, harn_lint::LintSeverity::Info)),
+                other => {
+                    eprintln!("warning: [lint.severity] `{rule}`: unknown severity `{other}`");
+                    None
+                }
+            },
+        )
+        .collect()
+}
+
 pub(crate) fn collect_harn_targets(targets: &[&str]) -> Vec<PathBuf> {
     super::super::collect_source_targets(targets, true, false).harn
 }

--- a/crates/harn-cli/src/commands/check/lint.rs
+++ b/crates/harn-cli/src/commands/check/lint.rs
@@ -77,6 +77,7 @@ pub(crate) fn lint_file_inner(
         persona_step_allowlist,
         require_stdlib_metadata: path_is_stdlib_source(path),
         engine_rules: &engine_rules,
+        severity_overrides: super::harn_lint_severity_overrides(path),
     };
     let mut diagnostics = harn_lint::lint_with_module_graph(
         &program,
@@ -136,6 +137,7 @@ pub(crate) fn lint_fix_file(
         persona_step_allowlist,
         require_stdlib_metadata: path_is_stdlib_source(path),
         engine_rules: &engine_rules,
+        severity_overrides: super::harn_lint_severity_overrides(path),
     };
     let lint_diags = harn_lint::lint_with_module_graph(
         &program,

--- a/crates/harn-cli/src/commands/check/lint_report.rs
+++ b/crates/harn-cli/src/commands/check/lint_report.rs
@@ -115,6 +115,7 @@ pub(crate) fn lint_file_report(
         persona_step_allowlist,
         require_stdlib_metadata: path_is_stdlib_source(path),
         engine_rules: &engine_rules,
+        severity_overrides: super::harn_lint_severity_overrides(path),
     };
     let lint_diagnostics = harn_lint::lint_with_module_graph(
         &program,

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use config::{
     apply_harn_lint_config, apply_loaded_harn_lint_config, build_module_graph,
     build_module_graph_and_seed_analysis, collect_cross_file_imports, collect_harn_targets,
     harn_lint_complexity_threshold, harn_lint_persona_step_allowlist,
-    harn_lint_require_file_header, load_harn_lint_config,
+    harn_lint_require_file_header, harn_lint_severity_overrides, load_harn_lint_config,
 };
 pub(crate) use fmt::{fmt_targets, fmt_targets_json, FmtMode, FMT_SCHEMA_VERSION};
 pub(crate) use host_capabilities::load_host_capabilities;

--- a/crates/harn-cli/src/commands/fix.rs
+++ b/crates/harn-cli/src/commands/fix.rs
@@ -634,6 +634,7 @@ fn count_remaining_diagnostics(target: &Path) -> Result<RemainingDiagnostics, St
             persona_step_allowlist: &persona_step_allowlist,
             require_stdlib_metadata: commands::check::path_is_stdlib_source(file),
             engine_rules: &engine_rules,
+            severity_overrides: commands::check::harn_lint_severity_overrides(file),
         };
         count += harn_lint::lint_with_module_graph(
             &program,
@@ -713,6 +714,7 @@ fn collect_file_candidates(
         persona_step_allowlist: &persona_step_allowlist,
         require_stdlib_metadata: commands::check::path_is_stdlib_source(file),
         engine_rules: &engine_rules,
+        severity_overrides: commands::check::harn_lint_severity_overrides(file),
     };
     let lint_diagnostics = harn_lint::lint_with_module_graph(
         &program,

--- a/crates/harn-cli/src/config.rs
+++ b/crates/harn-cli/src/config.rs
@@ -89,6 +89,11 @@ pub struct LintConfig {
     /// to [`harn_lint::DEFAULT_TEMPLATE_VARIANT_BRANCH_THRESHOLD`].
     #[serde(default, alias = "template-variant-branch-threshold")]
     pub template_variant_branch_threshold: Option<usize>,
+    /// `[lint.severity]` — per-rule severity overrides (#2851), a rule id →
+    /// `"error"` / `"warning"` / `"info"`. Applied after disable-filtering, so
+    /// a project can promote one rule to an error and demote another.
+    #[serde(default)]
+    pub severity: std::collections::HashMap<String, String>,
 }
 
 /// `[eval]` section of `harn.toml`. Reserves a `[eval.fleets.<name>]`

--- a/crates/harn-lint/src/diagnostic.rs
+++ b/crates/harn-lint/src/diagnostic.rs
@@ -78,4 +78,9 @@ pub struct LintOptions<'a> {
     /// (#2849), loaded from the project's `[rules] ruleDirs`. Each is compiled
     /// and wrapped as a `Rule`; an invalid one is skipped, not fatal.
     pub engine_rules: &'a [String],
+    /// Per-rule severity overrides (#2851): a rule id → the severity to report
+    /// its diagnostics at, applied after disable-filtering. Lets a project
+    /// promote a rule to `error` or demote one to `info` via `[lint]`. Owned
+    /// (not `&[..]`) because a `HashMap` reference has no const empty default.
+    pub severity_overrides: std::collections::HashMap<String, LintSeverity>,
 }

--- a/crates/harn-lint/src/lib.rs
+++ b/crates/harn-lint/src/lib.rs
@@ -213,7 +213,7 @@ fn lint_full(
         }
     }
     linter.finalize();
-    if disabled_rules.is_empty() {
+    let mut diagnostics: Vec<LintDiagnostic> = if disabled_rules.is_empty() {
         linter.diagnostics
     } else {
         linter
@@ -221,7 +221,16 @@ fn lint_full(
             .into_iter()
             .filter(|d| !rule_disabled(&d.rule, disabled_rules))
             .collect()
+    };
+    // Per-rule severity overrides (#2851), applied after disable-filtering.
+    if !options.severity_overrides.is_empty() {
+        for diagnostic in &mut diagnostics {
+            if let Some(&severity) = options.severity_overrides.get(diagnostic.rule.as_ref()) {
+                diagnostic.severity = severity;
+            }
+        }
     }
+    diagnostics
 }
 
 /// Convert type-checker diagnostics tagged as lint rules into ordinary

--- a/crates/harn-lint/src/tests/complexity.rs
+++ b/crates/harn-lint/src/tests/complexity.rs
@@ -107,12 +107,8 @@ pipeline default(task) {
     let program = parser.parse().unwrap();
     let externally_imported: HashSet<String> = HashSet::new();
     let options = LintOptions {
-        file_path: None,
-        require_file_header: false,
         complexity_threshold: Some(5),
-        persona_step_allowlist: &[],
-        require_stdlib_metadata: false,
-        engine_rules: &[],
+        ..Default::default()
     };
     let diags = lint_with_options(&program, &[], Some(source), &externally_imported, &options);
     let complexity_warnings: Vec<_> = diags
@@ -175,12 +171,8 @@ pipeline default(task) {
     let program = parser.parse().unwrap();
     let externally_imported: HashSet<String> = HashSet::new();
     let options = LintOptions {
-        file_path: None,
-        require_file_header: false,
         complexity_threshold: Some(100),
-        persona_step_allowlist: &[],
-        require_stdlib_metadata: false,
-        engine_rules: &[],
+        ..Default::default()
     };
     let diags = lint_with_options(&program, &[], Some(source), &externally_imported, &options);
     assert!(

--- a/crates/harn-lint/src/tests/engine_rules.rs
+++ b/crates/harn-lint/src/tests/engine_rules.rs
@@ -23,6 +23,33 @@ fn lint_with_engine_rules(
 }
 
 #[test]
+fn severity_override_remaps_a_rule() {
+    // `no-foo` defaults to `warning`; a project override promotes it to `error`
+    // (#2851). Applied after disable-filtering, by rule id.
+    use std::collections::HashMap;
+    let rules = vec![NO_FOO.to_string()];
+    let mut overrides: HashMap<String, crate::diagnostic::LintSeverity> = HashMap::new();
+    overrides.insert("no-foo".to_string(), crate::diagnostic::LintSeverity::Error);
+
+    let source = "fn main() {\n  foo()\n}\n";
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse().unwrap();
+    let options = LintOptions {
+        engine_rules: &rules,
+        severity_overrides: overrides,
+        ..Default::default()
+    };
+    let diags = lint_with_options(&program, &[], Some(source), &HashSet::new(), &options);
+    let d = diags
+        .iter()
+        .find(|d| d.rule == "no-foo")
+        .expect("no-foo fired");
+    assert_eq!(d.severity, crate::diagnostic::LintSeverity::Error);
+}
+
+#[test]
 fn engine_rule_emits_a_lint_with_its_fix() {
     let rules = vec![NO_FOO.to_string()];
     let diags = lint_with_engine_rules("fn main() {\n  foo()\n}\n", &rules, &[]);

--- a/crates/harn-lint/src/tests/persona_steps.rs
+++ b/crates/harn-lint/src/tests/persona_steps.rs
@@ -47,12 +47,8 @@ fn helper(ctx) {
     let program = parser.parse().unwrap();
     let allow = vec!["helper".to_string()];
     let options = LintOptions {
-        file_path: None,
-        require_file_header: false,
-        complexity_threshold: None,
         persona_step_allowlist: &allow,
-        require_stdlib_metadata: false,
-        engine_rules: &[],
+        ..Default::default()
     };
     let diagnostics = lint_with_options(&program, &[], Some(source), &HashSet::new(), &options);
     assert!(!has_rule(&diagnostics, "persona-body-must-call-steps"));


### PR DESCRIPTION
Part of #2851. Rule Engine Epic C (#2829).

## What

Projects can promote/demote a rule's severity from `harn.toml`:

```toml
[lint.severity]
unnecessary-parentheses = "error"
some-noisy-rule = "info"
```
```console
$ harn lint a.harn
error[HARN-LNT-043]: unnecessary parentheses around a single value   # promoted
warning[HARN-LNT-014]: variable `x` is declared but never used        # unchanged
```

Applied after `disable_rules` filtering, by rule id — works for **built-in and engine rules** (#2849) alike — and reflected in `harn lint`, `harn lint --fix`, `harn fix`, and the JSON report.

## How

- **harn-lint**: `LintOptions.severity_overrides: HashMap<String, LintSeverity>`, remapped in `lint_full` after disable-filtering.
- **harn-cli**: `[lint.severity]` → `LintConfig.severity` → `harn_lint_severity_overrides` (unknown severity strings warn, don't fail), threaded through all five lint `LintOptions` sites.
- Converted the explicit `LintOptions` literals to `..Default::default()` so future fields stop churning them.

## Scope note

This is the **config** half of #2851. The **`lint.run` VM builtin** (a new `harn-lint-hostlib` crate exposing the linter to agents/IDEs without shelling out — harn-hostlib can't depend on harn-lint without a cycle via harn-rules) is the remaining half, tracked on #2851.

## Verification

- `cargo test -p harn-lint` green incl. the new `severity_override_remaps_a_rule`.
- End-to-end: `[lint.severity]` promotes one rule to error, leaves others unchanged.
- `cargo fmt` + `clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)