### PR TITLE
test(smoke): cover agent_loop + documented quickstart, add install-channel smoke

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,114 @@
+name: Install channels smoke
+
+# Weekly smoke of the *user-facing install channels* against the latest
+# published release:
+#   * `cargo install harn-cli` (crates.io)
+#   * the `install.sh` GitHub-release download path
+#
+# `release-smoke.yml` validates the exact release bytes at tag-cut time but
+# never re-installs afterwards, so it cannot see drift that appears *between*
+# releases: a transitive dependency that stops building on crates.io, a
+# yanked crate, or `install.sh` OS/arch detection regressing against a live
+# release. This job re-walks both install paths from scratch on a schedule
+# and then runs the cross-platform smoke driver against whatever got
+# installed (pinned to the matching release tag via
+# scripts/smoke_installed_binary.sh).
+#
+# Cold `cargo install` builds are slow, so this runs weekly rather than
+# daily and is deliberately kept off the PR critical path.
+on:
+  schedule:
+    - cron: '23 11 * * 1' # Mondays
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Optional release tag to install, e.g. v0.8.65. Empty installs the latest published release.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-smoke-${{ inputs.version || github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  HARN_LLM_CALLS_DISABLED: "1"
+
+jobs:
+  cargo-install:
+    name: cargo install harn-cli (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            runner: ubuntu-latest
+          - platform: macos
+            runner: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      # Mirror the documented `cargo install harn-cli`. No `--locked`: a user
+      # typing the documented command gets a fresh dependency resolution, and
+      # catching breakage in that resolution is the whole point of this gate.
+      - name: cargo install harn-cli
+        shell: bash
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${VERSION_INPUT:-}" ]]; then
+            cargo install harn-cli --version "${VERSION_INPUT#v}"
+          else
+            cargo install harn-cli
+          fi
+          "$HOME/.cargo/bin/harn" --version
+
+      - name: Smoke the installed binary
+        shell: bash
+        run: HARN_BINARY="$HOME/.cargo/bin/harn" ./scripts/smoke_installed_binary.sh
+
+  install-sh:
+    name: install.sh (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            runner: ubuntu-latest
+          - platform: macos
+            runner: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Run the repo's own install.sh (identical to the bytes served at
+      # harnlang.com/install.sh) so the GitHub-release download, SHA256
+      # verification, and OS/arch detection are exercised against a live
+      # release. Install to a scratch dir and skip PATH edits — the smoke
+      # references the binary by absolute path.
+      - name: Run install.sh
+        shell: bash
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+          HARN_INSTALL_DIR: ${{ runner.temp }}/harn-install
+          HARN_NO_MODIFY_PATH: "1"
+        run: |
+          set -euo pipefail
+          export HARN_VERSION="${VERSION_INPUT:-}"
+          sh ./install.sh
+          "$HARN_INSTALL_DIR/harn" --version
+
+      - name: Smoke the installed binary
+        shell: bash
+        env:
+          HARN_BINARY: ${{ runner.temp }}/harn-install/harn
+        run: ./scripts/smoke_installed_binary.sh

--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -240,19 +240,35 @@ run_step "harn check --provider-matrix" smoke_provider_matrix
 # and `println` host call work end-to-end on this platform.
 run_step "harn run tests/smoke/hello.harn" "$HARN" run tests/smoke/hello.harn
 
-# Step 8: process tool. Spawns one short-lived child via std/command
+# Step 8: documented quickstart. Runs the literal first script from
+# docs/src/getting-started.md — the `fn main(harness: Harness)` entry
+# point plus a `harness.stdio.println` host call. CI only *typechecks*
+# that snippet (scripts/check_docs_snippets.sh runs `harn check`); running
+# it here freezes the documented first-run experience end-to-end against
+# the released binary and exercises the capability-aware entry path that
+# the `pipeline default()` hello fixture does not.
+run_step "harn run tests/smoke/quickstart.harn" "$HARN" run tests/smoke/quickstart.harn
+
+# Step 9: process tool. Spawns one short-lived child via std/command
 # with platform-appropriate argv. Confirms the sandboxed process
 # spawn path resolves on every platform — Seatbelt on macOS, Landlock
 # +seccomp on Linux, AppContainer/Job Objects on Windows. Failures
 # here usually mean the sandbox backend regressed for one platform.
 run_step "harn run tests/smoke/process.harn" "$HARN" run tests/smoke/process.harn
 
-# Step 9: no-credentials workflow. Drives the LLM call path through
+# Step 10: no-credentials workflow. Drives the LLM call path through
 # `provider: "mock"` so we touch the agent runtime without API keys,
 # secret stores, or network access.
 run_step "harn run tests/smoke/mock_workflow.harn" "$HARN" run tests/smoke/mock_workflow.harn
 
-# Step 10: file-watch boot. See smoke_watch_boot above.
+# Step 11: agent loop. Drives the headline `agent_loop` abstraction
+# through `provider: "mock"`: a scripted multi-turn loop that issues one
+# native tool call, consumes the deterministic tool result, then completes
+# naturally. Exercises the agent runtime, tool dispatch, and loop
+# termination that the flat mock_workflow `llm_call` cannot reach.
+run_step "harn run tests/smoke/agent_loop.harn" "$HARN" run tests/smoke/agent_loop.harn
+
+# Step 12: file-watch boot. See smoke_watch_boot above.
 run_step "harn watch boot" smoke_watch_boot
 
 if [[ "$FAILED" -ne 0 ]]; then

--- a/scripts/smoke_installed_binary.sh
+++ b/scripts/smoke_installed_binary.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Smoke an already-installed `harn` binary that came from a user-facing
+# install channel (`cargo install harn-cli` or `install.sh`) against the
+# cross-platform release smoke driver.
+#
+# The per-tag `release-smoke.yml` gate validates the binary at release
+# time. This helper backs `install-smoke.yml`, which catches drift
+# *between* releases — a transitive dependency that stops building on
+# crates.io, `install.sh` OS/arch detection regressing, a yanked crate —
+# that the release-time gate cannot observe because it never re-installs.
+#
+# It derives the release tag from the binary's reported version, overlays
+# `scripts/release_smoke.sh` and the `tests/smoke` fixtures from that tag
+# so the driver matches the published binary under test (the working tree
+# may be ahead of the latest release), then runs the driver.
+#
+# Usage: HARN_BINARY=/path/to/harn scripts/smoke_installed_binary.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+HARN="${HARN_BINARY:?HARN_BINARY must point at the installed harn binary}"
+if [[ ! -x "$HARN" ]]; then
+  echo "::error::install-smoke: harn binary not found or not executable at $HARN"
+  exit 1
+fi
+
+raw_version="$("$HARN" --version)"
+# `harn --version` prints `harn X.Y.Z`; take the first semver-looking token
+# so the parse survives banner tweaks (build metadata, extra fields).
+version="$(printf '%s\n' "$raw_version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+if [[ -z "$version" ]]; then
+  echo "::error::install-smoke: could not parse a version from '$raw_version'"
+  exit 1
+fi
+tag="v${version}"
+echo "::notice::install-smoke: installed harn reports '${raw_version}'; smoking against tag ${tag}"
+
+# Fetch just the matching tag (the checkout action does a shallow clone of
+# the triggering ref and omits tags) and overlay only the driver and
+# fixtures. Path-scoped checkout leaves this running script untouched.
+if ! git fetch --depth 1 origin "refs/tags/${tag}:refs/tags/${tag}"; then
+  echo "::error::install-smoke: could not fetch release tag ${tag}; is the release published?"
+  exit 1
+fi
+git checkout "$tag" -- scripts/release_smoke.sh tests
+
+HARN_BINARY="$HARN" ./scripts/release_smoke.sh

--- a/tests/smoke/agent_loop.harn
+++ b/tests/smoke/agent_loop.harn
@@ -1,0 +1,66 @@
+/**
+ * Agent-loop smoke fixture for the cross-platform release smoke matrix.
+ * Exercises the headline `agent_loop` abstraction end-to-end through the
+ * built-in `provider: "mock"` path: a scripted two-turn loop that issues
+ * one native tool call, consumes the deterministic tool result, then
+ * completes with a plain final turn (natural completion in native mode).
+ * Runs without API keys, network, or platform-specific secret stores.
+ *
+ * Complements mock_workflow.harn (a single flat `llm_call`) by covering
+ * the multi-iteration, tool-using loop that the flat fixture cannot: a
+ * regression in the agent runtime, tool dispatch, or loop termination
+ * lights up here before a release tag is cut. Mirrors
+ * conformance/tests/agents/agent_loop_native_natural_completion.harn but
+ * stays minimal and ASCII/LF-only so smoke output byte-compares on every
+ * platform.
+ */
+import { llm_text, llm_tool_call, with_llm_script } from "std/testing"
+
+fn smoke_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "add",
+    "Add two integers",
+    {
+      handler: { args -> args.lhs + args.rhs },
+      parameters: {
+        lhs: {type: "number", description: "Left addend"},
+        rhs: {type: "number", description: "Right addend"},
+      },
+      returns: {type: "number"},
+      annotations: {kind: "read"},
+    },
+  )
+  return tools
+}
+
+pipeline default() {
+  with_llm_script(
+    [llm_tool_call("add", {lhs: 2, rhs: 3}), llm_text("The sum is 5.")],
+    { ->
+      let result = agent_loop(
+        "Add 2 and 3 using the tool, then report the sum.",
+        nil,
+        {
+          provider: "mock",
+          tools: smoke_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 4,
+          done_judge: nil,
+        },
+      )
+      if result.status != "done" {
+        throw "agent loop smoke failed: expected status=done, got ${result.status}"
+      }
+      if result.llm.iterations < 2 {
+        throw "agent loop smoke failed: expected >=2 LLM iterations, got ${result.llm.iterations}"
+      }
+      if !contains(result.tools.successful, "add") {
+        throw "agent loop smoke failed: expected the add tool to run, got ${result.tools.successful}"
+      }
+      __io_println("agent loop ok")
+    },
+  )
+}

--- a/tests/smoke/quickstart.harn
+++ b/tests/smoke/quickstart.harn
@@ -1,0 +1,16 @@
+/**
+ * Documented-quickstart smoke fixture for the cross-platform release
+ * smoke matrix. This is the *literal* first runnable script from the
+ * getting-started guide (docs/src/getting-started.md): the
+ * `fn main(harness: Harness)` entry point plus a `harness.stdio.println`
+ * host call. The docs snippet is typecheck-only in CI (check_docs_snippets.sh
+ * runs `harn check`); this fixture *executes* it against the released
+ * binary so the documented first-run experience stays frozen end-to-end.
+ *
+ * Distinct from hello.harn, which covers the `pipeline default()` +
+ * `__io_println` path. Keep this byte-for-byte aligned with the docs
+ * snippet; if the documented quickstart changes, update both together.
+ */
+fn main(harness: Harness) {
+  harness.stdio.println("Hello, world!")
+}


### PR DESCRIPTION
## What & why

Extends the existing cross-platform release-smoke matrix and adds a **weekly** gate on the user-facing install channels. Everything here is **free and deterministic**: every LLM path runs through the built-in `provider: "mock"` with `HARN_LLM_CALLS_DISABLED=1` — no API keys, no network, no spend — and **nothing lands on the PR critical path** (release-smoke runs on cron/tag; install-smoke runs weekly).

Starting point (already comprehensive): `release-smoke.yml` + `scripts/release_smoke.sh` download the exact published release binary per platform and exercise `--version`/`--help`/`check`/`fmt`/`package`/`provider-matrix`/`run`/`process`/`watch` plus a single flat `llm_call` via the mock provider. This PR closes the three real gaps in that coverage.

## Changes

**1. `agent_loop` end-to-end smoke (the headline gap)**
`agent_loop` — the flagship abstraction — was never exercised end-to-end against a real binary, only via in-process conformance. Adds `tests/smoke/agent_loop.harn`: a scripted two-turn mock loop that issues one native tool call, consumes the deterministic tool result, then completes naturally. Asserts `status == "done"`, `>= 2` LLM iterations, and that the tool actually ran. Wired in as `release_smoke.sh` **step 11**.

**2. Documented quickstart, executed (gap #3 — light)**
The documented first-run script (`fn main(harness: Harness)` + `harness.stdio.println`) was only *typechecked* in CI (`check_docs_snippets.sh` runs `harn check`), never executed. Adds `tests/smoke/quickstart.harn` — the literal getting-started snippet — as **step 8**, so the documented first-run experience is frozen end-to-end against the released binary (and covers the capability-aware entry path the `pipeline default()` hello fixture doesn't).

**3. Weekly install-channel smoke (gap #2)**
The published install channels are only validated at tag-cut time and never re-installed, so drift *between* releases goes uncaught (a transitive dep that stops building on crates.io, a yanked crate, `install.sh` OS/arch detection regressing). Adds `.github/workflows/install-smoke.yml`: a weekly (Mondays) + `workflow_dispatch` job that runs `cargo install harn-cli` and `install.sh` on Linux + macOS, then smokes the installed binary via `scripts/smoke_installed_binary.sh`, which pins the smoke driver + fixtures to the installed binary's release tag to avoid version skew.

## Considered and rejected
A stand-in small CPU LLM (e.g. llama.cpp): non-deterministic output defeats byte-comparison, it's slow to pull/run in a worker, and it tests the inference engine more than Harn. The built-in mock provider exercises the full agent runtime deterministically — the correct choice for a smoke gate.

A default-on PR check: per-PR CI already drives `agent_loop` against mocks in conformance; a PR-time *binary* smoke would mostly duplicate that while adding minutes to merge. Kept off the critical path.

## Verification
- All three fixtures `harn check` + `harn run` clean (exit 0) with `HARN_LLM_CALLS_DISABLED=1`.
- Full `scripts/release_smoke.sh` driver: all 12 steps pass, driver exit 0 (caught + fixed a `fmt --check` miss on the new fixtures).
- `shellcheck` + `bash -n` clean on `smoke_installed_binary.sh`; `actionlint` + YAML parse clean on `install-smoke.yml`.
- Helper's version-parse → tag-derivation validated against the live binary (`harn 0.8.65` → `v0.8.65`), tag confirmed on origin, checkout paths confirmed present at the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)