### PR TITLE
docs(release): fix stale tag-push contract in release runbooks

### DIFF
--- a/.claude/commands/release-harn.md
+++ b/.claude/commands/release-harn.md
@@ -4,30 +4,43 @@ Run the merge-queue-safe Harn release workflow.
 
 The release is **one** human PR titled `Release vX.Y.Z`. It carries the
 changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` version bump together.
-After it lands through the merge queue, the Publish release workflow
-auto-fires on tag drift, ships to crates.io, tags `vX.Y.Z`, and triggers the
-binary/container build. No second PR.
+After it lands through the merge queue, the **`vX.Y.Z` tag is pushed at the
+release commit** — and *that tag push* (not the merge to `main`) is what triggers
+the Publish release workflow to `cargo publish` to crates.io and kick off the
+binary/container build.
+
+> **`publish-release.yml` does NOT tag `main` HEAD for you.** This changed with
+> the release-pipeline modernization (#2971–#2973). If the tag is missing when
+> the release commit lands on `main`, the publish run fails with
+> `Cargo.toml=X is ahead of latest tag vY, but vX does not exist. Push vX at the
+> release commit`. The canonical orchestrator
+> (`release_harn.harn --mode ship-pr`) pushes the tag as part of the ship; if you
+> run the steps by hand you push the tag yourself (step 10). No second PR.
 
 ```text
 human/agent: write & land "Release vX.Y.Z" PR
         │
         ▼  PR lands through merge queue (full audit ran in CI)
-bot:    Publish release workflow auto-fires on tag drift
-        │   pushes vX.Y.Z, runs cargo publish, creates GH release
+human/agent: push signed vX.Y.Z tag at the release commit
+        │   (orchestrator ship-pr does this; or push it by hand — step 10)
+        ▼  the TAG push (not the main push) triggers Publish release
+bot:    Publish release runs cargo publish + creates the GH release
+        │
         ▼  tag push cascades
-bot:    Release workflow builds binaries + multi-arch container
+bot:    Build release binaries builds binaries + multi-arch container
         │
         ▼
-        v0.7.X is shipped (binaries, container, crates.io, release notes)
+        v0.8.X is shipped (binaries, container, crates.io, release notes)
 ```
 
 ## What the human/agent owns
 
-Steps 1-9 are the only steps that need judgment. After step 9 you are done
-— do **not** run `release_ship.sh --finalize` locally as a default step.
+Steps 1-10 are the only steps that need judgment. After step 10 (the tag push)
+you are done — do **not** run `release_ship.sh --finalize` locally as a default
+step.
 
 1. Branch off main: `git checkout -b release/vX.Y.Z`. The branch name is
-   conventional; the workflow keys on tag drift, not branch name.
+   conventional; the publish keys on the `vX.Y.Z` tag, not the branch name.
 2. Inspect the worktree with `git status --short` and `git diff --stat`.
    Treat tracked and untracked changes as candidate release content unless the
    user scopes the release more narrowly.
@@ -90,18 +103,40 @@ Steps 1-9 are the only steps that need judgment. After step 9 you are done
    gh pr merge --auto         # merge-queue picks the strategy
    ```
 
-   Then walk away. The merge queue runs the full CI gate (`make lint`,
+   The merge queue runs the full CI gate (`make lint`,
    `make test`, `make conformance`, `make lint-harn`, `make fmt-harn`,
    `make check-highlight`, `make check-language-spec`,
    `make check-trigger-quickref`, `make check-trigger-examples`,
    `make check-docs-snippets`, `verify_release_metadata.py`, portal
-   lint+build, Windows smoke). Auto-merge fires it as soon as CI is
-   green; once it lands, Publish release fires on tag drift.
+   lint+build, Windows smoke). Auto-merge fires it as soon as CI is green.
+   Then go to step 10 — the merge alone does **not** publish.
 
    **Why rebase before push:** `--prepare` takes ~1-15 min depending on
    cache state; main may have moved while it ran. Rebasing now (instead
    of waiting for the merge queue to push back) catches CHANGELOG drift
    while the context is fresh and avoids a stale PR sitting in queue.
+
+10. **Push the `vX.Y.Z` tag at the release commit.** This is the step that
+    actually ships — `publish-release.yml` will not tag `main` HEAD for you, so
+    until the tag exists nothing is published (the post-merge `publish-release`
+    run on `main` fails fast with `… but vX.Y.Z does not exist. Push vX.Y.Z at
+    the release commit`). After the `Release vX.Y.Z` PR squash-merges, tag the
+    resulting `main` commit:
+
+    ```bash
+    git fetch origin main --tags
+    REL=$(git rev-parse origin/main)   # the squashed "Release vX.Y.Z (#N)" commit
+    git tag -s vX.Y.Z "$REL" -m "Release vX.Y.Z"   # signed (org rulesets); -a also works
+    git push origin vX.Y.Z
+    ```
+
+    The tag push (not the earlier main push) triggers `publish-release.yml` via
+    its `tags: ['v*']` trigger, which skips drift detection and publishes from
+    the tag. The canonical `release_harn.harn --mode ship-pr` orchestrator does
+    this tag push for you; the manual sequence above is the fallback when you ran
+    steps 1-9 by hand. **A transient red `publish-release` run on the `main` push
+    is expected** — it's the "tag missing" guard firing before you push the tag;
+    pushing the tag is what ships, and that run is the real signal.
 
    **Why `--auto`:** the merge queue gates a substantial CI suite, so
    the release sits in queue for ~10-15 min cold-cache. Auto-merge means
@@ -162,15 +197,20 @@ gh workflow run publish-release.yml -f bootstrap_new_crates=true
   --no-verify` step in `scripts/verify_crate_packages.sh` to catch
   packaging issues for the new crate as a separate audit signal.
 
-## What happens automatically after the release PR lands
+## What happens automatically after you push the tag (step 10)
 
-10. **Publish release** workflow (`.github/workflows/publish-release.yml`)
-    detects tag drift (`Cargo.toml` ahead of latest `vX.Y.Z` tag) and runs
-    `./scripts/release_ship.sh --finalize` under the App identity:
-    portal-check + publish dry-run + push tag + `cargo publish` + render
-    notes + create or update the GitHub release. **Audit is skipped** —
-    the merge-queue CI just proved it.
-11. The tag push triggers **Build release binaries** workflow
+11. **Publish release** workflow (`.github/workflows/publish-release.yml`) fires
+    on the `vX.Y.Z` **tag push** (its `tags: ['v*']` trigger), skips drift
+    detection, and runs `./scripts/release_ship.sh --finalize` under the App
+    identity: portal-check + publish dry-run + `cargo publish` + render notes +
+    create or update the GitHub release. **Audit is skipped** — the merge-queue
+    CI just proved it. Note: `--finalize` no longer *creates* the tag — the tag
+    you pushed in step 10 is the trigger and the source of truth for what
+    publishes (`ensure_tag_at_head` is a no-op when the tag already points at
+    HEAD). The separate `main`-push run of `publish-release.yml` is only a guard:
+    it errors if the tag is missing or points elsewhere and never tags `main`
+    HEAD itself.
+12. The tag push also triggers **Build release binaries** workflow
     (`.github/workflows/build-release-binaries.yml`), which builds darwin/linux × x86/arm
     binary tarballs, publishes a multi-arch GHCR container image, and
     attaches the binaries to the GitHub release.
@@ -226,9 +266,12 @@ When in doubt, prefer the repo scripts over re-inventing the steps:
   either a matching state (`Cargo.toml == CHANGELOG top`, the new
   consolidated baseline) or one-bump-ahead (the legacy intermediate
   state).
-- `release_ship.sh --finalize` pushes the tag **before** `cargo publish`
-  so binary build / GHCR / downstream fetchers (e.g. `burin-code`'s
-  `fetch-harn`) run in parallel with crates.io.
+- The `vX.Y.Z` tag is pushed in **step 10** (by `release_harn.harn --mode
+  ship-pr`, or by hand), *before* `publish-release.yml` runs `cargo publish`, so
+  binary build / GHCR / downstream fetchers (e.g. `burin-code`'s `fetch-harn`)
+  run in parallel with crates.io. `release_ship.sh --finalize` no longer pushes
+  the tag — it publishes from the existing tag (`ensure_tag_at_head` no-ops when
+  the tag already points at HEAD).
 - The release-bot App needs `Contents: write`, `Pull requests: write`,
   `Actions: write`, `Metadata: read` on the repo. Repo secrets:
   `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `CARGO_REGISTRY_TOKEN`.

--- a/.codex/commands/harn-release.md
+++ b/.codex/commands/harn-release.md
@@ -3,21 +3,32 @@
 Run the merge-queue-safe Harn release workflow.
 
 The release is **one** human PR titled `Release vX.Y.Z`. It carries the
-changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` bump together. After
-it lands through the merge queue, the Publish release workflow auto-fires on
-tag drift and ships everything. No second PR.
+changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` bump together. After it
+lands through the merge queue, you push the `vX.Y.Z` **tag** at the release
+commit — and *that tag push* (not the merge to `main`) is what triggers the
+Publish release workflow to `cargo publish` and build binaries. No second PR.
+
+> **`publish-release.yml` does NOT tag `main` HEAD for you** (changed with the
+> release-pipeline modernization, #2971–#2973). If the tag is missing when the
+> release commit lands on `main`, the publish run fails fast:
+> `Cargo.toml=X is ahead of latest tag vY, but vX does not exist. Push vX at the
+> release commit`. The canonical orchestrator
+> (`release_harn.harn --mode ship-pr`) pushes the tag for you; the manual flow
+> below pushes it in the final step.
 
 ## End-state flow
 
 ```text
 human/agent: write & land "Release vX.Y.Z" PR (changelog + code + docs + bump)
         │  ↓ merge queue runs full audit set in CI
-bot:    Publish release workflow auto-fires on tag drift
-        │   pushes vX.Y.Z, runs cargo publish, creates GH release notes
+human/agent: push signed vX.Y.Z tag at the release commit
+        │   (orchestrator ship-pr does this; or push it by hand)
+        │  ↓ the TAG push (not the main push) triggers Publish release
+bot:    Publish release runs cargo publish + creates GH release notes
         │  ↓ tag push cascades
-bot:    Release workflow builds binaries + multi-arch container
+bot:    Build release binaries builds binaries + multi-arch container
         │  ↓
-        v0.7.X is shipped (binaries, container, crates.io, release notes)
+        v0.8.X is shipped (binaries, container, crates.io, release notes)
 ```
 
 ## What you (the agent) actually do
@@ -25,7 +36,7 @@ bot:    Release workflow builds binaries + multi-arch container
 The work is in the one release PR. After that, hands off.
 
 1. Branch off main: `git checkout -b release/vX.Y.Z`. Conventional name; the
-   workflow keys on tag drift, not branch name.
+   publish keys on the `vX.Y.Z` tag, not the branch name.
 2. Inspect the worktree first with `git status --short` and `git diff --stat`.
    Treat tracked and untracked changes as candidate release content unless
    the user scopes it differently.
@@ -84,18 +95,37 @@ The work is in the one release PR. After that, hands off.
    the PR as soon as CI is green so you don't have to babysit a queue
    that takes ~10-15 min cold-cache.
 
-That's it. Stop here. The bot takes over once the PR lands.
+10. **Push the `vX.Y.Z` tag at the release commit — this is the step that ships.**
+    The merge alone publishes nothing; `publish-release.yml` will not tag `main`
+    HEAD. After the `Release vX.Y.Z` PR squash-merges:
 
-## What happens automatically after the release PR lands
+    ```bash
+    git fetch origin main --tags
+    REL=$(git rev-parse origin/main)   # the squashed "Release vX.Y.Z (#N)" commit
+    git tag -s vX.Y.Z "$REL" -m "Release vX.Y.Z"   # signed (org rulesets); -a also works
+    git push origin vX.Y.Z
+    ```
+
+    The tag push triggers `publish-release.yml` (its `tags: ['v*']` trigger),
+    which skips drift detection and publishes from the tag.
+    `release_harn.harn --mode ship-pr` does this for you. **A transient red
+    `publish-release` run on the `main` push is expected** — it's the "tag
+    missing" guard; pushing the tag is what ships.
+
+## What happens automatically after you push the tag
 
 - **`Publish release`** workflow
-  (`.github/workflows/publish-release.yml`) detects tag drift
-  (`Cargo.toml` ahead of latest `vX.Y.Z` tag) and runs
+  (`.github/workflows/publish-release.yml`) fires on the `vX.Y.Z` **tag push**,
+  skips drift detection, and runs
   `./scripts/release_ship.sh --finalize` under the App identity:
-  portal-check + publish dry-run + push tag + `cargo publish` + render
+  portal-check + publish dry-run + `cargo publish` + render
   notes + create or update the GitHub release. **Audit is skipped** —
   the merge-queue CI of the just-landed Release PR proved the same
-  gates a few minutes ago.
+  gates a few minutes ago. `--finalize` no longer *creates* the tag — the tag
+  you pushed in step 10 is the trigger and the source of truth for what
+  publishes. The separate `main`-push run of `publish-release.yml` is only a
+  guard: it errors if the tag is missing or points at the wrong commit and never
+  tags `main` HEAD itself.
 - The tag push triggers **`Build release binaries`** workflow
   (`.github/workflows/build-release-binaries.yml`), which builds the darwin/linux ×
   x86/arm binary tarballs, publishes the multi-arch GHCR container,

--- a/.codex/skills/harn-release/SKILL.md
+++ b/.codex/skills/harn-release/SKILL.md
@@ -7,20 +7,30 @@ description: Use this skill for Harn release prep, version bumps, publishing, ta
 
 The release is **one** human PR titled `Release vX.Y.Z`. It carries the
 changelog, code, docs, AND the `Cargo.toml`/`Cargo.lock` bump together.
-After it lands through the merge queue, the **publish-release**
-workflow auto-fires on tag drift, ships to crates.io, and tags
-`vX.Y.Z`. The tag push triggers the **build-release-binaries**
-workflow for binary tarballs and a multi-arch container.
+After it lands through the merge queue, push the `vX.Y.Z` **tag** at the
+release commit — *that tag push* (not the merge to `main`) triggers the
+**publish-release** workflow to `cargo publish`, and then the
+**build-release-binaries** workflow for binary tarballs and a multi-arch
+container.
+
+> **`publish-release.yml` does NOT tag `main` HEAD for you** (changed with the
+> release-pipeline modernization, #2971–#2973). A missing tag makes the
+> post-merge run fail: `Cargo.toml=X is ahead of latest tag vY, but vX does not
+> exist. Push vX at the release commit`. The canonical orchestrator
+> (`release_harn.harn --mode ship-pr`) pushes the tag for you; otherwise push it
+> by hand (step 9 / 10).
 
 ```text
 human/agent: write & land "Release vX.Y.Z" PR
         │  ↓ merge queue runs full audit set in CI
-bot:    publish-release workflow auto-fires on tag drift
-        │   pushes vX.Y.Z, runs cargo publish, creates GH release notes
+human/agent: push signed vX.Y.Z tag at the release commit
+        │   (orchestrator ship-pr does this; or push it by hand)
+        │  ↓ the TAG push (not the main push) triggers publish-release
+bot:    publish-release runs cargo publish, creates GH release notes
         │  ↓ tag push cascades
 bot:    build-release-binaries workflow assembles binaries + container
         │  ↓
-        v0.7.X is shipped (binaries, container, crates.io, release notes)
+        v0.8.X is shipped (binaries, container, crates.io, release notes)
 ```
 
 The bot workflows live at:
@@ -50,9 +60,10 @@ PR/merge queue: `Release vX.Y.Z`. It contains code, docs,
 bumps, and regenerated derived files (highlight keywords,
 language-spec mirror).
 
-After the prepare PR lands, watch the Actions runs. The publish and
-binary-build workflows fire downstream automatically. Wall-clock
-~3-5 min for crates.io publish + ~10-15 min for binary tarballs.
+After the release PR lands, **push the `vX.Y.Z` tag at the release commit**
+(step 10) — the publish and binary-build workflows fire off the *tag push*, not
+the merge. Wall-clock ~3-5 min for crates.io publish + ~10-15 min for binary
+tarballs.
 
 Failure modes, roughly in frequency order, with recovery:
 
@@ -76,8 +87,9 @@ the *published* version surface; it never blocks cross-repo iteration.
 
 ## What you actually do for a release
 
-Steps 1-9 are the only ones requiring judgment. After step 9 you are
-done — do **not** run `release_ship.sh --finalize` locally as a
+Steps 1-10 are the only ones requiring judgment. Step 10 (pushing the `vX.Y.Z`
+tag) is the step that actually ships — the merge alone publishes nothing. After
+step 10 you are done — do **not** run `release_ship.sh --finalize` locally as a
 default step.
 
 1. Branch off main: `git checkout -b release/vX.Y.Z`.
@@ -112,7 +124,7 @@ default step.
    This audits, dry-run-publishes, bumps `Cargo.toml`/`Cargo.lock`/per-crate
    manifests, regenerates derived files, and `git add`s everything.
 9. Commit, rebase onto latest `origin/main`, push, open the PR titled
-   `Release vX.Y.Z`, then `gh pr merge --auto`. Walk away.
+   `Release vX.Y.Z`, then `gh pr merge --auto`.
 
    ```bash
    git commit -m "Release vX.Y.Z"
@@ -133,12 +145,30 @@ default step.
    the PR lands as soon as CI is green so you don't have to babysit the
    ~10-15 min cold-cache merge-queue CI.
 
+10. **Push the `vX.Y.Z` tag at the release commit — this is what ships.**
+    `publish-release.yml` will not tag `main` HEAD; until the tag exists nothing
+    publishes. After the `Release vX.Y.Z` PR squash-merges:
+
+    ```bash
+    git fetch origin main --tags
+    REL=$(git rev-parse origin/main)   # the squashed "Release vX.Y.Z (#N)" commit
+    git tag -s vX.Y.Z "$REL" -m "Release vX.Y.Z"   # signed (org rulesets); -a also works
+    git push origin vX.Y.Z
+    ```
+
+    The tag push triggers `publish-release.yml` (`tags: ['v*']`), which skips
+    drift detection and publishes from the tag. `release_harn.harn --mode
+    ship-pr` does this for you. A transient red `publish-release` run on the
+    `main` push is expected (the "tag missing" guard) — the tag push is the real
+    ship signal.
+
 ## Expectations
 
 - Stop on the first failed gate during `--prepare`. Do not paper over.
-- Once the release PR lands, watch the Actions UI. The publish →
-  binary-build cascade should complete in ~12-18 min wall-clock total.
-  Each workflow has `workflow_dispatch` for manual recovery.
+- Once the release PR lands and you push the `vX.Y.Z` tag (step 10), watch the
+  Actions UI. The publish → binary-build cascade (off the tag push) should
+  complete in ~12-18 min wall-clock total. Each workflow has
+  `workflow_dispatch` for manual recovery.
 - Treat repo consistency as part of the release PR, not an optional
   cleanup pass. If behavior changes, update human-facing docs in the
   same PR.
@@ -162,14 +192,15 @@ default step.
   `verify_release_metadata.py` to reject malformed headings, empty
   section bodies, or out-of-order entries.
 - GitHub release artifacts (binary tarballs + GHCR container) are
-  produced by `build-release-binaries.yml` once the tag is pushed.
-  Tag push from `publish-release.yml` uses the App identity, so the
-  cascade fires normally — `GITHUB_TOKEN`-pushed tags would NOT
-  trigger it.
-- `release_ship.sh --finalize` pushes the tag **before** running
-  `cargo publish`, so the binary-build workflow and downstream
-  fetchers (e.g. `burin-code`'s `fetch-harn`) can start working in
-  parallel with crates.io publication.
+  produced by `build-release-binaries.yml` once the tag is pushed (step 10).
+  Push the tag with the App identity (`release_harn.harn --mode ship-pr`) or
+  your own credentials — a `GITHUB_TOKEN`-pushed tag would NOT trigger the
+  downstream workflows.
+- The tag is pushed in **step 10** (by `release_harn.harn --mode ship-pr`, or by
+  hand), *before* `publish-release.yml` runs `cargo publish`, so the binary-build
+  workflow and downstream fetchers (e.g. `burin-code`'s `fetch-harn`) start in
+  parallel with crates.io publication. `release_ship.sh --finalize` no longer
+  pushes the tag — it publishes from the existing tag.
 - `release_ship.sh --finalize` skips the audit by default
   (`RELEASE_FINALIZE_REAUDIT=0`); merge-queue CI of the just-landed
   Release PR proved the same gates a few minutes ago. Pass

--- a/.codex/skills/release-harn/SKILL.md
+++ b/.codex/skills/release-harn/SKILL.md
@@ -9,13 +9,21 @@ Use the same workflow as [`harn-release`](../harn-release/SKILL.md).
 
 The release is **one** human PR titled `Release vX.Y.Z` carrying
 changelog + code + docs + Cargo.toml bump together. After it lands
-through the merge queue, two GitHub Actions workflows cascade
-automatically under the `harn-release-bot` App identity:
+through the merge queue, **push the `vX.Y.Z` tag at the release commit** — that
+tag push (not the merge) drives the rest:
 
 ```text
-land "Release vX.Y.Z" → publish-release pushes tag + cargo publish + GH release
+land "Release vX.Y.Z" PR  →  push signed vX.Y.Z tag at the release commit
+   (release_harn.harn --mode ship-pr does the tag push; or do it by hand)
+        → TAG push → publish-release runs cargo publish + GH release
         → tag push → build-release-binaries assembles binaries + GHCR container
 ```
+
+> **`publish-release.yml` does NOT tag `main` HEAD** (changed with the
+> release-pipeline modernization, #2971–#2973). A missing `vX.Y.Z` tag makes the
+> post-merge run fail with `… but vX.Y.Z does not exist. Push vX.Y.Z at the
+> release commit`. Push it after merge with
+> `git tag -s vX.Y.Z $(git rev-parse origin/main) -m "Release vX.Y.Z" && git push origin vX.Y.Z`.
 
 The repo source of truth (only invoke locally for recovery):
 
@@ -50,15 +58,20 @@ Commit pattern for a real release:
    1-15 min and main may have moved), landed through PR/merge queue
    with `gh pr merge --auto` enabled so it lands as soon as CI is green.
 
-That's it. The bot takes over once it lands.
+2. **Push the `vX.Y.Z` tag at the release commit** once the PR lands — this is
+   the step that ships. The bot does NOT auto-tag. Use `release_harn.harn --mode
+   ship-pr` (which pushes the tag for you) or push it by hand after merge.
 
 Workflows:
 
 - `.github/workflows/publish-release.yml` (display name: "Publish release")
-  — fires on push to main when `Cargo.toml` is ahead of the latest
-  `vX.Y.Z` tag (i.e. tag drift). Pushes the tag using the App token so
-  downstream cascades fire (a `GITHUB_TOKEN` tag push would be
-  suppressed by GHA).
+  — publishes on the `vX.Y.Z` **tag push** (`tags: ['v*']`), running
+  `cargo publish` from the tag. Its `push: branches:[main]` trigger is only a
+  **guard**: it errors if `Cargo.toml` is ahead of the latest tag but the
+  matching tag is missing or points at a different commit — it does **not** tag
+  `main` HEAD. Push the tag with the App token or your own creds (a
+  `GITHUB_TOKEN` tag push would be suppressed by GHA, so downstream wouldn't
+  fire).
 - `.github/workflows/build-release-binaries.yml` (display name: "Build
   release binaries") — fires on tag push. Also accepts a `tag` input via
   `workflow_dispatch` for re-running against an existing tag.

--- a/changelog.d/3009.fixed.md
+++ b/changelog.d/3009.fixed.md
@@ -1,0 +1,8 @@
+- **Release runbooks now document the tag-push contract (#3009).** After the
+  release-pipeline modernization (#2971–#2973), `publish-release.yml` no longer
+  auto-tags `main` HEAD — the `vX.Y.Z` tag must be pushed at the release commit,
+  and that tag push (not the merge) triggers `cargo publish` + binary builds. The
+  four agent-facing runbooks (`.claude/commands/release-harn.md`,
+  `.codex/commands/harn-release.md`, and both `.codex/skills/*/SKILL.md`) still
+  described the old auto-tag behavior; they now document the explicit
+  signed-tag-push step.


### PR DESCRIPTION
## Why

The release-pipeline modernization (#2971–#2973) changed `publish-release.yml`: it **no longer auto-tags `main` HEAD** on drift. The `vX.Y.Z` tag must be pushed at the release commit, and that **tag push** (not the merge to `main`) triggers `cargo publish` + binary builds.

The four agent-facing release runbooks still described the old *"bot auto-fires on tag drift and pushes the tag"* behavior. Following them caused the **v0.8.69 publish to fail**:

```
Cargo.toml=0.8.69 is ahead of latest tag v0.8.68, but v0.8.69 does not exist.
Push v0.8.69 at the release commit before merging; publish-release.yml will not tag main HEAD.
```

(Recovered by pushing a signed `v0.8.69` tag at the release commit, which shipped normally.)

## What

Fixes all four runbooks:
- `.claude/commands/release-harn.md`
- `.codex/commands/harn-release.md`
- `.codex/skills/harn-release/SKILL.md`
- `.codex/skills/release-harn/SKILL.md`

Each now: removes the auto-tag claims; states publish-release will **not** tag `main` HEAD (and quotes the failure); adds the explicit signed-tag-push step (`git tag -s vX.Y.Z <release-commit> && git push origin vX.Y.Z`); notes `release_harn.harn --mode ship-pr` does the tag push for you; and explains the benign red `main`-push guard run.

No code/workflow changes — the orchestrator and `publish-release.yml` already implement the correct contract; only the docs lagged. `markdownlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)