### PR TITLE
Ignore runtime SQLite DBs in conformance fixture .harn dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,14 +26,17 @@ tree-sitter-harn/*.dll
 !conformance/tests/**/.harn/**
 # …but per-run metadata shards from project_deep_scan tests (namespace
 # dirs under .harn/metadata/<UUID>/entries.json) are always ephemeral
-# and must stay ignored. Same goes for SQLite event-log files and
-# checkpoint/workflow dirs that tests drop into the fixture's .harn/.
+# and must stay ignored. Same goes for the runtime SQLite DBs that tests
+# drop into the fixture's .harn/ (the event log, the provider rate-limit
+# store, and any future runtime DB) plus checkpoint/workflow dirs. The
+# tracked fixtures under these dirs are skill manifests/JSON, never a
+# root-level *.sqlite, so the glob below cannot shadow shipped content.
 conformance/tests/**/.harn/metadata/
 conformance/tests/**/.harn/checkpoints/
 conformance/tests/**/.harn/workflows/
-conformance/tests/**/.harn/events.sqlite
-conformance/tests/**/.harn/events.sqlite-shm
-conformance/tests/**/.harn/events.sqlite-wal
+conformance/tests/**/.harn/*.sqlite
+conformance/tests/**/.harn/*.sqlite-shm
+conformance/tests/**/.harn/*.sqlite-wal
 # Per-run timing cache the `harn test` runner drops next to the suite.
 conformance/tests/**/.harn/test-timings.json
 .cargo/config.toml

--- a/changelog.d/gitignore-runtime-sqlite.fixed.md
+++ b/changelog.d/gitignore-runtime-sqlite.fixed.md
@@ -1,0 +1,2 @@
+- Conformance fixture `.harn/` dirs now ignore every runtime SQLite DB tests drop in (e.g. the rate-limit
+  store `llm-rate-limits.sqlite`), not just the event log, so a stray DB no longer trips the release guard.


### PR DESCRIPTION
## Summary
The conformance suite writes per-run SQLite DBs into the fixtures' tracked `.harn/` directories. Only `events.sqlite` (+ `-shm`/`-wal`) was ignored, so the provider rate-limit store `llm-rate-limits.sqlite` leaked as untracked and **twice tripped the release `dirty-base-branch` guard** during a v0.8.81 cut.

Generalize the explicit `events.sqlite` entries to a `*.sqlite` glob (root-level DBs only) covering events, rate limits, and any future runtime DB.

## Safety
Tracked fixtures under these dirs are skill manifests / JSON (`SKILL.md`, `store.json`, `.sig`) — never a root-level `*.sqlite` — so the glob cannot shadow shipped content. Verified with `git check-ignore`:
- `llm-rate-limits.sqlite` (+ `-wal`) → now ignored
- `events.sqlite` → still ignored (no regression)
- `SKILL.md` / `store.json` fixtures → still tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)