### PR TITLE
Fix policy and parser edge cases

### DIFF
--- a/changelog.d/five-bugfixes.fixed.md
+++ b/changelog.d/five-bugfixes.fixed.md
@@ -1,0 +1,7 @@
+- **Policy, parser, host process, and OAuth edge cases are now handled more
+  strictly.** Unix-socket JSON requests and provider file uploads now
+  participate in network/file policy gates and handoff effects, malformed
+  loopback OAuth requests no longer abort a pending valid callback, background
+  command handles preserve unavailable process-group IDs as `nil`, background
+  feedback peeks no longer restamp unrelated inbox entries, generic and
+  `where` lists reject empty/trailing-comma forms.

--- a/crates/harn-cli/src/commands/connect/callback.rs
+++ b/crates/harn-cli/src/commands/connect/callback.rs
@@ -112,7 +112,7 @@ pub(super) fn wait_for_callback_query(
                     Err(error) => {
                         response = html_response(400, &error);
                         let _ = stream.write_all(response.as_bytes());
-                        return Err(error);
+                        continue;
                     }
                 }
             }

--- a/crates/harn-cli/src/commands/connect/tests.rs
+++ b/crates/harn-cli/src/commands/connect/tests.rs
@@ -409,6 +409,67 @@ fn github_install_callback_captures_installation_id() {
     assert_eq!(installation_id, "12345");
 }
 
+#[test]
+fn github_install_callback_ignores_invalid_request_before_valid_callback() {
+    let (listener, redirect_uri) = bind_loopback_listener("http://127.0.0.1:0/gh-install-callback")
+        .expect("loopback listener");
+    listener
+        .set_nonblocking(false)
+        .expect("revert listener to blocking for deterministic test accept");
+    let parsed = Url::parse(&redirect_uri).unwrap();
+    let port = parsed.port().unwrap();
+    let redirect_uri_for_server = redirect_uri;
+    let server_ready = Arc::new(Barrier::new(2));
+    let client_ready = Arc::clone(&server_ready);
+    let server = thread::spawn(move || {
+        client_ready.wait();
+        wait_for_github_installation(listener, &redirect_uri_for_server, Some("state-ok"))
+    });
+    let client = thread::spawn(move || {
+        server_ready.wait();
+        let mut invalid =
+            TcpStream::connect(("127.0.0.1", port)).expect("connect invalid callback");
+        invalid
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set invalid read timeout");
+        invalid
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .expect("set invalid write timeout");
+        invalid
+            .write_all(b"GET /wrong-path HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            .expect("write invalid callback");
+        let mut invalid_response = String::new();
+        invalid
+            .read_to_string(&mut invalid_response)
+            .expect("read invalid callback response");
+        assert!(invalid_response.contains("400 Bad Request"));
+
+        let mut valid = TcpStream::connect(("127.0.0.1", port)).expect("connect valid callback");
+        valid
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set valid read timeout");
+        valid
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .expect("set valid write timeout");
+        valid
+            .write_all(
+                b"GET /gh-install-callback?installation_id=12345&state=state-ok HTTP/1.1\r\nHost: 127.0.0.1\r\nOrigin: null\r\n\r\n",
+            )
+            .expect("write valid callback");
+        let mut valid_response = String::new();
+        valid
+            .read_to_string(&mut valid_response)
+            .expect("read valid callback response");
+        assert!(valid_response.contains("200 OK"));
+    });
+    let installation_id = server
+        .join()
+        .expect("server thread")
+        .expect("installation id");
+    client.join().expect("callback client");
+    assert_eq!(installation_id, "12345");
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn mocked_builtin_oauth_token_endpoints_receive_pkce_and_resource_indicators() {
     for provider in ["slack", "linear", "notion"] {

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -321,11 +321,10 @@ pub(crate) fn running_response(
         VmValue::String(Arc::from(sandbox_kind())),
     );
     sandbox.insert("enforced".to_string(), VmValue::Bool(sandbox_enforced()));
-    ResponseBuilder::new()
+    let mut builder = ResponseBuilder::new()
         .str("command_id", command_id.clone())
         .str("status", CommandStatus::Running.as_str())
         .int("pid", pid as i64)
-        .int("process_group_id", process_group_id.unwrap_or(pid) as i64)
         .str("handle_id", handle_id)
         .str("started_at", started_at)
         .nil("ended_at")
@@ -344,8 +343,12 @@ pub(crate) fn running_response(
         .dict("sandbox", sandbox)
         .str("audit_id", format!("audit_{command_id}"))
         .str("command", command_display.clone())
-        .str("command_or_op_descriptor", command_display)
-        .build()
+        .str("command_or_op_descriptor", command_display);
+    builder = match process_group_id {
+        Some(pgid) => builder.int("process_group_id", pgid as i64),
+        None => builder.nil("process_group_id"),
+    };
+    builder.build()
 }
 
 pub(crate) fn next_command_id() -> String {

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -116,11 +116,10 @@ fn wait_for_initial_background_feedback(
     if !harn_vm::orchestration::agent_inbox::wait_sync(session_id, timeout) {
         return None;
     }
+    let mut kept = Vec::new();
     let mut selected = None;
     for entry in harn_vm::orchestration::agent_inbox::drain(session_id) {
-        let kind = entry.kind;
-        let content = entry.content;
-        let parsed = serde_json::from_str::<serde_json::Value>(&content).ok();
+        let parsed = serde_json::from_str::<serde_json::Value>(&entry.content).ok();
         let matches_handle = parsed
             .as_ref()
             .and_then(|value| value.get("handle_id"))
@@ -131,19 +130,17 @@ fn wait_for_initial_background_feedback(
                 if let Some(object) = payload.as_object_mut() {
                     object.insert(
                         "feedback_kind".to_string(),
-                        serde_json::Value::String(kind.clone()),
+                        serde_json::Value::String(entry.kind.clone()),
                     );
                 }
                 selected = Some(harn_vm::json_to_vm_value(&payload));
                 continue;
             }
         }
-        harn_vm::orchestration::agent_inbox::push(
-            session_id,
-            &kind,
-            &content,
-            "hostlib.run_command.requeue",
-        );
+        kept.push(entry);
+    }
+    for entry in kept.into_iter().rev() {
+        harn_vm::orchestration::agent_inbox::requeue_front(entry);
     }
     selected
 }

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -90,6 +90,14 @@ fn require_bool(map: &BTreeMap<String, VmValue>, key: &str) -> bool {
     }
 }
 
+fn require_nil(map: &BTreeMap<String, VmValue>, key: &str) {
+    assert!(
+        matches!(map.get(key), Some(VmValue::Nil)),
+        "expected nil at {key}, got {:?}",
+        map.get(key)
+    );
+}
+
 fn require_nested_dict(map: &BTreeMap<String, VmValue>, key: &str) -> BTreeMap<String, VmValue> {
     match map.get(key) {
         Some(VmValue::Dict(value)) => (**value).clone(),
@@ -675,6 +683,36 @@ fn run_command_long_running_returns_handle_immediately() {
 }
 
 #[test]
+fn run_command_long_running_reports_nil_process_group_when_unavailable() {
+    let _session_guard = harn_vm::agent_sessions::enter_current_session(unique_session_id(
+        "test-run-command-long-running-no-pgid",
+    ));
+    let config = MockProcessConfig {
+        pgid: None,
+        ..MockProcessConfig::running()
+    };
+    let (_spawner, _controller, _guard) = install_mock_with(config);
+
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["sleep", "10"]));
+    req.insert("background".into(), VmValue::Bool(true));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+
+    assert_eq!(require_str(&resp, "status"), "running");
+    require_nil(&resp, "process_group_id");
+    let handle_id = require_str(&resp, "handle_id");
+    let completion_rx = register_completion_notifier(&handle_id);
+
+    let mut cancel_req = dict();
+    cancel_req.insert("handle_id".into(), vstr(&handle_id));
+    let cancel_resp = require_dict(call("hostlib_tools_cancel_handle", cancel_req).unwrap());
+    assert!(require_bool(&cancel_resp, "cancelled"));
+    if let Some(rx) = completion_rx {
+        let _ = rx.recv();
+    }
+}
+
+#[test]
 fn run_command_background_after_returns_progress_snapshot() {
     let _session_guard = harn_vm::agent_sessions::enter_current_session(unique_session_id(
         "test-run-command-background-after",
@@ -696,6 +734,39 @@ fn run_command_background_after_returns_progress_snapshot() {
     let handle_id = require_str(&resp, "handle_id");
 
     let completion_rx = register_completion_notifier(&handle_id);
+    let mut cancel_req = dict();
+    cancel_req.insert("handle_id".into(), vstr(&handle_id));
+    let cancel_resp = require_dict(call("hostlib_tools_cancel_handle", cancel_req).unwrap());
+    assert!(require_bool(&cancel_resp, "cancelled"));
+    if let Some(rx) = completion_rx {
+        let _ = rx.recv();
+    }
+}
+
+#[test]
+fn run_command_background_after_requeues_unrelated_feedback_without_restamping() {
+    let session_id = unique_session_id("test-run-command-background-after-requeue");
+    let _session_guard = harn_vm::agent_sessions::enter_current_session(session_id.clone());
+    let _ = harn_vm::orchestration::agent_inbox::drain(&session_id);
+    harn_vm::orchestration::agent_inbox::push(&session_id, "notice", "first", "test");
+    harn_vm::orchestration::agent_inbox::push(&session_id, "notice", "second", "test");
+
+    let (_spawner, _controller, _guard) = install_mock_with(MockProcessConfig::running());
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["sleep", "10"]));
+    req.insert("background_after_ms".into(), VmValue::Int(50));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+
+    assert_eq!(require_str(&resp, "status"), "running");
+    let remaining = harn_vm::orchestration::agent_inbox::drain(&session_id);
+    assert_eq!(remaining.len(), 2);
+    assert_eq!(remaining[0].content, "first");
+    assert_eq!(remaining[1].content, "second");
+    assert_eq!(remaining[0].sequence, 1);
+    assert_eq!(remaining[1].sequence, 2);
+    let handle_id = require_str(&resp, "handle_id");
+    let completion_rx = register_completion_notifier(&handle_id);
+
     let mut cancel_req = dict();
     cancel_req.insert("handle_id".into(), vstr(&handle_id));
     let cancel_resp = require_dict(call("hostlib_tools_cancel_handle", cancel_req).unwrap());

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -2288,6 +2288,8 @@ fn is_network_call(name: &str) -> bool {
             | "websocket_route"
             | "websocket_server"
             | "websocket_server_close"
+            | "unix_socket_json_request"
+            | "__net_unix_socket_json_request"
     )
 }
 
@@ -2932,6 +2934,24 @@ fn handler(client) {
             "unexpected diagnostics: {:?}",
             report.diagnostics
         );
+    }
+
+    #[test]
+    fn capability_policy_treats_unix_socket_json_request_as_network_access() {
+        let report = analyze(
+            r#"
+@invariant("capability.policy",
+  allow: "network.access",
+  require_egress_policy: "network.access")
+fn handler() {
+  unix_socket_json_request("/tmp/harn.sock", {})
+}
+"#,
+        );
+
+        let diags = diagnostics_by_invariant(&report, "capability.policy");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("network.access"));
     }
 
     #[test]

--- a/crates/harn-parser/src/parser/mod.rs
+++ b/crates/harn-parser/src/parser/mod.rs
@@ -540,6 +540,38 @@ pipeline test(task) {
     }
 
     #[test]
+    fn rejects_empty_generic_type_params() {
+        assert!(parse_source("fn f<>() { return 1 }").is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_generic_type_param_comma() {
+        assert!(parse_source("fn f<T,>() { return 1 }").is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_generic_call_type_arg_comma() {
+        let source = r"
+fn identity<T>(x: T) -> T { return x }
+pipeline test(task) {
+  let n = identity<int,>(42)
+}
+";
+
+        assert!(parse_source(source).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_where_clause_list() {
+        assert!(parse_source("fn f<T>() where { return 1 }").is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_where_clause_comma() {
+        assert!(parse_source("fn f<T>() where T: Displayable, { return 1 }").is_err());
+    }
+
+    #[test]
     fn parses_struct_literal_syntax_for_known_structs() {
         let source = r"
 struct Point {

--- a/crates/harn-parser/src/parser/types.rs
+++ b/crates/harn-parser/src/parser/types.rs
@@ -20,13 +20,22 @@ impl Parser {
     pub(super) fn parse_type_param_list(&mut self) -> Result<Vec<TypeParam>, ParserError> {
         let mut params = Vec::new();
         self.skip_newlines();
-        while !self.is_at_end() && !self.check(&TokenKind::Gt) {
+        if self.check(&TokenKind::Gt) {
+            return Err(self.error("type parameter name"));
+        }
+        loop {
             let variance = self.parse_optional_variance_marker();
             let name = self.consume_identifier("type parameter name")?;
             params.push(TypeParam { name, variance });
+            self.skip_newlines();
             if self.check(&TokenKind::Comma) {
                 self.advance();
                 self.skip_newlines();
+                if self.check(&TokenKind::Gt) || self.is_at_end() {
+                    return Err(self.error("type parameter name"));
+                }
+            } else {
+                break;
             }
         }
         self.consume(&TokenKind::Gt, ">")?;
@@ -46,6 +55,9 @@ impl Parser {
             if self.check(&TokenKind::Comma) {
                 self.advance();
                 self.skip_newlines();
+                if self.check(&TokenKind::Gt) || self.is_at_end() {
+                    return Err(self.error("type argument"));
+                }
             } else {
                 break;
             }
@@ -82,6 +94,10 @@ impl Parser {
                 if id == "where" {
                     self.advance();
                     let mut clauses = Vec::new();
+                    self.skip_newlines();
+                    if self.check(&TokenKind::LBrace) || self.is_at_end() {
+                        return Err(self.error("where clause"));
+                    }
                     loop {
                         self.skip_newlines();
                         if self.check(&TokenKind::LBrace) || self.is_at_end() {
@@ -93,6 +109,10 @@ impl Parser {
                         clauses.push(WhereClause { type_name, bound });
                         if self.check(&TokenKind::Comma) {
                             self.advance();
+                            self.skip_newlines();
+                            if self.check(&TokenKind::LBrace) || self.is_at_end() {
+                                return Err(self.error("where clause"));
+                            }
                         } else {
                             break;
                         }

--- a/crates/harn-stdlib/src/stdlib/stdlib_files.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_files.harn
@@ -4,7 +4,7 @@
 /**
  * Upload a local file to a provider Files API and return its reusable file_id.
  *
- * @effects: []
+ * @effects: [fs, network]
  * @allocation: heap
  * @errors: []
  * @api_stability: stable

--- a/crates/harn-vm/src/orchestration/policy/effects.rs
+++ b/crates/harn-vm/src/orchestration/policy/effects.rs
@@ -153,6 +153,20 @@ fn effects_from_call(call: &harn_ir::CallSemantics) -> Vec<EffectRecord> {
     // Primary extraction: name-based builtin recognition. This path
     // carries the richest information (resource from literal args,
     // provider/model on LLM calls) and is the authoritative shape.
+    if call.name == "__files_upload" || call.name == "upload" {
+        let mut effects = Vec::with_capacity(2);
+        let mut fs = EffectRecord::new(EffectKind::Fs, EffectScope::Read);
+        if let Some(path) = call.literal_args.first().and_then(literal_as_str) {
+            fs = fs.with_resource(path);
+        }
+        effects.push(fs);
+        let mut net = EffectRecord::new(EffectKind::Net, EffectScope::Write);
+        if let Some(provider) = call.literal_args.get(1).and_then(literal_as_str) {
+            net = net.with_resource(provider);
+        }
+        effects.push(net);
+        return effects;
+    }
     if let Some(effect) = builtin_effect(&call.name) {
         return vec![annotate_with_resource(effect, call)];
     }
@@ -244,7 +258,11 @@ fn builtin_effect(name: &str) -> Option<EffectRecord> {
         | "websocket_close"
         | "websocket_route"
         | "websocket_server"
-        | "websocket_server_close" => Some(EffectRecord::new(EffectKind::Net, EffectScope::Write)),
+        | "websocket_server_close"
+        | "unix_socket_json_request"
+        | "__net_unix_socket_json_request" => {
+            Some(EffectRecord::new(EffectKind::Net, EffectScope::Write))
+        }
 
         // llm
         "llm_call"
@@ -960,6 +978,65 @@ mod tests {
             .expect("net effect");
         assert_eq!(net.scope, EffectScope::Write);
         assert_eq!(net.resource.as_deref(), Some("https://example.test/api"));
+    }
+
+    #[test]
+    fn unix_socket_json_request_yields_net_effect_with_resource() {
+        let source = r#"fn main() { __net_unix_socket_json_request("/tmp/harn.sock", {}) }"#;
+        let effects = compute_handoff_effects(source, None);
+        let net = effects
+            .iter()
+            .find(|effect| matches!(effect.kind, EffectKind::Net))
+            .expect("net effect");
+        assert_eq!(net.scope, EffectScope::Write);
+        assert_eq!(net.resource.as_deref(), Some("/tmp/harn.sock"));
+    }
+
+    #[test]
+    fn files_upload_yields_fs_read_and_net_write_effects() {
+        let source = r#"fn main() { __files_upload("/tmp/input.pdf", "gemini") }"#;
+        let effects = compute_handoff_effects(source, None);
+        assert!(
+            effects.iter().any(|effect| {
+                matches!(effect.kind, EffectKind::Fs)
+                    && effect.scope == EffectScope::Read
+                    && effect.resource.as_deref() == Some("/tmp/input.pdf")
+            }),
+            "expected Fs read effect, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| {
+                matches!(effect.kind, EffectKind::Net)
+                    && effect.scope == EffectScope::Write
+                    && effect.resource.as_deref() == Some("gemini")
+            }),
+            "expected Net write effect, got {effects:?}"
+        );
+    }
+
+    #[test]
+    fn std_files_upload_wrapper_yields_fs_read_and_net_write_effects() {
+        let source = r#"
+import { upload } from "std/files"
+fn main() { upload("/tmp/input.pdf", "gemini") }
+"#;
+        let effects = compute_handoff_effects(source, None);
+        assert!(
+            effects.iter().any(|effect| {
+                matches!(effect.kind, EffectKind::Fs)
+                    && effect.scope == EffectScope::Read
+                    && effect.resource.as_deref() == Some("/tmp/input.pdf")
+            }),
+            "expected Fs read effect, got {effects:?}"
+        );
+        assert!(
+            effects.iter().any(|effect| {
+                matches!(effect.kind, EffectKind::Net)
+                    && effect.scope == EffectScope::Write
+                    && effect.resource.as_deref() == Some("gemini")
+            }),
+            "expected Net write effect, got {effects:?}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -310,11 +310,26 @@ pub fn enforce_current_policy_for_builtin(name: &str, args: &[VmValue]) -> Resul
         {
             return reject_policy(format!("builtin '{name}' exceeds process.exec ceiling"));
         }
-        "http_get" | "http_post" | "http_put" | "http_patch" | "http_delete" | "http_download"
+        "http_get"
+        | "http_post"
+        | "http_put"
+        | "http_patch"
+        | "http_delete"
+        | "http_download"
         | "http_request"
+        | "unix_socket_json_request"
+        | "__net_unix_socket_json_request"
             if !policy_allows_side_effect(&policy, "network") =>
         {
             return reject_policy(format!("builtin '{name}' exceeds network ceiling"));
+        }
+        "__files_upload"
+            if !policy_allows_capability(&policy, "workspace", "read_text")
+                || !policy_allows_side_effect(&policy, "network") =>
+        {
+            return reject_policy(
+                "builtin '__files_upload' exceeds workspace.read_text/network ceiling".to_string(),
+            );
         }
         "http_session_request"
         | "http_stream_open"
@@ -1051,6 +1066,57 @@ mod approval_policy_tests {
         assert!(
             error.to_string().contains("workspace write ceiling"),
             "unexpected error: {error}"
+        );
+
+        pop_execution_policy();
+    }
+
+    #[test]
+    fn unix_socket_json_request_requires_network_side_effect() {
+        clear_execution_policy_stacks();
+        push_execution_policy(CapabilityPolicy {
+            side_effect_level: Some("read_only".to_string()),
+            ..CapabilityPolicy::default()
+        });
+
+        let error =
+            enforce_current_policy_for_builtin("__net_unix_socket_json_request", &[]).unwrap_err();
+        assert!(
+            error.to_string().contains("network ceiling"),
+            "unexpected error: {error}"
+        );
+
+        pop_execution_policy();
+    }
+
+    #[test]
+    fn files_upload_requires_workspace_read_and_network_side_effect() {
+        clear_execution_policy_stacks();
+        push_execution_policy(CapabilityPolicy {
+            capabilities: BTreeMap::from([(
+                "workspace".to_string(),
+                vec!["read_text".to_string()],
+            )]),
+            side_effect_level: Some("read_only".to_string()),
+            ..CapabilityPolicy::default()
+        });
+
+        let network_error = enforce_current_policy_for_builtin("__files_upload", &[]).unwrap_err();
+        assert!(
+            network_error.to_string().contains("network ceiling"),
+            "unexpected error: {network_error}"
+        );
+        pop_execution_policy();
+
+        push_execution_policy(CapabilityPolicy {
+            capabilities: BTreeMap::from([("workspace".to_string(), vec!["exists".to_string()])]),
+            side_effect_level: Some("network".to_string()),
+            ..CapabilityPolicy::default()
+        });
+        let read_error = enforce_current_policy_for_builtin("__files_upload", &[]).unwrap_err();
+        assert!(
+            read_error.to_string().contains("workspace.read_text"),
+            "unexpected error: {read_error}"
         );
 
         pop_execution_policy();


### PR DESCRIPTION
## Summary
- Gate unix-socket JSON requests and provider file uploads through network/workspace policy and handoff effects.
- Keep OAuth loopback listeners alive after malformed callback requests so a later valid callback can complete.
- Preserve nil process-group IDs and requeue unrelated background feedback without restamping inbox metadata.
- Reject empty/trailing-comma generic and where lists in the parser.

## Verification
- cargo test -p harn-parser rejects_ --lib
- cargo test -p harn-vm unix_socket --lib
- cargo test -p harn-vm files_upload --lib
- cargo test -p harn-ir capability_policy_treats_unix_socket_json_request_as_network_access --lib
- cargo test -p harn-hostlib --test process_tools
- cargo test -p harn-cli github_install_callback_ignores_invalid_request_before_valid_callback --lib
- cargo fmt --check
- cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_files.harn
- cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/stdlib_files.harn
- make lint-test-patterns
- BASE_SHA=origin/main HEAD_SHA=HEAD .github/scripts/changelog-fragment-check.sh
- pre-push hook targeted checks