### PR TITLE
fix(agent/llm): recovered-call veto, UTF-8 tool args, Qwen3 routes, done-sentinel

### DIFF
--- a/changelog.d/3011.fixed.md
+++ b/changelog.d/3011.fixed.md
@@ -1,0 +1,10 @@
+- **Agent loop no longer drops recovered tool calls on protocol violations (#3011).**
+  When a model narrated prose before a tool call, the parser recovered the
+  call but flagged the stray prose as a protocol violation, and the structural
+  validator vetoed the whole turn — silently dropping the dispatchable call and
+  looping until the stall detector fired. The well-formed check now only vetoes
+  when no dispatchable call was recovered; genuine parse/schema errors still
+  veto. Also: decode multi-byte UTF-8 in quoted/template tool-argument string
+  values (was mojibaked one Latin-1 char per byte); flag the ollama `qwen3.6*`
+  and openrouter `qwen/qwen3-coder*` text routes as `reserved_tool_call_token`;
+  and soften the done-sentinel prompt's false "the runtime rejects it" claim.

--- a/conformance/tests/agents/agent_loop_structural_validator.expected
+++ b/conformance/tests/agents/agent_loop_structural_validator.expected
@@ -39,3 +39,6 @@ true
 true
 true
 true
+true
+true
+true

--- a/conformance/tests/agents/agent_loop_structural_validator.harn
+++ b/conformance/tests/agents/agent_loop_structural_validator.harn
@@ -25,6 +25,13 @@ fn write_tools() {
 pipeline default() {
   let tool_text = "<tool_call>\nwrite_note({ path: \"notes.txt\" })\n</tool_call>"
   let malformed_tool_text = "<tool_call>\nwrite_note({ path: })\n</tool_call>"
+  // Leading narration emitted as bare prose (NOT wrapped in
+  // <assistant_prose>) ahead of a well-formed wrapped call. The parser
+  // recovers the call AND flags the stray prose as a protocol violation.
+  // The turn did real work, so `tool_calls_well_formed` must NOT veto it —
+  // vetoing here drops the recovered call and strands the model in a
+  // re-emit loop until the stall detector fires (the create-heavy failure).
+  let stray_prose_with_call_text = "I'll create notes.txt now.\n" + tool_text
   with_llm_script(
     [
       llm_text("I fixed it already."),
@@ -249,6 +256,32 @@ pipeline default() {
       let well_formed_decisions = events_of(well_formed.events, "structural_validator_decision")
       __io_println(well_formed.result.status == "done")
       __io_println(len(well_formed_decisions) == 0)
+    },
+  )
+  with_llm_script(
+    [llm_text(stray_prose_with_call_text), llm_text("<done>##DONE##</done>")],
+    { ->
+      let stray_call_session = "structural-validator-stray-prose-call-" + uuid()
+      let stray_call = agent_capture_events(
+        stray_call_session,
+        fn() { return agent_loop(
+          "Update notes.txt and then finish.",
+          nil,
+          {
+            provider: "mock",
+            tool_format: "text",
+            loop_until_done: true,
+            max_iterations: 3,
+            tools: write_tools(),
+            session_id: stray_call_session,
+            structural_validator: with_structural_validator({rules: ["tool_calls_well_formed"]}),
+          },
+        ) },
+      )
+      let stray_call_decisions = events_of(stray_call.events, "structural_validator_decision")
+      __io_println(stray_call.result.status == "done")
+      __io_println(stray_call.result.tools.successful[0] == "write_note")
+      __io_println(len(stray_call_decisions) == 0)
     },
   )
   with_llm_script(

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text_response_protocol.harn.prompt
@@ -24,7 +24,7 @@ Final user-facing answer. Required when no more tool calls are needed.
 - After `<tool_call>`, the next non-whitespace text must be the tool name, not another wrapper or a language label.
 - `<assistant_prose>` is optional and must be brief. Never paste source code, file contents, command transcripts, or long plans here; wrap those in the relevant tool call instead.
 - `<user_response>` is reserved for the final user-facing answer that hosts should surface. Emit it when the user should see a wrap-up or answer, and keep it concise and grounded.
-{{ if done_sentinel }}- `<done>{{ done_sentinel }}</done>` signals task completion. Emit it only after a successful verifying tool call; the runtime rejects it otherwise.
+{{ if done_sentinel }}- `<done>{{ done_sentinel }}</done>` signals task completion. Emit it once the work is verified — ideally after a test/build/lint command has succeeded. If you cannot run a clean verification (e.g. the toolchain is unavailable in this environment), state what you confirmed and still wrap up rather than looping.
 {{ end }}- Do not prefix calls with labels like `tool_code:`, `python:`, `shell:`, or any language tag, and do not wrap tool calls in Markdown fences.
 {{ if done_sentinel }}- Do not write `<tool_call>{{ done_sentinel }}</tool_call>`; completion sentinels are only valid in `<done>...</done>`.
 {{ end }}

--- a/crates/harn-stdlib/src/stdlib/llm/structural_validator.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/structural_validator.harn
@@ -108,7 +108,7 @@ fn __sv_normalize_no_phantom_completion_catalog(value) {
   }
   var out = defaults
   for locale in raw.keys() {
-    out = out + {[locale]: __sv_merge_catalog_locale(out?[locale] ?? [], raw[locale])}
+    out = out + {[locale]: __sv_merge_catalog_locale(out[locale] ?? [], raw[locale])}
   }
   return out
 }
@@ -292,7 +292,7 @@ fn __sv_any_prior_write_tools(payload) -> bool {
 fn __sv_no_phantom_completion_phrases(cfg, rule_cfg) {
   let locale = __sv_locale(rule_cfg?.locale ?? cfg?.locale)
   let catalog = __sv_dict(cfg?.no_phantom_completion_catalog)
-  let phrases = __sv_string_list(catalog?[locale] ?? catalog?.en ?? [])
+  let phrases = __sv_string_list(catalog[locale] ?? catalog?.en ?? [])
   return __sv_merge_catalog_locale([], phrases)
 }
 
@@ -547,7 +547,19 @@ fn __sv_tool_calls_well_formed(payload) {
   } else {
     []
   }
-  let protocol_violations = if should_enforce_text_protocol {
+  // `protocol_violations` are the recoverable wrapper/stray-prose class
+  // (leading narration outside `<assistant_prose>`, a call emitted bare or
+  // angle-wrapped instead of in `<tool_call>` tags, etc.). The text parser
+  // already RECOVERS those calls and surfaces them in `tool_calls`, so when
+  // dispatchable calls exist the turn did real work — vetoing it here would
+  // silently drop a fully-parsed `edit({...})` and strand the model in a
+  // re-emit loop until the stall detector fires. Only let a
+  // protocol-violation complaint veto when no calls were recovered (a turn
+  // that was pure stray prose). Genuine `parse_errors` (a call that failed to
+  // parse) and `schema_violations` (a parsed call with bad args) still veto
+  // regardless, because those represent broken calls, not wrapper noise.
+  let has_dispatchable_calls = len(__sv_list(payload?.tool_calls)) > 0
+  let protocol_violations = if should_enforce_text_protocol && !has_dispatchable_calls {
     __sv_string_list(payload?.protocol_violations)
   } else {
     []

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -961,6 +961,9 @@ thinking_block_style = "none"
 model_match = "qwen3.6*"
 native_tools = false
 preferred_tool_format = "text"
+# Qwen3.x reserves <tool_call> as a single special token; serving text-format
+# without the wire remap re-exposes the opener-repetition collapse #2978 fixed.
+reserved_tool_call_token = true
 structured_output = "format_kw"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
@@ -1415,6 +1418,10 @@ thinking_block_style = "inline"
 model_match = "qwen/qwen3-coder*"
 native_tools = true
 preferred_tool_format = "text"
+# Qwen3-Coder reserves <tool_call> as a special token and emits the wrapper on
+# most turns (see tools/parse/bare.rs); remap it on the wire like the other
+# Qwen3 routes so the text format doesn't collapse.
+reserved_tool_call_token = true
 tool_mode_parity = "native_unreliable"
 tool_mode_parity_notes = "OpenRouter Qwen3-Coder Flash native tools exhausted the coding-agent fixture while text tools completed; default to Harn text tools for preset parity."
 structured_output = "native"

--- a/crates/harn-vm/src/llm/tools/tests/core_parser.rs
+++ b/crates/harn-vm/src/llm/tools/tests/core_parser.rs
@@ -1,4 +1,51 @@
-use super::{json, parse_bare_calls_in_body, sample_tool_registry};
+use super::{
+    json, parse_bare_calls_in_body, parse_text_tool_calls_with_tools, sample_tool_registry,
+};
+
+// Non-ASCII tool-argument values must round-trip intact. `advance()` yields one
+// byte at a time, so pushing each byte of a multi-byte UTF-8 scalar as a `char`
+// used to produce one Latin-1 char per byte (mojibake) for quoted and template
+// string values, while heredocs and `\u{...}` escapes decoded correctly.
+#[test]
+fn nonascii_string_value_not_mangled() {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body(r#"run({ command: "café ☕ 日本" })"#, Some(&tools));
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.calls.len(), 1);
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("café ☕ 日本")
+    );
+}
+
+#[test]
+fn nonascii_template_value_not_mangled() {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body("run({ command: `café ☕ 日本` })", Some(&tools));
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("café ☕ 日本")
+    );
+}
+
+#[test]
+fn nonascii_tagged_value_not_mangled() {
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\nrun({ command: \"café ☕ 日本\" })\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert!(
+        result.errors.is_empty(),
+        "errors: {:?} violations: {:?}",
+        result.errors,
+        result.violations
+    );
+    assert_eq!(result.calls.len(), 1);
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("café ☕ 日本")
+    );
+}
 
 #[test]
 fn parses_a_simple_object_literal_call() {

--- a/crates/harn-vm/src/llm/tools/ts_value_parser.rs
+++ b/crates/harn-vm/src/llm/tools/ts_value_parser.rs
@@ -40,6 +40,25 @@ impl<'a> TsValueParser<'a> {
         Some(b)
     }
 
+    /// Append a character to `out`, decoding a full multi-byte UTF-8 scalar from
+    /// the source when `b` is a non-ASCII lead byte. `advance()` yields one byte
+    /// at a time, so pushing `b as char` for a lead byte emits one Latin-1 char
+    /// per byte and mojibakes any accented / emoji / CJK value. Heredoc bodies
+    /// and `\u{...}` escapes already decode correctly; this keeps quoted and
+    /// template string values consistent with them.
+    fn push_scalar(&mut self, out: &mut String, b: u8) {
+        if b < 0x80 {
+            out.push(b as char);
+            return;
+        }
+        // `advance()` already consumed the lead byte (pos is past it). Decode the
+        // whole scalar from the lead byte and resync pos to the scalar's end.
+        let start = self.pos - 1;
+        let ch = self.text[start..].chars().next().unwrap_or('\u{FFFD}');
+        out.push(ch);
+        self.pos = start + ch.len_utf8();
+    }
+
     pub(super) fn skip_ws_and_comments(&mut self) {
         loop {
             while let Some(b) = self.peek() {
@@ -245,7 +264,7 @@ impl<'a> TsValueParser<'a> {
                     // syntax error. We accept it anyway so weaker models that
                     // forget the heredoc/template-literal rule still get their
                     // content through rather than silently dropping the call.
-                    out.push(b as char);
+                    self.push_scalar(&mut out, b);
                 }
             }
         }
@@ -311,12 +330,12 @@ impl<'a> TsValueParser<'a> {
                                 depth -= 1;
                                 out.push('}');
                             }
-                            Some(b) => out.push(b as char),
+                            Some(b) => self.push_scalar(&mut out, b),
                         }
                     }
                 }
                 Some(b) => {
-                    out.push(b as char);
+                    self.push_scalar(&mut out, b);
                 }
             }
         }


### PR DESCRIPTION
Four fixes from an adversarial QA sweep of Burin's local-model eval transcripts — all in the LLM/agent layer, each verified.

## 1. Structural validator drops recovered tool calls on protocol violations (HIGHEST IMPACT)

When a model narrates before a tool call — `Now I'll create the file…\n<tool_call>edit({...})</tool_call>` — the tagged parser *recovers* the `edit` call but also records the leading prose as a `protocol_violations` entry (the recoverable stray-prose class). `__sv_tool_calls_well_formed` (`structural_validator.harn:556`) vetoed the **whole turn whenever any protocol_violation existed — even though a dispatchable call was present** (its sibling rules correctly bail when `len(tool_calls) > 0`). On veto the loop (`loop.harn:1953`) sets `dispatch_skipped` and `continue`s, **silently dropping the parsed call**; the model re-emits the same prose+call, re-vetoes, and loops until the stall detector fires → **0 files written**.

This fails for *any* model that narrates before acting — which local/cheap models do constantly — so it's a broad create/edit killer, not a one-eval quirk. Fix: gate the `protocol_violations` veto on `!has_dispatchable_calls`; genuine `parse_errors` (unparseable call) and `schema_violations` (bad args) still veto. New conformance regression in `agent_loop_structural_validator.harn` (flips to failing on revert). 196/196 `tests/agents` conformance pass.

## 2. UTF-8 mojibake in tool-arg string values
`TsValueParser` pushed each byte of a multi-byte UTF-8 scalar as a `char`, mojibaking accented/emoji/CJK values in quoted/template tool args (heredocs were already fine). New `push_scalar` decodes the full scalar; 3 regression tests.

## 3. Two Qwen3 text routes miss `reserved_tool_call_token`
`ollama qwen3.6*` and `openrouter qwen/qwen3-coder*` reserve `<tool_call>` as a special token but weren't flagged, re-exposing the opener-repetition collapse the remap prevents.

## 4. Done-sentinel prompt over-claims a non-existent guardrail
"Emit `##DONE##` only after a successful verifying tool call; the runtime rejects it otherwise" — no such gate exists, making a model hesitant to wrap up when its in-loop verify is environmentally blocked. Reworded to non-load-bearing guidance.

## Validation
196/196 `tests/agents` conformance, 111/111 `harn-vm --lib llm::tools`, `cargo clippy -p harn-vm` clean, `harn fmt`/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)