### PR TITLE
fix harnpack entrypoint and trigger cost bugs

### DIFF
--- a/changelog.d/codex-general-bugfixes.fixed.md
+++ b/changelog.d/codex-general-bugfixes.fixed.md
@@ -1,0 +1,3 @@
+- **Harnpack and trigger budgets.** `harn run <bundle.harnpack>` now rejects
+  manifest entrypoints that are absolute or escape the unpacked source tree,
+  and trigger predicate cost averaging no longer overflows on large samples.

--- a/crates/harn-cli/src/commands/run/harnpack.rs
+++ b/crates/harn-cli/src/commands/run/harnpack.rs
@@ -142,7 +142,8 @@ pub fn prepare_harnpack<W: Write>(
         replay_archive(&cache_dir, &manifest, &contents)?;
     }
 
-    let entrypoint_path = cache_dir.join("sources").join(&manifest.entrypoint);
+    let entrypoint_rel = join_safe_nonempty(Path::new(""), &manifest.entrypoint)?;
+    let entrypoint_path = cache_dir.join("sources").join(entrypoint_rel);
     if !entrypoint_path.exists() {
         return Err(HarnpackError::new(
             "harnpack.missing_entrypoint",
@@ -335,6 +336,17 @@ fn join_safe(base: &Path, rel: &Path) -> Result<PathBuf, HarnpackError> {
     Ok(out)
 }
 
+fn join_safe_nonempty(base: &Path, rel: &Path) -> Result<PathBuf, HarnpackError> {
+    let out = join_safe(base, rel)?;
+    if out == base {
+        return Err(HarnpackError::new(
+            "harnpack.unsafe_path",
+            "refusing to use empty harnpack entrypoint",
+        ));
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -392,5 +404,66 @@ mod tests {
             join_safe(&base, Path::new("sources/hello.harn")).unwrap(),
             base.join("sources").join("hello.harn"),
         );
+    }
+
+    #[test]
+    fn prepare_harnpack_rejects_absolute_manifest_entrypoint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let external = temp.path().join("outside.harn");
+        fs::write(&external, "fn main() {}\n").expect("external source");
+
+        let mut bundle = WorkflowBundle {
+            entrypoint: external,
+            ..WorkflowBundle::default()
+        };
+        bundle.harn_version = env!("CARGO_PKG_VERSION").to_string();
+        let bytes = harn_vm::orchestration::build_harnpack(
+            &bundle,
+            &[HarnpackEntry::new("sources/inside.harn", b"fn main() {}\n")],
+        )
+        .expect("build pack");
+        let pack_path = temp.path().join("unsafe.harnpack");
+        fs::write(&pack_path, bytes).expect("pack file");
+
+        let mut stderr = String::new();
+        let err = prepare_harnpack(
+            &pack_path,
+            &HarnpackRunOptions {
+                allow_unsigned: true,
+                dry_run_verify: false,
+            },
+            &mut stderr,
+        )
+        .expect_err("absolute entrypoint must be rejected");
+        assert_eq!(err.code, "harnpack.unsafe_path");
+    }
+
+    #[test]
+    fn prepare_harnpack_rejects_traversing_manifest_entrypoint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut bundle = WorkflowBundle {
+            entrypoint: PathBuf::from("../outside.harn"),
+            ..WorkflowBundle::default()
+        };
+        bundle.harn_version = env!("CARGO_PKG_VERSION").to_string();
+        let bytes = harn_vm::orchestration::build_harnpack(
+            &bundle,
+            &[HarnpackEntry::new("outside.harn", b"fn main() {}\n")],
+        )
+        .expect("build pack");
+        let pack_path = temp.path().join("traversal.harnpack");
+        fs::write(&pack_path, bytes).expect("pack file");
+
+        let mut stderr = String::new();
+        let err = prepare_harnpack(
+            &pack_path,
+            &HarnpackRunOptions {
+                allow_unsigned: true,
+                dry_run_verify: false,
+            },
+            &mut stderr,
+        )
+        .expect_err("traversing entrypoint must be rejected");
+        assert_eq!(err.code, "harnpack.unsafe_path");
     }
 }

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -886,9 +886,8 @@ pub fn expected_predicate_cost_usd_micros(binding: &TriggerBinding) -> u64 {
         .predicate_state
         .lock()
         .expect("trigger predicate state poisoned");
-    if !state.recent_cost_usd_micros.is_empty() {
-        let total: u64 = state.recent_cost_usd_micros.iter().copied().sum();
-        return total / state.recent_cost_usd_micros.len() as u64;
+    if let Some(average) = average_cost_sample_micros(&state.recent_cost_usd_micros) {
+        return average;
     }
     binding
         .when_budget
@@ -907,6 +906,14 @@ pub fn record_predicate_cost_sample(binding: &TriggerBinding, cost_usd_micros: u
     while state.recent_cost_usd_micros.len() > PREDICATE_COST_WINDOW {
         state.recent_cost_usd_micros.pop_front();
     }
+}
+
+fn average_cost_sample_micros(samples: &VecDeque<u64>) -> Option<u64> {
+    if samples.is_empty() {
+        return None;
+    }
+    let total: u128 = samples.iter().map(|sample| u128::from(*sample)).sum();
+    Some((total / samples.len() as u128) as u64)
 }
 
 pub fn usd_to_micros(value: f64) -> u64 {
@@ -1875,6 +1882,15 @@ mod tests {
         assert!(matches!(error, TriggerRegistryError::DuplicateId(_)));
 
         clear_trigger_registry();
+    }
+
+    #[test]
+    fn expected_predicate_cost_average_does_not_overflow() {
+        let binding = TriggerBinding::new(manifest_spec("costed", "v1"), 1);
+        record_predicate_cost_sample(&binding, u64::MAX);
+        record_predicate_cost_sample(&binding, u64::MAX);
+
+        assert_eq!(expected_predicate_cost_usd_micros(&binding), u64::MAX);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary
- Reject absolute or traversing manifest entrypoints before running a `.harnpack` bundle.
- Average trigger predicate cost samples with wide accumulation so large samples cannot overflow.
- Add regression coverage and a changelog fragment for both fixes.

## Root Cause
- `prepare_harnpack` normalized archive members but joined `manifest.entrypoint` directly under the extracted `sources` tree.
- Trigger predicate cost estimates summed `u64` samples with `sum::<u64>()`, which can panic in debug builds and wrap in release builds.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-general-bugfixes cargo test -p harn-vm triggers::registry::tests::expected_predicate_cost_average_does_not_overflow`
- `CARGO_TARGET_DIR=/tmp/harn-target-general-bugfixes cargo test -p harn-cli harnpack`
- `CARGO_TARGET_DIR=/tmp/harn-target-general-bugfixes cargo clippy -p harn-vm -p harn-cli --all-targets -- -D warnings`
- `git push` pre-push checks
