### PR TITLE
Accept nested XML text tool calls

### DIFF
--- a/changelog.d/3132.fixed.md
+++ b/changelog.d/3132.fixed.md
@@ -1,0 +1,4 @@
+- **Text-tool parsing now recovers registered XML-wrapped JSON tool calls
+  (#3132).** Harn accepts `<tool_call><tool>{...}</tool></tool_call>` for
+  registered tools, rewrites replay to canonical `tool({ ... })` syntax, and
+  still rejects unknown XML tags.

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -672,11 +672,7 @@ fn try_parse_angle_wrapped_call(
     }
     let name_str = std::str::from_utf8(&bytes[name_start..name_start + name_len]).ok()?;
     // Only known tools are eligible — keeps `<notes>...` out of the path.
-    let known: BTreeSet<String> = collect_tool_schemas(tools_val, None)
-        .into_iter()
-        .map(|schema| schema.name)
-        .chain(["ledger".to_string(), "load_skill".to_string()])
-        .collect();
+    let known = known_tool_names_with_implicit(tools_val);
     if !known.contains(name_str) {
         return None;
     }
@@ -747,11 +743,7 @@ fn leading_call_name(body: &str, tools_val: Option<&VmValue>) -> Option<String> 
         return None;
     }
     let name = &trimmed[..name_len];
-    let known: BTreeSet<String> = collect_tool_schemas(tools_val, None)
-        .into_iter()
-        .map(|schema| schema.name)
-        .chain(["ledger".to_string(), "load_skill".to_string()])
-        .collect();
+    let known = known_tool_names_with_implicit(tools_val);
     known.contains(name).then(|| name.to_string())
 }
 
@@ -863,6 +855,9 @@ fn parse_single_tool_call(
     if let Some(call) = parse_json_tool_call_body(body, tools_val)? {
         return Ok(call);
     }
+    if let Some(call) = parse_xml_wrapped_json_args_body(body, tools_val)? {
+        return Ok(call);
+    }
     let inner = parse_bare_calls_in_body(body, tools_val);
     if let Some(err) = inner.errors.into_iter().next() {
         return Err(err);
@@ -881,6 +876,64 @@ fn parse_single_tool_call(
         ));
     }
     Ok(inner.calls.into_iter().next().expect("len == 1"))
+}
+
+fn known_tool_names_with_implicit(tools_val: Option<&VmValue>) -> BTreeSet<String> {
+    collect_tool_schemas(tools_val, None)
+        .into_iter()
+        .map(|schema| schema.name)
+        .chain(["ledger".to_string(), "load_skill".to_string()])
+        .collect()
+}
+
+fn parse_xml_wrapped_json_args_body(
+    body: &str,
+    tools_val: Option<&VmValue>,
+) -> Result<Option<serde_json::Value>, String> {
+    let trimmed = body.trim();
+    let bytes = trimmed.as_bytes();
+    if bytes.first() != Some(&b'<') {
+        return Ok(None);
+    }
+    let name_start = 1usize;
+    let Some(name_len) = ident_length(&bytes[name_start..]) else {
+        return Ok(None);
+    };
+    let name_end = name_start + name_len;
+    if bytes.get(name_end) != Some(&b'>') {
+        return Ok(None);
+    }
+    let name = &trimmed[name_start..name_end];
+    let close = format!("</{name}>");
+    if !trimmed.ends_with(&close) {
+        return Ok(None);
+    }
+    let known = known_tool_names_with_implicit(tools_val);
+    if !known.contains(name) {
+        let available: Vec<_> = known.iter().take(20).cloned().collect();
+        return Err(format!(
+            "Unknown tool '{}' in nested XML tool-call body. Available tools: [{}]",
+            name,
+            available.join(", ")
+        ));
+    }
+    let inner = trimmed[name_end + 1..trimmed.len() - close.len()].trim();
+    let arguments: serde_json::Value = serde_json::from_str(inner).map_err(|error| {
+        format!(
+            "<tool_call><{name}> body did not parse as a JSON object: {error}. \
+             Emit `<tool_call>{name}({{ ... }})</tool_call>` instead."
+        )
+    })?;
+    if !arguments.is_object() {
+        return Err(format!(
+            "Nested XML arguments for tool '{name}' must be a JSON object, got `{arguments}`."
+        ));
+    }
+    Ok(Some(serde_json::json!({
+        "id": format!("tc_xml_{name}"),
+        "name": name,
+        "arguments": arguments,
+    })))
 }
 
 fn parse_json_tool_call_body(
@@ -925,11 +978,7 @@ fn parse_json_tool_call_body(
     if name.is_empty() {
         return Err("<tool_call> JSON body did not contain a tool name".to_string());
     }
-    let known: BTreeSet<String> = collect_tool_schemas(tools_val, None)
-        .into_iter()
-        .map(|schema| schema.name)
-        .chain(["ledger".to_string(), "load_skill".to_string()])
-        .collect();
+    let known = known_tool_names_with_implicit(tools_val);
     if !known.contains(name) {
         let available: Vec<_> = known.iter().take(20).cloned().collect();
         return Err(format!(

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -211,6 +211,49 @@ fn tagged_parser_accepts_gemma_json_tool_call_body() {
 }
 
 #[test]
+fn tagged_parser_accepts_nested_xml_json_args_tool_call_body() {
+    // Some OpenAI-compatible value routes emit a generic XML function wrapper
+    // inside Harn's `<tool_call>` block, for example:
+    // `<tool_call><edit>{"action":"create",...}</edit></tool_call>`.
+    // Recover only registered tool names and JSON-object arguments.
+    let tools = sample_tool_registry();
+    let text = r#"<tool_call><edit>{"action":"create","path":"a.rs","content":"fn a() {}"}</edit></tool_call>"#;
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    assert!(
+        result.violations.is_empty(),
+        "violations: {:?}",
+        result.violations
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(result.calls.len(), 1);
+    assert_eq!(result.calls[0]["name"], json!("edit"));
+    assert_eq!(result.calls[0]["arguments"]["path"], json!("a.rs"));
+    assert!(
+        result.canonical.contains("edit({"),
+        "canonical replay should use Harn syntax: {}",
+        result.canonical
+    );
+}
+
+#[test]
+fn tagged_parser_rejects_unknown_nested_xml_tool_call_body() {
+    let tools = sample_tool_registry();
+    let text = r#"<tool_call><deploy>{"target":"prod"}</deploy></tool_call>"#;
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    assert!(result.calls.is_empty(), "unknown tool must not execute");
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|error| error.contains("Unknown tool 'deploy'")),
+        "unknown inner tag should be an actionable parse error: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn tagged_parser_recovers_mistral_tool_markers() {
     let tools = sample_tool_registry();
     let text = "I'll inspect first.[TOOL_CALLS]edit[ARGS]{\"action\":\"create\",\"path\":\"a.rs\"}";


### PR DESCRIPTION
## Summary
- accept `<tool_call><registered_tool>{...}</registered_tool></tool_call>` as a recoverable text-tool shape
- keep the guard constrained to registered/implicit tool names and JSON-object arguments
- canonicalize replay back to Harn's normal `<tool_call>name({ ... })</tool_call>` syntax

## Why
A Burin v0.8.85 diagnostic on OpenRouter DeepSeek showed repeated parse guidance because the model emitted XML-ish function wrappers inside `<tool_call>` blocks, for example `<tool_call><edit>{...}</edit></tool_call>`. Harn already has narrowly scoped parser tolerance for known value-model formats (Gemma JSON bodies, Mistral markers, DeepSeek DSML, Qwen angle calls); this adds the same kind of compatibility for a common OpenAI-compatible XML wrapper while rejecting unknown tags.

## Validation
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-codex-xml-nested cargo test -p harn-vm tagged_parser_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-codex-xml-nested cargo test -p harn-vm llm::tools::tests::validation_and_tagged --lib -- --nocapture`
- pre-commit ratchets + changed-package clippy
- pre-push targeted checks
