### PR TITLE
fix(agent): emit a final wrap-up turn on loop exhaustion so runs end with a sentinel

### DIFF
--- a/changelog.d/agent-loop-wrapup.fixed.md
+++ b/changelog.d/agent-loop-wrapup.fixed.md
@@ -1,0 +1,12 @@
+- **Agent loop now emits a final wrap-up turn on budget/iteration exhaustion.**
+  When the loop terminated because it ran out of iterations or budget *while the
+  model was still calling tools*, the surfaced final assistant text was whatever
+  the last tool-call turn produced — a dangling tool call with no clean
+  `<user_response>` or completion sentinel, so output-contract / done-sentinel
+  checks failed even when the work succeeded. The loop now fires exactly one
+  tool-less LLM call on exhaustion/cap (`budget_exhausted` / `verify_capped` /
+  `verify_exhausted` / `stuck`) to elicit the model's final answer + sentinel and
+  records it as the final assistant response, so the run ends with a real summary
+  instead of a dangling tool call. The wrap-up never changes
+  `final_status`/`stop_reason`, is skipped on clean completion / suspension /
+  terminal errors, and is opt-out via `final_wrapup: false`.

--- a/crates/harn-stdlib/src/stdlib/agent/chat.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/chat.harn
@@ -55,6 +55,7 @@ fn __chat_agent_option_keys() {
     "verify_completion_judge",
     "done_judge",
     "done_sentinel",
+    "final_wrapup",
     "max_verify_attempts",
     "llm_retries",
     "llm_backoff_ms",

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -64,7 +64,7 @@ import {
 import { omit } from "std/json"
 import { llm_call_options } from "std/llm/options"
 
-/*
+/**
  * Pipeline entrypoints execute agent loops without a lexical `Harness` binding,
  * so loop budget timing uses the ambient builtins that share the VM clock backend.
  */
@@ -1637,6 +1637,108 @@ fn __agent_loop_pop_structural_veto_turn(session_id) {
   return agent_session_pop_last_assistant(session_id)
 }
 
+/**
+ * Build the one-shot directive injected as a final system fragment when the
+ * loop terminates mid-tool-use. It tells the model the turn/budget is spent,
+ * that no more tool calls are possible, and how to wrap up — honoring the
+ * configured `done_sentinel` when present.
+ */
+fn __agent_loop_wrapup_directive(opts) {
+  let sentinel = opts?.done_sentinel
+  let base = "You have reached your turn/budget limit and cannot call any more tools. "
+    + "Provide your final answer now: briefly summarize what you accomplished and what you "
+    + "verified. Do not emit any tool call."
+  if sentinel == nil || to_string(sentinel) == "" {
+    return base
+      + " End with a concise `<user_response>...</user_response>` containing the final answer."
+  }
+  let tag = to_string(sentinel)
+  return base
+    + " Emit a concise `<user_response>...</user_response>` with the final answer, then end with "
+    + "`<done>"
+    + tag
+    + "</done>` exactly, as instructed by the response protocol."
+}
+
+/**
+ * True when the loop's terminal status is an exhaustion/cap (not a clean
+ * `done`, a suspension, a scope alert, or a hard provider/terminal error).
+ * These are the states where the model never produced a clean terminal
+ * response and a wrap-up turn is warranted.
+ */
+fn __agent_loop_wrapup_eligible_status(final_status) {
+  return final_status == "budget_exhausted"
+    || final_status == "verify_capped"
+    || final_status == "verify_exhausted"
+    || final_status == "stuck"
+}
+
+/**
+ * Forced terminal wrap-up turn. When the loop exits on exhaustion/cap while the
+ * last turn still called tools, the surfaced final text would otherwise be a
+ * dangling tool-call turn with no clean `<user_response>`/sentinel. This runs
+ * exactly one extra LLM call with tools DISABLED to elicit the model's final
+ * user-facing answer + completion sentinel, records it as the final assistant
+ * turn so `agent_session_finalize` surfaces it, and never mutates
+ * `final_status`/`stop_reason`. Defensive: any error falls back to existing
+ * behavior. Returns true when a wrap-up response was recorded.
+ */
+fn __agent_loop_final_wrapup(message, session, opts, final_status, stop_reason, iteration) {
+  let directive = __agent_loop_wrapup_directive(opts)
+  // Disable tools for this turn so the model cannot dispatch: empty tool
+  // surface + a system directive forbidding tool calls. Carry the tool format
+  // forward so the response protocol still matches what the model was trained
+  // on this run.
+  let wrapup_opts = opts
+    + {
+    tools: nil,
+    active_skills: nil,
+    skill_catalog_prompt: "",
+    _progress_tool_system_prompt_nudge: "",
+    transcript_projection: opts?.transcript_projection,
+  }
+  let base_fragments = agent_build_turn_system_fragments(session, wrapup_opts, iteration)
+  var turn_system_parts = []
+  for fragment in base_fragments {
+    turn_system_parts = turn_system_parts.push(fragment.body)
+  }
+  turn_system_parts = turn_system_parts.push(directive)
+  let turn_system = join(turn_system_parts, "\n\n")
+  let turn_messages = agent_build_turn_messages(session, wrapup_opts, iteration)
+  let llm_overrides = wrapup_opts?.llm_options ?? {}
+  let llm_opts = wrapup_opts
+    + llm_overrides
+    + {
+    messages: turn_messages,
+    session_id: session.session_id,
+    tool_format: wrapup_opts?.tool_format,
+    tools: nil,
+    _iteration: iteration + 1,
+    _final_wrapup: true,
+  }
+  let call = __invoke_llm(message, turn_system, llm_opts)
+  if !call.ok {
+    return false
+  }
+  let llm_result = call.value
+  let raw_text = llm_result?.text ?? ""
+  let parsed = agent_parse_tool_calls(raw_text, nil)
+  let visible_text = __visible_text(parsed, raw_text)
+  if to_string(visible_text) == "" {
+    return false
+  }
+  let normalized = llm_result + {text: visible_text, visible_text: visible_text}
+  agent_session_record_assistant(session.session_id, normalized)
+  let _ = try {
+    agent_emit_event(
+      session.session_id,
+      "final_wrapup",
+      {final_status: final_status, stop_reason: stop_reason ?? "", iteration: iteration},
+    )
+  }
+  return true
+}
+
 @complexity(allow)
 fn __agent_loop_run(message, session, initial_opts) {
   var opts = initial_opts
@@ -2423,6 +2525,16 @@ fn __agent_loop_run(message, session, initial_opts) {
       __agent_loop_emit_budget_exhausted(session.session_id, terminal_exhaustion)
       budget_exhausted_emitted = true
       budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, terminal_exhaustion.kind)
+    }
+    let wrapup_enabled = opts?.final_wrapup ?? true
+    if wrapup_enabled
+      && suspend_result == nil
+      && terminal_error == nil
+      && last_tool_count > 0
+      && __agent_loop_wrapup_eligible_status(final_status) {
+      let _ = try {
+        __agent_loop_final_wrapup(message, session, opts, final_status, stop_reason, iteration)
+      }
     }
     if opts?.daemon && final_status != "" {
       agent_daemon_snapshot(session, opts, final_status, iteration)

--- a/crates/harn-vm/tests/agent_loop_final_wrapup.rs
+++ b/crates/harn-vm/tests/agent_loop_final_wrapup.rs
@@ -1,0 +1,257 @@
+#![recursion_limit = "256"]
+//! Coverage for the forced terminal wrap-up turn (agent-loop-wrapup).
+//!
+//! When the agent loop terminates on iteration/budget exhaustion *while the
+//! model was still calling tools*, the surfaced final text would otherwise be
+//! a dangling tool-call turn with no clean `<user_response>` + completion
+//! sentinel. The loop now fires exactly one tool-less LLM call to elicit a real
+//! final answer, records it, and surfaces it as the run's `text`.
+//!
+//! These tests stub the LLM via the `llm_caller` seam (mirroring
+//! `agent_loop_steering_seams.rs`) and count calls / inspect surfaced text to
+//! prove:
+//!   (a) exhaustion mid-tool-use fires the wrap-up and the sentinel lands;
+//!   (b) a natural `done` exit fires NO wrap-up;
+//!   (c) `final_wrapup: false` disables it.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+
+use harn_vm::bridge::HostBridge;
+use harn_vm::value::VmError;
+
+fn run_with_bridge(source: &str) -> Result<String, String> {
+    harn_vm::reset_thread_local_state();
+    let chunk = harn_vm::compile_source(source)?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())?;
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let bridge = Arc::new(HostBridge::from_parts(
+                    Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(Mutex::new(())),
+                    1,
+                ));
+                harn_vm::llm::install_current_host_bridge(bridge.clone());
+                let mut vm = harn_vm::Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                let result = vm
+                    .execute(&chunk)
+                    .await
+                    .map_err(|e: VmError| format!("{e:?}"));
+                harn_vm::llm::clear_current_host_bridge();
+                result?;
+                Ok(vm.output().to_string())
+            })
+            .await
+    })
+}
+
+fn out_lines(raw: &str) -> Vec<String> {
+    raw.lines()
+        .filter_map(|l| l.strip_prefix("[harn] "))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Pipeline whose stub LLM always emits a tool call until `max_iterations`
+/// runs out. The stub distinguishes the wrap-up call via the `_final_wrapup`
+/// flag the loop sets on `llm_opts`; on that call it returns a clean
+/// `<user_response>` + `<done>` sentinel. Logs:
+///   1. result.status
+///   2. number of tool-calling (loop) LLM calls
+///   3. number of wrap-up LLM calls (0 or 1)
+///   4. whether result.text carries the wrap-up summary (the `<user_response>`
+///      body; the `<done>` sentinel itself is stripped from surfaced text by
+///      the response-protocol sanitizer, exactly as for a natural `done` turn)
+fn exhaustion_pipeline(session_id: &str, final_wrapup_opt: &str) -> String {
+    format!(
+        r#"
+pipeline main(task) {{
+  clear_tool_hooks()
+  let registry = tool_registry()
+  let tools = tool_define(
+    registry,
+    "keep_exploring",
+    "Test stand-in for a tool the model keeps calling.",
+    {{parameters: {{}}, handler: {{ _args -> return "explored" }}}},
+  )
+  let tool_calls_counter = shared_cell(
+    {{scope: "task_group", key: "wrapup-tool-calls-{session_id}", initial: 0}},
+  )
+  let wrapup_counter = shared_cell(
+    {{scope: "task_group", key: "wrapup-final-calls-{session_id}", initial: 0}},
+  )
+  let mock_llm = {{ _call ->
+    if _call?.opts?._final_wrapup == true {{
+      let wsnap = shared_snapshot(wrapup_counter)
+      shared_cas(wrapup_counter, wsnap, wsnap.value + 1)
+      return {{
+        ok: true,
+        value: {{
+          text: "<user_response>Refactored the parser and ran the tests.</user_response>\n<done>FINISHED</done>",
+          tool_calls: [],
+          provider: "mock",
+          model: "mock",
+        }},
+      }}
+    }}
+    let snap = shared_snapshot(tool_calls_counter)
+    shared_cas(tool_calls_counter, snap, snap.value + 1)
+    return {{
+      ok: true,
+      value: {{
+        text: "",
+        tool_calls: [{{id: "call_explore", name: "keep_exploring", arguments: {{}}}}],
+        provider: "mock",
+        model: "mock",
+      }},
+    }}
+  }}
+  let result = agent_loop(
+    "do the work",
+    nil,
+    {{
+      provider: "mock",
+      tools: tools,
+      tool_format: "native",
+      max_iterations: 3,
+      loop_until_done: true,
+      done_sentinel: "FINISHED",
+      session_id: "{session_id}",
+      llm_caller: mock_llm,
+{final_wrapup_opt}
+    }},
+  )
+  log(result.status)
+  log(shared_get(tool_calls_counter))
+  log(shared_get(wrapup_counter))
+  log(contains(result.text, "Refactored the parser"))
+}}
+"#
+    )
+}
+
+/// Pipeline whose stub LLM finishes cleanly on the first turn (no tool call,
+/// emits the sentinel). The natural `done` exit must NOT trigger a wrap-up.
+fn clean_done_pipeline(session_id: &str) -> String {
+    format!(
+        r#"
+pipeline main(task) {{
+  clear_tool_hooks()
+  let wrapup_counter = shared_cell(
+    {{scope: "task_group", key: "clean-done-wrapup-{session_id}", initial: 0}},
+  )
+  let mock_llm = {{ _call ->
+    if _call?.opts?._final_wrapup == true {{
+      let wsnap = shared_snapshot(wrapup_counter)
+      shared_cas(wrapup_counter, wsnap, wsnap.value + 1)
+    }}
+    return {{
+      ok: true,
+      value: {{
+        text: "<user_response>All done.</user_response>\n<done>FINISHED</done>",
+        tool_calls: [],
+        provider: "mock",
+        model: "mock",
+      }},
+    }}
+  }}
+  let result = agent_loop(
+    "do the work",
+    nil,
+    {{
+      provider: "mock",
+      max_iterations: 3,
+      loop_until_done: true,
+      done_sentinel: "FINISHED",
+      session_id: "{session_id}",
+      llm_caller: mock_llm,
+    }},
+  )
+  log(result.status)
+  log(shared_get(wrapup_counter))
+  log(contains(result.text, "All done."))
+}}
+"#
+    )
+}
+
+#[test]
+fn exhaustion_mid_tool_use_fires_wrapup_and_surfaces_sentinel() {
+    let raw =
+        run_with_bridge(&exhaustion_pipeline("wrapup-exhaustion", "")).expect("script must run");
+    let lines = out_lines(&raw);
+    // The loop exhausted iterations while still calling tools.
+    assert_eq!(
+        lines[0], "budget_exhausted",
+        "expected budget_exhausted; lines: {lines:?}"
+    );
+    // Three tool-calling loop turns (max_iterations = 3).
+    assert_eq!(
+        lines[1], "3",
+        "expected three loop LLM calls; lines: {lines:?}"
+    );
+    // Exactly one wrap-up call.
+    assert_eq!(
+        lines[2], "1",
+        "expected exactly one wrap-up LLM call; lines: {lines:?}"
+    );
+    // The surfaced final text is the wrap-up summary, not the dangling
+    // tool-call turn.
+    assert_eq!(
+        lines[3], "true",
+        "expected surfaced text to contain the wrap-up summary; lines: {lines:?}"
+    );
+}
+
+#[test]
+fn clean_done_exit_does_not_fire_wrapup() {
+    let raw = run_with_bridge(&clean_done_pipeline("wrapup-clean-done")).expect("script must run");
+    let lines = out_lines(&raw);
+    assert_eq!(lines[0], "done", "expected done; lines: {lines:?}");
+    // No wrap-up call — the model already produced a clean terminal turn.
+    assert_eq!(
+        lines[1], "0",
+        "expected zero wrap-up calls on a clean done; lines: {lines:?}"
+    );
+    // The naturally produced text is surfaced as-is.
+    assert_eq!(
+        lines[2], "true",
+        "expected surfaced text to contain the natural final answer; lines: {lines:?}"
+    );
+}
+
+#[test]
+fn final_wrapup_false_disables_the_wrapup_turn() {
+    let raw = run_with_bridge(&exhaustion_pipeline(
+        "wrapup-disabled",
+        "      final_wrapup: false,",
+    ))
+    .expect("script must run");
+    let lines = out_lines(&raw);
+    assert_eq!(
+        lines[0], "budget_exhausted",
+        "expected budget_exhausted; lines: {lines:?}"
+    );
+    assert_eq!(
+        lines[1], "3",
+        "expected three loop LLM calls; lines: {lines:?}"
+    );
+    // Wrap-up is opted out — no extra call.
+    assert_eq!(
+        lines[2], "0",
+        "expected zero wrap-up calls when final_wrapup:false; lines: {lines:?}"
+    );
+    // Without a wrap-up, the surfaced text is the dangling tool-call turn,
+    // which carries no summary.
+    assert_eq!(
+        lines[3], "false",
+        "expected no wrap-up summary in surfaced text when disabled; lines: {lines:?}"
+    );
+}


### PR DESCRIPTION
## Problem

The agent loop only completes *cleanly* on a **tool-call-free turn** (`tool_count == 0` → `agent_compute_post_turn` → `agent_verify_or_continue` → `final_status = "done"`). When it instead terminates on **iteration/budget exhaustion or a verify cap while the model is still calling tools**, it just `break`s — there is **no terminal LLM turn**. The surfaced final assistant text is then whatever the last *tool-call* turn produced: a dangling tool call with no clean `<user_response>` and no completion sentinel.

Consequence: any output-contract / done-sentinel check fails **even when the underlying work succeeded** — the run did the job but never got to declare it. (Root-caused while chasing why capable models that verifiably pass a task still fail the eval completion contract: they keep exploring until the turn/budget cap and never emit a terminal turn.)

## Fix

After the `while` loop exits on an **eligible terminal status** (`budget_exhausted`, `verify_capped`, `verify_exhausted`, `stuck`) with `last_tool_count > 0`, no suspension, and no hard terminal error, run **exactly one** extra LLM call with **tools disabled** to elicit the model's final user-facing answer + completion sentinel, and record it via `agent_session_record_assistant` so `agent_session_finalize` surfaces it as `text`/`visible_text`.

Properties:
- **Opt-out** via `final_wrapup: false` (default on); the key is threaded through `agent_chat`'s option allowlist.
- **Tools structurally disabled**: the wrap-up builds an empty tool surface (`tools: nil`) + a directive forbidding tool calls, and it only *parses* the response for visible text — it never dispatches, so no tool can run regardless of model output.
- **Honors `done_sentinel`**: when configured, the directive instructs `<user_response>…</user_response>` then `<done>{sentinel}</done>` exactly, per the response protocol. The `<done>` sentinel is stripped from surfaced text by `sanitize_visible_assistant_text`, identical to a natural `done` turn.
- **Non-invasive**: never mutates `final_status`/`stop_reason` (the run still terminated due to exhaustion — this only supplies a clean final message). Fully wrapped in `try {}`; any error falls back to existing behavior.
- **Bounded**: exactly one call, no looping, cannot re-trigger exhaustion handling.

This is also a product-UX improvement beyond evals: an agent that runs out of budget now ends with a real summary of what it did and verified, instead of a dangling tool call.

## Tests

New `crates/harn-vm/tests/agent_loop_final_wrapup.rs` (3 integration tests, existing `llm_caller`/`shared_cell` stub harness — mirrors `agent_loop_steering_seams.rs`):
- exhaustion mid-tool-use → 3 loop calls + exactly 1 wrap-up call; surfaced text carries the wrap-up summary.
- clean `done` exit → 0 wrap-up calls; natural text surfaced.
- `final_wrapup: false` → 0 wrap-up calls.

`cargo test -p harn-vm agent` → 221 passed / 0 failed (lib suite compiles `loop.harn` through the VM). `agent_loop_steering_seams` (4) + `agent_sessions` (25) unaffected. `cargo clippy -p harn-vm --tests` clean; `harn fmt --check` clean on both edited `.harn` files; `harn lint` introduces zero new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)