### PR TITLE
ci(docs): decouple docs deploy from full CI gate + add website README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,21 +504,24 @@ jobs:
 
   deploy-docs:
     name: Deploy docs
-    needs: [ci-status]
+    # Gate ONLY on the docs site build, not the whole `ci-status` graph. The
+    # docs site is static content built solely from docs/src + website/, so it
+    # should publish whenever it builds green — independent of unrelated backend
+    # or test lanes. Gating on `ci-status` previously meant a docs change that
+    # merged while main was red elsewhere (e.g. a flaky Windows test) had its
+    # deploy silently skipped, and no later non-docs push ever re-fired it. This
+    # decouples docs delivery from the rest of CI so that can't recur.
+    needs: [docs-site]
     # Single `curl` to the Render deploy hook; running it on a self-hosted
     # runner adds no value.
     runs-on: ubuntu-latest
-    # `always()` is required: without it, this job is skipped whenever ANY job
-    # in the `ci-status` dependency graph is skipped (e2e is label-gated, and
-    # windows/rust-builds are path-filtered), even though `ci-status` itself
-    # succeeds. That GitHub Actions quirk silently disabled docs auto-deploy
-    # for weeks. See actions/runner#2205. We re-assert the success gate
-    # explicitly via `needs.ci-status.result`.
+    # `always()` keeps the job evaluable even if `docs-site` were ever skipped
+    # (the actions/runner#2205 quirk); the explicit success check is the gate.
     if: >-
       always()
       && github.ref == 'refs/heads/main'
       && github.event_name == 'push'
-      && needs.ci-status.result == 'success'
+      && needs['docs-site'].result == 'success'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/changelog.d/docs-deploy-decouple.changed.md
+++ b/changelog.d/docs-deploy-decouple.changed.md
@@ -1,0 +1,6 @@
+- **Docs deploys are decoupled from the rest of CI.** The `deploy-docs` job now gates on the
+  `docs-site` build succeeding instead of the whole `ci-status` graph, so a docs/site change
+  publishes to harnlang.com whenever the site builds green — independent of unrelated backend or
+  test lanes. Previously a docs change that merged while `main` was red elsewhere (e.g. a flaky
+  Windows test) had its Render deploy silently skipped and never re-fired. Added a `website/README.md`
+  documenting the site's stack, build, and deploy flow.

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,61 @@
+# harnlang.com
+
+The marketing site and documentation for [harnlang.com](https://harnlang.com) — a custom
+Vite + React + Tailwind app that renders the Diataxis-structured Markdown in `../docs/src`.
+It replaced mdBook in #2922.
+
+The content stays in `docs/src/` (so every generator and checker — `check-docs-snippets`, the
+language-spec mirror, diagnostics, `harn-keywords.js` — is unaffected). This app is only the
+rendering layer.
+
+## Develop
+
+```bash
+npm install
+npm run dev
+```
+
+The dev server reads `../docs/src/**/*.md` live; edits to docs or to the app hot-reload.
+
+## Build
+
+```bash
+npm run build
+```
+
+This runs `tsc`, the Vite client build, the Vite SSR build, and `prerender.mjs`, emitting a
+statically prerendered, fully crawlable site into `../docs/dist`. The canonical build entry point
+is `../scripts/build_docs_site.sh`, which also mirrors the raw `.md` sources and the LLM
+quick-reference files into `docs/dist`.
+
+```bash
+npm run typecheck   # tsc -b --noEmit
+```
+
+## How it works
+
+- **Content pipeline** (`vite-plugins/content.ts`): globs `docs/src/**/*.md`, resolves mdBook
+  `{{#include}}` directives, rewrites intra-doc links to `.html` URLs, parses `SUMMARY.md` into the
+  nav tree + section tabs, and renders Markdown to HTML with `unified`/`remark`/`rehype`.
+- **Harn highlighting**: a grammar ported from the old `harn-hljs.js`, fed by the Rust-generated
+  `docs/theme/harn-keywords.js` (regenerate with `make gen-highlight`).
+- **Search**: a client-side index (`_content/search.json`) fetched on first ⌘K.
+- **SSG** (`prerender.mjs`): renders every route to a real HTML file, embeds per-page JSON for
+  hydration, and emits the legacy redirect stubs.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `index.html` | App shell + pre-hydration theme script |
+| `src/pages/` | `LandingPage`, `DocPage`, `DocRoute`, `NotFound` |
+| `src/layouts/RootLayout.tsx` | Navbar, footer, ⌘K search |
+| `src/components/` | Navbar, Footer, Logo, ThemeToggle, SearchModal, HarnMockup |
+| `vite-plugins/` | Build-time content pipeline + virtual modules |
+| `prerender.mjs` | Static-site generation |
+
+## Deploy
+
+Pushes to `main` that touch `docs/` or `website/` fire the `deploy-docs` CI job, which calls the
+Render deploy hook for the `harn-docs` static site (build command `./scripts/build_docs_site.sh`,
+publish directory `docs/dist`).


### PR DESCRIPTION
## Why

When the mdBook→custom-site cutover (#2922) merged, `main` happened to be red on an unrelated Windows test, so the `deploy-docs` job (gated on `ci-status == success`) was **skipped** and the new site never published. Because `deploy-docs`'s change-detection only inspects the immediate push diff, no later (Rust-only) push re-fired it — the docs deploy was silently lost. Fixing the Windows test (#2924) removed the gate, but nothing re-triggered the deploy.

## What

1. **Harden `deploy-docs`:** gate on the **`docs-site`** build succeeding instead of the whole **`ci-status`** graph. The docs site is static content built only from `docs/src` + `website/`, so it should publish whenever it builds green, independent of unrelated backend/test lanes. This makes "a docs change merged while main is red elsewhere" deploy correctly instead of being lost.
2. **Add `website/README.md`** documenting the site's stack, dev/build/typecheck commands, content pipeline, layout, and deploy flow. Touching `website/` here also **re-fires the docs deploy** that was lost in the cutover window.

## Settings double-check (per request)

- Merge gate = required checks **"CI status"** (org `main protection` ruleset) + **"drift"** (repo `release drift required`); merge queue is ALLGREEN/SQUASH.
- `deploy-docs` is **not** a required check and only runs on `push` (never in the merge queue), so changing its `needs`/gating **cannot affect merging**.
- The `ci-status` job keeps its exact name **"CI status"**, so the org gate still matches.
- Used bracket syntax `needs['docs-site'].result` (hyphenated job id) — actionlint-clean; `ci.yml` YAML validated; `website/README.md` markdownlint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)