### PR TITLE
[codex] Add MiniMax M3 catalog and video LLM content

### DIFF
--- a/changelog.d/minimax-m3.added.md
+++ b/changelog.d/minimax-m3.added.md
@@ -1,0 +1,4 @@
+- **MiniMax M3 provider catalog support.** Adds direct MiniMax and OpenRouter
+  catalog rows for MiniMax M3, exposes video input as a first-class LLM
+  capability/content block, and keeps static pricing on MiniMax's standard
+  non-promotional rate card.

--- a/conformance/tests/scenarios/llm_media_helpers.harn
+++ b/conformance/tests/scenarios/llm_media_helpers.harn
@@ -1,4 +1,10 @@
-import { image_content, image_message, media_type_for_path } from "std/llm/media"
+import {
+  image_content,
+  image_message,
+  media_type_for_path,
+  video_content,
+  video_message,
+} from "std/llm/media"
 
 pipeline test(task) {
   let png_path = "media_helper_fixture.png"
@@ -19,5 +25,12 @@ pipeline test(task) {
   assert(message.content[0].text == "caption", "text block created")
   assert(message.content[1].url == "https://example.com/image.webp", "url image kept as url")
   assert(media_type_for_path("clip.mp3") == "audio/mpeg", "audio type inferred")
+  assert(media_type_for_path("clip.mp4") == "video/mp4", "video type inferred")
+  let video = video_content("https://example.com/demo.webm")
+  assert(video.type == "video", "video block type")
+  assert(video.url == "https://example.com/demo.webm", "url video kept as url")
+  let video_msg = video_message("https://example.com/demo.mp4", "summarize", {})
+  assert(video_msg.content[0].text == "summarize", "video text block created")
+  assert(video_msg.content[1].type == "video", "video message block created")
   log("llm_media_helpers tests passed")
 }

--- a/crates/harn-cli/src/commands/check/provider_matrix.rs
+++ b/crates/harn-cli/src/commands/check/provider_matrix.rs
@@ -18,6 +18,7 @@ const FEATURES: &[&str] = &[
     "vision",
     "audio",
     "pdf",
+    "video",
     "streaming",
     "files_api",
     "json_schema",
@@ -72,14 +73,14 @@ pub(crate) fn generate_markdown(
     );
     out.push_str("Regenerate with `make gen-provider-matrix` and verify with `make check-provider-matrix`.\n\n");
     out.push_str(
-        "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |\n",
+        "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Video | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |\n",
     );
     out.push_str(
-        "|---|---|---|---|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---|---:|---:|---|---:|---:|\n",
+        "|---|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---|---:|---:|---|---:|---:|\n",
     );
     for row in rows {
         out.push_str(&format!(
-            "| `{}` | `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} | `{}` | {} | `{}` | `{}` | `{}` | `{}` | {} | {} | `{}` | {} | {} |\n",
+            "| `{}` | `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | `{}` | {} | `{}` | `{}` | `{}` | `{}` | {} | {} | `{}` | {} | {} |\n",
             row.provider,
             row.model,
             markdown_cell(&version_min_cell(row)),
@@ -87,6 +88,7 @@ pub(crate) fn generate_markdown(
             yes_no(row.vision),
             yes_no(row.audio),
             yes_no(row.pdf),
+            yes_no(row.video),
             yes_no(row.streaming),
             yes_no(row.files_api_supported),
             markdown_cell(&json_schema_cell(row)),
@@ -218,6 +220,7 @@ fn row_supports_feature(row: &ProviderCapabilityMatrixRow, feature: &str) -> boo
         "vision" => row.vision,
         "audio" => row.audio,
         "pdf" => row.pdf,
+        "video" => row.video,
         "streaming" => row.streaming,
         "files_api" => row.files_api_supported,
         "json_schema" => row.json_schema.is_some(),
@@ -240,7 +243,7 @@ fn row_supports_feature(row: &ProviderCapabilityMatrixRow, feature: &str) -> boo
 }
 
 fn print_text(rows: &[ProviderCapabilityMatrixRow]) {
-    let table_rows: Vec<[String; 21]> = rows
+    let table_rows: Vec<[String; 22]> = rows
         .iter()
         .map(|row| {
             [
@@ -250,6 +253,7 @@ fn print_text(rows: &[ProviderCapabilityMatrixRow]) {
                 yes_no(row.vision).to_string(),
                 yes_no(row.audio).to_string(),
                 yes_no(row.pdf).to_string(),
+                yes_no(row.video).to_string(),
                 yes_no(row.streaming).to_string(),
                 yes_no(row.files_api_supported).to_string(),
                 json_schema_cell(row),
@@ -275,6 +279,7 @@ fn print_text(rows: &[ProviderCapabilityMatrixRow]) {
         "vision".to_string(),
         "audio".to_string(),
         "pdf".to_string(),
+        "video".to_string(),
         "streaming".to_string(),
         "files_api".to_string(),
         "json_schema".to_string(),
@@ -479,7 +484,7 @@ mod tests {
         assert!(markdown.contains("Source of truth"));
         assert!(markdown.contains("harn providers matrix"));
         assert!(markdown.contains(
-            "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |"
+            "| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Video | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |"
         ));
         assert!(markdown.contains("Tool-format recommendations by catalog model"));
     }

--- a/crates/harn-stdlib/src/stdlib/llm/catalog.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/catalog.harn
@@ -73,13 +73,16 @@ fn __capability_field(caps, capability) {
   if capability == "pdf" {
     return caps?.pdf ?? false
   }
+  if capability == "video" {
+    return caps?.video ?? false
+  }
   return false
 }
 
 /**
  * True if (model, capability) is supported per the runtime catalog.
  * capability is one of: "thinking", "tool_search", "interleaved_thinking",
- * "prompt_caching", "vision", "audio", "pdf", "files_api",
+ * "prompt_caching", "vision", "audio", "pdf", "video", "files_api",
  * "reasoning_effort", "native_tools". Returns false on unknown model.
  *
  * @effects: []

--- a/crates/harn-stdlib/src/stdlib/llm/media.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/media.harn
@@ -35,6 +35,18 @@ pub fn media_type_for_path(path, fallback = nil) {
   if ext == ".pdf" {
     return "application/pdf"
   }
+  if ext == ".mp4" || ext == ".m4v" {
+    return "video/mp4"
+  }
+  if ext == ".mov" {
+    return "video/quicktime"
+  }
+  if ext == ".webm" {
+    return "video/webm"
+  }
+  if ext == ".mkv" {
+    return "video/x-matroska"
+  }
   if ext == ".wav" {
     return "audio/wav"
   }
@@ -87,6 +99,28 @@ pub fn image_content(source, options = nil) {
   }
   if opts?.detail != nil {
     block = block + {detail: opts.detail}
+  }
+  return block
+}
+
+/**
+ * video_content creates an llm_call-compatible video block from a URL or local path.
+ *
+ * @effects: [llm.call]
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: video_content(source, options)
+ */
+pub fn video_content(source, options = nil) {
+  if type_of(source) == "dict" {
+    return source
+  }
+  let opts = options ?? {}
+  let media_type = opts?.media_type ?? opts?.mime_type ?? media_type_for_path(source, "video/mp4")
+  var block = {type: "video"} + __llm_media_source_field(harness, source, media_type)
+  if block?.media_type == nil {
+    block = block + {media_type: media_type}
   }
   return block
 }
@@ -157,6 +191,24 @@ pub fn image_message(source, prompt = "", options = nil) {
     prompt
   }
   return {role: "user", content: [text_content(text), image_content(source, options)]}
+}
+
+/**
+ * video_message builds a user message containing text plus one video.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: video_message(source, prompt, options)
+ */
+pub fn video_message(source, prompt = "", options = nil) {
+  let text = if prompt == nil || prompt == "" {
+    "Analyze this video."
+  } else {
+    prompt
+  }
+  return {role: "user", content: [text_content(text), video_content(source, options)]}
 }
 
 /**

--- a/crates/harn-vm/src/llm/api/openai_normalize.rs
+++ b/crates/harn-vm/src/llm/api/openai_normalize.rs
@@ -1,6 +1,6 @@
 //! Message-shape normalization for OpenAI-style providers. Handles both
 //! string and structured `content` payloads, surfaces hidden reasoning
-//! fields (`reasoning` / `reasoning_content`), and splits inline
+//! fields (`reasoning` / `reasoning_content` / `reasoning_details`), and splits inline
 //! `<think>...</think>` blocks via [`super::thinking`].
 
 use super::thinking::split_openai_thinking_blocks;
@@ -118,8 +118,10 @@ pub(super) fn extract_openai_delta_field_str<'a>(
 
 pub(super) fn normalize_openai_message_text(message: &serde_json::Value) -> (String, String) {
     let raw_text = extract_openai_message_field_as_text(message, &["content"]);
-    let reasoning_text =
-        extract_openai_message_field_as_text(message, &["reasoning", "reasoning_content"]);
+    let reasoning_text = extract_openai_message_field_as_text(
+        message,
+        &["reasoning", "reasoning_content", "reasoning_details"],
+    );
     // Qwen3/3.5 emit inline `<think>...</think>` when
     // `chat_template_kwargs.enable_thinking` is set. Split them out so the
     // agent loop doesn't treat reasoning as output or parse tool calls
@@ -231,6 +233,17 @@ mod tests {
         let (visible, thinking) = normalize_openai_message_text(&message);
         assert_eq!(visible, "visible answer");
         assert_eq!(thinking, "separate reasoning\ninline reasoning");
+    }
+
+    #[test]
+    fn normalize_openai_message_text_uses_minimax_reasoning_details() {
+        let message = serde_json::json!({
+            "content": "visible answer",
+            "reasoning_details": "minimax private trace"
+        });
+        let (visible, thinking) = normalize_openai_message_text(&message);
+        assert_eq!(visible, "visible answer");
+        assert_eq!(thinking, "minimax private trace");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -907,8 +907,9 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
                 }
             }
             // Streaming deltas for `reasoning` (Ollama OpenAI-compat,
-            // OpenRouter passthrough) and `reasoning_content` (DashScope,
-            // Together) arrive as token-sized fragments — `"Here"`,
+            // OpenRouter passthrough), `reasoning_content` (DashScope,
+            // Together), and `reasoning_details` (MiniMax) arrive as
+            // token-sized fragments — `"Here"`,
             // `"'s"`, `" a"`, `" thinking"`. Concatenate them verbatim;
             // `extract_openai_message_field_as_text` + `append_paragraph`
             // would `.trim()` each fragment (losing inter-token spaces)
@@ -917,8 +918,10 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
             // `"The\ntask\nis\nto\nextend"`. The non-streaming response
             // path still uses `append_paragraph` because there each
             // field arrives as a single complete block.
-            let reasoning_delta =
-                extract_openai_delta_field_str(delta, &["reasoning", "reasoning_content"]);
+            let reasoning_delta = extract_openai_delta_field_str(
+                delta,
+                &["reasoning", "reasoning_content", "reasoning_details"],
+            );
             if !reasoning_delta.is_empty() {
                 thinking_text.push_str(reasoning_delta);
                 blocks.push(serde_json::json!({"type": "reasoning", "text": reasoning_delta, "visibility": "private"}));

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -231,6 +231,10 @@ pub struct ProviderRule {
     /// through Harn's LLM message path.
     #[serde(default, alias = "pdf_supported")]
     pub pdf: Option<bool>,
+    /// Whether this provider/model route accepts video input blocks
+    /// through Harn's LLM message path.
+    #[serde(default, alias = "video_supported")]
+    pub video: Option<bool>,
     /// Whether uploaded file references can be reused in message content.
     #[serde(default)]
     pub files_api_supported: Option<bool>,
@@ -332,7 +336,7 @@ pub struct ProviderRule {
     #[serde(default)]
     pub reasoning_none_supported: Option<bool>,
     /// Provider-specific reasoning request shape for OpenAI-compatible
-    /// transports. Known values are `openrouter` and `enabled`.
+    /// transports. Known values are `openrouter`, `enabled`, and `minimax`.
     #[serde(default)]
     pub reasoning_wire_format: Option<String>,
     #[serde(default)]
@@ -413,6 +417,7 @@ pub struct Capabilities {
     pub vision: bool,
     pub audio: bool,
     pub pdf: bool,
+    pub video: bool,
     pub files_api_supported: bool,
     pub file_upload_wire_format: Option<String>,
     pub structured_output: Option<String>,
@@ -474,6 +479,7 @@ impl Default for Capabilities {
             vision: false,
             audio: false,
             pdf: false,
+            video: false,
             files_api_supported: false,
             file_upload_wire_format: None,
             structured_output: None,
@@ -527,6 +533,7 @@ pub struct ProviderCapabilityMatrixRow {
     pub vision: bool,
     pub audio: bool,
     pub pdf: bool,
+    pub video: bool,
     pub streaming: bool,
     pub files_api_supported: bool,
     pub json_schema: Option<String>,
@@ -913,6 +920,7 @@ fn rule_to_matrix_row(
         vision: rule_vision(rule),
         audio: rule.audio.unwrap_or(false),
         pdf: rule.pdf.unwrap_or(false),
+        video: rule.video.unwrap_or(false),
         streaming: true,
         files_api_supported: rule.files_api_supported.unwrap_or(false),
         json_schema: rule_structured_output(rule),
@@ -1082,6 +1090,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         vision: None,
         audio: None,
         pdf: None,
+        video: None,
         files_api_supported: None,
         file_upload_wire_format: None,
         structured_output: None,
@@ -1153,6 +1162,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         vision: rule_vision(rule),
         audio: rule.audio.unwrap_or(false),
         pdf: rule.pdf.unwrap_or(false),
+        video: rule.video.unwrap_or(false),
         files_api_supported: rule
             .files_api_supported
             .or(defaults.files_api_supported)
@@ -1560,6 +1570,15 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     #[test]
     fn vision_capability_gates_known_multimodal_models() {
         reset();
+        let minimax_m3 = lookup("minimax", "MiniMax-M3");
+        assert!(minimax_m3.vision_supported);
+        assert!(minimax_m3.video);
+        assert_eq!(minimax_m3.thinking_modes, vec!["adaptive"]);
+        assert_eq!(minimax_m3.reasoning_wire_format.as_deref(), Some("minimax"));
+        assert!(minimax_m3.requires_completion_tokens);
+        let openrouter_m3 = lookup("openrouter", "minimax/minimax-m3");
+        assert!(openrouter_m3.vision_supported);
+        assert!(openrouter_m3.video);
         assert!(lookup("openai", "gpt-4o").vision_supported);
         assert!(lookup("openai", "gpt-5.4-preview").vision_supported);
         assert!(lookup("anthropic", "claude-sonnet-4-6").vision_supported);

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -50,6 +50,7 @@
 #   vision          : whether Harn can send visual input blocks on this route.
 #   audio_supported : whether Harn can send audio input blocks on this route.
 #   pdf_supported   : whether Harn can send PDF/document input blocks on this route.
+#   video_supported : whether Harn can send video input blocks on this route.
 #   files_api_supported:
 #                     whether file_id references from std/files::upload are accepted.
 #   file_upload_wire_format:
@@ -88,7 +89,7 @@
 #   reasoning_none_supported: whether reasoning_effort="none" is accepted.
 #   reasoning_wire_format:
 #                     OpenAI-compatible non-standard reasoning transport:
-#                     openrouter or enabled.
+#                     openrouter, enabled, or minimax.
 #   recommended_endpoint: preferred endpoint family for this route.
 #   text_tool_wire_format_supported: whether Harn text tool calls survive.
 #   preferred_tool_format:
@@ -2252,10 +2253,33 @@ prefers_xml_tools = false
 thinking_block_style = "inline"
 prompt_caching = true
 
-# ---------- MiniMax (open-weight, OpenAI-compatible /v1) ---------------------
-# MiniMax M2 family: 230B/10B MoE with native tool calls + thinking mode.
-# Prompt caching honored on M2.7+ at 20% of input. Highspeed variants
-# share the same wire shape, just skip the thinking-mode budget.
+# ---------- MiniMax (OpenAI-compatible /v1) ----------------------------------
+# MiniMax M3 adds adaptive thinking, 1M context, native tools, prompt
+# caching, and text/image/video input. The M2 family remains open-weight:
+# 230B/10B MoE with native tool calls + thinking mode. Prompt caching is
+# honored on M2.7+ at 20% of input. Highspeed variants share the same wire
+# shape, just skip the thinking-mode budget.
+
+[[provider.minimax]]
+model_match = "minimax-m3*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "delimited"
+thinking_modes = ["adaptive"]
+reasoning_wire_format = "minimax"
+requires_completion_tokens = true
+vision = true
+vision_supported = true
+video_supported = true
+prompt_caching = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
 
 [[provider.minimax]]
 model_match = "minimax-m2.7*"
@@ -2358,6 +2382,25 @@ thinking_block_style = "inline"
 # overrides only need to set `native_tools` + `preferred_tool_format`.
 # The audit test trips on missing entries because provider_family
 # inheritance does not cover specific OR slugs by itself.
+
+[[provider.openrouter]]
+model_match = "minimax/minimax-m3*"
+native_tools = true
+preferred_tool_format = "native"
+text_tool_wire_format_supported = true
+structured_output = "delimited"
+thinking_modes = ["adaptive"]
+vision = true
+vision_supported = true
+video_supported = true
+prompt_caching = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
 
 [[provider.openrouter]]
 model_match = "minimax/minimax-m2.7*"

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -1106,6 +1106,7 @@ pub(crate) fn capabilities_to_vm_value(
     );
     dict.insert("audio".to_string(), VmValue::Bool(caps.audio));
     dict.insert("pdf".to_string(), VmValue::Bool(caps.pdf));
+    dict.insert("video".to_string(), VmValue::Bool(caps.video));
     dict.insert(
         "files_api_supported".to_string(),
         VmValue::Bool(caps.files_api_supported),

--- a/crates/harn-vm/src/llm/content.rs
+++ b/crates/harn-vm/src/llm/content.rs
@@ -2,6 +2,7 @@
 //!
 //! Harn scripts represent multimodal inputs as content blocks:
 //! `{type: "image", url?: string, base64?: string, media_type: string, detail?: "low"|"high"|"auto"}`.
+//! `{type: "video", url?: string, base64?: string, media_type: string}`.
 //! `{type: "pdf", url?: string, base64?: string, file_id?: string}`.
 //! `{type: "audio", url?: string, base64?: string, file_id?: string, media_type: string}`.
 //! Provider serializers translate that one shape into their native wire format.
@@ -66,6 +67,63 @@ impl ImageContent {
             base64,
             media_type,
             detail,
+        }))
+    }
+
+    pub(crate) fn openai_url(&self) -> String {
+        self.url.clone().unwrap_or_else(|| {
+            format!(
+                "data:{};base64,{}",
+                self.media_type,
+                self.base64.as_deref().unwrap_or_default()
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct VideoContent {
+    pub url: Option<String>,
+    pub base64: Option<String>,
+    pub media_type: String,
+}
+
+impl VideoContent {
+    fn from_block(block: &serde_json::Value) -> Result<Option<Self>, VmError> {
+        let block_type = block.get("type").and_then(|value| value.as_str());
+        if !matches!(block_type, Some("video" | "video_url")) {
+            return Ok(None);
+        }
+        let nested_video_url = block.get("video_url");
+        let url = nested_video_url
+            .and_then(|value| value.get("url"))
+            .or_else(|| block.get("url"))
+            .or_else(|| block.get("file_uri"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let base64 = block
+            .get("base64")
+            .or_else(|| block.get("data"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        if url.is_some() == base64.is_some() {
+            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+                "llm_call video content requires exactly one of url or base64",
+            ))));
+        }
+        let media_type = block
+            .get("media_type")
+            .or_else(|| block.get("mime_type"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| "video/mp4".to_string());
+        Ok(Some(Self {
+            url,
+            base64,
+            media_type,
         }))
     }
 
@@ -194,6 +252,12 @@ pub(crate) fn parse_file_block(block: &serde_json::Value) -> Result<Option<FileC
     FileContent::from_block(block)
 }
 
+pub(crate) fn parse_video_block(
+    block: &serde_json::Value,
+) -> Result<Option<VideoContent>, VmError> {
+    VideoContent::from_block(block)
+}
+
 pub(crate) fn messages_contain_images(messages: &[serde_json::Value]) -> Result<bool, VmError> {
     for message in messages {
         if message
@@ -214,6 +278,35 @@ pub(crate) fn messages_contain_images(messages: &[serde_json::Value]) -> Result<
             Some(content @ serde_json::Value::Object(_)) => {
                 let contains_image = parse_image_block(content)?.is_some();
                 if contains_image {
+                    return Ok(true);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(false)
+}
+
+pub(crate) fn messages_contain_videos(messages: &[serde_json::Value]) -> Result<bool, VmError> {
+    for message in messages {
+        if message
+            .get("videos")
+            .and_then(|value| value.as_array())
+            .is_some_and(|videos| !videos.is_empty())
+        {
+            return Ok(true);
+        }
+        match message.get("content") {
+            Some(serde_json::Value::Array(blocks)) => {
+                for block in blocks {
+                    if parse_video_block(block)?.is_some() {
+                        return Ok(true);
+                    }
+                }
+            }
+            Some(content @ serde_json::Value::Object(_)) => {
+                let contains_video = parse_video_block(content)?.is_some();
+                if contains_video {
                     return Ok(true);
                 }
             }
@@ -329,6 +422,8 @@ pub(crate) fn anthropic_content(content: &serde_json::Value) -> serde_json::Valu
                         _ => continue,
                     };
                     out.push(serde_json::json!({"type": "image", "source": source}));
+                } else if parse_video_block(block).is_ok_and(|video| video.is_some()) {
+                    out.push(block.clone());
                 } else if let Ok(Some(file)) = parse_file_block(block) {
                     out.push(anthropic_file_block(block, file));
                 } else if let Some(text) = normalized_text_block(block) {
@@ -344,6 +439,8 @@ pub(crate) fn anthropic_content(content: &serde_json::Value) -> serde_json::Valu
                 anthropic_content(&serde_json::Value::Array(vec![serde_json::json!(
                     image_to_neutral_json(&image)
                 )]))
+            } else if parse_video_block(content).is_ok_and(|video| video.is_some()) {
+                content.clone()
             } else if let Ok(Some(file)) = parse_file_block(content) {
                 serde_json::Value::Array(vec![anthropic_file_block(content, file)])
             } else {
@@ -368,6 +465,13 @@ pub(crate) fn openai_content(content: &serde_json::Value) -> serde_json::Value {
                         "type": "image_url",
                         "image_url": image_url,
                     }));
+                } else if let Ok(Some(video)) = parse_video_block(block) {
+                    out.push(serde_json::json!({
+                        "type": "video_url",
+                        "video_url": {
+                            "url": video.openai_url(),
+                        },
+                    }));
                 } else if let Ok(Some(file)) = parse_file_block(block) {
                     out.push(openai_file_block(file));
                 } else if let Some(text) = normalized_text_block(block) {
@@ -387,6 +491,13 @@ pub(crate) fn openai_content(content: &serde_json::Value) -> serde_json::Value {
                 serde_json::Value::Array(vec![serde_json::json!({
                     "type": "image_url",
                     "image_url": image_url,
+                })])
+            } else if let Ok(Some(video)) = parse_video_block(content) {
+                serde_json::Value::Array(vec![serde_json::json!({
+                    "type": "video_url",
+                    "video_url": {
+                        "url": video.openai_url(),
+                    },
                 })])
             } else if let Ok(Some(file)) = parse_file_block(content) {
                 serde_json::Value::Array(vec![openai_file_block(file)])
@@ -496,6 +607,24 @@ pub(crate) fn gemini_parts(content: &serde_json::Value) -> Vec<serde_json::Value
                         return Some(serde_json::json!({
                             "file_data": {
                                 "mime_type": image.media_type,
+                                "file_uri": file_uri,
+                            }
+                        }));
+                    }
+                }
+                if let Ok(Some(video)) = parse_video_block(block) {
+                    if let Some(data) = video.base64 {
+                        return Some(serde_json::json!({
+                            "inline_data": {
+                                "mime_type": video.media_type,
+                                "data": data,
+                            }
+                        }));
+                    }
+                    if let Some(file_uri) = video.url {
+                        return Some(serde_json::json!({
+                            "file_data": {
+                                "mime_type": video.media_type,
                                 "file_uri": file_uri,
                             }
                         }));

--- a/crates/harn-vm/src/llm/helpers/options.rs
+++ b/crates/harn-vm/src/llm/helpers/options.rs
@@ -1924,6 +1924,8 @@ pub(crate) fn extract_llm_options(
         || crate::llm::content::messages_contain_audio(&messages)?;
     let pdf = option_is_enabled(options.as_ref(), "pdf")
         || crate::llm::content::messages_contain_pdf(&messages)?;
+    let video = option_is_enabled(options.as_ref(), "video")
+        || crate::llm::content::messages_contain_videos(&messages)?;
     let uses_file_ids = crate::llm::content::messages_contain_file_ids(&messages)?;
     if enforce_capability_gates && vision && !caps.vision_supported {
         return Err(unsupported_option_error("vision", &provider, &model));
@@ -1933,6 +1935,9 @@ pub(crate) fn extract_llm_options(
     }
     if enforce_capability_gates && pdf && !caps.pdf {
         return Err(unsupported_option_error("pdf", &provider, &model));
+    }
+    if enforce_capability_gates && video && !caps.video {
+        return Err(unsupported_option_error("video", &provider, &model));
     }
     if enforce_capability_gates && uses_file_ids && !caps.files_api_supported {
         return Err(unsupported_option_error("files_api", &provider, &model));
@@ -4110,6 +4115,7 @@ mod routing_tests {
         assert_unsupported_local_option("vision", vec![("vision", VmValue::Bool(true))]);
         assert_unsupported_local_option("audio", vec![("audio", VmValue::Bool(true))]);
         assert_unsupported_local_option("pdf", vec![("pdf", VmValue::Bool(true))]);
+        assert_unsupported_local_option("video", vec![("video", VmValue::Bool(true))]);
         assert_unsupported_local_option(
             "reasoning_effort",
             vec![(
@@ -4654,5 +4660,85 @@ thinking_modes = ["effort"]
         .err()
         .expect("non-multimodal model should reject pdf/audio content");
         assert!(err.to_string().contains("option `audio` is not supported"));
+    }
+
+    #[test]
+    fn video_content_requires_capability() {
+        crate::llm::capabilities::set_user_overrides_toml(
+            r#"
+[[provider.local]]
+model_match = "video-model"
+video_supported = true
+"#,
+        )
+        .expect("capability override");
+        let video_block = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            (
+                "type".to_string(),
+                VmValue::String(std::sync::Arc::from("video")),
+            ),
+            (
+                "base64".to_string(),
+                VmValue::String(std::sync::Arc::from("AAAA")),
+            ),
+            (
+                "media_type".to_string(),
+                VmValue::String(std::sync::Arc::from("video/mp4")),
+            ),
+        ])));
+        let message = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            (
+                "role".to_string(),
+                VmValue::String(std::sync::Arc::from("user")),
+            ),
+            (
+                "content".to_string(),
+                VmValue::List(std::sync::Arc::new(vec![video_block])),
+            ),
+        ])));
+        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            (
+                "provider".to_string(),
+                VmValue::String(std::sync::Arc::from("local")),
+            ),
+            (
+                "model".to_string(),
+                VmValue::String(std::sync::Arc::from("video-model")),
+            ),
+            (
+                "messages".to_string(),
+                VmValue::List(std::sync::Arc::new(vec![message.clone()])),
+            ),
+        ])));
+        extract_llm_options(&[
+            VmValue::String(std::sync::Arc::from("")),
+            VmValue::Nil,
+            options,
+        ])
+        .expect("video-capable route should accept video content");
+        crate::llm::capabilities::clear_user_overrides();
+
+        let bad_options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            (
+                "provider".to_string(),
+                VmValue::String(std::sync::Arc::from("mock")),
+            ),
+            (
+                "model".to_string(),
+                VmValue::String(std::sync::Arc::from("gpt-4o")),
+            ),
+            (
+                "messages".to_string(),
+                VmValue::List(std::sync::Arc::new(vec![message])),
+            ),
+        ])));
+        let err = extract_llm_options(&[
+            VmValue::String(std::sync::Arc::from("")),
+            VmValue::Nil,
+            bad_options,
+        ])
+        .err()
+        .expect("non-video model should reject video content");
+        assert!(err.to_string().contains("option `video` is not supported"));
     }
 }

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -219,11 +219,10 @@ latency_p50_ms = 1600
 method = "GET"
 path = "/models"
 
-# MiniMax — OpenAI-compatible endpoint for MiniMax-M2 family. The direct
-# API serves the open-weight `MiniMax-M2`, `MiniMax-M2.5`, and
-# `MiniMax-M2.7` (released 2026-03-18). All three sit on the same
-# /v1/chat/completions URL; the wire format mirrors OpenAI chat
-# completions with native tool calls and thinking blocks.
+# MiniMax — OpenAI-compatible endpoint for MiniMax M2/M3 models. The direct
+# API serves MiniMax-M3 plus the open-weight M2 family on the same
+# /v1/chat/completions URL; the wire format mirrors OpenAI chat completions
+# with native tool calls and model-specific thinking controls.
 [providers.minimax]
 base_url = "https://api.minimax.io/v1"
 base_url_env = "MINIMAX_BASE_URL"
@@ -231,8 +230,8 @@ auth_style = "bearer"
 auth_env = "MINIMAX_API_KEY"
 chat_endpoint = "/chat/completions"
 completion_endpoint = "/completions"
-cost_per_1k_in = 0.0003
-cost_per_1k_out = 0.0012
+cost_per_1k_in = 0.0006
+cost_per_1k_out = 0.0024
 latency_p50_ms = 1700
 
 [providers.minimax.healthcheck]
@@ -628,7 +627,7 @@ tool_format = "native"
 
 # MiniMax direct API aliases.
 [aliases.minimax]
-id = "MiniMax-M2.7"
+id = "MiniMax-M3"
 provider = "minimax"
 
 [aliases."minimax-m2"]
@@ -641,6 +640,10 @@ provider = "minimax"
 
 [aliases."minimax-m2.7"]
 id = "MiniMax-M2.7"
+provider = "minimax"
+
+[aliases."minimax-m3"]
+id = "MiniMax-M3"
 provider = "minimax"
 
 # Z.AI GLM aliases.
@@ -1201,13 +1204,23 @@ context_window = 131072
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.85, output_per_mtok = 1.20 }
 
-# MiniMax-M2 family ─ pricing pages:
-#   https://platform.minimax.io/docs (token-plan), llm-stats.com/models/minimax-m2-7.
-#   M2.5 release Feb 2026, M2.7 release 2026-03-18.
-# 230B total / 10B active MoE shared across M2/M2.5/M2.7. Context windows
-# from artificialanalysis.ai/models/minimax-m2-7 (205K). Pricing reflects
-# the direct MiniMax API surface; OpenRouter mirrors are listed
-# separately below.
+# MiniMax family ─ pricing pages:
+#   https://platform.minimax.io/docs/guides/pricing-paygo
+#   https://platform.minimax.io/docs/guides/model-invocation
+#   https://platform.minimax.io/docs/api-reference/text-openai-api
+#   llm-stats.com/models/minimax-m2-7.
+# M3 standard pricing below uses the non-promotional <=512K-input rate:
+# $0.60/M input, $2.40/M output, $0.12/M cache-read. MiniMax publishes a
+# higher standard tier for >512K input ($1.20/M input, $4.80/M output,
+# $0.24/M cache-read), but this catalog's ModelPricing shape is a single
+# rate card, so the base standard tier is the source of truth for now.
+# OpenRouter's June 2026 launch promotion is intentionally not copied into
+# static TOML.
+#
+# MiniMax M2: 230B total / 10B active MoE shared across M2/M2.5/M2.7.
+# Context windows from artificialanalysis.ai/models/minimax-m2-7 (205K).
+# Pricing reflects the direct MiniMax API surface; OpenRouter mirrors are
+# listed separately below.
 #
 # Tool calls + thinking-mode are supported (release notes call out
 # "agentic harness" support); structured output is delimited (no native
@@ -1215,6 +1228,15 @@ pricing = { input_per_mtok = 0.85, output_per_mtok = 1.20 }
 tier = "mid"
 open_weight = true
 strengths = ["speed", "tool_use"]
+[models."MiniMax-M3"]
+name = "MiniMax M3"
+provider = "minimax"
+context_window = 1000000
+capabilities = ["tools", "vision", "video", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.60, output_per_mtok = 2.40, cache_read_per_mtok = 0.12 }
+tier = "frontier"
+open_weight = false
+strengths = ["coding", "agentic", "tool_use", "reasoning", "long_context", "vision"]
 [models."MiniMax-M2"]
 name = "MiniMax M2"
 provider = "minimax"
@@ -1271,10 +1293,21 @@ pricing = { input_per_mtok = 0.20, output_per_mtok = 1.10 }
 
 # MiniMax mirror on OpenRouter — same family, OpenRouter adds margin and
 # bundles native-tools passthrough so the openai_chat_completions wire
-# format Just Works for callers without a direct MiniMax key.
+# format Just Works for callers without a direct MiniMax key. MiniMax M3
+# launch-promo rates shown by OpenRouter are excluded from this static
+# rate card; the M3 row uses the standard post-promo rate.
 tier = "mid"
 open_weight = true
 strengths = ["long_context"]
+[models."minimax/minimax-m3"]
+name = "MiniMax M3 (via OpenRouter)"
+provider = "openrouter"
+context_window = 1048576
+capabilities = ["tools", "vision", "video", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.60, output_per_mtok = 2.40, cache_read_per_mtok = 0.12 }
+tier = "frontier"
+open_weight = false
+strengths = ["coding", "agentic", "tool_use", "reasoning", "long_context", "vision"]
 [models."minimax/minimax-m2.7"]
 name = "MiniMax M2.7 (via OpenRouter)"
 provider = "openrouter"

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -197,6 +197,16 @@ impl OpenAiCompatibleProvider {
                     body["reasoning"] = reasoning;
                 }
             }
+            Some("minimax") => {
+                if let Some(thinking) = minimax_thinking_config(&opts.thinking) {
+                    let thinking_enabled = thinking.get("type").and_then(serde_json::Value::as_str)
+                        != Some("disabled");
+                    body["thinking"] = thinking;
+                    if thinking_enabled {
+                        body["reasoning_split"] = serde_json::json!(true);
+                    }
+                }
+            }
             _ => {}
         }
         if caps.reasoning_effort_supported {
@@ -520,6 +530,18 @@ fn enabled_reasoning_config(
             Some(serde_json::json!({ "enabled": true }))
         }
         ThinkingConfig::Effort { .. } => Some(serde_json::json!({ "enabled": true })),
+    }
+}
+
+fn minimax_thinking_config(thinking: &ThinkingConfig) -> Option<serde_json::Value> {
+    match thinking {
+        ThinkingConfig::Disabled
+        | ThinkingConfig::Effort {
+            level: crate::llm::api::ReasoningEffort::None,
+        } => Some(serde_json::json!({ "type": "disabled" })),
+        ThinkingConfig::Enabled { .. }
+        | ThinkingConfig::Adaptive
+        | ThinkingConfig::Effort { .. } => Some(serde_json::json!({ "type": "adaptive" })),
     }
 }
 
@@ -890,6 +912,37 @@ thinking_modes = ["enabled"]
     }
 
     #[test]
+    fn minimax_m3_uses_adaptive_thinking_and_completion_tokens() {
+        let mut payload = base_request_payload();
+        payload.provider = "minimax".to_string();
+        payload.model = "MiniMax-M3".to_string();
+        payload.thinking = ThinkingConfig::Enabled {
+            budget_tokens: Some(4096),
+        };
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["reasoning_split"], true);
+        assert_eq!(body["max_completion_tokens"], 64);
+        assert!(body.get("max_tokens").is_none());
+        assert!(body.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn minimax_m3_disables_thinking_explicitly() {
+        let mut payload = base_request_payload();
+        payload.provider = "minimax".to_string();
+        payload.model = "MiniMax-M3".to_string();
+        payload.thinking = ThinkingConfig::Disabled;
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert!(body.get("reasoning_split").is_none());
+    }
+
+    #[test]
     fn together_gpt_oss_effort_uses_reasoning_effort() {
         let mut payload = base_request_payload();
         payload.provider = "together".to_string();
@@ -990,6 +1043,32 @@ thinking_modes = ["enabled"]
                 "image_url": {
                     "url": "https://example.com/image.png",
                     "detail": "high",
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn video_content_maps_to_openai_video_url_block() {
+        let mut payload = base_request_payload();
+        payload.provider = "minimax".to_string();
+        payload.model = "MiniMax-M3".to_string();
+        payload.messages = vec![json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "summarize"},
+                {"type": "video", "base64": "AAAA", "media_type": "video/mp4"}
+            ],
+        })];
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(body["messages"][0]["content"][0]["text"], "summarize");
+        assert_eq!(
+            body["messages"][0]["content"][1],
+            json!({
+                "type": "video_url",
+                "video_url": {
+                    "url": "data:video/mp4;base64,AAAA",
                 }
             })
         );

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1639,6 +1639,9 @@ pub(crate) fn capability_tags_from_capabilities(
     if caps.pdf {
         tags.push("pdf".to_string());
     }
+    if caps.video {
+        tags.push("video".to_string());
+    }
     if caps.files_api_supported {
         tags.push("files".to_string());
     }

--- a/crates/harn-vm/src/provider_catalog.rs
+++ b/crates/harn-vm/src/provider_catalog.rs
@@ -1658,6 +1658,9 @@ fn modalities_from_caps(caps: &llm::capabilities::Capabilities) -> ModelModaliti
     if caps.pdf {
         input.push("pdf".to_string());
     }
+    if caps.video {
+        input.push("video".to_string());
+    }
     ModelModalities {
         input,
         output: vec!["text".to_string()],

--- a/docs/src/llm/llm_call.md
+++ b/docs/src/llm/llm_call.md
@@ -36,19 +36,20 @@ let result = llm_call(
 log(result.text)
 ```
 
-With image content:
+With image or video content:
 
 ```harn
-import { image_content } from "std/llm/media"
+import { image_content, video_content } from "std/llm/media"
 
 let result = llm_call("", nil, {
-  provider: "openai",
-  model: "gpt-4o",
+  provider: "minimax",
+  model: "MiniMax-M3",
   messages: [{
     role: "user",
     content: [
-      {type: "text", text: "Summarize this diagram."},
+      {type: "text", text: "Summarize these inputs."},
       image_content("diagram.png", {detail: "auto"}),
+      video_content("demo.mp4"),
     ],
   }],
 })
@@ -64,6 +65,13 @@ only accepts base64 image data, so `url` image blocks are rejected for
 `provider: "ollama"`. `std/llm/media` also provides `image_message(...)`
 and `image_vision_context(...)` helpers when a harness wants the same image
 as both LLM content and deterministic `vision_ocr(...)` context.
+
+Video blocks use the provider-neutral shape
+`{type: "video", url?: string, base64?: string, media_type: string}`. Exactly
+one of `url` or `base64` is required. Harn translates video blocks to OpenAI
+compatible `video_url` content, and to Gemini `inline_data`/`file_data` parts
+for routes that declare video support. `std/llm/media` also provides
+`video_message(...)`.
 
 ### Parameters
 

--- a/docs/src/llm/provider-catalog-refresh.md
+++ b/docs/src/llm/provider-catalog-refresh.md
@@ -13,6 +13,13 @@ The workflow never mutates the shipped catalog. The patch is a review
 aid: diff it against `crates/harn-vm/src/llm_config.rs` or your
 project's `harn.toml` overlay before landing changes.
 
+Static catalog pricing should reflect the provider's durable rate card,
+not launch promotions or short discount windows returned by aggregator
+APIs. When a provider publishes time-limited promotional rates, keep the
+normal post-promotion rate in `providers.toml` and capture the promotion
+only in human review notes unless the catalog schema grows an explicit
+promotion-period field.
+
 ## Running the workflow
 
 ```bash

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -9,126 +9,128 @@ This table is generated from Harn's live provider capability rules. `Model patte
 
 Regenerate with `make gen-provider-matrix` and verify with `make check-provider-matrix`.
 
-| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |
-|---|---|---|---|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---|---:|---:|---|---:|---:|
-| `anthropic` | `claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `anthropic` | `claude-*` | `any` | `enabled` | yes | yes | yes | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `azure_openai` | `gpt-*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `azure_openai` | `o1*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `azure_openai` | `o3*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `azure_openai` | `o4*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `bedrock` | `anthropic.claude-*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
-| `bedrock` | `*claude*` | `any` | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
-| `bedrock` | `*` | `any` | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `cerebras` | `gpt-oss-*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `cerebras` | `llama-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `cerebras` | `qwen-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `dashscope` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `dashscope` | `qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `deepseek` | `deepseek-v4-pro*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `deepseek` | `deepseek-v4-flash*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `deepseek` | `deepseek-chat*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | yes |
-| `deepseek` | `deepseek-reasoner*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `gemini` | `gemma-4*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `gemini` | `models/gemma-4*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `gemini` | `gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `gemini` | `models/gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `gemini` | `gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `gemini` | `models/gemini-*` | `any` | no | yes | yes | yes | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `huggingface` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `huggingface` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `huggingface` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `huggingface` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `llamacpp` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
-| `llamacpp` | `*qwen3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
-| `llamacpp` | `*devstral-small-2*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
-| `local` | `*qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `local` | `*qwen3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `local` | `gemma-4*` | `any` | `enabled` | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
-| `minimax` | `minimax-m2.7*` | `any` | `enabled` | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `minimax` | `minimax-m2.5*` | `any` | `enabled` | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `minimax` | `minimax-m2*` | `any` | `enabled` | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `minimax` | `minimax-text-*` | `any` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `mlx` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `mlx` | `*qwen3*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `ollama` | `llava*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
-| `ollama` | `bakllava*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
-| `ollama` | `llama3.2-vision*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
-| `ollama` | `gemma3*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
-| `ollama` | `gemma4:12b*` | `any` | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
-| `ollama` | `gemma4*` | `any` | no | yes | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
-| `ollama` | `qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
-| `ollama` | `qwen3*` | `any` | `enabled` | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | no | `native_only` | yes | no |
-| `ollama` | `devstral-small-2*` | `any` | no | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
-| `openai` | `gpt-4o*` | `any` | no | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `gpt-4.1*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `gpt-*` | `>=5.4` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `gpt-*` | `>=5.1` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `gpt-*` | `>=5.0` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `gpt-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `o1*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `o3*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `o4*` | `any` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/gpt-4o*` | `any` | no | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/gpt-4.1*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/gpt-*` | `>=5.4` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/gpt-*` | `>=5.1` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/gpt-*` | `>=5.0` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/gpt-*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/o1*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/o3*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openai` | `openai/o4*` | `any` | `effort` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `anthropic/claude-haiku-*` | `>=4.5` | `enabled` | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `openrouter` | `anthropic/claude-sonnet-*` | `>=4.6` | `adaptive` | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `openrouter` | `anthropic/claude-opus-*` | `>=4.6` | `adaptive` | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
-| `openrouter` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | yes | yes | `native_unreliable` | yes | no |
-| `openrouter` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `deepseek/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
-| `openrouter` | `deepseek/deepseek-v3.2*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | yes | yes | `native_unreliable` | yes | yes |
-| `openrouter` | `deepseek/deepseek-v3*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
-| `openrouter` | `mistralai/mistral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
-| `openrouter` | `google/gemma-4*` | `any` | no | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `meta-llama/llama-3*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `minimax/minimax-m2.7*` | `any` | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `minimax/minimax-m2*` | `any` | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `z-ai/glm-5*` | `any` | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `deepseek/deepseek-v4*` | `any` | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `qwen/qwen3-coder*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `qwen/*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `together` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
-| `together` | `deepseek-ai/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
-| `together` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `google/gemma-4*` | `any` | `enabled` | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `moonshotai/*` | `any` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `vertex` | `gemini-*` | `any` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `zai` | `glm-5.1*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `zai` | `glm-5*` | `any` | `enabled` | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Video | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |
+|---|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---|---:|---:|---|---:|---:|
+| `anthropic` | `claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-haiku-*` | `>=4.5` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-opus-*` | `>=4.6` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-opus-*` | `>=4.0` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.6` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-sonnet-*` | `>=4.0` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-*` | `any` | `enabled` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `azure_openai` | `gpt-*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `azure_openai` | `o1*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `azure_openai` | `o3*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `azure_openai` | `o4*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `bedrock` | `anthropic.claude-*` | `any` | no | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
+| `bedrock` | `*claude*` | `any` | no | no | no | no | no | yes | no | no | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | no |
+| `bedrock` | `*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `cerebras` | `gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `cerebras` | `llama-*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `cerebras` | `qwen-*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `dashscope` | `qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `dashscope` | `qwen*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `deepseek` | `deepseek-v4-pro*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `deepseek` | `deepseek-v4-flash*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `deepseek` | `deepseek-chat*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | yes |
+| `deepseek` | `deepseek-reasoner*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `gemma-4*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `models/gemma-4*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | no | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `models/gemini-2.5*` | `any` | `enabled,adaptive,effort` | yes | yes | yes | no | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `gemini-*` | `any` | no | yes | yes | yes | no | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `gemini` | `models/gemini-*` | `any` | no | yes | yes | yes | no | yes | yes | `native` | `xml,markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `qwen/qwen3-coder*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `qwen/*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `huggingface` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `llamacpp` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `llamacpp` | `*qwen3*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `llamacpp` | `*devstral-small-2*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `local` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `local` | `*qwen3*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `local` | `gemma-4*` | `any` | `enabled` | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `minimax` | `minimax-m3*` | `any` | `adaptive` | yes | no | no | yes | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `minimax` | `minimax-m2.7*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `minimax` | `minimax-m2.5*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `minimax` | `minimax-m2*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `minimax` | `minimax-text-*` | `any` | no | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `mlx` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `mlx` | `*qwen3*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `ollama` | `llava*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `bakllava*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `llama3.2-vision*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `gemma3*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `gemma4:12b*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `gemma4*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `text` | no | yes | `text_only` | yes | no |
+| `ollama` | `qwen3*` | `any` | `enabled` | no | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | no | `native_only` | yes | no |
+| `ollama` | `devstral-small-2*` | `any` | no | no | no | no | no | yes | no | `format_kw` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | no | yes | `text_only` | yes | no |
+| `openai` | `gpt-4o*` | `any` | no | yes | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-4.1*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `>=5.4` | `effort` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `>=5.1` | `effort` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `>=5.0` | `effort` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `gpt-*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `o1*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `o3*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `o4*` | `any` | `effort` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-4o*` | `any` | no | yes | yes | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-4.1*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `>=5.4` | `effort` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `>=5.1` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `>=5.0` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/gpt-*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/o1*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/o3*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openai` | `openai/o4*` | `any` | `effort` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `developer` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `anthropic/claude-haiku-*` | `>=4.5` | `enabled` | no | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `anthropic/claude-sonnet-*` | `>=4.6` | `adaptive` | no | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `anthropic/claude-opus-*` | `>=4.6` | `adaptive` | no | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `qwen/qwen3-coder*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | yes | yes | `native_unreliable` | yes | no |
+| `openrouter` | `qwen/*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `deepseek/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `deepseek/deepseek-v3.2*` | `any` | `enabled,effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | yes | yes | `native_unreliable` | yes | yes |
+| `openrouter` | `deepseek/deepseek-v3*` | `any` | `enabled,effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `mistralai/mistral*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `google/gemma-4*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `meta-llama/llama-3*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `minimax/minimax-m3*` | `any` | `adaptive` | yes | no | no | yes | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `minimax/minimax-m2.7*` | `any` | no | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `minimax/minimax-m2*` | `any` | no | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `z-ai/glm-5*` | `any` | no | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `deepseek/deepseek-v4*` | `any` | no | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `qwen/qwen3-coder*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `qwen/*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `together` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
+| `together` | `deepseek-ai/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
+| `together` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `google/gemma-4*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `moonshotai/*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `vertex` | `gemini-*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `zai` | `glm-5.1*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `zai` | `glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 
 ## Tool-format recommendations by catalog model
 
@@ -173,6 +175,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `minimax` | `MiniMax-M2.5-highspeed` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `minimax` | `MiniMax-M2.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `minimax` | `MiniMax-M2.7-highspeed` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `minimax` | `MiniMax-M3` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `minimax` | `MiniMax-Text-01` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `mlx` | `unsloth/Qwen3.6-27B-UD-MLX-4bit` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `devstral-small-2:24b` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
@@ -200,6 +203,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `google/gemma-4-31b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `minimax/minimax-m3` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `mistralai/mistral-large-2512` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `mistralai/mistral-small-2603` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `moonshotai/kimi-k2.6` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -3606,7 +3606,6 @@ public let harnProviderCatalogJSON = #"""
       "name": "MiniMax M2.7",
       "provider": "minimax",
       "aliases": [
-        "minimax",
         "minimax-m2.7"
       ],
       "context_window": 204800,
@@ -3745,6 +3744,86 @@ public let harnProviderCatalogJSON = #"""
         "speed",
         "coding",
         "agentic"
+      ]
+    },
+    {
+      "id": "MiniMax-M3",
+      "name": "MiniMax M3",
+      "provider": "minimax",
+      "aliases": [
+        "minimax",
+        "minimax-m3"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.4,
+        "cache_read_per_mtok": 0.12,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "reasoning",
+        "long_context",
+        "vision"
       ]
     },
     {
@@ -5648,6 +5727,83 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "minimax/minimax-m3",
+      "name": "MiniMax M3 (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 1048576,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.4,
+        "cache_read_per_mtok": 0.12,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "reasoning",
+        "long_context",
+        "vision"
+      ]
+    },
+    {
       "id": "mistralai/mistral-large-2512",
       "name": "Mistral Large 3 2512",
       "provider": "openrouter",
@@ -6620,7 +6776,7 @@ public let harnProviderCatalogJSON = #"""
     },
     {
       "name": "minimax",
-      "model_id": "MiniMax-M2.7",
+      "model_id": "MiniMax-M3",
       "provider": "minimax"
     },
     {
@@ -6636,6 +6792,11 @@ public let harnProviderCatalogJSON = #"""
     {
       "name": "minimax-m2.7",
       "model_id": "MiniMax-M2.7",
+      "provider": "minimax"
+    },
+    {
+      "name": "minimax-m3",
+      "model_id": "MiniMax-M3",
       "provider": "minimax"
     },
     {

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -3427,7 +3427,6 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "MiniMax M2.7",
       "provider": "minimax",
       "aliases": [
-        "minimax",
         "minimax-m2.7"
       ],
       "context_window": 204800,
@@ -3566,6 +3565,86 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "speed",
         "coding",
         "agentic"
+      ]
+    },
+    {
+      "id": "MiniMax-M3",
+      "name": "MiniMax M3",
+      "provider": "minimax",
+      "aliases": [
+        "minimax",
+        "minimax-m3"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.4,
+        "cache_read_per_mtok": 0.12,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "reasoning",
+        "long_context",
+        "vision"
       ]
     },
     {
@@ -5469,6 +5548,83 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "minimax/minimax-m3",
+      "name": "MiniMax M3 (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 1048576,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.4,
+        "cache_read_per_mtok": 0.12,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "reasoning",
+        "long_context",
+        "vision"
+      ]
+    },
+    {
       "id": "mistralai/mistral-large-2512",
       "name": "Mistral Large 3 2512",
       "provider": "openrouter",
@@ -6441,7 +6597,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
     },
     {
       "name": "minimax",
-      "model_id": "MiniMax-M2.7",
+      "model_id": "MiniMax-M3",
       "provider": "minimax"
     },
     {
@@ -6457,6 +6613,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
     {
       "name": "minimax-m2.7",
       "model_id": "MiniMax-M2.7",
+      "provider": "minimax"
+    },
+    {
+      "name": "minimax-m3",
+      "model_id": "MiniMax-M3",
       "provider": "minimax"
     },
     {

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -3250,7 +3250,6 @@
       "name": "MiniMax M2.7",
       "provider": "minimax",
       "aliases": [
-        "minimax",
         "minimax-m2.7"
       ],
       "context_window": 204800,
@@ -3389,6 +3388,86 @@
         "speed",
         "coding",
         "agentic"
+      ]
+    },
+    {
+      "id": "MiniMax-M3",
+      "name": "MiniMax M3",
+      "provider": "minimax",
+      "aliases": [
+        "minimax",
+        "minimax-m3"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.4,
+        "cache_read_per_mtok": 0.12,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "reasoning",
+        "long_context",
+        "vision"
       ]
     },
     {
@@ -5292,6 +5371,83 @@
       ]
     },
     {
+      "id": "minimax/minimax-m3",
+      "name": "MiniMax M3 (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 1048576,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.4,
+        "cache_read_per_mtok": 0.12,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "reasoning",
+        "long_context",
+        "vision"
+      ]
+    },
+    {
       "id": "mistralai/mistral-large-2512",
       "name": "Mistral Large 3 2512",
       "provider": "openrouter",
@@ -6264,7 +6420,7 @@
     },
     {
       "name": "minimax",
-      "model_id": "MiniMax-M2.7",
+      "model_id": "MiniMax-M3",
       "provider": "minimax"
     },
     {
@@ -6280,6 +6436,11 @@
     {
       "name": "minimax-m2.7",
       "model_id": "MiniMax-M2.7",
+      "provider": "minimax"
+    },
+    {
+      "name": "minimax-m3",
+      "model_id": "MiniMax-M3",
       "provider": "minimax"
     },
     {


### PR DESCRIPTION
## Summary
- add MiniMax M3 to the direct MiniMax and OpenRouter provider catalogs with 1M context, native tools, adaptive thinking, prompt caching, and text/image/video input
- add first-class video content parsing/serialization and capability gating across OpenAI-compatible, Gemini, provider matrix, catalog, and stdlib media helpers
- use durable non-promotional MiniMax/OpenRouter M3 pricing in static rate cards and document promo exclusion plus the current single-rate limitation for >512K MiniMax pricing

## Validation
- cargo fmt --all
- cargo build -q -p harn-cli
- target/debug/harn providers validate --check-artifacts
- target/debug/harn providers matrix --check
- target/debug/harn providers support --check
- cargo test -p harn-vm minimax_m3 --lib
- cargo test -p harn-vm video_content --lib
- cargo test -p harn-vm --lib
- cargo test -p harn-cli provider_matrix
- target/debug/harn test conformance --filter llm_media_helpers
- HARN_BIN=target/debug/harn ./scripts/check_docs_snippets.sh
- ./scripts/check_docs_model_refs.sh
- pre-commit and pre-push hooks

## Research Notes
- MiniMax official docs list MiniMax-M3 with 1,000,000 context, 512K guaranteed output, OpenAI-compatible chat completions, adaptive/disabled thinking, image and video input, native tools, and prompt caching.
- MiniMax standard pricing is $0.60/M input, $2.40/M output, and $0.12/M cache-read for <=512K input; static TOML intentionally excludes launch promotions.
- OpenRouter exposes minimax/minimax-m3 with text+image+video to text and currently displays a temporary promo, which is also excluded from static catalog pricing.
