### PR TITLE
[codex] Make LLM rate limits durable across processes

### DIFF
--- a/changelog.d/1873-llm-durable.changed.md
+++ b/changelog.d/1873-llm-durable.changed.md
@@ -1,0 +1,5 @@
+- **Durable LLM rate-limit admission.** Catalog and runtime LLM RPM/TPM
+  limits now use shared SQLite admission by default across Harn processes, so
+  parallel eval runners and worker fleets respect one provider/model quota
+  without relying on per-process sleeps or ad hoc environment-only guardrails
+  (#1873).

--- a/crates/harn-vm/src/durable_rate_limit.rs
+++ b/crates/harn-vm/src/durable_rate_limit.rs
@@ -16,7 +16,7 @@ const DEFAULT_BUSY_TIMEOUT_MS: u64 = 5_000;
 const MAX_SLEEP_MS: u64 = 60_000;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct RateBucket {
+pub(crate) struct RateBucket {
     key: String,
     limit: u64,
     units: u64,
@@ -24,10 +24,31 @@ struct RateBucket {
     window_ms: u64,
 }
 
+impl RateBucket {
+    pub(crate) fn new(key: String, limit: u64, units: u64, window_ms: u64) -> Self {
+        let charged_units = if units == 0 { 0 } else { units.min(limit) };
+        Self {
+            key,
+            limit,
+            units,
+            charged_units,
+            window_ms,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct ReserveAttempt {
     acquired: bool,
     retry_after_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DurableRateLimitOutcome {
+    pub(crate) acquired: bool,
+    pub(crate) timed_out: bool,
+    pub(crate) waited_ms: u64,
+    pub(crate) retry_after_ms: u64,
 }
 
 pub(crate) fn register_durable_rate_limit_builtins(vm: &mut Vm) {
@@ -56,77 +77,22 @@ async fn durable_rate_limit_acquire_impl(
 
     sandbox::enforce_fs_path("durable_rate_limit_acquire", &state_path, FsAccess::Write)?;
 
-    let started_ms = now_wall_ms();
-    let mut waited_ms = 0_u64;
-    loop {
-        if vm
-            .cancel_token
-            .as_ref()
-            .is_some_and(|token| token.load(std::sync::atomic::Ordering::SeqCst))
-        {
-            return Err(VmError::Thrown(VmValue::String(Arc::from(
-                "kind:cancelled:VM cancelled by host",
-            ))));
-        }
-
-        let now_ms = now_wall_ms();
-        let attempt_path = state_path.clone();
-        let attempt_buckets = buckets.clone();
-        let attempt = tokio::task::spawn_blocking(move || {
-            try_reserve_once(&attempt_path, &attempt_buckets, now_ms)
+    let outcome =
+        acquire_durable_rate_limit(state_path.clone(), buckets.clone(), timeout_ms, || {
+            vm.cancel_token
+                .as_ref()
+                .is_some_and(|token| token.load(std::sync::atomic::Ordering::SeqCst))
         })
-        .await
-        .map_err(|error| {
-            VmError::Runtime(format!(
-                "durable_rate_limit_acquire: worker failed: {error}"
-            ))
-        })??;
+        .await?;
 
-        if attempt.acquired {
-            return Ok(result_value(
-                true,
-                false,
-                waited_ms,
-                0,
-                &state_path,
-                &buckets,
-            ));
-        }
-
-        let retry_after_ms = attempt.retry_after_ms.max(1);
-        let elapsed_ms = now_ms.saturating_sub(started_ms).max(0) as u64;
-        if let Some(timeout_ms) = timeout_ms {
-            if elapsed_ms >= timeout_ms {
-                return Ok(result_value(
-                    false,
-                    true,
-                    waited_ms,
-                    retry_after_ms,
-                    &state_path,
-                    &buckets,
-                ));
-            }
-            let remaining_ms = timeout_ms.saturating_sub(elapsed_ms);
-            if retry_after_ms > remaining_ms {
-                if remaining_ms > 0 {
-                    sleep_ms(remaining_ms).await;
-                    waited_ms = waited_ms.saturating_add(remaining_ms);
-                }
-                return Ok(result_value(
-                    false,
-                    true,
-                    waited_ms,
-                    retry_after_ms,
-                    &state_path,
-                    &buckets,
-                ));
-            }
-        }
-
-        let sleep_for_ms = retry_after_ms.min(MAX_SLEEP_MS);
-        sleep_ms(sleep_for_ms).await;
-        waited_ms = waited_ms.saturating_add(sleep_for_ms);
-    }
+    Ok(result_value(
+        outcome.acquired,
+        outcome.timed_out,
+        outcome.waited_ms,
+        outcome.retry_after_ms,
+        &state_path,
+        &buckets,
+    ))
 }
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[&DURABLE_RATE_LIMIT_ACQUIRE_IMPL_DEF];
@@ -198,14 +164,7 @@ fn parse_bucket(dict: &BTreeMap<String, VmValue>) -> Result<RateBucket, VmError>
             "durable_rate_limit_acquire: bucket.window_ms must be positive".to_string(),
         ));
     }
-    let charged_units = if units == 0 { 0 } else { units.min(limit) };
-    Ok(RateBucket {
-        key,
-        limit,
-        units,
-        charged_units,
-        window_ms,
-    })
+    Ok(RateBucket::new(key, limit, units, window_ms))
 }
 
 fn required_string_field(
@@ -354,6 +313,78 @@ fn try_reserve_once(
     })
 }
 
+pub(crate) async fn acquire_durable_rate_limit<F>(
+    state_path: PathBuf,
+    buckets: Vec<RateBucket>,
+    timeout_ms: Option<u64>,
+    is_cancelled: F,
+) -> Result<DurableRateLimitOutcome, VmError>
+where
+    F: Fn() -> bool,
+{
+    let started_ms = now_wall_ms();
+    let mut waited_ms = 0_u64;
+    loop {
+        if is_cancelled() {
+            return Err(VmError::Thrown(VmValue::String(Arc::from(
+                "kind:cancelled:VM cancelled by host",
+            ))));
+        }
+
+        let now_ms = now_wall_ms();
+        let attempt_path = state_path.clone();
+        let attempt_buckets = buckets.clone();
+        let attempt = tokio::task::spawn_blocking(move || {
+            try_reserve_once(&attempt_path, &attempt_buckets, now_ms)
+        })
+        .await
+        .map_err(|error| {
+            VmError::Runtime(format!(
+                "durable_rate_limit_acquire: worker failed: {error}"
+            ))
+        })??;
+
+        if attempt.acquired {
+            return Ok(DurableRateLimitOutcome {
+                acquired: true,
+                timed_out: false,
+                waited_ms,
+                retry_after_ms: 0,
+            });
+        }
+
+        let retry_after_ms = attempt.retry_after_ms.max(1);
+        let elapsed_ms = now_ms.saturating_sub(started_ms).max(0) as u64;
+        if let Some(timeout_ms) = timeout_ms {
+            if elapsed_ms >= timeout_ms {
+                return Ok(DurableRateLimitOutcome {
+                    acquired: false,
+                    timed_out: true,
+                    waited_ms,
+                    retry_after_ms,
+                });
+            }
+            let remaining_ms = timeout_ms.saturating_sub(elapsed_ms);
+            if retry_after_ms > remaining_ms {
+                if remaining_ms > 0 {
+                    sleep_ms(remaining_ms).await;
+                    waited_ms = waited_ms.saturating_add(remaining_ms);
+                }
+                return Ok(DurableRateLimitOutcome {
+                    acquired: false,
+                    timed_out: true,
+                    waited_ms,
+                    retry_after_ms,
+                });
+            }
+        }
+
+        let sleep_for_ms = retry_after_ms.min(MAX_SLEEP_MS);
+        sleep_ms(sleep_for_ms).await;
+        waited_ms = waited_ms.saturating_add(sleep_for_ms);
+    }
+}
+
 fn prune_bucket(
     tx: &rusqlite::Transaction<'_>,
     bucket: &RateBucket,
@@ -486,305 +517,4 @@ fn bucket_list_value(buckets: &[RateBucket]) -> VmValue {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{compile_source, register_vm_stdlib, reset_thread_local_state, Vm};
-    use std::sync::Barrier;
-
-    async fn run_harn(base_dir: &std::path::Path, source: &str) -> Vec<String> {
-        reset_thread_local_state();
-        let chunk = compile_source(source).expect("compile source");
-        let mut vm = Vm::new();
-        register_vm_stdlib(&mut vm);
-        vm.set_source_dir(base_dir);
-        vm.execute(&chunk).await.expect("execute source");
-        vm.output()
-            .trim_end()
-            .lines()
-            .map(ToString::to_string)
-            .collect()
-    }
-
-    fn bucket(key: &str, limit: u64, units: u64, window_ms: u64) -> RateBucket {
-        RateBucket {
-            key: key.to_string(),
-            limit,
-            units,
-            charged_units: units.min(limit),
-            window_ms,
-        }
-    }
-
-    fn usage(path: &Path, key: &str) -> u64 {
-        let conn = Connection::open(path).expect("open sqlite");
-        conn.query_row(
-            "SELECT COALESCE(SUM(units), 0)
-             FROM durable_rate_limit_entries
-             WHERE bucket_key = ?1",
-            params![key],
-            |row| row.get::<_, i64>(0),
-        )
-        .expect("query")
-        .max(0) as u64
-    }
-
-    #[test]
-    fn reserve_blocks_until_window_expires() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("rate.sqlite");
-        let buckets = vec![bucket("provider:rpm", 1, 1, 1_000)];
-
-        assert!(
-            try_reserve_once(&path, &buckets, 10_000)
-                .expect("first reserve")
-                .acquired
-        );
-        let blocked = try_reserve_once(&path, &buckets, 10_250).expect("blocked reserve");
-        assert_eq!(
-            blocked,
-            ReserveAttempt {
-                acquired: false,
-                retry_after_ms: 750
-            }
-        );
-        assert!(
-            try_reserve_once(&path, &buckets, 11_000)
-                .expect("expired reserve")
-                .acquired
-        );
-    }
-
-    #[test]
-    fn multi_bucket_reservation_is_atomic_when_one_bucket_is_full() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("rate.sqlite");
-        let first = vec![
-            bucket("provider:rpm", 1, 1, 1_000),
-            bucket("model:tpm", 100, 50, 1_000),
-        ];
-        assert!(
-            try_reserve_once(&path, &first, 1_000)
-                .expect("initial reserve")
-                .acquired
-        );
-
-        let second = vec![
-            bucket("provider:rpm", 1, 1, 1_000),
-            bucket("model:tpm", 100, 10, 1_000),
-        ];
-        let blocked = try_reserve_once(&path, &second, 1_100).expect("blocked reserve");
-        assert!(!blocked.acquired);
-        assert_eq!(usage(&path, "model:tpm"), 50);
-    }
-
-    #[test]
-    fn oversized_reservation_charges_one_full_window() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("rate.sqlite");
-        let buckets = vec![bucket("model:tpm", 100, 250, 1_000)];
-
-        assert!(
-            try_reserve_once(&path, &buckets, 1_000)
-                .expect("oversized reserve")
-                .acquired
-        );
-        assert_eq!(usage(&path, "model:tpm"), 100);
-    }
-
-    #[test]
-    fn concurrent_threads_do_not_over_reserve_shared_bucket() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join("rate.sqlite");
-        let buckets = vec![bucket("provider:rpm", 1, 1, 60_000)];
-        let barrier = Arc::new(Barrier::new(8));
-
-        let mut handles = Vec::new();
-        for _ in 0..8 {
-            let path = path.clone();
-            let buckets = buckets.clone();
-            let barrier = barrier.clone();
-            handles.push(std::thread::spawn(move || {
-                barrier.wait();
-                try_reserve_once(&path, &buckets, 1_000).expect("reserve")
-            }));
-        }
-
-        let attempts: Vec<_> = handles
-            .into_iter()
-            .map(|handle| handle.join().expect("thread"))
-            .collect();
-        assert_eq!(
-            attempts.iter().filter(|attempt| attempt.acquired).count(),
-            1
-        );
-        assert_eq!(
-            attempts.iter().filter(|attempt| !attempt.acquired).count(),
-            7
-        );
-        assert_eq!(usage(&path, "provider:rpm"), 1);
-    }
-
-    #[test]
-    fn duplicate_bucket_keys_are_rejected() {
-        let options = BTreeMap::from([(
-            "buckets".to_string(),
-            VmValue::List(Arc::new(vec![
-                VmValue::Dict(Arc::new(BTreeMap::from([
-                    ("key".to_string(), VmValue::String(Arc::from("same"))),
-                    ("limit".to_string(), VmValue::Int(1)),
-                ]))),
-                VmValue::Dict(Arc::new(BTreeMap::from([
-                    ("key".to_string(), VmValue::String(Arc::from("same"))),
-                    ("limit".to_string(), VmValue::Int(1)),
-                ]))),
-            ])),
-        )]);
-        let error = parse_buckets(&options).expect_err("duplicate keys should fail");
-        assert!(error.to_string().contains("duplicate bucket key `same`"));
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn harn_builtin_returns_structured_timeout_without_real_sleep() {
-        tokio::task::LocalSet::new()
-            .run_until(async {
-                let temp = tempfile::tempdir().expect("tempdir");
-                let state_path = harn_string_path(temp.path().join("rate.sqlite"));
-                let source = r#"
-pipeline main(task) {
-  mock_time(1000)
-  let first = durable_rate_limit_acquire({
-    state_path: "__STATE_PATH__",
-    key: "provider:rpm",
-    limit: 1,
-    units: 1,
-    window_ms: 1000,
-  })
-  let second = durable_rate_limit_acquire({
-    state_path: "__STATE_PATH__",
-    key: "provider:rpm",
-    limit: 1,
-    units: 1,
-    window_ms: 1000,
-    timeout_ms: 0,
-  })
-  __io_println(to_string(first.ok))
-  __io_println(to_string(second.ok))
-  __io_println(to_string(second.timed_out))
-  __io_println(to_string(second.retry_after_ms))
-}
-"#
-                .replace("__STATE_PATH__", &state_path);
-                let lines = run_harn(temp.path(), &source).await;
-                assert_eq!(lines, vec!["true", "false", "true", "1000"]);
-            })
-            .await;
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn harn_parallel_tasks_share_one_durable_bucket() {
-        tokio::task::LocalSet::new()
-            .run_until(async {
-                let temp = tempfile::tempdir().expect("tempdir");
-                let state_path = harn_string_path(temp.path().join("rate.sqlite"));
-                let source = r#"
-pipeline main(task) {
-  mock_time(1000)
-  let attempts = parallel each [1, 2, 3, 4] with { max_concurrent: 4 } { _ ->
-    durable_rate_limit_acquire({
-      state_path: "__STATE_PATH__",
-      key: "provider:rpm",
-      limit: 1,
-      units: 1,
-      window_ms: 60000,
-      timeout_ms: 0,
-    })
-  }
-  var successes = 0
-  var timeouts = 0
-  for attempt in attempts {
-    if attempt.ok {
-      successes = successes + 1
-    }
-    if attempt.timed_out {
-      timeouts = timeouts + 1
-    }
-  }
-  __io_println(to_string(successes))
-  __io_println(to_string(timeouts))
-}
-"#
-                .replace("__STATE_PATH__", &state_path);
-                let lines = run_harn(temp.path(), &source).await;
-                assert_eq!(lines, vec!["1", "3"]);
-            })
-            .await;
-    }
-
-    #[test]
-    fn harn_vms_on_multiple_threads_share_one_durable_bucket() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let base_dir = temp.path().to_path_buf();
-        let state_path = harn_string_path(temp.path().join("rate.sqlite"));
-        let source = Arc::new(
-            r#"
-pipeline main(task) {
-  let attempt = durable_rate_limit_acquire({
-    state_path: "__STATE_PATH__",
-    key: "provider:rpm",
-    limit: 1,
-    units: 1,
-    window_ms: 60000,
-    timeout_ms: 0,
-  })
-  __io_println(to_string(attempt.ok))
-  __io_println(to_string(attempt.timed_out))
-}
-"#
-            .replace("__STATE_PATH__", &state_path),
-        );
-        let barrier = Arc::new(Barrier::new(4));
-
-        let mut handles = Vec::new();
-        for _ in 0..4 {
-            let base_dir = base_dir.clone();
-            let source = source.clone();
-            let barrier = barrier.clone();
-            handles.push(std::thread::spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_time()
-                    .build()
-                    .expect("current-thread runtime");
-                barrier.wait();
-                runtime.block_on(
-                    tokio::task::LocalSet::new()
-                        .run_until(async { run_harn(&base_dir, &source).await }),
-                )
-            }));
-        }
-
-        let outputs: Vec<_> = handles
-            .into_iter()
-            .map(|handle| handle.join().expect("thread"))
-            .collect();
-        assert_eq!(
-            outputs
-                .iter()
-                .filter(|lines| lines.as_slice() == ["true", "false"])
-                .count(),
-            1
-        );
-        assert_eq!(
-            outputs
-                .iter()
-                .filter(|lines| lines.as_slice() == ["false", "true"])
-                .count(),
-            3
-        );
-    }
-
-    fn harn_string_path(path: PathBuf) -> String {
-        path.to_string_lossy()
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"")
-    }
-}
+mod tests;

--- a/crates/harn-vm/src/durable_rate_limit/tests.rs
+++ b/crates/harn-vm/src/durable_rate_limit/tests.rs
@@ -1,0 +1,297 @@
+use super::*;
+use crate::{compile_source, register_vm_stdlib, reset_thread_local_state, Vm};
+use rusqlite::{params, Connection};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Barrier};
+
+async fn run_harn(base_dir: &std::path::Path, source: &str) -> Vec<String> {
+    reset_thread_local_state();
+    let chunk = compile_source(source).expect("compile source");
+    let mut vm = Vm::new();
+    register_vm_stdlib(&mut vm);
+    vm.set_source_dir(base_dir);
+    vm.execute(&chunk).await.expect("execute source");
+    vm.output()
+        .trim_end()
+        .lines()
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn bucket(key: &str, limit: u64, units: u64, window_ms: u64) -> RateBucket {
+    RateBucket::new(key.to_string(), limit, units, window_ms)
+}
+
+fn usage(path: &Path, key: &str) -> u64 {
+    let conn = Connection::open(path).expect("open sqlite");
+    conn.query_row(
+        "SELECT COALESCE(SUM(units), 0)
+         FROM durable_rate_limit_entries
+         WHERE bucket_key = ?1",
+        params![key],
+        |row| row.get::<_, i64>(0),
+    )
+    .expect("query")
+    .max(0) as u64
+}
+
+#[test]
+fn reserve_blocks_until_window_expires() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("rate.sqlite");
+    let buckets = vec![bucket("provider:rpm", 1, 1, 1_000)];
+
+    assert!(
+        try_reserve_once(&path, &buckets, 10_000)
+            .expect("first reserve")
+            .acquired
+    );
+    let blocked = try_reserve_once(&path, &buckets, 10_250).expect("blocked reserve");
+    assert_eq!(
+        blocked,
+        ReserveAttempt {
+            acquired: false,
+            retry_after_ms: 750
+        }
+    );
+    assert!(
+        try_reserve_once(&path, &buckets, 11_000)
+            .expect("expired reserve")
+            .acquired
+    );
+}
+
+#[test]
+fn multi_bucket_reservation_is_atomic_when_one_bucket_is_full() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("rate.sqlite");
+    let first = vec![
+        bucket("provider:rpm", 1, 1, 1_000),
+        bucket("model:tpm", 100, 50, 1_000),
+    ];
+    assert!(
+        try_reserve_once(&path, &first, 1_000)
+            .expect("initial reserve")
+            .acquired
+    );
+
+    let second = vec![
+        bucket("provider:rpm", 1, 1, 1_000),
+        bucket("model:tpm", 100, 10, 1_000),
+    ];
+    let blocked = try_reserve_once(&path, &second, 1_100).expect("blocked reserve");
+    assert!(!blocked.acquired);
+    assert_eq!(usage(&path, "model:tpm"), 50);
+}
+
+#[test]
+fn oversized_reservation_charges_one_full_window() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("rate.sqlite");
+    let buckets = vec![bucket("model:tpm", 100, 250, 1_000)];
+
+    assert!(
+        try_reserve_once(&path, &buckets, 1_000)
+            .expect("oversized reserve")
+            .acquired
+    );
+    assert_eq!(usage(&path, "model:tpm"), 100);
+}
+
+#[test]
+fn concurrent_threads_do_not_over_reserve_shared_bucket() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("rate.sqlite");
+    let buckets = vec![bucket("provider:rpm", 1, 1, 60_000)];
+    let barrier = Arc::new(Barrier::new(8));
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let path = path.clone();
+        let buckets = buckets.clone();
+        let barrier = barrier.clone();
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            try_reserve_once(&path, &buckets, 1_000).expect("reserve")
+        }));
+    }
+
+    let attempts: Vec<_> = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("thread"))
+        .collect();
+    assert_eq!(
+        attempts.iter().filter(|attempt| attempt.acquired).count(),
+        1
+    );
+    assert_eq!(
+        attempts.iter().filter(|attempt| !attempt.acquired).count(),
+        7
+    );
+    assert_eq!(usage(&path, "provider:rpm"), 1);
+}
+
+#[test]
+fn duplicate_bucket_keys_are_rejected() {
+    let options = BTreeMap::from([(
+        "buckets".to_string(),
+        VmValue::List(Arc::new(vec![
+            VmValue::Dict(Arc::new(BTreeMap::from([
+                ("key".to_string(), VmValue::String(Arc::from("same"))),
+                ("limit".to_string(), VmValue::Int(1)),
+            ]))),
+            VmValue::Dict(Arc::new(BTreeMap::from([
+                ("key".to_string(), VmValue::String(Arc::from("same"))),
+                ("limit".to_string(), VmValue::Int(1)),
+            ]))),
+        ])),
+    )]);
+    let error = parse_buckets(&options).expect_err("duplicate keys should fail");
+    assert!(error.to_string().contains("duplicate bucket key `same`"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn harn_builtin_returns_structured_timeout_without_real_sleep() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let state_path = harn_string_path(temp.path().join("rate.sqlite"));
+            let source = r#"
+pipeline main(task) {
+  mock_time(1000)
+  let first = durable_rate_limit_acquire({
+    state_path: "__STATE_PATH__",
+    key: "provider:rpm",
+    limit: 1,
+    units: 1,
+    window_ms: 1000,
+  })
+  let second = durable_rate_limit_acquire({
+    state_path: "__STATE_PATH__",
+    key: "provider:rpm",
+    limit: 1,
+    units: 1,
+    window_ms: 1000,
+    timeout_ms: 0,
+  })
+  __io_println(to_string(first.ok))
+  __io_println(to_string(second.ok))
+  __io_println(to_string(second.timed_out))
+  __io_println(to_string(second.retry_after_ms))
+}
+"#
+            .replace("__STATE_PATH__", &state_path);
+            let lines = run_harn(temp.path(), &source).await;
+            assert_eq!(lines, vec!["true", "false", "true", "1000"]);
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn harn_parallel_tasks_share_one_durable_bucket() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let state_path = harn_string_path(temp.path().join("rate.sqlite"));
+            let source = r#"
+pipeline main(task) {
+  mock_time(1000)
+  let attempts = parallel each [1, 2, 3, 4] with { max_concurrent: 4 } { _ ->
+    durable_rate_limit_acquire({
+      state_path: "__STATE_PATH__",
+      key: "provider:rpm",
+      limit: 1,
+      units: 1,
+      window_ms: 60000,
+      timeout_ms: 0,
+    })
+  }
+  var successes = 0
+  var timeouts = 0
+  for attempt in attempts {
+    if attempt.ok {
+      successes = successes + 1
+    }
+    if attempt.timed_out {
+      timeouts = timeouts + 1
+    }
+  }
+  __io_println(to_string(successes))
+  __io_println(to_string(timeouts))
+}
+"#
+            .replace("__STATE_PATH__", &state_path);
+            let lines = run_harn(temp.path(), &source).await;
+            assert_eq!(lines, vec!["1", "3"]);
+        })
+        .await;
+}
+
+#[test]
+fn harn_vms_on_multiple_threads_share_one_durable_bucket() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let base_dir = temp.path().to_path_buf();
+    let state_path = harn_string_path(temp.path().join("rate.sqlite"));
+    let source = Arc::new(
+        r#"
+pipeline main(task) {
+  let attempt = durable_rate_limit_acquire({
+    state_path: "__STATE_PATH__",
+    key: "provider:rpm",
+    limit: 1,
+    units: 1,
+    window_ms: 60000,
+    timeout_ms: 0,
+  })
+  __io_println(to_string(attempt.ok))
+  __io_println(to_string(attempt.timed_out))
+}
+"#
+        .replace("__STATE_PATH__", &state_path),
+    );
+    let barrier = Arc::new(Barrier::new(4));
+
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let base_dir = base_dir.clone();
+        let source = source.clone();
+        let barrier = barrier.clone();
+        handles.push(std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .expect("current-thread runtime");
+            barrier.wait();
+            runtime.block_on(
+                tokio::task::LocalSet::new()
+                    .run_until(async { run_harn(&base_dir, &source).await }),
+            )
+        }));
+    }
+
+    let outputs: Vec<_> = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("thread"))
+        .collect();
+    assert_eq!(
+        outputs
+            .iter()
+            .filter(|lines| lines.as_slice() == ["true", "false"])
+            .count(),
+        1
+    );
+    assert_eq!(
+        outputs
+            .iter()
+            .filter(|lines| lines.as_slice() == ["false", "true"])
+            .count(),
+        3
+    );
+}
+
+fn harn_string_path(path: PathBuf) -> String {
+    path.to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -25,6 +25,7 @@ pub mod composition;
 pub mod config;
 pub mod connectors;
 pub mod corrections;
+pub(crate) mod durable_rate_limit;
 pub mod egress;
 pub mod event_log;
 pub mod events;

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -905,7 +905,7 @@ pub(crate) async fn observed_llm_call(
         .unwrap_or_else(|| crate::llm_config::default_tool_format(&opts.model, &opts.provider));
     let mut attempt = 0usize;
     loop {
-        let rate_limit_permit = super::rate_limit::acquire_permit_for_llm_call(opts).await;
+        let rate_limit_permit = super::rate_limit::acquire_permit_for_llm_call(opts).await?;
 
         let call_id = next_call_id();
         let prompt_chars: usize = opts

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -563,7 +563,7 @@ async fn with_rate_limit_builtin(
     let mut attempt: usize = 0;
     loop {
         let (result, output) = {
-            let _rate_limit_permit = rate_limit::acquire_permit(&provider).await;
+            let _rate_limit_permit = rate_limit::acquire_permit(&provider).await?;
             let mut child_vm = ctx.child_vm();
             let result = child_vm.call_closure_pub(&closure, &[]).await;
             let output = child_vm.take_output();

--- a/crates/harn-vm/src/llm/rate_limit.rs
+++ b/crates/harn-vm/src/llm/rate_limit.rs
@@ -9,13 +9,21 @@
 //! 1. provider/model catalog `rate_limits` fields and legacy provider `rpm`
 //! 2. environment variables such as `HARN_RATE_LIMIT_<PROVIDER>_TPM=1000000`
 //! 3. runtime `llm_rate_limit("provider", {rpm: N, tpm: M})`
+//!
+//! Request/token buckets are durable across processes by default when a route
+//! has rate limits. `HARN_LLM_RATE_LIMIT_STATE_PATH` overrides the shared DB
+//! path and `HARN_LLM_RATE_LIMIT_DURABLE=0` disables the durable layer for
+//! debugging or constrained embeddings.
 
 use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
+const DURABLE_RATE_LIMIT_ENABLED_ENV: &str = "HARN_LLM_RATE_LIMIT_DURABLE";
+const DURABLE_RATE_LIMIT_STATE_PATH_ENV: &str = "HARN_LLM_RATE_LIMIT_STATE_PATH";
 const WINDOW_SECS: u64 = 60;
 const RATE_LIMIT_ENV_FIELD_SUFFIXES: [&str; 5] =
     ["_RPM", "_TPM", "_INPUT_TPM", "_OUTPUT_TPM", "_CONCURRENCY"];
@@ -535,6 +543,124 @@ fn record_for_keys(
     }
 }
 
+fn durable_rate_limit_disabled() -> bool {
+    let Ok(raw) = std::env::var(DURABLE_RATE_LIMIT_ENABLED_ENV) else {
+        return false;
+    };
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "0" | "false" | "off" | "none" | "disabled"
+    )
+}
+
+fn durable_state_path() -> Option<PathBuf> {
+    if durable_rate_limit_disabled() {
+        return None;
+    }
+
+    if let Ok(raw) = std::env::var(DURABLE_RATE_LIMIT_STATE_PATH_ENV) {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            let path = PathBuf::from(trimmed);
+            return if path.is_absolute() {
+                Some(path)
+            } else {
+                std::env::current_dir().ok().map(|cwd| cwd.join(path))
+            };
+        }
+    }
+
+    let base = crate::stdlib::process::runtime_root_base();
+    Some(crate::runtime_paths::state_root(&base).join("llm-rate-limits.sqlite"))
+}
+
+fn durable_bucket(
+    key: &str,
+    suffix: &str,
+    limit: u64,
+    units: u64,
+) -> crate::durable_rate_limit::RateBucket {
+    crate::durable_rate_limit::RateBucket::new(
+        format!("llm:{key}:{suffix}"),
+        limit.max(1),
+        units,
+        WINDOW_SECS * 1000,
+    )
+}
+
+fn durable_buckets_for_keys(
+    registry: &RateLimitRegistry,
+    keys: &[String],
+    request: RateLimitRequest,
+) -> Vec<crate::durable_rate_limit::RateBucket> {
+    let mut buckets = Vec::new();
+    for key in keys {
+        let Some(limiter) = registry.limiters.get(key) else {
+            continue;
+        };
+        if let Some(rpm) = limiter.limits.rpm {
+            buckets.push(durable_bucket(key, "rpm", u64::from(rpm), 1));
+        }
+        if let Some(tpm) = limiter.limits.tpm {
+            buckets.push(durable_bucket(key, "tpm", tpm, request.total_tokens()));
+        }
+        if let Some(input_tpm) = limiter.limits.input_tpm {
+            buckets.push(durable_bucket(
+                key,
+                "input_tpm",
+                input_tpm,
+                request.input_tokens,
+            ));
+        }
+        if let Some(output_tpm) = limiter.limits.output_tpm {
+            buckets.push(durable_bucket(
+                key,
+                "output_tpm",
+                output_tpm,
+                request.output_tokens,
+            ));
+        }
+    }
+    buckets
+}
+
+async fn acquire_durable_for_keys(
+    state_path: PathBuf,
+    provider: &str,
+    model: &str,
+    keys: &[String],
+    request: RateLimitRequest,
+) -> Result<(), crate::value::VmError> {
+    let buckets = {
+        let registry = registry().lock().expect("rate limiter mutex poisoned");
+        durable_buckets_for_keys(&registry, keys, request)
+    };
+    if buckets.is_empty() {
+        return Ok(());
+    }
+    let outcome =
+        crate::durable_rate_limit::acquire_durable_rate_limit(state_path, buckets, None, || false)
+            .await?;
+    if outcome.waited_ms > 0 {
+        let route = if model.trim().is_empty() {
+            provider.to_string()
+        } else {
+            format!(
+                "{provider}/{}",
+                crate::llm_config::normalize_model_id(model)
+            )
+        };
+        crate::events::log_debug(
+            "llm.rate_limit",
+            &format!(
+                "Durable rate limit for '{}': waited {}ms",
+                route, outcome.waited_ms
+            ),
+        );
+    }
+    Ok(())
+}
+
 async fn sleep_after_throttle(provider: &str, model: &str, duration: Duration) {
     let route = if model.trim().is_empty() {
         provider.to_string()
@@ -559,9 +685,14 @@ async fn acquire_permit_for(
     provider: &str,
     model: &str,
     request: RateLimitRequest,
-) -> RateLimitPermit {
+) -> Result<RateLimitPermit, crate::value::VmError> {
     ensure_initialized_from_config();
     let keys = limiter_keys(provider, model);
+    if let Some(state_path) = durable_state_path() {
+        let permits = acquire_concurrency(&keys).await;
+        acquire_durable_for_keys(state_path, provider, model, &keys, request).await?;
+        return Ok(RateLimitPermit { _permits: permits });
+    }
     loop {
         if let Some(duration) = {
             let mut registry = registry().lock().expect("rate limiter mutex poisoned");
@@ -587,13 +718,15 @@ async fn acquire_permit_for(
             continue;
         }
 
-        return RateLimitPermit { _permits: permits };
+        return Ok(RateLimitPermit { _permits: permits });
     }
 }
 
 /// Wait until the provider rate limit allows an opaque request, then record it.
 /// Returns immediately if no limit is configured or the window has capacity.
-pub(crate) async fn acquire_permit(provider: &str) -> RateLimitPermit {
+pub(crate) async fn acquire_permit(
+    provider: &str,
+) -> Result<RateLimitPermit, crate::value::VmError> {
     acquire_permit_for(provider, "", RateLimitRequest::default()).await
 }
 
@@ -602,7 +735,7 @@ pub(crate) async fn acquire_permit(provider: &str) -> RateLimitPermit {
 /// concurrency limits cover in-flight calls rather than just launch rate.
 pub(crate) async fn acquire_permit_for_llm_call(
     opts: &super::api::LlmCallOptions,
-) -> RateLimitPermit {
+) -> Result<RateLimitPermit, crate::value::VmError> {
     acquire_permit_for(
         &opts.provider,
         &opts.model,
@@ -680,9 +813,63 @@ mod tests {
         crate::llm_config::set_user_overrides(Some(overlay));
     }
 
+    fn install_durable_overlay() {
+        let overlay = crate::llm_config::parse_config_toml(
+            "[providers.durable]\n\
+             base_url = \"https://durable.invalid/v1\"\n\
+             chat_endpoint = \"/chat/completions\"\n\
+             rate_limits = { rpm = 1 }\n",
+        )
+        .expect("durable overlay parses");
+        crate::llm_config::set_user_overrides(Some(overlay));
+    }
+
     fn reset_test_rate_limit_state() {
         reset_rate_limit_state();
         crate::llm_config::clear_user_overrides();
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        old: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set_value(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let old = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, old }
+        }
+
+        fn set_path(key: &'static str, value: &std::path::Path) -> Self {
+            Self::set_value(key, value)
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.old.as_ref() {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn durable_usage(path: &std::path::Path, key: &str) -> u64 {
+        if !path.exists() {
+            return 0;
+        }
+        let conn = rusqlite::Connection::open(path).expect("open durable rate limit db");
+        conn.query_row(
+            "SELECT COALESCE(SUM(units), 0)
+             FROM durable_rate_limit_entries
+             WHERE bucket_key = ?1",
+            rusqlite::params![key],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query durable usage")
+        .max(0) as u64
     }
 
     #[test]
@@ -768,6 +955,7 @@ mod tests {
     #[test]
     fn concurrency_queue_does_not_consume_request_quota_until_started() {
         let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _durable_disabled = EnvVarGuard::set_value(DURABLE_RATE_LIMIT_ENABLED_ENV, "0");
         reset_test_rate_limit_state();
         install_concurrency_overlay();
         init_from_config();
@@ -778,7 +966,7 @@ mod tests {
             .expect("current-thread runtime");
 
         runtime.block_on(async {
-            let first = acquire_permit("queue").await;
+            let first = acquire_permit("queue").await.expect("first permit");
             assert_eq!(provider_request_usage("queue"), 1);
 
             let second = tokio::spawn(async { acquire_permit("queue").await });
@@ -789,16 +977,92 @@ mod tests {
             assert_eq!(provider_request_usage("queue"), 1);
 
             drop(first);
-            for _ in 0..5 {
-                if second.is_finished() {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-            assert!(second.is_finished());
-            let second = second.await.expect("second task completed");
+            let second = tokio::time::timeout(std::time::Duration::from_secs(2), second)
+                .await
+                .expect("second task should acquire after first permit drops")
+                .expect("second task completed")
+                .expect("second permit");
             assert_eq!(provider_request_usage("queue"), 2);
             drop(second);
+        });
+
+        reset_test_rate_limit_state();
+    }
+
+    #[test]
+    fn durable_concurrency_queue_does_not_consume_request_quota_until_started() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        reset_test_rate_limit_state();
+        install_concurrency_overlay();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state_path = temp.path().join("llm-rate-limits.sqlite");
+        let _env = EnvVarGuard::set_path(DURABLE_RATE_LIMIT_STATE_PATH_ENV, &state_path);
+        init_from_config();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("current-thread runtime");
+
+        runtime.block_on(async {
+            let first = acquire_permit("queue").await.expect("first permit");
+            assert_eq!(durable_usage(&state_path, "llm:provider:queue:rpm"), 1);
+
+            let second = tokio::spawn(async { acquire_permit("queue").await });
+            for _ in 0..5 {
+                tokio::task::yield_now().await;
+            }
+            assert!(!second.is_finished());
+            assert_eq!(durable_usage(&state_path, "llm:provider:queue:rpm"), 1);
+
+            drop(first);
+            let second = tokio::time::timeout(std::time::Duration::from_secs(2), second)
+                .await
+                .expect("second task should acquire after first permit drops")
+                .expect("second task completed")
+                .expect("second permit");
+            assert_eq!(durable_usage(&state_path, "llm:provider:queue:rpm"), 2);
+            drop(second);
+        });
+
+        reset_test_rate_limit_state();
+    }
+
+    #[test]
+    fn durable_state_path_coordinates_after_process_local_reset() {
+        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        reset_test_rate_limit_state();
+        install_durable_overlay();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _env = EnvVarGuard::set_path(
+            DURABLE_RATE_LIMIT_STATE_PATH_ENV,
+            &temp.path().join("llm-rate-limits.sqlite"),
+        );
+        let _clock =
+            crate::clock_mock::install_override(crate::clock_mock::MockClock::at_wall_ms(1_000));
+        init_from_config();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("current-thread runtime");
+
+        runtime.block_on(async {
+            let first = acquire_permit("durable").await.expect("first permit");
+            drop(first);
+
+            reset_rate_limit_state();
+            init_from_config();
+
+            let before = crate::clock_mock::now_ms();
+            let second = acquire_permit("durable").await.expect("second permit");
+            let after = crate::clock_mock::now_ms();
+            drop(second);
+
+            assert!(
+                after.saturating_sub(before) >= 60_000,
+                "second process-local registry should wait on durable SQLite state"
+            );
         });
 
         reset_test_rate_limit_state();

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -38,7 +38,6 @@ mod cookies;
 mod crypto;
 mod csv;
 mod datetime;
-mod durable_rate_limit;
 mod durable_step;
 mod event_log;
 mod external_agent;
@@ -71,7 +70,7 @@ mod net_policy;
 mod oauth_dynreg;
 mod oauth_storage;
 pub(crate) mod observability;
-mod options;
+pub(crate) mod options;
 mod path;
 pub(crate) mod path_scope_guard;
 pub(crate) mod pool;
@@ -181,7 +180,7 @@ pub fn register_io_stdlib(vm: &mut Vm) {
     // Clock builtins overlay process::timestamp/elapsed so they honor
     // mock_time / advance_time. Register AFTER process to take precedence.
     clock::register_clock_builtins(vm);
-    durable_rate_limit::register_durable_rate_limit_builtins(vm);
+    crate::durable_rate_limit::register_durable_rate_limit_builtins(vm);
     testbench::register_testbench_builtins(vm);
     project::register_project_builtins(vm);
     grounding::register_grounding_builtins(vm);

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -4010,8 +4010,12 @@ Per-provider and per-model rate limiting is built in:
   to acquire a permit and auto-retry retryable failures.
 
 RPM/TPM shape sustained throughput; route `concurrency` and
-`max_concurrent` cap simultaneous in-flight work. Use both when
-batching LLM calls at scale.
+`max_concurrent` cap simultaneous in-flight work. RPM/TPM buckets are
+durable across Harn processes by default, using SQLite under Harn's runtime
+state root. Set `HARN_LLM_RATE_LIMIT_STATE_PATH` only to force an explicit
+shared path for an eval fleet, and set `HARN_LLM_RATE_LIMIT_DURABLE=0` only
+for constrained tests or embeddings. Use throughput and concurrency limits
+together when batching LLM calls at scale.
 
 ## Cache (`std/cache`)
 

--- a/docs/src/concurrency.md
+++ b/docs/src/concurrency.md
@@ -645,7 +645,9 @@ the throughput layer. Harn enforces catalog `rate_limits` metadata
 before each `llm_call`: requests per minute (`rpm`), total tokens per
 minute (`tpm`), split input/output token buckets (`input_tpm`,
 `output_tpm`), and route concurrency. Requests past the budget wait
-for the window to free up rather than error.
+for the window to free up rather than error. RPM/TPM buckets are durable
+across Harn processes by default, so parallel CLI, eval, and worker
+processes share the same sliding-window admission state.
 
 Configure provider limits via:
 
@@ -660,10 +662,14 @@ Configure provider limits via:
 
 The controls compose: `max_concurrent` prevents caller-side bursts,
 route `concurrency` caps in-flight provider calls, and RPM/TPM shapes
-sustained throughput. When batching hundreds of LLM calls against a
-local single-GPU server or a low-tier hosted key, set both concurrency
-and token/request throughput caps so a burst does not exhaust the
-minute window and drop requests.
+sustained throughput. Harn stores the default durable limiter under its
+runtime state root; set `HARN_LLM_RATE_LIMIT_STATE_PATH` only when a
+fleet runner needs an explicit shared SQLite path, and set
+`HARN_LLM_RATE_LIMIT_DURABLE=0` only to bypass the durable layer in
+constrained tests or embeddings. When batching hundreds of LLM calls
+against a local single-GPU server or a low-tier hosted key, set both
+concurrency and token/request throughput caps so a burst does not
+exhaust the minute window and drop requests.
 
 ## Connector task groups
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -659,7 +659,12 @@ let active = llm_rate_limit("anthropic", {details: true})
 ```
 
 The limiter uses a sliding-window budget and pauses before sending requests
-that would exceed the configured request or token quota.
+that would exceed the configured request or token quota. Request and token
+buckets are durable across Harn processes by default, using a SQLite state file
+under Harn's runtime state root. Fleet runners that need every child process to
+share one explicit file can set `HARN_LLM_RATE_LIMIT_STATE_PATH`; constrained
+tests or embeddings can disable the durable layer with
+`HARN_LLM_RATE_LIMIT_DURABLE=0`.
 
 ## Troubleshooting
 
@@ -667,8 +672,10 @@ that would exceed the configured request or token quota.
   set for your provider. Run `echo $ANTHROPIC_API_KEY` to verify.
 - **Wrong provider selected** — Set `HARN_LLM_PROVIDER` explicitly to
   override automatic detection.
-- **Rate limit errors** — Use `HARN_RATE_LIMIT_<PROVIDER>_RPM` and
-  `HARN_RATE_LIMIT_<PROVIDER>_TPM` to throttle requests below your plan's
-  applied limits. `HARN_RATE_LIMIT_<PROVIDER>` remains a legacy RPM shorthand.
+- **Rate limit errors** — Prefer fixing the provider/model catalog
+  `rate_limits` entry for shared defaults. Use `HARN_RATE_LIMIT_<PROVIDER>_RPM`
+  and `HARN_RATE_LIMIT_<PROVIDER>_TPM` only when your local key has a different
+  paid/custom quota. `HARN_RATE_LIMIT_<PROVIDER>` remains a legacy RPM
+  shorthand.
 - **Debug message shapes** — Set `HARN_DEBUG_MESSAGE_SHAPES=1` to log
   the structure of messages sent to the LLM provider.


### PR DESCRIPTION
## Summary
- route LLM RPM/TPM/input/output token buckets through the SQLite durable rate-limit substrate by default
- keep route concurrency process-local but acquire it before durable quota so queued work does not consume request budget
- split durable limiter tests out of the production module and document catalog/runtime limits as the normal guardrail path

Refs burin-labs/burin-code#1873.

## Verification
- cargo test -p harn-vm llm::rate_limit -- --nocapture
- cargo test -p harn-vm durable_rate_limit -- --nocapture
- cargo test -p harn-vm --test builtin_registry_alignment -- --nocapture
- cargo test -p harn-vm --test builtin_signature_text_drift -- --nocapture
- cargo clippy -p harn-vm --all-targets -- -D warnings
- make check-docs-snippets
- pre-commit/pre-push targeted checks