### PR TITLE
Add experimental harn-codegen native compiler for the scalar subset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
 
 [[package]]
+name = "cranelift-jit"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b48c2a0720c7d62aadd508c662b9bf666b614a47a888589e553e0511620635e"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "memmap2 0.2.3",
+ "region",
+ "target-lexicon",
+ "wasmtime-internal-jit-icache-coherence",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f05d9efce7a4e8c2ceec49c76d26e53f1ee8cb13de822b6ca5118d48f50976"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
 name = "cranelift-native"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1216,21 @@ checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
 dependencies = [
  "cranelift-codegen",
  "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-object"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7a263727954f7b310796e1b5543e6dfd6afed7e15c62f2454b51b6f38a39e1"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-module",
+ "log",
+ "object",
  "target-lexicon",
 ]
 
@@ -2229,7 +2276,7 @@ dependencies = [
  "grep-matcher",
  "log",
  "memchr",
- "memmap2",
+ "memmap2 0.9.10",
 ]
 
 [[package]]
@@ -2368,6 +2415,20 @@ dependencies = [
  "serde",
  "time",
  "tokio",
+]
+
+[[package]]
+name = "harn-codegen"
+version = "0.8.81"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
+ "cranelift-object",
+ "harn-parser",
+ "harn-vm",
 ]
 
 [[package]]
@@ -3664,6 +3725,15 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
@@ -4903,6 +4973,18 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rend"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/harn-lexer",
     "crates/harn-parser",
     "crates/harn-ir",
+    "crates/harn-codegen",
     "crates/harn-cli",
     "crates/harn-serve",
     "crates/harn-skills",

--- a/changelog.d/native-codegen.added.md
+++ b/changelog.d/native-codegen.added.md
@@ -1,0 +1,9 @@
+- **Experimental `harn-codegen` crate: a Cranelift-backed native compiler for
+  Harn's scalar-compute subset.** Lowers `int`/`float`/`bool` functions
+  (arithmetic, comparisons, logical ops, branches, loops, locals) from VM
+  bytecode to native machine code, with an in-process JIT (`NativeFunction`),
+  an object-file backend (`emit_object`), a pure-Rust reference interpreter,
+  and a `harn-nativec` CLI. It is `publish = false` and is not a dependency of
+  `harn-cli`/`harn-vm`, so the distributed binary never links Cranelift; build
+  it explicitly with `-p harn-codegen`. See
+  `docs/src/dev/native-codegen.md`.

--- a/crates/harn-codegen/Cargo.toml
+++ b/crates/harn-codegen/Cargo.toml
@@ -1,0 +1,39 @@
+# harn-codegen — experimental ahead-of-time / JIT native compiler for the
+# scalar-compute subset of Harn bytecode.
+#
+# This crate is intentionally NOT a dependency of `harn-cli`, `harn-vm`, or any
+# other crate that ships in the distributed Harn binary. It pulls in the
+# Cranelift code generator (the same vetted code generator the optional
+# `testbench-wasi` feature already links via wasmtime), which would otherwise
+# bloat the shipped CLI. It builds and tests under `cargo *--workspace` so CI
+# keeps it honest, but `publish = false` keeps it off crates.io and nothing in
+# the published dependency graph links it. See `docs/src/dev/native-codegen.md`.
+[package]
+name = "harn-codegen"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Experimental Cranelift-backed native compiler for the scalar subset of Harn bytecode"
+publish = false
+
+[lib]
+name = "harn_codegen"
+
+[[bin]]
+name = "harn-nativec"
+path = "src/bin/harn-nativec.rs"
+
+[dependencies]
+harn-vm = { path = "../harn-vm", version = "0.8" }
+harn-parser = { path = "../harn-parser", version = "0.8" }
+cranelift-codegen = "0.132"
+cranelift-frontend = "0.132"
+cranelift-module = "0.132"
+cranelift-jit = "0.132"
+cranelift-native = "0.132"
+cranelift-object = "0.132"
+
+[lints]
+workspace = true

--- a/crates/harn-codegen/src/aot.rs
+++ b/crates/harn-codegen/src/aot.rs
@@ -1,0 +1,60 @@
+//! Ahead-of-time object-file backend.
+//!
+//! Emits a relocatable native object (ELF/Mach-O/COFF for the host target)
+//! exporting the compiled function under a stable C symbol. The object can be
+//! linked into a normal executable or shared library with any system linker —
+//! this is the "compile Harn to a binary" path.
+
+use cranelift_codegen::settings::{self, Configurable};
+use cranelift_module::default_libcall_names;
+use cranelift_object::{ObjectBuilder, ObjectModule};
+
+use crate::error::CodegenError;
+use crate::lower::define_scalar_function;
+use crate::symbol_name;
+use crate::verify::ScalarFunction;
+
+/// A compiled object file plus the symbol the function is exported under.
+#[derive(Debug, Clone)]
+pub struct ObjectArtifact {
+    /// The exported C symbol name (derived from the function name).
+    pub symbol: String,
+    /// The encoded object-file bytes for the host target.
+    pub bytes: Vec<u8>,
+}
+
+/// Compile `sf` to a host-target object file.
+///
+/// # Errors
+///
+/// Returns [`CodegenError::Backend`] if the host ISA is unavailable or
+/// Cranelift fails to compile or encode the object.
+pub fn emit_object(sf: &ScalarFunction) -> Result<ObjectArtifact, CodegenError> {
+    let mut flags = settings::builder();
+    // Relocatable, position-independent code is the right default for a `.o`
+    // that a linker will later place into a PIE or shared object.
+    flags
+        .set("is_pic", "true")
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+    let _ = flags.set("opt_level", "speed");
+
+    let isa_builder =
+        cranelift_native::builder().map_err(|e| CodegenError::backend(e.to_string()))?;
+    let isa = isa_builder
+        .finish(settings::Flags::new(flags))
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+
+    let symbol = symbol_name(&sf.name);
+    let builder = ObjectBuilder::new(isa, symbol.clone(), default_libcall_names())
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+    let mut module = ObjectModule::new(builder);
+
+    define_scalar_function(&mut module, sf, &symbol)?;
+
+    let product = module.finish();
+    let bytes = product
+        .emit()
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+
+    Ok(ObjectArtifact { symbol, bytes })
+}

--- a/crates/harn-codegen/src/bin/harn-nativec.rs
+++ b/crates/harn-codegen/src/bin/harn-nativec.rs
@@ -1,0 +1,166 @@
+//! `harn-nativec` — experimental Harn-to-native compiler CLI.
+//!
+//! Compiles a single scalar Harn function to machine code (JIT or object file)
+//! and, optionally, runs it. This binary is the human-facing front door to the
+//! `harn-codegen` crate and is never part of the distributed `harn` binary.
+//!
+//! ```text
+//! harn-nativec <file.harn> <function> [--object <out.o>] [--run <arg>...] [--debug]
+//! ```
+
+use std::process::ExitCode;
+
+use harn_codegen::{
+    analyze_named, emit_object, evaluate, jit_compile, ScalarFunction, ScalarType, ScalarValue,
+};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match run(&args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(message) => {
+            eprintln!("harn-nativec: {message}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+struct Options {
+    file: String,
+    function: String,
+    object_out: Option<String>,
+    run_args: Option<Vec<String>>,
+    debug: bool,
+}
+
+fn run(args: &[String]) -> Result<(), String> {
+    let opts = parse_args(args)?;
+
+    let source = std::fs::read_to_string(&opts.file)
+        .map_err(|e| format!("cannot read `{}`: {e}", opts.file))?;
+
+    let scalar = analyze_named(&source, &opts.function).map_err(|e| e.to_string())?;
+
+    println!(
+        "fn {} : ({}) -> {}",
+        scalar.name,
+        scalar
+            .params
+            .iter()
+            .map(|ty| ty.harn_name())
+            .collect::<Vec<_>>()
+            .join(", "),
+        scalar.ret
+    );
+    println!(
+        "  scalar subset OK — {} block(s), {} local slot(s)",
+        scalar.blocks.len(),
+        scalar.slot_count()
+    );
+    if opts.debug {
+        println!("{scalar:#?}");
+    }
+
+    if let Some(path) = &opts.object_out {
+        let artifact = emit_object(&scalar).map_err(|e| e.to_string())?;
+        std::fs::write(path, &artifact.bytes).map_err(|e| format!("cannot write `{path}`: {e}"))?;
+        println!(
+            "  wrote {} byte object exporting `{}` to {path}",
+            artifact.bytes.len(),
+            artifact.symbol
+        );
+    }
+
+    if let Some(raw_args) = &opts.run_args {
+        let parsed = parse_run_args(&scalar, raw_args)?;
+        let native = jit_compile(&scalar).map_err(|e| e.to_string())?;
+        let jit_result = native.call(&parsed).map_err(|e| e.to_string())?;
+        // Cross-check against the reference interpreter — they must agree.
+        let ref_result = evaluate(&scalar, &parsed).map_err(|e| e.to_string())?;
+        if jit_result != ref_result {
+            return Err(format!(
+                "internal mismatch: jit={jit_result} reference={ref_result}"
+            ));
+        }
+        println!("  => {jit_result}");
+    }
+
+    Ok(())
+}
+
+fn parse_args(args: &[String]) -> Result<Options, String> {
+    let mut positional = Vec::new();
+    let mut object_out = None;
+    let mut run_args = None;
+    let mut debug = false;
+
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--object" => {
+                idx += 1;
+                object_out = Some(args.get(idx).ok_or("--object requires a path")?.clone());
+            }
+            "--run" => {
+                // Everything after --run is a positional argument value.
+                run_args = Some(args[idx + 1..].to_vec());
+                break;
+            }
+            "--debug" => debug = true,
+            "--help" | "-h" => return Err(usage()),
+            other if other.starts_with("--") => {
+                return Err(format!("unknown flag `{other}`\n{}", usage()));
+            }
+            other => positional.push(other.to_string()),
+        }
+        idx += 1;
+    }
+
+    if positional.len() != 2 {
+        return Err(usage());
+    }
+    Ok(Options {
+        file: positional[0].clone(),
+        function: positional[1].clone(),
+        object_out,
+        run_args,
+        debug,
+    })
+}
+
+fn parse_run_args(scalar: &ScalarFunction, raw: &[String]) -> Result<Vec<ScalarValue>, String> {
+    if raw.len() != scalar.params.len() {
+        return Err(format!(
+            "`{}` takes {} argument(s), got {}",
+            scalar.name,
+            scalar.params.len(),
+            raw.len()
+        ));
+    }
+    raw.iter()
+        .zip(&scalar.params)
+        .map(|(text, ty)| parse_scalar(text, *ty))
+        .collect()
+}
+
+fn parse_scalar(text: &str, ty: ScalarType) -> Result<ScalarValue, String> {
+    match ty {
+        ScalarType::Int => text
+            .parse::<i64>()
+            .map(ScalarValue::Int)
+            .map_err(|_| format!("`{text}` is not an int")),
+        ScalarType::Float => text
+            .parse::<f64>()
+            .map(ScalarValue::Float)
+            .map_err(|_| format!("`{text}` is not a float")),
+        ScalarType::Bool => text
+            .parse::<bool>()
+            .map(ScalarValue::Bool)
+            .map_err(|_| format!("`{text}` is not a bool")),
+    }
+}
+
+fn usage() -> String {
+    "usage: harn-nativec <file.harn> <function> [--object <out.o>] [--run <arg>...] [--debug]"
+        .to_string()
+}

--- a/crates/harn-codegen/src/bytecode.rs
+++ b/crates/harn-codegen/src/bytecode.rs
@@ -1,0 +1,299 @@
+//! Decoding of the Harn VM bytecode subset that the native compiler
+//! understands.
+//!
+//! We deliberately avoid coupling to `harn-vm`'s private dispatch tables: the
+//! only thing this module relies on is that [`harn_vm::Op`] is a public
+//! `#[repr(u8)]` enum, so `Op::Foo as u8` yields its canonical byte. That
+//! keeps the whole compiler additive — nothing in the shipped VM changes, and
+//! the distributed binary never links Cranelift.
+//!
+//! Decoding is *reachability driven* (see [`crate::verify`]): the Harn
+//! compiler routinely emits an unreachable `Nil; Return` epilogue after an
+//! explicit `return`, and `Nil` is outside the scalar subset. Walking control
+//! flow instead of the raw byte stream means that dead epilogue never
+//! disqualifies an otherwise-scalar function.
+
+use harn_vm::{Constant, Op};
+
+use crate::error::CodegenError;
+use crate::value::ScalarValue;
+
+/// A scalar binary arithmetic operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+}
+
+/// A scalar comparison operator. Always produces a `bool`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+}
+
+/// A decoded instruction in the scalar subset. Operands are fully resolved
+/// (constants materialised, jump targets as absolute byte offsets) so neither
+/// the verifier nor the backends need to re-touch the raw byte stream.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Instr {
+    /// Push a scalar constant.
+    Const(ScalarValue),
+    /// Pop two operands, push `a <op> b`.
+    Bin(BinOp),
+    /// Pop two operands, push the boolean comparison result.
+    Cmp(CmpOp),
+    /// Pop one operand, push its arithmetic negation.
+    Neg,
+    /// Pop one boolean, push its logical negation.
+    Not,
+    /// Discard the top operand.
+    Pop,
+    /// Duplicate the top operand.
+    Dup,
+    /// Swap the top two operands.
+    Swap,
+    /// Push the value of a local slot.
+    GetLocal(u16),
+    /// Pop a value and bind it to a local slot (first definition).
+    DefLocal(u16),
+    /// Pop a value and assign it to an already-defined local slot.
+    SetLocal(u16),
+    /// Unconditional jump to an absolute byte offset.
+    Jump(usize),
+    /// Branch to an absolute byte offset when the (peeked, not popped) top of
+    /// stack is falsy; fall through otherwise.
+    JumpIfFalse(usize),
+    /// Branch to an absolute byte offset when the (peeked) top of stack is
+    /// truthy; fall through otherwise.
+    JumpIfTrue(usize),
+    /// Pop the result and return it from the function.
+    Return,
+    /// No operand-stack or slot effect. Used for bytecode that only touches
+    /// runtime bookkeeping irrelevant to scalar code — `PushScope`/`PopScope`
+    /// manage the name environment and lexical scope depth, neither of which a
+    /// slot-based scalar function observes.
+    Nop,
+    /// Push the `nil` unit value. Harn emits this for the discarded result of
+    /// statement-level `while`/`if`/blocks, always immediately followed by a
+    /// `Pop`. The verifier strips those `PushUnit; Pop` pairs; any surviving
+    /// unit (e.g. an implicit nil return) falls outside the scalar subset.
+    PushUnit,
+}
+
+impl Instr {
+    /// True for instructions that end a basic block.
+    pub(crate) const fn is_terminator(&self) -> bool {
+        matches!(
+            self,
+            Self::Jump(_) | Self::JumpIfFalse(_) | Self::JumpIfTrue(_) | Self::Return
+        )
+    }
+}
+
+/// A single decoded instruction together with its position in the byte stream
+/// and the offset of the following instruction (its fall-through successor).
+#[derive(Debug, Clone)]
+pub(crate) struct Decoded {
+    pub next: usize,
+    pub instr: Instr,
+}
+
+/// Decode the instruction at `ip`, resolving constant-pool references against
+/// `constants`. Returns the decoded instruction and the offset of the next
+/// instruction, or [`CodegenError::Unsupported`] for any opcode outside the
+/// scalar subset.
+pub(crate) fn decode_at(
+    code: &[u8],
+    constants: &[Constant],
+    ip: usize,
+) -> Result<Decoded, CodegenError> {
+    let byte = *code
+        .get(ip)
+        .ok_or_else(|| CodegenError::verify(format!("instruction pointer {ip} out of bounds")))?;
+
+    let read_u16 = |pos: usize| -> Result<u16, CodegenError> {
+        match (code.get(pos), code.get(pos + 1)) {
+            (Some(hi), Some(lo)) => Ok((u16::from(*hi) << 8) | u16::from(*lo)),
+            _ => Err(CodegenError::verify("truncated u16 operand")),
+        }
+    };
+
+    // Helper that builds a `Decoded` for a bare (operand-less) instruction.
+    let bare = |instr: Instr| {
+        Ok(Decoded {
+            next: ip + 1,
+            instr,
+        })
+    };
+    // Helper for instructions with a single u16 operand.
+    let with_u16 = |instr: Instr| {
+        Ok(Decoded {
+            next: ip + 3,
+            instr,
+        })
+    };
+
+    // === bare scalar ops ===
+    if byte == Op::True as u8 {
+        return bare(Instr::Const(ScalarValue::Bool(true)));
+    }
+    if byte == Op::False as u8 {
+        return bare(Instr::Const(ScalarValue::Bool(false)));
+    }
+    if let Some(op) = bare_binop(byte) {
+        return bare(Instr::Bin(op));
+    }
+    if let Some(op) = bare_cmpop(byte) {
+        return bare(Instr::Cmp(op));
+    }
+    if byte == Op::Negate as u8 {
+        return bare(Instr::Neg);
+    }
+    if byte == Op::Not as u8 {
+        return bare(Instr::Not);
+    }
+    if byte == Op::Pop as u8 {
+        return bare(Instr::Pop);
+    }
+    if byte == Op::Dup as u8 {
+        return bare(Instr::Dup);
+    }
+    if byte == Op::Swap as u8 {
+        return bare(Instr::Swap);
+    }
+    if byte == Op::Return as u8 {
+        return bare(Instr::Return);
+    }
+    // Lexical-scope bookkeeping with no effect on the operand stack or
+    // slot-indexed locals; transparent to scalar code.
+    if byte == Op::PushScope as u8 || byte == Op::PopScope as u8 {
+        return bare(Instr::Nop);
+    }
+    if byte == Op::Nil as u8 {
+        return bare(Instr::PushUnit);
+    }
+
+    // === operand-carrying ops ===
+    if byte == Op::Constant as u8 {
+        let idx = read_u16(ip + 1)? as usize;
+        let constant = constants
+            .get(idx)
+            .ok_or_else(|| CodegenError::verify(format!("constant index {idx} out of bounds")))?;
+        return with_u16(Instr::Const(scalar_constant(constant)?));
+    }
+    if byte == Op::GetLocalSlot as u8 {
+        return with_u16(Instr::GetLocal(read_u16(ip + 1)?));
+    }
+    if byte == Op::DefLocalSlot as u8 {
+        return with_u16(Instr::DefLocal(read_u16(ip + 1)?));
+    }
+    if byte == Op::SetLocalSlot as u8 {
+        return with_u16(Instr::SetLocal(read_u16(ip + 1)?));
+    }
+    if byte == Op::Jump as u8 {
+        return with_u16(Instr::Jump(read_u16(ip + 1)? as usize));
+    }
+    if byte == Op::JumpIfFalse as u8 {
+        return with_u16(Instr::JumpIfFalse(read_u16(ip + 1)? as usize));
+    }
+    if byte == Op::JumpIfTrue as u8 {
+        return with_u16(Instr::JumpIfTrue(read_u16(ip + 1)? as usize));
+    }
+
+    Err(CodegenError::unsupported(unsupported_label(byte)))
+}
+
+/// Map the operand-less arithmetic opcodes (generic and int/float-typed) onto
+/// a [`BinOp`]. `Pow` is intentionally absent: its result type depends on the
+/// *value* of the exponent at runtime, so it cannot be statically monomorphic.
+fn bare_binop(byte: u8) -> Option<BinOp> {
+    let table = [
+        (Op::Add, BinOp::Add),
+        (Op::Sub, BinOp::Sub),
+        (Op::Mul, BinOp::Mul),
+        (Op::Div, BinOp::Div),
+        (Op::Mod, BinOp::Mod),
+        (Op::AddInt, BinOp::Add),
+        (Op::SubInt, BinOp::Sub),
+        (Op::MulInt, BinOp::Mul),
+        (Op::DivInt, BinOp::Div),
+        (Op::ModInt, BinOp::Mod),
+        (Op::AddFloat, BinOp::Add),
+        (Op::SubFloat, BinOp::Sub),
+        (Op::MulFloat, BinOp::Mul),
+        (Op::DivFloat, BinOp::Div),
+        (Op::ModFloat, BinOp::Mod),
+    ];
+    table
+        .into_iter()
+        .find(|(op, _)| byte == *op as u8)
+        .map(|(_, bin)| bin)
+}
+
+/// Map the operand-less comparison opcodes (generic and typed) onto a
+/// [`CmpOp`].
+fn bare_cmpop(byte: u8) -> Option<CmpOp> {
+    let table = [
+        (Op::Equal, CmpOp::Eq),
+        (Op::NotEqual, CmpOp::Ne),
+        (Op::Less, CmpOp::Lt),
+        (Op::Greater, CmpOp::Gt),
+        (Op::LessEqual, CmpOp::Le),
+        (Op::GreaterEqual, CmpOp::Ge),
+        (Op::EqualInt, CmpOp::Eq),
+        (Op::NotEqualInt, CmpOp::Ne),
+        (Op::LessInt, CmpOp::Lt),
+        (Op::GreaterInt, CmpOp::Gt),
+        (Op::LessEqualInt, CmpOp::Le),
+        (Op::GreaterEqualInt, CmpOp::Ge),
+        (Op::EqualFloat, CmpOp::Eq),
+        (Op::NotEqualFloat, CmpOp::Ne),
+        (Op::LessFloat, CmpOp::Lt),
+        (Op::GreaterFloat, CmpOp::Gt),
+        (Op::LessEqualFloat, CmpOp::Le),
+        (Op::GreaterEqualFloat, CmpOp::Ge),
+        (Op::EqualBool, CmpOp::Eq),
+        (Op::NotEqualBool, CmpOp::Ne),
+    ];
+    table
+        .into_iter()
+        .find(|(op, _)| byte == *op as u8)
+        .map(|(_, cmp)| cmp)
+}
+
+/// Resolve a constant-pool entry to a scalar value, or reject it.
+fn scalar_constant(constant: &Constant) -> Result<ScalarValue, CodegenError> {
+    match constant {
+        Constant::Int(n) => Ok(ScalarValue::Int(*n)),
+        Constant::Float(f) => Ok(ScalarValue::Float(*f)),
+        Constant::Bool(b) => Ok(ScalarValue::Bool(*b)),
+        Constant::String(_) => Err(CodegenError::unsupported("string constant")),
+        Constant::Nil => Err(CodegenError::unsupported("nil constant")),
+        Constant::Duration(_) => Err(CodegenError::unsupported("duration constant")),
+    }
+}
+
+/// Best-effort human-readable label for an unsupported opcode, for diagnostics.
+fn unsupported_label(byte: u8) -> String {
+    if byte == Op::Pow as u8 {
+        return "exponentiation (`**`) has a value-dependent result type".to_string();
+    }
+    if byte == Op::Concat as u8 {
+        return "string concatenation".to_string();
+    }
+    if byte == Op::Call as u8 || byte == Op::CallBuiltin as u8 || byte == Op::TailCall as u8 {
+        return "function call".to_string();
+    }
+    if byte == Op::GetVar as u8 || byte == Op::SetVar as u8 {
+        return "non-local (captured/global) variable access".to_string();
+    }
+    format!("opcode byte 0x{byte:02x}")
+}

--- a/crates/harn-codegen/src/error.rs
+++ b/crates/harn-codegen/src/error.rs
@@ -1,0 +1,76 @@
+//! Error types for the native compiler.
+
+use std::fmt;
+
+/// Why a chunk could not be lowered to native code.
+///
+/// `Unsupported` is the common, *expected* outcome: the function uses a
+/// language feature outside the scalar-compute subset (a string, a host call,
+/// `await`, …). Callers treat it as "fall back to the interpreter", not as a
+/// hard failure. `Verify` means the bytecode is in the subset but is not
+/// well-typed enough to lower soundly. `Backend` wraps a Cranelift failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodegenError {
+    /// A feature outside the supported scalar subset was encountered. The
+    /// payload names the offending construct so tooling can explain *why* a
+    /// function stayed on the interpreter.
+    Unsupported(String),
+    /// The bytecode is in the supported subset but failed verification (e.g.
+    /// inconsistent operand-stack types across a control-flow merge).
+    Verify(String),
+    /// The Cranelift backend rejected or failed to compile the lowered IR.
+    Backend(String),
+}
+
+impl CodegenError {
+    pub(crate) fn unsupported(msg: impl Into<String>) -> Self {
+        Self::Unsupported(msg.into())
+    }
+
+    pub(crate) fn verify(msg: impl Into<String>) -> Self {
+        Self::Verify(msg.into())
+    }
+
+    pub(crate) fn backend(msg: impl Into<String>) -> Self {
+        Self::Backend(msg.into())
+    }
+
+    /// True when the function simply falls outside the scalar subset, as
+    /// opposed to being malformed or hitting a backend bug.
+    #[must_use]
+    pub const fn is_unsupported(&self) -> bool {
+        matches!(self, Self::Unsupported(_))
+    }
+}
+
+impl fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported(msg) => write!(f, "unsupported for native compilation: {msg}"),
+            Self::Verify(msg) => write!(f, "bytecode verification failed: {msg}"),
+            Self::Backend(msg) => write!(f, "native backend error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for CodegenError {}
+
+/// A runtime fault raised by JIT-compiled code through the side-channel trap
+/// flag. Mirrors the interpreter's behaviour of returning an error rather than
+/// aborting the process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeTrap {
+    /// Integer division or remainder by zero. Matches the interpreter, which
+    /// raises a runtime error for `x / 0` and `x % 0` on integers.
+    DivideByZero,
+}
+
+impl fmt::Display for NativeTrap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DivideByZero => f.write_str("integer divide by zero"),
+        }
+    }
+}
+
+impl std::error::Error for NativeTrap {}

--- a/crates/harn-codegen/src/eval.rs
+++ b/crates/harn-codegen/src/eval.rs
@@ -1,0 +1,221 @@
+//! A small reference interpreter for [`ScalarFunction`].
+//!
+//! It serves three purposes: it is the executable specification the JIT must
+//! match (its arithmetic mirrors the Harn VM — wrapping integer ops, IEEE-754
+//! floats), it is the differential-test oracle, and it is a pure-Rust fallback
+//! for callers that want scalar evaluation without linking a code generator.
+
+use crate::bytecode::{BinOp, CmpOp, Instr};
+use crate::error::NativeTrap;
+use crate::value::ScalarValue;
+use crate::verify::{ScalarFunction, Terminator};
+
+/// Upper bound on executed instructions, guarding the reference interpreter
+/// against runaway loops in malformed input. Generous enough for any realistic
+/// scalar kernel.
+const STEP_BUDGET: u64 = 1 << 32;
+
+/// An error from reference evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvalError {
+    /// A runtime trap that the JIT would also raise (e.g. integer `x / 0`).
+    Trap(NativeTrap),
+    /// An argument count or type mismatch against the function signature.
+    Signature(String),
+    /// The step budget was exhausted (likely a non-terminating loop).
+    Budget,
+}
+
+impl std::fmt::Display for EvalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Trap(trap) => write!(f, "{trap}"),
+            Self::Signature(msg) => write!(f, "signature mismatch: {msg}"),
+            Self::Budget => f.write_str("evaluation step budget exhausted"),
+        }
+    }
+}
+
+impl std::error::Error for EvalError {}
+
+/// Evaluate `func` with `args`, returning the scalar result.
+///
+/// # Errors
+///
+/// Returns [`EvalError`] on a signature mismatch, a runtime trap, or budget
+/// exhaustion.
+pub fn evaluate(func: &ScalarFunction, args: &[ScalarValue]) -> Result<ScalarValue, EvalError> {
+    if args.len() != func.params.len() {
+        return Err(EvalError::Signature(format!(
+            "expected {} argument(s), got {}",
+            func.params.len(),
+            args.len()
+        )));
+    }
+    for (idx, (arg, expected)) in args.iter().zip(&func.params).enumerate() {
+        if arg.ty() != *expected {
+            return Err(EvalError::Signature(format!(
+                "argument {idx} expected {expected}, got {}",
+                arg.ty()
+            )));
+        }
+    }
+
+    let mut locals: Vec<Option<ScalarValue>> = vec![None; func.slot_count()];
+    for (slot, arg) in args.iter().enumerate() {
+        locals[slot] = Some(*arg);
+    }
+
+    let mut block_idx = 0usize;
+    let mut stack: Vec<ScalarValue> = Vec::new();
+    let mut steps = 0u64;
+
+    loop {
+        let block = &func.blocks[block_idx];
+        for instr in &block.body {
+            steps += 1;
+            if steps > STEP_BUDGET {
+                return Err(EvalError::Budget);
+            }
+            step(&mut stack, &mut locals, instr)?;
+        }
+        match block.term {
+            Terminator::Return => {
+                return stack
+                    .pop()
+                    .ok_or_else(|| EvalError::Signature("return with empty stack".into()));
+            }
+            Terminator::Jump(target) => block_idx = target,
+            Terminator::Branch { on_true, on_false } => {
+                let cond = matches!(stack.last(), Some(ScalarValue::Bool(true)));
+                block_idx = if cond { on_true } else { on_false };
+            }
+        }
+    }
+}
+
+fn step(
+    stack: &mut Vec<ScalarValue>,
+    locals: &mut [Option<ScalarValue>],
+    instr: &Instr,
+) -> Result<(), EvalError> {
+    match instr {
+        Instr::Const(value) => stack.push(*value),
+        Instr::Bin(op) => {
+            let b = pop(stack);
+            let a = pop(stack);
+            stack.push(eval_bin(*op, a, b)?);
+        }
+        Instr::Cmp(op) => {
+            let b = pop(stack);
+            let a = pop(stack);
+            stack.push(ScalarValue::Bool(eval_cmp(*op, a, b)));
+        }
+        Instr::Neg => {
+            let a = pop(stack);
+            stack.push(match a {
+                ScalarValue::Int(n) => ScalarValue::Int(n.wrapping_neg()),
+                ScalarValue::Float(x) => ScalarValue::Float(-x),
+                ScalarValue::Bool(_) => unreachable!("verified"),
+            });
+        }
+        Instr::Not => {
+            let a = pop(stack);
+            stack.push(ScalarValue::Bool(!matches!(a, ScalarValue::Bool(true))));
+        }
+        Instr::Pop => {
+            pop(stack);
+        }
+        Instr::Dup => {
+            let top = *stack.last().expect("verified non-empty");
+            stack.push(top);
+        }
+        Instr::Swap => {
+            let len = stack.len();
+            stack.swap(len - 1, len - 2);
+        }
+        Instr::GetLocal(slot) => {
+            let value = locals[*slot as usize].expect("verified initialised");
+            stack.push(value);
+        }
+        Instr::DefLocal(slot) | Instr::SetLocal(slot) => {
+            let value = pop(stack);
+            locals[*slot as usize] = Some(value);
+        }
+        Instr::Nop => {}
+        // The verifier proved this unit is only ever discarded; a placeholder
+        // keeps the stack balanced and is never observed.
+        Instr::PushUnit => stack.push(ScalarValue::Int(0)),
+        Instr::Jump(_) | Instr::JumpIfFalse(_) | Instr::JumpIfTrue(_) | Instr::Return => {
+            unreachable!("terminators are not in block bodies")
+        }
+    }
+    Ok(())
+}
+
+fn pop(stack: &mut Vec<ScalarValue>) -> ScalarValue {
+    stack.pop().expect("verified non-empty operand stack")
+}
+
+fn eval_bin(op: BinOp, a: ScalarValue, b: ScalarValue) -> Result<ScalarValue, EvalError> {
+    match (a, b) {
+        (ScalarValue::Int(x), ScalarValue::Int(y)) => Ok(ScalarValue::Int(match op {
+            BinOp::Add => x.wrapping_add(y),
+            BinOp::Sub => x.wrapping_sub(y),
+            BinOp::Mul => x.wrapping_mul(y),
+            BinOp::Div => {
+                if y == 0 {
+                    return Err(EvalError::Trap(NativeTrap::DivideByZero));
+                }
+                x.wrapping_div(y)
+            }
+            BinOp::Mod => {
+                if y == 0 {
+                    return Err(EvalError::Trap(NativeTrap::DivideByZero));
+                }
+                x.wrapping_rem(y)
+            }
+        })),
+        (ScalarValue::Float(x), ScalarValue::Float(y)) => Ok(ScalarValue::Float(match op {
+            BinOp::Add => x + y,
+            BinOp::Sub => x - y,
+            BinOp::Mul => x * y,
+            BinOp::Div => x / y,
+            BinOp::Mod => unreachable!("float modulo is rejected by the verifier"),
+        })),
+        _ => unreachable!("verified matching numeric operands"),
+    }
+}
+
+fn eval_cmp(op: CmpOp, a: ScalarValue, b: ScalarValue) -> bool {
+    match (a, b) {
+        (ScalarValue::Int(x), ScalarValue::Int(y)) => cmp_ord(op, x, y),
+        (ScalarValue::Float(x), ScalarValue::Float(y)) => match op {
+            // IEEE-754: a NaN operand makes `==`/ordered comparisons false and
+            // `!=` true. Rust's float operators already do exactly this.
+            CmpOp::Eq => x == y,
+            CmpOp::Ne => x != y,
+            CmpOp::Lt => x < y,
+            CmpOp::Gt => x > y,
+            CmpOp::Le => x <= y,
+            CmpOp::Ge => x >= y,
+        },
+        (ScalarValue::Bool(x), ScalarValue::Bool(y)) => match op {
+            CmpOp::Eq => x == y,
+            CmpOp::Ne => x != y,
+            _ => unreachable!("verified equality-only comparison on bool"),
+        },
+        _ => unreachable!("verified matching operands"),
+    }
+}
+
+fn cmp_ord<T: PartialOrd + PartialEq>(op: CmpOp, x: T, y: T) -> bool {
+    match op {
+        CmpOp::Eq => x == y,
+        CmpOp::Ne => x != y,
+        CmpOp::Lt => x < y,
+        CmpOp::Gt => x > y,
+        CmpOp::Le => x <= y,
+        CmpOp::Ge => x >= y,
+    }
+}

--- a/crates/harn-codegen/src/jit.rs
+++ b/crates/harn-codegen/src/jit.rs
@@ -1,0 +1,140 @@
+//! In-process JIT backend.
+//!
+//! Compiles a [`ScalarFunction`] to native machine code in memory and hands
+//! back a [`NativeFunction`] that can be called with marshalled scalar
+//! arguments. This is the path that could shave interpreter dispatch overhead
+//! off a hot, pure-compute Harn kernel.
+
+use std::mem;
+
+use cranelift_codegen::settings::{self, Configurable};
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::default_libcall_names;
+
+use crate::error::{CodegenError, NativeTrap};
+use crate::lower::define_scalar_function;
+use crate::symbol_name;
+use crate::value::{ScalarType, ScalarValue};
+use crate::verify::ScalarFunction;
+
+/// The raw uniform ABI of every compiled function.
+type RawFn = extern "C" fn(args: *const u64, ret: *mut u64, trap: *mut u8);
+
+/// A JIT-compiled scalar function with live executable code.
+///
+/// The owned [`JITModule`] backs the code mapping; dropping the
+/// `NativeFunction` unmaps it, so the function pointer must not outlive this
+/// value. Not `Send`/`Sync`: call it from the thread that compiled it.
+pub struct NativeFunction {
+    // Field order matters: `module` owns the executable mapping that
+    // `func_ptr` points into, and struct fields drop in declaration order.
+    func_ptr: *const u8,
+    params: Vec<ScalarType>,
+    ret: ScalarType,
+    _module: JITModule,
+}
+
+impl NativeFunction {
+    /// The parameter types this function expects, in order.
+    #[must_use]
+    pub fn params(&self) -> &[ScalarType] {
+        &self.params
+    }
+
+    /// The function's return type.
+    #[must_use]
+    pub fn ret(&self) -> ScalarType {
+        self.ret
+    }
+
+    /// Call the compiled function.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `args` does not match the function's parameter arity and
+    /// types — that is a caller bug, analogous to calling a Rust `fn` with the
+    /// wrong signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NativeTrap`] when the code raised a runtime trap (integer
+    /// divide by zero).
+    pub fn call(&self, args: &[ScalarValue]) -> Result<ScalarValue, NativeTrap> {
+        assert_eq!(
+            args.len(),
+            self.params.len(),
+            "argument count mismatch: expected {}, got {}",
+            self.params.len(),
+            args.len()
+        );
+        for (idx, (arg, expected)) in args.iter().zip(&self.params).enumerate() {
+            assert_eq!(
+                arg.ty(),
+                *expected,
+                "argument {idx} type mismatch: expected {expected}, got {}",
+                arg.ty()
+            );
+        }
+
+        // A non-empty backing buffer keeps `as_ptr` valid even for nullary
+        // functions (which never dereference it).
+        let mut arg_bits: Vec<u64> = args.iter().map(|v| v.to_bits()).collect();
+        if arg_bits.is_empty() {
+            arg_bits.push(0);
+        }
+        let mut ret_bits: u64 = 0;
+        let mut trap: u8 = 0;
+
+        // SAFETY: `func_ptr` was produced by Cranelift for the uniform ABI
+        // declared in `lower`, and the backing module is kept alive by `self`.
+        let raw: RawFn = unsafe { mem::transmute::<*const u8, RawFn>(self.func_ptr) };
+        raw(arg_bits.as_ptr(), &raw mut ret_bits, &raw mut trap);
+
+        if trap != 0 {
+            return Err(NativeTrap::DivideByZero);
+        }
+        Ok(ScalarValue::from_bits(self.ret, ret_bits))
+    }
+}
+
+/// Compile `sf` to native code with the in-process JIT.
+///
+/// # Errors
+///
+/// Returns [`CodegenError::Backend`] if the host ISA is unavailable or
+/// Cranelift fails to compile the lowered IR.
+pub fn compile(sf: &ScalarFunction) -> Result<NativeFunction, CodegenError> {
+    let mut flags = settings::builder();
+    // The JIT maps code into this process; non-PIC, in-process libcalls.
+    set_flag(&mut flags, "use_colocated_libcalls", "false")?;
+    set_flag(&mut flags, "is_pic", "false")?;
+    let _ = flags.set("opt_level", "speed");
+
+    let isa_builder =
+        cranelift_native::builder().map_err(|e| CodegenError::backend(e.to_string()))?;
+    let isa = isa_builder
+        .finish(settings::Flags::new(flags))
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+
+    let builder = JITBuilder::with_isa(isa, default_libcall_names());
+    let mut module = JITModule::new(builder);
+
+    let id = define_scalar_function(&mut module, sf, &symbol_name(&sf.name))?;
+    module
+        .finalize_definitions()
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+    let func_ptr = module.get_finalized_function(id);
+
+    Ok(NativeFunction {
+        func_ptr,
+        params: sf.params.clone(),
+        ret: sf.ret,
+        _module: module,
+    })
+}
+
+fn set_flag(builder: &mut settings::Builder, name: &str, value: &str) -> Result<(), CodegenError> {
+    builder
+        .set(name, value)
+        .map_err(|e| CodegenError::backend(format!("setting `{name}`: {e}")))
+}

--- a/crates/harn-codegen/src/lib.rs
+++ b/crates/harn-codegen/src/lib.rs
@@ -1,0 +1,124 @@
+//! # harn-codegen
+//!
+//! An experimental ahead-of-time / JIT native compiler for the *scalar-compute
+//! subset* of Harn.
+//!
+//! Harn is an orchestration language: most real programs are dominated by LLM
+//! calls, tool dispatch, and other I/O, where native code generation buys
+//! nothing. The honest, useful niche this crate targets is the opposite end —
+//! small, hot, side-effect-free numeric kernels (scoring, parsing helpers,
+//! bit-twiddling, geometry, …) that run in tight loops. For those, lowering
+//! the bytecode to machine code removes interpreter dispatch overhead entirely.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Harn source ──(harn-vm front-end)──▶ Chunk/bytecode
+//!            │
+//!            ├─ decode  (bytecode.rs)  reachable scalar instructions
+//!            ├─ verify  (verify.rs)    typed control-flow graph (ScalarFunction)
+//!            ├─ lower   (lower.rs)     Cranelift IR
+//!            └─ backend
+//!                 ├─ jit.rs   in-process machine code  ▶ NativeFunction
+//!                 └─ aot.rs   relocatable object file  ▶ ObjectArtifact
+//! ```
+//!
+//! [`eval`] provides a pure-Rust reference interpreter over `ScalarFunction`
+//! that mirrors the VM's semantics; it is the differential-test oracle and a
+//! dependency-free fallback.
+//!
+//! ## Supported subset
+//!
+//! `int` (`i64`), `float` (`f64`), and `bool`; arithmetic (`+ - * / %`, integer
+//! `%` and `/` trap-checked, no float `%`), comparisons, logical `!`, `if`/
+//! `else`, `while` loops, ternaries, short-circuit `&&`/`||`, and `let`/`var`
+//! locals. Anything else — strings, lists, dicts, `nil`, closures,
+//! host/`harness` calls, `await`, `**` — is reported as
+//! [`CodegenError::Unsupported`], which callers treat as "stay on the
+//! interpreter".
+//!
+//! ## Not part of the distributed binary
+//!
+//! This crate links Cranelift and is intentionally absent from the dependency
+//! graph of `harn-cli`/`harn-vm`. It is `publish = false` and never ships in
+//! the crates.io binary. See `docs/src/dev/native-codegen.md`.
+
+mod aot;
+mod bytecode;
+mod error;
+mod eval;
+mod jit;
+mod lower;
+mod source;
+mod value;
+mod verify;
+
+pub use aot::{emit_object, ObjectArtifact};
+pub use bytecode::{BinOp, CmpOp, Instr};
+pub use error::{CodegenError, NativeTrap};
+pub use eval::{evaluate, EvalError};
+pub use jit::{compile as jit_compile, NativeFunction};
+pub use source::{analyze_function, analyze_named};
+pub use value::{ScalarType, ScalarValue};
+pub use verify::{verify, Block, ScalarFunction, Terminator};
+
+/// Compile a named top-level Harn function from `source` to in-process native
+/// code in one step.
+///
+/// # Errors
+///
+/// Propagates any [`CodegenError`] from front-end compilation, verification,
+/// or the JIT backend.
+pub fn compile_named(source: &str, function: &str) -> Result<NativeFunction, CodegenError> {
+    let scalar = analyze_named(source, function)?;
+    jit_compile(&scalar)
+}
+
+/// Compile a named top-level Harn function from `source` to a host-target
+/// object file in one step.
+///
+/// # Errors
+///
+/// Propagates any [`CodegenError`] from front-end compilation, verification,
+/// or the object backend.
+pub fn compile_named_object(source: &str, function: &str) -> Result<ObjectArtifact, CodegenError> {
+    let scalar = analyze_named(source, function)?;
+    emit_object(&scalar)
+}
+
+/// Derive a stable, linker-safe C symbol from a Harn function name.
+///
+/// Non-identifier characters become `_`; the `harn_scalar_` prefix avoids
+/// leading-digit and reserved-name collisions and namespaces the export.
+pub(crate) fn symbol_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 12);
+    out.push_str("harn_scalar_");
+    let mut any = false;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch);
+            any = true;
+        } else {
+            out.push('_');
+        }
+    }
+    if !any {
+        out.push_str("anon");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::symbol_name;
+
+    #[test]
+    fn symbol_names_are_sanitised() {
+        assert_eq!(symbol_name("add"), "harn_scalar_add");
+        assert_eq!(symbol_name("score_v2"), "harn_scalar_score_v2");
+        assert_eq!(symbol_name("foo.bar-baz"), "harn_scalar_foo_bar_baz");
+        assert_eq!(symbol_name(""), "harn_scalar_anon");
+        // No identifier characters at all -> substitutes plus the `anon` tag.
+        assert_eq!(symbol_name("!!!"), "harn_scalar____anon");
+    }
+}

--- a/crates/harn-codegen/src/lower.rs
+++ b/crates/harn-codegen/src/lower.rs
@@ -1,0 +1,385 @@
+//! Lowering of a verified [`ScalarFunction`] to Cranelift IR.
+//!
+//! # Calling convention
+//!
+//! Every compiled function is emitted with one uniform C signature regardless
+//! of its Harn arity or types:
+//!
+//! ```text
+//! extern "C" fn(args: *const u64, ret: *mut u64, trap: *mut u8)
+//! ```
+//!
+//! Arguments and the result are passed as raw 64-bit slots (see
+//! [`ScalarValue::to_bits`]). This keeps the Rust ↔ native boundary a single
+//! monomorphic function pointer — no per-signature transmute zoo — and makes
+//! the AOT object expose one stable, easily-called symbol.
+//!
+//! Integer `/` and `%` by zero set `*trap = 1` and return, mirroring the
+//! interpreter's runtime error instead of executing a hardware trap that would
+//! abort the host process.
+
+use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
+use cranelift_codegen::ir::{
+    types, AbiParam, BlockArg, Function, InstBuilder, MemFlags, Signature, Type, Value,
+};
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+use cranelift_module::{FuncId, Linkage, Module};
+
+use crate::bytecode::{BinOp, CmpOp, Instr};
+use crate::error::CodegenError;
+use crate::value::{ScalarType, ScalarValue};
+use crate::verify::{ScalarFunction, Terminator};
+
+/// Number of pointer parameters in the uniform ABI: `args`, `ret`, `trap`.
+const ABI_PARAM_COUNT: usize = 3;
+
+/// Fill in `sig` with the uniform native calling convention for `ptr_ty`.
+pub(crate) fn build_signature(sig: &mut Signature, ptr_ty: Type) {
+    sig.params.clear();
+    sig.returns.clear();
+    for _ in 0..ABI_PARAM_COUNT {
+        sig.params.push(AbiParam::new(ptr_ty));
+    }
+}
+
+/// Declare and define `sf` as an exported function named `symbol` in any
+/// Cranelift [`Module`] (JIT or object). Shared by both backends so the
+/// signature, lowering, and error mapping stay in one place.
+pub(crate) fn define_scalar_function<M: Module>(
+    module: &mut M,
+    sf: &ScalarFunction,
+    symbol: &str,
+) -> Result<FuncId, CodegenError> {
+    let ptr_ty = module.target_config().pointer_type();
+    let mut sig = module.make_signature();
+    build_signature(&mut sig, ptr_ty);
+
+    let id = module
+        .declare_function(symbol, Linkage::Export, &sig)
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+
+    let mut ctx = module.make_context();
+    ctx.func.signature = sig;
+    let mut fb_ctx = FunctionBuilderContext::new();
+    lower(&mut ctx.func, &mut fb_ctx, sf)?;
+    module
+        .define_function(id, &mut ctx)
+        .map_err(|e| CodegenError::backend(e.to_string()))?;
+    module.clear_context(&mut ctx);
+    Ok(id)
+}
+
+/// Cranelift type for a scalar: `int` → `i64`, `bool` → `i8`, `float` → `f64`.
+fn clif_ty(ty: ScalarType) -> Type {
+    match ty {
+        ScalarType::Int => types::I64,
+        ScalarType::Bool => types::I8,
+        ScalarType::Float => types::F64,
+    }
+}
+
+/// Lower `sf` into `func` (whose signature must already be set via
+/// [`build_signature`]).
+pub(crate) fn lower(
+    func: &mut Function,
+    fb_ctx: &mut FunctionBuilderContext,
+    sf: &ScalarFunction,
+) -> Result<(), CodegenError> {
+    let mut builder = FunctionBuilder::new(func, fb_ctx);
+
+    let entry = builder.create_block();
+    builder.append_block_params_for_function_params(entry);
+    builder.switch_to_block(entry);
+    let abi = builder.block_params(entry).to_vec();
+    let args_ptr = abi[0];
+    let ret_ptr = abi[1];
+    let trap_ptr = abi[2];
+
+    // Declare one Cranelift variable per local slot; initialise parameters
+    // from the args array and everything else to a typed zero. The verifier
+    // guarantees non-parameter slots are written before any meaningful read,
+    // so the zero is never observed — it just keeps the SSA builder happy.
+    let mut vars = Vec::with_capacity(sf.slot_count());
+    for slot_ty in &sf.slot_types {
+        vars.push(builder.declare_var(clif_ty(*slot_ty)));
+    }
+    for (idx, slot_ty) in sf.slot_types.iter().enumerate() {
+        let value = if idx < sf.params.len() {
+            load_arg(&mut builder, args_ptr, idx, *slot_ty)
+        } else {
+            zero_of(&mut builder, *slot_ty)
+        };
+        builder.def_var(vars[idx], value);
+    }
+
+    // Clear the trap flag up front; only the trap block ever sets it.
+    let zero8 = builder.ins().iconst(types::I8, 0);
+    builder.ins().store(MemFlags::trusted(), zero8, trap_ptr, 0);
+
+    // One Cranelift block per scalar block, carrying the operand-stack shape
+    // as block parameters.
+    let clif_blocks: Vec<_> = sf
+        .blocks
+        .iter()
+        .map(|block| {
+            let clb = builder.create_block();
+            for ty in &block.stack_in {
+                builder.append_block_param(clb, clif_ty(*ty));
+            }
+            clb
+        })
+        .collect();
+
+    // Shared block for the divide-by-zero trap path.
+    let trap_block = builder.create_block();
+
+    // Entry falls into block 0 (whose entry stack is empty).
+    let no_args: Vec<BlockArg> = Vec::new();
+    builder.ins().jump(clif_blocks[0], &no_args);
+
+    for (idx, block) in sf.blocks.iter().enumerate() {
+        builder.switch_to_block(clif_blocks[idx]);
+        let mut stack: Vec<Value> = builder.block_params(clif_blocks[idx]).to_vec();
+        for instr in &block.body {
+            lower_instr(&mut builder, &vars, &mut stack, instr, trap_block);
+        }
+        match block.term {
+            Terminator::Return => {
+                let value = stack.pop().expect("verified non-empty return stack");
+                store_ret(&mut builder, ret_ptr, sf.ret, value);
+                builder.ins().return_(&[]);
+            }
+            Terminator::Jump(target) => {
+                let args = block_args(&stack);
+                builder.ins().jump(clif_blocks[target], &args);
+            }
+            Terminator::Branch { on_true, on_false } => {
+                let cond = *stack.last().expect("verified non-empty branch stack");
+                let args = block_args(&stack);
+                builder.ins().brif(
+                    cond,
+                    clif_blocks[on_true],
+                    &args,
+                    clif_blocks[on_false],
+                    &args,
+                );
+            }
+        }
+    }
+
+    // Emit the trap path: set *trap = 1, write a zero result, return.
+    builder.switch_to_block(trap_block);
+    let one8 = builder.ins().iconst(types::I8, 1);
+    builder.ins().store(MemFlags::trusted(), one8, trap_ptr, 0);
+    let zero_ret = zero_of(&mut builder, sf.ret);
+    store_ret(&mut builder, ret_ptr, sf.ret, zero_ret);
+    builder.ins().return_(&[]);
+
+    builder.seal_all_blocks();
+    builder.finalize();
+    Ok(())
+}
+
+fn lower_instr(
+    builder: &mut FunctionBuilder,
+    vars: &[Variable],
+    stack: &mut Vec<Value>,
+    instr: &Instr,
+    trap_block: cranelift_codegen::ir::Block,
+) {
+    match instr {
+        Instr::Const(value) => {
+            let v = const_value(builder, *value);
+            stack.push(v);
+        }
+        Instr::Bin(op) => {
+            let b = stack.pop().unwrap();
+            let a = stack.pop().unwrap();
+            let result = lower_bin(builder, *op, a, b, trap_block);
+            stack.push(result);
+        }
+        Instr::Cmp(op) => {
+            let b = stack.pop().unwrap();
+            let a = stack.pop().unwrap();
+            stack.push(lower_cmp(builder, *op, a, b));
+        }
+        Instr::Neg => {
+            let a = stack.pop().unwrap();
+            let result = if is_float(builder, a) {
+                builder.ins().fneg(a)
+            } else {
+                builder.ins().ineg(a)
+            };
+            stack.push(result);
+        }
+        Instr::Not => {
+            let a = stack.pop().unwrap();
+            stack.push(builder.ins().icmp_imm(IntCC::Equal, a, 0));
+        }
+        Instr::Pop => {
+            stack.pop();
+        }
+        Instr::Dup => {
+            let top = *stack.last().unwrap();
+            stack.push(top);
+        }
+        Instr::Swap => {
+            let len = stack.len();
+            stack.swap(len - 1, len - 2);
+        }
+        Instr::GetLocal(slot) => {
+            let value = builder.use_var(vars[*slot as usize]);
+            stack.push(value);
+        }
+        Instr::DefLocal(slot) | Instr::SetLocal(slot) => {
+            let value = stack.pop().unwrap();
+            builder.def_var(vars[*slot as usize], value);
+        }
+        Instr::Nop => {}
+        // The verifier proved this unit is only ever discarded; an `int` zero
+        // placeholder keeps the operand stack and any block parameters
+        // type-consistent without ever being observed.
+        Instr::PushUnit => {
+            let placeholder = builder.ins().iconst(types::I64, 0);
+            stack.push(placeholder);
+        }
+        Instr::Jump(_) | Instr::JumpIfFalse(_) | Instr::JumpIfTrue(_) | Instr::Return => {
+            unreachable!("terminators are not in block bodies")
+        }
+    }
+}
+
+fn const_value(builder: &mut FunctionBuilder, value: ScalarValue) -> Value {
+    match value {
+        ScalarValue::Int(n) => builder.ins().iconst(types::I64, n),
+        ScalarValue::Bool(b) => builder.ins().iconst(types::I8, i64::from(b)),
+        ScalarValue::Float(f) => builder.ins().f64const(f),
+    }
+}
+
+fn lower_bin(
+    builder: &mut FunctionBuilder,
+    op: BinOp,
+    a: Value,
+    b: Value,
+    trap_block: cranelift_codegen::ir::Block,
+) -> Value {
+    if is_float(builder, a) {
+        return match op {
+            BinOp::Add => builder.ins().fadd(a, b),
+            BinOp::Sub => builder.ins().fsub(a, b),
+            BinOp::Mul => builder.ins().fmul(a, b),
+            BinOp::Div => builder.ins().fdiv(a, b),
+            BinOp::Mod => unreachable!("float modulo rejected by the verifier"),
+        };
+    }
+    match op {
+        BinOp::Add => builder.ins().iadd(a, b),
+        BinOp::Sub => builder.ins().isub(a, b),
+        BinOp::Mul => builder.ins().imul(a, b),
+        BinOp::Div => lower_idiv(builder, a, b, trap_block, true),
+        BinOp::Mod => lower_idiv(builder, a, b, trap_block, false),
+    }
+}
+
+/// Lower integer `/` (`is_div = true`) or `%` (`is_div = false`) with the
+/// interpreter's exact wrapping semantics:
+///
+/// * divisor `0` → branch to the trap block (runtime error, no hardware trap);
+/// * `i64::MIN / -1` → `i64::MIN`, and `i64::MIN % -1` → `0` (matching
+///   `wrapping_div`/`wrapping_rem`), avoiding Cranelift's overflow trap.
+fn lower_idiv(
+    builder: &mut FunctionBuilder,
+    a: Value,
+    b: Value,
+    trap_block: cranelift_codegen::ir::Block,
+    is_div: bool,
+) -> Value {
+    let is_zero = builder.ins().icmp_imm(IntCC::Equal, b, 0);
+    let cont = builder.create_block();
+    let no_args: Vec<BlockArg> = Vec::new();
+    builder
+        .ins()
+        .brif(is_zero, trap_block, &no_args, cont, &no_args);
+    builder.switch_to_block(cont);
+
+    let int_min = builder.ins().iconst(types::I64, i64::MIN);
+    let neg_one = builder.ins().iconst(types::I64, -1);
+    let is_min = builder.ins().icmp(IntCC::Equal, a, int_min);
+    let is_neg_one = builder.ins().icmp(IntCC::Equal, b, neg_one);
+    let overflow = builder.ins().band(is_min, is_neg_one);
+    let one = builder.ins().iconst(types::I64, 1);
+    let safe_b = builder.ins().select(overflow, one, b);
+
+    if is_div {
+        let quotient = builder.ins().sdiv(a, safe_b);
+        // sdiv(MIN, 1) == MIN, so the select restores the wrapped result.
+        builder.ins().select(overflow, int_min, quotient)
+    } else {
+        // srem(MIN, 1) == 0 == wrapping_rem(MIN, -1); no fix-up needed.
+        builder.ins().srem(a, safe_b)
+    }
+}
+
+fn lower_cmp(builder: &mut FunctionBuilder, op: CmpOp, a: Value, b: Value) -> Value {
+    if is_float(builder, a) {
+        let cc = match op {
+            CmpOp::Eq => FloatCC::Equal,
+            CmpOp::Ne => FloatCC::NotEqual,
+            CmpOp::Lt => FloatCC::LessThan,
+            CmpOp::Gt => FloatCC::GreaterThan,
+            CmpOp::Le => FloatCC::LessThanOrEqual,
+            CmpOp::Ge => FloatCC::GreaterThanOrEqual,
+        };
+        return builder.ins().fcmp(cc, a, b);
+    }
+    let cc = match op {
+        CmpOp::Eq => IntCC::Equal,
+        CmpOp::Ne => IntCC::NotEqual,
+        CmpOp::Lt => IntCC::SignedLessThan,
+        CmpOp::Gt => IntCC::SignedGreaterThan,
+        CmpOp::Le => IntCC::SignedLessThanOrEqual,
+        CmpOp::Ge => IntCC::SignedGreaterThanOrEqual,
+    };
+    builder.ins().icmp(cc, a, b)
+}
+
+/// Load argument `idx` from the args array and reinterpret it per `ty`.
+fn load_arg(builder: &mut FunctionBuilder, args_ptr: Value, idx: usize, ty: ScalarType) -> Value {
+    let offset = i32::try_from(idx * 8).expect("argument index fits in i32 offset");
+    let raw = builder
+        .ins()
+        .load(types::I64, MemFlags::trusted(), args_ptr, offset);
+    match ty {
+        ScalarType::Int => raw,
+        ScalarType::Bool => builder.ins().ireduce(types::I8, raw),
+        ScalarType::Float => builder.ins().bitcast(types::F64, MemFlags::new(), raw),
+    }
+}
+
+/// Encode `value` back to its raw 64-bit slot and store it through `ret_ptr`.
+fn store_ret(builder: &mut FunctionBuilder, ret_ptr: Value, ty: ScalarType, value: Value) {
+    let bits = match ty {
+        ScalarType::Int => value,
+        ScalarType::Bool => builder.ins().uextend(types::I64, value),
+        ScalarType::Float => builder.ins().bitcast(types::I64, MemFlags::new(), value),
+    };
+    builder.ins().store(MemFlags::trusted(), bits, ret_ptr, 0);
+}
+
+fn zero_of(builder: &mut FunctionBuilder, ty: ScalarType) -> Value {
+    match ty {
+        ScalarType::Int => builder.ins().iconst(types::I64, 0),
+        ScalarType::Bool => builder.ins().iconst(types::I8, 0),
+        ScalarType::Float => builder.ins().f64const(0.0),
+    }
+}
+
+fn is_float(builder: &FunctionBuilder, value: Value) -> bool {
+    builder.func.dfg.value_type(value) == types::F64
+}
+
+/// Convert operand-stack SSA values into block-call arguments.
+fn block_args(stack: &[Value]) -> Vec<BlockArg> {
+    stack.iter().map(|v| BlockArg::from(*v)).collect()
+}

--- a/crates/harn-codegen/src/source.rs
+++ b/crates/harn-codegen/src/source.rs
@@ -1,0 +1,81 @@
+//! Front-end glue: go from Harn source (or an already-compiled function) to a
+//! verified [`ScalarFunction`].
+//!
+//! This reuses the real Harn compiler ([`harn_vm::compile_source`]) — the
+//! native compiler never re-implements lexing, parsing, or bytecode emission.
+//! It only consumes the public [`harn_vm::Chunk`]/[`harn_vm::CompiledFunction`]
+//! surface, so it always tracks the language the installed VM actually speaks.
+
+use harn_parser::TypeExpr;
+use harn_vm::{compile_source, CompiledFunction};
+
+use crate::error::CodegenError;
+use crate::value::ScalarType;
+use crate::verify::{verify, ScalarFunction};
+
+/// Verify an already-compiled Harn function, inferring its scalar signature
+/// from its declared parameter types.
+///
+/// # Errors
+///
+/// Returns [`CodegenError::Unsupported`] if a parameter lacks a scalar type
+/// annotation, or any verification error from the body.
+pub fn analyze_function(func: &CompiledFunction) -> Result<ScalarFunction, CodegenError> {
+    if func.is_generator || func.is_stream {
+        return Err(CodegenError::unsupported("generator/stream function"));
+    }
+    if func.has_rest_param {
+        return Err(CodegenError::unsupported("rest parameter"));
+    }
+    if func.default_start.is_some() {
+        return Err(CodegenError::unsupported("default parameter values"));
+    }
+
+    let mut params = Vec::with_capacity(func.params.len());
+    for param in &func.params {
+        let ty = param
+            .type_expr
+            .as_ref()
+            .and_then(scalar_from_type_expr)
+            .ok_or_else(|| {
+                CodegenError::unsupported(format!(
+                    "parameter `{}` must be annotated `int`, `float`, or `bool`",
+                    param.name
+                ))
+            })?;
+        params.push(ty);
+    }
+
+    verify(
+        func.name.clone(),
+        &func.chunk.code,
+        &func.chunk.constants,
+        &params,
+    )
+}
+
+/// Compile Harn `source`, then verify the named top-level function.
+///
+/// # Errors
+///
+/// Returns [`CodegenError::Verify`] if the source fails to compile,
+/// [`CodegenError::Unsupported`] if no such function exists, or any error from
+/// [`analyze_function`].
+pub fn analyze_named(source: &str, function: &str) -> Result<ScalarFunction, CodegenError> {
+    let chunk = compile_source(source).map_err(CodegenError::verify)?;
+    let func = chunk
+        .functions
+        .iter()
+        .find(|f| f.name == function)
+        .ok_or_else(|| CodegenError::unsupported(format!("no function named `{function}`")))?;
+    analyze_function(func)
+}
+
+/// Map a parameter `TypeExpr` to a scalar type, if it names exactly one of the
+/// three unboxed scalars.
+fn scalar_from_type_expr(type_expr: &TypeExpr) -> Option<ScalarType> {
+    match type_expr {
+        TypeExpr::Named(name) => ScalarType::from_harn_name(name),
+        _ => None,
+    }
+}

--- a/crates/harn-codegen/src/value.rs
+++ b/crates/harn-codegen/src/value.rs
@@ -1,0 +1,142 @@
+//! Scalar value and type model shared by the verifier, the reference
+//! evaluator, and the Cranelift backends.
+//!
+//! The native compiler only handles Harn's three unboxed scalar shapes —
+//! `int` (`i64`), `float` (`f64`), and `bool`. Everything heap-allocated or
+//! runtime-tagged (strings, lists, dicts, nil, closures, host handles) is out
+//! of scope by construction, which is exactly what lets the generated code use
+//! flat machine registers with no tag checks.
+
+use std::fmt;
+
+/// The static type of a scalar operand stack slot, local, parameter, or
+/// return value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ScalarType {
+    Int,
+    Float,
+    Bool,
+}
+
+impl ScalarType {
+    /// The Harn surface-syntax name for this type, as it appears in a
+    /// parameter annotation.
+    #[must_use]
+    pub const fn harn_name(self) -> &'static str {
+        match self {
+            Self::Int => "int",
+            Self::Float => "float",
+            Self::Bool => "bool",
+        }
+    }
+
+    /// Parse a Harn `TypeExpr::Named` payload into a scalar type, if it names
+    /// one of the three unboxed scalars.
+    #[must_use]
+    pub fn from_harn_name(name: &str) -> Option<Self> {
+        match name {
+            "int" => Some(Self::Int),
+            "float" => Some(Self::Float),
+            "bool" => Some(Self::Bool),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ScalarType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.harn_name())
+    }
+}
+
+/// A concrete scalar value. Used as the argument/return marshalling type for
+/// both the reference evaluator and the JIT-compiled function.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ScalarValue {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+}
+
+impl ScalarValue {
+    #[must_use]
+    pub const fn ty(self) -> ScalarType {
+        match self {
+            Self::Int(_) => ScalarType::Int,
+            Self::Float(_) => ScalarType::Float,
+            Self::Bool(_) => ScalarType::Bool,
+        }
+    }
+
+    /// Encode the value as the raw 64-bit pattern used by the uniform native
+    /// calling convention: `int` keeps its two's-complement bits, `float`
+    /// uses IEEE-754 bits, and `bool` is `0`/`1`.
+    #[must_use]
+    pub const fn to_bits(self) -> u64 {
+        match self {
+            Self::Int(n) => n as u64,
+            Self::Float(f) => f.to_bits(),
+            Self::Bool(b) => b as u64,
+        }
+    }
+
+    /// Decode a raw 64-bit pattern back into a typed value given the slot's
+    /// statically known type. Inverse of [`ScalarValue::to_bits`].
+    #[must_use]
+    pub const fn from_bits(ty: ScalarType, bits: u64) -> Self {
+        match ty {
+            ScalarType::Int => Self::Int(bits as i64),
+            ScalarType::Float => Self::Float(f64::from_bits(bits)),
+            ScalarType::Bool => Self::Bool(bits & 1 != 0),
+        }
+    }
+}
+
+impl fmt::Display for ScalarValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Int(n) => write!(f, "{n}"),
+            Self::Float(x) => write!(f, "{x}"),
+            Self::Bool(b) => write!(f, "{b}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ScalarType, ScalarValue};
+
+    #[test]
+    fn bits_roundtrip() {
+        for value in [
+            ScalarValue::Int(0),
+            ScalarValue::Int(-42),
+            ScalarValue::Int(i64::MIN),
+            ScalarValue::Int(i64::MAX),
+            ScalarValue::Float(3.5),
+            ScalarValue::Float(-0.0),
+            ScalarValue::Bool(true),
+            ScalarValue::Bool(false),
+        ] {
+            assert_eq!(ScalarValue::from_bits(value.ty(), value.to_bits()), value);
+        }
+    }
+
+    #[test]
+    fn nan_bits_survive_roundtrip() {
+        let bits = ScalarValue::Float(f64::NAN).to_bits();
+        match ScalarValue::from_bits(ScalarType::Float, bits) {
+            ScalarValue::Float(x) => assert!(x.is_nan()),
+            other => panic!("expected float, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scalar_type_names() {
+        assert_eq!(ScalarType::from_harn_name("int"), Some(ScalarType::Int));
+        assert_eq!(ScalarType::from_harn_name("float"), Some(ScalarType::Float));
+        assert_eq!(ScalarType::from_harn_name("bool"), Some(ScalarType::Bool));
+        assert_eq!(ScalarType::from_harn_name("Widget"), None);
+        assert_eq!(ScalarType::Int.harn_name(), "int");
+    }
+}

--- a/crates/harn-codegen/src/verify.rs
+++ b/crates/harn-codegen/src/verify.rs
@@ -1,0 +1,586 @@
+//! Bytecode verification and scalar type inference.
+//!
+//! This stage turns a flat slice of [`Instr`]s into a typed control-flow graph
+//! ([`ScalarFunction`]) that the backends can lower directly. It does three
+//! things:
+//!
+//! 1. **Reachability decode** — walk control flow from the entry, decoding only
+//!    reachable instructions. Dead epilogues never disqualify a function.
+//! 2. **Basic-block construction** — split at branch targets and the
+//!    fall-through after a conditional branch.
+//! 3. **Type inference** — a monotone fixpoint that assigns one static
+//!    [`ScalarType`] to every operand-stack position (per block entry) and
+//!    every local slot, rejecting anything that is not provably monomorphic.
+//!
+//! The inference is deliberately conservative: a slot that is `int` on one
+//! path and `float` on another, or a control-flow merge with mismatched stack
+//! shapes, is rejected as [`CodegenError::Verify`]. That is what lets the
+//! backend use unboxed machine registers with zero runtime tag checks.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use harn_vm::Constant;
+
+use crate::bytecode::{decode_at, BinOp, CmpOp, Decoded, Instr};
+use crate::error::CodegenError;
+use crate::value::ScalarType;
+
+/// A verified, fully typed scalar function ready for lowering.
+#[derive(Debug, Clone)]
+pub struct ScalarFunction {
+    /// Diagnostic name (the Harn function name, when known).
+    pub name: String,
+    /// Parameter types, in declaration order. They occupy local slots
+    /// `0..params.len()`.
+    pub params: Vec<ScalarType>,
+    /// The function's return type, inferred from every reachable `return`.
+    pub ret: ScalarType,
+    /// Static type of every local slot, indexed by slot id.
+    pub slot_types: Vec<ScalarType>,
+    /// Basic blocks. Block `0` is always the entry.
+    pub blocks: Vec<Block>,
+}
+
+impl ScalarFunction {
+    /// Number of local slots (parameters plus `let`/`var` bindings).
+    #[must_use]
+    pub fn slot_count(&self) -> usize {
+        self.slot_types.len()
+    }
+}
+
+/// A basic block: a straight-line run of body instructions ending in a single
+/// terminator.
+#[derive(Debug, Clone)]
+pub struct Block {
+    /// Operand-stack types on entry, bottom to top. These become the block's
+    /// SSA parameters in the lowered IR.
+    pub stack_in: Vec<ScalarType>,
+    /// Non-terminator instructions, in order.
+    pub body: Vec<Instr>,
+    /// How the block transfers control.
+    pub term: Terminator,
+}
+
+/// The control transfer at the end of a [`Block`]. Successor blocks are
+/// referenced by index into [`ScalarFunction::blocks`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Terminator {
+    /// Return the popped top-of-stack value.
+    Return,
+    /// Unconditional transfer (covers both explicit `Jump` and implicit
+    /// fall-through into a shared block).
+    Jump(usize),
+    /// Branch on the (peeked, not popped) boolean top-of-stack.
+    Branch { on_true: usize, on_false: usize },
+}
+
+/// Verify a decoded scalar function body and infer its types.
+///
+/// `code`/`constants` are the function's bytecode and constant pool; `params`
+/// are the statically known parameter types occupying the leading slots.
+pub fn verify(
+    name: impl Into<String>,
+    code: &[u8],
+    constants: &[Constant],
+    params: &[ScalarType],
+) -> Result<ScalarFunction, CodegenError> {
+    if code.is_empty() {
+        return Err(CodegenError::verify("empty function body"));
+    }
+
+    let decoded = decode_reachable(code, constants)?;
+    let (blocks_raw, block_of) = build_blocks(&decoded)?;
+    infer_types(name.into(), &blocks_raw, &block_of, params)
+}
+
+/// Decode every reachable instruction, keyed by byte offset.
+fn decode_reachable(
+    code: &[u8],
+    constants: &[Constant],
+) -> Result<BTreeMap<usize, Decoded>, CodegenError> {
+    let mut decoded: BTreeMap<usize, Decoded> = BTreeMap::new();
+    let mut worklist = vec![0usize];
+
+    while let Some(ip) = worklist.pop() {
+        if decoded.contains_key(&ip) {
+            continue;
+        }
+        let d = decode_at(code, constants, ip)?;
+        let mut successors = Vec::new();
+        match &d.instr {
+            Instr::Return => {}
+            Instr::Jump(target) => successors.push(*target),
+            Instr::JumpIfFalse(target) | Instr::JumpIfTrue(target) => {
+                successors.push(*target);
+                successors.push(d.next);
+            }
+            _ => successors.push(d.next),
+        }
+        decoded.insert(ip, d);
+        worklist.extend(successors);
+    }
+
+    Ok(decoded)
+}
+
+/// Structural (pre-typing) block representation.
+struct RawBlock {
+    body: Vec<Instr>,
+    term: Terminator,
+}
+
+/// Partition the reachable instructions into basic blocks and resolve every
+/// terminator to successor block indices.
+fn build_blocks(
+    decoded: &BTreeMap<usize, Decoded>,
+) -> Result<(Vec<RawBlock>, HashMap<usize, usize>), CodegenError> {
+    // Leaders: entry, every branch target, and the fall-through after a
+    // conditional branch.
+    let mut leaders: BTreeSet<usize> = BTreeSet::new();
+    leaders.insert(0);
+    for d in decoded.values() {
+        match &d.instr {
+            Instr::Jump(target) => {
+                leaders.insert(*target);
+            }
+            Instr::JumpIfFalse(target) | Instr::JumpIfTrue(target) => {
+                leaders.insert(*target);
+                leaders.insert(d.next);
+            }
+            _ => {}
+        }
+    }
+
+    let block_of: HashMap<usize, usize> = leaders
+        .iter()
+        .enumerate()
+        .map(|(idx, offset)| (*offset, idx))
+        .collect();
+
+    let resolve = |offset: usize| -> Result<usize, CodegenError> {
+        block_of
+            .get(&offset)
+            .copied()
+            .ok_or_else(|| CodegenError::verify(format!("jump to non-leader offset {offset}")))
+    };
+
+    let mut blocks = Vec::with_capacity(leaders.len());
+    for &leader in &leaders {
+        let mut body = Vec::new();
+        let mut ip = leader;
+        let term = loop {
+            let d = decoded
+                .get(&ip)
+                .ok_or_else(|| CodegenError::verify(format!("unreachable leader at {ip}")))?;
+            if d.instr.is_terminator() {
+                break match &d.instr {
+                    Instr::Return => Terminator::Return,
+                    Instr::Jump(target) => Terminator::Jump(resolve(*target)?),
+                    Instr::JumpIfFalse(target) => Terminator::Branch {
+                        on_false: resolve(*target)?,
+                        on_true: resolve(d.next)?,
+                    },
+                    Instr::JumpIfTrue(target) => Terminator::Branch {
+                        on_true: resolve(*target)?,
+                        on_false: resolve(d.next)?,
+                    },
+                    _ => unreachable!("is_terminator covered above"),
+                };
+            }
+            body.push(d.instr.clone());
+            // Stop before the next leader: that boundary becomes an implicit
+            // fall-through edge.
+            if leaders.contains(&d.next) {
+                break Terminator::Jump(resolve(d.next)?);
+            }
+            if !decoded.contains_key(&d.next) {
+                return Err(CodegenError::unsupported(
+                    "control falls off the end of the function (implicit nil return)",
+                ));
+            }
+            ip = d.next;
+        };
+        blocks.push(RawBlock {
+            body: strip_unit_discards(body),
+            term,
+        });
+    }
+
+    Ok((blocks, block_of))
+}
+
+/// Remove `PushUnit; Pop` peepholes — the discarded `nil` result of a
+/// statement-level `while`/`if`/block. Any `PushUnit` that survives (because
+/// it is not immediately discarded) is left in place and rejected later.
+fn strip_unit_discards(body: Vec<Instr>) -> Vec<Instr> {
+    let mut out: Vec<Instr> = Vec::with_capacity(body.len());
+    let mut iter = body.into_iter().peekable();
+    while let Some(instr) = iter.next() {
+        if matches!(instr, Instr::PushUnit) && matches!(iter.peek(), Some(Instr::Pop)) {
+            iter.next();
+            continue;
+        }
+        out.push(instr);
+    }
+    out
+}
+
+/// An abstract operand-stack entry during inference.
+///
+/// `Unit` tracks the `nil` produced by statement-level expressions (`while`,
+/// `if`, blocks). It is allowed to flow along the stack and across control-flow
+/// merges but may only ever be discarded by a `Pop` — never used in an
+/// operation, stored, branched on, or returned. In the lowered IR a surviving
+/// unit is encoded as a throwaway `int` placeholder (see [`StackTy::to_scalar`]),
+/// which the verifier has proven is never observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StackTy {
+    Scalar(ScalarType),
+    Unit,
+}
+
+impl StackTy {
+    /// The scalar type, or an error naming the offending unit use.
+    fn require_scalar(self, context: &str) -> Result<ScalarType, CodegenError> {
+        match self {
+            Self::Scalar(ty) => Ok(ty),
+            Self::Unit => Err(CodegenError::unsupported(format!(
+                "nil value used in {context} (only discarded statement results are allowed)"
+            ))),
+        }
+    }
+
+    /// Public-IR encoding: units become a harmless `int` placeholder that the
+    /// verifier has proven is only ever discarded.
+    const fn to_scalar(self) -> ScalarType {
+        match self {
+            Self::Scalar(ty) => ty,
+            Self::Unit => ScalarType::Int,
+        }
+    }
+}
+
+/// Abstract operand stack during inference/simulation.
+type TypeStack = Vec<StackTy>;
+
+/// Run the monotone fixpoint that assigns types to stack positions and slots,
+/// then assemble the final [`ScalarFunction`].
+fn infer_types(
+    name: String,
+    blocks: &[RawBlock],
+    block_of: &HashMap<usize, usize>,
+    params: &[ScalarType],
+) -> Result<ScalarFunction, CodegenError> {
+    let entry = *block_of
+        .get(&0)
+        .ok_or_else(|| CodegenError::verify("missing entry block"))?;
+
+    let slot_count = slot_count(blocks, params.len());
+    let mut slot_types: Vec<Option<ScalarType>> = vec![None; slot_count];
+    for (slot, ty) in params.iter().enumerate() {
+        slot_types[slot] = Some(*ty);
+    }
+
+    let mut block_in: Vec<Option<TypeStack>> = vec![None; blocks.len()];
+    block_in[entry] = Some(Vec::new());
+
+    // Monotone fixpoint: each pass can only learn more slot/stack types. The
+    // lattice is finite (slots × types, blocks × bounded stack shapes), so it
+    // terminates. `Pending` (a read of a not-yet-typed slot) is tolerated here
+    // and only becomes an error in the final validation pass.
+    loop {
+        let before = known_count(&slot_types) + block_in.iter().filter(|s| s.is_some()).count();
+        for b in 0..blocks.len() {
+            let Some(stack_in) = block_in[b].clone() else {
+                continue;
+            };
+            simulate_block(
+                &blocks[b],
+                stack_in,
+                &mut slot_types,
+                &mut block_in,
+                &mut None,
+                false,
+            )?;
+        }
+        let after = known_count(&slot_types) + block_in.iter().filter(|s| s.is_some()).count();
+        if after == before {
+            break;
+        }
+    }
+
+    // Final authoritative pass: pending slots are now hard errors, and we
+    // gather the (consistent) return type.
+    let mut ret: Option<ScalarType> = None;
+    for b in 0..blocks.len() {
+        let Some(stack_in) = block_in[b].clone() else {
+            continue; // genuinely unreachable block (no predecessor typed it)
+        };
+        simulate_block(
+            &blocks[b],
+            stack_in,
+            &mut slot_types,
+            &mut block_in,
+            &mut ret,
+            true,
+        )?;
+    }
+
+    let ret = ret.ok_or_else(|| {
+        CodegenError::unsupported("function never returns a scalar value (implicit nil return)")
+    })?;
+
+    let slot_types = slot_types
+        .into_iter()
+        .map(|ty| ty.unwrap_or(ScalarType::Int))
+        .collect();
+
+    let blocks = blocks
+        .iter()
+        .enumerate()
+        .map(|(idx, raw)| Block {
+            stack_in: block_in[idx]
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(StackTy::to_scalar)
+                .collect(),
+            body: raw.body.clone(),
+            term: raw.term,
+        })
+        .collect();
+
+    Ok(ScalarFunction {
+        name,
+        params: params.to_vec(),
+        ret,
+        slot_types,
+        blocks,
+    })
+}
+
+/// The maximum slot index referenced anywhere, plus one — or the parameter
+/// count, whichever is larger.
+fn slot_count(blocks: &[RawBlock], param_count: usize) -> usize {
+    let mut max = param_count;
+    for block in blocks {
+        for instr in &block.body {
+            let slot = match instr {
+                Instr::GetLocal(s) | Instr::DefLocal(s) | Instr::SetLocal(s) => Some(*s as usize),
+                _ => None,
+            };
+            if let Some(slot) = slot {
+                max = max.max(slot + 1);
+            }
+        }
+    }
+    max
+}
+
+fn known_count(slots: &[Option<ScalarType>]) -> usize {
+    slots.iter().filter(|s| s.is_some()).count()
+}
+
+/// Simulate one block's type effects.
+///
+/// Updates `slot_types` and propagates the exit stack to successor `block_in`
+/// entries. When `pending_is_error` is false, a read of an untyped slot simply
+/// stops the block early (it will be retried once the slot is typed). When
+/// true, it is reported as an error.
+fn simulate_block(
+    block: &RawBlock,
+    stack_in: TypeStack,
+    slot_types: &mut [Option<ScalarType>],
+    block_in: &mut [Option<TypeStack>],
+    ret: &mut Option<ScalarType>,
+    pending_is_error: bool,
+) -> Result<(), CodegenError> {
+    let mut stack = stack_in;
+
+    for instr in &block.body {
+        if step_type(&mut stack, slot_types, instr, pending_is_error)? {
+            // Pending read of an untyped slot: stop here for now.
+            return Ok(());
+        }
+    }
+
+    match block.term {
+        Terminator::Return => {
+            let entry = stack
+                .pop()
+                .ok_or_else(|| CodegenError::verify("return with empty operand stack"))?;
+            let ty = entry.require_scalar("a return value")?;
+            match ret {
+                Some(existing) if *existing != ty => {
+                    return Err(CodegenError::verify(format!(
+                        "inconsistent return types: {existing} vs {ty}"
+                    )));
+                }
+                slot => *slot = Some(ty),
+            }
+        }
+        Terminator::Jump(target) => propagate(block_in, target, &stack)?,
+        Terminator::Branch { on_true, on_false } => {
+            match stack.last() {
+                Some(StackTy::Scalar(ScalarType::Bool)) => {}
+                Some(StackTy::Scalar(other)) => {
+                    return Err(CodegenError::verify(format!(
+                        "branch condition must be bool, found {other}"
+                    )));
+                }
+                Some(StackTy::Unit) => {
+                    return Err(CodegenError::verify(
+                        "branch condition must be bool, found nil",
+                    ));
+                }
+                None => return Err(CodegenError::verify("branch with empty operand stack")),
+            }
+            propagate(block_in, on_true, &stack)?;
+            propagate(block_in, on_false, &stack)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Propagate an exit stack into a successor's entry, requiring agreement with
+/// any previously recorded shape.
+fn propagate(
+    block_in: &mut [Option<TypeStack>],
+    target: usize,
+    stack: &TypeStack,
+) -> Result<(), CodegenError> {
+    match &block_in[target] {
+        Some(existing) if existing != stack => Err(CodegenError::verify(format!(
+            "operand-stack shape mismatch at control-flow merge into block {target}: \
+             {existing:?} vs {stack:?}"
+        ))),
+        Some(_) => Ok(()),
+        None => {
+            block_in[target] = Some(stack.clone());
+            Ok(())
+        }
+    }
+}
+
+/// Apply one instruction's type transition to the abstract stack. Returns
+/// `Ok(true)` when the instruction is a *pending* read of an untyped slot and
+/// the caller should stop simulating this block for now.
+fn step_type(
+    stack: &mut TypeStack,
+    slot_types: &mut [Option<ScalarType>],
+    instr: &Instr,
+    pending_is_error: bool,
+) -> Result<bool, CodegenError> {
+    match instr {
+        Instr::Const(value) => stack.push(StackTy::Scalar(value.ty())),
+        Instr::PushUnit => stack.push(StackTy::Unit),
+        Instr::Bin(op) => {
+            let (a, b) = pop2_scalar(stack, "an arithmetic operand")?;
+            if a != b {
+                return Err(CodegenError::verify(format!(
+                    "binary operands must match: {a} vs {b}"
+                )));
+            }
+            match (op, a) {
+                (_, ScalarType::Bool) => {
+                    return Err(CodegenError::verify("arithmetic on bool operands"));
+                }
+                (BinOp::Mod, ScalarType::Float) => {
+                    return Err(CodegenError::unsupported(
+                        "float modulo (no native frem; would need a libm call)",
+                    ));
+                }
+                _ => {}
+            }
+            stack.push(StackTy::Scalar(a));
+        }
+        Instr::Cmp(op) => {
+            let (a, b) = pop2_scalar(stack, "a comparison operand")?;
+            if a != b {
+                return Err(CodegenError::verify(format!(
+                    "comparison operands must match: {a} vs {b}"
+                )));
+            }
+            if matches!(a, ScalarType::Bool) && !matches!(op, CmpOp::Eq | CmpOp::Ne) {
+                return Err(CodegenError::verify("ordered comparison on bool operands"));
+            }
+            stack.push(StackTy::Scalar(ScalarType::Bool));
+        }
+        Instr::Neg => {
+            let a = pop1(stack)?.require_scalar("negation")?;
+            if matches!(a, ScalarType::Bool) {
+                return Err(CodegenError::verify("negation of bool operand"));
+            }
+            stack.push(StackTy::Scalar(a));
+        }
+        Instr::Not => {
+            let a = pop1(stack)?.require_scalar("logical not")?;
+            if !matches!(a, ScalarType::Bool) {
+                return Err(CodegenError::verify(format!("logical not of {a} operand")));
+            }
+            stack.push(StackTy::Scalar(ScalarType::Bool));
+        }
+        Instr::Pop => {
+            pop1(stack)?;
+        }
+        Instr::Dup => {
+            let top = *stack
+                .last()
+                .ok_or_else(|| CodegenError::verify("dup on empty stack"))?;
+            stack.push(top);
+        }
+        Instr::Swap => {
+            let len = stack.len();
+            if len < 2 {
+                return Err(CodegenError::verify("swap needs two operands"));
+            }
+            stack.swap(len - 1, len - 2);
+        }
+        Instr::GetLocal(slot) => match slot_types[*slot as usize] {
+            Some(ty) => stack.push(StackTy::Scalar(ty)),
+            None => {
+                if pending_is_error {
+                    return Err(CodegenError::verify(format!(
+                        "read of local slot {slot} before it is assigned a scalar type"
+                    )));
+                }
+                return Ok(true);
+            }
+        },
+        Instr::DefLocal(slot) | Instr::SetLocal(slot) => {
+            let value = pop1(stack)?.require_scalar("a local binding")?;
+            let entry = &mut slot_types[*slot as usize];
+            match entry {
+                Some(existing) if *existing != value => {
+                    return Err(CodegenError::verify(format!(
+                        "local slot {slot} reused with conflicting types: {existing} vs {value}"
+                    )));
+                }
+                slot_ref => *slot_ref = Some(value),
+            }
+        }
+        Instr::Nop => {}
+        // Terminators are handled by the caller.
+        Instr::Jump(_) | Instr::JumpIfFalse(_) | Instr::JumpIfTrue(_) | Instr::Return => {
+            return Err(CodegenError::verify("terminator in block body"));
+        }
+    }
+    Ok(false)
+}
+
+fn pop1(stack: &mut TypeStack) -> Result<StackTy, CodegenError> {
+    stack
+        .pop()
+        .ok_or_else(|| CodegenError::verify("operand stack underflow"))
+}
+
+fn pop2_scalar(
+    stack: &mut TypeStack,
+    context: &str,
+) -> Result<(ScalarType, ScalarType), CodegenError> {
+    let b = pop1(stack)?.require_scalar(context)?;
+    let a = pop1(stack)?.require_scalar(context)?;
+    Ok((a, b))
+}

--- a/crates/harn-codegen/tests/aot.rs
+++ b/crates/harn-codegen/tests/aot.rs
@@ -1,0 +1,50 @@
+//! Ahead-of-time object emission tests.
+//!
+//! We assert the backend produces a well-formed host object exporting the
+//! expected symbol. We deliberately do *not* invoke a system linker — that
+//! would make the test depend on an external toolchain. The object's format
+//! magic plus the presence of the export symbol is enough to prove the backend
+//! ran end to end.
+
+use harn_codegen::compile_named_object;
+
+#[test]
+fn emits_object_with_expected_symbol() {
+    let artifact =
+        compile_named_object("fn add(a: int, b: int) -> int { return a + b }", "add").unwrap();
+
+    assert_eq!(artifact.symbol, "harn_scalar_add");
+    assert!(!artifact.bytes.is_empty(), "object should not be empty");
+
+    // The export symbol name appears in the object's string/symbol table.
+    let needle = artifact.symbol.as_bytes();
+    let found = artifact
+        .bytes
+        .windows(needle.len())
+        .any(|window| window == needle);
+    assert!(
+        found,
+        "exported symbol `{}` not present in object",
+        artifact.symbol
+    );
+
+    assert!(
+        has_known_object_magic(&artifact.bytes),
+        "object does not start with a recognised format magic"
+    );
+}
+
+/// Recognise the leading magic for the host object formats Cranelift emits.
+fn has_known_object_magic(bytes: &[u8]) -> bool {
+    const ELF: &[u8] = &[0x7f, b'E', b'L', b'F'];
+    const MACHO64_LE: &[u8] = &[0xcf, 0xfa, 0xed, 0xfe];
+    const MACHO64_BE: &[u8] = &[0xfe, 0xed, 0xfa, 0xcf];
+    // COFF (Windows) object files begin with a 2-byte machine type rather than
+    // a fixed magic; accept the common x86-64/aarch64 machine words too.
+    const COFF_X64: &[u8] = &[0x64, 0x86];
+    const COFF_ARM64: &[u8] = &[0xaa, 0x64];
+
+    [ELF, MACHO64_LE, MACHO64_BE, COFF_X64, COFF_ARM64]
+        .iter()
+        .any(|magic| bytes.starts_with(magic))
+}

--- a/crates/harn-codegen/tests/native.rs
+++ b/crates/harn-codegen/tests/native.rs
@@ -1,0 +1,280 @@
+//! End-to-end differential tests: compile real Harn source to native code and
+//! assert the JIT agrees with the reference interpreter (and with hand-computed
+//! expectations) across a grid of inputs.
+//!
+//! These are fully in-process and deterministic — no wall-clock, no threads,
+//! no external toolchain.
+
+use harn_codegen::{
+    analyze_named, evaluate, jit_compile, CodegenError, EvalError, NativeTrap, ScalarValue,
+};
+
+use ScalarValue::{Bool, Float, Int};
+
+/// Compare two scalar results, treating floats bit-for-bit so NaN results
+/// (which are never `==` under `PartialEq`) compare equal when identical.
+fn same(a: ScalarValue, b: ScalarValue) -> bool {
+    match (a, b) {
+        (Float(x), Float(y)) => x.to_bits() == y.to_bits(),
+        _ => a == b,
+    }
+}
+
+/// Compile `function` from `source`, then assert the JIT and the reference
+/// interpreter agree on every input row.
+fn check(source: &str, function: &str, rows: &[Vec<ScalarValue>]) {
+    let scalar = analyze_named(source, function)
+        .unwrap_or_else(|e| panic!("`{function}` should be scalar-eligible: {e}"));
+    let native = jit_compile(&scalar).expect("jit compile");
+
+    for args in rows {
+        let jit = native.call(args);
+        let reference = evaluate(&scalar, args);
+        match (jit, reference) {
+            (Ok(j), Ok(r)) => assert!(
+                same(j, r),
+                "jit={j:?} reference={r:?} for {function}{args:?}"
+            ),
+            (Err(jt), Err(EvalError::Trap(rt))) => {
+                assert_eq!(jt, rt, "trap mismatch for {function}{args:?}");
+            }
+            (j, r) => panic!("jit/reference disagree for {function}{args:?}: {j:?} vs {r:?}"),
+        }
+    }
+}
+
+fn ints(values: &[i64]) -> Vec<Vec<ScalarValue>> {
+    values.iter().map(|&n| vec![Int(n)]).collect()
+}
+
+fn int_pairs(values: &[(i64, i64)]) -> Vec<Vec<ScalarValue>> {
+    values.iter().map(|&(a, b)| vec![Int(a), Int(b)]).collect()
+}
+
+const INT_SAMPLES: &[i64] = &[0, 1, -1, 2, -7, 42, 1000, i64::MIN, i64::MAX, -123_456];
+
+#[test]
+fn integer_arithmetic_matches_interpreter() {
+    let pairs: Vec<(i64, i64)> = [
+        (0, 0),
+        (1, 2),
+        (-3, 9),
+        (i64::MAX, 1),
+        (i64::MIN, -1),
+        (7, -2),
+        (-7, 2),
+        (i64::MIN, 1),
+        (100, 7),
+    ]
+    .to_vec();
+
+    for (name, op) in [
+        ("add", "+"),
+        ("sub", "-"),
+        ("mul", "*"),
+        ("idiv", "/"),
+        ("imod", "%"),
+    ] {
+        let src = format!("fn {name}(a: int, b: int) -> int {{ return a {op} b }}");
+        check(&src, name, &int_pairs(&pairs));
+    }
+}
+
+#[test]
+fn integer_wrapping_overflow() {
+    // i64::MAX + 1 must wrap to i64::MIN, matching the VM's wrapping_add.
+    check(
+        "fn add(a: int, b: int) -> int { return a + b }",
+        "add",
+        &int_pairs(&[(i64::MAX, 1), (i64::MIN, -1), (i64::MAX, i64::MAX)]),
+    );
+}
+
+#[test]
+fn integer_min_div_neg_one_does_not_trap() {
+    // i64::MIN / -1 overflows in two's complement; the VM uses wrapping_div
+    // (-> i64::MIN) and wrapping_rem (-> 0). The JIT must not hardware-trap.
+    let div = analyze_named("fn d(a: int, b: int) -> int { return a / b }", "d").unwrap();
+    let native = jit_compile(&div).unwrap();
+    assert_eq!(
+        native.call(&[Int(i64::MIN), Int(-1)]).unwrap(),
+        Int(i64::MIN)
+    );
+
+    let rem = analyze_named("fn m(a: int, b: int) -> int { return a % b }", "m").unwrap();
+    let native = jit_compile(&rem).unwrap();
+    assert_eq!(native.call(&[Int(i64::MIN), Int(-1)]).unwrap(), Int(0));
+}
+
+#[test]
+fn divide_by_zero_traps_in_jit_and_interpreter() {
+    for op in ["/", "%"] {
+        let src = format!("fn d(a: int, b: int) -> int {{ return a {op} b }}");
+        let scalar = analyze_named(&src, "d").unwrap();
+        let native = jit_compile(&scalar).unwrap();
+        assert_eq!(
+            native.call(&[Int(5), Int(0)]),
+            Err(NativeTrap::DivideByZero)
+        );
+        assert_eq!(
+            evaluate(&scalar, &[Int(5), Int(0)]),
+            Err(EvalError::Trap(NativeTrap::DivideByZero))
+        );
+        // A subsequent non-trapping call on the same compiled function still
+        // works (the trap flag is reset on every entry).
+        let ok = native.call(&[Int(6), Int(2)]).unwrap();
+        assert_eq!(ok, evaluate(&scalar, &[Int(6), Int(2)]).unwrap());
+    }
+}
+
+#[test]
+fn unary_and_comparisons() {
+    check(
+        "fn neg(a: int) -> int { return -a }",
+        "neg",
+        &ints(INT_SAMPLES),
+    );
+    for (name, op) in [
+        ("lt", "<"),
+        ("gt", ">"),
+        ("le", "<="),
+        ("ge", ">="),
+        ("eq", "=="),
+        ("ne", "!="),
+    ] {
+        let src = format!("fn {name}(a: int, b: int) -> bool {{ return a {op} b }}");
+        check(
+            &src,
+            name,
+            &int_pairs(&[(1, 2), (2, 1), (3, 3), (-1, -1), (i64::MIN, i64::MAX)]),
+        );
+    }
+}
+
+#[test]
+fn float_arithmetic_and_special_values() {
+    let rows: Vec<Vec<ScalarValue>> = [
+        (1.5, 2.25),
+        (-3.0, 0.0),
+        (1.0, 0.0),  // -> +inf
+        (-1.0, 0.0), // -> -inf
+        (0.0, 0.0),  // -> NaN for div
+        (f64::INFINITY, 1.0),
+        (f64::NAN, 1.0),
+        (2.0, 0.5),
+    ]
+    .iter()
+    .map(|&(a, b)| vec![Float(a), Float(b)])
+    .collect();
+
+    for (name, op) in [("add", "+"), ("sub", "-"), ("mul", "*"), ("fdiv", "/")] {
+        let src = format!("fn {name}(a: float, b: float) -> float {{ return a {op} b }}");
+        check(&src, name, &rows);
+    }
+}
+
+#[test]
+fn float_comparisons_with_nan() {
+    let rows: Vec<Vec<ScalarValue>> = [
+        (1.0, 2.0),
+        (2.0, 1.0),
+        (1.0, 1.0),
+        (f64::NAN, 1.0),
+        (f64::NAN, f64::NAN),
+    ]
+    .iter()
+    .map(|&(a, b)| vec![Float(a), Float(b)])
+    .collect();
+
+    for (name, op) in [("lt", "<"), ("gt", ">"), ("eq", "=="), ("ne", "!=")] {
+        let src = format!("fn {name}(a: float, b: float) -> bool {{ return a {op} b }}");
+        check(&src, name, &rows);
+    }
+}
+
+#[test]
+fn boolean_logic_and_short_circuit() {
+    let rows = [
+        vec![Bool(false), Bool(false)],
+        vec![Bool(false), Bool(true)],
+        vec![Bool(true), Bool(false)],
+        vec![Bool(true), Bool(true)],
+    ];
+    check(
+        "fn band(a: bool, b: bool) -> bool { return a && b }",
+        "band",
+        &rows,
+    );
+    check(
+        "fn bor(a: bool, b: bool) -> bool { return a || b }",
+        "bor",
+        &rows,
+    );
+    check(
+        "fn bnot(a: bool) -> bool { return !a }",
+        "bnot",
+        &[vec![Bool(true)], vec![Bool(false)]],
+    );
+}
+
+#[test]
+fn control_flow_branches_and_loops() {
+    let abs = "fn iabs(n: int) -> int {\n  if n < 0 {\n    return -n\n  }\n  return n\n}";
+    check(abs, "iabs", &ints(INT_SAMPLES));
+
+    let clamp = "fn clamp(n: int, lo: int, hi: int) -> int {\n  if n < lo {\n    return lo\n  }\n  if n > hi {\n    return hi\n  }\n  return n\n}";
+    check(
+        clamp,
+        "clamp",
+        &[
+            vec![Int(5), Int(0), Int(10)],
+            vec![Int(-3), Int(0), Int(10)],
+            vec![Int(99), Int(0), Int(10)],
+        ],
+    );
+
+    let sum = "fn sum_to(n: int) -> int {\n  var total = 0\n  var i = 1\n  while i <= n {\n    total = total + i\n    i = i + 1\n  }\n  return total\n}";
+    check(sum, "sum_to", &ints(&[0, 1, 5, 10, 100, -5]));
+}
+
+#[test]
+fn nested_loops_collatz_steps() {
+    let src = "fn collatz(start: int) -> int {\n  var n = start\n  var steps = 0\n  while n > 1 {\n    if n % 2 == 0 {\n      n = n / 2\n    } else {\n      n = 3 * n + 1\n    }\n    steps = steps + 1\n  }\n  return steps\n}";
+    check(src, "collatz", &ints(&[1, 2, 3, 6, 7, 27]));
+}
+
+#[test]
+fn unsupported_constructs_are_reported() {
+    let cases: &[(&str, &str)] = &[
+        ("fn f(s: string) -> int { return 1 }", "f"),
+        ("fn f(a: int) -> int { return a ** 2 }", "f"),
+        ("fn f(a: float, b: float) -> float { return a % b }", "f"),
+        ("fn f(a: int) -> string { return \"hi\" }", "f"),
+        ("fn f(a: int) { let x = a }", "f"),
+    ];
+    for (src, name) in cases {
+        let err = analyze_named(src, name)
+            .expect_err(&format!("expected `{name}` to be unsupported: {src}"));
+        assert!(
+            matches!(err, CodegenError::Unsupported(_)),
+            "expected Unsupported, got {err:?} for: {src}"
+        );
+    }
+}
+
+#[test]
+fn missing_function_is_unsupported() {
+    let err = analyze_named("fn a(x: int) -> int { return x }", "b").unwrap_err();
+    assert!(matches!(err, CodegenError::Unsupported(_)));
+}
+
+#[test]
+fn jit_argument_validation_panics() {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    let scalar = analyze_named("fn f(a: int) -> int { return a }", "f").unwrap();
+    let native = jit_compile(&scalar).unwrap();
+    let result = catch_unwind(AssertUnwindSafe(|| native.call(&[Int(1), Int(2)])));
+    assert!(result.is_err(), "wrong arity should panic");
+    let result = catch_unwind(AssertUnwindSafe(|| native.call(&[Float(1.0)])));
+    assert!(result.is_err(), "wrong type should panic");
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -260,6 +260,7 @@
 - [Annotation tape format](./dev/annotation-tape-format.md)
 - [DES runtime mode](./dev/des-mode.md)
 - [VM and stdlib perf notes](./dev/vm-stdlib-perf-notes.md)
+- [Native code generation (experimental)](./dev/native-codegen.md)
 - [Bytecode cache](./perf/bytecode-cache.md)
 
 # Migrations

--- a/docs/src/dev/native-codegen.md
+++ b/docs/src/dev/native-codegen.md
@@ -1,0 +1,137 @@
+# Native code generation (experimental)
+
+The `harn-codegen` crate is an **experimental, opt-in** ahead-of-time / JIT
+compiler that lowers a subset of Harn to native machine code via
+[Cranelift](https://cranelift.dev/). It is a side project, not a shipped
+feature.
+
+> **Not part of the distributed binary.** `harn-codegen` is `publish = false`
+> and is *not* a dependency of `harn-cli` or `harn-vm`. The crates.io `harn`
+> binary never links Cranelift. The crate builds and tests under
+> `cargo … --workspace` (so CI keeps it honest), but you opt in explicitly with
+> `-p harn-codegen`.
+
+## Why (and why not)
+
+Harn is an orchestration language: real programs are dominated by LLM calls,
+tool dispatch, and other I/O, where native code generation buys nothing — the
+bottleneck is the network, not interpreter dispatch. So this is **not** a
+general "make harnesses faster" feature, and it is deliberately kept out of the
+default build.
+
+The honest, narrow niche it targets is the opposite end of the spectrum: small,
+hot, side-effect-free **numeric kernels** — scoring functions, parsers,
+bit-twiddling, geometry, fixed-point math — that run in tight loops. For those,
+compiling the bytecode to machine code removes interpreter overhead entirely.
+If you have such a kernel and have measured it as a real cost, this is a tool
+worth reaching for.
+
+## The scalar subset
+
+The compiler handles Harn's three unboxed scalar types — `int` (`i64`),
+`float` (`f64`), and `bool` — and the operations over them:
+
+- arithmetic `+ - * /` and integer `%` (trap-checked divide-by-zero; `i64::MIN
+  / -1` wraps like the VM rather than trapping);
+- comparisons `== != < > <= >=` and logical `!`, `&&`, `||`;
+- `if`/`else`, `while` loops, ternaries, short-circuit operators;
+- `let`/`var` locals and reassignment.
+
+Anything else — strings, lists, dicts, `nil` as a value, closures,
+`harness.*`/host calls, `await`, `**` (its result type is value-dependent),
+float `%` — is reported as `CodegenError::Unsupported`. Callers treat that as
+"this function stays on the interpreter"; it is the expected outcome for most
+functions, not an error.
+
+Parameters must carry a scalar type annotation:
+
+```harn,ignore
+fn score(hits: int, misses: int) -> int {
+  var total = 0
+  var i = 0
+  while i < hits {
+    total = total + 10
+    i = i + 1
+  }
+  return total - misses
+}
+```
+
+## Pipeline
+
+```text
+Harn source ──(harn-vm front-end)──▶ Chunk / bytecode
+           │
+           ├─ decode   reachable scalar instructions
+           ├─ verify   typed control-flow graph (ScalarFunction)
+           ├─ lower    Cranelift IR
+           └─ backend
+                ├─ jit    in-process machine code  ▶ NativeFunction
+                └─ aot    relocatable object file  ▶ ObjectArtifact
+```
+
+The front end is the real Harn compiler (`harn_vm::compile_source`) — the
+native compiler never re-implements lexing, parsing, or bytecode emission, so
+it always tracks the language the installed VM actually speaks. It then:
+
+1. **decodes** only *reachable* bytecode (control-flow walk), so the unreachable
+   `Nil; Return` epilogue the compiler appends after an explicit `return` never
+   disqualifies an otherwise-scalar function;
+2. **verifies** with a monotone type-inference fixpoint that assigns one static
+   type to every operand-stack position and local slot, rejecting anything not
+   provably monomorphic (an `int`-on-one-path/`float`-on-another slot, a
+   mismatched control-flow merge);
+3. **lowers** to Cranelift IR and hands off to a backend.
+
+A pure-Rust reference interpreter (`harn_codegen::evaluate`) mirrors the VM's
+semantics exactly (wrapping integer arithmetic, IEEE-754 floats with NaN
+ordering). It is the differential-test oracle and a dependency-free fallback.
+
+## Calling convention
+
+Every compiled function is emitted with one uniform C signature, regardless of
+its Harn arity or types:
+
+```text
+extern "C" fn(args: *const u64, ret: *mut u64, trap: *mut u8)
+```
+
+Arguments and the result are raw 64-bit slots (`int` keeps its bits, `float`
+uses IEEE-754 bits, `bool` is `0`/`1`). This keeps the Rust ↔ native boundary a
+single monomorphic function pointer and gives the AOT object one stable,
+easily-linked symbol (`harn_scalar_<name>`). Integer divide-by-zero sets
+`*trap = 1` and returns, surfacing as a `NativeTrap` instead of a hardware trap
+that would abort the host.
+
+## Using it
+
+Library:
+
+```text
+use harn_codegen::{compile_named, ScalarValue};
+
+let f = compile_named("fn add(a: int, b: int) -> int { return a + b }", "add")?;
+let sum = f.call(&[ScalarValue::Int(2), ScalarValue::Int(3)])?; // Int(5)
+```
+
+CLI (`harn-nativec`):
+
+```text
+# Report whether a function is scalar-eligible and JIT it
+harn-nativec kernel.harn score
+
+# Emit a relocatable object you can link with any system linker
+harn-nativec kernel.harn score --object score.o
+
+# JIT and run with arguments (cross-checked against the reference interpreter)
+harn-nativec kernel.harn score --run 12 3
+```
+
+## Tests
+
+All tests are in-process and deterministic — no wall clock, no threads, no
+external toolchain. `tests/native.rs` is a differential suite that compiles
+real Harn source and asserts the JIT agrees with the reference interpreter
+across input grids (including overflow, divide-by-zero traps, `i64::MIN / -1`,
+and NaN comparisons); `tests/aot.rs` checks object emission without invoking a
+linker.


### PR DESCRIPTION
## What

A new, self-contained **`harn-codegen`** crate: an experimental ahead-of-time / JIT compiler that lowers Harn's **scalar-compute subset** (`int`/`float`/`bool`) from VM bytecode to native machine code via [Cranelift](https://cranelift.dev/) (the same vetted code generator the optional `testbench-wasi` feature already links through wasmtime).

This is a side project, scoped deliberately. It is **not** part of the distributed binary: the crate is `publish = false` and is not a dependency of `harn-cli`/`harn-vm`, so crates.io builds never link Cranelift. It builds and tests under `cargo … --workspace` so CI keeps it honest; you opt in with `-p harn-codegen`.

## Why (honest take)

Harnesses are I/O/LLM-bound — native codegen of orchestration buys nothing, which is exactly why this stays out of the default build. The real niche is the opposite end: small, hot, side-effect-free **numeric kernels** (scoring, parsing, bit-twiddling, geometry) that run in tight loops, where removing interpreter dispatch is a measurable win. The docs say this plainly so nobody reaches for it expecting faster pipelines.

## Architecture (modular building blocks)

```
Harn source ──(harn-vm front-end)──▶ Chunk / bytecode
           ├─ bytecode  reachability-driven decode of the scalar opcode subset
           ├─ verify    typed CFG via a monotone type-inference fixpoint
           ├─ lower     Cranelift IR, uniform (args*, ret*, trap*) C ABI
           └─ backend   jit → NativeFunction   |   aot → relocatable object
```

- **Reuses the real compiler** (`harn_vm::compile_source`) — no re-implemented lexer/parser/bytecode. The only coupling is that `harn_vm::Op` is a public `#[repr(u8)]` enum, so **zero changes to any shipped crate** were needed.
- **Reachability-driven decode** so the unreachable `Nil; Return` epilogue the compiler appends never disqualifies a scalar function.
- **Sound type inference**: one static type per operand-stack slot and local; rejects non-monomorphic merges/slots as `Unsupported`/`Verify`, which is what lets the backend use unboxed registers with no tag checks.
- **Faithful semantics**: wrapping integer arithmetic, `i64::MIN / -1` wraps (no hardware trap), integer `/0` and `%0` surface as a `NativeTrap` via a side-channel flag rather than aborting the host, IEEE-754 floats with NaN ordering. A pure-Rust reference interpreter mirrors the VM and is the differential-test oracle.
- A `harn-nativec` CLI: report eligibility, emit an object file, or JIT-and-run.

## Tests

18 in-process, deterministic tests (no wall clock, no threads, no external linker): differential JIT-vs-interpreter over input grids (overflow, divide-by-zero traps, `i64::MIN / -1`, NaN comparisons, short-circuit logic, loops/branches), unsupported-construct detection, AOT object-format checks, and bit-roundtrip/symbol unit tests.

Verified locally: `cargo test -p harn-codegen` (all pass), `cargo clippy -p harn-codegen --all-targets -- -D warnings` (clean), `cargo fmt --check` (clean). Rebased on latest `origin/main`.

Docs: `docs/src/dev/native-codegen.md` (+ SUMMARY entry); changelog fragment added.

https://claude.ai/code/session_011tPzXjgV1quVxBHPmaJ8PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011tPzXjgV1quVxBHPmaJ8PQ)_