### PR TITLE
fix: cross-cutting correctness/perf sweep + DRY cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,6 +2266,7 @@ dependencies = [
  "harn-skills",
  "harn-stdlib",
  "harn-vm",
+ "hex",
  "hmac 0.13.0",
  "ignore",
  "include_dir",

--- a/changelog.d/bugfix-dry-sweep-2026-06-02.changed.md
+++ b/changelog.d/bugfix-dry-sweep-2026-06-02.changed.md
@@ -1,0 +1,7 @@
+- DRY / leaky-abstraction cleanup alongside the fixes above:
+  - `harn-cli` now depends on the `hex` crate (as the rest of the workspace already does) and the two hand-rolled hex
+    encoders (`registry::hex_bytes`, `skill_provenance::hex_encode`) were removed in favour of `hex::encode`.
+  - `outline`'s `extract_rust` now delegates to the shared `extract_with_prefixes` helper instead of inlining a
+    verbatim copy of its prefix-matching loop, matching every other per-language extractor.
+  - `fs_watch` dropped its private re-implementation of `optional_string_list` and reuses `value_args::optional_string_list`.
+  - Removed a dead, fully-subsumed early-return branch in the LSP `line_byte_range` helper.

--- a/changelog.d/bugfix-dry-sweep-2026-06-02.fixed.md
+++ b/changelog.d/bugfix-dry-sweep-2026-06-02.fixed.md
@@ -1,0 +1,13 @@
+- Cross-cutting correctness + performance sweep:
+  - `fs_snapshot`: a snapshot whose captured bytes exceed the whole session byte cap is no longer evicted by the very
+    call that created it — `enforce_byte_cap` now protects the snapshot currently being written, fixing a panic in
+    `snapshot()` (it re-fetched the just-evicted snapshot) and silent loss of rollback for an in-flight write.
+  - `fs_snapshot`: `atomic_write` no longer leaks its temp file when both the rename and the
+    remove-then-rename retry fail.
+  - Package registry: `harn add <pkg>` with no version constraint now resolves the highest **stable** release rather
+    than letting an `x.y.z-rc.1` prerelease shadow it (matching cargo/npm); packages that have only ever published
+    prereleases still resolve to the highest prerelease.
+  - `harn scan` regex rules: row/column for each match is now computed with a single forward cursor instead of
+    rescanning the document from byte 0 per match — the matcher was O(matches × file length) on files with many hits.
+  - Deterministic `search` tool: the compiled `RegexMatcher` is now borrowed per file instead of deep-cloned, so a
+    repo-wide scan no longer re-copies the compiled regex program once per file.

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -63,6 +63,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 futures = "0.3"
 blake3 = "1"
 sha2 = "0.11"
+hex = "0.4"
 hmac = "0.13"
 ipnet = "2"
 tar = { version = "0.4", default-features = false }

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -105,18 +105,7 @@ pub(crate) fn cache_root() -> Result<PathBuf, PackageError> {
 }
 
 pub(crate) fn sha256_hex(bytes: impl AsRef<[u8]>) -> String {
-    hex_bytes(Sha256::digest(bytes.as_ref()))
-}
-
-pub(crate) fn hex_bytes(bytes: impl AsRef<[u8]>) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let bytes = bytes.as_ref();
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for &byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    out
+    hex::encode(Sha256::digest(bytes.as_ref()))
 }
 
 pub(crate) fn git_cache_dir_in(
@@ -278,7 +267,7 @@ pub(crate) fn compute_content_hash(dir: &Path) -> Result<String, PackageError> {
         hasher.update([0]);
         hasher.update(sha256_hex(contents).as_bytes());
     }
-    Ok(format!("sha256:{}", hex_bytes(hasher.finalize())))
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 
 pub(crate) fn verify_content_hash_or_compute(
@@ -748,7 +737,7 @@ pub(crate) fn registry_package_matches(package: &RegistryPackage, query: &str) -
 pub(crate) fn latest_registry_version(
     package: &RegistryPackage,
 ) -> Option<&RegistryPackageVersion> {
-    package
+    let parsed: Vec<(Version, &RegistryPackageVersion)> = package
         .versions
         .iter()
         .filter(|version| !version.yanked)
@@ -757,8 +746,21 @@ pub(crate) fn latest_registry_version(
                 .ok()
                 .map(|semver| (semver, version))
         })
+        .collect();
+    // Match cargo/npm: a bare `harn add foo` (no constraint) resolves the
+    // highest *stable* release. Prereleases are only considered when the
+    // package has published nothing stable yet, so an `x.y.z-rc.1` tag never
+    // shadows a real release.
+    parsed
+        .iter()
+        .filter(|(semver, _)| semver.pre.is_empty())
         .max_by(|(left, _), (right, _)| left.cmp(right))
-        .map(|(_, version)| version)
+        .or_else(|| {
+            parsed
+                .iter()
+                .max_by(|(left, _), (right, _)| left.cmp(right))
+        })
+        .map(|(_, version)| *version)
 }
 
 impl PackageRegistryIndex {
@@ -1958,6 +1960,50 @@ abc123abc123abc123abc123abc123abc1234567\trefs/tags/v0.0.1\n";
     #[test]
     fn pick_ls_remote_commit_returns_none_on_empty_output() {
         assert_eq!(pick_ls_remote_commit(""), None);
+    }
+
+    fn registry_package_with_versions(versions: &[(&str, bool)]) -> RegistryPackage {
+        let entries: Vec<serde_json::Value> = versions
+            .iter()
+            .map(|(version, yanked)| {
+                serde_json::json!({
+                    "version": version,
+                    "git": "https://example.com/pkg.git",
+                    "yanked": yanked,
+                })
+            })
+            .collect();
+        serde_json::from_value(serde_json::json!({
+            "name": "@burin/pkg",
+            "repository": "https://example.com/pkg.git",
+            "version": entries,
+        }))
+        .expect("registry package fixture deserializes")
+    }
+
+    #[test]
+    fn latest_registry_version_prefers_stable_over_newer_prerelease() {
+        let package = registry_package_with_versions(&[
+            ("1.2.0", false),
+            ("2.0.0-rc.1", false),
+            ("1.3.0", false),
+        ]);
+        let latest = latest_registry_version(&package).expect("a version is selected");
+        assert_eq!(
+            latest.version, "1.3.0",
+            "a prerelease must not shadow the highest stable release"
+        );
+    }
+
+    #[test]
+    fn latest_registry_version_falls_back_to_prerelease_when_no_stable_exists() {
+        let package =
+            registry_package_with_versions(&[("0.1.0-alpha.1", false), ("0.1.0-alpha.2", false)]);
+        let latest = latest_registry_version(&package).expect("a version is selected");
+        assert_eq!(
+            latest.version, "0.1.0-alpha.2",
+            "packages with only prereleases still resolve to the highest prerelease"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/harn-cli/src/skill_provenance.rs
+++ b/crates/harn-cli/src/skill_provenance.rs
@@ -774,21 +774,11 @@ fn append_suffix(path: &Path, suffix: &str) -> PathBuf {
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    hex_encode(&digest)
+    hex::encode(Sha256::digest(bytes))
 }
 
 pub(crate) fn fingerprint_for_key(key: &VerifyingKey) -> String {
-    let digest = Sha256::digest(key.as_bytes());
-    hex_encode(&digest)
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push_str(&format!("{byte:02x}"));
-    }
-    out
+    hex::encode(Sha256::digest(key.as_bytes()))
 }
 
 fn user_home_dir() -> Option<PathBuf> {

--- a/crates/harn-hostlib/src/fs_snapshot.rs
+++ b/crates/harn-hostlib/src/fs_snapshot.rs
@@ -225,7 +225,7 @@ pub fn configure_session_byte_cap(session_id: &str, bytes: u64) -> u64 {
     let bundle = guard.entry(session_id.to_string()).or_default();
     let previous = bundle.byte_cap;
     bundle.byte_cap = bytes.max(1);
-    enforce_byte_cap(bundle, session_id);
+    enforce_byte_cap(bundle, session_id, None);
     previous
 }
 
@@ -313,12 +313,12 @@ pub fn snapshot(
             captured_paths.push(path.to_string_lossy().into_owned());
         }
     }
-    enforce_byte_cap(bundle, session_id);
+    enforce_byte_cap(bundle, session_id, Some(scope_id));
     let state = bundle
         .snapshots
         .iter()
         .find(|snap| snap.snapshot_id == scope_id)
-        .expect("snapshot just upserted");
+        .expect("snapshot just upserted is protected from byte-cap eviction");
     persist_manifest(state).map_err(|err| HostlibError::Backend {
         builtin: SNAPSHOT_BUILTIN,
         message: err,
@@ -488,7 +488,7 @@ pub(crate) fn auto_capture_for_write(builtin: &'static str, path: &Path) {
             );
         }
     }
-    enforce_byte_cap(bundle, &session_id);
+    enforce_byte_cap(bundle, &session_id, Some(&snapshot_id));
 }
 
 fn snapshot_builtin(args: &[VmValue]) -> Result<VmValue, HostlibError> {
@@ -770,6 +770,9 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
         Err(rename_err) => {
             let _ = stdfs::remove_file(path);
             stdfs::rename(&tmp, path).map_err(|retry| {
+                // Both renames failed; the temp file would otherwise linger
+                // and accumulate in the snapshot directory.
+                let _ = stdfs::remove_file(&tmp);
                 format!(
                     "rename {} to {}: {rename_err}; retry: {retry}",
                     tmp.display(),
@@ -780,9 +783,23 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
     }
 }
 
-fn enforce_byte_cap(bundle: &mut SessionSnapshots, session_id: &str) {
-    while bundle.byte_count > bundle.byte_cap && !bundle.snapshots.is_empty() {
-        let evicted = bundle.snapshots.remove(0);
+/// Evict snapshots oldest-first until the session is back under its byte
+/// cap. `protected` names the snapshot currently being written (if any);
+/// it is never evicted, even when it alone exceeds the cap — otherwise the
+/// caller would lose the very snapshot it just captured (and `snapshot`
+/// would panic re-fetching it). A snapshot larger than the whole cap is
+/// therefore retained: rollback for an in-flight write takes precedence
+/// over the soft budget.
+fn enforce_byte_cap(bundle: &mut SessionSnapshots, session_id: &str, protected: Option<&str>) {
+    while bundle.byte_count > bundle.byte_cap {
+        let Some(idx) = bundle
+            .snapshots
+            .iter()
+            .position(|snap| Some(snap.snapshot_id.as_str()) != protected)
+        else {
+            break;
+        };
+        let evicted = bundle.snapshots.remove(idx);
         bundle.byte_count = bundle.byte_count.saturating_sub(entry_byte_count(&evicted));
         tracing::info!(
             "fs_snapshot: evicting snapshot `{}` from session `{session_id}` (over byte cap {})",
@@ -1108,6 +1125,40 @@ mod tests {
             ids,
             vec![scope_b],
             "older snapshot must be evicted when the per-session byte cap is exceeded"
+        );
+    }
+
+    #[test]
+    fn snapshot_larger_than_cap_is_retained_not_evicted() {
+        // A single snapshot whose captured bytes exceed the whole cap must
+        // survive — evicting the snapshot we just took would lose rollback
+        // for the in-flight write (and previously panicked re-fetching it).
+        let dir = TempDir::new().unwrap();
+        let session = unique_session("snap-oversized");
+        let _session_guard = enter_session(&session);
+        configure_session_byte_cap(&session, 4);
+
+        let scope = unique_scope();
+        let file = dir.path().join("big.txt");
+        stdfs::write(&file, b"0123456789").unwrap();
+        let result = snapshot(
+            &session,
+            &scope,
+            &[file.to_string_lossy().into_owned()],
+            Some(dir.path()),
+        )
+        .unwrap();
+        assert_eq!(result.byte_count, 10);
+
+        let ids: Vec<String> = list_snapshots(&session)
+            .unwrap()
+            .into_iter()
+            .map(|summary| summary.snapshot_id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec![scope],
+            "an oversized snapshot must be retained rather than evicting itself"
         );
     }
 

--- a/crates/harn-hostlib/src/fs_watch/mod.rs
+++ b/crates/harn-hostlib/src/fs_watch/mod.rs
@@ -22,6 +22,7 @@ use crate::registry::{BuiltinRegistry, HostlibCapability, RegisteredBuiltin, Syn
 use crate::tools::args::{
     build_dict, dict_arg, optional_bool, optional_int, optional_string, str_value,
 };
+use crate::value_args::optional_string_list;
 
 const SUBSCRIBE_BUILTIN: &str = "hostlib_fs_watch_subscribe";
 const UNSUBSCRIBE_BUILTIN: &str = "hostlib_fs_watch_unsubscribe";
@@ -512,37 +513,6 @@ fn normalize_glob(glob: &str) -> String {
         glob
     } else {
         format!("**/{glob}")
-    }
-}
-
-fn optional_string_list(
-    builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
-    key: &'static str,
-) -> Result<Option<Vec<String>>, HostlibError> {
-    let Some(value) = dict.get(key) else {
-        return Ok(None);
-    };
-    match value {
-        VmValue::Nil => Ok(None),
-        VmValue::List(items) => items
-            .iter()
-            .enumerate()
-            .map(|(idx, item)| match item {
-                VmValue::String(value) => Ok(value.to_string()),
-                other => Err(HostlibError::InvalidParameter {
-                    builtin,
-                    param: key,
-                    message: format!("item {idx} must be a string, got {}", other.type_name()),
-                }),
-            })
-            .collect::<Result<Vec<_>, _>>()
-            .map(Some),
-        other => Err(HostlibError::InvalidParameter {
-            builtin,
-            param: key,
-            message: format!("expected list of strings, got {}", other.type_name()),
-        }),
     }
 }
 

--- a/crates/harn-hostlib/src/tools/outline.rs
+++ b/crates/harn-hostlib/src/tools/outline.rs
@@ -144,20 +144,7 @@ fn extract_rust(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {
         ("pub type ", "type"),
         ("type ", "type"),
     ];
-    for (prefix, kind) in prefixes {
-        if let Some(rest) = line.strip_prefix(prefix) {
-            let name = take_ident(rest);
-            if !name.is_empty() {
-                return Some(OutlineItem {
-                    name,
-                    kind: kind.to_string(),
-                    start_row: idx,
-                    end_row: idx.min(total.saturating_sub(1)),
-                });
-            }
-        }
-    }
-    None
+    extract_with_prefixes(line, idx, total, prefixes)
 }
 
 fn extract_swift(line: &str, idx: usize, total: usize) -> Option<OutlineItem> {

--- a/crates/harn-hostlib/src/tools/search.rs
+++ b/crates/harn-hostlib/src/tools/search.rs
@@ -134,7 +134,7 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             continue;
         }
         let mut sink = CollectorSink {
-            matcher: matcher.clone(),
+            matcher: &matcher,
             rows: Vec::new(),
             pending_before: VecDeque::new(),
             context_before,
@@ -251,8 +251,12 @@ struct RowWithPath {
     row: MatchRow,
 }
 
-struct CollectorSink {
-    matcher: RegexMatcher,
+struct CollectorSink<'a> {
+    // Borrowed rather than owned: the compiled matcher is reused across every
+    // file in the walk, and `grep_regex::RegexMatcher::clone` deep-copies the
+    // compiled program — cloning it per file made a repo-wide scan pay that
+    // cost N times for no reason.
+    matcher: &'a RegexMatcher,
     rows: Vec<MatchRow>,
     /// Sliding window of recent before-context lines published by
     /// [`Sink::context`] before each [`Sink::matched`] call.
@@ -261,7 +265,7 @@ struct CollectorSink {
     remaining: usize,
 }
 
-impl Sink for CollectorSink {
+impl Sink for CollectorSink<'_> {
     type Error = std::io::Error;
 
     fn matched(

--- a/crates/harn-lsp/src/helpers.rs
+++ b/crates/harn-lsp/src/helpers.rs
@@ -191,9 +191,6 @@ fn line_byte_range(source: &str, line: usize) -> Option<(usize, usize)> {
     let mut current_line = 0usize;
     let mut line_start = 0usize;
     for (idx, ch) in source.char_indices() {
-        if current_line == line && ch == '\n' {
-            return Some((line_start, idx));
-        }
         if ch == '\n' {
             if current_line == line {
                 return Some((line_start, idx));

--- a/crates/harn-rules/src/engine.rs
+++ b/crates/harn-rules/src/engine.rs
@@ -435,11 +435,24 @@ impl CompiledRule {
 
     fn run_regex(&self, regex: &regex::Regex, source: &str) -> Vec<RuleMatch> {
         let mut matches = Vec::new();
+        // `find_iter` yields non-overlapping matches in ascending byte order, so
+        // a single forward-walking cursor computes every row/col without
+        // rescanning from the start of the document for each match (which made
+        // this O(matches × len) — quadratic on files with many hits).
+        let mut cursor = RowColCursor::new(source);
         for m in regex.find_iter(source) {
-            let span = byte_span(source, m.start(), m.end());
+            let (start_row, start_col) = cursor.advance_to(m.start());
+            let (end_row, end_col) = cursor.advance_to(m.end());
             matches.push(RuleMatch {
                 rule_id: self.rule_id.clone(),
-                span,
+                span: Span {
+                    start_byte: m.start(),
+                    end_byte: m.end(),
+                    start_row,
+                    start_col,
+                    end_row,
+                    end_col,
+                },
                 text: m.as_str().to_string(),
                 bindings: BTreeMap::new(),
             });
@@ -478,36 +491,42 @@ fn dedupe_overlapping(mut matches: Vec<RuleMatch>) -> Vec<RuleMatch> {
     kept
 }
 
-/// Compute a [`Span`] for a byte range by counting rows/cols. Used by the
-/// regex matcher, which has no tree-sitter node to read positions from.
-fn byte_span(source: &str, start: usize, end: usize) -> Span {
-    let (start_row, start_col) = row_col(source, start);
-    let (end_row, end_col) = row_col(source, end);
-    Span {
-        start_byte: start,
-        end_byte: end,
-        start_row,
-        start_col,
-        end_row,
-        end_col,
-    }
+/// Forward-only cursor that maps byte offsets to `(row, col)` while walking a
+/// document at most once. The regex matcher has no tree-sitter node to read
+/// positions from and visits offsets in ascending order, so advancing this
+/// cursor avoids the per-match rescan a stateless lookup would cost.
+struct RowColCursor<'a> {
+    source: &'a str,
+    byte: usize,
+    row: usize,
+    col: usize,
 }
 
-fn row_col(source: &str, byte: usize) -> (usize, usize) {
-    let mut row = 0;
-    let mut col = 0;
-    for (i, ch) in source.char_indices() {
-        if i >= byte {
-            break;
-        }
-        if ch == '\n' {
-            row += 1;
-            col = 0;
-        } else {
-            col += 1;
+impl<'a> RowColCursor<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            byte: 0,
+            row: 0,
+            col: 0,
         }
     }
-    (row, col)
+
+    /// Advance to `target` (which must be `>=` the current position and a char
+    /// boundary) and return the row/col there. `row` counts preceding newlines;
+    /// `col` counts characters since the last newline.
+    fn advance_to(&mut self, target: usize) -> (usize, usize) {
+        for ch in self.source[self.byte..target].chars() {
+            if ch == '\n' {
+                self.row += 1;
+                self.col = 0;
+            } else {
+                self.col += 1;
+            }
+        }
+        self.byte = target;
+        (self.row, self.col)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A small, high-confidence sweep of unambiguous bugs and DRY/leaky-abstraction cleanups across crates. Each fix is self-contained and verified by tests.

## Bugs

1. **`fs_snapshot` — active-snapshot eviction panic + rollback loss.** `enforce_byte_cap` evicted snapshots FIFO without exempting the one currently being written. A snapshot whose captured bytes exceed the whole session cap would evict *itself*, so `snapshot()` then panicked on `.expect("snapshot just upserted")`, and an in-flight write lost its rollback. `enforce_byte_cap` now takes a `protected` scope id that is never evicted. Regression test added.
2. **`fs_snapshot` — temp-file leak.** `atomic_write` left its temp file on disk when both the rename and the remove-then-rename retry failed; now cleaned up in the error path.
3. **Package registry — prerelease shadows stable.** `harn add <pkg>` with no constraint resolved the numerically-highest version, so `2.0.0-rc.1` would win over `1.3.0`. Now resolves the highest **stable** release (cargo/npm semantics), falling back to a prerelease only when nothing stable was ever published. Two tests added.
4. **`harn-rules` — quadratic regex match positions.** `run_regex` called `byte_span`, which rescanned the document from byte 0 for every match → O(matches × len). Replaced with a single forward `RowColCursor` (matches arrive in ascending byte order).
5. **`search` tool — per-file deep clone of the compiled regex.** `CollectorSink` owned and `.clone()`d the `grep_regex::RegexMatcher` (a deep copy of the compiled program) once per file in a repo-wide walk. It only reads the matcher, so it now borrows it.

## DRY / leaky abstractions

6. `harn-cli` now depends on the `hex` crate (as the rest of the workspace does) and drops two hand-rolled hex encoders (`registry::hex_bytes`, `skill_provenance::hex_encode`).
7. `outline::extract_rust` delegated a verbatim copy of the prefix-match loop; now calls the shared `extract_with_prefixes` like every other per-language extractor.
8. `fs_watch` dropped its private re-implementation of `optional_string_list` in favour of `value_args::optional_string_list`.
9. Removed a dead, fully-subsumed early-return branch in the LSP `line_byte_range` helper.

## Verification
- `cargo test` for `harn-hostlib` (fs_snapshot + search), `harn-cli` (registry), `harn-rules` — all green, including new regression tests.
- `cargo clippy` clean on all touched crates.
- Pre-commit/pre-push workspace hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)