### PR TITLE
Add package-manager sandbox config preset

### DIFF
--- a/changelog.d/2988.fixed.md
+++ b/changelog.d/2988.fixed.md
@@ -1,0 +1,3 @@
+- **Package-manager sandbox config (#2988).** OS-hardened process sandboxes now
+  read common per-user npm, pip, cargo, git, and CA config/cache roots by
+  default without making those paths writable or readable by Harn file builtins.

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -182,6 +182,9 @@ pub enum ProcessSandboxPreset {
     /// OS/vendor developer toolchains such as Xcode, Command Line Tools,
     /// Homebrew, and language runtimes installed under standard system paths.
     DeveloperToolchains,
+    /// Per-user package-manager config/cache roots used by npm, pip, cargo,
+    /// git credential helpers, and enterprise CA configuration.
+    PackageManagerConfig,
     /// Per-user scratch/cache locations used by developer tools. Write access
     /// is granted only when the active policy already allows workspace writes.
     UserTemp,
@@ -192,6 +195,7 @@ impl ProcessSandboxPreset {
         &[
             Self::SystemRuntime,
             Self::DeveloperToolchains,
+            Self::PackageManagerConfig,
             Self::UserTemp,
         ]
     }

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -89,6 +89,16 @@ fn capability_intersection_narrows_process_sandbox_policy() {
 }
 
 #[test]
+fn process_sandbox_defaults_include_package_manager_config() {
+    assert!(
+        ProcessSandboxPolicy::default()
+            .effective_presets()
+            .contains(&ProcessSandboxPreset::PackageManagerConfig),
+        "package-manager config roots should be part of the default process sandbox presets"
+    );
+}
+
+#[test]
 fn mutation_session_normalize_fills_defaults() {
     let normalized = MutationSessionRecord::default().normalize();
     assert!(normalized.session_id.starts_with("session_"));

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -12,9 +12,9 @@ use std::process::Command;
 
 use super::{
     policy_allows_capability, policy_allows_network, policy_allows_workspace_write,
-    process_sandbox_policy_read_roots, process_sandbox_policy_write_roots,
-    process_sandbox_readonly_roots, process_sandbox_roots, sandbox_rejection, warn_once,
-    PrepareOutcome, SandboxBackend, SandboxFallback,
+    process_sandbox_package_manager_config_read_roots, process_sandbox_policy_read_roots,
+    process_sandbox_policy_write_roots, process_sandbox_readonly_roots, process_sandbox_roots,
+    sandbox_rejection, warn_once, PrepareOutcome, SandboxBackend, SandboxFallback,
 };
 use crate::orchestration::{CapabilityPolicy, SandboxProfile};
 use crate::value::VmError;
@@ -178,6 +178,9 @@ fn landlock_profile(
     }
     for root in process_sandbox_policy_read_roots(policy) {
         push_rule(&mut profile, root, read_only_access(), false)?;
+    }
+    for root in process_sandbox_package_manager_config_read_roots(policy) {
+        push_rule(&mut profile, root, read_only_access(), true)?;
     }
     if policy_allows_workspace_write(policy) {
         for root in process_sandbox_policy_write_roots(policy) {
@@ -552,6 +555,37 @@ mod tests {
             read_only_access() & WRITE_BITS,
             0,
             "read-only roots stay unwritable regardless of workspace write capability",
+        );
+    }
+
+    #[test]
+    fn package_manager_config_roots_are_read_only() {
+        let temp_home = tempfile::tempdir().expect("temp home");
+        std::fs::write(
+            temp_home.path().join(".npmrc"),
+            "registry=https://registry.example\n",
+        )
+        .expect("write npmrc");
+        let roots = super::super::package_manager_config_read_roots_for_home(temp_home.path());
+
+        assert!(
+            roots.iter().any(|path| path.ends_with(".npmrc")),
+            "npmrc should be part of the package-manager preset"
+        );
+        assert!(
+            roots
+                .iter()
+                .any(|path| path.ends_with(".cargo/config.toml")),
+            "cargo config should be part of the package-manager preset"
+        );
+        assert!(
+            roots.iter().all(|path| path.starts_with(temp_home.path())),
+            "package-manager roots must stay under HOME"
+        );
+        assert_eq!(
+            read_only_access() & WRITE_BITS,
+            0,
+            "package-manager Landlock rules use read-only access bits"
         );
     }
 

--- a/crates/harn-vm/src/stdlib/sandbox/macos.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/macos.rs
@@ -15,7 +15,8 @@ use std::path::Path;
 use std::process::Command;
 
 use super::{
-    policy_allows_network, policy_allows_workspace_write, process_sandbox_policy_read_roots,
+    policy_allows_network, policy_allows_workspace_write,
+    process_sandbox_package_manager_config_read_roots, process_sandbox_policy_read_roots,
     process_sandbox_policy_write_roots, process_sandbox_presets, process_sandbox_readonly_roots,
     process_sandbox_roots, unavailable, PrepareOutcome, SandboxBackend,
 };
@@ -134,6 +135,14 @@ fn has_swiftpm_option(args: &[String], option: &str) -> bool {
 }
 
 fn render_profile(policy: &CapabilityPolicy) -> String {
+    let package_manager_read_roots = process_sandbox_package_manager_config_read_roots(policy);
+    render_profile_with_package_manager_read_roots(policy, &package_manager_read_roots)
+}
+
+fn render_profile_with_package_manager_read_roots(
+    policy: &CapabilityPolicy,
+    package_manager_read_roots: &[std::path::PathBuf],
+) -> String {
     let roots = process_sandbox_roots(policy);
     let read_only_roots = process_sandbox_readonly_roots(policy);
     let policy_read_roots = process_sandbox_policy_read_roots(policy);
@@ -160,6 +169,7 @@ fn render_profile(policy: &CapabilityPolicy) -> String {
         .iter()
         .chain(read_only_roots.iter())
         .chain(policy_read_roots.iter())
+        .chain(package_manager_read_roots.iter())
     {
         profile.push_str(&format!(
             "(allow file-read* (subpath \"{}\"))\n",
@@ -202,7 +212,10 @@ fn render_profile(policy: &CapabilityPolicy) -> String {
         // *after* every write allow re-asserts hermetic read-only scope
         // even when the lists are not disjoint. The deny is a no-op for
         // disjoint read-only roots (which never received a write allow).
-        for root in read_only_roots.iter() {
+        for root in read_only_roots
+            .iter()
+            .chain(package_manager_read_roots.iter())
+        {
             profile.push_str(&format!(
                 "(deny file-write* (subpath \"{}\"))\n",
                 sandbox_profile_escape(&root.display().to_string())
@@ -235,6 +248,7 @@ fn preset_read_roots(policy: &CapabilityPolicy) -> Vec<&'static str> {
                 "/Library/Developer",
                 "/System/Library/Developer",
             ]),
+            ProcessSandboxPreset::PackageManagerConfig => {}
             ProcessSandboxPreset::UserTemp => {}
         }
     }
@@ -366,6 +380,43 @@ mod tests {
         assert!(
             !profile.contains("(subpath \"/private/var/folders\")"),
             "disabling user_temp should remove per-user temp cache access: {profile}"
+        );
+    }
+
+    #[test]
+    fn sandbox_profile_allows_package_manager_config_read_only() {
+        let temp_home = tempfile::tempdir().expect("temp home");
+        std::fs::write(
+            temp_home.path().join(".npmrc"),
+            "registry=https://registry.example\n",
+        )
+        .expect("write npmrc");
+
+        let package_roots =
+            super::super::package_manager_config_read_roots_for_home(temp_home.path());
+        let profile = render_profile_with_package_manager_read_roots(
+            &macos_policy_with_workspace_ops(&["read_text", "write_text", "delete"]),
+            &package_roots,
+        );
+        let npmrc_path = super::super::package_manager_config_read_roots_for_home(temp_home.path())
+            .into_iter()
+            .find(|path| path.ends_with(".npmrc"))
+            .expect("npmrc root")
+            .display()
+            .to_string();
+        let escaped = sandbox_profile_escape(&npmrc_path);
+
+        assert!(
+            profile.contains(&format!("(allow file-read* (subpath \"{escaped}\"))")),
+            "package manager config should be readable: {profile}"
+        );
+        assert!(
+            profile.contains(&format!("(deny file-write* (subpath \"{escaped}\"))")),
+            "package manager config should be explicitly re-denied writes: {profile}"
+        );
+        assert!(
+            !profile.contains(&format!("(allow file-write* (subpath \"{escaped}\"))")),
+            "package manager config must not get direct write access: {profile}"
         );
     }
 

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -39,7 +39,7 @@ use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::orchestration::ProcessSandboxPreset;
 use crate::orchestration::{CapabilityPolicy, SandboxProfile};
 use crate::value::{ErrorCategory, VmError, VmValue};
@@ -741,9 +741,58 @@ pub(crate) fn process_sandbox_policy_write_roots(policy: &CapabilityPolicy) -> V
     normalized_process_roots(&policy.process_sandbox.write_roots)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub(crate) fn process_sandbox_presets(policy: &CapabilityPolicy) -> Vec<ProcessSandboxPreset> {
     policy.process_sandbox.effective_presets()
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn process_sandbox_package_manager_config_read_roots(
+    policy: &CapabilityPolicy,
+) -> Vec<PathBuf> {
+    if !process_sandbox_presets(policy).contains(&ProcessSandboxPreset::PackageManagerConfig) {
+        return Vec::new();
+    }
+    let Some(home) = package_manager_config_home_dir() else {
+        return Vec::new();
+    };
+    package_manager_config_read_roots_for_home(&home)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn package_manager_config_home_dir() -> Option<PathBuf> {
+    ["HOME", "USERPROFILE"]
+        .into_iter()
+        .filter_map(std::env::var_os)
+        .map(PathBuf::from)
+        .find(|path| path.is_absolute())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn package_manager_config_read_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    let mut roots: Vec<_> = [
+        ".npmrc",
+        ".gitconfig",
+        ".netrc",
+        ".yarnrc.yml",
+        ".config",
+        ".npm",
+        ".cache",
+        ".pip",
+        ".pypirc",
+        ".cargo/config",
+        ".cargo/config.toml",
+        ".cargo/credentials",
+        ".cargo/credentials.toml",
+        ".cargo/registry",
+        ".cargo/git",
+    ]
+    .into_iter()
+    .map(|entry| normalize_for_policy(&home.join(entry)))
+    .collect();
+    roots.sort_unstable();
+    roots.dedup();
+    roots
 }
 
 #[cfg(any(

--- a/docs/src/sandboxing.md
+++ b/docs/src/sandboxing.md
@@ -51,7 +51,12 @@ those paths unless they are also in `workspace_roots` or `read_only_roots`.
 ```json
 {
   "process_sandbox": {
-    "presets": ["system_runtime", "developer_toolchains", "user_temp"],
+    "presets": [
+      "system_runtime",
+      "developer_toolchains",
+      "package_manager_config",
+      "user_temp"
+    ],
     "read_roots": ["/opt/vendor-sdk"],
     "write_roots": ["/opt/vendor-cache"]
   }
@@ -63,6 +68,9 @@ those paths unless they are also in `workspace_roots` or `read_only_roots`.
 - `system_runtime`: host runtime directories needed to launch common binaries.
 - `developer_toolchains`: standard compiler/toolchain locations such as Xcode,
   Command Line Tools, Homebrew, and language runtime roots.
+- `package_manager_config`: read-only per-user npm, pip, cargo, git, and CA
+  config/cache roots under `$HOME`, such as `.npmrc`, `.gitconfig`, `.netrc`,
+  `.config`, `.cache`, and cargo config/registry paths.
 - `user_temp`: scratch/cache roots used by developer tools. These roots are
   writable only when the active capability policy already allows workspace
   writes.
@@ -156,6 +164,7 @@ small, named kernel feature, never an open-ended escape hatch.
 | `workspace.write_text` | Landlock `_WRITE_FILE` + `_REMOVE_*` + `_MAKE_*` + (ABI ≥ 2) `_REFER` + (ABI ≥ 3) `_TRUNCATE` | writes scoped to `workspace_roots` |
 | `workspace.delete` | Landlock `_REMOVE_DIR` + `_REMOVE_FILE` | removes scoped to `workspace_roots` |
 | `read_only_roots: [...]` | Landlock `_READ_FILE` + `_READ_DIR` + `_EXECUTE` only | each read-only root is readable but never writable, regardless of the `workspace.*` capabilities |
+| `process_sandbox.presets` includes `package_manager_config` | Landlock read-only rules for existing npm, pip, cargo, git, and CA config/cache roots under `$HOME` | package managers can resolve real per-user config without granting Harn file builtin access or write rights |
 | `process_sandbox.read_roots` / `.write_roots` | Landlock read-only rules, plus writable rules only when workspace writes are allowed | process-only roots for SDKs/caches without widening Harn file builtins |
 | standard process devices | Landlock grants read/write on `/dev/null` and read-only access on `/dev/zero`, `/dev/random`, and `/dev/urandom`; ABI ≥ 5 also handles `_IOCTL_DEV` but does not grant it to these device rules | language runtimes and test harnesses can open the devices they normally need without broad `/dev` access or device ioctl rights |
 | `side_effect_level < network` | seccomp-bpf blocklist on `socket`, `socketpair`, `connect`, `accept`, `accept4`, `bind`, `listen`, `sendto`, `sendmsg`, `recvfrom`, `recvmsg` (return `EPERM`) | network syscalls fail without taking down the process |
@@ -174,7 +183,7 @@ falls back to the warn/enforce decision documented above.
 | always | `(deny default)` | every operation requires an explicit allow |
 | always | `(allow process*)` + `(allow sysctl-read)` + `(allow mach-lookup)` + `(allow file-read-data (literal "/"))` | minimum surface required to exec a binary |
 | standard process devices | `(allow file-read* ...)` for `/dev/null`, `/dev/zero`, `/dev/random`, `/dev/urandom`, `/dev/stdin`, `/dev/stdout`, `/dev/stderr`, and `/dev/fd`; `(allow file-write* ...)` only for `/dev/null`, `/dev/stdout`, `/dev/stderr`, and `/dev/fd` | common stdio, entropy, and zero devices work without granting broad `/dev` writes |
-| `process_sandbox.presets` | named read/write rules for `system_runtime`, `developer_toolchains`, and `user_temp` | default process reach for system binaries, Xcode/Homebrew/toolchains, and per-user developer-tool caches without granting Harn file builtin access |
+| `process_sandbox.presets` | named read/write rules for `system_runtime`, `developer_toolchains`, `package_manager_config`, and `user_temp` | default process reach for system binaries, Xcode/Homebrew/toolchains, read-only package-manager home config, and per-user developer-tool caches without granting Harn file builtin access |
 | `workspace_roots: [...]` / `read_only_roots: [...]` | `(allow file-read* (subpath "<root>"))` | workspace and read-only roots are readable |
 | `workspace.write_text` / `workspace.delete` (or empty `capabilities`) | writable `user_temp`, `process_sandbox.write_roots`, and `workspace_roots`, followed by `(deny file-write* (subpath "<read_only_root>"))` | scratch dirs, explicit process-write roots, and writable `workspace_roots` are writable; each `read_only_roots` entry is then re-denied write. `sandbox-exec` is last-match-wins, so the trailing deny keeps a read-only root nested under a writable root unwritable even though the two lists are nominally disjoint |
 | `side_effect_level >= network` | `(allow network*)` | otherwise outbound network is denied |


### PR DESCRIPTION
## Summary
- add `package_manager_config` as a default process sandbox preset
- grant read-only HOME package-manager config/cache roots to macOS sandbox-exec and Linux Landlock child-process profiles
- keep those roots process-only and unwritable, and document the default preset contract

Closes burin-labs/harn#2988
Part of burin-labs/burin-code#1774

## Verification
- `cargo test -p harn-vm package_manager_config`
- `cargo test -p harn-vm sandbox`
- `cargo clippy -p harn-vm -- -D warnings`
- `cargo clippy -p harn-vm --all-targets -- -D warnings`
- `make lint-md`
- `make check-generated-registry`
- `git diff --check HEAD~1..HEAD`
- pre-commit hook
- pre-push hook targeted local checks