### PR TITLE
Add catalog-equivalent LLM failover option

### DIFF
--- a/changelog.d/3135.added.md
+++ b/changelog.d/3135.added.md
@@ -1,0 +1,5 @@
+- **LLM calls can opt into catalog-equivalent provider failover (#3135).**
+  Passing `equivalent_failover: true` now builds a first-class routing policy
+  from compatible same-logical-model catalog routes, preserving routing receipts,
+  budget checks, and transcript metadata while failing over on provider outages
+  and rate limits.

--- a/crates/harn-vm/src/llm/helpers/options/extract.rs
+++ b/crates/harn-vm/src/llm/helpers/options/extract.rs
@@ -31,7 +31,8 @@ pub(crate) fn extract_llm_options(
     apply_model_role_defaults(&mut options);
     apply_active_step_defaults(&mut options);
 
-    let routing_policy = crate::llm::routing::extract_routing_policy(options.as_ref())?;
+    let mut routing_policy = crate::llm::routing::extract_routing_policy(options.as_ref())?;
+    let explicit_routing_policy = routing_policy.is_some();
     let route_policy = parse_route_policy_option(options.as_ref())?;
     let mut provider = vm_resolve_provider(&options);
     let mut model = vm_resolve_model(&options, &provider);
@@ -39,6 +40,15 @@ pub(crate) fn extract_llm_options(
     if let Some(decision) = routing_decision.as_ref() {
         provider = decision.selected_provider.clone();
         model = decision.selected_model.clone();
+    }
+    let equivalent_failover_policy = parse_equivalent_failover_option(
+        options.as_ref(),
+        &provider,
+        &model,
+        explicit_routing_policy,
+    )?;
+    if routing_policy.is_none() {
+        routing_policy = equivalent_failover_policy;
     }
     // A routing_policy chain owns provider/model selection: snap the
     // base options to the first link so transcript-only consumers see

--- a/crates/harn-vm/src/llm/helpers/options/routing.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const DEFAULT_EQUIVALENT_FAILOVER_MAX_ROUTES: usize = 3;
+
 pub(super) fn quality_rank(tier: &str) -> i32 {
     match tier.to_ascii_lowercase().as_str() {
         "small" => 0,
@@ -178,6 +180,74 @@ pub(super) fn parse_fallback_chain_option(
         _ => {}
     }
     out
+}
+
+pub(super) fn parse_equivalent_failover_option(
+    options: Option<&BTreeMap<String, VmValue>>,
+    provider: &str,
+    model: &str,
+    explicit_routing_policy: bool,
+) -> Result<Option<std::sync::Arc<crate::llm::routing::RoutingPolicyConfig>>, VmError> {
+    let Some(raw) = options.and_then(|o| o.get("equivalent_failover")) else {
+        return Ok(None);
+    };
+
+    let mut enabled = true;
+    let mut max_routes = DEFAULT_EQUIVALENT_FAILOVER_MAX_ROUTES;
+    match raw {
+        VmValue::Nil | VmValue::Bool(false) => return Ok(None),
+        VmValue::Bool(true) => {}
+        VmValue::Dict(dict) => {
+            if let Some(value) = dict.get("enabled") {
+                enabled = match value {
+                    VmValue::Nil => true,
+                    VmValue::Bool(value) => *value,
+                    other => {
+                        return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+                            format!(
+                                "equivalent_failover.enabled: expected bool, got {}",
+                                other.type_name()
+                            ),
+                        ))));
+                    }
+                };
+            }
+            if let Some(value) = dict.get("max_routes") {
+                let raw_max = value.as_int().ok_or_else(|| {
+                    VmError::Thrown(VmValue::String(std::sync::Arc::from(
+                        "equivalent_failover.max_routes: expected a positive integer",
+                    )))
+                })?;
+                if raw_max < 1 {
+                    return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+                        "equivalent_failover.max_routes: expected a positive integer",
+                    ))));
+                }
+                max_routes = raw_max as usize;
+            }
+        }
+        other => {
+            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+                format!(
+                    "equivalent_failover: expected bool or dict, got {}",
+                    other.type_name()
+                ),
+            ))));
+        }
+    }
+
+    if !enabled {
+        return Ok(None);
+    }
+    if explicit_routing_policy {
+        return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+            "equivalent_failover cannot be combined with explicit routing_policy(...)",
+        ))));
+    }
+
+    Ok(crate::llm::routing::build_equivalent_failover_policy(
+        provider, model, max_routes,
+    ))
 }
 
 pub(super) fn route_alternative(

--- a/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
@@ -1,7 +1,9 @@
 use super::extract::*;
 use super::*;
 
-use crate::llm_config::{AliasDef, AuthEnv, ProviderDef, ProvidersConfig, TierRule};
+use crate::llm_config::{
+    AliasDef, AuthEnv, ModelAvailability, ModelDef, ProviderDef, ProvidersConfig, TierRule,
+};
 
 fn install_test_routes() {
     let mut overlay = ProvidersConfig::default();
@@ -59,6 +61,87 @@ fn install_test_routes() {
         contains: None,
         tier: "mid".to_string(),
     });
+    crate::llm_config::set_user_overrides(Some(overlay));
+    super::super::reset_provider_key_cache();
+}
+
+fn test_provider(url: &str) -> ProviderDef {
+    ProviderDef {
+        base_url: url.to_string(),
+        auth_style: "none".to_string(),
+        auth_env: AuthEnv::None,
+        chat_endpoint: "/chat/completions".to_string(),
+        cost_per_1k_in: Some(0.0),
+        cost_per_1k_out: Some(0.0),
+        latency_p50_ms: Some(1000),
+        ..Default::default()
+    }
+}
+
+fn test_equivalent_model(provider: &str, group: &str) -> ModelDef {
+    ModelDef {
+        name: format!("{provider} equivalent model"),
+        provider: provider.to_string(),
+        context_window: 32_000,
+        logical_model: None,
+        equivalence_group: Some(group.to_string()),
+        served_variant: None,
+        wire_model: None,
+        api_dialect: None,
+        rate_limits: None,
+        architecture: None,
+        local_memory: None,
+        runtime_context_window: None,
+        stream_timeout: None,
+        capabilities: Vec::new(),
+        pricing: None,
+        deprecated: false,
+        deprecation_note: None,
+        superseded_by: None,
+        fast_mode: None,
+        quality_tags: Vec::new(),
+        availability: ModelAvailability::Serverless,
+        tier: Some("mid".to_string()),
+        open_weight: Some(true),
+        strengths: Vec::new(),
+        benchmarks: BTreeMap::new(),
+        family: Some("test-equivalent-family".to_string()),
+        lineage: None,
+        complementary_with: Vec::new(),
+        avoid_as_reviewer_for: Vec::new(),
+    }
+}
+
+fn install_equivalent_routes() {
+    let mut overlay = ProvidersConfig::default();
+    overlay.providers.insert(
+        "primary".to_string(),
+        test_provider("https://primary.example/v1"),
+    );
+    overlay.providers.insert(
+        "backup-a".to_string(),
+        test_provider("https://backup-a.example/v1"),
+    );
+    overlay.providers.insert(
+        "backup-b".to_string(),
+        test_provider("https://backup-b.example/v1"),
+    );
+    overlay.models.insert(
+        "primary-model".to_string(),
+        test_equivalent_model("primary", "test-equivalent-model"),
+    );
+    overlay.models.insert(
+        "backup-a-model".to_string(),
+        test_equivalent_model("backup-a", "test-equivalent-model"),
+    );
+    overlay.models.insert(
+        "backup-b-model".to_string(),
+        test_equivalent_model("backup-b", "test-equivalent-model"),
+    );
+    overlay.models.insert(
+        "same-provider-model".to_string(),
+        test_equivalent_model("primary", "test-equivalent-model"),
+    );
     crate::llm_config::set_user_overrides(Some(overlay));
     super::super::reset_provider_key_cache();
 }
@@ -419,6 +502,92 @@ fn preference_list_cheapest_first_sets_route_fallbacks() {
     assert_eq!(opts.route_fallbacks.len(), 1);
     assert_eq!(opts.route_fallbacks[0].provider, "fast");
     assert_eq!(opts.route_fallbacks[0].model, "fast-mid-model");
+    crate::llm_config::clear_user_overrides();
+    super::super::reset_provider_key_cache();
+}
+
+#[test]
+fn equivalent_failover_builds_catalog_backed_routing_policy() {
+    install_equivalent_routes();
+    let mut failover = BTreeMap::new();
+    failover.insert("max_routes".to_string(), VmValue::Int(2));
+    let opts = extract_with_options(BTreeMap::from([
+        (
+            "provider".to_string(),
+            VmValue::String(std::sync::Arc::from("primary")),
+        ),
+        (
+            "model".to_string(),
+            VmValue::String(std::sync::Arc::from("primary-model")),
+        ),
+        (
+            "equivalent_failover".to_string(),
+            VmValue::Dict(std::sync::Arc::new(failover)),
+        ),
+    ]))
+    .expect("options");
+
+    let policy = opts.routing_policy.expect("equivalent routing policy");
+    assert_eq!(opts.provider, "primary");
+    assert_eq!(opts.model, "primary-model");
+    assert_eq!(policy.label, "equivalent_failover(primary:primary-model)");
+    assert_eq!(policy.chain.len(), 2);
+    assert_eq!(policy.chain[0].provider, "primary");
+    assert_eq!(policy.chain[0].model, "primary-model");
+    assert_eq!(policy.chain[1].provider, "backup-a");
+    assert_eq!(policy.chain[1].model, "backup-a-model");
+    assert!(policy
+        .chain
+        .iter()
+        .all(|link| link.model != "same-provider-model"));
+    assert_eq!(policy.failover.max_attempts, Some(2));
+
+    crate::llm_config::clear_user_overrides();
+    super::super::reset_provider_key_cache();
+}
+
+#[test]
+fn equivalent_failover_rejects_explicit_routing_policy() {
+    install_equivalent_routes();
+    let chain = VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
+        std::sync::Arc::new(BTreeMap::from([
+            (
+                "provider".to_string(),
+                VmValue::String(std::sync::Arc::from("primary")),
+            ),
+            (
+                "model".to_string(),
+                VmValue::String(std::sync::Arc::from("primary-model")),
+            ),
+        ])),
+    )]));
+    let routing =
+        crate::llm::routing::build_routing_policy(&BTreeMap::from([("chain".to_string(), chain)]))
+            .expect("routing policy");
+
+    let err = match extract_with_options(BTreeMap::from([
+        (
+            "provider".to_string(),
+            VmValue::String(std::sync::Arc::from("primary")),
+        ),
+        (
+            "model".to_string(),
+            VmValue::String(std::sync::Arc::from("primary-model")),
+        ),
+        ("routing".to_string(), routing),
+        ("equivalent_failover".to_string(), VmValue::Bool(true)),
+    ])) {
+        Ok(_) => panic!("ambiguous routing should fail"),
+        Err(err) => err,
+    };
+
+    match err {
+        VmError::Thrown(VmValue::String(message)) => {
+            assert!(message.contains("cannot be combined"), "{message}");
+        }
+        other => panic!("expected thrown ambiguity error, got {other:?}"),
+    }
+
     crate::llm_config::clear_user_overrides();
     super::super::reset_provider_key_cache();
 }

--- a/crates/harn-vm/src/llm/routing.rs
+++ b/crates/harn-vm/src/llm/routing.rs
@@ -37,6 +37,70 @@ const DEFAULT_RACE_PRIMARY_TIMEOUT_MS: u64 = 120_000;
 
 const DEFAULT_FAILOVER_STATUSES: &[u16] = &[408, 429, 500, 502, 503, 504];
 
+/// Build a first-class routing policy from catalog-declared same-logical-model
+/// routes. This intentionally feeds the existing routing executor instead of
+/// adding another transport fallback path, so receipts, budget checks, and
+/// transcript metadata stay in one schema.
+pub(crate) fn build_equivalent_failover_policy(
+    provider: &str,
+    model: &str,
+    max_routes: usize,
+) -> Option<Arc<RoutingPolicyConfig>> {
+    if max_routes < 2 {
+        return None;
+    }
+
+    let mut chain = vec![ChainLink {
+        provider: provider.to_string(),
+        model: model.to_string(),
+        timeout_ms: None,
+        label: Some("primary".to_string()),
+    }];
+
+    for (candidate_model, candidate) in crate::llm_config::equivalent_model_catalog_entries(model) {
+        if chain.len() >= max_routes {
+            break;
+        }
+        if candidate.provider == provider {
+            continue;
+        }
+        if chain
+            .iter()
+            .any(|link| link.provider == candidate.provider && link.model == candidate_model)
+        {
+            continue;
+        }
+        if super::helpers::resolve_api_key(&candidate.provider).is_err() {
+            continue;
+        }
+        chain.push(ChainLink {
+            provider: candidate.provider.clone(),
+            model: candidate_model,
+            timeout_ms: None,
+            label: Some(format!("equivalent:{}", candidate.provider)),
+        });
+    }
+
+    if chain.len() < 2 {
+        return None;
+    }
+
+    let label = format!("equivalent_failover({provider}:{model})");
+    Some(Arc::new(RoutingPolicyConfig {
+        failover: FailoverRules {
+            max_attempts: Some(chain.len()),
+            ..FailoverRules::default()
+        },
+        latency: LatencyRules::default(),
+        budget: BudgetRules::default(),
+        observe: ObserveRules::default(),
+        escalate_on: Vec::new(),
+        max_refines_per_link: 0,
+        label,
+        chain,
+    }))
+}
+
 /// What to do when a budget cap is exceeded while the chain is running.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BudgetExceedAction {


### PR DESCRIPTION
## Summary
- add opt-in `equivalent_failover` LLM call option that synthesizes a first-class routing policy from catalog-equivalent routes
- reuse the existing routing executor so failover attempts keep routing receipts, budget checks, and transcript metadata in one schema
- reject ambiguous `routing_policy(...)` + `equivalent_failover: true` combinations

Closes #3134.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-equivalent-failover cargo test -p harn-vm equivalent_failover --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-equivalent-failover cargo test -p harn-vm llm::helpers::options::routing_tests --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-equivalent-failover cargo test -p harn-vm llm::routing --lib`
- `cargo fmt --check`
- pre-commit clippy on changed package (`harn-vm`)
