### PR TITLE
Add Postgres query ergonomics module

### DIFF
--- a/changelog.d/3072.added.md
+++ b/changelog.d/3072.added.md
@@ -1,0 +1,3 @@
+- **Postgres query ergonomics.** `std/postgres/query` now provides Harn-native
+  named query records, `one`/`many`/`exec`/`run` wrappers over `std/postgres`,
+  and safe static projection helpers for UUID and timestamp columns (#3072).

--- a/conformance/tests/stdlib/postgres_query_helpers.expected
+++ b/conformance/tests/stdlib/postgres_query_helpers.expected
@@ -1,0 +1,12 @@
+r1
+tenant-a
+true
+1
+2026-06-05T12:00:00Z
+4
+SELECT id::text AS id FROM receipts WHERE id = $1::uuid
+r1
+true
+true
+true
+true

--- a/conformance/tests/stdlib/postgres_query_helpers.harn
+++ b/conformance/tests/stdlib/postgres_query_helpers.harn
@@ -1,0 +1,69 @@
+import "std/postgres"
+import {
+  exec,
+  many,
+  named,
+  nullable_timestamptz_json,
+  one,
+  run,
+  select_clause,
+  timestamptz_json,
+  uuid_text,
+} from "std/postgres/query"
+
+pipeline default() {
+  let list_sql = select_clause(
+    [
+      uuid_text("id"),
+      uuid_text("tenant_id"),
+      "payload",
+      nullable_timestamptz_json("finished_at"),
+      timestamptz_json("created_at"),
+    ],
+  )
+    + " FROM receipts WHERE tenant_id = $1::uuid ORDER BY created_at DESC"
+  let get_sql = "SELECT " + uuid_text("id") + " FROM receipts WHERE id = $1::uuid"
+  let update_sql = "UPDATE receipts SET status = $2 WHERE id = $1::uuid"
+  let db = pg_mock_pool(
+    [
+      {sql: get_sql, params: ["r1"], rows: [{id: "r1"}]},
+      {
+        sql: list_sql,
+        params: ["tenant-a"],
+        rows: [
+          {
+            id: "r1",
+            tenant_id: "tenant-a",
+            payload: {ok: true},
+            finished_at: nil,
+            created_at: "2026-06-05T12:00:00Z",
+          },
+        ],
+      },
+      {sql: update_sql, params: ["r1", "read"], rows_affected: 1},
+    ],
+  )
+  let row = one(db, {name: "get_receipt", sql: get_sql, params: ["r1"]})
+  __io_println(row.id)
+  let rows = many(db, {name: "list_receipts", sql: list_sql, params: ["tenant-a"]})
+  __io_println(rows[0].tenant_id)
+  __io_println(rows[0].payload.ok)
+  let result = exec(db, {name: "mark_receipt_read", sql: update_sql, params: ["r1", "read"]})
+  __io_println(result.rows_affected)
+  let named_rows = run(db, named("list_receipts_named", "many", list_sql, ["tenant-a"]))
+  __io_println(named_rows[0].created_at)
+  let calls = pg_mock_calls(db)
+  __io_println(len(calls))
+  __io_println(calls[0].sql)
+  __io_println(calls[0].params[0])
+  __io_println(calls[2].execute)
+  let unsafe_ident = try {
+    uuid_text("bad;drop")
+  }
+  __io_println(is_err(unsafe_ident))
+  let named_error = try {
+    many(db, {name: "missing_query", sql: "SELECT missing", params: []})
+  }
+  __io_println(is_err(named_error))
+  __io_println(regex_match("missing_query", to_string(unwrap_err(named_error))) != nil)
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -514,6 +514,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_postgres.harn"),
     },
     StdlibSource {
+        module: "postgres/query",
+        source: include_str!("stdlib/postgres/query.harn"),
+    },
+    StdlibSource {
         module: "checkpoint",
         source: include_str!("stdlib/stdlib_checkpoint.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/postgres/query.harn
+++ b/crates/harn-stdlib/src/stdlib/postgres/query.harn
@@ -1,0 +1,236 @@
+/**
+ * std/postgres/query - small SQL ergonomics over std/postgres.
+ *
+ * SQL remains the source of truth. These helpers only normalize query
+ * records, keep values in the `params` list, and centralize safe static
+ * projection fragments.
+ */
+import "std/postgres"
+
+type PgQueryMode = "one" | "many" | "exec"
+
+type PgNamedQuery = {name: string, mode: PgQueryMode, sql: string, params: list<any>}
+
+type PgQuery = {name?: string, mode?: PgQueryMode, sql: string, params?: list<any>}
+
+let __QUERY_MODES = ["one", "many", "exec"]
+
+let __IDENTIFIER_PATTERN = "^[A-Za-z_][A-Za-z0-9_]*$"
+
+fn __query_name(query) -> string {
+  if type_of(query) != "dict" {
+    return ""
+  }
+  let name = query?.name
+  if name == nil {
+    return ""
+  }
+  if type_of(name) != "string" {
+    throw "std/postgres/query: query name must be a string"
+  }
+  return name
+}
+
+fn __query_error_prefix(query) -> string {
+  let name = __query_name(query)
+  if name == "" {
+    return "std/postgres/query: "
+  }
+  return "std/postgres/query `" + name + "`: "
+}
+
+fn __normalize_query(query, expected_mode = nil) {
+  if type_of(query) != "dict" {
+    throw "std/postgres/query: query must be a dict"
+  }
+  let sql = query?.sql
+  if type_of(sql) != "string" || trim(sql) == "" {
+    throw __query_error_prefix(query) + "sql must be a non-empty string"
+  }
+  let params = query?.params ?? []
+  if type_of(params) != "list" {
+    throw __query_error_prefix(query) + "params must be a list"
+  }
+  let mode = query?.mode ?? expected_mode
+  if mode != nil && !contains(__QUERY_MODES, mode) {
+    throw __query_error_prefix(query) + "mode must be one of one, many, exec"
+  }
+  if expected_mode != nil && query?.mode != nil && query.mode != expected_mode {
+    throw __query_error_prefix(query) + "mode " + query.mode + " cannot run through " + expected_mode
+  }
+  return {name: __query_name(query), mode: mode, sql: sql, params: params}
+}
+
+fn __with_query_name(query, body) {
+  try {
+    return body()
+  } catch (error) {
+    if query.name == "" {
+      throw error
+    }
+    throw __query_error_prefix(query) + to_string(error)
+  }
+}
+
+/**
+ * Build a serializable named-query record.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: named("list_receipts", "many", sql, [tenant_id])
+ */
+pub fn named(name: string, mode: PgQueryMode, sql: string, params: list<any> = []) -> PgNamedQuery {
+  return __normalize_query({name: name, mode: mode, sql: sql, params: params})
+}
+
+/**
+ * Run a query that returns zero or one row.
+ *
+ * @effects: [postgres]
+ * @allocation: heap
+ * @errors: validation, postgres
+ * @api_stability: experimental
+ * @example: one(db, {name: "get_receipt", sql: sql, params: [id]})
+ */
+pub fn one(handle, query: PgQuery) {
+  let q = __normalize_query(query, "one")
+  return __with_query_name(q, { -> pg_query_one(handle, q.sql, q.params) })
+}
+
+/**
+ * Run a query that returns a list of rows.
+ *
+ * @effects: [postgres]
+ * @allocation: heap
+ * @errors: validation, postgres
+ * @api_stability: experimental
+ * @example: many(db, {name: "list_receipts", sql: sql, params: [tenant_id]})
+ */
+pub fn many(handle, query: PgQuery) -> list {
+  let q = __normalize_query(query, "many")
+  return __with_query_name(q, { -> pg_query(handle, q.sql, q.params) })
+}
+
+/**
+ * Execute a statement and return the underlying PgExecuteResult.
+ *
+ * @effects: [postgres]
+ * @allocation: heap
+ * @errors: validation, postgres
+ * @api_stability: experimental
+ * @example: exec(db, {name: "mark_read", sql: sql, params: [id, status]})
+ */
+pub fn exec(handle, query: PgQuery) -> PgExecuteResult {
+  let q = __normalize_query(query, "exec")
+  return __with_query_name(q, { -> pg_execute(handle, q.sql, q.params) })
+}
+
+/**
+ * Run a named query according to its `mode`.
+ *
+ * @effects: [postgres]
+ * @allocation: heap
+ * @errors: validation, postgres
+ * @api_stability: experimental
+ * @example: run(db, named("list_receipts", "many", sql, [tenant_id]))
+ */
+pub fn run(handle, query: PgNamedQuery) {
+  let q = __normalize_query(query)
+  if q.mode == nil {
+    throw __query_error_prefix(q) + "mode is required"
+  }
+  if q.mode == "one" {
+    return one(handle, q)
+  }
+  if q.mode == "many" {
+    return many(handle, q)
+  }
+  return exec(handle, q)
+}
+
+/**
+ * Validate and return a static SQL identifier for projection helpers.
+ *
+ * @effects: []
+ * @allocation: stack-only
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: identifier("created_at")
+ */
+pub fn identifier(name: string) -> string {
+  if type_of(name) != "string" || trim(name) == "" {
+    throw "std/postgres/query: SQL identifier must be a non-empty string"
+  }
+  if regex_match(__IDENTIFIER_PATTERN, name) == nil {
+    throw "std/postgres/query: unsafe SQL identifier `" + to_string(name) + "`"
+  }
+  return name
+}
+
+/**
+ * Render `SELECT a, b, c` from already-static projection fragments.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: select_clause([uuid_text("id"), "payload"])
+ */
+pub fn select_clause(fragments: list<string>) -> string {
+  if type_of(fragments) != "list" {
+    throw "std/postgres/query: select_clause requires a list of fragments"
+  }
+  if len(fragments) == 0 {
+    throw "std/postgres/query: select_clause requires at least one fragment"
+  }
+  return "SELECT " + join(fragments, ", ")
+}
+
+/**
+ * Render `column::text AS column` for UUID columns.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: uuid_text("id")
+ */
+pub fn uuid_text(name: string) -> string {
+  let ident = identifier(name)
+  return ident + "::text AS " + ident
+}
+
+/**
+ * Render `to_json(column)#>>'{}' AS column` for timestamp columns.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: timestamptz_json("created_at")
+ */
+pub fn timestamptz_json(name: string) -> string {
+  let ident = identifier(name)
+  return "to_json(" + ident + ")#>>'{}' AS " + ident
+}
+
+/**
+ * Render a nullable timestamp projection that preserves nulls as null.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: nullable_timestamptz_json("finished_at")
+ */
+pub fn nullable_timestamptz_json(name: string) -> string {
+  let ident = identifier(name)
+  return "CASE WHEN "
+    + ident
+    + " IS NULL THEN NULL ELSE to_json("
+    + ident
+    + ")#>>'{}' END AS "
+    + ident
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -960,6 +960,35 @@ let graphemes = unicode_graphemes("éx")
 let parsed = uuid_parse(uuid_v7())
 ```
 
+### Postgres query helpers
+
+For Harn data-access modules, prefer `std/postgres/query` when direct
+`pg_query` calls become hard to review. It is not an ORM: SQL stays visible and
+dynamic values still go through `params`.
+
+```harn,ignore
+import "std/postgres"
+import { many, named, run, uuid_text, nullable_timestamptz_json, select_clause } from "std/postgres/query"
+
+fn list_receipts_query(tenant_id: string, limit: int) {
+  let sql = select_clause([
+    uuid_text("id"),
+    "payload",
+    nullable_timestamptz_json("finished_at"),
+  ]) + " FROM receipts WHERE tenant_id = $1::uuid ORDER BY created_at DESC LIMIT $2"
+  return named("list_receipts", "many", sql, [tenant_id, limit])
+}
+
+let rows = run(db, list_receipts_query(tenant_id, 50))
+let direct = many(db, {name: "recent_receipts", sql: "SELECT id::text AS id FROM receipts LIMIT $1", params: [10]})
+```
+
+Helpers: `one(handle, query)`, `many(handle, query)`, `exec(handle, query)`,
+`run(handle, named_query)`, `named(name, mode, sql, params?)`,
+`uuid_text(name)`, `timestamptz_json(name)`,
+`nullable_timestamptz_json(name)`, and `select_clause(fragments)`.
+Identifier helpers accept only static names matching `[A-Za-z_][A-Za-z0-9_]*`.
+
 ## LLM surface
 
 ```harn

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -764,6 +764,28 @@ claims, and audit records:
 See [Postgres](./postgres.md) for parameter binding, transaction settings,
 RLS examples, pool options, and migration boundaries.
 
+### std/postgres/query
+
+Harn-native query ergonomics over `std/postgres`. This module keeps raw SQL as
+the source of truth while making named query records and repeated projection
+fragments easier to review:
+
+| Function | Description |
+|---|---|
+| `named(name, mode, sql, params?)` | Build a serializable query record with `name`, `mode`, `sql`, and `params` |
+| `one(handle, query)` | Run a query record through `pg_query_one` |
+| `many(handle, query)` | Run a query record through `pg_query` |
+| `exec(handle, query)` | Run a query record through `pg_execute` |
+| `run(handle, named_query)` | Dispatch a named query by `mode` (`one`, `many`, or `exec`) |
+| `identifier(name)` | Validate a static SQL identifier for projection helpers |
+| `select_clause(fragments)` | Render `SELECT ...` from static projection fragments |
+| `uuid_text(name)` | Render `name::text AS name` |
+| `timestamptz_json(name)` | Render `to_json(name)#>>'{}' AS name` |
+| `nullable_timestamptz_json(name)` | Render a timestamp projection that preserves nulls |
+
+Dynamic values must still be passed through `params`; identifier helpers reject
+unsafe names and are only for source-controlled column identifiers.
+
 ### std/io
 
 Terminal-oriented helpers for scripts that need direct operator input without

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -88,6 +88,82 @@ nulls, booleans, integer and float types, text, `uuid`, `json`/`jsonb`, `bytea`,
 types, and Postgres geometric types. Unknown types are decoded as text when the
 Postgres driver can expose them that way.
 
+## Query ergonomics
+
+`std/postgres/query` is a small Harn-native layer over the raw `pg_*`
+builtins. It is not an ORM: SQL stays visible, Postgres-specific casts and
+operators stay available, and every dynamic value still goes through `params`.
+The helpers are intended for data-access modules where long inline SQL calls
+make reviews noisy.
+
+```harn,ignore
+import "std/postgres"
+import { many, named, nullable_timestamptz_json, run, select_clause, uuid_text } from "std/postgres/query"
+
+pub fn list_receipts_query(tenant_id: string, limit: int) {
+  let sql = select_clause([
+    uuid_text("id"),
+    uuid_text("tenant_id"),
+    "payload",
+    nullable_timestamptz_json("finished_at"),
+  ]) + " FROM receipts WHERE tenant_id = $1::uuid ORDER BY created_at DESC LIMIT $2"
+
+  return named("list_receipts", "many", sql, [tenant_id, limit])
+}
+
+pub fn list_receipts(db, tenant_id: string) {
+  return run(db, list_receipts_query(tenant_id, 50))
+}
+```
+
+For one-off call sites, pass a plain query record directly:
+
+```harn,ignore
+let rows = many(db, {
+  name: "list_receipts",
+  sql: "SELECT id::text AS id, payload FROM receipts WHERE tenant_id = $1::uuid",
+  params: [tenant_id],
+})
+```
+
+Compared with direct `pg_query`, named query records make the SQL and params
+easy to inspect in tests while keeping execution explicit:
+
+```harn,ignore
+let db = pg_mock_pool([
+  {
+    sql: "SELECT id::text AS id, payload FROM receipts WHERE tenant_id = $1::uuid",
+    params: ["tenant-a"],
+    rows: [{id: "r1", payload: {ok: true}}],
+  },
+])
+
+let rows = run(db, named(
+  "list_receipts",
+  "many",
+  "SELECT id::text AS id, payload FROM receipts WHERE tenant_id = $1::uuid",
+  ["tenant-a"],
+))
+assert_eq(rows[0].id, "r1")
+assert_eq(pg_mock_calls(db)[0].params[0], "tenant-a")
+```
+
+`one(handle, query)`, `many(handle, query)`, and `exec(handle, query)` force the
+matching mode when a record includes `mode`. `run(handle, named_query)` dispatches
+from the record's `mode`. When a named query fails, the thrown error includes
+the query name before the underlying Postgres or mock-pool error.
+
+Projection helpers only accept static SQL identifiers matching
+`[A-Za-z_][A-Za-z0-9_]*`. They are for source-controlled column names, not
+user input:
+
+| Helper | Output |
+|---|---|
+| `uuid_text("id")` | `id::text AS id` |
+| `timestamptz_json("created_at")` | `to_json(created_at)#>>'{}' AS created_at` |
+| `nullable_timestamptz_json("finished_at")` | `CASE WHEN finished_at IS NULL THEN NULL ELSE to_json(finished_at)#>>'{}' END AS finished_at` |
+| `select_clause([...])` | `SELECT ...` |
+
 ## Transactions and tenant settings
 
 Use `pg_transaction` for changes that must commit or roll back together. The


### PR DESCRIPTION
## Summary
- Add pure-Harn `std/postgres/query` with named query records, `one`/`many`/`exec`/`run`, and validated projection helpers.
- Register the module in the embedded stdlib catalog.
- Add mock-pool conformance coverage for exact SQL/params, helper dispatch, named errors, and unsafe identifier rejection.
- Document the module in the Postgres guide, module reference, LLM quickref, and changelog fragment.

Closes #3072.

## Verification
- `cargo run --quiet --bin harn -- test conformance --filter postgres_query_helpers`
- `cargo run --quiet --bin harn -- test conformance --filter postgres`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/postgres/query.harn`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/postgres/query.harn conformance/tests/stdlib/postgres_query_helpers.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/postgres/query.harn`
- `make fmt-harn`
- `make lint-harn`
- `make check-docs-snippets`
- `make lint-test-patterns`
- `cargo check -p harn-stdlib`
- pre-commit and pre-push hooks
