### PR TITLE
Add OTel sample ratio config

### DIFF
--- a/changelog.d/2989.added.md
+++ b/changelog.d/2989.added.md
@@ -1,0 +1,3 @@
+- **Observability:** Added `HARN_OTEL_SAMPLE_RATIO` so OTLP trace export can
+  downsample root traces at the source while keeping the default at full
+  fidelity.

--- a/crates/harn-vm/src/observability/otel.rs
+++ b/crates/harn-vm/src/observability/otel.rs
@@ -534,7 +534,7 @@ fn build_tracer_provider_from_env(
     use opentelemetry_otlp::{Protocol, WithExportConfig as _, WithHttpConfig as _};
     use opentelemetry_sdk::runtime;
     use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
-    use opentelemetry_sdk::trace::SimpleSpanProcessor;
+    use opentelemetry_sdk::trace::{Sampler, SimpleSpanProcessor};
     use opentelemetry_sdk::Resource;
 
     let Some(raw_endpoint) = std::env::var("HARN_OTEL_ENDPOINT")
@@ -559,6 +559,13 @@ fn build_tracer_provider_from_env(
             .map(str::trim)
             .filter(|value| !value.is_empty()),
     )?;
+    let sample_ratio = parse_sample_ratio(
+        std::env::var("HARN_OTEL_SAMPLE_RATIO")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+    )?;
 
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
@@ -575,6 +582,11 @@ fn build_tracer_provider_from_env(
 
     let mut builder = opentelemetry_sdk::trace::SdkTracerProvider::builder()
         .with_resource(Resource::builder().with_service_name(service_name).build());
+    if sample_ratio < 1.0 {
+        builder = builder.with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+            sample_ratio,
+        ))));
+    }
     builder = match processor_kind {
         SpanProcessorKind::Batch => builder
             .with_span_processor(BatchSpanProcessor::builder(exporter, runtime::Tokio).build()),
@@ -589,6 +601,25 @@ fn build_tracer_provider_from_env(
     let provider = builder.build();
     global::set_tracer_provider(provider.clone());
     Ok(Some(provider))
+}
+
+#[cfg(feature = "otel")]
+fn parse_sample_ratio(value: Option<&str>) -> Result<f64, String> {
+    let Some(value) = value else {
+        return Ok(1.0);
+    };
+    let ratio = value.parse::<f64>().map_err(|error| {
+        format!(
+            "invalid HARN_OTEL_SAMPLE_RATIO value {value:?}; expected a number in [0, 1]: {error}"
+        )
+    })?;
+    if ratio.is_finite() && (0.0..=1.0).contains(&ratio) {
+        Ok(ratio)
+    } else {
+        Err(format!(
+            "invalid HARN_OTEL_SAMPLE_RATIO value {value:?}; expected a number in [0, 1]"
+        ))
+    }
 }
 
 #[cfg(feature = "otel")]
@@ -794,6 +825,27 @@ mod tests {
         assert!(error.contains("forwarder"), "{error}");
         assert!(error.contains("batch"), "{error}");
         assert!(error.contains("simple"), "{error}");
+    }
+
+    #[test]
+    fn parse_sample_ratio_defaults_to_keep_all() {
+        assert_eq!(parse_sample_ratio(None).unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_sample_ratio_accepts_valid_ratio() {
+        assert_eq!(parse_sample_ratio(Some("0.1")).unwrap(), 0.1);
+        assert_eq!(parse_sample_ratio(Some("0")).unwrap(), 0.0);
+        assert_eq!(parse_sample_ratio(Some("1")).unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_sample_ratio_rejects_invalid_values() {
+        for value in ["2.0", "-1", "x", "NaN", "inf"] {
+            let error = parse_sample_ratio(Some(value)).unwrap_err();
+            assert!(error.contains(value), "{error}");
+            assert!(error.contains("[0, 1]"), "{error}");
+        }
     }
 
     #[test]

--- a/docs/src/orchestrator/observability.md
+++ b/docs/src/orchestrator/observability.md
@@ -139,6 +139,15 @@ newline-separated `key=value` entries:
 HARN_OTEL_HEADERS='authorization=Bearer token,x-tenant-id=acme'
 ```
 
+Set `HARN_OTEL_SAMPLE_RATIO` to downsample root traces at the source before
+export. The default is `1.0`, which keeps every trace. Values must be between
+`0.0` and `1.0`; sampled parent decisions continue to propagate through child
+spans.
+
+```bash
+HARN_OTEL_SAMPLE_RATIO=0.1 harn orchestrator serve
+```
+
 ## Dashboard
 
 An example Grafana dashboard is available at


### PR DESCRIPTION
Closes burin-labs/harn#2989
Part of burin-labs/burin-code#1774

## Summary
- add `HARN_OTEL_SAMPLE_RATIO` parsing for OTLP trace export
- install a parent-based trace-id ratio sampler when the ratio is below 1.0
- document the env var and add a changelog fragment

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-launch-t07 cargo test -p harn-vm --features otel parse_sample_ratio`
- `cargo fmt --all --check`
- `git diff --check`
- `make lint-md`
- `make check-docs-snippets`
- pre-commit hook
- pre-push hook