### PR TITLE
test: de-flake and de-slow tests relying on wall-clock time and process-global state

### DIFF
--- a/changelog.d/flaky-time-tests.fixed.md
+++ b/changelog.d/flaky-time-tests.fixed.md
@@ -1,0 +1,7 @@
+- De-flaked and de-slowed several tests that relied on wall-clock timing or
+  process-global state. The `ResourceGate` scheduler tests now assert gate
+  state in-process via a non-blocking `try_acquire` instead of
+  `thread::sleep`-coaxed thread ordering, the worker-snapshot round-trip test
+  uses an explicit path instead of mutating the global `HARN_WORKER_STATE_DIR`
+  env var, and diagnostic color in tests is forced off via a thread-local
+  override instead of the process-global `NO_COLOR` env var.

--- a/crates/harn-cli/src/test_runner.rs
+++ b/crates/harn-cli/src/test_runner.rs
@@ -903,20 +903,44 @@ impl ResourceGate {
         let weight = weight.min(self.capacity).max(1);
         let mut state = self.state.lock().unwrap();
         loop {
-            let group_free = group.is_none_or(|g| !state.busy_groups.contains(g));
-            if state.available >= weight && group_free {
-                state.available -= weight;
-                if let Some(g) = group {
-                    state.busy_groups.insert(g.to_string());
-                }
-                return GateGuard {
-                    gate: self,
-                    weight,
-                    group: group.map(str::to_owned),
-                };
+            if let Some(guard) = self.try_grab_locked(&mut state, weight, group) {
+                return guard;
             }
             state = self.cond.wait(state).unwrap();
         }
+    }
+
+    /// Grab a permit if one is immediately available, holding the already-locked
+    /// state. Returns `None` without blocking when the pool is exhausted or the
+    /// group is busy. Shared by `acquire` (which retries) and `try_acquire`.
+    fn try_grab_locked<'a>(
+        &'a self,
+        state: &mut GateState,
+        weight: usize,
+        group: Option<&str>,
+    ) -> Option<GateGuard<'a>> {
+        let group_free = group.is_none_or(|g| !state.busy_groups.contains(g));
+        if state.available >= weight && group_free {
+            state.available -= weight;
+            if let Some(g) = group {
+                state.busy_groups.insert(g.to_string());
+            }
+            return Some(GateGuard {
+                gate: self,
+                weight,
+                group: group.map(str::to_owned),
+            });
+        }
+        None
+    }
+
+    /// Non-blocking variant of `acquire` used by tests to assert gate state
+    /// deterministically (in-process, no threads or wall-clock sleeps).
+    #[cfg(test)]
+    fn try_acquire(&self, weight: usize, group: Option<&str>) -> Option<GateGuard<'_>> {
+        let weight = weight.min(self.capacity).max(1);
+        let mut state = self.state.lock().unwrap();
+        self.try_grab_locked(&mut state, weight, group)
     }
 }
 
@@ -1097,7 +1121,6 @@ mod tests {
     use super::*;
 
     use std::sync::Arc;
-    use std::time::Duration;
 
     struct TempTestDir {
         inner: tempfile::TempDir,
@@ -1324,74 +1347,51 @@ pipeline test_cli_skills(task) {
 
     #[test]
     fn resource_gate_serializes_same_group() {
-        let gate = Arc::new(ResourceGate::new(4));
-        let trace = Arc::new(Mutex::new(Vec::<&'static str>::new()));
-
-        let g_a = {
-            let trace = Arc::clone(&trace);
-            let gate = Arc::clone(&gate);
-            thread::spawn(move || {
-                let _guard = gate.acquire(1, Some("login"));
-                trace.lock().unwrap().push("a-start");
-                thread::sleep(Duration::from_millis(50));
-                trace.lock().unwrap().push("a-end");
-            })
-        };
-        // Give thread A time to grab the lock first.
-        thread::sleep(Duration::from_millis(10));
-        let g_b = {
-            let trace = Arc::clone(&trace);
-            let gate = Arc::clone(&gate);
-            thread::spawn(move || {
-                let _guard = gate.acquire(1, Some("login"));
-                trace.lock().unwrap().push("b-start");
-                trace.lock().unwrap().push("b-end");
-            })
-        };
-        g_a.join().unwrap();
-        g_b.join().unwrap();
-
-        let trace = trace.lock().unwrap();
-        // B must not start until A ends.
-        let a_end = trace.iter().position(|t| *t == "a-end").unwrap();
-        let b_start = trace.iter().position(|t| *t == "b-start").unwrap();
-        assert!(a_end < b_start, "B started before A finished: {trace:?}");
+        // Deterministic, in-process: while one permit for a group is held, a
+        // second acquire for the SAME group cannot proceed; releasing frees it.
+        // (Previously this used two threads + `thread::sleep` to coax an
+        // ordering, which was both flaky and ~60ms of wall-clock per run.)
+        let gate = ResourceGate::new(4);
+        let g_a = gate.acquire(1, Some("login"));
+        assert!(
+            gate.try_acquire(1, Some("login")).is_none(),
+            "second acquire of a busy group must not proceed",
+        );
+        drop(g_a);
+        assert!(
+            gate.try_acquire(1, Some("login")).is_some(),
+            "group should be free once the holder releases",
+        );
     }
 
     #[test]
     fn resource_gate_allows_independent_groups_in_parallel() {
-        let gate = Arc::new(ResourceGate::new(4));
+        // Holding one group must never block an unrelated group, as long as
+        // permits remain. No threads needed — `try_acquire` proves it directly.
+        let gate = ResourceGate::new(4);
         let _guard_a = gate.acquire(1, Some("alpha"));
-        // Acquiring beta should not block — the other group is unrelated.
-        let acquired = std::sync::Mutex::new(false);
-        thread::scope(|s| {
-            s.spawn(|| {
-                let _ = gate.acquire(1, Some("beta"));
-                *acquired.lock().unwrap() = true;
-            });
-        });
-        assert!(*acquired.lock().unwrap());
+        assert!(
+            gate.try_acquire(1, Some("beta")).is_some(),
+            "an unrelated group must acquire without blocking",
+        );
     }
 
     #[test]
     fn resource_gate_caps_heavy_weight_at_capacity() {
         // A test that asks for more than the pool size must still be
-        // schedulable rather than deadlocking.
-        let gate = Arc::new(ResourceGate::new(2));
-        let _g = gate.acquire(99, None);
-        // Available is now 0; another single-weight task must still wait.
-        let started = Arc::new(Mutex::new(false));
-        let inner = Arc::clone(&started);
-        let gate2 = Arc::clone(&gate);
-        let handle = thread::spawn(move || {
-            let _guard = gate2.acquire(1, None);
-            *inner.lock().unwrap() = true;
-        });
-        thread::sleep(Duration::from_millis(20));
-        assert!(!*started.lock().unwrap(), "should still be waiting");
-        drop(_g);
-        handle.join().unwrap();
-        assert!(*started.lock().unwrap());
+        // schedulable (weight is capped to capacity) rather than deadlocking,
+        // and while it holds the whole pool no other task can acquire.
+        let gate = ResourceGate::new(2);
+        let g = gate.acquire(99, None);
+        assert!(
+            gate.try_acquire(1, None).is_none(),
+            "pool is fully consumed; a single-weight task must wait",
+        );
+        drop(g);
+        assert!(
+            gate.try_acquire(1, None).is_some(),
+            "permit becomes available once the heavy holder releases",
+        );
     }
 
     #[tokio::test]

--- a/crates/harn-parser/src/diagnostic.rs
+++ b/crates/harn-parser/src/diagnostic.rs
@@ -546,7 +546,26 @@ fn style_fragment(text: &str, color: Color, bold: bool) -> String {
     paint.to_string()
 }
 
+thread_local! {
+    /// Per-thread override for color output. When `Some`, it wins over the
+    /// `NO_COLOR` env var and TTY detection. This lets tests force colors off
+    /// deterministically without mutating the process-global `NO_COLOR` env
+    /// var, which races across parallel tests (each test runs on its own
+    /// thread, so the override is naturally isolated).
+    static COLOR_OVERRIDE: std::cell::Cell<Option<bool>> = const { std::cell::Cell::new(None) };
+}
+
+/// Force color output on (`Some(true)`), off (`Some(false)`), or restore the
+/// default env/TTY behavior (`None`) for the current thread only.
+#[cfg(test)]
+pub(crate) fn set_color_override(force: Option<bool>) {
+    COLOR_OVERRIDE.with(|cell| cell.set(force));
+}
+
 fn colors_enabled() -> bool {
+    if let Some(forced) = COLOR_OVERRIDE.with(std::cell::Cell::get) {
+        return forced;
+    }
     std::env::var_os("NO_COLOR").is_none() && std::io::stderr().is_terminal()
 }
 
@@ -602,9 +621,11 @@ mod tests {
     use super::*;
 
     /// Ensure ANSI colors are off so plain-text assertions work regardless
-    /// of whether the test runner's stderr is a TTY.
+    /// of whether the test runner's stderr is a TTY. Uses a thread-local
+    /// override rather than the process-global `NO_COLOR` env var so it can't
+    /// race with color-sensitive assertions in parallel tests.
     fn disable_colors() {
-        std::env::set_var("NO_COLOR", "1");
+        set_color_override(Some(false));
     }
 
     #[test]

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -1422,7 +1422,7 @@ fn test_assignment_type_check() {
 
 #[test]
 fn test_type_mismatch_render_snapshot_with_coercion_help() {
-    std::env::set_var("NO_COLOR", "1");
+    crate::diagnostic::set_color_override(Some(false));
     let source = r"pipeline t(task) {
   let label: string = 42
 }";
@@ -1448,7 +1448,7 @@ fn test_type_mismatch_render_snapshot_with_coercion_help() {
 
 #[test]
 fn test_type_mismatch_render_snapshot_with_nested_note() {
-    std::env::set_var("NO_COLOR", "1");
+    crate::diagnostic::set_color_override(Some(false));
     let source = r"pipeline t(task) {
   let item: {name: string, count: int} = {name: 1, count: 2}
 }";

--- a/crates/harn-vm/src/stdlib/agents_workers/tests.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/tests.rs
@@ -23,11 +23,15 @@ fn vm_dict(pairs: Vec<(&str, VmValue)>) -> VmValue {
 
 #[test]
 fn worker_snapshot_round_trip_preserves_resume_fields() {
+    // Use an explicit per-test snapshot path inside a unique temp dir instead of
+    // routing through the process-global `HARN_WORKER_STATE_DIR` env var. Mutating
+    // that var raced with any other test in this binary that reads it in parallel;
+    // `persist_worker_state_snapshot` writes `state.snapshot_path` directly and
+    // `load_worker_state_snapshot` accepts a full path, so the env var is unneeded.
     let dir = std::env::temp_dir().join(format!("harn-worker-test-{}", uuid::Uuid::now_v7()));
     std::fs::create_dir_all(&dir).unwrap();
-    unsafe { std::env::set_var("HARN_WORKER_STATE_DIR", &dir) };
 
-    let snapshot_path = worker_snapshot_path("worker_test");
+    let snapshot_path = dir.join("worker_test.json").to_string_lossy().into_owned();
     let state = WorkerState {
         id: "worker_test".to_string(),
         name: "worker".to_string(),
@@ -163,7 +167,6 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
     assert_eq!(loaded.audit.mutation_scope, "apply_worktree");
 
     let _ = std::fs::remove_dir_all(&dir);
-    unsafe { std::env::remove_var("HARN_WORKER_STATE_DIR") };
 }
 
 #[test]


### PR DESCRIPTION
## What

Swept every crate for tests with timing / non-determinism / process-env smells and re-architected the three genuine offenders so they can't go flaky or burn wall-clock time. All become deterministic and in-process.

### 1. `harn-cli` `ResourceGate` scheduler tests (`test_runner.rs`)
The three gate tests choreographed two threads with `thread::sleep(50ms)/sleep(10ms)/sleep(20ms)` to *coax* a thread ordering and then assert on it — flaky under CI load (the "give thread A time to grab the lock first" sleep is a classic race) and ~80ms of wall-clock per run.

Added a non-blocking `try_acquire` (sharing a new `try_grab_locked` helper with `acquire`, so production behavior is unchanged) and rewrote all three tests to assert gate state directly, single-threaded, in 0ms. Each test now checks the real invariant — busy-group serialization, independent-group concurrency, and full-pool exhaustion — without depending on the scheduler.

### 2. `harn-vm` `worker_snapshot_round_trip` (`agents_workers/tests.rs`)
The test mutated the process-global `HARN_WORKER_STATE_DIR` env var (unguarded), which races any sibling test reading it in parallel. The persist path writes `state.snapshot_path` directly and the load path accepts a full path, so the env var was never actually needed — the test now uses an explicit per-test temp path and the global mutation (and its `remove_var` cleanup) is gone.

### 3. `harn-parser` diagnostic/typing snapshot tests (`diagnostic.rs`, `typing.rs`)
These set `NO_COLOR=1` process-globally to force plain-text rendering, then asserted on exact output — an unguarded global mutation that could flip color for a color-sensitive sibling test running in parallel. Replaced with a thread-local `set_color_override(Some(false))`; `colors_enabled()` consults it first. Each test runs on its own thread, so the override is naturally isolated.

## Not changed (deliberately)
Reviewed and left alone — these are either legitimate event-waits on genuinely external I/O or already correctly guarded:
- MCP integration-test helpers (`recv_until`, `wait_for_child_log_suffix`) — block on `recv_timeout` waiting for real subprocess output; mock time isn't applicable and they're not flaky (block-until-event with a generous timeout).
- `otel_sink_export` env set — single-test integration binary, already documented.
- env/cwd mutations elsewhere — already serialized via `env_lock`/`cwd_lock`.
- `TcpListener::bind(:0)` sites — correctly use an ephemeral port.

## Verification
Ran the affected tests in each crate — all pass, and the gate tests now finish in `0.00s` (was ~80ms of sleeps):
- `cargo test -p harn-cli --lib resource_gate` → 3 passed
- `cargo test -p harn-vm --lib worker_snapshot_round_trip` → 1 passed
- `cargo test -p harn-parser --lib diagnostic:: ` + `test_type_mismatch_render_snapshot` → 9 passed

Full pre-commit/pre-push hook suite (build + clippy + tests + lint) passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)