### PR TITLE
Add runnable example gallery to landing page

### DIFF
--- a/changelog.d/2993.added.md
+++ b/changelog.d/2993.added.md
@@ -1,0 +1,2 @@
+- Added a landing-page example gallery backed by runnable `harn demo`
+  scenarios.

--- a/scripts/check_site_snippets.sh
+++ b/scripts/check_site_snippets.sh
@@ -28,7 +28,15 @@ checked=0
 failures=0
 
 shopt -s nullglob
-for snippet in website/src/examples/*.harn.txt; do
+site_snippets=(website/src/examples/*.harn.txt)
+site_checked=${#site_snippets[@]}
+gallery_scenarios=(
+  crates/harn-cli/assets/demo/mcp-host/scenario.harn
+  crates/harn-cli/assets/demo/merge-captain/scenario.harn
+  crates/harn-cli/assets/demo/stdlib-toolkit/scenario.harn
+)
+
+for snippet in "${site_snippets[@]}" "${gallery_scenarios[@]}"; do
   checked=$((checked + 1))
   if ! "$HARN_BIN" check "$snippet"; then
     failures=$((failures + 1))
@@ -37,7 +45,7 @@ done
 
 echo
 echo "site snippets: $checked checked, $failures failed"
-if (( checked == 0 )); then
+if (( site_checked == 0 )); then
   echo "FAIL: no website/src/examples/*.harn.txt snippets found"
   exit 1
 fi

--- a/website/src/components/ExampleGallery.tsx
+++ b/website/src/components/ExampleGallery.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react"
+import { exampleScenarios } from "../examples/gallery"
+import { highlightHarnSource } from "../lib/harn-highlight"
+
+export { exampleScenarios }
+
+export function ExampleGallery() {
+  const [activeSlug, setActiveSlug] = useState(exampleScenarios[0]?.slug ?? "")
+  const [copiedSlug, setCopiedSlug] = useState<string | null>(null)
+  const active = exampleScenarios.find((scenario) => scenario.slug === activeSlug) ?? exampleScenarios[0]
+
+  async function copyActiveSource() {
+    if (!active) return
+    if (typeof navigator === "undefined" || !navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(active.source)
+      setCopiedSlug(active.slug)
+      window.setTimeout(() => setCopiedSlug(null), 1600)
+    } catch {
+      setCopiedSlug(null)
+    }
+  }
+
+  if (!active) return null
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-card-border bg-card-bg">
+      <div className="border-b border-border bg-surface-secondary px-4 pt-4 sm:px-5">
+        <div
+          role="tablist"
+          aria-label="Runnable Harn examples"
+          className="flex gap-2 overflow-x-auto pb-4"
+        >
+          {exampleScenarios.map((scenario) => {
+            const isActive = scenario.slug === active.slug
+            return (
+              <button
+                key={scenario.slug}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`example-panel-${scenario.slug}`}
+                id={`example-tab-${scenario.slug}`}
+                onClick={() => setActiveSlug(scenario.slug)}
+                className={`h-9 shrink-0 rounded-lg border px-3 text-sm font-semibold transition-colors ${
+                  isActive
+                    ? "border-accent-500 bg-accent-600 text-white dark:bg-accent-500 dark:text-accent-950"
+                    : "border-border-strong bg-card-bg text-foreground-secondary hover:border-accent-400 hover:text-foreground"
+                }`}
+              >
+                {scenario.tab}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+      <div
+        role="tabpanel"
+        id={`example-panel-${active.slug}`}
+        aria-labelledby={`example-tab-${active.slug}`}
+        className="grid lg:grid-cols-[minmax(0,0.86fr)_minmax(0,1.14fr)]"
+      >
+        <div className="border-b border-border p-5 lg:border-r lg:border-b-0">
+          <div className="text-xs font-semibold uppercase tracking-wider text-accent-700 dark:text-accent-300">
+            {active.command}
+          </div>
+          <h3 className="mt-3 text-xl font-semibold tracking-tight text-foreground">
+            {active.title}
+          </h3>
+          <p className="mt-3 text-sm leading-relaxed text-foreground-secondary">
+            {active.outcome}
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <a
+              href={active.runHref}
+              className="inline-flex h-9 items-center justify-center rounded-lg bg-accent-600 px-4 text-sm font-semibold text-white transition-colors hover:bg-accent-700 dark:bg-accent-500 dark:text-accent-950 dark:hover:bg-accent-400"
+            >
+              Run this
+            </a>
+            <a
+              href={active.sourceHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-9 items-center justify-center rounded-lg border border-border-strong px-4 text-sm font-semibold text-foreground transition-colors hover:bg-surface-tertiary"
+            >
+              Source
+            </a>
+          </div>
+          <div className="mt-6 rounded-lg border border-border bg-surface-tertiary px-3 py-2 font-mono text-xs text-foreground-secondary">
+            {active.sourcePath}
+          </div>
+        </div>
+        <div className="min-w-0 bg-[#07100f]">
+          <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-[#0c1413] px-4 py-3">
+            <span className="font-mono text-xs font-medium text-white/55">scenario.harn</span>
+            <button
+              type="button"
+              onClick={copyActiveSource}
+              className="inline-flex h-8 items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 text-xs font-semibold text-white/75 transition-colors hover:bg-white/[0.08] hover:text-white"
+            >
+              <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <path d="M8 8h10v12H8z" />
+                <path d="M6 16H4V4h12v2" />
+              </svg>
+              {copiedSlug === active.slug ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <pre className="m-0 max-h-[30rem] overflow-auto p-4 text-[12px] leading-relaxed text-white/80">
+            <code data-example-gallery-code="true" className="language-harn">
+              {highlightHarnSource(active.source)}
+            </code>
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/website/src/components/HarnMockup.tsx
+++ b/website/src/components/HarnMockup.tsx
@@ -1,87 +1,10 @@
 import type { ReactNode } from "react"
-import type { Mode } from "highlight.js"
-import { createLowlight, type LanguageFn } from "lowlight"
 import heroSnippetRaw from "../examples/hero.harn.txt?raw"
+import { highlightHarnSource } from "../lib/harn-highlight"
 
 // Hero mockup — a Harn pipeline source pane beside a live agent run, echoing the
 // Burin Code editor mockup but expressing what Harn itself is: orchestration code.
 export const heroSnippetSource = heroSnippetRaw.trimEnd()
-
-const harnLanguage: LanguageFn = (hljs) => {
-  const keywords = {
-    keyword: "agent_loop break continue each else fn for if in let parallel pipeline retry return spawn while",
-    literal: "false nil true",
-    built_in: "llm_call log read_file read_text tool_select",
-  }
-  const interpolation: Mode = {
-    className: "subst",
-    begin: /\$\{/,
-    end: /\}/,
-    keywords,
-    contains: [],
-  }
-  const string: Mode = {
-    className: "string",
-    begin: '"',
-    end: '"',
-    illegal: "\\n",
-    contains: [{ begin: "\\\\." }, interpolation],
-  }
-  const mainContains: Mode[] = [
-    hljs.C_LINE_COMMENT_MODE,
-    hljs.C_BLOCK_COMMENT_MODE,
-    string,
-    {
-      className: "number",
-      begin: /\b\d+(?:\.\d+)?(?:ms|s|m|h)?\b/,
-      relevance: 0,
-    },
-    {
-      className: "title.function",
-      beginKeywords: "fn pipeline",
-      end: /[(\s]/,
-      excludeEnd: true,
-      contains: [{ begin: /[a-z_][A-Za-z0-9_]*/ }],
-      relevance: 0,
-    },
-  ]
-  interpolation.contains = mainContains
-  return {
-    name: "Harn",
-    aliases: ["harn"],
-    keywords,
-    contains: mainContains,
-  }
-}
-
-type HighlightNode = {
-  type: string
-  value?: string
-  tagName?: string
-  properties?: { className?: string[] | string }
-  children?: HighlightNode[]
-}
-
-const harnLowlight = createLowlight({ harn: harnLanguage })
-
-function renderHighlightNode(node: HighlightNode, index: number): ReactNode {
-  if (node.type === "text") return node.value ?? ""
-  if (node.type !== "element") return null
-
-  const className = node.properties?.className
-  return (
-    <span
-      key={index}
-      className={Array.isArray(className) ? className.join(" ") : className}
-    >
-      {(node.children ?? []).map(renderHighlightNode)}
-    </span>
-  )
-}
-
-function highlightedHeroSource() {
-  return harnLowlight.highlight("harn", heroSnippetSource).children.map(renderHighlightNode)
-}
 
 function ChatRow({
   tone,
@@ -117,7 +40,7 @@ export function HarnMockup() {
         <div className="grid grid-cols-12 text-[13px] leading-relaxed">
           <div className="col-span-12 px-5 py-4 font-mono text-[12.5px] sm:col-span-7">
             <pre className="m-0 whitespace-pre text-white/80">
-              <code data-hero-snippet="true" className="language-harn">{highlightedHeroSource()}</code>
+              <code data-hero-snippet="true" className="language-harn">{highlightHarnSource(heroSnippetSource)}</code>
               <span className="ml-px inline-block h-3 w-1.5 -translate-y-px bg-accent-400 align-middle" />
             </pre>
           </div>

--- a/website/src/examples/gallery.ts
+++ b/website/src/examples/gallery.ts
@@ -1,0 +1,53 @@
+import mcpHostSource from "../../../crates/harn-cli/assets/demo/mcp-host/scenario.harn?raw"
+import mergeCaptainSource from "../../../crates/harn-cli/assets/demo/merge-captain/scenario.harn?raw"
+import stdlibToolkitSource from "../../../crates/harn-cli/assets/demo/stdlib-toolkit/scenario.harn?raw"
+
+const GITHUB_DEMO_ROOT = "https://github.com/burin-labs/harn/blob/main/crates/harn-cli/assets/demo"
+
+export type ExampleScenario = {
+  slug: string
+  tab: string
+  title: string
+  outcome: string
+  command: string
+  runHref: string
+  sourcePath: string
+  sourceHref: string
+  source: string
+}
+
+export const exampleScenarios: ExampleScenario[] = [
+  {
+    slug: "mcp-host",
+    tab: "MCP host",
+    title: "Register supervised MCP servers without a live server fixture.",
+    outcome: "The receipt proves lazy registration, status snapshots, and graceful stop paths stay offline-runnable.",
+    command: "harn demo mcp-host",
+    runHref: "/cli-reference.html#harn-demo",
+    sourcePath: "crates/harn-cli/assets/demo/mcp-host/scenario.harn",
+    sourceHref: `${GITHUB_DEMO_ROOT}/mcp-host/scenario.harn`,
+    source: mcpHostSource.trimEnd(),
+  },
+  {
+    slug: "merge-captain",
+    tab: "Merge captain",
+    title: "Triage a mock PR queue with deterministic replay.",
+    outcome: "Three mocked PRs become a structured merge, handoff, or block receipt using the bundled LLM tape.",
+    command: "harn demo merge-captain",
+    runHref: "/cli-reference.html#harn-demo",
+    sourcePath: "crates/harn-cli/assets/demo/merge-captain/scenario.harn",
+    sourceHref: `${GITHUB_DEMO_ROOT}/merge-captain/scenario.harn`,
+    source: mergeCaptainSource.trimEnd(),
+  },
+  {
+    slug: "stdlib-toolkit",
+    tab: "Stdlib toolkit",
+    title: "Assemble an XML prompt context from local stdlib primitives.",
+    outcome: "Clone, merge, dedupe, XML round-trip, wrap, and indent steps compose into a checked prompt receipt.",
+    command: "harn demo stdlib-toolkit",
+    runHref: "/cli-reference.html#harn-demo",
+    sourcePath: "crates/harn-cli/assets/demo/stdlib-toolkit/scenario.harn",
+    sourceHref: `${GITHUB_DEMO_ROOT}/stdlib-toolkit/scenario.harn`,
+    source: stdlibToolkitSource.trimEnd(),
+  },
+]

--- a/website/src/lib/harn-highlight.tsx
+++ b/website/src/lib/harn-highlight.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react"
+import type { Mode } from "highlight.js"
+import { createLowlight, type LanguageFn } from "lowlight"
+
+const harnLanguage: LanguageFn = (hljs) => {
+  const keywords = {
+    keyword: "agent_loop break continue each else fn for if in let parallel pipeline retry return spawn while",
+    literal: "false nil true",
+    built_in: "llm_call log read_file read_text tool_select",
+  }
+  const interpolation: Mode = {
+    className: "subst",
+    begin: /\$\{/,
+    end: /\}/,
+    keywords,
+    contains: [],
+  }
+  const string: Mode = {
+    className: "string",
+    begin: '"',
+    end: '"',
+    illegal: "\\n",
+    contains: [{ begin: "\\\\." }, interpolation],
+  }
+  const mainContains: Mode[] = [
+    hljs.C_LINE_COMMENT_MODE,
+    hljs.C_BLOCK_COMMENT_MODE,
+    string,
+    {
+      className: "number",
+      begin: /\b\d+(?:\.\d+)?(?:ms|s|m|h)?\b/,
+      relevance: 0,
+    },
+    {
+      className: "title.function",
+      beginKeywords: "fn pipeline",
+      end: /[(\s]/,
+      excludeEnd: true,
+      contains: [{ begin: /[a-z_][A-Za-z0-9_]*/ }],
+      relevance: 0,
+    },
+  ]
+  interpolation.contains = mainContains
+  return {
+    name: "Harn",
+    aliases: ["harn"],
+    keywords,
+    contains: mainContains,
+  }
+}
+
+type HighlightNode = {
+  type: string
+  value?: string
+  tagName?: string
+  properties?: { className?: string[] | string }
+  children?: HighlightNode[]
+}
+
+const harnLowlight = createLowlight({ harn: harnLanguage })
+
+function renderHighlightNode(node: HighlightNode, index: number): ReactNode {
+  if (node.type === "text") return node.value ?? ""
+  if (node.type !== "element") return null
+
+  const className = node.properties?.className
+  return (
+    <span
+      key={index}
+      className={Array.isArray(className) ? className.join(" ") : className}
+    >
+      {(node.children ?? []).map(renderHighlightNode)}
+    </span>
+  )
+}
+
+export function highlightHarnSource(source: string) {
+  return harnLowlight.highlight("harn", source).children.map(renderHighlightNode)
+}

--- a/website/src/pages/LandingPage.tsx
+++ b/website/src/pages/LandingPage.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 import { Link } from "react-router"
+import { ExampleGallery } from "../components/ExampleGallery"
 import { HarnMockup } from "../components/HarnMockup"
 
 const GITHUB = "https://github.com/burin-labs/harn"
@@ -57,6 +58,22 @@ export function LandingPage() {
           <div className="mt-16 animate-fade-up-delay-4">
             <HarnMockup />
           </div>
+        </div>
+      </section>
+
+      {/* Examples */}
+      <section className="border-b border-border bg-surface-secondary">
+        <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+          <div className="mb-10 max-w-2xl">
+            <h2 className="text-3xl font-bold tracking-tight text-foreground">
+              Runnable examples with real receipts
+            </h2>
+            <p className="mt-3 text-foreground-secondary">
+              The same checked scenario files ship in the CLI demo bundle and run locally with
+              deterministic fixtures.
+            </p>
+          </div>
+          <ExampleGallery />
         </div>
       </section>
 

--- a/website/tests/ExampleGallery.test.tsx
+++ b/website/tests/ExampleGallery.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { ExampleGallery, exampleScenarios } from "../src/components/ExampleGallery"
+
+describe("ExampleGallery", () => {
+  it("renders the curated runnable example tabs", () => {
+    const markup = renderToStaticMarkup(<ExampleGallery />)
+    const tabCount = (markup.match(/role="tab"/g) ?? []).length
+
+    expect(tabCount).toBe(3)
+    expect(exampleScenarios.map((scenario) => scenario.slug)).toMatchInlineSnapshot(`
+      [
+        "mcp-host",
+        "merge-captain",
+        "stdlib-toolkit",
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
Closes burin-labs/harn#2993
Part of burin-labs/burin-code#1774

## Summary
- add a landing-page ExampleGallery with three raw-imported demo scenarios: mcp-host, merge-captain, and stdlib-toolkit
- share the Harn lowlight helper between the hero mockup and gallery code panes
- extend the site snippet gate to `harn check` the three gallery scenarios while preserving the existing hero-snippet guard

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-launch-t16 make check-site-snippets`
- `cd website && npm test -- ExampleGallery`
- `cd website && npm test -- HarnMockup ExampleGallery`
- `cd website && npm test`
- `cd website && npm run typecheck`
- `cd website && npm run build`
- `make lint-md`
- `git diff --check`

Note: attempted in-app Browser verification against `http://127.0.0.1:5174/`, but the `iab` browser surface was unavailable in this session. The production prerender output was checked for the gallery heading, three tabs, run link, source link, and highlighted code block.
