### PR TITLE
Close out rule-engine project discovery polish

### DIFF
--- a/changelog.d/2826.fixed.md
+++ b/changelog.d/2826.fixed.md
@@ -1,0 +1,3 @@
+- Kept `harn rule test` project discovery aligned with rule-pack loading:
+  missing `[rules] ruleDirs` now fail clearly, and nested utility directories
+  are no longer swept into the default rule-test gate.

--- a/crates/harn-cli/src/cli/scan.rs
+++ b/crates/harn-cli/src/cli/scan.rs
@@ -4,7 +4,7 @@ use clap::Args;
 ///
 /// Two shapes:
 ///   * `harn scan '<pattern>' [paths...] --lang <lang>` — inline pattern.
-///   * `harn scan --rule <file>|--rule-pack <dir> [paths...]` — saved rule(s).
+///   * `harn scan --rule <file>|--rule-pack <pack> [paths...]` — saved rule(s).
 ///
 /// With `--rule`/`--rule-pack` every positional is a path; otherwise the first
 /// positional is the pattern and the rest are paths (the shim disambiguates,
@@ -20,8 +20,8 @@ pub(crate) struct ScanArgs {
     /// Run a rule from a TOML file instead of an inline pattern.
     #[arg(long = "rule", value_name = "FILE")]
     pub rule: Option<String>,
-    /// Run every `*.toml` rule in a directory (a rule pack).
-    #[arg(long = "rule-pack", value_name = "DIR", conflicts_with = "rule")]
+    /// Run every `*.toml` rule in a directory or installed package.
+    #[arg(long = "rule-pack", value_name = "PACK", conflicts_with = "rule")]
     pub rule_pack: Option<String>,
     /// Emit a JSON envelope instead of human-readable output.
     #[arg(long)]

--- a/crates/harn-cli/src/commands/rule.rs
+++ b/crates/harn-cli/src/commands/rule.rs
@@ -55,16 +55,30 @@ fn run_test(args: crate::cli::RuleTestArgs) {
     use harn_rules::{load_rule_file, run_inline_test, CompiledRule, InlineTestReport};
 
     // An explicit path wins; otherwise discover the project's `[rules]
-    // ruleDirs` (#2843), falling back to the current directory. This makes
-    // `harn rule test` a zero-config CI gate for a project's rule pack.
+    // ruleDirs` (#2843), falling back to the current directory. Project
+    // discovery uses the same top-level rule files as scan/codemod/publish so
+    // utility directories are not swept into the CI gate accidentally.
     let (rule_files, source): (Vec<PathBuf>, String) = match args.path.as_deref() {
         Some(path) => (discover_rule_files(Path::new(path)), path.to_string()),
-        None => match project_rule_dirs() {
-            Some(dirs) => (
-                dirs.iter().flat_map(|d| discover_rule_files(d)).collect(),
-                "[rules] ruleDirs".to_string(),
-            ),
-            None => (discover_rule_files(Path::new(".")), ".".to_string()),
+        None => match crate::commands::rules_cli::project_rule_dirs() {
+            Ok(dirs) if !dirs.is_empty() => {
+                let mut files = Vec::new();
+                for dir in dirs {
+                    match crate::commands::rules_cli::collect_rule_files_in_dir(&dir) {
+                        Ok(mut found) => files.append(&mut found),
+                        Err(error) => {
+                            eprintln!("rule test: {error}");
+                            std::process::exit(2);
+                        }
+                    }
+                }
+                (files, "[rules] ruleDirs".to_string())
+            }
+            Ok(_) => (discover_rule_files(Path::new(".")), ".".to_string()),
+            Err(error) => {
+                eprintln!("rule test: {error}");
+                std::process::exit(2);
+            }
         },
     };
     if rule_files.is_empty() {
@@ -189,23 +203,4 @@ fn discover_rule_files(root: &std::path::Path) -> Vec<std::path::PathBuf> {
     }
     out.sort();
     out
-}
-
-/// The project's `[rules] ruleDirs` (resolved relative to the manifest dir),
-/// or `None` when there is no manifest or it declares no `ruleDirs`.
-#[cfg(feature = "hostlib")]
-fn project_rule_dirs() -> Option<Vec<std::path::PathBuf>> {
-    let cwd = std::env::current_dir().ok()?;
-    let (manifest, dir) = crate::package::find_nearest_manifest(&cwd)?;
-    if manifest.rules.rule_dirs.is_empty() {
-        return None;
-    }
-    Some(
-        manifest
-            .rules
-            .rule_dirs
-            .iter()
-            .map(|rel| dir.join(rel))
-            .collect(),
-    )
 }

--- a/crates/harn-cli/src/commands/rules_cli.rs
+++ b/crates/harn-cli/src/commands/rules_cli.rs
@@ -2,10 +2,10 @@
 //! `harn codemod`).
 //!
 //! Both surfaces resolve a rule (an inline pattern, a `--rule` TOML file, or a
-//! `--rule-pack` directory) and walk a fileset in Rust — where the tree-sitter
-//! `Language` registry and the gitignore-aware walker live — then hand the
-//! `.harn` handler a per-rule *plan* (the rule TOML plus the files that match
-//! its language). The handler runs `std/rules` over the plan.
+//! `--rule-pack` directory/package) and walk a fileset in Rust — where the
+//! tree-sitter `Language` registry and the gitignore-aware walker live — then
+//! hand the `.harn` handler a per-rule *plan* (the rule TOML plus the files
+//! that match its language). The handler runs `std/rules` over the plan.
 
 #![cfg(feature = "hostlib")]
 
@@ -21,7 +21,7 @@ pub(crate) struct RuleSpec {
 
 /// Resolve the rule(s) to run. Exactly one source is used, in priority order:
 /// an inline `pattern` (requires `lang`), a `rule_file`, or a `rule_pack`
-/// directory of `*.toml` rules.
+/// directory/package of `*.toml` rules.
 pub(crate) fn resolve_rules(
     inline_pattern: Option<&str>,
     lang: Option<&str>,
@@ -55,7 +55,7 @@ pub(crate) fn resolve_rules(
         let discovered = discover_project_rules()?;
         if discovered.is_empty() {
             Err("no rule given: pass an inline `<pattern> --lang <lang>`, \
-                 `--rule <file>`, `--rule-pack <dir>`, or declare \
+                 `--rule <file>`, `--rule-pack <pack>`, or declare \
                  `[rules] ruleDirs` in harn.toml"
                 .into())
         } else {
@@ -64,20 +64,32 @@ pub(crate) fn resolve_rules(
     }
 }
 
-/// Load the `*.toml` rules in `dir` as [`RuleSpec`]s, sorted by path.
-fn load_rule_dir_specs(dir: &std::path::Path) -> Result<Vec<RuleSpec>, String> {
+/// Return the top-level `*.toml` rule files in `dir`, sorted by path.
+///
+/// Rule-pack `ruleDirs` are intentionally not recursive: nested directories
+/// are reserved for utility rules, fixtures, and other pack-local support
+/// files unless the manifest names them explicitly.
+pub(crate) fn collect_rule_files_in_dir(
+    dir: &std::path::Path,
+) -> Result<Vec<std::path::PathBuf>, String> {
     use std::fs;
 
     let mut paths: Vec<_> = fs::read_dir(dir)
         .map_err(|e| format!("read rule dir `{}`: {e}", dir.display()))?
         .filter_map(Result::ok)
         .map(|e| e.path())
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("toml"))
+        .filter(|p| p.is_file() && p.extension().and_then(|e| e.to_str()) == Some("toml"))
         .collect();
     paths.sort();
+    Ok(paths)
+}
+
+/// Load the top-level `*.toml` rules in `dir` as [`RuleSpec`]s, sorted by path.
+fn load_rule_dir_specs(dir: &std::path::Path) -> Result<Vec<RuleSpec>, String> {
+    use std::fs;
 
     let mut specs = Vec::new();
-    for path in paths {
+    for path in collect_rule_files_in_dir(dir)? {
         let toml =
             fs::read_to_string(&path).map_err(|e| format!("read `{}`: {e}", path.display()))?;
         let language = rule_language(&toml)?;
@@ -153,12 +165,23 @@ fn load_pack_rules(dir: &std::path::Path) -> Result<Vec<RuleSpec>, String> {
 /// there is no manifest or it declares no `ruleDirs`, so callers fall through
 /// to their usual "no rule given" error.
 fn discover_project_rules() -> Result<Vec<RuleSpec>, String> {
+    let mut specs = Vec::new();
+    for rule_dir in project_rule_dirs()? {
+        specs.extend(load_rule_dir_specs(&rule_dir)?);
+    }
+    Ok(specs)
+}
+
+/// Resolve the nearest project manifest's `[rules] ruleDirs` and validate that
+/// each entry names a directory. Returns an empty vec when no manifest or no
+/// rule directories are declared.
+pub(crate) fn project_rule_dirs() -> Result<Vec<PathBuf>, String> {
     let cwd = std::env::current_dir().map_err(|e| format!("current dir: {e}"))?;
     let Some((manifest, manifest_dir)) = crate::package::find_nearest_manifest(&cwd) else {
         return Ok(Vec::new());
     };
 
-    let mut specs = Vec::new();
+    let mut dirs = Vec::new();
     for rel in &manifest.rules.rule_dirs {
         let rule_dir = manifest_dir.join(rel);
         if !rule_dir.is_dir() {
@@ -167,9 +190,9 @@ fn discover_project_rules() -> Result<Vec<RuleSpec>, String> {
                 rule_dir.display()
             ));
         }
-        specs.extend(load_rule_dir_specs(&rule_dir)?);
+        dirs.push(rule_dir);
     }
-    Ok(specs)
+    Ok(dirs)
 }
 
 /// Build the per-rule plan JSON: each rule paired with the files (recursively

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -179,7 +179,7 @@ impl ContributionEntry {
 /// Paths are resolved relative to the manifest's directory.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RulesConfig {
-    /// Directories of rule `*.toml` files to load.
+    /// Directories of top-level rule `*.toml` files to load.
     #[serde(default, alias = "rule-dirs", alias = "ruleDirs")]
     pub rule_dirs: Vec<String>,
     /// Directories of utility-rule `*.toml` files (referenced via `matches`).

--- a/crates/harn-cli/tests/rule_test_dispatch.rs
+++ b/crates/harn-cli/tests/rule_test_dispatch.rs
@@ -62,6 +62,65 @@ fn no_path_discovers_project_ruledirs() {
 }
 
 #[test]
+fn no_path_validates_project_ruledirs() {
+    let dir = fixture_dir("missing-dir");
+    write(&dir, "harn.toml", "[rules]\nruleDirs = [\"missing\"]\n");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(&dir)
+        .args(["rule", "test"])
+        .output()
+        .expect("spawn");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_ne!(out.status.code().unwrap_or(-1), 0, "stderr={stderr}");
+    assert!(stderr.contains("not a directory"), "stderr={stderr}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_path_project_discovery_does_not_sweep_nested_utility_dirs() {
+    let dir = fixture_dir("nested-util");
+    std::fs::create_dir_all(dir.join("rules/util")).unwrap();
+    write(
+        &dir,
+        "harn.toml",
+        "[rules]\nruleDirs = [\"rules\"]\nutilDirs = [\"rules/util\"]\n",
+    );
+    write(&dir, "rules/no-foo.toml", NO_FOO);
+    write(
+        &dir,
+        "rules/no-foo.ts",
+        "// ruleid: no-foo\nfoo();\n// ok: no-foo\nbar();\n",
+    );
+    write(
+        &dir,
+        "rules/util/helper.toml",
+        "id = \"helper\"\nlanguage = \"typescript\"\n[rule]\npattern = \"helper()\"\n",
+    );
+
+    let out = Command::new(env!("CARGO_BIN_EXE_harn"))
+        .current_dir(&dir)
+        .args(["rule", "test"])
+        .output()
+        .expect("spawn");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code().unwrap_or(-1),
+        0,
+        "stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.contains("1 passed"), "stdout={stdout}");
+    assert!(
+        !stdout.contains("helper"),
+        "nested utility rule should not be tested: {stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn passing_fixture_exits_zero() {
     let dir = fixture_dir("pass");
     write(&dir, "no-foo.toml", NO_FOO);

--- a/crates/harn-skills/src/corpus/harn-rules/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-rules/SKILL.md
@@ -69,7 +69,7 @@ conformance fixtures.
 ## From the CLI
 
 - `harn scan '<pattern>' <paths> --lang <lang>` — structural search; also
-  `--rule <file>` / `--rule-pack <dir>`, `--report-only` (per-file counts),
+  `--rule <file>` / `--rule-pack <pack>`, `--report-only` (per-file counts),
   `--json`.
 - `harn codemod --rule <file> <paths>` — **dry-run by default** (a unified diff
   per file with safety + idempotency); `--apply` writes (capability-gated),

--- a/docs/src/cookbooks/rules-engine.md
+++ b/docs/src/cookbooks/rules-engine.md
@@ -110,7 +110,8 @@ rewrote src/config.ts  [safety=BehaviorPreserving]
 ```
 
 Re-running a folded file changes nothing — fixes are checked for idempotency.
-Point `--rule-pack <dir>` at a directory to run every `*.toml` rule in it.
+Point `--rule-pack <pack>` at a directory or installed package to run its
+top-level `*.toml` rules.
 Installed packages work by name, and built-in packs live under `std/rules`.
 
 ```console
@@ -141,7 +142,9 @@ With `[rules] ruleDirs` set, `harn scan <paths>` needs no inline pattern — a
 pattern is signalled by `--lang`, so its absence means "use the project's
 rules." `harn codemod` applies only the rules that have a `fix`; lint/search
 rules in the same pack are ignored. Paths are resolved relative to the
-`harn.toml` directory.
+`harn.toml` directory. Each `ruleDirs` entry loads top-level `*.toml` files;
+put utility rules or fixtures in nested directories unless the manifest names
+that directory explicitly.
 
 ## How do I publish and install a rule pack?
 


### PR DESCRIPTION
## Summary
- align `harn rule test` project discovery with rule-pack loading by using top-level rule TOML files from `[rules] ruleDirs`
- fail clearly when configured project rule directories are missing
- document directory/package rule-pack wording and add a changelog fragment

Closes #2826

## Cross-repo closeout
- harn epics #2827, #2828, and #2829 are closed
- burin-labs/burin-code#1630 is closed after all tracked children and #1629 were completed
- burin-labs/harn-cloud#542 is closed after #543-#547 were completed; harn-cloud#548 remains open as stretch work independent of this program closeout
- harn-cloud PR #646 merged the final required hosted nightly/fleet-impact work and closed harn-cloud#547

## Verification
- cargo fmt --check
- cargo test -p harn-cli --test rule_test_dispatch --test rule_discovery_dispatch --test rule_pack_install_dispatch
- make check-docs-snippets
- git diff --check
- pre-commit hook: markdown, rustfmt, prompt-prose ratchet, changed-package clippy
- pre-push hook: markdown and targeted local checks