### PR TITLE
Fix release notes sandbox output path

### DIFF
--- a/changelog.d/3046.fixed.md
+++ b/changelog.d/3046.fixed.md
@@ -1,0 +1,4 @@
+- **Release finalization writes generated GitHub release notes inside the repo
+  workspace (#3046).** `release_ship.sh --finalize` no longer asks Harn to
+  write its default notes file under `/tmp`, avoiding sandbox rejection in the
+  publish-release recovery workflow.

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -744,7 +744,9 @@ log_step "Publish"
 ./scripts/release_gate.sh publish
 
 if [[ -z "$NOTES_OUTPUT" ]]; then
-  NOTES_OUTPUT="$(mktemp)"
+  NOTES_DIR="$ROOT_DIR/.harn/release-notes"
+  mkdir -p "$NOTES_DIR"
+  NOTES_OUTPUT="$(mktemp "$NOTES_DIR/notes.XXXXXX.md")"
   CLEANUP_NOTES=1
 else
   CLEANUP_NOTES=0


### PR DESCRIPTION
## Summary
- write default release finalization notes under the repo-local .harn directory instead of /tmp
- keep explicit --notes-output behavior unchanged

## Verification
- bash -n scripts/release_ship.sh
- CARGO_TARGET_DIR=/tmp/harn-release-notes-target ./scripts/release_gate.sh notes --version v0.8.72 --output .harn/release-notes/test-v0.8.72.md