### PR TITLE
Make member-access nil safety uniform across `.`, `[]`, and `.()`

### DIFF
--- a/changelog.d/sound-nil-member-access.breaking.md
+++ b/changelog.d/sound-nil-member-access.breaking.md
@@ -1,0 +1,19 @@
+- **Member-access nil safety is now uniform across `.`, `[]`, and `.()`.**
+  Subscript (`obj[key]`) and method-call (`obj.method(..)`) receivers are
+  now held to the same standard the checker already applied to property
+  reads: a statically-`nil` or `T | nil` receiver is an **error**, and an
+  `unknown` receiver is a **warning**. Previously only `obj.field` was
+  diagnosed, so `obj[key]` / `obj.method()` on a possibly-nil value passed
+  `harn check` and failed at runtime instead. Migrate with the matching
+  optional operator (`?[…]`, `?.method()`), a `!= nil` guard, or a `??`
+  default. `any` receivers remain a deliberate, undiagnosed escape hatch,
+  and the ambient dict-literal idiom (`let d = {a: 1}; d["b"]`) stays loose.
+
+  To keep the stricter rule pleasant, two long-standing narrowing gaps were
+  closed alongside it: an `o?.field != nil` (or `?[]` / `?.()`) guard now
+  narrows the **base** identifier `o` to non-nil on the matching branch, and
+  the `??` coalesce operator now drops the nil arm even when its left operand
+  is a **named type alias** that expands to a nilable union (previously only
+  inline `T | nil` unions were narrowed). The conformance harness also labels
+  failures by stage — `type error` / `compile error` / `runtime error` —
+  instead of calling every pre-runtime failure a "runtime error".

--- a/conformance/tests/agents/agent_runtime_features.harn
+++ b/conformance/tests/agents/agent_runtime_features.harn
@@ -94,7 +94,7 @@ pipeline test(task) {
     },
   )
   __io_println(
-    transcript_summary(loop_compacted?.transcript).contains("loop compact retain_current_plan"),
+    transcript_summary(loop_compacted?.transcript)?.contains("loop compact retain_current_plan"),
   )
   let request_compacted = agent_loop(
     "Inspect the workspace",
@@ -114,7 +114,7 @@ pipeline test(task) {
     },
   )
   __io_println(
-    transcript_summary(request_compacted?.transcript).contains("request compact resume_request host"),
+    transcript_summary(request_compacted?.transcript)?.contains("request compact resume_request host"),
   )
   let stopped_after_tool_turn = agent_loop(
     "Inspect the workspace",

--- a/conformance/tests/agents/agent_session_compact_policy.harn
+++ b/conformance/tests/agents/agent_session_compact_policy.harn
@@ -21,7 +21,7 @@ pipeline test(task) {
   let snapshot = agent_session_snapshot(session)
   let events = transcript_events_by_kind(snapshot, "compaction")
   let event = events[0]
-  __io_println(transcript_summary(snapshot).contains("host compact bug_fix_resumption host 2"))
+  __io_println(transcript_summary(snapshot)?.contains("host compact bug_fix_resumption host 2"))
   __io_println(event.metadata?.mode == "host")
   __io_println(event.metadata?.instruction_mode == "extend")
   __io_println(event.metadata?.instruction_source == "host")

--- a/conformance/tests/agents/compaction_policy_primitive.harn
+++ b/conformance/tests/agents/compaction_policy_primitive.harn
@@ -53,7 +53,7 @@ pipeline test(task) {
   __io_println(outcome["archived_messages"] == 2)
   __io_println(outcome["latency_ms"] >= 0)
   __io_println(outcome["engine_strategy"] == "custom")
-  __io_println(transcript_summary(outcome["transcript"]).contains("policy compacted 2"))
+  __io_println(transcript_summary(outcome["transcript"])?.contains("policy compacted 2"))
   // After running, check should return defer again — transcript is below
   // threshold once the summary message replaces the archived ones.
   let after_decision = compaction.check(session)

--- a/conformance/tests/agents/plan_primitives.harn
+++ b/conformance/tests/agents/plan_primitives.harn
@@ -25,7 +25,7 @@ pipeline main() {
   mock_host_response("hitl", "approval", {approved: true, reviewer: "lead", reason: "ready"})
   let approved = request_plan_approval(artifact, {reviewers: ["lead"]})
   require approved.approval.state == "approved", "plan approval should use HITL"
-  require approved.approval.reviewers[0] == "lead", "reviewer should round-trip"
+  require approved.approval.reviewers?[0] == "lead", "reviewer should round-trip"
   with_llm_script(
     [
       {

--- a/conformance/tests/reminders/reminder_compact_preserve_custom.harn
+++ b/conformance/tests/reminders/reminder_compact_preserve_custom.harn
@@ -29,7 +29,7 @@ pipeline main() {
     },
   )
   let reminders = transcript_events_by_kind(compacted, "system_reminder")
-  __io_println(transcript_summary(compacted).contains("2 reminders compactable"))
+  __io_println(transcript_summary(compacted)?.contains("2 reminders compactable"))
   __io_println(len(reminders))
   __io_println(reminders[0].reminder.body)
 }

--- a/conformance/tests/reminders/reminder_compact_preserve_truncate.harn
+++ b/conformance/tests/reminders/reminder_compact_preserve_truncate.harn
@@ -22,5 +22,5 @@ pipeline main() {
   __io_println(len(reminders))
   __io_println(reminders[0].reminder.body)
   __io_println(reminders[0].reminder.ttl_turns)
-  __io_println(transcript_summary(compacted).contains("auto-compacted"))
+  __io_println(transcript_summary(compacted)?.contains("auto-compacted"))
 }

--- a/conformance/tests/scenarios/agent_session_system_prompt_parts.harn
+++ b/conformance/tests/scenarios/agent_session_system_prompt_parts.harn
@@ -58,7 +58,7 @@ pipeline default() {
       __io_println(
         occurrences(json_stringify(resumed_without_prompt.transcript), "Persistent contract.") == 1,
       )
-      __io_println(agent_session_system_prompt(sid).contains("Persistent contract."))
+      __io_println(agent_session_system_prompt(sid)?.contains("Persistent contract."))
       __io_println(
         resumed_without_prompt.transcript.metadata.system_prompt.content.contains("Persistent contract."),
       )

--- a/conformance/tests/stdlib/calendar_country_lookup.harn
+++ b/conformance/tests/stdlib/calendar_country_lookup.harn
@@ -13,7 +13,7 @@ pipeline default() {
   }
   __io_println(us.name)
   __io_println(us.default_timezone == nil)
-  __io_println(country_timezones("US")[0])
+  __io_println(country_timezones("US")?[0])
   __io_println(default_timezone_for_country("GB"))
   __io_println(default_timezone_for_country("US") == nil)
   __io_println(country_info("ZZ") == nil)

--- a/conformance/tests/stdlib/compact_transcript.harn
+++ b/conformance/tests/stdlib/compact_transcript.harn
@@ -10,7 +10,7 @@ pipeline test(task) {
     ],
   )
   let truncated = transcript_compact(base, {strategy: "truncate", keep_last: 1, target_tokens: 1})
-  __io_println(transcript_summary(truncated).contains("auto-compacted"))
+  __io_println(transcript_summary(truncated)?.contains("auto-compacted"))
   __io_println(transcript_events_by_kind(truncated, "compaction")[0].metadata?.strategy == "truncate")
   let truncate_assets = transcript_assets(truncated)
   __io_println(len(truncate_assets) == 1)
@@ -28,7 +28,7 @@ pipeline test(task) {
     ],
   )
   let masked = transcript_compact(masked_base, {strategy: "observation_mask", keep_last: 1, target_tokens: 1})
-  __io_println(transcript_summary(masked).contains("masked"))
+  __io_println(transcript_summary(masked)?.contains("masked"))
   __io_println(
     transcript_events_by_kind(masked, "compaction")[0].metadata?.strategy == "observation_mask",
   )
@@ -48,7 +48,7 @@ pipeline test(task) {
           summarize_prompt: "compact_transcript_summary.harn.prompt",
         },
       )
-      __io_println(transcript_summary(llm_compacted).contains("LLM compact summary"))
+      __io_println(transcript_summary(llm_compacted)?.contains("LLM compact summary"))
       let llm_calls = llm_mock_calls()
       let prompt = llm_calls[0].messages[0].content
       __io_println(prompt.contains("Compact prompt from asset."))

--- a/conformance/tests/stdlib/compact_transcript_custom.harn
+++ b/conformance/tests/stdlib/compact_transcript_custom.harn
@@ -16,7 +16,7 @@ pipeline test(task) {
       custom_compactor: { messages -> "CUSTOM SUMMARY " + to_string(len(messages)) },
     },
   )
-  assert(transcript_summary(compacted).contains("CUSTOM SUMMARY 1"), "custom summary retained")
+  assert(transcript_summary(compacted)?.contains("CUSTOM SUMMARY 1"), "custom summary retained")
   assert(
     transcript_events_by_kind(compacted, "compaction")[0].metadata?.strategy == "custom",
     "custom event recorded",

--- a/conformance/tests/stdlib/postgres_query_helpers.harn
+++ b/conformance/tests/stdlib/postgres_query_helpers.harn
@@ -95,13 +95,13 @@ LIMIT {limit}
   __io_println(contains(list_query.sql, "owner_tenant_id = $1::uuid"))
   let brace_query = sql("SELECT '{{}}' AS empty, {value} AS value", {value: "ok"})
   __io_println(brace_query.sql)
-  __io_println(brace_query.params[0])
+  __io_println(brace_query.params?[0])
   let path_query = sql("SELECT * FROM {table}", {table: ident_path(["tenant data", "receipts\"live"])})
   __io_println(path_query.sql)
   __io_println(quote_identifier("select"))
   let ordinary_dict = sql("SELECT {payload}", {payload: {_type: "std/postgres/query.sql_fragment.v1", sql: "danger"}})
   __io_println(ordinary_dict.sql)
-  __io_println(ordinary_dict.params[0].sql)
+  __io_println(ordinary_dict.params?[0]?.sql)
   let unsafe_ident = try {
     uuid_text("bad;drop")
   }
@@ -136,7 +136,7 @@ LIMIT {limit}
     },
   )
   __io_println(columns_query.sql)
-  __io_println(columns_query.params[0])
+  __io_println(columns_query.params?[0])
   let empty_columns = try {
     columns([])
   }

--- a/conformance/tests/types/method_call_on_nil.error
+++ b/conformance/tests/types/method_call_on_nil.error
@@ -1,0 +1,1 @@
+cannot access method `foo` on `nil`; the value is statically known to be nil here

--- a/conformance/tests/types/method_call_on_nil.harn
+++ b/conformance/tests/types/method_call_on_nil.harn
@@ -1,0 +1,6 @@
+// Calling a method on a value statically known to be `nil` fails at
+// runtime; the checker flags the receiver and points at `?.m(…)`.
+pipeline default(_) {
+  let x: nil = nil
+  __io_println(x.foo())
+}

--- a/conformance/tests/types/method_call_on_nilable.error
+++ b/conformance/tests/types/method_call_on_nilable.error
@@ -1,0 +1,1 @@
+cannot access method `upper` on nilable type

--- a/conformance/tests/types/method_call_on_nilable.harn
+++ b/conformance/tests/types/method_call_on_nilable.harn
@@ -1,0 +1,6 @@
+// Calling a method on a `T | nil` receiver may hit nil at runtime. The
+// method may well exist on the non-nil arm — the problem is the nil arm.
+pipeline default(_) {
+  let s: string? = nil
+  __io_println(s.upper())
+}

--- a/conformance/tests/types/nil_narrowing_and_coalesce.expected
+++ b/conformance/tests/types/nil_narrowing_and_coalesce.expected
@@ -1,0 +1,2 @@
+hello
+base

--- a/conformance/tests/types/nil_narrowing_and_coalesce.harn
+++ b/conformance/tests/types/nil_narrowing_and_coalesce.harn
@@ -1,0 +1,15 @@
+type Opts = {label?: string, tags?: list<string>}?
+
+fn describe(options: Opts = nil) -> string {
+  let opts = options ?? {}
+  var out = "base"
+  if opts?.label != nil {
+    out = opts.label
+  }
+  return out
+}
+
+pipeline main() {
+  __io_println(describe({label: "hello"}))
+  __io_println(describe(nil))
+}

--- a/conformance/tests/types/subscript_access_on_nil.error
+++ b/conformance/tests/types/subscript_access_on_nil.error
@@ -1,0 +1,1 @@
+cannot access an index on `nil`; the value is statically known to be nil here

--- a/conformance/tests/types/subscript_access_on_nil.harn
+++ b/conformance/tests/types/subscript_access_on_nil.harn
@@ -1,0 +1,7 @@
+// Subscript access on a value statically known to be `nil` fails at
+// runtime; the checker flags it with the same guidance as property
+// access, pointing at `?[…]` / a nil guard.
+pipeline default(_) {
+  let x: nil = nil
+  __io_println(x["k"])
+}

--- a/conformance/tests/types/subscript_access_on_nilable.error
+++ b/conformance/tests/types/subscript_access_on_nilable.error
@@ -1,0 +1,1 @@
+cannot access an index on nilable type

--- a/conformance/tests/types/subscript_access_on_nilable.harn
+++ b/conformance/tests/types/subscript_access_on_nilable.harn
@@ -1,0 +1,6 @@
+// Indexing a `T | nil` receiver may hit nil at runtime. Same diagnostic
+// shape as property access on a nilable value, but for `[]`.
+pipeline default(_) {
+  let xs: list? = nil
+  __io_println(xs[0])
+}

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -14,7 +14,7 @@ use crate::env_guard::ScopedEnvVar;
 use crate::json_envelope::{self, JsonEnvelope, JsonError};
 use crate::test_report::{self, TestCaseReport, TestOutcome, TestReport};
 use crate::test_runner;
-use crate::{execute_with_skill_dirs, execute_with_skill_dirs_and_harness};
+use crate::{execute_with_skill_dirs, execute_with_skill_dirs_and_harness, ExecError};
 
 /// Report-writing options threaded into `run_user_tests`. Each `Some`
 /// path triggers a write at end-of-run; a missing parent directory or
@@ -429,7 +429,7 @@ fn harness_kind_name(kind: harn_vm::HarnessKind) -> &'static str {
 }
 
 enum ConformanceExecution {
-    Completed(Result<String, String>),
+    Completed(Result<String, ExecError>),
     TimedOut,
 }
 
@@ -1090,7 +1090,7 @@ async fn evaluate_conformance_case(
                 }
             }
             ConformanceExecution::Completed(Err(e)) => ConformanceCaseEvaluation::fail(
-                format!("{rel_path}: runtime error: {e}"),
+                format!("{rel_path}: {}: {}", e.stage.label(), e.message),
                 duration_ms,
             ),
             ConformanceExecution::TimedOut => ConformanceCaseEvaluation::fail(
@@ -1146,7 +1146,9 @@ async fn evaluate_conformance_case(
         }
 
         return match run.execution {
-            ConformanceExecution::Completed(Err(ref err)) if error_matches(err, &expected_error) => {
+            ConformanceExecution::Completed(Err(ref err))
+                if error_matches(&err.message, &expected_error) =>
+            {
                 if options.differential_optimizations {
                     if let Err(error) = verify_unoptimized_conformance_subprocess(
                         harn_file,
@@ -1961,7 +1963,7 @@ async fn execute_determinism_run(
     persist_result?;
     match result {
         Ok(Ok(output)) => Ok(output),
-        Ok(Err(error)) => Err(error),
+        Ok(Err(error)) => Err(error.to_string()),
         Err(_) => Err(format!("timed out after {timeout_ms}ms")),
     }
 }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -2951,8 +2951,57 @@ fn error_span_from_parse(e: &harn_parser::ParserError) -> harn_lexer::Span {
     }
 }
 
+/// The pipeline stage at which an `execute_*` call failed. Callers (the
+/// conformance harness, the REPL) use this to label a failure accurately
+/// instead of calling every failure a "runtime error" — a parse, typecheck,
+/// or compile failure never reaches the VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExecStage {
+    Parse,
+    Typecheck,
+    Compile,
+    Runtime,
+}
+
+impl ExecStage {
+    /// Human-facing label for this stage, e.g. `"type error"`.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            ExecStage::Parse => "parse error",
+            ExecStage::Typecheck => "type error",
+            ExecStage::Compile => "compile error",
+            ExecStage::Runtime => "runtime error",
+        }
+    }
+}
+
+/// An `execute_*` failure tagged with the stage it came from. `Display`
+/// renders only the bare message (matching the historical `String` error),
+/// so callers that just print `{e}` are unaffected; the `stage` is available
+/// for callers that want to label the failure.
+#[derive(Debug, Clone)]
+pub(crate) struct ExecError {
+    pub(crate) stage: ExecStage,
+    pub(crate) message: String,
+}
+
+impl ExecError {
+    fn new(stage: ExecStage, message: impl Into<String>) -> Self {
+        Self {
+            stage,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ExecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 /// Used by REPL and conformance tests.
-pub(crate) async fn execute(source: &str, source_path: Option<&Path>) -> Result<String, String> {
+pub(crate) async fn execute(source: &str, source_path: Option<&Path>) -> Result<String, ExecError> {
     execute_with_skill_dirs(source, source_path, &[]).await
 }
 
@@ -2960,7 +3009,7 @@ pub(crate) async fn execute_with_skill_dirs(
     source: &str,
     source_path: Option<&Path>,
     cli_skill_dirs: &[PathBuf],
-) -> Result<String, String> {
+) -> Result<String, ExecError> {
     execute_with_skill_dirs_and_optional_harness(source, source_path, cli_skill_dirs, None).await
 }
 
@@ -2969,7 +3018,7 @@ pub(crate) async fn execute_with_skill_dirs_and_harness(
     source_path: Option<&Path>,
     cli_skill_dirs: &[PathBuf],
     harness: harn_vm::Harness,
-) -> Result<String, String> {
+) -> Result<String, ExecError> {
     execute_with_skill_dirs_and_optional_harness(source, source_path, cli_skill_dirs, Some(harness))
         .await
 }
@@ -2979,11 +3028,15 @@ async fn execute_with_skill_dirs_and_optional_harness(
     source_path: Option<&Path>,
     cli_skill_dirs: &[PathBuf],
     harness: Option<harn_vm::Harness>,
-) -> Result<String, String> {
+) -> Result<String, ExecError> {
     let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| e.to_string())?;
+    let tokens = lexer
+        .tokenize()
+        .map_err(|e| ExecError::new(ExecStage::Parse, e.to_string()))?;
     let mut parser = Parser::new(tokens);
-    let program = parser.parse().map_err(|e| e.to_string())?;
+    let program = parser
+        .parse()
+        .map_err(|e| ExecError::new(ExecStage::Parse, e.to_string()))?;
 
     // Static cross-module resolution: when executed from a file, derive the
     // import graph so `execute` catches undefined calls at typecheck time.
@@ -3006,7 +3059,9 @@ async fn execute_with_skill_dirs_and_optional_harness(
     let mut warning_lines = Vec::new();
     for diag in &type_diagnostics {
         match diag.severity {
-            DiagnosticSeverity::Error => return Err(diag.message.clone()),
+            DiagnosticSeverity::Error => {
+                return Err(ExecError::new(ExecStage::Typecheck, diag.message.clone()))
+            }
             DiagnosticSeverity::Warning => {
                 warning_lines.push(format!("warning: {}", diag.message));
             }
@@ -3015,7 +3070,7 @@ async fn execute_with_skill_dirs_and_optional_harness(
 
     let chunk = harn_vm::Compiler::new()
         .compile(&program)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| ExecError::new(ExecStage::Compile, e.to_string()))?;
 
     let local = tokio::task::LocalSet::new();
     local
@@ -3081,10 +3136,20 @@ async fn execute_with_skill_dirs_and_optional_harness(
                 package::install_runtime_extensions(&extensions);
                 package::install_manifest_triggers(&mut vm, &extensions)
                     .await
-                    .map_err(|error| format!("failed to install manifest triggers: {error}"))?;
+                    .map_err(|error| {
+                        ExecError::new(
+                            ExecStage::Runtime,
+                            format!("failed to install manifest triggers: {error}"),
+                        )
+                    })?;
                 package::install_manifest_hooks(&mut vm, &extensions)
                     .await
-                    .map_err(|error| format!("failed to install manifest hooks: {error}"))?;
+                    .map_err(|error| {
+                        ExecError::new(
+                            ExecStage::Runtime,
+                            format!("failed to install manifest hooks: {error}"),
+                        )
+                    })?;
             }
             let _event_log = harn_vm::event_log::active_event_log()
                 .unwrap_or_else(|| harn_vm::event_log::install_memory_for_current_thread(64));
@@ -3093,9 +3158,17 @@ async fn execute_with_skill_dirs_and_optional_harness(
             if connector_clients_installed {
                 install_default_connector_clients(store_base)
                     .await
-                    .map_err(|error| format!("failed to initialize connector clients: {error}"))?;
+                    .map_err(|error| {
+                        ExecError::new(
+                            ExecStage::Runtime,
+                            format!("failed to initialize connector clients: {error}"),
+                        )
+                    })?;
             }
-            let execution_result = vm.execute(&chunk).await.map_err(|e| e.to_string());
+            let execution_result = vm
+                .execute(&chunk)
+                .await
+                .map_err(|e| ExecError::new(ExecStage::Runtime, e.to_string()));
             harn_vm::egress::reset_egress_policy_for_host();
             if connector_clients_installed {
                 harn_vm::clear_active_connector_clients();

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -543,6 +543,16 @@ impl TypeChecker {
                 }
                 let lt = self.infer_type(left, scope);
                 let rt = self.infer_type(right, scope);
+                if op == "??" {
+                    // `??` strips the nil arm from its left operand, but the
+                    // structural `without_nil`/`contains_nil` helpers can't see
+                    // through a named alias — so `type T = {..}?; x: T; x ?? d`
+                    // would keep `T` (still nilable) as the result. Resolve
+                    // aliases first so the coalesce drops nil for aliased
+                    // nilable types exactly as it does for inline unions.
+                    let lt = lt.map(|t| self.resolve_alias(&t, scope));
+                    return infer_binary_op_type(op, &lt, &rt);
+                }
                 infer_binary_op_type(op, &lt, &rt)
             }
 

--- a/crates/harn-parser/src/typechecker/inference/flow.rs
+++ b/crates/harn-parser/src/typechecker/inference/flow.rs
@@ -92,6 +92,35 @@ fn extract_property_var(node: &SNode) -> Option<(String, String)> {
     None
 }
 
+/// Walk an *optional*-access chain (`o?.a`, `o?[i]`, `o?.m()`, and nestings
+/// thereof) down to the base identifier it is rooted on. Returns `None`
+/// unless `node` is itself an optional access whose object resolves — through
+/// further optional links only — to a bare identifier.
+///
+/// Soundness: by optional-chaining semantics `obj?.x` (and `?[]`/`?.()`)
+/// evaluates to `nil` whenever `obj` is `nil`. So if the *outermost* optional
+/// access is non-nil, its object was non-nil; applying that fact down a chain
+/// of optional links proves the base identifier is non-nil. We deliberately
+/// do **not** descend through *non-optional* links (`o.a?.b`), since a plain
+/// `.a` being read tells the type system nothing it is willing to assume.
+fn optional_chain_base_identifier(node: &SNode) -> Option<&str> {
+    fn root(node: &SNode) -> Option<&str> {
+        match &node.node {
+            Node::Identifier(name) => Some(name.as_str()),
+            Node::OptionalPropertyAccess { object, .. }
+            | Node::OptionalSubscriptAccess { object, .. }
+            | Node::OptionalMethodCall { object, .. } => root(object),
+            _ => None,
+        }
+    }
+    match &node.node {
+        Node::OptionalPropertyAccess { object, .. }
+        | Node::OptionalSubscriptAccess { object, .. }
+        | Node::OptionalMethodCall { object, .. } => root(object),
+        _ => None,
+    }
+}
+
 /// Project a literal expression node to a [`DiscriminantValue`]. Only the
 /// literal kinds eligible as tagged-shape-union discriminants
 /// (`StringLiteral`, `IntLiteral`) are recognised here.
@@ -498,6 +527,27 @@ impl TypeChecker {
                 _ => {}
             }
         }
+
+        // `o?.a != nil` (and `?[]`/`?.()` chains) proves the *base* identifier
+        // is non-nil on the branch where the chain is non-nil. We can only
+        // refine the one branch — `o?.a == nil` is satisfiable with `o`
+        // non-nil but `o.a` nil — so the opposite branch stays unrefined.
+        if let Some(base) = optional_chain_base_identifier(var_node) {
+            if let Some(TypeExpr::Union(members)) = scope.get_var(base).cloned().flatten() {
+                if let Some(narrowed) = remove_from_union(&members, "nil") {
+                    let nonnil = Refinements {
+                        truthy: vec![(base.to_string(), Some(narrowed))],
+                        ..Refinements::default()
+                    };
+                    return if op == "!=" {
+                        nonnil
+                    } else {
+                        nonnil.inverted()
+                    };
+                }
+            }
+        }
+
         Refinements::empty()
     }
 

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -55,6 +55,75 @@ impl UntypedAccessKind {
     }
 }
 
+/// The three runtime forms that dereference a receiver value: a property
+/// read (`obj.name`), a subscript (`obj[idx]`), and a method call
+/// (`obj.name(..)`). All three fail identically at runtime when the
+/// receiver is statically `nil`, may-be-`nil` (a `T | nil` union), or
+/// `unknown`. This enum lets a single diagnosis routine phrase the shared
+/// error/help for whichever form the author actually wrote, so the
+/// nil-safety guidance stays consistent across `.`, `[]`, and `.()`.
+#[derive(Clone, Copy)]
+enum AccessForm<'a> {
+    Property(&'a str),
+    Subscript,
+    Method(&'a str),
+}
+
+impl AccessForm<'_> {
+    /// Subject phrase for the "cannot access … on nil" message, e.g.
+    /// "property `name`", "an index", "method `greet`".
+    fn subject(self) -> String {
+        match self {
+            Self::Property(name) => format!("property `{name}`"),
+            Self::Subscript => "an index".to_string(),
+            Self::Method(name) => format!("method `{name}`"),
+        }
+    }
+
+    /// The `?`-form operator to recommend in help text, e.g.
+    /// "the optional access operator `?.name`".
+    fn optional_hint(self) -> String {
+        match self {
+            Self::Property(name) => {
+                format!("the optional access operator `?.{name}`")
+            }
+            Self::Subscript => "the optional subscript operator `?[…]`".to_string(),
+            Self::Method(name) => {
+                format!("the optional call operator `?.{name}(…)`")
+            }
+        }
+    }
+
+    /// Leading clause for the "on an `unknown` value" warning, e.g.
+    /// "property access `.name`", "subscript access", "method call `.greet()`".
+    fn unknown_label(self) -> String {
+        match self {
+            Self::Property(name) => format!("property access `.{name}`"),
+            Self::Subscript => "subscript access".to_string(),
+            Self::Method(name) => format!("method call `.{name}()`"),
+        }
+    }
+
+    /// What the receiver would have to be for the access to succeed,
+    /// completing "… will fail at runtime if the value is not {…}".
+    fn unknown_requirement(self) -> &'static str {
+        match self {
+            Self::Property(_) => "a shape with that field",
+            Self::Subscript => "a list, dict, or string",
+            Self::Method(_) => "a value with that method",
+        }
+    }
+
+    /// Trailing clause for the nil-guard help, e.g. "before reading fields".
+    fn guard_clause(self) -> &'static str {
+        match self {
+            Self::Property(_) => "before reading fields",
+            Self::Subscript => "before indexing",
+            Self::Method(_) => "before calling methods",
+        }
+    }
+}
+
 impl TypeChecker {
     pub(in crate::typechecker) fn check_block(&mut self, stmts: &[SNode], scope: &mut TypeScope) {
         self.check_block_with_expected_tail(stmts, None, scope);
@@ -317,40 +386,21 @@ impl TypeChecker {
             return;
         };
         let resolved = self.resolve_alias(&raw, scope);
-        // Decide whether to take the strict path. The "loose" case is the
-        // ambient dict literal idiom (`let d = {a: 1}; d.missing` returns
-        // nil at runtime) and the unannotated `var x = nil; ...; x.field`
-        // widening pattern — both rely on the runtime's silent-nil
-        // behavior. Strict diagnostics fire when the type came from a
-        // real contract: a written annotation, a named alias or struct,
-        // a struct/function-call return, or a nested property access.
-        let is_strict_source = match &object.node {
-            Node::Identifier(name) => {
-                scope.is_annotated(name) || self.is_named_contract_type(&raw, scope)
-            }
-            _ => true,
-        };
-        if !is_strict_source {
+        if !self.is_strict_access_source(object, &raw, scope) {
+            return;
+        }
+        // `nil` and `unknown` receivers fail identically for any access
+        // form, so route them through the shared diagnosis. Once it fires,
+        // the field-existence checks below would be redundant noise.
+        if self.diagnose_nil_or_unknown_receiver(
+            &resolved,
+            AccessForm::Property(property),
+            span,
+            optional,
+        ) {
             return;
         }
         match &resolved {
-            TypeExpr::Named(name) if name == "nil" && !optional => {
-                self.error_at_with_help(Code::InvalidOptionalAccess,
-                    format!(
-                        "cannot access property `{property}` on `nil`; the value is statically known to be nil here"
-                    ),
-                    span,
-                    format!("use the optional access operator `?.{property}`, or narrow the value with a `!= nil` guard before reading fields"),
-                );
-            }
-            TypeExpr::Named(name) if matches!(name.as_str(), "unknown") => {
-                self.warning_at_with_help(Code::UnknownField,
-                    format!("property access `.{property}` on an `unknown` value will fail at runtime if the value is not a shape with that field"),
-                    span,
-                    "narrow with `is_a`/`type_of`, validate with `assert_shape`, or annotate with a shape type before accessing fields"
-                        .to_string(),
-                );
-            }
             TypeExpr::Shape(fields) if !fields.iter().any(|f| f.name == *property) => {
                 let actual: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
                 let max_dist = if property.len() <= 4 { 1 } else { 2 };
@@ -375,6 +425,25 @@ impl TypeChecker {
             }
             _ if !optional => self.check_nilable_property_access(&resolved, property, scope, span),
             _ => {}
+        }
+    }
+
+    /// Decide whether an access (`.`, `[]`, or `.()`) should take the
+    /// strict diagnostic path. The "loose" case is the ambient dict-literal
+    /// idiom (`let d = {a: 1}; d.missing` returns nil at runtime) and the
+    /// unannotated `var x = nil; …; x.field` widening pattern — both rely
+    /// on the runtime's silent-nil behavior. Strict diagnostics fire when
+    /// the type came from a real contract: a written annotation, a named
+    /// alias / struct / enum, a struct or function-call return, or any
+    /// non-identifier expression (a call chain, literal, etc.). Shared by
+    /// property, subscript, and method-receiver checks so all three honour
+    /// the same boundary.
+    fn is_strict_access_source(&self, object: &SNode, raw: &TypeExpr, scope: &TypeScope) -> bool {
+        match &object.node {
+            Node::Identifier(name) => {
+                scope.is_annotated(name) || self.is_named_contract_type(raw, scope)
+            }
+            _ => true,
         }
     }
 
@@ -465,16 +534,142 @@ impl TypeChecker {
         if !non_nil_admits_property {
             return;
         }
-        self.error_at_with_help(Code::InvalidOptionalAccess,
+        self.emit_nilable_access_error(AccessForm::Property(property), ty, span);
+    }
+
+    /// Diagnose a statically-`nil` or `unknown` receiver for any access
+    /// form. Returns `true` when a diagnostic was emitted so the caller can
+    /// skip the access-kind-specific checks (field existence, etc.) that
+    /// would then be redundant. Optional access (`?.`, `?[]`, `?.()`)
+    /// suppresses the `nil` diagnostic — that is exactly what those
+    /// operators are for — but an `unknown` receiver is still flagged
+    /// because `?.` only guards `nil`, not a non-shape concrete value.
+    fn diagnose_nil_or_unknown_receiver(
+        &mut self,
+        resolved: &TypeExpr,
+        form: AccessForm,
+        span: Span,
+        optional: bool,
+    ) -> bool {
+        match resolved {
+            TypeExpr::Named(name) if name == "nil" => {
+                if optional {
+                    return false;
+                }
+                self.error_at_with_help(
+                    Code::InvalidOptionalAccess,
+                    format!(
+                        "cannot access {} on `nil`; the value is statically known to be nil here",
+                        form.subject()
+                    ),
+                    span,
+                    format!(
+                        "use {}, or narrow the value with a `!= nil` guard {}",
+                        form.optional_hint(),
+                        form.guard_clause()
+                    ),
+                );
+                true
+            }
+            TypeExpr::Named(name) if name == "unknown" => {
+                self.warning_at_with_help(
+                    Code::UnknownField,
+                    format!(
+                        "{} on an `unknown` value will fail at runtime if the value is not {}",
+                        form.unknown_label(),
+                        form.unknown_requirement()
+                    ),
+                    span,
+                    "narrow with `is_a`/`type_of`, validate with `assert_shape`, or annotate with a shape type before accessing fields"
+                        .to_string(),
+                );
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Emit the shared "value may be nil at runtime" error for a `T | nil`
+    /// receiver, phrased for whichever access form was written.
+    fn emit_nilable_access_error(&mut self, form: AccessForm, ty: &TypeExpr, span: Span) {
+        self.error_at_with_help(
+            Code::InvalidOptionalAccess,
             format!(
-                "cannot access property `{property}` on nilable type `{ty}`; the value may be nil at runtime",
-                ty = format_type(ty)
+                "cannot access {} on nilable type `{}`; the value may be nil at runtime",
+                form.subject(),
+                format_type(ty)
             ),
             span,
             format!(
-                "use the optional access operator `?.{property}`, or narrow the value with a `!= nil` guard to drop the nil arm"
+                "use {}, or narrow the value with a `!= nil` guard to drop the nil arm",
+                form.optional_hint()
             ),
         );
+    }
+
+    /// True when `ty` is a `T | nil` union of any width. Subscript and
+    /// method-call receivers have no per-field semantics, so any nil arm
+    /// is grounds to warn (unlike property access, which first checks
+    /// whether the non-nil arm even admits the field).
+    fn is_nilable_union(&self, ty: &TypeExpr, scope: &TypeScope) -> bool {
+        matches!(ty, TypeExpr::Union(members)
+            if members.iter().any(|m| self.type_is_nil(m, scope)))
+    }
+
+    /// Subscript (`obj[idx]`) nil-safety, mirroring `check_property_access`:
+    /// a statically-`nil`, may-be-`nil`, or `unknown` receiver is diagnosed
+    /// with the same guidance, pointing at `?[…]` instead of `?.`.
+    fn check_subscript_access(
+        &mut self,
+        object: &SNode,
+        scope: &TypeScope,
+        span: Span,
+        optional: bool,
+    ) {
+        let Some(raw) = self.infer_type(object, scope) else {
+            return;
+        };
+        let resolved = self.resolve_alias(&raw, scope);
+        if !self.is_strict_access_source(object, &raw, scope) {
+            return;
+        }
+        if self.diagnose_nil_or_unknown_receiver(&resolved, AccessForm::Subscript, span, optional) {
+            return;
+        }
+        if !optional && self.is_nilable_union(&resolved, scope) {
+            self.emit_nilable_access_error(AccessForm::Subscript, &resolved, span);
+        }
+    }
+
+    /// Method-call (`obj.name(..)`) receiver nil-safety, mirroring
+    /// `check_property_access`: a statically-`nil`, may-be-`nil`, or
+    /// `unknown` receiver is diagnosed before the args/bound checks run.
+    fn check_method_receiver(
+        &mut self,
+        object: &SNode,
+        method: &str,
+        scope: &TypeScope,
+        span: Span,
+        optional: bool,
+    ) {
+        let Some(raw) = self.infer_type(object, scope) else {
+            return;
+        };
+        let resolved = self.resolve_alias(&raw, scope);
+        if !self.is_strict_access_source(object, &raw, scope) {
+            return;
+        }
+        if self.diagnose_nil_or_unknown_receiver(
+            &resolved,
+            AccessForm::Method(method),
+            span,
+            optional,
+        ) {
+            return;
+        }
+        if !optional && self.is_nilable_union(&resolved, scope) {
+            self.emit_nilable_access_error(AccessForm::Method(method), &resolved, span);
+        }
     }
 
     fn check_strict_untyped_access(
@@ -1796,6 +1991,7 @@ impl TypeChecker {
                 ..
             } => {
                 self.check_node(object, scope);
+                self.check_method_receiver(object, method, scope, span, false);
                 if self.check_harness_method_call(object, method, args, scope, span) {
                     return;
                 }
@@ -1810,6 +2006,7 @@ impl TypeChecker {
             } => {
                 self.check_unnecessary_safe_method_call(snode, object, scope);
                 self.check_node(object, scope);
+                self.check_method_receiver(object, method, scope, span, true);
                 if self.check_harness_method_call(object, method, args, scope, span) {
                     return;
                 }
@@ -1829,12 +2026,14 @@ impl TypeChecker {
             }
             Node::SubscriptAccess { object, index } => {
                 self.check_strict_untyped_access(object, scope, span, UntypedAccessKind::Subscript);
+                self.check_subscript_access(object, scope, span, false);
                 self.check_node(object, scope);
                 self.check_node(index, scope);
             }
             Node::OptionalSubscriptAccess { object, index } => {
                 self.check_unnecessary_safe_subscript_access(snode, object, scope);
                 self.check_strict_untyped_access(object, scope, span, UntypedAccessKind::Subscript);
+                self.check_subscript_access(object, scope, span, true);
                 self.check_node(object, scope);
                 self.check_node(index, scope);
             }

--- a/crates/harn-parser/src/typechecker/tests/mod.rs
+++ b/crates/harn-parser/src/typechecker/tests/mod.rs
@@ -15,6 +15,7 @@ mod imports;
 mod interfaces;
 mod main_signature;
 mod narrowing;
+mod nil_safety;
 mod ownership;
 mod reachability;
 mod repair;

--- a/crates/harn-parser/src/typechecker/tests/nil_safety.rs
+++ b/crates/harn-parser/src/typechecker/tests/nil_safety.rs
@@ -1,0 +1,201 @@
+//! Member-access nil safety: property (`obj.field`), subscript
+//! (`obj[key]`), and method-call (`obj.m()`) receivers are all held to
+//! the same standard. A statically-`nil` or `T | nil` receiver is an
+//! error; an `unknown` receiver is a warning; `any` opts out; and the
+//! optional forms (`?.`, `?[]`, `?.()`) suppress the nil diagnostic.
+
+use super::*;
+
+fn has(msgs: &[String], needle: &str) -> bool {
+    msgs.iter().any(|m| m.contains(needle))
+}
+
+// --- subscript parity ---------------------------------------------------
+
+#[test]
+fn subscript_on_nil_is_error() {
+    let errs = errors("pipeline t(task) { let x: nil = nil\nlog(x[\"k\"]) }");
+    assert!(
+        has(&errs, "cannot access an index on `nil`"),
+        "got: {errs:?}"
+    );
+}
+
+#[test]
+fn subscript_on_nilable_is_error() {
+    let errs = errors("pipeline t(task) { let xs: list | nil = nil\nlog(xs[0]) }");
+    assert!(
+        has(&errs, "cannot access an index on nilable type"),
+        "got: {errs:?}"
+    );
+}
+
+#[test]
+fn subscript_on_unknown_is_warning() {
+    let warns = warnings("pipeline t(task) { let u: unknown = task\nlog(u[\"k\"]) }");
+    assert!(
+        has(&warns, "subscript access on an `unknown` value"),
+        "got: {warns:?}"
+    );
+}
+
+#[test]
+fn subscript_on_any_is_silent() {
+    let errs = errors("pipeline t(task) { let x: any = task\nlog(x[\"k\"]) }");
+    let warns = warnings("pipeline t(task) { let x: any = task\nlog(x[\"k\"]) }");
+    assert!(
+        !has(&errs, "index") && !has(&warns, "subscript"),
+        "any should opt out; errs={errs:?} warns={warns:?}"
+    );
+}
+
+#[test]
+fn optional_subscript_on_nil_is_allowed() {
+    let errs = errors("pipeline t(task) { let x: list | nil = nil\nlog(x?[0]) }");
+    assert!(
+        !has(&errs, "cannot access an index"),
+        "?[ ] should suppress the nil error; got: {errs:?}"
+    );
+}
+
+#[test]
+fn subscript_on_concrete_list_is_silent() {
+    let errs = errors("pipeline t(task) { let xs: list = []\nlog(xs[0]) }");
+    let warns = warnings("pipeline t(task) { let xs: list = []\nlog(xs[0]) }");
+    assert!(
+        errs.is_empty() && warns.is_empty(),
+        "errs={errs:?} warns={warns:?}"
+    );
+}
+
+// --- method-call parity -------------------------------------------------
+
+#[test]
+fn method_on_nil_is_error() {
+    let errs = errors("pipeline t(task) { let x: nil = nil\nlog(x.foo()) }");
+    assert!(
+        has(&errs, "cannot access method `foo` on `nil`"),
+        "got: {errs:?}"
+    );
+}
+
+#[test]
+fn method_on_nilable_is_error() {
+    let errs = errors("pipeline t(task) { let s: string | nil = nil\nlog(s.upper()) }");
+    assert!(
+        has(&errs, "cannot access method `upper` on nilable type"),
+        "got: {errs:?}"
+    );
+}
+
+#[test]
+fn method_on_unknown_is_warning() {
+    let warns = warnings("pipeline t(task) { let u: unknown = task\nlog(u.run()) }");
+    assert!(
+        has(&warns, "method call `.run()` on an `unknown` value"),
+        "got: {warns:?}"
+    );
+}
+
+#[test]
+fn method_on_any_is_silent() {
+    let errs = errors("pipeline t(task) { let x: any = task\nlog(x.run()) }");
+    let warns = warnings("pipeline t(task) { let x: any = task\nlog(x.run()) }");
+    assert!(
+        !has(&errs, "method") && !has(&warns, "method call"),
+        "any should opt out; errs={errs:?} warns={warns:?}"
+    );
+}
+
+#[test]
+fn optional_method_on_nilable_is_allowed() {
+    let errs = errors("pipeline t(task) { let s: string | nil = nil\nlog(s?.upper()) }");
+    assert!(
+        !has(&errs, "cannot access method"),
+        "?.m() should suppress the nil error; got: {errs:?}"
+    );
+}
+
+#[test]
+fn method_on_concrete_string_is_silent() {
+    let errs = errors("pipeline t(task) { let s: string = \"x\"\nlog(s.upper()) }");
+    assert!(!has(&errs, "cannot access method"), "got: {errs:?}");
+}
+
+// --- property access still behaves (regression after the refactor) ------
+
+#[test]
+fn property_on_nil_still_errors() {
+    let errs = errors("pipeline t(task) { let x: nil = nil\nlog(x.foo) }");
+    assert!(
+        has(&errs, "cannot access property `foo` on `nil`"),
+        "got: {errs:?}"
+    );
+}
+
+#[test]
+fn property_on_unknown_still_warns() {
+    let warns = warnings("pipeline t(task) { let u: unknown = task\nlog(u.field) }");
+    assert!(
+        has(&warns, "property access `.field` on an `unknown` value"),
+        "got: {warns:?}"
+    );
+}
+
+// --- narrowing that keeps the strict rule usable ------------------------
+
+#[test]
+fn optional_chain_guard_narrows_base() {
+    // `o?.a != nil` proves `o` is non-nil on the truthy branch, so a plain
+    // `o.a` read inside the guard must not fire the nilable-receiver error.
+    let errs = errors(
+        "pipeline t(task) { let o: {a?: string} | nil = nil\n\
+         if o?.a != nil {\nlog(o.a)\n} }",
+    );
+    assert!(
+        !has(&errs, "cannot access property"),
+        "o?.a != nil should narrow o to non-nil; got: {errs:?}"
+    );
+}
+
+#[test]
+fn optional_chain_guard_does_not_narrow_wrong_branch() {
+    // `o?.a == nil` is satisfiable with `o` itself nil, so the truthy branch
+    // must NOT be narrowed — the strict receiver error still fires.
+    let errs = errors(
+        "pipeline t(task) { let o: {a?: string} | nil = nil\n\
+         if o?.a == nil {\nlog(o.a)\n} }",
+    );
+    assert!(
+        has(&errs, "cannot access property"),
+        "o?.a == nil must not narrow o; got: {errs:?}"
+    );
+}
+
+#[test]
+fn coalesce_strips_nil_through_named_alias() {
+    // `??` drops the nil arm even when the left operand's type is a named
+    // alias that expands to a nilable union (the inline-union case already
+    // worked; this is the alias parity fix).
+    let errs = errors(
+        "type Opts = {a?: string} | nil\n\
+         pipeline t(task) { let o: Opts = nil\n\
+         let p = o ?? {}\nlog(p.a) }",
+    );
+    assert!(
+        !has(&errs, "cannot access property"),
+        "o ?? {{}} should be non-nil even for an aliased nilable type; got: {errs:?}"
+    );
+}
+
+// --- the loose dict-literal idiom stays loose ---------------------------
+
+#[test]
+fn dict_literal_subscript_stays_loose() {
+    let errs = errors("pipeline t(task) { let d = {a: 1}\nlog(d[\"b\"]) }");
+    let warns = warnings("pipeline t(task) { let d = {a: 1}\nlog(d[\"b\"]) }");
+    assert!(
+        !has(&errs, "index") && !has(&warns, "subscript"),
+        "ambient dict idiom should stay loose; errs={errs:?} warns={warns:?}"
+    );
+}

--- a/crates/harn-vm/tests/compaction_policy_primitive.rs
+++ b/crates/harn-vm/tests/compaction_policy_primitive.rs
@@ -110,7 +110,7 @@ pipeline main(task) {
   log(outcome["archived_messages"])
   log(outcome["engine_strategy"])
   log(outcome["strategy"])
-  log(transcript_summary(outcome["transcript"]).contains("policy compacted"))
+  log(transcript_summary(outcome["transcript"])?.contains("policy compacted"))
 }
 "#);
     assert_eq!(

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3937,6 +3937,45 @@ Interop between `any` and `unknown`:
   `unknown` unless you have a specific reason to defeat checking
   bidirectionally.
 
+### Member access and nil safety
+
+Three syntactic forms dereference a receiver value at runtime — property
+read (`obj.field`), subscript (`obj[key]`), and method call
+(`obj.method(..)`). All three fail identically when the receiver is `nil`
+or is not the kind of value the access expects, so the checker applies one
+consistent set of diagnostics to all three rather than treating property
+access as special:
+
+| Receiver type | `obj.field` / `obj[key]` / `obj.m()` | `obj?.field` / `obj?[key]` / `obj?.m()` |
+|---|---|---|
+| statically `nil` | **error** — known nil here | allowed (the `?` short-circuits) |
+| `T \| nil` (nilable) | **error** — may be nil at runtime | allowed |
+| `unknown` | **warning** — narrow or validate first | **warning** — `?` only guards nil, not a non-shape value |
+| `any` | no diagnostic (checking opted out) | no diagnostic |
+| concrete (`struct`, shape, `list`, …) | field/index/method checked against the type | unnecessary-`?` lint if the receiver can't be nil |
+
+The fix for a `nil` / nilable receiver is always one of: the matching
+optional operator (`?.`, `?[…]`, or `?.m()`), a `!= nil` guard that
+narrows the value, or a `??` default. For an `unknown` receiver, narrow
+with `is_a` / `type_of`, validate with `assert_shape` / `schema_is`, or
+add a shape annotation. `any` is the deliberate escape hatch and is never
+diagnosed — see the `any` vs `unknown` guidance above.
+
+Two narrowings keep this rule ergonomic. A guard on an optional-access
+chain narrows the **base** identifier: inside `if o?.field != nil { … }`
+the value `o` is non-nil (if `o` were nil, `o?.field` would be nil), so a
+plain `o.field` read in that branch is allowed. And `value ?? default`
+drops the `nil` arm of `value` even when `value`'s type is a **named
+alias** that expands to a nilable union (`type Opts = {…} | nil`), so the
+common `let opts = options ?? {}` option-defaulting idiom yields a non-nil
+value.
+
+These diagnostics fire only when the receiver's type comes from a real
+contract — a written annotation, a named struct / alias / enum, a
+call-return, or any non-identifier expression. The ambient dict-literal
+idiom (`let d = {a: 1}; d.missing`) stays loose and returns `nil` at
+runtime, matching the gradual-typing affordance for one-off glue.
+
 ### Union types
 
 ```harn

--- a/docs/src/stdlib/calendar.md
+++ b/docs/src/stdlib/calendar.md
@@ -134,7 +134,7 @@ pipeline default() {
   let us = country_info("US")
   log(us.name)
   log(default_timezone_for_country("US") == nil)
-  log(country_timezones("GB")[0])
+  log(country_timezones("GB")?[0])
   log(default_timezone_for_country("GB"))
 }
 ```

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3935,6 +3935,45 @@ Interop between `any` and `unknown`:
   `unknown` unless you have a specific reason to defeat checking
   bidirectionally.
 
+### Member access and nil safety
+
+Three syntactic forms dereference a receiver value at runtime — property
+read (`obj.field`), subscript (`obj[key]`), and method call
+(`obj.method(..)`). All three fail identically when the receiver is `nil`
+or is not the kind of value the access expects, so the checker applies one
+consistent set of diagnostics to all three rather than treating property
+access as special:
+
+| Receiver type | `obj.field` / `obj[key]` / `obj.m()` | `obj?.field` / `obj?[key]` / `obj?.m()` |
+|---|---|---|
+| statically `nil` | **error** — known nil here | allowed (the `?` short-circuits) |
+| `T \| nil` (nilable) | **error** — may be nil at runtime | allowed |
+| `unknown` | **warning** — narrow or validate first | **warning** — `?` only guards nil, not a non-shape value |
+| `any` | no diagnostic (checking opted out) | no diagnostic |
+| concrete (`struct`, shape, `list`, …) | field/index/method checked against the type | unnecessary-`?` lint if the receiver can't be nil |
+
+The fix for a `nil` / nilable receiver is always one of: the matching
+optional operator (`?.`, `?[…]`, or `?.m()`), a `!= nil` guard that
+narrows the value, or a `??` default. For an `unknown` receiver, narrow
+with `is_a` / `type_of`, validate with `assert_shape` / `schema_is`, or
+add a shape annotation. `any` is the deliberate escape hatch and is never
+diagnosed — see the `any` vs `unknown` guidance above.
+
+Two narrowings keep this rule ergonomic. A guard on an optional-access
+chain narrows the **base** identifier: inside `if o?.field != nil { … }`
+the value `o` is non-nil (if `o` were nil, `o?.field` would be nil), so a
+plain `o.field` read in that branch is allowed. And `value ?? default`
+drops the `nil` arm of `value` even when `value`'s type is a **named
+alias** that expands to a nilable union (`type Opts = {…} | nil`), so the
+common `let opts = options ?? {}` option-defaulting idiom yields a non-nil
+value.
+
+These diagnostics fire only when the receiver's type comes from a real
+contract — a written annotation, a named struct / alias / enum, a
+call-return, or any non-identifier expression. The ambient dict-literal
+idiom (`let d = {a: 1}; d.missing`) stays loose and returns `nil` at
+runtime, matching the gradual-typing affordance for one-off glue.
+
 ### Union types
 
 ```harn


### PR DESCRIPTION
## What

Closes the principled gap in Harn's nil-safety: the typechecker already
diagnosed `obj.field` on a `nil` / `T | nil` receiver, but **subscript**
(`obj[key]`) and **method-call** (`obj.method(..)`) receivers slipped through —
so possibly-nil code passed `harn check` and only blew up at runtime.

All three forms now share one rule (and one DRY `AccessForm` /
`diagnose_nil_or_unknown_receiver` / `emit_nilable_access_error` path):

| Receiver | `.`/`[]`/`.()` | `?.`/`?[]`/`?.()` |
|---|---|---|
| `nil` | error | allowed |
| `T \| nil` | error | allowed |
| `unknown` | warning | warning |
| `any` | silent (escape hatch) | silent |
| concrete | checked | unnecessary-`?` lint |

## Narrowings (so the strict rule stays ergonomic)

Two long-standing narrowing gaps are closed alongside the rule:

- **`o?.field != nil` narrows the base.** Inside `if o?.x != nil { … }`, `o`
  is non-nil (a nil `o` would make the chain nil), so a plain `o.x` read is
  allowed — and only on the matching branch (`== nil` does **not** narrow).
- **`??` strips nil through named aliases.** `let opts = options ?? {}` now
  yields a non-nil value for `type Opts = {..} | nil`, matching the existing
  behaviour for inline `T | nil` unions. (This was the root cause of a
  pre-existing false positive in the shipped stdlib.)

## Harness label fix

The conformance harness used to label **every** pre-runtime failure
`runtime error`. A typed `ExecError` now labels failures by stage —
`type error` / `compile error` / `runtime error`.

## Validation

- `cargo test -p harn-parser` — **441 pass** (18 in the new `nil_safety` suite,
  incl. narrowing + `??`-alias coverage).
- Full conformance — **1581 pass, 0 fail** (was 11 failing on the new rule).
- 11 fixtures that relied on the old gap migrated to optional operators;
  added a positive `nil_narrowing_and_coalesce` fixture.
- Spec updated (member-access table + narrowing notes); mirror in sync.
- Pre-commit clippy/fmt/lint clean on `harn-cli` + `harn-parser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)