### PR TITLE
chore(hooks): run cheap validators before clippy/cargo (fail-fast)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,10 +13,93 @@ hook_write_staged_files "$changed"
 hook_disable_cargo_incremental_if_release_bump staged
 
 # Track whether the python prompt-prose ratchet has already run in this
-# hook, so the Rust and ratchet blocks don't pay for it twice when both
+# hook, so the ratchet and clippy blocks don't pay for it twice when both
 # patterns match (the common case for a Rust crate edit that also
-# touches scripts/ or Makefile).
+# touches scripts/ or Makefile). Whichever block runs first sets the flag.
 prompt_prose_done=0
+
+# ---------------------------------------------------------------------------
+# Phase 1 — fast, read-only validators (fail-fast).
+#
+# These are cheap (python / npx, sub-second) and never build Rust or the
+# `harn` binary, so a trivial failure (a stray markdown heading, a keyword
+# mirror drift) aborts the commit in seconds instead of after the
+# multi-minute clippy build that used to run first. None of them mutate the
+# tree, so they are safe to run against the originally-staged file set before
+# the formatters re-stage anything.
+#
+# Note on markdown vs. the generated language spec: `docs/src/language-spec.md`
+# is `spec/HARN_SPEC.md` behind a transparent HTML-comment banner, and the
+# source is markdown-linted here too, so linting the mirror before the
+# Phase-2 sync step yields the same result the sync would produce.
+# ---------------------------------------------------------------------------
+
+if hook_paths_match "$changed" "$HOOK_RATCHET_PATTERN"; then
+  echo "=== Pre-commit: checking CI ratchets ==="
+  if [ "$prompt_prose_done" -eq 0 ]; then
+    make lint-no-rust-prompt-prose
+    prompt_prose_done=1
+  fi
+  make lint-no-xfail-regression
+  echo "    CI ratchets OK."
+else
+  echo "=== Pre-commit: skipping CI ratchets (no protected paths changed) ==="
+fi
+
+# Pure-Python, sub-second, no harn build — cheap enough to check (not just
+# at push) so drift in the lexer<->tree-sitter keyword mirror or the
+# generated-artifact registry is caught at the moment it's introduced. We
+# check rather than auto-regenerate so the hand-curated grouping/comments
+# in keywords.js survive; the hint points at `make gen-tree-sitter-keywords`.
+if hook_paths_match "$changed" "$HOOK_TREESITTER_PATTERN"; then
+  echo "=== Pre-commit: checking tree-sitter keyword mirror ==="
+  make -s check-tree-sitter-keywords
+  echo "    Tree-sitter keywords OK."
+else
+  echo "=== Pre-commit: skipping tree-sitter keyword check (no lexer/grammar changes) ==="
+fi
+
+if hook_paths_match "$changed" "$HOOK_GENREGISTRY_PATTERN"; then
+  echo "=== Pre-commit: checking generated-artifact registry ==="
+  make -s check-generated-registry
+  echo "    Generated-artifact registry OK."
+else
+  echo "=== Pre-commit: skipping generated-artifact registry check (no registry/Makefile/workflow/hook changes) ==="
+fi
+
+if hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN" && command -v npx >/dev/null 2>&1; then
+  echo "=== Pre-commit: checking markdown ==="
+  make lint-md
+  echo "    Markdown OK."
+elif hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN"; then
+  echo "=== Pre-commit: skipping markdown lint (npx not found) ==="
+else
+  echo "=== Pre-commit: skipping markdown lint (no markdown changes) ==="
+fi
+
+if hook_paths_match "$changed" "$HOOK_ACTIONS_PATTERN"; then
+  echo "=== Pre-commit: checking GitHub Actions workflows ==="
+  make lint-actions
+  echo "    GitHub Actions workflows OK."
+else
+  echo "=== Pre-commit: skipping GitHub Actions lint (no workflow/hook changes) ==="
+fi
+
+if hook_paths_match "$changed" "$HOOK_PORTAL_PATTERN" && command -v npm >/dev/null 2>&1; then
+  echo "=== Pre-commit: linting portal frontend ==="
+  ./scripts/ensure_portal_deps.sh
+  npm run portal:lint
+  echo "    Portal lint OK."
+elif hook_paths_match "$changed" "$HOOK_PORTAL_PATTERN"; then
+  echo "=== Pre-commit: skipping portal lint (npm not found) ==="
+else
+  echo "=== Pre-commit: skipping portal lint (no portal changes) ==="
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2 — formatters, clippy, and generated-file sync (the expensive,
+# tree-mutating steps). Reached only once the fast validators above pass.
+# ---------------------------------------------------------------------------
 
 if hook_paths_match "$changed" "$HOOK_RUST_PATTERN"; then
   echo "=== Pre-commit: formatting Rust ==="
@@ -68,9 +151,11 @@ if hook_paths_match "$changed" "$HOOK_RUST_PATTERN"; then
   # `--all-targets` clippy is still enforced by the `Rust lint` CI job
   # and by `make lint` for ad-hoc local runs; pre-push catches
   # test-target compile errors via `cargo check --tests`.
-  echo "=== Pre-commit: lint-no-rust-prompt-prose ==="
-  make lint-no-rust-prompt-prose
-  prompt_prose_done=1
+  if [ "$prompt_prose_done" -eq 0 ]; then
+    echo "=== Pre-commit: lint-no-rust-prompt-prose ==="
+    make lint-no-rust-prompt-prose
+    prompt_prose_done=1
+  fi
 
   hook_write_changed_cargo_packages "$changed" "$changed_packages"
   if hook_paths_match "$changed" '(^Cargo\.toml$|^Cargo\.lock$|^Makefile$)'; then
@@ -95,17 +180,6 @@ else
   echo "=== Pre-commit: skipping clippy (no Rust/Cargo changes) ==="
 fi
 
-if hook_paths_match "$changed" "$HOOK_RATCHET_PATTERN"; then
-  echo "=== Pre-commit: checking CI ratchets ==="
-  if [ "$prompt_prose_done" -eq 0 ]; then
-    make lint-no-rust-prompt-prose
-  fi
-  make lint-no-xfail-regression
-  echo "    CI ratchets OK."
-else
-  echo "=== Pre-commit: skipping CI ratchets (no protected paths changed) ==="
-fi
-
 if hook_paths_match "$changed" "$HOOK_HIGHLIGHT_PATTERN"; then
   echo "=== Pre-commit: syncing generated highlight keywords ==="
   make gen-highlight
@@ -126,56 +200,6 @@ if hook_paths_match "$changed" "$HOOK_LANGSPEC_PATTERN"; then
   echo "    Language spec OK."
 else
   echo "=== Pre-commit: skipping language spec sync (no spec changes) ==="
-fi
-
-# Pure-Python, sub-second, no harn build — cheap enough to check (not just
-# at push) so drift in the lexer<->tree-sitter keyword mirror or the
-# generated-artifact registry is caught at the moment it's introduced. We
-# check rather than auto-regenerate so the hand-curated grouping/comments
-# in keywords.js survive; the hint points at `make gen-tree-sitter-keywords`.
-if hook_paths_match "$changed" "$HOOK_TREESITTER_PATTERN"; then
-  echo "=== Pre-commit: checking tree-sitter keyword mirror ==="
-  make -s check-tree-sitter-keywords
-  echo "    Tree-sitter keywords OK."
-else
-  echo "=== Pre-commit: skipping tree-sitter keyword check (no lexer/grammar changes) ==="
-fi
-
-if hook_paths_match "$changed" "$HOOK_GENREGISTRY_PATTERN"; then
-  echo "=== Pre-commit: checking generated-artifact registry ==="
-  make -s check-generated-registry
-  echo "    Generated-artifact registry OK."
-else
-  echo "=== Pre-commit: skipping generated-artifact registry check (no registry/Makefile/workflow/hook changes) ==="
-fi
-
-if hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN" && command -v npx >/dev/null 2>&1; then
-  echo "=== Pre-commit: checking markdown ==="
-  make lint-md
-  echo "    Markdown OK."
-elif hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN"; then
-  echo "=== Pre-commit: skipping markdown lint (npx not found) ==="
-else
-  echo "=== Pre-commit: skipping markdown lint (no markdown changes) ==="
-fi
-
-if hook_paths_match "$changed" "$HOOK_ACTIONS_PATTERN"; then
-  echo "=== Pre-commit: checking GitHub Actions workflows ==="
-  make lint-actions
-  echo "    GitHub Actions workflows OK."
-else
-  echo "=== Pre-commit: skipping GitHub Actions lint (no workflow/hook changes) ==="
-fi
-
-if hook_paths_match "$changed" "$HOOK_PORTAL_PATTERN" && command -v npm >/dev/null 2>&1; then
-  echo "=== Pre-commit: linting portal frontend ==="
-  ./scripts/ensure_portal_deps.sh
-  npm run portal:lint
-  echo "    Portal lint OK."
-elif hook_paths_match "$changed" "$HOOK_PORTAL_PATTERN"; then
-  echo "=== Pre-commit: skipping portal lint (npm not found) ==="
-else
-  echo "=== Pre-commit: skipping portal lint (no portal changes) ==="
 fi
 
 echo "=== All pre-commit checks passed. ==="

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,7 +15,9 @@ hook_disable_cargo_incremental_if_release_bump "push $(hook_push_base)"
 # Merge-queue guard. GitHub does not reject pushes to a PR that's already
 # in the merge queue — it just keeps using the snapshot it took when the
 # PR was enqueued. Any commit pushed after that point is silently dropped
-# from the merged state. Bypass with `--no-verify` if you mean it.
+# from the merged state. Bypass with `--no-verify` if you mean it. Kept
+# first because it's a cheap correctness gate: there's no point running
+# any local check if the push itself would be silently dropped.
 if command -v gh >/dev/null 2>&1; then
   branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
   if [ -n "$branch" ] && [ "$branch" != "HEAD" ] && [ "$branch" != "main" ]; then
@@ -50,6 +52,69 @@ if command -v gh >/dev/null 2>&1; then
     fi
   fi
 fi
+
+# ---------------------------------------------------------------------------
+# Phase 1 — fast, read-only validators (fail-fast).
+#
+# Cheap (python / npx / actionlint, sub-second) and no Rust or `harn` build,
+# so a trivial drift fails the push in seconds instead of after the
+# `cargo check --tests` / generated-mirror rebuilds below.
+# ---------------------------------------------------------------------------
+
+if hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN" && command -v npx >/dev/null 2>&1; then
+  echo "=== Pre-push: checking markdown ==="
+  make lint-md
+elif hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN"; then
+  echo "=== Pre-push: skipping markdown lint (npx not found) ==="
+else
+  echo "=== Pre-push: skipping markdown lint (no markdown changes) ==="
+fi
+
+if hook_paths_match "$changed" "$HOOK_ACTIONS_PATTERN"; then
+  echo "=== Pre-push: checking GitHub Actions workflows ==="
+  make lint-actions
+else
+  echo "=== Pre-push: skipping GitHub Actions lint (no workflow/hook changes) ==="
+fi
+
+if hook_paths_match "$changed" "$HOOK_TREESITTER_PATTERN"; then
+  echo "=== Pre-push: checking tree-sitter keyword mirror ==="
+  make -s check-tree-sitter-keywords
+  echo "    Tree-sitter keywords OK."
+else
+  echo "=== Pre-push: skipping tree-sitter keyword check (no lexer/grammar changes) ==="
+fi
+
+# Meta-guard: keep scripts/generated_artifacts.toml in agreement with the
+# Makefile `all:` recipe and the CI workflows, so a new gen/check pair
+# can't silently skip CI. Pure-Python; no harn build.
+if hook_paths_match "$changed" "$HOOK_GENREGISTRY_PATTERN"; then
+  echo "=== Pre-push: checking generated-artifact registry ==="
+  make -s check-generated-registry
+  echo "    Generated-artifact registry OK."
+else
+  echo "=== Pre-push: skipping generated-artifact registry check (no registry/Makefile/workflow/hook changes) ==="
+fi
+
+# Block retroactive edits to released CHANGELOG sections. New entries
+# belong under `## Unreleased` (or the in-progress next-version heading
+# in a release PR), not under a section that already shipped under a tag.
+if hook_paths_match "$changed" '^CHANGELOG\.md$'; then
+  echo "=== Pre-push: checking CHANGELOG for retroactive edits ==="
+  if ! python3 scripts/check_changelog_no_retroactive_edits.py; then
+    echo "" >&2
+    echo "  Bypass for genuine fix-ups (typos, broken links):" >&2
+    echo "    ALLOW_CHANGELOG_RETROACTIVE_EDIT=1 git push" >&2
+    exit 1
+  fi
+else
+  echo "=== Pre-push: skipping CHANGELOG retroactive-edit check (no CHANGELOG.md changes) ==="
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Rust/Harn compilation and generated-mirror rebuilds (the
+# expensive steps). Reached only once the fast validators above pass.
+# ---------------------------------------------------------------------------
 
 echo "=== Pre-push: running targeted local checks ==="
 if [ "${HARN_PREPUSH_FULL_TESTS:-0}" = "1" ] && hook_paths_match "$changed" "$HOOK_TEST_PATTERN"; then
@@ -102,20 +167,6 @@ else
   echo "=== Pre-push: skipping Harn format/lint (no Harn changes) ==="
 fi
 
-if hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN" && command -v npx >/dev/null 2>&1; then
-  make lint-md
-elif hook_paths_match "$changed" "$HOOK_MARKDOWN_PATTERN"; then
-  echo "=== Pre-push: skipping markdown lint (npx not found) ==="
-else
-  echo "=== Pre-push: skipping markdown lint (no markdown changes) ==="
-fi
-
-if hook_paths_match "$changed" "$HOOK_ACTIONS_PATTERN"; then
-  make lint-actions
-else
-  echo "=== Pre-push: skipping GitHub Actions lint (no workflow/hook changes) ==="
-fi
-
 if hook_paths_match "$changed" "$HOOK_PORTAL_PATTERN" && command -v npm >/dev/null 2>&1; then
   ./scripts/ensure_portal_deps.sh
   npm run portal:lint
@@ -163,25 +214,6 @@ else
   echo "=== Pre-push: skipping highlight check (no lexer/stdlib changes) ==="
 fi
 
-if hook_paths_match "$changed" "$HOOK_TREESITTER_PATTERN"; then
-  echo "=== Pre-push: checking tree-sitter keyword mirror ==="
-  make -s check-tree-sitter-keywords
-  echo "    Tree-sitter keywords OK."
-else
-  echo "=== Pre-push: skipping tree-sitter keyword check (no lexer/grammar changes) ==="
-fi
-
-# Meta-guard: keep scripts/generated_artifacts.toml in agreement with the
-# Makefile `all:` recipe and the CI workflows, so a new gen/check pair
-# can't silently skip CI. Pure-Python; no harn build.
-if hook_paths_match "$changed" "$HOOK_GENREGISTRY_PATTERN"; then
-  echo "=== Pre-push: checking generated-artifact registry ==="
-  make -s check-generated-registry
-  echo "    Generated-artifact registry OK."
-else
-  echo "=== Pre-push: skipping generated-artifact registry check (no registry/Makefile/workflow/hook changes) ==="
-fi
-
 if hook_paths_match "$changed" "$HOOK_DIAGCATALOG_PATTERN"; then
   echo "=== Pre-push: checking diagnostic-code catalog ==="
   if ! make -s check-diagnostics-catalog >/tmp/harn-prepush-diagcatalog.log 2>&1; then
@@ -199,21 +231,6 @@ if hook_paths_match "$changed" "$HOOK_DIAGCATALOG_PATTERN"; then
   echo "    Diagnostic-code catalog OK."
 else
   echo "=== Pre-push: skipping diagnostic catalog check (no registry changes) ==="
-fi
-
-# Block retroactive edits to released CHANGELOG sections. New entries
-# belong under `## Unreleased` (or the in-progress next-version heading
-# in a release PR), not under a section that already shipped under a tag.
-if hook_paths_match "$changed" '^CHANGELOG\.md$'; then
-  echo "=== Pre-push: checking CHANGELOG for retroactive edits ==="
-  if ! python3 scripts/check_changelog_no_retroactive_edits.py; then
-    echo "" >&2
-    echo "  Bypass for genuine fix-ups (typos, broken links):" >&2
-    echo "    ALLOW_CHANGELOG_RETROACTIVE_EDIT=1 git push" >&2
-    exit 1
-  fi
-else
-  echo "=== Pre-push: skipping CHANGELOG retroactive-edit check (no CHANGELOG.md changes) ==="
 fi
 
 echo "=== Pre-push checks passed. ==="


### PR DESCRIPTION
## Summary

The git hooks already skip Rust checks when no Rust files are staged, but the **ordering** meant that a commit touching both Rust and (say) a markdown file ran the expensive **clippy** / `cargo check --tests` build *first*, and a trivial markdown/heading error only surfaced minutes later — wasting the build. (Hit exactly this on PR #2965: a cold ~4-min clippy ran, then the commit aborted on an `MD001` heading nit.)

This reorders **`pre-commit`** and **`pre-push`** into two phases so cheap failures are caught in seconds:

- **Phase 1 (fail-fast)** — read-only validators that never build Rust or the `harn` binary: CI ratchets, tree-sitter keyword mirror, generated-artifact registry, markdown lint, actions lint, and (pre-push) the CHANGELOG retroactive-edit check.
- **Phase 2** — formatters, clippy / `cargo check --tests`, and the generated-file syncs (highlight, language-spec, diagnostics) — the steps that actually build.

## Notes / invariants preserved

- **No checks added or removed** — same conditions, same coverage; only order changed.
- The pre-push **merge-queue guard stays first** (cheap correctness gate — no point running anything if the push would be silently dropped).
- The **prompt-prose ratchet dedup** now sets its done-flag in whichever block runs first, so it still runs at most once whether the ratchet or clippy block reaches it first.
- **Markdown before language-spec sync is safe**: the generated `docs/src/language-spec.md` mirror is `spec/HARN_SPEC.md` behind a transparent HTML-comment banner, so its lint result equals the source's — and the source is markdown-linted in the same phase.

## Verification

- `sh -n` clean on both hooks; every `HOOK_*_PATTERN` block and all three `cargo clippy` invocations preserved.
- Dry-ran the reordered `pre-commit` against staged changes (fast phase runs first, exit 0) and committed/pushed this PR through the new hooks themselves.

`no-changelog-needed`: dev-tooling only, no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)