### PR TITLE
Stabilize bytecode codegen fingerprints

### DIFF
--- a/changelog.d/codegen-fingerprint.fixed.md
+++ b/changelog.d/codegen-fingerprint.fixed.md
@@ -1,0 +1,4 @@
+- **Bytecode cache fingerprints are now checkout-path stable.** Harn no longer
+  bakes absolute compiler source paths into `HARN_CODEGEN_FINGERPRINT`, so
+  precompiled `.harnbc` artifacts generated from the same Harn source match
+  across Linux, macOS, and separate local worktrees.

--- a/crates/harn-vm/build.rs
+++ b/crates/harn-vm/build.rs
@@ -19,74 +19,23 @@
 //! recompile; omitting a code-generation input would reintroduce the bug, so
 //! the set is deliberately drawn wide around the front-end.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use sha2::{Digest, Sha256};
+#[path = "build_support/codegen_fingerprint.rs"]
+mod codegen_fingerprint;
 
 fn main() {
     let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    let crates_dir = manifest_dir.parent().expect("crate dir has a parent");
-
-    // Directory roots whose `.rs` content determines emitted bytecode.
-    let roots = [
-        crates_dir.join("harn-lexer").join("src"),
-        crates_dir.join("harn-parser").join("src"),
-        crates_dir.join("harn-ir").join("src"),
-        manifest_dir.join("src").join("compiler"),
-    ];
-    // Single files outside those roots that still shape the bytecode/`Chunk`
-    // format written to and read from the cache.
-    let single_files = [manifest_dir.join("src").join("chunk.rs")];
-
-    let mut files = Vec::new();
-    for root in &roots {
-        collect_rs_files(root, &mut files);
-    }
-    for file in &single_files {
-        if file.is_file() {
-            files.push(file.clone());
-        }
-    }
-    // Stable order → reproducible digest across builds.
-    files.sort();
-
-    let mut hasher = Sha256::new();
-    for path in &files {
-        println!("cargo:rerun-if-changed={}", path.display());
-        // Mix the path in too, so adding/removing/renaming a file shifts the
-        // digest even when total content is unchanged.
-        hasher.update(path.to_string_lossy().as_bytes());
-        hasher.update([0u8]);
-        if let Ok(bytes) = std::fs::read(path) {
-            hasher.update(&bytes);
-        }
+    let inputs = codegen_fingerprint::compiler_inputs(&manifest_dir);
+    for input in &inputs {
+        println!("cargo:rerun-if-changed={}", input.disk_path.display());
     }
     // Watch the roots themselves so file additions and removals also retrigger
     // the build script, not just edits to already-tracked files.
-    for root in &roots {
+    for root in codegen_fingerprint::watch_roots(&manifest_dir) {
         println!("cargo:rerun-if-changed={}", root.display());
     }
 
-    // `sha2`'s digest is a byte `Array` that does not implement `LowerHex`, so
-    // hex-encode it ourselves.
-    let digest = hasher.finalize();
-    let hex: String = digest.iter().map(|byte| format!("{byte:02x}")).collect();
+    let hex = codegen_fingerprint::fingerprint_inputs(&inputs);
     println!("cargo:rustc-env=HARN_CODEGEN_FINGERPRINT={hex}");
-}
-
-/// Recursively collect every `.rs` file under `dir`. A missing directory is
-/// skipped so the build still succeeds outside the workspace (e.g. a packaged
-/// crate), degrading to whatever sources are present.
-fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_rs_files(&path, out);
-        } else if path.extension().is_some_and(|ext| ext == "rs") {
-            out.push(path);
-        }
-    }
 }

--- a/crates/harn-vm/build_support/codegen_fingerprint.rs
+++ b/crates/harn-vm/build_support/codegen_fingerprint.rs
@@ -1,0 +1,101 @@
+use std::path::{Component, Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompilerInput {
+    pub logical_path: String,
+    pub disk_path: PathBuf,
+}
+
+pub fn compiler_inputs(manifest_dir: &Path) -> Vec<CompilerInput> {
+    let crates_dir = manifest_dir.parent().expect("crate dir has a parent");
+    let mut inputs = Vec::new();
+
+    let roots = [
+        (crates_dir.join("harn-lexer").join("src"), "harn-lexer/src"),
+        (
+            crates_dir.join("harn-parser").join("src"),
+            "harn-parser/src",
+        ),
+        (crates_dir.join("harn-ir").join("src"), "harn-ir/src"),
+        (
+            manifest_dir.join("src").join("compiler"),
+            "harn-vm/src/compiler",
+        ),
+    ];
+    for (root, logical_prefix) in roots {
+        collect_rs_files(&root, logical_prefix, &mut inputs);
+    }
+
+    let chunk = manifest_dir.join("src").join("chunk.rs");
+    if chunk.is_file() {
+        inputs.push(CompilerInput {
+            logical_path: "harn-vm/src/chunk.rs".to_string(),
+            disk_path: chunk,
+        });
+    }
+
+    inputs.sort_by(|left, right| left.logical_path.cmp(&right.logical_path));
+    inputs
+}
+
+pub fn watch_roots(manifest_dir: &Path) -> Vec<PathBuf> {
+    let crates_dir = manifest_dir.parent().expect("crate dir has a parent");
+    vec![
+        crates_dir.join("harn-lexer").join("src"),
+        crates_dir.join("harn-parser").join("src"),
+        crates_dir.join("harn-ir").join("src"),
+        manifest_dir.join("src").join("compiler"),
+    ]
+}
+
+pub fn fingerprint_inputs(inputs: &[CompilerInput]) -> String {
+    let mut hasher = Sha256::new();
+    for input in inputs {
+        hasher.update(input.logical_path.as_bytes());
+        hasher.update([0u8]);
+        if let Ok(bytes) = std::fs::read(&input.disk_path) {
+            hasher.update(&bytes);
+        }
+    }
+    let digest = hasher.finalize();
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn collect_rs_files(root: &Path, logical_prefix: &str, out: &mut Vec<CompilerInput>) {
+    collect_rs_files_under(root, root, logical_prefix, out);
+}
+
+fn collect_rs_files_under(
+    root: &Path,
+    dir: &Path,
+    logical_prefix: &str,
+    out: &mut Vec<CompilerInput>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files_under(root, &path, logical_prefix, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            let relative = path.strip_prefix(root).unwrap_or(path.as_path());
+            out.push(CompilerInput {
+                logical_path: format!("{logical_prefix}/{}", normalize_path(relative)),
+                disk_path: path,
+            });
+        }
+    }
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => Some(segment.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}

--- a/crates/harn-vm/tests/codegen_fingerprint.rs
+++ b/crates/harn-vm/tests/codegen_fingerprint.rs
@@ -1,0 +1,55 @@
+#[path = "../build_support/codegen_fingerprint.rs"]
+mod codegen_fingerprint;
+
+use std::fs;
+use std::path::Path;
+
+use codegen_fingerprint::{compiler_inputs, fingerprint_inputs, watch_roots};
+
+#[test]
+fn codegen_fingerprint_is_checkout_path_stable() {
+    let left = tempfile::tempdir().unwrap();
+    let right = tempfile::tempdir().unwrap();
+    seed_compiler_sources(left.path(), "return 1;");
+    seed_compiler_sources(right.path(), "return 1;");
+    assert_eq!(watch_roots(&left.path().join("harn-vm")).len(), 4);
+
+    let left_hash = fingerprint_inputs(&compiler_inputs(&left.path().join("harn-vm")));
+    let right_hash = fingerprint_inputs(&compiler_inputs(&right.path().join("harn-vm")));
+
+    assert_eq!(
+        left_hash, right_hash,
+        "same compiler sources in different checkout roots must produce the same fingerprint"
+    );
+}
+
+#[test]
+fn codegen_fingerprint_changes_when_input_content_changes() {
+    let left = tempfile::tempdir().unwrap();
+    let right = tempfile::tempdir().unwrap();
+    seed_compiler_sources(left.path(), "return 1;");
+    seed_compiler_sources(right.path(), "return 2;");
+
+    let left_hash = fingerprint_inputs(&compiler_inputs(&left.path().join("harn-vm")));
+    let right_hash = fingerprint_inputs(&compiler_inputs(&right.path().join("harn-vm")));
+
+    assert_ne!(
+        left_hash, right_hash,
+        "compiler source edits must still invalidate bytecode cache keys"
+    );
+}
+
+fn seed_compiler_sources(root: &Path, compiler_body: &str) {
+    let files = [
+        ("harn-lexer/src/lib.rs", "pub fn lex() {}"),
+        ("harn-parser/src/lib.rs", "pub fn parse() {}"),
+        ("harn-ir/src/lib.rs", "pub fn lower() {}"),
+        ("harn-vm/src/compiler/state.rs", compiler_body),
+        ("harn-vm/src/chunk.rs", "pub struct Chunk;"),
+    ];
+    for (relative, contents) in files {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- make `HARN_CODEGEN_FINGERPRINT` hash crate-relative compiler input paths instead of absolute checkout paths
- keep Cargo rebuild tracking on real disk paths while making bytecode cache keys portable across Linux/macOS/worktrees
- add focused in-process tests for checkout-path stability and content invalidation

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-stable-codegen cargo test -p harn-vm --test codegen_fingerprint`
- `CARGO_TARGET_DIR=/tmp/harn-target-stable-codegen cargo test -p harn-vm codegen_fingerprint --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-stable-codegen cargo build -p harn-cli --bin harn`
- Burin injected-binary smoke from `/Users/ksinder/projects/burin-code-worktrees/bytecode-drift-080`: `/tmp/harn-target-stable-codegen/debug/harn precompile --quiet --out <tmp> Sources/BurinCore/Resources/host-pipelines` twice, then `cmp` each `.harnbc` pair`
- Harn pre-commit and pre-push hooks passed

## Root cause
The stale Burin `.harnbc` check was not caused by payload drift. Only the 32-byte `import_graph_hash` header differed. Harn v0.8.80 folded `HARN_CODEGEN_FINGERPRINT` into that header, and the build script computed the fingerprint from absolute Rust source paths. Same source bytes built under Linux runner paths and macOS local paths therefore produced different bytecode cache keys.