### PR TITLE
Guard typed fast-path opcodes with a generic fallback

### DIFF
--- a/changelog.d/typed-opcode-guard-fallback.fixed.md
+++ b/changelog.d/typed-opcode-guard-fallback.fixed.md
@@ -1,0 +1,12 @@
+- Typed fast-path opcodes (`AddInt`, `LessInt`, `EqualString`, …) now guard
+  their operands and fall back to generic semantics on a type miss instead of
+  hard-erroring. The compiler emits these from a static type guess, but a guess
+  can be wrong at runtime — an `any`-typed value flowing through a typed
+  parameter or an annotated binding initializer (`let x: int = <any>`) is not
+  runtime-checked, so the operand may be a different primitive than the
+  annotation claims. The optimized build previously threw a
+  specialization-internal error (e.g. `Typed int add expected int operands, got
+  int and float`) on programs the unoptimized build runs correctly; it now
+  produces the same result as the unoptimized build by construction. The hot
+  path where the guess holds is unchanged, and genuinely incompatible operands
+  still error with the same generic message in both builds.

--- a/crates/harn-vm/src/vm/mod.rs
+++ b/crates/harn-vm/src/vm/mod.rs
@@ -20,6 +20,8 @@ mod depth_regression_tests;
 mod tests_debug;
 #[cfg(test)]
 mod tests_runtime;
+#[cfg(test)]
+mod tests_typed_op_fallback;
 
 pub(crate) use async_builtin::run_async_builtin_with;
 pub use async_builtin::AsyncBuiltinCtx;

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -192,7 +192,10 @@ impl super::super::Vm {
         }
     }
 
-    fn generic_binary_result(
+    /// Generic (non-specialized) result for a binary op, matching exactly what
+    /// the unoptimized build computes. Exposed so the typed fast-path opcodes can
+    /// fall back to it on an operand-type miss — see [`Self::run_typed_binary`].
+    pub(super) fn generic_binary_result(
         vm: &Self,
         op: AdaptiveBinaryOp,
         a: VmValue,
@@ -333,93 +336,110 @@ impl super::super::Vm {
         Some(VmValue::Bool(result))
     }
 
-    pub(super) fn execute_add_int(&mut self) -> Result<(), VmError> {
+    /// Shared driver for the typed fast-path binary opcodes. Pops the two
+    /// operands, runs the supplied monomorphic fast path, and — when the
+    /// operands do not match the specialized shape — falls back to the exact
+    /// generic result the unoptimized build would produce (`op`).
+    ///
+    /// This is the runtime-guard half of typed-opcode specialization. The
+    /// compiler emits a typed op (`AddInt`, `LessInt`, …) from a *static* type
+    /// guess, but a guess can be wrong at runtime — e.g. an `any`-typed value
+    /// flowing through a typed parameter or an annotated binding initializer is
+    /// not runtime-checked, so the operand may be a different primitive than the
+    /// annotation claims. Hard-erroring there made the optimized build throw on
+    /// programs the unoptimized build runs correctly; guarding and falling back
+    /// keeps `optimized ≡ unoptimized` by construction. The fast path is a
+    /// monomorphic match the optimizer fully inlines, so the common case where
+    /// the guess holds pays nothing beyond the type check it already performed.
+    #[inline]
+    pub(super) fn run_typed_binary(
+        &mut self,
+        op: AdaptiveBinaryOp,
+        fast: impl FnOnce(&VmValue, &VmValue) -> Option<Result<VmValue, VmError>>,
+    ) -> Result<(), VmError> {
         let b = self.pop()?;
         let a = self.pop()?;
-        let (x, y) = typed_int_pair("add", a, b)?;
-        self.stack.push(VmValue::Int(x.wrapping_add(y)));
+        let result = match fast(&a, &b) {
+            Some(result) => result,
+            None => Self::generic_binary_result(self, op, a, b),
+        }?;
+        self.stack.push(result);
         Ok(())
+    }
+
+    pub(super) fn execute_add_int(&mut self) -> Result<(), VmError> {
+        self.run_typed_binary(AdaptiveBinaryOp::Add, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_add(*y)))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_sub_int(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_int_pair("subtract", a, b)?;
-        self.stack.push(VmValue::Int(x.wrapping_sub(y)));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Sub, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_sub(*y)))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_mul_int(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_int_pair("multiply", a, b)?;
-        self.stack.push(VmValue::Int(x.wrapping_mul(y)));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Mul, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_mul(*y)))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_div_int(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_int_pair("divide", a, b)?;
-        if y == 0 {
-            return Err(VmError::DivisionByZero);
-        }
-        self.stack.push(VmValue::Int(x.wrapping_div(y)));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Div, |a, b| match (a, b) {
+            (VmValue::Int(_), VmValue::Int(0)) => Some(Err(VmError::DivisionByZero)),
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_div(*y)))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_mod_int(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_int_pair("modulo", a, b)?;
-        if y == 0 {
-            return Err(VmError::DivisionByZero);
-        }
-        self.stack.push(VmValue::Int(x.wrapping_rem(y)));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Mod, |a, b| match (a, b) {
+            (VmValue::Int(_), VmValue::Int(0)) => Some(Err(VmError::DivisionByZero)),
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_rem(*y)))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_add_float(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_float_pair("add", a, b)?;
-        self.stack.push(VmValue::Float(x + y));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Add, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Float(x + y))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_sub_float(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_float_pair("subtract", a, b)?;
-        self.stack.push(VmValue::Float(x - y));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Sub, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Float(x - y))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_mul_float(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_float_pair("multiply", a, b)?;
-        self.stack.push(VmValue::Float(x * y));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Mul, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Float(x * y))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_div_float(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_float_pair("divide", a, b)?;
-        self.stack.push(VmValue::Float(x / y));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Div, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Float(x / y))),
+            _ => None,
+        })
     }
 
     pub(super) fn execute_mod_float(&mut self) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        let (x, y) = typed_float_pair("modulo", a, b)?;
-        if y == 0.0 {
-            return Err(VmError::DivisionByZero);
-        }
-        self.stack.push(VmValue::Float(x % y));
-        Ok(())
+        self.run_typed_binary(AdaptiveBinaryOp::Mod, |a, b| match (a, b) {
+            (VmValue::Float(_), VmValue::Float(y)) if *y == 0.0 => {
+                Some(Err(VmError::DivisionByZero))
+            }
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Float(x % y))),
+            _ => None,
+        })
     }
 
     fn add(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
@@ -596,29 +616,5 @@ impl BinaryShape {
             }
             _ => None,
         }
-    }
-}
-
-#[inline]
-fn typed_int_pair(name: &str, a: VmValue, b: VmValue) -> Result<(i64, i64), VmError> {
-    match (a, b) {
-        (VmValue::Int(x), VmValue::Int(y)) => Ok((x, y)),
-        (a, b) => Err(VmError::TypeError(format!(
-            "Typed int {name} expected int operands, got {} and {}",
-            a.type_name(),
-            b.type_name()
-        ))),
-    }
-}
-
-#[inline]
-fn typed_float_pair(name: &str, a: VmValue, b: VmValue) -> Result<(f64, f64), VmError> {
-    match (a, b) {
-        (VmValue::Float(x), VmValue::Float(y)) => Ok((x, y)),
-        (a, b) => Err(VmError::TypeError(format!(
-            "Typed float {name} expected float operands, got {} and {}",
-            a.type_name(),
-            b.type_name()
-        ))),
     }
 }

--- a/crates/harn-vm/src/vm/ops/comparison.rs
+++ b/crates/harn-vm/src/vm/ops/comparison.rs
@@ -1,19 +1,7 @@
-use std::sync::Arc;
-
 use crate::chunk::AdaptiveBinaryOp;
 use crate::value::{values_equal, VmError, VmValue};
 
 impl super::super::Vm {
-    fn push_compare_result(
-        &mut self,
-        f: impl FnOnce(VmValue, VmValue) -> Result<bool, VmError>,
-    ) -> Result<(), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        self.stack.push(VmValue::Bool(f(a, b)?));
-        Ok(())
-    }
-
     pub(super) fn execute_equal(&mut self) -> Result<(), VmError> {
         self.execute_adaptive_binary(AdaptiveBinaryOp::Equal)
     }
@@ -67,162 +55,114 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_equal_int(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_int_pair("equal", a, b)?;
-            Ok(x == y)
+        self.run_typed_binary(AdaptiveBinaryOp::Equal, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Bool(x == y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_not_equal_int(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_int_pair("not-equal", a, b)?;
-            Ok(x != y)
+        self.run_typed_binary(AdaptiveBinaryOp::NotEqual, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Bool(x != y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_less_int(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_int_pair("less-than", a, b)?;
-            Ok(x < y)
+        self.run_typed_binary(AdaptiveBinaryOp::Less, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Bool(x < y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_greater_int(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_int_pair("greater-than", a, b)?;
-            Ok(x > y)
+        self.run_typed_binary(AdaptiveBinaryOp::Greater, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Bool(x > y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_less_equal_int(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_int_pair("less-equal", a, b)?;
-            Ok(x <= y)
+        self.run_typed_binary(AdaptiveBinaryOp::LessEqual, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Bool(x <= y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_greater_equal_int(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_int_pair("greater-equal", a, b)?;
-            Ok(x >= y)
+        self.run_typed_binary(AdaptiveBinaryOp::GreaterEqual, |a, b| match (a, b) {
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Bool(x >= y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_equal_float(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_float_pair("equal", a, b)?;
-            Ok(x == y)
+        self.run_typed_binary(AdaptiveBinaryOp::Equal, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Bool(x == y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_not_equal_float(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_float_pair("not-equal", a, b)?;
-            Ok(x != y)
+        self.run_typed_binary(AdaptiveBinaryOp::NotEqual, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Bool(x != y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_less_float(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_float_pair("less-than", a, b)?;
-            Ok(x < y)
+        self.run_typed_binary(AdaptiveBinaryOp::Less, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Bool(x < y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_greater_float(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_float_pair("greater-than", a, b)?;
-            Ok(x > y)
+        self.run_typed_binary(AdaptiveBinaryOp::Greater, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Bool(x > y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_less_equal_float(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_float_pair("less-equal", a, b)?;
-            Ok(x <= y)
+        self.run_typed_binary(AdaptiveBinaryOp::LessEqual, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Bool(x <= y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_greater_equal_float(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_float_pair("greater-equal", a, b)?;
-            Ok(x >= y)
+        self.run_typed_binary(AdaptiveBinaryOp::GreaterEqual, |a, b| match (a, b) {
+            (VmValue::Float(x), VmValue::Float(y)) => Some(Ok(VmValue::Bool(x >= y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_equal_bool(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_bool_pair("equal", a, b)?;
-            Ok(x == y)
+        self.run_typed_binary(AdaptiveBinaryOp::Equal, |a, b| match (a, b) {
+            (VmValue::Bool(x), VmValue::Bool(y)) => Some(Ok(VmValue::Bool(x == y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_not_equal_bool(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_bool_pair("not-equal", a, b)?;
-            Ok(x != y)
+        self.run_typed_binary(AdaptiveBinaryOp::NotEqual, |a, b| match (a, b) {
+            (VmValue::Bool(x), VmValue::Bool(y)) => Some(Ok(VmValue::Bool(x != y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_equal_string(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_string_pair("equal", a, b)?;
-            Ok(x == y)
+        self.run_typed_binary(AdaptiveBinaryOp::Equal, |a, b| match (a, b) {
+            (VmValue::String(x), VmValue::String(y)) => Some(Ok(VmValue::Bool(x == y))),
+            _ => None,
         })
     }
 
     pub(super) fn execute_not_equal_string(&mut self) -> Result<(), VmError> {
-        self.push_compare_result(|a, b| {
-            let (x, y) = typed_string_pair("not-equal", a, b)?;
-            Ok(x != y)
+        self.run_typed_binary(AdaptiveBinaryOp::NotEqual, |a, b| match (a, b) {
+            (VmValue::String(x), VmValue::String(y)) => Some(Ok(VmValue::Bool(x != y))),
+            _ => None,
         })
-    }
-}
-
-#[inline]
-fn typed_int_pair(name: &str, a: VmValue, b: VmValue) -> Result<(i64, i64), VmError> {
-    match (a, b) {
-        (VmValue::Int(x), VmValue::Int(y)) => Ok((x, y)),
-        (a, b) => Err(VmError::TypeError(format!(
-            "Typed int {name} expected int operands, got {} and {}",
-            a.type_name(),
-            b.type_name()
-        ))),
-    }
-}
-
-#[inline]
-fn typed_float_pair(name: &str, a: VmValue, b: VmValue) -> Result<(f64, f64), VmError> {
-    match (a, b) {
-        (VmValue::Float(x), VmValue::Float(y)) => Ok((x, y)),
-        (a, b) => Err(VmError::TypeError(format!(
-            "Typed float {name} expected float operands, got {} and {}",
-            a.type_name(),
-            b.type_name()
-        ))),
-    }
-}
-
-#[inline]
-fn typed_bool_pair(name: &str, a: VmValue, b: VmValue) -> Result<(bool, bool), VmError> {
-    match (a, b) {
-        (VmValue::Bool(x), VmValue::Bool(y)) => Ok((x, y)),
-        (a, b) => Err(VmError::TypeError(format!(
-            "Typed bool {name} expected bool operands, got {} and {}",
-            a.type_name(),
-            b.type_name()
-        ))),
-    }
-}
-
-#[inline]
-fn typed_string_pair(name: &str, a: VmValue, b: VmValue) -> Result<(Arc<str>, Arc<str>), VmError> {
-    match (a, b) {
-        (VmValue::String(x), VmValue::String(y)) => Ok((x, y)),
-        (a, b) => Err(VmError::TypeError(format!(
-            "Typed string {name} expected string operands, got {} and {}",
-            a.type_name(),
-            b.type_name()
-        ))),
     }
 }

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -346,7 +346,15 @@ fn test_mixed_arithmetic() {
 }
 
 #[test]
-fn test_typed_opcode_drift_reports_type_error() {
+fn test_typed_opcode_drift_falls_back_to_generic() {
+    // A value that drifts from its declared type no longer makes the typed
+    // opcode hard-error with a specialization-internal message. The typed op
+    // guards its operands and falls back to generic semantics — which here, for
+    // genuinely incompatible `string + int`, still errors, but with the same
+    // generic message the unoptimized build produces (so opt and unopt agree).
+    // For a *compatible* drift (e.g. an `any` float into a declared int) the
+    // fallback yields the correct coerced result instead of throwing; that is
+    // covered in `vm::tests_typed_op_fallback`.
     let err = run_vm_err(
         r#"pipeline t(task) {
   let x: int = "bad"
@@ -354,8 +362,12 @@ fn test_typed_opcode_drift_reports_type_error() {
 }"#,
     );
     assert!(
-        err.contains("Typed int add expected int operands"),
-        "unexpected error: {err}"
+        err.contains("Cannot add") && err.contains("string"),
+        "expected the generic add error, got: {err}"
+    );
+    assert!(
+        !err.contains("Typed int"),
+        "typed opcodes must no longer surface specialization-internal errors: {err}"
     );
 }
 

--- a/crates/harn-vm/src/vm/tests_typed_op_fallback.rs
+++ b/crates/harn-vm/src/vm/tests_typed_op_fallback.rs
@@ -1,0 +1,167 @@
+//! Runtime guard / fallback behavior for typed fast-path opcodes.
+//!
+//! The compiler emits typed opcodes (`AddInt`, `LessInt`, `EqualString`, …)
+//! from a *static* type guess. A guess can be wrong at runtime — an `any`-typed
+//! value flowing through a typed parameter or an annotated binding initializer
+//! is not runtime-checked, so the operand may be a different primitive than the
+//! annotation claims. These opcodes therefore guard their operands and fall back
+//! to the exact generic result the unoptimized build produces, instead of
+//! hard-erroring. Every test asserts `optimized == unoptimized`.
+
+use crate::compiler::{Compiler, CompilerOptions};
+use crate::stdlib::register_vm_stdlib;
+use crate::vm::Vm;
+use harn_lexer::Lexer;
+use harn_parser::Parser;
+
+/// Compile + run `source` under the given options, returning either the
+/// captured stdout (Ok) or the runtime/compile error rendered as a string
+/// (Err). Single-threaded current-thread runtime; fully in-process.
+fn run(source: &str, options: CompilerOptions) -> Result<String, String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let tokens = Lexer::new(source).tokenize().map_err(|e| e.to_string())?;
+                let program = Parser::new(tokens).parse().map_err(|e| e.to_string())?;
+                let chunk = Compiler::with_options(options)
+                    .compile(&program)
+                    .map_err(|e| e.to_string())?;
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                vm.execute(&chunk).await.map_err(|e| e.to_string())?;
+                Ok(vm.output().trim_end().to_string())
+            })
+            .await
+    })
+}
+
+/// Assert the optimized and unoptimized builds agree, and return the shared
+/// result for the caller to pin down further.
+#[track_caller]
+fn assert_opt_matches_unopt(source: &str) -> Result<String, String> {
+    let optimized = run(source, CompilerOptions::optimized());
+    let baseline = run(source, CompilerOptions::without_optimizations());
+    assert_eq!(
+        optimized, baseline,
+        "optimized build must match the unoptimized (generic) build"
+    );
+    optimized
+}
+
+#[test]
+fn typed_param_fed_dynamic_float_falls_back() {
+    // `n: int` is a static guess; the `any` argument is actually a float. The
+    // typed `MulInt` must fall back to generic multiply, not throw.
+    let result = assert_opt_matches_unopt(
+        r#"pipeline default(task) {
+  fn f(n: int) { return n * 2 }
+  let cell = shared_cell("k", 2.5)
+  log("${f(shared_get(cell))}")
+}"#,
+    );
+    assert_eq!(result.unwrap(), "[harn] 5.0");
+}
+
+#[test]
+fn annotated_let_initializer_from_dynamic_float_falls_back() {
+    // `let x: int = <any float>` — the annotation is not runtime-enforced, so
+    // the initializer is really a float. `x + 1` must fall back to generic add.
+    let result = assert_opt_matches_unopt(
+        r#"pipeline default(task) {
+  let cell = shared_cell("k", 2.5)
+  let x: int = shared_get(cell)
+  log("${x + 1}")
+}"#,
+    );
+    assert_eq!(result.unwrap(), "[harn] 3.5");
+}
+
+#[test]
+fn annotated_var_initializer_from_dynamic_float_falls_back() {
+    // The `var` analogue: an annotated, never-reassigned `var` whose initializer
+    // is a dynamic float. (The monomorphic-binding analysis trusts it because it
+    // is never reassigned; the runtime guard is what keeps it sound.)
+    let result = assert_opt_matches_unopt(
+        r#"pipeline default(task) {
+  let cell = shared_cell("k", 4.5)
+  var x: int = shared_get(cell)
+  log("${x - 1}")
+}"#,
+    );
+    assert_eq!(result.unwrap(), "[harn] 3.5");
+}
+
+#[test]
+fn typed_comparison_fed_dynamic_float_falls_back() {
+    // A typed `LessInt` fed a float operand must fall back to the generic
+    // comparison rather than throwing.
+    let result = assert_opt_matches_unopt(
+        r#"pipeline default(task) {
+  let cell = shared_cell("k", 2.5)
+  let x: int = shared_get(cell)
+  log("${x < 3}")
+}"#,
+    );
+    assert_eq!(result.unwrap(), "[harn] true");
+}
+
+#[test]
+fn typed_string_equality_fed_dynamic_int_falls_back() {
+    // `EqualString` guarded: comparing a declared-string binding that actually
+    // holds an int against a string literal is `false` generically, not a throw.
+    let result = assert_opt_matches_unopt(
+        r#"pipeline default(task) {
+  let cell = shared_cell("k", 7)
+  let s: string = shared_get(cell)
+  log("${s == "7"}")
+}"#,
+    );
+    assert_eq!(result.unwrap(), "[harn] false");
+}
+
+#[test]
+fn genuinely_incompatible_operands_error_identically() {
+    // The fallback is to *generic* semantics, which still rejects truly
+    // incompatible operands (int + string) — and with the same error in both
+    // builds, so no optimized-only crash and no silent wrong answer.
+    let optimized = run(
+        r#"pipeline default(task) {
+  let cell = shared_cell("k", "hi")
+  let x: int = shared_get(cell)
+  log("${x + 1}")
+}"#,
+        CompilerOptions::optimized(),
+    );
+    let baseline = run(
+        r#"pipeline default(task) {
+  let cell = shared_cell("k", "hi")
+  let x: int = shared_get(cell)
+  log("${x + 1}")
+}"#,
+        CompilerOptions::without_optimizations(),
+    );
+    assert!(optimized.is_err(), "int + string must still error");
+    assert_eq!(optimized, baseline, "error must match the generic build");
+}
+
+#[test]
+fn monomorphic_fast_path_still_correct() {
+    // The hot path (operands match the static guess) is unaffected.
+    let result = assert_opt_matches_unopt(
+        r#"pipeline default(task) {
+  var i = 0
+  var total = 0
+  while i < 10 {
+    total = total + (i + 3) * 2 - 1
+    i = i + 1
+  }
+  log("${total}")
+}"#,
+    );
+    assert_eq!(result.unwrap(), "[harn] 140");
+}


### PR DESCRIPTION
## Summary

Follow-up to #3102, addressing the related bug noted in that PR's description and
generalizing it. The same root cause spans **annotated binding initializers**,
**typed parameters**, and the reassignable-binding case #3102 fixed: typed
fast-path opcodes (`AddInt`, `LessInt`, `EqualString`, …) are emitted from a
*static type guess* and **hard-errored** when the runtime operands didn't match,
so the optimized build threw on programs the unoptimized build runs correctly.

A guess can be wrong at runtime because an `any`-typed value flowing into a
statically-typed slot is **not runtime-checked** (gradual typing — `any` is
assignable to any annotation). So both of these threw under the optimizer while
printing the right answer unoptimized:

```harn
fn f(n: int) { return n * 2 }
f(shared_get(cell))          // cell holds 2.5 (float, typed `any`)
// opt: error: Typed int add expected int operands ...   unopt: 5.0

let x: int = shared_get(cell)
x + 1                        // opt: throws   unopt: 3.5
```

`#3102` proved this couldn't be fixed for annotated initializers / params by a
compile-time binding analysis alone (the VM's lightweight inferencer can't tell
the sound `let n: int = items.len()` from the unsound `let x: int = anyCall()`),
and deferred it. The right fix is at the runtime layer.

## Fix

Make typed opcodes the **runtime-guard half** of specialization: each guards its
operands and, on a miss, falls back to the *exact* generic result the
unoptimized build computes. `optimized ≡ unoptimized` now holds by construction:

- A **compatible** drift (an `any` float into a declared `int`) yields the
  correct coerced result instead of throwing.
- A **genuinely incompatible** drift (`int + string`) still errors — with the
  same generic message in both builds, so there's no optimized-only crash and no
  silent wrong answer.
- The **hot path** where the guess holds is unchanged: the fast path is a
  monomorphic match the optimizer fully inlines, paying nothing beyond the type
  check it already performed.

This is the standard adaptive-interpreter design — specialize on a hint, guard,
deopt on a miss — and it composes cleanly with #3102's two-layer model:

| Layer | Job |
|---|---|
| Monomorphic-binding analysis (#3102, compile time) | route provably-dynamic bindings to the adaptive path |
| Typed-opcode guard + fallback (this PR, runtime) | make a wrong static guess safe — covers typed params and annotated initializers no binding analysis can prove |

## Implementation

A shared `run_typed_binary` driver pops the operands, runs the op's monomorphic
fast path, and falls back to the now-shared `generic_binary_result`. This also
removes a DRY violation: the `typed_*_pair` operand-coercion helpers were
duplicated across the arithmetic and comparison modules, and the
`push_compare_result` shim is gone — every typed op now flows through one driver.

## Tests

In-process and deterministic (no timers, no wall-clock), all asserting
`optimized == unoptimized`:

- typed param fed a dynamic float; annotated `let` / `var` initializer from a
  dynamic float; typed comparison fed a dynamic float; typed string-equality fed
  a dynamic int — all fall back to the correct result.
- genuinely incompatible operands (`int + string`) error identically in both
  builds.
- the monomorphic counter/accumulator hot path stays correct.
- updated the existing drift test to assert the new fallback semantics.

`cargo test -p harn-vm` is green except two pre-existing environmental failures
(git commit-signing, process-sandbox); `harn test conformance` is unchanged
(1573 passing; same 4 environmental failures); `cargo clippy -p harn-vm` is
clean. Rebased on latest `main` (includes #3102); the two changes are orthogonal
(this touches only `vm/ops/`).

https://claude.ai/code/session_01Fcu3e7fa87ZhmFQiXFC8hc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fcu3e7fa87ZhmFQiXFC8hc)_