### PR TITLE
fix(agent): extend the loop on any progress, not only tool-call turns

### DIFF
--- a/changelog.d/2983.fixed.md
+++ b/changelog.d/2983.fixed.md
@@ -1,0 +1,11 @@
+- **The adaptive agent loop no longer cuts a productive task off on a planning turn (#2983).**
+  The default loop-control policy extended the iteration budget only when a turn
+  both made progress *and* issued a tool call this turn. But "progress" already
+  includes visible text, so an interleaved planning/narration turn (no tool call)
+  at the budget boundary was treated as no-progress and denied an extension —
+  stopping a methodical model mid-way through a large multi-file task. The
+  extension now keys off a single `progress` definition (the only place that term
+  is defined), and the policy is expressed as an explicit, named, ordered rule
+  table instead of inline compound conditions, so a second competing notion of
+  "progress" can't be silently ANDed onto a rule again. Degenerate narration that
+  never acts is still bounded by the iteration max and the stall detector.

--- a/crates/harn-stdlib/src/stdlib/agent/control.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/control.harn
@@ -94,19 +94,53 @@ fn __agent_loop_state(args) -> AgentLoopState {
   }
 }
 
+/**
+ * Single source of truth for "the agent is still advancing the task."
+ * `progress.changed` (computed once in `agent_loop_snapshot_state`) already
+ * covers tool calls, successful tool results, AND visible text — so a turn that
+ * is pure planning/narration toward the next edit (no tool call *this* turn) is
+ * still forward progress. This is deliberately NOT re-gated on a tool call here:
+ * an earlier inline `progress.changed && tool_call_count > 0` denied the
+ * extension whenever the budget boundary happened to land on a planning turn,
+ * cutting a productive multi-file refactor off mid-work (a methodical model
+ * editing across ~6 files stopped at its initial cap because one interleaved
+ * planning turn was treated as "no progress"). Degenerate narration that never
+ * acts is bounded independently by the iteration max and the stall detector, so
+ * progress alone is the correct extension signal. Keep this the *only* place
+ * that defines "progress" so a second, competing notion can't be ANDed in.
+ */
+fn agent_loop_is_progressing(state: AgentLoopState) -> bool {
+  return state.progress.changed
+}
+
+/**
+ * Ordered extension policy for the default loop control: each entry pairs a
+ * named, eagerly-evaluated condition with the reason recorded on the resulting
+ * budget decision, and the first satisfied entry wins. Expressing the policy as
+ * an explicit table — rather than a chain of inline compound `if`s — keeps every
+ * extension trigger auditable in one place and forces each signal through a
+ * single definition (there is nowhere to silently AND an extra condition onto a
+ * rule, which is exactly the class of bug this replaced).
+ */
+fn __agent_loop_extension_rules(state: AgentLoopState) {
+  return [
+    {when: state.completion.vetoed, reason: "completion gate vetoed"},
+    {when: !state.session.required_tools_satisfied, reason: "required tools missing"},
+    {when: agent_loop_is_progressing(state), reason: "recent turn made progress"},
+  ]
+}
+
 fn __agent_default_loop_control(state: AgentLoopState) {
+  // Only decide at the budget boundary; below it, keep looping untouched.
   if state.budget.remaining > 0 {
     return nil
   }
-  if state.completion.vetoed {
-    return {action: "extend", reason: "completion gate vetoed"}
+  for rule in __agent_loop_extension_rules(state) {
+    if rule.when {
+      return {action: "extend", reason: rule.reason}
+    }
   }
-  if !state.session.required_tools_satisfied {
-    return {action: "extend", reason: "required tools missing"}
-  }
-  if state.progress.changed && state.turn.tool_call_count > 0 {
-    return {action: "extend", reason: "recent turn made progress"}
-  }
+  // No extension rule matched — let the loop stop at the current cap.
   return nil
 }
 

--- a/tests/agent/loop_control_test.harn
+++ b/tests/agent/loop_control_test.harn
@@ -1,0 +1,75 @@
+// Run: harn test tests/agent/loop_control_test.harn
+//
+// Unit tests for the default adaptive loop-control policy
+// (`std/agent/control`), exercised at the public seam
+// `agent_loop_control_invoke(opts, budget, state)` with hand-built loop state —
+// no agent_loop, no mock LLM, no inference. The policy decides, at the budget
+// boundary, whether to extend the iteration cap (and why) or let the loop stop.
+//
+// The headline case is the regression that motivated the rule-table refactor:
+// a turn that produced visible-text progress but made NO tool call this turn
+// (an interleaved planning turn) must still extend. The previous inline
+// `progress.changed && tool_call_count > 0` denied that extension and cut a
+// productive multi-file refactor off mid-work.
+import { agent_loop_control_invoke } from "std/agent/control"
+
+// Adaptive budget so the default policy (not a caller override) is consulted.
+const BUDGET = {mode: "adaptive", initial: 8, max: 50, extend_by: 4, expose_decisions: false}
+
+/**
+ * Build a loop state. `remaining` is the budget headroom: the policy only
+ * decides once it reaches 0 (the boundary).
+ */
+fn _state(progress_changed, tool_call_count, remaining, vetoed, required_ok) {
+  return {
+    iteration: 10,
+    budget: {remaining: remaining},
+    turn: {tool_call_count: tool_call_count},
+    session: {required_tools_satisfied: required_ok},
+    completion: {vetoed: vetoed},
+    progress: {changed: progress_changed},
+  }
+}
+
+pipeline test_text_only_progress_extends(task) {
+  // Visible-text progress, ZERO tool calls this turn, at the boundary → extend.
+  // This is the bug the rule table fixed.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state(true, 0, 0, false, true))
+  assert_eq(cmd.action, "extend")
+  assert_eq(cmd.reason, "recent turn made progress")
+}
+
+pipeline test_tool_progress_extends(task) {
+  // Tool-call progress at the boundary → extend (unchanged behavior).
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state(true, 2, 0, false, true))
+  assert_eq(cmd.action, "extend")
+  assert_eq(cmd.reason, "recent turn made progress")
+}
+
+pipeline test_no_progress_does_not_extend(task) {
+  // No progress at the boundary → no extension; the loop stops at its cap.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state(false, 0, 0, false, true))
+  assert_eq(cmd.action, "none")
+}
+
+pipeline test_below_boundary_is_noop(task) {
+  // remaining > 0 → not at the boundary yet, the policy makes no decision even
+  // when progress is being made.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state(true, 1, 5, false, true))
+  assert_eq(cmd.action, "none")
+}
+
+pipeline test_completion_veto_extends(task) {
+  // A vetoed completion gate extends regardless of per-turn progress, and is
+  // ordered ahead of the progress rule.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state(false, 0, 0, true, true))
+  assert_eq(cmd.action, "extend")
+  assert_eq(cmd.reason, "completion gate vetoed")
+}
+
+pipeline test_required_tools_missing_extends(task) {
+  // Required tools not yet satisfied extends even with no fresh progress.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state(false, 0, 0, false, false))
+  assert_eq(cmd.action, "extend")
+  assert_eq(cmd.reason, "required tools missing")
+}


### PR DESCRIPTION
## Problem

The default adaptive loop-control policy (`std/agent/control`, `__agent_default_loop_control`) decided, at the budget boundary, whether to extend the iteration cap. The extension rule was an inline:

```
if state.progress.changed && state.turn.tool_call_count > 0 { extend }
```

But `progress.changed` is computed (in `agent_loop_snapshot_state`) as `tool_count > 0 || successful_tools || visible_text != ""` — it **already includes visible text**. So a turn that was pure planning/narration toward the next edit (no tool call *that* turn) had `progress.changed = true` but `tool_call_count = 0`, and the compound `&&` denied the extension.

A methodical model working a large multi-file task (a refactor across ~6 files) was cut off mid-work whenever the budget boundary landed on such a planning turn — surfacing to callers as `stopReason: max_turn_requests` despite the agent still making steady progress. Empirically: the run stopped at exactly `initial + N×extend_by` iterations on a planning turn, with files still pending.

## Fix + hardening

- **Single definition of progress.** Extension now keys off one `agent_loop_is_progressing(state)` predicate — the *only* place "progress" is defined — so a second, competing notion can't be ANDed onto the rule again.
- **Named, ordered rule table.** The policy is an explicit `[{when, reason}, …]` table (first match wins) instead of inline compound `if`s, so every extension trigger is auditable in one place and each is independently testable.
- Degenerate narration that never acts stays bounded by the iteration `max` and the stall detector (unchanged).

## Behavior preserved / changed
- *Changed:* a text-only planning turn at the boundary now extends (the bug).
- *Preserved:* below-boundary is a no-op; completion-veto and required-tools rules keep their order and precedence; no-progress at the boundary still declines (loop stops at its cap).

Validated end-to-end against the real local-model eval: a 6-file Rust refactor that previously stopped at 32 iterations / `max_turn_requests` now extends to ~48 and stops naturally with `end_turn`.

## Tests
New unit test `tests/agent/loop_control_test.harn` exercises the decision at the public seam `agent_loop_control_invoke` with hand-built loop state (no `agent_loop`, no mock LLM, zero inference): text-only progress extends, tool progress extends, no-progress declines, below-boundary is a no-op, completion-veto and required-tools rules fire with the right reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)