### PR TITLE
Gate docs CLI flag examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
           make check-trigger-examples
           make check-docs-model-refs
           make check-docs-snippets
+          make check-docs-cli-flags
           make check-diagnostics-catalog
           # Drift guards that previously existed only in `make all` and so
           # never ran in any workflow — a contributor could edit

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-site-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
+.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-site-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-connector-schemas check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-site-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift check-tree-sitter-keywords check-generated-registry portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-connector-schemas check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-site-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift check-tree-sitter-keywords check-generated-registry portal-check
 
 check: all
 
@@ -521,6 +521,12 @@ check-diagnostics-catalog:
 check-docs-snippets:
 	@echo "=== Checking docs snippets parse under harn check ==="
 	@./scripts/check_docs_snippets.sh
+
+# CI guard: every harn long flag in docs/src bash/sh blocks must exist in
+# the corresponding `harn ... --help` output.
+check-docs-cli-flags:
+	@echo "=== Checking docs bash/sh harn flags against --help ==="
+	@./scripts/check_docs_cli_flags.sh
 
 # CI guard: every checked-in Harn snippet used by website/src parses under
 # `harn check`.

--- a/changelog.d/2987.fixed.md
+++ b/changelog.d/2987.fixed.md
@@ -1,0 +1,3 @@
+- **Docs CLI flag validation (#2987).** Bash/sh Harn examples in the docs now
+  check their long flags against the live CLI help, and stale doctor/test/try
+  examples were updated to current syntax.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -356,7 +356,7 @@ Run a pipeline against a Harn-native host module for fast local iteration.
 harn playground --host host.harn --script pipeline.harn --task "Explain this repo"
 harn playground --watch --task "Refine the prompt"
 harn playground --llm ollama:qwen2.5-coder:latest --task "Use a local model"
-harn try --yes --task "Use local Ollama"
+harn try "Use local Ollama"
 ```
 
 | Flag | Description |
@@ -1098,8 +1098,8 @@ command surfaces actionable, secret-free output for both humans and machine
 consumers (Burin Code preflight, Harn Cloud onboarding).
 
 ```bash
-harn doctor                # default: full check including provider /models probes
-harn doctor --no-network   # skip remote checks (CI-friendly)
+harn doctor                # local checks; skips remote provider probes by default
+harn doctor --check-providers  # actively probe configured providers
 harn doctor --json         # versioned machine-readable output
 ```
 
@@ -1135,7 +1135,7 @@ The command exits non-zero when at least one check is `fail`.
   triggers.
 - **Runtime state** — event log backend, metadata cache, loaded skills,
   Ollama presence and pulled models, hardware snapshot.
-- **Provider connectivity** (`--no-network` to skip) — for OpenAI-compatible
+- **Provider connectivity** (`--check-providers` to include) — for OpenAI-compatible
   local providers, `/v1/models` probes parse the listing and report missing
   configured models instead of only checking HTTP reachability.
 
@@ -1699,7 +1699,7 @@ curl http://127.0.0.1:8080/metrics
 harn orchestrator inspect --state-dir .harn/orchestrator
 
 # Inject a synthetic TriggerEvent to exercise a specific binding.
-harn orchestrator fire <trigger-id> --payload event.json
+harn orchestrator fire <trigger-id>
 
 # Replay a historical event through the dispatcher.
 harn orchestrator replay <event-id>
@@ -1819,7 +1819,7 @@ empty Flow store.
 ```bash
 harn flow replay-audit --since 2026-04-26
 harn flow replay-audit --since 2026-04-26T12:00:00Z --json
-harn flow replay-audit --store .harn/flow.sqlite --root . --target-dir crates/harn-vm --since 2026-04-26 --fail-on-drift
+harn flow replay-audit --store .harn/flow.sqlite --predicate-root . --touched-dir crates/harn-vm --since 2026-04-26 --fail-on-drift
 ```
 
 | Flag | Description |
@@ -2021,7 +2021,7 @@ Start a workflow server through one of the outbound transport adapters.
 ```bash
 harn serve a2a agent.harn                  # explicit A2A
 harn serve agent.harn                      # legacy A2A shorthand
-harn serve --port 3000 agent.harn          # legacy A2A shorthand with custom port
+harn serve a2a --port 3000 agent.harn      # A2A with custom port
 harn serve a2a --bind 0.0.0.0:3000 --api-key "$HARN_SERVE_API_KEY" agent.harn
 harn serve acp agent.harn                  # ACP session server over stdio
 harn serve acp --profile-json /tmp/acp.ndjson agent.harn

--- a/docs/src/debugging.md
+++ b/docs/src/debugging.md
@@ -91,7 +91,7 @@ token usage, timing, and final output.
 Compare a run against a baseline to identify regressions:
 
 ```bash
-harn runs inspect .harn-runs/new.json --baseline .harn-runs/old.json
+harn runs inspect .harn-runs/new.json --compare .harn-runs/old.json
 ```
 
 This highlights differences in tool calls, outputs, and token consumption.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -84,8 +84,8 @@ red/yellow/green summary with the exact fix command for anything that needs
 attention.
 
 ```bash
-harn doctor                # full check incl. provider connectivity
-harn doctor --no-network   # skip remote /models probes (CI-friendly)
+harn doctor                # local checks; skips remote provider probes by default
+harn doctor --check-providers  # actively probe configured providers
 harn doctor --json         # machine-readable output for preflight automation
 ```
 
@@ -226,7 +226,7 @@ harn new my-agent --template agent
 cd my-agent
 harn quickstart --non-interactive
 source .env
-harn doctor --no-network
+harn doctor
 ```
 
 This creates a directory with `harn.toml` (project config) and starter files

--- a/docs/src/orchestrator/secrets.md
+++ b/docs/src/orchestrator/secrets.md
@@ -14,8 +14,8 @@ The default chain is:
 env -> keyring
 ```
 
-Use `harn doctor --no-network` to inspect the active chain and to verify
-that the keyring backend is reachable on the current machine.
+Use `harn doctor` to inspect the active chain and to verify that the keyring
+backend is reachable on the current machine.
 
 ## Secret model
 

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -50,8 +50,8 @@ harn test conformance
 # Filter by name (substring match)
 harn test conformance --filter workflow_runtime
 
-# Filter by tag (if test uses tags)
-harn test conformance --tag agent
+# Filter by name or path
+harn test conformance --filter agent
 
 # Verbose output
 harn test conformance --filter my_test -v

--- a/scripts/check_docs_cli_flags.sh
+++ b/scripts/check_docs_cli_flags.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+#
+# Verify long flags in docs/src bash/sh Harn examples exist in `harn --help`.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+HARN_BIN="${HARN_BIN:-}"
+if [[ -z "$HARN_BIN" ]]; then
+  # Match check_docs_snippets.sh: prefer an already-built worktree binary, and
+  # fall back to a quiet harn-cli build in fresh clones.
+  target_dir=""
+  if command -v cargo >/dev/null 2>&1; then
+    target_dir="$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin).get("target_directory", ""))' 2>/dev/null)"
+  fi
+  if [[ -z "$target_dir" ]]; then
+    target_dir="${CARGO_TARGET_DIR:-target}"
+  fi
+
+  if [[ -x "$target_dir/debug/harn" ]]; then
+    HARN_BIN="$target_dir/debug/harn"
+  else
+    echo "building harn-cli (set HARN_BIN to skip)..." >&2
+    cargo build -q -p harn-cli
+    HARN_BIN="$target_dir/debug/harn"
+  fi
+fi
+
+export HARN_BIN
+python3 <<'PY'
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+HARN_BIN = os.environ["HARN_BIN"]
+DOCS_DIR = Path("docs/src")
+ALLOW_STALE = "harn-doc-cli: allow-stale"
+COMMAND_SEPARATORS = {"&&", "||", ";", "|"}
+
+help_cache: dict[tuple[str, ...], str] = {}
+command_cache: dict[tuple[str, ...], set[str]] = {}
+flag_cache: dict[tuple[str, ...], tuple[set[str], dict[str, bool]]] = {}
+
+
+def help_text(path: tuple[str, ...]) -> str:
+    if path not in help_cache:
+        proc = subprocess.run(
+            [HARN_BIN, *path, "--help"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        help_cache[path] = proc.stdout if proc.returncode == 0 else ""
+    return help_cache[path]
+
+
+def command_names(path: tuple[str, ...]) -> set[str]:
+    if path in command_cache:
+        return command_cache[path]
+
+    commands: set[str] = set()
+    in_commands = False
+    for line in help_text(path).splitlines():
+        if line.strip() == "Commands:":
+            in_commands = True
+            continue
+        if in_commands and not line.strip():
+            break
+        if in_commands:
+            match = re.match(r"\s{2}([A-Za-z0-9_-]+)\b", line)
+            if match:
+                commands.add(match.group(1))
+    command_cache[path] = commands
+    return commands
+
+
+def help_flags(path: tuple[str, ...]) -> tuple[set[str], dict[str, bool]]:
+    if path in flag_cache:
+        return flag_cache[path]
+
+    flags: set[str] = set()
+    takes_value: dict[str, bool] = {}
+    for line in help_text(path).splitlines():
+        for match in re.finditer(r"(?<![\w-])--([A-Za-z0-9][A-Za-z0-9-]*)\b", line):
+            flag = f"--{match.group(1)}"
+            flags.add(flag)
+            after = line[match.end() :]
+            takes_value[flag] = bool(re.match(r"\s+(?:<|\[<)", after))
+    flag_cache[path] = (flags, takes_value)
+    return flags, takes_value
+
+
+def accepted_flags(path: tuple[str, ...]) -> set[str]:
+    accepted: set[str] = set()
+    for depth in range(len(path) + 1):
+        flags, _ = help_flags(path[:depth])
+        accepted.update(flags)
+    return accepted
+
+
+def logical_lines(block_lines: list[str], first_line: int):
+    buffer: list[str] = []
+    start_line = first_line
+    allow_stale = False
+
+    for offset, line in enumerate(block_lines):
+        line_number = first_line + offset
+        raw = line.rstrip("\n")
+        if not buffer:
+            start_line = line_number
+            allow_stale = False
+        if ALLOW_STALE in raw:
+            allow_stale = True
+
+        continued = raw.rstrip().endswith("\\")
+        if continued:
+            raw = raw.rstrip()[:-1]
+        buffer.append(raw)
+        if not continued:
+            yield start_line, " ".join(buffer), allow_stale
+            buffer = []
+
+    if buffer:
+        yield start_line, " ".join(buffer), allow_stale
+
+
+def shell_tokens(command: str) -> list[str] | None:
+    # shlex does not split shell separators unless they are whitespace-delimited.
+    command = re.sub(r"(\|\||&&|[;|])", r" \1 ", command)
+    try:
+        return shlex.split(command, comments=True, posix=True)
+    except ValueError:
+        return None
+
+
+def command_segments(tokens: list[str]):
+    segment: list[str] = []
+    for token in tokens:
+        if token in COMMAND_SEPARATORS:
+            if segment:
+                yield segment
+                segment = []
+        else:
+            segment.append(token)
+    if segment:
+        yield segment
+
+
+def is_assignment(token: str) -> bool:
+    return re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", token) is not None
+
+
+def find_harn_segment(segment: list[str]) -> list[str] | None:
+    index = 0
+    while index < len(segment) and segment[index] in {"$", ">"}:
+        index += 1
+    if index < len(segment) and segment[index] == "env":
+        index += 1
+    while index < len(segment) and is_assignment(segment[index]):
+        index += 1
+
+    if index < len(segment) and segment[index] == "harn":
+        return segment[index + 1 :]
+    return None
+
+
+def analyze_harn_args(args: list[str]) -> tuple[tuple[str, ...], list[str]]:
+    path: list[str] = []
+    missing: list[str] = []
+    index = 0
+
+    while index < len(args):
+        token = args[index]
+        current_path = tuple(path)
+
+        if token == "--":
+            break
+        if token.startswith("--"):
+            flag = token.split("=", 1)[0]
+            if flag not in accepted_flags(current_path):
+                missing.append(flag)
+
+            _, takes_value = help_flags(current_path)
+            if (
+                "=" not in token
+                and index + 1 < len(args)
+                and not args[index + 1].startswith("-")
+                and (takes_value.get(flag, False) or flag not in accepted_flags(current_path))
+            ):
+                index += 2
+            else:
+                index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        if token in command_names(current_path):
+            path.append(token)
+        index += 1
+
+    return tuple(path), missing
+
+
+def iter_bash_blocks(path: Path):
+    lines = path.read_text().splitlines()
+    in_block = False
+    block_start = 0
+    block_lines: list[str] = []
+
+    for line_number, line in enumerate(lines, 1):
+        if not in_block:
+            if re.match(r"^```(?:bash|sh)$", line):
+                in_block = True
+                block_start = line_number + 1
+                block_lines = []
+            continue
+
+        if line.startswith("```"):
+            yield block_start, block_lines
+            in_block = False
+            continue
+
+        block_lines.append(line)
+
+
+failures: list[tuple[Path, int, str, tuple[str, ...], list[str]]] = []
+checked = 0
+skipped = 0
+parse_errors: list[tuple[Path, int, str]] = []
+
+for md_file in sorted(DOCS_DIR.rglob("*.md")):
+    for first_line, block_lines in iter_bash_blocks(md_file):
+        for line_number, command, allow_stale in logical_lines(block_lines, first_line):
+            if allow_stale:
+                skipped += 1
+                continue
+
+            tokens = shell_tokens(command)
+            if tokens is None:
+                if "harn" in command:
+                    parse_errors.append((md_file, line_number, command))
+                continue
+
+            for segment in command_segments(tokens):
+                args = find_harn_segment(segment)
+                if args is None:
+                    continue
+                path, missing = analyze_harn_args(args)
+                if any(token.startswith("--") for token in args):
+                    checked += 1
+                if missing:
+                    failures.append((md_file, line_number, " ".join(segment), path, missing))
+
+for md_file, line_number, command in parse_errors:
+    print(f"FAIL: {md_file}:{line_number}")
+    print("      could not parse shell command containing harn")
+    print(f"      command: {command}")
+
+for md_file, line_number, command, path, missing in failures:
+    help_target = "harn " + " ".join(path) if path else "harn"
+    print(f"FAIL: {md_file}:{line_number}")
+    print(f"      command: {command}")
+    print(f"      checked: {help_target} --help")
+    print(f"      missing long flag(s): {', '.join(missing)}")
+
+total_failures = len(parse_errors) + len(failures)
+print()
+print(
+    f"docs CLI flags: {checked} flag-bearing harn invocation(s) checked, "
+    f"{skipped} skipped, {total_failures} failed"
+)
+if total_failures:
+    print()
+    print(f"hint: fix the docs or add inline `# {ALLOW_STALE}` for intentional stale examples.")
+    sys.exit(1)
+PY

--- a/scripts/generated_artifacts.toml
+++ b/scripts/generated_artifacts.toml
@@ -48,6 +48,7 @@ exempt_checks = [
   "check-trigger-examples",         # validates example projects parse, not a mirror
   "check-docs-model-refs",          # validates docs track provider aliases, not a mirror
   "check-docs-snippets",            # validates ```harn blocks parse, not a mirror
+  "check-docs-cli-flags",           # validates docs bash/sh harn flags, not a mirror
   "check-site-snippets",            # validates website Harn fixtures parse, not a mirror
   "check-generated-registry",       # the auditor itself
 ]


### PR DESCRIPTION
## Summary
- add `check-docs-cli-flags` to validate long `harn` flags in docs bash/sh blocks against live `--help` output
- wire the guard into `make all`, CI, and the generated-artifact registry exemptions
- update stale docs examples for `doctor`, `test conformance`, `try`, `runs inspect`, `flow replay-audit`, `orchestrator fire`, and `serve`

Closes burin-labs/harn#2987
Part of burin-labs/burin-code#1774

## Verification
- `make check-docs-cli-flags`
- negative injection: `harn doctor --bogus-flag` fails at `docs/src/getting-started.md:87` and names `--bogus-flag`
- `make check-docs-snippets`
- `make check-generated-registry`
- `make lint-md`
- `make lint-actions`
- `git diff --check HEAD~1..HEAD`
- pre-commit hook, including full workspace clippy
- pre-push hook targeted local checks