### PR TITLE
Maturity sweep follow-up: shared FixEdit apply policy + Vertex output_format fix

### DIFF
--- a/changelog.d/maturity-sweep-2.changed.md
+++ b/changelog.d/maturity-sweep-2.changed.md
@@ -1,0 +1,4 @@
+- **`harn fmt`, `harn lint --fix`, and the LSP on-save fixer share one autofix
+  apply/dedup policy.** The "drop overlapping fixes and splice right-to-left"
+  logic now lives in one place (`FixEdit::apply_all` / `dedupe_overlapping`), so
+  the three surfaces can no longer drift on which conflicting fixes win.

--- a/changelog.d/maturity-sweep-2.fixed.md
+++ b/changelog.d/maturity-sweep-2.fixed.md
@@ -1,0 +1,4 @@
+- **Vertex honors the modern `output_format` for structured output.** It
+  previously read only the legacy `response_format`/`json_schema` mirror, so a
+  call using `output_format: {kind: "json_schema", schema}` silently produced no
+  structured-output directive on the Vertex backend.

--- a/crates/harn-cli/src/commands/check/lint.rs
+++ b/crates/harn-cli/src/commands/check/lint.rs
@@ -194,7 +194,7 @@ pub(crate) fn lint_fix_file(
         &options,
     );
 
-    let mut edits: Vec<&harn_lexer::FixEdit> = lint_diags
+    let edits: Vec<harn_lexer::FixEdit> = lint_diags
         .iter()
         .filter_map(|d| d.fix.as_ref())
         .chain(
@@ -205,34 +205,18 @@ pub(crate) fn lint_fix_file(
                 .filter_map(|d| d.fix.as_ref()),
         )
         .flatten()
+        .cloned()
         .collect();
 
     if edits.is_empty() {
         return 0;
     }
 
-    // Descending by span.start so edits apply right-to-left without
-    // invalidating earlier offsets; drop overlaps in that same order.
-    edits.sort_by_key(|edit| std::cmp::Reverse(edit.span.start));
-
-    let mut accepted: Vec<&harn_lexer::FixEdit> = Vec::new();
-    for edit in &edits {
-        let overlaps = accepted
-            .iter()
-            .any(|prev| edit.span.start < prev.span.end && edit.span.end > prev.span.start);
-        if !overlaps {
-            accepted.push(edit);
-        }
-    }
-
-    let mut result = source;
-    for edit in &accepted {
-        let before = &result[..edit.span.start];
-        let after = &result[edit.span.end..];
-        result = format!("{before}{}{after}", edit.replacement);
-    }
-
-    let applied = accepted.len();
+    // Drop overlaps and splice right-to-left via the shared FixEdit policy, so
+    // the result is byte-for-byte what `harn fmt` and the LSP on-save fixer
+    // produce.
+    let applied = harn_lexer::FixEdit::dedupe_overlapping(&edits).len();
+    let result = harn_lexer::FixEdit::apply_all(&source, &edits);
     std::fs::write(path, &result).unwrap_or_else(|e| {
         eprintln!("Failed to write {path_str}: {e}");
         process::exit(1);

--- a/crates/harn-fmt/src/trailing_comma.rs
+++ b/crates/harn-fmt/src/trailing_comma.rs
@@ -314,22 +314,8 @@ fn end_minus_one(span: Span) -> usize {
     span.end.saturating_sub(1)
 }
 
-fn apply_edits(source: &str, mut edits: Vec<FixEdit>) -> String {
-    edits.sort_by_key(|e| std::cmp::Reverse(e.span.start));
-    let mut out = source.to_string();
-    let mut accepted_start: Option<usize> = None;
-    for edit in edits {
-        if let Some(prev_start) = accepted_start {
-            if edit.span.end > prev_start {
-                continue;
-            }
-        }
-        let before = &out[..edit.span.start];
-        let after = &out[edit.span.end..];
-        out = format!("{before}{}{after}", edit.replacement);
-        accepted_start = Some(edit.span.start);
-    }
-    out
+fn apply_edits(source: &str, edits: Vec<FixEdit>) -> String {
+    FixEdit::apply_all(source, &edits)
 }
 
 fn span_at_offset(source: &str, start: usize, end: usize) -> Span {

--- a/crates/harn-lexer/src/token.rs
+++ b/crates/harn-lexer/src/token.rs
@@ -81,6 +81,74 @@ pub struct FixEdit {
     pub replacement: String,
 }
 
+impl FixEdit {
+    /// Sort edits right-to-left by start offset and drop any that overlap an
+    /// already-accepted edit, returning the survivors in descending-start
+    /// order — ready to splice right-to-left without invalidating earlier
+    /// offsets. This is the single source of truth for the "apply all fixes,
+    /// drop conflicts" policy that `harn fmt`, `harn lint --fix`, and the LSP
+    /// on-save fixer must agree on byte-for-byte.
+    pub fn dedupe_overlapping(edits: &[FixEdit]) -> Vec<FixEdit> {
+        let mut sorted = edits.to_vec();
+        sorted.sort_by_key(|edit| std::cmp::Reverse(edit.span.start));
+        let mut accepted: Vec<FixEdit> = Vec::new();
+        for edit in sorted {
+            let overlaps = accepted
+                .iter()
+                .any(|prev| edit.span.start < prev.span.end && edit.span.end > prev.span.start);
+            if !overlaps {
+                accepted.push(edit);
+            }
+        }
+        accepted
+    }
+
+    /// Apply `edits` to `source`, dropping overlaps via
+    /// [`Self::dedupe_overlapping`] and splicing right-to-left. Callers that
+    /// also need the accepted-edit list (e.g. to build LSP `TextEdit`s) should
+    /// call `dedupe_overlapping` directly.
+    pub fn apply_all(source: &str, edits: &[FixEdit]) -> String {
+        let mut out = source.to_string();
+        for edit in Self::dedupe_overlapping(edits) {
+            let before = &out[..edit.span.start];
+            let after = &out[edit.span.end..];
+            out = format!("{before}{}{after}", edit.replacement);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod fix_edit_tests {
+    use super::*;
+
+    fn edit(start: usize, end: usize, replacement: &str) -> FixEdit {
+        FixEdit {
+            span: Span::with_offsets(start, end, 1, start + 1),
+            replacement: replacement.to_string(),
+        }
+    }
+
+    #[test]
+    fn apply_all_splices_right_to_left() {
+        // Order-independent input; non-overlapping edits both apply.
+        let out = FixEdit::apply_all("0123456789", &[edit(2, 4, "AB"), edit(6, 8, "CD")]);
+        assert_eq!(out, "01AB45CD89");
+    }
+
+    #[test]
+    fn apply_all_drops_overlapping_edits_descending_start_wins() {
+        // Sorted descending by start, edit(4,8) is accepted and edit(2,6)
+        // overlaps it, so it's dropped — matching fmt/lsp/cli semantics.
+        let out = FixEdit::apply_all("0123456789", &[edit(2, 6, "XXXX"), edit(4, 8, "YYYY")]);
+        assert_eq!(out, "0123YYYY89");
+        assert_eq!(
+            FixEdit::dedupe_overlapping(&[edit(2, 6, "x"), edit(4, 8, "y")]).len(),
+            1
+        );
+    }
+}
+
 /// Canonical list of Harn language keywords. Single source of truth; the lexer's
 /// identifier-to-keyword match must stay in sync (enforced by
 /// `test_keywords_const_covers_lexer`). External tooling should consume this

--- a/crates/harn-lsp/src/handlers/formatting.rs
+++ b/crates/harn-lsp/src/handlers/formatting.rs
@@ -300,19 +300,9 @@ pub(crate) fn build_code_actions(
                 all_edits.extend(fix.iter().cloned());
             }
         }
-        // Apply fixes right-to-left and drop overlaps to mirror the
-        // CLI's `harn lint --fix` semantics; this keeps the on-save
-        // path consistent with what `harn lint --fix` would produce.
-        all_edits.sort_by_key(|e| std::cmp::Reverse(e.span.start));
-        let mut accepted: Vec<harn_lexer::FixEdit> = Vec::new();
-        for edit in all_edits {
-            let overlaps = accepted
-                .iter()
-                .any(|prev| edit.span.start < prev.span.end && edit.span.end > prev.span.start);
-            if !overlaps {
-                accepted.push(edit);
-            }
-        }
+        // Drop overlaps via the shared policy so the on-save path produces
+        // byte-for-byte what `harn lint --fix` would.
+        let accepted = harn_lexer::FixEdit::dedupe_overlapping(&all_edits);
         if !accepted.is_empty() {
             let text_edits: Vec<TextEdit> = accepted
                 .iter()

--- a/crates/harn-vm/src/llm/providers/vertex.rs
+++ b/crates/harn-vm/src/llm/providers/vertex.rs
@@ -94,13 +94,36 @@ impl VertexProvider {
         if let Some(stop) = request.stop.as_ref() {
             generation.insert("stopSequences".to_string(), serde_json::json!(stop));
         }
-        if request.response_format.as_deref() == Some("json") {
-            generation.insert(
-                "responseMimeType".to_string(),
-                serde_json::json!("application/json"),
-            );
-            if let Some(schema) = request.json_schema.as_ref() {
+        // The modern `output_format` is the source of truth; Vertex previously
+        // read only the legacy `response_format`/`json_schema` mirror, which is
+        // never backfilled from a nested `output_format.schema`, so a call using
+        // `output_format: {kind: "json_schema", schema}` silently produced no
+        // structured-output directive. Honor `output_format` first, falling back
+        // to the legacy mirror for callers that only set those.
+        match &request.output_format {
+            crate::llm::api::OutputFormat::JsonObject => {
+                generation.insert(
+                    "responseMimeType".to_string(),
+                    serde_json::json!("application/json"),
+                );
+            }
+            crate::llm::api::OutputFormat::JsonSchema { schema, .. } => {
+                generation.insert(
+                    "responseMimeType".to_string(),
+                    serde_json::json!("application/json"),
+                );
                 generation.insert("responseSchema".to_string(), schema.clone());
+            }
+            crate::llm::api::OutputFormat::Text => {
+                if request.response_format.as_deref() == Some("json") {
+                    generation.insert(
+                        "responseMimeType".to_string(),
+                        serde_json::json!("application/json"),
+                    );
+                    if let Some(schema) = request.json_schema.as_ref() {
+                        generation.insert("responseSchema".to_string(), schema.clone());
+                    }
+                }
             }
         }
         if !generation.is_empty() {
@@ -354,6 +377,26 @@ mod tests {
         assert_eq!(body["contents"][0]["role"], "user");
         assert_eq!(body["contents"][0]["parts"][0]["text"], "hello");
         assert_eq!(body["generationConfig"]["maxOutputTokens"], 32);
+    }
+
+    #[test]
+    fn build_request_honors_modern_output_format_json_schema() {
+        // Regression: Vertex read only the legacy response_format/json_schema
+        // mirror, so a modern `output_format` was silently dropped.
+        let mut request = base_request();
+        request.output_format = crate::llm::api::OutputFormat::JsonSchema {
+            schema: json!({"type": "object", "properties": {"answer": {"type": "string"}}}),
+            strict: true,
+        };
+        let body = VertexProvider::build_request_body(&request);
+        assert_eq!(
+            body["generationConfig"]["responseMimeType"],
+            "application/json"
+        );
+        assert_eq!(
+            body["generationConfig"]["responseSchema"]["properties"]["answer"]["type"],
+            "string"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #3040. From the same maturity-sweep survey's deferred list, this lands the items that have **unambiguous, architectural, generalizable, in-process-testable** solutions — and deliberately leaves the rest documented (they're genuinely not clean single-PR cutovers; see below).

### FixEdit: one source of truth for the autofix overlap policy (DRY)
`harn fmt`, `harn lint --fix`, and the LSP on-save fixer each re-implemented the identical "sort right-to-left, drop overlapping edits, splice" loop. Hoisted onto the type that owns it, in the crate below all three consumers: `FixEdit::dedupe_overlapping` (the policy) and `FixEdit::apply_all` (dedup + splice) in `harn-lexer`. The LSP path needs the accepted-edit list to build `TextEdit`s so it calls `dedupe_overlapping`; fmt/cli call `apply_all`. The three loops were semantically identical given the descending sort (fmt's single-`accepted_start` form and the lsp/cli full-overlap form coincide — verified, and harn-fmt's 18 trailing-comma tests stay green), so this is behavior-preserving — the surfaces can no longer drift on which conflicting fix wins. `fix.rs`'s `FixEditWire` path stays separate (it errors on bad spans rather than silently dropping). Unit-tested.

### Vertex structured-output silent drop (bug)
`VertexProvider::build_request_body` read only the legacy `response_format`/`json_schema` mirror, which is never backfilled from a nested `output_format.schema` — so a call using the modern `output_format: {kind: "json_schema", schema}` silently produced no structured-output directive. Now honors `output_format` first (matching the other adapters), falling back to the legacy mirror. Unit-tested.

### Deliberately left documented (not clean cutovers)
Evaluated against the code and confirmed each is **not** an unambiguous single-PR cutover:
- **`number` static type alias** — needs the same change sprinkled across ≥3 duplicated binop checkers (`binary_ops.rs`, `statements.rs`, plus `infer_binary_op_type`) with uncertain completeness; the architectural fix (resolve aliases at operand inference) is a deeper refactor. A half-fix (param resolves, arithmetic still errors) is worse than none.
- **Write-boundary redaction of signed provenance receipts** — the `record_hash` is sealed over *raw* bytes at write time, so redacting at the export boundary breaks hash verification, and redacting at write time is a broader semantic shift (every reader + replay).
- **Import-resolution cache** — perf-only with no behavioral test; not worth adding VM state + a module-resolution regression surface without a way to demonstrate value.
- **Backoff / compaction-parser consolidation** — real behavior-diff (curve rounding) and validation-guard-regression risk respectively.

### Verification
harn-fmt / harn-lexer / harn-vm targeted tests green; lsp + cli build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
