### PR TITLE
Honor retry-after with trailing punctuation

### DIFF
--- a/changelog.d/retry-after-punctuation.fixed.md
+++ b/changelog.d/retry-after-punctuation.fixed.md
@@ -1,0 +1,4 @@
+- **LLM retry-after handling now parses provider messages with trailing
+  punctuation.** Rate-limit retries such as Cerebras
+  `(retry-after: 60))` now honor the full provider delay instead of falling
+  back to short exponential retries that can immediately hit another 429.

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -223,8 +223,12 @@ pub(crate) fn parse_retry_after(msg: &str) -> Option<u64> {
     if value.is_empty() {
         return None;
     }
-    if let Some(num_str) = value.split_whitespace().next() {
-        if let Ok(secs) = num_str.parse::<f64>() {
+    let numeric_prefix = value
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit() || *ch == '.')
+        .collect::<String>();
+    if !numeric_prefix.is_empty() {
+        if let Ok(secs) = numeric_prefix.parse::<f64>() {
             if !secs.is_finite() || secs < 0.0 {
                 return Some(0);
             }
@@ -1440,6 +1444,12 @@ mod retry_tests {
     #[test]
     fn retry_after_fractional_seconds() {
         assert_eq!(parse_retry_after("retry-after: 2.5"), Some(2_500));
+    }
+
+    #[test]
+    fn retry_after_seconds_with_provider_message_punctuation() {
+        let msg = "cerebras HTTP 429 Too Many Requests [rate_limited]: Tokens per minute limit exceeded (type: too_many_tokens_error, code: token_quota_exceeded) (retry-after: 60))";
+        assert_eq!(parse_retry_after(msg), Some(60_000));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse `retry-after` numeric prefixes even when provider error messages include trailing punctuation
- keep honoring decimal retry delays and the existing 60s cap
- add a regression test for the Cerebras 429 shape observed during Burin meter-stick baseline runs

## Why
During local SHA validation for the Burin eval meter stick, Cerebras returned messages like:

`token_quota_exceeded ... (retry-after: 60))`

The existing parser split on whitespace, tried to parse `60))`, failed, and fell back to short exponential retries. That makes quota pressure noisier across concurrent eval/runtime work and hides provider intent. This keeps the retry path deterministic while preserving the broader durable limiter behavior already merged.

## Verification
- `cargo fmt --all --check`
- `cargo test -p harn-vm retry_after_seconds_with_provider_message_punctuation --lib`
- `cargo test -p harn-vm retry_after --lib`
- pre-commit hook
- pre-push hook
