### PR TITLE
fix(providers): Gemini/Vertex thinking tokens + Vertex/Bedrock cache tokens

### DIFF
--- a/changelog.d/token-accounting-google-bedrock.fixed.md
+++ b/changelog.d/token-accounting-google-bedrock.fixed.md
@@ -1,0 +1,7 @@
+- **Gemini/Vertex thinking tokens + Vertex/Bedrock cache tokens in usage
+  accounting.** The Gemini and Vertex adapters now fold
+  `usageMetadata.thoughtsTokenCount` into `output_tokens`, so thinking-enabled
+  models no longer under-report billed output (and cost). Vertex now also reads
+  `cachedContentTokenCount` into `cache_read_tokens` (previously dropped), and
+  the Bedrock Converse adapter surfaces `cacheReadInputTokens` /
+  `cacheWriteInputTokens` as `cache_read_tokens` / `cache_write_tokens`.

--- a/crates/harn-vm/src/llm/providers/bedrock.rs
+++ b/crates/harn-vm/src/llm/providers/bedrock.rs
@@ -243,6 +243,8 @@ fn parse_bedrock_converse_response(
     }
     result.input_tokens = json["usage"]["inputTokens"].as_i64().unwrap_or(0);
     result.output_tokens = json["usage"]["outputTokens"].as_i64().unwrap_or(0);
+    result.cache_read_tokens = json["usage"]["cacheReadInputTokens"].as_i64().unwrap_or(0);
+    result.cache_write_tokens = json["usage"]["cacheWriteInputTokens"].as_i64().unwrap_or(0);
     result.stop_reason = json["stopReason"].as_str().map(str::to_string);
     Ok(result)
 }
@@ -503,6 +505,26 @@ mod tests {
         assert_eq!(result.input_tokens, 2);
         assert_eq!(result.output_tokens, 3);
         assert_eq!(result.tool_calls[0]["name"], "lookup");
+    }
+
+    #[test]
+    fn parse_converse_response_surfaces_prompt_cache_tokens() {
+        let json = json!({
+            "output": {"message": {"content": [{"text": "hi"}]}},
+            "usage": {
+                "inputTokens": 5,
+                "outputTokens": 7,
+                "cacheReadInputTokens": 11,
+                "cacheWriteInputTokens": 13
+            },
+            "stopReason": "end_turn"
+        });
+        let result = parse_bedrock_converse_response(&json, "anthropic.claude-3-5-sonnet-v2:0")
+            .expect("result");
+        assert_eq!(result.input_tokens, 5);
+        assert_eq!(result.output_tokens, 7);
+        assert_eq!(result.cache_read_tokens, 11);
+        assert_eq!(result.cache_write_tokens, 13);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/providers/gemini.rs
+++ b/crates/harn-vm/src/llm/providers/gemini.rs
@@ -438,7 +438,10 @@ fn parse_response(
         .unwrap_or(0);
     let output_tokens = json["usageMetadata"]["candidatesTokenCount"]
         .as_i64()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        + json["usageMetadata"]["thoughtsTokenCount"]
+            .as_i64()
+            .unwrap_or(0);
     let cache_read_tokens = json["usageMetadata"]["cachedContentTokenCount"]
         .as_i64()
         .unwrap_or(0);
@@ -911,6 +914,7 @@ mod tests {
             "usageMetadata": {
                 "promptTokenCount": 10,
                 "candidatesTokenCount": 3,
+                "thoughtsTokenCount": 5,
                 "cachedContentTokenCount": 7
             },
             "responseId": "resp-1"
@@ -925,6 +929,9 @@ mod tests {
         assert_eq!(result.tool_calls[0]["arguments"]["query"], "harn");
         assert_eq!(result.tool_calls[0]["thought_signature"], "sig-1");
         assert_eq!(result.tool_calls[1]["id"], "gemini_tool_1");
+        // output_tokens must fold in thinking tokens: candidates(3) + thoughts(5).
+        assert_eq!(result.output_tokens, 8);
+        assert_eq!(result.input_tokens, 10);
         assert_eq!(result.cache_read_tokens, 7);
         assert_eq!(
             result.telemetry.source,

--- a/crates/harn-vm/src/llm/providers/vertex.rs
+++ b/crates/harn-vm/src/llm/providers/vertex.rs
@@ -261,6 +261,12 @@ fn parse_vertex_response(json: &serde_json::Value, model: &str) -> Result<LlmRes
         .unwrap_or(0);
     result.output_tokens = json["usageMetadata"]["candidatesTokenCount"]
         .as_i64()
+        .unwrap_or(0)
+        + json["usageMetadata"]["thoughtsTokenCount"]
+            .as_i64()
+            .unwrap_or(0);
+    result.cache_read_tokens = json["usageMetadata"]["cachedContentTokenCount"]
+        .as_i64()
         .unwrap_or(0);
     result.stop_reason = json["candidates"][0]["finishReason"]
         .as_str()
@@ -367,6 +373,27 @@ mod tests {
         assert_eq!(result.input_tokens, 3);
         assert_eq!(result.output_tokens, 4);
         assert_eq!(result.tool_calls[0]["name"], "lookup");
+    }
+
+    #[test]
+    fn parse_response_folds_thinking_and_cache_tokens() {
+        let response = json!({
+            "candidates": [{
+                "content": {"parts": [{"text": "done"}]},
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 12,
+                "candidatesTokenCount": 4,
+                "thoughtsTokenCount": 9,
+                "cachedContentTokenCount": 6
+            }
+        });
+        let result = parse_vertex_response(&response, "gemini-2.5-pro").expect("result");
+        assert_eq!(result.input_tokens, 12);
+        // candidates(4) + thoughts(9) so thinking tokens are billed as output.
+        assert_eq!(result.output_tokens, 13);
+        assert_eq!(result.cache_read_tokens, 6);
     }
 
     fn base_request() -> LlmRequestPayload {


### PR DESCRIPTION
Token-accounting corrections found by an empirical harn-side provider audit.

- **Gemini + Vertex fold `thoughtsTokenCount` into `output_tokens`** — Google's `usageMetadata` reports `total = prompt + thoughts + candidates`, and `candidatesTokenCount` excludes thinking tokens, so output (and billed cost via `cost.rs`) was understated on thinking-enabled calls.
- **Vertex reads `cachedContentTokenCount`** — it never did (gemini.rs already does), so Vertex context-cache hits reported 0 cache-read.
- **Bedrock Converse reads `cacheReadInputTokens` / `cacheWriteInputTokens`** — prompt-cache usage was invisible and uncosted.

`telemetry.rs::server_output_tokens` is intentionally left as the raw server-reported `candidatesTokenCount` (a diagnostic mirror, not a billed-output computation).

## Validation
Parse-test fixtures for all three adapters (`parse_response_folds_thinking_and_cache_tokens`, `parse_converse_response_surfaces_prompt_cache_tokens`, gemini cache-usage). `cargo test -p harn-vm` providers suite: 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)