### PR TITLE
fix(parse): flag truncated tool calls instead of a silent no-op stall

### DIFF
--- a/changelog.d/3016.fixed.md
+++ b/changelog.d/3016.fixed.md
@@ -1,0 +1,9 @@
+- **Truncated tool calls are flagged instead of silently stalling (#3016).**
+  When a model hit its output-token cap mid-argument while streaming a large
+  tool call, the closing `</tool_call>` never arrived; the parser treated the
+  unclosed open tag as an "unknown top-level tag" and the partial call body as
+  stray prose, so the turn produced zero tool calls and the agent loop stalled
+  (re-emitting until the stall detector fired, with no file written). The
+  tagged parser now detects an unclosed `<tool_call>` open, recovers the tool
+  name, and emits an actionable `TOOL CALL TRUNCATED … likely hit max output
+  token limit` error so the loop/model can react instead of silently looping.

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -126,6 +126,41 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                 Err(msg) => errors.push(msg),
             }
             cursor = after;
+        } else if let Some(open_len) = unclosed_tool_call_open(src, cursor) {
+            // A `<tool_call>` open tag with no matching `</tool_call>` anywhere
+            // ahead. This is the signature of an output truncated mid-tool-call
+            // — typically the model hit its `max_tokens` cap while emitting a
+            // large argument (e.g. a multi-hundred-line `edit({ content: … })`).
+            // Without this branch the open tag falls through to the generic
+            // "unknown top-level tag" path and the call body becomes "stray
+            // text", so the whole turn parses to zero tool calls and the agent
+            // loop silently stalls as if the model had only produced prose.
+            //
+            // Surface it as an actionable `error` (and recover the partial call
+            // name when possible) so the loop sees a truncated-tool-call signal
+            // rather than an empty text turn.
+            let body = &src[cursor + open_len..];
+            let recovered_name = leading_call_name(body, tools_val);
+            match recovered_name {
+                Some(name) => errors.push(format!(
+                    "TOOL CALL TRUNCATED: `<tool_call>` opening `{name}(...)` was never \
+                     closed — the response appears to have been cut off mid-call (likely \
+                     the model hit its max output token limit). Re-emit the complete \
+                     `<tool_call>{name}({{ ... }})</tool_call>` block; for very large \
+                     arguments, split the work into smaller calls."
+                )),
+                None => errors.push(
+                    "TOOL CALL TRUNCATED: a `<tool_call>` block was opened but never \
+                     closed — the response appears to have been cut off (likely the model \
+                     hit its max output token limit). Re-emit the complete \
+                     `<tool_call>name({ ... })</tool_call>` block, splitting very large \
+                     arguments into smaller calls if needed."
+                        .to_string(),
+                ),
+            }
+            // Consume the rest of the stream: everything after a truncated open
+            // tag is the unterminated call body, not further top-level blocks.
+            cursor = bytes.len();
         } else if let Some((body, after)) = match_block(src, cursor, "assistant_prose")
             .or_else(|| match_block(src, cursor, "assistantprose"))
         {
@@ -642,6 +677,53 @@ fn try_parse_angle_wrapped_call(
         "arguments": arguments,
     });
     Some((call, end))
+}
+
+/// If `cursor` sits on a `<tool_call>` / `<toolcall>` open tag that has no
+/// matching closing tag anywhere ahead in `src`, return the open tag's byte
+/// length. `None` when the cursor isn't on a tool-call open tag, or when the
+/// block is properly closed (the normal `match_block` path handles that).
+///
+/// This detects an output truncated mid-tool-call (the model hit its
+/// `max_tokens` cap while streaming a large argument), so the caller can emit
+/// a precise diagnostic instead of shredding the partial call into stray text.
+fn unclosed_tool_call_open(src: &str, cursor: usize) -> Option<usize> {
+    let rest = &src[cursor..];
+    let (open, close) = if rest.starts_with(&format!("<{TEXT_TOOL_CALL_TAG}>")) {
+        (
+            format!("<{TEXT_TOOL_CALL_TAG}>"),
+            format!("</{TEXT_TOOL_CALL_TAG}>"),
+        )
+    } else if rest.starts_with(&format!("<{TEXT_TOOL_CALL_TAG_COMPACT}>")) {
+        (
+            format!("<{TEXT_TOOL_CALL_TAG_COMPACT}>"),
+            format!("</{TEXT_TOOL_CALL_TAG_COMPACT}>"),
+        )
+    } else {
+        return None;
+    };
+    if src[cursor + open.len()..].contains(&close) {
+        return None;
+    }
+    Some(open.len())
+}
+
+/// Best-effort recovery of the tool name from a truncated `<tool_call>` body:
+/// the leading `name(` of an unterminated call, when `name` is a registered
+/// tool. Used only for a clearer truncation diagnostic — never to dispatch.
+fn leading_call_name(body: &str, tools_val: Option<&VmValue>) -> Option<String> {
+    let trimmed = body.trim_start();
+    let name_len = ident_length(trimmed.as_bytes())?;
+    if name_len == 0 || trimmed.as_bytes().get(name_len) != Some(&b'(') {
+        return None;
+    }
+    let name = &trimmed[..name_len];
+    let known: BTreeSet<String> = collect_tool_schemas(tools_val, None)
+        .into_iter()
+        .map(|schema| schema.name)
+        .chain(["ledger".to_string(), "load_skill".to_string()])
+        .collect();
+    known.contains(name).then(|| name.to_string())
 }
 
 fn is_top_level_tag_position(src: &str, cursor: usize) -> bool {

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -540,3 +540,66 @@ fn tagged_parser_accepts_configured_done_body() {
     assert_eq!(result.done_marker.as_deref(), Some("PLAN_READY"));
     assert!(result.violations.is_empty());
 }
+
+// Regression (#3011 follow-up): a large `<tool_call>edit({ content: … })`
+// turn that the model truncated mid-argument (it hit its max output token
+// limit before emitting `</tool_call>`). Before the fix the unclosed open
+// tag fell through to the generic "unknown top-level tag" path and the
+// `edit(...)` body became stray text, so the turn parsed to ZERO tool calls
+// and the agent loop silently stalled as if the model had produced only
+// prose. The parser must now surface an actionable TOOL CALL TRUNCATED
+// error (naming the recovered tool) instead of dropping the signal.
+#[test]
+fn tagged_parser_flags_truncated_unclosed_tool_call() {
+    let tools = sample_tool_registry();
+    // Prose, then an opened-but-never-closed tool call cut off mid-string.
+    let text = "Now I'll create the error module.\n\
+                <tool_call>\n\
+                edit({ action: \"create\", path: \"src/error.rs\", content: \"//! Unified storage error types.\\nuse std::io;\\n\
+                pub enum StorageError {\\n    IoError(";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    // The truncated call cannot be dispatched (the argument string is
+    // unterminated), so there are no recovered calls...
+    assert!(
+        result.calls.is_empty(),
+        "truncated call must not dispatch: {:?}",
+        result.calls
+    );
+    // ...but the loop must see a precise, recoverable truncation error that
+    // names the tool, NOT a generic "unknown top-level tag" / "stray text".
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.contains("TOOL CALL TRUNCATED") && e.contains("edit")),
+        "expected a TOOL CALL TRUNCATED error naming `edit`, got errors={:?} violations={:?}",
+        result.errors,
+        result.violations
+    );
+    assert!(
+        !result
+            .violations
+            .iter()
+            .any(|v| v.contains("Unknown top-level tag")),
+        "must not misreport the truncated open tag as an unknown tag: {:?}",
+        result.violations
+    );
+}
+
+// A properly closed `<tool_call>` is unaffected by the truncation branch:
+// it still parses and dispatches normally.
+#[test]
+fn tagged_parser_closed_tool_call_unaffected_by_truncation_branch() {
+    let tools = sample_tool_registry();
+    let text =
+        "<tool_call>\nedit({ action: \"create\", path: \"a.rs\", content: \"x\" })\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors={:?}", result.errors);
+    assert_eq!(result.calls[0]["name"], json!("edit"));
+    assert!(
+        !result.errors.iter().any(|e| e.contains("TRUNCATED")),
+        "closed call must not be flagged as truncated: {:?}",
+        result.errors
+    );
+}


### PR DESCRIPTION
## Problem

When a model hits its output-token cap **mid-argument** while streaming a large tool call, the closing `</tool_call>` (wire: `[[/CALL]]`) never arrives. `match_block` then fails to find the closer, so the unclosed `<tool_call>` open tag fell through to the generic *"unknown top-level tag"* branch and the partial `edit(...)` body became stray prose — yielding **zero recovered calls**. The agent loop treated the turn as prose-only and **stalled**, re-emitting the same truncated call until the stall detector fired, **with no file ever written**.

Found by adversarially root-causing a local-model `rust-refactor` eval where a large `edit(create)` silently failed to dispatch. Confirmed: complete input always parses byte-exact through the streaming `DeltaCanonicalizer`; the drop reproduces only when the closer is removed (i.e. truncation). Small edits fit under the cap and close fine; the large edit didn't.

## Fix

The tagged parser now detects an unclosed `<tool_call>`/`<toolcall>` open with no closer ahead, recovers the tool name from the partial body, and emits an actionable `TOOL CALL TRUNCATED … was never closed (likely hit max output token limit)` **error** (consuming the rest of the stream) — so the loop/model gets a real signal instead of silently looping. Properly-closed calls and genuine unknown tags are untouched.

2 regression tests (`tagged_parser_flags_truncated_unclosed_tool_call`, `tagged_parser_closed_tool_call_unaffected_by_truncation_branch`). `cargo test -p harn-vm --lib llm` → all pass; clippy clean.

Complementary follow-ups (not in this PR): loop-level handling of `finish_reason == "length"`, and raising the eval's per-turn `max_tokens` for large-edit scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)