### PR TITLE
docs(fmt): document trailing-comment / line-width policy + lock it in with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "harn-guard"
-version = "0.8.66"
+version = "0.8.67"
 dependencies = [
  "harn-vm",
  "ort",

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -1797,6 +1797,83 @@ fn test_top_level_trailing_comment_on_import_preserved() {
     assert_eq!(result, result2, "must be idempotent");
 }
 
+// ---------------------------------------------------------------------------
+// Trailing comments vs. line width.
+//
+// Policy (matches rustfmt/Prettier/gofmt — see `docs/src/cli-reference.md`):
+// a trailing same-line comment is treated as an unbreakable token that does
+// NOT count toward `line_width`. The formatter never relocates a trailing
+// comment to its own line and never reflows code to "make room" for one — it
+// simply lets the line overflow. Code still wraps on its own merits (the
+// comment is appended afterward, to the last physical line).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_trailing_comment_overflow_is_allowed_not_wrapped() {
+    // Short statement, long comment: the comment is left over-length on the
+    // same line — never moved up and never wrapped.
+    let source =
+        "let r = f(x) // this explanatory comment is long enough to push the whole line past one hundred columns\n";
+    let result = format_source(source).unwrap();
+    let line = result.lines().next().unwrap();
+    assert!(
+        line.starts_with("let r = f(x)") && line.contains("// this explanatory comment"),
+        "code and trailing comment must stay on one line; got:\n{result}"
+    );
+    assert_eq!(
+        result.lines().count(),
+        1,
+        "comment must not be relocated to its own line; got:\n{result}"
+    );
+    assert!(
+        line.len() > 100,
+        "the line is expected to overflow rather than be reflowed; got width {}",
+        line.len()
+    );
+    let result2 = format_source(&result).unwrap();
+    assert_eq!(result, result2, "must be idempotent");
+}
+
+#[test]
+fn test_trailing_comment_does_not_trigger_statement_wrap() {
+    // The code fits within `line_width` on its own; only the trailing comment
+    // pushes the line over. The formatter must NOT wrap the code to compensate
+    // (don't reflow code to fit a comment).
+    let source = "let xs = [alpha, beta, gamma, delta, epsilon, zeta, eta, theta] // greek letters that overflow\n";
+    let result = format_source(source).unwrap();
+    assert_eq!(
+        result.lines().count(),
+        1,
+        "code under the width must stay inline despite the comment; got:\n{result}"
+    );
+    assert!(
+        result.contains("[alpha, beta, gamma, delta, epsilon, zeta, eta, theta]"),
+        "list literal must remain inline; got:\n{result}"
+    );
+    let result2 = format_source(&result).unwrap();
+    assert_eq!(result, result2, "must be idempotent");
+}
+
+#[test]
+fn test_wrapped_statement_keeps_trailing_comment_on_last_line() {
+    // When the *code itself* exceeds the width it wraps one-item-per-line; the
+    // trailing comment then rides on the last physical line (the closer), still
+    // trailing — never promoted to its own line.
+    let source = "let xs = [alpha, beta, gamma, delta, epsilon, zeta, eta, theta, iota, kappa, lambda, mu, nu, xi, omicron, pi, rho] // greek\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.lines().count() > 3,
+        "long list literal should wrap one item per line; got:\n{result}"
+    );
+    let last = result.trim_end().lines().last().unwrap();
+    assert!(
+        last.trim_start().starts_with(']') && last.contains("// greek"),
+        "trailing comment should ride the closing `]` line; got last line: {last:?}"
+    );
+    let result2 = format_source(&result).unwrap();
+    assert_eq!(result, result2, "must be idempotent");
+}
+
 #[test]
 fn test_method_call_args_dont_overcount_multiline_receiver() {
     // When the receiver of a method call wraps to multiple lines, the

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -681,6 +681,22 @@ contexts, but they are not preserved in formatter output.
   parenthesised) and for clarity when mixing `&&` / `||`
   (e.g. `a && b || c` becomes `(a && b) || c`).
 
+### Trailing comments and line width
+
+A trailing (same-line) comment is treated as an **unbreakable token that does
+not count toward the line width**. This matches `rustfmt`, Prettier, and
+`gofmt`, and is the least-surprising behaviour:
+
+- The formatter **never relocates** a trailing comment to its own line, and
+  **never reflows code to make room** for one. If `let x = compute() // why`
+  exceeds the width *because of the comment*, the line is simply left long.
+- Code still wraps on its **own** merits. The wrap decision is based on the
+  code alone; the comment is appended afterward, riding the **last** physical
+  line of a wrapped construct (e.g. the closing `]` of a wrapped list literal).
+
+There is no separate "line too long" lint — width is a formatter concern, so a
+trailing comment that overflows is never reported as a diagnostic.
+
 ## harn lint
 
 Lint one or more `.harn` files or directories for common issues (unused


### PR DESCRIPTION
## Summary

Follow-up to a question about how **inline (trailing) comments** interact with the formatter's line-width limit. After empirically tracing Harn's behavior and surveying the ecosystem, the conclusion is that **Harn already does the least-surprising, SOTA-aligned thing** — so this PR documents that policy and locks it in with tests rather than changing behavior.

### What Harn does today (verified empirically)

- A trailing same-line comment is treated as an **unbreakable token that does not count toward `line_width`**.
- The formatter **never relocates** a trailing comment to its own line and **never reflows code** to make room for one — an over-length line caused purely by a comment is left long (e.g. `let r = f(x)  // long comment…` stays at 136 cols, untouched).
- Code still wraps on its **own** merits; the wrap decision is computed from the code alone, and the comment is appended afterward, riding the **last** physical line of a wrapped construct (e.g. the closing `]` of a wrapped list literal).
- There is **no** line-length lint rule, so a comment-driven over-length line is never reported as a diagnostic.

### SOTA survey (why no behavior change)

Surveyed rustfmt, gofmt, Prettier, Black, clang-format, golines, ESLint `max-len`, flake8 `E501`, golangci-lint `lll`:

- **No major formatter automatically relocates a trailing comment to its own line.** Black is the only one that even *repositions* one, and it keeps it trailing (never promotes it).
- The dominant width behavior is **"leave the trailing comment on the line even if it overflows; don't reflow code to accommodate it"** (rustfmt's `error_on_line_overflow` explicitly excludes comments; Prettier treats `printWidth` as a non-binding guideline with comments as an unbreakable edge case; gofmt has no limit at all).
- Where formatters touch comments it's *text reflow*, never *relocation*, and it's off by default.

Harn's current behavior matches the rustfmt/Prettier/gofmt consensus exactly. Changing it would be the surprising move.

## Changes

- **`crates/harn-fmt/src/tests.rs`** — 3 regression tests: overflow is allowed (comment not moved/wrapped); a trailing comment never triggers a statement wrap; a statement that wraps on its own keeps the comment on its last line. All assert idempotency.
- **`docs/src/cli-reference.md`** — new *"Trailing comments and line width"* subsection under `## harn fmt` stating the policy.
- **`Cargo.lock`** — incidental: corrects `harn-guard` `0.8.66 → 0.8.67` (lockfile drift the v0.8.67 reconcile missed).

No behavior change; `no-changelog-needed` (docs + tests). All `harn-fmt` tests pass (153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)