### PR TITLE
Return SQL projection helpers as trusted fragments

### DIFF
--- a/changelog.d/postgres-query-projection-fragments.added.md
+++ b/changelog.d/postgres-query-projection-fragments.added.md
@@ -1,0 +1,6 @@
+- `std/postgres/query` projection helpers (`uuid_text`, `timestamptz_json`,
+  `nullable_timestamptz_json`, `select_clause`) now return trusted
+  `PgSqlFragment`s, and a new `columns(parts)` helper joins projection
+  fragments/strings into one `{projection}` fragment. Column projections now
+  drop into `sql(...)` placeholders without an `unsafe_sql(...)` wrapper, and
+  carry the literal `'{}'` JSON path safely.

--- a/conformance/tests/stdlib/postgres_query_helpers.expected
+++ b/conformance/tests/stdlib/postgres_query_helpers.expected
@@ -23,3 +23,7 @@ true
 true
 true
 true
+SELECT id::text AS id, to_json(created_at)#>>'{}' AS created_at, payload FROM receipts WHERE tenant_id = $1::uuid
+tenant-a
+true
+true

--- a/conformance/tests/stdlib/postgres_query_helpers.harn
+++ b/conformance/tests/stdlib/postgres_query_helpers.harn
@@ -1,5 +1,6 @@
 import "std/postgres"
 import {
+  columns,
   exec,
   ident,
   ident_path,
@@ -13,7 +14,6 @@ import {
   select_clause,
   sql,
   timestamptz_json,
-  unsafe_sql,
   uuid_text,
 } from "std/postgres/query"
 
@@ -30,16 +30,14 @@ ORDER BY {created_column} DESC
 LIMIT {limit}
 """,
     {
-      projection: unsafe_sql(
-        select_clause(
-          [
-            uuid_text("id"),
-            uuid_text("tenant_id"),
-            "payload",
-            nullable_timestamptz_json("finished_at"),
-            timestamptz_json("created_at"),
-          ],
-        ),
+      projection: select_clause(
+        [
+          uuid_text("id"),
+          uuid_text("tenant_id"),
+          "payload",
+          nullable_timestamptz_json("finished_at"),
+          timestamptz_json("created_at"),
+        ],
       ),
       table: ident("receipts"),
       tenant_id: "tenant-a",
@@ -52,7 +50,7 @@ LIMIT {limit}
     "get_receipt",
     "one",
     "SELECT {id_projection} FROM {table} WHERE id = {id}::uuid",
-    {id_projection: unsafe_sql(uuid_text("id")), table: ident("receipts"), id: "r1"},
+    {id_projection: uuid_text("id"), table: ident("receipts"), id: "r1"},
   )
   let update_query = named_sql(
     "mark_receipt_read",
@@ -130,4 +128,21 @@ LIMIT {limit}
   }
   __io_println(is_err(named_error))
   __io_println(regex_match("missing_query", to_string(unwrap_err(named_error))) != nil)
+  let columns_query = sql(
+    "SELECT {projection} FROM receipts WHERE tenant_id = {tenant_id}::uuid",
+    {
+      projection: columns([uuid_text("id"), timestamptz_json("created_at"), "payload"]),
+      tenant_id: "tenant-a",
+    },
+  )
+  __io_println(columns_query.sql)
+  __io_println(columns_query.params[0])
+  let empty_columns = try {
+    columns([])
+  }
+  __io_println(is_err(empty_columns))
+  let bad_columns = try {
+    columns([123])
+  }
+  __io_println(is_err(bad_columns))
 }

--- a/crates/harn-stdlib/src/stdlib/postgres/query.harn
+++ b/crates/harn-stdlib/src/stdlib/postgres/query.harn
@@ -399,8 +399,57 @@ pub fn unsafe_sql(fragment: string) -> PgSqlFragment {
   return __sql_fragment(fragment)
 }
 
+fn __projection_part_text(part) -> string {
+  if __is_sql_fragment(part) {
+    return __sql_fragment_text(part)
+  }
+  if type_of(part) == "string" {
+    if trim(part) == "" {
+      throw "std/postgres/query: projection part must be a non-empty string"
+    }
+    return part
+  }
+  throw "std/postgres/query: projection part must be a SQL fragment or string"
+}
+
 /**
- * Render `SELECT a, b, c` from already-static projection fragments.
+ * Join projection parts into a single comma-separated `PgSqlFragment`.
+ *
+ * Each part is a `PgSqlFragment` (e.g. `uuid_text(...)`, `ident(...)`,
+ * `unsafe_sql(...)`) or a source-controlled projection string. The result is a
+ * trusted fragment, so it drops into a `{name}` placeholder without
+ * `unsafe_sql(...)` and carries any literal braces (such as the `'{}'` JSON
+ * path) safely:
+ *
+ * ```harn,ignore
+ * sql(
+ *   "SELECT {projection} FROM receipts WHERE tenant_id = {tenant_id}::uuid",
+ *   {projection: columns([uuid_text("id"), timestamptz_json("created_at"), "payload"]), tenant_id: tenant_id},
+ * )
+ * ```
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: columns([uuid_text("id"), timestamptz_json("created_at")])
+ */
+pub fn columns(parts: list) -> PgSqlFragment {
+  if type_of(parts) != "list" {
+    throw "std/postgres/query: columns requires a list of projection parts"
+  }
+  if len(parts) == 0 {
+    throw "std/postgres/query: columns requires at least one projection part"
+  }
+  var rendered = []
+  for part in parts {
+    rendered = rendered.push(__projection_part_text(part))
+  }
+  return __sql_fragment(join(rendered, ", "))
+}
+
+/**
+ * Prefix `columns(parts)` with `SELECT `, returning a trusted `PgSqlFragment`.
  *
  * @effects: []
  * @allocation: heap
@@ -408,18 +457,12 @@ pub fn unsafe_sql(fragment: string) -> PgSqlFragment {
  * @api_stability: experimental
  * @example: select_clause([uuid_text("id"), "payload"])
  */
-pub fn select_clause(fragments: list<string>) -> string {
-  if type_of(fragments) != "list" {
-    throw "std/postgres/query: select_clause requires a list of fragments"
-  }
-  if len(fragments) == 0 {
-    throw "std/postgres/query: select_clause requires at least one fragment"
-  }
-  return "SELECT " + join(fragments, ", ")
+pub fn select_clause(parts: list) -> PgSqlFragment {
+  return __sql_fragment("SELECT " + __sql_fragment_text(columns(parts)))
 }
 
 /**
- * Render `column::text AS column` for UUID columns.
+ * Render `column::text AS column` for UUID columns as a trusted fragment.
  *
  * @effects: []
  * @allocation: heap
@@ -427,13 +470,14 @@ pub fn select_clause(fragments: list<string>) -> string {
  * @api_stability: experimental
  * @example: uuid_text("id")
  */
-pub fn uuid_text(name: string) -> string {
+pub fn uuid_text(name: string) -> PgSqlFragment {
   let ident = identifier(name)
-  return ident + "::text AS " + ident
+  return __sql_fragment(ident + "::text AS " + ident)
 }
 
 /**
- * Render `to_json(column)#>>'{}' AS column` for timestamp columns.
+ * Render `to_json(column)#>>'{}' AS column` for timestamp columns as a trusted
+ * fragment.
  *
  * @effects: []
  * @allocation: heap
@@ -441,13 +485,14 @@ pub fn uuid_text(name: string) -> string {
  * @api_stability: experimental
  * @example: timestamptz_json("created_at")
  */
-pub fn timestamptz_json(name: string) -> string {
+pub fn timestamptz_json(name: string) -> PgSqlFragment {
   let ident = identifier(name)
-  return "to_json(" + ident + ")#>>'{}' AS " + ident
+  return __sql_fragment("to_json(" + ident + ")#>>'{}' AS " + ident)
 }
 
 /**
- * Render a nullable timestamp projection that preserves nulls as null.
+ * Render a nullable timestamp projection that preserves nulls as null, as a
+ * trusted fragment.
  *
  * @effects: []
  * @allocation: heap
@@ -455,12 +500,9 @@ pub fn timestamptz_json(name: string) -> string {
  * @api_stability: experimental
  * @example: nullable_timestamptz_json("finished_at")
  */
-pub fn nullable_timestamptz_json(name: string) -> string {
+pub fn nullable_timestamptz_json(name: string) -> PgSqlFragment {
   let ident = identifier(name)
-  return "CASE WHEN "
-    + ident
-    + " IS NULL THEN NULL ELSE to_json("
-    + ident
-    + ")#>>'{}' END AS "
-    + ident
+  return __sql_fragment(
+    "CASE WHEN " + ident + " IS NULL THEN NULL ELSE to_json(" + ident + ")#>>'{}' END AS " + ident,
+  )
 }

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -990,7 +990,7 @@ dynamic values still go through Postgres bind parameters.
 
 ```harn,ignore
 import "std/postgres"
-import { ident, many, named_sql, run, sql, unsafe_sql, uuid_text, nullable_timestamptz_json } from "std/postgres/query"
+import { ident, many, named_sql, run, sql, uuid_text, nullable_timestamptz_json } from "std/postgres/query"
 
 fn list_receipts_query(tenant_id: string, limit: int) {
   return named_sql(
@@ -1004,8 +1004,8 @@ ORDER BY {created_at} DESC
 LIMIT {limit}
 """,
     {
-      id: unsafe_sql(uuid_text("id")),
-      finished_at: unsafe_sql(nullable_timestamptz_json("finished_at")),
+      id: uuid_text("id"),
+      finished_at: nullable_timestamptz_json("finished_at"),
       table: ident("receipts"),
       tenant_id: tenant_id,
       created_at: ident("created_at"),
@@ -1024,12 +1024,15 @@ Helpers: `one(handle, query)`, `many(handle, query)`, `exec(handle, query)`,
 `named_sql(name, mode, template, values?, options?)`,
 `named(name, mode, sql, params?)`, `ident(name)`, `ident_path(parts)`,
 `unsafe_sql(fragment)`, `uuid_text(name)`, `timestamptz_json(name)`,
-`nullable_timestamptz_json(name)`, and `select_clause(fragments)`.
-In `sql(...)`, ordinary `{name}` placeholders become `$n` params and repeated
-placeholders reuse the first parameter index. Use `{{` and `}}` for literal
-braces. SQL structure is never inferred from strings; use `ident(...)` /
-`ident_path(...)` for identifiers and reserve `unsafe_sql(...)` for
-source-controlled fragments.
+`nullable_timestamptz_json(name)`, `columns(parts)`, and `select_clause(parts)`.
+The projection helpers (`uuid_text`, `timestamptz_json`,
+`nullable_timestamptz_json`, `columns`, `select_clause`) return trusted
+`PgSqlFragment`s, so they drop into `{name}` placeholders without
+`unsafe_sql(...)`. In `sql(...)`, ordinary `{name}` placeholders become `$n`
+params and repeated placeholders reuse the first parameter index. Use `{{` and
+`}}` for literal braces. SQL structure is never inferred from strings; use
+`ident(...)` / `ident_path(...)` for identifiers and reserve `unsafe_sql(...)`
+for source-controlled fragments no typed helper covers.
 
 ## LLM surface
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -785,10 +785,11 @@ repeated projection fragments easier to review:
 | `ident(name)` | Build a quoted identifier fragment for `sql(...)` |
 | `ident_path(parts)` | Build a dotted quoted identifier fragment for `sql(...)` |
 | `unsafe_sql(fragment)` | Mark a source-controlled SQL fragment for insertion into `sql(...)` |
-| `select_clause(fragments)` | Render `SELECT ...` from static projection fragments |
-| `uuid_text(name)` | Render `name::text AS name` |
-| `timestamptz_json(name)` | Render `to_json(name)#>>'{}' AS name` |
-| `nullable_timestamptz_json(name)` | Render a timestamp projection that preserves nulls |
+| `columns(parts)` | Join projection fragments/strings into one `{projection}` fragment |
+| `select_clause(parts)` | Render `SELECT ...` from projection parts as a fragment |
+| `uuid_text(name)` | Fragment `name::text AS name` |
+| `timestamptz_json(name)` | Fragment `to_json(name)#>>'{}' AS name` |
+| `nullable_timestamptz_json(name)` | Fragment timestamp projection that preserves nulls |
 
 In SQL templates, ordinary `{name}` placeholders are always bound as params;
 use `{{` and `}}` for literal braces. SQL structure must be explicit through

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -106,7 +106,6 @@ import {
   nullable_timestamptz_json,
   run,
   sql,
-  unsafe_sql,
   uuid_text,
 } from "std/postgres/query"
 
@@ -122,9 +121,9 @@ ORDER BY {created_at} DESC
 LIMIT {limit}
 """,
     {
-      id: unsafe_sql(uuid_text("id")),
-      tenant_id_column: unsafe_sql(uuid_text("tenant_id")),
-      finished_at: unsafe_sql(nullable_timestamptz_json("finished_at")),
+      id: uuid_text("id"),
+      tenant_id_column: uuid_text("tenant_id"),
+      finished_at: nullable_timestamptz_json("finished_at"),
       table: ident("receipts"),
       tenant_id: tenant_id,
       created_at: ident("created_at"),
@@ -154,8 +153,9 @@ let q = sql(
 ```
 
 Postgres cannot bind identifiers as parameters. Use `ident(...)` or
-`ident_path(...)` when SQL structure must be dynamic, and use `unsafe_sql(...)`
-only for source-controlled fragments such as projection helpers:
+`ident_path(...)` when SQL structure must be dynamic, and reserve
+`unsafe_sql(...)` for the rare source-controlled fragment that no typed helper
+covers:
 
 ```harn,ignore
 let q = sql(
@@ -204,14 +204,33 @@ through to `pg_query_one` and `pg_query`.
 
 Projection helpers only accept static SQL identifiers matching
 `[A-Za-z_][A-Za-z0-9_]*`. They are for source-controlled column names, not
-user input:
+user input. Each returns a trusted `PgSqlFragment`, so it drops straight into a
+`{name}` placeholder — no `unsafe_sql(...)` wrapper — and carries the literal
+`'{}'` JSON path safely:
 
 | Helper | Output |
 |---|---|
 | `uuid_text("id")` | `id::text AS id` |
 | `timestamptz_json("created_at")` | `to_json(created_at)#>>'{}' AS created_at` |
 | `nullable_timestamptz_json("finished_at")` | `CASE WHEN finished_at IS NULL THEN NULL ELSE to_json(finished_at)#>>'{}' END AS finished_at` |
+| `columns([uuid_text("id"), "payload"])` | `id::text AS id, payload` |
 | `select_clause([...])` | `SELECT ...` |
+
+`columns([...])` joins projection parts — fragments or source-controlled
+strings — into one fragment for a `{projection}` placeholder, so a whole column
+list composes without `unsafe_sql(...)`:
+
+```harn,ignore
+let q = sql(
+  "SELECT {projection} FROM receipts WHERE tenant_id = {tenant_id}::uuid",
+  {
+    projection: columns([uuid_text("id"), timestamptz_json("created_at"), "payload"]),
+    tenant_id: tenant_id,
+  },
+)
+// q.sql == "SELECT id::text AS id, to_json(created_at)#>>'{}' AS created_at, payload
+//           FROM receipts WHERE tenant_id = $1::uuid"
+```
 
 ## Transactions and tenant settings
 


### PR DESCRIPTION
## Summary
- `std/postgres/query` projection helpers (`uuid_text`, `timestamptz_json`, `nullable_timestamptz_json`, `select_clause`) now return trusted `PgSqlFragment`s instead of raw strings.
- Adds `columns(parts)` to join projection fragments/strings into a single `{projection}` fragment.
- Column projections now drop into `sql(...)` placeholders **without** an `unsafe_sql(...)` wrapper, and the literal `'{}'` JSON path rides through safely (fragment text is spliced, not re-scanned for `{name}` holes).

## Why
The previous helpers returned raw strings containing `'{}'`, so the natural "concatenate into a template" usage threw `empty SQL template placeholder` at runtime, and the only safe path was wrapping validated, source-controlled SQL in `unsafe_sql(...)` — alarmist and verbose. Fragments are the secure, ergonomic primitive: dynamic values still bind as params; only source-controlled identifiers/expressions become fragments.

## Verification
- `cargo run --quiet --bin harn -- test conformance --filter postgres` (6 passed)
- `make check-docs-snippets` (648 checked, 0 failed)
- `make lint-test-patterns`
- `cargo check -p harn-stdlib`
- `harn fmt --check` / `harn lint` on edited `.harn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)