### PR TITLE
fix(highlighting): cover missing keywords, nested comments, raw strings

### DIFF
--- a/changelog.d/syntax-highlighting-drift.fixed.md
+++ b/changelog.d/syntax-highlighting-drift.fixed.md
@@ -1,0 +1,8 @@
+- Tree-sitter highlighting now covers `break`, `continue`, `require`, and the
+  HITL keywords (`ask_user`, `dual_control`, `escalate_to`,
+  `request_approval`). They are valid grammar keywords but were silently
+  rendered as plain identifiers in Neovim and other tree-sitter editors.
+- The VS Code TextMate grammar now nests block comments, so a `*/` inside a
+  `/* ... */` no longer ends the comment early, and recognizes raw string
+  literals (`r"..."`), which previously orphaned the `r` prefix and
+  mis-highlighted backslashes as escape sequences.

--- a/editors/vscode/syntaxes/harn.tmLanguage.json
+++ b/editors/vscode/syntaxes/harn.tmLanguage.json
@@ -22,14 +22,33 @@
           "match": "//.*$"
         },
         {
-          "name": "comment.block.harn",
-          "begin": "/\\*",
-          "end": "\\*/"
+          "include": "#block-comment"
+        }
+      ]
+    },
+    "block-comment": {
+      "name": "comment.block.harn",
+      "begin": "/\\*",
+      "end": "\\*/",
+      "patterns": [
+        {
+          "include": "#block-comment"
         }
       ]
     },
     "strings": {
       "patterns": [
+        {
+          "name": "string.quoted.raw.harn",
+          "begin": "r\"",
+          "end": "\"",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.string.begin.harn" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.string.end.harn" }
+          }
+        },
         {
           "name": "string.quoted.double.harn",
           "begin": "\"",

--- a/tree-sitter-harn/queries/highlights.scm
+++ b/tree-sitter-harn/queries/highlights.scm
@@ -10,6 +10,8 @@
 "for" @keyword.repeat
 "in" @keyword.repeat
 "while" @keyword.repeat
+"break" @keyword.repeat
+"continue" @keyword.repeat
 "match" @keyword.conditional
 "retry" @keyword
 "try" @keyword.exception
@@ -34,6 +36,7 @@
 "emit" @keyword
 "deadline" @keyword
 "guard" @keyword
+"require" @keyword
 "mutex" @keyword
 "select" @keyword
 "from" @keyword
@@ -45,6 +48,12 @@
 "not" @keyword.operator
 "to" @keyword.operator
 "exclusive" @keyword.operator
+
+; HITL primitives (reserved keywords parsed as call-like statements)
+"ask_user" @keyword
+"dual_control" @keyword
+"escalate_to" @keyword
+"request_approval" @keyword
 
 ; Literals
 (true) @boolean


### PR DESCRIPTION
## Summary

Fixes two independent, genuinely-reachable syntax-highlighting defects across the two hand-maintained editor grammars. Both were verified end-to-end with the real highlighting engines.

### 1. tree-sitter `queries/highlights.scm` — missing keyword highlights

`grammar/keywords.js` is lexer-synced and CI-guarded (`make check-tree-sitter-keywords`), but the highlight **queries** are not guarded and had drifted. Seven keywords that the grammar genuinely produces were never highlighted and rendered as plain identifiers in Neovim and other tree-sitter consumers:

- `break`, `continue` → now `@keyword.repeat`
- `require` → now `@keyword`
- HITL primitives `ask_user`, `dual_control`, `escalate_to`, `request_approval` → now `@keyword`

**Verification:** regenerated the parser and ran `tree-sitter query queries/highlights.scm` against a sample exercising all seven — every one now captures. `tree-sitter test` still passes 50/50 corpus tests.

### 2. VS Code `harn.tmLanguage.json` — nested comments & raw strings

- **Nested block comments:** the lexer supports nesting (depth tracking + `lexer.rs` test `/* outer /* nested */ still */ 42` → `42`), but the TextMate `/* … */` rule could not nest. `/* a /* b */ c */` leaked `c */` back out as code (highlighting `c` as a type). Fixed with a self-including `#block-comment` rule.
- **Raw strings:** the lexer lexes `r"..."` (`read_raw_string`), but the grammar had no pattern — the `r` prefix was orphaned and backslashes were mis-highlighted as escape sequences. Added a `string.quoted.raw.harn` rule with no escape/interpolation handling, matching the lexer.

**Verification:** tokenized before/after with `vscode-textmate` + `vscode-oniguruma`. Before: `STILL_COMMENT` highlighted as a type, `r"C:\Users\n"` split with false `\U`/`\n` escapes. After: comment stays fully commented, raw string is a single `string.quoted.raw.harn` span, and plain strings/escapes are unchanged.

## Scope

Editor-grammar only — no Rust, no lexer/grammar, no new primitives. Single changelog fragment added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)