### PR TITLE
fix(cli): harn-lsp/harn-dap answer --version/--help (regression from #2972)

### DIFF
--- a/changelog.d/2976.fixed.md
+++ b/changelog.d/2976.fixed.md
@@ -1,0 +1,7 @@
+- **`harn-lsp --version` / `harn-dap --version` print a version again (#2976).**
+  After the multi-call binary collapse (#2972) the argv[0] shim dispatched a
+  `--version`/`-V` probe straight into the stdio server, which hung waiting on
+  input. The shim now answers `--version`/`-V` and `--help`/`-h` before starting
+  the server, printing `<name> <version>` (matching `harn --version`). Normal
+  editor LSP/DAP usage, which speaks the protocol rather than passing flags, is
+  unchanged.

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -6,10 +6,12 @@
 //! `harn-dap` by path keep working unchanged, while the release ships one
 //! binary instead of three near-identical statically-linked copies.
 
+use std::ffi::OsStr;
+
 fn main() {
     match invoked_as().as_deref() {
-        Some("harn-lsp") => harn_lsp::run(),
-        Some("harn-dap") => harn_dap::run(),
+        Some("harn-lsp") => run_sidecar("harn-lsp", harn_lsp::run),
+        Some("harn-dap") => run_sidecar("harn-dap", harn_dap::run),
         _ => harn_cli::run(),
     }
 }
@@ -26,4 +28,92 @@ fn invoked_as() -> Option<String> {
         .and_then(std::path::Path::file_stem)
         .and_then(|stem| stem.to_str())
         .map(str::to_owned)
+}
+
+/// Run a stdio sidecar (`harn-lsp` / `harn-dap`), but answer a bare
+/// `--version`/`-V` or `--help`/`-h` probe first.
+///
+/// The sidecars speak a wire protocol over stdin/stdout and don't otherwise
+/// parse argv, so without this a `--version` probe would silently start the
+/// server and hang waiting on stdin. As standalone binaries they used to
+/// answer `--version`; the multi-call collapse dropped that. Regression fix
+/// for #2975.
+fn run_sidecar(name: &str, serve: fn()) {
+    match sidecar_query(std::env::args_os().skip(1)) {
+        Some(SidecarQuery::Version) => println!("{name} {}", env!("CARGO_PKG_VERSION")),
+        Some(SidecarQuery::Help) => print_sidecar_help(name),
+        None => serve(),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum SidecarQuery {
+    Version,
+    Help,
+}
+
+/// Detect a leading `--version`/`-V`/`--help`/`-h` probe in a sidecar's args.
+///
+/// Only the first argument is inspected: editors launch the sidecars with no
+/// arguments, so anything else falls through to the server unchanged rather
+/// than risk intercepting a future protocol-relevant flag.
+fn sidecar_query<I, S>(mut args: I) -> Option<SidecarQuery>
+where
+    I: Iterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    match args.next()?.as_ref().to_str()? {
+        "--version" | "-V" => Some(SidecarQuery::Version),
+        "--help" | "-h" => Some(SidecarQuery::Help),
+        _ => None,
+    }
+}
+
+fn print_sidecar_help(name: &str) {
+    let kind = if name.ends_with("dap") {
+        "debug adapter (DAP)"
+    } else {
+        "language server (LSP)"
+    };
+    println!("{name} {}", env!("CARGO_PKG_VERSION"));
+    println!();
+    println!("The Harn {kind}. It communicates over stdio and is normally");
+    println!("launched by an editor rather than run directly.");
+    println!();
+    println!("Options:");
+    println!("  -V, --version    Print version and exit");
+    println!("  -h, --help       Print this help and exit");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sidecar_query, SidecarQuery};
+
+    #[test]
+    fn detects_version_flags() {
+        assert_eq!(
+            sidecar_query(["--version"].iter()),
+            Some(SidecarQuery::Version)
+        );
+        assert_eq!(sidecar_query(["-V"].iter()), Some(SidecarQuery::Version));
+    }
+
+    #[test]
+    fn detects_help_flags() {
+        assert_eq!(sidecar_query(["--help"].iter()), Some(SidecarQuery::Help));
+        assert_eq!(sidecar_query(["-h"].iter()), Some(SidecarQuery::Help));
+    }
+
+    #[test]
+    fn no_args_runs_server() {
+        let empty: [&str; 0] = [];
+        assert_eq!(sidecar_query(empty.iter()), None);
+    }
+
+    #[test]
+    fn unrelated_first_arg_runs_server() {
+        // A non-query leading arg falls through to the server untouched.
+        assert_eq!(sidecar_query(["--stdio"].iter()), None);
+        assert_eq!(sidecar_query(["serve", "--version"].iter()), None);
+    }
 }

--- a/crates/harn-cli/tests/sidecar_version_cli.rs
+++ b/crates/harn-cli/tests/sidecar_version_cli.rs
@@ -1,0 +1,89 @@
+//! Regression test for #2975.
+//!
+//! `harn-lsp` / `harn-dap` are argv[0]-dispatched into the single multi-call
+//! `harn` binary. They must answer `--version`/`-V`/`--help` instead of
+//! silently starting the stdio server (which a version-probe would otherwise
+//! do, hanging on stdin). We invoke the built `harn` binary with a spoofed
+//! `argv[0]` via `CommandExt::arg0`, which exercises the real dispatch path
+//! without needing an on-disk symlink. Unix-only because `arg0` is a Unix
+//! extension; the shipped Windows aliases are copies and hit the same code.
+
+#![cfg(unix)]
+
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+
+fn run_as(argv0: &str, args: &[&str]) -> (String, i32) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harn"));
+    cmd.arg0(argv0);
+    cmd.args(args);
+    // Null stdin: if dispatch were broken and the server started, it would get
+    // EOF and exit rather than hang the test forever.
+    cmd.stdin(Stdio::null());
+    let output = cmd.output().expect("spawn harn");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn lsp_prints_version() {
+    for flag in ["--version", "-V"] {
+        let (stdout, code) = run_as("harn-lsp", &[flag]);
+        assert_eq!(code, 0, "harn-lsp {flag} exit code; stdout={stdout:?}");
+        assert!(
+            stdout.starts_with("harn-lsp "),
+            "expected 'harn-lsp <version>' for {flag}, got {stdout:?}"
+        );
+        assert!(
+            stdout.trim().ends_with(env!("CARGO_PKG_VERSION")),
+            "version string missing for {flag}: {stdout:?}"
+        );
+    }
+}
+
+#[test]
+fn dap_prints_version() {
+    for flag in ["--version", "-V"] {
+        let (stdout, code) = run_as("harn-dap", &[flag]);
+        assert_eq!(code, 0, "harn-dap {flag} exit code; stdout={stdout:?}");
+        assert!(
+            stdout.starts_with("harn-dap "),
+            "expected 'harn-dap <version>' for {flag}, got {stdout:?}"
+        );
+        assert!(
+            stdout.trim().ends_with(env!("CARGO_PKG_VERSION")),
+            "version string missing for {flag}: {stdout:?}"
+        );
+    }
+}
+
+#[test]
+fn lsp_prints_help_and_exits() {
+    let (stdout, code) = run_as("harn-lsp", &["--help"]);
+    assert_eq!(code, 0, "stdout={stdout:?}");
+    assert!(stdout.contains("harn-lsp"), "help banner: {stdout:?}");
+    assert!(
+        stdout.to_lowercase().contains("language server"),
+        "help should describe the LSP: {stdout:?}"
+    );
+}
+
+#[test]
+fn dap_help_describes_debug_adapter() {
+    let (stdout, code) = run_as("harn-dap", &["-h"]);
+    assert_eq!(code, 0, "stdout={stdout:?}");
+    assert!(
+        stdout.to_lowercase().contains("debug adapter"),
+        "help should describe the DAP: {stdout:?}"
+    );
+}
+
+#[test]
+fn plain_harn_version_unaffected() {
+    // argv[0] == harn → the normal CLI version path, untouched by the shim.
+    let (stdout, code) = run_as("harn", &["--version"]);
+    assert_eq!(code, 0, "stdout={stdout:?}");
+    assert!(stdout.contains("harn"), "plain harn --version: {stdout:?}");
+}


### PR DESCRIPTION
Closes #2975.

## Regression
Since #2972 collapsed `harn`/`harn-lsp`/`harn-dap` into one argv[0]-dispatched binary, a `harn-lsp --version` / `-V` probe fell straight into the stdio server loop and hung on stdin instead of printing a version — breaking tooling that version-checks the sidecars.

## Fix
Handle `--version`/`-V` and `--help`/`-h` in the dispatch shim **before** entering the server, printing `<name> <version>` (same format as `harn --version`). Only the leading arg is inspected, so editors that spawn the sidecars with no args hit the server unchanged.

## Verification (matches the issue repro)
```
$ harn-lsp -V        → harn-lsp 0.8.68
$ harn-lsp --version → harn-lsp 0.8.68
$ harn-dap -V        → harn-dap 0.8.68
$ harn -V            → harn 0.8.68   (unaffected)
$ printf '' | harn-lsp → server runs, exits 0 (editor path preserved)
```
Tests: 4 unit tests for the arg detection + a Unix integration test that spoofs argv[0] via `CommandExt::arg0` to exercise the real dispatch end-to-end (incl. `--help` and that plain `harn --version` is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)