### PR TITLE
fix(agent): count agent_progress-only turns as no-progress for stall detection

### DIFF
--- a/changelog.d/3001.fixed.md
+++ b/changelog.d/3001.fixed.md
@@ -1,0 +1,7 @@
+- **The stall detector now catches `agent_progress` spam (#3001).** A turn whose
+  only tool call is a soft progress-report tool (`agent_progress`) reports status
+  without advancing the task, but it was counted as real activity — so a model
+  that emitted `agent_progress` repeatedly after getting stuck never tripped the
+  no-progress detector. Such turns now count toward the no-progress streak (the
+  same as a text-only monologue), so a run of them trips and the loop can recover
+  or hard-stop. A turn that also makes a real tool call is unaffected.

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -60,6 +60,14 @@ const STALL_REPEAT_CONTEXT_WINDOW_ERROR = 2
 // nudging forever.
 const STALL_HARD_STOP_AFTER_TRIPS = 3
 
+// Tools that report progress without changing task state. A turn whose only
+// tool call is one of these is "narrating progress without making it": it is
+// counted as a no-progress turn for stall accounting, so a run of them (e.g. a
+// model spamming `agent_progress` after it gets stuck) trips the no-progress
+// detector instead of masquerading as activity. A turn that also makes a real
+// tool call is unaffected — the real call carries the action stream.
+const SOFT_PROGRESS_TOOLS = ["agent_progress"]
+
 type AgentStallConfig = {
   enabled: bool,
   threshold: int,
@@ -722,11 +730,17 @@ pub fn agent_stall_observe_tool_calls(
       hard_stop: false,
     }
   }
-  if len(tool_calls) == 0 {
-    // No tool call this turn. A turn with visible text but no tool call is a
-    // no-progress monologue candidate; a fully empty turn just resets the
-    // action stream.
-    if to_string(turn_text) != "" {
+  // Soft progress-report tools (e.g. `agent_progress`) report status without
+  // advancing task state, so they are excluded from the real-action stream: a
+  // turn whose only call is such a report is treated as no-progress.
+  let substantive_calls = tool_calls
+    .filter({ c -> !contains(SOFT_PROGRESS_TOOLS, __agent_tool_call_name(c)) })
+  if len(substantive_calls) == 0 {
+    // No substantive tool call this turn — either none at all, or only soft
+    // progress reports. With visible text or a progress report, that is a
+    // no-progress monologue candidate; a fully empty turn resets the action
+    // stream.
+    if to_string(turn_text) != "" || len(tool_calls) > 0 {
       return __agent_stall_observe_no_progress(session_id, iteration, config, state, defer_feedback)
     }
     return {
@@ -741,7 +755,7 @@ pub fn agent_stall_observe_tool_calls(
   var next_state = state + {no_progress_streak: 0}
   var emitted_warning = nil
   var feedback_deferred = false
-  for call in tool_calls {
+  for call in substantive_calls {
     let tool_name = __agent_tool_call_name(call)
     if tool_name == "" || contains(config.exempt_tools, tool_name) {
       next_state = __agent_stall_register_recovery(__agent_stall_reset_action(next_state))

--- a/tests/agent/stall_test.harn
+++ b/tests/agent/stall_test.harn
@@ -1,0 +1,53 @@
+// Run: harn test tests/agent/stall_test.harn
+//
+// Unit tests for the stall detector's handling of soft progress-report tools.
+// A turn whose ONLY tool call is `agent_progress` reports status without
+// advancing the task, so it must count toward the no-progress streak — a model
+// that spams `agent_progress` after getting stuck should trip the detector
+// rather than masquerade as activity. A turn that also makes a real tool call
+// is unaffected.
+import { agent_stall_initial_state, agent_stall_observe_tool_calls } from "std/agent/stall"
+
+const CONFIG = {enabled: true, no_progress_messages: 3}
+
+fn _progress_only() {
+  return [{name: "agent_progress", arguments: {message: "still working"}}]
+}
+
+fn _real_only() {
+  return [{name: "edit", arguments: {path: "x.rs"}}]
+}
+
+fn _observe(state, calls, iteration) {
+  return agent_stall_observe_tool_calls("unit", calls, iteration, CONFIG, state, true, nil, "")
+}
+
+pipeline test_agent_progress_spam_trips_no_progress(task) {
+  // Three consecutive turns whose only call is agent_progress → trips at the
+  // third (no_progress_messages = 3). Before the fix these were treated as real
+  // tool calls and never tripped.
+  let o1 = _observe(agent_stall_initial_state(), _progress_only(), 1)
+  assert(o1.warning == nil)
+  let o2 = _observe(o1.state, _progress_only(), 2)
+  assert(o2.warning == nil)
+  let o3 = _observe(o2.state, _progress_only(), 3)
+  assert(o3.warning != nil)
+}
+
+pipeline test_real_tool_calls_do_not_trip_no_progress(task) {
+  // Real (substantive) tool calls are genuine activity — no no-progress trip.
+  let o1 = _observe(agent_stall_initial_state(), _real_only(), 1)
+  let o2 = _observe(o1.state, _real_only(), 2)
+  let o3 = _observe(o2.state, _real_only(), 3)
+  assert(o3.warning == nil)
+}
+
+pipeline test_mixed_turn_with_real_call_is_progress(task) {
+  // agent_progress alongside a real edit is progress — the real call carries the
+  // action stream, so the no-progress streak never accumulates.
+  let mixed = [{name: "agent_progress", arguments: {}}, {name: "edit", arguments: {path: "y.rs"}}]
+  let o1 = _observe(agent_stall_initial_state(), mixed, 1)
+  let o2 = _observe(o1.state, mixed, 2)
+  let o3 = _observe(o2.state, mixed, 3)
+  assert(o3.warning == nil)
+}


### PR DESCRIPTION
Closes #3001.

## Problem
A turn whose only tool call is a soft progress-report tool (`agent_progress`) reports status without advancing task state, but the stall detector counted it as real activity. So a model that got stuck and then emitted `agent_progress` repeatedly (observed: **9 consecutive calls** before the turn ended, in the rust-refactor eval) never tripped any stall condition:
- not the no-progress monologue (condition 3 requires **no** tool call — agent_progress *is* one),
- not the identical-observation rule (condition 1 needs byte-identical observations; the calls' varying todo-list args reset the streak).

## Fix
Filter `SOFT_PROGRESS_TOOLS` (`agent_progress`) out of the real-action stream in `agent_stall_observe_tool_calls`. A turn with no *substantive* tool call — none, or only soft progress reports — now routes to the no-progress path and counts toward the streak, so a run of them trips at `no_progress_messages` and the loop recovers or hard-stops. A turn that **also** makes a real tool call is unaffected (the real call carries the action stream).

## Tests
`tests/agent/stall_test.harn` (unit tier): agent_progress spam trips at 3; real tool calls don't; a mixed turn (agent_progress + a real edit) is progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)