### PR TITLE
rules: add rule pack registry publishing

### DIFF
--- a/changelog.d/2846.added.md
+++ b/changelog.d/2846.added.md
@@ -1,5 +1,5 @@
-- `harn scan` / `harn codemod --rule-pack <name>` now resolves an **installed package** as a rule pack (Rule Engine
-  Epic B) — a pack fetched with `harn add` materializes under `<project>/.harn/packages/<name>`, and `--rule-pack
-  <name>` loads its rules (from the pack's own `[rules] ruleDirs`, falling back to `*.toml` at the pack root). A local
-  directory path still works as before; an unknown name suggests `harn add`. This is the consumption side of the rule
-  registry (#2846); `@scope/name` registry lookup and `harn rule publish`/`search` are the remaining distribution layer.
+- Added the rule-pack registry surface (Rule Engine Epic B): `harn rule publish` validates `[rules] ruleDirs`, marks the
+  package-index row with rule-pack metadata, and delegates to the existing package publish flow; `harn rule search`
+  filters the package registry to rule packs and shows languages, rule count, safety summary, and descriptions. `harn
+  scan` / `harn codemod --rule-pack <name>` now resolves both installed package aliases and canonical registry names
+  such as `@scope/name` from `harn.lock`, while local rule-pack directories still work.

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -148,8 +148,8 @@ pub(crate) use orchestrator::{
 pub use pack::{PackArgs, PackCommand, PackVerifyArgs};
 pub(crate) use package::{
     AddArgs, InstallArgs, PackageArgs, PackageArtifactsCommand, PackageCacheCommand,
-    PackageCommand, PackageScaffoldCommand, PackageScaffoldOpenapiArgs, PublishArgs, RemoveArgs,
-    UpdateArgs,
+    PackageCommand, PackageScaffoldCommand, PackageScaffoldOpenapiArgs, PackageSearchArgs,
+    PublishArgs, RemoveArgs, UpdateArgs,
 };
 pub(crate) use parse_tokens::{ParseArgs, TokensArgs};
 pub(crate) use persona::{

--- a/crates/harn-cli/src/cli/rule.rs
+++ b/crates/harn-cli/src/cli/rule.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use super::package::{PackageSearchArgs, PublishArgs};
+
 /// `harn rule` — author and test structural rules.
 #[derive(Debug, Args)]
 pub(crate) struct RuleArgs {
@@ -9,6 +11,10 @@ pub(crate) struct RuleArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum RuleCommand {
+    /// Publish a rule pack package to the package registry.
+    Publish(PublishArgs),
+    /// Search the package registry for rule packs.
+    Search(PackageSearchArgs),
     /// Run a rule's inline-annotation tests (`// ruleid:` / `// ok:`).
     Test(RuleTestArgs),
 }

--- a/crates/harn-cli/src/cli/tests.rs
+++ b/crates/harn-cli/src/cli/tests.rs
@@ -9,9 +9,9 @@ use super::{
     OrchestratorQueueCommand, OrchestratorTenantCommand, PackageArtifactsCommand,
     PackageCacheCommand, PackageCommand, PackageScaffoldCommand, PersonaCommand, ProjectTemplate,
     ProviderCapabilitiesCommand, ProviderCommand, ProviderToolProbeModeArg, ProvidersCommand,
-    PublishArgs, RunsCommand, SessionCommand, SkillCommand, SkillKeyCommand, SkillTrustCommand,
-    SkillsCommand, ToolCommand, TraceCommand, TriggerCommand, TrustCommand, TrustOutcomeArg,
-    TrustTierArg,
+    PublishArgs, RuleCommand, RunsCommand, SessionCommand, SkillCommand, SkillKeyCommand,
+    SkillTrustCommand, SkillsCommand, ToolCommand, TraceCommand, TriggerCommand, TrustCommand,
+    TrustOutcomeArg, TrustTierArg,
 };
 use clap::{CommandFactory, Parser};
 
@@ -2503,6 +2503,51 @@ fn test_parses_publish_git_tag_flow_options() {
     assert_eq!(registry_name.as_deref(), Some("@burin/acme-lib"));
     assert!(skip_index_pr);
     assert!(json);
+}
+
+#[test]
+fn test_parses_rule_publish_and_search() {
+    let cli = Cli::parse_from([
+        "harn",
+        "rule",
+        "publish",
+        "pkg",
+        "--dry-run",
+        "--registry-name",
+        "@acme/rules",
+        "--skip-index-pr",
+        "--json",
+    ]);
+    let Command::Rule(args) = cli.command.unwrap() else {
+        panic!("expected rule command");
+    };
+    let RuleCommand::Publish(publish) = args.command else {
+        panic!("expected rule publish");
+    };
+    assert_eq!(publish.package, Some(PathBuf::from("pkg")));
+    assert!(publish.dry_run);
+    assert_eq!(publish.registry_name.as_deref(), Some("@acme/rules"));
+    assert!(publish.skip_index_pr);
+    assert!(publish.json);
+
+    let cli = Cli::parse_from([
+        "harn",
+        "rule",
+        "search",
+        "typescript",
+        "--registry",
+        "index.toml",
+        "--json",
+    ]);
+    let Command::Rule(args) = cli.command.unwrap() else {
+        panic!("expected rule command");
+    };
+    let RuleCommand::Search(search) = args.command else {
+        panic!("expected rule search");
+    };
+    assert_eq!(search.query.as_deref(), Some("typescript"));
+    assert_eq!(search.registry.as_deref(), Some("index.toml"));
+    assert!(search.json);
 }
 
 #[test]

--- a/crates/harn-cli/src/commands/rule.rs
+++ b/crates/harn-cli/src/commands/rule.rs
@@ -17,8 +17,34 @@ pub(crate) async fn run(_args: RuleArgs) {
 #[cfg(feature = "hostlib")]
 pub(crate) async fn run(args: RuleArgs) {
     match args.command {
+        crate::cli::RuleCommand::Publish(publish) => run_publish(publish),
+        crate::cli::RuleCommand::Search(search) => run_search(search),
         crate::cli::RuleCommand::Test(test) => run_test(test),
     }
+}
+
+#[cfg(feature = "hostlib")]
+fn run_publish(args: crate::cli::PublishArgs) {
+    crate::package::publish_rule_package(
+        args.package.as_deref(),
+        args.dry_run,
+        &args.remote,
+        &args.index_repo,
+        &args.index_path,
+        args.registry_name.as_deref(),
+        args.skip_index_pr,
+        args.registry.as_deref(),
+        args.json,
+    );
+}
+
+#[cfg(feature = "hostlib")]
+fn run_search(args: crate::cli::PackageSearchArgs) {
+    crate::package::search_rule_package_registry(
+        args.query.as_deref(),
+        args.registry.as_deref(),
+        args.json,
+    );
 }
 
 #[cfg(feature = "hostlib")]

--- a/crates/harn-cli/src/commands/rules_cli.rs
+++ b/crates/harn-cli/src/commands/rules_cli.rs
@@ -103,12 +103,30 @@ fn resolve_rule_pack(pack: &str) -> Result<Vec<RuleSpec>, String> {
     ))
 }
 
-/// The local directory of an installed package named `name`
-/// (`<project>/.harn/packages/<name>`), if it exists.
+/// The local directory of an installed package named by dependency alias or
+/// canonical registry name, if it exists.
 fn installed_package_dir(name: &str) -> Option<std::path::PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     let (_, project_dir) = crate::package::find_nearest_manifest(&cwd)?;
-    let dir = project_dir.join(".harn").join("packages").join(name);
+    let packages_dir = project_dir.join(".harn").join("packages");
+    if crate::package::validate_package_alias(name).is_ok() {
+        let dir = packages_dir.join(name);
+        if dir.is_dir() {
+            return Some(dir);
+        }
+    }
+
+    let (registry_name, requested_version) = crate::package::parse_registry_package_spec(name)?;
+    let lock = crate::package::LockFile::load(&project_dir.join("harn.lock"))
+        .ok()
+        .flatten()?;
+    let entry = lock.packages.iter().find(|entry| {
+        entry.registry.as_ref().is_some_and(|registry| {
+            registry.name == registry_name
+                && requested_version.is_none_or(|version| registry.version == version)
+        })
+    })?;
+    let dir = packages_dir.join(&entry.name);
     dir.is_dir().then_some(dir)
 }
 

--- a/crates/harn-cli/src/package/mod.rs
+++ b/crates/harn-cli/src/package/mod.rs
@@ -58,8 +58,8 @@ pub use maturity::{
 pub use package_ops::*;
 pub(crate) use registry::*;
 pub use registry::{
-    clean_package_cache, list_package_cache, search_package_registry, show_package_registry_info,
-    verify_package_cache,
+    clean_package_cache, list_package_cache, search_package_registry, search_rule_package_registry,
+    show_package_registry_info, verify_package_cache,
 };
 pub use skills::*;
 pub(crate) use validation::*;

--- a/crates/harn-cli/src/package/package_ops.rs
+++ b/crates/harn-cli/src/package/package_ops.rs
@@ -264,6 +264,67 @@ pub fn publish_package(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn publish_rule_package(
+    anchor: Option<&Path>,
+    dry_run: bool,
+    remote: &str,
+    index_repo: &str,
+    index_path: &Path,
+    registry_name: Option<&str>,
+    skip_index_pr: bool,
+    registry: Option<&str>,
+    json: bool,
+) {
+    let options = PackagePublishOptions {
+        dry_run,
+        remote,
+        index_repo,
+        index_path,
+        registry_name,
+        skip_index_pr,
+        registry,
+    };
+
+    match publish_rule_package_impl(anchor, &options) {
+        Ok(report) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
+                );
+            } else {
+                if report.dry_run {
+                    println!(
+                        "Rule-pack publish dry run to {} succeeded.",
+                        report.registry
+                    );
+                } else {
+                    println!("Published rule pack {}.", report.tag);
+                }
+                println!("tag: {}", report.tag);
+                println!("sha: {}", report.sha);
+                if let Some(command) = report.tag_command.as_deref() {
+                    println!("tag command: {command}");
+                }
+                if let Some(diff) = report.index_diff.as_deref() {
+                    println!("\nindex diff:\n{diff}");
+                }
+                if let Some(url) = report.index_pr_url.as_deref() {
+                    println!("index PR: {url}");
+                }
+                println!("artifact: {}", report.artifact_dir);
+                println!("files: {}", report.files.len());
+            }
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
 pub fn list_packages(json: bool) {
     match list_packages_impl() {
         Ok(report) if json => {
@@ -389,6 +450,7 @@ pub(crate) fn check_package_impl(
     if let Err(error) = validate_handoff_routes(&ctx.manifest.handoff_routes, &ctx.manifest) {
         push_error(&mut errors, "handoff_routes", error.to_string());
     }
+    validate_rule_pack_for_publish(&ctx, &mut errors);
     let exports = validate_exports_for_publish(&ctx, &mut errors, &mut warnings);
     let (tools, skills) = validate_package_interface_exports(&ctx, &mut errors, &mut warnings);
 
@@ -402,6 +464,124 @@ pub(crate) fn check_package_impl(
         exports,
         tools,
         skills,
+    })
+}
+
+fn validate_rule_pack_for_publish(ctx: &ManifestContext, errors: &mut Vec<PackageCheckDiagnostic>) {
+    if ctx.manifest.rules.rule_dirs.is_empty() {
+        return;
+    }
+    if let Err(error) = collect_rule_pack_metadata(ctx) {
+        push_error(errors, "[rules] ruleDirs", error.to_string());
+    }
+}
+
+pub(crate) fn collect_rule_pack_metadata(
+    ctx: &ManifestContext,
+) -> Result<Option<RegistryRulePackInfo>, PackageError> {
+    if ctx.manifest.rules.rule_dirs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut rule_count = 0usize;
+    let mut languages = BTreeSet::new();
+    let mut safety = BTreeMap::<String, usize>::new();
+    for rel in &ctx.manifest.rules.rule_dirs {
+        let dir = safe_package_relative_path(&ctx.dir, rel)?;
+        if !dir.is_dir() {
+            return Err(PackageError::Validation(format!(
+                "`[rules] ruleDirs` entry `{rel}` is not a directory ({})",
+                dir.display()
+            )));
+        }
+        let mut paths: Vec<_> = fs::read_dir(&dir)
+            .map_err(|error| format!("failed to read rule dir {}: {error}", dir.display()))?
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("toml")
+            })
+            .collect();
+        paths.sort();
+        for path in paths {
+            let rule = read_rule_file_metadata(&path)?;
+            rule_count += 1;
+            languages.insert(rule.language);
+            *safety.entry(rule.safety).or_default() += 1;
+        }
+    }
+
+    if rule_count == 0 {
+        return Err(PackageError::Validation(
+            "rule packs must contain at least one `*.toml` rule under `[rules] ruleDirs`"
+                .to_string(),
+        ));
+    }
+
+    Ok(Some(RegistryRulePackInfo {
+        rule_count,
+        languages: languages.into_iter().collect(),
+        safety_summary: safety
+            .into_iter()
+            .map(|(name, count)| format!("{name}:{count}"))
+            .collect(),
+    }))
+}
+
+struct RuleFileMetadata {
+    language: String,
+    safety: String,
+}
+
+#[cfg(feature = "hostlib")]
+fn read_rule_file_metadata(path: &Path) -> Result<RuleFileMetadata, PackageError> {
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read rule {}: {error}", path.display()))?;
+    let rule = harn_rules::Rule::from_toml_str(&source)
+        .map_err(|error| format!("failed to parse rule {}: {error}", path.display()))?;
+    let safety = if rule.fix.is_some() {
+        rule.safety.as_str()
+    } else {
+        "no-fix"
+    };
+    Ok(RuleFileMetadata {
+        language: rule.language,
+        safety: safety.to_string(),
+    })
+}
+
+#[cfg(not(feature = "hostlib"))]
+fn read_rule_file_metadata(path: &Path) -> Result<RuleFileMetadata, PackageError> {
+    #[derive(Deserialize)]
+    struct MinimalRule {
+        id: String,
+        language: String,
+        #[serde(default)]
+        safety: Option<String>,
+        #[serde(default)]
+        fix: Option<String>,
+        rule: toml::Value,
+    }
+
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read rule {}: {error}", path.display()))?;
+    let rule: MinimalRule = toml::from_str(&source)
+        .map_err(|error| format!("failed to parse rule {}: {error}", path.display()))?;
+    if rule.id.trim().is_empty() || rule.language.trim().is_empty() {
+        return Err(PackageError::Validation(format!(
+            "rule {} must declare non-empty `id` and `language`",
+            path.display()
+        )));
+    }
+    let safety = if rule.fix.is_some() {
+        rule.safety.unwrap_or_else(|| "scope-local".to_string())
+    } else {
+        "no-fix".to_string()
+    };
+    let _ = rule.rule;
+    Ok(RuleFileMetadata {
+        language: rule.language,
+        safety,
     })
 }
 
@@ -763,6 +943,27 @@ pub(crate) fn publish_package_impl(
     anchor: Option<&Path>,
     options: &PackagePublishOptions<'_>,
 ) -> Result<PackagePublishReport, PackageError> {
+    publish_package_impl_with_rule_pack(anchor, options, None)
+}
+
+pub(crate) fn publish_rule_package_impl(
+    anchor: Option<&Path>,
+    options: &PackagePublishOptions<'_>,
+) -> Result<PackagePublishReport, PackageError> {
+    let ctx = load_manifest_context_for_anchor(anchor)?;
+    let rule_pack = collect_rule_pack_metadata(&ctx)?.ok_or_else(|| {
+        PackageError::Validation(
+            "rule packs must declare `[rules] ruleDirs` in harn.toml".to_string(),
+        )
+    })?;
+    publish_package_impl_with_rule_pack(anchor, options, Some(rule_pack))
+}
+
+fn publish_package_impl_with_rule_pack(
+    anchor: Option<&Path>,
+    options: &PackagePublishOptions<'_>,
+    rule_pack: Option<RegistryRulePackInfo>,
+) -> Result<PackagePublishReport, PackageError> {
     let registry = options
         .registry
         .map(str::trim)
@@ -780,7 +981,7 @@ pub(crate) fn publish_package_impl(
     } else {
         fetch_package_index_from_github(options.index_repo, options.index_path)?
     };
-    let mut plan = prepare_publish_plan(anchor, options, index_content, &registry)?;
+    let mut plan = prepare_publish_plan(anchor, options, index_content, &registry, rule_pack)?;
     if !options.dry_run && !options.skip_index_pr {
         ensure_github_repo_writeable(options.index_repo)?;
     }
@@ -816,6 +1017,7 @@ fn prepare_publish_plan(
     options: &PackagePublishOptions<'_>,
     index_content: String,
     registry: &str,
+    rule_pack: Option<RegistryRulePackInfo>,
 ) -> Result<PackagePublishPlan, PackageError> {
     let pack = pack_package_impl(anchor, None, true)?;
     let ctx = load_manifest_context_for_anchor(anchor)?;
@@ -876,6 +1078,7 @@ fn prepare_publish_plan(
             &entry,
             &version,
             &git,
+            rule_pack.as_ref(),
         )?;
         parse_package_registry_index(registry, &updated)?;
         let diff = render_unified_diff(
@@ -1187,6 +1390,7 @@ fn add_registry_version_entry(
     version_entry: &str,
     version: &str,
     git: &str,
+    rule_pack: Option<&RegistryRulePackInfo>,
 ) -> Result<String, PackageError> {
     let snapshot = parse_publish_index_snapshot(content)?;
     if let Some(package) = snapshot
@@ -1203,7 +1407,12 @@ fn add_registry_version_entry(
                 "package index already contains {registry_name}@{version}"
             )));
         }
-        return insert_version_entry(content, registry_name, version_entry);
+        let updated = insert_version_entry(content, registry_name, version_entry)?;
+        return if let Some(rule_pack) = rule_pack {
+            upsert_rule_pack_metadata(&updated, registry_name, rule_pack)
+        } else {
+            Ok(updated)
+        };
     }
 
     let mut updated = content.trim_end().to_string();
@@ -1214,6 +1423,7 @@ fn add_registry_version_entry(
         registry_name,
         git,
         version_entry,
+        rule_pack,
     )?);
     Ok(updated)
 }
@@ -1240,6 +1450,83 @@ fn insert_version_entry(
     Err(PackageError::Registry(format!(
         "failed to locate package index block for {registry_name}"
     )))
+}
+
+fn upsert_rule_pack_metadata(
+    content: &str,
+    registry_name: &str,
+    rule_pack: &RegistryRulePackInfo,
+) -> Result<String, PackageError> {
+    let starts = package_block_offsets(content);
+    for (idx, start) in starts.iter().enumerate() {
+        let end = starts.get(idx + 1).copied().unwrap_or(content.len());
+        let block = &content[*start..end];
+        if block_has_registry_name(block, registry_name) {
+            let updated_block = upsert_rule_pack_metadata_in_block(block, rule_pack)?;
+            let mut updated = String::with_capacity(content.len() + updated_block.len());
+            updated.push_str(&content[..*start]);
+            updated.push_str(&updated_block);
+            updated.push_str(&content[end..]);
+            return Ok(updated);
+        }
+    }
+    Err(PackageError::Registry(format!(
+        "failed to locate package index block for {registry_name}"
+    )))
+}
+
+fn upsert_rule_pack_metadata_in_block(
+    block: &str,
+    rule_pack: &RegistryRulePackInfo,
+) -> Result<String, PackageError> {
+    let metadata = render_rule_pack_metadata(rule_pack)?;
+    let line_ranges = block_line_ranges(block);
+    let metadata_start = line_ranges
+        .iter()
+        .find(|(_, _, line)| line.trim() == "[package.rule_pack]")
+        .map(|(start, _, _)| *start);
+
+    if let Some(start) = metadata_start {
+        let end = line_ranges
+            .iter()
+            .find(|(line_start, _, line)| *line_start > start && line.trim_start().starts_with('['))
+            .map(|(line_start, _, _)| *line_start)
+            .unwrap_or(block.len());
+        let mut out = String::with_capacity(block.len() + metadata.len());
+        out.push_str(block[..start].trim_end());
+        out.push_str("\n\n");
+        out.push_str(&metadata);
+        out.push('\n');
+        out.push_str(block[end..].trim_start_matches('\n'));
+        return Ok(out);
+    }
+
+    let insert_at = line_ranges
+        .iter()
+        .find(|(_, _, line)| line.trim() == "[[package.version]]")
+        .map(|(start, _, _)| *start)
+        .unwrap_or(block.len());
+    let mut out = String::with_capacity(block.len() + metadata.len() + 2);
+    out.push_str(block[..insert_at].trim_end());
+    out.push_str("\n\n");
+    out.push_str(&metadata);
+    out.push_str("\n\n");
+    out.push_str(block[insert_at..].trim_start_matches('\n'));
+    Ok(out)
+}
+
+fn block_line_ranges(block: &str) -> Vec<(usize, usize, &str)> {
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+    for line in block.split_inclusive('\n') {
+        let end = cursor + line.len();
+        ranges.push((cursor, end, line.trim_end_matches('\n')));
+        cursor = end;
+    }
+    if cursor < block.len() {
+        ranges.push((cursor, block.len(), &block[cursor..]));
+    }
+    ranges
 }
 
 fn package_block_offsets(content: &str) -> Vec<usize> {
@@ -1299,6 +1586,7 @@ fn render_registry_package_block(
     registry_name: &str,
     git: &str,
     version_entry: &str,
+    rule_pack: Option<&RegistryRulePackInfo>,
 ) -> Result<String, PackageError> {
     let mut out = String::new();
     out.push_str("[[package]]\n");
@@ -1331,9 +1619,32 @@ fn render_registry_package_block(
     }
     push_toml_string_field(&mut out, "provenance", git)?;
     out.push('\n');
+    if let Some(rule_pack) = rule_pack {
+        out.push_str(&render_rule_pack_metadata(rule_pack)?);
+        out.push('\n');
+    }
     out.push_str(version_entry.trim_end());
     out.push('\n');
     Ok(out)
+}
+
+fn render_rule_pack_metadata(rule_pack: &RegistryRulePackInfo) -> Result<String, PackageError> {
+    let languages = rule_pack
+        .languages
+        .iter()
+        .map(|language| toml_string_literal(language))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    let safety = rule_pack
+        .safety_summary
+        .iter()
+        .map(|entry| toml_string_literal(entry))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(format!(
+        "[package.rule_pack]\nrule_count = {}\nlanguages = [{}]\nsafety_summary = [{}]\n",
+        rule_pack.rule_count, languages, safety
+    ))
 }
 
 fn render_registry_version_entry(
@@ -1675,11 +1986,13 @@ pub(crate) fn validate_exports_for_publish(
     warnings: &mut Vec<PackageCheckDiagnostic>,
 ) -> Vec<PackageExportReport> {
     if ctx.manifest.exports.is_empty() {
-        push_error(
-            errors,
-            "[exports]",
-            "publishable packages require at least one stable export",
-        );
+        if ctx.manifest.rules.rule_dirs.is_empty() {
+            push_error(
+                errors,
+                "[exports]",
+                "publishable packages require at least one stable export or `[rules] ruleDirs`",
+            );
+        }
         return Vec::new();
     }
 
@@ -2775,8 +3088,14 @@ rev = "feedface"
             registry: None,
         };
 
-        let plan =
-            prepare_publish_plan(Some(tmp.path()), &options, index.to_string(), "fixture").unwrap();
+        let plan = prepare_publish_plan(
+            Some(tmp.path()),
+            &options,
+            index.to_string(),
+            "fixture",
+            None,
+        )
+        .unwrap();
 
         assert!(plan.tag_command.contains("git -C"));
         assert!(plan.tag_command.contains("tag v0.1.0"));
@@ -2804,6 +3123,88 @@ rev = "feedface"
     }
 
     #[test]
+    fn rule_publish_marks_pure_rule_pack_in_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_publishable_rule_pack(tmp.path());
+        write_release_changelog(tmp.path(), "0.1.0");
+        let _remote = init_publishable_repo(tmp.path());
+        let index_path = Path::new("package-index/harn-package-index.toml");
+        let options = PackagePublishOptions {
+            dry_run: true,
+            remote: "origin",
+            index_repo: "burin-labs/harn-cloud",
+            index_path,
+            registry_name: Some("@acme/rules"),
+            skip_index_pr: false,
+            registry: None,
+        };
+        let rule_pack = collect_rule_pack_metadata(
+            &load_manifest_context_for_anchor(Some(tmp.path())).unwrap(),
+        )
+        .unwrap()
+        .expect("rule pack metadata");
+
+        let plan = prepare_publish_plan(
+            Some(tmp.path()),
+            &options,
+            "version = 1\n".to_string(),
+            "fixture",
+            Some(rule_pack),
+        )
+        .unwrap();
+
+        assert!(plan.updated_index_content.contains("[package.rule_pack]"));
+        assert!(plan.updated_index_content.contains("rule_count = 2"));
+        assert!(plan
+            .updated_index_content
+            .contains("languages = [\"typescript\"]"));
+        assert!(plan
+            .updated_index_content
+            .contains("safety_summary = [\"behavior-preserving:1\", \"no-fix:1\"]"));
+        let registry_path = tmp.path().join("index.toml");
+        fs::write(&registry_path, &plan.updated_index_content).unwrap();
+        let workspace = TestWorkspace::new(tmp.path());
+        let matches = search_rule_package_registry_in(
+            workspace.env(),
+            Some("typescript"),
+            Some(registry_path.to_string_lossy().as_ref()),
+        )
+        .unwrap();
+        assert_eq!(matches.len(), 1);
+        let package = serde_json::to_value(&matches[0]).unwrap();
+        assert_eq!(package["name"], "@acme/rules");
+        assert_eq!(package["rule_pack"]["rule_count"], 2);
+        assert!(plan.index_diff.contains("+[package.rule_pack]"));
+    }
+
+    #[test]
+    fn rule_pack_metadata_upsert_marks_existing_package_block() {
+        let content = r#"version = 1
+
+[[package]]
+name = "@acme/rules"
+repository = "https://github.com/acme/rules"
+
+[[package.version]]
+version = "0.1.0"
+git = "https://github.com/acme/rules"
+tag = "v0.1.0"
+"#;
+        let metadata = RegistryRulePackInfo {
+            rule_count: 1,
+            languages: vec!["typescript".to_string()],
+            safety_summary: vec!["no-fix:1".to_string()],
+        };
+
+        let updated = upsert_rule_pack_metadata(content, "@acme/rules", &metadata).unwrap();
+
+        let marker = updated.find("[package.rule_pack]").unwrap();
+        let version = updated.find("[[package.version]]").unwrap();
+        assert!(marker < version, "{updated}");
+        parse_package_registry_index("fixture", &updated).unwrap();
+    }
+
+    #[test]
     fn publish_preflight_rejects_existing_tag_and_missing_changelog_entry() {
         let tmp = tempfile::tempdir().unwrap();
         write_publishable_package(tmp.path());
@@ -2824,6 +3225,7 @@ rev = "feedface"
             &options,
             "version = 1\n".to_string(),
             "fixture",
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -2839,6 +3241,7 @@ rev = "feedface"
             &options,
             "version = 1\n".to_string(),
             "fixture",
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -2868,6 +3271,7 @@ rev = "feedface"
             &options,
             "version = 1\n".to_string(),
             "fixture",
+            None,
         )
         .unwrap_err()
         .to_string();
@@ -3133,6 +3537,45 @@ name = "consumer"
             format!("# Changelog\n\n## {version}\n\n- Initial release.\n"),
         )
         .unwrap();
+    }
+
+    fn write_publishable_rule_pack(root: &Path) {
+        fs::create_dir_all(root.join("rules")).unwrap();
+        fs::create_dir_all(root.join("docs")).unwrap();
+        let harn_range = current_harn_range_example();
+        fs::write(
+            root.join(MANIFEST),
+            format!(
+                r#"[package]
+name = "acme-rules"
+version = "0.1.0"
+description = "Acme structural rules"
+license = "MIT"
+repository = "https://github.com/acme/acme-rules"
+harn = "{harn_range}"
+docs_url = "docs/api.md"
+
+[rules]
+ruleDirs = ["rules"]
+
+[dependencies]
+"#
+            ),
+        )
+        .unwrap();
+        fs::write(
+            root.join("rules/no-foo.toml"),
+            "id = \"no-foo\"\nlanguage = \"typescript\"\nmessage = \"no foo\"\n[rule]\npattern = \"foo()\"\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("rules/rename.toml"),
+            "id = \"rename\"\nlanguage = \"typescript\"\nfix = \"bar()\"\nsafety = \"behavior-preserving\"\n[rule]\npattern = \"foo()\"\n",
+        )
+        .unwrap();
+        fs::write(root.join("README.md"), "# acme-rules\n").unwrap();
+        fs::write(root.join("LICENSE"), "MIT\n").unwrap();
+        fs::write(root.join("docs/api.md"), "").unwrap();
     }
 
     fn init_publishable_repo(root: &Path) -> tempfile::TempDir {

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -41,6 +41,8 @@ pub(crate) struct RegistryPackage {
     harn: Option<String>,
     #[serde(default)]
     exports: Vec<String>,
+    #[serde(default, alias = "rule-pack", alias = "rulePack")]
+    rule_pack: Option<RegistryRulePackInfo>,
     #[serde(default, alias = "connector-contract")]
     connector_contract: Option<String>,
     #[serde(default)]
@@ -51,6 +53,16 @@ pub(crate) struct RegistryPackage {
     provenance: Option<String>,
     #[serde(default, rename = "version")]
     versions: Vec<RegistryPackageVersion>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RegistryRulePackInfo {
+    #[serde(default)]
+    pub(crate) rule_count: usize,
+    #[serde(default)]
+    pub(crate) languages: Vec<String>,
+    #[serde(default, alias = "safety-summary", alias = "safetySummary")]
+    pub(crate) safety_summary: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -669,6 +681,9 @@ pub(crate) fn validate_package_registry_index(
                 package.name
             )
         })?;
+        if let Some(rule_pack) = package.rule_pack.as_mut() {
+            normalize_rule_pack_info(rule_pack);
+        }
         let mut versions = HashSet::new();
         for version in &package.versions {
             if version.version.trim().is_empty() {
@@ -712,6 +727,19 @@ pub(crate) fn validate_package_registry_index(
     Ok(())
 }
 
+fn normalize_rule_pack_info(rule_pack: &mut RegistryRulePackInfo) {
+    rule_pack
+        .languages
+        .retain(|language| !language.trim().is_empty());
+    rule_pack.languages.sort();
+    rule_pack.languages.dedup();
+    rule_pack
+        .safety_summary
+        .retain(|entry| !entry.trim().is_empty());
+    rule_pack.safety_summary.sort();
+    rule_pack.safety_summary.dedup();
+}
+
 fn selected_git_ref_count(version: &RegistryPackageVersion) -> usize {
     usize::from(version.tag.is_some())
         + usize::from(version.tag.is_none() && version.rev.is_some())
@@ -743,6 +771,13 @@ pub(crate) fn registry_package_matches(package: &RegistryPackage, query: &str) -
             .exports
             .iter()
             .any(|export| export.to_ascii_lowercase().contains(&query))
+        || package.rule_pack.as_ref().is_some_and(|rule_pack| {
+            rule_pack
+                .languages
+                .iter()
+                .chain(rule_pack.safety_summary.iter())
+                .any(|value| value.to_ascii_lowercase().contains(&query))
+        })
 }
 
 pub(crate) fn latest_registry_version(
@@ -932,6 +967,28 @@ pub(crate) fn search_package_registry_in(
         .into_iter()
         .filter(|package| registry_package_matches(package, query.unwrap_or("")))
         .collect())
+}
+
+pub(crate) fn search_rule_package_registry_impl(
+    query: Option<&str>,
+    registry: Option<&str>,
+) -> Result<Vec<RegistryPackage>, PackageError> {
+    search_rule_package_registry_in(&PackageWorkspace::from_current_dir()?, query, registry)
+}
+
+pub(crate) fn search_rule_package_registry_in(
+    workspace: &PackageWorkspace,
+    query: Option<&str>,
+    registry: Option<&str>,
+) -> Result<Vec<RegistryPackage>, PackageError> {
+    Ok(search_package_registry_in(workspace, query, registry)?
+        .into_iter()
+        .filter(registry_package_is_rule_pack)
+        .collect())
+}
+
+fn registry_package_is_rule_pack(package: &RegistryPackage) -> bool {
+    package.rule_pack.is_some()
 }
 
 pub(crate) fn package_registry_info_impl(
@@ -1853,6 +1910,55 @@ pub fn search_package_registry(query: Option<&str>, registry: Option<&str>, json
     }
 }
 
+pub fn search_rule_package_registry(query: Option<&str>, registry: Option<&str>, json: bool) {
+    match search_rule_package_registry_impl(query, registry) {
+        Ok(packages) if json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&packages)
+                    .unwrap_or_else(|error| format!(r#"{{"error":"{error}"}}"#))
+            );
+        }
+        Ok(packages) => {
+            if packages.is_empty() {
+                println!("No rule packs found.");
+                return;
+            }
+            println!("name\tlatest\tlanguages\trules\tsafety\tdescription");
+            for package in packages {
+                let latest = latest_registry_version(&package)
+                    .map(|version| version.version.as_str())
+                    .unwrap_or("-")
+                    .to_string();
+                let rule_pack = package.rule_pack.unwrap_or_default();
+                let languages = if rule_pack.languages.is_empty() {
+                    "-".to_string()
+                } else {
+                    rule_pack.languages.join(",")
+                };
+                let safety = if rule_pack.safety_summary.is_empty() {
+                    "-".to_string()
+                } else {
+                    rule_pack.safety_summary.join(",")
+                };
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}",
+                    package.name,
+                    latest,
+                    languages,
+                    rule_pack.rule_count,
+                    safety,
+                    package.description.as_deref().unwrap_or("")
+                );
+            }
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(1);
+        }
+    }
+}
+
 pub fn show_package_registry_info(spec: &str, registry: Option<&str>, json: bool) {
     match package_registry_info_impl(spec, registry) {
         Ok(info) if json => {
@@ -1889,6 +1995,16 @@ pub fn show_package_registry_info(spec: &str, registry: Option<&str>, json: bool
             }
             if !package.exports.is_empty() {
                 println!("exports: {}", package.exports.join(", "));
+            }
+            if let Some(rule_pack) = package.rule_pack.as_ref() {
+                println!("rule_pack: yes");
+                println!("rules: {}", rule_pack.rule_count);
+                if !rule_pack.languages.is_empty() {
+                    println!("languages: {}", rule_pack.languages.join(", "));
+                }
+                if !rule_pack.safety_summary.is_empty() {
+                    println!("safety: {}", rule_pack.safety_summary.join(", "));
+                }
             }
             if let Some(version) = info.selected_version {
                 println!("selected: {}", version.version);
@@ -2177,6 +2293,64 @@ abc123abc123abc123abc123abc123abc1234567\trefs/tags/v0.0.1\n";
                 .as_ref()
                 .map(|version| version.git.as_str()),
             Some(git.as_str())
+        );
+    }
+
+    #[test]
+    fn rule_registry_search_filters_to_rule_pack_metadata() {
+        let project_tmp = tempfile::tempdir().unwrap();
+        let root = project_tmp.path();
+        let workspace = TestWorkspace::new(root);
+        let registry_path = root.join("index.toml");
+        fs::write(
+            &registry_path,
+            r#"
+version = 1
+
+[[package]]
+name = "@acme/plain"
+description = "Plain package"
+repository = "https://github.com/acme/plain"
+
+[[package.version]]
+version = "1.0.0"
+git = "https://github.com/acme/plain"
+tag = "v1.0.0"
+
+[[package]]
+name = "@acme/rules"
+description = "TypeScript and Rust cleanup rules"
+repository = "https://github.com/acme/rules"
+
+[package.rule_pack]
+rule_count = 3
+languages = ["typescript", "rust", "typescript"]
+safety_summary = ["no-fix:1", "behavior-preserving:2"]
+
+[[package.version]]
+version = "1.0.0"
+git = "https://github.com/acme/rules"
+tag = "v1.0.0"
+"#,
+        )
+        .unwrap();
+        fs::write(root.join(MANIFEST), "[package]\nname = \"workspace\"\n").unwrap();
+
+        let matches = search_rule_package_registry_in(
+            workspace.env(),
+            Some("rust"),
+            Some(registry_path.to_string_lossy().as_ref()),
+        )
+        .unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].name, "@acme/rules");
+        let metadata = matches[0].rule_pack.as_ref().expect("rule pack metadata");
+        assert_eq!(metadata.rule_count, 3);
+        assert_eq!(metadata.languages, vec!["rust", "typescript"]);
+        assert_eq!(
+            metadata.safety_summary,
+            vec!["behavior-preserving:2", "no-fix:1"]
         );
     }
 

--- a/crates/harn-cli/tests/rule_pack_install_dispatch.rs
+++ b/crates/harn-cli/tests/rule_pack_install_dispatch.rs
@@ -14,6 +14,21 @@ fn project_with_installed_pack(name: &str) -> PathBuf {
     std::fs::create_dir_all(dir.join("src")).unwrap();
     // The consuming project.
     std::fs::write(dir.join("harn.toml"), "[package]\nname = \"app\"\n").unwrap();
+    std::fs::write(
+        dir.join("harn.lock"),
+        r#"version = 4
+
+[[package]]
+name = "my-rules"
+source = "git+https://github.com/acme/my-rules"
+
+[package.registry]
+source = "index.toml"
+name = "@acme/my-rules"
+version = "0.1.0"
+"#,
+    )
+    .unwrap();
     // The installed pack ships its own manifest declaring where its rules live.
     std::fs::write(
         dir.join(".harn/packages/my-rules/harn.toml"),
@@ -50,6 +65,44 @@ fn rule_pack_resolves_an_installed_package_by_name() {
     assert_eq!(code, 0, "stderr={stderr}");
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
     assert_eq!(json["summary"]["total"], 2);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rule_pack_resolves_an_installed_package_by_registry_name() {
+    let dir = project_with_installed_pack("scoped");
+    std::fs::write(dir.join("src/a.ts"), "foo();\nfoo();\n").unwrap();
+
+    let (stdout, stderr, code) = run(
+        &dir,
+        &["scan", "--rule-pack", "@acme/my-rules", "src", "--json"],
+    );
+    assert_eq!(code, 0, "stderr={stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(json["summary"]["total"], 2);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rule_pack_resolves_an_installed_package_by_registry_name_and_version() {
+    let dir = project_with_installed_pack("scoped-version");
+    std::fs::write(dir.join("src/a.ts"), "foo();\n").unwrap();
+
+    let (stdout, stderr, code) = run(
+        &dir,
+        &[
+            "scan",
+            "--rule-pack",
+            "@acme/my-rules@0.1.0",
+            "src",
+            "--json",
+        ],
+    );
+    assert_eq!(code, 0, "stderr={stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(json["summary"]["total"], 1);
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -2304,6 +2304,22 @@ harn package search --registry ./harn-package-index.toml --json
 The registry source comes from `--registry`, `HARN_PACKAGE_REGISTRY`,
 `[registry].url` in `harn.toml`, or Harn's default hosted index.
 
+## harn rule publish / search
+
+Publish and discover structural rule packs through the package registry.
+
+```bash
+harn rule publish ./acme-rules --registry-name @acme/rules --dry-run
+harn rule search typescript
+harn rule search --registry ./harn-package-index.toml --json
+```
+
+`harn rule publish` is a rule-pack alias over `harn publish`: it requires the
+package manifest to declare `[rules] ruleDirs`, validates the rule files, and
+adds rule-pack metadata to the package-index row. `harn rule search` filters the
+package registry to rule packs and reports the pack description, languages, rule
+count, and safety summary.
+
 ## harn package info
 
 Show registry metadata for one package, optionally at a specific version.

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -134,6 +134,35 @@ rules." `harn codemod` applies only the rules that have a `fix`; lint/search
 rules in the same pack are ignored. Paths are resolved relative to the
 `harn.toml` directory.
 
+## How do I publish and install a rule pack?
+
+A rule pack is a Harn package that declares its rule directories:
+
+```toml
+[package]
+name = "acme-rules"
+version = "0.1.0"
+
+[rules]
+ruleDirs = ["rules"]
+```
+
+Publish it through the rule-specific package alias:
+
+```console
+harn rule publish --registry-name @acme/rules
+harn rule search acme
+harn add @acme/rules@0.1.0
+harn scan --rule-pack @acme/rules src
+```
+
+`harn rule publish` uses the same tag + package-index PR flow as `harn
+publish`, but first validates the rule files and writes rule-pack metadata to
+the registry index. `harn rule search` lists only rule packs and includes the
+pack description, languages, rule count, and safety summary. After `harn add`,
+`--rule-pack` accepts either the dependency alias or the canonical registry name
+recorded in `harn.lock`.
+
 ## How do I run a rule from `.harn`?
 
 `std/rules` is the same engine, callable inline — an agent can author and run a


### PR DESCRIPTION
Closes #2846.

## What

- Add `harn rule publish` as a rule-pack-aware alias over package publishing.
- Add `harn rule search` over package registry entries marked with rule-pack metadata.
- Mark published rule packs in the registry index with languages, rule count, and safety summary.
- Resolve `harn scan` / `harn codemod --rule-pack @scope/name` through registry provenance in `harn.lock`.
- Document the rule-pack publish/search/install flow.

## Verification

- `cargo fmt --check && git diff --check`
- `make lint-test-patterns`
- `CARGO_TARGET_DIR=/tmp/harn-target-2846 cargo test -p harn-cli --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2846 cargo test -p harn-cli --test rule_pack_install_dispatch`
- `CARGO_TARGET_DIR=/tmp/harn-target-2846 cargo test -p harn-cli --test rule_discovery_dispatch`
- `CARGO_TARGET_DIR=/tmp/harn-target-2846 cargo test -p harn-cli --test rule_test_dispatch`
- `CARGO_TARGET_DIR=/tmp/harn-target-2846 cargo test -p harn-cli --test harn_script_lint_rules_dispatch`
- `CARGO_TARGET_DIR=/tmp/harn-target-2846 cargo clippy -p harn-cli --all-targets -- -D warnings`
- pre-commit hook
- pre-push hook