### PR TITLE
[codex] fix harn test worker stack overflows

### DIFF
--- a/changelog.d/test-worker-stack.fixed.md
+++ b/changelog.d/test-worker-stack.fixed.md
@@ -1,0 +1,1 @@
+- Increased `harn test --parallel` worker thread stack size so deep agent/runtime tests do not crash with a Rust stack overflow.

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -9,6 +9,7 @@ use harn_lexer::Lexer;
 use harn_parser::{Attribute, Node, Parser, SNode};
 
 use crate::env_guard::ScopedEnvVar;
+use crate::CLI_RUNTIME_STACK_SIZE;
 
 /// Drain `harn-hostlib`'s process-global fs-snapshot sessions between test
 /// cases. The snapshot map is keyed by session id and only drained
@@ -791,6 +792,7 @@ async fn execute_cases(
         let diagnose = options.diagnose;
         let handle = thread::Builder::new()
             .name(format!("harn-test-worker-{worker_idx}"))
+            .stack_size(CLI_RUNTIME_STACK_SIZE)
             .spawn(move || {
                 let runtime = match tokio::runtime::Builder::new_current_thread()
                     .enable_all()


### PR DESCRIPTION
## Summary
- give `harn test --parallel` worker threads the same `CLI_RUNTIME_STACK_SIZE` used by the main CLI runtime
- add a changelog fragment for the stack overflow fix

## Why
The Burin destructuring migration exposed a runner-level failure: the default parallel Harn suite crashed in a `harn-test-worker-*` Rust thread with a stack overflow, while the same transformed tests passed sequentially. The worker threads were using the platform default stack even though other deep Harn CLI execution paths already opt into the larger CLI stack.

## Validation
- `cargo test -p harn-cli test_runner --lib`
- `cargo build -p harn-cli --bin harn`
- pre-commit hook: rustfmt, changed-package clippy, markdownlint
- pre-push hook: targeted local checks, markdownlint
- Burin regression: `BURIN_HARN_BINARY=/Users/ksinder/projects/harn-worktrees/test-worker-stack/target/debug/harn npm run test:harn` is running past the previous stack-overflow area under 8 workers
