### PR TITLE
Make child process liveness and timeout-kill cross-platform

### DIFF
--- a/changelog.d/3033.fixed.md
+++ b/changelog.d/3033.fixed.md
@@ -1,0 +1,6 @@
+- **Cross-platform process timeout and liveness (#3033).** A timed-out child
+  process is now terminated through the cross-platform
+  `std::process::Child::kill()` so `wait_with_timeout` can no longer hang on
+  Windows, and supervisor liveness checks use `sysinfo` instead of shelling out
+  to `kill -0` (collapsing the prior `#[cfg(unix)]`/stub split into one portable
+  function).

--- a/crates/harn-cli/src/commands/supervisor.rs
+++ b/crates/harn-cli/src/commands/supervisor.rs
@@ -673,21 +673,19 @@ async fn wait_for_running_snapshot(
     Ok(SupervisorStartWait::TimedOut)
 }
 
-#[cfg(unix)]
+/// Whether `pid` is still a live process. Uses `sysinfo` (already a
+/// dependency) rather than shelling out to `kill -0`, so it works on every
+/// platform and avoids spawning a subprocess on the liveness-polling hot path
+/// in `wait_for_process_exit`.
 fn process_is_alive(pid: u32) -> bool {
-    Command::new("kill")
-        .arg("-0")
-        .arg(pid.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-}
-
-#[cfg(not(unix))]
-fn process_is_alive(_pid: u32) -> bool {
-    false
+    let pid = sysinfo::Pid::from_u32(pid);
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        true,
+        sysinfo::ProcessRefreshKind::nothing(),
+    );
+    sys.process(pid).is_some()
 }
 
 #[cfg(unix)]

--- a/crates/harn-hostlib/src/process/real.rs
+++ b/crates/harn-hostlib/src/process/real.rs
@@ -170,7 +170,15 @@ impl ProcessHandle for RealProcess {
                 None => {
                     let elapsed = start.elapsed();
                     if elapsed >= timeout {
+                        // `killer.kill()` kills the whole process group on Unix
+                        // (negative pid) to reap grandchildren. That path is a
+                        // no-op on non-Unix targets, where `kill_pid_or_group`
+                        // cannot signal by bare pid — so also kill the child
+                        // handle directly (TerminateProcess on Windows) to
+                        // guarantee the subsequent `child.wait()` cannot block
+                        // forever on a timed-out process.
                         self.killer.kill();
+                        let _ = child.kill();
                         let _ = child.wait();
                         return Ok((None, true));
                     }


### PR DESCRIPTION
## Problem
Two Unix-only assumptions in the process-management layer misbehave on the shipping `x86_64-pc-windows-msvc` target:

1. **`RealChild::wait_with_timeout` could hang on Windows.** It killed a timed-out child via `kill_pid_or_group`, which is a no-op on `#[cfg(not(unix))]` (it cannot signal a bare pid). The subsequent `child.wait()` could then block forever because nothing had terminated the child.

2. **`supervisor::process_is_alive` shelled out to `kill -0`**, gated behind `#[cfg(unix)]` with a `false`-returning Windows stub, so supervisor liveness was always wrong on Windows.

## Change
1. Also call `std::process::Child::kill()` (TerminateProcess on Windows) on the handle already in scope before `child.wait()`. On Unix the process-group kill stays the primary path and this is harmless redundancy on an already-dying child; on Windows it is what actually stops the process so the wait can't hang.

2. Replace both cfg variants of `process_is_alive` with one `sysinfo`-based check (`sysinfo` is already a `harn-cli` dependency). This collapses the cfg split into a single portable function and stops spawning a `kill` subprocess on the liveness-polling hot path in `wait_for_process_exit`.

## Verification
- `harn-cli` + `harn-hostlib` compile clean; clippy `-D warnings` clean.
- `process_tools` integration suite green on macOS (42 tests), including `run_command_kills_child_when_timeout_elapses`, which drives the modified timeout→kill→wait path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)