### PR TITLE
ci(publish-release): don't force a doomed re-publish on a transient asset query

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -199,8 +199,27 @@ jobs:
             # — so re-running is a no-op for crates that landed and a
             # recovery for those that didn't.
             if [[ "$EVENT_NAME" == "push" ]]; then
-              ASSET_COUNT="$(gh release view "$LATEST_TAG" --json assets --jq '.assets | length' 2>/dev/null || echo 0)"
-              if (( ASSET_COUNT >= 5 )); then
+              # Distinguish a genuine low asset count (recover) from a transient
+              # or eventually-consistent query failure. The old `|| echo 0`
+              # collapsed "gh could not answer" into "0 assets", forcing
+              # DRIFT=true → a doomed `release_ship.sh --finalize` from main HEAD
+              # when the tag is an older (squash-orphaned) commit. That produced
+              # a spurious red X on a routine main push right after the tag-first
+              # publish (harn#2964: a `gh release view` raced the release becoming
+              # visible). Retry briefly; only force a re-publish on a *confirmed*
+              # low count, and on a persistent query failure assume the tag-first
+              # publish already shipped (crates.io is the source of truth) and skip.
+              ASSET_COUNT=""
+              for _ in 1 2 3; do
+                if ASSET_COUNT="$(gh release view "$LATEST_TAG" --json assets --jq '.assets | length' 2>/dev/null)"; then
+                  break
+                fi
+                ASSET_COUNT=""
+                sleep 5
+              done
+              if [[ -z "$ASSET_COUNT" ]]; then
+                echo "::notice::Could not read $LATEST_TAG release assets after retries; assuming the tag-first publish already shipped and skipping (avoids a spurious finalize from main HEAD)."
+              elif (( ASSET_COUNT >= 5 )); then
                 echo "::notice::$LATEST_TAG already published — $ASSET_COUNT assets on https://github.com/$GITHUB_REPOSITORY/releases/tag/$LATEST_TAG. Publish job will skip; this is the intended behavior under tag-first publishing."
               else
                 DRIFT=true


### PR DESCRIPTION
## Problem

On a push to `main` where `Cargo.toml` version equals the latest `vX.Y.Z` tag, the publish-release `check` job self-heals by re-publishing if the GitHub release has fewer than 5 assets. The query was:

```bash
ASSET_COUNT="$(gh release view "$LATEST_TAG" --json assets --jq '.assets | length' 2>/dev/null || echo 0)"
```

`|| echo 0` collapses **"gh could not answer"** into **"0 assets"**, forcing `DRIFT=true` → a `release_ship.sh --finalize` from main HEAD. When the tag is an older, squash-orphaned commit (the normal post-release shape), that finalize fails (`detached at <X> but <prev-tag> points to <Y>`).

That's exactly what produced the lone red X in harn#2964: a routine main push moments after a tag-first publish, where `gh release view` briefly raced the release becoming queryable. The very next main pushes (#2965, #2966) passed once the release was visible — confirming it was transient, not a real drift.

## Fix

Retry the asset query a few times, and only force a re-publish on a **confirmed** low count. On a persistent query failure, assume the tag-first publish already shipped (crates.io is the source of truth) and skip — rather than firing a finalize that can't succeed.

- Preserves the genuine missing-assets recovery path (successful query, `<5` assets → `DRIFT=true`).
- Removes the transient false positive.
- `actionlint` clean; `.github/`-only change (no changelog fragment required per the gate's ignore list).

Out of scope: the deeper `release_ship.sh --finalize` detached-HEAD guard comparing against the previous tag is left as-is — it only matters in a genuine recovery on a squash-orphaned tag, which this change makes far rarer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)