### PR TITLE
Add live rule diagnostics to harn-lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tower 0.5.3",
  "tracing",
  "url",
@@ -2417,14 +2417,19 @@ name = "harn-lsp"
 version = "0.8.66"
 dependencies = [
  "harn-fmt",
+ "harn-hostlib",
  "harn-ir",
  "harn-lexer",
  "harn-lint",
  "harn-modules",
  "harn-parser",
+ "harn-rules",
  "harn-vm",
+ "serde",
  "serde_json",
+ "tempfile",
  "tokio",
+ "toml 0.9.12+spec-1.1.0",
  "tower-lsp",
 ]
 
@@ -2453,7 +2458,7 @@ dependencies = [
  "harn-stdlib",
  "serde",
  "tempfile",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2507,7 +2512,7 @@ dependencies = [
  "streaming-iterator",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tree-sitter",
 ]
 
@@ -2560,7 +2565,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -2659,7 +2664,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5885,6 +5890,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -5892,10 +5912,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5914,9 +5943,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5925,7 +5954,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7627,6 +7656,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/changelog.d/1634.added.md
+++ b/changelog.d/1634.added.md
@@ -1,0 +1,1 @@
+Live LSP diagnostics now run configured rule packs and expose rule fixes through `harn.applyRepair`.

--- a/crates/harn-lsp/Cargo.toml
+++ b/crates/harn-lsp/Cargo.toml
@@ -19,9 +19,16 @@ harn-lint = { path = "../harn-lint", version = "0.8" }
 harn-modules = { path = "../harn-modules", version = "0.8" }
 harn-fmt = { path = "../harn-fmt", version = "0.8" }
 harn-vm = { path = "../harn-vm", version = "0.8" }
+harn-hostlib = { path = "../harn-hostlib", version = "0.8" }
+harn-rules = { path = "../harn-rules", version = "0.8" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.9"
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/harn-lsp/src/document.rs
+++ b/crates/harn-lsp/src/document.rs
@@ -7,10 +7,12 @@ use tower_lsp::lsp_types::*;
 use crate::helpers::{
     diagnostic_data_value, lexer_error_to_diagnostic, parser_error_to_diagnostic, span_to_range,
 };
+use crate::rules::{RuleDiagnostic, RuleWorkspace};
 use crate::symbols::{build_symbol_table, SymbolInfo};
 
 pub(crate) struct DocumentState {
     pub(crate) source: String,
+    pub(crate) language_id: String,
     analysis: AnalysisDatabase,
     source_id: SourceId,
     version: SourceVersion,
@@ -19,6 +21,7 @@ pub(crate) struct DocumentState {
     pub(crate) diagnostics: Vec<Diagnostic>,
     pub(crate) lint_diagnostics: Vec<harn_lint::LintDiagnostic>,
     pub(crate) type_diagnostics: Vec<harn_parser::TypeDiagnostic>,
+    pub(crate) rule_diagnostics: Vec<RuleDiagnostic>,
     pub(crate) invariant_diagnostics: Vec<harn_ir::InvariantDiagnostic>,
     pub(crate) inlay_hints: Vec<harn_parser::InlayHintInfo>,
     pub(crate) dirty: bool,
@@ -26,11 +29,30 @@ pub(crate) struct DocumentState {
 
 impl DocumentState {
     pub(crate) fn new(source: String) -> Self {
+        let mut state = Self::new_unparsed(source, "harn");
+        state.reparse_if_dirty();
+        state
+    }
+
+    pub(crate) fn new_for_language_with_rules(
+        source: String,
+        language_id: impl Into<String>,
+        uri: &Url,
+        rule_workspace: &RuleWorkspace,
+    ) -> Self {
+        let mut state = Self::new_unparsed(source, language_id);
+        state.reparse_if_dirty_with_rules(Some(uri), Some(rule_workspace));
+        state
+    }
+
+    fn new_unparsed(source: String, language_id: impl Into<String>) -> Self {
+        let language_id = language_id.into();
         let mut analysis = AnalysisDatabase::new();
         let source_id = SourceId::new("document");
         analysis.set_source(source_id.clone(), source.clone(), SourceVersion(1));
-        let mut state = Self {
+        Self {
             source,
+            language_id,
             analysis,
             source_id,
             version: SourceVersion(1),
@@ -39,12 +61,11 @@ impl DocumentState {
             diagnostics: Vec::new(),
             lint_diagnostics: Vec::new(),
             type_diagnostics: Vec::new(),
+            rule_diagnostics: Vec::new(),
             invariant_diagnostics: Vec::new(),
             inlay_hints: Vec::new(),
             dirty: true,
-        };
-        state.reparse_if_dirty();
-        state
+        }
     }
 
     pub(crate) fn update_source(&mut self, source: String) {
@@ -56,6 +77,14 @@ impl DocumentState {
     }
 
     pub(crate) fn reparse_if_dirty(&mut self) {
+        self.reparse_if_dirty_with_rules(None, None);
+    }
+
+    pub(crate) fn reparse_if_dirty_with_rules(
+        &mut self,
+        uri: Option<&Url>,
+        rule_workspace: Option<&RuleWorkspace>,
+    ) {
         if !self.dirty {
             return;
         }
@@ -63,10 +92,17 @@ impl DocumentState {
         self.diagnostics.clear();
         self.lint_diagnostics.clear();
         self.type_diagnostics.clear();
+        self.rule_diagnostics.clear();
         self.invariant_diagnostics.clear();
         self.inlay_hints.clear();
         self.symbols.clear();
         self.cached_ast = None;
+
+        if self.language_id != "harn" {
+            self.append_rule_diagnostics(uri, rule_workspace);
+            self.dirty = false;
+            return;
+        }
 
         let analysis = match self
             .analysis
@@ -85,6 +121,7 @@ impl DocumentState {
                     }
                     AnalysisError::MissingSource(_) => {}
                 }
+                self.append_rule_diagnostics(uri, rule_workspace);
                 self.dirty = false;
                 return;
             }
@@ -159,13 +196,39 @@ impl DocumentState {
 
         self.symbols = build_symbol_table(&program, &self.source);
         self.cached_ast = Some(program);
+        self.append_rule_diagnostics(uri, rule_workspace);
         self.dirty = false;
+    }
+
+    fn append_rule_diagnostics(
+        &mut self,
+        uri: Option<&Url>,
+        rule_workspace: Option<&RuleWorkspace>,
+    ) {
+        let (Some(uri), Some(rule_workspace)) = (uri, rule_workspace) else {
+            return;
+        };
+        self.rule_diagnostics =
+            rule_workspace.diagnostics_for_document(uri, &self.language_id, &self.source);
+        self.diagnostics.extend(
+            self.rule_diagnostics
+                .iter()
+                .map(|item| item.diagnostic.clone()),
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::DocumentState;
+    use crate::rules::RuleWorkspace;
+    use std::path::Path;
+    use tower_lsp::lsp_types::Url;
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
 
     #[test]
     fn update_source_marks_document_dirty_until_reparse() {
@@ -229,6 +292,46 @@ fn handler() {
                 .map(|diag| (&diag.source, &diag.message))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn non_harn_documents_run_rules_without_harn_parse_diagnostics() {
+        let temp = tempfile::tempdir().unwrap();
+        write(
+            &temp.path().join("harn.toml"),
+            "[rules]\nruleDirs = [\"rules\"]\n",
+        );
+        write(
+            &temp.path().join("rules/no-debugger.toml"),
+            r#"
+id = "no-debugger"
+language = "typescript"
+message = "remove debugger statements"
+severity = "warning"
+safety = "behavior-preserving"
+fix = ""
+
+[rule]
+regex = "debugger;"
+"#,
+        );
+
+        let workspace = RuleWorkspace::from_root(temp.path());
+        let uri = Url::from_file_path(temp.path().join("src/main.ts")).unwrap();
+        let state = DocumentState::new_for_language_with_rules(
+            "function f() { debugger; }\n".to_string(),
+            "typescript",
+            &uri,
+            &workspace,
+        );
+
+        assert!(
+            state.cached_ast.is_none(),
+            "TypeScript should not parse as Harn"
+        );
+        assert_eq!(state.rule_diagnostics.len(), 1);
+        assert_eq!(state.diagnostics.len(), 1);
+        assert_eq!(state.diagnostics[0].source.as_deref(), Some("harn-rules"));
     }
 
     #[test]

--- a/crates/harn-lsp/src/handlers/commands.rs
+++ b/crates/harn-lsp/src/handlers/commands.rs
@@ -32,7 +32,7 @@ impl HarnLsp {
             return Ok(None);
         };
 
-        let (source, diagnostics, lint_diags, type_diags) = {
+        let (source, diagnostics, lint_diags, type_diags, rule_diags) = {
             let docs = self.documents.lock().unwrap();
             let Some(state) = docs.get(&uri) else {
                 return Ok(None);
@@ -42,6 +42,7 @@ impl HarnLsp {
                 state.diagnostics.clone(),
                 state.lint_diagnostics.clone(),
                 state.type_diagnostics.clone(),
+                state.rule_diagnostics.clone(),
             )
         };
 
@@ -51,6 +52,7 @@ impl HarnLsp {
             &diagnostics,
             &lint_diags,
             &type_diags,
+            &rule_diags,
             &repair_id,
         );
 
@@ -85,6 +87,7 @@ fn resolve_repair_edit(
     diagnostics: &[Diagnostic],
     lint_diags: &[harn_lint::LintDiagnostic],
     type_diags: &[harn_parser::TypeDiagnostic],
+    rule_diags: &[crate::rules::RuleDiagnostic],
     repair_id: &str,
 ) -> Option<WorkspaceEdit> {
     let context = CodeActionContext {
@@ -92,7 +95,7 @@ fn resolve_repair_edit(
         only: None,
         trigger_kind: None,
     };
-    let actions = build_code_actions(uri, source, lint_diags, type_diags, &context);
+    let actions = build_code_actions(uri, source, lint_diags, type_diags, rule_diags, &context);
     actions.into_iter().find_map(|action| match action {
         CodeActionOrCommand::CodeAction(action) => {
             let matches = action
@@ -141,6 +144,7 @@ mod tests {
             &state.diagnostics,
             &state.lint_diagnostics,
             &state.type_diagnostics,
+            &state.rule_diagnostics,
             &repair_id,
         )
         .expect("known repair_id should resolve to a workspace edit");
@@ -162,6 +166,7 @@ mod tests {
             &state.diagnostics,
             &state.lint_diagnostics,
             &state.type_diagnostics,
+            &state.rule_diagnostics,
             "no/such-repair",
         );
         assert!(edit.is_none());

--- a/crates/harn-lsp/src/handlers/formatting.rs
+++ b/crates/harn-lsp/src/handlers/formatting.rs
@@ -6,10 +6,12 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
 use crate::helpers::{
-    diagnostic_repair_code_action_data, diagnostic_repair_code_action_kind, extract_backtick_name,
-    find_word_in_region, lsp_position_to_offset, offset_to_position, repair_code_action_data,
-    repair_code_action_kind, span_to_range,
+    code_action_kind_for_safety_name, diagnostic_repair_code_action_data,
+    diagnostic_repair_code_action_kind, extract_backtick_name, find_word_in_region,
+    lsp_position_to_offset, offset_to_position, repair_code_action_data, repair_code_action_kind,
+    span_to_range,
 };
+use crate::rules::RuleDiagnostic;
 use crate::HarnLsp;
 
 impl HarnLsp {
@@ -55,7 +57,7 @@ impl HarnLsp {
     ) -> Result<Option<CodeActionResponse>> {
         let uri = &params.text_document.uri;
 
-        let (source, lint_diags, type_diags) = {
+        let (source, lint_diags, type_diags, rule_diags) = {
             let docs = self.documents.lock().unwrap();
             let state = match docs.get(uri) {
                 Some(s) => s,
@@ -65,10 +67,18 @@ impl HarnLsp {
                 state.source.clone(),
                 state.lint_diagnostics.clone(),
                 state.type_diagnostics.clone(),
+                state.rule_diagnostics.clone(),
             )
         };
 
-        let actions = build_code_actions(uri, &source, &lint_diags, &type_diags, &params.context);
+        let actions = build_code_actions(
+            uri,
+            &source,
+            &lint_diags,
+            &type_diags,
+            &rule_diags,
+            &params.context,
+        );
 
         Ok(Some(actions))
     }
@@ -79,11 +89,41 @@ pub(crate) fn build_code_actions(
     source: &str,
     lint_diags: &[harn_lint::LintDiagnostic],
     type_diags: &[harn_parser::TypeDiagnostic],
+    rule_diags: &[RuleDiagnostic],
     context: &CodeActionContext,
 ) -> CodeActionResponse {
     let mut actions = Vec::new();
 
     for diag in &context.diagnostics {
+        if let Some(rule_diag) = matching_rule_diagnostic(rule_diags, diag) {
+            if let (Some(text_edit), Some(repair_id)) = (&rule_diag.edit, &rule_diag.repair_id) {
+                let safety = diag
+                    .data
+                    .as_ref()
+                    .and_then(|data| data.get("safety"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("scope-local");
+                let mut changes = HashMap::new();
+                changes.insert(uri.clone(), vec![text_edit.clone()]);
+                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                    title: rule_diag.title.clone(),
+                    kind: Some(code_action_kind_for_safety_name(safety)),
+                    diagnostics: Some(vec![diag.clone()]),
+                    data: Some(serde_json::json!({
+                        "repair_id": repair_id,
+                        "safety": safety,
+                        "diagnostic_code": crate::helpers::diagnostic_code_string(diag.code.as_ref()),
+                    })),
+                    edit: Some(WorkspaceEdit {
+                        changes: Some(changes),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }));
+                continue;
+            }
+        }
+
         let msg = &diag.message;
 
         if let Some(ld) = lint_diags.iter().find(|ld| {
@@ -301,6 +341,22 @@ pub(crate) fn build_code_actions(
     actions
 }
 
+fn matching_rule_diagnostic<'a>(
+    rule_diags: &'a [RuleDiagnostic],
+    diagnostic: &Diagnostic,
+) -> Option<&'a RuleDiagnostic> {
+    let repair_id = diagnostic
+        .data
+        .as_ref()
+        .and_then(|data| data.get("repair_id"))
+        .and_then(|value| value.as_str());
+    rule_diags.iter().find(|item| {
+        item.diagnostic.range == diagnostic.range
+            && item.diagnostic.message == diagnostic.message
+            && item.repair_id.as_deref() == repair_id
+    })
+}
+
 fn format_whole_document_edit(source: &str) -> Option<TextEdit> {
     let formatted = harn_fmt::format_source(source).ok()?;
     if formatted == source {
@@ -433,6 +489,7 @@ mod tests {
             &state.source,
             &state.lint_diagnostics,
             &state.type_diagnostics,
+            &state.rule_diagnostics,
             &context,
         );
 

--- a/crates/harn-lsp/src/handlers/lifecycle.rs
+++ b/crates/harn-lsp/src/handlers/lifecycle.rs
@@ -13,8 +13,10 @@ use crate::HarnLsp;
 impl HarnLsp {
     pub(super) async fn handle_initialize(
         &self,
-        _params: InitializeParams,
+        params: InitializeParams,
     ) -> Result<InitializeResult> {
+        *self.rule_workspace.lock().unwrap() =
+            crate::rules::RuleWorkspace::from_initialize(&params);
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
@@ -107,8 +109,11 @@ impl HarnLsp {
     pub(super) async fn handle_did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri.clone();
         let source = params.text_document.text.clone();
+        let language_id = params.text_document.language_id.clone();
 
-        let state = DocumentState::new(source);
+        let rule_workspace = self.rule_workspace.lock().unwrap().clone();
+        let state =
+            DocumentState::new_for_language_with_rules(source, language_id, &uri, &rule_workspace);
         let diagnostics = state.diagnostics.clone();
         self.documents.lock().unwrap().insert(uri.clone(), state);
 
@@ -151,7 +156,8 @@ impl HarnLsp {
                 let Some(entry) = docs.get_mut(&uri) else {
                     return;
                 };
-                entry.reparse_if_dirty();
+                let rule_workspace = self.rule_workspace.lock().unwrap().clone();
+                entry.reparse_if_dirty_with_rules(Some(&uri), Some(&rule_workspace));
                 diagnostics = entry.diagnostics.clone();
             }
             self.client
@@ -165,5 +171,33 @@ impl HarnLsp {
             .lock()
             .unwrap()
             .remove(&params.text_document.uri);
+    }
+
+    pub(super) async fn handle_did_change_configuration(
+        &self,
+        params: DidChangeConfigurationParams,
+    ) {
+        let rule_workspace = {
+            let mut workspace = self.rule_workspace.lock().unwrap();
+            workspace.reconfigure(Some(&params.settings));
+            workspace.clone()
+        };
+
+        let updates = {
+            let mut docs = self.documents.lock().unwrap();
+            docs.iter_mut()
+                .map(|(uri, state)| {
+                    state.dirty = true;
+                    state.reparse_if_dirty_with_rules(Some(uri), Some(&rule_workspace));
+                    (uri.clone(), state.diagnostics.clone())
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (uri, diagnostics) in updates {
+            self.client
+                .publish_diagnostics(uri, diagnostics, None)
+                .await;
+        }
     }
 }

--- a/crates/harn-lsp/src/handlers/mod.rs
+++ b/crates/harn-lsp/src/handlers/mod.rs
@@ -52,6 +52,10 @@ impl tower_lsp::LanguageServer for HarnLsp {
         self.handle_did_close(params).await;
     }
 
+    async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
+        self.handle_did_change_configuration(params).await;
+    }
+
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
         self.handle_completion(params).await
     }

--- a/crates/harn-lsp/src/helpers.rs
+++ b/crates/harn-lsp/src/helpers.rs
@@ -57,7 +57,7 @@ pub(crate) fn diagnostic_data_value(
 
 pub(crate) fn repair_code_action_kind(repair: Option<&Repair>) -> CodeActionKind {
     repair
-        .map(|repair| code_action_kind_for_safety(repair.safety))
+        .map(|repair| code_action_kind_for_repair_safety(repair.safety))
         .unwrap_or(CodeActionKind::QUICKFIX)
 }
 
@@ -80,7 +80,7 @@ pub(crate) fn diagnostic_repair_code_action_kind(diagnostic: &Diagnostic) -> Cod
         .and_then(|data| data.get("safety"))
         .and_then(|value| value.as_str())
         .and_then(|safety| RepairSafety::from_str(safety).ok())
-        .map(code_action_kind_for_safety)
+        .map(code_action_kind_for_repair_safety)
         .unwrap_or(CodeActionKind::QUICKFIX)
 }
 
@@ -97,7 +97,7 @@ pub(crate) fn diagnostic_repair_code_action_data(
     }))
 }
 
-fn diagnostic_code_string(code: Option<&NumberOrString>) -> Option<String> {
+pub(crate) fn diagnostic_code_string(code: Option<&NumberOrString>) -> Option<String> {
     match code {
         Some(NumberOrString::String(code)) => Some(code.clone()),
         Some(NumberOrString::Number(code)) => Some(code.to_string()),
@@ -112,15 +112,20 @@ fn diagnostic_code_string(code: Option<&NumberOrString>) -> Option<String> {
 /// they consume from `Diagnostic.data.safety`. `RepairSafety::as_str()`
 /// returns a stable `&'static str` so the kind constants below avoid an
 /// allocation on the diagnostic hot path.
-fn code_action_kind_for_safety(safety: RepairSafety) -> CodeActionKind {
-    CodeActionKind::new(match safety {
-        RepairSafety::FormatOnly => "quickfix.harn.format-only",
-        RepairSafety::BehaviorPreserving => "quickfix.harn.behavior-preserving",
-        RepairSafety::ScopeLocal => "quickfix.harn.scope-local",
-        RepairSafety::SurfaceChanging => "quickfix.harn.surface-changing",
-        RepairSafety::CapabilityChanging => "quickfix.harn.capability-changing",
-        RepairSafety::NeedsHuman => "quickfix.harn.needs-human",
-    })
+fn code_action_kind_for_repair_safety(safety: RepairSafety) -> CodeActionKind {
+    code_action_kind_for_safety_name(safety.as_str())
+}
+
+pub(crate) fn code_action_kind_for_safety_name(safety: &str) -> CodeActionKind {
+    match safety {
+        "format-only" => CodeActionKind::new("quickfix.harn.format-only"),
+        "behavior-preserving" => CodeActionKind::new("quickfix.harn.behavior-preserving"),
+        "scope-local" => CodeActionKind::new("quickfix.harn.scope-local"),
+        "surface-changing" => CodeActionKind::new("quickfix.harn.surface-changing"),
+        "capability-changing" => CodeActionKind::new("quickfix.harn.capability-changing"),
+        "needs-human" => CodeActionKind::new("quickfix.harn.needs-human"),
+        _ => CodeActionKind::QUICKFIX,
+    }
 }
 
 /// Convert a 1-based Span to a 0-based LSP Range.

--- a/crates/harn-lsp/src/main.rs
+++ b/crates/harn-lsp/src/main.rs
@@ -5,6 +5,7 @@ mod folding;
 mod handlers;
 mod helpers;
 mod references;
+mod rules;
 mod semantic_tokens;
 mod symbols;
 
@@ -19,6 +20,7 @@ struct HarnLsp {
     client: Client,
     documents: Mutex<HashMap<Url, DocumentState>>,
     pending_reparse_versions: Mutex<HashMap<Url, u64>>,
+    rule_workspace: Mutex<rules::RuleWorkspace>,
 }
 
 impl HarnLsp {
@@ -27,6 +29,7 @@ impl HarnLsp {
             client,
             documents: Mutex::new(HashMap::new()),
             pending_reparse_versions: Mutex::new(HashMap::new()),
+            rule_workspace: Mutex::new(rules::RuleWorkspace::default()),
         }
     }
 }

--- a/crates/harn-lsp/src/rules.rs
+++ b/crates/harn-lsp/src/rules.rs
@@ -1,0 +1,639 @@
+//! Live rule-engine diagnostics for harn-lsp.
+//!
+//! The normal Harn-language diagnostics still come from the parser,
+//! typechecker, and harn-lint. This module adds the language-agnostic rule
+//! engine path: load configured TOML rules, run rules that target the opened
+//! document's language, and expose their fixes through the same LSP
+//! `repair_id`/`safety` envelope as native Harn repairs.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use harn_hostlib::ast::Language;
+use harn_rules::{CompiledRule, Rule, Safety, Severity};
+use serde::Deserialize;
+use serde_json::Value;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range, TextEdit, Url};
+
+use crate::helpers::offset_to_position;
+
+const RULE_DIAGNOSTIC_CODE: &str = "HARN-RUL-001";
+const RULE_CONFIG_CODE: &str = "HARN-RUL-CONFIG";
+const RULE_SOURCE: &str = "harn-rules";
+
+#[derive(Clone)]
+pub(crate) struct RuleWorkspace {
+    root: Option<PathBuf>,
+    enabled: bool,
+    specs: Arc<Vec<RuleSpec>>,
+    load_errors: Arc<Vec<RuleLoadError>>,
+}
+
+impl Default for RuleWorkspace {
+    fn default() -> Self {
+        Self {
+            root: None,
+            enabled: true,
+            specs: Arc::new(Vec::new()),
+            load_errors: Arc::new(Vec::new()),
+        }
+    }
+}
+
+impl RuleWorkspace {
+    pub(crate) fn from_initialize(params: &tower_lsp::lsp_types::InitializeParams) -> Self {
+        let root = workspace_root(params);
+        let settings = RuleSettings::from_value(params.initialization_options.as_ref());
+        Self::load(root, settings)
+    }
+
+    pub(crate) fn reconfigure(&mut self, value: Option<&Value>) {
+        let root = self.root.clone();
+        let settings = RuleSettings::from_value(value);
+        *self = Self::load(root, settings);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_root(root: impl Into<PathBuf>) -> Self {
+        Self::load(Some(root.into()), RuleSettings::default())
+    }
+
+    pub(crate) fn diagnostics_for_document(
+        &self,
+        uri: &Url,
+        language_id: &str,
+        source: &str,
+    ) -> Vec<RuleDiagnostic> {
+        if !self.enabled {
+            return Vec::new();
+        }
+
+        let language = document_language(uri, language_id);
+        let mut diagnostics = self
+            .load_errors
+            .iter()
+            .map(RuleDiagnostic::from_load_error)
+            .collect::<Vec<_>>();
+
+        let Some(language) = language else {
+            return diagnostics;
+        };
+
+        for spec in self.specs.iter().filter(|spec| spec.language == language) {
+            diagnostics.extend(spec.diagnostics(source));
+        }
+
+        diagnostics
+    }
+
+    fn load(root: Option<PathBuf>, settings: RuleSettings) -> Self {
+        if !settings.enabled {
+            return Self {
+                root,
+                enabled: false,
+                specs: Arc::new(Vec::new()),
+                load_errors: Arc::new(Vec::new()),
+            };
+        }
+
+        let mut specs = Vec::new();
+        let mut errors = Vec::new();
+        let Some(root_path) = root.as_deref() else {
+            return Self {
+                root,
+                enabled: true,
+                specs: Arc::new(specs),
+                load_errors: Arc::new(errors),
+            };
+        };
+
+        let mut seen_dirs = HashSet::new();
+        for dir in project_rule_dirs(root_path).into_iter().chain(
+            settings
+                .rule_dirs
+                .iter()
+                .map(|dir| resolve_path(root_path, dir)),
+        ) {
+            if seen_dirs.insert(dir.clone()) {
+                load_rule_dir(&dir, &mut specs, &mut errors);
+            }
+        }
+
+        for pack in &settings.rule_packs {
+            match resolve_rule_pack(root_path, pack) {
+                Some(paths) => {
+                    for dir in paths {
+                        if seen_dirs.insert(dir.clone()) {
+                            load_rule_dir(&dir, &mut specs, &mut errors);
+                        }
+                    }
+                }
+                None => errors.push(RuleLoadError {
+                    path: root_path.to_path_buf(),
+                    message: format!("rule pack `{pack}` is not installed or is not a directory"),
+                }),
+            }
+        }
+
+        Self {
+            root,
+            enabled: true,
+            specs: Arc::new(specs),
+            load_errors: Arc::new(errors),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RuleDiagnostic {
+    pub(crate) diagnostic: Diagnostic,
+    pub(crate) edit: Option<TextEdit>,
+    pub(crate) repair_id: Option<String>,
+    pub(crate) title: String,
+}
+
+impl RuleDiagnostic {
+    fn from_load_error(error: &RuleLoadError) -> Self {
+        Self {
+            diagnostic: Diagnostic {
+                range: Range::default(),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some(RULE_SOURCE.to_string()),
+                code: Some(NumberOrString::String(RULE_CONFIG_CODE.to_string())),
+                message: format!(
+                    "Rule pack load failed for `{}`: {}",
+                    error.path.display(),
+                    error.message
+                ),
+                ..Default::default()
+            },
+            edit: None,
+            repair_id: None,
+            title: "Rule pack load failed".to_string(),
+        }
+    }
+
+    fn from_rule(rule: &RuleSpec, diag: harn_rules::Diagnostic, source: &str) -> Self {
+        let range = rule_span_to_range(&diag.span, source);
+        let repair_id = diag.fix.as_ref().map(|_| {
+            format!(
+                "rules/{}/{}-{}",
+                diag.rule_id, diag.span.start_byte, diag.span.end_byte
+            )
+        });
+        let safety = rule.safety.as_str();
+        let title = if diag.fix.is_some() {
+            format!("Apply rule fix `{}`", diag.rule_id)
+        } else {
+            format!("Inspect rule `{}`", diag.rule_id)
+        };
+        let data = repair_id.as_ref().map(|id| {
+            serde_json::json!({
+                "code": RULE_DIAGNOSTIC_CODE,
+                "rule_id": diag.rule_id,
+                "repair_id": id,
+                "safety": safety,
+                "repair": {
+                    "id": id,
+                    "summary": title,
+                    "safety": safety,
+                },
+            })
+        });
+        let message = if diag.message.is_empty() {
+            format!("[{}] rule matched", diag.rule_id)
+        } else {
+            format!("[{}] {}", diag.rule_id, diag.message)
+        };
+        Self {
+            diagnostic: Diagnostic {
+                range,
+                severity: Some(severity_to_lsp(diag.severity)),
+                source: Some(RULE_SOURCE.to_string()),
+                code: Some(NumberOrString::String(RULE_DIAGNOSTIC_CODE.to_string())),
+                message,
+                data,
+                ..Default::default()
+            },
+            edit: diag.fix.map(|replacement| TextEdit {
+                range,
+                new_text: replacement,
+            }),
+            repair_id,
+            title,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RuleSpec {
+    path: PathBuf,
+    language: Language,
+    rule: Rule,
+    safety: Safety,
+}
+
+impl RuleSpec {
+    fn diagnostics(&self, source: &str) -> Vec<RuleDiagnostic> {
+        let compiled = match CompiledRule::compile(&self.rule) {
+            Ok(compiled) => compiled,
+            Err(error) => {
+                return vec![RuleDiagnostic::from_load_error(&RuleLoadError {
+                    path: self.path.clone(),
+                    message: error.to_string(),
+                })];
+            }
+        };
+        match compiled.diagnostics(source) {
+            Ok(items) => items
+                .into_iter()
+                .map(|diagnostic| RuleDiagnostic::from_rule(self, diagnostic, source))
+                .collect(),
+            Err(error) => vec![RuleDiagnostic::from_load_error(&RuleLoadError {
+                path: self.path.clone(),
+                message: error.to_string(),
+            })],
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RuleLoadError {
+    path: PathBuf,
+    message: String,
+}
+
+struct RuleSettings {
+    enabled: bool,
+    rule_dirs: Vec<String>,
+    rule_packs: Vec<String>,
+}
+
+impl Default for RuleSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            rule_dirs: Vec::new(),
+            rule_packs: Vec::new(),
+        }
+    }
+}
+
+impl RuleSettings {
+    fn from_value(value: Option<&Value>) -> Self {
+        let Some(value) = value else {
+            return Self {
+                enabled: true,
+                ..Default::default()
+            };
+        };
+        let harn = value.get("harn").unwrap_or(value);
+        let rules = harn
+            .get("rules")
+            .or_else(|| harn.get("ruleEngine"))
+            .unwrap_or(harn);
+        Self {
+            enabled: rules
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+            rule_dirs: string_array(rules, &["ruleDirs", "rule_dirs", "rule-dirs"]),
+            rule_packs: string_array(rules, &["rulePacks", "rule_packs", "rule-packs"]),
+        }
+    }
+}
+
+fn string_array(value: &Value, keys: &[&str]) -> Vec<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn workspace_root(params: &tower_lsp::lsp_types::InitializeParams) -> Option<PathBuf> {
+    params
+        .workspace_folders
+        .as_ref()
+        .and_then(|folders| folders.first())
+        .and_then(|folder| folder.uri.to_file_path().ok())
+        .or_else(|| {
+            params
+                .root_uri
+                .as_ref()
+                .and_then(|uri| uri.to_file_path().ok())
+        })
+}
+
+fn document_language(uri: &Url, language_id: &str) -> Option<Language> {
+    let normalized = match language_id {
+        "typescriptreact" => "tsx",
+        "javascriptreact" => "jsx",
+        other => other,
+    };
+    let path = uri.to_file_path().ok();
+    path.as_deref()
+        .and_then(|path| {
+            Language::detect(path, Some(normalized)).or_else(|| Language::detect(path, None))
+        })
+        .or_else(|| Language::from_name(normalized))
+}
+
+fn resolve_path(root: &Path, raw: &str) -> PathBuf {
+    let path = Path::new(raw);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+#[derive(Default, Deserialize)]
+struct MinimalManifest {
+    #[serde(default)]
+    rules: MinimalRules,
+}
+
+#[derive(Default, Deserialize)]
+struct MinimalRules {
+    #[serde(default, alias = "ruleDirs", alias = "rule-dirs")]
+    rule_dirs: Vec<String>,
+}
+
+fn project_rule_dirs(root: &Path) -> Vec<PathBuf> {
+    let Some((manifest, dir)) = find_nearest_manifest(root) else {
+        return Vec::new();
+    };
+    manifest
+        .rules
+        .rule_dirs
+        .iter()
+        .map(|rel| dir.join(rel))
+        .collect()
+}
+
+fn find_nearest_manifest(start: &Path) -> Option<(MinimalManifest, PathBuf)> {
+    let mut dir = if start.is_file() {
+        start.parent()?.to_path_buf()
+    } else {
+        start.to_path_buf()
+    };
+    loop {
+        let path = dir.join("harn.toml");
+        if path.is_file() {
+            let source = std::fs::read_to_string(&path).ok()?;
+            let manifest = toml::from_str::<MinimalManifest>(&source).ok()?;
+            return Some((manifest, dir));
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn load_rule_dir(dir: &Path, specs: &mut Vec<RuleSpec>, errors: &mut Vec<RuleLoadError>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            errors.push(RuleLoadError {
+                path: dir.to_path_buf(),
+                message: format!("read `{}`: {error}", dir.display()),
+            });
+            return;
+        }
+    };
+    let mut files: Vec<_> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+        .collect();
+    files.sort();
+    for file in files {
+        load_rule_file(&file, specs, errors);
+    }
+}
+
+fn load_rule_file(path: &Path, specs: &mut Vec<RuleSpec>, errors: &mut Vec<RuleLoadError>) {
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(error) => {
+            errors.push(RuleLoadError {
+                path: path.to_path_buf(),
+                message: format!("read `{}`: {error}", path.display()),
+            });
+            return;
+        }
+    };
+    let rule = match Rule::from_toml_str(&source) {
+        Ok(rule) => rule,
+        Err(error) => {
+            errors.push(RuleLoadError {
+                path: path.to_path_buf(),
+                message: format!("parse `{}`: {error}", path.display()),
+            });
+            return;
+        }
+    };
+    let Some(language) = Language::from_name(&rule.language) else {
+        errors.push(RuleLoadError {
+            path: path.to_path_buf(),
+            message: format!(
+                "rule `{}` uses unknown language `{}`",
+                rule.id, rule.language
+            ),
+        });
+        return;
+    };
+    specs.push(RuleSpec {
+        path: path.to_path_buf(),
+        language,
+        safety: rule.safety,
+        rule,
+    });
+}
+
+fn resolve_rule_pack(root: &Path, pack: &str) -> Option<Vec<PathBuf>> {
+    let local = resolve_path(root, pack);
+    if local.is_dir() {
+        return Some(pack_rule_dirs(&local));
+    }
+
+    let package_dir = root.join(".harn").join("packages").join(pack);
+    if package_dir.is_dir() {
+        return Some(pack_rule_dirs(&package_dir));
+    }
+
+    let locked = lockfile_package_dir(root, pack)?;
+    locked.is_dir().then(|| pack_rule_dirs(&locked))
+}
+
+fn pack_rule_dirs(dir: &Path) -> Vec<PathBuf> {
+    let manifest_path = dir.join("harn.toml");
+    if manifest_path.is_file() {
+        if let Ok(source) = std::fs::read_to_string(&manifest_path) {
+            if let Ok(manifest) = toml::from_str::<MinimalManifest>(&source) {
+                if !manifest.rules.rule_dirs.is_empty() {
+                    return manifest
+                        .rules
+                        .rule_dirs
+                        .iter()
+                        .map(|rel| dir.join(rel))
+                        .collect();
+                }
+            }
+        }
+    }
+    vec![dir.to_path_buf()]
+}
+
+#[derive(Deserialize)]
+struct MinimalLockFile {
+    #[serde(default, rename = "package")]
+    packages: Vec<MinimalLockEntry>,
+}
+
+#[derive(Deserialize)]
+struct MinimalLockEntry {
+    name: String,
+    #[serde(default)]
+    registry: Option<MinimalRegistry>,
+}
+
+#[derive(Deserialize)]
+struct MinimalRegistry {
+    name: String,
+}
+
+fn lockfile_package_dir(root: &Path, pack: &str) -> Option<PathBuf> {
+    let lock_path = root.join("harn.lock");
+    let source = std::fs::read_to_string(lock_path).ok()?;
+    let lock = toml::from_str::<MinimalLockFile>(&source).ok()?;
+    let entry = lock.packages.iter().find(|entry| {
+        entry.name == pack
+            || entry
+                .registry
+                .as_ref()
+                .is_some_and(|registry| registry.name == pack)
+    })?;
+    Some(root.join(".harn").join("packages").join(&entry.name))
+}
+
+fn severity_to_lsp(severity: Severity) -> DiagnosticSeverity {
+    match severity {
+        Severity::Info => DiagnosticSeverity::INFORMATION,
+        Severity::Warning => DiagnosticSeverity::WARNING,
+        Severity::Error => DiagnosticSeverity::ERROR,
+    }
+}
+
+fn rule_span_to_range(span: &harn_rules::Span, source: &str) -> Range {
+    Range {
+        start: offset_to_position(source, span.start_byte),
+        end: offset_to_position(
+            source,
+            span.end_byte.max(span.start_byte + 1).min(source.len()),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn project_rule_dir_publishes_diagnostic_with_repair_data() {
+        let temp = tempfile::tempdir().unwrap();
+        write(
+            &temp.path().join("harn.toml"),
+            "[rules]\nruleDirs = [\"rules\"]\n",
+        );
+        write(
+            &temp.path().join("rules/no-debugger.toml"),
+            r#"
+id = "no-debugger"
+language = "typescript"
+message = "remove debugger statements"
+severity = "warning"
+safety = "behavior-preserving"
+fix = ""
+
+[rule]
+regex = "debugger;"
+"#,
+        );
+
+        let workspace = RuleWorkspace::from_root(temp.path());
+        let uri = Url::from_file_path(temp.path().join("src/main.ts")).unwrap();
+        let diagnostics =
+            workspace.diagnostics_for_document(&uri, "typescript", "function f() { debugger; }\n");
+
+        assert_eq!(diagnostics.len(), 1);
+        let diagnostic = &diagnostics[0].diagnostic;
+        assert_eq!(diagnostic.source.as_deref(), Some(RULE_SOURCE));
+        assert_eq!(
+            diagnostic.message,
+            "[no-debugger] remove debugger statements"
+        );
+        let data = diagnostic.data.as_ref().expect("repair data");
+        assert_eq!(
+            data.get("repair_id").and_then(Value::as_str),
+            Some("rules/no-debugger/15-24")
+        );
+        assert_eq!(
+            data.get("safety").and_then(Value::as_str),
+            Some("behavior-preserving")
+        );
+        assert_eq!(diagnostics[0].edit.as_ref().unwrap().new_text, "");
+    }
+
+    #[test]
+    fn document_language_falls_back_to_file_extension() {
+        let temp = tempfile::tempdir().unwrap();
+        write(
+            &temp.path().join("harn.toml"),
+            "[rules]\nruleDirs = [\"rules\"]\n",
+        );
+        write(
+            &temp.path().join("rules/no-debugger.toml"),
+            r#"
+id = "no-debugger"
+language = "typescript"
+message = "remove debugger statements"
+severity = "warning"
+safety = "behavior-preserving"
+fix = ""
+
+[rule]
+regex = "debugger;"
+"#,
+        );
+
+        let workspace = RuleWorkspace::from_root(temp.path());
+        let uri = Url::from_file_path(temp.path().join("src/main.ts")).unwrap();
+        let diagnostics = workspace.diagnostics_for_document(
+            &uri,
+            "harn-rule-engine",
+            "function f() { debugger; }\n",
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].diagnostic.message,
+            "[no-debugger] remove debugger statements"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- load project rule directories and configured rule packs in harn-lsp
- publish rule-engine diagnostics with repair_id/safety metadata
- expose rule fixes through code actions and harn.applyRepair

## Verification
- CARGO_TARGET_DIR=/tmp/harn-lsp-rule-diagnostics-target cargo test -p harn-lsp
- CARGO_TARGET_DIR=/tmp/harn-lsp-rule-diagnostics-target cargo clippy -p harn-lsp --all-targets -- -D warnings
- CARGO_TARGET_DIR=/tmp/harn-lsp-rule-diagnostics-target cargo build -p harn-lsp --bin harn-lsp
- JSON-RPC smoke: TypeScript project rule published harn-rules diagnostic, quickfix.harn.behavior-preserving code action, and harn.applyRepair edit
- commit/pre-push hooks: Rust fmt, workspace clippy, markdownlint, targeted local checks

Companion for burin-labs/burin-code#1634.