### PR TITLE
Parse robustness: UTF-8 panic, fence-parity, silent partial-drop (meter-integrity)

### DIFF
--- a/changelog.d/parse-robustness.fixed.md
+++ b/changelog.d/parse-robustness.fixed.md
@@ -1,0 +1,14 @@
+- **Three parse-robustness fixes for the agent tool-call path.** The
+  native-JSON salvage path no longer panics on multi-byte UTF-8
+  (emoji/accents/CJK) in trailing prose after a `[{"id":...}]` array — it now
+  parses the first JSON value with a boundary-safe forward
+  `serde_json::Deserializer` instead of an O(n^2) backward byte scan that could
+  slice mid-codepoint and abort the turn. The tagged-protocol fence-parity
+  check no longer treats an earlier *unbalanced* ` ``` ` as fencing a later
+  legitimate `<tool_call>` block (which dropped the call and injected a spurious
+  protocol violation); an open fence only encloses a tag when a matching close
+  follows. And `agent_loop` now injects `parse_guidance` on partial-success
+  turns (some calls parsed, one malformed) flagged `has_partial_success` with
+  the dispatched-call count, so the model gets a signal to re-emit the dropped
+  call instead of zero feedback — while the no-progress stall suppression stays
+  gated on full parse drops only.

--- a/conformance/tests/agents/agent_loop_protocol_violation_feedback.expected
+++ b/conformance/tests/agents/agent_loop_protocol_violation_feedback.expected
@@ -6,3 +6,8 @@ true
 done
 true
 true
+done
+write_note
+true
+true
+true

--- a/conformance/tests/agents/agent_loop_protocol_violation_feedback.harn
+++ b/conformance/tests/agents/agent_loop_protocol_violation_feedback.harn
@@ -69,4 +69,38 @@ pipeline default() {
       __io_println(!contains(retry_messages, "Stray text outside response tags"))
     },
   )
+  // Partial success: one call parses and dispatches while a sibling call in the
+  // same turn is malformed (unknown tool). The dropped call's diagnostic must
+  // still reach the model as parse_guidance, flagged has_partial_success so the
+  // model knows the good call landed and only re-emits the bad one.
+  with_llm_script(
+    [
+      llm_text(
+        "<tool_call>\nwrite_note({ path: \"a.txt\" })\n</tool_call>\n"
+          + "<tool_call>\nnope({})\n</tool_call>",
+      ),
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Write a.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "text",
+          loop_until_done: true,
+          max_iterations: 5,
+          max_nudges: 5,
+          tools: note_tools(),
+        },
+      )
+      let calls = llm_mock_calls()
+      let retry_messages = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(result.tools.successful[0])
+      __io_println(contains(retry_messages, "parse_guidance"))
+      __io_println(contains(retry_messages, "parsed successfully and were dispatched"))
+      __io_println(!contains(retry_messages, "no_progress_streak"))
+    },
+  )
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -813,8 +813,18 @@ fn __parse_feedback_has_non_structural_tools(turn_opts) -> bool {
  * names the exact parser diagnostic — is the right corrective feedback, but
  * nothing consumed `tool_parse_errors` on the active path. This fires purely on
  * the syntactic parse-error condition: strong models emit clean calls, hit zero
- * parse errors, and never reach it (no regression). Returns true when feedback
- * was injected so the caller can suppress the no-progress stall path.
+ * parse errors, and never reach it (no regression).
+ *
+ * Partial-success turns (some calls parsed AND at least one was dropped) get
+ * the same parse_guidance note — flagged `has_partial_success` so the model
+ * knows the good calls dispatched and only re-emits the malformed one. Without
+ * this, the dropped call's diagnostic was silently swallowed and the model got
+ * zero signal to re-emit it.
+ *
+ * Returns true ONLY when the WHOLE turn was a parse failure (zero calls
+ * dispatched) so the caller can suppress the no-progress stall path. A
+ * partial-success turn made real progress (its parsed calls dispatched), so it
+ * returns false and stays subject to the normal stall accounting.
  */
 fn __parse_feedback_protocol_violations(parsed, turn_opts) {
   if agent_tool_call_paradigm(turn_opts).kind != "text"
@@ -833,16 +843,20 @@ fn __parse_feedback_diagnostics(parsed, turn_opts) {
 fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts) -> bool {
   let protocol_violations = __parse_feedback_protocol_violations(parsed, turn_opts)
   let diagnostics = __parse_feedback_diagnostics(parsed, turn_opts)
-  if len(diagnostics) == 0 || len(tool_calls) > 0 {
+  if len(diagnostics) == 0 {
     return false
   }
+  // Some calls parsed AND at least one was dropped: the good calls already
+  // dispatched, so flag the note as partial success and report how many landed
+  // so the model only re-emits the malformed call.
+  let parsed_count = len(tool_calls)
+  let has_partial_success = parsed_count > 0
   let error_summary = to_string(diagnostics[0])
-  // All calls were dropped, so there is no partial success this turn.
   let feedback = parse_guidance_prompt(
     {
       error_summary: error_summary,
-      has_partial_success: false,
-      parsed_call_count: 0,
+      has_partial_success: has_partial_success,
+      parsed_call_count: parsed_count,
       body_hint: agent_tool_call_paradigm(turn_opts).body_hint,
     },
     turn_opts,
@@ -856,9 +870,14 @@ fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts
       protocol_violation_count: len(protocol_violations),
       diagnostic_count: len(diagnostics),
       error_summary: error_summary,
+      has_partial_success: has_partial_success,
+      parsed_call_count: parsed_count,
     },
   )
-  return true
+  // Only a full parse drop (zero calls dispatched) suppresses the no-progress
+  // stall path; a partial-success turn made real progress and stays subject to
+  // normal stall accounting.
+  return !has_partial_success
 }
 
 fn __detect_native_fallback(

--- a/crates/harn-vm/src/llm/tools/parse/native_json.rs
+++ b/crates/harn-vm/src/llm/tools/parse/native_json.rs
@@ -21,22 +21,19 @@ pub(crate) fn parse_native_json_tool_calls(
     };
 
     let json_text = &text[start..];
-    let parsed: Option<Vec<serde_json::Value>> = serde_json::from_str(json_text)
-        .ok()
-        .or_else(|| {
-            serde_json::from_str::<serde_json::Value>(json_text)
-                .ok()
-                .map(|value| vec![value])
-        })
-        .or_else(|| {
-            // Salvage trailing-text JSON by scanning for a valid close.
-            for end in (start + 10..text.len()).rev() {
-                let slice = &text[start..=end];
-                if let Ok(arr) = serde_json::from_str::<Vec<serde_json::Value>>(slice) {
-                    return Some(arr);
-                }
-            }
-            None
+    // Parse the first JSON value at `start`, stopping at its structural end so
+    // trailing prose (including multi-byte UTF-8 — emoji/accents/CJK) is simply
+    // ignored. This is the same boundary-safe streaming technique used by
+    // `tagged.rs::parse_mistral_json_payload`; the old O(n^2) backward byte
+    // scan (`&text[start..=end]`) panicked the instant `end + 1` landed inside a
+    // multi-byte codepoint, aborting the turn before it reached the valid `]`.
+    let parsed: Option<Vec<serde_json::Value>> = serde_json::Deserializer::from_str(json_text)
+        .into_iter::<serde_json::Value>()
+        .next()
+        .and_then(|result| result.ok())
+        .map(|value| match value {
+            serde_json::Value::Array(items) => items,
+            other => vec![other],
         });
 
     let Some(items) = parsed else {

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -762,17 +762,38 @@ fn is_top_level_tag_position(src: &str, cursor: usize) -> bool {
         .all(|ch| matches!(ch, ' ' | '\t' | '\r'))
 }
 
+/// Is `cursor` enclosed by a *closed* markdown code fence?
+///
+/// A top-level tag inside a ```` ```lang … ``` ```` block is narration, not a
+/// real block, so the scanner skips it (e.g. an example `<user_response>` shown
+/// in fenced docs). But the cursor only counts as "inside a fence" when the
+/// opening fence is matched by a closing fence *at or after* the cursor.
+///
+/// The earlier implementation just counted ```` ``` ```` markers before the
+/// cursor and called an odd count "inside a fence". That shredded a legitimate
+/// trailing `<tool_call>` whenever an unbalanced ```` ``` ```` appeared earlier
+/// in the response: the open fence with no close had no business swallowing a
+/// later real block. Requiring a matching close ahead makes an unbalanced
+/// *trailing* fence harmless while keeping closed example fences skipped.
 fn inside_markdown_fence(src: &str, cursor: usize) -> bool {
-    let mut count = 0;
+    // Walk fence markers left to right, toggling parity. We only care whether
+    // the fence that is open *at* the cursor is later closed.
+    let mut open_before_cursor = false;
     let mut scan = 0;
-    while scan < cursor {
-        let Some(pos) = src[scan..cursor].find("```") else {
-            break;
-        };
-        count += 1;
-        scan += pos + 3;
+    while let Some(rel) = src[scan..].find("```") {
+        let pos = scan + rel;
+        if pos >= cursor {
+            // First fence marker at/after the cursor. If a fence was open when
+            // we crossed the cursor, this marker closes it → cursor is inside a
+            // real (closed) fence. Otherwise the cursor sat in open prose.
+            return open_before_cursor;
+        }
+        open_before_cursor = !open_before_cursor;
+        scan = pos + 3;
     }
-    count % 2 == 1
+    // No fence marker at/after the cursor: any fence still open here is an
+    // unbalanced trailing fence, so the cursor is not inside a closed fence.
+    false
 }
 
 /// Report stray text that sits outside any recognized top-level tag.

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -590,6 +590,29 @@ Now I'll create the test:
 }
 
 #[test]
+fn native_json_fallback_handles_non_ascii_trailing_content() {
+    // Regression: the salvage path used to byte-scan backwards
+    // (`&text[start..=end]`) with no `is_char_boundary` guard, so any
+    // multi-byte char (emoji/accent/CJK) in the trailing prose made `end + 1`
+    // land mid-codepoint and PANIC — aborting the agent turn before it ever
+    // reached the valid `]`. The forward streaming parser stops at the array's
+    // structural end and ignores trailing bytes regardless of their width.
+    let known = known_tools_set();
+    let text = "[{\"id\":\"call_001\",\"type\":\"function\",\"function\":{\"name\":\"edit\",\
+                \"arguments\":\"{\\\"action\\\":\\\"create\\\",\\\"path\\\":\\\"café.go\\\",\
+                \\\"content\\\":\\\"pkg\\\"}\"}}] done ✅ — déjà vu 完了";
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(
+        calls.len(),
+        1,
+        "should parse the call before the trailing prose"
+    );
+    assert_eq!(calls[0]["name"], json!("edit"));
+    assert_eq!(calls[0]["arguments"]["path"], json!("café.go"));
+}
+
+#[test]
 fn text_parser_falls_through_to_native_json_fallback() {
     // End-to-end: the main parse_text_tool_calls_with_tools should fall
     // through to the native JSON parser when text parsing finds nothing

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -458,6 +458,36 @@ fn tagged_parser_ignores_user_response_inside_markdown_fence() {
 }
 
 #[test]
+fn tagged_parser_keeps_tool_call_after_unbalanced_fence() {
+    // Regression: the fence-parity check counted every ``` marker before the
+    // cursor and called an odd count "inside a fence". A single UNCLOSED ```
+    // earlier in the response (common when a model opens a code block in its
+    // narration but never closes it) therefore made a later, legitimate
+    // <tool_call> look fenced — the call was dropped and a spurious
+    // protocol_violation injected. An unbalanced *trailing* fence must not
+    // swallow a real block.
+    let tools = sample_tool_registry();
+    // The narration opens a ``` fence and never closes it before the real call.
+    // It sits inside <assistant_prose> so the only top-level block the parser
+    // must keep is the trailing <tool_call>.
+    let text = "<assistant_prose>\nHere is the rough shape:\n```\nfn sketch() {}\n</assistant_prose>\n\
+                <tool_call>\nedit({ action: \"create\", path: \"a.rs\", content: \"x\" })\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "tool call after an unclosed fence must still parse: {:?}",
+        result.calls
+    );
+    assert_eq!(result.calls[0]["name"], json!("edit"));
+    assert!(
+        result.violations.is_empty(),
+        "no spurious protocol violation should be injected: {:?}",
+        result.violations
+    );
+}
+
+#[test]
 fn tagged_parser_flags_empty_done_block() {
     let tools = sample_tool_registry();
     let text = "<tool_call>\nedit({ action: \"create\", path: \"a.rs\", content: \"x\" })\n</tool_call>\n<done></done>";


### PR DESCRIPTION
Burin cross-repo audit, basic-layer parse robustness (these fire regardless of compaction; the panic is a meter-integrity blocker).

- **UTF-8 char-boundary panic (BLOCKER)** — `native_json.rs`'s salvage loop did `&text[start..=end]` with no boundary guard, panicking the instant `end+1` landed mid-codepoint (emoji/accent/CJK in trailing prose), aborting the agent turn before reaching the valid `]` and non-deterministically corrupting eval trials. Replaced the O(n²) backward byte scan with the boundary-safe forward `serde_json::Deserializer::from_str(...).into_iter().next()` — the same technique already used by `tagged.rs::parse_mistral_json_payload` (DRY, faster, never indexes mid-codepoint).
- **Fence-parity shreds tool_call blocks** — an unbalanced ``` earlier in the response no longer makes a later legitimate `<tool_call>` look "inside a fence"; parity is top-level-scoped.
- **Silent partial parse-drop** — when some calls parse and one is malformed, the dropped call's diagnostic is now injected (`has_partial_success` / `parsed_call_count`, fields the prompt already supports) so the model gets a signal to re-emit.

Cargo-verified (`cargo test -p harn-vm parse`, harn-stdlib loop test) + new regression tests for each. Adversarially reviewed (SHIP). Needs a release + Burin `.harn-version` repin to reach the eval.