### PR TITLE
Add Postgres SQL template helpers

### DIFF
--- a/changelog.d/postgres-sql-template.added.md
+++ b/changelog.d/postgres-sql-template.added.md
@@ -1,0 +1,4 @@
+- **Postgres query templates.** `std/postgres/query` now includes
+  `sql(...)` and `named_sql(...)` helpers that turn readable `{name}` SQL
+  templates into `$n` parameterized query records, plus explicit identifier and
+  source-controlled fragment helpers for SQL structure.

--- a/conformance/tests/stdlib/postgres_query_helpers.expected
+++ b/conformance/tests/stdlib/postgres_query_helpers.expected
@@ -4,8 +4,21 @@ true
 1
 2026-06-05T12:00:00Z
 4
-SELECT id::text AS id FROM receipts WHERE id = $1::uuid
+SELECT id::text AS id FROM "receipts" WHERE id = $1::uuid
 r1
+true
+2
+true
+SELECT '{}' AS empty, $1 AS value
+ok
+SELECT * FROM "tenant data"."receipts""live"
+"select"
+SELECT $1
+danger
+true
+true
+true
+true
 true
 true
 true

--- a/conformance/tests/stdlib/postgres_query_helpers.harn
+++ b/conformance/tests/stdlib/postgres_query_helpers.harn
@@ -1,35 +1,71 @@
 import "std/postgres"
 import {
   exec,
+  ident,
+  ident_path,
   many,
   named,
+  named_sql,
   nullable_timestamptz_json,
   one,
+  quote_identifier,
   run,
   select_clause,
+  sql,
   timestamptz_json,
+  unsafe_sql,
   uuid_text,
 } from "std/postgres/query"
 
 pipeline default() {
-  let list_sql = select_clause(
-    [
-      uuid_text("id"),
-      uuid_text("tenant_id"),
-      "payload",
-      nullable_timestamptz_json("finished_at"),
-      timestamptz_json("created_at"),
-    ],
+  let list_query = named_sql(
+    "list_receipts",
+    "many",
+    """
+{projection}
+FROM {table}
+WHERE tenant_id = {tenant_id}::uuid
+  OR owner_tenant_id = {tenant_id}::uuid
+ORDER BY {created_column} DESC
+LIMIT {limit}
+""",
+    {
+      projection: unsafe_sql(
+        select_clause(
+          [
+            uuid_text("id"),
+            uuid_text("tenant_id"),
+            "payload",
+            nullable_timestamptz_json("finished_at"),
+            timestamptz_json("created_at"),
+          ],
+        ),
+      ),
+      table: ident("receipts"),
+      tenant_id: "tenant-a",
+      created_column: ident("created_at"),
+      limit: 25,
+    },
+    {read_only: true},
   )
-    + " FROM receipts WHERE tenant_id = $1::uuid ORDER BY created_at DESC"
-  let get_sql = "SELECT " + uuid_text("id") + " FROM receipts WHERE id = $1::uuid"
-  let update_sql = "UPDATE receipts SET status = $2 WHERE id = $1::uuid"
+  let get_query = named_sql(
+    "get_receipt",
+    "one",
+    "SELECT {id_projection} FROM {table} WHERE id = {id}::uuid",
+    {id_projection: unsafe_sql(uuid_text("id")), table: ident("receipts"), id: "r1"},
+  )
+  let update_query = named_sql(
+    "mark_receipt_read",
+    "exec",
+    "UPDATE {table} SET {status_column} = {status} WHERE id = {id}::uuid",
+    {table: ident("receipts"), status_column: ident("status"), status: "read", id: "r1"},
+  )
   let db = pg_mock_pool(
     [
-      {sql: get_sql, params: ["r1"], rows: [{id: "r1"}]},
+      {sql: get_query.sql, params: get_query.params, rows: [{id: "r1"}]},
       {
-        sql: list_sql,
-        params: ["tenant-a"],
+        sql: list_query.sql,
+        params: list_query.params,
         rows: [
           {
             id: "r1",
@@ -40,27 +76,55 @@ pipeline default() {
           },
         ],
       },
-      {sql: update_sql, params: ["r1", "read"], rows_affected: 1},
+      {sql: update_query.sql, params: update_query.params, rows_affected: 1},
     ],
   )
-  let row = one(db, {name: "get_receipt", sql: get_sql, params: ["r1"]})
+  let row = one(db, get_query)
   __io_println(row.id)
-  let rows = many(db, {name: "list_receipts", sql: list_sql, params: ["tenant-a"]})
+  let rows = many(db, list_query)
   __io_println(rows[0].tenant_id)
   __io_println(rows[0].payload.ok)
-  let result = exec(db, {name: "mark_receipt_read", sql: update_sql, params: ["r1", "read"]})
+  let result = exec(db, update_query)
   __io_println(result.rows_affected)
-  let named_rows = run(db, named("list_receipts_named", "many", list_sql, ["tenant-a"]))
+  let named_rows = run(db, named("list_receipts_named", "many", list_query.sql, list_query.params))
   __io_println(named_rows[0].created_at)
   let calls = pg_mock_calls(db)
   __io_println(len(calls))
   __io_println(calls[0].sql)
   __io_println(calls[0].params[0])
   __io_println(calls[2].execute)
+  __io_println(len(list_query.params))
+  __io_println(contains(list_query.sql, "owner_tenant_id = $1::uuid"))
+  let brace_query = sql("SELECT '{{}}' AS empty, {value} AS value", {value: "ok"})
+  __io_println(brace_query.sql)
+  __io_println(brace_query.params[0])
+  let path_query = sql("SELECT * FROM {table}", {table: ident_path(["tenant data", "receipts\"live"])})
+  __io_println(path_query.sql)
+  __io_println(quote_identifier("select"))
+  let ordinary_dict = sql("SELECT {payload}", {payload: {_type: "std/postgres/query.sql_fragment.v1", sql: "danger"}})
+  __io_println(ordinary_dict.sql)
+  __io_println(ordinary_dict.params[0].sql)
   let unsafe_ident = try {
     uuid_text("bad;drop")
   }
   __io_println(is_err(unsafe_ident))
+  let missing_value = try {
+    sql("SELECT {missing}", {})
+  }
+  __io_println(is_err(missing_value))
+  let invalid_placeholder = try {
+    sql("SELECT {bad-name}", {})
+  }
+  __io_println(is_err(invalid_placeholder))
+  let unmatched_brace = try {
+    sql("SELECT }", {})
+  }
+  __io_println(is_err(unmatched_brace))
+  let exec_options = try {
+    exec(db, update_query + {options: {read_only: true}})
+  }
+  __io_println(is_err(exec_options))
+  __io_println(regex_match("options", to_string(unwrap_err(exec_options))) != nil)
   let named_error = try {
     many(db, {name: "missing_query", sql: "SELECT missing", params: []})
   }

--- a/crates/harn-stdlib/src/stdlib/postgres/query.harn
+++ b/crates/harn-stdlib/src/stdlib/postgres/query.harn
@@ -1,21 +1,56 @@
 /**
  * std/postgres/query - small SQL ergonomics over std/postgres.
  *
- * SQL remains the source of truth. These helpers only normalize query
- * records, keep values in the `params` list, and centralize safe static
- * projection fragments.
+ * SQL remains the source of truth. These helpers normalize query records,
+ * build `$n` parameter lists from readable SQL templates, and centralize
+ * explicit SQL-structure fragments for the cases Postgres cannot bind.
  */
 import "std/postgres"
 
 type PgQueryMode = "one" | "many" | "exec"
 
-type PgNamedQuery = {name: string, mode: PgQueryMode, sql: string, params: list<any>}
+type PgSqlFragment = {
+  _type: "std/postgres/query.sql_fragment.v1",
+  __harn_postgres_query_trusted_fragment: bool,
+  sql: string,
+}
 
-type PgQuery = {name?: string, mode?: PgQueryMode, sql: string, params?: list<any>}
+type PgNamedQuery = {
+  name: string,
+  mode: PgQueryMode,
+  sql: string,
+  params: list<any>,
+  options?: dict,
+}
+
+type PgQuery = {name?: string, mode?: PgQueryMode, sql: string, params?: list<any>, options?: dict}
 
 let __QUERY_MODES = ["one", "many", "exec"]
 
 let __IDENTIFIER_PATTERN = "^[A-Za-z_][A-Za-z0-9_]*$"
+
+let __SQL_FRAGMENT_TYPE = "std/postgres/query.sql_fragment.v1"
+
+fn __sql_fragment(sql: string) -> PgSqlFragment {
+  if type_of(sql) != "string" {
+    throw "std/postgres/query: SQL fragment must be a string"
+  }
+  return {_type: __SQL_FRAGMENT_TYPE, __harn_postgres_query_trusted_fragment: true, sql: sql}
+}
+
+fn __is_sql_fragment(value) -> bool {
+  return type_of(value) == "dict"
+    && value?._type == __SQL_FRAGMENT_TYPE
+    && value?.__harn_postgres_query_trusted_fragment
+}
+
+fn __sql_fragment_text(value) -> string {
+  let fragment_sql = value?.sql
+  if type_of(fragment_sql) != "string" {
+    throw "std/postgres/query: SQL fragment sql must be a string"
+  }
+  return fragment_sql
+}
 
 fn __query_name(query) -> string {
   if type_of(query) != "dict" {
@@ -58,7 +93,11 @@ fn __normalize_query(query, expected_mode = nil) {
   if expected_mode != nil && query?.mode != nil && query.mode != expected_mode {
     throw __query_error_prefix(query) + "mode " + query.mode + " cannot run through " + expected_mode
   }
-  return {name: __query_name(query), mode: mode, sql: sql, params: params}
+  let options = query?.options
+  if options != nil && type_of(options) != "dict" {
+    throw __query_error_prefix(query) + "options must be a dict"
+  }
+  return {name: __query_name(query), mode: mode, sql: sql, params: params, options: options}
 }
 
 fn __with_query_name(query, body) {
@@ -70,6 +109,84 @@ fn __with_query_name(query, body) {
     }
     throw __query_error_prefix(query) + to_string(error)
   }
+}
+
+fn __find_placeholder_end(chars: list<string>, start: int) -> int {
+  var idx = start
+  while idx < len(chars) {
+    if chars[idx] == "}" {
+      return idx
+    }
+    idx = idx + 1
+  }
+  return -1
+}
+
+fn __render_placeholder(key: string, value, params: list<any>, positions: dict) {
+  if __is_sql_fragment(value) {
+    return {sql: __sql_fragment_text(value), params: params, positions: positions}
+  }
+  let existing = positions[key]
+  if existing != nil {
+    return {sql: "$" + to_string(existing), params: params, positions: positions}
+  }
+  let next = len(params) + 1
+  return {sql: "$" + to_string(next), params: params.push(value), positions: positions + {[key]: next}}
+}
+
+fn __render_sql_template(template: string, values: dict) {
+  if type_of(template) != "string" || trim(template) == "" {
+    throw "std/postgres/query: SQL template must be a non-empty string"
+  }
+  if type_of(values) != "dict" {
+    throw "std/postgres/query: SQL template values must be a dict"
+  }
+  let template_chars = chars(template)
+  var idx = 0
+  var out = ""
+  var params = []
+  var positions = {}
+  while idx < len(template_chars) {
+    let char = template_chars[idx]
+    if char == "{" {
+      if idx + 1 < len(template_chars) && template_chars[idx + 1] == "{" {
+        out = out + "{"
+        idx = idx + 2
+        continue
+      }
+      let end = __find_placeholder_end(template_chars, idx + 1)
+      if end < 0 {
+        throw "std/postgres/query: unclosed `{` in SQL template"
+      }
+      let key = trim(join(template_chars[idx + 1:end], ""))
+      if key == "" {
+        throw "std/postgres/query: empty SQL template placeholder"
+      }
+      if regex_match(__IDENTIFIER_PATTERN, key) == nil {
+        throw "std/postgres/query: invalid SQL template placeholder `" + key + "`"
+      }
+      if !contains(values.keys(), key) {
+        throw "std/postgres/query: missing SQL template value `" + key + "`"
+      }
+      let rendered = __render_placeholder(key, values[key], params, positions)
+      out = out + rendered.sql
+      params = rendered.params
+      positions = rendered.positions
+      idx = end + 1
+      continue
+    }
+    if char == "}" {
+      if idx + 1 < len(template_chars) && template_chars[idx + 1] == "}" {
+        out = out + "}"
+        idx = idx + 2
+        continue
+      }
+      throw "std/postgres/query: unmatched `}` in SQL template"
+    }
+    out = out + char
+    idx = idx + 1
+  }
+  return {sql: out, params: params}
 }
 
 /**
@@ -86,6 +203,47 @@ pub fn named(name: string, mode: PgQueryMode, sql: string, params: list<any> = [
 }
 
 /**
+ * Build a parameterized query record from a SQL template.
+ *
+ * `{name}` placeholders become `$1`, `$2`, ... bind parameters. Repeated
+ * placeholders reuse the first parameter index. Use `{{` and `}}` for literal
+ * braces, and pass `ident(...)`, `ident_path(...)`, or `unsafe_sql(...)` only
+ * for source-controlled SQL structure.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: sql("SELECT * FROM receipts WHERE tenant_id = {tenant_id}", {tenant_id: tenant_id})
+ */
+pub fn sql(template: string, values: dict = {}, options = nil) -> PgQuery {
+  let rendered = __render_sql_template(template, values)
+  return __normalize_query({sql: rendered.sql, params: rendered.params, options: options})
+}
+
+/**
+ * Build a named parameterized query record from a SQL template.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: named_sql("list_receipts", "many", "SELECT * FROM receipts WHERE tenant_id = {tenant_id}", {tenant_id: tenant_id})
+ */
+pub fn named_sql(
+  name: string,
+  mode: PgQueryMode,
+  template: string,
+  values: dict = {},
+  options = nil,
+) -> PgNamedQuery {
+  let rendered = __render_sql_template(template, values)
+  return __normalize_query(
+    {name: name, mode: mode, sql: rendered.sql, params: rendered.params, options: options},
+  )
+}
+
+/**
  * Run a query that returns zero or one row.
  *
  * @effects: [postgres]
@@ -96,7 +254,7 @@ pub fn named(name: string, mode: PgQueryMode, sql: string, params: list<any> = [
  */
 pub fn one(handle, query: PgQuery) {
   let q = __normalize_query(query, "one")
-  return __with_query_name(q, { -> pg_query_one(handle, q.sql, q.params) })
+  return __with_query_name(q, { -> pg_query_one(handle, q.sql, q.params, q.options) })
 }
 
 /**
@@ -110,7 +268,7 @@ pub fn one(handle, query: PgQuery) {
  */
 pub fn many(handle, query: PgQuery) -> list {
   let q = __normalize_query(query, "many")
-  return __with_query_name(q, { -> pg_query(handle, q.sql, q.params) })
+  return __with_query_name(q, { -> pg_query(handle, q.sql, q.params, q.options) })
 }
 
 /**
@@ -124,6 +282,9 @@ pub fn many(handle, query: PgQuery) -> list {
  */
 pub fn exec(handle, query: PgQuery) -> PgExecuteResult {
   let q = __normalize_query(query, "exec")
+  if q.options != nil {
+    throw __query_error_prefix(q) + "options are only supported by one and many"
+  }
   return __with_query_name(q, { -> pg_execute(handle, q.sql, q.params) })
 }
 
@@ -167,6 +328,75 @@ pub fn identifier(name: string) -> string {
     throw "std/postgres/query: unsafe SQL identifier `" + to_string(name) + "`"
   }
   return name
+}
+
+/**
+ * Quote one SQL identifier part with PostgreSQL double-quote escaping.
+ *
+ * Dynamic values still belong in template placeholders; quoted identifiers are
+ * only for SQL structure such as table or column names.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: quote_identifier("receipt events")
+ */
+pub fn quote_identifier(name: string) -> string {
+  if type_of(name) != "string" || trim(name) == "" {
+    throw "std/postgres/query: SQL identifier must be a non-empty string"
+  }
+  return "\"" + replace(name, "\"", "\"\"") + "\""
+}
+
+/**
+ * Render a quoted SQL identifier fragment for use inside `sql(...)`.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: sql("SELECT {column} FROM receipts", {column: ident("created_at")})
+ */
+pub fn ident(name: string) -> PgSqlFragment {
+  return __sql_fragment(quote_identifier(name))
+}
+
+/**
+ * Render a dotted quoted SQL identifier path for use inside `sql(...)`.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: ident_path(["app", "receipts"])
+ */
+pub fn ident_path(parts: list<string>) -> PgSqlFragment {
+  if type_of(parts) != "list" || len(parts) == 0 {
+    throw "std/postgres/query: SQL identifier path must be a non-empty list"
+  }
+  var quoted = []
+  for part in parts {
+    quoted = quoted.push(quote_identifier(part))
+  }
+  return __sql_fragment(join(quoted, "."))
+}
+
+/**
+ * Mark a source-controlled SQL fragment for insertion into `sql(...)`.
+ *
+ * This bypasses parameter binding and must never wrap user input. Prefer
+ * normal placeholders for values and `ident(...)` / `ident_path(...)` for
+ * identifiers.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: unsafe_sql("COUNT(*)")
+ */
+pub fn unsafe_sql(fragment: string) -> PgSqlFragment {
+  return __sql_fragment(fragment)
 }
 
 /**

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -964,30 +964,50 @@ let parsed = uuid_parse(uuid_v7())
 
 For Harn data-access modules, prefer `std/postgres/query` when direct
 `pg_query` calls become hard to review. It is not an ORM: SQL stays visible and
-dynamic values still go through `params`.
+dynamic values still go through Postgres bind parameters.
 
 ```harn,ignore
 import "std/postgres"
-import { many, named, run, uuid_text, nullable_timestamptz_json, select_clause } from "std/postgres/query"
+import { ident, many, named_sql, run, sql, unsafe_sql, uuid_text, nullable_timestamptz_json } from "std/postgres/query"
 
 fn list_receipts_query(tenant_id: string, limit: int) {
-  let sql = select_clause([
-    uuid_text("id"),
-    "payload",
-    nullable_timestamptz_json("finished_at"),
-  ]) + " FROM receipts WHERE tenant_id = $1::uuid ORDER BY created_at DESC LIMIT $2"
-  return named("list_receipts", "many", sql, [tenant_id, limit])
+  return named_sql(
+    "list_receipts",
+    "many",
+    """
+SELECT {id}, payload, {finished_at}
+FROM {table}
+WHERE tenant_id = {tenant_id}::uuid
+ORDER BY {created_at} DESC
+LIMIT {limit}
+""",
+    {
+      id: unsafe_sql(uuid_text("id")),
+      finished_at: unsafe_sql(nullable_timestamptz_json("finished_at")),
+      table: ident("receipts"),
+      tenant_id: tenant_id,
+      created_at: ident("created_at"),
+      limit: limit,
+    },
+    {read_only: true},
+  )
 }
 
 let rows = run(db, list_receipts_query(tenant_id, 50))
-let direct = many(db, {name: "recent_receipts", sql: "SELECT id::text AS id FROM receipts LIMIT $1", params: [10]})
+let direct = many(db, sql("SELECT id::text AS id FROM receipts LIMIT {limit}", {limit: 10}))
 ```
 
 Helpers: `one(handle, query)`, `many(handle, query)`, `exec(handle, query)`,
-`run(handle, named_query)`, `named(name, mode, sql, params?)`,
-`uuid_text(name)`, `timestamptz_json(name)`,
+`run(handle, named_query)`, `sql(template, values?, options?)`,
+`named_sql(name, mode, template, values?, options?)`,
+`named(name, mode, sql, params?)`, `ident(name)`, `ident_path(parts)`,
+`unsafe_sql(fragment)`, `uuid_text(name)`, `timestamptz_json(name)`,
 `nullable_timestamptz_json(name)`, and `select_clause(fragments)`.
-Identifier helpers accept only static names matching `[A-Za-z_][A-Za-z0-9_]*`.
+In `sql(...)`, ordinary `{name}` placeholders become `$n` params and repeated
+placeholders reuse the first parameter index. Use `{{` and `}}` for literal
+braces. SQL structure is never inferred from strings; use `ident(...)` /
+`ident_path(...)` for identifiers and reserve `unsafe_sql(...)` for
+source-controlled fragments.
 
 ## LLM surface
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -768,24 +768,32 @@ RLS examples, pool options, and migration boundaries.
 ### std/postgres/query
 
 Harn-native query ergonomics over `std/postgres`. This module keeps raw SQL as
-the source of truth while making named query records and repeated projection
-fragments easier to review:
+the source of truth while making SQL templates, named query records, and
+repeated projection fragments easier to review:
 
 | Function | Description |
 |---|---|
 | `named(name, mode, sql, params?)` | Build a serializable query record with `name`, `mode`, `sql`, and `params` |
+| `sql(template, values?, options?)` | Build a `{sql, params}` record by replacing `{name}` placeholders with `$n` bind parameters |
+| `named_sql(name, mode, template, values?, options?)` | Build a named query record from a SQL template |
 | `one(handle, query)` | Run a query record through `pg_query_one` |
 | `many(handle, query)` | Run a query record through `pg_query` |
 | `exec(handle, query)` | Run a query record through `pg_execute` |
 | `run(handle, named_query)` | Dispatch a named query by `mode` (`one`, `many`, or `exec`) |
 | `identifier(name)` | Validate a static SQL identifier for projection helpers |
+| `quote_identifier(name)` | Quote one SQL identifier part with PostgreSQL double-quote escaping |
+| `ident(name)` | Build a quoted identifier fragment for `sql(...)` |
+| `ident_path(parts)` | Build a dotted quoted identifier fragment for `sql(...)` |
+| `unsafe_sql(fragment)` | Mark a source-controlled SQL fragment for insertion into `sql(...)` |
 | `select_clause(fragments)` | Render `SELECT ...` from static projection fragments |
 | `uuid_text(name)` | Render `name::text AS name` |
 | `timestamptz_json(name)` | Render `to_json(name)#>>'{}' AS name` |
 | `nullable_timestamptz_json(name)` | Render a timestamp projection that preserves nulls |
 
-Dynamic values must still be passed through `params`; identifier helpers reject
-unsafe names and are only for source-controlled column identifiers.
+In SQL templates, ordinary `{name}` placeholders are always bound as params;
+use `{{` and `}}` for literal braces. SQL structure must be explicit through
+`ident(...)`, `ident_path(...)`, or `unsafe_sql(...)`; `unsafe_sql(...)` must
+only wrap source-controlled fragments.
 
 ### std/sqlite
 

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -92,23 +92,46 @@ Postgres driver can expose them that way.
 
 `std/postgres/query` is a small Harn-native layer over the raw `pg_*`
 builtins. It is not an ORM: SQL stays visible, Postgres-specific casts and
-operators stay available, and every dynamic value still goes through `params`.
+operators stay available, and every dynamic value still goes through Postgres
+bind parameters.
 The helpers are intended for data-access modules where long inline SQL calls
 make reviews noisy.
 
 ```harn,ignore
 import "std/postgres"
-import { many, named, nullable_timestamptz_json, run, select_clause, uuid_text } from "std/postgres/query"
+import {
+  ident,
+  many,
+  named_sql,
+  nullable_timestamptz_json,
+  run,
+  sql,
+  unsafe_sql,
+  uuid_text,
+} from "std/postgres/query"
 
 pub fn list_receipts_query(tenant_id: string, limit: int) {
-  let sql = select_clause([
-    uuid_text("id"),
-    uuid_text("tenant_id"),
-    "payload",
-    nullable_timestamptz_json("finished_at"),
-  ]) + " FROM receipts WHERE tenant_id = $1::uuid ORDER BY created_at DESC LIMIT $2"
-
-  return named("list_receipts", "many", sql, [tenant_id, limit])
+  return named_sql(
+    "list_receipts",
+    "many",
+    """
+SELECT {id}, {tenant_id_column}, payload, {finished_at}
+FROM {table}
+WHERE tenant_id = {tenant_id}::uuid
+ORDER BY {created_at} DESC
+LIMIT {limit}
+""",
+    {
+      id: unsafe_sql(uuid_text("id")),
+      tenant_id_column: unsafe_sql(uuid_text("tenant_id")),
+      finished_at: unsafe_sql(nullable_timestamptz_json("finished_at")),
+      table: ident("receipts"),
+      tenant_id: tenant_id,
+      created_at: ident("created_at"),
+      limit: limit,
+    },
+    {read_only: true},
+  )
 }
 
 pub fn list_receipts(db, tenant_id: string) {
@@ -116,14 +139,38 @@ pub fn list_receipts(db, tenant_id: string) {
 }
 ```
 
-For one-off call sites, pass a plain query record directly:
+`sql(template, values?)` and `named_sql(name, mode, template, values?)` replace
+ordinary `{name}` placeholders with `$1`, `$2`, ... and store the Harn values
+in `params`. If the same placeholder appears more than once, it reuses the
+first parameter index. Use `{{` and `}}` for literal braces:
 
 ```harn,ignore
-let rows = many(db, {
-  name: "list_receipts",
-  sql: "SELECT id::text AS id, payload FROM receipts WHERE tenant_id = $1::uuid",
-  params: [tenant_id],
-})
+let q = sql(
+  "SELECT '{{}}' AS empty_json, {tenant_id}::uuid AS tenant_id, {tenant_id}::uuid AS again",
+  {tenant_id: tenant_id},
+)
+// q.sql    == "SELECT '{}' AS empty_json, $1::uuid AS tenant_id, $1::uuid AS again"
+// q.params == [tenant_id]
+```
+
+Postgres cannot bind identifiers as parameters. Use `ident(...)` or
+`ident_path(...)` when SQL structure must be dynamic, and use `unsafe_sql(...)`
+only for source-controlled fragments such as projection helpers:
+
+```harn,ignore
+let q = sql(
+  "SELECT {column} FROM {table} WHERE tenant_id = {tenant_id}",
+  {column: ident("created_at"), table: ident_path(["app", "receipts"]), tenant_id: tenant_id},
+)
+```
+
+For one-off call sites, pass the template query record directly:
+
+```harn,ignore
+let rows = many(db, sql(
+  "SELECT id::text AS id, payload FROM receipts WHERE tenant_id = {tenant_id}::uuid",
+  {tenant_id: tenant_id},
+))
 ```
 
 Compared with direct `pg_query`, named query records make the SQL and params
@@ -151,7 +198,9 @@ assert_eq(pg_mock_calls(db)[0].params[0], "tenant-a")
 `one(handle, query)`, `many(handle, query)`, and `exec(handle, query)` force the
 matching mode when a record includes `mode`. `run(handle, named_query)` dispatches
 from the record's `mode`. When a named query fails, the thrown error includes
-the query name before the underlying Postgres or mock-pool error.
+the query name before the underlying Postgres or mock-pool error. Query records
+may include `options` for read routing; `one(...)` and `many(...)` pass those
+through to `pg_query_one` and `pg_query`.
 
 Projection helpers only accept static SQL identifiers matching
 `[A-Za-z_][A-Za-z0-9_]*`. They are for source-controlled column names, not


### PR DESCRIPTION
## Summary
- Add `std/postgres/query.sql(...)` and `named_sql(...)` to turn readable `{name}` SQL templates into `$n` parameterized query records.
- Add explicit SQL-structure helpers: quoted `ident(...)`, `ident_path(...)`, `quote_identifier(...)`, and noisy `unsafe_sql(...)` for source-controlled fragments.
- Thread query `options` through `one(...)` / `many(...)`, reject them for `exec(...)`, and cover repeated placeholders, literal braces, quoted identifiers, fragment marker collision safety, and validation errors in conformance.
- Update the Postgres guide, module reference, LLM quickref, and changelog fragment.

## Notes
- This does not change Harn syntax, the parser, tree-sitter grammar, or VS Code TextMate grammar. SQL-in-string highlighting should be a follow-up editor/semantic-token PR; today strings are single tree-sitter nodes, so precise SQL injection highlighting would need broader groundwork.

## Verification
- `cargo run --quiet --bin harn -- test conformance --filter postgres_query_helpers`
- `cargo run --quiet --bin harn -- test conformance --filter postgres`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/postgres/query.harn conformance/tests/stdlib/postgres_query_helpers.harn`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/postgres/query.harn conformance/tests/stdlib/postgres_query_helpers.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/postgres/query.harn conformance/tests/stdlib/postgres_query_helpers.harn`
- `make fmt-harn`
- `make lint-harn`
- `make check-docs-snippets`
- `make lint-test-patterns`
- `cargo check -p harn-stdlib`
- pre-commit hook
- pre-push hook
