### PR TITLE
feat(cli): gate testbench-wasi (wasmtime) behind an opt-in feature

### DIFF
--- a/changelog.d/2974.changed.md
+++ b/changelog.d/2974.changed.md
@@ -1,0 +1,8 @@
+- **`harn testbench run --process-wasi` is now an opt-in build (#2974).** wasmtime
+  and the cranelift JIT (~36 crates, ~8.6 MB of the stripped binary) are no longer
+  linked into the default `harn` binary; they only powered the WASI subprocess
+  toolchain mode. Every other testbench path — record/replay tapes, filesystem
+  overlay, paused clock, LLM fixtures, fidelity scoring, annotations, and the
+  conformance-test sidecars — is unchanged. To use `--process-wasi`, build with the
+  feature: `cargo install harn-cli --features testbench-wasi`. Without it the flag
+  returns a clear "requires the testbench-wasi Cargo feature" error.

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -36,7 +36,16 @@ path = "src/main.rs"
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-ir = { path = "../harn-ir", version = "0.8" }
-harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel", "testbench-wasi"] }
+# testbench-wasi (wasmtime + the cranelift JIT, ~36 crates, ~8.6 MB of the
+# stripped binary plus real compile time) is NOT enabled by default — it only
+# backs the advanced `harn testbench run --process-wasi <dir>`
+# subprocess mode, which substitutes real subprocesses with pre-compiled
+# wasm32-wasi modules. Every other testbench path (record/replay tapes, FS
+# overlay, paused clock, LLM fixtures, fidelity, annotations, conformance
+# sidecars) works without it, so the default binary stays lean. Opt in with the
+# `testbench-wasi` feature below; without it `--process-wasi` returns a clear
+# "requires the testbench-wasi Cargo feature" error.
+harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel"] }
 harn-hostlib = { path = "../harn-hostlib", version = "0.8", optional = true }
 harn-rules = { path = "../harn-rules", version = "0.8", optional = true }
 harn-rules-hostlib = { path = "../harn-rules-hostlib", version = "0.8", optional = true }
@@ -121,9 +130,11 @@ libc = "0.2"
 # purpose: resolver=2 isolates build- and runtime-dep feature sets, and a
 # divergent set would compile `harn-vm` twice with different cfgs. Keeping
 # the lists in sync lets Cargo dedupe and keeps clippy diagnostics aligned
-# across the two compile units.
+# across the two compile units. The build script never needs testbench-wasi
+# (it only compiles/encodes bytecode), so wasmtime stays out of this compile
+# unit; the optional `testbench-wasi` feature only toggles the runtime dep.
 [build-dependencies]
-harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel", "testbench-wasi"] }
+harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel"] }
 harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 
 [features]
@@ -143,6 +154,12 @@ hostlib = [
 # The default release binary stays lean — `harn guard` management works without
 # it, falling back to the built-in heuristic at runtime.
 guard-neural = ["harn-guard/neural"]
+# Off by default: link wasmtime + the cranelift JIT so `harn testbench run
+# --process-wasi <dir>` can run subprocesses as wasm32-wasi modules under a
+# virtualized clock. Adds ~36 crates / ~8.6 MB stripped. Every other testbench path
+# works without it, so the default distributed binary stays lean. Opt in for a
+# from-source build: `cargo install harn-cli --features testbench-wasi`.
+testbench-wasi = ["harn-vm/testbench-wasi"]
 
 [dev-dependencies]
 harn-mcp-rc-compat = { path = "../harn-mcp-rc-compat" }

--- a/crates/harn-cli/tests/test_bench_cli.rs
+++ b/crates/harn-cli/tests/test_bench_cli.rs
@@ -453,7 +453,10 @@ pipeline default() {
 
 /// A `WasiToolchain` testbench routes `command_output` to a WASI-compiled
 /// tool, virtualizes its clocks via the testbench `MockClock`, and surfaces
-/// the WASM module's stdout to the parent.
+/// the WASM module's stdout to the parent. Only meaningful when the
+/// `testbench-wasi` feature is built in; without it the `WasiToolchain`
+/// subprocess mode returns a "requires the feature" error by design.
+#[cfg(feature = "testbench-wasi")]
 #[test]
 fn wasi_toolchain_runs_module_with_virtualized_clock() {
     use harn_vm::process_sandbox::{command_output, ProcessCommandConfig};

--- a/docs/src/dev/testbench.md
+++ b/docs/src/dev/testbench.md
@@ -192,6 +192,14 @@ WASM.
 
 ### WASI subprocess sandbox
 
+> **Requires an opt-in build.** wasmtime + the cranelift JIT are *not*
+> compiled into the default/distributed `harn` binary (they add ~36 crates and
+> ~8.6 MB of the stripped binary, plus compile time, for this one mode). Build
+> with the feature to enable it:
+> `cargo install harn-cli --features testbench-wasi`. Without it,
+> `--process-wasi` returns `WasiToolchain requires the testbench-wasi Cargo
+> feature`. Every other testbench mode below works in the default binary.
+
 `--process-wasi <dir>` resolves every subprocess invocation against
 `<dir>/<program>.wasm`. Programs that match are run inside wasmtime
 with the testbench's mock clock virtualized into `clock_time_get` and


### PR DESCRIPTION
Follow-up to the binary-size work — gates the last large non-essential chunk out of the default binary.

## Why
The default `harn` binary linked **wasmtime + the cranelift JIT (~36 crates)** unconditionally, but they back exactly one mode: `harn testbench run --process-wasi <dir>`, which substitutes real subprocesses with pre-compiled `wasm32-wasi` modules. **Every other testbench path** — record/replay tapes, FS overlay, paused clock, LLM fixtures, fidelity, annotations, and the **conformance-test sidecars** — works without it. Nothing in CI/conformance/production uses `--process-wasi` (one cli test + the docs reference it).

## What
- Drop `testbench-wasi` from harn-cli's default; expose it as an **opt-in feature**: `cargo install harn-cli --features testbench-wasi`.
- Without it, `--process-wasi` returns the existing clear `WasiToolchain requires the testbench-wasi Cargo feature` error.
- The one WASI cli test is `#[cfg(feature = "testbench-wasi")]`-gated; docs note the opt-in.

## Measured impact
- **−8.6 MB** stripped release binary (176.8 → **168.2 MB**), verified by building both ways with the shipping profile (thin LTO + strip).
- 36 wasmtime/cranelift crates no longer compile in the default build (faster default/release builds too).
- `cargo tree` confirms the default graph drops wasmtime; `--features testbench-wasi` restores it.

## Tradeoff
Binary-download users lose `--process-wasi` unless they rebuild via cargo (the error tells them how). That audience overlaps with people already compiling WASM toolchains, so it's an acceptable trade for a leaner default. A separate "fat" tarball variant can be added later if there's demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)