### PR TITLE
Retry release publish on crates.io propagation timeout

### DIFF
--- a/changelog.d/publish-retry-propagation-timeout.fixed.md
+++ b/changelog.d/publish-retry-propagation-timeout.fixed.md
@@ -1,0 +1,7 @@
+- The release publish step (`scripts/publish.sh`) now treats cargo's "timeout
+  while waiting for published dependencies" / "timed out waiting for … to be
+  available" as a retryable index-propagation condition. Previously a slow
+  crates.io index could leave the last crate (e.g. `harn-cli`, waiting on
+  `harn-lsp`) unpublished and abort the run as a "non-retryable error" without
+  even trying the per-crate fallback; it now retries and falls back, so a
+  propagation lag no longer leaves a release half-published.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -95,7 +95,14 @@ WORKSPACE_CRATES=(
 #                                            after a successful upload
 #   - "already exists on crates.io index"  — crate succeeded on an earlier
 #                                            attempt; nothing to do
-RETRYABLE_PATTERN='429|Too Many Requests|unexpected cargo internal error|packages remain in plan|already exists on crates.io index'
+#   - "timeout while waiting for published  — a dependency was uploaded but the
+#      dependencies" / "timed out waiting     index hadn't propagated before
+#      for ... to be available"               cargo tried to publish a dependent
+#                                            (e.g. harn-cli waiting on harn-lsp).
+#                                            Pure propagation lag: retrying or the
+#                                            per-crate fallback (which skips the
+#                                            already-uploaded crates) completes it.
+RETRYABLE_PATTERN='429|Too Many Requests|unexpected cargo internal error|packages remain in plan|already exists on crates.io index|timeout while waiting for published dependencies|timed out waiting for'
 
 attempt_workspace_publish() {
   local attempt=1


### PR DESCRIPTION
## Summary

The v0.8.82 release publish run failed with:

```
error: unable to publish harn-cli v0.8.82 due to a timeout while waiting for published dependencies to be available.
  FAILED to publish workspace (non-retryable error)
```

`cargo publish --workspace` uploads crates in dependency order and waits for each to appear in the index before publishing dependents. When the index lags, the last crate (here `harn-cli`, waiting on `harn-lsp`) times out. `scripts/publish.sh`'s `RETRYABLE_PATTERN` didn't match this message, so it returned a **non-retryable** error and never reached the per-crate fallback — leaving the release half-published (every crate but `harn-cli`; it required a manual workflow re-trigger to finish).

This is pure index-propagation lag — exactly the class the retry/fallback exists for. The fix adds `timeout while waiting for published dependencies` and `timed out waiting for` to `RETRYABLE_PATTERN`, so the workspace publish retries (skipping already-uploaded crates via "already exists") and, failing that, escalates to the per-crate fallback that completes the publish.

## Test plan
- `bash -n scripts/publish.sh` (syntax).
- Behavioral: validated against the real failure — re-running publish after the timeout (the manual recovery this automates) published `harn-cli 0.8.82` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)