### PR TITLE
fix(pool): close max_concurrent over-admission race in dispatch

### DIFF
--- a/changelog.d/pool-cap-over-admission.fixed.md
+++ b/changelog.d/pool-cap-over-admission.fixed.md
@@ -1,0 +1,7 @@
+- **Pool `max_concurrent` could transiently over-admit under concurrent dispatch.** A worker-pool dispatcher
+  popped a queued task under the pool lock but inserted it into the active set under a *separate* lock hold,
+  so a `submit` racing a finishing task's `finalize_task` could both admit into the same free slot —
+  momentarily running `max_concurrent + 1` (or more) tasks. Dispatchers now reserve the slot at pop time and
+  the admission check counts in-flight reservations, so the cap holds strictly. (Surfaced as a rare flake in
+  `tests/pool/max_concurrent_caps_in_flight.harn`; a higher-contention reproduction over-admitted ~50% of
+  runs before the fix and 0% after.)

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -155,6 +155,13 @@ struct PoolEntry {
     backpressure: BackpressureStrategy,
     round_robin_after: Option<String>,
     active: HashMap<String, Arc<parking_lot::Mutex<TaskState>>>,
+    /// Tasks popped from `queue` by a dispatcher but not yet inserted into
+    /// `active`. The pop (in `dispatch_ready`) and the insert (in `spawn_task`)
+    /// happen under separate lock holds, so without counting these reservations
+    /// two concurrent dispatchers — e.g. a `submit` racing a `finalize_task` —
+    /// could both admit into the same free slot and momentarily run more than
+    /// `max_concurrent` tasks. The admission check counts `active + reserved`.
+    reserved_slots: usize,
     tasks: BTreeMap<String, Arc<parking_lot::Mutex<TaskState>>>,
     space_waiters: Vec<tokio::sync::oneshot::Sender<()>>,
     /// Optional per-create user-supplied config (queue strategy, priority
@@ -1199,6 +1206,7 @@ async fn pool_create_sync(
         backpressure,
         round_robin_after: None,
         active: HashMap::new(),
+        reserved_slots: 0,
         tasks: BTreeMap::new(),
         space_waiters: Vec::new(),
         config: ordered_pool_config(&opts),
@@ -2057,11 +2065,15 @@ fn dispatch_ready(pool: &Arc<parking_lot::Mutex<PoolEntry>>) {
     loop {
         let next = {
             let mut pool_ref = pool.lock();
-            if pool_ref.active.len() >= pool_ref.max_concurrent {
+            // Reserve against tasks already popped by a concurrent dispatcher but
+            // not yet inserted into `active`, so two dispatchers can never admit
+            // into the same free slot (transient over-admission past the cap).
+            if pool_ref.active.len() + pool_ref.reserved_slots >= pool_ref.max_concurrent {
                 break;
             }
             let next = pop_next_task(&mut pool_ref);
             if next.is_some() {
+                pool_ref.reserved_slots += 1;
                 freed_queue_space = true;
             }
             next
@@ -2369,6 +2381,9 @@ fn spawn_task(pool: Arc<parking_lot::Mutex<PoolEntry>>, pending: PendingTask) {
     let dequeue_receipt = {
         let mut pool_ref = pool.lock();
         pool_ref.active.insert(task_id, state.clone());
+        // The reservation `dispatch_ready` made for this task is now realized as
+        // a live `active` entry.
+        pool_ref.reserved_slots = pool_ref.reserved_slots.saturating_sub(1);
         let slot_index = pool_ref.active.len().saturating_sub(1);
         let receipt = pool_dequeue_receipt(&pool_ref, &state.lock(), slot_index);
         persist_task_if_durable(&pool_ref, &state.lock());


### PR DESCRIPTION
## Fix transient `max_concurrent` over-admission in the worker pool

`tests/pool/max_concurrent_caps_in_flight.harn` flaked in the merge queue
(`peak <= 2` observed `false`). The test is correct — `peak` can only exceed the
cap if the pool runs more than `max_concurrent` task bodies at once — so this is
a real, if rare, **over-admission bug**.

### Root cause

`dispatch_ready` is the pool's sole admission chokepoint. It pops a queued task
**under the pool lock**, then `spawn_task` inserts it into `active` under a
**separate** lock acquisition. Between the pop and the insert, `active.len()`
does not yet reflect the in-flight task. Two dispatchers running concurrently —
a main-thread `submit` and a worker-thread `finalize_task` (or two finishing
tasks) — can therefore both observe `active.len() < max_concurrent` for the same
free slot and both admit, momentarily running `max_concurrent + 1` (or more)
bodies.

### Fix

Reserve the slot at pop time. `PoolEntry` gains a `reserved_slots` counter:
`dispatch_ready` increments it when it pops (still under the lock) and the
admission check is now `active.len() + reserved_slots >= max_concurrent`;
`spawn_task` decrements it when the task lands in `active`. Pop→reserve and
insert→release are each atomic under the lock, so no two dispatchers can admit
into the same slot. The counter can never leak: every `dispatch_ready` pop is
immediately followed by exactly one `spawn_task`, which always inserts (and so
always releases the reservation, even on the no-context early-return path).

### Verification

A higher-contention reproduction (`max_concurrent: 3`, 40 tasks) made the race
frequent:

| | peak=3 (ok) | peak=4 | peak=5 |
|---|---|---|---|
| before | 30/60 | 23/60 | 7/60 |
| after  | 60/60 | 0 | 0 |

So the cap held strictly in 60/60 runs after the fix (and the in-tree
conformance test passes). No behavior change otherwise — the reservation only
tightens admission; it cannot cause under-admission or deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
