### PR TITLE
Release v0.8.67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "harn-guard"
-version = "0.8.66"
+version = "0.8.67"
 dependencies = [
  "harn-vm",
  "ort",


### PR DESCRIPTION
## Summary
- Add the release-marker commit that lets main satisfy the existing v0.8.67 tag-state guard after the release branch diverged.
- Update the harn-guard Cargo.lock package version from 0.8.66 to 0.8.67 so the lockfile matches the workspace release version.

## Verification
- ./scripts/verify_release_metadata.py
- pre-commit hook: cargo fmt, lint-no-rust-prompt-prose, workspace clippy
- pre-push hook: targeted local checks