### PR TITLE
fix(vm): make structural hash key consistent with values_equal

### DIFF
--- a/changelog.d/2979.fixed.md
+++ b/changelog.d/2979.fixed.md
@@ -1,0 +1,7 @@
+- **`list.unique()` now agrees with the `==` operator (#2979).** The
+  structural hash key is consistent with `values_equal`: a float that is
+  numerically an integer (and `-0.0` vs `0.0`) hashes like the equal integer,
+  and numeric normalization now propagates into pairs, enum variants, and
+  struct instances. De-duplication confirms hash hits with `values_equal`, so
+  `[1, 1.0].unique()` collapses to `[1]` while two distinct `NaN`s are both
+  kept — matching `==`, `contains`, and set membership.

--- a/conformance/tests/collections/unique_equality.expected
+++ b/conformance/tests/collections/unique_equality.expected
@@ -1,0 +1,6 @@
+[harn] [1, 2]
+[harn] true
+[harn] [(1, a), (2, b)]
+[harn] [0.0]
+[harn] 2
+[harn] [3, 1, 2]

--- a/conformance/tests/collections/unique_equality.harn
+++ b/conformance/tests/collections/unique_equality.harn
@@ -1,0 +1,18 @@
+pipeline test(task) {
+  // `unique()` must agree with the `==` operator (and with `contains`, which
+  // uses the same value equality). `1 == 1.0`, so they are duplicates and
+  // collapse to one element — keeping the first occurrence.
+  log([1, 1.0, 2].unique())
+  log([1, 2, 3].contains(1.0))
+  // Numeric equality also collapses when nested inside pairs (hashing
+  // recurses, so it stays consistent with ==).
+  log([pair(1, "a"), pair(1.0, "a"), pair(2, "b")].unique())
+  // Signed zero: 0.0 == -0.0, so they collapse too.
+  log([0.0, 0.0 - 0.0].unique())
+  // NaN is never equal to anything, including another NaN, so unique() keeps
+  // every NaN rather than collapsing them.
+  let nan = sqrt(-1.0)
+  log([nan, nan].unique().count)
+  // Plain de-duplication still works and preserves order.
+  log([3, 1, 3, 2, 1].unique())
+}

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -19,8 +19,8 @@ pub use handles::{
     VmRngHandle, VmStream, VmStreamCancel, VmSyncPermitHandle, VmTaskHandle,
 };
 pub use structural::{
-    compare_values, try_compare_values, value_identity_key, value_structural_hash_key,
-    values_equal, values_identical,
+    compare_values, dedup_values, try_compare_values, value_identity_key,
+    value_structural_hash_key, values_equal, values_identical,
 };
 
 #[cfg(test)]

--- a/crates/harn-vm/src/value/structural.rs
+++ b/crates/harn-vm/src/value/structural.rs
@@ -63,22 +63,27 @@ fn write_structural_hash_key(v: &VmValue, out: &mut String) {
         VmValue::Bool(b) => {
             out.push(if *b { 'T' } else { 'F' });
         }
-        VmValue::Int(n) => {
-            out.push('i');
-            out.push_str(&n.to_string());
-            out.push(';');
-        }
+        VmValue::Int(n) => write_int_hash_key(*n, out),
         VmValue::Float(n) => {
-            out.push('f');
-            out.push_str(&n.to_bits().to_string());
-            out.push(';');
+            // A float that is numerically an integer must hash identically to
+            // that integer, because `values_equal` treats `1 == 1.0` (and
+            // `0.0 == -0.0`) as equal — otherwise hash-keyed de-duplication
+            // would disagree with `==`. Non-integral / non-finite floats keep
+            // their bit pattern (so distinct NaNs may collide, which is fine:
+            // dedup confirms every hash hit with `values_equal`).
+            match float_as_equivalent_int(*n) {
+                Some(i) => write_int_hash_key(i, out),
+                None => {
+                    out.push('f');
+                    out.push_str(&n.to_bits().to_string());
+                    out.push(';');
+                }
+            }
         }
         VmValue::String(s) => {
             // Length-prefixed: s<len>:<content> — no ambiguity from content
             out.push('s');
-            out.push_str(&s.len().to_string());
-            out.push(':');
-            out.push_str(s);
+            write_len_prefixed(s, out);
         }
         VmValue::Bytes(bytes) => {
             out.push('b');
@@ -103,10 +108,7 @@ fn write_structural_hash_key(v: &VmValue, out: &mut String) {
         VmValue::Dict(map) => {
             out.push('D');
             for (k, v) in map.iter() {
-                // Length-prefixed key
-                out.push_str(&k.len().to_string());
-                out.push(':');
-                out.push_str(k);
+                write_len_prefixed(k, out);
                 out.push('=');
                 write_structural_hash_key(v, out);
                 out.push(',');
@@ -124,18 +126,74 @@ fn write_structural_hash_key(v: &VmValue, out: &mut String) {
             }
             out.push('}');
         }
+        // Composite values that can contain numbers recurse through this
+        // function (rather than the display fallback below) so numeric
+        // normalization propagates — e.g. `Some(1)` and `Some(1.0)`, which
+        // `values_equal` treats as equal, must hash alike.
+        VmValue::Pair(pair) => {
+            out.push('P');
+            write_structural_hash_key(&pair.0, out);
+            out.push(',');
+            write_structural_hash_key(&pair.1, out);
+            out.push(';');
+        }
+        VmValue::EnumVariant(ev) => {
+            out.push('E');
+            write_len_prefixed(&ev.enum_name, out);
+            write_len_prefixed(&ev.variant, out);
+            for field in ev.fields.iter() {
+                write_structural_hash_key(field, out);
+                out.push(',');
+            }
+            out.push(';');
+        }
+        VmValue::StructInstance { layout, fields } => {
+            // Use the same name-keyed map `values_equal` compares, so field
+            // order in the layout never affects the key.
+            out.push('I');
+            write_len_prefixed(layout.struct_name(), out);
+            for (k, v) in super::struct_fields_to_map(layout, fields) {
+                write_len_prefixed(&k, out);
+                out.push('=');
+                write_structural_hash_key(&v, out);
+                out.push(',');
+            }
+            out.push('}');
+        }
         other => {
-            let tn = other.type_name();
+            // Identity-only values (handles, channels, …) that `values_equal`
+            // never reports equal. Keyed by type + display purely so distinct
+            // ones rarely collide; dedup still confirms with `values_equal`.
             out.push('o');
-            out.push_str(&tn.len().to_string());
-            out.push(':');
-            out.push_str(tn);
-            let d = other.display();
-            out.push_str(&d.len().to_string());
-            out.push(':');
-            out.push_str(&d);
+            write_len_prefixed(other.type_name(), out);
+            write_len_prefixed(&other.display(), out);
         }
     }
+}
+
+/// Length-prefixed `<len>:<content>` encoding, so variable-length content can
+/// never be confused with surrounding structure (e.g. `"a,b"` vs `"a", "b"`).
+fn write_len_prefixed(s: &str, out: &mut String) {
+    out.push_str(&s.len().to_string());
+    out.push(':');
+    out.push_str(s);
+}
+
+/// Canonical integer hash-key encoding, shared by `Int` and by any `Float`
+/// that is numerically an integer (see [`float_as_equivalent_int`]).
+fn write_int_hash_key(n: i64, out: &mut String) {
+    out.push('i');
+    out.push_str(&n.to_string());
+    out.push(';');
+}
+
+/// Returns `Some(i)` when `n` compares equal to the `i64` value `i` under the
+/// same coercion `values_equal` uses for `Int`/`Float` (`(i as f64) == n`).
+/// `None` for non-integral or non-finite floats (incl. NaN / ±inf). This is
+/// the single source of truth that keeps the hash key consistent with `==`.
+fn float_as_equivalent_int(n: f64) -> Option<i64> {
+    let candidate = n as i64; // saturating, and NaN -> 0
+    ((candidate as f64) == n).then_some(candidate)
 }
 
 pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
@@ -217,6 +275,32 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
         (VmValue::Harness(_), VmValue::Harness(_)) => false,
         _ => false,
     }
+}
+
+/// Structural de-duplication that honors `values_equal`, preserving
+/// first-occurrence order.
+///
+/// Candidates are bucketed by [`value_structural_hash_key`] (so the common
+/// case stays near-O(n)), then every hash hit is confirmed with
+/// [`values_equal`]. Because the hash key is consistent with `values_equal`,
+/// numerically-equal values that hash alike (e.g. `1` and `1.0`) collapse to a
+/// single entry, while hash collisions between unequal values (e.g. two `NaN`s
+/// sharing a bit pattern) never merge — matching the `==` operator exactly.
+pub fn dedup_values<'a, I>(items: I) -> Vec<VmValue>
+where
+    I: IntoIterator<Item = &'a VmValue>,
+{
+    use std::collections::HashMap;
+    let mut buckets: HashMap<String, Vec<VmValue>> = HashMap::new();
+    let mut result = Vec::new();
+    for item in items {
+        let bucket = buckets.entry(value_structural_hash_key(item)).or_default();
+        if !bucket.iter().any(|kept| values_equal(kept, item)) {
+            bucket.push(item.clone());
+            result.push(item.clone());
+        }
+    }
+    result
 }
 
 /// Total-order comparison used for sorting, `min`/`max`, and similar reductions.

--- a/crates/harn-vm/src/value/tests.rs
+++ b/crates/harn-vm/src/value/tests.rs
@@ -93,14 +93,68 @@ fn hash_key_nil() {
 }
 
 #[test]
-fn hash_key_float_zero_vs_neg_zero() {
-    let pos = VmValue::Float(0.0);
-    let neg = VmValue::Float(-0.0);
-    // 0.0 and -0.0 have different bit representations
-    assert_ne!(
-        value_structural_hash_key(&pos),
-        value_structural_hash_key(&neg)
+fn hash_key_signed_zero_and_int_zero_all_match() {
+    // `values_equal` treats `0.0 == -0.0 == 0`, so all three must hash alike
+    // even though `0.0` and `-0.0` have different bit patterns.
+    let pos = value_structural_hash_key(&VmValue::Float(0.0));
+    let neg = value_structural_hash_key(&VmValue::Float(-0.0));
+    let int = value_structural_hash_key(&i(0));
+    assert_eq!(pos, neg);
+    assert_eq!(pos, int);
+}
+
+#[test]
+fn hash_key_integral_float_matches_int() {
+    // `1 == 1.0` per `values_equal`, so they must share a hash key; `1.5` must
+    // not collide with any integer.
+    assert_eq!(
+        value_structural_hash_key(&i(1)),
+        value_structural_hash_key(&VmValue::Float(1.0))
     );
+    assert_ne!(
+        value_structural_hash_key(&i(1)),
+        value_structural_hash_key(&VmValue::Float(1.5))
+    );
+}
+
+#[test]
+fn hash_key_nan_is_not_an_int() {
+    // NaN is non-integral, so it keeps a float-shaped key (it must never alias
+    // an integer bucket).
+    let nan = value_structural_hash_key(&VmValue::Float(f64::NAN));
+    assert!(
+        nan.starts_with('f'),
+        "NaN key should be float-shaped: {nan}"
+    );
+    assert_ne!(nan, value_structural_hash_key(&i(0)));
+}
+
+#[test]
+fn dedup_values_matches_equality_operator() {
+    // `1 == 1.0` -> collapses; nested inside a pair too.
+    let collapsed = dedup_values(&[i(1), VmValue::Float(1.0), i(1)]);
+    assert_eq!(collapsed.len(), 1);
+
+    let pair = |a, b| VmValue::Pair(std::sync::Arc::new((a, b)));
+    let pairs = dedup_values(&[pair(i(1), s("x")), pair(VmValue::Float(1.0), s("x"))]);
+    assert_eq!(pairs.len(), 1, "Pair(1, x) and Pair(1.0, x) are ==");
+
+    // NaN != NaN, so two NaNs are both kept despite sharing a hash bucket.
+    let nans = dedup_values(&[VmValue::Float(f64::NAN), VmValue::Float(f64::NAN)]);
+    assert_eq!(nans.len(), 2);
+}
+
+#[test]
+fn dedup_values_preserves_first_occurrence_order() {
+    let out = dedup_values(&[i(3), i(1), i(3), i(2), i(1)]);
+    let got: Vec<i64> = out
+        .iter()
+        .map(|v| match v {
+            VmValue::Int(n) => *n,
+            other => panic!("expected int, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(got, vec![3, 1, 2]);
 }
 
 #[test]

--- a/crates/harn-vm/src/vm/methods/list.rs
+++ b/crates/harn-vm/src/vm/methods/list.rs
@@ -119,17 +119,9 @@ impl crate::vm::Vm {
                     items[start..end].to_vec(),
                 )))
             }
-            "unique" => {
-                let mut seen = std::collections::HashSet::with_capacity(items.len());
-                let mut result = Vec::with_capacity(items.len());
-                for item in items.iter() {
-                    let key = crate::value::value_structural_hash_key(item);
-                    if seen.insert(key) {
-                        result.push(item.clone());
-                    }
-                }
-                Ok(VmValue::List(std::sync::Arc::new(result)))
-            }
+            "unique" => Ok(VmValue::List(std::sync::Arc::new(
+                crate::value::dedup_values(items.iter()),
+            ))),
             "take" => {
                 let n = args.first().and_then(|a| a.as_int()).unwrap_or(0).max(0) as usize;
                 Ok(VmValue::List(std::sync::Arc::new(


### PR DESCRIPTION
Follow-up to #2977. `value_structural_hash_key` violated the fundamental hash invariant `a == b ⟹ hash(a) == hash(b)`, so `list.unique()` — the one value-dedup consumer that trusts the hash key — disagreed with the `==` operator and `contains`:

```harn
1 == 1.0                  // true
[1, 2, 3].contains(1.0)   // true
[1, 1.0].unique()         // was [1, 1.0]  ← kept two values that are ==

let nan = sqrt(-1.0)
[nan, nan].contains(nan)  // false  (nan != nan)
[nan, nan].unique()       // was [nan]     ← merged two values that are !=
```

### Root cause
- Integral floats hashed by bit pattern, so `Int(1)` / `Float(1.0)` (and `0.0` / `-0.0`) landed in different buckets despite being `==`.
- `Pair` / `EnumVariant` / `StructInstance` fell back to a `display()`-based key, so numeric normalization didn't propagate into composites (`Some(1)` vs `Some(1.0)`).
- `unique()` treated hash-key equality as value equality with no `values_equal` tiebreak, so two distinct `NaN`s sharing a bit pattern were wrongly merged.

### Fix (DRY)
- A `Float` that is numerically an integer hashes via a shared `write_int_hash_key`, mirroring `values_equal`'s exact coercion (`float_as_equivalent_int` = single source of truth). Covers int/float **and** signed-zero.
- `Pair` / `EnumVariant` / `StructInstance` get recursive hash arms (no more `display()` fallback), so normalization propagates into composites. `StructInstance` reuses the same `struct_fields_to_map` `values_equal` compares, so layout field order never affects the key.
- New reusable `dedup_values` buckets by hash key then confirms each hit with `values_equal` (so collisions like NaN never merge unequal values). `list.unique()` delegates to it; stays near-O(n).
- Factored the length-prefixed encoding into `write_len_prefixed`.

### Not touched (already correct)
`==`, `!=`, `contains`, `index_of`, and all `set.*` ops use `values_equal` directly and were already self-consistent. The schema cache (`schema/api.rs`) and parallel resource keys (`vm/ops/parallel.rs`) key off the same hash and become *more* consistent for free.

### Tests
- `conformance/tests/collections/unique_equality.harn` — pins `unique()` to `==` for int/float, signed-zero, nested-pair, and NaN cases.
- Unit tests for the hash key (int/float, signed-zero-vs-int-zero, NaN-not-an-int) and `dedup_values` (collapse, NaN-keep-both, order). Repurposes the prior `hash_key_float_zero_vs_neg_zero` test, which had enshrined the bug.

Full `harn-vm` unit suite (3302) + collections/types/stdlib/language conformance pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)