### PR TITLE
fix unused lint reference tracking

### DIFF
--- a/changelog.d/unused-lint-reference-tracking.fixed.md
+++ b/changelog.d/unused-lint-reference-tracking.fixed.md
@@ -1,0 +1,6 @@
+- **Unused-symbol linting now counts references from callable defaults and
+  type-only positions.** Imports, parameters, locals, and types referenced from
+  default parameter expressions, keyed mutex expressions, binding annotations,
+  pipeline return annotations, closure parameter annotations, typed catch
+  clauses, explicit generic call type arguments, or `schema_of(T)` are no
+  longer reported as unused.

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -786,6 +786,25 @@ impl<'a> Linter<'a> {
         }
     }
 
+    pub(super) fn record_callable_signature_type_references(
+        &mut self,
+        params: &[TypedParam],
+        return_type: &Option<TypeExpr>,
+    ) {
+        self.record_param_type_references(params);
+        if let Some(type_expr) = return_type {
+            self.record_type_expr_references(type_expr);
+        }
+    }
+
+    pub(super) fn lint_param_default_values(&mut self, params: &[TypedParam]) {
+        for param in params {
+            if let Some(default_value) = param.default_value.as_deref() {
+                self.lint_node(default_value);
+            }
+        }
+    }
+
     pub(super) fn has_interpolation(node: &SNode) -> bool {
         use harn_lexer::StringSegment;
         matches!(&node.node, Node::InterpolatedString(segments) if segments.iter().any(|segment| matches!(segment, StringSegment::Expression(_, _, _))))

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -30,6 +30,9 @@ impl<'a> Linter<'a> {
                 ..
             } => {
                 self.known_functions.insert(name.clone());
+                if let Some(type_expr) = return_type {
+                    self.record_type_expr_references(type_expr);
+                }
                 if return_type.is_none()
                     && *is_pub
                     && !Self::is_entry_pipeline_name(name)
@@ -112,10 +115,7 @@ impl<'a> Linter<'a> {
                 if *is_pub && self.require_stdlib_metadata {
                     self.check_stdlib_metadata(name, snode.span);
                 }
-                self.record_param_type_references(params);
-                if let Some(type_expr) = return_type {
-                    self.record_type_expr_references(type_expr);
-                }
+                self.record_callable_signature_type_references(params, return_type);
                 for clause in where_clauses {
                     self.type_references.insert(clause.bound.clone());
                 }
@@ -132,6 +132,7 @@ impl<'a> Linter<'a> {
                 if harn_vm::connector_export_effect_class(name).is_some() {
                     self.connector_effect_export_stack.push(name.clone());
                 }
+                self.lint_param_default_values(params);
                 let _ = self.analyze_secret_scan_block(body, false);
                 self.enter_long_running_body(body);
                 self.lint_block(body);
@@ -161,10 +162,7 @@ impl<'a> Linter<'a> {
                     is_pub: *is_pub,
                     is_method: false,
                 });
-                self.record_param_type_references(params);
-                if let Some(type_expr) = return_type {
-                    self.record_type_expr_references(type_expr);
-                }
+                self.record_callable_signature_type_references(params, return_type);
                 self.check_cyclomatic_complexity(name, body, snode.span);
                 self.push_scope();
                 let saved_loop_depth = self.loop_depth;
@@ -175,6 +173,7 @@ impl<'a> Linter<'a> {
                 self.return_type_stack.push(return_type.clone());
                 self.harness_param_stack
                     .push(Self::callable_harness_param(params));
+                self.lint_param_default_values(params);
                 let _ = self.analyze_secret_scan_block(body, false);
                 self.enter_long_running_body(body);
                 self.lint_block(body);
@@ -255,6 +254,7 @@ impl<'a> Linter<'a> {
                 }
                 self.lint_node(value);
                 if let Some(ann) = type_ann {
+                    self.record_type_expr_references(ann);
                     self.check_eager_collection_conversion(ann, value);
                 }
                 self.declare_pattern_variables(pattern, snode.span, false);
@@ -271,6 +271,7 @@ impl<'a> Linter<'a> {
                 }
                 self.lint_node(value);
                 if let Some(ann) = type_ann {
+                    self.record_type_expr_references(ann);
                     self.check_eager_collection_conversion(ann, value);
                 }
                 self.declare_pattern_variables(pattern, snode.span, true);
@@ -285,6 +286,7 @@ impl<'a> Linter<'a> {
                 self.record_mcp_registry_binding(name, value);
                 self.lint_node(value);
                 if let Some(ann) = type_ann {
+                    self.record_type_expr_references(ann);
                     self.check_eager_collection_conversion(ann, value);
                 }
                 let pattern = harn_parser::BindingPattern::Identifier(name.clone());
@@ -306,7 +308,11 @@ impl<'a> Linter<'a> {
                 self.function_references.insert(name.clone());
             }
 
-            Node::FunctionCall { name, args, .. } => {
+            Node::FunctionCall {
+                name,
+                type_args,
+                args,
+            } => {
                 self.check_renamed_stdlib_symbol(name, snode.span);
                 self.check_ambient_clock_builtin(name, snode.span);
                 self.check_ambient_stdio_builtin(name, snode.span);
@@ -394,6 +400,14 @@ impl<'a> Linter<'a> {
                 }
                 if Self::call_uses_long_running_flag(name, args) {
                     self.warn_unmanaged_long_running_call(name, snode.span);
+                }
+                for type_arg in type_args {
+                    self.record_type_expr_references(type_arg);
+                }
+                if name == "schema_of" && args.len() == 1 {
+                    if let Node::Identifier(type_name) = &args[0].node {
+                        self.type_references.insert(type_name.clone());
+                    }
                 }
                 for arg in args {
                     self.lint_node(arg);
@@ -836,10 +850,14 @@ impl<'a> Linter<'a> {
                 has_catch: _,
                 body,
                 error_var,
+                error_type,
                 catch_body,
                 finally_body,
                 ..
             } => {
+                if let Some(error_type) = error_type {
+                    self.record_type_expr_references(error_type);
+                }
                 if body.is_empty() {
                     self.diagnostics.push(LintDiagnostic {
                         code: Code::LintEmptyBlock,
@@ -941,12 +959,14 @@ impl<'a> Linter<'a> {
             }
 
             Node::Closure { params, body, .. } => {
+                self.record_param_type_references(params);
                 self.push_scope();
                 let saved_loop_depth = self.loop_depth;
                 self.loop_depth = 0;
                 for p in params {
                     self.declare_parameter(&p.name, snode.span);
                 }
+                self.lint_param_default_values(params);
                 self.enter_long_running_body(body);
                 self.lint_block(body);
                 self.exit_long_running_body();
@@ -1005,7 +1025,10 @@ impl<'a> Linter<'a> {
                 self.pop_scope();
             }
 
-            Node::MutexBlock { body, .. } => {
+            Node::MutexBlock { key, body } => {
+                if let Some(key) = key {
+                    self.lint_node(key);
+                }
                 self.push_scope();
                 self.lint_block(body);
                 self.pop_scope();

--- a/crates/harn-lint/src/tests/imports.rs
+++ b/crates/harn-lint/src/tests/imports.rs
@@ -87,6 +87,29 @@ pipeline default(task) {
 }
 
 #[test]
+fn test_import_used_in_parameter_default_is_kept() {
+    let source = r#"import { eval_repo_root } from "mod"
+
+fn load_cases(root = eval_repo_root()) {
+  return root
+}
+
+pipeline default(task) {
+  log(load_cases())
+}
+"#;
+    let diags = lint_source(source);
+    assert!(
+        !has_rule(&diags, "unused-import"),
+        "imports used in parameter defaults should not be removed: {diags:?}"
+    );
+    assert!(
+        !has_rule(&diags, "undefined-function"),
+        "parameter default calls should register imported function references: {diags:?}"
+    );
+}
+
+#[test]
 fn test_import_order_fires_when_out_of_order() {
     let source = "import \"std/io\"\nimport \"std/fs\"\n\nfn a() -> int { return 1 }\n";
     let diags = lint_source(source);

--- a/crates/harn-lint/src/tests/naming_types.rs
+++ b/crates/harn-lint/src/tests/naming_types.rs
@@ -113,3 +113,117 @@ pipeline default(task) {
         "referenced aliases should not trigger unused-type: {diags:?}"
     );
 }
+
+#[test]
+fn test_unused_type_ignores_binding_annotation_reference() {
+    let diags = lint_source(
+        r"
+type Payload = {value: int}
+
+pipeline default(task) {
+  let item: Payload = {value: 1}
+  log(item.value)
+}
+",
+    );
+    assert!(
+        !has_rule(&diags, "unused-type"),
+        "types referenced by binding annotations should not trigger unused-type: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unused_type_ignores_pipeline_return_annotation_reference() {
+    let diags = lint_source(
+        r"
+type Payload = {value: int}
+
+pipeline default(task) -> Payload {
+  return {value: 1}
+}
+",
+    );
+    assert!(
+        !has_rule(&diags, "unused-type"),
+        "types referenced by pipeline return annotations should not trigger unused-type: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unused_type_ignores_closure_param_annotation_reference() {
+    let diags = lint_source(
+        r"
+type Payload = {value: int}
+
+pipeline default(task) {
+  let read_value = { item: Payload -> item.value }
+  log(read_value({value: 1}))
+}
+",
+    );
+    assert!(
+        !has_rule(&diags, "unused-type"),
+        "types referenced by closure parameter annotations should not trigger unused-type: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unused_type_ignores_function_call_type_arg_reference() {
+    let diags = lint_source(
+        r"
+type Payload = {value: int}
+
+fn identity<T>(item: T) -> T {
+  return item
+}
+
+pipeline default(task) {
+  let item = identity<Payload>({value: 1})
+  log(item.value)
+}
+",
+    );
+    assert!(
+        !has_rule(&diags, "unused-type"),
+        "types referenced by call type arguments should not trigger unused-type: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unused_type_ignores_schema_of_reference() {
+    let diags = lint_source(
+        r"
+type Payload = {value: int}
+
+pipeline default(task) {
+  let schema = schema_of(Payload)
+  log(schema)
+}
+",
+    );
+    assert!(
+        !has_rule(&diags, "unused-type"),
+        "types referenced by schema_of(T) should not trigger unused-type: {diags:?}"
+    );
+}
+
+#[test]
+fn test_unused_type_ignores_typed_catch_reference() {
+    let diags = lint_source(
+        r#"
+type AppError = {message: string}
+
+pipeline default(task) {
+  try {
+    throw {message: "boom"}
+  } catch (err: AppError) {
+    log(err.message)
+  }
+}
+"#,
+    );
+    assert!(
+        !has_rule(&diags, "unused-type"),
+        "types referenced by typed catch clauses should not trigger unused-type: {diags:?}"
+    );
+}

--- a/crates/harn-lint/src/tests/unused.rs
+++ b/crates/harn-lint/src/tests/unused.rs
@@ -148,6 +148,44 @@ log(function_name)
 }
 
 #[test]
+fn test_parameter_defaults_mark_referenced_parameters_used() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+fn child_path(root, child = path_join(root, "child")) {
+    return child
+}
+log(child_path("/tmp"))
+}
+"#,
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.rule == "unused-parameter" && d.message.contains("`root`")),
+        "parameters used by default values should not trigger unused-parameter: {diags:?}"
+    );
+}
+
+#[test]
+fn test_mutex_key_marks_variable_used() {
+    let diags = lint_source(
+        r#"
+pipeline default(task) {
+let key = "tenant-a"
+mutex(key) {
+    log("locked")
+}
+}
+"#,
+    );
+    assert!(
+        !has_rule(&diags, "unused-variable"),
+        "mutex key expressions should mark referenced variables used: {diags:?}"
+    );
+}
+
+#[test]
 fn test_multiple_rules() {
     let diags = lint_source(
         r#"

--- a/crates/harn-parser/src/visit.rs
+++ b/crates/harn-parser/src/visit.rs
@@ -21,7 +21,7 @@
 //! into its children (pre-order). To stop recursion at a particular
 //! node, prefer using [`walk_children`] directly.
 
-use crate::ast::{BindingPattern, DictEntry, MatchArm, Node, SNode, SelectCase};
+use crate::ast::{BindingPattern, DictEntry, MatchArm, Node, SNode, SelectCase, TypedParam};
 
 /// Walk every node in `program` in pre-order, invoking `visitor` on
 /// each.
@@ -83,14 +83,22 @@ fn collect_children<'a>(node: &'a SNode, children: &mut Vec<&'a SNode>) {
         Node::ConstBinding { value, .. } => {
             children.push(value);
         }
-        Node::EnumDecl { .. }
-        | Node::StructDecl { .. }
-        | Node::InterfaceDecl { .. }
+        Node::EnumDecl { variants, .. } => {
+            for variant in variants {
+                collect_typed_param_defaults(&variant.fields, children);
+            }
+        }
+        Node::StructDecl { .. }
         | Node::ImportDecl { .. }
         | Node::SelectiveImport { .. }
         | Node::TypeDecl { .. }
         | Node::BreakStmt
         | Node::ContinueStmt => {}
+        Node::InterfaceDecl { methods, .. } => {
+            for method in methods {
+                collect_typed_param_defaults(&method.params, children);
+            }
+        }
         Node::ImplBlock { methods, .. } => collect_nodes(methods, children),
         Node::IfElse {
             condition,
@@ -152,15 +160,19 @@ fn collect_children<'a>(node: &'a SNode, children: &mut Vec<&'a SNode>) {
         | Node::SpawnExpr { body }
         | Node::ScopeBlock { body }
         | Node::DeferStmt { body }
-        | Node::Block(body)
-        | Node::Closure { body, .. } => collect_nodes(body, children),
+        | Node::Block(body) => collect_nodes(body, children),
+        Node::Closure { params, body, .. } => {
+            collect_typed_param_defaults(params, children);
+            collect_nodes(body, children);
+        }
         Node::MutexBlock { key, body } => {
             if let Some(key) = key {
                 children.push(key);
             }
             collect_nodes(body, children);
         }
-        Node::FnDecl { body, .. } | Node::ToolDecl { body, .. } => {
+        Node::FnDecl { params, body, .. } | Node::ToolDecl { params, body, .. } => {
+            collect_typed_param_defaults(params, children);
             collect_nodes(body, children);
         }
         Node::SkillDecl { fields, .. } => collect_field_values(fields, children),
@@ -314,6 +326,14 @@ fn collect_option_values<'a>(options: &'a [(String, SNode)], children: &mut Vec<
     }
 }
 
+fn collect_typed_param_defaults<'a>(params: &'a [TypedParam], children: &mut Vec<&'a SNode>) {
+    for param in params {
+        if let Some(default) = &param.default_value {
+            children.push(default);
+        }
+    }
+}
+
 fn collect_match_arm<'a>(arm: &'a MatchArm, children: &mut Vec<&'a SNode>) {
     children.push(&arm.pattern);
     if let Some(guard) = &arm.guard {
@@ -350,7 +370,7 @@ fn collect_binding_pattern<'a>(pattern: &'a BindingPattern, children: &mut Vec<&
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{spanned, Node};
+    use crate::ast::{spanned, Node, TypedParam};
     use harn_lexer::Span;
 
     fn dummy(node: Node) -> SNode {
@@ -397,5 +417,34 @@ mod tests {
         walk_node(&node, &mut |_| count += 1);
 
         assert_eq!(count, 10_001);
+    }
+
+    #[test]
+    fn walk_node_visits_typed_param_defaults() {
+        let default = dummy(Node::Identifier("fallback".to_string()));
+        let node = dummy(Node::FnDecl {
+            name: "load".to_string(),
+            type_params: Vec::new(),
+            params: vec![TypedParam {
+                name: "root".to_string(),
+                type_expr: None,
+                default_value: Some(Box::new(default)),
+                rest: false,
+            }],
+            return_type: None,
+            where_clauses: Vec::new(),
+            body: Vec::new(),
+            is_pub: false,
+            is_stream: false,
+        });
+        let mut seen = Vec::new();
+
+        walk_node(&node, &mut |node| {
+            if let Node::Identifier(name) = &node.node {
+                seen.push(name.clone());
+            }
+        });
+
+        assert_eq!(seen, vec!["fallback"]);
     }
 }


### PR DESCRIPTION
## Summary
- Track unused-symbol references from parameter defaults, mutex keys, callable and binding type positions, typed catches, generic type arguments, and schema_of type operands.
- DRY callable signature reference handling in the linter and make parser visiting include typed parameter default expressions.
- Add regression coverage for the false-positive cases plus a changelog fragment.

## Verification
- cargo test -p harn-lint --lib
- cargo test -p harn-parser --lib
- cargo fmt --check --package harn-lint --package harn-parser
- make lint-test-patterns
- pre-commit hook passed
- pre-push hook passed