### PR TITLE
chore(hooks): block NOCOMMIT markers + verify tagref refs in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,6 +12,35 @@ trap 'rm -f "$changed" "$harn_format_files" "$harn_lint_files" "$changed_package
 hook_write_staged_files "$changed"
 hook_disable_cargo_incremental_if_release_bump staged
 
+# ── Guard: block accidental commits of throwaway / temporary code ──────────────
+# Mark scratch code so it can never be committed by accident:
+#   NOCOMMIT   @nocommit   DO NOT COMMIT   (case-insensitive; -/_ also accepted)
+# Only newly *added* staged lines are scanned; this hook excludes itself. Bypass
+# a false positive with `git commit --no-verify`. The regex literal is split so
+# this file's own definition is not itself a matchable marker.
+nocommit_re="NO""COMMIT|@no""commit|DO[ _-]NOT[ _-]COMMIT"
+staged_nocommit=$(git diff --cached --no-color -U0 --diff-filter=ACM \
+  -- . ":(exclude).githooks/pre-commit" \
+  | grep -E '^\+[^+]' | grep -inE "$nocommit_re" 2>/dev/null || true)
+if [ -n "$staged_nocommit" ]; then
+  echo "✖ Commit blocked: staged changes contain a no-commit marker:" >&2
+  printf '%s\n' "$staged_nocommit" | sed 's/^/    /' >&2
+  echo "  Remove the temporary code, or bypass intentionally: git commit --no-verify" >&2
+  exit 1
+fi
+
+# ── Guard: verify tagref cross-references resolve (when tagref is installed) ────
+# tagref links code via [tag:name] / [ref:name] comments; fails on a dangling
+# [ref:...] or duplicate [tag:...]. Respects .gitignore. Skipped (not failed)
+# when absent, keeping the hook portable. Install: `cargo install tagref`.
+if command -v tagref >/dev/null 2>&1; then
+  if ! tagref --path "$(git rev-parse --show-toplevel)" check >/dev/null 2>&1; then
+    echo "✖ tagref check failed: a [ref:...] has no matching [tag:...], or a tag is duplicated." >&2
+    echo "  Run \`tagref --path . check\` for details, or \`git commit --no-verify\` to bypass." >&2
+    exit 1
+  fi
+fi
+
 # Track whether the python prompt-prose ratchet has already run in this
 # hook, so the ratchet and clippy blocks don't pay for it twice when both
 # patterns match (the common case for a Rust crate edit that also


### PR DESCRIPTION
Mirror of burin-code's pre-commit guards (burin-code#1770) for cross-repo consistency.

- **NOCOMMIT guard** — any newly *added* staged line containing `NOCOMMIT`, `@nocommit`, or `DO NOT COMMIT` (case-insensitive; `-`/`_` accepted) blocks the commit, so temporary/throwaway code (debug prints, local `[patch]` overrides, scaffolding) can't land by accident. Only added lines scanned; hook excludes itself; bypass with `--no-verify`.
- **tagref guard** — when [`tagref`](https://github.com/stepchowfun/tagref) is installed, verifies `[tag:name]`/`[ref:name]` cross-references resolve. Respects `.gitignore`. Skipped (not failed) when absent. Install: `cargo install tagref`.

Added to the Phase-1 fast-validator block in `.githooks/pre-commit`; `sh -n` clean; the new guard ran on its own commit and correctly excluded itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)