### PR TITLE
fix(llm): remap reserved <tool_call> token to a non-special wire delimiter

### DIFF
--- a/changelog.d/2978.fixed.md
+++ b/changelog.d/2978.fixed.md
@@ -1,0 +1,12 @@
+- **Models that reserve `<tool_call>` as a special token no longer collapse on the text tool format (#2978).**
+  Qwen3.x and other Hermes-tool finetunes encode `<tool_call>`/`</tool_call>` as
+  single special tokens. Reusing those exact strings as harn's text tool-call
+  delimiters — embedded as instructional and wrapper text throughout the system
+  prompt — drove such models into degenerate opener repetition
+  (`<tool_call>\n<tool_call>\n…`). A new `reserved_tool_call_token` capability
+  remaps the two colliding delimiters to a non-special bracket form on the wire
+  and maps the response back (across streamed chunk boundaries) before the
+  parser and transcript see it, so the canonical format is unchanged everywhere
+  except the bytes sent to the model. Flagged for the llamacpp Qwen3 / Qwen3.6
+  rules. Measured on Qwen3.6-35B-A3B: `<tool_call>` 0/5 no-collapse vs the
+  remapped delimiter 5/5.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -250,6 +250,12 @@ pub struct ProviderRule {
     /// `<task>` / `<examples>` over Markdown headings.
     #[serde(default)]
     pub prefers_xml_scaffolding: Option<bool>,
+    /// Whether this model's tokenizer reserves `<tool_call>` / `</tool_call>`
+    /// as single special tokens (the native Hermes tool-call markers). When
+    /// true, harn remaps those delimiters to a non-special bracket form on the
+    /// wire to avoid degenerate opener repetition; see [`crate::llm::tool_delimiter`].
+    #[serde(default)]
+    pub reserved_tool_call_token: Option<bool>,
     /// Whether prompt sections should prefer Markdown headings such as
     /// `## Task` / `## Examples`.
     #[serde(default)]
@@ -413,6 +419,8 @@ pub struct Capabilities {
     /// Legacy mirror for CLI display and older callers.
     pub json_schema: Option<String>,
     pub prefers_xml_scaffolding: bool,
+    /// See [`ProviderRule::reserved_tool_call_token`].
+    pub reserved_tool_call_token: bool,
     pub prefers_markdown_scaffolding: bool,
     pub structured_output_mode: String,
     pub supports_assistant_prefill: bool,
@@ -471,6 +479,7 @@ impl Default for Capabilities {
             structured_output: None,
             json_schema: None,
             prefers_xml_scaffolding: false,
+            reserved_tool_call_token: false,
             prefers_markdown_scaffolding: false,
             structured_output_mode: "none".to_string(),
             supports_assistant_prefill: false,
@@ -522,6 +531,7 @@ pub struct ProviderCapabilityMatrixRow {
     pub files_api_supported: bool,
     pub json_schema: Option<String>,
     pub prefers_xml_scaffolding: bool,
+    pub reserved_tool_call_token: bool,
     pub prefers_markdown_scaffolding: bool,
     pub structured_output_mode: String,
     pub supports_assistant_prefill: bool,
@@ -907,6 +917,7 @@ fn rule_to_matrix_row(
         files_api_supported: rule.files_api_supported.unwrap_or(false),
         json_schema: rule_structured_output(rule),
         prefers_xml_scaffolding: rule.prefers_xml_scaffolding.unwrap_or(false),
+        reserved_tool_call_token: rule.reserved_tool_call_token.unwrap_or(false),
         prefers_markdown_scaffolding: rule.prefers_markdown_scaffolding.unwrap_or(false),
         structured_output_mode: rule_structured_output_mode(rule),
         supports_assistant_prefill: rule.supports_assistant_prefill.unwrap_or(false),
@@ -1075,6 +1086,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         file_upload_wire_format: None,
         structured_output: None,
         prefers_xml_scaffolding: None,
+        reserved_tool_call_token: None,
         prefers_markdown_scaffolding: None,
         structured_output_mode: None,
         supports_assistant_prefill: None,
@@ -1152,6 +1164,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         structured_output: rule_structured_output(rule),
         json_schema: rule_structured_output(rule),
         prefers_xml_scaffolding: rule.prefers_xml_scaffolding.unwrap_or(false),
+        reserved_tool_call_token: rule.reserved_tool_call_token.unwrap_or(false),
         prefers_markdown_scaffolding: rule.prefers_markdown_scaffolding.unwrap_or(false),
         structured_output_mode: rule_structured_output_mode(rule),
         supports_assistant_prefill: rule.supports_assistant_prefill.unwrap_or(false),

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -994,6 +994,10 @@ model_match = "*qwen3.6*"
 native_tools = false
 preferred_tool_format = "text"
 structured_output = "native"
+# Qwen3.6's tokenizer reserves <tool_call>/</tool_call> as single special
+# tokens; reusing them as text-format delimiters collapses the agent loop into
+# opener repetition. Remap to a non-special wire form (validated: 5/5 vs 0/5).
+reserved_tool_call_token = true
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
 preserve_thinking = true
@@ -1015,6 +1019,9 @@ model_match = "*qwen3*"
 native_tools = false
 preferred_tool_format = "text"
 structured_output = "native"
+# Qwen3 family reserves <tool_call>/</tool_call> as special tokens; see the
+# qwen3.6 rule above. Remapped to a non-special wire delimiter.
+reserved_tool_call_token = true
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
 server_parser = "none"

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -134,6 +134,7 @@ pub(crate) mod providers;
 pub(crate) mod rate_limit;
 pub mod receipts;
 mod stream;
+pub(crate) mod tool_delimiter;
 pub(crate) mod tools;
 mod trace;
 pub(crate) mod trigger_predicate;

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -108,13 +108,28 @@ impl OpenAiCompatibleProvider {
         opts: &LlmRequestPayload,
         force_string_content: bool,
     ) -> serde_json::Value {
+        let caps = crate::llm::capabilities::lookup(&opts.provider, &opts.model);
+        // Models that reserve `<tool_call>` as a special token collapse when
+        // they meet it as instructional/wrapper text. Remap the colliding
+        // delimiters to a non-special wire form on every outgoing message
+        // (system + full history + prefill); the response is mapped back in
+        // `chat_impl`. This is the single, comprehensive boundary — it covers
+        // every prompt fragment that references the text tool-call paradigm
+        // because it operates on the assembled wire bytes, not per-template.
+        let remap_tool_call = caps.reserved_tool_call_token;
         let mut msgs = Vec::new();
         if let Some(ref sys) = opts.system {
+            let sys = maybe_remap_tool_call_text(sys, remap_tool_call);
             msgs.push(serde_json::json!({"role": "system", "content": sys}));
         }
         msgs.extend(opts.messages.iter().cloned().map(|mut message| {
             if let Some(object) = message.as_object_mut() {
                 if let Some(content) = object.get("content").cloned() {
+                    let content = if remap_tool_call {
+                        remap_tool_call_content(&content)
+                    } else {
+                        content
+                    };
                     object.insert(
                         "content".to_string(),
                         crate::llm::content::openai_content(&content),
@@ -124,6 +139,7 @@ impl OpenAiCompatibleProvider {
             message
         }));
         if let Some(ref prefill) = opts.prefill {
+            let prefill = maybe_remap_tool_call_text(prefill, remap_tool_call);
             msgs.push(serde_json::json!({
                 "role": "assistant",
                 "content": prefill,
@@ -135,7 +151,6 @@ impl OpenAiCompatibleProvider {
             "model": opts.model,
             "messages": msgs,
         });
-        let caps = crate::llm::capabilities::lookup(&opts.provider, &opts.model);
         if opts.max_tokens > 0 {
             let token_limit_field = if caps.requires_completion_tokens {
                 "max_completion_tokens"
@@ -263,12 +278,77 @@ impl OpenAiCompatibleProvider {
 
         let mut body = Self::build_request_body(request, false);
         self.transform_request(&mut body);
-        crate::llm::api::vm_call_llm_api_with_body(
+
+        // For reserved-tool-call-token models the prompt was sent with the
+        // delimiters remapped (see `build_request_body`); map the response
+        // back to canonical `<tool_call>` before the parser/transcript see it.
+        let remap_tool_call = crate::llm::capabilities::lookup(&request.provider, &request.model)
+            .reserved_tool_call_token;
+        let delta_tx = if remap_tool_call {
+            delta_tx.map(canonicalizing_delta_tx)
+        } else {
+            delta_tx
+        };
+        let mut result = crate::llm::api::vm_call_llm_api_with_body(
             request, delta_tx, body, false, // is_anthropic_style
             false, // is_ollama
         )
-        .await
+        .await?;
+        if remap_tool_call {
+            result.text = crate::llm::tool_delimiter::wire_to_canonical(&result.text);
+        }
+        Ok(result)
     }
+}
+
+/// Remap canonical `<tool_call>` delimiters to the non-special wire form for a
+/// reserved-token model (no-op when `remap` is false). Applied to every outgoing
+/// message; see [`crate::llm::tool_delimiter`].
+fn maybe_remap_tool_call_text(text: &str, remap: bool) -> String {
+    if remap {
+        crate::llm::tool_delimiter::canonical_to_wire(text)
+    } else {
+        text.to_string()
+    }
+}
+
+/// Apply the tool-call delimiter remap to an OpenAI `content` value, which may
+/// be a bare string or an array of typed parts (`{type:"text", text:"…"}`).
+fn remap_tool_call_content(content: &serde_json::Value) -> serde_json::Value {
+    use crate::llm::tool_delimiter::canonical_to_wire;
+    match content {
+        serde_json::Value::String(s) => serde_json::Value::String(canonical_to_wire(s)),
+        serde_json::Value::Array(parts) => serde_json::Value::Array(
+            parts
+                .iter()
+                .map(|part| {
+                    let mut part = part.clone();
+                    if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                        let remapped = canonical_to_wire(text);
+                        if let Some(obj) = part.as_object_mut() {
+                            obj.insert("text".to_string(), serde_json::Value::String(remapped));
+                        }
+                    }
+                    part
+                })
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// Wrap a delta sender so streamed chunks are mapped from the wire tool-call
+/// delimiter back to canonical before reaching the live display. The authoritative
+/// reverse map is on the final completion text; this keeps the streaming preview
+/// consistent (best-effort across chunk boundaries).
+fn canonicalizing_delta_tx(orig: DeltaSender) -> DeltaSender {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    tokio::spawn(async move {
+        while let Some(chunk) = rx.recv().await {
+            let _ = orig.send(crate::llm::tool_delimiter::wire_to_canonical(&chunk));
+        }
+    });
+    tx
 }
 
 pub(crate) fn ensure_openrouter_require_parameters(body: &mut serde_json::Value) {
@@ -977,5 +1057,43 @@ thinking_modes = ["enabled"]
             prefill: None,
             reminder_lifecycle: Vec::new(),
         }
+    }
+
+    #[test]
+    fn build_request_body_remaps_reserved_tool_call_token() {
+        // llamacpp + qwen3.6 is flagged `reserved_tool_call_token` in
+        // capabilities.toml, so the colliding delimiters must be remapped off
+        // the wire across both system and history messages.
+        let mut payload = base_request_payload();
+        payload.provider = "llamacpp".to_string();
+        payload.model = "qwen3.6-35b-a3b-ud-q4-k-xl".to_string();
+        payload.system = Some("Use <tool_call>\nname({})\n</tool_call> blocks.".to_string());
+        payload.messages = vec![json!({
+            "role": "assistant",
+            "content": "<tool_call>\nlook({})\n</tool_call>"
+        })];
+        let serialized = OpenAiCompatibleProvider::build_request_body(&payload, false).to_string();
+        assert!(
+            !serialized.contains("<tool_call>") && !serialized.contains("</tool_call>"),
+            "canonical delimiters must be remapped off the wire: {serialized}"
+        );
+        assert!(
+            serialized.contains("[[CALL]]") && serialized.contains("[[/CALL]]"),
+            "non-special wire delimiters must be present: {serialized}"
+        );
+    }
+
+    #[test]
+    fn build_request_body_keeps_canonical_for_normal_models() {
+        // openrouter gemini is not a reserved-token model: leave the canonical
+        // text tool-call delimiters exactly as authored.
+        let mut payload = base_request_payload();
+        payload.system = Some("Use <tool_call>\nname({})\n</tool_call> blocks.".to_string());
+        let serialized = OpenAiCompatibleProvider::build_request_body(&payload, false).to_string();
+        assert!(
+            serialized.contains("<tool_call>"),
+            "non-reserved model keeps canonical delimiter: {serialized}"
+        );
+        assert!(!serialized.contains("[[CALL]]"));
     }
 }

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -337,15 +337,72 @@ fn remap_tool_call_content(content: &serde_json::Value) -> serde_json::Value {
     }
 }
 
+/// Stateful canonicalizer for a streamed completion. The wire delimiter
+/// (`[[CALL]]`) usually arrives split across token deltas (`[[`, `CALL`, `]]`),
+/// so a per-chunk replace would miss it and leak the wire form into the
+/// transcript / live display. `push` returns the text safe to emit now —
+/// everything except a trailing tail that could still be the start of a
+/// delimiter — and `flush` returns the remainder at end-of-stream.
+#[derive(Default)]
+struct DeltaCanonicalizer {
+    buf: String,
+}
+
+impl DeltaCanonicalizer {
+    fn push(&mut self, chunk: &str) -> String {
+        use crate::llm::tool_delimiter::{
+            wire_to_canonical, WIRE_TOOL_CALL_CLOSE, WIRE_TOOL_CALL_OPEN,
+        };
+        self.buf.push_str(chunk);
+        let max = WIRE_TOOL_CALL_OPEN.len().max(WIRE_TOOL_CALL_CLOSE.len());
+        let blen = self.buf.len();
+        // The wire delimiters are pure ASCII, so any partial-delimiter tail is
+        // ASCII and lands on a char boundary — byte slicing is safe here.
+        let mut hold = 0;
+        for k in (1..=max.min(blen)).rev() {
+            let tail = &self.buf.as_bytes()[blen - k..];
+            if WIRE_TOOL_CALL_OPEN.as_bytes().starts_with(tail)
+                || WIRE_TOOL_CALL_CLOSE.as_bytes().starts_with(tail)
+            {
+                hold = k;
+                break;
+            }
+        }
+        let safe_end = blen - hold;
+        if safe_end == 0 {
+            return String::new();
+        }
+        let emit = wire_to_canonical(&self.buf[..safe_end]);
+        self.buf.drain(..safe_end);
+        emit
+    }
+
+    fn flush(&mut self) -> String {
+        if self.buf.is_empty() {
+            return String::new();
+        }
+        let out = crate::llm::tool_delimiter::wire_to_canonical(&self.buf);
+        self.buf.clear();
+        out
+    }
+}
+
 /// Wrap a delta sender so streamed chunks are mapped from the wire tool-call
-/// delimiter back to canonical before reaching the live display. The authoritative
-/// reverse map is on the final completion text; this keeps the streaming preview
-/// consistent (best-effort across chunk boundaries).
+/// delimiter back to canonical (across chunk boundaries) before reaching the
+/// live display / ACP text stream.
 fn canonicalizing_delta_tx(orig: DeltaSender) -> DeltaSender {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
     tokio::spawn(async move {
+        let mut canon = DeltaCanonicalizer::default();
         while let Some(chunk) = rx.recv().await {
-            let _ = orig.send(crate::llm::tool_delimiter::wire_to_canonical(&chunk));
+            let emit = canon.push(&chunk);
+            if !emit.is_empty() {
+                let _ = orig.send(emit);
+            }
+        }
+        let tail = canon.flush();
+        if !tail.is_empty() {
+            let _ = orig.send(tail);
         }
     });
     tx
@@ -1081,6 +1138,40 @@ thinking_modes = ["enabled"]
             serialized.contains("[[CALL]]") && serialized.contains("[[/CALL]]"),
             "non-special wire delimiters must be present: {serialized}"
         );
+    }
+
+    #[test]
+    fn delta_canonicalizer_reassembles_split_wire_delimiters() {
+        // The wire delimiter arrives split across token deltas; the canonical
+        // form must still be emitted intact in order.
+        let mut c = DeltaCanonicalizer::default();
+        let chunks = [
+            "[[",
+            "CALL",
+            "]]",
+            "\nlook({ a: 1 })\n",
+            "[[",
+            "/CALL",
+            "]]",
+            " done",
+        ];
+        let mut out = String::new();
+        for ch in chunks {
+            out.push_str(&c.push(ch));
+        }
+        out.push_str(&c.flush());
+        assert_eq!(out, "<tool_call>\nlook({ a: 1 })\n</tool_call> done");
+    }
+
+    #[test]
+    fn delta_canonicalizer_passes_through_plain_text() {
+        let mut c = DeltaCanonicalizer::default();
+        let mut out = String::new();
+        for ch in ["Here is ", "some [pro", "se] text."] {
+            out.push_str(&c.push(ch));
+        }
+        out.push_str(&c.flush());
+        assert_eq!(out, "Here is some [prose] text.");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/tool_delimiter.rs
+++ b/crates/harn-vm/src/llm/tool_delimiter.rs
@@ -1,0 +1,94 @@
+//! Wire-level tool-call delimiter remapping for Hermes-family models.
+//!
+//! Some models reserve `<tool_call>` / `</tool_call>` as **single special
+//! tokens** in their tokenizer (the native Hermes tool-call markers used by
+//! Qwen and several derivative finetunes). Harn's text tool format reuses those
+//! exact strings as block delimiters, embedding them as instructional and
+//! wrapper text throughout the system prompt. When the model meets its own
+//! reserved tool-call token in dozens of out-of-distribution positions it
+//! collapses into degenerate opener repetition (`<tool_call>\n<tool_call>\n…`),
+//! with literal-char `_call>` fragments leaking against the special token.
+//!
+//! For models flagged `reserved_tool_call_token` in `capabilities.toml`, we
+//! swap the two colliding delimiters for a non-special bracket form on the wire
+//! to the model, and swap them back before the canonical parser and transcript
+//! ever see the completion. Everything upstream and downstream stays canonical
+//! `<tool_call>`; only the bytes on the wire change. The bracket form was
+//! validated empirically against Qwen3.6 (`[[CALL]]`: 5/5 no-collapse vs
+//! `<tool_call>`: 0/5).
+//!
+//! Only `<tool_call>`/`</tool_call>` are remapped — the sibling protocol tags
+//! (`<assistant_prose>`, `<user_response>`, `<done>`) are ordinary multi-token
+//! text in these tokenizers and do not trigger the collapse.
+//!
+//! ## Mid-transcript model switch
+//!
+//! The remap is a pure wire transform: the transcript and every cache key stay
+//! canonical (`request_hash` keys on `model` + canonical messages), and the
+//! swap is re-derived from the full canonical history on every turn. So a
+//! conversation that switches between a reserved-token model and a normal one
+//! is always *correct* — there is never a half-remapped prefix, and the
+//! model-keyed result cache cannot serve one regime's output for the other. The
+//! only cost of a regime flip is a one-time prefix-cache miss on the new
+//! model's server (the re-delimited prefix differs), which is unavoidable and
+//! self-healing; forcing a compaction at that boundary would be a pure latency
+//! optimization, not a correctness requirement.
+
+use crate::llm::tools::{TEXT_TOOL_CALL_CLOSE, TEXT_TOOL_CALL_OPEN};
+
+/// Non-special wire delimiter substituted for `<tool_call>`.
+pub(crate) const WIRE_TOOL_CALL_OPEN: &str = "[[CALL]]";
+/// Non-special wire delimiter substituted for `</tool_call>`.
+pub(crate) const WIRE_TOOL_CALL_CLOSE: &str = "[[/CALL]]";
+
+/// Rewrite outgoing prompt text from canonical `<tool_call>` delimiters to the
+/// non-special wire form. Applied to every message (system + history) sent to a
+/// `reserved_tool_call_token` model.
+pub(crate) fn canonical_to_wire(text: &str) -> String {
+    if !text.contains(TEXT_TOOL_CALL_OPEN) && !text.contains(TEXT_TOOL_CALL_CLOSE) {
+        return text.to_string();
+    }
+    text.replace(TEXT_TOOL_CALL_OPEN, WIRE_TOOL_CALL_OPEN)
+        .replace(TEXT_TOOL_CALL_CLOSE, WIRE_TOOL_CALL_CLOSE)
+}
+
+/// Rewrite an incoming completion from the non-special wire form back to
+/// canonical `<tool_call>` delimiters before the parser/transcript see it.
+pub(crate) fn wire_to_canonical(text: &str) -> String {
+    if !text.contains(WIRE_TOOL_CALL_OPEN) && !text.contains(WIRE_TOOL_CALL_CLOSE) {
+        return text.to_string();
+    }
+    // Close before open: neither is a substring of the other, so order is not
+    // load-bearing, but this keeps the intent explicit.
+    text.replace(WIRE_TOOL_CALL_CLOSE, TEXT_TOOL_CALL_CLOSE)
+        .replace(WIRE_TOOL_CALL_OPEN, TEXT_TOOL_CALL_OPEN)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_canonical_delimiters() {
+        let canonical = "<tool_call>\nlook({ file: \"src\" })\n</tool_call>";
+        let wire = canonical_to_wire(canonical);
+        assert_eq!(wire, "[[CALL]]\nlook({ file: \"src\" })\n[[/CALL]]");
+        assert_eq!(wire_to_canonical(&wire), canonical);
+    }
+
+    #[test]
+    fn leaves_text_without_delimiters_untouched() {
+        let plain = "no tool calls here, just prose and code: let x = [[a]];";
+        assert_eq!(canonical_to_wire(plain), plain);
+        assert_eq!(wire_to_canonical(plain), plain);
+    }
+
+    #[test]
+    fn rewrites_every_occurrence() {
+        let canonical = "<tool_call>a</tool_call> then <tool_call>b</tool_call>";
+        let wire = canonical_to_wire(canonical);
+        assert_eq!(wire.matches(WIRE_TOOL_CALL_OPEN).count(), 2);
+        assert_eq!(wire.matches(WIRE_TOOL_CALL_CLOSE).count(), 2);
+        assert_eq!(wire_to_canonical(&wire), canonical);
+    }
+}


### PR DESCRIPTION
## Problem

Models that reserve `<tool_call>` / `</tool_call>` as **single special tokens** (the native Hermes tool-call markers — Qwen3.x and derivative finetunes) collapse when running harn's text tool format. That format reuses those exact strings as block delimiters and embeds them as instructional + wrapper text throughout the system prompt. Meeting its own reserved tool-call token in dozens of out-of-distribution positions drives the model into degenerate opener repetition (`<tool_call>\n<tool_call>\n…`), with literal-char `_call>` fragments leaking against the special token.

Measured on Qwen3.6-35B-A3B against the **real eval system prompt** (temperature 0.6, identical prompt, only the delimiter varied):

| Delimiter | Special token? | No-collapse |
|---|---|---|
| `<tool_call>` | yes (id 248058) | **0/5** |
| `<toolcall>` (parser already accepts) | no, but angle-bracket → primes XML | 0/3 |
| `[[CALL]]` (non-special, non-angle) | no | **5/5** |

## Fix

Add a `reserved_tool_call_token` capability. For models that carry it, remap `<tool_call>`/`</tool_call>` to a non-special bracket form (`[[CALL]]`/`[[/CALL]]`) on the **wire** and map the response back before the canonical parser/transcript see it.

The swap is a single boundary in `openai_compat` (every reserved-token model serves over an OpenAI-compatible endpoint — llama.cpp / vLLM / local / OpenRouter). Because it operates on the **assembled wire bytes**, it comprehensively covers every prompt fragment that references the text tool-call paradigm — response protocol, violation feedback, action-turn nudge, done-sentinel rules, inline mentions — with no per-template parameterization to miss.

### Correctness under mid-transcript model switch

The transcript and all cache keys stay canonical (`request_hash` keys on model + canonical messages); the swap is re-derived from the full canonical history each turn. So a conversation that switches between a reserved-token model and a normal one is always correct — no half-remapped prefix, no cross-regime cache reuse. A regime flip costs only a one-time, self-healing prefix-cache miss on the new model's server (forcing compaction there would be a pure latency optimization, not a correctness fix).

## Scope

Flagged for the llamacpp Qwen3 / Qwen3.6 rules. Broader, data-driven per-model population (a probe sweep across the model zoo) is a follow-up.

## Tests

- `tool_delimiter`: round-trip + idempotent-on-plain-text (3).
- `build_request_body`: remaps for a reserved model across system + history; preserves canonical for a normal model (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)