### PR TITLE
Add ACP staged-fs discard method

### DIFF
--- a/changelog.d/3017.added.md
+++ b/changelog.d/3017.added.md
@@ -1,0 +1,4 @@
+- **ACP staged-fs discard (#3017).** ACP clients can now call
+  `session/fs_discard_staged` to drop all pending staged filesystem writes, or
+  only selected `paths`, using the same session-scoped hostlib staged-FS store
+  as `session/fs_commit_staged`.

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts.rs
@@ -79,6 +79,7 @@ const ACP_DISPATCHED_METHODS: &[&str] = &[
     "session/set_config_option",
     "session/fs_mode",
     "session/fs_commit_staged",
+    "session/fs_discard_staged",
     "session/restore_tool_call",
     "session/prompt",
     "session/cancel",

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -162,6 +162,20 @@ fn session_id_param(params: &serde_json::Value) -> Option<String> {
     string_param(params, "sessionId", "session_id")
 }
 
+fn staged_fs_paths_param(params: &serde_json::Value) -> Vec<String> {
+    params
+        .get("paths")
+        .and_then(serde_json::Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn parse_session_timeline_query(
     params: &serde_json::Value,
 ) -> Result<harn_vm::session_timeline::SessionTimelineQuery, String> {
@@ -3498,30 +3512,16 @@ impl AcpServer {
         id: &serde_json::Value,
         params: &serde_json::Value,
     ) {
-        let Some(session_id) = params
-            .get("sessionId")
-            .or_else(|| params.get("session_id"))
-            .and_then(serde_json::Value::as_str)
-        else {
+        let Some(session_id) = session_id_param(params) else {
             self.send_error(id, -32602, "session/fs_commit_staged requires sessionId");
             return;
         };
-        if !self.sessions.contains_key(session_id) {
+        if !self.sessions.contains_key(session_id.as_str()) {
             self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
             return;
         }
-        let paths = params
-            .get("paths")
-            .and_then(serde_json::Value::as_array)
-            .map(|values| {
-                values
-                    .iter()
-                    .filter_map(serde_json::Value::as_str)
-                    .map(str::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-        match harn_hostlib::fs::commit_staged(session_id, &paths) {
+        let paths = staged_fs_paths_param(params);
+        match harn_hostlib::fs::commit_staged(session_id.as_str(), &paths) {
             Ok(result) => {
                 self.send_response(
                     id,
@@ -3537,7 +3537,7 @@ impl AcpServer {
                             .collect::<Vec<_>>(),
                     }),
                 );
-                self.emit_staged_writes_update(session_id);
+                self.emit_staged_writes_update(session_id.as_str());
             }
             Err(error) => self.send_error(id, -32000, &error.to_string()),
         }
@@ -3553,6 +3553,48 @@ impl AcpServer {
             id,
             -32601,
             "session/fs_commit_staged requires the hostlib feature",
+        );
+    }
+
+    #[cfg(feature = "hostlib")]
+    fn handle_session_fs_discard_staged(
+        &mut self,
+        id: &serde_json::Value,
+        params: &serde_json::Value,
+    ) {
+        let Some(session_id) = session_id_param(params) else {
+            self.send_error(id, -32602, "session/fs_discard_staged requires sessionId");
+            return;
+        };
+        if !self.sessions.contains_key(session_id.as_str()) {
+            self.send_error(id, -32602, &format!("Unknown session: {session_id}"));
+            return;
+        }
+        let paths = staged_fs_paths_param(params);
+        match harn_hostlib::fs::discard_staged(session_id.as_str(), &paths) {
+            Ok(result) => {
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "discardedPaths": result.discarded_paths,
+                    }),
+                );
+                self.emit_staged_writes_update(session_id.as_str());
+            }
+            Err(error) => self.send_error(id, -32000, &error.to_string()),
+        }
+    }
+
+    #[cfg(not(feature = "hostlib"))]
+    fn handle_session_fs_discard_staged(
+        &mut self,
+        id: &serde_json::Value,
+        _params: &serde_json::Value,
+    ) {
+        self.send_error(
+            id,
+            -32601,
+            "session/fs_discard_staged requires the hostlib feature",
         );
     }
 
@@ -3966,6 +4008,12 @@ impl AcpServer {
                     return;
                 }
                 self.handle_session_fs_commit_staged(&id, &params);
+            }
+            "session/fs_discard_staged" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_session_fs_discard_staged(&id, &params);
             }
             "session/restore_tool_call" => {
                 if self.reject_unauthenticated(&id) {

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -1047,7 +1047,7 @@ async fn session_inject_rejects_cross_actor_mutation() {
 
 #[cfg(feature = "hostlib")]
 #[tokio::test(flavor = "current_thread")]
-async fn acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes() {
+async fn acp_fs_mode_commit_and_discard_staged_hostlib_writes() {
     use harn_hostlib::{
         tools::{permissions, ToolsCapability},
         BuiltinRegistry, HostlibCapability,
@@ -1057,7 +1057,8 @@ async fn acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes() {
     permissions::enable_for_test();
 
     let dir = tempfile::TempDir::new().unwrap();
-    let file = dir.path().join("draft.txt");
+    let committed_file = dir.path().join("draft.txt");
+    let discarded_file = dir.path().join("discard.txt");
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut server = AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
 
@@ -1098,27 +1099,68 @@ async fn acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes() {
 
     let mut registry = BuiltinRegistry::new();
     ToolsCapability.register_builtins(&mut registry);
-    let mut args = BTreeMap::new();
-    args.insert(
-        "session_id".to_string(),
-        VmValue::String(Arc::from(session_id.as_str())),
+    let stage_write = |path: &std::path::Path, content: &str| {
+        let mut args = BTreeMap::new();
+        args.insert(
+            "session_id".to_string(),
+            VmValue::String(Arc::from(session_id.as_str())),
+        );
+        args.insert(
+            "path".to_string(),
+            VmValue::String(Arc::from(path.to_string_lossy().as_ref())),
+        );
+        args.insert("content".to_string(), VmValue::String(Arc::from(content)));
+        (registry
+            .find("hostlib_tools_write_file")
+            .expect("write_file builtin")
+            .handler)(&[VmValue::Dict(Arc::new(args))])
+        .expect("stage write");
+    };
+    stage_write(&committed_file, "draft");
+    stage_write(&discarded_file, "scratch");
+    assert!(
+        !committed_file.exists(),
+        "ACP staged mode should defer disk writes"
     );
-    args.insert(
-        "path".to_string(),
-        VmValue::String(Arc::from(file.to_string_lossy().as_ref())),
+    assert!(
+        !discarded_file.exists(),
+        "ACP staged mode should defer disk writes"
     );
-    args.insert("content".to_string(), VmValue::String(Arc::from("draft")));
-    (registry
-        .find("hostlib_tools_write_file")
-        .expect("write_file builtin")
-        .handler)(&[VmValue::Dict(Arc::new(args))])
-    .expect("stage write");
-    assert!(!file.exists(), "ACP staged mode should defer disk writes");
 
     server
         .handle_incoming_message(serde_json::json!({
             "jsonrpc": "2.0",
             "id": 3,
+            "method": "session/fs_discard_staged",
+            "params": {
+                "sessionId": session_id.clone(),
+                "paths": [discarded_file.to_string_lossy()],
+            },
+        }))
+        .await;
+    let discard_response = recv_json(&mut rx).await;
+    assert_eq!(
+        discard_response["result"]["discardedPaths"],
+        serde_json::json!([discarded_file.to_string_lossy()])
+    );
+    assert!(
+        !discarded_file.exists(),
+        "discarding a staged write must not touch disk"
+    );
+    let discard_update = recv_json(&mut rx).await;
+    assert_eq!(
+        discard_update["params"]["update"]["_meta"]["harn"]["kind"],
+        "staged_writes_pending"
+    );
+    assert_eq!(
+        discard_update["params"]["update"]["_meta"]["harn"]["pendingCount"],
+        1
+    );
+
+    server
+        .handle_incoming_message(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "session/fs_commit_staged",
             "params": {"sessionId": session_id.clone()},
         }))
@@ -1131,7 +1173,11 @@ async fn acp_fs_mode_and_commit_staged_apply_deferred_hostlib_writes() {
             .len(),
         1
     );
-    assert_eq!(std::fs::read_to_string(&file).unwrap(), "draft");
+    assert_eq!(std::fs::read_to_string(&committed_file).unwrap(), "draft");
+    assert!(
+        !discarded_file.exists(),
+        "discarded staged writes stay absent"
+    );
 
     let commit_update = recv_json(&mut rx).await;
     assert_eq!(

--- a/docs/src/hostlib/staged-fs.md
+++ b/docs/src/hostlib/staged-fs.md
@@ -44,6 +44,7 @@ The ACP adapter exposes host controls for the same state:
 
 - `session/fs_mode` with `{ sessionId, mode }`
 - `session/fs_commit_staged` with `{ sessionId, paths? }`
+- `session/fs_discard_staged` with `{ sessionId, paths? }`
 
 Every staging mutation emits a `session/update` progress extension with
 `_meta.harn.kind = "staged_writes_pending"`, `_meta.harn.pendingCount`,

--- a/spec/protocol-artifacts/harn-protocol.rs
+++ b/spec/protocol-artifacts/harn-protocol.rs
@@ -69,6 +69,7 @@ pub const ACP_DISPATCHED_METHOD_SESSION_SET_MODE: &str = "session/set_mode";
 pub const ACP_DISPATCHED_METHOD_SESSION_SET_CONFIG_OPTION: &str = "session/set_config_option";
 pub const ACP_DISPATCHED_METHOD_SESSION_FS_MODE: &str = "session/fs_mode";
 pub const ACP_DISPATCHED_METHOD_SESSION_FS_COMMIT_STAGED: &str = "session/fs_commit_staged";
+pub const ACP_DISPATCHED_METHOD_SESSION_FS_DISCARD_STAGED: &str = "session/fs_discard_staged";
 pub const ACP_DISPATCHED_METHOD_SESSION_RESTORE_TOOL_CALL: &str = "session/restore_tool_call";
 pub const ACP_DISPATCHED_METHOD_SESSION_PROMPT: &str = "session/prompt";
 pub const ACP_DISPATCHED_METHOD_SESSION_CANCEL: &str = "session/cancel";
@@ -117,6 +118,7 @@ pub const ACP_DISPATCHED_METHODS: &[&str] = &[
     "session/set_config_option",
     "session/fs_mode",
     "session/fs_commit_staged",
+    "session/fs_discard_staged",
     "session/restore_tool_call",
     "session/prompt",
     "session/cancel",


### PR DESCRIPTION
## Summary
- add ACP `session/fs_discard_staged` beside `session/fs_commit_staged`
- reuse shared staged-FS path parsing and hostlib `discard_staged`
- emit staged-writes progress updates after discard and publish the Rust protocol method constant
- update staged-FS docs and changelog fragment

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-1560-discard-acp RUSTC_WRAPPER= cargo test -p harn-serve --features hostlib acp_fs_mode_commit_and_discard_staged_hostlib_writes -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-1560-discard-acp RUSTC_WRAPPER= make gen-protocol-artifacts`
- `CARGO_TARGET_DIR=/tmp/harn-target-1560-discard-acp RUSTC_WRAPPER= make check-protocol-artifacts`
- `CARGO_TARGET_DIR=/tmp/harn-target-1560-discard-acp RUSTC_WRAPPER= cargo test -p harn-cli dispatched_acp_methods_match_artifact -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-1560-discard-acp RUSTC_WRAPPER= cargo clippy -p harn-serve -p harn-cli --features harn-serve/hostlib --all-targets -- -D warnings`
- `npx --yes markdownlint-cli2 docs/src/hostlib/staged-fs.md changelog.d/3016.added.md`
- `CARGO_TARGET_DIR=/tmp/harn-target-1560-discard-acp RUSTC_WRAPPER= make check-bindings`
- repo pre-commit hook
- repo pre-push hook