### PR TITLE
Add docs internal link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
       # check-tree-sitter-keywords are cross-crate sync guards that need no
       # harn build.
       - run: make check-receipt-structs
+      - run: make check-docs-links
       - run: make check-tree-sitter-keywords
       - run: make check-generated-registry
       - run: python3 scripts/verify_release_metadata.py

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-site-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
+.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-trigger-quickref check-trigger-quickref gen-provider-matrix check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-docs-links check-site-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-generated-registry
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
 #        make all           (sequential, also works)
 all: fmt
-	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-connector-schemas check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-site-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift check-tree-sitter-keywords check-generated-registry portal-check
+	$(MAKE) lint lint-md lint-actions lint-harn spec-lint fmt-harn test test-harn-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench check-highlight check-protocol-artifacts check-connector-schemas check-bindings check-session-bundle-schema check-language-spec check-trigger-quickref check-provider-matrix check-provider-support check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-docs-links check-site-snippets check-docs-workflow-quickstart check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs check-provider-catalog-drift check-tree-sitter-keywords check-generated-registry portal-check
 
 check: all
 
@@ -527,6 +527,13 @@ check-docs-snippets:
 check-docs-cli-flags:
 	@echo "=== Checking docs bash/sh harn flags against --help ==="
 	@./scripts/check_docs_cli_flags.sh
+
+# CI guard: every local Markdown/HTML href under docs/src resolves to a
+# checked-in repository file. Fragments are ignored; this only catches dead
+# file paths.
+check-docs-links:
+	@echo "=== Checking docs internal links ==="
+	@python3 scripts/check_docs_links.py
 
 # CI guard: every checked-in Harn snippet used by website/src parses under
 # `harn check`.

--- a/changelog.d/2995.fixed.md
+++ b/changelog.d/2995.fixed.md
@@ -1,0 +1,3 @@
+- **Docs CI now checks internal documentation links (#2995).** Broken local links
+  under `docs/src` are caught by a fast CI gate, including the prompt assembly
+  page's stale `agent_loop` target.

--- a/docs/src/prompt-assembly.md
+++ b/docs/src/prompt-assembly.md
@@ -35,7 +35,7 @@ included `after` fragments, joined by a blank line.
 The agent's per-turn primary system text is itself a composite — the base system
 prompt, MCP advisory context, active skills, the skill catalog, the progress-tool
 nudge, and the loop/tool contracts. Rather than glue these into one opaque
-`primary` string, [`agent_loop`](./agents.md) hands the assembler each part as its
+`primary` string, [`agent_loop`](./llm-and-agents.md) hands the assembler each part as its
 own fragment through the internal `_system_fragments` channel, so every part is
 traced on its own (`primary:system`, `primary:active_skills`,
 `primary:loop_contract`, …) and can be gated with `requires_tools` independently.
@@ -86,7 +86,7 @@ project guidance an opaque always-on paragraph.
 ## Inspecting the assembled prompt
 
 `prompt_explain(options)` assembles the system prompt from the same options you
-would hand [`agent_loop`](./agents.md) and returns the final string plus a
+would hand [`agent_loop`](./llm-and-agents.md) and returns the final string plus a
 provenance record for every fragment — included or excluded, with the reason and
 byte count:
 

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Check local links in docs/src Markdown files resolve to repository files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs" / "src"
+
+INLINE_LINK_RE = re.compile(
+    r"!?\[[^\]\n]*(?:\][^\[\]\n]*)?\]\(([^)\s]+)(?:\s+[^)]*)?\)"
+)
+REFERENCE_LINK_RE = re.compile(r"^\s{0,3}\[[^\]]+\]:\s+(\S+)", re.MULTILINE)
+HTML_ATTR_RE = re.compile(r"\b(?:href|src)=(['\"])(.*?)\1", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Link:
+    raw_target: str
+    start: int
+
+
+@dataclass(frozen=True)
+class BrokenLink:
+    source: Path
+    line: int
+    target: str
+    expected: Path
+
+
+def strip_fenced_blocks(text: str) -> str:
+    """Blank fenced code blocks while preserving line numbers."""
+    lines: list[str] = []
+    in_fence = False
+    fence_marker = ""
+
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        is_fence = marker in {"```", "~~~"}
+        if is_fence:
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+                fence_marker = ""
+            lines.append("\n" if line.endswith("\n") else "")
+            continue
+
+        if in_fence:
+            lines.append("\n" if line.endswith("\n") else "")
+        else:
+            lines.append(line)
+
+    return "".join(lines)
+
+
+def iter_links(text: str) -> list[Link]:
+    links: list[Link] = []
+
+    for regex in (INLINE_LINK_RE, REFERENCE_LINK_RE):
+        for match in regex.finditer(text):
+            links.append(Link(match.group(1), match.start(1)))
+
+    for match in HTML_ATTR_RE.finditer(text):
+        links.append(Link(match.group(2), match.start(2)))
+
+    return sorted(links, key=lambda link: link.start)
+
+
+def local_path(raw_target: str) -> str | None:
+    target = raw_target.strip().strip("<>")
+    if not target or target.startswith("#"):
+        return None
+
+    parts = urlsplit(target)
+    if parts.scheme or parts.netloc:
+        return None
+
+    path = unquote(parts.path)
+    if not path:
+        return None
+
+    return path
+
+
+def candidate_paths(source: Path, link_path: str) -> list[Path]:
+    if link_path.startswith("/"):
+        primary = DOCS_DIR / link_path.lstrip("/")
+    else:
+        primary = source.parent / link_path
+
+    candidates = [primary.resolve(strict=False)]
+    if primary.suffix == ".html":
+        candidates.append(primary.with_suffix(".md").resolve(strict=False))
+    elif not primary.suffix:
+        candidates.append(primary.with_suffix(".md").resolve(strict=False))
+        candidates.append((primary / "index.md").resolve(strict=False))
+    elif str(link_path).endswith("/"):
+        candidates.append((primary / "index.md").resolve(strict=False))
+
+    return candidates
+
+
+def within_repo(path: Path) -> bool:
+    try:
+        path.relative_to(REPO_ROOT)
+        return True
+    except ValueError:
+        return False
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def main() -> int:
+    checked = 0
+    failures: list[BrokenLink] = []
+
+    for source in sorted(DOCS_DIR.rglob("*.md")):
+        text = strip_fenced_blocks(source.read_text(encoding="utf-8"))
+        for link in iter_links(text):
+            path = local_path(link.raw_target)
+            if path is None:
+                continue
+
+            checked += 1
+            candidates = candidate_paths(source, path)
+            if any(candidate.exists() and within_repo(candidate) for candidate in candidates):
+                continue
+
+            failures.append(
+                BrokenLink(
+                    source=source,
+                    line=text.count("\n", 0, link.start) + 1,
+                    target=link.raw_target,
+                    expected=candidates[0],
+                )
+            )
+
+    if failures:
+        print("error: dead docs internal link(s):", file=sys.stderr)
+        for failure in failures:
+            print(
+                f"  {display_path(failure.source)}:{failure.line}: "
+                f"{failure.target} -> missing {display_path(failure.expected)}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"docs links OK: {checked} local link target(s) checked")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generated_artifacts.toml
+++ b/scripts/generated_artifacts.toml
@@ -49,6 +49,7 @@ exempt_checks = [
   "check-docs-model-refs",          # validates docs track provider aliases, not a mirror
   "check-docs-snippets",            # validates ```harn blocks parse, not a mirror
   "check-docs-cli-flags",           # validates docs bash/sh harn flags, not a mirror
+  "check-docs-links",               # validates docs/src local links resolve, not a mirror
   "check-site-snippets",            # validates website Harn fixtures parse, not a mirror
   "check-generated-registry",       # the auditor itself
 ]


### PR DESCRIPTION
## Summary
- adds `scripts/check_docs_links.py` and a `make check-docs-links` target for local docs links under `docs/src`
- wires the docs link check into CI and the generated-artifact registry exemption list
- fixes the dead `./agents.md` links in `docs/src/prompt-assembly.md`

## Verification
- `make check-docs-links`
- `make check-generated-registry`
- `make lint-actions`
- `npx markdownlint-cli2 docs/src/prompt-assembly.md changelog.d/2995.fixed.md`
- `git diff --check`
- pre-commit hook passed, including full workspace clippy/check triggered by Makefile/CI changes
- pre-push hook passed, including targeted local checks

Closes burin-labs/harn#2995
Part of burin-labs/burin-code#1774
