### PR TITLE
Clean up first-party example/test harn-check errors

### DIFF
--- a/examples/playground/echo.harn
+++ b/examples/playground/echo.harn
@@ -1,3 +1,5 @@
+import { build_prompt } from "./host"
+
 pipeline default(task) {
   let prompt = build_prompt(harness.env.get_or("HARN_TASK", "say hi"))
   let result = llm_call(prompt, "You are concise. Reply with a single sentence that acknowledges the task.")

--- a/examples/task_plan/summarize_runs.harn
+++ b/examples/task_plan/summarize_runs.harn
@@ -104,15 +104,15 @@ fn __format_strategy_label(strategy) {
 fn __strategy_summary(records, strategy) {
   let tasks_seen = __distinct(records, "task_id")
   var rows = []
-  var pass_total = 0
+  var pass_total = 0.0
   var pass_count = 0
   var struct_total = 0
   var struct_count = 0
   var det_total = 0
   var det_count = 0
-  var validate_pass = 0
+  var validate_pass = 0.0
   var validate_total = 0
-  var workflow_pass = 0
+  var workflow_pass = 0.0
   var workflow_total = 0
   var tok_in = 0
   var tok_out = 0

--- a/tests/agent/loop_control_test.harn
+++ b/tests/agent/loop_control_test.harn
@@ -14,7 +14,16 @@
 import { agent_loop_control_invoke } from "std/agent/control"
 
 // Adaptive budget so the default policy (not a caller override) is consulted.
-const BUDGET = {mode: "adaptive", initial: 8, max: 50, extend_by: 4, expose_decisions: false}
+const BUDGET = {
+  mode: "adaptive",
+  initial: 8,
+  max: 50,
+  extend_by: 4,
+  expose_decisions: false,
+  wall_clock_ms: nil,
+  total_cost_usd: nil,
+  consecutive_failures: nil,
+}
 
 /**
  * Build a loop state. `remaining` is the budget headroom: the policy only


### PR DESCRIPTION
## What

The final sweep of the typing-overhaul arc: fixes the last three real
`harn check` errors in first-party example/test `.harn` files, so the **entire
first-party corpus type-checks cleanly** (every stdlib file, example, and test).

- **examples/playground/echo.harn** — `import { build_prompt } from "./host"`
  (it was used unimported).
- **examples/task_plan/summarize_runs.harn** — pass-rate accumulators are
  fractional (`rate * 1000.0`, consumed via float division); init `0.0` not `0`.
- **tests/agent/loop_control_test.harn** — the `BUDGET` literal sets the nullable
  `wall_clock_ms` / `total_cost_usd` / `consecutive_failures` keys `AgentLoopBudget`
  requires (to `nil`); all 6 tests still pass.

## Deliberately left erroring (the errors are correct, not skipped)
- `tests/bridge/test_host_call.harn` / `test_combined.harn` exercise **dynamic**
  `host_call` (HARN-CAP-006 is the point; their mock-host assertions depend on the
  non-dotted operation names).
- `agents-protocol-replay/fixtures/valid/replay-source.harn` names its param
  `input` per the documented replay-protocol contract (it's the payload, not a
  `Harness` handle).

## Validation
- Full first-party survey (excluding the 3 intentional fixtures): **0 errors**.
- Conformance **1583 / 0**; `tests/agent/loop_control_test.harn` 6/6 pass.

Completes the typing overhaul: sound nil #3109, row polymorphism #3111, stdlib
clean #3113 + #3115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)