### PR TITLE
fix(agent): surface parse errors to the model + recover JSON-escaped heredoc bodies

### DIFF
--- a/changelog.d/parse-error-feedback-and-heredoc-recovery.fixed.md
+++ b/changelog.d/parse-error-feedback-and-heredoc-recovery.fixed.md
@@ -1,0 +1,13 @@
+- **Cheap models no longer loop on JSON-escaped heredoc bodies; parse errors now
+  reach the model.** Two fixes for the failure where a model's `edit(...)` turn
+  yielded zero tool calls and then re-emitted the identical malformed call until
+  the loop exhausted. (1) Parser recovery: a `<<EOF` heredoc whose body uses
+  literal `\n` line breaks (the JSON-escaped one-liner form cheap models like
+  qwen3.6 emit) is now decoded and dispatched instead of hard-rejected with
+  "expected newline after heredoc tag"; real-newline heredocs are parsed exactly
+  as before. (2) Feedback fidelity: a turn whose tool calls were all dropped by
+  the parser now gets the purpose-built `parse_guidance` feedback (which names
+  the exact diagnostic and shows the heredoc syntax) and is excluded from the
+  no-progress stall streak, instead of the misleading "emit one well-formed tool
+  call" nudge. Both fire purely on the syntactic parse-error condition, so strong
+  models that emit clean calls never trigger them.

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -18,7 +18,7 @@ import {
 import { agent_build_turn_messages, agent_build_turn_system_fragments } from "std/agent/preflight"
 import { agent_dispatch_tool_batch, agent_dispatch_tool_call } from "std/agent/primitives"
 import { agent_progress_apply_options } from "std/agent/progress"
-import { native_tool_contract_feedback_prompt } from "std/agent/prompts"
+import { native_tool_contract_feedback_prompt, parse_guidance_prompt } from "std/agent/prompts"
 import {
   agent_required_tools_enforce,
   agent_required_tools_inject_feedback,
@@ -630,6 +630,36 @@ fn __tool_call_args(call) {
 
 fn __native_fallback_feedback(policy, fallback_index) {
   return native_tool_contract_feedback_prompt({policy: policy, fallback_index: fallback_index})
+}
+
+/**
+ * A turn whose tool calls were ALL dropped by the parser (>=1 parse error and 0
+ * dispatched calls) is a malformed-call turn, not a no-progress monologue. The
+ * purpose-built `parse_guidance` prompt — which shows the heredoc syntax and
+ * names the exact parser diagnostic — is the right corrective feedback, but
+ * nothing consumed `tool_parse_errors` on the active path. This fires purely on
+ * the syntactic parse-error condition: strong models emit clean calls, hit zero
+ * parse errors, and never reach it (no regression). Returns true when feedback
+ * was injected so the caller can suppress the no-progress stall path.
+ */
+fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts) -> bool {
+  let parse_errors = parsed?.tool_parse_errors ?? []
+  if len(parse_errors) == 0 || len(tool_calls) > 0 {
+    return false
+  }
+  let error_summary = to_string(parse_errors[0])
+  // All calls were dropped, so there is no partial success this turn.
+  let feedback = parse_guidance_prompt(
+    {error_summary: error_summary, has_partial_success: false, parsed_call_count: 0},
+    turn_opts,
+  )
+  agent_session_inject_feedback(session_id, "parse_guidance", feedback)
+  agent_emit_event(
+    session_id,
+    "tool_parse_error_feedback",
+    {parse_error_count: len(parse_errors), error_summary: error_summary},
+  )
+  return true
 }
 
 fn __detect_native_fallback(
@@ -2011,6 +2041,7 @@ fn __agent_loop_run(message, session, initial_opts) {
         normalized
       }
       agent_session_record_assistant(session.session_id, recorded_assistant)
+      let had_parse_errors = __maybe_inject_parse_error_feedback(session.session_id, parsed, tool_calls, turn_opts)
       let await_call = __agent_await_resumption_call(tool_calls)
       if await_call != nil {
         let await_result = try {
@@ -2089,6 +2120,7 @@ fn __agent_loop_run(message, session, initial_opts) {
         stall_judge_due,
         stall_prev_dispatch,
         visible_text,
+        had_parse_errors,
       )
       stall_state = stall_observation.state
       stall_enabled_seen = stall_enabled_seen || stall_observation.enabled
@@ -2674,6 +2706,9 @@ fn __agent_loop_run(message, session, initial_opts) {
   return unwrap(run)
 }
 
+// A turn whose calls were all dropped by the parser gets the purpose-built
+// parse-guidance feedback (not the generic no-progress nudge), and is
+// excluded from the no-progress stall streak below.
 // Host pushed an `interrupt_immediate` injection between the
 // model emitting tool calls and the dispatcher starting. Honor
 // the host's "stop, do this instead" by skipping the pending

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -718,12 +718,29 @@ pub fn agent_stall_observe_tool_calls(
   defer_feedback: bool,
   prev_dispatch = nil,
   turn_text = "",
+  had_parse_errors = false,
 ) -> AgentStallObservation {
   let config = __agent_stall_config(raw_config)
   if !config.enabled {
     return {
       state: state,
       enabled: false,
+      warning: nil,
+      feedback_deferred: false,
+      config: config,
+      hard_stop: false,
+    }
+  }
+  // A turn whose tool calls were all dropped by the parser carries real intent
+  // (it tried to act); the malformed-call path already injected purpose-built
+  // parse-guidance feedback. Treat it as a neutral recovery turn so it does NOT
+  // count toward the no-progress monologue streak — otherwise the loop nags the
+  // model to "emit one well-formed tool call" when it already did, just with a
+  // malformed body. Gated purely on the syntactic parse-error signal.
+  if had_parse_errors {
+    return {
+      state: __agent_stall_register_recovery(__agent_stall_reset_action(state)),
+      enabled: true,
       warning: nil,
       feedback_deferred: false,
       config: config,

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -2098,6 +2098,18 @@ fn build_agent_event(
             kind: "no_progress_streak_nudge".to_string(),
             content: get_usize("turns_since_progress").to_string(),
         }),
+        // `tool_parse_error_feedback` fires when a turn's tool calls were ALL
+        // dropped by the parser (>= 1 parse error, 0 dispatched). The engine
+        // injects the purpose-built parse-guidance prompt instead of the
+        // generic no-progress nudge; this surfaces that correction to operators
+        // on the FeedbackInjected stream (engine-injected, not user-injected),
+        // exactly like the sibling text-mode nudges above. `content` carries the
+        // first parser diagnostic that drove the correction.
+        "tool_parse_error_feedback" => Ok(AgentEvent::FeedbackInjected {
+            session_id: session_id.to_string(),
+            kind: "tool_parse_error_feedback".to_string(),
+            content: get_string("error_summary"),
+        }),
         other => Err(VmError::Runtime(format!(
             "{HOST_AGENT_EMIT_EVENT}: unsupported event type `{other}`"
         ))),

--- a/crates/harn-vm/src/llm/tools/parse/mod.rs
+++ b/crates/harn-vm/src/llm/tools/parse/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use bare::parse_bare_calls_in_body;
 pub(crate) use native_json::parse_native_json_tool_calls;
 pub(crate) use streaming::StreamingToolCallDetector;
 pub(crate) use syntax::ident_length;
+pub(crate) use syntax::unescape_heredoc_body;
 pub(crate) use syntax::{scan_heredoc, HeredocError};
 pub(crate) use tagged::parse_text_tool_calls_with_tools;
 

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -211,6 +211,12 @@ pub(crate) struct HeredocSpan {
     pub content: std::ops::Range<usize>,
     /// Byte offset immediately after the closing tag on its line.
     pub end: usize,
+    /// True when the heredoc body used literal JSON/string escape sequences
+    /// (`\n`, `\t`, ...) as line separators instead of real newlines — the
+    /// degraded form cheap models emit when they treat the heredoc body as a
+    /// one-line JSON string. The caller must unescape `content` before use.
+    /// A body that used real newlines (the normal case) is always `false`.
+    pub escaped: bool,
 }
 
 /// Why a `<<` opener is not a complete heredoc. Carries the tag where one was
@@ -260,6 +266,16 @@ pub(crate) fn scan_heredoc(src: &str, start: usize) -> Result<HeredocSpan, Hered
         pos += 1;
     }
     if bytes.get(pos) != Some(&b'\n') {
+        // Degraded form: cheap models (e.g. qwen3.6) JSON-escape the heredoc
+        // body, so the line break after the tag is the two literal bytes
+        // backslash + 'n' rather than a real `\n`. Recover those calls by
+        // scanning the escaped body to a literal-`\n`-delimited closing tag
+        // line; the caller unescapes `content`. A genuinely-truncated opener
+        // (`<<EOF` then end-of-input, a real shift operator, etc.) still hits
+        // the original MissingNewline error below.
+        if bytes.get(pos) == Some(&b'\\') && bytes.get(pos + 1) == Some(&b'n') {
+            return scan_escaped_heredoc_body(src, pos, tag);
+        }
         return Err(HeredocError::MissingNewline { tag });
     }
     pos += 1;
@@ -287,6 +303,7 @@ pub(crate) fn scan_heredoc(src: &str, start: usize) -> Result<HeredocSpan, Hered
                 return Ok(HeredocSpan {
                     content: content_start..content_start + stripped.len(),
                     end: line_start + leading_ws_len + tag.len(),
+                    escaped: false,
                 });
             }
         }
@@ -297,6 +314,126 @@ pub(crate) fn scan_heredoc(src: &str, start: usize) -> Result<HeredocSpan, Hered
         }
     }
     Err(HeredocError::Unterminated { tag })
+}
+
+/// Scan a JSON/string-escaped heredoc body whose line breaks are the two
+/// literal bytes `\` + `n` instead of real newlines. `esc_nl_start` must sit on
+/// the `\` of the `\n` that immediately follows the opening `<<TAG`. The closing
+/// tag is found on a literal-`\n`-delimited "line" that — after optional literal
+/// leading whitespace — begins with `tag` at a word boundary, mirroring the
+/// real-newline grammar. The returned `content` range is the still-escaped body
+/// (callers unescape it via [`unescape_heredoc_body`]); `escaped` is `true`.
+fn scan_escaped_heredoc_body(
+    src: &str,
+    esc_nl_start: usize,
+    tag: String,
+) -> Result<HeredocSpan, HeredocError> {
+    let bytes = src.as_bytes();
+    // Body content starts after the leading literal `\n`.
+    let content_start = esc_nl_start + 2;
+    let mut pos = content_start;
+    // `line_start` tracks the first content byte of the current escaped "line".
+    let mut line_start = content_start;
+    while pos < bytes.len() {
+        // An escaped backslash `\\` is one decoded `\` — consume both bytes so a
+        // following `n` (e.g. a Go source `"...\n"`, on the wire `\\n`) is NOT
+        // misread as the escaped line separator. Keeps splitting consistent with
+        // `unescape_heredoc_body`.
+        if bytes.get(pos) == Some(&b'\\') && bytes.get(pos + 1) == Some(&b'\\') {
+            pos += 2;
+            continue;
+        }
+        // A literal `\n` (backslash + 'n') is the escaped line separator.
+        if bytes.get(pos) == Some(&b'\\') && bytes.get(pos + 1) == Some(&b'n') {
+            if let Some(span) = escaped_close_at(src, content_start, line_start, pos, &tag) {
+                return Ok(span);
+            }
+            pos += 2;
+            line_start = pos;
+            continue;
+        }
+        pos += src[pos..].chars().next().map_or(1, char::len_utf8);
+    }
+    // The closing tag may sit on the final escaped line with no trailing `\n`
+    // (e.g. `...\nEOF` at end of the string value, just before the closing
+    // quote/paren). Check the trailing line.
+    if let Some(span) = escaped_close_at(src, content_start, line_start, bytes.len(), &tag) {
+        return Ok(span);
+    }
+    Err(HeredocError::Unterminated { tag })
+}
+
+/// Test whether the escaped "line" `src[line_start..line_end]` is the closing
+/// tag line. `line_end` is the offset of the separating literal `\n` (or the end
+/// of the body). On a match, returns a [`HeredocSpan`] whose `content` runs from
+/// `content_start` to the start of the closing line's leading whitespace and
+/// whose `end` is just past the tag. Returns `None` when the line is body text.
+fn escaped_close_at(
+    src: &str,
+    content_start: usize,
+    line_start: usize,
+    line_end: usize,
+    tag: &str,
+) -> Option<HeredocSpan> {
+    let line = &src[line_start..line_end];
+    let leading_ws_len = line.len() - line.trim_start().len();
+    let after_ws = &line[leading_ws_len..];
+    let rest = after_ws.strip_prefix(tag)?;
+    let at_word_boundary = rest
+        .chars()
+        .next()
+        .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || ch == '_'));
+    if !at_word_boundary {
+        return None;
+    }
+    // Exclude the closing line (and the literal `\n` that introduced it) from
+    // the body content, matching the real-newline grammar which excludes the
+    // trailing newline before the close tag. The first body line shares its
+    // start with `content_start`, so clamp to avoid an inverted range.
+    let content_end = line_start.saturating_sub(2).max(content_start);
+    // Real-newline closes leave the trailing newline + any tail (`EOF\n})`) for
+    // the outer parser's `skip_ws_and_comments`. In the escaped form that
+    // separator is the two literal bytes `\` + `n`, which the outer parser does
+    // NOT treat as whitespace — so consume one optional trailing literal `\n`
+    // here, leaving `end` on the structural tail (`})`/`,`).
+    let bytes = src.as_bytes();
+    let mut end = line_start + leading_ws_len + tag.len();
+    if bytes.get(end) == Some(&b'\\') && bytes.get(end + 1) == Some(&b'n') {
+        end += 2;
+    }
+    Some(HeredocSpan {
+        content: content_start..content_end,
+        end,
+        escaped: true,
+    })
+}
+
+/// Unescape a JSON/string-escaped heredoc body recovered from the degraded
+/// literal-`\n` form. Decodes `\n`, `\t`, `\r`, `\"`, and `\\`; any other escape
+/// is left verbatim (both the backslash and the following byte) so unrecognized
+/// sequences in code survive unchanged. A trailing lone backslash is preserved.
+pub(crate) fn unescape_heredoc_body(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('"') => out.push('"'),
+            Some('\\') => out.push('\\'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 /// Skip past a `<<TAG\n...\nTAG` heredoc body starting at `start` in `src`.

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -905,3 +905,138 @@ fn tagged_tool_call_with_close_tag_inside_a_string_arg() {
     let command = result.calls[0]["arguments"]["command"].as_str().unwrap();
     assert_eq!(command, "echo </tool_call> done");
 }
+
+// --- JSON-escaped heredoc recovery (Change B) -------------------------------
+// Cheap models (e.g. qwen3.6) emit the heredoc body as a JSON-escaped one-liner
+// where the line breaks are the two literal bytes `\` + `n`, not real newlines.
+// The parser must recover those calls (dispatch with a real body) while leaving
+// genuine real-newline heredocs byte-for-byte unchanged.
+
+#[test]
+fn heredoc_recovers_json_escaped_literal_newline_body() {
+    let tools = sample_tool_registry();
+    // `\\n`, `\\t`, `\\"` here are the literal backslash-escape *bytes* — this
+    // mirrors the on-the-wire degraded form, e.g.
+    //   content: <<EOF\npackage manifest\n\nimport (\n\t"strings"\n)\n...EOF
+    let text = "edit({ path: \"parser_test.go\", content: <<EOF\\npackage manifest\\n\\nimport (\\n\\t\\\"strings\\\"\\n\\t\\\"testing\\\"\\n)\\n\\nfunc TestX(t *testing.T) {\\n\\tif 1 != 1 {\\n\\t\\tt.Fatal(\\\"bad\\\")\\n\\t}\\n}\\nEOF\\n })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "escaped heredoc must yield exactly one call, errors: {:?}",
+        result.errors
+    );
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    // No literal backslash-n / backslash-t survives — they were unescaped.
+    assert!(
+        !content.contains("\\n") && !content.contains("\\t"),
+        "literal escapes must be decoded, got: {content:?}"
+    );
+    // Real newlines and tabs are present.
+    assert!(content.contains('\n'), "must contain real newlines");
+    assert!(content.contains('\t'), "must contain real tabs");
+    // Escaped quotes were decoded to bare quotes (valid Go source).
+    assert!(content.contains("\"strings\""), "must contain \"strings\"");
+    assert!(
+        content.starts_with("package manifest"),
+        "content should start with the package clause: {content:?}"
+    );
+    // The closing `EOF` tag is not part of the body.
+    assert!(
+        !content.contains("EOF"),
+        "closing tag must not leak into the body: {content:?}"
+    );
+}
+
+#[test]
+fn heredoc_real_newline_body_is_not_unescaped() {
+    // GUARD: a heredoc whose body uses REAL newlines must parse exactly as
+    // before — a literal `\n` typed inside such a body (e.g. a Go format string
+    // `"%d\n"`) must be preserved verbatim, never collapsed to a newline.
+    let tools = sample_tool_registry();
+    let text = "edit({ path: \"main.go\", content: <<EOF\npackage main\nimport \"fmt\"\nfunc main() { fmt.Printf(\"%d\\n\", 1) }\nEOF\n})";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "real-newline heredoc must parse, errors: {:?}",
+        result.errors
+    );
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    // The literal `\n` inside the format string survives untouched.
+    assert!(
+        content.contains("%d\\n"),
+        "literal \\n in a real-newline body must be preserved verbatim: {content:?}"
+    );
+    assert!(content.starts_with("package main"));
+}
+
+#[test]
+fn heredoc_escaped_body_with_escaped_backslash_n_is_not_a_line_break() {
+    // An escaped-backslash sequence `\\n` on the wire is a single decoded `\`
+    // followed by `n` (e.g. a Go format string `"%d\n"`), NOT the escaped line
+    // separator. The closing-tag scan must not split there, and the decoded body
+    // must keep the literal `\n`.
+    let tools = sample_tool_registry();
+    // Wire bytes: <<EOF \n package main \n s := "x\n" \n EOF
+    // where the inner `"x\\n"` is an escaped-backslash + n (decodes to `x\n`).
+    let text =
+        "edit({ path: \"m.go\", content: <<EOF\\npackage main\\nvar s = \\\"x\\\\n\\\"\\nEOF\\n})";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "escaped-backslash body must still parse to one call, errors: {:?}",
+        result.errors
+    );
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert!(
+        content.contains("\"x\\n\""),
+        "decoded body must keep the literal backslash-n from `\\\\n`: {content:?}"
+    );
+    assert!(
+        content.starts_with("package main"),
+        "body must not be truncated at the false separator: {content:?}"
+    );
+    assert!(
+        !content.contains("EOF"),
+        "close tag must not leak: {content:?}"
+    );
+}
+
+#[test]
+fn heredoc_genuinely_missing_newline_still_errors() {
+    // `<<EOF` followed by end-of-input (no newline, no literal `\n`) is a
+    // genuinely-malformed heredoc and must still surface a parse error.
+    let tools = sample_tool_registry();
+    let text = "edit({ path: \"x.go\", content: <<EOF";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        0,
+        "truncated heredoc opener must not produce a call"
+    );
+    assert!(
+        !result.errors.is_empty(),
+        "truncated heredoc opener must surface a parse error"
+    );
+}
+
+#[test]
+fn heredoc_escaped_body_unterminated_errors() {
+    // Literal-`\n` form that never reaches a closing tag line must error, not
+    // silently swallow the rest of the call.
+    let tools = sample_tool_registry();
+    let text = "edit({ path: \"x.go\", content: <<EOF\\npackage main\\nfunc main() {}";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        0,
+        "unterminated escaped heredoc must not produce a call, calls: {:?}",
+        result.calls
+    );
+    assert!(
+        !result.errors.is_empty(),
+        "unterminated escaped heredoc must surface a parse error"
+    );
+}

--- a/crates/harn-vm/src/llm/tools/tests/reserved_token.rs
+++ b/crates/harn-vm/src/llm/tools/tests/reserved_token.rs
@@ -71,28 +71,35 @@ fn registered_tools_dispatch_only_after_canonicalization_for_tagged_blocks() {
     // With a registry containing the emitted tools, the canonical (tagged) form
     // dispatches the `look`/`edit` calls cleanly. The sample registry has
     // `edit`; assert the captured single-edit turn dispatches the edit on the
-    // canonical path and is silent on the wire path.
+    // canonical path.
+    //
+    // NOTE: `EDIT_BLOCK`'s body uses the model's degraded JSON-escaped heredoc
+    // form (`<<EOF\npackage…` with *literal* `\n`). The JSON-escaped-heredoc
+    // recovery now lets bare-rescue parse that body on the wire path too, so the
+    // edit is no longer silently lost there — a strict improvement. The
+    // canonical path remains the robust route (real `<tool_call>` blocks); both
+    // must surface the edit.
     let tools = sample_tool_registry();
 
+    let saw_edit_call = |calls: &[serde_json::Value]| {
+        calls.iter().any(|c| {
+            c.get("name").and_then(|v| v.as_str()) == Some("edit")
+                || c.get("tool").and_then(|v| v.as_str()) == Some("edit")
+        })
+    };
+
     let wire = parse_text_tool_calls_with_tools(EDIT_BLOCK, Some(&tools));
-    assert_eq!(
-        wire.calls.len(),
-        0,
-        "wire form: no tagged edit block to parse"
-    );
     assert!(
-        wire.errors.is_empty(),
-        "wire form: silently lost, no diagnostic: {:?}",
+        saw_edit_call(&wire.calls),
+        "wire form: heredoc recovery must surface the edit (no silent loss): \
+         calls={:?} errors={:?}",
+        wire.calls,
         wire.errors
     );
 
     let canon = parse_text_tool_calls_with_tools(&wire_to_canonical(EDIT_BLOCK), Some(&tools));
-    let saw_edit = canon.calls.iter().any(|c| {
-        c.get("name").and_then(|v| v.as_str()) == Some("edit")
-            || c.get("tool").and_then(|v| v.as_str()) == Some("edit")
-    });
     assert!(
-        saw_edit || !canon.errors.is_empty(),
+        saw_edit_call(&canon.calls) || !canon.errors.is_empty(),
         "after remap the edit block must be visible (dispatched or diagnosed): \
          calls={:?} errors={:?}",
         canon.calls,

--- a/crates/harn-vm/src/llm/tools/ts_value_parser.rs
+++ b/crates/harn-vm/src/llm/tools/ts_value_parser.rs
@@ -4,7 +4,7 @@
 //! the limited set of keywords (`true` / `false` / `null` / `undefined`)
 //! that models emit when transcribing tool calls.
 
-use super::parse::{ident_length, scan_heredoc, HeredocError};
+use super::parse::{ident_length, scan_heredoc, unescape_heredoc_body, HeredocError};
 
 /// Minimal recursive-descent parser for a TypeScript value expression. Handles
 /// object and array literals, string literals (double-quoted and single-quoted),
@@ -357,7 +357,20 @@ impl<'a> TsValueParser<'a> {
         // `self.pos` to right after the tag.
         match scan_heredoc(self.text, self.pos) {
             Ok(span) => {
-                let content = self.text[span.content].to_string();
+                let raw = &self.text[span.content];
+                let content = if span.escaped {
+                    // Degraded literal-`\n` form: the body is JSON/string-escaped
+                    // on one physical line. Dispatch the call with a real body
+                    // (non-fatal — strong models emit clean heredocs and never
+                    // reach this branch). Surfaced to telemetry via tracing.
+                    tracing::debug!(
+                        target: "harn::tool_parse",
+                        "recovered JSON-escaped heredoc body (literal \\n line breaks)"
+                    );
+                    unescape_heredoc_body(raw)
+                } else {
+                    raw.to_string()
+                };
                 self.pos = span.end;
                 Ok(serde_json::Value::String(content))
             }

--- a/tests/agent/stall_test.harn
+++ b/tests/agent/stall_test.harn
@@ -51,3 +51,64 @@ pipeline test_mixed_turn_with_real_call_is_progress(task) {
   let o3 = _observe(o2.state, mixed, 3)
   assert(o3.warning == nil)
 }
+
+fn _observe_parse_error(state, iteration) {
+  // 0 tool calls + non-empty text, but the turn carried parser errors (the calls
+  // were dropped). `had_parse_errors = true`.
+  return agent_stall_observe_tool_calls(
+    "unit",
+    [],
+    iteration,
+    CONFIG,
+    state,
+    true,
+    nil,
+    "I edited the file.",
+    true,
+  )
+}
+
+fn _observe_text_only(state, iteration) {
+  // Same shape but a genuine no-progress monologue (no parser errors).
+  return agent_stall_observe_tool_calls(
+    "unit",
+    [],
+    iteration,
+    CONFIG,
+    state,
+    true,
+    nil,
+    "I edited the file.",
+    false,
+  )
+}
+
+pipeline test_parse_error_turn_is_not_no_progress(task) {
+  // A turn whose calls were ALL dropped by the parser is a malformed-call turn,
+  // not a no-progress monologue. Even across the no_progress_messages threshold
+  // (3) it must NOT trip the stall detector and must NOT accumulate the
+  // no-progress streak — the model already tried to act; parse-guidance feedback
+  // (injected by the loop) is the correct response, not a narration-loop nudge.
+  let o1 = _observe_parse_error(agent_stall_initial_state(), 1)
+  assert(o1.warning == nil)
+  assert(o1.state.no_progress_streak == 0)
+  let o2 = _observe_parse_error(o1.state, 2)
+  assert(o2.warning == nil)
+  assert(o2.state.no_progress_streak == 0)
+  let o3 = _observe_parse_error(o2.state, 3)
+  assert(o3.warning == nil)
+  assert(o3.state.no_progress_streak == 0)
+}
+
+pipeline test_text_only_turn_without_parse_errors_still_trips(task) {
+  // Control: the SAME 0-call + text turn WITHOUT parse errors is a real
+  // no-progress monologue and must still trip at the threshold. Guards against
+  // the parse-error gate accidentally disabling no-progress detection wholesale.
+  let o1 = _observe_text_only(agent_stall_initial_state(), 1)
+  assert(o1.warning == nil)
+  assert(o1.state.no_progress_streak == 1)
+  let o2 = _observe_text_only(o1.state, 2)
+  assert(o2.warning == nil)
+  let o3 = _observe_text_only(o2.state, 3)
+  assert(o3.warning != nil)
+}


### PR DESCRIPTION
## Verified root cause

Cheap models (e.g. qwen3.6) emit `edit()` heredoc bodies as JSON-escaped
one-liners: `content: <<EOF\npackage...` where the `\n` are **literal**
backslash-n bytes, not real newlines. `scan_heredoc`
(`crates/harn-vm/src/llm/tools/parse/syntax.rs`) hard-rejected this
(`MissingNewline`), so the whole `edit()` yielded **0 tool_calls** with error
"expected newline after heredoc tag `<<EOF`".

`loop.harn` captured `tool_parse_errors` but **nothing consumed it** on the
active path — the purpose-built `parse_guidance_prompt` had **zero live
callers**. Meanwhile `stall.harn` routed the (non-empty text, 0 substantive
calls) turn to the **no-progress monologue** path and nagged the model to "emit
one well-formed `<tool_call>`" — which it *had*; the heredoc body was just
malformed. So the model re-emitted the identical bad `edit` ~5× until the loop
exhausted.

## Changes

**B — Parser recovery** (`syntax.rs`, `ts_value_parser.rs`): when the byte after
a heredoc tag is the two literal bytes `\` + `n` instead of a real newline, scan
the escaped body to a literal-`\n`-delimited closing-tag line, unescape it
(`\n`,`\t`,`\r`,`\"`,`\\`; unknown escapes left verbatim; an escaped `\\` is
consumed so a following `n` is not a false separator), and **dispatch** the
call. Real-newline heredocs parse **byte-for-byte as before** (branch only on the
literal-`\`-`n`-after-tag condition); a genuinely-truncated opener (`<<EOF` then
end-of-input) still errors. Recovery is surfaced to telemetry via `tracing`.

**A — Feedback fidelity** (`loop.harn`, `stall.harn`): a turn whose tool calls
were all dropped by the parser (`>=1` parse error, `0` dispatched calls) now
injects the existing `parse_guidance_prompt` as runtime feedback (binds
`error_summary` from the first `tool_parse_error`), and a new `had_parse_errors`
gate on `agent_stall_observe_tool_calls` excludes that turn from the no-progress
streak (it is a malformed-call turn, not a narration loop).

## Non-overfit argument

Both changes fire **purely on the syntactic parse-error condition** — no
model-name / language / scenario predicate. Strong models emit clean heredocs,
hit zero parse errors, and **never reach either branch** → zero regression. The
real-newline control test asserts a literal `\n` inside a real-newline body is
preserved verbatim.

## Phase 0 — parser replay (deterministic, no LLM)

Replayed both saved go-test transcripts through the patched parser
(every literal-`\n` `edit` turn → tool_call with real-newline `content`):

| transcript | literal-`\n` edit turns | tool_calls before | tool_calls after | recovery byte-faithful |
|---|---|---|---|---|
| `eval-go-test-…232135` | 5 | 0 | **5** | yes (5/5 gofmt-clean Go) |
| `eval-go-test-…193038` | 2 | 0 | **2** | yes (0/2 gofmt-clean — a *model-authored* Go bug, adjacent raw-string literals missing a comma, faithfully reproduced; the call now dispatches and the bad Go surfaces at the test step instead of vanishing) |

Control: a real-newline heredoc body containing a literal `\n` (a Go format
string) is left **unchanged**.

## Phase 1 — loop/stall unit replay (no LLM)

`tests/agent/stall_test.harn`: a synthetic turn with
`tool_parse_errors=["expected newline after heredoc tag <<EOF"]` and zero tool
calls, fed through the patched stall observer with `had_parse_errors=true`:
- does **not** trip the stall detector (no `no_progress_monologue` warning),
  even across the threshold;
- the no-progress streak **did not increment** (`no_progress_streak == 0`).
- Control: the same 0-call+text turn **without** parse errors still trips at the
  threshold (guards against disabling no-progress detection wholesale).

## Tests / checks

- `cargo test -p harn-vm` — **3277 passed, 0 failed** (incl. new parser tests:
  literal-`\n` recovery, escaped-backslash edge case, real-newline control,
  truncated + unterminated still error).
- `reserved_token.rs` updated: the captured `EDIT_BLOCK` wire form now **recovers
  the edit** (was asserting the old silent-loss behavior — a strict improvement).
- `cargo clippy -p harn-vm -p harn-stdlib` — clean.
- `harn fmt` / `harn lint` — clean on changed `.harn`.
- Full `harn test conformance` — **1569 passed, 1 failed**, identical to
  pristine `origin/main` (the one failure,
  `tests/agents/agent_loop_structural_validator.harn`, **pre-exists** and is
  unrelated to this change).

### Heads-up (pre-existing, out of scope)

`tests/agent/stall_test.harn::test_real_tool_calls_do_not_trip_no_progress` and
`::test_mixed_turn_with_real_call_is_progress` fail on **pristine origin/main**
(introduced by #3004's repeated-action detector interaction). Not touched here —
the two new Phase-1 tests are isolated and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)