### PR TITLE
Expand process sandbox access for home-managed toolchains

### DIFF
--- a/changelog.d/1799.fixed.md
+++ b/changelog.d/1799.fixed.md
@@ -1,0 +1,5 @@
+- Expanded the default process sandbox `developer_toolchains` preset to cover
+  common home-dir runtimes such as `uv`, `rustup`/`cargo`, `pyenv`, `nvm`,
+  `volta`, and `~/go`, and extended the same home-scoped preset logic to the
+  Windows AppContainer backend so sandboxed child processes can load user-managed
+  toolchains without widening Harn's file builtins.

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -180,7 +180,8 @@ pub enum ProcessSandboxPreset {
     /// Minimal host runtime roots needed to execute common system binaries.
     SystemRuntime,
     /// OS/vendor developer toolchains such as Xcode, Command Line Tools,
-    /// Homebrew, and language runtimes installed under standard system paths.
+    /// Homebrew, plus common user-managed runtime roots such as
+    /// `~/.local/share/uv`, `~/.rustup`, `~/.cargo`, `~/.pyenv`, and `~/.nvm`.
     DeveloperToolchains,
     /// Per-user package-manager config/cache roots used by npm, pip, cargo,
     /// git credential helpers, and enterprise CA configuration.

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -12,6 +12,7 @@ use std::process::Command;
 
 use super::{
     policy_allows_capability, policy_allows_network, policy_allows_workspace_write,
+    process_sandbox_developer_toolchain_read_roots,
     process_sandbox_package_manager_config_read_roots, process_sandbox_policy_read_roots,
     process_sandbox_policy_write_roots, process_sandbox_readonly_roots, process_sandbox_roots,
     sandbox_rejection, warn_once, PrepareOutcome, SandboxBackend, SandboxFallback,
@@ -168,6 +169,9 @@ fn landlock_profile(
             LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR | LANDLOCK_ACCESS_FS_EXECUTE,
             true,
         )?;
+    }
+    for root in process_sandbox_developer_toolchain_read_roots(policy) {
+        push_rule(&mut profile, root, read_only_access(), true)?;
     }
     let workspace_access = workspace_access(policy);
     for root in process_sandbox_roots(policy) {
@@ -586,6 +590,30 @@ mod tests {
             read_only_access() & WRITE_BITS,
             0,
             "package-manager Landlock rules use read-only access bits"
+        );
+    }
+
+    #[test]
+    fn developer_toolchain_roots_are_read_only() {
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let roots = super::super::developer_toolchain_read_roots_for_home(temp_home.path());
+
+        assert!(
+            roots.iter().any(|path| path.ends_with(".local/share/uv")),
+            "uv runtimes should be part of the developer-toolchain preset"
+        );
+        assert!(
+            roots.iter().any(|path| path.ends_with(".rustup")),
+            "rustup should be part of the developer-toolchain preset"
+        );
+        assert!(
+            roots.iter().all(|path| path.starts_with(temp_home.path())),
+            "developer-toolchain roots must stay under HOME"
+        );
+        assert_eq!(
+            read_only_access() & WRITE_BITS,
+            0,
+            "developer-toolchain Landlock rules use read-only access bits"
         );
     }
 

--- a/crates/harn-vm/src/stdlib/sandbox/macos.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/macos.rs
@@ -16,6 +16,7 @@ use std::process::Command;
 
 use super::{
     policy_allows_network, policy_allows_workspace_write,
+    process_sandbox_developer_toolchain_read_roots,
     process_sandbox_package_manager_config_read_roots, process_sandbox_policy_read_roots,
     process_sandbox_policy_write_roots, process_sandbox_presets, process_sandbox_readonly_roots,
     process_sandbox_roots, unavailable, PrepareOutcome, SandboxBackend,
@@ -135,12 +136,18 @@ fn has_swiftpm_option(args: &[String], option: &str) -> bool {
 }
 
 fn render_profile(policy: &CapabilityPolicy) -> String {
+    let developer_toolchain_read_roots = process_sandbox_developer_toolchain_read_roots(policy);
     let package_manager_read_roots = process_sandbox_package_manager_config_read_roots(policy);
-    render_profile_with_package_manager_read_roots(policy, &package_manager_read_roots)
+    render_profile_with_extra_read_roots(
+        policy,
+        &developer_toolchain_read_roots,
+        &package_manager_read_roots,
+    )
 }
 
-fn render_profile_with_package_manager_read_roots(
+fn render_profile_with_extra_read_roots(
     policy: &CapabilityPolicy,
+    developer_toolchain_read_roots: &[std::path::PathBuf],
     package_manager_read_roots: &[std::path::PathBuf],
 ) -> String {
     let roots = process_sandbox_roots(policy);
@@ -161,6 +168,12 @@ fn render_profile_with_package_manager_read_roots(
         profile.push_str(&format!(
             "(allow file-read* (subpath \"{}\"))\n",
             sandbox_profile_escape(root)
+        ));
+    }
+    for root in developer_toolchain_read_roots {
+        profile.push_str(&format!(
+            "(allow file-read* (subpath \"{}\"))\n",
+            sandbox_profile_escape(&root.display().to_string())
         ));
     }
     // Process-only read roots and Harn read-only roots are granted read but
@@ -394,8 +407,9 @@ mod tests {
 
         let package_roots =
             super::super::package_manager_config_read_roots_for_home(temp_home.path());
-        let profile = render_profile_with_package_manager_read_roots(
+        let profile = render_profile_with_extra_read_roots(
             &macos_policy_with_workspace_ops(&["read_text", "write_text", "delete"]),
+            &[],
             &package_roots,
         );
         let npmrc_path = super::super::package_manager_config_read_roots_for_home(temp_home.path())
@@ -418,6 +432,42 @@ mod tests {
             !profile.contains(&format!("(allow file-write* (subpath \"{escaped}\"))")),
             "package manager config must not get direct write access: {profile}"
         );
+    }
+
+    #[test]
+    fn sandbox_profile_allows_home_toolchain_roots_read_only() {
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let toolchain_roots =
+            super::super::developer_toolchain_read_roots_for_home(temp_home.path());
+        let uv_path = toolchain_roots
+            .iter()
+            .find(|path| path.ends_with(std::path::Path::new(".local/share/uv")))
+            .expect("uv root")
+            .display()
+            .to_string();
+        let rustup_path = toolchain_roots
+            .iter()
+            .find(|path| path.ends_with(std::path::Path::new(".rustup")))
+            .expect("rustup root")
+            .display()
+            .to_string();
+        let profile = render_profile_with_extra_read_roots(
+            &macos_policy_with_workspace_ops(&["read_text", "write_text", "delete"]),
+            &toolchain_roots,
+            &[],
+        );
+
+        for path in [uv_path, rustup_path] {
+            let escaped = sandbox_profile_escape(&path);
+            assert!(
+                profile.contains(&format!("(allow file-read* (subpath \"{escaped}\"))")),
+                "home toolchain root should be readable: {profile}"
+            );
+            assert!(
+                !profile.contains(&format!("(allow file-write* (subpath \"{escaped}\"))")),
+                "home toolchain root must stay read-only: {profile}"
+            );
+        }
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -533,15 +533,19 @@ pub fn process_violation_error(output: &std::process::Output) -> Option<VmError>
             || stderr.contains("access is denied")
             || stdout.contains("operation not permitted"))
     {
-        return Some(sandbox_rejection(format!(
-            "sandbox violation: process was denied by the OS sandbox (status {})",
-            output.status.code().unwrap_or(-1)
+        return Some(sandbox_rejection(sandbox_process_violation_message(
+            format!(
+                "sandbox violation: process was denied by the OS sandbox (status {})",
+                output.status.code().unwrap_or(-1)
+            ),
         )));
     }
     if sandbox_signal_status(output) {
-        return Some(sandbox_rejection(format!(
-            "sandbox violation: process was terminated by the OS sandbox (status {})",
-            output.status
+        return Some(sandbox_rejection(sandbox_process_violation_message(
+            format!(
+                "sandbox violation: process was terminated by the OS sandbox (status {})",
+                output.status
+            ),
         )));
     }
     None
@@ -563,8 +567,8 @@ pub fn process_spawn_error(error: &std::io::Error) -> Option<VmError> {
         || message.contains("permission denied")
         || message.contains("access is denied")
     {
-        return Some(sandbox_rejection(format!(
-            "sandbox violation: process was denied by the OS sandbox before exec: {error}"
+        return Some(sandbox_rejection(sandbox_process_violation_message(
+            format!("sandbox violation: process was denied by the OS sandbox before exec: {error}"),
         )));
     }
     None
@@ -657,6 +661,12 @@ pub(crate) fn sandbox_rejection(message: String) -> VmError {
     }
 }
 
+fn sandbox_process_violation_message(summary: String) -> String {
+    format!(
+        "{summary}; if the command depends on a user-managed toolchain or cache outside the workspace, add that root to process_sandbox.read_roots or process_sandbox.write_roots"
+    )
+}
+
 /// Helper for backends that can't attach confinement at all (macOS
 /// without `/usr/bin/sandbox-exec`, Windows when called through the
 /// `Command`-returning entry points): either fail loudly under
@@ -741,32 +751,84 @@ pub(crate) fn process_sandbox_policy_write_roots(policy: &CapabilityPolicy) -> V
     normalized_process_roots(&policy.process_sandbox.write_roots)
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn process_sandbox_presets(policy: &CapabilityPolicy) -> Vec<ProcessSandboxPreset> {
     policy.process_sandbox.effective_presets()
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub(crate) fn process_sandbox_developer_toolchain_read_roots(
+    policy: &CapabilityPolicy,
+) -> Vec<PathBuf> {
+    if !process_sandbox_presets(policy).contains(&ProcessSandboxPreset::DeveloperToolchains) {
+        return Vec::new();
+    }
+    let Some(home) = sandbox_user_home_dir() else {
+        return Vec::new();
+    };
+    developer_toolchain_read_roots_for_home(&home)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn process_sandbox_package_manager_config_read_roots(
     policy: &CapabilityPolicy,
 ) -> Vec<PathBuf> {
     if !process_sandbox_presets(policy).contains(&ProcessSandboxPreset::PackageManagerConfig) {
         return Vec::new();
     }
-    let Some(home) = package_manager_config_home_dir() else {
+    let Some(home) = sandbox_user_home_dir() else {
         return Vec::new();
     };
     package_manager_config_read_roots_for_home(&home)
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-fn package_manager_config_home_dir() -> Option<PathBuf> {
-    // Only an absolute home grounds the package-manager read-roots below; a
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+fn sandbox_user_home_dir() -> Option<PathBuf> {
+    // Only an absolute home grounds the user-scope read-roots below; a
     // relative or unset home yields no extra roots (the safe direction).
     crate::user_dirs::home_dir().filter(|path| path.is_absolute())
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub(crate) fn developer_toolchain_read_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    let mut roots: Vec<_> = [
+        ".asdf",
+        ".bun",
+        ".cargo",
+        ".fnm",
+        ".juliaup",
+        ".local/bin",
+        ".local/share/mise",
+        ".local/share/uv",
+        ".nvm",
+        ".pyenv",
+        ".rbenv",
+        ".rustup",
+        ".sdkman",
+        ".swiftly",
+        ".volta",
+        "go",
+    ]
+    .into_iter()
+    .map(|entry| normalize_for_policy(&home.join(entry)))
+    .collect();
+    #[cfg(target_os = "windows")]
+    roots.extend(
+        [
+            "AppData/Local/Programs/Python",
+            "AppData/Local/uv",
+            "AppData/Roaming/uv",
+            "scoop",
+        ]
+        .into_iter()
+        .map(|entry| normalize_for_policy(&home.join(entry))),
+    );
+    roots.sort_unstable();
+    roots.dedup();
+    roots
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub(crate) fn package_manager_config_read_roots_for_home(home: &Path) -> Vec<PathBuf> {
     let mut roots: Vec<_> = [
         ".npmrc",
@@ -1230,6 +1292,34 @@ mod tests {
             Path::new("/tmp/harn-root-other/file"),
             root
         ));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn developer_toolchain_roots_cover_common_home_managed_runtimes() {
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let roots = developer_toolchain_read_roots_for_home(temp_home.path());
+        let normalized_home = normalize_for_policy(temp_home.path());
+
+        for suffix in [
+            Path::new(".cargo"),
+            Path::new(".rustup"),
+            Path::new(".pyenv"),
+            Path::new(".nvm"),
+            Path::new(".volta"),
+            Path::new(".local/share/uv"),
+            Path::new("go"),
+        ] {
+            assert!(
+                roots.iter().any(|path| path.ends_with(suffix)),
+                "expected a developer-toolchain grant for {}",
+                suffix.display()
+            );
+        }
+        assert!(
+            roots.iter().all(|path| path.starts_with(&normalized_home)),
+            "developer-toolchain roots must stay under HOME"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/sandbox/windows.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/windows.rs
@@ -39,7 +39,8 @@ use windows_sys::Win32::System::Threading::{
 };
 
 use super::{
-    policy_allows_workspace_write, process_sandbox_policy_read_roots,
+    policy_allows_workspace_write, process_sandbox_developer_toolchain_read_roots,
+    process_sandbox_package_manager_config_read_roots, process_sandbox_policy_read_roots,
     process_sandbox_policy_write_roots, process_sandbox_readonly_roots, process_sandbox_roots,
     process_spawn_error, sandbox_rejection, unavailable, PrepareOutcome, ProcessCommandConfig,
     SandboxBackend,
@@ -307,27 +308,38 @@ impl WorkspaceAclGrants {
         let mut paths = Vec::new();
         let writable = process_sandbox_roots(policy)
             .into_iter()
-            .map(|root| (root, workspace_permission));
+            .map(|root| (root, workspace_permission, false));
         let read_only = process_sandbox_readonly_roots(policy)
             .into_iter()
-            .map(|root| (root, "(OI)(CI)RX"));
+            .map(|root| (root, "(OI)(CI)RX", false));
         let process_read = process_sandbox_policy_read_roots(policy)
             .into_iter()
-            .map(|root| (root, "(OI)(CI)RX"));
+            .map(|root| (root, "(OI)(CI)RX", false));
+        let preset_toolchains = process_sandbox_developer_toolchain_read_roots(policy)
+            .into_iter()
+            .map(|root| (root, "(OI)(CI)RX", true));
+        let package_manager = process_sandbox_package_manager_config_read_roots(policy)
+            .into_iter()
+            .map(|root| (root, "(OI)(CI)RX", true));
         let process_write = if policy_allows_workspace_write(policy) {
             process_sandbox_policy_write_roots(policy)
                 .into_iter()
-                .map(|root| (root, workspace_permission))
+                .map(|root| (root, workspace_permission, false))
                 .collect::<Vec<_>>()
         } else {
             Vec::new()
         };
-        for (root, permission) in writable
+        for (root, permission, optional) in writable
             .chain(read_only)
             .chain(process_read)
+            .chain(preset_toolchains)
+            .chain(package_manager)
             .chain(process_write)
         {
             if !root.exists() {
+                if optional {
+                    continue;
+                }
                 return Err(io::Error::new(
                     io::ErrorKind::NotFound,
                     format!("sandbox workspace root '{}' does not exist", root.display()),

--- a/docs/src/sandboxing.md
+++ b/docs/src/sandboxing.md
@@ -67,7 +67,9 @@ those paths unless they are also in `workspace_roots` or `read_only_roots`.
 
 - `system_runtime`: host runtime directories needed to launch common binaries.
 - `developer_toolchains`: standard compiler/toolchain locations such as Xcode,
-  Command Line Tools, Homebrew, and language runtime roots.
+  Command Line Tools, Homebrew, plus common home-dir toolchain managers and
+  runtimes such as `~/.local/share/uv`, `~/.rustup`, `~/.cargo`, `~/.pyenv`,
+  `~/.nvm`, `~/.volta`, and `~/go`.
 - `package_manager_config`: read-only per-user npm, pip, cargo, git, and CA
   config/cache roots under `$HOME`, such as `.npmrc`, `.gitconfig`, `.netrc`,
   `.config`, `.cache`, and cargo config/registry paths.
@@ -88,14 +90,18 @@ toolchains that depend on enterprise package-manager state. It constrains what
 the child process can open; it does not rewrite npm, pip, cargo, git, proxy, or
 CA configuration.
 
-With the default `package_manager_config` preset, the Linux and macOS backends
-grant child processes read-only access to these paths under the first absolute
-`$HOME` or `$USERPROFILE`: `.npmrc`, `.gitconfig`, `.netrc`, `.yarnrc.yml`,
-`.config`, `.npm`, `.cache`, `.pip`, `.pypirc`, `.cargo/config`,
-`.cargo/config.toml`, `.cargo/credentials`, `.cargo/credentials.toml`,
-`.cargo/registry`, and `.cargo/git`. These grants are process-only: Harn file
-builtins still need `workspace_roots` or `read_only_roots`, and the package
-manager paths are explicitly kept unwritable by the OS profile.
+With the default `developer_toolchains` and `package_manager_config` presets,
+the desktop backends grant child processes read-only access to common
+home-scoped toolchain and package-manager roots under the first absolute
+`$HOME` or `%USERPROFILE%`. That includes user-managed runtimes such as
+`.local/share/uv`, `.cargo`, `.rustup`, `.pyenv`, `.nvm`, `.volta`, and `go`,
+plus package-manager config/cache paths such as `.npmrc`, `.gitconfig`,
+`.netrc`, `.yarnrc.yml`, `.config`, `.npm`, `.cache`, `.pip`, `.pypirc`,
+`.cargo/config`, `.cargo/config.toml`, `.cargo/credentials`,
+`.cargo/credentials.toml`, `.cargo/registry`, and `.cargo/git`. These grants
+are process-only: Harn file builtins still need `workspace_roots` or
+`read_only_roots`, and the extra home-dir paths stay unwritable by the OS
+profile.
 
 Child processes spawned without env overrides inherit the parent environment.
 That includes corporate proxy and CA variables such as `HTTP_PROXY`,


### PR DESCRIPTION
## Summary
- extend the default `developer_toolchains` process-sandbox preset to cover common home-managed runtimes and shims
- grant those roots read-only access across the macOS, Linux, and Windows sandbox backends
- improve sandbox denial text so agents/users get a direct remediation hint when a process needs an extra toolchain root

## Testing
- `env CARGO_TARGET_DIR=/tmp/harn-1799-target cargo test -p harn-vm sandbox_profile_allows_home_toolchain_roots_read_only --lib`
- `env CARGO_TARGET_DIR=/tmp/harn-1799-target cargo test -p harn-vm developer_toolchain_roots_cover_common_home_managed_runtimes --lib`
- `env CARGO_TARGET_DIR=/tmp/harn-1799-target cargo test -p harn-vm sandbox_profile_allows_package_manager_config_read_only --lib`

Refs burin-labs/burin-code#1799.