### PR TITLE
Parse: native-json detection robustness

### DIFF
--- a/crates/harn-vm/src/llm/tools/parse/native_json.rs
+++ b/crates/harn-vm/src/llm/tools/parse/native_json.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeSet;
 
 /// Detect and parse OpenAI-style native function calling JSON that a model
-/// emitted as raw text. Looks for `[{"id":"call_...","function":{"name":"...",
+/// emitted as raw text. Matches `[{"id":...,"function":{"name":"...",
 /// "arguments":"..."}}]` patterns (array or single object) embedded anywhere
-/// in the text.
+/// in the text — whitespace-tolerant and id-agnostic, so pretty-printed
+/// payloads and non-`call_` ids (common from local vLLM/llama.cpp templates)
+/// parse instead of silently vanishing. See [`find_native_json_items`].
 pub(crate) fn parse_native_json_tool_calls(
     text: &str,
     known_tools: &BTreeSet<String>,
@@ -11,32 +13,7 @@ pub(crate) fn parse_native_json_tool_calls(
     let mut results = Vec::new();
     let mut errors = Vec::new();
 
-    let json_start = text
-        .find("[{\"id\":")
-        .or_else(|| text.find("[{\"id\":"))
-        .or_else(|| text.find("{\"id\":\"call_"));
-
-    let Some(start) = json_start else {
-        return (results, errors);
-    };
-
-    let json_text = &text[start..];
-    // Parse the first JSON value at `start`, stopping at its structural end so
-    // trailing prose (including multi-byte UTF-8 — emoji/accents/CJK) is simply
-    // ignored. This is the same boundary-safe streaming technique used by
-    // `tagged.rs::parse_mistral_json_payload`; the old O(n^2) backward byte
-    // scan (`&text[start..=end]`) panicked the instant `end + 1` landed inside a
-    // multi-byte codepoint, aborting the turn before it reached the valid `]`.
-    let parsed: Option<Vec<serde_json::Value>> = serde_json::Deserializer::from_str(json_text)
-        .into_iter::<serde_json::Value>()
-        .next()
-        .and_then(|result| result.ok())
-        .map(|value| match value {
-            serde_json::Value::Array(items) => items,
-            other => vec![other],
-        });
-
-    let Some(items) = parsed else {
+    let Some(items) = find_native_json_items(text) else {
         return (results, errors);
     };
 
@@ -90,4 +67,47 @@ pub(crate) fn parse_native_json_tool_calls(
     }
 
     (results, errors)
+}
+
+/// Locate a native-JSON tool-call payload anywhere in `text` and return its
+/// items (a single object is wrapped in a one-element vec).
+///
+/// Detection is whitespace- and id-agnostic: we no longer match brittle
+/// `[{"id":` / `{"id":"call_` prefixes (those silently dropped pretty-printed
+/// arrays like `[{ "id": "0", "function": {...} }]` and any non-`call_` id).
+/// Instead we walk every position where a JSON value can begin (`[` or `{`),
+/// let the boundary-safe `serde_json::Deserializer` attempt a parse, and accept
+/// the first candidate whose decoded value actually carries a tool call (an
+/// item with a `function` field). The Deserializer stops at the value's
+/// structural end, so trailing prose — including multi-byte UTF-8
+/// (emoji/accents/CJK) — is ignored without the old O(n^2) backward byte scan
+/// that panicked on mid-codepoint slicing.
+fn find_native_json_items(text: &str) -> Option<Vec<serde_json::Value>> {
+    let bytes = text.as_bytes();
+    for (offset, &byte) in bytes.iter().enumerate() {
+        if byte != b'[' && byte != b'{' {
+            continue;
+        }
+        let parsed = serde_json::Deserializer::from_str(&text[offset..])
+            .into_iter::<serde_json::Value>()
+            .next()
+            .and_then(|result| result.ok())
+            .map(|value| match value {
+                serde_json::Value::Array(items) => items,
+                other => vec![other],
+            });
+        let Some(items) = parsed else {
+            continue;
+        };
+        // Only accept JSON that looks like a native tool-call payload. This
+        // skips incidental prose JSON (config snippets, examples) without a
+        // `function` field and keeps scanning for the real call.
+        if items.iter().any(|item| {
+            item.get("function")
+                .is_some_and(serde_json::Value::is_object)
+        }) {
+            return Some(items);
+        }
+    }
+    None
 }

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -489,6 +489,30 @@ fn native_json_fallback_parses_openai_array_format() {
 }
 
 #[test]
+fn native_json_fallback_parses_pretty_printed_non_call_id() {
+    // Regression: detection used three brittle substring needles
+    // (`[{"id":` / a byte-identical dead duplicate / `{"id":"call_`), so a
+    // pretty-printed native array with a space after `[{` AND a non-OpenAI id
+    // (no `call_` prefix) matched NONE of them — the entire tool call was
+    // silently dropped with zero parse feedback, reading to the loop as a
+    // stall. Local vLLM/llama.cpp tool templates and pretty-printers emit
+    // exactly this shape. Detection is now whitespace- and id-agnostic.
+    let known = known_tools_set();
+    let text =
+        r#"[{ "id": "0", "function": { "name": "read", "arguments": "{\"path\":\"main.go\"}" } }]"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(calls.len(), 1, "should parse the pretty-printed call");
+    assert_eq!(calls[0]["name"], json!("read"));
+    assert_eq!(calls[0]["arguments"]["path"], json!("main.go"));
+    assert_eq!(
+        calls[0]["id"],
+        json!("0"),
+        "non-call_ id should be preserved"
+    );
+}
+
+#[test]
 fn normalize_tool_args_coerces_integer_like_string_fields() {
     let normalized = normalize_tool_args(
         "edit",


### PR DESCRIPTION
Native-json detection robustness fix layered on #3114. cargo-tested. (get-ahead review.)
🤖 get-ahead cheap-model-taming review (adversarially verified + cargo-tested). For the next release after v0.8.83.