### PR TITLE
Expose session timeline API

### DIFF
--- a/changelog.d/2913.added.md
+++ b/changelog.d/2913.added.md
@@ -1,0 +1,5 @@
+- **Session timelines can now be queried and streamed from Harn-owned
+  observability data (#2913).** Harn projects persisted run spans, agent events,
+  and channel lifecycle/audit receipts into a redacted timeline shape with
+  parent/child span links, channel emit→match links, and ACP query/subscribe
+  methods for live clients.

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -68,6 +68,7 @@ use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use harn_vm::agent_events::{clear_session_sinks, register_sink, AgentEventSink};
 use harn_vm::visible_text::{sanitize_visible_assistant_text, VisibleTextState};
 use serde::Deserialize;
@@ -144,12 +145,43 @@ struct InjectControlRecord {
     status: String,
 }
 
-fn session_id_param(params: &serde_json::Value) -> Option<String> {
+struct TimelineSubscription {
+    session_id: Option<String>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+fn string_param(params: &serde_json::Value, camel: &str, snake: &str) -> Option<String> {
     params
-        .get("sessionId")
-        .or_else(|| params.get("session_id"))
+        .get(camel)
+        .or_else(|| params.get(snake))
         .and_then(|value| value.as_str())
         .map(str::to_string)
+}
+
+fn session_id_param(params: &serde_json::Value) -> Option<String> {
+    string_param(params, "sessionId", "session_id")
+}
+
+fn parse_session_timeline_query(
+    params: &serde_json::Value,
+) -> Result<harn_vm::session_timeline::SessionTimelineQuery, String> {
+    let source = params.get("query").unwrap_or(params);
+    let mut query: harn_vm::session_timeline::SessionTimelineQuery =
+        serde_json::from_value(source.clone())
+            .map_err(|error| format!("invalid session timeline query: {error}"))?;
+    if query.session_id.is_none() {
+        query.session_id = session_id_param(params);
+    }
+    if query.run_id.is_none() {
+        query.run_id = string_param(params, "runId", "run_id");
+    }
+    if query.run_path.is_none() {
+        query.run_path = string_param(params, "runPath", "run_path");
+    }
+    if query.project_id.is_none() {
+        query.project_id = string_param(params, "projectId", "project_id");
+    }
+    Ok(query)
 }
 
 fn harn_meta(params: &serde_json::Value) -> Option<&serde_json::Map<String, serde_json::Value>> {
@@ -722,6 +754,9 @@ pub struct AcpServer {
     /// ACP control-plane ownership for pending injected messages, keyed by
     /// session id then message id.
     inject_controls: HashMap<String, BTreeMap<String, InjectControlRecord>>,
+    /// Live timeline subscriptions created by Harn-specific ACP extension
+    /// methods. Each task fans event-log appends into notifications.
+    timeline_subscriptions: HashMap<String, TimelineSubscription>,
     /// Monotonically increasing JSON-RPC request ID for outgoing requests.
     next_id: AtomicU64,
     /// Pending outgoing request waiters, keyed by JSON-RPC id.
@@ -776,6 +811,7 @@ impl AcpServer {
             runtime_configurator: config.runtime_configurator,
             sessions: HashMap::new(),
             inject_controls: HashMap::new(),
+            timeline_subscriptions: HashMap::new(),
             next_id: AtomicU64::new(1),
             pending: Arc::new(Mutex::new(HashMap::new())),
             session_cancellations: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -1050,6 +1086,143 @@ impl AcpServer {
                 self.llm_capability_overrides.as_ref(),
             ))
             .expect("provider catalog serializes"),
+        );
+    }
+
+    async fn handle_session_timeline_query(
+        &self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+    ) {
+        let query = match parse_session_timeline_query(params) {
+            Ok(query) => query,
+            Err(message) => {
+                self.send_error(id, -32602, &message);
+                return;
+            }
+        };
+        let log = harn_vm::event_log::active_event_log();
+        match harn_vm::session_timeline::query_session_timeline(log.as_deref(), None, query).await {
+            Ok(snapshot) => self.send_response(
+                id,
+                serde_json::to_value(snapshot).expect("session timeline snapshot serializes"),
+            ),
+            Err(error) => self.send_error(id, -32000, &format!("session timeline query: {error}")),
+        }
+    }
+
+    async fn handle_session_timeline_subscribe(
+        &mut self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+    ) {
+        let query = match parse_session_timeline_query(params) {
+            Ok(query) => query,
+            Err(message) => {
+                self.send_error(id, -32602, &message);
+                return;
+            }
+        };
+        let Some(log) = harn_vm::event_log::active_event_log() else {
+            self.send_error(
+                id,
+                -32000,
+                "session timeline subscribe: no active event log",
+            );
+            return;
+        };
+        let subscription_id = params
+            .get("subscriptionId")
+            .or_else(|| params.get("subscription_id"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("timeline_sub_{}", uuid::Uuid::now_v7().simple()));
+
+        let mut stream =
+            match harn_vm::session_timeline::subscribe_session_timeline(log, query.clone()).await {
+                Ok(stream) => stream,
+                Err(error) => {
+                    self.send_error(id, -32000, &format!("session timeline subscribe: {error}"));
+                    return;
+                }
+            };
+        if let Some(existing) = self.timeline_subscriptions.remove(&subscription_id) {
+            existing.handle.abort();
+        }
+
+        let output = self.output.clone();
+        let notification_subscription_id = subscription_id.clone();
+        let handle = tokio::spawn(async move {
+            while let Some(update) = stream.next().await {
+                let params = match update {
+                    Ok(update) => serde_json::json!({
+                        "subscriptionId": notification_subscription_id,
+                        "update": update,
+                    }),
+                    Err(error) => serde_json::json!({
+                        "subscriptionId": notification_subscription_id,
+                        "error": {
+                            "message": error.to_string(),
+                        },
+                    }),
+                };
+                let notification = harn_vm::jsonrpc::notification(
+                    harn_vm::session_timeline::SESSION_TIMELINE_UPDATE_METHOD,
+                    params,
+                );
+                if let Ok(line) = serde_json::to_string(&notification) {
+                    output.write_line(&line);
+                }
+            }
+        });
+        self.timeline_subscriptions.insert(
+            subscription_id.clone(),
+            TimelineSubscription {
+                session_id: query.session_id.clone(),
+                handle,
+            },
+        );
+        self.send_response(
+            id,
+            serde_json::json!({
+                "subscriptionId": subscription_id,
+                "updateMethod": harn_vm::session_timeline::SESSION_TIMELINE_UPDATE_METHOD,
+            }),
+        );
+    }
+
+    fn handle_session_timeline_unsubscribe(
+        &mut self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+    ) {
+        let Some(subscription_id) = params
+            .get("subscriptionId")
+            .or_else(|| params.get("subscription_id"))
+            .and_then(serde_json::Value::as_str)
+        else {
+            self.send_error(
+                id,
+                -32602,
+                "session timeline unsubscribe requires subscriptionId",
+            );
+            return;
+        };
+        let removed = self
+            .timeline_subscriptions
+            .remove(subscription_id)
+            .map(|subscription| {
+                subscription.handle.abort();
+                true
+            })
+            .unwrap_or(false);
+        self.send_response(
+            id,
+            serde_json::json!({
+                "subscriptionId": subscription_id,
+                "removed": removed,
+            }),
         );
     }
 
@@ -1921,6 +2094,14 @@ impl AcpServer {
             .unwrap_or_else(|error| error.into_inner())
             .remove(session_id);
         self.inject_controls.remove(session_id);
+        self.timeline_subscriptions.retain(|_, subscription| {
+            if subscription.session_id.as_deref() == Some(session_id) {
+                subscription.handle.abort();
+                false
+            } else {
+                true
+            }
+        });
         clear_session_sinks(session_id);
         #[cfg(feature = "hostlib")]
         {
@@ -3714,6 +3895,24 @@ impl AcpServer {
                 }
                 self.handle_provider_catalog(&id);
             }
+            harn_vm::session_timeline::SESSION_TIMELINE_QUERY_METHOD => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_timeline_query(&id, &params).await;
+            }
+            harn_vm::session_timeline::SESSION_TIMELINE_SUBSCRIBE_METHOD => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_timeline_subscribe(&id, &params).await;
+            }
+            harn_vm::session_timeline::SESSION_TIMELINE_UNSUBSCRIBE_METHOD => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_timeline_unsubscribe(&id, &params);
+            }
             "session/new" => {
                 if self.reject_unauthenticated(&id) {
                     return;
@@ -3918,6 +4117,14 @@ impl AcpServer {
                     self.send_error(&id, -32601, &format!("Method not found: {method}"));
                 }
             }
+        }
+    }
+}
+
+impl Drop for AcpServer {
+    fn drop(&mut self) {
+        for (_, subscription) in self.timeline_subscriptions.drain() {
+            subscription.handle.abort();
         }
     }
 }

--- a/crates/harn-serve/src/adapters/acp/tests/sessions.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/sessions.rs
@@ -1,4 +1,14 @@
 use super::*;
+use harn_vm::event_log::EventLog as _;
+use harn_vm::orchestration::{save_run_record, RunRecord, RunTraceSpanRecord};
+
+struct ResetActiveEventLog;
+
+impl Drop for ResetActiveEventLog {
+    fn drop(&mut self) {
+        harn_vm::event_log::reset_active_event_log();
+    }
+}
 
 async fn run_prompt_with_project_capability(
     request_tx: &mpsc::UnboundedSender<serde_json::Value>,
@@ -112,6 +122,187 @@ async fn run_json_prompt(
         }
     }
     panic!("prompt {id} did not complete")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn acp_session_timeline_query_and_subscribe_use_event_log() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let _reset = ResetActiveEventLog;
+            let log = harn_vm::event_log::install_memory_for_current_thread(16);
+            let (request_tx, mut response_rx, server, session_id) =
+                start_acp_channel_session().await;
+            let topic = harn_vm::session_timeline::agent_events_topic(&session_id);
+
+            log.append(
+                &topic,
+                harn_vm::event_log::LogEvent::new(
+                    "tool_call",
+                    serde_json::json!({
+                        "session_id": session_id.clone(),
+                        "event": {
+                            "type": "tool_call",
+                            "session_id": session_id.clone(),
+                            "tool_call_id": "tool-1",
+                            "tool_name": "read",
+                            "status": "pending",
+                            "raw_input": {"authorization": "should-redact"}
+                        }
+                    }),
+                )
+                .with_headers(BTreeMap::from([(
+                    "session_id".to_string(),
+                    session_id.clone(),
+                )])),
+            )
+            .await
+            .unwrap();
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 20,
+                    "method": harn_vm::session_timeline::SESSION_TIMELINE_QUERY_METHOD,
+                    "params": {"sessionId": session_id.clone()},
+                }))
+                .expect("send timeline query");
+            let snapshot = recv_json(&mut response_rx).await;
+            assert_eq!(snapshot["id"], 20);
+            assert_eq!(snapshot["result"]["schemaVersion"], 1);
+            assert_eq!(snapshot["result"]["nodes"][0]["category"], "agent_event");
+            assert_eq!(
+                snapshot["result"]["nodes"][0]["attributes"]["event"]["raw_input"]["authorization"],
+                serde_json::json!(harn_vm::redact::REDACTED_PLACEHOLDER)
+            );
+
+            let temp = tempfile::tempdir().unwrap();
+            let run_path = temp.path().join("timeline-run.json");
+            save_run_record(
+                &RunRecord {
+                    id: "timeline-run".to_string(),
+                    trace_spans: vec![
+                        RunTraceSpanRecord {
+                            trace_id: "trace-acp".to_string(),
+                            span_id: 1,
+                            kind: "pipeline".to_string(),
+                            name: "root".to_string(),
+                            start_ms: 1,
+                            duration_ms: 2,
+                            metadata: BTreeMap::from([(
+                                "session_id".to_string(),
+                                serde_json::json!(session_id.clone()),
+                            )]),
+                            ..RunTraceSpanRecord::default()
+                        },
+                        RunTraceSpanRecord {
+                            trace_id: "trace-acp".to_string(),
+                            span_id: 2,
+                            parent_id: Some(1),
+                            kind: "tool_call".to_string(),
+                            name: "child".to_string(),
+                            start_ms: 2,
+                            duration_ms: 3,
+                            metadata: BTreeMap::from([(
+                                "session_id".to_string(),
+                                serde_json::json!(session_id.clone()),
+                            )]),
+                            ..RunTraceSpanRecord::default()
+                        },
+                    ],
+                    ..RunRecord::default()
+                },
+                Some(run_path.to_str().unwrap()),
+            )
+            .unwrap();
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 23,
+                    "method": harn_vm::session_timeline::SESSION_TIMELINE_QUERY_METHOD,
+                    "params": {
+                        "sessionId": session_id.clone(),
+                        "runId": "timeline-run",
+                        "runPath": run_path.display().to_string(),
+                    },
+                }))
+                .expect("send timeline run query");
+            let run_snapshot = recv_json(&mut response_rx).await;
+            assert_eq!(run_snapshot["id"], 23);
+            let root = run_snapshot["result"]["nodes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|node| node["id"] == "span:trace-acp:1")
+                .expect("timeline root span");
+            assert_eq!(root["children"][0], "span:trace-acp:2");
+
+            let from_cursor = serde_json::json!({
+                "topics": BTreeMap::from([(topic.as_str().to_string(), 1_u64)]),
+            });
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 21,
+                    "method": harn_vm::session_timeline::SESSION_TIMELINE_SUBSCRIBE_METHOD,
+                    "params": {
+                        "sessionId": session_id.clone(),
+                        "subscriptionId": "timeline-test",
+                        "fromCursor": from_cursor,
+                    },
+                }))
+                .expect("send timeline subscribe");
+            let subscribed = recv_json(&mut response_rx).await;
+            assert_eq!(subscribed["id"], 21);
+            assert_eq!(subscribed["result"]["subscriptionId"], "timeline-test");
+
+            log.append(
+                &topic,
+                harn_vm::event_log::LogEvent::new(
+                    "agent_message_chunk",
+                    serde_json::json!({
+                        "session_id": session_id.clone(),
+                        "event": {
+                            "type": "agent_message_chunk",
+                            "session_id": session_id.clone(),
+                            "content": "hello"
+                        }
+                    }),
+                )
+                .with_headers(BTreeMap::from([(
+                    "session_id".to_string(),
+                    session_id.clone(),
+                )])),
+            )
+            .await
+            .unwrap();
+            let update = recv_json(&mut response_rx).await;
+            assert_eq!(
+                update["method"],
+                harn_vm::session_timeline::SESSION_TIMELINE_UPDATE_METHOD
+            );
+            assert_eq!(update["params"]["subscriptionId"], "timeline-test");
+            assert_eq!(
+                update["params"]["update"]["node"]["name"],
+                "agent_message_chunk"
+            );
+
+            request_tx
+                .send(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 22,
+                    "method": harn_vm::session_timeline::SESSION_TIMELINE_UNSUBSCRIBE_METHOD,
+                    "params": {"subscriptionId": "timeline-test"},
+                }))
+                .expect("send timeline unsubscribe");
+            let unsubscribed = recv_json(&mut response_rx).await;
+            assert_eq!(unsubscribed["id"], 22);
+            assert_eq!(unsubscribed["result"]["removed"], true);
+
+            drop(request_tx);
+            server.await.unwrap();
+        })
+        .await;
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -75,6 +75,7 @@ pub mod schema;
 pub(crate) mod secret_patterns;
 pub mod secrets;
 pub mod session_bundle;
+pub mod session_timeline;
 pub mod sessions;
 pub(crate) mod shared_state;
 pub mod shells;

--- a/crates/harn-vm/src/session_timeline.rs
+++ b/crates/harn-vm/src/session_timeline.rs
@@ -1,0 +1,875 @@
+//! Session timeline projection for client-facing observability.
+//!
+//! This module does not own persistence. It projects the existing run record
+//! spans and event-log topics into one stable, redacted shape that clients can
+//! query or subscribe to without learning Harn's storage internals.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use futures::stream::{self, BoxStream};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use crate::event_log::{AnyEventLog, EventId, EventLog, LogError, LogEvent, Topic};
+use crate::orchestration::{load_run_record, RunRecord, RunTraceSpanRecord};
+use crate::redact::{current_policy, RedactionPolicy};
+
+pub const SESSION_TIMELINE_SCHEMA_VERSION: u32 = 1;
+pub const SESSION_TIMELINE_QUERY_METHOD: &str = "harn.session_timeline.query";
+pub const SESSION_TIMELINE_SUBSCRIBE_METHOD: &str = "harn.session_timeline.subscribe";
+pub const SESSION_TIMELINE_UNSUBSCRIBE_METHOD: &str = "harn.session_timeline.unsubscribe";
+pub const SESSION_TIMELINE_UPDATE_METHOD: &str = "harn.session_timeline.update";
+
+const DEFAULT_QUERY_LIMIT: usize = 1024;
+const READ_BATCH_SIZE: usize = 256;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SessionTimelineQuery {
+    #[serde(alias = "session_id")]
+    pub session_id: Option<String>,
+    #[serde(alias = "run_id")]
+    pub run_id: Option<String>,
+    #[serde(alias = "run_path")]
+    pub run_path: Option<String>,
+    #[serde(alias = "project_id")]
+    pub project_id: Option<String>,
+    #[serde(alias = "from_cursor")]
+    pub from_cursor: SessionTimelineCursor,
+    pub limit: Option<usize>,
+}
+
+impl SessionTimelineQuery {
+    pub fn for_session(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: Some(session_id.into()),
+            ..Self::default()
+        }
+    }
+
+    fn limit(&self) -> usize {
+        self.limit.unwrap_or(DEFAULT_QUERY_LIMIT).max(1)
+    }
+
+    fn topics(&self) -> Vec<Topic> {
+        let mut topics = Vec::new();
+        if let Some(session_id) = self.session_id.as_deref() {
+            topics.push(agent_events_topic(session_id));
+        }
+        topics.push(static_topic(crate::channels::CHANNEL_TRANSCRIPT_TOPIC));
+        topics.push(static_topic(crate::channels::CHANNEL_AUDIT_TOPIC));
+        topics
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SessionTimelineCursor {
+    pub topics: BTreeMap<String, EventId>,
+}
+
+impl SessionTimelineCursor {
+    pub fn event_id_for(&self, topic: &Topic) -> Option<EventId> {
+        self.topics.get(topic.as_str()).copied()
+    }
+
+    fn bump(&mut self, topic: &str, event_id: EventId) {
+        self.topics
+            .entry(topic.to_string())
+            .and_modify(|cursor| *cursor = (*cursor).max(event_id))
+            .or_insert(event_id);
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTimelineSnapshot {
+    pub schema_version: u32,
+    pub query: SessionTimelineQuery,
+    pub cursor: SessionTimelineCursor,
+    pub nodes: Vec<SessionTimelineNode>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTimelineUpdate {
+    pub schema_version: u32,
+    pub cursor: SessionTimelineCursor,
+    pub node: SessionTimelineNode,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTimelineNode {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<String>,
+    pub category: String,
+    pub kind: String,
+    pub name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurred_at_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub attributes: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub references: Vec<SessionTimelineReference>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<SessionTimelineLink>,
+    pub order: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTimelineReference {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<EventId>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTimelineLink {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum SessionTimelineError {
+    EventLog(LogError),
+    RunRecord(String),
+}
+
+impl std::fmt::Display for SessionTimelineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EventLog(error) => error.fmt(f),
+            Self::RunRecord(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for SessionTimelineError {}
+
+impl From<LogError> for SessionTimelineError {
+    fn from(error: LogError) -> Self {
+        Self::EventLog(error)
+    }
+}
+
+#[derive(Clone)]
+struct TimelineDraft {
+    sort_ms: i128,
+    node: SessionTimelineNode,
+}
+
+pub fn agent_events_topic(session_id: &str) -> Topic {
+    Topic::new(format!(
+        "observability.agent_events.{}",
+        crate::event_log::sanitize_topic_component(session_id)
+    ))
+    .expect("sanitized session id should produce a valid topic")
+}
+
+pub fn timeline_from_run_record(
+    run: &RunRecord,
+    query: SessionTimelineQuery,
+) -> SessionTimelineSnapshot {
+    let policy = current_policy();
+    let mut builder = TimelineBuilder::new(query.clone());
+    if run_matches_query(run, &query) {
+        builder.add_run_spans(run, &policy);
+    }
+    builder.finish()
+}
+
+pub async fn query_session_timeline(
+    log: Option<&AnyEventLog>,
+    run: Option<&RunRecord>,
+    query: SessionTimelineQuery,
+) -> Result<SessionTimelineSnapshot, SessionTimelineError> {
+    let policy = current_policy();
+    let mut builder = TimelineBuilder::new(query.clone());
+    if let Some(run) = run.filter(|run| run_matches_query(run, &query)) {
+        builder.add_run_spans(run, &policy);
+    } else if run.is_none() {
+        if let Some(run) = load_run_for_timeline(&query)? {
+            if run_matches_query(&run, &query) {
+                builder.add_run_spans(&run, &policy);
+            }
+        }
+    }
+    if let Some(log) = log {
+        builder.add_event_log(log, &policy).await?;
+    }
+    Ok(builder.finish())
+}
+
+pub async fn subscribe_session_timeline(
+    log: Arc<AnyEventLog>,
+    query: SessionTimelineQuery,
+) -> Result<
+    BoxStream<'static, Result<SessionTimelineUpdate, SessionTimelineError>>,
+    SessionTimelineError,
+> {
+    let policy = current_policy();
+    let mut streams = Vec::new();
+    for topic in query.topics() {
+        let topic_name = topic.as_str().to_string();
+        let from_cursor = query.from_cursor.event_id_for(&topic);
+        let events = log.clone().subscribe(&topic, from_cursor).await?;
+        let query = query.clone();
+        let policy = policy.clone();
+        streams.push(Box::pin(events.filter_map(move |item| {
+            let topic_name = topic_name.clone();
+            let query = query.clone();
+            let policy = policy.clone();
+            async move {
+                match item {
+                    Ok((event_id, event)) => {
+                        event_update(&query, &policy, &topic_name, event_id, event).map(Ok)
+                    }
+                    Err(error) => Some(Err(SessionTimelineError::EventLog(error))),
+                }
+            }
+        }))
+            as BoxStream<
+                'static,
+                Result<SessionTimelineUpdate, SessionTimelineError>,
+            >);
+    }
+    Ok(Box::pin(stream::select_all(streams)))
+}
+
+struct TimelineBuilder {
+    query: SessionTimelineQuery,
+    cursor: SessionTimelineCursor,
+    nodes: Vec<TimelineDraft>,
+}
+
+impl TimelineBuilder {
+    fn new(query: SessionTimelineQuery) -> Self {
+        Self {
+            cursor: query.from_cursor.clone(),
+            query,
+            nodes: Vec::new(),
+        }
+    }
+
+    fn add_run_spans(&mut self, run: &RunRecord, policy: &RedactionPolicy) {
+        for span in &run.trace_spans {
+            if !span_matches_query(span, &self.query) {
+                continue;
+            }
+            let node = span_node(span, policy);
+            self.nodes.push(TimelineDraft {
+                sort_ms: i128::from(span.start_ms),
+                node,
+            });
+        }
+    }
+
+    async fn add_event_log(
+        &mut self,
+        log: &AnyEventLog,
+        policy: &RedactionPolicy,
+    ) -> Result<(), SessionTimelineError> {
+        for topic in self.query.topics() {
+            let topic_name = topic.as_str().to_string();
+            let mut from = self.query.from_cursor.event_id_for(&topic);
+            loop {
+                let batch = log.read_range(&topic, from, READ_BATCH_SIZE).await?;
+                let batch_len = batch.len();
+                for (event_id, event) in batch {
+                    from = Some(event_id);
+                    self.cursor.bump(&topic_name, event_id);
+                    if let Some(node) =
+                        event_node(&self.query, policy, &topic_name, event_id, event)
+                    {
+                        let sort_ms = node
+                            .occurred_at_ms
+                            .map(i128::from)
+                            .or_else(|| node.start_ms.map(i128::from))
+                            .unwrap_or(i128::from(event_id));
+                        self.nodes.push(TimelineDraft { sort_ms, node });
+                    }
+                }
+                if batch_len < READ_BATCH_SIZE || self.nodes.len() >= self.query.limit() {
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(mut self) -> SessionTimelineSnapshot {
+        self.nodes.sort_by(|left, right| {
+            left.sort_ms
+                .cmp(&right.sort_ms)
+                .then_with(|| left.node.id.cmp(&right.node.id))
+        });
+        self.nodes.truncate(self.query.limit());
+
+        let visible_ids: BTreeSet<String> = self
+            .nodes
+            .iter()
+            .map(|draft| draft.node.id.clone())
+            .collect();
+        let mut children_by_parent: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for draft in &self.nodes {
+            let Some(parent_id) = draft.node.parent_id.as_ref() else {
+                continue;
+            };
+            if visible_ids.contains(parent_id) {
+                children_by_parent
+                    .entry(parent_id.clone())
+                    .or_default()
+                    .push(draft.node.id.clone());
+            }
+        }
+
+        let nodes = self
+            .nodes
+            .into_iter()
+            .enumerate()
+            .map(|(index, mut draft)| {
+                draft.node.order = index as u64;
+                draft.node.children = children_by_parent
+                    .remove(&draft.node.id)
+                    .unwrap_or_default();
+                draft.node
+            })
+            .collect();
+
+        SessionTimelineSnapshot {
+            schema_version: SESSION_TIMELINE_SCHEMA_VERSION,
+            query: self.query,
+            cursor: self.cursor,
+            nodes,
+        }
+    }
+}
+
+fn event_update(
+    query: &SessionTimelineQuery,
+    policy: &RedactionPolicy,
+    topic: &str,
+    event_id: EventId,
+    event: LogEvent,
+) -> Option<SessionTimelineUpdate> {
+    let mut node = event_node(query, policy, topic, event_id, event)?;
+    node.order = 0;
+    let mut cursor = SessionTimelineCursor::default();
+    cursor.bump(topic, event_id);
+    Some(SessionTimelineUpdate {
+        schema_version: SESSION_TIMELINE_SCHEMA_VERSION,
+        cursor,
+        node,
+    })
+}
+
+fn event_node(
+    query: &SessionTimelineQuery,
+    policy: &RedactionPolicy,
+    topic: &str,
+    event_id: EventId,
+    mut event: LogEvent,
+) -> Option<SessionTimelineNode> {
+    event.redact_in_place(policy);
+    if topic.starts_with("observability.agent_events.") {
+        return agent_event_node(query, topic, event_id, event);
+    }
+    if topic == crate::channels::CHANNEL_TRANSCRIPT_TOPIC {
+        return channel_lifecycle_node(query, topic, event_id, event);
+    }
+    if topic == crate::channels::CHANNEL_AUDIT_TOPIC {
+        return channel_audit_node(query, topic, event_id, event);
+    }
+    None
+}
+
+fn span_node(span: &RunTraceSpanRecord, policy: &RedactionPolicy) -> SessionTimelineNode {
+    let mut attributes = serde_json::json!(span.metadata);
+    policy.redact_json_in_place(&mut attributes);
+    let status = attributes
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("completed")
+        .to_string();
+    SessionTimelineNode {
+        id: span_node_id(&span.trace_id, span.span_id),
+        parent_id: span
+            .parent_id
+            .map(|parent| span_node_id(&span.trace_id, parent)),
+        children: Vec::new(),
+        category: "span".to_string(),
+        kind: span.kind.clone(),
+        name: span.name.clone(),
+        status,
+        trace_id: Some(span.trace_id.clone()),
+        span_id: Some(span.span_id.to_string()),
+        occurred_at_ms: None,
+        start_ms: Some(span.start_ms),
+        duration_ms: Some(span.duration_ms),
+        attributes,
+        references: vec![SessionTimelineReference {
+            kind: "run_trace_span".to_string(),
+            id: Some(span.span_id.to_string()),
+            topic: None,
+            event_id: None,
+        }],
+        links: span
+            .links
+            .iter()
+            .map(|link| SessionTimelineLink {
+                kind: link
+                    .attributes
+                    .get("harn.link.kind")
+                    .cloned()
+                    .unwrap_or_else(|| "span_link".to_string()),
+                target_id: Some(format!("span:{}:{}", link.trace_id, link.span_id)),
+                trace_id: Some(link.trace_id.clone()),
+                span_id: Some(link.span_id.clone()),
+                event_id: None,
+            })
+            .collect(),
+        order: 0,
+    }
+}
+
+fn agent_event_node(
+    query: &SessionTimelineQuery,
+    topic: &str,
+    event_id: EventId,
+    event: LogEvent,
+) -> Option<SessionTimelineNode> {
+    if !event_matches_query(
+        query,
+        &event.payload,
+        Some(&event.headers),
+        &["session_id"],
+        &[],
+    ) {
+        return None;
+    }
+    let event_value = event.payload.get("event").unwrap_or(&event.payload);
+    let event_type = event_value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(event.kind.as_str());
+    let status = event_status(event_value).unwrap_or("observed").to_string();
+    Some(SessionTimelineNode {
+        id: format!("event:{topic}:{event_id}"),
+        parent_id: None,
+        children: Vec::new(),
+        category: "agent_event".to_string(),
+        kind: event.kind.clone(),
+        name: event_type.to_string(),
+        status,
+        trace_id: None,
+        span_id: None,
+        occurred_at_ms: Some(event.occurred_at_ms),
+        start_ms: None,
+        duration_ms: duration_ms(event_value),
+        attributes: event.payload,
+        references: vec![event_ref(topic, event_id)],
+        links: Vec::new(),
+        order: 0,
+    })
+}
+
+fn channel_lifecycle_node(
+    query: &SessionTimelineQuery,
+    topic: &str,
+    event_id: EventId,
+    event: LogEvent,
+) -> Option<SessionTimelineNode> {
+    if !event_matches_query(
+        query,
+        &event.payload,
+        Some(&event.headers),
+        &["session_id", "matched_in_session_id"],
+        &["pipeline_id"],
+    ) {
+        return None;
+    }
+    let channel_event_id = string_field(&event.payload, "event_id");
+    let trigger_id = string_field(&event.payload, "trigger_id");
+    let is_match = event.kind == crate::channels::CHANNEL_MATCH_TRANSCRIPT_KIND;
+    let id = if is_match {
+        format!(
+            "channel:{}:match:{}",
+            channel_event_id.as_deref().unwrap_or("unknown"),
+            trigger_id.as_deref().unwrap_or("unknown")
+        )
+    } else {
+        format!(
+            "channel:{}:emit",
+            channel_event_id.as_deref().unwrap_or("unknown")
+        )
+    };
+    let mut links: Vec<SessionTimelineLink> = if is_match {
+        channel_event_id
+            .as_ref()
+            .map(|event_id| SessionTimelineLink {
+                kind: "channel_emit".to_string(),
+                target_id: Some(format!("channel:{event_id}:emit")),
+                trace_id: None,
+                span_id: None,
+                event_id: Some(event_id.clone()),
+            })
+            .into_iter()
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if is_match {
+        links.extend(channel_batch_links(&event.payload));
+    }
+    Some(SessionTimelineNode {
+        id,
+        parent_id: None,
+        children: Vec::new(),
+        category: "channel".to_string(),
+        kind: event.kind.clone(),
+        name: string_field(&event.payload, "name_resolved")
+            .or_else(|| string_field(&event.payload, "name"))
+            .unwrap_or_else(|| event.kind.clone()),
+        status: if event
+            .payload
+            .get("duplicate")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+        {
+            "duplicate".to_string()
+        } else {
+            "observed".to_string()
+        },
+        trace_id: None,
+        span_id: string_field(&event.payload, "span_id"),
+        occurred_at_ms: Some(event.occurred_at_ms),
+        start_ms: None,
+        duration_ms: None,
+        attributes: event.payload,
+        references: vec![event_ref(topic, event_id)],
+        links,
+        order: 0,
+    })
+}
+
+fn channel_audit_node(
+    query: &SessionTimelineQuery,
+    topic: &str,
+    event_id: EventId,
+    event: LogEvent,
+) -> Option<SessionTimelineNode> {
+    if !event_matches_query(
+        query,
+        &event.payload,
+        Some(&event.headers),
+        &["session_id", "matched_in_session_id"],
+        &["pipeline_id", "run_id"],
+    ) {
+        return None;
+    }
+    let channel_event_id = string_field(&event.payload, "event_id");
+    let trigger_id = string_field(&event.payload, "trigger_id");
+    let is_match = event.kind == crate::channels::CHANNEL_MATCH_RECEIPT_KIND;
+    let id = if is_match {
+        format!(
+            "channel_receipt:{}:match:{}",
+            channel_event_id.as_deref().unwrap_or("unknown"),
+            trigger_id.as_deref().unwrap_or("unknown")
+        )
+    } else {
+        format!(
+            "channel_receipt:{}:emit",
+            channel_event_id.as_deref().unwrap_or("unknown")
+        )
+    };
+    let mut links: Vec<SessionTimelineLink> = if is_match {
+        channel_event_id
+            .as_ref()
+            .map(|event_id| SessionTimelineLink {
+                kind: "channel_emit".to_string(),
+                target_id: Some(format!("channel_receipt:{event_id}:emit")),
+                trace_id: None,
+                span_id: None,
+                event_id: Some(event_id.clone()),
+            })
+            .into_iter()
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if is_match {
+        links.extend(channel_batch_links(&event.payload));
+    }
+    Some(SessionTimelineNode {
+        id,
+        parent_id: None,
+        children: Vec::new(),
+        category: "channel_audit".to_string(),
+        kind: event.kind.clone(),
+        name: string_field(&event.payload, "name_resolved").unwrap_or_else(|| event.kind.clone()),
+        status: event
+            .payload
+            .get("handler_result")
+            .and_then(|value| value.get("status"))
+            .and_then(serde_json::Value::as_str)
+            .or_else(|| {
+                event.payload.get("inserted").and_then(|inserted| {
+                    if inserted.as_bool() == Some(false) {
+                        Some("duplicate")
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or("recorded")
+            .to_string(),
+        trace_id: None,
+        span_id: string_field(&event.payload, "span_id"),
+        occurred_at_ms: Some(event.occurred_at_ms),
+        start_ms: None,
+        duration_ms: None,
+        attributes: event.payload,
+        references: vec![event_ref(topic, event_id)],
+        links,
+        order: 0,
+    })
+}
+
+fn event_matches_query(
+    query: &SessionTimelineQuery,
+    payload: &serde_json::Value,
+    headers: Option<&BTreeMap<String, String>>,
+    session_keys: &[&str],
+    run_keys: &[&str],
+) -> bool {
+    field_query_matches(query.session_id.as_deref(), payload, headers, session_keys)
+        && field_query_matches(query.run_id.as_deref(), payload, headers, run_keys)
+        && field_query_matches(
+            query.project_id.as_deref(),
+            payload,
+            headers,
+            &["project_id", "projectId", "workspace_id", "workspaceId"],
+        )
+}
+
+fn field_query_matches(
+    expected: Option<&str>,
+    payload: &serde_json::Value,
+    headers: Option<&BTreeMap<String, String>>,
+    keys: &[&str],
+) -> bool {
+    let Some(expected) = expected else {
+        return true;
+    };
+    if expected.is_empty() {
+        return true;
+    }
+    if keys.is_empty() {
+        return true;
+    }
+    keys.iter().any(|key| {
+        payload
+            .get(*key)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| value == expected)
+            || payload
+                .get("event")
+                .and_then(|event| event.get(*key))
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| value == expected)
+            || headers
+                .and_then(|headers| headers.get(*key))
+                .is_some_and(|value| value == expected)
+    })
+}
+
+fn span_matches_query(span: &RunTraceSpanRecord, query: &SessionTimelineQuery) -> bool {
+    if let Some(session_id) = query.session_id.as_deref() {
+        let has_session_attr = span.metadata.contains_key("session_id")
+            || span.metadata.contains_key("agent_session_id");
+        if has_session_attr
+            && !metadata_matches(
+                &span.metadata,
+                &["session_id", "agent_session_id"],
+                session_id,
+            )
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn run_matches_query(run: &RunRecord, query: &SessionTimelineQuery) -> bool {
+    if let Some(run_id) = query.run_id.as_deref() {
+        if run.id != run_id {
+            return false;
+        }
+    }
+    if let Some(project_id) = query.project_id.as_deref() {
+        if !metadata_matches(&run.metadata, &["project_id", "projectId"], project_id) {
+            return false;
+        }
+    }
+    true
+}
+
+fn metadata_matches(
+    metadata: &BTreeMap<String, serde_json::Value>,
+    keys: &[&str],
+    expected: &str,
+) -> bool {
+    keys.iter().any(|key| {
+        metadata
+            .get(*key)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| value == expected)
+    })
+}
+
+fn event_status(value: &serde_json::Value) -> Option<&str> {
+    value
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| value.get("verdict").and_then(serde_json::Value::as_str))
+}
+
+fn duration_ms(value: &serde_json::Value) -> Option<u64> {
+    value
+        .get("duration_ms")
+        .or_else(|| value.get("judge_duration_ms"))
+        .and_then(serde_json::Value::as_u64)
+}
+
+fn string_field(value: &serde_json::Value, key: &str) -> Option<String> {
+    let value = value.get(key)?;
+    if let Some(text) = value.as_str() {
+        if !text.is_empty() {
+            return Some(text.to_string());
+        }
+        return None;
+    }
+    value.as_u64().map(|number| number.to_string())
+}
+
+fn channel_batch_links(payload: &serde_json::Value) -> Vec<SessionTimelineLink> {
+    payload
+        .get("batch")
+        .and_then(|batch| batch.get("constituent_event_ids"))
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.as_str())
+        .map(|event_id| SessionTimelineLink {
+            kind: "channel_batch_member".to_string(),
+            target_id: None,
+            trace_id: None,
+            span_id: None,
+            event_id: Some(event_id.to_string()),
+        })
+        .collect()
+}
+
+fn span_node_id(trace_id: &str, span_id: u64) -> String {
+    format!("span:{trace_id}:{span_id}")
+}
+
+fn event_ref(topic: &str, event_id: EventId) -> SessionTimelineReference {
+    SessionTimelineReference {
+        kind: "event_log".to_string(),
+        id: None,
+        topic: Some(topic.to_string()),
+        event_id: Some(event_id),
+    }
+}
+
+fn static_topic(topic: &str) -> Topic {
+    Topic::new(topic).expect("static session timeline topic should be valid")
+}
+
+fn load_run_for_timeline(
+    query: &SessionTimelineQuery,
+) -> Result<Option<RunRecord>, SessionTimelineError> {
+    if let Some(path) = query
+        .run_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        return load_run_record_for_timeline(Path::new(path), true);
+    }
+
+    let Some(run_id) = query
+        .run_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|run_id| !run_id.is_empty())
+    else {
+        return Ok(None);
+    };
+    let path = default_run_record_path(run_id)?;
+    load_run_record_for_timeline(&path, false)
+}
+
+fn load_run_record_for_timeline(
+    path: &Path,
+    explicit: bool,
+) -> Result<Option<RunRecord>, SessionTimelineError> {
+    if !path.exists() {
+        if explicit {
+            return Err(SessionTimelineError::RunRecord(format!(
+                "session timeline run record not found: {}",
+                path.display()
+            )));
+        }
+        return Ok(None);
+    }
+    load_run_record(path).map(Some).map_err(|error| {
+        SessionTimelineError::RunRecord(format!(
+            "failed to load session timeline run record {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn default_run_record_path(run_id: &str) -> Result<PathBuf, SessionTimelineError> {
+    if run_id == "." || run_id == ".." || run_id.contains('/') || run_id.contains('\\') {
+        return Err(SessionTimelineError::RunRecord(format!(
+            "session timeline runId is not a valid default run-record filename: {run_id}"
+        )));
+    }
+    let base = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    Ok(crate::runtime_paths::run_root(&base).join(format!("{run_id}.json")))
+}
+
+#[cfg(test)]
+#[path = "session_timeline_tests.rs"]
+mod session_timeline_tests;

--- a/crates/harn-vm/src/session_timeline_tests.rs
+++ b/crates/harn-vm/src/session_timeline_tests.rs
@@ -1,0 +1,264 @@
+use super::*;
+use crate::event_log::{FileEventLog, MemoryEventLog};
+use crate::orchestration::{save_run_record, RunRecord};
+use futures::StreamExt;
+use serde_json::json;
+
+fn span(span_id: u64, parent_id: Option<u64>, metadata: serde_json::Value) -> RunTraceSpanRecord {
+    RunTraceSpanRecord {
+        trace_id: "trace-1".to_string(),
+        span_id,
+        parent_id,
+        kind: if parent_id.is_some() {
+            "tool_call".to_string()
+        } else {
+            "pipeline".to_string()
+        },
+        name: format!("span-{span_id}"),
+        start_ms: span_id * 10,
+        duration_ms: 5,
+        metadata: serde_json::from_value(metadata).unwrap_or_default(),
+        links: Vec::new(),
+    }
+}
+
+#[test]
+fn run_record_spans_project_parent_child_tree_and_redact_metadata() {
+    let mut run = RunRecord {
+        id: "run-1".to_string(),
+        trace_spans: vec![
+            span(
+                2,
+                Some(1),
+                json!({"status": "ok", "api_key": "should-redact"}),
+            ),
+            span(1, None, json!({"session_id": "s1"})),
+        ],
+        ..RunRecord::default()
+    };
+    run.metadata
+        .insert("project_id".to_string(), json!("project-1"));
+
+    let snapshot = timeline_from_run_record(
+        &run,
+        SessionTimelineQuery {
+            session_id: Some("s1".to_string()),
+            run_id: Some("run-1".to_string()),
+            project_id: Some("project-1".to_string()),
+            ..SessionTimelineQuery::default()
+        },
+    );
+
+    assert_eq!(snapshot.nodes.len(), 2);
+    let root = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.id == "span:trace-1:1")
+        .expect("root span node");
+    assert_eq!(root.children, vec!["span:trace-1:2"]);
+    let child = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.id == "span:trace-1:2")
+        .expect("child span node");
+    assert_eq!(child.parent_id.as_deref(), Some("span:trace-1:1"));
+    assert_eq!(
+        child.attributes["api_key"],
+        json!(crate::redact::REDACTED_PLACEHOLDER)
+    );
+}
+
+#[tokio::test]
+async fn channel_emit_and_match_project_causal_links() {
+    let log = AnyEventLog::Memory(MemoryEventLog::new(16));
+    let topic = static_topic(crate::channels::CHANNEL_TRANSCRIPT_TOPIC);
+    log.append(
+        &topic,
+        LogEvent::new(
+            crate::channels::CHANNEL_EMIT_TRANSCRIPT_KIND,
+            json!({
+                "event_id": "evt-1",
+                "name_resolved": "session:s1:updates",
+                "scope": "session",
+                "scope_id": "s1",
+                "session_id": "s1",
+                "payload_summary": {"kind": "object"},
+                "span_id": 7
+            }),
+        ),
+    )
+    .await
+    .unwrap();
+    log.append(
+        &topic,
+        LogEvent::new(
+            crate::channels::CHANNEL_MATCH_TRANSCRIPT_KIND,
+            json!({
+                "event_id": "evt-1",
+                "name_resolved": "session:s1:updates",
+                "scope": "session",
+                "scope_id": "s1",
+                "trigger_id": "trigger-1",
+                "matched_in_session_id": "s1",
+                "batch": {
+                    "count": 2,
+                    "constituent_event_ids": ["evt-a", "evt-b"]
+                },
+                "span_id": 8
+            }),
+        ),
+    )
+    .await
+    .unwrap();
+
+    let snapshot =
+        query_session_timeline(Some(&log), None, SessionTimelineQuery::for_session("s1"))
+            .await
+            .unwrap();
+
+    let emit = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.id == "channel:evt-1:emit")
+        .expect("emit node");
+    assert_eq!(emit.category, "channel");
+    let matched = snapshot
+        .nodes
+        .iter()
+        .find(|node| node.id == "channel:evt-1:match:trigger-1")
+        .expect("match node");
+    assert_eq!(
+        matched.links[0].target_id.as_deref(),
+        Some("channel:evt-1:emit")
+    );
+    assert!(matched.links.iter().any(|link| {
+        link.kind == "channel_batch_member" && link.event_id.as_deref() == Some("evt-a")
+    }));
+    assert!(matched.links.iter().any(|link| {
+        link.kind == "channel_batch_member" && link.event_id.as_deref() == Some("evt-b")
+    }));
+}
+
+#[tokio::test]
+async fn persisted_file_log_reads_agent_events() {
+    let temp = tempfile::tempdir().unwrap();
+    let log = AnyEventLog::File(FileEventLog::open(temp.path().to_path_buf(), 16).unwrap());
+    let topic = agent_events_topic("s1");
+    log.append(
+        &topic,
+        LogEvent::new(
+            "tool_call",
+            json!({
+                "session_id": "s1",
+                "event": {
+                    "type": "tool_call",
+                    "session_id": "s1",
+                    "tool_call_id": "tool-1",
+                    "tool_name": "read",
+                    "status": "pending",
+                    "raw_input": {"token": "should-redact"}
+                }
+            }),
+        )
+        .with_headers(BTreeMap::from([(
+            "session_id".to_string(),
+            "s1".to_string(),
+        )])),
+    )
+    .await
+    .unwrap();
+    log.flush().await.unwrap();
+
+    let snapshot = query_session_timeline(
+        Some(&log),
+        None,
+        SessionTimelineQuery {
+            session_id: Some("s1".to_string()),
+            run_id: Some("run_session_timeline_filter_00000000".to_string()),
+            ..SessionTimelineQuery::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(snapshot.nodes.len(), 1);
+    assert_eq!(snapshot.nodes[0].category, "agent_event");
+    assert_eq!(
+        snapshot.nodes[0].attributes["event"]["raw_input"]["token"],
+        json!(crate::redact::REDACTED_PLACEHOLDER)
+    );
+}
+
+#[tokio::test]
+async fn persisted_run_record_reads_nested_spans() {
+    let temp = tempfile::tempdir().unwrap();
+    let run_path = temp.path().join("run-1.json");
+    let mut run = RunRecord {
+        id: "run-1".to_string(),
+        trace_spans: vec![
+            span(1, None, json!({"session_id": "s1"})),
+            span(2, Some(1), json!({"session_id": "s1"})),
+        ],
+        ..RunRecord::default()
+    };
+    run.metadata
+        .insert("project_id".to_string(), json!("project-1"));
+    save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
+
+    let snapshot = query_session_timeline(
+        None,
+        None,
+        SessionTimelineQuery {
+            session_id: Some("s1".to_string()),
+            run_id: Some("run-1".to_string()),
+            run_path: Some(run_path.display().to_string()),
+            project_id: Some("project-1".to_string()),
+            ..SessionTimelineQuery::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(snapshot.nodes.len(), 2);
+    assert_eq!(snapshot.nodes[0].id, "span:trace-1:1");
+    assert_eq!(snapshot.nodes[0].children, vec!["span:trace-1:2"]);
+    assert_eq!(
+        snapshot.nodes[1].parent_id.as_deref(),
+        Some("span:trace-1:1")
+    );
+}
+
+#[tokio::test]
+async fn subscription_streams_live_appends_without_polling() {
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
+    let mut stream =
+        subscribe_session_timeline(log.clone(), SessionTimelineQuery::for_session("s1"))
+            .await
+            .unwrap();
+    let topic = agent_events_topic("s1");
+    log.append(
+        &topic,
+        LogEvent::new(
+            "agent_message_chunk",
+            json!({
+                "session_id": "s1",
+                "event": {
+                    "type": "agent_message_chunk",
+                    "session_id": "s1",
+                    "content": "hello"
+                }
+            }),
+        )
+        .with_headers(BTreeMap::from([(
+            "session_id".to_string(),
+            "s1".to_string(),
+        )])),
+    )
+    .await
+    .unwrap();
+
+    let update = stream.next().await.unwrap().unwrap();
+    assert_eq!(update.node.category, "agent_event");
+    assert_eq!(update.node.name, "agent_message_chunk");
+    assert_eq!(update.cursor.topics.get(topic.as_str()).copied(), Some(1));
+}

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -609,6 +609,9 @@ The ACP server supports these JSON-RPC methods:
 | `session/stop` | Deprecated alias for `session/close` |
 | `session/set_mode` | Switch the active session mode |
 | `session/set_config_option` | Switch a preferred ACP session config option (`mode`, `model`, `thought_level`, or `budget`) |
+| `harn.session_timeline.query` | Return the Harn-owned redacted session timeline snapshot |
+| `harn.session_timeline.subscribe` | Subscribe to newly appended timeline events |
+| `harn.session_timeline.unsubscribe` | Stop a timeline subscription |
 | `workflow/signal` | Enqueue a workflow signal message in the current session workspace |
 | `workflow/query` | Read a named workflow query value from the current session workspace |
 | `workflow/update` | Send a workflow update request and wait for a response |
@@ -633,6 +636,65 @@ and `session.remind.pending = {list: true, revoke: true}` for host-side
 system-reminder queue controls. Harn-only methods such as
 `session/fork` remain documented extensions instead of being inserted into
 upstream `sessionCapabilities`.
+
+### Session timeline extension
+
+`harn.session_timeline.query` projects existing Harn observability records into
+one client-facing timeline shape. The query accepts `sessionId`/`session_id`,
+optional `runId`/`run_id`, optional `runPath`/`run_path`, optional
+`projectId`/`project_id`, optional `fromCursor`, and optional `limit`. The
+response includes:
+
+- `schemaVersion`
+- `cursor.topics`, a per-event-log-topic cursor map for later queries
+- `nodes`, ordered timeline entries with stable `id`, `parentId`, `children`,
+  `category`, `kind`, `status`, redacted `attributes`, source `references`, and
+  causal `links`
+
+Span nodes come from run trace spans when a run record is supplied to the VM API
+or when ACP can load a persisted run record from `runPath` or from `runId` in
+the default Harn run directory. ACP queries also use the active event log and
+include session agent events plus channel lifecycle/audit events. Channel match
+nodes link back to the matching channel emit node through
+`links.kind = "channel_emit"`. Batched channel match nodes also include
+`links.kind = "channel_batch_member"` entries for the recorded constituent event
+ids.
+
+```json
+{
+  "method": "harn.session_timeline.query",
+  "params": {
+    "sessionId": "sess_abc",
+    "runId": "run_123",
+    "fromCursor": {
+      "topics": {
+        "observability.agent_events.sess_abc": 42
+      }
+    }
+  }
+}
+```
+
+`harn.session_timeline.subscribe` accepts the same query fields plus an optional
+`subscriptionId`. It returns `{subscriptionId, updateMethod}` and then emits
+`harn.session_timeline.update` notifications:
+
+```json
+{
+  "method": "harn.session_timeline.update",
+  "params": {
+    "subscriptionId": "timeline-1",
+    "update": {
+      "schemaVersion": 1,
+      "cursor": {"topics": {"observability.agent_events.sess_abc": 43}},
+      "node": {"id": "event:observability.agent_events.sess_abc:43"}
+    }
+  }
+}
+```
+
+Use `harn.session_timeline.unsubscribe` with `subscriptionId` to stop the live
+stream. Closing a session also cancels subscriptions scoped to that session.
 
 ### Session forking
 


### PR DESCRIPTION
## Summary

- Add a shared Harn session timeline projection for run spans, agent events, channel lifecycle events, and channel audit receipts.
- Expose ACP `harn.session_timeline.query`, `harn.session_timeline.subscribe`, and `harn.session_timeline.unsubscribe` methods with redacted timeline nodes and live append notifications.
- Include persisted run-record lookup via `runId`/`runPath`, parent/child span ordering, channel emit-to-match links, batch-member links, docs, and changelog coverage.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-2913 cargo test -p harn-vm session_timeline --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-2913 cargo test -p harn-serve adapters::acp::tests::sessions --lib`
- `make check-docs-snippets`
- pre-commit hook: Rust fmt, changed-package clippy, markdown lint, generated highlight check
- pre-push hook: targeted local checks, markdown lint, generated highlight check

Fixes #2913
