### PR TITLE
Respect Cargo target dir in local hooks

### DIFF
--- a/.githooks/lib.sh
+++ b/.githooks/lib.sh
@@ -23,12 +23,16 @@ hook_paths_match() {
   [ -s "$file_list" ] && grep -Eq "$pattern" "$file_list"
 }
 
-# Resolve the workspace target dir, matching the logic in
-# scripts/sign_local_macos.sh. Used by hook_run_harn to find the
-# freshly-built `harn` binary after `cargo build`.
+# Resolve the workspace target dir. Used by hook_run_harn and
+# scripts/sign_local_macos.sh to find freshly-built binaries after
+# `cargo build`.
 hook_target_dir() {
   if [ -n "${HARN_DEV_TARGET_DIR:-}" ]; then
     printf '%s\n' "$HARN_DEV_TARGET_DIR"
+    return
+  fi
+  if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    printf '%s\n' "$CARGO_TARGET_DIR"
     return
   fi
   if [ -f .cargo/config.toml ]; then

--- a/scripts/sign_local_macos.sh
+++ b/scripts/sign_local_macos.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
+. .githooks/lib.sh
 
 # The Apple-issued canonical name for the team's Developer ID Application
 # certificate. Resolves by exact CN; Team ID (8SXG5TMV2X) is embedded for
@@ -38,16 +39,7 @@ if [ "$mode" = "ad-hoc" ] && [ "${HARN_LOCAL_SIGN_QUIET:-0}" != "1" ]; then
   echo "  → Import the team .p12 from 1Password ('Developer ID Application: Burin Labs') to upgrade."
 fi
 
-# Resolve target dir: respect HARN_DEV_TARGET_DIR or the value baked into
-# .cargo/config.toml's [build] target-dir; otherwise default to ./target.
-target_dir="${HARN_DEV_TARGET_DIR:-}"
-if [ -z "$target_dir" ] && [ -f .cargo/config.toml ]; then
-  target_dir="$(awk -F'"' '
-    /^\[build\][[:space:]]*$/ { in_build = 1; next }
-    /^\[/ { in_build = 0 }
-    in_build && /^[[:space:]]*target-dir[[:space:]]*=/ { print $2; exit }
-  ' .cargo/config.toml)"
-fi
+target_dir="$(hook_target_dir)"
 target_dir="${target_dir:-target}"
 
 sign_one() {


### PR DESCRIPTION
## Summary

- Make the hook target-dir resolver honor `CARGO_TARGET_DIR` after `HARN_DEV_TARGET_DIR`.
- Reuse that resolver from `scripts/sign_local_macos.sh` so hook execution and local signing agree on where Cargo wrote binaries.

## Why

During the v0.8.74 release repair, pre-push built Harn into a redirected `CARGO_TARGET_DIR` but tried to execute `target/debug/harn`. That made redirected local/release worktrees fragile and wasted wall-clock time.

## Validation

- `bash -n scripts/sign_local_macos.sh`
- `CARGO_TARGET_DIR=/tmp/cargo-target-test HARN_DEV_TARGET_DIR= sh -c '. .githooks/lib.sh; hook_target_dir'`
- `CARGO_TARGET_DIR=/tmp/cargo-target-test HARN_DEV_TARGET_DIR=/tmp/harn-dev-target-test sh -c '. .githooks/lib.sh; hook_target_dir'`
- `make -s check-generated-registry`
- `make lint-actions`
- pre-commit and pre-push hooks with `CARGO_TARGET_DIR=/tmp/harn-hook-target-dir-env-target HARN_DEV_TARGET_DIR=/tmp/harn-hook-target-dir-env-target`
