### PR TITLE
Refresh DeepSeek V4 OpenRouter catalog

### DIFF
--- a/changelog.d/deepseek-v4-catalog.changed.md
+++ b/changelog.d/deepseek-v4-catalog.changed.md
@@ -1,0 +1,4 @@
+- **Provider catalog.** OpenRouter DeepSeek V4 Flash and V4 Pro now use the
+  current OpenRouter 1,048,576-token context windows, cache-read prices, and
+  standard rate cards while retaining the direct DeepSeek V4 entries and legacy
+  alias metadata.

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -1426,25 +1426,26 @@ pricing = { input_per_mtok = 0.14, output_per_mtok = 0.28, cache_read_per_mtok =
 deprecated = true
 deprecation_note = "Maps to deepseek-v4-flash thinking mode; retirement 2026-07-24 15:59 UTC per provider docs."
 
-# DeepSeek V4 OpenRouter mirrors. Same model, OR adds margin.
+# DeepSeek V4 OpenRouter mirrors. OpenRouter publishes an independent
+# rate card and a binary 1M-token context window for these routes.
 tier = "reasoning"
 open_weight = true
 strengths = ["reasoning", "coding"]
 [models."deepseek/deepseek-v4-flash"]
 name = "DeepSeek V4 Flash (via OpenRouter)"
 provider = "openrouter"
-context_window = 1000000
+context_window = 1048576
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.10, output_per_mtok = 0.20 }
+pricing = { input_per_mtok = 0.0983, output_per_mtok = 0.1966, cache_read_per_mtok = 0.0197 }
 tier = "mid"
 open_weight = true
 strengths = ["speed", "cheap", "tool_use", "reasoning", "long_context"]
 [models."deepseek/deepseek-v4-pro"]
 name = "DeepSeek V4 Pro (via OpenRouter)"
 provider = "openrouter"
-context_window = 1000000
+context_window = 1048576
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.435, output_per_mtok = 0.87 }
+pricing = { input_per_mtok = 0.435, output_per_mtok = 0.87, cache_read_per_mtok = 0.003625 }
 
 # Open-router Qwen3.5 9B (kept for the `small` tier alias).
 tier = "frontier"

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -5238,7 +5238,7 @@ public let harnProviderCatalogJSON = #"""
       "name": "DeepSeek V4 Flash (via OpenRouter)",
       "provider": "openrouter",
       "aliases": [],
-      "context_window": 1000000,
+      "context_window": 1048576,
       "modalities": {
         "input": [
           "text"
@@ -5276,9 +5276,9 @@ public let harnProviderCatalogJSON = #"""
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.1,
-        "output_per_mtok": 0.2,
-        "cache_read_per_mtok": null,
+        "input_per_mtok": 0.0983,
+        "output_per_mtok": 0.1966,
+        "cache_read_per_mtok": 0.0197,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -5311,7 +5311,7 @@ public let harnProviderCatalogJSON = #"""
       "name": "DeepSeek V4 Pro (via OpenRouter)",
       "provider": "openrouter",
       "aliases": [],
-      "context_window": 1000000,
+      "context_window": 1048576,
       "modalities": {
         "input": [
           "text"
@@ -5351,7 +5351,7 @@ public let harnProviderCatalogJSON = #"""
       "pricing": {
         "input_per_mtok": 0.435,
         "output_per_mtok": 0.87,
-        "cache_read_per_mtok": null,
+        "cache_read_per_mtok": 0.003625,
         "cache_write_per_mtok": null
       },
       "deprecation": {

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -5059,7 +5059,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "DeepSeek V4 Flash (via OpenRouter)",
       "provider": "openrouter",
       "aliases": [],
-      "context_window": 1000000,
+      "context_window": 1048576,
       "modalities": {
         "input": [
           "text"
@@ -5097,9 +5097,9 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.1,
-        "output_per_mtok": 0.2,
-        "cache_read_per_mtok": null,
+        "input_per_mtok": 0.0983,
+        "output_per_mtok": 0.1966,
+        "cache_read_per_mtok": 0.0197,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -5132,7 +5132,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "DeepSeek V4 Pro (via OpenRouter)",
       "provider": "openrouter",
       "aliases": [],
-      "context_window": 1000000,
+      "context_window": 1048576,
       "modalities": {
         "input": [
           "text"
@@ -5172,7 +5172,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "pricing": {
         "input_per_mtok": 0.435,
         "output_per_mtok": 0.87,
-        "cache_read_per_mtok": null,
+        "cache_read_per_mtok": 0.003625,
         "cache_write_per_mtok": null
       },
       "deprecation": {

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -4882,7 +4882,7 @@
       "name": "DeepSeek V4 Flash (via OpenRouter)",
       "provider": "openrouter",
       "aliases": [],
-      "context_window": 1000000,
+      "context_window": 1048576,
       "modalities": {
         "input": [
           "text"
@@ -4920,9 +4920,9 @@
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.1,
-        "output_per_mtok": 0.2,
-        "cache_read_per_mtok": null,
+        "input_per_mtok": 0.0983,
+        "output_per_mtok": 0.1966,
+        "cache_read_per_mtok": 0.0197,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -4955,7 +4955,7 @@
       "name": "DeepSeek V4 Pro (via OpenRouter)",
       "provider": "openrouter",
       "aliases": [],
-      "context_window": 1000000,
+      "context_window": 1048576,
       "modalities": {
         "input": [
           "text"
@@ -4995,7 +4995,7 @@
       "pricing": {
         "input_per_mtok": 0.435,
         "output_per_mtok": 0.87,
-        "cache_read_per_mtok": null,
+        "cache_read_per_mtok": 0.003625,
         "cache_write_per_mtok": null
       },
       "deprecation": {


### PR DESCRIPTION
## Summary
- refresh OpenRouter DeepSeek V4 Flash/Pro catalog rows to the current 1,048,576-token context window
- add OpenRouter cache-read pricing for both V4 Flash and V4 Pro
- regenerate provider catalog JSON, TypeScript, and Swift exports
- keep the direct DeepSeek V4 provider entries and legacy DeepSeek alias/deprecation metadata intact

## Fact-checking
- DeepSeek official pricing/docs list `deepseek-v4-flash` and `deepseek-v4-pro` as the current direct API models, each with 1M context and 384K max output: https://api-docs.deepseek.com/quick_start/pricing
- DeepSeek thinking-mode docs confirm the V4 thinking toggle and `reasoning_effort` behavior: https://api-docs.deepseek.com/guides/thinking_mode
- OpenRouter's live model API currently reports `context_length: 1048576` for `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`: https://openrouter.ai/api/v1/models
- OpenRouter model pages show the current non-promotional route prices for V4 Flash and V4 Pro: https://openrouter.ai/deepseek/deepseek-v4-flash/api and https://openrouter.ai/deepseek/deepseek-v4-pro/api

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-deepseek-target cargo build -q -p harn-cli`
- `/tmp/harn-deepseek-target/debug/harn providers validate --check-artifacts`
- `/tmp/harn-deepseek-target/debug/harn providers export --check`
- `/tmp/harn-deepseek-target/debug/harn providers matrix --check`
- `/tmp/harn-deepseek-target/debug/harn providers support --check`
- `HARN_BIN=/tmp/harn-deepseek-target/debug/harn ./scripts/check_docs_model_refs.sh`
- `CARGO_TARGET_DIR=/tmp/harn-deepseek-target cargo test -q -p harn-vm provider_catalog --lib`
- `CARGO_TARGET_DIR=/tmp/harn-deepseek-target cargo test -q -p harn-cli provider_matrix`
- `CARGO_TARGET_DIR=/tmp/harn-deepseek-target cargo fmt --all`
- `git diff --check`
- pre-commit hook
- pre-push hook
