### PR TITLE
Add release binary size gate

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -13,8 +13,9 @@ name: Build release binaries
 #      Skips sign/notarize/package/upload/release/container.
 #
 #      The setup job below short-circuits this mode unless the push
-#      changed Cargo.lock, any **/Cargo.toml, rust-toolchain.toml, or
-#      this workflow. The Cargo files are exactly the inputs Swatinem
+#      changed Cargo.lock, any **/Cargo.toml, rust-toolchain.toml, this
+#      workflow, or the binary-size gate script. The Cargo files are exactly
+#      the inputs Swatinem
 #      hashes into its exact cache key, and workflow edits can change
 #      runner labels, cache topology, or build flags without changing
 #      Cargo inputs. Re-warm in both cases so the next tag does not pay
@@ -137,7 +138,7 @@ jobs:
             # changed something that rotates Swatinem's exact cache key.
             # For non-keying pushes the previous warm cache is still good
             # and a rebuild adds no signal.
-            CHANGED_KEYING_FILES="$(git diff --name-only HEAD^ HEAD -- Cargo.lock Cargo.toml '**/Cargo.toml' rust-toolchain.toml .github/workflows/build-release-binaries.yml 2>/dev/null || true)"
+            CHANGED_KEYING_FILES="$(git diff --name-only HEAD^ HEAD -- Cargo.lock Cargo.toml '**/Cargo.toml' rust-toolchain.toml scripts/check_binary_size.sh .github/workflows/build-release-binaries.yml 2>/dev/null || true)"
             if [[ -n "$CHANGED_KEYING_FILES" ]]; then
               SHOULD_BUILD_BINARIES=true
               VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
@@ -146,7 +147,7 @@ jobs:
               echo "::notice::Building release binaries to populate the per-target Swatinem rust-cache on main. No sign/notarize/package/upload/release/container."
             else
               VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
-              echo "::notice::Push to main did not change Cargo.lock / Cargo.toml / **/Cargo.toml / rust-toolchain.toml / build-release-binaries.yml — existing warm cache still keys cleanly. Skipping build matrix."
+              echo "::notice::Push to main did not change Cargo.lock / Cargo.toml / **/Cargo.toml / rust-toolchain.toml / scripts/check_binary_size.sh / build-release-binaries.yml — existing warm cache still keys cleanly. Skipping build matrix."
             fi
           else
             VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
@@ -364,6 +365,12 @@ jobs:
           cache-bin: false
           save-if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' }}
 
+      - name: Install cargo-bloat
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: taiki-e/install-action@8f531eaecd1898bc3da7d104ad91bee98d1b97bd # v2.79.9
+        with:
+          tool: cargo-bloat
+
       - name: Add cross-compile target to pinned toolchain
         run: |
           # rust-toolchain.toml pins the channel; `rustup show` triggers install
@@ -570,6 +577,22 @@ jobs:
           cp dist/harn.exe dist/harn-dap.exe
           cd dist
           7z a "harn-${{ matrix.target }}.zip" harn.exe harn-dap.exe harn-lsp.exe
+
+      - name: Check binary size
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        env:
+          BINARY_SIZE_REPORT_DIR: dist/binary-size-${{ matrix.target }}
+          HARN_RELEASE_TARGET: ${{ matrix.target }}
+        run: ./scripts/check_binary_size.sh --no-build --target "$HARN_RELEASE_TARGET"
+
+      - name: Upload binary-size report
+        if: always() && matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: harn-binary-size-${{ matrix.target }}
+          path: dist/binary-size-${{ matrix.target }}
+          if-no-files-found: ignore
 
       - name: Upload artifact (unix)
         if: needs.setup.outputs.is_release == 'true' && runner.os != 'Windows'

--- a/changelog.d/2992.added.md
+++ b/changelog.d/2992.added.md
@@ -1,0 +1,2 @@
+- Added a release binary-size gate for the shipped `harn` binary, including a
+  `cargo bloat` report artifact for release-build runs.

--- a/scripts/check_binary_size.sh
+++ b/scripts/check_binary_size.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Build-or-check the shipped harn release binary against a size budget and
+# write a cargo-bloat report for follow-up analysis.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+build_release=1
+target="${HARN_RELEASE_TARGET:-}"
+harn_bin="${HARN_BIN:-}"
+budget_mb="${BINARY_SIZE_BUDGET_MB:-185}"
+report_dir="${BINARY_SIZE_REPORT_DIR:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check_binary_size.sh [options]
+
+Build the release harn binary with symbol stripping enabled, assert it stays
+below the configured size budget, and emit a cargo-bloat top-crates report.
+
+Options:
+  --no-build           Check an already-built release binary
+  --target TARGET      Cargo target triple to build/check
+  --bin PATH           Override the harn binary path
+  --budget-mb MB       Maximum binary size in MiB (default: 185)
+  --report-dir DIR     Directory for binary-size and cargo-bloat reports
+  -h, --help           Show this help
+
+Environment:
+  BINARY_SIZE_BUDGET_MB   Default budget in MiB
+  BINARY_SIZE_REPORT_DIR  Default report directory
+  CARGO_TARGET_DIR        Cargo target directory
+  HARN_BIN                Default harn binary path
+  HARN_RELEASE_TARGET     Default Cargo target triple
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-build)
+      build_release=0
+      shift
+      ;;
+    --target)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --target requires a value" >&2
+        exit 2
+      fi
+      target="${2:-}"
+      shift 2
+      ;;
+    --bin)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --bin requires a path" >&2
+        exit 2
+      fi
+      harn_bin="${2:-}"
+      shift 2
+      ;;
+    --budget-mb)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --budget-mb requires a value" >&2
+        exit 2
+      fi
+      budget_mb="${2:-}"
+      shift 2
+      ;;
+    --report-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --report-dir requires a path" >&2
+        exit 2
+      fi
+      report_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! awk -v mb="$budget_mb" 'BEGIN { exit !(mb > 0) }'; then
+  echo "error: --budget-mb must be a positive number, got '$budget_mb'" >&2
+  exit 2
+fi
+
+target_dir="${CARGO_TARGET_DIR:-$repo_root/target}"
+target_args=()
+target_component=""
+if [[ -n "$target" ]]; then
+  target_args=(--target "$target")
+  target_component="$target/"
+fi
+
+if [[ -z "$harn_bin" ]]; then
+  exe_suffix=""
+  case "$target" in
+    *windows*|*msvc*) exe_suffix=".exe" ;;
+  esac
+  harn_bin="$target_dir/${target_component}release/harn${exe_suffix}"
+fi
+
+if [[ -z "$report_dir" ]]; then
+  report_dir="$target_dir/binary-size/${target:-host}"
+fi
+
+budget_bytes="$(awk -v mb="$budget_mb" 'BEGIN { printf "%.0f", mb * 1024 * 1024 }')"
+
+if [[ "$build_release" -eq 1 ]]; then
+  export CARGO_PROFILE_RELEASE_STRIP="${CARGO_PROFILE_RELEASE_STRIP:-symbols}"
+  cargo build --release -p harn-cli --bin harn "${target_args[@]}"
+fi
+
+if [[ ! -f "$harn_bin" ]]; then
+  echo "error: harn binary not found at $harn_bin" >&2
+  exit 1
+fi
+
+mkdir -p "$report_dir"
+
+# `cargo bloat` performs its own analysis build and can relink the target
+# binary with different metadata. Preserve the exact stripped binary whose size
+# we checked so the script is safe to run before a packaging step.
+restore_dir="$(mktemp -d "${TMPDIR:-/tmp}/harn-binary-size.XXXXXX")"
+checked_binary="$restore_dir/harn"
+cp -p "$harn_bin" "$checked_binary"
+restore_checked_binary() {
+  if [[ -f "$checked_binary" ]]; then
+    cp -p "$checked_binary" "$harn_bin"
+  fi
+  rm -rf "$restore_dir"
+}
+trap restore_checked_binary EXIT
+
+actual_bytes="$(wc -c < "$harn_bin" | tr -d '[:space:]')"
+actual_mib="$(awk -v bytes="$actual_bytes" 'BEGIN { printf "%.2f", bytes / 1024 / 1024 }')"
+budget_mib="$(awk -v bytes="$budget_bytes" 'BEGIN { printf "%.2f", bytes / 1024 / 1024 }')"
+size_report="$report_dir/binary-size.txt"
+bloat_report="$report_dir/cargo-bloat-crates.txt"
+
+{
+  echo "harn binary size"
+  echo "================"
+  echo "binary: $harn_bin"
+  echo "target: ${target:-host}"
+  echo "bytes: $actual_bytes"
+  echo "mib: $actual_mib"
+  echo "budget_bytes: $budget_bytes"
+  echo "budget_mib: $budget_mib"
+} | tee "$size_report"
+
+size_ok=1
+if (( actual_bytes > budget_bytes )); then
+  size_ok=0
+  echo "error: harn binary is ${actual_mib} MiB, above budget ${budget_mib} MiB" >&2
+fi
+
+if ! command -v cargo-bloat >/dev/null 2>&1; then
+  echo "error: cargo-bloat is required to produce $bloat_report" >&2
+  exit 2
+fi
+
+cargo_bloat_target_dir_args=()
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  cargo_bloat_target_dir_args=(--target-dir "$CARGO_TARGET_DIR")
+fi
+
+cargo bloat \
+  --release \
+  --crates \
+  -p harn-cli \
+  --bin harn \
+  "${target_args[@]}" \
+  "${cargo_bloat_target_dir_args[@]}" \
+  -n 40 \
+  > "$bloat_report"
+
+{
+  echo
+  echo "cargo-bloat report: $bloat_report"
+} | tee -a "$size_report"
+
+if [[ "$size_ok" -ne 1 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Closes burin-labs/harn#2992
Part of burin-labs/burin-code#1774

## Summary
- add `scripts/check_binary_size.sh` to assert the stripped release `harn` binary stays under a checked-in 185 MiB budget
- generate a `cargo bloat --release --crates` report alongside the size report
- run and upload the binary-size report in `build-release-binaries.yml` for `x86_64-unknown-linux-gnu` before release artifact upload

## Verification
- `bash -n scripts/check_binary_size.sh`
- `make lint-actions`
- `make lint-md`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-launch-t27 BINARY_SIZE_REPORT_DIR=/tmp/harn-binary-size-rebase-pass scripts/check_binary_size.sh`
- `CARGO_TARGET_DIR=/tmp/harn-target-launch-t27 BINARY_SIZE_REPORT_DIR=/tmp/harn-binary-size-rebase-fail scripts/check_binary_size.sh --no-build --budget-mb 1` exits 1 and writes the cargo-bloat report
