### PR TITLE
Parse: fix a UTF-8 char-boundary panic in the native-json preview path

### DIFF
--- a/crates/harn-vm/src/llm/tools/parse/native_json.rs
+++ b/crates/harn-vm/src/llm/tools/parse/native_json.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use super::syntax::preview_str;
+
 /// Detect and parse OpenAI-style native function calling JSON that a model
 /// emitted as raw text. Looks for `[{"id":"call_...","function":{"name":"...",
 /// "arguments":"..."}}]` patterns (array or single object) embedded anywhere
@@ -70,7 +72,7 @@ pub(crate) fn parse_native_json_tool_calls(
                         "Could not parse arguments for tool '{}': {}. Raw: {}",
                         name,
                         error,
-                        &raw[..raw.len().min(200)]
+                        preview_str(raw, 200)
                     ));
                     continue;
                 }

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -554,6 +554,46 @@ fn native_json_fallback_reports_malformed_arguments() {
 }
 
 #[test]
+fn native_json_fallback_malformed_arguments_truncates_on_char_boundary() {
+    let known = known_tools_set();
+    // Malformed `arguments` >200 bytes with a 3-byte char ('€') straddling
+    // byte index 200 (198 ASCII bytes, then '€' occupies bytes 198..201).
+    // A byte slice `&raw[..200]` would land mid-codepoint and panic; the
+    // char-safe `preview_str` helper must truncate cleanly instead.
+    let mut bad_args = String::from("x"); // leading 'x' makes this invalid JSON
+    bad_args.push_str(&"a".repeat(197)); // 198 ASCII bytes total
+    bad_args.push('€'); // bytes 198..201 — index 200 is inside this codepoint
+    bad_args.push_str(" trailing"); // ensure raw.len() > 200
+    assert!(
+        bad_args.len() > 200,
+        "args must exceed the 200-byte preview cap"
+    );
+    assert!(
+        !bad_args.is_char_boundary(200),
+        "byte 200 must fall inside a multi-byte char to exercise the panic path"
+    );
+
+    // Embed `bad_args` as a JSON string inside the native-JSON envelope.
+    let escaped = json!(bad_args).to_string();
+    let text = format!(
+        r#"[{{"id":"call_001","type":"function","function":{{"name":"edit","arguments":{escaped}}}}}]"#
+    );
+
+    let (calls, errors) = parse_native_json_tool_calls(&text, &known);
+    assert_eq!(calls.len(), 0, "should not produce a call with bad args");
+    assert_eq!(
+        errors.len(),
+        1,
+        "should report exactly one parse error, not panic"
+    );
+    assert!(
+        errors[0].contains("Could not parse arguments"),
+        "error should describe the parse failure: {}",
+        errors[0]
+    );
+}
+
+#[test]
 fn native_json_fallback_returns_empty_for_no_json() {
     let known = known_tools_set();
     let text = "Just some prose without any tool calls.";


### PR DESCRIPTION
A second UTF-8 char-boundary panic in the native-json parse PREVIEW path, distinct from the salvage-loop panic fixed by #3114. Boundary-safe slice. Regression test. (get-ahead review.)
🤖 get-ahead cheap-model-taming review (adversarially verified + cargo-tested). For the next release after v0.8.83.