### PR TITLE
fix(fmt,lexer): correct multi-line block-comment spans and stop dropping top-level trailing comments

### DIFF
--- a/changelog.d/block-comment-span-and-top-level-comments.fixed.md
+++ b/changelog.d/block-comment-span-and-top-level-comments.fixed.md
@@ -1,0 +1,8 @@
+- **Multi-line `/* ... */` block comments now report their span at the opening `/*` instead of the closing
+  `*/`.** The lexer had stamped the span's start line with the comment's *end* line, so every consumer that
+  keys off it — the `harn fmt` comment map, LSP positions, and the `legacy-doc-comment` lint rule —
+  misattributed multi-line block comments. The span now records the open line/column with `end_line` at the
+  close, mirroring how multi-line strings are recorded.
+- **`harn fmt` no longer drops a trailing same-line comment on a top-level statement or import.** A comment
+  like `let x = 1 // note` at the top level was silently discarded; block bodies already preserved these, but
+  `format_program` never attached them. Top-level items now keep their trailing comment inline.

--- a/crates/harn-fmt/src/formatter/mod.rs
+++ b/crates/harn-fmt/src/formatter/mod.rs
@@ -246,6 +246,7 @@ impl<'a> Formatter<'a> {
             // Imports inside a sorted block stay tight — no blank line between them.
             self.emit_comments_in_range(comment_from, node.span.line);
             self.format_node(node);
+            self.attach_trailing_comment(node.span.end_line);
         }
     }
 
@@ -295,6 +296,11 @@ impl<'a> Formatter<'a> {
                 self.emit_top_level_comments_in_range(prev_end, node.span.line);
             }
             self.format_node(node);
+            // Preserve a trailing same-line comment on this top-level item.
+            // Without this, `let x = 1 // note` at the top level silently
+            // drops the comment — block bodies handle it via `format_body`,
+            // but `format_program` previously did not.
+            self.attach_trailing_comment(node.span.end_line);
         }
         if !self.comments.is_empty() {
             let max_line = *self.comments.keys().max().unwrap_or(&0);

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -1752,6 +1752,52 @@ fn test_trailing_block_comment_preserved_on_statement() {
 }
 
 #[test]
+fn test_trailing_line_comment_preserved_on_top_level_statement() {
+    // Regression: trailing same-line comments on *top-level* statements were
+    // silently dropped — `format_program` (unlike `format_body`) never
+    // attached them. Comments must never be lost by `harn fmt`.
+    let source = "let a = 1 // note\nlet b = 2\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.contains("let a = 1") && result.contains("// note"),
+        "trailing comment should be preserved on the same line; got:\n{result}"
+    );
+    assert!(
+        !result.trim_end().ends_with("// note"),
+        "trailing comment must not be relocated to end-of-file; got:\n{result}"
+    );
+    let result2 = format_source(&result).unwrap();
+    assert_eq!(result, result2, "must be idempotent");
+}
+
+#[test]
+fn test_trailing_block_comment_preserved_on_top_level_statement() {
+    // Same regression as above, for a single-line block comment.
+    let source = "let a = 1 /* note */\nlet b = 2\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.contains("let a = 1") && result.contains("/* note */"),
+        "trailing block comment should be preserved on the same line; got:\n{result}"
+    );
+    let result2 = format_source(&result).unwrap();
+    assert_eq!(result, result2, "must be idempotent");
+}
+
+#[test]
+fn test_top_level_trailing_comment_on_import_preserved() {
+    // Imports go through `format_sorted_import_block`, which also needs to
+    // attach trailing comments rather than drop them.
+    let source = "import { a } from \"std/io\" // why\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.contains("// why"),
+        "trailing comment on an import should be preserved; got:\n{result}"
+    );
+    let result2 = format_source(&result).unwrap();
+    assert_eq!(result, result2, "must be idempotent");
+}
+
+#[test]
 fn test_method_call_args_dont_overcount_multiline_receiver() {
     // When the receiver of a method call wraps to multiple lines, the
     // method-call args should be laid out based on the new line's column,

--- a/crates/harn-lexer/src/lexer.rs
+++ b/crates/harn-lexer/src/lexer.rs
@@ -261,9 +261,17 @@ impl Lexer {
         if depth > 0 {
             return Err(LexerError::UnterminatedBlockComment(start));
         }
+        // The span must point at the opening `/*` (line/column of `start`),
+        // with `end_line` at the closing `*/` — mirroring how multi-line
+        // strings record their span. Using `self.line` for the start line
+        // here would report the comment's *end* line, which misplaces
+        // multi-line block comments for every span consumer (`harn fmt`,
+        // the LSP, diagnostics).
+        let mut span = Span::with_offsets(start_byte, self.byte_pos, start.line, start.column);
+        span.end_line = self.line;
         Ok(Token::with_span(
             TokenKind::BlockComment { text, is_doc },
-            Span::with_offsets(start_byte, self.byte_pos, self.line, start.column),
+            span,
         ))
     }
 
@@ -1093,6 +1101,31 @@ mod tests {
         let mut lexer = Lexer::new("/* outer /* nested */ still */ 42");
         let tokens = lexer.tokenize().unwrap();
         assert_eq!(tokens[0].kind, TokenKind::IntLiteral(42));
+    }
+
+    #[test]
+    fn test_multiline_block_comment_span_starts_at_open() {
+        // A block comment that opens on line 2 and closes on line 4. Its span's
+        // `line`/`column` must point at the opening `/*` (line 2), and `end_line`
+        // at the closing `*/` (line 4) — matching how multi-line strings record
+        // their span. Downstream consumers (`harn fmt`, the LSP) key comments by
+        // `span.line`, so reporting the end line there misplaces the comment.
+        let src = "let a = 1\n/* block\n   spanning\n   lines */\nlet b = 2";
+        let mut lex = Lexer::new(src);
+        let tokens = lex.tokenize_with_comments().unwrap();
+        let block = tokens
+            .iter()
+            .find(|t| matches!(t.kind, TokenKind::BlockComment { .. }))
+            .expect("block comment token");
+        assert_eq!(block.span.line, 2, "start line should be the opening `/*`");
+        assert_eq!(
+            block.span.column, 1,
+            "start column should be the `/*` column"
+        );
+        assert_eq!(
+            block.span.end_line, 4,
+            "end line should be the closing `*/`"
+        );
     }
 
     #[test]

--- a/crates/harn-lint/src/harndoc.rs
+++ b/crates/harn-lint/src/harndoc.rs
@@ -45,13 +45,14 @@ pub(crate) fn collect_comment_tokens(source: &str) -> Vec<LegacyCommentTok> {
                 });
             }
             harn_lexer::TokenKind::BlockComment { text, is_doc } => {
-                // The lexer keeps internal newlines in `text` and stamps the
-                // span line at the comment's *end*, so the start line is the
-                // end line minus the number of contained newlines.
-                let newlines = text.matches('\n').count();
+                // `line` is the comment's *bottom* line (adjacent to an item
+                // below it); `start_line` is its *top* line. The lexer records
+                // these as `span.end_line` and `span.line` respectively, so a
+                // multi-line block comment spans the inclusive range
+                // `[start_line, line]`.
                 out.push(LegacyCommentTok {
-                    line: tok.span.line,
-                    start_line: tok.span.line.saturating_sub(newlines),
+                    line: tok.span.end_line,
+                    start_line: tok.span.line,
                     start_byte: tok.span.start,
                     end_byte: tok.span.end,
                     is_line: false,


### PR DESCRIPTION
## Summary

Two related, **independently-reachable** defects in how the toolchain handles comments, found while auditing the lexer/formatter. Both are reachable through ordinary `harn fmt` / LSP usage on real source files.

### Bug 1 — multi-line block-comment spans point at the wrong line (lexer)

`Span.line` is documented as *"1-based line number of start position"*, but `read_block_comment` stamped it with `self.line` — the line of the **closing** `*/` — and never set `end_line`. So for any multi-line `/* … */` comment, `span.line` reported the **end** line.

Every consumer that keys off `span.line` was affected:
- `harn fmt` builds its comment map as `comments[tok.span.line]` → multi-line block comments were filed under their end line.
- `harn-lsp` derives positions from comment spans.
- the `legacy-doc-comment` lint rule had to **hand-compensate** for the bug (subtracting the contained newline count to recover the start line — see the deleted code in `harndoc.rs`).

The fix mirrors how multi-line *strings* already record their span: `line`/`column` at the opening `/*`, `end_line` at the closing `*/`. `harndoc.rs` now reads `span.end_line` (bottom line) and `span.line` (top line) directly instead of compensating.

### Bug 2 — `harn fmt` silently drops top-level trailing comments (formatter)

A trailing same-line comment on a **top-level** statement or import was silently discarded:

```harn
let x = 1 // note   →   let x = 1
```

Block bodies preserve these via `format_body` → `attach_trailing_comment`, but `format_program` (and the sorted-import path) never called it. This is data loss — `harn fmt` should never drop a comment. Top-level items now attach their trailing comment, matching in-block behavior.

> Note: fixing Bug 1 alone would have *regressed* multi-line trailing block comments into a drop; fixing Bug 2 covers both, which is why they ship together.

## Tests

- `harn-lexer`: `test_multiline_block_comment_span_starts_at_open` — asserts start line/column at `/*` and `end_line` at `*/`.
- `harn-fmt`: 3 new regression tests for top-level trailing line/block comments and on imports (incl. idempotency).
- Updated `harn-lint` harndoc rule to consume the corrected span; full lint suite green.
- Verified zero formatting churn: ran the new formatter over all 1917 committed `.harn` files — the only 2 that reformat already reformat on pristine `main` (pre-existing `conformance/errors/types/` fixtures, unrelated).

All suites pass: `harn-lexer` (30), `harn-fmt` (150), `harn-lint` (268), `harn-lsp` (49), `harn-parser` (415); `cargo check --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)