### PR TITLE
fix(lint): don't fold float self-comparison in lint --fix (NaN-unsafe)

### DIFF
--- a/changelog.d/2980.fixed.md
+++ b/changelog.d/2980.fixed.md
@@ -1,0 +1,10 @@
+- **`lint --fix` no longer unsoundly folds float self-comparisons (#2980).**
+  The `pointless-comparison` lint (HARN-LNT-031) rewrote `x == x` to `true` and
+  `x != x` to `false` unconditionally. That is wrong for floats: when `x` is
+  NaN, `x == x` is `false` and `x != x` is `true` — and `x != x` is the
+  idiomatic NaN test — so `harn lint --fix` could silently flip program
+  behavior. The autofix is now gated on a conservative `is_nan_free` operand
+  check and only fires when the operand provably cannot be a NaN float (a
+  non-float literal, or a list/dict built only from such literals). For any
+  operand that could be a float the lint still warns — a self-comparison is
+  usually a typo — but leaves the source untouched and points at `is_nan(...)`.

--- a/crates/harn-lint/src/fixes.rs
+++ b/crates/harn-lint/src/fixes.rs
@@ -252,6 +252,33 @@ pub(crate) fn is_pure_expression(node: &Node) -> bool {
     }
 }
 
+/// Conservative NaN analysis for the self-comparison autofix. Returns true
+/// only when the expression provably cannot evaluate to a NaN float, nor to a
+/// list/dict transitively containing one.
+///
+/// `x == x` is `false` and `x != x` is `true` whenever `x` is a NaN float (and
+/// the same holds element-wise for containers holding a NaN), so folding a
+/// self-comparison to a constant is only sound for NaN-free operands. There is
+/// no NaN float *literal* syntax, so a `FloatLiteral` is always a real number;
+/// any computed value — an identifier, call, arithmetic, or field/index access
+/// — could be NaN and is therefore treated as unsafe.
+pub(crate) fn is_nan_free(node: &Node) -> bool {
+    match node {
+        Node::IntLiteral(_)
+        | Node::StringLiteral(_)
+        | Node::RawStringLiteral(_)
+        | Node::BoolLiteral(_)
+        | Node::NilLiteral
+        | Node::DurationLiteral(_)
+        | Node::FloatLiteral(_) => true,
+        Node::ListLiteral(items) => items.iter().all(|n| is_nan_free(&n.node)),
+        Node::DictLiteral(entries) => entries
+            .iter()
+            .all(|e| is_nan_free(&e.key.node) && is_nan_free(&e.value.node)),
+        _ => false,
+    }
+}
+
 /// Remove a whole statement including its leading indent and trailing
 /// newline. Returns `None` when the rewrite cannot be performed safely,
 /// in which case the lint still fires without an autofix.

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -9,7 +9,7 @@ use super::Linter;
 use crate::decls::{FnDeclaration, ImportInfo, TypeDeclaration};
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 use crate::fixes::{
-    empty_statement_removal_fix, is_pure_expression, nil_fallback_ternary_parts,
+    empty_statement_removal_fix, is_nan_free, is_pure_expression, nil_fallback_ternary_parts,
     unnecessary_cast_fix,
 };
 use crate::harndoc::extract_harndoc;
@@ -490,25 +490,46 @@ impl<'a> Linter<'a> {
                         }]),
                     });
                 }
-                let is_pointless_self_comparison = (op == "==" || op == "!=")
+                let is_self_comparison = (op == "==" || op == "!=")
                     && left.node == right.node
                     && is_pure_expression(&left.node);
-                if is_pointless_self_comparison {
+                if is_self_comparison {
                     let replacement = if op == "==" { "true" } else { "false" };
+                    // A float operand may be NaN, for which `x == x` is `false`
+                    // and `x != x` is `true` (the idiomatic NaN test). Folding
+                    // the comparison to a constant is only sound when the
+                    // operand provably cannot be a NaN float, so gate both the
+                    // autofix and the "replace with <const>" suggestion on
+                    // `is_nan_free`. Otherwise still flag the smell, but leave
+                    // the code untouched and point at `is_nan(...)`.
+                    let (suggestion, fix) = if is_nan_free(&left.node) {
+                        (
+                            format!("replace this comparison with `{replacement}`"),
+                            Some(vec![FixEdit {
+                                span: snode.span,
+                                replacement: replacement.to_string(),
+                            }]),
+                        )
+                    } else {
+                        (
+                            format!(
+                                "use `is_nan(...)` to test for NaN; this is otherwise \
+                                 always `{replacement}` for non-NaN values"
+                            ),
+                            None,
+                        )
+                    };
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintPointlessComparison,
                         rule: "pointless-comparison".into(),
                         message: format!("expression is compared to itself with `{op}`"),
                         span: snode.span,
                         severity: LintSeverity::Warning,
-                        suggestion: Some(format!("replace this comparison with `{replacement}`")),
-                        fix: Some(vec![FixEdit {
-                            span: snode.span,
-                            replacement: replacement.to_string(),
-                        }]),
+                        suggestion: Some(suggestion),
+                        fix,
                     });
                 }
-                if (op == "==" || op == "!=") && !is_pointless_self_comparison {
+                if (op == "==" || op == "!=") && !is_self_comparison {
                     let is_bool_left = matches!(left.node, Node::BoolLiteral(_));
                     let is_bool_right = matches!(right.node, Node::BoolLiteral(_));
                     if is_bool_left || is_bool_right {

--- a/crates/harn-lint/src/tests/hygiene.rs
+++ b/crates/harn-lint/src/tests/hygiene.rs
@@ -52,8 +52,10 @@ pipeline default(task) {
 }
 
 #[test]
-fn test_pointless_self_comparison_autofix() {
-    let source = "pipeline default(task) {\n  let always = task == task\n  log(always)\n}";
+fn test_pointless_self_comparison_autofix_for_nan_free_operand() {
+    // String/int/bool/nil operands cannot be NaN, so the self-comparison is a
+    // genuine constant and the autofix is sound.
+    let source = "pipeline default(task) {\n  let always = \"x\" == \"x\"\n  log(always)\n}";
     let diags = lint_source(source);
     assert!(
         has_rule(&diags, "pointless-comparison"),
@@ -64,6 +66,35 @@ fn test_pointless_self_comparison_autofix() {
         fixed.contains("let always = true"),
         "expected self-comparison to become true, got: {fixed}"
     );
+}
+
+#[test]
+fn test_self_comparison_warns_but_does_not_autofix_possible_float() {
+    // `task` has unknown type and could be a NaN float, for which `task == task`
+    // is `false` — folding it to `true` would silently change behavior. The
+    // linter must warn but leave the source untouched. Mirrors the `!=` (NaN
+    // test) direction, which is `true` for NaN and must not fold to `false`.
+    for (op, label) in [("==", "eq"), ("!=", "ne")] {
+        let source = format!("pipeline default(task) {{\n  let v = task {op} task\n  log(v)\n}}");
+        let diags = lint_source(&source);
+        assert!(
+            has_rule(&diags, "pointless-comparison"),
+            "[{label}] expected pointless-comparison warning, got: {diags:?}"
+        );
+        let pointless = diags
+            .iter()
+            .find(|d| d.rule == "pointless-comparison")
+            .expect("pointless-comparison diagnostic");
+        assert!(
+            pointless.fix.is_none(),
+            "[{label}] self-comparison on a possibly-float operand must not carry an autofix"
+        );
+        let fixed = apply_fixes(&source, &diags);
+        assert!(
+            fixed.contains(&format!("task {op} task")),
+            "[{label}] expected source left untouched, got: {fixed}"
+        );
+    }
 }
 
 #[test]

--- a/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-031.md
+++ b/crates/harn-parser/src/diagnostic_codes/explanations/HARN-LNT-031.md
@@ -4,3 +4,13 @@
 
 - Apply the lint's auto-fix where one is offered (`harn lint --fix`).
 - Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
+
+## NaN caveat
+
+A self-comparison such as `x == x` or `x != x` is **not** constant when `x` is a
+NaN float: `x == x` is `false` and `x != x` is `true` for NaN (and the same
+holds element-wise for lists/dicts containing a NaN). The lint therefore only
+offers an auto-fix when the operand provably cannot be NaN (a non-float literal,
+or a list/dict built only from such literals). When the operand could be a float
+the lint still warns — a self-comparison is usually a typo — but leaves the code
+untouched and points you at `is_nan(...)`, the idiomatic NaN test.

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -2608,6 +2608,16 @@ pointless comparison lint
 - Apply the lint's auto-fix where one is offered (`harn lint --fix`).
 - Suppress the lint with an attribute only when the surrounding code is intentionally non-idiomatic.
 
+#### NaN caveat
+
+A self-comparison such as `x == x` or `x != x` is **not** constant when `x` is a
+NaN float: `x == x` is `false` and `x != x` is `true` for NaN (and the same
+holds element-wise for lists/dicts containing a NaN). The lint therefore only
+offers an auto-fix when the operand provably cannot be NaN (a non-float literal,
+or a list/dict built only from such literals). When the operand could be a float
+the lint still warns — a self-comparison is usually a typo — but leaves the code
+untouched and points you at `is_nan(...)`, the idiomatic NaN test.
+
 ### `HARN-LNT-032`
 
 **Category:** `LNT` (Lint rules) &nbsp;·&nbsp; **API stability:** `stable`


### PR DESCRIPTION
## Problem

`harn lint --fix` rewrote `x == x` → `true` and `x != x` → `false` unconditionally (rule `pointless-comparison`, HARN-LNT-031). For a float that is **NaN** this is wrong: `x == x` is `false` and `x != x` is `true`. `x != x` is the idiomatic NaN test, so the automated fix silently flips program behavior.

Repro (before this PR):

```harn
fn check_ne(x: float) -> bool { return x != x }   // is_nan(x)
let nan = 0.0 / 0.0
log(check_ne(nan))    // true
```

`harn lint --fix` rewrote the body to `return false`, flipping `check_ne(nan)` from `true` to `false`.

## Fix

The linter is purely syntactic, so a bare identifier's type is unknown. Added a conservative `is_nan_free` helper (parity with the existing `is_pure_expression`) and gated **both** the autofix and the "replace with `<const>`" suggestion on it:

- Fold only when the operand provably cannot be a NaN float — a non-float literal, or a list/dict built only from such literals.
- Otherwise still **warn** (a self-comparison is usually a typo) but leave the source untouched and point at `is_nan(...)`.

The VM/compiler constant-folder is already NaN-correct via `values_equal`/`try_compare_values` (verified: `(0.0/0.0) == (0.0/0.0)` folds to `false`); only the lint autofix was unsound.

## Verification

- `cargo test -p harn-lint` — 269 lib tests pass, including the reworked `test_pointless_self_comparison_autofix_for_nan_free_operand` and new `test_self_comparison_warns_but_does_not_autofix_possible_float` (covers both `==` and `!=`).
- End-to-end with the built binary: `harn lint --fix` now leaves `x == x`/`x != x` on a float operand untouched, still folds NaN-free `"x" == "x"` / `5 == 5` → `true`, and runtime stays correct (`check_ne(nan) == true`).
- clippy + rustfmt clean on changed crates; diagnostics catalog regenerated.

Closes #2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)