### PR TITLE
Make typed-opcode specialization sound for reassignable bindings

### DIFF
--- a/changelog.d/monomorphic-var-specialization.fixed.md
+++ b/changelog.d/monomorphic-var-specialization.fixed.md
@@ -1,0 +1,13 @@
+- Fixed unsound typed-opcode specialization for reassignable bindings. The
+  compiler trusted a `var` / `for`-item binding's initializer-inferred primitive
+  type when emitting typed fast-path opcodes (`AddInt`, `LessInt`, …), even
+  though such a binding can be reassigned through an `any`-typed value of a
+  different runtime primitive. Because typed opcodes hard-error on an operand
+  type mismatch, the optimized build could throw a spurious
+  `Typed int add expected int operands, got int and float` on a program the
+  unoptimized build runs correctly. The compiler now keeps the typed fast path
+  only for bindings a new monomorphism analysis can prove keep a single
+  primitive type across their initializer and every reassignment in scope; all
+  others fall back to the generic adaptive path, which re-checks operand shapes
+  at runtime. The common loop-counter and accumulator idioms stay fully
+  specialized.

--- a/crates/harn-vm/src/compiler/mod.rs
+++ b/crates/harn-vm/src/compiler/mod.rs
@@ -142,6 +142,18 @@ pub struct Compiler {
     /// from the parser's diagnostic type checker so compile-only callers keep
     /// working without a required type-check pass.
     type_scopes: Vec<std::collections::HashMap<String, TypeExpr>>,
+    /// `(span.start, span.end)` of every mutable binding (`var` / `for`-item)
+    /// proven *monomorphic*: its value keeps a single primitive type across its
+    /// initializer and every reassignment in scope. Only these bindings may
+    /// carry an initializer-inferred primitive type fact into typed-opcode
+    /// specialization (`AddInt`, `LessInt`, …), which hard-errors on a runtime
+    /// operand-type mismatch. A mutable binding that is reassigned through an
+    /// `any`-typed (or otherwise non-matching) value is *not* recorded here, so
+    /// the compiler keeps it on the generic adaptive path that re-checks operand
+    /// shapes at runtime — see [`Compiler::record_monomorphic_var_bindings`].
+    /// Populated per lexical scope before that scope's statements are compiled;
+    /// keyed by byte span because `Span` is not `Hash`.
+    monomorphic_bindings: std::collections::HashSet<(usize, usize)>,
     /// Current-chunk string constant index. This avoids repeatedly scanning the
     /// constant pool while compiling name-heavy scripts.
     string_constants: std::collections::HashMap<String, u16>,
@@ -222,6 +234,14 @@ impl Compiler {
                 };
                 self.compile_node(value)?;
                 self.compile_destructuring(pattern, true)?;
+                // A `var` is reassignable, so its initializer-inferred primitive
+                // type is only safe for typed-opcode specialization when the
+                // binding is provably monomorphic (proven by
+                // `record_monomorphic_var_bindings`, run before this scope's
+                // statements). Otherwise drop the primitive fact so arithmetic
+                // stays on the generic adaptive path, which re-checks operand
+                // shapes at runtime instead of hard-committing to `AddInt` etc.
+                let binding_type = self.gate_mutable_primitive_type(snode.span, binding_type);
                 self.record_binding_type(pattern, binding_type.clone());
                 self.maybe_register_owned_drop(pattern, binding_type.as_ref(), snode.span);
             }

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -43,6 +43,7 @@ impl Compiler {
             scope_depth: 0,
             type_aliases: std::collections::HashMap::new(),
             type_scopes: vec![std::collections::HashMap::new()],
+            monomorphic_bindings: std::collections::HashSet::new(),
             string_constants: std::collections::HashMap::new(),
             local_scopes: vec![std::collections::HashMap::new()],
             module_level: true,
@@ -919,6 +920,7 @@ impl Compiler {
         stmts: &[SNode],
     ) -> Result<(), CompileError> {
         self.begin_scope();
+        self.record_monomorphic_var_bindings(stmts);
         let finally_floor = self.finally_bodies.len();
         for sn in stmts {
             self.compile_discarded_stmt(sn)?;
@@ -1066,6 +1068,7 @@ impl Compiler {
     }
 
     pub(super) fn compile_block(&mut self, stmts: &[SNode]) -> Result<(), CompileError> {
+        self.record_monomorphic_var_bindings(stmts);
         for (i, snode) in stmts.iter().enumerate() {
             if i == stmts.len() - 1 {
                 // The block's value is its last statement's. Backfill a `Nil`

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -247,7 +247,14 @@ impl Compiler {
         self.begin_scope();
         let finally_floor = self.finally_bodies.len();
         self.compile_destructuring(pattern, true)?;
+        // A `for`-item binding is reassignable per iteration, so — like a `var`
+        // — its inferred primitive type may only feed typed-opcode
+        // specialization when no reassignment in the loop body can change its
+        // primitive kind. Otherwise drop the primitive fact and stay on the
+        // generic adaptive path.
+        let item_type = self.gate_for_item_type(pattern, item_type, body);
         self.record_binding_type(pattern, item_type);
+        self.record_monomorphic_var_bindings(body);
         for sn in body {
             self.compile_discarded_stmt(sn)?;
         }

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -147,6 +147,120 @@ fn test_compile_generic_ops_for_overloaded_or_mixed_cases() {
 }
 
 #[test]
+fn monomorphic_var_keeps_typed_int_ops() {
+    // A `var` only ever reassigned through int-typed values is provably
+    // monomorphic, so its arithmetic keeps the typed fast path even when the
+    // use precedes the reassignment in source order.
+    let chunk = compile_source(
+        "pipeline test(task) {
+  var x = 0
+  var i = 0
+  while i < 3 {
+    log(x + 1)
+    x = x + 2
+    i = i + 1
+  }
+}",
+    );
+    let disasm = chunk.disassemble("test");
+    assert!(
+        disasm.contains("ADD_INT"),
+        "expected typed add, got:\n{disasm}"
+    );
+    assert!(disasm.contains("LESS_INT"));
+}
+
+#[test]
+fn polymorphic_var_reassigned_from_dynamic_falls_back_to_generic() {
+    // `x` is inferred `int` from its initializer but later reassigned from a
+    // statically-unknown (`any`) call result, so its runtime primitive type can
+    // change. Committing `x + 1` to ADD_INT would be unsound, so the compiler
+    // must keep the generic adaptive ADD. (No int counter here, so ADD_INT
+    // appearing at all would mean `x` was wrongly specialized.)
+    let chunk = compile_source(
+        "pipeline test(task) {
+  var x = 0
+  let cell = shared_cell(\"k\", 2.5)
+  log(x + 1)
+  x = shared_get(cell)
+}",
+    );
+    let disasm = chunk.disassemble("test");
+    assert!(
+        disasm.contains("ADD"),
+        "expected generic add, got:\n{disasm}"
+    );
+    assert!(
+        !disasm.contains("ADD_INT"),
+        "polymorphic var must not specialize, got:\n{disasm}"
+    );
+}
+
+#[test]
+fn polymorphic_var_demotes_dependent_sibling() {
+    // `sum` only ever takes `sum + x`, but `x` is polymorphic, so `sum`'s
+    // primitive type is not provable either — the fixpoint must demote both.
+    let chunk = compile_source(
+        "pipeline test(task) {
+  var x = 0
+  var sum = 0
+  let cell = shared_cell(\"k\", 2.5)
+  sum = sum + x
+  x = shared_get(cell)
+  log(sum)
+}",
+    );
+    let disasm = chunk.disassemble("test");
+    assert!(
+        !disasm.contains("ADD_INT"),
+        "x and its dependent sum must both fall back, got:\n{disasm}"
+    );
+}
+
+#[test]
+fn for_item_reassigned_from_dynamic_falls_back_to_generic() {
+    // A `for`-item binding is reassignable per iteration; reassigning it from an
+    // `any` value makes its primitive type unprovable, so arithmetic on it must
+    // stay generic.
+    let chunk = compile_source(
+        "pipeline test(task) {
+  var sum = 0
+  let cell = shared_cell(\"k\", 2.5)
+  for n in [1, 2, 3] {
+    sum = sum + n
+    n = shared_get(cell)
+  }
+  log(sum)
+}",
+    );
+    let disasm = chunk.disassemble("test");
+    assert!(
+        !disasm.contains("ADD_INT"),
+        "reassigned for-item must not specialize, got:\n{disasm}"
+    );
+}
+
+#[test]
+fn for_item_never_reassigned_keeps_typed_ops() {
+    // The common case: a `for`-item that is never reassigned stays on the typed
+    // fast path.
+    let chunk = compile_source(
+        "pipeline test(task) {
+  var sum = 0
+  for n in [1, 2, 3] {
+    sum = sum + n
+  }
+  log(sum)
+}",
+    );
+    let disasm = chunk.disassemble("test");
+    assert!(
+        disasm.contains("ADD_INT"),
+        "unreassigned for-item should specialize, got:\n{disasm}"
+    );
+}
+
+#[test]
 fn test_optimizer_folds_scalar_constants() {
     let chunk = compile_source("pipeline test(task) { log(2 + 3 * 4) }");
     let disasm = chunk.disassemble("test");

--- a/crates/harn-vm/src/compiler/type_facts.rs
+++ b/crates/harn-vm/src/compiler/type_facts.rs
@@ -327,6 +327,428 @@ impl Compiler {
         }
     }
 
+    /// Canonical primitive tag (`"int"` / `"float"` / `"bool"` / `"string"`)
+    /// for a type expression that resolves to one of the four
+    /// specialization-relevant primitives, else `None`. `nil` is excluded
+    /// because no typed opcode specializes on it. Used by the monomorphic-var
+    /// analysis and the mutable-binding gate.
+    pub(super) fn primitive_type_tag(&self, type_expr: &TypeExpr) -> Option<&'static str> {
+        match Self::primitive_kind(&self.expand_alias(type_expr)) {
+            Some(PrimitiveType::Int) => Some("int"),
+            Some(PrimitiveType::Float) => Some("float"),
+            Some(PrimitiveType::Bool) => Some("bool"),
+            Some(PrimitiveType::String) => Some("string"),
+            Some(PrimitiveType::Nil) | None => None,
+        }
+    }
+
+    /// Drop an initializer-inferred *primitive* type for a reassignable binding
+    /// (`var` / `for`-item) that the monomorphic analysis did not prove safe, so
+    /// typed-opcode specialization stays sound. Non-primitive types and
+    /// proven-monomorphic bindings pass through unchanged.
+    pub(super) fn gate_mutable_primitive_type(
+        &self,
+        span: harn_lexer::Span,
+        type_expr: Option<TypeExpr>,
+    ) -> Option<TypeExpr> {
+        if !self.options.optimizations_enabled() {
+            // No typed-opcode specialization happens, and the monomorphic set is
+            // never populated — leave facts byte-identical to the pre-gate path.
+            return type_expr;
+        }
+        match &type_expr {
+            Some(t)
+                if self.primitive_type_tag(t).is_some()
+                    && !self.monomorphic_bindings.contains(&(span.start, span.end)) =>
+            {
+                None
+            }
+            _ => type_expr,
+        }
+    }
+
+    /// Gate the inferred item type of a `for`-loop binding the same way `var`
+    /// bindings are gated. For a simple `for name in …` the primitive item type
+    /// is kept only when no body reassignment can change `name`'s primitive
+    /// kind. A destructuring item pattern (`for [a, b] in …`) is left untouched
+    /// unless one of its names is reassigned in the body, in which case the whole
+    /// inferred type is dropped — destructured items are rarely reassigned, so
+    /// this stays sound without per-element kind tracking.
+    pub(super) fn gate_for_item_type(
+        &mut self,
+        pattern: &BindingPattern,
+        item_type: Option<TypeExpr>,
+        body: &[SNode],
+    ) -> Option<TypeExpr> {
+        if !self.options.optimizations_enabled() {
+            return item_type;
+        }
+        match pattern {
+            BindingPattern::Identifier(name) => {
+                let Some(tag) = item_type.as_ref().and_then(|t| self.primitive_type_tag(t)) else {
+                    return item_type;
+                };
+                if self.for_item_binding_is_monomorphic(name, tag, body) {
+                    item_type
+                } else {
+                    None
+                }
+            }
+            other => {
+                let mut names = Vec::new();
+                Self::collect_pattern_names(other, &mut names);
+                if names
+                    .iter()
+                    .any(|name| Self::body_reassigns_name(name, body))
+                {
+                    None
+                } else {
+                    item_type
+                }
+            }
+        }
+    }
+
+    fn collect_pattern_names(pattern: &BindingPattern, out: &mut Vec<String>) {
+        match pattern {
+            BindingPattern::Identifier(name) => out.push(name.clone()),
+            BindingPattern::Dict(fields) => {
+                for field in fields {
+                    out.push(field.alias.clone().unwrap_or_else(|| field.key.clone()));
+                }
+            }
+            BindingPattern::List(elements) => {
+                for element in elements {
+                    out.push(element.name.clone());
+                }
+            }
+            BindingPattern::Pair(a, b) => {
+                out.push(a.clone());
+                out.push(b.clone());
+            }
+        }
+    }
+
+    fn body_reassigns_name(name: &str, body: &[SNode]) -> bool {
+        let mut found = false;
+        for sn in body {
+            harn_parser::visit::walk_node(sn, &mut |node| {
+                if let Node::Assignment { target, .. } = &node.node {
+                    if let Node::Identifier(target_name) = &target.node {
+                        if target_name == name {
+                            found = true;
+                        }
+                    }
+                }
+            });
+        }
+        found
+    }
+
+    /// Prove which mutable `var` bindings declared at the top level of `stmts`
+    /// are *monomorphic* — their value keeps one primitive type across the
+    /// initializer and every reassignment reachable in this scope — and record
+    /// their spans in [`Compiler::monomorphic_bindings`].
+    ///
+    /// This is the soundness gate for typed-opcode specialization. A typed op
+    /// such as `AddInt` hard-errors when an operand is not the expected
+    /// primitive at runtime, so the compiler may only emit it for operands whose
+    /// type it can *prove*, not merely guess. A `var`'s initializer type is a
+    /// guess: the binding can later be reassigned through an `any`-typed value
+    /// (which the type checker accepts as assignable to the inferred type) of a
+    /// different runtime primitive, at which point a hard-committed `AddInt`
+    /// would spuriously throw on a program the generic path runs correctly.
+    ///
+    /// Only `var`/`for`-item bindings need this gate. `let`/`const` are
+    /// immutable — the runtime rejects reassignment — so their initializer type
+    /// is sound as-is and is left untouched.
+    ///
+    /// Strategy: gather the primitive-typed `var` candidates, collect every
+    /// reassignment to each (the only way Harn can rebind a name; there is no
+    /// destructuring assignment and values are immutable, so an `Identifier`
+    /// assignment target is the sole rebind site), then run a monotone fixpoint.
+    /// Each round assumes the not-yet-disproven candidates hold their initializer
+    /// kind and demotes any whose reassignment then fails to yield that kind.
+    /// The mutual assumption lets the common accumulator idiom
+    /// (`total = total + (i + 3) * 2`, which depends on the sibling counter `i`)
+    /// stay proven, while a counter fed from an `any` value is demoted. The
+    /// fixpoint only ever demotes, so it terminates; a candidate that survives
+    /// to the end is monomorphic under a self-consistent assignment.
+    ///
+    /// Candidates the analysis cannot prove are simply left unrecorded: the gate
+    /// then drops their primitive fact and they fall back to the correct generic
+    /// adaptive path. Soundness therefore never depends on the analysis being
+    /// complete — only its reach affects how much code keeps the fast path.
+    pub(super) fn record_monomorphic_var_bindings(&mut self, stmts: &[SNode]) {
+        if !self.options.optimizations_enabled() {
+            return;
+        }
+
+        // 1. Gather primitive-typed `var name = init` candidates declared at the
+        //    top level of this scope. The first declaration of a name wins; a
+        //    later same-name `var` in this block is a redeclaration we leave on
+        //    the generic path (it would not be reached as a candidate here).
+        let mut order: Vec<String> = Vec::new();
+        let mut tag: std::collections::HashMap<String, &'static str> =
+            std::collections::HashMap::new();
+        let mut span: std::collections::HashMap<String, harn_lexer::Span> =
+            std::collections::HashMap::new();
+        for sn in stmts {
+            let Node::VarBinding {
+                pattern: BindingPattern::Identifier(name),
+                value,
+                type_ann,
+            } = &sn.node
+            else {
+                continue;
+            };
+            if tag.contains_key(name) {
+                continue;
+            }
+            let declared = type_ann.clone().or_else(|| self.infer_expr_type(value));
+            let Some(primitive) = declared.as_ref().and_then(|t| self.primitive_type_tag(t)) else {
+                continue;
+            };
+            order.push(name.clone());
+            tag.insert(name.clone(), primitive);
+            span.insert(name.clone(), sn.span);
+        }
+        if order.is_empty() {
+            return;
+        }
+
+        // 2. The set of names rebound anywhere in this subtree (an `Identifier`
+        //    assignment target is the only rebind site — Harn has no
+        //    destructuring assignment and values are immutable).
+        let reassigned_names = Self::collect_reassigned_names(stmts);
+
+        // 3. Seed map: bindings whose primitive type is stable across this
+        //    subtree and can therefore be assumed while proving the candidates —
+        //    immutable `let`/`const`, plus `var`/`for`-item bindings that are
+        //    never reassigned here. This lets a candidate that depends on a
+        //    sibling binding introduced later or in a nested scope (notably
+        //    `for n in xs { sum = sum + n }`) still be proven monomorphic. A
+        //    *reassigned* mutable binding is deliberately excluded: it cannot be
+        //    assumed safe, so candidates depending on it are demoted to the
+        //    generic path.
+        let seeds = self.collect_primitive_seeds(stmts, &reassigned_names);
+
+        // 4. Collect every reassignment `name = value` / `name op= value` to a
+        //    candidate, anywhere in this scope's statement subtree.
+        let candidate_names: std::collections::HashSet<&str> =
+            order.iter().map(String::as_str).collect();
+        let mut reassigns: std::collections::HashMap<String, Vec<(Option<String>, SNode)>> =
+            std::collections::HashMap::new();
+        for sn in stmts {
+            harn_parser::visit::walk_node(sn, &mut |node| {
+                if let Node::Assignment { target, value, op } = &node.node {
+                    if let Node::Identifier(name) = &target.node {
+                        if candidate_names.contains(name.as_str()) {
+                            reassigns
+                                .entry(name.clone())
+                                .or_default()
+                                .push((op.clone(), (**value).clone()));
+                        }
+                    }
+                }
+            });
+        }
+
+        // 5. Monotone fixpoint: assume every still-trusted candidate holds its
+        //    initializer kind (on top of the stable seeds), then demote any whose
+        //    reassignment does not yield that same kind under those assumptions.
+        //    Repeat until stable.
+        let mut demoted: std::collections::HashSet<String> = std::collections::HashSet::new();
+        loop {
+            let mut assumptions: std::collections::HashMap<String, TypeExpr> = seeds.clone();
+            for name in &order {
+                if !demoted.contains(name) {
+                    assumptions.insert(name.clone(), TypeExpr::Named(tag[name].to_string()));
+                }
+            }
+            self.type_scopes.push(assumptions);
+
+            let mut newly_demoted: Vec<String> = Vec::new();
+            for name in &order {
+                if demoted.contains(name) {
+                    continue;
+                }
+                let expected = tag[name];
+                let preserved = reassigns
+                    .get(name)
+                    .into_iter()
+                    .flatten()
+                    .all(|(op, value)| {
+                        self.reassignment_primitive_tag(expected, op.as_deref(), value)
+                            == Some(expected)
+                    });
+                if !preserved {
+                    newly_demoted.push(name.clone());
+                }
+            }
+
+            self.type_scopes.pop();
+            if newly_demoted.is_empty() {
+                break;
+            }
+            demoted.extend(newly_demoted);
+        }
+
+        // 6. Record the survivors as monomorphic.
+        for name in &order {
+            if !demoted.contains(name) {
+                let s = span[name];
+                self.monomorphic_bindings.insert((s.start, s.end));
+            }
+        }
+    }
+
+    /// Names rebound by an assignment anywhere in `stmts`' subtree. Used to
+    /// decide which mutable bindings are stable enough to seed the monomorphic
+    /// fixpoint.
+    fn collect_reassigned_names(stmts: &[SNode]) -> std::collections::HashSet<String> {
+        let mut names = std::collections::HashSet::new();
+        for sn in stmts {
+            harn_parser::visit::walk_node(sn, &mut |node| {
+                if let Node::Assignment { target, .. } = &node.node {
+                    if let Node::Identifier(name) = &target.node {
+                        names.insert(name.clone());
+                    }
+                }
+            });
+        }
+        names
+    }
+
+    /// Build the seed assumptions for the monomorphic fixpoint: every binding in
+    /// `stmts`' subtree whose value provably keeps a single primitive type here.
+    /// Immutable `let`/`const` always qualify; `var` and `for`-item bindings
+    /// qualify only when their name is never reassigned in this subtree.
+    fn collect_primitive_seeds(
+        &self,
+        stmts: &[SNode],
+        reassigned: &std::collections::HashSet<String>,
+    ) -> std::collections::HashMap<String, TypeExpr> {
+        let mut seeds: std::collections::HashMap<String, TypeExpr> =
+            std::collections::HashMap::new();
+        for sn in stmts {
+            harn_parser::visit::walk_node(sn, &mut |node| {
+                let (name, declared) = match &node.node {
+                    Node::LetBinding {
+                        pattern: BindingPattern::Identifier(name),
+                        type_ann,
+                        value,
+                    }
+                    | Node::VarBinding {
+                        pattern: BindingPattern::Identifier(name),
+                        type_ann,
+                        value,
+                    } => {
+                        // A reassigned `var` is not stable; `let` is immutable so
+                        // it always is, even though they share this arm.
+                        if matches!(node.node, Node::VarBinding { .. }) && reassigned.contains(name)
+                        {
+                            return;
+                        }
+                        (
+                            name,
+                            type_ann.clone().or_else(|| self.infer_expr_type(value)),
+                        )
+                    }
+                    Node::ConstBinding {
+                        name,
+                        type_ann,
+                        value,
+                    } => (
+                        name,
+                        type_ann.clone().or_else(|| self.infer_expr_type(value)),
+                    ),
+                    Node::ForIn {
+                        pattern: BindingPattern::Identifier(name),
+                        iterable,
+                        ..
+                    } => {
+                        if reassigned.contains(name) {
+                            return;
+                        }
+                        (name, self.infer_for_item_type(iterable))
+                    }
+                    _ => return,
+                };
+                if let Some(t) = declared.as_ref().and_then(|t| self.primitive_type_tag(t)) {
+                    seeds
+                        .entry(name.clone())
+                        .or_insert_with(|| TypeExpr::Named(t.to_string()));
+                }
+            });
+        }
+        seeds
+    }
+
+    /// Primitive tag a single reassignment to `name` (assumed to currently hold
+    /// `expected`) would produce, or `None` when it is non-primitive or
+    /// statically unknown. A plain `name = value` takes the value's type; a
+    /// compound `name op= value` takes `name op value` with `name` held at
+    /// `expected`. Candidate assumptions are supplied via a pushed type scope.
+    fn reassignment_primitive_tag(
+        &self,
+        expected: &str,
+        op: Option<&str>,
+        value: &SNode,
+    ) -> Option<&'static str> {
+        match op {
+            None => self
+                .infer_expr_type(value)
+                .as_ref()
+                .and_then(|t| self.primitive_type_tag(t)),
+            Some(op) => {
+                let left = TypeExpr::Named(expected.to_string());
+                let right = self.infer_expr_type(value);
+                self.infer_binary_result_type(op, Some(&left), right.as_ref())
+                    .as_ref()
+                    .and_then(|t| self.primitive_type_tag(t))
+            }
+        }
+    }
+
+    /// Prove a single `for`-loop item binding is monomorphic over `body`: it is
+    /// reassignable per iteration like a `var`, so the same gate applies. The
+    /// item starts each iteration at `item_tag`; the binding stays monomorphic
+    /// only if every reassignment in the loop body again yields `item_tag`.
+    pub(super) fn for_item_binding_is_monomorphic(
+        &mut self,
+        name: &str,
+        item_tag: &str,
+        body: &[SNode],
+    ) -> bool {
+        if !self.options.optimizations_enabled() {
+            return false;
+        }
+        let mut reassigns: Vec<(Option<String>, SNode)> = Vec::new();
+        for sn in body {
+            harn_parser::visit::walk_node(sn, &mut |node| {
+                if let Node::Assignment { target, value, op } = &node.node {
+                    if let Node::Identifier(target_name) = &target.node {
+                        if target_name == name {
+                            reassigns.push((op.clone(), (**value).clone()));
+                        }
+                    }
+                }
+            });
+        }
+        if reassigns.is_empty() {
+            return true;
+        }
+        let mut assumptions = std::collections::HashMap::new();
+        assumptions.insert(name.to_string(), TypeExpr::Named(item_tag.to_string()));
+        self.type_scopes.push(assumptions);
+        let preserved = reassigns.iter().all(|(op, value)| {
+            self.reassignment_primitive_tag(item_tag, op.as_deref(), value) == Some(item_tag)
+        });
+        self.type_scopes.pop();
+        preserved
+    }
+
     fn primitive_kind(type_expr: &TypeExpr) -> Option<PrimitiveType> {
         match type_expr {
             TypeExpr::Named(name) => match name.as_str() {

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -2760,3 +2760,79 @@ fn typed_param_lambda_uses_check_type_and_walks() {
     );
     assert_eq!(out, "[harn] [2, 3, 4]\n");
 }
+
+/// Regression: a `var` inferred `int` from its initializer but later reassigned
+/// through an `any`-typed value of a different primitive must not be specialized
+/// into a typed opcode (`AddInt`), which would hard-error at runtime on a
+/// program the generic path runs correctly. The optimized result must match the
+/// unoptimized one exactly. (Previously the optimizer threw
+/// "Typed int add expected int operands, got int and float".)
+#[test]
+fn var_reassigned_via_any_matches_unoptimized() {
+    let source = r#"pipeline default(task) {
+  var x = 0
+  var sum = 0
+  var i = 0
+  let cell = shared_cell("k", 2.5)
+  while i < 3 {
+    sum = sum + x
+    if i == 0 { x = shared_get(cell) }
+    i = i + 1
+  }
+  log("${sum}")
+}"#;
+    let optimized = run_harn_result_display_with_options(source, CompilerOptions::optimized())
+        .expect("optimized run should not spuriously type-error");
+    let baseline =
+        run_harn_result_display_with_options(source, CompilerOptions::without_optimizations())
+            .expect("unoptimized run is the ground truth");
+    assert_eq!(
+        optimized.0, baseline.0,
+        "stdout must match the generic path"
+    );
+    assert_eq!(optimized.0.trim_end(), "[harn] 5.0");
+}
+
+/// Companion to the above for the `for`-item binding, which is reassignable per
+/// iteration. Reassigning it from an `any` value previously crashed under the
+/// optimizer; it must now match the unoptimized result.
+#[test]
+fn for_item_reassigned_via_any_matches_unoptimized() {
+    let source = r#"pipeline default(task) {
+  var sum = 0
+  let cell = shared_cell("k", 2.5)
+  for n in [1, 2, 3] {
+    sum = sum + n
+    n = shared_get(cell)
+    sum = sum + n
+  }
+  log("${sum}")
+}"#;
+    let optimized = run_harn_result_display_with_options(source, CompilerOptions::optimized())
+        .expect("optimized run should not spuriously type-error");
+    let baseline =
+        run_harn_result_display_with_options(source, CompilerOptions::without_optimizations())
+            .expect("unoptimized run is the ground truth");
+    assert_eq!(
+        optimized.0, baseline.0,
+        "stdout must match the generic path"
+    );
+}
+
+/// The monomorphic loop counter / accumulator idiom keeps producing the right
+/// result with the typed fast path engaged (guards against the gate
+/// over-demoting and silently changing arithmetic results).
+#[test]
+fn monomorphic_counter_loop_result_is_correct() {
+    let source = r#"pipeline default(task) {
+  var i = 0
+  var total = 0
+  while i < 10 {
+    total = total + (i + 3) * 2 - 1
+    i = i + 1
+  }
+  log("${total}")
+}"#;
+    let (out, _) = run_harn(source);
+    assert_eq!(out.trim_end(), "[harn] 140");
+}


### PR DESCRIPTION
## Summary

While studying the Harn VM against SOTA bytecode interpreters, the highest-value
opportunity turned out to be a **correctness fix that legitimizes an existing
optimization**: the compiler's typed-opcode specialization was unsound for
reassignable bindings, so the "fast path" was a latent crash.

The VM emits typed fast-path opcodes — `AddInt`, `LessInt`, `EqualString`, … —
when it can infer both operands of a binary op share a primitive type. These
opcodes **hard-error on a runtime operand-type mismatch** (`typed_int_pair`
returns `Err` for non-int operands), so they are only sound when operand types
are *guaranteed*, not merely guessed.

For a `var` / `for`-item binding the inferred type came from its **initializer**,
but the binding is reassignable. It can later be set to an `any`-typed value
(which the type checker accepts as assignable to the inferred type — gradual
typing) of a different runtime primitive. Because the compiler is single-pass, a
use compiled *before* the reassignment in source order is re-executed *after* it
on a loop back-edge, so the optimized build threw a spurious error on programs
the unoptimized build runs correctly:

```harn
pipeline default(task) {
  var x = 0
  var sum = 0
  var i = 0
  let cell = shared_cell("k", 2.5)   // holds a float, typed `any`
  while i < 3 {
    sum = sum + x                     // compiled as AddInt (x inferred int)
    if i == 0 { x = shared_get(cell) }// x is now 2.5 at runtime
    i = i + 1
  }
  log("${sum}")
}
```

```
# optimized (default)
error: Type error: Typed int add expected int operands, got int and float
# HARN_DISABLE_OPTIMIZATIONS=1
[harn] 5.0   ✅ correct
```

The parser's type checker already treats a `var`'s initializer type as untrusted
for exactly this reason (`inference/decls.rs`: *"a `var` can be reassigned to
another type, so trusting its initializer would be unsound"*); the VM compiler
diverged from that and trusted it for codegen.

## Fix

A **monomorphism analysis** (`compiler/type_facts.rs`) runs before each lexical
scope is compiled. It proves which mutable bindings keep a single primitive type
across their initializer and every reassignment in scope, then only those keep
their primitive type fact for specialization; the rest fall back to the generic
adaptive path, which re-checks operand shapes at runtime and stays correct.

- **Monotone fixpoint** that mutually assumes the not-yet-disproven candidates
  and demotes any whose reassignment fails to preserve its kind. The mutual
  assumption keeps the accumulator-with-sibling-counter idiom proven
  (`total = total + (i + 3) * 2 - 1`).
- **Stable seeds** — immutable `let`/`const` and never-reassigned `var`/`for`-item
  bindings seed the assumptions, so a counter that depends on a binding
  introduced later or nested (notably `for n in xs { sum = sum + n }`) stays on
  the fast path.
- Only an `Identifier` assignment target rebinds a binding (Harn has no
  destructuring assignment and values are immutable), which keeps the rebind
  scan exact.

Soundness never depends on the analysis being complete: an unrecorded binding is
dropped to the generic path, so its reach only affects how much code keeps the
fast path. The unoptimized path is left byte-identical (the gate is a no-op when
optimizations are disabled).

The loop-counter and accumulator patterns that dominate arithmetic-heavy code
(every `perf/vm` arithmetic benchmark, `local_variable_lookup`, `comparison_loop`,
…) stay fully specialized — verified by disasm tests and a smoke run of the
perf suite.

## Tests

All in-process and deterministic — no timers, no wall-clock:

- Disasm tests: polymorphic `var` / `for`-item demote to generic; dependent
  sibling demotes; monomorphic `var` and never-reassigned `for`-item keep typed
  ops; the existing `test_compile_typed_int_loop_ops` still passes.
- Runtime regression tests: the previously-crashing `var` and `for`-item
  programs now produce results identical to the unoptimized build; the
  monomorphic counter/accumulator loop computes the correct value.

`cargo test -p harn-vm` and `harn test conformance` (1573 passing; the only
failures are pre-existing environmental ones — git commit-signing, `/tmp`
worktree paths, LLM mock 503, process-sandbox) are green for everything touching
compilation. `cargo clippy -p harn-vm` is clean.

## Follow-up (not in this PR)

A related but distinct latent bug exists: an **annotated** binding's initializer
is not runtime-checked, so `let x: int = <any value of another type>` trusts the
annotation and the optimizer can throw the same way. A sound fix needs the
parser type checker's return-type information (the VM's lightweight inferencer
can't distinguish the sound `let n: int = items.len()` from the unsound case) or
binding-time runtime guards, so it's left for a separate change to avoid
regressing idiomatic typed code.

https://claude.ai/code/session_01Fcu3e7fa87ZhmFQiXFC8hc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fcu3e7fa87ZhmFQiXFC8hc)_