### PR TITLE
fix(stream): give prefill (time-to-first-token) a longer idle budget

### DIFF
--- a/changelog.d/stream-first-token-timeout.fixed.md
+++ b/changelog.d/stream-first-token-timeout.fixed.md
@@ -1,0 +1,7 @@
+- **Streaming no longer idle-times-out during a slow prefill.** The time to the
+  first token (prefill) is processed with no SSE bytes, so a slow model on a
+  large context could trip the short inter-token idle timeout *before its first
+  token* (observed: a local 35B model idle-timing-out mid-prefill). The first
+  token now gets a more generous budget (default 4x the idle timeout, min 120s,
+  still bounded by the overall stream deadline; tune with
+  `HARN_LLM_FIRST_TOKEN_TIMEOUT`); inter-token gaps keep the normal idle timeout.

--- a/crates/harn-vm/src/llm/stream.rs
+++ b/crates/harn-vm/src/llm/stream.rs
@@ -69,6 +69,20 @@ pub(crate) async fn vm_stream_llm(
     });
     let idle_dur = std::time::Duration::from_secs(idle_timeout_secs);
 
+    // Prefill (time-to-first-token) streams no SSE bytes while the server
+    // processes the prompt, so a slow model on a large context would trip the
+    // short inter-token idle timeout *mid-prefill* (observed: a local 35B model
+    // idle-timing-out before its first token on a long context). Give the first
+    // token a more generous budget; subsequent inter-token gaps use the normal
+    // idle timeout. Still bounded by the overall deadline below. Configurable via
+    // HARN_LLM_FIRST_TOKEN_TIMEOUT; defaults to 4x the idle timeout, min 120s.
+    let first_token_timeout_secs = std::env::var("HARN_LLM_FIRST_TOKEN_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or_else(|| idle_timeout_secs.saturating_mul(4).max(120));
+    let first_token_dur = std::time::Duration::from_secs(first_token_timeout_secs);
+    let mut got_first_token = false;
+
     // Bound total stream duration: a provider that dribbles bytes fast
     // enough to keep resetting the idle timer would otherwise hold the
     // stream open forever.
@@ -84,20 +98,33 @@ pub(crate) async fn vm_stream_llm(
             )))));
         }
         let remaining_overall = overall_dur.saturating_sub(stream_start.elapsed());
-        let wait = idle_dur.min(remaining_overall);
+        // Before the first token, allow the longer prefill budget; after, the
+        // normal inter-token idle timeout.
+        let active_idle = if got_first_token {
+            idle_dur
+        } else {
+            first_token_dur
+        };
+        let wait = active_idle.min(remaining_overall);
         let event = match tokio::time::timeout(wait, es.next()).await {
             Ok(Some(event)) => event,
             Ok(None) => break,
             Err(_) => {
                 es.close();
-                // Report as idle-timeout; overall-deadline is caught at loop top.
+                // Overall-deadline is caught at loop top; this is a gap timeout.
+                let (secs, phase) = if got_first_token {
+                    (idle_timeout_secs, "inter-token idle")
+                } else {
+                    (first_token_timeout_secs, "time-to-first-token (prefill)")
+                };
                 return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                    format!("stream idle timeout: no data received for {idle_timeout_secs}s"),
+                    format!("stream {phase} timeout: no data received for {secs}s"),
                 ))));
             }
         };
         match event {
             Ok(Event::Message(msg)) => {
+                got_first_token = true;
                 if msg.data == "[DONE]" {
                     break;
                 }


### PR DESCRIPTION
## Problem

The streaming loop applied one short inter-token idle timeout (`HARN_LLM_IDLE_TIMEOUT`, default 30s) to **every** gap — including the time-to-first-token, during which the server processes the prompt and streams no SSE bytes. A slow model on a large context could therefore **idle-timeout mid-prefill, before emitting any token**.

Found empirically: a local 35B model (llama.cpp) on a long eval context idle-timed-out during prefill — the last record was a `provider_call_request` with `"idle timeout"`, never reaching the first token.

## Fix

Track whether the first token has arrived; until then, use a more generous **first-token (prefill) budget** (default `4 × idle_timeout`, min 120s, still bounded by the overall stream deadline; override with `HARN_LLM_FIRST_TOKEN_TIMEOUT`). Inter-token gaps keep the normal idle timeout. The timeout error now names the phase (`time-to-first-token (prefill)` vs `inter-token idle`).

`cargo build` + `clippy` clean on harn-vm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)