### PR TITLE
Isolate harn-guard store test directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,6 +2322,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/changelog.d/2961.fixed.md
+++ b/changelog.d/2961.fixed.md
@@ -1,0 +1,4 @@
+- **harn-guard store tests no longer share temp directories under nextest
+  (#2961).** The model-store tests now use owned temporary directories, avoiding
+  parallel release-gate collisions that could make corruption checks fail
+  nondeterministically.

--- a/crates/harn-guard/Cargo.toml
+++ b/crates/harn-guard/Cargo.toml
@@ -16,6 +16,9 @@ serde_json = "1"
 sha2 = "0.11"
 thiserror = "2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [features]
 # Management layer (catalog + store + resolve) is dependency-light and always on.
 default = []

--- a/crates/harn-guard/src/store.rs
+++ b/crates/harn-guard/src/store.rs
@@ -219,14 +219,12 @@ impl GuardStore {
 mod tests {
     use super::*;
     use crate::catalog;
+    use tempfile::TempDir;
 
-    fn temp_root() -> PathBuf {
-        // A unique-enough dir without pulling a tempfile dep or a clock: the test
-        // thread id plus the test name embedded by callers keeps these distinct.
-        let mut p = std::env::temp_dir();
-        p.push(format!("harn-guard-test-{:?}", std::thread::current().id()));
-        let _ = fs::remove_dir_all(&p);
-        p
+    fn temp_store() -> (TempDir, GuardStore) {
+        let temp_dir = TempDir::new().unwrap();
+        let store = GuardStore::at_root(temp_dir.path().join("guard"));
+        (temp_dir, store)
     }
 
     fn payload(files: &[(&str, &[u8])]) -> Vec<(String, Vec<u8>)> {
@@ -247,7 +245,7 @@ mod tests {
 
     #[test]
     fn install_then_read_and_list_roundtrips() {
-        let store = GuardStore::at_root(temp_root());
+        let (_temp_dir, store) = temp_store();
         let model = catalog::default_model();
         // Provide bytes for every catalog file; the pinned model.onnx digest will
         // NOT match these stub bytes, so use a model with no pinned digests for a
@@ -260,13 +258,11 @@ mod tests {
         // default model pins model.onnx -> mismatch expected.
         let err = store.install(model, &stub, true).unwrap_err();
         assert!(matches!(err, GuardError::ChecksumMismatch { .. }));
-
-        let _ = fs::remove_dir_all(store.root());
     }
 
     #[test]
     fn install_requires_license_acceptance() {
-        let store = GuardStore::at_root(temp_root());
+        let (_temp_dir, store) = temp_store();
         let model = catalog::find("llama-prompt-guard-2-86m").unwrap();
         let stub = payload(&[
             ("model.onnx", b"a"),
@@ -275,12 +271,11 @@ mod tests {
         ]);
         let err = store.install(model, &stub, false).unwrap_err();
         assert!(matches!(err, GuardError::LicenseNotAccepted { .. }));
-        let _ = fs::remove_dir_all(store.root());
     }
 
     #[test]
     fn install_unpinned_model_roundtrips_and_verifies() {
-        let store = GuardStore::at_root(temp_root());
+        let (_temp_dir, store) = temp_store();
         // The gated entry pins nothing, so stub bytes install cleanly (TOFU).
         let model = catalog::find("llama-prompt-guard-2-86m").unwrap();
         let files = payload(&[
@@ -305,22 +300,20 @@ mod tests {
         assert!(store.remove("llama-prompt-guard-2-86m").unwrap());
         assert!(!store.is_installed("llama-prompt-guard-2-86m"));
         assert!(!store.remove("llama-prompt-guard-2-86m").unwrap());
-        let _ = fs::remove_dir_all(store.root());
     }
 
     #[test]
     fn missing_file_in_payload_errors() {
-        let store = GuardStore::at_root(temp_root());
+        let (_temp_dir, store) = temp_store();
         let model = catalog::find("llama-prompt-guard-2-86m").unwrap();
         let incomplete = payload(&[("model.onnx", b"weights")]);
         let err = store.install(model, &incomplete, true).unwrap_err();
         assert!(matches!(err, GuardError::MissingFile(f) if f == "tokenizer.json"));
-        let _ = fs::remove_dir_all(store.root());
     }
 
     #[test]
     fn verify_detects_corruption() {
-        let store = GuardStore::at_root(temp_root());
+        let (_temp_dir, store) = temp_store();
         let model = catalog::find("llama-prompt-guard-2-86m").unwrap();
         let files = payload(&[
             ("model.onnx", b"weights"),
@@ -331,6 +324,5 @@ mod tests {
         // Corrupt a file on disk.
         fs::write(store.model_dir(model.name).join("config.json"), b"tampered").unwrap();
         assert!(!store.verify_installed(model.name).unwrap());
-        let _ = fs::remove_dir_all(store.root());
     }
 }


### PR DESCRIPTION
## Summary
- replace harn-guard store tests' thread-id temp path with owned tempfile directories
- remove manual cleanup that could race under nextest parallel processes

## Verification
- cargo fmt --all -- --check
- cargo nextest run -p harn-guard
- cargo clippy -p harn-guard --all-targets -- -D warnings
- make test
- pre-commit hook
- pre-push hook