### PR TITLE
fix(ollama): capture done_reason for truncation visibility + stop mislabeling truncation as a parser bug

### DIFF
--- a/changelog.d/ollama-done-reason.fixed.md
+++ b/changelog.d/ollama-done-reason.fixed.md
@@ -1,0 +1,10 @@
+- **Ollama truncation visibility & cache mislabeling.** The `/api/chat` NDJSON
+  done-frame parser now captures Ollama's `done_reason` into `stop_reason`, so
+  length-truncation is visible on the most-used local chat path (it was
+  hard-coded to `None`). A `done_reason == "length"` cut-off no longer surfaces
+  as the retryable `[ollama_empty_content_parser_bug]` error — it returns
+  cleanly with `stop_reason: "length"`, a non-retryable signal, so the retry
+  loop no longer spins re-truncating a deterministic token cap. Native Ollama
+  responses (`/api/chat`, `/api/generate`, completion) now report cache as
+  `cache_visibility: "unsupported"` with a null `cache_hit_ratio` instead of a
+  fabricated `0.0` ratio that scored a local model as a 100% cache miss.

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -542,6 +542,7 @@ mod tests {
             output_tokens: 1,
             cache_read_tokens: 0,
             cache_write_tokens: 0,
+            cache_supported: true,
             model: "claude-sonnet-4-6".to_string(),
             provider: "anthropic".to_string(),
             thinking: None,

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -148,6 +148,7 @@ async fn vm_call_completion_openai_style(
         output_tokens: json["usage"]["completion_tokens"].as_i64().unwrap_or(0),
         cache_read_tokens: extract_cache_read_tokens(&json["usage"]),
         cache_write_tokens: extract_cache_write_tokens(&json["usage"]),
+        cache_supported: true,
         model: opts.model.clone(),
         provider: opts.provider.clone(),
         thinking: None,
@@ -245,8 +246,12 @@ async fn vm_call_completion_ollama(
         tool_calls: Vec::new(),
         input_tokens: json["prompt_eval_count"].as_i64().unwrap_or(0),
         output_tokens: json["eval_count"].as_i64().unwrap_or(0),
+        // Native Ollama generate responses carry no cache field; 0 is
+        // "unknown", not a real miss. `cache_supported: false` keeps the cost
+        // layer from scoring a local model as a 100% cache miss.
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: false,
         model: opts.model.clone(),
         provider: opts.provider.clone(),
         thinking: None,

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -480,6 +480,7 @@ pub(crate) fn parse_openai_responses_response(
         output_tokens,
         cache_read_tokens,
         cache_write_tokens,
+        cache_supported: true,
         model: model.to_string(),
         provider: provider.to_string(),
         thinking: None,
@@ -623,6 +624,7 @@ pub(crate) fn parse_llm_response(
             output_tokens,
             cache_read_tokens,
             cache_write_tokens,
+            cache_supported: true,
             model: model.to_string(),
             provider: provider.to_string(),
             thinking: if thinking_text.is_empty() {
@@ -801,6 +803,7 @@ pub(crate) fn parse_llm_response(
             output_tokens,
             cache_read_tokens,
             cache_write_tokens,
+            cache_supported: true,
             model: model.to_string(),
             provider: provider.to_string(),
             thinking: if extracted_thinking.is_empty() {

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -6,6 +6,19 @@ use std::collections::BTreeMap;
 use super::telemetry::ProviderTelemetry;
 use crate::value::VmValue;
 
+fn default_true() -> bool {
+    true
+}
+
+/// `skip_serializing_if` for `cache_supported`: omit the field in the common
+/// (supported) case so recordings/replay tapes/transcripts only carry it for the
+/// rare unsupported (native-Ollama) result. Keeps serialized output byte-stable
+/// with pre-existing goldens; `default_true` restores `true` on deserialize.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_true(value: &bool) -> bool {
+    *value
+}
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 pub(crate) struct LlmResult {
     pub text: String,
@@ -22,6 +35,16 @@ pub(crate) struct LlmResult {
     /// (Anthropic `usage.cache_creation_input_tokens`). Helps distinguish
     /// "warm-up" calls from cache hits.
     pub cache_write_tokens: i64,
+    /// Whether the provider reports prompt-cache accounting at all. Native
+    /// Ollama (`/api/chat`, `/api/generate`, the completion endpoint) sends no
+    /// cache field in its done frame — and the `/v1` shim on these hosts also
+    /// omits `prompt_tokens_details` — so `cache_read_tokens: 0` there means
+    /// "unknown", NOT a real 100% cache miss. When `false`, cache hit-ratio is
+    /// surfaced as `cache_visibility: "unsupported"` with a null ratio rather
+    /// than scoring a local model as a 0.0-ratio total miss. Defaults to `true`
+    /// for every provider that does report cache counts.
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub cache_supported: bool,
     pub model: String,
     pub provider: String,
     pub thinking: Option<String>,
@@ -76,10 +99,22 @@ fn build_usage_dict(result: &LlmResult) -> BTreeMap<String, VmValue> {
         "cache_creation_input_tokens".to_string(),
         VmValue::Int(result.cache_write_tokens),
     );
-    usage.insert(
-        "cache_hit_ratio".to_string(),
-        VmValue::Float(cache_hit_ratio),
-    );
+    if result.cache_supported {
+        usage.insert(
+            "cache_hit_ratio".to_string(),
+            VmValue::Float(cache_hit_ratio),
+        );
+        usage.insert("cache_visibility".to_string(), VmValue::Nil);
+    } else {
+        // Native local runtimes report no cache field; a 0.0 ratio here would
+        // mislabel a local model as a 100% cache miss. Surface the unknown
+        // explicitly instead of fabricating a number.
+        usage.insert("cache_hit_ratio".to_string(), VmValue::Nil);
+        usage.insert(
+            "cache_visibility".to_string(),
+            VmValue::String(std::sync::Arc::from("unsupported")),
+        );
+    }
     usage.insert(
         "cache_savings_usd".to_string(),
         VmValue::Float(cache_savings_usd),
@@ -134,6 +169,9 @@ pub(crate) fn vm_build_llm_result(
     let usage = build_usage_dict(result);
     if let Some(value) = usage.get("cache_hit_ratio") {
         dict.insert("cache_hit_ratio".to_string(), value.clone());
+    }
+    if let Some(value) = usage.get("cache_visibility") {
+        dict.insert("cache_visibility".to_string(), value.clone());
     }
     if let Some(value) = usage.get("cache_savings_usd") {
         dict.insert("cache_savings_usd".to_string(), value.clone());
@@ -345,6 +383,7 @@ pub(super) fn mock_completion_response(prefix: &str, suffix: Option<&str>) -> Ll
         output_tokens: 16,
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: true,
         model: "mock".to_string(),
         provider: "mock".to_string(),
         thinking: None,
@@ -357,5 +396,46 @@ pub(super) fn mock_completion_response(prefix: &str, suffix: Option<&str>) -> Ll
         })],
         logprobs: Vec::new(),
         telemetry: ProviderTelemetry::default(),
+    }
+}
+
+#[cfg(test)]
+mod cache_supported_serde_tests {
+    use super::mock_completion_response;
+    use super::LlmResult;
+
+    #[test]
+    fn cache_supported_true_is_omitted_from_serialization() {
+        // The common (cache-supported) case must serialize byte-identically to
+        // pre-`cache_supported` recordings / replay tapes, so the field is
+        // omitted when true and restored to true on deserialize via
+        // `default_true`. This keeps the testbench replay-fidelity golden stable.
+        let result = mock_completion_response("hi", None);
+        assert!(result.cache_supported);
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert!(
+            json.get("cache_supported").is_none(),
+            "cache_supported=true must be omitted from serialized output, got: {json}"
+        );
+        let back: LlmResult = serde_json::from_value(json).expect("deserialize");
+        assert!(
+            back.cache_supported,
+            "missing field must default back to true"
+        );
+    }
+
+    #[test]
+    fn cache_supported_false_is_serialized_and_round_trips() {
+        let mut result = mock_completion_response("hi", None);
+        result.cache_supported = false;
+        let json = serde_json::to_value(&result).expect("serialize");
+        assert_eq!(
+            json.get("cache_supported")
+                .and_then(serde_json::Value::as_bool),
+            Some(false),
+            "the meaningful unsupported case must serialize the field"
+        );
+        let back: LlmResult = serde_json::from_value(json).expect("deserialize");
+        assert!(!back.cache_supported);
     }
 }

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -425,6 +425,11 @@ async fn vm_call_llm_api_with_body_inner(
             )
             .await
             {
+                // A `done_reason == "length"` truncation now returns Ok with an
+                // empty body and `stop_reason: Some("length")`, so it bypasses
+                // the retry guard below entirely — a deterministic token-cap cut
+                // would just re-truncate on every retry. Only the genuine
+                // empty-content parser bug (done_reason stop/absent) is retried.
                 Ok(result) => return Ok(result),
                 Err(err)
                     if is_ollama
@@ -1158,6 +1163,7 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
         output_tokens,
         cache_read_tokens,
         cache_write_tokens,
+        cache_supported: true,
         model: model.to_string(),
         provider: result_provider,
         thinking: if thinking_text.is_empty() {
@@ -1235,6 +1241,7 @@ where
     let mut blocks = Vec::new();
     let mut saw_done = false;
     let mut saw_chunk = false;
+    let mut done_reason: Option<String> = None;
     let mut telemetry = ProviderTelemetry::default();
 
     loop {
@@ -1300,6 +1307,10 @@ where
             if let Some(n) = json["eval_count"].as_i64() {
                 output_tokens = n;
             }
+            // Capture Ollama's `done_reason` so length-truncation is visible on
+            // the most-used local chat path. Without this the agent never learns
+            // it was cut off at the token cap.
+            done_reason = json["done_reason"].as_str().map(str::to_string);
             telemetry = ProviderTelemetry::from_ollama_done(&json, telemetry_source::OLLAMA_CHAT);
             saw_done = true;
             break;
@@ -1332,7 +1343,18 @@ where
     // nonzero but every delta and the done chunk are empty strings.
     // Silently returning empty text would make the agent loop burn
     // iterations on a no-op.
-    if text.is_empty() && tool_calls.is_empty() && output_tokens > 0 {
+    //
+    // BUT: `done_reason == "length"` is a deterministic token-cap
+    // truncation, not a parser bug. Re-running it just re-truncates, so we
+    // must NOT raise the retryable parser-bug error here. Surface the empty
+    // result carrying `stop_reason: Some("length")` so the caller sees a
+    // non-retryable truncation signal instead. The parser-bug error stays
+    // reserved for `done_reason` == stop/absent.
+    if text.is_empty()
+        && tool_calls.is_empty()
+        && output_tokens > 0
+        && done_reason.as_deref() != Some("length")
+    {
         return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
             "ollama model {model} reported eval_count={output_tokens} but delivered no content or thinking [ollama_empty_content_parser_bug]"
         )))));
@@ -1343,8 +1365,14 @@ where
         tool_calls,
         input_tokens,
         output_tokens,
+        // Native Ollama `/api/chat` NDJSON done frames carry no cache field;
+        // 0 is "unknown", not a real miss. The `/v1` shim on these hosts also
+        // omits `prompt_tokens_details`, so routing to `/v1` is not a fix.
+        // `cache_supported: false` keeps cost/telemetry from scoring a local
+        // model as a 100% cache miss.
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: false,
         model: result_model,
         // NDJSON is currently only consumed for Ollama's `/api/chat`, but
         // pass the caller-supplied provider through anyway so the result
@@ -1354,7 +1382,7 @@ where
         provider: provider.to_string(),
         thinking,
         thinking_summary: None,
-        stop_reason: None,
+        stop_reason: done_reason,
         // NDJSON (Ollama) has no accelerated-serving tier.
         served_fast: false,
         blocks,
@@ -1549,6 +1577,81 @@ mod tests {
         assert_eq!(
             result.telemetry.runtime_loaded_model.as_deref(),
             Some("devstral-small-2:24b")
+        );
+    }
+
+    #[tokio::test]
+    async fn ollama_ndjson_done_reason_stop_is_captured_as_stop_reason() {
+        // Fix 1: a normal `done_reason:"stop"` frame surfaces stop_reason.
+        let body = b"{\"message\":{\"role\":\"assistant\",\"content\":\"hi\"},\"done\":true,\
+            \"done_reason\":\"stop\",\"prompt_eval_count\":5,\"eval_count\":2}\n";
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut warmup_gate = false;
+        let result = consume_ollama_ndjson_lines(
+            &body[..],
+            "ollama",
+            "stub-model",
+            tx,
+            Duration::ZERO,
+            &mut warmup_gate,
+            None,
+        )
+        .await
+        .expect("ollama stream parses");
+        assert_eq!(result.stop_reason.as_deref(), Some("stop"));
+        // Fix 3: native Ollama reports no cache field — it is unsupported,
+        // not a real 0% cache hit.
+        assert!(!result.cache_supported);
+    }
+
+    #[tokio::test]
+    async fn ollama_ndjson_done_reason_length_surfaces_truncation_not_parser_bug() {
+        // Fix 1 + Fix 2: a length-capped frame with empty content must NOT
+        // raise the retryable parser-bug error; instead it returns Ok carrying
+        // stop_reason: Some("length") as a non-retryable truncation signal.
+        let body = b"{\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\
+            \"done_reason\":\"length\",\"prompt_eval_count\":10,\"eval_count\":8}\n";
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut warmup_gate = false;
+        let result = consume_ollama_ndjson_lines(
+            &body[..],
+            "ollama",
+            "stub-model",
+            tx,
+            Duration::ZERO,
+            &mut warmup_gate,
+            None,
+        )
+        .await
+        .expect("length truncation should return Ok, not the parser-bug error");
+        assert_eq!(result.stop_reason.as_deref(), Some("length"));
+        assert!(result.text.is_empty());
+        assert!(result.tool_calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ollama_ndjson_empty_content_without_done_reason_is_still_parser_bug() {
+        // Fix 2 guardrail: empty content with no `done_reason` (or stop) keeps
+        // the retryable parser-bug behavior — only "length" is special-cased.
+        let body = b"{\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\
+            \"done_reason\":\"stop\",\"prompt_eval_count\":10,\"eval_count\":4}\n";
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut warmup_gate = false;
+        let err = consume_ollama_ndjson_lines(
+            &body[..],
+            "ollama",
+            "stub-model",
+            tx,
+            Duration::ZERO,
+            &mut warmup_gate,
+            None,
+        )
+        .await
+        .expect_err("empty content with done_reason=stop is still a parser bug");
+        assert!(
+            err.to_string()
+                .contains("[ollama_empty_content_parser_bug]"),
+            "err was: {err}"
         );
     }
 }

--- a/crates/harn-vm/src/llm/fake.rs
+++ b/crates/harn-vm/src/llm/fake.rs
@@ -458,6 +458,7 @@ async fn play_stream(
         output_tokens: 0,
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: true,
         model: request.model.clone(),
         provider: "fake".to_string(),
         thinking: None,

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -384,6 +384,7 @@ fn build_mock_result(mock: &LlmMock, last_msg_len: usize) -> LlmResult {
         output_tokens: mock.output_tokens.unwrap_or(30),
         cache_read_tokens: mock.cache_read_tokens.unwrap_or(0),
         cache_write_tokens: mock.cache_write_tokens.unwrap_or(0),
+        cache_supported: true,
         model: mock.model.clone(),
         provider: mock.provider.clone().unwrap_or_else(|| "mock".to_string()),
         thinking: mock.thinking.clone(),
@@ -825,6 +826,7 @@ pub(crate) fn load_fixture(hash: &str) -> Option<LlmResult> {
             .as_i64()
             .or_else(|| json["cache_creation_input_tokens"].as_i64())
             .unwrap_or(0),
+        cache_supported: json["cache_supported"].as_bool().unwrap_or(true),
         model: json["model"].as_str().unwrap_or("").to_string(),
         provider: json["provider"].as_str().unwrap_or("mock").to_string(),
         thinking: json["thinking"].as_str().map(|s| s.to_string()),
@@ -959,6 +961,7 @@ pub(crate) fn mock_llm_response(
                 output_tokens: 20,
                 cache_read_tokens: 0,
                 cache_write_tokens: 0,
+                cache_supported: true,
                 model: request.model.clone(),
                 provider: "mock".to_string(),
                 thinking: None,
@@ -1010,6 +1013,7 @@ pub(crate) fn mock_llm_response(
         output_tokens: 30,
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: true,
         model: request.model.clone(),
         provider: "mock".to_string(),
         thinking: None,

--- a/crates/harn-vm/src/llm/providers/acp.rs
+++ b/crates/harn-vm/src/llm/providers/acp.rs
@@ -296,6 +296,7 @@ where
         output_tokens,
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: true,
         model: request.model.clone(),
         provider: request.provider.clone(),
         thinking: None,

--- a/crates/harn-vm/src/llm/providers/common.rs
+++ b/crates/harn-vm/src/llm/providers/common.rs
@@ -43,6 +43,7 @@ pub(super) fn empty_result(provider: &str, model: &str) -> LlmResult {
         output_tokens: 0,
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: true,
         model: model.to_string(),
         provider: provider.to_string(),
         thinking: None,

--- a/crates/harn-vm/src/llm/providers/gemini.rs
+++ b/crates/harn-vm/src/llm/providers/gemini.rs
@@ -457,6 +457,7 @@ fn parse_response(
         output_tokens,
         cache_read_tokens,
         cache_write_tokens: 0,
+        cache_supported: true,
         model: request.model.clone(),
         provider: request.provider.clone(),
         thinking: if thinking.is_empty() {

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -402,8 +402,12 @@ async fn parse_raw_generate_response(
         tool_calls: Vec::new(),
         input_tokens,
         output_tokens,
+        // Native Ollama `/api/chat` done frames carry no cache field; 0 here
+        // means "unknown", not a real miss. `cache_supported: false` keeps the
+        // cost layer from scoring a local model as a 100% cache miss.
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: false,
         model: json
             .get("model")
             .and_then(|value| value.as_str())
@@ -505,8 +509,11 @@ async fn parse_raw_generate_stream(
         tool_calls: Vec::new(),
         input_tokens,
         output_tokens,
+        // Native Ollama `/api/generate` streaming reports no cache field;
+        // 0 is "unknown", not a real miss. See `cache_supported` on LlmResult.
         cache_read_tokens: 0,
         cache_write_tokens: 0,
+        cache_supported: false,
         model: result_model,
         provider: provider.to_string(),
         thinking: (!thinking.is_empty()).then_some(thinking),


### PR DESCRIPTION
## What

Three related fixes to the Ollama local-model path, all on the most-used `/api/chat` NDJSON surface.

### Fix 1 — capture `done_reason` → `stop_reason` (highest leverage)
The Ollama `/api/chat` NDJSON done-frame parser in `transport.rs` hard-coded `stop_reason: None`, silently discarding `done_reason`. Length-truncation was therefore invisible on the most-used local chat path. We now bind `done_reason` off the done frame and surface it as `stop_reason`, matching the sibling patterns already in `providers/ollama.rs` (`/api/generate`) and `api/completion.rs`.

This has a real consumer: `llm/call.rs` already special-cases `stop_reason == "length" | "max_tokens"` to detect token-limited structured output — that branch never fired on the Ollama chat path before, because the value was always `None`.

### Fix 2 — don't mislabel length-truncation as a parser bug, and don't retry it
The empty-content guard previously threw `[ollama_empty_content_parser_bug]` (a retryable error) whenever `eval_count > 0` but no visible content arrived. A deterministic `done_reason == "length"` cut-off hits that path, and retrying just re-truncates every time. We now special-case `done_reason == "length"`: return the result cleanly carrying `stop_reason: Some("length")` (a non-retryable truncation signal) and bypass the retry guard. The parser-bug error stays reserved for `done_reason` stop/absent.

### Fix 3 — stop reporting native-Ollama `cache_read_tokens: 0` as a real 100% cache miss
Native Ollama done frames carry no cache field, and the `/v1` shim on these hosts also omits `prompt_tokens_details`, so routing to `/v1` is not a fix. A hard-coded `cache_read_tokens: 0` made `cost::cache_hit_ratio` score every local model as a 0.0-ratio total cache miss. We add a `cache_supported` flag to `LlmResult` (defaults `true`, serde-defaulted for back-compat) and set it `false` at the four native-Ollama construction sites (`providers/ollama.rs` ×2, `api/transport.rs`, `api/completion.rs`). When false, usage surfaces `cache_visibility: "unsupported"` with a null `cache_hit_ratio` instead of a fabricated `0.0`. No numbers are invented.

## Tests

New unit tests in `transport.rs` drive `consume_ollama_ndjson_lines` against captured done-frame fixtures:
- `ollama_ndjson_done_reason_stop_is_captured_as_stop_reason` — `done_reason:"stop"` → `stop_reason == Some("stop")`, `cache_supported == false`
- `ollama_ndjson_done_reason_length_surfaces_truncation_not_parser_bug` — `done_reason:"length"` + empty content → returns Ok with `stop_reason == Some("length")`, no parser-bug throw
- `ollama_ndjson_empty_content_without_done_reason_is_still_parser_bug` — empty content with `done_reason:"stop"` still raises the retryable parser-bug error

All 6 `ollama_ndjson*` tests pass; full `llm::` module suite green (771 passed).

## Live validation

Ran a throwaway harn script calling `gemma4:12b-mlx` (Ollama `:11434`) with `max_tokens: 8` on a verbose prompt:

```
[INFO] [llm] warming up Ollama model gemma4:12b-mlx
stop_reason=length
text_len=54
cache_visibility=unsupported
cache_hit_ratio=nil
cache_read_tokens=0
output_tokens=8
PASS Fix1: stop_reason surfaced length-truncation
PASS Fix3: native Ollama cache reported as unsupported (not 0% miss)
```

Confirms all three fixes end-to-end on the real NDJSON chat path: truncation is now visible, no `[ollama_empty_content_parser_bug]` thrown, and cache is reported unsupported rather than a false 100% miss.

`cargo build -p harn-vm`, `cargo clippy -p harn-vm --tests`, and `cargo fmt` are all clean.