### PR TITLE
Fix code-index line_count overcounting trailing-newline files

### DIFF
--- a/changelog.d/code-index-line-count.fixed.md
+++ b/changelog.d/code-index-line-count.fixed.md
@@ -1,0 +1,7 @@
+- **`hostlib_code_index_*` `line_count` no longer overcounts files that end in a newline.**
+  The code-index file scanner counted lines with `content.split('\n').count()`,
+  which reports one phantom extra line for any file with a trailing newline (the
+  common case) — e.g. a two-line file ending in `\n` was reported as 3 lines.
+  Line counting is now shared through a single `count_lines` helper, matching the
+  scanner and process-artifact surfaces that already counted correctly, so the
+  `line_count` field surfaced to scripts is accurate.

--- a/crates/harn-hostlib/src/code_index/state.rs
+++ b/crates/harn-hostlib/src/code_index/state.rs
@@ -197,11 +197,7 @@ impl IndexState {
             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
             .map(|d| d.as_millis() as i64)
             .unwrap_or(0);
-        let line_count = if content.is_empty() {
-            0
-        } else {
-            content.split('\n').count() as u32
-        };
+        let line_count = crate::text::count_lines(content.as_bytes()) as u32;
 
         let file = IndexedFile {
             id,

--- a/crates/harn-hostlib/src/lib.rs
+++ b/crates/harn-hostlib/src/lib.rs
@@ -43,6 +43,7 @@ pub mod secret_store;
 pub mod tools;
 
 mod registry;
+mod text;
 mod value_args;
 
 pub use error::HostlibError;

--- a/crates/harn-hostlib/src/scanner/mod.rs
+++ b/crates/harn-hostlib/src/scanner/mod.rs
@@ -372,7 +372,7 @@ fn extract_per_file(
         let language = extensions::file_extension(&entry.relative_path);
         let imports = imports::extract_imports(&content, &language);
         let file_symbols = symbols::extract_symbols(&content, &language, &entry.relative_path);
-        let line_count = count_lines(&content);
+        let line_count = crate::text::count_lines(content.as_bytes()) as usize;
 
         for imp in &imports {
             dependencies.push(DependencyEdge {
@@ -397,15 +397,6 @@ fn extract_per_file(
     }
 
     (files, symbols, dependencies)
-}
-
-fn count_lines(content: &str) -> usize {
-    if content.is_empty() {
-        return 0;
-    }
-    let nl = content.bytes().filter(|b| *b == b'\n').count();
-    let trailing = content.as_bytes().last() != Some(&b'\n');
-    nl + usize::from(trailing)
 }
 
 fn sort_for_output(

--- a/crates/harn-hostlib/src/text.rs
+++ b/crates/harn-hostlib/src/text.rs
@@ -1,0 +1,43 @@
+//! Small text utilities shared across hostlib capabilities.
+
+/// Count the number of lines in `bytes`.
+///
+/// Empty input has zero lines. Otherwise the count is the number of `\n`
+/// bytes plus one for a final line that is not newline-terminated, so a
+/// trailing newline does not introduce a phantom empty line. This is the
+/// single source of truth for line counting across the scanner, code
+/// index, and process-artifact surfaces, which all expose `line_count`.
+#[allow(clippy::naive_bytecount)]
+pub(crate) fn count_lines(bytes: &[u8]) -> u64 {
+    if bytes.is_empty() {
+        return 0;
+    }
+    let newlines = bytes.iter().filter(|b| **b == b'\n').count() as u64;
+    if bytes.ends_with(b"\n") {
+        newlines
+    } else {
+        newlines + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_lines;
+
+    #[test]
+    fn empty_input_has_no_lines() {
+        assert_eq!(count_lines(b""), 0);
+    }
+
+    #[test]
+    fn trailing_newline_does_not_add_phantom_line() {
+        assert_eq!(count_lines(b"line1\nline2\n"), 2);
+        assert_eq!(count_lines(b"line1\n"), 1);
+    }
+
+    #[test]
+    fn missing_trailing_newline_still_counts_final_line() {
+        assert_eq!(count_lines(b"line1\nline2"), 2);
+        assert_eq!(count_lines(b"line1"), 1);
+    }
+}

--- a/crates/harn-hostlib/src/tools/proc/artifacts.rs
+++ b/crates/harn-hostlib/src/tools/proc/artifacts.rs
@@ -60,7 +60,7 @@ pub(crate) fn persist_artifacts(
         output_path: artifacts.output_path,
         stdout_path: artifacts.stdout_path,
         stderr_path: artifacts.stderr_path,
-        line_count: line_count(&combined),
+        line_count: crate::text::count_lines(&combined),
         byte_count: combined.len() as u64,
         output_sha256,
     };
@@ -100,20 +100,5 @@ fn register_artifacts(command_id: &str, handle_id: Option<&str>, artifacts: &Com
     store.insert(command_id.to_string(), artifacts.clone());
     if let Some(handle_id) = handle_id {
         store.insert(handle_id.to_string(), artifacts.clone());
-    }
-}
-
-fn line_count(bytes: &[u8]) -> u64 {
-    if bytes.is_empty() {
-        return 0;
-    }
-    // Hot enough to matter, but pulling in the `bytecount` crate just for
-    // newline counts is overkill — the manual loop is fine here.
-    #[allow(clippy::naive_bytecount)]
-    let newlines = bytes.iter().filter(|b| **b == b'\n').count() as u64;
-    if bytes.ends_with(b"\n") {
-        newlines
-    } else {
-        newlines + 1
     }
 }


### PR DESCRIPTION
## Problem

The code-index file scanner computed line counts with:

```rust
let line_count = if content.is_empty() { 0 } else { content.split('\n').count() as u32 };
```

`split('\n')` yields a trailing empty element for any string ending in `\n`, so
every file with a trailing newline (the overwhelmingly common case) was counted
with **one phantom extra line** — e.g. a 2-line file ending in `\n` was reported
as 3 lines. This `line_count` is surfaced to Harn scripts via the
`hostlib_code_index_*` builtins (`code_index/builtins.rs`), so user-visible facts
were wrong.

## Why it's an unambiguous defect

The same crate already had **two** correct, newline-aware implementations of the
exact same logic — `scanner/mod.rs::count_lines` and
`tools/proc/artifacts.rs::line_count`. The code-index copy disagreed with both,
which is also what let it drift in the first place.

## Fix (DRY)

Extracted a single shared `count_lines(bytes: &[u8]) -> u64` helper into a new
`crates/harn-hostlib/src/text.rs` and routed all three call sites through it,
deleting the two local duplicates. There is now one source of truth, with unit
tests covering empty input, trailing-newline, and no-trailing-newline cases.

## Verification

- `cargo build -p harn-hostlib --features ast` — ✅
- New `text::tests` (3) + full lib suite — ✅ 301 passed
- `line_count`-exercising e2e tests: `scanner_e2e` (27), `code_index_live_state`
  (44), `process_tools` (8) — ✅ all pass
- `cargo clippy` and `cargo fmt --check` — ✅ clean

One unrelated lib-test failure (`sandbox::local::...`) is environmental — it
requires Linux Landlock, unavailable in the CI sandbox — and is in a code path
this change never touches.

A changelog fragment is included at `changelog.d/code-index-line-count.fixed.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4woTMRfn421f3dAJDyqn4)_