### PR TITLE
Validate homepage hero snippet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,8 @@ jobs:
           cache-dependency-path: website/package-lock.json
       - run: npm ci
         working-directory: website
+      - run: npm test
+        working-directory: website
       - run: npm run build
         working-directory: website
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix gen-provider-support check-provider-support gen-provider-catalog check-provider-catalog gen-connector-matrix check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
+.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-site-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-connector-schemas check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift check-tree-sitter-keywords check-generated-registry portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-connector-schemas check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-site-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift check-tree-sitter-keywords check-generated-registry portal-check
 
 check: all
 
@@ -521,6 +521,12 @@ check-diagnostics-catalog:
 check-docs-snippets:
 	@echo "=== Checking docs snippets parse under harn check ==="
 	@./scripts/check_docs_snippets.sh
+
+# CI guard: every checked-in Harn snippet used by website/src parses under
+# `harn check`.
+check-site-snippets:
+	@echo "=== Checking site snippets parse under harn check ==="
+	@./scripts/check_site_snippets.sh
 
 # CI guard: the workflow-authoring quickstart fixtures still produce the
 # bundle digests, executed-node sequences, and connector-status shapes

--- a/changelog.d/2986.fixed.md
+++ b/changelog.d/2986.fixed.md
@@ -1,0 +1,3 @@
+- **Homepage hero snippet validation (#2986).** The marketing-site hero now
+  renders a checked-in `.harn.txt` example that passes `harn check`, and the
+  site snippet fixtures are covered by a dedicated parse guard.

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -1110,6 +1110,7 @@ fn collect_harn_targets_recurses_directories_and_deduplicates() {
     std::fs::create_dir_all(dir.join(".harn-eval-abc123")).unwrap();
     std::fs::create_dir_all(dir.join("node_modules").join("pkg")).unwrap();
     std::fs::write(dir.join("a.harn"), "pipeline a() {}\n").unwrap();
+    std::fs::write(dir.join("site.harn.txt"), "pipeline site() {}\n").unwrap();
     std::fs::write(dir.join("nested").join("b.harn"), "pipeline b() {}\n").unwrap();
     std::fs::write(
         dir.join("nested").join("skipped.harn"),
@@ -1157,8 +1158,9 @@ fn collect_harn_targets_recurses_directories_and_deduplicates() {
     let target_file = dir.join("a.harn").display().to_string();
     let files = collect_harn_targets(&[target_dir.as_str(), target_file.as_str()]);
 
-    assert_eq!(files.len(), 2);
+    assert_eq!(files.len(), 3);
     assert!(files.contains(&dir.join("a.harn")));
+    assert!(files.contains(&dir.join("site.harn.txt")));
     assert!(files.contains(&dir.join("nested").join("b.harn")));
     assert!(!files.contains(&dir.join("ignored_by_gitignore.harn")));
     assert!(!files.contains(&dir.join("nested").join("skipped.harn")));
@@ -1169,12 +1171,18 @@ fn collect_harn_targets_recurses_directories_and_deduplicates() {
         .join("skipped.harn")
         .display()
         .to_string();
-    let explicit_files = collect_harn_targets(&[ignored_file.as_str(), skipped_file.as_str()]);
+    let site_snippet = dir.join("site.harn.txt").display().to_string();
+    let explicit_files = collect_harn_targets(&[
+        ignored_file.as_str(),
+        skipped_file.as_str(),
+        site_snippet.as_str(),
+    ]);
     assert_eq!(
         explicit_files,
         vec![
             dir.join("ignored_by_gitignore.harn"),
             dir.join("nested").join("skipped.harn"),
+            dir.join("site.harn.txt"),
         ]
     );
     let explicit_generated_dir = dir.join(".harn-eval-abc123").display().to_string();

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -217,7 +217,7 @@ pub(crate) fn is_harn_program_file(path: &Path) -> bool {
     if name.ends_with(".harn.prompt") || name.ends_with(".prompt") {
         return false;
     }
-    path.extension().is_some_and(|ext| ext == "harn")
+    name.ends_with(".harn") || name.ends_with(".harn.txt")
 }
 
 pub(crate) fn is_harn_prompt_file(path: &Path) -> bool {

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -443,10 +443,10 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                 if args.json {
                     print_check_error(
                         "no_harn_files",
-                        "no .harn files found under the given target(s)",
+                        "no .harn or .harn.txt files found under the given target(s)",
                     );
                 }
-                command_error("no .harn files found under the given target(s)");
+                command_error("no .harn or .harn.txt files found under the given target(s)");
             }
             let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
             let module_graph =
@@ -561,10 +561,12 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                 if args.json {
                     print_lint_error(
                         "no_lint_targets",
-                        "no .harn or .harn.prompt files found under the given target(s)",
+                        "no .harn, .harn.txt, or .harn.prompt files found under the given target(s)",
                     );
                 }
-                command_error("no .harn or .harn.prompt files found under the given target(s)");
+                command_error(
+                    "no .harn, .harn.txt, or .harn.prompt files found under the given target(s)",
+                );
             }
             let mut analysis = harn_parser::analysis::AnalysisDatabase::new();
             let module_graph =

--- a/scripts/check_site_snippets.sh
+++ b/scripts/check_site_snippets.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Verify checked-in Harn snippets used by the marketing site parse cleanly.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+HARN_BIN="${HARN_BIN:-}"
+if [[ -z "$HARN_BIN" ]]; then
+  target_dir=""
+  if command -v cargo >/dev/null 2>&1; then
+    target_dir="$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin).get("target_directory", ""))' 2>/dev/null)"
+  fi
+  if [[ -z "$target_dir" ]]; then
+    target_dir="${CARGO_TARGET_DIR:-target}"
+  fi
+  if [[ ! -x "$target_dir/debug/harn" ]]; then
+    echo "building harn-cli (set HARN_BIN to skip)..." >&2
+    cargo build -q -p harn-cli
+  fi
+  HARN_BIN="$target_dir/debug/harn"
+fi
+
+checked=0
+failures=0
+
+shopt -s nullglob
+for snippet in website/src/examples/*.harn.txt; do
+  checked=$((checked + 1))
+  if ! "$HARN_BIN" check "$snippet"; then
+    failures=$((failures + 1))
+  fi
+done
+
+echo
+echo "site snippets: $checked checked, $failures failed"
+if (( checked == 0 )); then
+  echo "FAIL: no website/src/examples/*.harn.txt snippets found"
+  exit 1
+fi
+if (( failures > 0 )); then
+  exit 1
+fi

--- a/scripts/generated_artifacts.toml
+++ b/scripts/generated_artifacts.toml
@@ -48,6 +48,7 @@ exempt_checks = [
   "check-trigger-examples",         # validates example projects parse, not a mirror
   "check-docs-model-refs",          # validates docs track provider aliases, not a mirror
   "check-docs-snippets",            # validates ```harn blocks parse, not a mirror
+  "check-site-snippets",            # validates website Harn fixtures parse, not a mirror
   "check-generated-registry",       # the auditor itself
 ]
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -33,7 +33,8 @@
         "typescript": "^5.9.2",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1206,6 +1207,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -1535,6 +1543,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1544,6 +1563,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1644,6 +1670,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1652,6 +1791,16 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/bail": {
@@ -1742,6 +1891,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -1915,6 +2074,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -1992,6 +2158,26 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -3633,6 +3819,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3645,6 +3842,13 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3995,6 +4199,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4022,6 +4233,20 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4069,6 +4294,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4084,6 +4326,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -4388,6 +4640,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -4397,6 +4739,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
     "build:server": "vite build --ssr src/entry-server.tsx --outDir .ssr",
     "build": "tsc -b && npm run build:client && npm run build:server && node prerender.mjs",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
@@ -38,6 +39,7 @@
     "typescript": "^5.9.2",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^4.1.8"
   }
 }

--- a/website/src/components/HarnMockup.tsx
+++ b/website/src/components/HarnMockup.tsx
@@ -1,9 +1,86 @@
 import type { ReactNode } from "react"
+import type { Mode } from "highlight.js"
+import { createLowlight, type LanguageFn } from "lowlight"
+import heroSnippetRaw from "../examples/hero.harn.txt?raw"
 
 // Hero mockup — a Harn pipeline source pane beside a live agent run, echoing the
 // Burin Code editor mockup but expressing what Harn itself is: orchestration code.
-function Tok({ c, children }: { c: string; children: ReactNode }) {
-  return <span className={c}>{children}</span>
+export const heroSnippetSource = heroSnippetRaw.trimEnd()
+
+const harnLanguage: LanguageFn = (hljs) => {
+  const keywords = {
+    keyword: "agent_loop break continue each else fn for if in let parallel pipeline retry return spawn while",
+    literal: "false nil true",
+    built_in: "llm_call log read_file read_text tool_select",
+  }
+  const interpolation: Mode = {
+    className: "subst",
+    begin: /\$\{/,
+    end: /\}/,
+    keywords,
+    contains: [],
+  }
+  const string: Mode = {
+    className: "string",
+    begin: '"',
+    end: '"',
+    illegal: "\\n",
+    contains: [{ begin: "\\\\." }, interpolation],
+  }
+  const mainContains: Mode[] = [
+    hljs.C_LINE_COMMENT_MODE,
+    hljs.C_BLOCK_COMMENT_MODE,
+    string,
+    {
+      className: "number",
+      begin: /\b\d+(?:\.\d+)?(?:ms|s|m|h)?\b/,
+      relevance: 0,
+    },
+    {
+      className: "title.function",
+      beginKeywords: "fn pipeline",
+      end: /[(\s]/,
+      excludeEnd: true,
+      contains: [{ begin: /[a-z_][A-Za-z0-9_]*/ }],
+      relevance: 0,
+    },
+  ]
+  interpolation.contains = mainContains
+  return {
+    name: "Harn",
+    aliases: ["harn"],
+    keywords,
+    contains: mainContains,
+  }
+}
+
+type HighlightNode = {
+  type: string
+  value?: string
+  tagName?: string
+  properties?: { className?: string[] | string }
+  children?: HighlightNode[]
+}
+
+const harnLowlight = createLowlight({ harn: harnLanguage })
+
+function renderHighlightNode(node: HighlightNode, index: number): ReactNode {
+  if (node.type === "text") return node.value ?? ""
+  if (node.type !== "element") return null
+
+  const className = node.properties?.className
+  return (
+    <span
+      key={index}
+      className={Array.isArray(className) ? className.join(" ") : className}
+    >
+      {(node.children ?? []).map(renderHighlightNode)}
+    </span>
+  )
+}
+
+function highlightedHeroSource() {
+  return harnLowlight.highlight("harn", heroSnippetSource).children.map(renderHighlightNode)
 }
 
 function ChatRow({
@@ -40,30 +117,8 @@ export function HarnMockup() {
         <div className="grid grid-cols-12 text-[13px] leading-relaxed">
           <div className="col-span-12 px-5 py-4 font-mono text-[12.5px] sm:col-span-7">
             <pre className="m-0 whitespace-pre text-white/80">
-              <Tok c="text-amber-300">pipeline</Tok> <Tok c="text-teal-300">review</Tok>
-              {"(path: "}
-              <Tok c="text-cyan-300">String</Tok>
-              {") {\n  "}
-              <Tok c="text-amber-300">let</Tok>
-              {" diff = git.diff(path)\n  "}
-              <Tok c="text-amber-300">let</Tok>
-              {" notes = diff\n    |> "}
-              <Tok c="text-teal-300">llm_call</Tok>
-              {'(model: '}
-              <Tok c="text-emerald-300">"claude-opus-4-8"</Tok>
-              {")\n    |> "}
-              <Tok c="text-teal-300">tool_select</Tok>
-              {"(max: "}
-              <Tok c="text-rose-300">8</Tok>
-              {")\n\n  "}
-              <Tok c="text-amber-300">spawn</Tok>
-              {" agent(notes, deadline: "}
-              <Tok c="text-rose-300">30s</Tok>
-              {")\n  "}
-              <Tok c="text-amber-300">return</Tok>
-              {" notes"}
+              <code data-hero-snippet="true" className="language-harn">{highlightedHeroSource()}</code>
               <span className="ml-px inline-block h-3 w-1.5 -translate-y-px bg-accent-400 align-middle" />
-              {"\n}"}
             </pre>
           </div>
           <div className="col-span-12 border-t border-white/5 bg-[#060c0b] sm:col-span-5 sm:border-t-0 sm:border-l">

--- a/website/src/examples/hero.harn.txt
+++ b/website/src/examples/hero.harn.txt
@@ -1,0 +1,14 @@
+pipeline review(task) {
+  let files = ["src/main.rs", "src/lib.rs"]
+
+  let reviews = parallel each files { file ->
+    let content = harness.fs.read_text(file)
+    retry 3 {
+      llm_call("Review this code:\n${content}", "You are a code reviewer.")
+    }
+  }
+
+  for review in reviews {
+    log(review)
+  }
+}

--- a/website/tests/HarnMockup.test.tsx
+++ b/website/tests/HarnMockup.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { HarnMockup, heroSnippetSource } from "../src/components/HarnMockup"
+import heroSnippetRaw from "../src/examples/hero.harn.txt?raw"
+
+function decodeEntities(value: string) {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#x27;", "'")
+    .replaceAll("&#39;", "'")
+}
+
+function heroSnippetText(markup: string) {
+  const match = markup.match(/<code[^>]*data-hero-snippet="true"[^>]*>([\s\S]*?)<\/code>/)
+  if (!match) throw new Error("hero snippet code block was not rendered")
+  return decodeEntities(match[1].replace(/<[^>]*>/g, ""))
+}
+
+describe("HarnMockup", () => {
+  it("renders the checked-in hero snippet source", () => {
+    expect(heroSnippetSource).toBe(heroSnippetRaw.trimEnd())
+    expect(heroSnippetText(renderToStaticMarkup(<HarnMockup />))).toBe(heroSnippetSource)
+  })
+})


### PR DESCRIPTION
Closes burin-labs/harn#2986
Part of burin-labs/burin-code#1774

## Summary
- Replace the hand-coded homepage hero source with a checked-in `website/src/examples/hero.harn.txt` snippet rendered through lowlight.
- Teach `harn check` target collection to accept exact `.harn.txt` snippet files while still excluding prompt templates.
- Add site snippet and hero render guards, wire the website Vitest check into CI, and register the new Make target as a behavioral validator.

## Verification
- `env PATH="$PWD/target/debug:$PATH" sh -c 'for f in website/src/examples/*.harn.txt; do harn check "$f" || exit 1; done'`\n- `make check-site-snippets`\n- `make check-generated-registry`\n- `cargo test -p harn-cli collect_harn_targets_recurses_directories_and_deduplicates`\n- `(cd website && npm test)`\n- `(cd website && npm run build)`\n- pre-commit hook: full workspace clippy passed\n- pre-push hook: targeted local checks passed