### PR TITLE
lint: harden harn script rule dispatch

### DIFF
--- a/changelog.d/2826.fixed.md
+++ b/changelog.d/2826.fixed.md
@@ -1,0 +1,5 @@
+- **Project script lint rules now stay scoped to their owning package (#2826).**
+  Multi-target `harn lint` runs no longer apply a sibling package's
+  `*.lint.harn` rules to unrelated files, and script rules can return direct
+  findings or `rules_diagnostics(...)` results without losing fail-safe
+  diagnostics.

--- a/crates/harn-cli/src/commands/check/script_rules.rs
+++ b/crates/harn-cli/src/commands/check/script_rules.rs
@@ -1,5 +1,5 @@
-//! `.harn`-authored custom lint rules (#2850) — the ESLint-plugin equivalent,
-//! but in Harn.
+//! `.harn`-authored custom lint rules — the ESLint-plugin equivalent, but in
+//! Harn.
 //!
 //! A project drops a `*.lint.harn` module into a `[rules] ruleDirs` directory.
 //! `harn lint` discovers it, runs its exported `pub fn lint(source)` over each
@@ -11,12 +11,12 @@
 //!
 //! ```harn
 //! // rules/no-foo.lint.harn
-//! pub fn lint(source) -> list {
-//!   // Inspect `source` (the raw text of the file being linted) and return a
-//!   // list of findings. The structural rule engine is available read-only,
-//!   // so a rule can delegate to `rules.diagnostics` / `rules.search` and
-//!   // return their output directly:
-//!   return rules_diagnostics(source, "<rule toml>") ?? []
+//! pub fn lint(source) {
+//!   // Inspect `source` (the raw text of the file being linted) and return
+//!   // findings. The structural rule engine is available read-only, so a rule
+//!   // can delegate to `rules_diagnostics` and return its diagnostics envelope
+//!   // directly:
+//!   return rules_diagnostics({rule: rule_src, source: source, language: "harn"})
 //! }
 //! ```
 //!
@@ -28,6 +28,9 @@
 //! - `line` / `column` — 1-based location (default `1` / `1`).
 //! - `start_byte` / `end_byte` — byte span for the underline (default `0`).
 //!
+//! A rule can also return the dict emitted by `rules_diagnostics(...)`; its
+//! `diagnostics` list is mapped onto the same lint output.
+//!
 //! ## Sandbox + fail-safe
 //!
 //! Rules run in a dedicated VM with the language, the standard library, and the
@@ -36,8 +39,7 @@
 //! findings; it has no business touching the host.
 //!
 //! A buggy rule **fails safe**: a load error, a runtime throw, or a malformed
-//! return becomes a diagnostic attributed to the rule, never a linter crash
-//! (the C1 acceptance criterion).
+//! return becomes a diagnostic attributed to the rule, never a linter crash.
 
 #[cfg(feature = "hostlib")]
 mod imp {
@@ -141,27 +143,43 @@ mod imp {
         if message.is_empty() {
             return None;
         }
-        let int = |key: &str, default: usize| {
+        let optional_int = |key: &str| {
             dict.get(key)
                 .and_then(VmValue::as_int)
                 .filter(|n| *n >= 0)
                 .map(|n| n as usize)
-                .unwrap_or(default)
         };
-        let line = int("line", 1).max(1);
-        let column = int("column", 1).max(1);
-        let start = int("start_byte", 0);
-        let end = int("end_byte", start).max(start);
+        let line = optional_int("line")
+            .or_else(|| optional_int("start_row").map(|row| row + 1))
+            .unwrap_or(1)
+            .max(1);
+        let column = optional_int("column")
+            .or_else(|| optional_int("start_col").map(|col| col + 1))
+            .unwrap_or(1)
+            .max(1);
+        let end_line = optional_int("end_line")
+            .or_else(|| optional_int("end_row").map(|row| row + 1))
+            .unwrap_or(line)
+            .max(line);
+        let start = optional_int("start_byte").unwrap_or(0);
+        let end = optional_int("end_byte").unwrap_or(start).max(start);
+        let rule_id = dict
+            .get("rule")
+            .or_else(|| dict.get("rule_id"))
+            .map(VmValue::as_str_cow)
+            .filter(|rule| !rule.is_empty())
+            .map(|rule| rule.into_owned())
+            .unwrap_or_else(|| id.to_string());
         Some(LintDiagnostic {
             code: DiagnosticCode::LintRuleEngine,
-            rule: std::borrow::Cow::Owned(id.to_string()),
+            rule: std::borrow::Cow::Owned(rule_id),
             message,
             span: Span {
                 start,
                 end,
                 line,
                 column,
-                end_line: line,
+                end_line,
             },
             severity: severity_from(dict.get("severity")),
             suggestion: None,
@@ -169,33 +187,63 @@ mod imp {
         })
     }
 
-    /// Map a rule's return value (expected: a list of finding dicts) onto
-    /// diagnostics. A non-list return (e.g. `nil`) yields nothing.
+    fn map_findings(id: &str, items: &[VmValue], out: &mut Vec<LintDiagnostic>) {
+        for item in items {
+            if let Some(diag) = finding_to_diagnostic(id, item) {
+                out.push(diag);
+            }
+        }
+    }
+
+    /// Map a rule's return value onto diagnostics. Rules can return a direct
+    /// finding dict, a list of finding dicts, or the `rules_diagnostics(...)`
+    /// envelope.
     fn map_return(id: &str, value: &VmValue, out: &mut Vec<LintDiagnostic>) {
-        if let VmValue::List(items) = value {
-            for item in items.iter() {
-                if let Some(diag) = finding_to_diagnostic(id, item) {
-                    out.push(diag);
+        match value {
+            VmValue::List(items) => map_findings(id, items, out),
+            VmValue::Dict(dict) => {
+                if dict.contains_key("message") {
+                    if let Some(diag) = finding_to_diagnostic(id, value) {
+                        out.push(diag);
+                    }
+                } else if let Some(VmValue::List(items)) = dict.get("diagnostics") {
+                    map_findings(id, items, out);
+                } else {
+                    out.push(rule_error_diagnostic(
+                        id,
+                        "lint(source) returned a dict without `message` or a `diagnostics` list",
+                    ));
                 }
             }
+            _ => out.push(rule_error_diagnostic(
+                id,
+                "lint(source) must return a finding, a list of findings, or a rules_diagnostics result",
+            )),
         }
     }
 
     pub(crate) async fn run(files: &[PathBuf]) -> HashMap<PathBuf, Vec<LintDiagnostic>> {
         let mut out: HashMap<PathBuf, Vec<LintDiagnostic>> = HashMap::new();
 
-        // The union of rule files across all targets. Most targets share a
-        // manifest, so this is usually a single small directory listing.
-        let mut rule_paths: Vec<PathBuf> = Vec::new();
+        // Discover rules per target file. A single `harn lint` invocation can
+        // span multiple packages, and a package's conventions must not leak
+        // into sibling packages just because their files were linted together.
+        let mut file_rule_paths: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
+        let mut unique_rule_paths: Vec<PathBuf> = Vec::new();
         let mut seen = HashSet::new();
         for file in files {
-            for path in discover_rule_paths(file) {
+            let paths = discover_rule_paths(file);
+            if paths.is_empty() {
+                continue;
+            }
+            for path in &paths {
                 if seen.insert(path.clone()) {
-                    rule_paths.push(path);
+                    unique_rule_paths.push(path.clone());
                 }
             }
+            file_rule_paths.insert(file.clone(), paths);
         }
-        if rule_paths.is_empty() {
+        if unique_rule_paths.is_empty() {
             return out; // Common path: no project rules — near-zero cost.
         }
 
@@ -203,11 +251,21 @@ mod imp {
 
         // Load each rule's `lint` closure once. A `*.lint.harn` without a `lint`
         // export is a no-op (skipped); a module that won't load fails safe.
-        let mut rules: Vec<LoadedRule> = Vec::new();
-        for path in &rule_paths {
+        let mut loaded_rules: HashMap<PathBuf, LoadedRule> = HashMap::new();
+        for path in &unique_rule_paths {
             let id = rule_id_for(path);
-            let Ok(source) = std::fs::read_to_string(path) else {
-                continue;
+            let source = match std::fs::read_to_string(path) {
+                Ok(source) => source,
+                Err(error) => {
+                    loaded_rules.insert(
+                        path.clone(),
+                        LoadedRule::Failed {
+                            id,
+                            error: error.to_string(),
+                        },
+                    );
+                    continue;
+                }
             };
             match vm
                 .load_module_exports_from_source(path.clone(), &source)
@@ -215,28 +273,42 @@ mod imp {
             {
                 Ok(exports) => {
                     if let Some(lint) = exports.get("lint") {
-                        rules.push(LoadedRule::Ok {
-                            id,
-                            lint: lint.clone(),
-                        });
+                        loaded_rules.insert(
+                            path.clone(),
+                            LoadedRule::Ok {
+                                id,
+                                lint: lint.clone(),
+                            },
+                        );
                     }
                 }
-                Err(error) => rules.push(LoadedRule::Failed {
-                    id,
-                    error: error.to_string(),
-                }),
+                Err(error) => {
+                    loaded_rules.insert(
+                        path.clone(),
+                        LoadedRule::Failed {
+                            id,
+                            error: error.to_string(),
+                        },
+                    );
+                }
             }
         }
-        if rules.is_empty() {
+        if loaded_rules.is_empty() {
             return out;
         }
 
         for file in files {
+            let Some(rule_paths) = file_rule_paths.get(file) else {
+                continue;
+            };
             let Ok(source) = std::fs::read_to_string(file) else {
                 continue;
             };
             let mut diagnostics = Vec::new();
-            for rule in &rules {
+            for path in rule_paths {
+                let Some(rule) = loaded_rules.get(path) else {
+                    continue;
+                };
                 match rule {
                     LoadedRule::Failed { id, error } => {
                         diagnostics.push(rule_error_diagnostic(id, error));
@@ -282,6 +354,7 @@ mod imp {
                 "no-todo",
                 &finding(&[
                     ("message", s("nope")),
+                    ("rule_id", s("delegated-rule")),
                     ("severity", s("error")),
                     ("line", VmValue::Int(7)),
                     ("column", VmValue::Int(3)),
@@ -292,9 +365,47 @@ mod imp {
             .expect("maps");
             assert_eq!(d.message, "nope");
             assert_eq!(d.severity, LintSeverity::Error);
-            assert_eq!(d.rule.as_ref(), "no-todo");
+            assert_eq!(d.rule.as_ref(), "delegated-rule");
             assert_eq!((d.span.line, d.span.column), (7, 3));
             assert_eq!((d.span.start, d.span.end), (10, 14));
+        }
+
+        #[test]
+        fn maps_a_rules_diagnostics_envelope() {
+            let diagnostics = VmValue::List(Arc::new(vec![finding(&[
+                ("message", s("delegated")),
+                ("rule_id", s("structural-rule")),
+                ("severity", s("info")),
+                ("start_row", VmValue::Int(4)),
+                ("start_col", VmValue::Int(2)),
+                ("end_row", VmValue::Int(5)),
+            ])]));
+            let mut out = Vec::new();
+            map_return(
+                "script-rule",
+                &finding(&[("diagnostics", diagnostics)]),
+                &mut out,
+            );
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].rule.as_ref(), "structural-rule");
+            assert_eq!(out[0].severity, LintSeverity::Info);
+            assert_eq!(
+                (out[0].span.line, out[0].span.column, out[0].span.end_line),
+                (5, 3, 6)
+            );
+        }
+
+        #[test]
+        fn maps_a_single_finding_dict() {
+            let mut out = Vec::new();
+            map_return(
+                "script-rule",
+                &finding(&[("message", s("single"))]),
+                &mut out,
+            );
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].message, "single");
+            assert_eq!(out[0].rule.as_ref(), "script-rule");
         }
 
         #[test]
@@ -311,10 +422,12 @@ mod imp {
         }
 
         #[test]
-        fn non_list_return_yields_nothing() {
+        fn non_list_return_is_rule_error() {
             let mut out = Vec::new();
             map_return("r", &VmValue::Nil, &mut out);
-            assert!(out.is_empty());
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].severity, LintSeverity::Error);
+            assert!(out[0].message.contains("must return a finding"));
         }
 
         #[test]

--- a/crates/harn-cli/tests/harn_script_lint_rules_dispatch.rs
+++ b/crates/harn-cli/tests/harn_script_lint_rules_dispatch.rs
@@ -1,5 +1,5 @@
-//! End-to-end coverage for `.harn`-authored custom lint rules (#2850): with a
-//! `[rules] ruleDirs` in `harn.toml`, `harn lint` discovers `*.lint.harn`
+//! End-to-end coverage for `.harn`-authored custom lint rules: with a `[rules]`
+//! `ruleDirs` in `harn.toml`, `harn lint` discovers `*.lint.harn`
 //! modules, runs their `pub fn lint(source)` over each linted file, and merges
 //! the findings into the normal lint output. A deliberately-buggy rule fails
 //! safe. Spawns the real `harn` binary with its cwd set to the project root.
@@ -13,6 +13,13 @@ fn project(name: &str) -> PathBuf {
     std::fs::create_dir_all(dir.join("rules")).expect("mkdir rules");
     std::fs::create_dir_all(dir.join("src")).expect("mkdir src");
     std::fs::write(dir.join("harn.toml"), "[rules]\nruleDirs = [\"rules\"]\n").unwrap();
+    dir
+}
+
+fn temp_root(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("harn-scriptlint-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir root");
     dir
 }
 
@@ -40,6 +47,14 @@ const TODO_RULE: &str = r#"pub fn lint(source) -> list {
     return [{column: 1, line: 1, message: "TODO markers are banned", severity: "error"}]
   }
   return []
+}
+"#;
+
+const DELEGATING_RULE: &str = r#"import { rules_diagnostics } from "std/rules"
+
+pub fn lint(source) {
+  let rule = "id = \"no-greet-call\"\nlanguage = \"harn\"\nmessage = \"greet calls are banned\"\nseverity = \"error\"\n[rule]\npattern = \"greet()\"\n"
+  return rules_diagnostics({language: "harn", path: "current.harn", rule: rule, source: source})
 }
 "#;
 
@@ -130,4 +145,84 @@ fn json_output_includes_script_rule_findings() {
     );
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn script_rule_can_return_rules_diagnostics_envelope() {
+    let dir = project("delegate");
+    write(&dir, "rules/no-greet.lint.harn", DELEGATING_RULE);
+    write(
+        &dir,
+        "src/main.harn",
+        "fn main() {\n  greet()\n}\n\nfn greet() {}\n",
+    );
+
+    let (stdout, stderr, code) = run(&dir, &["lint", "src/main.harn", "--json"]);
+    assert_ne!(code, 0, "delegated diagnostic must fail: stderr={stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let blob = json.to_string();
+    assert!(
+        blob.contains("greet calls are banned"),
+        "json report should carry delegated structural diagnostics: {blob}"
+    );
+
+    write(
+        &dir,
+        "harn.toml",
+        "[rules]\nruleDirs = [\"rules\"]\n\n[lint]\ndisabled = [\"no-greet-call\"]\n",
+    );
+    let (stdout, stderr, code) = run(&dir, &["lint", "src/main.harn", "--json"]);
+    assert_eq!(
+        code, 0,
+        "disabling the delegated structural rule should pass: stdout={stdout} stderr={stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let blob = json.to_string();
+    assert!(
+        !blob.contains("greet calls are banned"),
+        "disabled delegated structural diagnostic should be filtered: {blob}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn script_rules_do_not_leak_between_project_manifests() {
+    let root = temp_root("multi-project");
+    for project in ["a", "b"] {
+        std::fs::create_dir_all(root.join(project).join("src")).expect("mkdir src");
+    }
+    std::fs::create_dir_all(root.join("a").join("rules")).expect("mkdir rules");
+    write(&root, "a/harn.toml", "[rules]\nruleDirs = [\"rules\"]\n");
+    write(&root, "b/harn.toml", "[rules]\nruleDirs = []\n");
+    write(
+        &root,
+        "a/rules/no-project-a-marker.lint.harn",
+        r#"pub fn lint(source) -> list {
+  if source.contains("PROJECT_A_ONLY") {
+    return [{column: 1, line: 1, message: "project-a marker is banned", severity: "error"}]
+  }
+  return []
+}
+"#,
+    );
+    write(&root, "a/src/main.harn", CLEAN_SRC);
+    write(
+        &root,
+        "b/src/main.harn",
+        "pub fn greet() -> string {\n  // PROJECT_A_ONLY is allowed here.\n  return \"hi\"\n}\n",
+    );
+
+    let (stdout, stderr, code) = run(&root, &["lint", "a/src/main.harn", "b/src/main.harn"]);
+    let all = format!("{stdout}{stderr}");
+    assert_eq!(
+        code, 0,
+        "project a's script rule must not run against project b: {all}"
+    );
+    assert!(
+        !all.contains("project-a marker is banned"),
+        "sibling project should not receive the script-rule finding: {all}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-059.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-059.md
@@ -2,10 +2,11 @@
 
 ## What it means
 
-A project-supplied rule matched here. This is not a built-in lint: it is either
-a structural rule (a `*.toml` pattern from the project's `[rules] ruleDirs`) run
-through the linter via the rule engine (`harn-rules`), or a trusted native rule
-library loaded from `[rules] nativeRuleDirs`.
+A project-supplied rule matched here. This is not a built-in lint: it is a
+structural rule (a `*.toml` pattern from the project's `[rules] ruleDirs`) run
+through the linter via the rule engine (`harn-rules`), a `.lint.harn` script
+rule loaded from `ruleDirs`, or a trusted native rule library loaded from
+`[rules] nativeRuleDirs`.
 
 The message, severity, and any suggested fix come from the matched rule. The
 diagnostic's reported rule id is the project rule's id, so you filter it with
@@ -22,9 +23,9 @@ nativeRuleDirs = ["native-rules"]
 ```
 
 and a rule in one of them matched this code. Declarative rules pair a structural
-`pattern` with a `message`; native rules emit diagnostics through the
-`harn_lint::native` ABI. Rules that carry a fix surface it as a
-machine-applicable lint fix.
+`pattern` with a `message`; script rules return findings from `lint(source)`;
+native rules emit diagnostics through the `harn_lint::native` ABI. Rules that
+carry a fix surface it as a machine-applicable lint fix.
 
 ## How to fix
 

--- a/crates/harn-skills/src/corpus/harn-rules/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-rules/SKILL.md
@@ -75,12 +75,13 @@ conformance fixtures.
   per file with safety + idempotency); `--apply` writes (capability-gated),
   `--allow-unsafe` applies above machine-applicable safety, `--json`.
 - `harn lint <paths>` — runs project lint rules. Declarative `language = "harn"`
-  rules and imperative `*.lint.harn` modules (a `pub fn lint(source) -> list` of
-  `{message, severity?, line?, column?}` findings) in `[rules] ruleDirs` merge
-  into the normal output. `.harn` rules run read-only and fail safe. Trusted
-  native Rust rule libraries can also be loaded from `[rules] nativeRuleDirs`;
-  they export `harn_native_lint_register_v1` and emit the same diagnostic/fix
-  shape as built-ins.
+  rules and imperative `*.lint.harn` modules in `[rules] ruleDirs` merge into
+  the normal output. A script rule exports `lint(source)` and returns a
+  `{message, severity?, line?, column?}` finding, a list of findings, or the
+  `rules_diagnostics(...)` result. `.harn` rules run read-only and fail safe.
+  Trusted native Rust rule libraries can also be loaded from
+  `[rules] nativeRuleDirs`; they export `harn_native_lint_register_v1` and emit
+  the same diagnostic/fix shape as built-ins.
 
 ## From `.harn` (`std/rules`)
 

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -189,8 +189,8 @@ report(s) (`nil`/`false` to skip, a `{message, fix, safety}` dict, or a list).
 
 For a project convention that a declarative rule can't capture, author an
 imperative rule in Harn — the ESLint-plugin equivalent. Drop a `*.lint.harn`
-module into a `ruleDirs` directory; it exports `lint(source)` and returns a list
-of findings:
+module into a `ruleDirs` directory; it exports `lint(source)` and returns either
+a finding, a list of findings, or a `rules_diagnostics(...)` result:
 
 ```harn,ignore
 // rules/no-todo.lint.harn
@@ -208,16 +208,26 @@ harn lint src             # discovers rules/*.lint.harn and runs them per file
 
 `harn lint` discovers these alongside the built-in rules and merges their
 findings into the normal output — same exit code, same `--json` report, same
-`disable` filtering. Each finding is a dict with a required `message` plus
-optional `severity` (`"error"`/`"warning"`/`"info"`, default `"warning"`),
-`line`/`column` (default `1`), and `start_byte`/`end_byte`. The fields mirror
-what `rules_diagnostics` emits, so a rule can delegate to the structural engine
-and `return` its output directly.
+`disable` filtering. A finding is a dict with a required `message` plus optional
+`severity` (`"error"`/`"warning"`/`"info"`, default `"warning"`), `line` /
+`column` (default `1`), and `start_byte` / `end_byte`.
+
+A script rule can also delegate to the structural engine and return the
+`rules_diagnostics(...)` result directly:
+
+```harn,ignore
+import { rules_diagnostics } from "std/rules"
+
+pub fn lint(source) {
+  let rule = "id = \"no-foo\"\nlanguage = \"harn\"\nmessage = \"no foo\"\n[rule]\npattern = \"foo()\"\n"
+  return rules_diagnostics({language: "harn", rule: rule, source: source})
+}
+```
 
 Rules run in a read-only sandbox — the language, stdlib, and the structural rule
 engine, but no filesystem / network / process access. A buggy rule **fails
-safe**: a load error or a runtime throw becomes a diagnostic attributed to the
-rule, never a linter crash.
+safe**: a load error, runtime throw, or malformed return becomes a diagnostic
+attributed to the rule, never a linter crash.
 
 ## How do I load a native lint rule library?
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -3158,10 +3158,11 @@ project rule-engine or native lint rule
 
 #### What it means
 
-A project-supplied rule matched here. This is not a built-in lint: it is either
-a structural rule (a `*.toml` pattern from the project's `[rules] ruleDirs`) run
-through the linter via the rule engine (`harn-rules`), or a trusted native rule
-library loaded from `[rules] nativeRuleDirs`.
+A project-supplied rule matched here. This is not a built-in lint: it is a
+structural rule (a `*.toml` pattern from the project's `[rules] ruleDirs`) run
+through the linter via the rule engine (`harn-rules`), a `.lint.harn` script
+rule loaded from `ruleDirs`, or a trusted native rule library loaded from
+`[rules] nativeRuleDirs`.
 
 The message, severity, and any suggested fix come from the matched rule. The
 diagnostic's reported rule id is the project rule's id, so you filter it with
@@ -3178,9 +3179,9 @@ nativeRuleDirs = ["native-rules"]
 ```
 
 and a rule in one of them matched this code. Declarative rules pair a structural
-`pattern` with a `message`; native rules emit diagnostics through the
-`harn_lint::native` ABI. Rules that carry a fix surface it as a
-machine-applicable lint fix.
+`pattern` with a `message`; script rules return findings from `lint(source)`;
+native rules emit diagnostics through the `harn_lint::native` ABI. Rules that
+carry a fix surface it as a machine-applicable lint fix.
 
 #### How to fix
 


### PR DESCRIPTION
## Summary

- scope `.lint.harn` rules to each target file's nearest manifest so multi-target lint runs do not leak sibling package rules
- accept direct findings, finding lists, and `rules_diagnostics(...)` envelopes from script lint rules while preserving delegated rule IDs for filtering
- update harn-rules docs/skill/diagnostic text and add closeout regression coverage

## Validation

- `cargo test -p harn-cli --test harn_script_lint_rules_dispatch`
- `cargo test -p harn-cli script_rules`
- `cargo test -p harn-cli --test rule_discovery_dispatch --test rule_pack_install_dispatch --test native_rule_libraries`
- `cargo test -p harn-lint engine_rules`
- `cargo fmt --check`
- `make lint-test-patterns`
- `make check-docs-snippets`
- `make check-diagnostics-catalog`
- `make lint-diagnostic-codes`
- `make lint-md`
- pre-commit changed-package clippy + markdown
- pre-push targeted checks + diagnostics catalog

Closes #2828.
Closes #2829.
Closes #2850.
Refs #2826.

Note: #2826 also tracks external Burin and harn-cloud epics that are still open, so this PR intentionally references rather than closes the umbrella.