### PR TITLE
codemod: expose Harn destructure defaults pack

### DIFF
--- a/changelog.d/destructure-defaults-codemod.fixed.md
+++ b/changelog.d/destructure-defaults-codemod.fixed.md
@@ -1,0 +1,3 @@
+- Fixed the built-in `destructure-defaults` codemod path so
+  `harn codemod --rule-pack std/rules/destructure-defaults` folds Harn
+  statement runs, including aliased bindings.

--- a/crates/harn-cli/src/cli/codemod.rs
+++ b/crates/harn-cli/src/cli/codemod.rs
@@ -13,8 +13,8 @@ pub(crate) struct CodemodArgs {
     /// Run a codemod rule from a TOML file (must declare a `fix`).
     #[arg(long = "rule", value_name = "FILE")]
     pub rule: Option<String>,
-    /// Run every `*.toml` rule in a directory (a rule pack).
-    #[arg(long = "rule-pack", value_name = "DIR", conflicts_with = "rule")]
+    /// Run every `*.toml` rule in a directory, installed package, or built-in pack.
+    #[arg(long = "rule-pack", value_name = "PACK", conflicts_with = "rule")]
     pub rule_pack: Option<String>,
     /// Write the fixes to disk. Without this, codemod is a dry-run preview.
     #[arg(long)]

--- a/crates/harn-cli/src/commands/codemod.rs
+++ b/crates/harn-cli/src/commands/codemod.rs
@@ -20,15 +20,32 @@ pub(crate) async fn run(args: CodemodArgs) {
 
     // No early `--rule` check: `resolve` falls back to the project's
     // `[rules] ruleDirs` (#2843) and errors itself if nothing is found.
-    let plan = match resolve(&args) {
-        Ok(plan) => plan,
+    let resolved = match resolve(&args) {
+        Ok(resolved) => resolved,
         Err(message) => {
             eprintln!("codemod: {message}");
             std::process::exit(2);
         }
     };
 
-    let _plan = ScopedEnvVar::set("HARN_CODEMOD_PLAN_JSON", &plan);
+    let _plan;
+    let _recipe;
+    let _recipe_files;
+    match resolved {
+        ResolvedCodemod::RulePlan(plan) => {
+            _plan = Some(ScopedEnvVar::set("HARN_CODEMOD_PLAN_JSON", &plan));
+            _recipe = None;
+            _recipe_files = None;
+        }
+        ResolvedCodemod::BuiltinRecipe { name, files_json } => {
+            _plan = None;
+            _recipe = Some(ScopedEnvVar::set("HARN_CODEMOD_RECIPE", name));
+            _recipe_files = Some(ScopedEnvVar::set(
+                "HARN_CODEMOD_RECIPE_FILES_JSON",
+                &files_json,
+            ));
+        }
+    }
     let _apply = ScopedEnvVar::set("HARN_CODEMOD_APPLY", if args.apply { "1" } else { "0" });
     let _unsafe = ScopedEnvVar::set(
         "HARN_CODEMOD_ALLOW_UNSAFE",
@@ -41,8 +58,28 @@ pub(crate) async fn run(args: CodemodArgs) {
 }
 
 #[cfg(feature = "hostlib")]
-fn resolve(args: &CodemodArgs) -> Result<String, String> {
+enum ResolvedCodemod {
+    RulePlan(String),
+    BuiltinRecipe {
+        name: &'static str,
+        files_json: String,
+    },
+}
+
+#[cfg(feature = "hostlib")]
+fn resolve(args: &CodemodArgs) -> Result<ResolvedCodemod, String> {
     use crate::commands::rules_cli;
+    use harn_hostlib::ast::Language;
+
+    if let Some(recipe) = builtin_recipe(args.rule_pack.as_deref()) {
+        let files = rules_cli::collect_files_for_language(&args.paths, Language::Harn);
+        let files_json =
+            serde_json::to_string(&files).map_err(|e| format!("serialize recipe files: {e}"))?;
+        return Ok(ResolvedCodemod::BuiltinRecipe {
+            name: recipe,
+            files_json,
+        });
+    }
 
     let specs =
         rules_cli::resolve_rules(None, None, args.rule.as_deref(), args.rule_pack.as_deref())?;
@@ -62,5 +99,15 @@ fn resolve(args: &CodemodArgs) -> Result<String, String> {
             "no codemod rules (rules with a `fix`) found in the project `[rules] ruleDirs`".into()
         });
     }
-    rules_cli::build_plan(codemod_specs, &args.paths)
+    rules_cli::build_plan(codemod_specs, &args.paths).map(ResolvedCodemod::RulePlan)
+}
+
+#[cfg(feature = "hostlib")]
+fn builtin_recipe(pack: Option<&str>) -> Option<&'static str> {
+    match pack {
+        Some("std/rules/destructure-defaults") | Some("stdlib/destructure-defaults") => {
+            Some("destructure-defaults")
+        }
+        _ => None,
+    }
 }

--- a/crates/harn-cli/src/commands/rules_cli.rs
+++ b/crates/harn-cli/src/commands/rules_cli.rs
@@ -195,6 +195,17 @@ pub(crate) fn build_plan(specs: Vec<RuleSpec>, paths: &[String]) -> Result<Strin
     serde_json::to_string(&plan).map_err(|e| format!("serialize plan: {e}"))
 }
 
+/// Collect files matching one language with the same gitignore-aware walker the
+/// rule-pack paths use.
+pub(crate) fn collect_files_for_language(paths: &[String], language: Language) -> Vec<String> {
+    let lang_name = language.name();
+    collect_files(paths)
+        .into_iter()
+        .filter(|path| Language::detect(path, None).map(|l| l.name()) == Some(lang_name))
+        .map(|path| path.display().to_string())
+        .collect()
+}
+
 /// True if a rule TOML declares a top-level `fix` (i.e. it is a codemod, not a
 /// lint/search). Used to filter discovered packs down to applicable rules.
 pub(crate) fn rule_has_fix(src: &str) -> bool {

--- a/crates/harn-cli/tests/codemod_dispatch.rs
+++ b/crates/harn-cli/tests/codemod_dispatch.rs
@@ -40,6 +40,21 @@ fn codemod(dir: &Path, extra: &[&str]) -> Outcome {
     }
 }
 
+fn built_in_codemod(dir: &Path, extra: &[&str]) -> Outcome {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harn"));
+    cmd.arg("codemod")
+        .arg("--rule-pack")
+        .arg("std/rules/destructure-defaults")
+        .arg(dir)
+        .args(extra);
+    let output = cmd.output().expect("spawn harn codemod");
+    Outcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        code: output.status.code().unwrap_or(-1),
+    }
+}
+
 #[test]
 fn dry_run_previews_without_writing() {
     let dir = fixture_dir("dry");
@@ -82,6 +97,53 @@ fn apply_writes_and_is_idempotent() {
     let again = codemod(&dir, &["--json"]);
     let json2: serde_json::Value = serde_json::from_str(&again.stdout).expect("valid json");
     assert_eq!(json2["summary"]["changed"], 0);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn built_in_destructure_defaults_pack_folds_harn_alias_runs() {
+    let dir = fixture_dir("builtin-fold");
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    let file = dir.join("src/main.harn");
+    std::fs::write(
+        &file,
+        "fn f() {\n  let ready = intake?.ready ?? false\n  let metadata = intake?.metadata_ready_state ?? \"<none>\"\n}\n",
+    )
+    .unwrap();
+
+    let dry = built_in_codemod(&dir.join("src"), &["--json"]);
+    assert_eq!(dry.code, 0, "stderr={}", dry.stderr);
+    let json: serde_json::Value = serde_json::from_str(&dry.stdout).expect("valid json");
+    assert_eq!(json["mode"], "codemod");
+    assert_eq!(json["summary"]["changed"], 1);
+    assert_eq!(json["summary"]["applied"], 0);
+    let preview = json["files"][0]["preview"].as_str().expect("preview");
+    assert!(preview.contains("ready = false"), "preview={preview}");
+    assert!(
+        preview.contains("metadata_ready_state: metadata = \"<none>\""),
+        "preview={preview}",
+    );
+
+    let on_disk = std::fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("let ready = intake?.ready ?? false"));
+
+    let applied = built_in_codemod(&dir.join("src"), &["--apply", "--json"]);
+    assert_eq!(applied.code, 0, "stderr={}", applied.stderr);
+    let applied_json: serde_json::Value =
+        serde_json::from_str(&applied.stdout).expect("valid json");
+    assert_eq!(applied_json["summary"]["applied"], 1);
+
+    let folded = std::fs::read_to_string(&file).unwrap();
+    assert!(folded.contains("ready = false"), "folded={folded}");
+    assert!(
+        folded.contains("metadata_ready_state: metadata = \"<none>\""),
+        "folded={folded}",
+    );
+
+    let again = built_in_codemod(&dir.join("src"), &["--json"]);
+    let again_json: serde_json::Value = serde_json::from_str(&again.stdout).expect("valid json");
+    assert_eq!(again_json["summary"]["changed"], 0);
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -318,10 +318,23 @@ fn fold_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     let mut entries = Vec::new();
     for file in &files {
-        let folded =
+        let raw_folded =
             harn_rules::fold::fold_destructure_defaults(&file.source, file.language.name())
                 .map_err(|e| backend(FOLD, &e))?;
+        let raw_changed = raw_folded != file.source;
+        let formatted = raw_changed && file.language == Language::Harn;
+        let folded = if formatted {
+            match harn_fmt::format_source(&raw_folded) {
+                Ok(canonical) => canonical,
+                Err(_) => raw_folded,
+            }
+        } else {
+            raw_folded
+        };
         let changed = folded != file.source;
+        let idempotent = harn_rules::fold::fold_destructure_defaults(&folded, file.language.name())
+            .map(|again| again == folded)
+            .unwrap_or(false);
         let applied = !dry_run && changed;
         if applied {
             std::fs::write(&file.path, &folded).map_err(|e| HostlibError::Backend {
@@ -333,6 +346,9 @@ fn fold_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             ("path", str_vm(file.path.display().to_string())),
             ("changed", VmValue::Bool(changed)),
             ("applied", VmValue::Bool(applied)),
+            ("idempotent", VmValue::Bool(idempotent)),
+            ("formatted", VmValue::Bool(formatted)),
+            ("safety", str_vm("BehaviorPreserving")),
             ("before", str_vm(&file.source)),
             ("preview", str_vm(folded)),
         ]));

--- a/crates/harn-rules/src/fold.rs
+++ b/crates/harn-rules/src/fold.rs
@@ -16,9 +16,8 @@
 //! `let { x = d } = nil` throws, whereas `cfg?.x ?? d` yields `d`. Coalescing
 //! the source to `{}` first reproduces the `?.`/`??` semantics exactly.
 //!
-//! Only the **non-alias** case (binding name == property name) is folded, via
-//! the engine's metavar unification (`let $K = $X?.$K ?? $D`); aliased sites
-//! (`let t = cfg?.timeout ?? d`) are left untouched. Only consecutive lines
+//! Aliased sites (`let t = cfg?.timeout ?? d`) are folded with the Harn dict
+//! pattern alias form (`{ timeout: t = d }`). Only consecutive statements
 //! sharing one source are merged; a blank line, comment, or other statement
 //! between two `let`s breaks the run.
 
@@ -26,36 +25,47 @@ use crate::engine::{CompiledRule, RuleMatch};
 use crate::error::RulesError;
 use crate::model::Rule;
 
-/// The matcher for a single migratable site. `$K` is unified (binding name ==
-/// property name), so aliased sites do not match.
+/// The matcher for a single migratable site.
 fn site_rule(language: &str) -> CompiledRule {
     let toml = format!(
-        "id = \"destructure-fold\"\nlanguage = \"{language}\"\n[rule]\npattern = \"let $K = $X?.$K ?? $D\"\n"
+        "id = \"destructure-fold\"\nlanguage = \"{language}\"\n[rule]\npattern = \"let $N:identifier = $X?.$K:identifier ?? $D\"\n"
     );
     let rule = Rule::from_toml_str(&toml).expect("internal fold rule parses");
     CompiledRule::compile(&rule).expect("internal fold rule compiles")
 }
 
-/// One captured site: the binding/property key, default, and source expression.
+/// One captured site: the binding name, property key, default, and source.
 struct Site {
+    binding: String,
     key: String,
     default: String,
     source: String,
     start_byte: usize,
     end_byte: usize,
     start_row: usize,
+    end_row: usize,
 }
 
 impl Site {
     fn from_match(m: &RuleMatch) -> Option<Self> {
         Some(Self {
+            binding: m.bindings.get("N")?.text.clone(),
             key: m.bindings.get("K")?.text.clone(),
             default: m.bindings.get("D")?.text.clone(),
             source: m.bindings.get("X")?.text.clone(),
             start_byte: m.span.start_byte,
             end_byte: m.span.end_byte,
             start_row: m.span.start_row,
+            end_row: m.span.end_row,
         })
+    }
+
+    fn field(&self) -> String {
+        if self.binding == self.key {
+            format!("{} = {}", self.key, self.default)
+        } else {
+            format!("{}: {} = {}", self.key, self.binding, self.default)
+        }
     }
 }
 
@@ -70,13 +80,15 @@ pub fn fold_destructure_defaults(source: &str, language: &str) -> Result<String,
     let mut sites: Vec<Site> = matches.iter().filter_map(Site::from_match).collect();
     sites.sort_by_key(|s| s.start_byte);
 
-    // Group consecutive sites: same source, and on the immediately next line.
+    // Group consecutive sites: same source, and starting on the line after the
+    // previous statement ends. This supports wrapped defaults/source
+    // expressions without merging across blank lines or comments.
     let mut groups: Vec<Vec<Site>> = Vec::new();
     for site in sites {
         match groups.last_mut() {
             Some(group)
                 if group.last().is_some_and(|prev| {
-                    prev.source == site.source && site.start_row == prev.start_row + 1
+                    prev.source == site.source && site.start_row == prev.end_row + 1
                 }) =>
             {
                 group.push(site);
@@ -90,12 +102,9 @@ pub fn fold_destructure_defaults(source: &str, language: &str) -> Result<String,
     let mut edits: Vec<(usize, usize, String)> = groups
         .into_iter()
         .filter(|group| group.len() >= 2)
+        .filter(|group| has_unique_keys(group))
         .map(|group| {
-            let fields = group
-                .iter()
-                .map(|s| format!("{} = {}", s.key, s.default))
-                .collect::<Vec<_>>()
-                .join(", ");
+            let fields = group.iter().map(Site::field).collect::<Vec<_>>().join(", ");
             let replacement = format!("let {{ {fields} }} = {} ?? {{}}", group[0].source);
             (
                 group[0].start_byte,
@@ -111,6 +120,11 @@ pub fn fold_destructure_defaults(source: &str, language: &str) -> Result<String,
         out.replace_range(start..end, &replacement);
     }
     Ok(out)
+}
+
+fn has_unique_keys(group: &[Site]) -> bool {
+    let mut seen = std::collections::BTreeSet::new();
+    group.iter().all(|site| seen.insert(&site.key))
 }
 
 #[cfg(test)]
@@ -163,9 +177,28 @@ mod tests {
     }
 
     #[test]
-    fn aliased_site_is_left_untouched() {
-        // Binding `t` != property `timeout`, so `$K` cannot unify → no match.
-        let src = "fn f() {\n  let t = cfg?.timeout ?? 30\n  let r = cfg?.retries ?? 3\n}\n";
+    fn folds_aliased_sites() {
+        let src = "fn f() {\n  let t = cfg?.timeout ?? 30\n  let retries = cfg?.retries ?? 3\n  let label = cfg?.name ?? \"anon\"\n}\n";
+        let out = fold(src);
+        assert_eq!(
+            out,
+            "fn f() {\n  let { timeout: t = 30, retries = 3, name: label = \"anon\" } = cfg ?? {}\n}\n"
+        );
+    }
+
+    #[test]
+    fn folds_after_a_wrapped_previous_site() {
+        let src = "fn f() {\n  let path = parse({name: \"x\"}, argv).ok?.path\n    ?? \"\"\n  let verbose = parse({name: \"x\"}, argv).ok?.verbose ?? false\n}\n";
+        let out = fold(src);
+        assert_eq!(
+            out,
+            "fn f() {\n  let { path = \"\", verbose = false } = parse({name: \"x\"}, argv).ok ?? {}\n}\n"
+        );
+    }
+
+    #[test]
+    fn leaves_duplicate_property_keys_untouched() {
+        let src = "fn f() {\n  let first = cfg?.value ?? 1\n  let second = cfg?.value ?? 2\n}\n";
         assert_eq!(fold(src), src);
     }
 }

--- a/crates/harn-stdlib/src/stdlib/cli/codemod.harn
+++ b/crates/harn-stdlib/src/stdlib/cli/codemod.harn
@@ -1,5 +1,5 @@
 import { unified_diff } from "std/diff"
-import { rules_apply } from "std/rules"
+import { rules_apply, rules_fold } from "std/rules"
 
 /**
  * `harn codemod` — apply a codemod rule's `fix` across a fileset.
@@ -14,10 +14,12 @@ import { rules_apply } from "std/rules"
  * engine (`std/rules` `rules_apply`) and formats the diffs / summary.
  *
  * Inputs:
- *   HARN_CODEMOD_PLAN_JSON     — JSON array of {rule, language, files: [...]}.
- *   HARN_CODEMOD_APPLY         — "1" to write, "0" for a dry-run preview.
- *   HARN_CODEMOD_ALLOW_UNSAFE  — "1" to apply above machine-applicable safety.
- *   HARN_OUTPUT_JSON           — "1" for the JSON envelope, else human diffs.
+ *   HARN_CODEMOD_PLAN_JSON          — JSON array of {rule, language, files: [...]}.
+ *   HARN_CODEMOD_RECIPE             — Built-in recipe id, e.g. "destructure-defaults".
+ *   HARN_CODEMOD_RECIPE_FILES_JSON  — JSON array of files for the built-in recipe.
+ *   HARN_CODEMOD_APPLY              — "1" to write, "0" for a dry-run preview.
+ *   HARN_CODEMOD_ALLOW_UNSAFE       — "1" to apply above machine-applicable safety.
+ *   HARN_OUTPUT_JSON                — "1" for the JSON envelope, else human diffs.
  */
 fn summary_line(changed: int, applied: int, apply: bool) -> string {
   if apply {
@@ -48,13 +50,27 @@ fn run_codemod(plan: list, apply: bool, allow_unsafe: bool) -> dict {
   return {files: file_results, changed: changed, applied: applied}
 }
 
-fn main(harness: Harness) {
-  let raw = harness.env.get_or("HARN_CODEMOD_PLAN_JSON", "")
-  if raw == "" {
-    harness.stdio.eprintln("codemod: internal error — HARN_CODEMOD_PLAN_JSON not set by the shim")
-    exit(70)
+fn run_builtin_recipe(name: string, files: list, apply: bool) -> dict {
+  if name == "destructure-defaults" {
+    let res = rules_fold({paths: files, dry_run: !apply})
+    var file_results = []
+    var changed = 0
+    var applied = 0
+    for f in res.files ?? [] {
+      if f.changed {
+        changed = changed + 1
+        if f.applied {
+          applied = applied + 1
+        }
+        file_results = file_results.push(f)
+      }
+    }
+    return {files: file_results, changed: changed, applied: applied}
   }
-  let plan = json_parse(raw)
+  throw "unknown built-in codemod recipe: " + name
+}
+
+fn main(harness: Harness) {
   let apply = harness.env.get_or("HARN_CODEMOD_APPLY", "0") == "1"
   let allow_unsafe = harness.env.get_or("HARN_CODEMOD_ALLOW_UNSAFE", "0") == "1"
   let json_mode = harness.env.get_or("HARN_OUTPUT_JSON", "0") == "1"
@@ -63,7 +79,18 @@ fn main(harness: Harness) {
   // `dry_run`/safety checks protect the files). `harn codemod` is a first-party
   // command the user invoked directly, so enabling it here is the intended use.
   hostlib_enable("tools:deterministic")
-  let out = run_codemod(plan, apply, allow_unsafe)
+  let recipe = harness.env.get_or("HARN_CODEMOD_RECIPE", "")
+  let out = if recipe {
+    let files = json_parse(harness.env.get_or("HARN_CODEMOD_RECIPE_FILES_JSON", "[]"))
+    run_builtin_recipe(recipe, files, apply)
+  } else {
+    let raw = harness.env.get_or("HARN_CODEMOD_PLAN_JSON", "")
+    if raw == "" {
+      harness.stdio.eprintln("codemod: internal error — no codemod plan or recipe set by the shim")
+      exit(70)
+    }
+    run_codemod(json_parse(raw), apply, allow_unsafe)
+  }
   if json_mode {
     let envelope = {
       schemaVersion: 1,

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -111,6 +111,15 @@ rewrote src/config.ts  [safety=BehaviorPreserving]
 
 Re-running a folded file changes nothing — fixes are checked for idempotency.
 Point `--rule-pack <dir>` at a directory to run every `*.toml` rule in it.
+Installed packages work by name, and built-in packs live under `std/rules`.
+
+```console
+harn codemod --rule-pack std/rules/destructure-defaults src --apply
+```
+
+The built-in `destructure-defaults` pack handles Harn statement runs such as
+`let x = input?.x ?? d` / `let alias = input?.field ?? d`, where a sequence fold
+needs more context than a single-node TOML rule can express.
 
 ## How do I run my project's rules without naming them?
 


### PR DESCRIPTION
## Summary

- expose the Harn destructure-defaults sequence fold through `harn codemod --rule-pack std/rules/destructure-defaults`
- teach the fold recipe to handle aliased bindings such as `let alias = input?.field ?? default`
- preserve behavior with `?? {}`, Harn formatting, idempotency reporting, and duplicate-key safeguards
- document the built-in pack path and add a changelog fragment

## Validation

- `CARGO_TARGET_DIR=/tmp/codex-harn-fold-target cargo test -p harn-rules --lib fold:: -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/codex-harn-fold-target cargo test -p harn-cli --test codemod_dispatch -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/codex-harn-fold-target cargo test -p harn-rules-hostlib -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/codex-harn-fold-target cargo test -p harn-cli --test rule_pack_install_dispatch -- --nocapture`
- `/tmp/codex-harn-fold-target/debug/harn check crates/harn-stdlib/src/stdlib/cli/codemod.harn`
- `/tmp/codex-harn-fold-target/debug/harn fmt --check crates/harn-stdlib/src/stdlib/cli/codemod.harn`
- `CARGO_TARGET_DIR=/tmp/codex-harn-fold-target make check-docs-snippets`
- pre-commit hook
- pre-push hook
