### PR TITLE
lint: .harn-authored custom lint rules (#2850)

### DIFF
--- a/changelog.d/2850.added.md
+++ b/changelog.d/2850.added.md
@@ -1,0 +1,6 @@
+- Custom lint rules can now be authored in Harn (Rule Engine Epic C, #2850) — the ESLint-plugin equivalent. Drop a
+  `*.lint.harn` module exporting `pub fn lint(source) -> [finding]` into a `[rules] ruleDirs` directory and `harn lint`
+  discovers it, runs it over every linted file, and merges its findings into the normal output (same exit code, same
+  `--json` report, same `disable` filtering). Rules run in a read-only sandbox — the language, stdlib, and the
+  structural rule engine, but no filesystem / network / process access — and a buggy rule fails safe: its error
+  becomes a diagnostic instead of crashing the linter.

--- a/crates/harn-cli/src/commands/check/lint.rs
+++ b/crates/harn-cli/src/commands/check/lint.rs
@@ -53,6 +53,7 @@ fn rule_targets_harn(src: &str) -> bool {
         == Some("harn")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn lint_file_inner(
     analysis: &mut AnalysisDatabase,
     path: &Path,
@@ -62,6 +63,7 @@ pub(crate) fn lint_file_inner(
     require_file_header: bool,
     complexity_threshold: Option<usize>,
     persona_step_allowlist: &[String],
+    script_rule_diagnostics: &[harn_lint::LintDiagnostic],
 ) -> CommandOutcome {
     let path_str = path.to_string_lossy().into_owned();
     let output = analyze_file(analysis, path, config, module_graph)
@@ -92,6 +94,20 @@ pub(crate) fn lint_file_inner(
         &output.diagnostics,
         &config.disable_rules,
     ));
+    // `.harn`-authored custom lint rules (#2850), pre-computed in the async
+    // command handler (they need the VM) and merged here so they render and
+    // affect the exit code exactly like built-in rules.
+    diagnostics.extend(
+        script_rule_diagnostics
+            .iter()
+            .filter(|d| {
+                !config
+                    .disable_rules
+                    .iter()
+                    .any(|r| r.as_str() == d.rule.as_ref())
+            })
+            .cloned(),
+    );
 
     if diagnostics.is_empty() {
         println!("{path_str}: no issues found");

--- a/crates/harn-cli/src/commands/check/lint_report.rs
+++ b/crates/harn-cli/src/commands/check/lint_report.rs
@@ -89,6 +89,7 @@ impl LintReport {
 /// [`super::lint::lint_file_inner`] but suppresses human-readable
 /// stderr rendering and captures every diagnostic into a serializable
 /// shape.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn lint_file_report(
     analysis: &mut AnalysisDatabase,
     path: &Path,
@@ -98,6 +99,7 @@ pub(crate) fn lint_file_report(
     require_file_header: bool,
     complexity_threshold: Option<usize>,
     persona_step_allowlist: &[String],
+    script_rule_diagnostics: &[harn_lint::LintDiagnostic],
 ) -> LintFileReport {
     let path_str = path.to_string_lossy().into_owned();
     let output = match analyze_file(analysis, path, config, module_graph) {
@@ -163,6 +165,30 @@ pub(crate) fn lint_file_report(
         }
         if diag.fix.is_some() {
             fixable += 1;
+        }
+        diagnostics.push(CheckDiagnostic {
+            source: "lint",
+            severity: lint_severity_label(diag.severity),
+            code: Some(diag.code.to_string()),
+            message: diag.message.clone(),
+            span: Some(check_span(diag.span)),
+            help: diag.suggestion.clone(),
+        });
+    }
+
+    // `.harn`-authored custom lint rules (#2850), pre-computed in the async
+    // command handler (they need the VM) and merged into the report so they
+    // appear and affect status exactly like built-in rules.
+    for diag in script_rule_diagnostics.iter().filter(|d| {
+        !config
+            .disable_rules
+            .iter()
+            .any(|r| r.as_str() == d.rule.as_ref())
+    }) {
+        match diag.severity {
+            LintSeverity::Error => has_error = true,
+            LintSeverity::Warning => has_warning = true,
+            LintSeverity::Info => {}
         }
         diagnostics.push(CheckDiagnostic {
             source: "lint",

--- a/crates/harn-cli/src/commands/check/mod.rs
+++ b/crates/harn-cli/src/commands/check/mod.rs
@@ -12,6 +12,7 @@ mod mock_host;
 mod outcome;
 mod preflight;
 pub(crate) mod provider_matrix;
+mod script_rules;
 mod source;
 mod template_lint;
 
@@ -38,4 +39,5 @@ pub(crate) use lint::{
 };
 pub(crate) use lint_report::{lint_file_report, LintFileReport, LintReport, LINT_SCHEMA_VERSION};
 pub(crate) use preflight::{collect_preflight_diagnostics, is_preflight_allowed};
+pub(crate) use script_rules::run_project_script_rules;
 pub(crate) use template_lint::{collect_lint_targets, lint_prompt_file_inner};

--- a/crates/harn-cli/src/commands/check/script_rules.rs
+++ b/crates/harn-cli/src/commands/check/script_rules.rs
@@ -1,0 +1,339 @@
+//! `.harn`-authored custom lint rules (#2850) — the ESLint-plugin equivalent,
+//! but in Harn.
+//!
+//! A project drops a `*.lint.harn` module into a `[rules] ruleDirs` directory.
+//! `harn lint` discovers it, runs its exported `pub fn lint(source)` over each
+//! linted `.harn` file, and merges the returned findings into the normal lint
+//! output — indistinguishable from a built-in rule (same exit code, same
+//! report).
+//!
+//! ## The rule contract
+//!
+//! ```harn
+//! // rules/no-foo.lint.harn
+//! pub fn lint(source) -> list {
+//!   // Inspect `source` (the raw text of the file being linted) and return a
+//!   // list of findings. The structural rule engine is available read-only,
+//!   // so a rule can delegate to `rules.diagnostics` / `rules.search` and
+//!   // return their output directly:
+//!   return rules_diagnostics(source, "<rule toml>") ?? []
+//! }
+//! ```
+//!
+//! Each finding is a dict; the recognised fields mirror what `rules.diagnostics`
+//! emits, so a rule can pass that output straight through:
+//!
+//! - `message` (required) — the diagnostic text. A finding without it is skipped.
+//! - `severity` — `"error"` / `"warning"` / `"info"` (default `"warning"`).
+//! - `line` / `column` — 1-based location (default `1` / `1`).
+//! - `start_byte` / `end_byte` — byte span for the underline (default `0`).
+//!
+//! ## Sandbox + fail-safe
+//!
+//! Rules run in a dedicated VM with the language, the standard library, and the
+//! **read-only** structural rule engine — but *not* the default host I/O
+//! (filesystem / network / process). A lint rule inspects source and returns
+//! findings; it has no business touching the host.
+//!
+//! A buggy rule **fails safe**: a load error, a runtime throw, or a malformed
+//! return becomes a diagnostic attributed to the rule, never a linter crash
+//! (the C1 acceptance criterion).
+
+#[cfg(feature = "hostlib")]
+mod imp {
+    use std::collections::{HashMap, HashSet};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    use harn_lexer::Span;
+    use harn_lint::{LintDiagnostic, LintSeverity};
+    use harn_parser::DiagnosticCode;
+    use harn_vm::{VmClosure, VmValue};
+
+    /// Suffix that marks a `.harn` module as an imperative lint rule.
+    const RULE_SUFFIX: &str = ".lint.harn";
+
+    /// A discovered rule, either loaded or failed-to-load. Both variants carry
+    /// the rule id (the file stem minus `.lint`) so findings and load errors are
+    /// attributable.
+    enum LoadedRule {
+        Ok { id: String, lint: Arc<VmClosure> },
+        Failed { id: String, error: String },
+    }
+
+    /// Collect `*.lint.harn` files declared by `file`'s nearest manifest's
+    /// `[rules] ruleDirs`. Mirrors `lint::project_engine_rule_sources` (the
+    /// declarative-rule discovery) but for imperative `.harn` modules.
+    fn discover_rule_paths(file: &Path) -> Vec<PathBuf> {
+        let Some((manifest, dir)) = crate::package::find_nearest_manifest(file) else {
+            return Vec::new();
+        };
+        let mut paths = Vec::new();
+        for rel in &manifest.rules.rule_dirs {
+            let Ok(entries) = std::fs::read_dir(dir.join(rel)) else {
+                continue;
+            };
+            let mut files: Vec<_> = entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.ends_with(RULE_SUFFIX))
+                })
+                .collect();
+            files.sort();
+            paths.extend(files);
+        }
+        paths
+    }
+
+    fn rule_id_for(path: &Path) -> String {
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.trim_end_matches(RULE_SUFFIX).to_string())
+            .filter(|stem| !stem.is_empty())
+            .unwrap_or_else(|| "harn-script-rule".to_string())
+    }
+
+    /// Build the read-only sandbox VM: language + stdlib + the structural rule
+    /// engine, but no default host I/O.
+    fn sandbox_vm() -> harn_vm::Vm {
+        let mut vm = harn_vm::Vm::new();
+        harn_vm::register_vm_stdlib(&mut vm);
+        harn_rules_hostlib::install(&mut vm);
+        vm
+    }
+
+    /// A fail-safe diagnostic attributing an error to a rule. Anchored at the
+    /// start of the file so it always renders.
+    fn rule_error_diagnostic(id: &str, error: &str) -> LintDiagnostic {
+        LintDiagnostic {
+            code: DiagnosticCode::LintRuleEngine,
+            rule: std::borrow::Cow::Owned(id.to_string()),
+            message: format!("lint rule '{id}' failed: {error}"),
+            span: Span {
+                start: 0,
+                end: 0,
+                line: 1,
+                column: 1,
+                end_line: 1,
+            },
+            severity: LintSeverity::Error,
+            suggestion: None,
+            fix: None,
+        }
+    }
+
+    fn severity_from(value: Option<&VmValue>) -> LintSeverity {
+        match value.map(VmValue::as_str_cow).as_deref() {
+            Some("error") => LintSeverity::Error,
+            Some("info") => LintSeverity::Info,
+            _ => LintSeverity::Warning,
+        }
+    }
+
+    /// Map one finding dict onto a [`LintDiagnostic`], or `None` if it has no
+    /// `message` (the one required field).
+    fn finding_to_diagnostic(id: &str, finding: &VmValue) -> Option<LintDiagnostic> {
+        let dict = finding.as_dict()?;
+        let message = dict.get("message")?.as_str_cow().into_owned();
+        if message.is_empty() {
+            return None;
+        }
+        let int = |key: &str, default: usize| {
+            dict.get(key)
+                .and_then(VmValue::as_int)
+                .filter(|n| *n >= 0)
+                .map(|n| n as usize)
+                .unwrap_or(default)
+        };
+        let line = int("line", 1).max(1);
+        let column = int("column", 1).max(1);
+        let start = int("start_byte", 0);
+        let end = int("end_byte", start).max(start);
+        Some(LintDiagnostic {
+            code: DiagnosticCode::LintRuleEngine,
+            rule: std::borrow::Cow::Owned(id.to_string()),
+            message,
+            span: Span {
+                start,
+                end,
+                line,
+                column,
+                end_line: line,
+            },
+            severity: severity_from(dict.get("severity")),
+            suggestion: None,
+            fix: None,
+        })
+    }
+
+    /// Map a rule's return value (expected: a list of finding dicts) onto
+    /// diagnostics. A non-list return (e.g. `nil`) yields nothing.
+    fn map_return(id: &str, value: &VmValue, out: &mut Vec<LintDiagnostic>) {
+        if let VmValue::List(items) = value {
+            for item in items.iter() {
+                if let Some(diag) = finding_to_diagnostic(id, item) {
+                    out.push(diag);
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn run(files: &[PathBuf]) -> HashMap<PathBuf, Vec<LintDiagnostic>> {
+        let mut out: HashMap<PathBuf, Vec<LintDiagnostic>> = HashMap::new();
+
+        // The union of rule files across all targets. Most targets share a
+        // manifest, so this is usually a single small directory listing.
+        let mut rule_paths: Vec<PathBuf> = Vec::new();
+        let mut seen = HashSet::new();
+        for file in files {
+            for path in discover_rule_paths(file) {
+                if seen.insert(path.clone()) {
+                    rule_paths.push(path);
+                }
+            }
+        }
+        if rule_paths.is_empty() {
+            return out; // Common path: no project rules — near-zero cost.
+        }
+
+        let mut vm = sandbox_vm();
+
+        // Load each rule's `lint` closure once. A `*.lint.harn` without a `lint`
+        // export is a no-op (skipped); a module that won't load fails safe.
+        let mut rules: Vec<LoadedRule> = Vec::new();
+        for path in &rule_paths {
+            let id = rule_id_for(path);
+            let Ok(source) = std::fs::read_to_string(path) else {
+                continue;
+            };
+            match vm
+                .load_module_exports_from_source(path.clone(), &source)
+                .await
+            {
+                Ok(exports) => {
+                    if let Some(lint) = exports.get("lint") {
+                        rules.push(LoadedRule::Ok {
+                            id,
+                            lint: lint.clone(),
+                        });
+                    }
+                }
+                Err(error) => rules.push(LoadedRule::Failed {
+                    id,
+                    error: error.to_string(),
+                }),
+            }
+        }
+        if rules.is_empty() {
+            return out;
+        }
+
+        for file in files {
+            let Ok(source) = std::fs::read_to_string(file) else {
+                continue;
+            };
+            let mut diagnostics = Vec::new();
+            for rule in &rules {
+                match rule {
+                    LoadedRule::Failed { id, error } => {
+                        diagnostics.push(rule_error_diagnostic(id, error));
+                    }
+                    LoadedRule::Ok { id, lint } => {
+                        let arg = VmValue::String(Arc::from(source.as_str()));
+                        match vm.call_closure_pub(lint, &[arg]).await {
+                            Ok(value) => map_return(id, &value, &mut diagnostics),
+                            Err(error) => {
+                                diagnostics.push(rule_error_diagnostic(id, &error.to_string()));
+                            }
+                        }
+                    }
+                }
+            }
+            if !diagnostics.is_empty() {
+                out.insert(file.clone(), diagnostics);
+            }
+        }
+        out
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::collections::BTreeMap;
+
+        fn finding(pairs: &[(&str, VmValue)]) -> VmValue {
+            let mut map = BTreeMap::new();
+            for (k, v) in pairs {
+                map.insert((*k).to_string(), v.clone());
+            }
+            VmValue::Dict(Arc::new(map))
+        }
+
+        fn s(text: &str) -> VmValue {
+            VmValue::String(Arc::from(text))
+        }
+
+        #[test]
+        fn maps_a_full_finding() {
+            let d = finding_to_diagnostic(
+                "no-todo",
+                &finding(&[
+                    ("message", s("nope")),
+                    ("severity", s("error")),
+                    ("line", VmValue::Int(7)),
+                    ("column", VmValue::Int(3)),
+                    ("start_byte", VmValue::Int(10)),
+                    ("end_byte", VmValue::Int(14)),
+                ]),
+            )
+            .expect("maps");
+            assert_eq!(d.message, "nope");
+            assert_eq!(d.severity, LintSeverity::Error);
+            assert_eq!(d.rule.as_ref(), "no-todo");
+            assert_eq!((d.span.line, d.span.column), (7, 3));
+            assert_eq!((d.span.start, d.span.end), (10, 14));
+        }
+
+        #[test]
+        fn defaults_location_and_severity() {
+            let d = finding_to_diagnostic("r", &finding(&[("message", s("m"))])).expect("maps");
+            assert_eq!(d.severity, LintSeverity::Warning);
+            assert_eq!((d.span.line, d.span.column), (1, 1));
+        }
+
+        #[test]
+        fn a_finding_without_a_message_is_skipped() {
+            assert!(finding_to_diagnostic("r", &finding(&[("severity", s("error"))])).is_none());
+            assert!(finding_to_diagnostic("r", &finding(&[("message", s(""))])).is_none());
+        }
+
+        #[test]
+        fn non_list_return_yields_nothing() {
+            let mut out = Vec::new();
+            map_return("r", &VmValue::Nil, &mut out);
+            assert!(out.is_empty());
+        }
+
+        #[test]
+        fn rule_error_is_an_error_diagnostic() {
+            let d = rule_error_diagnostic("boom", "kaboom");
+            assert_eq!(d.severity, LintSeverity::Error);
+            assert!(d.message.contains("boom") && d.message.contains("kaboom"));
+        }
+    }
+}
+
+#[cfg(feature = "hostlib")]
+pub(crate) use imp::run as run_project_script_rules;
+
+/// Without the `hostlib` feature there is no VM to host `.harn` rules, so the
+/// linter simply has none. Keeps the call site in `harn lint` unconditional.
+#[cfg(not(feature = "hostlib"))]
+pub(crate) async fn run_project_script_rules(
+    _files: &[std::path::PathBuf],
+) -> std::collections::HashMap<std::path::PathBuf, Vec<harn_lint::LintDiagnostic>> {
+    std::collections::HashMap::new()
+}

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -1617,6 +1617,7 @@ pipeline main(task) {
         false,
         None,
         &[],
+        &[],
     );
     assert!(
         outcome.has_warning,
@@ -1669,6 +1670,7 @@ pipeline main() {
         &module_graph,
         false,
         None,
+        &[],
         &[],
     );
     assert!(matches!(

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -561,6 +561,17 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
             let module_graph =
                 commands::check::build_module_graph_and_seed_analysis(&files, &mut analysis);
             let cross_file_imports = commands::check::collect_cross_file_imports(&module_graph);
+            // `.harn`-authored custom lint rules (#2850) run in a sandboxed VM,
+            // so they're computed once here in the async handler and merged into
+            // each file's diagnostics below. Empty (near-zero cost) when the
+            // project declares no `*.lint.harn` rules.
+            let script_rule_diags = commands::check::run_project_script_rules(&files).await;
+            let script_diags_for = |file: &std::path::Path| -> &[harn_lint::LintDiagnostic] {
+                script_rule_diags
+                    .get(file)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[])
+            };
             if args.json {
                 // `--json` always reports without modifying source — `--fix`
                 // is intentionally orthogonal to structured output so agents
@@ -584,6 +595,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                         require_header,
                         complexity_threshold,
                         &lint_config.persona_step_allowlist,
+                        script_diags_for(file.as_path()),
                     );
                     should_fail |= report.outcome().should_fail(config.strict);
                     json_files.push(report);
@@ -661,6 +673,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                         require_header,
                         complexity_threshold,
                         &lint_config.persona_step_allowlist,
+                        script_diags_for(file.as_path()),
                     );
                     total_findings += outcome.findings;
                     total_fixable += outcome.fixable;

--- a/crates/harn-cli/tests/harn_script_lint_rules_dispatch.rs
+++ b/crates/harn-cli/tests/harn_script_lint_rules_dispatch.rs
@@ -1,0 +1,133 @@
+//! End-to-end coverage for `.harn`-authored custom lint rules (#2850): with a
+//! `[rules] ruleDirs` in `harn.toml`, `harn lint` discovers `*.lint.harn`
+//! modules, runs their `pub fn lint(source)` over each linted file, and merges
+//! the findings into the normal lint output. A deliberately-buggy rule fails
+//! safe. Spawns the real `harn` binary with its cwd set to the project root.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn project(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("harn-scriptlint-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("rules")).expect("mkdir rules");
+    std::fs::create_dir_all(dir.join("src")).expect("mkdir src");
+    std::fs::write(dir.join("harn.toml"), "[rules]\nruleDirs = [\"rules\"]\n").unwrap();
+    dir
+}
+
+fn write(dir: &Path, rel: &str, contents: &str) {
+    std::fs::write(dir.join(rel), contents).expect("write");
+}
+
+fn run(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("spawn harn");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// A `.harn` lint rule banning `TODO` markers — keys alphabetical (Harn dict
+/// literal convention).
+const TODO_RULE: &str = r#"pub fn lint(source) -> list {
+  if source.contains("TODO") {
+    return [{column: 1, line: 1, message: "TODO markers are banned", severity: "error"}]
+  }
+  return []
+}
+"#;
+
+const CLEAN_SRC: &str = "pub fn greet() -> string {\n  return \"hi\"\n}\n";
+
+#[test]
+fn script_rule_flags_a_convention_violation() {
+    let dir = project("flag");
+    write(&dir, "rules/no-todo.lint.harn", TODO_RULE);
+    write(
+        &dir,
+        "src/main.harn",
+        "pub fn greet() -> string {\n  // TODO: rename\n  return \"hi\"\n}\n",
+    );
+
+    let (stdout, stderr, code) = run(&dir, &["lint", "src/main.harn"]);
+    let all = format!("{stdout}{stderr}");
+    assert_ne!(code, 0, "a violation must fail the lint: {all}");
+    assert!(
+        all.contains("TODO markers are banned"),
+        "script-rule finding should surface: {all}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn script_rule_leaves_a_clean_file_clean() {
+    let dir = project("clean");
+    write(&dir, "rules/no-todo.lint.harn", TODO_RULE);
+    write(&dir, "src/main.harn", CLEAN_SRC);
+
+    let (stdout, stderr, code) = run(&dir, &["lint", "src/main.harn"]);
+    let all = format!("{stdout}{stderr}");
+    assert_eq!(code, 0, "a clean file must pass: {all}");
+    assert!(
+        !all.contains("TODO markers are banned"),
+        "no finding expected on a clean file: {all}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn buggy_script_rule_fails_safe() {
+    let dir = project("buggy");
+    // A rule that throws at runtime must not crash the linter.
+    write(
+        &dir,
+        "rules/explode.lint.harn",
+        "pub fn lint(source) -> list {\n  throw \"deliberate rule bug\"\n}\n",
+    );
+    write(&dir, "src/main.harn", CLEAN_SRC);
+
+    let (stdout, stderr, code) = run(&dir, &["lint", "src/main.harn"]);
+    let all = format!("{stdout}{stderr}");
+    // The linter completed (a real exit code, not a panic/abort) and reported
+    // the rule failure as a diagnostic instead of crashing.
+    assert!(
+        code == 0 || code == 1,
+        "linter must not crash on a buggy rule (got {code}): {all}"
+    );
+    assert!(
+        all.contains("explode") && all.to_lowercase().contains("failed"),
+        "a buggy rule should be reported as a failed diagnostic: {all}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_output_includes_script_rule_findings() {
+    let dir = project("json");
+    write(&dir, "rules/no-todo.lint.harn", TODO_RULE);
+    write(
+        &dir,
+        "src/main.harn",
+        "pub fn greet() -> string {\n  // TODO: rename\n  return \"hi\"\n}\n",
+    );
+
+    let (stdout, stderr, code) = run(&dir, &["lint", "src/main.harn", "--json"]);
+    assert_ne!(code, 0, "violation must fail: stderr={stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let blob = json.to_string();
+    assert!(
+        blob.contains("TODO markers are banned"),
+        "json report should carry the script-rule finding: {blob}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/harn-skills/src/corpus/harn-rules/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-rules/SKILL.md
@@ -74,6 +74,10 @@ conformance fixtures.
 - `harn codemod --rule <file> <paths>` — **dry-run by default** (a unified diff
   per file with safety + idempotency); `--apply` writes (capability-gated),
   `--allow-unsafe` applies above machine-applicable safety, `--json`.
+- `harn lint <paths>` — runs project lint rules. Declarative `language = "harn"`
+  rules and imperative `*.lint.harn` modules (a `pub fn lint(source) -> list` of
+  `{message, severity?, line?, column?}` findings) in `[rules] ruleDirs` merge
+  into the normal output. `.harn` rules run read-only and fail safe.
 
 ## From `.harn` (`std/rules`)
 

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -156,6 +156,40 @@ For logic a declarative rule can't express, `rules_visit({rule, ..., on_match:
 fn(node, ctx) { ... }})` calls a visitor per match; the visitor *returns* its
 report(s) (`nil`/`false` to skip, a `{message, fix, safety}` dict, or a list).
 
+## How do I write a custom lint rule in Harn?
+
+For a project convention that a declarative rule can't capture, author an
+imperative rule in Harn — the ESLint-plugin equivalent. Drop a `*.lint.harn`
+module into a `ruleDirs` directory; it exports `lint(source)` and returns a list
+of findings:
+
+```harn,ignore
+// rules/no-todo.lint.harn
+pub fn lint(source) -> list {
+  if source.contains("TODO") {
+    return [{column: 1, line: 1, message: "TODO markers are banned", severity: "error"}]
+  }
+  return []
+}
+```
+
+```console
+harn lint src             # discovers rules/*.lint.harn and runs them per file
+```
+
+`harn lint` discovers these alongside the built-in rules and merges their
+findings into the normal output — same exit code, same `--json` report, same
+`disable` filtering. Each finding is a dict with a required `message` plus
+optional `severity` (`"error"`/`"warning"`/`"info"`, default `"warning"`),
+`line`/`column` (default `1`), and `start_byte`/`end_byte`. The fields mirror
+what `rules_diagnostics` emits, so a rule can delegate to the structural engine
+and `return` its output directly.
+
+Rules run in a read-only sandbox — the language, stdlib, and the structural rule
+engine, but no filesystem / network / process access. A buggy rule **fails
+safe**: a load error or a runtime throw becomes a diagnostic attributed to the
+rule, never a linter crash.
+
 ## See also
 
 - [Structured refactorings cookbook](./structured-refactorings.md) — the


### PR DESCRIPTION
Closes **#2850** (Rule Engine Epic C). The ESLint-plugin equivalent, in Harn.

## What
Drop a `*.lint.harn` module exporting `pub fn lint(source) -> [finding]` into a `[rules] ruleDirs` directory. `harn lint` discovers it, runs it over each linted `.harn` file, and merges its findings into the normal output — **same exit code, same `--json` report, same `disable` filtering** as a built-in rule.

```harn
// rules/no-todo.lint.harn
pub fn lint(source) -> list {
  if source.contains("TODO") {
    return [{column: 1, line: 1, message: "TODO markers are banned", severity: "error"}]
  }
  return []
}
```

A finding is a dict: required `message`, optional `severity` (`error`/`warning`/`info`, default `warning`), `line`/`column` (default `1`), `start_byte`/`end_byte`. The fields mirror `rules_diagnostics` output, so a rule can delegate to the structural engine and `return` it directly.

## Sandbox + fail-safe
Rules run in a dedicated VM with the language, stdlib, and the **read-only** structural rule engine (`rules.*`) — but no default host I/O (filesystem / network / process). A buggy rule **fails safe**: a load error or runtime throw becomes a diagnostic attributed to the rule, never a linter crash (the C1 acceptance criterion).

## Design
Findings are computed in the async command handler (the VM is async), pre-computed once per file, then merged into both the human-readable and `--json` paths via a small `&[LintDiagnostic]` param on `lint_file_inner` / `lint_file_report`.

## Tests
- 4 e2e dispatch tests (`tests/harn_script_lint_rules_dispatch.rs`): a rule flags a convention violation; a clean file stays clean; **a buggy (throwing) rule fails safe**; `--json` carries the finding.
- 5 unit tests for the finding→diagnostic mapping (full finding, defaults, missing-message skip, non-list return, rule-error shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)