### PR TITLE
fix(event-log): make file-log flush() fsync work on Windows

### DIFF
--- a/changelog.d/win-event-log-fsync.fixed.md
+++ b/changelog.d/win-event-log-fsync.fixed.md
@@ -1,0 +1,7 @@
+- **File event log `flush()` no longer fails on Windows.** `sync_tree` opened each topic/consumer
+  file read-only and called `sync_all()`, which on Windows lowers to `FlushFileBuffers` — and that
+  requires a write-access handle, so it failed with "Access is denied" (on Unix, `fsync` on a
+  read-only descriptor is fine, which masked the bug). `flush()` now fsyncs through a hardened
+  `fsync_file` helper that opens for write, with a read-only fallback so a durability flush can never
+  hard-error on a genuinely read-only file. Fixes the `session_timeline::persisted_file_log_reads_agent_events`
+  failure that was red on the Windows CI lane (and blocking docs auto-deploys).

--- a/crates/harn-vm/src/event_log/util.rs
+++ b/crates/harn-vm/src/event_log/util.rs
@@ -165,11 +165,37 @@ pub(super) fn sync_tree(root: &Path) -> Result<(), LogError> {
             sync_tree(&path)?;
             continue;
         }
-        std::fs::File::open(&path)
-            .and_then(|file| file.sync_all())
+        fsync_file(&path)
             .map_err(|error| LogError::Io(format!("event log sync error: {error}")))?;
     }
     Ok(())
+}
+
+/// Flush a file's contents to durable storage in a cross-platform way.
+///
+/// `File::sync_all` lowers to `FlushFileBuffers` on Windows, which requires a
+/// handle opened with **write** access — calling it on a read-only handle
+/// (`File::open`) fails with `ERROR_ACCESS_DENIED` ("Access is denied"). On
+/// Unix, `fsync(2)` on a read-only descriptor is fine, which is why opening
+/// read-only "worked" everywhere except Windows. Always open for write so the
+/// sync succeeds on every platform.
+///
+/// If the file genuinely can't be opened for writing (e.g. read-only
+/// permissions), fall back to a read-only sync. That still flushes on Unix,
+/// and on Windows the OS write-back cache will persist the data on its own —
+/// so a durability *flush* must never become a hard error just because a file
+/// isn't writable.
+fn fsync_file(path: &Path) -> std::io::Result<()> {
+    match std::fs::OpenOptions::new().write(true).open(path) {
+        Ok(file) => file.sync_all(),
+        Err(write_err) => match std::fs::File::open(path) {
+            // Best-effort on a read-only file: succeeds on Unix; on Windows the
+            // access-denied here is expected and not worth failing the flush.
+            Ok(file) => file.sync_all().or(Ok(())),
+            // Surface the original write-open failure (e.g. the file vanished).
+            Err(_) => Err(write_err),
+        },
+    }
 }
 
 pub(super) fn now_ms() -> i64 {


### PR DESCRIPTION
## Problem

`FileEventLog::flush()` → `sync_tree()` opened every topic/consumer file **read-only** (`File::open`) and called `sync_all()`. On Windows `sync_all` lowers to `FlushFileBuffers`, which **requires a write-access handle** and fails with `ERROR_ACCESS_DENIED` ("Access is denied") on a read-only one. On Unix, `fsync(2)` on a read-only descriptor succeeds — which is exactly why this only ever broke on the Windows CI lane.

It surfaced as a hard `log.flush().await.unwrap()` panic in `harn-vm session_timeline::persisted_file_log_reads_agent_events`. That failed the Windows job → `ci-status` → and since `deploy-docs` is gated on `ci-status == success`, it **silently blocked all docs auto-deploys** (last successful auto-deploy was #2915).

## Fix

Route file fsync through a hardened `fsync_file` helper that opens the file **for write** so `sync_all` succeeds on every platform, with a read-only fallback so a durability flush never hard-errors on a genuinely read-only file (still flushes on Unix; the Windows write-back cache covers the rest).

## Why this is the complete fix (audited the class)

Swept every `sync_all`/`sync_data` call in the workspace:
- All other sites sync a **freshly-written write handle** (`File::create` / `OpenOptions.write/append`) — fine on Windows.
- The two **directory** fsyncs (`atomic_io`, `agent_state/backend`) are already best-effort `let _ = dir.sync_all()` (directory fsync isn't supported on Windows, and is correctly ignored).

So `sync_tree` was the sole read-only-fsync offender.

## Verification

- `cargo test -p harn-vm --lib event_log` → 26 passed
- `cargo test -p harn-vm --lib session_timeline` → 5 passed (incl. the previously Windows-failing test)
- The existing `persisted_file_log_reads_agent_events` test exercises `flush()` on the Windows lane, so it is the cross-platform regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)