### PR TITLE
Deflake env-racing and wall-clock-dependent tests

### DIFF
--- a/crates/harn-cli/src/skill_loader.rs
+++ b/crates/harn-cli/src/skill_loader.rs
@@ -611,6 +611,9 @@ mod tests {
 
     #[test]
     fn cli_dirs_produce_registry_entries() {
+        // Acquire the env lock: `load_skills` reads HOME and HARN_SKILLS_PATH,
+        // which sibling tests mutate while holding this same lock.
+        let _env = lock_env().blocking_lock();
         let tmp = tempfile::tempdir().unwrap();
         write_skill(tmp.path(), "deploy", "deploy", "body A");
         let loaded = load_skills(&SkillLoaderInputs {

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -1874,11 +1874,30 @@ fn vm_string_list(value: &VmValue) -> Option<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::OnceLock;
+
+    use tokio::sync::Mutex;
+
     use super::{
         HITL_APPROVALS_TOPIC, HITL_DUAL_CONTROL_TOPIC, HITL_ESCALATIONS_TOPIC, HITL_QUESTIONS_TOPIC,
     };
     use crate::event_log::{install_default_for_base_dir, EventLog, Topic};
     use crate::{compile_source, register_vm_stdlib, reset_thread_local_state, Vm, VmError};
+
+    /// Serialize tests that exercise the request-approval path. Those tests
+    /// drive the Harn VM through its full HITL state machine and rely on
+    /// thread-local event-log handles that are set up by
+    /// `execute_hitl_script` → `reset_thread_local_state()`. Under heavy
+    /// parallel load the OS thread that a `current_thread` tokio runtime
+    /// runs on can be reused between tests; if the outgoing test's async
+    /// drop runs concurrently with the incoming test's reset the thread-
+    /// local event log is in a transitional state and events can be double-
+    /// counted or missed. Holding this mutex for the duration of each test
+    /// turns the hazard into a hard serialize.
+    fn hitl_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     async fn execute_hitl_script(
         base_dir: &std::path::Path,
@@ -1967,8 +1986,10 @@ pipeline test(task) {
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_approval_waits_for_quorum_and_emits_a_record() {
+        let _guard = hitl_lock().lock().await;
         tokio::task::LocalSet::new()
             .run_until(async {
+                reset_thread_local_state();
                 let dir = tempfile::tempdir().expect("tempdir");
                 let source = r#"
 pipeline test(task) {
@@ -2049,8 +2070,10 @@ pipeline test(task) {
 
     #[tokio::test(flavor = "current_thread")]
     async fn request_approval_surfaces_denials_as_typed_errors() {
+        let _guard = hitl_lock().lock().await;
         tokio::task::LocalSet::new()
             .run_until(async {
+                reset_thread_local_state();
                 let dir = tempfile::tempdir().expect("tempdir");
                 let source = r#"
 pipeline test(task) {

--- a/crates/harn-vm/src/tracing.rs
+++ b/crates/harn-vm/src/tracing.rs
@@ -753,14 +753,26 @@ mod tests {
 
     #[test]
     fn test_span_event_offset_is_monotonic() {
+        // Use a mock clock so the test is deterministic under any load and
+        // requires zero wall-clock time. The mock is advanced by 10 ms
+        // between the two events, guaranteeing a strictly-increasing offset
+        // rather than relying on the OS scheduler to deliver >= 1 ms of
+        // real elapsed time between the two `record_event` calls.
+        let clock = crate::clock_mock::MockClock::at_wall_ms(1_000_000_000_000);
+        let _guard = crate::clock_mock::install_override(clock.clone());
         let mut c = SpanCollector::new();
         let id = c.start(SpanKind::UserTiming, "outer".into());
         assert!(c.record_event(id, "before".into(), BTreeMap::new()));
-        // Wait a beat so the offsets diverge on real Instant clocks.
-        std::thread::sleep(std::time::Duration::from_millis(2));
+        clock.advance_std_sync(std::time::Duration::from_millis(10));
         assert!(c.record_event(id, "after".into(), BTreeMap::new()));
         let closed = c.end(id).expect("open span");
         assert_eq!(closed.events.len(), 2);
-        assert!(closed.events[1].offset_ms >= closed.events[0].offset_ms);
+        assert!(
+            closed.events[1].offset_ms > closed.events[0].offset_ms,
+            "second event should have a strictly greater offset after a 10ms advance; \
+             before={} after={}",
+            closed.events[0].offset_ms,
+            closed.events[1].offset_ms
+        );
     }
 }

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -1772,9 +1772,7 @@ mod tests {
     use super::*;
     use crate::event_log::{install_default_for_base_dir, reset_active_event_log};
     use crate::events::{add_event_sink, clear_event_sinks, CollectorSink, EventLevel};
-    use crate::triggers::test_util::timing::FILE_WATCH_FALLBACK_POLL;
     use std::rc::Rc;
-    use time::OffsetDateTime;
 
     fn manifest_spec(id: &str, fingerprint: &str) -> TriggerBindingSpec {
         TriggerBindingSpec {
@@ -2065,8 +2063,14 @@ mod tests {
         install_manifest_triggers(vec![manifest_spec("github-new-issue", "v1")])
             .await
             .expect("initial manifest trigger installs");
+        // Capture before_reload from real wall-clock. The event log's
+        // occurred_at_ms also uses the real wall-clock (util::now_ms via
+        // std::time::SystemTime), so the same reference frame applies.
+        // The 50ms sleep gives at least one full timer-tick on any POSIX
+        // platform (even those with a ~15ms tick), ensuring v2's event
+        // timestamp is strictly after before_reload.
         let before_reload = OffsetDateTime::now_utc();
-        std::thread::sleep(FILE_WATCH_FALLBACK_POLL);
+        std::thread::sleep(std::time::Duration::from_millis(50));
 
         install_manifest_triggers(vec![manifest_spec("github-new-issue", "v2")])
             .await
@@ -2106,8 +2110,11 @@ mod tests {
         install_manifest_triggers(vec![manifest_spec("github-new-issue", "v3")])
             .await
             .expect("install v3");
+        // received_at uses the real wall-clock (same reference frame as the
+        // event log's occurred_at_ms). The 50ms sleep guarantees v4's event
+        // timestamp is strictly after received_at on any POSIX platform.
         let received_at = OffsetDateTime::now_utc();
-        std::thread::sleep(FILE_WATCH_FALLBACK_POLL);
+        std::thread::sleep(std::time::Duration::from_millis(50));
         install_manifest_triggers(vec![manifest_spec("github-new-issue", "v4")])
             .await
             .expect("install v4");


### PR DESCRIPTION
Eliminates the remaining flaky / wall-clock-dependent tests surfaced during the dependency-bump sweep (the v0.8.66 pass already covered ResourceGate / NO_COLOR; these are the stragglers).

- **`skill_loader::cli_dirs_produce_registry_entries`** — acquire the shared `lock_env()` guard; it reads `HOME`/`HARN_SKILLS_PATH` that sibling tests mutate under the same lock, so it raced under parallel load.
- **`stdlib::hitl::request_approval_{waits_for_quorum,surfaces_denials}`** — serialize via a static mutex + `reset_thread_local_state()` inside the `LocalSet`. A `current_thread` runtime's reused OS thread could run the outgoing test's async drop concurrently with the incoming reset, double-counting/missing events.
- **`tracing::test_span_event_offset_is_monotonic`** — drive a `MockClock` advanced by 10 ms instead of `thread::sleep(2ms)`; deterministic, zero wall-clock, strict-monotonic assertion.
- **`triggers::registry` reload tests** — widen the wall-clock fence to a documented 50 ms (the event log stamps `occurred_at_ms` from real `SystemTime`, so the reference frame stays real-clock; a full mock would have to mock the log clock too).

**Verification:** each race-prone test looped 25×/25× green; full `harn-vm` lib suite (3164 tests) green twice back-to-back under parallel load; build + clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)