### PR TITLE
docs(spec): correct division/modulo-by-zero semantics (was wrongly documented as nil)

### DIFF
--- a/changelog.d/3006.fixed.md
+++ b/changelog.d/3006.fixed.md
@@ -1,0 +1,8 @@
+- **Documented division- and modulo-by-zero semantics accurately (#3006).** The
+  language spec and `language-basics` tutorial previously claimed "division by
+  zero returns `nil`", which is wrong on every count. Integer division by zero
+  raises a catchable runtime error; float division by zero follows IEEE-754
+  (`±inf`, or `NaN` for `0.0 / 0.0`); and modulo by any zero divisor always
+  raises. The docs now state this, and new conformance fixtures
+  (`errors/runtime/{int_div,int_mod,float_mod}_by_zero` plus
+  `language/division_by_zero_float`) lock the runtime contract in.

--- a/changelog.d/3007.fixed.md
+++ b/changelog.d/3007.fixed.md
@@ -1,4 +1,4 @@
-- **Documented division- and modulo-by-zero semantics accurately (#3006).** The
+- **Documented division- and modulo-by-zero semantics accurately (#3007).** The
   language spec and `language-basics` tutorial previously claimed "division by
   zero returns `nil`", which is wrong on every count. Integer division by zero
   raises a catchable runtime error; float division by zero follows IEEE-754

--- a/conformance/errors/runtime/float_mod_by_zero.error
+++ b/conformance/errors/runtime/float_mod_by_zero.error
@@ -1,0 +1,1 @@
+Division by zero

--- a/conformance/errors/runtime/float_mod_by_zero.harn
+++ b/conformance/errors/runtime/float_mod_by_zero.harn
@@ -1,0 +1,6 @@
+// Modulo by a zero divisor raises even for floats — unlike float division,
+// which yields NaN. Documents that `%` never produces NaN.
+pipeline default() {
+  let d = 0.0
+  let _ = 5.0 % d
+}

--- a/conformance/errors/runtime/int_div_by_zero.error
+++ b/conformance/errors/runtime/int_div_by_zero.error
@@ -1,0 +1,1 @@
+Division by zero

--- a/conformance/errors/runtime/int_div_by_zero.harn
+++ b/conformance/errors/runtime/int_div_by_zero.harn
@@ -1,0 +1,7 @@
+// Integer division by a zero divisor raises at runtime. The divisor is a
+// `let` (not a literal) so this exercises the runtime path rather than the
+// compile-time const-fold path (see tests/language/const_eval_division_by_zero).
+pipeline default() {
+  let d = 0
+  let _ = 1 / d
+}

--- a/conformance/errors/runtime/int_mod_by_zero.error
+++ b/conformance/errors/runtime/int_mod_by_zero.error
@@ -1,0 +1,1 @@
+Division by zero

--- a/conformance/errors/runtime/int_mod_by_zero.harn
+++ b/conformance/errors/runtime/int_mod_by_zero.harn
@@ -1,0 +1,6 @@
+// Integer modulo by a zero divisor raises at runtime (a non-const divisor,
+// so this is the runtime path, not const-fold).
+pipeline default() {
+  let d = 0
+  let _ = 5 % d
+}

--- a/conformance/tests/language/division_by_zero_float.expected
+++ b/conformance/tests/language/division_by_zero_float.expected
@@ -1,0 +1,3 @@
+[harn] inf
+[harn] -inf
+[harn] NaN

--- a/conformance/tests/language/division_by_zero_float.harn
+++ b/conformance/tests/language/division_by_zero_float.harn
@@ -1,0 +1,14 @@
+/**
+ * Float division by zero follows IEEE-754: it yields ±inf (or NaN for
+ * 0.0 / 0.0) and never raises. Integer division by zero raises instead —
+ * at runtime for a non-const divisor (see errors/runtime/int_div_by_zero)
+ * or at compile time when const-folded (see const_eval_division_by_zero).
+ * The divisor is a `let` (not a literal) so the float path is exercised at
+ * runtime rather than folded.
+ */
+pipeline test(task) {
+  let z = 0.0
+  log(1.0 / z)
+  log(-1.0 / z)
+  log(z / z)
+}

--- a/docs/src/language-basics.md
+++ b/docs/src/language-basics.md
@@ -225,7 +225,9 @@ Ordered by precedence (lowest to highest):
 | 10 | `!` `-` | Unary not, negate |
 | 11 | `.` `?.` `[]` `[:]` `()` `?` | Member access, optional chaining, subscript, slice, call, try |
 
-Division by zero returns `nil`. Integer division truncates.
+Integer division truncates toward zero. Integer division (and any modulo) by
+zero raises a catchable runtime error, while float division by zero follows
+IEEE-754 (`±inf`, or `NaN` for `0.0 / 0.0`).
 Arithmetic operators are strictly typed — mismatched operands (e.g.
 `"hello" + 5`) produce a `TypeError`. Use `to_string()` or string
 interpolation (`"value=${x}"`) for explicit conversion.

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1141,7 +1141,11 @@ Comparison between other types returns 0 (equal).
 | dict | dict | dict (merge, right wins) | **TypeError** | **TypeError** | **TypeError** |
 | other | other | **TypeError** | **TypeError** | **TypeError** | **TypeError** |
 
-Division by zero returns `nil`.
+Division by zero depends on the result type. Integer division by zero
+(`int / int`) raises a runtime error that propagates like any other thrown
+value (catchable with `try`/`catch`). Float division by zero follows
+IEEE-754: it yields `±inf` (or `NaN` for `0.0 / 0.0`) and never raises — this
+applies whenever either operand is a `float`, since the result is a `float`.
 `string * int` repeats the string; negative or zero counts return `""`.
 
 Type mismatches that are not listed as valid combinations above produce a
@@ -1152,8 +1156,8 @@ interpolation (`"${expr}"`) for explicit type conversion.
 ### Modulo (`%`)
 
 `%` is numeric-only. `int % int` returns `int`; any case involving a `float`
-returns `float`. Modulo by zero follows the same runtime error path as
-division by zero.
+returns `float`. Modulo by a zero divisor always raises a runtime error,
+regardless of operand types (unlike float division, it never yields `NaN`).
 
 ### Exponentiation (`**`)
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1139,7 +1139,11 @@ Comparison between other types returns 0 (equal).
 | dict | dict | dict (merge, right wins) | **TypeError** | **TypeError** | **TypeError** |
 | other | other | **TypeError** | **TypeError** | **TypeError** | **TypeError** |
 
-Division by zero returns `nil`.
+Division by zero depends on the result type. Integer division by zero
+(`int / int`) raises a runtime error that propagates like any other thrown
+value (catchable with `try`/`catch`). Float division by zero follows
+IEEE-754: it yields `±inf` (or `NaN` for `0.0 / 0.0`) and never raises — this
+applies whenever either operand is a `float`, since the result is a `float`.
 `string * int` repeats the string; negative or zero counts return `""`.
 
 Type mismatches that are not listed as valid combinations above produce a
@@ -1150,8 +1154,8 @@ interpolation (`"${expr}"`) for explicit type conversion.
 ### Modulo (`%`)
 
 `%` is numeric-only. `int % int` returns `int`; any case involving a `float`
-returns `float`. Modulo by zero follows the same runtime error path as
-division by zero.
+returns `float`. Modulo by a zero divisor always raises a runtime error,
+regardless of operand types (unlike float division, it never yields `NaN`).
 
 ### Exponentiation (`**`)
 


### PR DESCRIPTION
## Bug

The language spec and the `language-basics` tutorial both claimed:

> Division by zero returns `nil`.

This is **wrong on every count**, and the spec even contradicted itself — the
modulo section four lines down already described "the same runtime error path
as division by zero." A user reading the spec would write `let x = a / b`
expecting a `nil` sentinel on a zero divisor and instead get an uncaught throw
that aborts the pipeline.

## Verified actual behavior

| expression | result |
|---|---|
| `int / 0` (int divisor) | **raises** a catchable runtime error |
| `1.0 / 0.0`, `1 / 0.0`, `1.0 / 0` (any float operand) | IEEE-754 `±inf` |
| `0.0 / 0.0` | `NaN` |
| `int % 0`, `float % 0.0` (any zero divisor) | **raises** (never `NaN`) |

Integer division/modulo by zero is a normal throwable value (`try`/`catch`
catches it). Float division never raises; modulo never yields `NaN`.

## Fix

- Correct the claim in `spec/HARN_SPEC.md` (canonical source) — both the
  `Arithmetic` and `Modulo` sections.
- Regenerate the `docs/src/language-spec.md` mirror (`sync_language_spec`).
- Correct the hand-written `docs/src/language-basics.md` tutorial copy.
- Add conformance coverage that was **entirely missing for the runtime path**:
  - `errors/runtime/int_div_by_zero`, `int_mod_by_zero`, `float_mod_by_zero`
    (each uses a non-const `let` divisor so the runtime throw is exercised,
    not the existing compile-time const-fold path).
  - `tests/language/division_by_zero_float` locking the IEEE float result
    (`inf` / `-inf` / `NaN`).

No runtime/behavior change — this corrects documentation and adds tests that
pin the existing, verified semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)