### PR TITLE
fix(openai-compat): openrouter structured 404 + truncated-reasoning leak + error class

### DIFF
--- a/changelog.d/openrouter-structured-reasoning.fixed.md
+++ b/changelog.d/openrouter-structured-reasoning.fixed.md
@@ -1,0 +1,16 @@
+- **OpenRouter structured calls to non-reasoning models no longer 404.** When a
+  model declares no reasoning capability, harn no longer emits a
+  `reasoning: {enabled: false}` disable directive alongside
+  `require_parameters: true` — that combination made OpenRouter drop every
+  endpoint that doesn't support the reasoning param (e.g. `qwen/qwen3-coder`
+  JSON-schema calls returned `404 No endpoints found`). The disable was a no-op
+  for these models anyway.
+- **Truncated reasoning no longer leaks into the final answer.** On an
+  OpenAI-compatible response cut off at `finish_reason: "length"` with empty
+  content, harn no longer promotes the partial reasoning trace into
+  `.text`/`.visible_text`; the surfaced answer stays empty/flagged and the
+  partial trace is exposed via `thinking` instead.
+- **Unknown-model errors classify uniformly.** OpenRouter reports an unknown
+  model as an HTTP-400 `"<id> is not a valid model ID"` body (no status/typed
+  signal); harn now maps that prose to `NotFound`/`model_unavailable`, matching
+  Cerebras's 404 path.

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -380,6 +380,12 @@ fn is_model_unavailable(lower: &str) -> bool {
         // so caller fallback logic routes around it instead of surfacing a
         // generic invalid_request to the agent.
         || lower.contains("non-serverless model")
+        // OpenRouter's HTTP-400 wording for an unknown model ID
+        // ("<id> is not a valid model ID"). Mirror the `not_found` mapping in
+        // `value::error::classify_error_message` so the reason taxonomy agrees
+        // across both classifiers and matches Cerebras's 404 path.
+        || lower.contains("is not a valid model id")
+        || lower.contains("invalid model id")
 }
 
 #[cfg(test)]
@@ -544,6 +550,32 @@ mod tests {
         );
         let info =
             classify_provider_http_error("together", reqwest::StatusCode::BAD_REQUEST, None, body);
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ModelUnavailable);
+        assert!(
+            info.message.contains("[model_unavailable]"),
+            "msg was: {}",
+            info.message
+        );
+    }
+
+    #[test]
+    fn classifies_openrouter_invalid_model_id_as_model_unavailable() {
+        // OpenRouter returns HTTP 400 with a prose body for an unknown model
+        // ID rather than a typed `model_not_found`. Cerebras returns 404 for
+        // the same situation; both should land on `model_unavailable` so the
+        // reason taxonomy is uniform across providers.
+        let body = concat!(
+            r#"{"error":{"message":"#,
+            r#""qwen/qwen3-coder-bogus is not a valid model ID","#,
+            r#""code":400}}"#,
+        );
+        let info = classify_provider_http_error(
+            "openrouter",
+            reqwest::StatusCode::BAD_REQUEST,
+            None,
+            body,
+        );
         assert_eq!(info.kind, LlmErrorKind::Terminal);
         assert_eq!(info.reason, LlmErrorReason::ModelUnavailable);
         assert!(

--- a/crates/harn-vm/src/llm/api/openai_normalize.rs
+++ b/crates/harn-vm/src/llm/api/openai_normalize.rs
@@ -116,7 +116,10 @@ pub(super) fn extract_openai_delta_field_str<'a>(
     ""
 }
 
-pub(super) fn normalize_openai_message_text(message: &serde_json::Value) -> (String, String) {
+pub(super) fn normalize_openai_message_text(
+    message: &serde_json::Value,
+    finish_reason: Option<&str>,
+) -> (String, String) {
     let raw_text = extract_openai_message_field_as_text(message, &["content"]);
     let reasoning_text = extract_openai_message_field_as_text(
         message,
@@ -130,7 +133,13 @@ pub(super) fn normalize_openai_message_text(message: &serde_json::Value) -> (Str
     let mut extracted_thinking = String::new();
     append_paragraph(&mut extracted_thinking, &reasoning_text);
     append_paragraph(&mut extracted_thinking, &inline_thinking);
-    if text.is_empty() && !extracted_thinking.is_empty() {
+    // When a reasoning model is cut off mid-thought (finish_reason == "length")
+    // with no committed content, the reasoning trace is a partial, garbage
+    // not-an-answer. Promoting it into `.text` surfaces that garbage as the
+    // final answer. Keep `text` empty and expose only the partial trace via
+    // `thinking`, so the caller can emit a clean truncation signal instead.
+    let truncated = finish_reason == Some("length");
+    if !truncated && text.is_empty() && !extracted_thinking.is_empty() {
         text = extracted_thinking.clone();
     }
     (text, extracted_thinking)
@@ -219,7 +228,7 @@ mod tests {
         let message = serde_json::json!({
             "reasoning": "hello from reasoning"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message);
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
         assert_eq!(visible, "hello from reasoning");
         assert_eq!(thinking, "hello from reasoning");
     }
@@ -230,9 +239,40 @@ mod tests {
             "content": "<think>inline reasoning</think>visible answer",
             "reasoning": "separate reasoning"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message);
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
         assert_eq!(visible, "visible answer");
         assert_eq!(thinking, "separate reasoning\ninline reasoning");
+    }
+
+    #[test]
+    fn normalize_openai_message_text_does_not_promote_reasoning_when_truncated() {
+        // A reasoning model cut off mid-thought (finish_reason == "length")
+        // with empty content must NOT have its partial reasoning trace
+        // promoted into `.text` — that garbage would surface as the answer.
+        let message = serde_json::json!({
+            "content": "",
+            "reasoning": "Let me think step by step about the problem. First I need to"
+        });
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("length"));
+        assert_eq!(visible, "", "truncated reasoning leaked into visible text");
+        assert_eq!(
+            thinking,
+            "Let me think step by step about the problem. First I need to"
+        );
+    }
+
+    #[test]
+    fn normalize_openai_message_text_promotes_reasoning_on_clean_stop() {
+        // The same reasoning-only message on a clean finish (finish_reason
+        // != "length") still promotes the trace, preserving prior behaviour
+        // for models that legitimately answer inside the reasoning channel.
+        let message = serde_json::json!({
+            "content": "",
+            "reasoning": "the answer is 42"
+        });
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
+        assert_eq!(visible, "the answer is 42");
+        assert_eq!(thinking, "the answer is 42");
     }
 
     #[test]
@@ -241,7 +281,7 @@ mod tests {
             "content": "visible answer",
             "reasoning_details": "minimax private trace"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message);
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
         assert_eq!(visible, "visible answer");
         assert_eq!(thinking, "minimax private trace");
     }

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -659,7 +659,8 @@ pub(crate) fn parse_llm_response(
                 "{provider} API response missing choices[0].message"
             ))))
         })?;
-        let (text, extracted_thinking) = normalize_openai_message_text(message);
+        let finish_reason = choice["finish_reason"].as_str();
+        let (text, extracted_thinking) = normalize_openai_message_text(message, finish_reason);
         let reasoning_summary = extract_openai_reasoning_summary(json, message);
         let mut blocks = if text.is_empty() {
             Vec::new()
@@ -764,7 +765,7 @@ pub(crate) fn parse_llm_response(
         let output_tokens = json["usage"]["completion_tokens"].as_i64().unwrap_or(0);
         let cache_read_tokens = extract_cache_read_tokens(&json["usage"]);
         let cache_write_tokens = extract_cache_write_tokens(&json["usage"]);
-        let stop_reason = choice["finish_reason"].as_str().map(|s| s.to_string());
+        let stop_reason = finish_reason.map(|s| s.to_string());
         let request_id = json["id"].as_str().filter(|value| !value.is_empty());
         let telemetry = ProviderTelemetry::from_openai_usage(&json["usage"], request_id);
 

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -1111,7 +1111,13 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
 
     let _ = in_thinking_block; // suppress unused warning
 
-    if text.is_empty() && !thinking_text.is_empty() {
+    // When the stream is cut off mid-thought (finish_reason == "length") with
+    // no committed visible content, the reasoning trace is a partial, garbage
+    // not-an-answer. Promoting it into `.text` surfaces that garbage as the
+    // final answer. Leave `text` empty and expose the partial trace only via
+    // `thinking`, mirroring `openai_normalize::normalize_openai_message_text`.
+    let truncated = stop_reason.as_deref() == Some("length");
+    if !truncated && text.is_empty() && !thinking_text.is_empty() {
         text = thinking_text.clone();
         blocks
             .push(serde_json::json!({"type": "output_text", "text": text, "visibility": "public"}));
@@ -1756,6 +1762,57 @@ mod streaming_tool_call_tests {
             first_raw.unwrap().contains("hello"),
             "raw_input_partial should carry the concatenated bytes verbatim"
         );
+
+        clear_session_sinks(&session_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn openai_stream_truncated_reasoning_does_not_leak_into_text() {
+        // A reasoning model cut off mid-thought streams only `reasoning`
+        // deltas with no committed `content`, then finish_reason="length".
+        // The partial trace must NOT be promoted into `.text` (that garbage
+        // would surface as the answer); it stays under `.thinking`.
+        let body = concat!(
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"Let me think step\"}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\" by step about\"}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"finish_reason\":\"length\",\"delta\":{}}],\"usage\":{\"prompt_tokens\":4,\"completion_tokens\":6}}\n",
+            "data: [DONE]\n",
+        );
+        let session_id = fresh_session_id("oai-trunc");
+        let (result, _events) = drive(body.as_bytes(), &session_id, false).await;
+
+        assert_eq!(result.stop_reason.as_deref(), Some("length"));
+        assert_eq!(
+            result.text, "",
+            "truncated reasoning leaked into visible text: {:?}",
+            result.text
+        );
+        assert_eq!(
+            result.thinking.as_deref(),
+            Some("Let me think step by step about"),
+            "partial reasoning trace must survive under thinking"
+        );
+
+        clear_session_sinks(&session_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn openai_stream_reasoning_promotes_to_text_on_clean_stop() {
+        // Control: the same reasoning-only stream on a clean finish
+        // (finish_reason != "length") still promotes the trace into `.text`,
+        // preserving behaviour for models that answer in the reasoning channel.
+        let body = concat!(
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"the answer\"}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\" is 42\"}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":{\"prompt_tokens\":4,\"completion_tokens\":3}}\n",
+            "data: [DONE]\n",
+        );
+        let session_id = fresh_session_id("oai-clean");
+        let (result, _events) = drive(body.as_bytes(), &session_id, false).await;
+
+        assert_eq!(result.stop_reason.as_deref(), Some("stop"));
+        assert_eq!(result.text, "the answer is 42");
+        assert_eq!(result.thinking.as_deref(), Some("the answer is 42"));
 
         clear_session_sinks(&session_id);
     }

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -189,7 +189,18 @@ impl OpenAiCompatibleProvider {
         match caps.reasoning_wire_format.as_deref() {
             Some("openrouter") => {
                 if let Some(reasoning) = openrouter_reasoning_config(&opts.thinking) {
-                    body["reasoning"] = reasoning;
+                    // OpenRouter excludes every endpoint that doesn't support the
+                    // `reasoning` param when `require_parameters: true` is set
+                    // (which structured/top_k calls force below). For models that
+                    // declare NO reasoning capability, emitting a reasoning DISABLE
+                    // directive shrinks the candidate set to zero -> 404 "No
+                    // endpoints found" (e.g. qwen/qwen3-coder json_object calls).
+                    // The disable is a no-op for these models anyway, so skip it.
+                    let skip_disable = is_openrouter_reasoning_disable(&reasoning)
+                        && !model_declares_reasoning(&caps);
+                    if !skip_disable {
+                        body["reasoning"] = reasoning;
+                    }
                 }
             }
             Some("enabled") => {
@@ -476,6 +487,28 @@ fn sanitize_openai_tool_for_request(
     }
 
     tool
+}
+
+/// True when the OpenRouter `reasoning` body explicitly disables reasoning
+/// (`{"enabled": false}`). These are the directives that, on a model with no
+/// reasoning support, cause OpenRouter to drop every endpoint under
+/// `require_parameters: true`.
+fn is_openrouter_reasoning_disable(reasoning: &serde_json::Value) -> bool {
+    reasoning
+        .get("enabled")
+        .and_then(serde_json::Value::as_bool)
+        == Some(false)
+}
+
+/// True when the (provider, model) capability row advertises ANY reasoning
+/// support: a non-empty `thinking_modes` list, `reasoning_effort_supported`,
+/// or `reasoning_none_supported`. When all three are absent the model declares
+/// no reasoning capability and the `reasoning` request param must be omitted on
+/// OpenRouter to avoid the empty-endpoint 404.
+fn model_declares_reasoning(caps: &crate::llm::capabilities::Capabilities) -> bool {
+    !caps.thinking_modes.is_empty()
+        || caps.reasoning_effort_supported
+        || caps.reasoning_none_supported
 }
 
 fn openrouter_reasoning_config(thinking: &ThinkingConfig) -> Option<serde_json::Value> {
@@ -771,6 +804,47 @@ mod tests {
 
         assert_eq!(body["reasoning"]["enabled"], true);
         assert!(body.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn openrouter_no_reasoning_model_omits_reasoning_on_structured_disable() {
+        // Regression: qwen/qwen3-coder declares no reasoning capability. With
+        // a structured (json_object) call, `require_parameters: true` is set,
+        // which makes OpenRouter exclude any endpoint lacking the `reasoning`
+        // param. Emitting `reasoning: {enabled: false}` then drops every
+        // candidate -> 404 "No endpoints found". The disable must be omitted.
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "qwen/qwen3-coder".to_string();
+        payload.thinking = ThinkingConfig::Disabled;
+        payload.output_format = crate::llm::api::OutputFormat::JsonObject;
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert!(
+            body.get("reasoning").is_none(),
+            "reasoning disable must be omitted for a no-reasoning model: {body}"
+        );
+        // The structured directive and require_parameters must still be present.
+        assert_eq!(body["response_format"]["type"], "json_object");
+        assert_eq!(body["provider"]["require_parameters"], true);
+    }
+
+    #[test]
+    fn openrouter_reasoning_capable_model_still_disables_on_directive() {
+        // Control: a reasoning-capable OpenRouter model (qwen/qwen3.6* declares
+        // thinking_modes + reasoning_none_supported) must keep the explicit
+        // disable so it doesn't fall back to unbounded thinking.
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "qwen/qwen3.6-35b-a3b".to_string();
+        payload.thinking = ThinkingConfig::Disabled;
+        payload.output_format = crate::llm::api::OutputFormat::JsonObject;
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(
+            body["reasoning"]["enabled"], false,
+            "reasoning-capable model must keep the explicit disable: {body}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/value/error.rs
+++ b/crates/harn-vm/src/value/error.rs
@@ -314,6 +314,14 @@ pub fn classify_error_message(msg: &str) -> ErrorCategory {
     if msg.contains("not_found_error") || msg.contains("model_not_found") {
         return ErrorCategory::NotFound;
     }
+    // OpenRouter reports an unknown model as HTTP 400 with the body
+    // "<id> is not a valid model ID" — no status-code or typed-error signal
+    // that `classify_by_http_status` / the checks above can latch onto. Map
+    // the prose to NotFound so it lines up with Cerebras's 404 path (and with
+    // `errors::is_model_unavailable`'s reason taxonomy).
+    if lower.contains("is not a valid model id") || lower.contains("invalid model id") {
+        return ErrorCategory::NotFound;
+    }
     if msg.contains("circuit_open") {
         return ErrorCategory::CircuitOpen;
     }
@@ -472,6 +480,23 @@ mod tests {
         assert_eq!(
             classify_error_message("operation canceled by host"),
             ErrorCategory::Cancelled
+        );
+    }
+
+    #[test]
+    fn classifies_openrouter_invalid_model_id_as_not_found() {
+        // OpenRouter reports an unknown model as HTTP 400 + prose. The 400 is
+        // not classified by status, so the prose substring must lift it to
+        // NotFound to match Cerebras's 404 path.
+        assert_eq!(
+            classify_error_message(
+                "openrouter API error: qwen/qwen3-coder-bogus is not a valid model ID"
+            ),
+            ErrorCategory::NotFound
+        );
+        assert_eq!(
+            classify_error_message("invalid model id supplied"),
+            ErrorCategory::NotFound
         );
     }
 


### PR DESCRIPTION
Three empirically-confirmed fixes on the OpenAI-compatible provider path (found by a harn-side provider audit, reproduced against live OpenRouter + local qwen3.6).

- **OpenRouter structured calls to non-reasoning models no longer 404.** harn emitted `reasoning:{enabled:false}` alongside `require_parameters:true`, which made OpenRouter exclude every endpoint lacking the reasoning param — `qwen/qwen3-coder` JSON-schema calls returned `404 No endpoints found`. Now skipped for models declaring no reasoning capability (the disable is a no-op there).
- **Truncated reasoning no longer leaks into `.text`.** On `finish_reason == "length"` with empty content, the reasoning→text promotion is suppressed; the partial trace goes to `thinking`, `.text` stays empty/flagged.
- **Unknown-model errors classify uniformly.** OpenRouter's HTTP-400 `"<id> is not a valid model ID"` prose now maps to `NotFound`/`model_unavailable`, matching Cerebras's 404 path.

## Validation
Unit tests for all three (`classifies_openrouter_invalid_model_id_as_not_found`, `..._as_model_unavailable`, openai_normalize truncation guard). `cargo test -p harn-vm` (errors/value-error/normalize area: 25 pass) + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)