### PR TITLE
fix(sandbox): bypass rustc wrapper so sandboxed builds can't poison sccache

### DIFF
--- a/changelog.d/sandbox-no-sccache-poison.fixed.md
+++ b/changelog.d/sandbox-no-sccache-poison.fixed.md
@@ -1,0 +1,11 @@
+- **Sandboxed builds no longer poison the shared `sccache` daemon.** `sccache`
+  runs as a single long-lived per-user server; if a sandboxed cargo build was the
+  first caller to spawn it, the daemon inherited harn's `sandbox-exec`
+  confinement permanently (even after reparenting to launchd) and then failed
+  *every* later build machine-wide with `Operation not permitted` — unable to
+  read build inputs outside the sandbox root or write its cache dir under
+  `~/Library/Caches`. Sandboxed process spawns now bypass the rustc wrapper
+  (empty `CARGO_BUILD_RUSTC_WRAPPER` / `RUSTC_WRAPPER`, which overrides
+  `build.rustc-wrapper` in `.cargo/config.toml`), so a per-command sandbox can
+  never confine the cross-workspace daemon. The on-disk cache and all
+  unsandboxed builds are unaffected.

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -494,7 +494,31 @@ fn sandboxed_process_config(
     } else {
         resolved.cwd = Some(default_process_cwd_for_policy(policy)?);
     }
+    neutralize_rustc_wrapper(&mut resolved.env);
     Ok(resolved)
+}
+
+/// Disable any Cargo `rustc` wrapper (e.g. `sccache`) for a sandboxed spawn.
+///
+/// `sccache` is a single shared, long-lived per-user daemon. If a sandboxed
+/// cargo build is the first caller to spawn it, the daemon inherits the
+/// `sandbox-exec` confinement permanently — even after it reparents to
+/// launchd — and then fails *every* later build machine-wide with
+/// `Operation not permitted` (it can no longer read build inputs outside the
+/// sandbox root nor write its cache dir under `~/Library/Caches`). A
+/// per-command sandbox must never be allowed to poison a cross-workspace
+/// daemon, so sandboxed builds bypass the wrapper entirely. Cargo treats an
+/// empty `CARGO_BUILD_RUSTC_WRAPPER` / `RUSTC_WRAPPER` as "no wrapper", which
+/// overrides any `build.rustc-wrapper` set in `.cargo/config.toml`. The
+/// on-disk cache and all unsandboxed builds are unaffected.
+fn neutralize_rustc_wrapper(env: &mut Vec<(String, String)>) {
+    for key in ["RUSTC_WRAPPER", "CARGO_BUILD_RUSTC_WRAPPER"] {
+        if let Some(entry) = env.iter_mut().find(|(existing, _)| existing == key) {
+            entry.1.clear();
+        } else {
+            env.push((key.to_string(), String::new()));
+        }
+    }
 }
 
 fn default_process_cwd_for_policy(policy: &CapabilityPolicy) -> Result<PathBuf, VmError> {
@@ -1198,6 +1222,48 @@ mod tests {
         };
 
         assert!(sandboxed_process_config(&config, &policy).is_err());
+    }
+
+    #[test]
+    fn sandboxed_process_config_neutralizes_rustc_wrapper() {
+        let cwd = std::env::current_dir().unwrap();
+        let policy = CapabilityPolicy {
+            sandbox_profile: SandboxProfile::Worktree,
+            workspace_roots: vec![cwd.to_string_lossy().into_owned()],
+            ..CapabilityPolicy::default()
+        };
+
+        // A sandboxed spawn must bypass sccache so it can never spawn (and
+        // thereby permanently confine) the shared daemon.
+        let resolved = sandboxed_process_config(&ProcessCommandConfig::default(), &policy).unwrap();
+        let env: std::collections::BTreeMap<_, _> = resolved.env.into_iter().collect();
+        assert_eq!(env.get("RUSTC_WRAPPER").map(String::as_str), Some(""));
+        assert_eq!(
+            env.get("CARGO_BUILD_RUSTC_WRAPPER").map(String::as_str),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn neutralize_rustc_wrapper_overrides_caller_supplied_wrapper() {
+        // Even if a caller (or inherited env) asked for sccache, the sandboxed
+        // config forces it off rather than appending a duplicate entry.
+        let mut env = vec![
+            ("RUSTC_WRAPPER".to_string(), "sccache".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ];
+        neutralize_rustc_wrapper(&mut env);
+        let collected: std::collections::BTreeMap<_, _> = env.iter().cloned().collect();
+        assert_eq!(collected.get("RUSTC_WRAPPER").map(String::as_str), Some(""));
+        assert_eq!(
+            collected
+                .get("CARGO_BUILD_RUSTC_WRAPPER")
+                .map(String::as_str),
+            Some("")
+        );
+        assert_eq!(collected.get("PATH").map(String::as_str), Some("/usr/bin"));
+        // No duplicate RUSTC_WRAPPER entries.
+        assert_eq!(env.iter().filter(|(k, _)| k == "RUSTC_WRAPPER").count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`sccache` is a single long-lived per-user daemon. If a **sandboxed** cargo build (anything harn runs under a `Worktree`/`OsHardened` profile via `sandbox-exec`) is the first caller to spawn it, the daemon **inherits the seatbelt confinement permanently** — even after it reparents to launchd. From then on it fails **every** build machine-wide with `Operation not permitted`:

- can't read build inputs outside the original sandbox root → `sccache: Failed to open file for hashing … (os error 1)`
- can't write its cache dir under `~/Library/Caches` → hundreds of `Cache write errors`

This is how a release run that used `--no-sandbox` still died in its `cargo build --workspace` warm-prebuild: it connected to a daemon a *prior* sandboxed build had already confined. (Repro: the poisoned daemon showed 956/956 cache-write-errors; stopping it and letting a fresh one spawn made the identical build exit 0.)

## Fix

A per-command sandbox must never be able to poison a cross-workspace, cross-session daemon. `sandboxed_process_config` now forces an empty `CARGO_BUILD_RUSTC_WRAPPER` / `RUSTC_WRAPPER` for sandboxed spawns. Cargo treats an empty wrapper as "no wrapper", overriding `build.rustc-wrapper` in `.cargo/config.toml` (verified: empty wrapper → 0 sccache compile-requests). Sandboxed builds therefore never touch sccache; the on-disk cache and all unsandboxed builds are unaffected.

Only the `command_output` spawn path (used by the proc/command tools) is affected — exactly the path that runs cargo under a sandbox.

## Tests
- `sandboxed_process_config_neutralizes_rustc_wrapper` and `neutralize_rustc_wrapper_overrides_caller_supplied_wrapper` (no duplicate entries; caller-supplied wrapper forced off).
- Full `stdlib::sandbox::tests` green (16); `cargo clippy -p harn-vm` and `cargo fmt --check` clean; pre-commit checks passed.

## Notes
Complements two harn-bump-fleet changes (release-harness sccache health preflight + a machine-wide keepalive LaunchAgent). This PR is the upstream root cause: stop harn from creating the confined daemon in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)