### PR TITLE
Consolidate user home-dir resolution behind one portable seam

### DIFF
--- a/changelog.d/3032.fixed.md
+++ b/changelog.d/3032.fixed.md
@@ -1,0 +1,6 @@
+- **Portable user home-directory resolution (#3032).** Harn now resolves the
+  user home directory through a single `user_dirs` seam that falls back to
+  `%USERPROFILE%` when `$HOME` is unset, fixing a class of silent Windows
+  degradations — a cwd-relative bytecode/pack cache, an unloaded
+  `~/.config/harn/providers.toml` overlay, and unresolved Bedrock AWS profiles —
+  and collapsing five drifted home-dir helpers into one tested implementation.

--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -2128,13 +2128,11 @@ fn unquote_env_value(value: &str) -> String {
 fn expand_home(path: &Path) -> PathBuf {
     let raw = path.to_string_lossy();
     if raw == "~" {
-        return std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| path.to_path_buf());
+        return harn_vm::user_dirs::home_dir().unwrap_or_else(|| path.to_path_buf());
     }
     if let Some(rest) = raw.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home).join(rest);
+        if let Some(home) = harn_vm::user_dirs::home_dir() {
+            return home.join(rest);
         }
     }
     path.to_path_buf()

--- a/crates/harn-cli/src/commands/guard.rs
+++ b/crates/harn-cli/src/commands/guard.rs
@@ -12,10 +12,7 @@ use harn_guard::{catalog, GuardStore};
 use crate::cli::{GuardInstallArgs, GuardListArgs, GuardRemoveArgs, GuardStatusArgs};
 
 fn store() -> GuardStore {
-    let home = std::env::var("HOME")
-        .ok()
-        .filter(|home| !home.trim().is_empty())
-        .map_or_else(|| PathBuf::from("."), PathBuf::from);
+    let home = harn_vm::user_dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
     GuardStore::new(&home)
 }
 

--- a/crates/harn-cli/src/commands/package_scaffold.rs
+++ b/crates/harn-cli/src/commands/package_scaffold.rs
@@ -305,8 +305,8 @@ fn harn_openapi_candidates(args: &PackageScaffoldOpenapiArgs) -> Vec<PathBuf> {
         candidates.push(cwd.join("../harn-openapi"));
         candidates.push(cwd.join("harn-openapi"));
     }
-    if let Some(home) = std::env::var_os("HOME") {
-        candidates.push(PathBuf::from(home).join("projects/harn-openapi"));
+    if let Some(home) = harn_vm::user_dirs::home_dir() {
+        candidates.push(home.join("projects/harn-openapi"));
     }
     candidates
 }
@@ -909,13 +909,11 @@ fn is_harn_reserved(value: &str) -> bool {
 
 fn expand_tilde(raw: &str) -> PathBuf {
     if raw == "~" {
-        return std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(raw));
+        return harn_vm::user_dirs::home_dir().unwrap_or_else(|| PathBuf::from(raw));
     }
     if let Some(rest) = raw.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os("HOME") {
-            return PathBuf::from(home).join(rest);
+        if let Some(home) = harn_vm::user_dirs::home_dir() {
+            return home.join(rest);
         }
     }
     PathBuf::from(raw)

--- a/crates/harn-cli/src/commands/quickstart.rs
+++ b/crates/harn-cli/src/commands/quickstart.rs
@@ -623,12 +623,8 @@ fn providers_config_path() -> PathBuf {
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .or_else(|| {
-            env::var_os("HOME").map(|home| {
-                PathBuf::from(home)
-                    .join(".config")
-                    .join("harn")
-                    .join("providers.toml")
-            })
+            harn_vm::user_dirs::home_dir()
+                .map(|home| home.join(".config").join("harn").join("providers.toml"))
         })
         .unwrap_or_else(|| PathBuf::from(".config/harn/providers.toml"))
 }

--- a/crates/harn-cli/src/commands/repl.rs
+++ b/crates/harn-cli/src/commands/repl.rs
@@ -257,8 +257,8 @@ fn repl_builtin_names() -> Vec<String> {
 }
 
 fn repl_history_path() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(|home| PathBuf::from(home).join(".harn").join("repl_history"))
+    harn_vm::user_dirs::home_dir()
+        .map(|home| home.join(".harn").join("repl_history"))
         .unwrap_or_else(|| PathBuf::from(".harn").join("repl_history"))
 }
 

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -1625,9 +1625,9 @@ impl PackageWorkspace {
             }
         }
 
-        let home = std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set and HARN_CACHE_DIR was not provided".to_string())?;
+        let home = harn_vm::user_dirs::home_dir().ok_or_else(|| {
+            "neither HOME nor USERPROFILE is set and HARN_CACHE_DIR was not provided".to_string()
+        })?;
         if cfg!(target_os = "macos") {
             return Ok(home.join("Library/Caches/harn"));
         }

--- a/crates/harn-cli/src/provider_bootstrap.rs
+++ b/crates/harn-cli/src/provider_bootstrap.rs
@@ -129,10 +129,7 @@ fn project_llm_configured(anchor: &Path) -> bool {
 }
 
 fn default_providers_path() -> Option<PathBuf> {
-    std::env::var("HOME")
-        .ok()
-        .filter(|home| !home.trim().is_empty())
-        .map(|home| PathBuf::from(home).join(".config/harn/providers.toml"))
+    harn_vm::user_dirs::home_dir().map(|home| home.join(".config/harn/providers.toml"))
 }
 
 async fn ollama_tags_ready(url: &str) -> bool {

--- a/crates/harn-cli/src/skill_provenance.rs
+++ b/crates/harn-cli/src/skill_provenance.rs
@@ -782,9 +782,7 @@ pub(crate) fn fingerprint_for_key(key: &VerifyingKey) -> String {
 }
 
 fn user_home_dir() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+    harn_vm::user_dirs::home_dir()
 }
 
 #[cfg(test)]

--- a/crates/harn-hostlib/src/code_index/walker.rs
+++ b/crates/harn-hostlib/src/code_index/walker.rs
@@ -134,7 +134,14 @@ pub(crate) fn is_sensitive_path(path: &Path) -> bool {
 /// Returns `true` if the path looks like a credentials/secrets file that
 /// must never enter the index.
 pub(crate) fn is_sensitive(path: &Path) -> bool {
-    let lower = path.to_string_lossy().to_ascii_lowercase();
+    // Normalize Windows backslashes to `/` before the component scan below so
+    // the `split('/')` SENSITIVE_DIRS check sees directory parts on every
+    // platform. This mirrors the `to_posix`-style normalization already used
+    // elsewhere in this crate (walker.rs, state.rs, fs_watch.rs).
+    let lower = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
     let base = Path::new(&lower)
         .file_name()
         .and_then(|s| s.to_str())

--- a/crates/harn-hostlib/src/secret_store/file.rs
+++ b/crates/harn-hostlib/src/secret_store/file.rs
@@ -124,13 +124,7 @@ fn env_nonempty(key: &str) -> Option<String> {
 }
 
 fn home_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "windows")]
-    {
-        if let Some(userprofile) = env_nonempty("USERPROFILE") {
-            return Some(PathBuf::from(userprofile));
-        }
-    }
-    env_nonempty("HOME").map(PathBuf::from)
+    harn_vm::user_dirs::home_dir()
 }
 
 fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -153,11 +153,8 @@ pub fn cache_dir() -> PathBuf {
             return xdg.join("harn").join("bytecode");
         }
     }
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home)
-            .join(".cache")
-            .join("harn")
-            .join("bytecode");
+    if let Some(home) = crate::user_dirs::home_dir() {
+        return home.join(".cache").join("harn").join("bytecode");
     }
     // Final fallback: a directory beside the binary's working dir. Mostly
     // hit in tests that scrub HOME from the environment.
@@ -178,11 +175,8 @@ pub fn packs_cache_dir() -> PathBuf {
             return xdg.join("harn").join("packs");
         }
     }
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home)
-            .join(".cache")
-            .join("harn")
-            .join("packs");
+    if let Some(home) = crate::user_dirs::home_dir() {
+        return home.join(".cache").join("harn").join("packs");
     }
     PathBuf::from(".harn-cache").join("packs")
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -96,6 +96,7 @@ pub mod tracing;
 pub mod triggers;
 pub mod trust_graph;
 pub(crate) mod url_encoding;
+pub mod user_dirs;
 
 /// Crate-wide deterministic clock mock used by stdlib time builtins, the
 /// trigger dispatcher, the cron scheduler, and Rust-side tests. Re-exports

--- a/crates/harn-vm/src/llm/providers/bedrock.rs
+++ b/crates/harn-vm/src/llm/providers/bedrock.rs
@@ -307,10 +307,10 @@ async fn resolve_aws_credentials() -> Result<AwsCredentials, VmError> {
 }
 
 fn read_aws_profile_value(file_kind: &str, profile: &str, key: &str) -> Option<String> {
-    let home = std::env::var("HOME").ok()?;
+    let home = crate::user_dirs::home_dir()?;
     let path = match file_kind {
-        "credentials" => format!("{home}/.aws/credentials"),
-        "config" => format!("{home}/.aws/config"),
+        "credentials" => home.join(".aws").join("credentials"),
+        "config" => home.join(".aws").join("config"),
         _ => return None,
     };
     let text = std::fs::read_to_string(path).ok()?;

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -2075,7 +2075,7 @@ fn glob_match(pattern: &str, input: &str) -> bool {
 }
 
 fn dirs_or_home() -> Option<String> {
-    std::env::var("HOME").ok()
+    crate::user_dirs::home_dir().map(|home| home.to_string_lossy().into_owned())
 }
 
 /// Resolve the effective base URL for a provider, checking the `base_url_env`

--- a/crates/harn-vm/src/mcp_oauth.rs
+++ b/crates/harn-vm/src/mcp_oauth.rs
@@ -711,13 +711,9 @@ fn harn_home_dir() -> PathBuf {
     if let Some(path) = std::env::var_os(HARN_HOME_ENV) {
         return PathBuf::from(path);
     }
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home).join(".harn");
-    }
-    if let Some(home) = std::env::var_os("USERPROFILE") {
-        return PathBuf::from(home).join(".harn");
-    }
-    std::env::temp_dir().join("harn")
+    crate::user_dirs::home_dir()
+        .map(|home| home.join(".harn"))
+        .unwrap_or_else(|| std::env::temp_dir().join("harn"))
 }
 
 // --- keyring storage ---------------------------------------------------------

--- a/crates/harn-vm/src/skills/mod.rs
+++ b/crates/harn-vm/src/skills/mod.rs
@@ -197,10 +197,7 @@ pub fn default_user_dir() -> Option<PathBuf> {
 }
 
 fn dirs_home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from).or_else(|| {
-        // Windows fallback without pulling in the `dirs` crate.
-        std::env::var_os("USERPROFILE").map(PathBuf::from)
-    })
+    crate::user_dirs::home_dir()
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -303,8 +303,8 @@ fn arch_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
 
 #[harn_builtin(sig = "home_dir() -> string", category = "process")]
 fn home_dir_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
+    let home = crate::user_dirs::home_dir()
+        .map(|home| home.to_string_lossy().into_owned())
         .unwrap_or_default();
     Ok(VmValue::String(std::sync::Arc::from(home)))
 }

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -761,11 +761,9 @@ pub(crate) fn process_sandbox_package_manager_config_read_roots(
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn package_manager_config_home_dir() -> Option<PathBuf> {
-    ["HOME", "USERPROFILE"]
-        .into_iter()
-        .filter_map(std::env::var_os)
-        .map(PathBuf::from)
-        .find(|path| path.is_absolute())
+    // Only an absolute home grounds the package-manager read-roots below; a
+    // relative or unset home yields no extra roots (the safe direction).
+    crate::user_dirs::home_dir().filter(|path| path.is_absolute())
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/harn-vm/src/user_dirs.rs
+++ b/crates/harn-vm/src/user_dirs.rs
@@ -1,0 +1,91 @@
+//! Portable resolution of the current user's home directory.
+//!
+//! Unix exposes the home directory through `$HOME`. Windows usually leaves
+//! `HOME` unset and exposes `%USERPROFILE%` instead. Historically a dozen
+//! call sites across the workspace read `$HOME` directly and silently
+//! degraded on Windows — falling back to a cwd-relative cache, a missing
+//! config overlay, or an unresolved AWS profile — while a handful of others
+//! hand-rolled their own `HOME`-then-`USERPROFILE` cascade. This module is
+//! the single source of truth.
+//!
+//! The pure [`home_dir_from`] core takes the environment values explicitly so
+//! it can be unit-tested for every platform's env shape (including Windows)
+//! on any host. [`home_dir`] is the thin wrapper over the live process
+//! environment that production code calls.
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
+fn non_empty(value: Option<&OsStr>) -> Option<PathBuf> {
+    value.filter(|v| !v.is_empty()).map(PathBuf::from)
+}
+
+/// Resolve a home directory from explicit `$HOME` / `%USERPROFILE%` values.
+///
+/// Prefers `home` (the Unix convention), falling back to `userprofile` (the
+/// Windows convention). Empty values are treated as unset. Pure and
+/// platform-agnostic so the resolution order can be unit-tested for every OS.
+pub fn home_dir_from(home: Option<&OsStr>, userprofile: Option<&OsStr>) -> Option<PathBuf> {
+    non_empty(home).or_else(|| non_empty(userprofile))
+}
+
+/// The current user's home directory, resolved portably from the environment
+/// (`$HOME`, then `%USERPROFILE%`). Returns `None` only when neither is set to
+/// a non-empty value (e.g. a stripped-down container with no home).
+pub fn home_dir() -> Option<PathBuf> {
+    home_dir_from(
+        std::env::var_os("HOME").as_deref(),
+        std::env::var_os("USERPROFILE").as_deref(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(value: &str) -> Option<&OsStr> {
+        Some(OsStr::new(value))
+    }
+
+    #[test]
+    fn unix_shape_prefers_home() {
+        // Typical Unix: HOME set, USERPROFILE unset.
+        assert_eq!(
+            home_dir_from(os("/home/ada"), None),
+            Some(PathBuf::from("/home/ada"))
+        );
+    }
+
+    #[test]
+    fn windows_shape_falls_back_to_userprofile() {
+        // Typical Windows: HOME unset, USERPROFILE set. This is the case the
+        // bare `var("HOME")` sites used to get wrong.
+        assert_eq!(
+            home_dir_from(None, os(r"C:\Users\Ada")),
+            Some(PathBuf::from(r"C:\Users\Ada"))
+        );
+    }
+
+    #[test]
+    fn empty_home_falls_back_to_userprofile() {
+        // Some shells export HOME="" rather than leaving it unset.
+        assert_eq!(
+            home_dir_from(os(""), os(r"C:\Users\Ada")),
+            Some(PathBuf::from(r"C:\Users\Ada"))
+        );
+    }
+
+    #[test]
+    fn home_wins_when_both_present() {
+        assert_eq!(
+            home_dir_from(os("/home/ada"), os(r"C:\Users\Ada")),
+            Some(PathBuf::from("/home/ada"))
+        );
+    }
+
+    #[test]
+    fn none_when_both_unset_or_empty() {
+        assert_eq!(home_dir_from(None, None), None);
+        assert_eq!(home_dir_from(os(""), os("")), None);
+    }
+}


### PR DESCRIPTION
## Problem
A dozen call sites resolved the user's home directory by reading `$HOME` directly. On Windows `HOME` is usually unset (the convention is `%USERPROFILE%`), so each of these silently degraded:
- `bytecode_cache` / `packs` caches fell back to a cwd-relative `.harn-cache`
- `~/.config/harn/providers.toml` overlay (`llm_config`, `provider_bootstrap`, `quickstart`) silently never loaded
- Bedrock AWS profile/credentials resolution returned `None`
- the guard store fell back to `.`, repl history to a cwd path, etc.

Five *other* sites hand-rolled their own `HOME`-then-`USERPROFILE` cascade (`skills`, `mcp_oauth`, `process`, `secret_store`, `skill_provenance`), so the behavior had drifted five different ways.

## Change
One `harn_vm::user_dirs` module is now the single source of truth:
- a pure, OS-parameterized `home_dir_from(home, userprofile)` core, **unit-tested for the Unix, Windows, and empty-env shapes on any host** (the Windows fallback is verified on macOS/Linux CI, not just asserted), and
- a thin `home_dir()` wrapper over the live environment.

Every home-dir site now routes through it, including the previously-divergent helpers and the sandbox package-manager read-root resolver. Net effect: every site gains the Windows fallback, five duplicate helpers collapse to one, and the resolution order is covered by tests instead of scattered comments.

Also: normalize Windows backslashes before the `split('/')` component scan in `code_index::walker::is_sensitive`, matching the `to_posix`-style normalization already used elsewhere in that crate, so the sensitive-dir heuristic sees path components on every platform.

## Footprint
**Net −29 LOC** across the touched files, plus the new tested `user_dirs` module. No new external dependency (the repo deliberately avoids the `dirs` crate).

## Verification
- 5 new `user_dirs` unit tests pass (incl. the Windows `%USERPROFILE%`-fallback shape, validated on macOS).
- `harn-vm` + `harn-hostlib` + `harn-cli` compile clean; pre-commit clippy/fmt pass.
- The new `macos-nightly.yml` + existing `windows-nightly.yml` exercise the resolution on the other platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)