### PR TITLE
feat(catalog): add Gemma 4 to the model catalog (12B local + hosted 26B/31B)

### DIFF
--- a/changelog.d/3000.added.md
+++ b/changelog.d/3000.added.md
@@ -1,0 +1,8 @@
+- **Gemma 4 12B in the model catalog (#3000).** Google's encoder-free unified
+  multimodal model (Apache 2.0, built to run on a 16GB laptop) is now wired via
+  Ollama as `gemma4:12b-mlx` (Apple Silicon), `gemma4:12b-nvfp4` (NVIDIA
+  Blackwell), and `gemma4:12b-mxfp8`, with `ollama-gemma4-12b`,
+  `ollama-gemma4-12b-nvfp4`, and `local-gemma4-12b` aliases. The Ollama-published
+  12B quants are text-only at 128K context (vision projector dropped, verified via
+  `ollama show`), so a `gemma4:12b*` capabilities rule keeps them out of
+  vision routing while the 26b/31b builds stay multimodal.

--- a/changelog.d/3000.added.md
+++ b/changelog.d/3000.added.md
@@ -1,8 +1,13 @@
-- **Gemma 4 12B in the model catalog (#3000).** Google's encoder-free unified
-  multimodal model (Apache 2.0, built to run on a 16GB laptop) is now wired via
-  Ollama as `gemma4:12b-mlx` (Apple Silicon), `gemma4:12b-nvfp4` (NVIDIA
-  Blackwell), and `gemma4:12b-mxfp8`, with `ollama-gemma4-12b`,
-  `ollama-gemma4-12b-nvfp4`, and `local-gemma4-12b` aliases. The Ollama-published
-  12B quants are text-only at 128K context (vision projector dropped, verified via
-  `ollama show`), so a `gemma4:12b*` capabilities rule keeps them out of
-  vision routing while the 26b/31b builds stay multimodal.
+- **Gemma 4 in the model catalog — local and hosted (#3000).** Google's Gemma 4
+  (encoder-free unified multimodal, Apache 2.0) is now wired across the board:
+  - **Local (Ollama):** the 12B on-device model as `gemma4:12b-mlx` (Apple
+    Silicon), `gemma4:12b-nvfp4` (NVIDIA Blackwell), and `gemma4:12b-mxfp8`. The
+    Ollama 12B quants are text-only at 128K (vision projector dropped, verified
+    via `ollama show`), so a `gemma4:12b*` rule keeps them out of vision routing.
+  - **Hosted:** the multimodal 26B MoE and 31B dense via the Gemini API
+    (`gemini-gemma4-26b`/`-31b`), OpenRouter (`google/gemma-4-26b-a4b-it`,
+    `google/gemma-4-31b-it` + aliases), and Together (`together-gemma4-31b`).
+  - Fixes a latent bug where the `google/gemma-4*` OpenRouter/Together capability
+    rules omitted `vision_supported`, so hosted Gemma 4 now correctly advertises
+    image input. The 12B is on-device only and is intentionally not given a
+    hosted route.

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -932,6 +932,20 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
 
+# The Ollama-published Gemma 4 12B quants are TEXT-ONLY (vision projector dropped
+# in the conversion — verified via `ollama show gemma4:12b-mlx`), unlike the 26b/
+# 31b builds. Keep this ahead of the `gemma4*` family rule (first match wins).
+[[provider.ollama]]
+model_match = "gemma4:12b*"
+vision_supported = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
 [[provider.ollama]]
 model_match = "gemma4*"
 vision_supported = true

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1736,6 +1736,24 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
 
+# Gemma 4 (26B MoE / 31B) served directly by the Gemini API. Multimodal
+# text+image with native function calling and thinking; no Gemini-only adaptive
+# effort modes. Ahead of the broader gemini rules (first match wins).
+[[provider.gemini]]
+model_match = "gemma-4*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
 [[provider.gemini]]
 model_match = "gemini-2.5*"
 native_tools = true
@@ -1809,6 +1827,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "google/gemma-4*"
 native_tools = true
+vision_supported = true
 preferred_tool_format = "native"
 structured_output = "native"
 top_k_supported = true
@@ -1925,6 +1944,7 @@ thinking_block_style = "inline"
 [[provider.together]]
 model_match = "google/gemma-4*"
 native_tools = true
+vision_supported = true
 preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1738,9 +1738,25 @@ thinking_block_style = "reasoning_summary"
 
 # Gemma 4 (26B MoE / 31B) served directly by the Gemini API. Multimodal
 # text+image with native function calling and thinking; no Gemini-only adaptive
-# effort modes. Ahead of the broader gemini rules (first match wins).
+# effort modes. Both the bare id and the `models/` REST resource name resolve to
+# the same model. Ahead of the broader gemini rules (first match wins).
 [[provider.gemini]]
 model_match = "gemma-4*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.gemini]]
+model_match = "models/gemma-4*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -562,11 +562,11 @@ provider = "local"
 # Gemma 4 26B/31B via hosted APIs (the 12B is on-device only). The Gemini API
 # serves Gemma under its bare id; OpenRouter/Together use org-prefixed ids.
 [aliases.gemini-gemma4-31b]
-id = "gemma-4-31b-it"
+id = "models/gemma-4-31b-it"
 provider = "gemini"
 
 [aliases.gemini-gemma4-26b]
-id = "gemma-4-26b-a4b-it"
+id = "models/gemma-4-26b-a4b-it"
 provider = "gemini"
 
 [aliases.openrouter-gemma4-31b]
@@ -1576,11 +1576,21 @@ capabilities = ["streaming", "thinking"]
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "long_context"]
+[models."gemma-4-12b-it"]
+name = "Gemma 4 12B (local)"
+provider = "local"
+context_window = 131072
+stream_timeout = 300.0
+capabilities = ["streaming", "thinking"]
+tier = "mid"
+open_weight = true
+strengths = ["cheap", "speed"]
 # Gemma 4 — hosted (Apache 2.0, multimodal text+image, 256K context, native
 # thinking). The 12B is on-device only; the 26B MoE and 31B dense are also served
-# directly by hosted APIs. OpenRouter ids are org-prefixed (collision-free with
-# the bare `local` keys above); the Gemini API and Together routes are aliases
-# below since their wire ids match the bare keys.
+# directly by hosted APIs. Each provider route is registered as its own catalog
+# row keyed by that provider's wire id (the alias-validation contract requires a
+# matching row): OpenRouter ids are org-prefixed and the Gemini API rows use the
+# `models/` REST resource name — both collision-free with the bare `local` keys.
 [models."google/gemma-4-31b-it"]
 name = "Gemma 4 31B (OpenRouter)"
 provider = "openrouter"
@@ -1599,3 +1609,28 @@ pricing = { input_per_mtok = 0.06, output_per_mtok = 0.33 }
 tier = "mid"
 open_weight = true
 strengths = ["vision", "cheap", "speed"]
+[models."models/gemma-4-31b-it"]
+name = "Gemma 4 31B (Gemini API)"
+provider = "gemini"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking"]
+tier = "frontier"
+open_weight = true
+strengths = ["vision", "reasoning", "coding", "cheap"]
+[models."models/gemma-4-26b-a4b-it"]
+name = "Gemma 4 26B MoE (Gemini API)"
+provider = "gemini"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking"]
+tier = "mid"
+open_weight = true
+strengths = ["vision", "cheap", "speed"]
+[models."google/gemma-4-31B-it"]
+name = "Gemma 4 31B (Together)"
+provider = "together"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.20, output_per_mtok = 0.50 }
+tier = "frontier"
+open_weight = true
+strengths = ["vision", "reasoning", "coding"]

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -545,6 +545,20 @@ id = "gemma4:26b"
 provider = "ollama"
 tool_format = "text"
 
+[aliases.ollama-gemma4-12b]
+id = "gemma4:12b-mlx"
+provider = "ollama"
+tool_format = "text"
+
+[aliases.ollama-gemma4-12b-nvfp4]
+id = "gemma4:12b-nvfp4"
+provider = "ollama"
+tool_format = "text"
+
+[aliases.local-gemma4-12b]
+id = "gemma-4-12b-it"
+provider = "local"
+
 # qwen3.6 has no working Ollama route — Ollama's qwen3.5-family server-side
 # tool-call parser 500s on text-tool output (ollama/ollama#14986, #14570).
 # Use the llamacpp provider for local qwen3.x.
@@ -663,6 +677,13 @@ tool_format = "native"
 # update these via providers.toml overlays as they re-probe a model.
 
 [alias_tool_calling.ollama-gemma4]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "disabled"
+failure_reason = "requires_tool_probe"
+
+[alias_tool_calling.ollama-gemma4-12b]
 native = "unknown"
 text = "unknown"
 streaming_native = "unknown"
@@ -1405,6 +1426,43 @@ capabilities = ["tools", "vision", "streaming", "thinking"]
 tier = "mid"
 open_weight = true
 strengths = ["vision", "tool_use"]
+# Gemma 4 12B — encoder-free unified multimodal model (Apache 2.0), built to run
+# on a 16GB laptop. Published on Ollama only as quantized variants (no bare
+# `gemma4:12b` tag). Verified via `ollama show`: the quantized 12B builds expose
+# `tools` + native `thinking` but are TEXT-ONLY at 128K context — the vision
+# projector is dropped in these conversions, unlike the larger 26b/31b builds.
+# MLX is the Apple-Silicon path; nvfp4 targets NVIDIA Blackwell; mxfp8 is the
+# higher-fidelity quant.
+[models."gemma4:12b-mlx"]
+name = "Gemma 4 12B (MLX)"
+provider = "ollama"
+context_window = 131072
+runtime_context_window = 32768
+stream_timeout = 240.0
+capabilities = ["tools", "streaming", "thinking"]
+tier = "mid"
+open_weight = true
+strengths = ["speed", "cheap"]
+[models."gemma4:12b-nvfp4"]
+name = "Gemma 4 12B (NVFP4)"
+provider = "ollama"
+context_window = 131072
+runtime_context_window = 32768
+stream_timeout = 240.0
+capabilities = ["tools", "streaming", "thinking"]
+tier = "mid"
+open_weight = true
+strengths = ["cheap", "tool_use"]
+[models."gemma4:12b-mxfp8"]
+name = "Gemma 4 12B (MXFP8)"
+provider = "ollama"
+context_window = 131072
+runtime_context_window = 32768
+stream_timeout = 240.0
+capabilities = ["tools", "streaming", "thinking"]
+tier = "mid"
+open_weight = true
+strengths = ["cheap", "tool_use"]
 [models."devstral-small-2:24b"]
 name = "Devstral Small 2 24B"
 provider = "ollama"

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -559,6 +559,28 @@ tool_format = "text"
 id = "gemma-4-12b-it"
 provider = "local"
 
+# Gemma 4 26B/31B via hosted APIs (the 12B is on-device only). The Gemini API
+# serves Gemma under its bare id; OpenRouter/Together use org-prefixed ids.
+[aliases.gemini-gemma4-31b]
+id = "gemma-4-31b-it"
+provider = "gemini"
+
+[aliases.gemini-gemma4-26b]
+id = "gemma-4-26b-a4b-it"
+provider = "gemini"
+
+[aliases.openrouter-gemma4-31b]
+id = "google/gemma-4-31b-it"
+provider = "openrouter"
+
+[aliases.openrouter-gemma4-26b]
+id = "google/gemma-4-26b-a4b-it"
+provider = "openrouter"
+
+[aliases.together-gemma4-31b]
+id = "google/gemma-4-31B-it"
+provider = "together"
+
 # qwen3.6 has no working Ollama route — Ollama's qwen3.5-family server-side
 # tool-call parser 500s on text-tool output (ollama/ollama#14986, #14570).
 # Use the llamacpp provider for local qwen3.x.
@@ -1554,3 +1576,26 @@ capabilities = ["streaming", "thinking"]
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "long_context"]
+# Gemma 4 — hosted (Apache 2.0, multimodal text+image, 256K context, native
+# thinking). The 12B is on-device only; the 26B MoE and 31B dense are also served
+# directly by hosted APIs. OpenRouter ids are org-prefixed (collision-free with
+# the bare `local` keys above); the Gemini API and Together routes are aliases
+# below since their wire ids match the bare keys.
+[models."google/gemma-4-31b-it"]
+name = "Gemma 4 31B (OpenRouter)"
+provider = "openrouter"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.12, output_per_mtok = 0.37 }
+tier = "frontier"
+open_weight = true
+strengths = ["vision", "reasoning", "coding", "cheap"]
+[models."google/gemma-4-26b-a4b-it"]
+name = "Gemma 4 26B MoE (OpenRouter)"
+provider = "openrouter"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.06, output_per_mtok = 0.33 }
+tier = "mid"
+open_weight = true
+strengths = ["vision", "cheap", "speed"]

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -47,6 +47,8 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `gemma-4*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `models/gemma-4*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `gemini` | `gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `gemini` | `models/gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `gemini` | `gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
@@ -71,6 +73,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `ollama` | `bakllava*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
 | `ollama` | `llama3.2-vision*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
 | `ollama` | `gemma3*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `gemma4:12b*` | `any` | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
 | `ollama` | `gemma4*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
 | `ollama` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
 | `ollama` | `qwen3*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | no | `native_only` | yes | no |
@@ -106,7 +109,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
-| `openrouter` | `google/gemma-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `google/gemma-4*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `meta-llama/llama-3*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `minimax/minimax-m2.7*` | `any` | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
@@ -121,7 +124,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `together` | `deepseek-ai/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `google/gemma-4*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `google/gemma-4*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `moonshotai/*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `vertex` | `gemini-*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `zai` | `glm-5.1*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
@@ -155,9 +158,12 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `deepseek` | `deepseek-v4-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `gemini` | `models/gemma-4-26b-a4b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `gemini` | `models/gemma-4-31b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `llamacpp` | `qwen3.6-35b-a3b` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `llamacpp` | `qwen3.6-35b-a3b-ud-q4-k-xl` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `llamacpp` | `qwen3.6-35b-a3b-ud-q5-k-xl` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
+| `local` | `gemma-4-12b-it` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `local` | `gemma-4-26b-a4b-it` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `local` | `gemma-4-31b-it` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `local` | `gemma-4-e2b-it` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
@@ -170,6 +176,9 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `minimax` | `MiniMax-Text-01` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `mlx` | `unsloth/Qwen3.6-27B-UD-MLX-4bit` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `devstral-small-2:24b` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
+| `ollama` | `gemma4:12b-mlx` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
+| `ollama` | `gemma4:12b-mxfp8` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
+| `ollama` | `gemma4:12b-nvfp4` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `gemma4:26b` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `llama3.2` | `text` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openai` | `gpt-4-turbo` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
@@ -187,6 +196,8 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `deepseek/deepseek-v4-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `deepseek/deepseek-v4-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `google/gemini-2.5-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `google/gemma-4-26b-a4b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `google/gemma-4-31b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `mistralai/mistral-large-2512` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
@@ -198,5 +209,6 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `z-ai/glm-5.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `z-ai/glm-5v-turbo` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `Qwen/Qwen3-Coder-Next-FP8` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `together` | `google/gemma-4-31B-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `zai` | `glm-5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `zai` | `glm-5.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -2732,6 +2732,141 @@ public let harnProviderCatalogJSON = #"""
       }
     },
     {
+      "id": "models/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B MoE (Gemini API)",
+      "provider": "gemini",
+      "aliases": [
+        "gemini-gemma4-26b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "files",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "cheap",
+        "speed"
+      ]
+    },
+    {
+      "id": "models/gemma-4-31b-it",
+      "name": "Gemma 4 31B (Gemini API)",
+      "provider": "gemini",
+      "aliases": [
+        "gemini-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "files",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding",
+        "cheap"
+      ]
+    },
+    {
       "id": "qwen3.6-35b-a3b",
       "name": "Qwen3.6 35B (llama.cpp)",
       "provider": "llamacpp",
@@ -2927,6 +3062,71 @@ public let harnProviderCatalogJSON = #"""
       "open_weight": true,
       "strengths": [
         "coding"
+      ]
+    },
+    {
+      "id": "gemma-4-12b-it",
+      "name": "Gemma 4 12B (local)",
+      "provider": "local",
+      "aliases": [
+        "local-gemma4-12b"
+      ],
+      "context_window": 131072,
+      "stream_timeout": 300.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "speed"
       ]
     },
     {
@@ -6060,6 +6260,78 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "google/gemma-4-31B-it",
+      "name": "Gemma 4 31B (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.2,
+        "output_per_mtok": 0.5,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding"
+      ]
+    },
+    {
       "id": "glm-5",
       "name": "GLM 5",
       "provider": "zai",
@@ -6246,12 +6518,12 @@ public let harnProviderCatalogJSON = #"""
     },
     {
       "name": "gemini-gemma4-26b",
-      "model_id": "gemma-4-26b-a4b-it",
+      "model_id": "models/gemma-4-26b-a4b-it",
       "provider": "gemini"
     },
     {
       "name": "gemini-gemma4-31b",
-      "model_id": "gemma-4-31b-it",
+      "model_id": "models/gemma-4-31b-it",
       "provider": "gemini"
     },
     {

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -3748,6 +3748,193 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "gemma4:12b-mlx",
+      "name": "Gemma 4 12B (MLX)",
+      "provider": "ollama",
+      "aliases": [
+        "ollama-gemma4-12b"
+      ],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "cheap"
+      ]
+    },
+    {
+      "id": "gemma4:12b-mxfp8",
+      "name": "Gemma 4 12B (MXFP8)",
+      "provider": "ollama",
+      "aliases": [],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
+      "id": "gemma4:12b-nvfp4",
+      "name": "Gemma 4 12B (NVFP4)",
+      "provider": "ollama",
+      "aliases": [
+        "ollama-gemma4-12b-nvfp4"
+      ],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
       "id": "gemma4:26b",
       "name": "Gemma 4 26B MoE",
       "provider": "ollama",
@@ -5963,6 +6150,11 @@ public let harnProviderCatalogJSON = #"""
       "provider": "local"
     },
     {
+      "name": "local-gemma4-12b",
+      "model_id": "gemma-4-12b-it",
+      "provider": "local"
+    },
+    {
       "name": "local-gemma4-26b",
       "model_id": "gemma-4-26b-a4b-it",
       "provider": "local"
@@ -6073,6 +6265,25 @@ public let harnProviderCatalogJSON = #"""
         "fallback_mode": "disabled",
         "failure_reason": "requires_tool_probe"
       }
+    },
+    {
+      "name": "ollama-gemma4-12b",
+      "model_id": "gemma4:12b-mlx",
+      "provider": "ollama",
+      "tool_format": "text",
+      "tool_calling": {
+        "native": "unknown",
+        "text": "unknown",
+        "streaming_native": "unknown",
+        "fallback_mode": "disabled",
+        "failure_reason": "requires_tool_probe"
+      }
+    },
+    {
+      "name": "ollama-gemma4-12b-nvfp4",
+      "model_id": "gemma4:12b-nvfp4",
+      "provider": "ollama",
+      "tool_format": "text"
     },
     {
       "name": "ollama-gemma4-26b",

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -5177,6 +5177,145 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "google/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B MoE (OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-gemma4-26b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.06,
+        "output_per_mtok": 0.33,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "cheap",
+        "speed"
+      ]
+    },
+    {
+      "id": "google/gemma-4-31b-it",
+      "name": "Gemma 4 31B (OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.12,
+        "output_per_mtok": 0.37,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding",
+        "cheap"
+      ]
+    },
+    {
       "id": "minimax/minimax-m2",
       "name": "MiniMax M2 (via OpenRouter)",
       "provider": "openrouter",
@@ -6106,6 +6245,16 @@ public let harnProviderCatalogJSON = #"""
       "provider": "anthropic"
     },
     {
+      "name": "gemini-gemma4-26b",
+      "model_id": "gemma-4-26b-a4b-it",
+      "provider": "gemini"
+    },
+    {
+      "name": "gemini-gemma4-31b",
+      "model_id": "gemma-4-31b-it",
+      "provider": "gemini"
+    },
+    {
       "name": "glm",
       "model_id": "glm-5.1",
       "provider": "zai"
@@ -6292,6 +6441,16 @@ public let harnProviderCatalogJSON = #"""
       "tool_format": "text"
     },
     {
+      "name": "openrouter-gemma4-26b",
+      "model_id": "google/gemma-4-26b-a4b-it",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-gemma4-31b",
+      "model_id": "google/gemma-4-31b-it",
+      "provider": "openrouter"
+    },
+    {
       "name": "opus",
       "model_id": "claude-opus-4-8",
       "provider": "anthropic"
@@ -6320,6 +6479,11 @@ public let harnProviderCatalogJSON = #"""
       "name": "tier/small",
       "model_id": "Qwen/Qwen3.5-9B",
       "provider": "openrouter"
+    },
+    {
+      "name": "together-gemma4-31b",
+      "model_id": "google/gemma-4-31B-it",
+      "provider": "together"
     }
   ],
   "variants": [

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -2553,6 +2553,141 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       }
     },
     {
+      "id": "models/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B MoE (Gemini API)",
+      "provider": "gemini",
+      "aliases": [
+        "gemini-gemma4-26b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "files",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "cheap",
+        "speed"
+      ]
+    },
+    {
+      "id": "models/gemma-4-31b-it",
+      "name": "Gemma 4 31B (Gemini API)",
+      "provider": "gemini",
+      "aliases": [
+        "gemini-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "files",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding",
+        "cheap"
+      ]
+    },
+    {
       "id": "qwen3.6-35b-a3b",
       "name": "Qwen3.6 35B (llama.cpp)",
       "provider": "llamacpp",
@@ -2748,6 +2883,71 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "open_weight": true,
       "strengths": [
         "coding"
+      ]
+    },
+    {
+      "id": "gemma-4-12b-it",
+      "name": "Gemma 4 12B (local)",
+      "provider": "local",
+      "aliases": [
+        "local-gemma4-12b"
+      ],
+      "context_window": 131072,
+      "stream_timeout": 300.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "speed"
       ]
     },
     {
@@ -5881,6 +6081,78 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "google/gemma-4-31B-it",
+      "name": "Gemma 4 31B (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.2,
+        "output_per_mtok": 0.5,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding"
+      ]
+    },
+    {
       "id": "glm-5",
       "name": "GLM 5",
       "provider": "zai",
@@ -6067,12 +6339,12 @@ export const harnProviderCatalog: HarnProviderCatalog = {
     },
     {
       "name": "gemini-gemma4-26b",
-      "model_id": "gemma-4-26b-a4b-it",
+      "model_id": "models/gemma-4-26b-a4b-it",
       "provider": "gemini"
     },
     {
       "name": "gemini-gemma4-31b",
-      "model_id": "gemma-4-31b-it",
+      "model_id": "models/gemma-4-31b-it",
       "provider": "gemini"
     },
     {

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -3569,6 +3569,193 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "gemma4:12b-mlx",
+      "name": "Gemma 4 12B (MLX)",
+      "provider": "ollama",
+      "aliases": [
+        "ollama-gemma4-12b"
+      ],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "cheap"
+      ]
+    },
+    {
+      "id": "gemma4:12b-mxfp8",
+      "name": "Gemma 4 12B (MXFP8)",
+      "provider": "ollama",
+      "aliases": [],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
+      "id": "gemma4:12b-nvfp4",
+      "name": "Gemma 4 12B (NVFP4)",
+      "provider": "ollama",
+      "aliases": [
+        "ollama-gemma4-12b-nvfp4"
+      ],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
       "id": "gemma4:26b",
       "name": "Gemma 4 26B MoE",
       "provider": "ollama",
@@ -5784,6 +5971,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "local"
     },
     {
+      "name": "local-gemma4-12b",
+      "model_id": "gemma-4-12b-it",
+      "provider": "local"
+    },
+    {
       "name": "local-gemma4-26b",
       "model_id": "gemma-4-26b-a4b-it",
       "provider": "local"
@@ -5894,6 +6086,25 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "fallback_mode": "disabled",
         "failure_reason": "requires_tool_probe"
       }
+    },
+    {
+      "name": "ollama-gemma4-12b",
+      "model_id": "gemma4:12b-mlx",
+      "provider": "ollama",
+      "tool_format": "text",
+      "tool_calling": {
+        "native": "unknown",
+        "text": "unknown",
+        "streaming_native": "unknown",
+        "fallback_mode": "disabled",
+        "failure_reason": "requires_tool_probe"
+      }
+    },
+    {
+      "name": "ollama-gemma4-12b-nvfp4",
+      "model_id": "gemma4:12b-nvfp4",
+      "provider": "ollama",
+      "tool_format": "text"
     },
     {
       "name": "ollama-gemma4-26b",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -4998,6 +4998,145 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "google/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B MoE (OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-gemma4-26b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.06,
+        "output_per_mtok": 0.33,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "cheap",
+        "speed"
+      ]
+    },
+    {
+      "id": "google/gemma-4-31b-it",
+      "name": "Gemma 4 31B (OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.12,
+        "output_per_mtok": 0.37,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding",
+        "cheap"
+      ]
+    },
+    {
       "id": "minimax/minimax-m2",
       "name": "MiniMax M2 (via OpenRouter)",
       "provider": "openrouter",
@@ -5927,6 +6066,16 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "anthropic"
     },
     {
+      "name": "gemini-gemma4-26b",
+      "model_id": "gemma-4-26b-a4b-it",
+      "provider": "gemini"
+    },
+    {
+      "name": "gemini-gemma4-31b",
+      "model_id": "gemma-4-31b-it",
+      "provider": "gemini"
+    },
+    {
       "name": "glm",
       "model_id": "glm-5.1",
       "provider": "zai"
@@ -6113,6 +6262,16 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "tool_format": "text"
     },
     {
+      "name": "openrouter-gemma4-26b",
+      "model_id": "google/gemma-4-26b-a4b-it",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-gemma4-31b",
+      "model_id": "google/gemma-4-31b-it",
+      "provider": "openrouter"
+    },
+    {
       "name": "opus",
       "model_id": "claude-opus-4-8",
       "provider": "anthropic"
@@ -6141,6 +6300,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "tier/small",
       "model_id": "Qwen/Qwen3.5-9B",
       "provider": "openrouter"
+    },
+    {
+      "name": "together-gemma4-31b",
+      "model_id": "google/gemma-4-31B-it",
+      "provider": "together"
     }
   ],
   "variants": [

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -2376,6 +2376,141 @@
       }
     },
     {
+      "id": "models/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B MoE (Gemini API)",
+      "provider": "gemini",
+      "aliases": [
+        "gemini-gemma4-26b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "files",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "cheap",
+        "speed"
+      ]
+    },
+    {
+      "id": "models/gemma-4-31b-it",
+      "name": "Gemma 4 31B (Gemini API)",
+      "provider": "gemini",
+      "aliases": [
+        "gemini-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "files",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding",
+        "cheap"
+      ]
+    },
+    {
       "id": "qwen3.6-35b-a3b",
       "name": "Qwen3.6 35B (llama.cpp)",
       "provider": "llamacpp",
@@ -2571,6 +2706,71 @@
       "open_weight": true,
       "strengths": [
         "coding"
+      ]
+    },
+    {
+      "id": "gemma-4-12b-it",
+      "name": "Gemma 4 12B (local)",
+      "provider": "local",
+      "aliases": [
+        "local-gemma4-12b"
+      ],
+      "context_window": 131072,
+      "stream_timeout": 300.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "speed"
       ]
     },
     {
@@ -5704,6 +5904,78 @@
       ]
     },
     {
+      "id": "google/gemma-4-31B-it",
+      "name": "Gemma 4 31B (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.2,
+        "output_per_mtok": 0.5,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding"
+      ]
+    },
+    {
       "id": "glm-5",
       "name": "GLM 5",
       "provider": "zai",
@@ -5890,12 +6162,12 @@
     },
     {
       "name": "gemini-gemma4-26b",
-      "model_id": "gemma-4-26b-a4b-it",
+      "model_id": "models/gemma-4-26b-a4b-it",
       "provider": "gemini"
     },
     {
       "name": "gemini-gemma4-31b",
-      "model_id": "gemma-4-31b-it",
+      "model_id": "models/gemma-4-31b-it",
       "provider": "gemini"
     },
     {

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -3392,6 +3392,193 @@
       ]
     },
     {
+      "id": "gemma4:12b-mlx",
+      "name": "Gemma 4 12B (MLX)",
+      "provider": "ollama",
+      "aliases": [
+        "ollama-gemma4-12b"
+      ],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "cheap"
+      ]
+    },
+    {
+      "id": "gemma4:12b-mxfp8",
+      "name": "Gemma 4 12B (MXFP8)",
+      "provider": "ollama",
+      "aliases": [],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
+      "id": "gemma4:12b-nvfp4",
+      "name": "Gemma 4 12B (NVFP4)",
+      "provider": "ollama",
+      "aliases": [
+        "ollama-gemma4-12b-nvfp4"
+      ],
+      "context_window": 131072,
+      "runtime_context_window": 32768,
+      "stream_timeout": 240.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "text",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
       "id": "gemma4:26b",
       "name": "Gemma 4 26B MoE",
       "provider": "ollama",
@@ -5607,6 +5794,11 @@
       "provider": "local"
     },
     {
+      "name": "local-gemma4-12b",
+      "model_id": "gemma-4-12b-it",
+      "provider": "local"
+    },
+    {
       "name": "local-gemma4-26b",
       "model_id": "gemma-4-26b-a4b-it",
       "provider": "local"
@@ -5717,6 +5909,25 @@
         "fallback_mode": "disabled",
         "failure_reason": "requires_tool_probe"
       }
+    },
+    {
+      "name": "ollama-gemma4-12b",
+      "model_id": "gemma4:12b-mlx",
+      "provider": "ollama",
+      "tool_format": "text",
+      "tool_calling": {
+        "native": "unknown",
+        "text": "unknown",
+        "streaming_native": "unknown",
+        "fallback_mode": "disabled",
+        "failure_reason": "requires_tool_probe"
+      }
+    },
+    {
+      "name": "ollama-gemma4-12b-nvfp4",
+      "model_id": "gemma4:12b-nvfp4",
+      "provider": "ollama",
+      "tool_format": "text"
     },
     {
       "name": "ollama-gemma4-26b",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -4821,6 +4821,145 @@
       ]
     },
     {
+      "id": "google/gemma-4-26b-a4b-it",
+      "name": "Gemma 4 26B MoE (OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-gemma4-26b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.06,
+        "output_per_mtok": 0.33,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "cheap",
+        "speed"
+      ]
+    },
+    {
+      "id": "google/gemma-4-31b-it",
+      "name": "Gemma 4 31B (OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-gemma4-31b"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.12,
+        "output_per_mtok": 0.37,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "gemma",
+      "lineage": "gemma4",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "vision",
+        "reasoning",
+        "coding",
+        "cheap"
+      ]
+    },
+    {
       "id": "minimax/minimax-m2",
       "name": "MiniMax M2 (via OpenRouter)",
       "provider": "openrouter",
@@ -5750,6 +5889,16 @@
       "provider": "anthropic"
     },
     {
+      "name": "gemini-gemma4-26b",
+      "model_id": "gemma-4-26b-a4b-it",
+      "provider": "gemini"
+    },
+    {
+      "name": "gemini-gemma4-31b",
+      "model_id": "gemma-4-31b-it",
+      "provider": "gemini"
+    },
+    {
       "name": "glm",
       "model_id": "glm-5.1",
       "provider": "zai"
@@ -5936,6 +6085,16 @@
       "tool_format": "text"
     },
     {
+      "name": "openrouter-gemma4-26b",
+      "model_id": "google/gemma-4-26b-a4b-it",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-gemma4-31b",
+      "model_id": "google/gemma-4-31b-it",
+      "provider": "openrouter"
+    },
+    {
       "name": "opus",
       "model_id": "claude-opus-4-8",
       "provider": "anthropic"
@@ -5964,6 +6123,11 @@
       "name": "tier/small",
       "model_id": "Qwen/Qwen3.5-9B",
       "provider": "openrouter"
+    },
+    {
+      "name": "together-gemma4-31b",
+      "model_id": "google/gemma-4-31B-it",
+      "provider": "together"
     }
   ],
   "variants": [


### PR DESCRIPTION
## What

Adds Google's **Gemma 4 12B** — the encoder-free unified multimodal model (Apache 2.0, built for 16GB laptops) released June 3, 2026 — to the provider/model catalog via Ollama.

Ollama publishes the 12B only as quantized variants (there is **no bare `gemma4:12b` tag**), so this wires the three real tags:

| Model id | Target | Notes |
|----------|--------|-------|
| `gemma4:12b-mlx` | Apple Silicon | MLX runtime |
| `gemma4:12b-nvfp4` | NVIDIA Blackwell | FP4, mirrors existing 26b/31b nvfp4 |
| `gemma4:12b-mxfp8` | higher fidelity | MXFP8 quant |

Aliases: `ollama-gemma4-12b` → mlx, `ollama-gemma4-12b-nvfp4`, `local-gemma4-12b` (vLLM/OpenAI-compat).

## Verified on hardware

Pulled and ran `gemma4:12b-mlx` on an M5 Pro (48GB). `ollama show` reports `architecture gemma4_unified`, `13.0B`, `131072` context, capabilities `tools` + native `thinking`, and **no vision** — the Ollama quantized 12B conversions are text-only (vision projector dropped), unlike the 26b/31b builds.

To keep routing honest, a `gemma4:12b*` rule sits ahead of the `gemma4*` family glob (first-match-wins) and sets `vision_supported = false`, so image tasks aren't routed to a model that can't see. The 26b entry is unchanged (still `text + image`).

## Artifacts

Regenerated `provider-catalog.{json,schema.json}`, `harn-provider-catalog.ts`, and `HarnProviderCatalog.swift` via `make gen-provider-catalog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)