### PR TITLE
Fix four latent stdlib bugs surfaced by precise record-merge typing

### DIFF
--- a/changelog.d/stdlib-merge-fallout-fixes.fixed.md
+++ b/changelog.d/stdlib-merge-fallout-fixes.fixed.md
@@ -1,0 +1,16 @@
+- **Fixed four latent stdlib type bugs surfaced by precise record-merge typing.**
+  Now that `merge` infers the exact merged shape, the type checker caught
+  mismatches the old untyped `dict` return had hidden:
+  - `github.enable_auto_merge` reads `method`/`merge_method` options that
+    `GitHubCallOptions` never declared — added them.
+  - `github.wait_until_deploy_succeeds` / `wait_until_ci_green` /
+    `wait_until_pr_merged` built monitor options with GitHub's millisecond
+    field names (`timeout_ms`, `poll_interval_ms`, `max_wait_ms`), which
+    `wait_for` silently dropped — and since the monitor requires a `timeout`
+    duration, those calls would have **thrown at runtime**. They now translate
+    the millisecond cadence into the duration-typed `MonitorWaitOptions` so the
+    caller's timing is honored.
+  - The git-forge pull-request event builder is now annotated so its
+    `filter_nil`-projected fields type as the declared `GitForge*` structs.
+  - `graphql_parse_schema`'s `current` accumulator no longer trips a
+    narrow-to-`never` reassignment error.

--- a/crates/harn-stdlib/src/stdlib/stdlib_connectors_github.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_connectors_github.harn
@@ -31,6 +31,8 @@ type GitHubCallOptions = {
   headers?: dict<string, string>,
   timeout_ms?: int,
   retry_attempts?: int,
+  method?: string,
+  merge_method?: string,
 }
 
 /** Options for `wait_until_*` helpers — adds a polling cadence to the call options. */
@@ -572,7 +574,7 @@ pub fn github_release_assets(
  */
 pub fn enable_auto_merge(repo: any, pull_number: any, options: GitHubCallOptions = {}) -> GitHubAutoMergeResult {
   let r = __github_repo_or_throw(repo)
-  let requested_method = uppercase(to_string(options?.method ?? options?.merge_method ?? "merge"))
+  let requested_method = uppercase(to_string(options.method ?? options.merge_method ?? "merge"))
   let result = try {
     call(
       "github.pr.enable_auto_merge",
@@ -892,6 +894,26 @@ pub fn pull_request_merged_source(repo: string, number: any, options: GitHubCall
   }
 }
 
+/** Default overall wait cap (ms) applied when a GitHubWaitOptions supplies none. */
+const GITHUB_DEFAULT_WAIT_MS = 300000
+
+/**
+ * Translate a GitHubWaitOptions (millisecond cadence fields) plus a source and
+ * condition into the duration-typed MonitorWaitOptions shape that `wait_for`
+ * consumes. `max_wait_ms`/`timeout_ms` become the overall `timeout` duration
+ * and `poll_interval_ms` becomes the `poll_interval` duration so the caller's
+ * cadence is actually honored by the monitor.
+ */
+fn __github_wait_options(options: GitHubWaitOptions, source, condition) {
+  let timeout_ms = options.max_wait_ms ?? options.timeout_ms ?? GITHUB_DEFAULT_WAIT_MS
+  let base = {source: source, condition: condition, timeout: duration_ms(timeout_ms)}
+  let poll_interval_ms = options.poll_interval_ms
+  if poll_interval_ms != nil {
+    return merge(base, {poll_interval: duration_ms(poll_interval_ms)})
+  }
+  return base
+}
+
 /**
  * wait_until_deploy_succeeds.
  *
@@ -903,12 +925,10 @@ pub fn pull_request_merged_source(repo: string, number: any, options: GitHubCall
  */
 pub fn wait_until_deploy_succeeds(repo: string, deployment_id: any, options: GitHubWaitOptions = {}) {
   return wait_for(
-    merge(
+    __github_wait_options(
       options,
-      {
-        source: deployment_status_source(repo, deployment_id, options),
-        condition: { state -> state.state == "success" },
-      },
+      deployment_status_source(repo, deployment_id, options),
+      { state -> state.state == "success" },
     ),
   )
 }
@@ -924,12 +944,10 @@ pub fn wait_until_deploy_succeeds(repo: string, deployment_id: any, options: Git
  */
 pub fn wait_until_ci_green(repo: string, check_run_id: any, options: GitHubWaitOptions = {}) {
   return wait_for(
-    merge(
+    __github_wait_options(
       options,
-      {
-        source: check_run_source(repo, check_run_id, options),
-        condition: { state -> state.status == "completed" && state.conclusion == "success" },
-      },
+      check_run_source(repo, check_run_id, options),
+      { state -> state.status == "completed" && state.conclusion == "success" },
     ),
   )
 }
@@ -945,9 +963,10 @@ pub fn wait_until_ci_green(repo: string, check_run_id: any, options: GitHubWaitO
  */
 pub fn wait_until_pr_merged(repo: string, number: any, options: GitHubWaitOptions = {}) {
   return wait_for(
-    merge(
+    __github_wait_options(
       options,
-      {source: pull_request_merged_source(repo, number, options), condition: { state -> state.merged }},
+      pull_request_merged_source(repo, number, options),
+      { state -> state.merged },
     ),
   )
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_connectors_shared.harn
@@ -37,7 +37,7 @@ type GitForgePullRequestEvent = {
   repository: GitForgeRepositoryRef,
   pull_request: GitForgePullRequestRef,
   writeback: GitForgeWritebackTarget,
-  delivery_id?: string,
+  delivery_id: string?,
   signature_status?: any,
   provider_metadata: dict<string, any>,
   raw_payload: any,
@@ -845,7 +845,7 @@ fn __git_forge_lifecycle(provider, action, change) {
   return "updated"
 }
 
-fn __git_forge_repo_from_full_name(provider, full_name, id, web_url) {
+fn __git_forge_repo_from_full_name(provider, full_name, id, web_url) -> GitForgeRepositoryRef {
   return filter_nil(
     {
       provider: provider,
@@ -874,7 +874,7 @@ fn __git_forge_delivery_id(raw) {
   )
 }
 
-fn __git_forge_event(provider, lifecycle, repo, pr, raw, options) {
+fn __git_forge_event(provider, lifecycle, repo, pr, raw, options) -> GitForgePullRequestEvent? {
   let number = to_int(pr?.number ?? pr?.iid ?? pr?.index)
   if number == nil {
     return nil
@@ -886,7 +886,7 @@ fn __git_forge_event(provider, lifecycle, repo, pr, raw, options) {
     repo?.id,
     repo?.web_url ?? repo?.html_url,
   )
-  let pull_request = filter_nil(
+  let pull_request: GitForgePullRequestRef = filter_nil(
     {
       number: number,
       id: __git_forge_text(pr?.id),
@@ -902,15 +902,16 @@ fn __git_forge_event(provider, lifecycle, repo, pr, raw, options) {
       merged: __git_forge_bool(pr?.merged),
     },
   )
-  let writeback = filter_nil(
+  let writeback: GitForgeWritebackTarget = filter_nil(
     {
       provider: provider,
-      repository_full_name: repository?.full_name,
-      repository_id: repository?.id,
+      repository_full_name: repository.full_name,
+      repository_id: repository.id,
       pull_request_number: number,
-      web_url: pull_request?.web_url,
+      web_url: pull_request.web_url,
     },
   )
+  let provider_metadata: dict<string, any> = filter_nil(merge(raw?.provider_metadata ?? {}, options?.provider_metadata ?? {}))
   return {
     topic: GIT_FORGE_PULL_REQUEST_TOPIC,
     event: "pull_request",
@@ -922,7 +923,7 @@ fn __git_forge_event(provider, lifecycle, repo, pr, raw, options) {
     writeback: writeback,
     delivery_id: __git_forge_delivery_id(raw),
     signature_status: raw?.signature_status,
-    provider_metadata: filter_nil(merge(raw?.provider_metadata ?? {}, options?.provider_metadata ?? {})),
+    provider_metadata: provider_metadata,
     raw_payload: raw?.raw ?? raw,
   }
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_graphql.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_graphql.harn
@@ -495,7 +495,7 @@ fn __graphql_field_from_line(line) {
  */
 pub fn graphql_parse_schema(schema_text) {
   var types = []
-  var current = nil
+  var current: {kind: string, name: string, fields: list}? = nil
   for raw_line in split(schema_text ?? "", "\n") {
     let line = trim(raw_line)
     if line == "" || starts_with(line, "#") {
@@ -513,12 +513,13 @@ pub fn graphql_parse_schema(schema_text) {
       }
       continue
     }
-    if current != nil {
+    let open = current
+    if open != nil {
       if starts_with(line, "}") {
-        types = types + [current]
+        types = types + [open]
         current = nil
       } else if contains(line, ":") {
-        current = merge(current, {fields: current.fields + [__graphql_field_from_line(line)]})
+        current = merge(open, {fields: open.fields + [__graphql_field_from_line(line)]})
       }
     }
   }


### PR DESCRIPTION
## What

Row polymorphism (#3111) made `merge` infer the exact merged shape instead of an
untyped `dict`. That precision **caught four pre-existing latent bugs** in the
shipped stdlib that the loose `dict` return had hidden. Each is fixed to make
the type accurately describe runtime behaviour (no `any`-suppression, no
type-loosening to silence the checker).

1. **`github.enable_auto_merge`** read `method` / `merge_method` options that
   `GitHubCallOptions` never declared (HARN-NAM-004) → added the two optional
   fields.
2. **`github.wait_until_deploy_succeeds` / `wait_until_ci_green` /
   `wait_until_pr_merged`** built monitor options with GitHub's *millisecond*
   field names (`timeout_ms`, `poll_interval_ms`, `max_wait_ms`), which
   `wait_for` silently dropped. Since `monitor_wait_for_native` **requires** a
   `timeout` duration, those calls would have **thrown at runtime**. They now
   translate the ms cadence into the duration-typed `MonitorWaitOptions` (new
   `__github_wait_options` helper), so the caller's timing is actually honoured.
   *(This is a real runtime-bug fix, not just a type fix.)*
3. **git-forge PR-event builder** (`connectors_shared`): annotated
   `__git_forge_event` + helpers so the `filter_nil` projections type as the
   declared `GitForge*` structs; `delivery_id` is a required key with a nullable
   value (matches the always-emitted runtime shape).
4. **`graphql_parse_schema`**: typed the `current` accumulator so reassignment
   isn't checked against a narrowed `never` (HARN-TYP-005) — a flow-typing issue
   independent of row polymorphism.

## Validation
- All three stdlib files `harn check`-clean (0 errors, 0 warnings).
- Full conformance **1583 passed, 0 failed**; `cargo test -p harn-parser` 450/0.
- No conformance fixture exercises the changed functions, so #2's behavioural
  change (ms→duration) can't silently regress a fixture.

Builds on the row-polymorphism work merged in #3111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)