### PR TITLE
[codex] Harden agent recovery and provider cooldowns

### DIFF
--- a/changelog.d/3094.fixed.md
+++ b/changelog.d/3094.fixed.md
@@ -1,0 +1,4 @@
+- **Agent loop recovery and provider cooldowns are more robust (#3094).**
+  Agent loops now turn zero-dispatch tool-call protocol violations into
+  actionable retry feedback, and provider `Retry-After` rate-limit signals
+  temporarily cool down matching provider/model routes across subsequent calls.

--- a/conformance/tests/agents/agent_loop_dynamic_llm_context.expected
+++ b/conformance/tests/agents/agent_loop_dynamic_llm_context.expected
@@ -1,0 +1,1 @@
+dynamic llm context ok

--- a/conformance/tests/agents/agent_loop_dynamic_llm_context.harn
+++ b/conformance/tests/agents/agent_loop_dynamic_llm_context.harn
@@ -1,0 +1,81 @@
+import { agent_capture_events } from "std/agent/events"
+
+fn iteration_events(events) {
+  return events.filter({ event -> event.type == "iteration_start" })
+}
+
+pipeline test(task) {
+  let call_count = atomic(0)
+  let first_context_ok = atomic(0)
+  let second_context_ok = atomic(0)
+  let second_call_options_ok = atomic(0)
+  let caller = { call ->
+    let index = atomic_add(call_count, 1) + 1
+    if index == 1
+      && contains(call?.system ?? "", "ctx provider=cheap-provider model=cheap-model") {
+      atomic_set(first_context_ok, 1)
+    }
+    if index == 2
+      && contains(call?.system ?? "", "ctx provider=frontier-provider model=frontier-model") {
+      atomic_set(second_context_ok, 1)
+    }
+    if index == 2
+      && call?.opts?.provider == "frontier-provider"
+      && call?.opts?.model == "frontier-model" {
+      atomic_set(second_call_options_ok, 1)
+    }
+    let text = if index == 1 {
+      "still working"
+    } else {
+      "<user_response>done</user_response>\n<done>##DONE##</done>"
+    }
+    return {
+      ok: true,
+      value: {
+        text: text,
+        provider: call?.opts?.provider ?? "",
+        model: call?.opts?.model ?? "",
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    }
+  }
+  let session = "agent-loop-dynamic-llm-context-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "finish",
+      nil,
+      {
+        provider: "cheap-provider",
+        model: "cheap-model",
+        session_id: session,
+        llm_caller: caller,
+        loop_until_done: true,
+        done_judge: false,
+        max_iterations: 2,
+        prompts: {
+          "agent.loop_contract": {text: "ctx provider={{ llm.provider }} model={{ llm.model }} sentinel={{ done_sentinel }}"},
+        },
+        post_turn_callback: { info ->
+          if info?.iteration == 0 {
+            return {
+              message: "escalating after first turn",
+              llm_options: {provider: "frontier-provider", model: "frontier-model"},
+            }
+          }
+          return nil
+        },
+      },
+    ) },
+  )
+  let starts = iteration_events(captured.events)
+  assert(captured.result.status == "done", "loop completed after dynamic model switch")
+  assert(atomic_get(call_count) == 2, "two LLM calls were made")
+  assert(atomic_get(first_context_ok) == 1, "first turn rendered cheap model context")
+  assert(atomic_get(second_context_ok) == 1, "second turn rendered frontier model context")
+  assert(atomic_get(second_call_options_ok) == 1, "second call used frontier options")
+  assert(starts[1].provider == "frontier-provider", "iteration telemetry used frontier provider")
+  assert(starts[1].model == "frontier-model", "iteration telemetry used frontier model")
+  __io_println("dynamic llm context ok")
+}

--- a/conformance/tests/agents/agent_loop_protocol_violation_feedback.expected
+++ b/conformance/tests/agents/agent_loop_protocol_violation_feedback.expected
@@ -1,0 +1,5 @@
+done
+write_note
+true
+true
+true

--- a/conformance/tests/agents/agent_loop_protocol_violation_feedback.expected
+++ b/conformance/tests/agents/agent_loop_protocol_violation_feedback.expected
@@ -3,3 +3,6 @@ write_note
 true
 true
 true
+done
+true
+true

--- a/conformance/tests/agents/agent_loop_protocol_violation_feedback.harn
+++ b/conformance/tests/agents/agent_loop_protocol_violation_feedback.harn
@@ -45,4 +45,28 @@ pipeline default() {
       __io_println(!contains(retry_messages, "no_progress_streak"))
     },
   )
+  with_llm_script(
+    [llm_text("_call>_call>"), llm_text("##DONE##")],
+    { ->
+      let result = agent_loop(
+        "Write notes.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          done_judge: nil,
+          max_iterations: 3,
+          max_nudges: 3,
+          tools: note_tools(),
+        },
+      )
+      let calls = llm_mock_calls()
+      let retry_messages = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(!contains(retry_messages, "parse_guidance"))
+      __io_println(!contains(retry_messages, "Stray text outside response tags"))
+    },
+  )
 }

--- a/conformance/tests/agents/agent_loop_protocol_violation_feedback.harn
+++ b/conformance/tests/agents/agent_loop_protocol_violation_feedback.harn
@@ -1,0 +1,48 @@
+import { llm_text, with_llm_script } from "std/testing"
+
+fn note_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note.",
+    {
+      handler: { args -> "wrote " + args.path },
+      parameters: {path: {type: "string", description: "Path to write"}},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+  return tools
+}
+
+pipeline default() {
+  with_llm_script(
+    [
+      llm_text("_call>_call>"),
+      llm_text("<tool_call>\nwrite_note({ path: \"notes.txt\" })\n</tool_call>"),
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Write notes.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "text",
+          loop_until_done: true,
+          max_iterations: 5,
+          max_nudges: 5,
+          tools: note_tools(),
+        },
+      )
+      let calls = llm_mock_calls()
+      let retry_messages = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(result.tools.successful[0])
+      __io_println(contains(retry_messages, "parse_guidance"))
+      __io_println(contains(retry_messages, "Stray text outside response tags"))
+      __io_println(!contains(retry_messages, "no_progress_streak"))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -636,6 +636,38 @@ fn __native_fallback_feedback(policy, fallback_index) {
   return native_tool_contract_feedback_prompt({policy: policy, fallback_index: fallback_index})
 }
 
+fn __parse_feedback_tool_annotations(entry) {
+  let direct = entry?.annotations
+  if type_of(direct) == "dict" {
+    return direct
+  }
+  let func = entry?.function
+  if type_of(func) == "dict" && type_of(func?.annotations) == "dict" {
+    return func.annotations
+  }
+  return {}
+}
+
+fn __parse_feedback_annotation_enabled(value) -> bool {
+  return type_of(value) == "bool" && value
+}
+
+fn __parse_feedback_tool_is_structural(entry) -> bool {
+  let annotations = __parse_feedback_tool_annotations(entry)
+  return __parse_feedback_annotation_enabled(annotations?.structural)
+    || __parse_feedback_annotation_enabled(annotations?.agent_lifecycle)
+}
+
+fn __parse_feedback_has_non_structural_tools(turn_opts) -> bool {
+  let entries = turn_opts?.tools?.tools ?? []
+  for entry in entries {
+    if type_of(entry) == "dict" && !__parse_feedback_tool_is_structural(entry) {
+      return true
+    }
+  }
+  return false
+}
+
 /**
  * A turn whose tool calls were ALL dropped by the parser, or whose response
  * violates the tagged protocol with 0 dispatched calls, is a malformed-output
@@ -647,14 +679,23 @@ fn __native_fallback_feedback(policy, fallback_index) {
  * parse errors, and never reach it (no regression). Returns true when feedback
  * was injected so the caller can suppress the no-progress stall path.
  */
-fn __parse_feedback_diagnostics(parsed) {
+fn __parse_feedback_protocol_violations(parsed, turn_opts) {
+  if agent_tool_call_paradigm(turn_opts).kind != "text"
+    || !__parse_feedback_has_non_structural_tools(turn_opts) {
+    return []
+  }
+  return parsed?.protocol_violations ?? []
+}
+
+fn __parse_feedback_diagnostics(parsed, turn_opts) {
   let parse_errors = parsed?.tool_parse_errors ?? []
-  let protocol_violations = parsed?.protocol_violations ?? []
+  let protocol_violations = __parse_feedback_protocol_violations(parsed, turn_opts)
   return parse_errors + protocol_violations
 }
 
 fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts) -> bool {
-  let diagnostics = __parse_feedback_diagnostics(parsed)
+  let protocol_violations = __parse_feedback_protocol_violations(parsed, turn_opts)
+  let diagnostics = __parse_feedback_diagnostics(parsed, turn_opts)
   if len(diagnostics) == 0 || len(tool_calls) > 0 {
     return false
   }
@@ -675,7 +716,7 @@ fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts
     "tool_parse_error_feedback",
     {
       parse_error_count: len(parsed?.tool_parse_errors ?? []),
-      protocol_violation_count: len(parsed?.protocol_violations ?? []),
+      protocol_violation_count: len(protocol_violations),
       diagnostic_count: len(diagnostics),
       error_summary: error_summary,
     },

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1019,6 +1019,50 @@ fn __apply_post_turn_options(opts, outcome) {
   return updated
 }
 
+fn __agent_loop_llm_overrides(opts) {
+  let overrides = opts?.llm_options
+  if type_of(overrides) == "dict" {
+    return overrides
+  }
+  return {}
+}
+
+fn __agent_loop_effective_llm_options(opts) {
+  let base = opts ?? {}
+  return base + __agent_loop_llm_overrides(base)
+}
+
+fn __agent_loop_with_llm_render_context(opts, render) {
+  let effective = __agent_loop_effective_llm_options(opts)
+  let provider = to_string(effective?.provider ?? "")
+  let model = to_string(effective?.model ?? "")
+  let pushed = __push_llm_render_context(provider, model)
+  defer {
+    if pushed {
+      __pop_llm_render_context()
+    }
+  }
+  return render(effective)
+}
+
+fn __agent_loop_build_turn_prompt(session, opts, iteration) {
+  return __agent_loop_with_llm_render_context(
+    opts,
+    { effective ->
+      let fragments = agent_build_turn_system_fragments(session, effective, iteration)
+      var parts = []
+      for fragment in fragments {
+        parts = parts.push(fragment.body)
+      }
+      return {
+        fragments: fragments,
+        system: join(parts, "\n\n"),
+        messages: agent_build_turn_messages(session, effective, iteration),
+      }
+    },
+  )
+}
+
 fn __next_text_only_count(tool_count, consecutive_text_only) {
   if tool_count == 0 {
     return consecutive_text_only + 1
@@ -1788,19 +1832,16 @@ fn __agent_loop_final_wrapup(message, session, opts, final_status, stop_reason, 
     _progress_tool_system_prompt_nudge: "",
     transcript_projection: opts?.transcript_projection,
   }
-  let base_fragments = agent_build_turn_system_fragments(session, wrapup_opts, iteration)
+  let turn_prompt = __agent_loop_build_turn_prompt(session, wrapup_opts, iteration)
   var turn_system_parts = []
-  for fragment in base_fragments {
-    turn_system_parts = turn_system_parts.push(fragment.body)
+  if trim(turn_prompt.system ?? "") != "" {
+    turn_system_parts = turn_system_parts.push(turn_prompt.system)
   }
   turn_system_parts = turn_system_parts.push(directive)
   let turn_system = join(turn_system_parts, "\n\n")
-  let turn_messages = agent_build_turn_messages(session, wrapup_opts, iteration)
-  let llm_overrides = wrapup_opts?.llm_options ?? {}
-  let llm_opts = wrapup_opts
-    + llm_overrides
+  let llm_opts = __agent_loop_effective_llm_options(wrapup_opts)
     + {
-    messages: turn_messages,
+    messages: turn_prompt.messages,
     session_id: session.session_id,
     tool_format: wrapup_opts?.tool_format,
     tools: nil,
@@ -1835,20 +1876,7 @@ fn __agent_loop_run(message, session, initial_opts) {
   var opts = initial_opts
   var iteration = 0
   var session_finalized = false
-  // Publish the resolved provider/model so any `.harn.prompt` rendered
-  // during turn-system construction (loop contract, tool contract,
-  // skills, …) can branch on `llm.capabilities.*` without manual
-  // option threading. Skipped when provider is empty — the render
-  // sees `llm = nil` and the existing branch falls through.
-  let __llm_ctx_provider = to_string(initial_opts?.provider ?? "")
-  let __llm_ctx_model = to_string(initial_opts?.model ?? "")
-  let __llm_ctx_pushed = __push_llm_render_context(__llm_ctx_provider, __llm_ctx_model)
   var audit_background_tasks = []
-  defer {
-    if __llm_ctx_pushed {
-      __pop_llm_render_context()
-    }
-  }
   let run = try {
     opts = agent_mcp_bootstrap_if_needed(session, opts)
     var stop_reason = nil
@@ -1919,10 +1947,15 @@ fn __agent_loop_run(message, session, initial_opts) {
         break
       }
       let iteration_index = iteration
+      let iteration_opts = __agent_loop_effective_llm_options(opts)
       agent_emit_event(
         session.session_id,
         "iteration_start",
-        {iteration: iteration_index + 1, provider: opts?.provider ?? "", model: opts?.model ?? ""},
+        {
+          iteration: iteration_index + 1,
+          provider: iteration_opts?.provider ?? "",
+          model: iteration_opts?.model ?? "",
+        },
       )
       try {
         __host_drain_file_edits(session.session_id)
@@ -1930,21 +1963,22 @@ fn __agent_loop_run(message, session, initial_opts) {
         nil
       }
       __agent_loop_checkpoint(session.session_id, "iteration_start", {iteration: iteration_index + 1})
-      var turn_opts = agent_skills_match(session, opts, iteration_index)
+      var turn_opts = agent_skills_match(session, iteration_opts, iteration_index)
       if turn_opts?._skill_activated_this_turn ?? false {
         opts = agent_reset_tool_surface_narrowing(opts)
         turn_opts = agent_reset_tool_surface_narrowing(turn_opts)
       }
       turn_opts = agent_tool_search_inject_if_needed(turn_opts)
       turn_opts = agent_apply_tool_surface_narrowing(turn_opts)
+      let turn_llm_opts = __agent_loop_effective_llm_options(turn_opts)
       __agent_loop_checkpoint(session.session_id, "pre_compact", {iteration: iteration_index + 1})
-      agent_autocompact_if_needed(session, turn_opts)
+      agent_autocompact_if_needed(session, turn_llm_opts)
       __agent_loop_checkpoint(session.session_id, "post_compact", {iteration: iteration_index + 1})
       let scope_verdict = __run_pre_turn_scope_classifier(
-        turn_opts?._pre_turn_scope_classifier ?? opts?._pre_turn_scope_classifier,
+        turn_llm_opts?._pre_turn_scope_classifier ?? opts?._pre_turn_scope_classifier,
         session,
         message,
-        turn_opts,
+        turn_llm_opts,
         iteration_index,
       )
       if __scope_classifier_skip_main(scope_verdict) {
@@ -1954,24 +1988,16 @@ fn __agent_loop_run(message, session, initial_opts) {
         stop_reason = "out_of_scope"
         break
       }
-      let turn_system_fragments = agent_build_turn_system_fragments(session, turn_opts, iteration_index)
-      var turn_system_parts = []
-      for fragment in turn_system_fragments {
-        turn_system_parts = turn_system_parts.push(fragment.body)
-      }
-      let turn_system = join(turn_system_parts, "\n\n")
-      let turn_messages = agent_build_turn_messages(session, turn_opts, iteration_index)
-      let llm_overrides = turn_opts?.llm_options ?? {}
-      let base_opts = turn_opts + llm_overrides
-      let llm_opts = base_opts
+      let turn_prompt = __agent_loop_build_turn_prompt(session, turn_llm_opts, iteration_index)
+      let llm_opts = turn_llm_opts
         + {
-        messages: turn_messages,
+        messages: turn_prompt.messages,
         session_id: session.session_id,
-        tool_format: turn_opts.tool_format,
+        tool_format: turn_llm_opts.tool_format,
         _iteration: iteration_index + 1,
-        _system_fragments: turn_system_fragments,
+        _system_fragments: turn_prompt.fragments,
       }
-      let call = __invoke_llm(message, turn_system, llm_opts)
+      let call = __invoke_llm(message, turn_prompt.system, llm_opts)
       if !call.ok {
         let failure_config = __agent_loop_consecutive_failure_config(budget)
         if __agent_loop_tracks_failure(call?.error, failure_config) {
@@ -2040,7 +2066,7 @@ fn __agent_loop_run(message, session, initial_opts) {
       )
       fallback_index = fallback_outcome.fallback_index
       let tool_calls = if fallback_outcome.triggered {
-        fallback_outcome.calls
+        fallback_outcome.calls ?? []
       } else {
         __resolve_tool_calls(llm_result, parsed)
       }
@@ -2063,7 +2089,7 @@ fn __agent_loop_run(message, session, initial_opts) {
             "agent_await_resumption",
             __agent_loop_invalid_await_resumption_feedback(await_error),
           )
-          let await_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+          let await_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
           agent_emit_event(
             session.session_id,
             "iteration_end",
@@ -2099,7 +2125,7 @@ fn __agent_loop_run(message, session, initial_opts) {
           continue
         }
         suspend_result = unwrap(await_result)
-        let _totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+        let _totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
         agent_emit_event(
           session.session_id,
           "iteration_end",
@@ -2158,7 +2184,7 @@ fn __agent_loop_run(message, session, initial_opts) {
         if feedback != "" {
           agent_session_inject_feedback(session.session_id, "structural_validator", feedback)
         }
-        let structural_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+        let structural_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
         agent_emit_event(
           session.session_id,
           "iteration_end",
@@ -2222,7 +2248,7 @@ fn __agent_loop_run(message, session, initial_opts) {
             )
           }
         } else {
-          let stall_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+          let stall_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
           let tool_count = len(tool_calls)
           agent_emit_event(
             session.session_id,
@@ -2302,7 +2328,7 @@ fn __agent_loop_run(message, session, initial_opts) {
           if critique != "" {
             agent_session_inject_feedback(session.session_id, "step_judge", critique)
           }
-          let step_totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+          let step_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
           agent_emit_event(
             session.session_id,
             "iteration_end",
@@ -2348,7 +2374,7 @@ fn __agent_loop_run(message, session, initial_opts) {
       let pre_dispatch_checkpoint = __agent_loop_checkpoint(session.session_id, "pre_tool_dispatch", {iteration: iteration_index + 1})
       if pre_dispatch_checkpoint.dispatch_skipped {
         let tool_count_skipped = len(tool_calls)
-        let totals_skipped = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+        let totals_skipped = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
         agent_emit_event(
           session.session_id,
           "iteration_end",
@@ -2401,7 +2427,7 @@ fn __agent_loop_run(message, session, initial_opts) {
       opts = __sync_tool_search_state(opts, dispatched.turn_opts)
       successful_tools_seen = __merge_tool_names(successful_tools_seen, __tool_names_by_status(dispatch, true))
       rejected_tools_seen = __merge_tool_names(rejected_tools_seen, __tool_names_by_status(dispatch, false))
-      let totals = agent_session_record_usage(session.session_id, llm_result, turn_opts, iteration_index + 1)
+      let totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
       let tool_count = len(tool_calls)
       agent_emit_event(
         session.session_id,
@@ -2487,12 +2513,15 @@ fn __agent_loop_run(message, session, initial_opts) {
         _done_judge_invocations: done_judge_invocations,
         _done_judge_loop_state: cadence_loop_state,
       }
-      let outcome = agent_compute_post_turn(
-        session,
-        normalized + {raw_text: raw_text, parsed_done_marker: parsed?.done_marker ?? ""},
-        dispatch,
-        post_turn_opts,
-        iteration_index,
+      let outcome = __agent_loop_with_llm_render_context(
+        turn_llm_opts,
+        { _effective -> agent_compute_post_turn(
+          session,
+          normalized + {raw_text: raw_text, parsed_done_marker: parsed?.done_marker ?? ""},
+          dispatch,
+          post_turn_opts,
+          iteration_index,
+        ) },
       )
       opts = __apply_post_turn_options(opts, outcome)
       var should_continue = outcome.kind == "continue" || bridge_step_delivered > 0

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -637,8 +637,9 @@ fn __native_fallback_feedback(policy, fallback_index) {
 }
 
 /**
- * A turn whose tool calls were ALL dropped by the parser (>=1 parse error and 0
- * dispatched calls) is a malformed-call turn, not a no-progress monologue. The
+ * A turn whose tool calls were ALL dropped by the parser, or whose response
+ * violates the tagged protocol with 0 dispatched calls, is a malformed-output
+ * turn, not a no-progress monologue. The
  * purpose-built `parse_guidance` prompt — which shows the heredoc syntax and
  * names the exact parser diagnostic — is the right corrective feedback, but
  * nothing consumed `tool_parse_errors` on the active path. This fires purely on
@@ -646,12 +647,18 @@ fn __native_fallback_feedback(policy, fallback_index) {
  * parse errors, and never reach it (no regression). Returns true when feedback
  * was injected so the caller can suppress the no-progress stall path.
  */
-fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts) -> bool {
+fn __parse_feedback_diagnostics(parsed) {
   let parse_errors = parsed?.tool_parse_errors ?? []
-  if len(parse_errors) == 0 || len(tool_calls) > 0 {
+  let protocol_violations = parsed?.protocol_violations ?? []
+  return parse_errors + protocol_violations
+}
+
+fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts) -> bool {
+  let diagnostics = __parse_feedback_diagnostics(parsed)
+  if len(diagnostics) == 0 || len(tool_calls) > 0 {
     return false
   }
-  let error_summary = to_string(parse_errors[0])
+  let error_summary = to_string(diagnostics[0])
   // All calls were dropped, so there is no partial success this turn.
   let feedback = parse_guidance_prompt(
     {
@@ -666,7 +673,12 @@ fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts
   agent_emit_event(
     session_id,
     "tool_parse_error_feedback",
-    {parse_error_count: len(parse_errors), error_summary: error_summary},
+    {
+      parse_error_count: len(parsed?.tool_parse_errors ?? []),
+      protocol_violation_count: len(parsed?.protocol_violations ?? []),
+      diagnostic_count: len(diagnostics),
+      error_summary: error_summary,
+    },
   )
   return true
 }

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -1088,6 +1088,11 @@ pub(crate) async fn observed_llm_call(
                 let category = crate::value::error_to_category(&error);
                 let message = error.to_string();
                 let classified = super::api::classify_llm_error(category.clone(), &message);
+                if classified.reason == super::api::LlmErrorReason::RateLimit {
+                    if let Some(retry_after_ms) = extract_retry_after_ms(&error) {
+                        super::rate_limit::observe_retry_after_for_llm_call(opts, retry_after_ms);
+                    }
+                }
                 let retryable = is_retryable_llm_error(&error);
                 let can_retry = retryable && attempt < retry_config.retries;
                 let status = if can_retry {

--- a/crates/harn-vm/src/llm/rate_limit.rs
+++ b/crates/harn-vm/src/llm/rate_limit.rs
@@ -182,6 +182,7 @@ struct RouteLimiter {
     input_token_window: Option<SlidingWindow>,
     output_token_window: Option<SlidingWindow>,
     concurrency: Option<Arc<Semaphore>>,
+    cooldown_until_ms: Option<u128>,
     limits: EffectiveRateLimits,
 }
 
@@ -195,6 +196,7 @@ impl RouteLimiter {
             concurrency: limits
                 .concurrency
                 .map(|limit| Arc::new(Semaphore::new(limit.max(1) as usize))),
+            cooldown_until_ms: None,
             limits,
         }
     }
@@ -213,6 +215,13 @@ impl RouteLimiter {
             self.output_token_window
                 .as_mut()
                 .and_then(|window| window.check(now_ms, request.output_tokens)),
+            self.cooldown_until_ms
+                .filter(|until_ms| *until_ms > now_ms)
+                .map(|until_ms| {
+                    Duration::from_millis(
+                        until_ms.saturating_sub(now_ms).min(u128::from(u64::MAX)) as u64
+                    )
+                }),
         ];
         waits.into_iter().flatten().max()
     }
@@ -230,6 +239,14 @@ impl RouteLimiter {
         if let Some(window) = self.output_token_window.as_mut() {
             window.record(now_ms, request.output_tokens);
         }
+    }
+
+    fn observe_retry_after(&mut self, now_ms: u128, retry_after_ms: u64) {
+        if retry_after_ms == 0 {
+            return;
+        }
+        let until_ms = now_ms.saturating_add(u128::from(retry_after_ms));
+        self.cooldown_until_ms = Some(self.cooldown_until_ms.unwrap_or(0).max(until_ms));
     }
 }
 
@@ -340,6 +357,15 @@ fn insert_limiter(
     } else {
         limiters.insert(key, RouteLimiter::new(limits));
     }
+}
+
+fn limiter_for_key<'a>(
+    limiters: &'a mut HashMap<String, RouteLimiter>,
+    key: &str,
+) -> &'a mut RouteLimiter {
+    limiters
+        .entry(key.to_string())
+        .or_insert_with(|| RouteLimiter::new(EffectiveRateLimits::default()))
 }
 
 fn provider_limits_from_config(
@@ -689,9 +715,20 @@ async fn acquire_permit_for(
     ensure_initialized_from_config();
     let keys = limiter_keys(provider, model);
     if let Some(state_path) = durable_state_path() {
-        let permits = acquire_concurrency(&keys).await;
-        acquire_durable_for_keys(state_path, provider, model, &keys, request).await?;
-        return Ok(RateLimitPermit { _permits: permits });
+        loop {
+            let permits = acquire_concurrency(&keys).await;
+            if let Some(duration) = {
+                let mut registry = registry().lock().expect("rate limiter mutex poisoned");
+                let now_ms = crate::clock_mock::instant_now().as_millis();
+                check_wait_for_keys(&mut registry, &keys, request, now_ms)
+            } {
+                drop(permits);
+                sleep_after_throttle(provider, model, duration).await;
+                continue;
+            }
+            acquire_durable_for_keys(state_path, provider, model, &keys, request).await?;
+            return Ok(RateLimitPermit { _permits: permits });
+        }
     }
     loop {
         if let Some(duration) = {
@@ -719,6 +756,29 @@ async fn acquire_permit_for(
         }
 
         return Ok(RateLimitPermit { _permits: permits });
+    }
+}
+
+/// Share a provider Retry-After signal with the route limiter.
+///
+/// Catalog limits prevent most known quota overruns. Provider 429 responses are
+/// still useful live feedback: account tier, burst windows, or remote-side
+/// throttles can differ from the catalog. Recording the cooldown here lets
+/// sibling and subsequent calls wait on the same route instead of stampeding
+/// the provider after the first failed call.
+pub(crate) fn observe_retry_after_for_llm_call(
+    opts: &super::api::LlmCallOptions,
+    retry_after_ms: u64,
+) {
+    if retry_after_ms == 0 {
+        return;
+    }
+    ensure_initialized_from_config();
+    let keys = limiter_keys(&opts.provider, &opts.model);
+    let now_ms = crate::clock_mock::instant_now().as_millis();
+    let mut registry = registry().lock().expect("rate limiter mutex poisoned");
+    for key in keys {
+        limiter_for_key(&mut registry.limiters, &key).observe_retry_after(now_ms, retry_after_ms);
     }
 }
 
@@ -906,6 +966,33 @@ mod tests {
         window.record(0, 25);
         assert_eq!(window.usage(), 10);
         assert!(window.check(0, 1).is_some());
+    }
+
+    #[test]
+    fn retry_after_cooldown_blocks_route_without_catalog_limit() {
+        let mut limiter = RouteLimiter::new(EffectiveRateLimits::default());
+        limiter.observe_retry_after(1_000, 2_500);
+
+        let wait = limiter
+            .check(1_000, RateLimitRequest::default())
+            .expect("cooldown should block route");
+        assert_eq!(wait.as_millis(), 2_500);
+        assert!(
+            limiter.check(3_500, RateLimitRequest::default()).is_none(),
+            "cooldown should expire exactly at the provider-supplied deadline"
+        );
+    }
+
+    #[test]
+    fn retry_after_cooldown_extends_existing_route_cooldown() {
+        let mut limiter = RouteLimiter::new(EffectiveRateLimits::default());
+        limiter.observe_retry_after(1_000, 1_000);
+        limiter.observe_retry_after(1_500, 3_000);
+
+        let wait = limiter
+            .check(2_000, RateLimitRequest::default())
+            .expect("extended cooldown should block route");
+        assert_eq!(wait.as_millis(), 2_500);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- integrate the dynamic LLM render-context fix so post-turn `llm_options` changes render prompts against the actual next provider/model
- route zero-call text-tool protocol violations through parse-guidance feedback instead of treating them as ordinary no-progress prose
- share provider `Retry-After` rate-limit signals with the route limiter so sibling/subsequent calls back off together

## Validation
- `target/debug/harn check conformance/tests/agents/agent_loop_protocol_violation_feedback.harn conformance/tests/agents/agent_loop_dynamic_llm_context.harn`
- `target/debug/harn test conformance --filter agent_loop_protocol_violation_feedback --timeout 30000`
- `target/debug/harn test conformance --filter agent_loop_dynamic_llm_context --timeout 30000`
- `target/debug/harn test conformance --filter agent_loop_text_mode_action_nudges --timeout 30000`
- `target/debug/harn test conformance --filter agent_loop_provider_error_structured --timeout 30000`
- `cargo test -p harn-vm llm::rate_limit::tests::retry_after_cooldown -- --nocapture`
- `cargo test -p harn-vm llm::agent_observe::retry_tests::retry_after -- --nocapture`
- pre-commit and pre-push hooks passed
