### PR TITLE
Fix Windows process sandbox preset import

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -7,8 +7,8 @@ name: Release smoke
 # release gate tied to the bytes users download without paying a second compile
 # on release artifact checks.
 #
-# The per-PR `windows` job in `ci.yml` covers Windows-specific compile
-# breaks and the curated unit slice. This job is the explicit
+# The post-merge `windows` job in `ci.yml` and the tag-push release binary
+# build cover Windows-specific compile breaks. This job is the explicit
 # *capability* gate — failures point at a specific (platform, capability)
 # pair via `::error::` annotations from the smoke driver. See
 # docs/src/dev/platform-compatibility.md for the support matrix.
@@ -267,9 +267,9 @@ jobs:
         continue-on-error: true
         with:
           # Piggy-back on the per-platform release cache key from
-          # build-release-binaries.yml whenever it lines up. On Windows
-          # we share the per-PR `workspace-windows` key so the smoke
-          # boots quickly when the unit slice already filled the cache.
+          # build-release-binaries.yml whenever it lines up. Windows source
+          # smoke uses its own release-smoke key because the CI Windows job is
+          # a post-merge backstop, not a PR cache warmer.
           shared-key: release-smoke-${{ matrix.platform }}
           cache-on-failure: true
           # Keep rustup's freshly-installed cargo shim authoritative.

--- a/changelog.d/3068.fixed.md
+++ b/changelog.d/3068.fixed.md
@@ -1,0 +1,3 @@
+- **Windows release binaries.** Fixed the Windows release binary build by
+  importing the process-sandbox preset type wherever the shared sandbox preset
+  helpers are compiled (#3068).

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -39,7 +39,7 @@ use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use crate::orchestration::ProcessSandboxPreset;
 use crate::orchestration::{CapabilityPolicy, SandboxProfile};
 use crate::value::{ErrorCategory, VmError, VmValue};


### PR DESCRIPTION
## Summary
- Fix the Windows release binary compile failure by importing `ProcessSandboxPreset` anywhere the shared sandbox preset helpers compile.
- Correct stale release-smoke comments that still described the Windows CI job as PR coverage.
- Add a changelog fragment for the corrective release note.

## Verification
- `cargo check -p harn-vm`
- `git diff --check`
- pre-commit hook
- pre-push hook

## Notes
- The v0.8.75 tag build failed on `x86_64-pc-windows-msvc` with `cannot find type ProcessSandboxPreset in this scope`.
- A local macOS-hosted `--target x86_64-pc-windows-msvc` check cannot complete because C dependencies require a Windows SDK, but after this import change it no longer reaches the original Rust name-resolution error before failing on SDK headers/libs.