### PR TITLE
Record LLM first-token latency in run profiles

### DIFF
--- a/changelog.d/2985.added.md
+++ b/changelog.d/2985.added.md
@@ -1,0 +1,3 @@
+- Added `first_token_ms` to run profiles so `harn run --profile-json` and
+  profile rendering expose LLM time-to-first-token when streaming deltas are
+  observed.

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -748,6 +748,7 @@ pub(super) fn spawn_progress_forwarder(
     call_id: String,
     user_visible: bool,
     detector_ctx: Option<StreamingDetectorContext>,
+    mut first_token: super::first_token::FirstTokenTimer,
 ) -> DeltaSender {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
     let bridge = bridge.clone();
@@ -757,6 +758,7 @@ pub(super) fn spawn_progress_forwarder(
     tokio::task::spawn_local(async move {
         let mut token_count: u64 = 0;
         while let Some(delta) = rx.recv().await {
+            first_token.observe_delta();
             token_count += 1;
             bridge.send_call_progress(&call_id, &delta, token_count, user_visible);
             if let Some(d) = detector.as_mut() {
@@ -780,9 +782,12 @@ pub(super) fn spawn_progress_forwarder(
 /// one). Used so non-bridge callers (offthread VM, CLI loops without an
 /// attached host) still see candidate events when they have a
 /// `StreamingDetectorContext`.
-pub(super) fn spawn_detector_only_forwarder(detector_ctx: StreamingDetectorContext) -> DeltaSender {
+pub(super) fn spawn_detector_only_forwarder(
+    detector_ctx: StreamingDetectorContext,
+    first_token: super::first_token::FirstTokenTimer,
+) -> DeltaSender {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-    tokio::task::spawn_local(run_detector_loop(detector_ctx, rx));
+    tokio::task::spawn_local(run_detector_loop(detector_ctx, rx, first_token));
     tx
 }
 
@@ -797,6 +802,7 @@ pub(super) fn spawn_detector_only_forwarder(detector_ctx: StreamingDetectorConte
 /// captures into a local buffer — sidestepping the global registry,
 /// which other tests in this binary mutate via `reset_all_sinks` and
 /// can race the per-session install.
+#[cfg(test)]
 async fn run_detector_loop_with_sink(
     detector_ctx: StreamingDetectorContext,
     mut rx: tokio::sync::mpsc::UnboundedReceiver<String>,
@@ -820,12 +826,22 @@ async fn run_detector_loop_with_sink(
 /// session sink registry so ACP / external sinks see them.
 async fn run_detector_loop(
     detector_ctx: StreamingDetectorContext,
-    rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+    mut first_token: super::first_token::FirstTokenTimer,
 ) {
-    run_detector_loop_with_sink(detector_ctx, rx, |event| {
-        crate::agent_events::emit_event(event);
-    })
-    .await;
+    let mut detector = crate::llm::tools::StreamingToolCallDetector::new(
+        detector_ctx.session_id,
+        detector_ctx.known_tools,
+    );
+    while let Some(delta) = rx.recv().await {
+        first_token.observe_delta();
+        for event in detector.push(&delta) {
+            crate::agent_events::emit_event(&event);
+        }
+    }
+    for event in detector.finalize() {
+        crate::agent_events::emit_event(&event);
+    }
 }
 
 /// Configuration for LLM call retries.
@@ -942,6 +958,7 @@ pub(crate) async fn observed_llm_call(
             opts,
         );
 
+        let first_token = super::first_token::FirstTokenTimer::for_current_span();
         let start = std::time::Instant::now();
         // The streaming detector runs once per LLM call. Move the
         // context into whichever forwarder we end up spawning so the
@@ -955,7 +972,13 @@ pub(crate) async fn observed_llm_call(
                 known_tools: c.known_tools.clone(),
             });
         let llm_result = if let Some(b) = bridge {
-            let delta_tx = spawn_progress_forwarder(b, call_id.clone(), user_visible, detector_ctx);
+            let delta_tx = spawn_progress_forwarder(
+                b,
+                call_id.clone(),
+                user_visible,
+                detector_ctx,
+                first_token,
+            );
             if offthread {
                 vm_call_llm_full_streaming_offthread(opts, delta_tx).await
             } else {
@@ -963,7 +986,7 @@ pub(crate) async fn observed_llm_call(
             }
         } else if offthread {
             let delta_tx = match detector_ctx {
-                Some(ctx) => spawn_detector_only_forwarder(ctx),
+                Some(ctx) => spawn_detector_only_forwarder(ctx, first_token),
                 None => {
                     let (tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
                     tx

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -123,8 +123,24 @@ fn parse_displayed_categorized_error(message: &str) -> Option<(ErrorCategory, &s
 /// handling; non-streaming callers just drop the receiver.
 pub(crate) async fn vm_call_llm_full(opts: &LlmCallOptions) -> Result<LlmResult, VmError> {
     super::cost::check_llm_preflight_budget(opts)?;
-    let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-    let result = vm_call_llm_full_inner(opts, Some(delta_tx)).await?;
+    let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let mut first_token = super::first_token::FirstTokenTimer::for_current_span();
+    let mut deltas_open = true;
+    let mut call = Box::pin(vm_call_llm_full_inner(opts, Some(delta_tx)));
+    let result = loop {
+        tokio::select! {
+            maybe_delta = delta_rx.recv(), if deltas_open => {
+                match maybe_delta {
+                    Some(_) => first_token.observe_delta(),
+                    None => deltas_open = false,
+                }
+            }
+            result = &mut call => break result?,
+        }
+    };
+    while delta_rx.try_recv().is_ok() {
+        first_token.observe_delta();
+    }
     super::cost::record_llm_usage_for_provider(
         &result.provider,
         &result.model,

--- a/crates/harn-vm/src/llm/first_token.rs
+++ b/crates/harn-vm/src/llm/first_token.rs
@@ -1,0 +1,36 @@
+pub(crate) const FIRST_TOKEN_METADATA_KEY: &str = "first_token_ms";
+
+pub(crate) struct FirstTokenTimer {
+    span_id: Option<u64>,
+    started_at: tokio::time::Instant,
+    recorded: bool,
+}
+
+impl FirstTokenTimer {
+    pub(crate) fn for_current_span() -> Self {
+        Self {
+            span_id: crate::tracing::current_span_id(),
+            started_at: tokio::time::Instant::now(),
+            recorded: false,
+        }
+    }
+
+    pub(crate) fn observe_delta(&mut self) {
+        if self.recorded {
+            return;
+        }
+        self.recorded = true;
+        let first_token_ms = duration_ms(self.started_at.elapsed());
+        if let Some(span_id) = self.span_id {
+            crate::tracing::span_attach_metadata_if_absent(
+                span_id,
+                FIRST_TOKEN_METADATA_KEY,
+                serde_json::json!(first_token_ms),
+            );
+        }
+    }
+}
+
+pub(crate) fn duration_ms(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -423,6 +423,7 @@ pub fn resolve_api_key(provider: &str) -> Result<String, VmError> {
     use crate::llm_config;
 
     if provider == "mock"
+        || provider == "fake"
         || crate::llm::mock::cli_llm_mock_replay_active()
         || crate::llm::mock::builtin_llm_mock_active()
     {

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod daemon;
 pub mod eval;
 pub(crate) mod fake;
 pub(crate) mod fast_mode;
+pub(crate) mod first_token;
 pub(crate) mod helpers;
 pub mod introspection;
 pub mod jsonl;

--- a/crates/harn-vm/src/llm/stream_builtins.rs
+++ b/crates/harn-vm/src/llm/stream_builtins.rs
@@ -122,6 +122,7 @@ pub(super) async fn llm_stream_call_impl(args: Vec<VmValue>) -> Result<VmValue, 
     let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
     let cancel = VmStreamCancel::new();
     let mut cancel_rx = cancel.subscribe();
+    let mut first_token = super::first_token::FirstTokenTimer::for_current_span();
 
     tokio::task::spawn_local(async move {
         let mut visible = crate::visible_text::VisibleTextState::default();
@@ -144,6 +145,7 @@ pub(super) async fn llm_stream_call_impl(args: Vec<VmValue>) -> Result<VmValue, 
                 maybe_delta = delta_rx.recv(), if deltas_open => {
                     match maybe_delta {
                         Some(delta) => {
+                            first_token.observe_delta();
                             match forward_llm_stream_delta(&stream_tx, &mut visible, delta).await {
                                 Ok(next_partial) => partial = next_partial,
                                 Err(()) => {
@@ -157,6 +159,7 @@ pub(super) async fn llm_stream_call_impl(args: Vec<VmValue>) -> Result<VmValue, 
                 }
                 joined = &mut llm_task => {
                     while let Ok(delta) = delta_rx.try_recv() {
+                        first_token.observe_delta();
                         match forward_llm_stream_delta(&stream_tx, &mut visible, delta).await {
                             Ok(next_partial) => partial = next_partial,
                             Err(()) => break,
@@ -194,4 +197,96 @@ pub(super) async fn llm_stream_call_impl(args: Vec<VmValue>) -> Result<VmValue, 
         receiver: Arc::new(tokio::sync::Mutex::new(stream_rx)),
         cancel: Some(cancel),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use crate::llm::fake::{install_fake_llm_script, FakeLlmEvent, FakeLlmScript, FakeStopReason};
+    use crate::tracing::SpanKind;
+    use crate::value::{VmError, VmValue};
+
+    use super::llm_stream_call_impl;
+
+    #[tokio::test(start_paused = true)]
+    async fn first_token_budget_records_streaming_ttft_under_virtual_time() {
+        crate::llm::reset_llm_state();
+        crate::tracing::set_tracing_enabled(true);
+        let local = tokio::task::LocalSet::new();
+        let stall = Duration::from_millis(1_500);
+
+        local
+            .run_until(async move {
+                let _guard = install_fake_llm_script(FakeLlmScript::streaming(vec![
+                    FakeLlmEvent::Stall(stall),
+                    FakeLlmEvent::Token("hello".into()),
+                    FakeLlmEvent::Done(FakeStopReason::EndTurn),
+                ]));
+
+                let span_id =
+                    crate::tracing::span_start(SpanKind::LlmCall, "llm_stream_call".into());
+                let stream = match llm_stream_call_impl(fake_stream_args()).await? {
+                    VmValue::Stream(stream) => stream,
+                    other => {
+                        return Err(VmError::Runtime(format!(
+                            "expected stream, got {}",
+                            other.type_name()
+                        )));
+                    }
+                };
+                crate::tracing::span_end(span_id);
+
+                let mut receiver = stream.receiver.lock().await;
+                let first_chunk =
+                    tokio::time::timeout(stall + Duration::from_millis(250), receiver.recv())
+                        .await
+                        .expect("first stream chunk should arrive within the TTFT budget")
+                        .expect("stream should produce first chunk")?;
+                assert_eq!(dict_string(&first_chunk, "delta").as_deref(), Some("hello"));
+                drop(first_chunk);
+
+                let profile = crate::profile::build(&crate::tracing::peek_spans());
+                let first_token_ms = profile
+                    .first_token_ms
+                    .expect("profile should include first_token_ms");
+                assert!(
+                    first_token_ms >= 1_500,
+                    "first token should include fake provider stall, got {first_token_ms}ms"
+                );
+                assert!(
+                    first_token_ms < 1_750,
+                    "stream assembly overhead should stay under 250ms, got {first_token_ms}ms"
+                );
+                Ok::<(), VmError>(())
+            })
+            .await
+            .expect("streaming first-token budget test should pass");
+    }
+
+    fn fake_stream_args() -> Vec<VmValue> {
+        let mut options = BTreeMap::new();
+        options.insert(
+            "provider".to_string(),
+            VmValue::String(Arc::from("fake".to_string())),
+        );
+        options.insert(
+            "model".to_string(),
+            VmValue::String(Arc::from("fake".to_string())),
+        );
+        vec![
+            VmValue::String(Arc::from("hello".to_string())),
+            VmValue::Nil,
+            VmValue::Dict(Arc::new(options)),
+        ]
+    }
+
+    fn dict_string(value: &VmValue, key: &str) -> Option<String> {
+        let VmValue::Dict(dict) = value else {
+            return None;
+        };
+        dict.get(key).map(VmValue::display)
+    }
 }

--- a/crates/harn-vm/src/profile.rs
+++ b/crates/harn-vm/src/profile.rs
@@ -25,6 +25,8 @@ const TOP_N: usize = 5;
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct RunProfile {
     pub total_wall_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_token_ms: Option<u64>,
     pub by_kind: Vec<KindBucket>,
     pub residual_ms: u64,
     pub top_llm_calls: Vec<SpanRef>,
@@ -96,9 +98,11 @@ pub fn build(spans: &[Span]) -> RunProfile {
     let top_llm_calls = top_n_by_duration(spans, "llm_call");
     let top_tool_calls = top_n_by_duration(spans, "tool_call");
     let steps = build_step_summaries(spans);
+    let first_token_ms = first_token_ms(spans);
 
     RunProfile {
         total_wall_ms,
+        first_token_ms,
         by_kind,
         residual_ms,
         top_llm_calls,
@@ -126,6 +130,18 @@ pub fn build_aggregate(span_groups: &[Vec<Span>]) -> RunProfile {
         next_offset += max_id + 1;
     }
     build(&merged)
+}
+
+fn first_token_ms(spans: &[Span]) -> Option<u64> {
+    spans
+        .iter()
+        .filter(|span| span.kind.as_str() == "llm_call")
+        .filter_map(|span| {
+            span.metadata
+                .get(crate::llm::first_token::FIRST_TOKEN_METADATA_KEY)
+                .and_then(serde_json::Value::as_u64)
+        })
+        .min()
 }
 
 fn is_pipeline_root(spans: &[Span], id: u64) -> bool {
@@ -267,6 +283,9 @@ pub fn render(profile: &RunProfile) -> String {
         "  Total wall time: {}",
         format_secs(profile.total_wall_ms)
     );
+    if let Some(first_token_ms) = profile.first_token_ms {
+        let _ = writeln!(out, "  First token:     {}", format_secs(first_token_ms));
+    }
     let _ = writeln!(out, "\n  By category:");
     for bucket in &profile.by_kind {
         let _ = writeln!(
@@ -388,6 +407,7 @@ mod tests {
     fn empty_spans_yield_default_profile() {
         let profile = build(&[]);
         assert_eq!(profile.total_wall_ms, 0);
+        assert_eq!(profile.first_token_ms, None);
         assert!(profile.by_kind.is_empty());
         assert_eq!(profile.residual_ms, 0);
     }
@@ -409,6 +429,53 @@ mod tests {
         assert_eq!(profile.by_kind[1].count, 2);
         // 1000 wall - (600 + 300) depth-1 = 100 ms residual
         assert_eq!(profile.residual_ms, 100);
+    }
+
+    #[test]
+    fn first_token_ms_uses_earliest_llm_span_metadata() {
+        let spans = vec![
+            span(1, None, SpanKind::Pipeline, "main", 1000),
+            span_with_meta(
+                2,
+                Some(1),
+                SpanKind::LlmCall,
+                "llm_call",
+                600,
+                &[("first_token_ms", serde_json::json!(350))],
+            ),
+            span_with_meta(
+                3,
+                Some(1),
+                SpanKind::LlmCall,
+                "llm_call",
+                300,
+                &[("first_token_ms", serde_json::json!(125))],
+            ),
+        ];
+
+        let profile = build(&spans);
+
+        assert_eq!(profile.first_token_ms, Some(125));
+    }
+
+    #[test]
+    fn render_includes_first_token_when_present() {
+        let mut profile = RunProfile {
+            total_wall_ms: 1000,
+            first_token_ms: Some(120),
+            ..RunProfile::default()
+        };
+        profile.by_kind.push(KindBucket {
+            kind: "llm_call".to_string(),
+            total_ms: 900,
+            count: 1,
+            pct_of_wall: 90.0,
+        });
+
+        let rendered = render(&profile);
+
+        assert!(rendered.contains("First token:"));
+        assert!(rendered.contains("120 ms"));
     }
 
     #[test]

--- a/crates/harn-vm/src/tracing.rs
+++ b/crates/harn-vm/src/tracing.rs
@@ -259,6 +259,22 @@ impl SpanCollector {
         }
     }
 
+    /// Attach metadata to an open or completed span unless the key exists.
+    pub fn attach_metadata_if_absent(&mut self, span_id: u64, key: &str, value: serde_json::Value) {
+        if let Some(span) = self.open.get_mut(&span_id) {
+            span.metadata.entry(key.to_string()).or_insert(value);
+            return;
+        }
+        if let Some(span) = self
+            .completed
+            .iter_mut()
+            .rev()
+            .find(|span| span.span_id == span_id)
+        {
+            span.metadata.entry(key.to_string()).or_insert(value);
+        }
+    }
+
     /// Append a sub-phase annotation to an open span. Returns `true` if
     /// the event was attached; `false` if `span_id` does not match any
     /// open span (already closed or never opened).
@@ -489,13 +505,24 @@ pub fn span_record_event(
     COLLECTOR.with(|c| c.borrow_mut().record_event(span_id, name, attributes))
 }
 
-/// Attach metadata to an open span. No-op when `span_id` is 0 or
-/// already closed.
+/// Attach metadata to an open span. No-op when `span_id` is 0 or already
+/// closed.
 pub fn span_attach_metadata(span_id: u64, key: &str, value: serde_json::Value) {
     if span_id == 0 {
         return;
     }
     COLLECTOR.with(|c| c.borrow_mut().set_metadata(span_id, key, value));
+}
+
+/// Attach metadata to an open or completed span unless the key already exists.
+pub fn span_attach_metadata_if_absent(span_id: u64, key: &str, value: serde_json::Value) {
+    if span_id == 0 {
+        return;
+    }
+    COLLECTOR.with(|c| {
+        c.borrow_mut()
+            .attach_metadata_if_absent(span_id, key, value);
+    });
 }
 
 /// Get the currently active span id, if tracing is enabled and a span is open.
@@ -672,6 +699,21 @@ mod tests {
         c.set_metadata(id, "tokens", serde_json::json!(100));
         c.end(id);
         assert_eq!(c.spans()[0].metadata["tokens"], serde_json::json!(100));
+    }
+
+    #[test]
+    fn test_completed_span_metadata_can_be_attached_late() {
+        let mut c = SpanCollector::new();
+        let id = c.start(SpanKind::LlmCall, "gpt-4".into());
+        c.end(id);
+
+        c.attach_metadata_if_absent(id, "first_token_ms", serde_json::json!(125));
+        c.attach_metadata_if_absent(id, "first_token_ms", serde_json::json!(250));
+
+        assert_eq!(
+            c.spans()[0].metadata["first_token_ms"],
+            serde_json::json!(125)
+        );
     }
 
     #[test]

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -452,6 +452,10 @@ NON_TEST_WALL_CLOCK_ALLOWLIST=(
   "crates/harn-vm/src/llm/api/transport.rs"
   "crates/harn-vm/src/llm/autonomy_budget.rs"
   "crates/harn-vm/src/llm/cache.rs"
+  # `first_token.rs` records host-observed elapsed time from LLM dispatch
+  # to the first streamed delta as RunProfile telemetry; real provider
+  # latency is the source of truth.
+  "crates/harn-vm/src/llm/first_token.rs"
   "crates/harn-vm/src/llm/mod.rs"
   "crates/harn-vm/src/llm/model_test.rs"
   # Ollama raw `/api/generate` bypasses the shared transport wrapper, so it


### PR DESCRIPTION
Closes burin-labs/harn#2985

Part of burin-labs/burin-code#1774

## Summary
- add `first_token_ms` to run profile JSON/rendering from LLM span metadata
- record first streamed delta timing for plain, bridge-observed, detector-only, and first-class streaming LLM paths
- add a paused-time fake-provider TTFT budget test

## Verification
- `cargo test -p harn-vm first_token_budget`