### PR TITLE
Harn cheap-model hardening (v0.8.88 batch): parser tolerance, narration-as-prose, code-bearing args, tool_format reject-or-work-well, [no-compact] pin

### DIFF
--- a/changelog.d/args-grammar-tolerance.fixed.md
+++ b/changelog.d/args-grammar-tolerance.fixed.md
@@ -1,0 +1,16 @@
+- **Tool-call argument grammar now accepts the code-bearing value shapes weak
+  value models naturally emit**, instead of dropping the turn to
+  parse-guidance. Three shapes from the transcript corpus now parse and
+  canonicalize back to `name({ ... })` on replay: (1) `+`-concatenated
+  string/template fragments — including the multi-line backtick template
+  literals and `` `…` + "`json:\"x\"`" + `…` `` struct-tag concatenation Go
+  forces — collapse into one string value; (2) a heredoc whose closing tag is
+  indented, misspelled, or omitted but whose call is structurally closed (a
+  trailing `})`/`)` call-tail) is implicitly terminated at that tail; and (3)
+  `=` is accepted as a synonym for `:` as the object key/value separator
+  (`{ new_body= <<EOF … }`). A flat JSON-RPC/MCP envelope
+  (`[{"name":"read","arguments":{…}}]` or a single object with `parameters`)
+  also maps to the matching call. The recover/reject boundary stays sharp: a
+  `+` with a non-string right operand, a heredoc body truncated mid-token with
+  no structural tail, an ambiguous bare-`}` code close, and prose JSON that
+  merely has a `name` key all still error loudly.

--- a/changelog.d/assistant-prose-narration.fixed.md
+++ b/changelog.d/assistant-prose-narration.fixed.md
@@ -1,0 +1,13 @@
+- **Text tool-call parser no longer wastes a turn on narration wrapped in
+  `<tool_call>` tags.** Weak value models (DeepSeek) wrap their thinking in
+  `<assistant_prose>` *inside* a `<tool_call>` block. The parser previously
+  treated this as a malformed call, dropped it, and emitted a "could not be
+  parsed" diagnostic — costing the model its whole turn for merely narrating.
+  Such a block is now reclassified as assistant narration: the inner text is
+  preserved as prose, no tool call and no parse error are emitted, and a
+  prose-only turn surfaces to the loop as "said X but took no action" so the
+  normal no-tool-call nudge applies. If the same wrapper also carries a real
+  `name({ ... })` / nested-XML call, that call is still recovered and
+  dispatched. The allowance is scoped to a small narration allowlist
+  (`assistant_prose`, `thinking`, `reasoning`); unknown wrapped tags that look
+  like attempted calls (e.g. `<frobnicate>{...}`) are still rejected.

--- a/changelog.d/honor-no-compact-pin.fixed.md
+++ b/changelog.d/honor-no-compact-pin.fixed.md
@@ -1,0 +1,13 @@
+- **Transcript compaction now honors the host `[no-compact]` pin so an agent's
+  live grounding survives a compaction pass.** Both compaction surfaces in the
+  `observation_mask` strategy — archived-window masking and kept-window
+  `clamp_tool_outputs` length-clamping — now treat any tool-output or message
+  body that contains the literal `[no-compact]` marker (emitted by the host
+  around the current file view and the just-edited window) as pinned: masking
+  preserves it verbatim and clamping leaves it intact. Previously the marker was
+  ignored, so on long sessions the model lost sight of the file it was editing,
+  then drifted, re-read, and stalled. The pin is bounded to the most recent
+  `MAX_PINNED_SEGMENTS` (3) pinned bodies — older duplicate snapshots from
+  earlier in the session compact normally — so a pin can never accumulate
+  unbounded and overflow the context window. With no pins present, compaction
+  behaves exactly as before.

--- a/changelog.d/toolcall-bootcamp-tool-format-validation.changed.md
+++ b/changelog.d/toolcall-bootcamp-tool-format-validation.changed.md
@@ -1,0 +1,25 @@
+- **`tool_format` is now reject-or-work-well: a bad value fails loudly instead
+  of silently degrading.** The agent-loop `tool_format` knob
+  (`agent_tool_format_resolution` in `std/agent/options`) previously accepted
+  any explicit string verbatim — a typo like `"nativ"` or a wrong value like
+  `"json"` / `"tool_use"` flowed straight through as `source: "explicit"` with
+  no warning, and every downstream branch that gates on `tool_format ==
+  "native"` read it as `false`, so the agent silently ran the text protocol.
+  Resolution now throws on any value that is not `native`, `text`, `auto`, or
+  omitted. It also rejects requesting the side the capability matrix marks
+  *impossible* for a model (`native` on a `text_only` model, or `text` on a
+  `native_only` model); pass `tool_format_override_reason` to force the marked
+  side deliberately (probe/matrix use). `*_unreliable` parity stays a
+  recoverable warning, not a hard reject.
+- **The provider-catalog validator now rejects alias `tool_format` pins that
+  the target model cannot serve.** An alias may only pin `tool_format =
+  "native"` / `"text"`, and only when the model's `tool_support` advertises
+  that side. This caught a real shipped footgun: the
+  `ollama-devstral-small-2-native` alias pinned `native` on a model the
+  capability matrix marks `native_tools = false` (`text_only`). That alias has
+  been removed — Devstral Small 2 on Ollama is text-tool-only.
+- Added a deterministic tool-calling boot-camp battery
+  (`crates/harn-vm/tests/tool_calling_bootcamp.rs`) that exercises the real
+  resolution layer across a pairwise sample of {capability-profile ×
+  requested-format × config-source} and asserts the reject-or-work-well
+  invariant with zero live LLM calls.

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -123,6 +123,75 @@ fn __valid_tool_format(value) {
   return nil
 }
 
+/**
+ * Reject an explicit `tool_format` that is neither `native`, `text`, nor a
+ * recognized auto sentinel. Without this, a typo like `"nativ"` or a wrong
+ * value like `"json"` / `"tool_use"` silently flows through resolution
+ * (`source: "explicit"`, no override event), and every downstream branch that
+ * gates on `tool_format == "native"` reads it as `false` — so the agent
+ * silently runs the text protocol instead of either honoring the request or
+ * failing loudly. This is the "never silently half-supported" gate for the
+ * single knob harness authors touch most. `auto`/`""`/nil are handled before
+ * this is reached and never land here.
+ *
+ * @effects: []
+ * @allocation: none
+ * @errors: [agent_loop_invalid_tool_format]
+ * @api_stability: experimental
+ */
+fn __validate_explicit_tool_format(value) {
+  if __valid_tool_format(value) == nil {
+    throw "agent_loop: `tool_format` must be one of native, text, auto (or omitted); got "
+      + to_string(value)
+  }
+}
+
+/**
+ * Reject a tool_format the catalog marks as *impossible* for this model
+ * (`native_only` asked for `text`, or `text_only` asked for `native`). Unlike
+ * the `*_unreliable` parity classes — which stay a recoverable warning the
+ * harness author can override with a reason — the `*_only` classes mean the
+ * requested side does not work at all, so honoring the request would silently
+ * produce a broken request envelope. Rejecting here turns a silent quirk into
+ * a loud, actionable error.
+ *
+ * Escape hatch: a non-empty `tool_format_override_reason` lets a probe / matrix
+ * harness force the marked-impossible side deliberately. That keeps the "never
+ * SILENTLY half-supported" invariant — the only way past the gate is an
+ * explicit, recorded acknowledgment, mirroring the `*_unreliable` reason path.
+ *
+ * @effects: []
+ * @allocation: none
+ * @errors: [agent_loop_unsupported_tool_format]
+ * @api_stability: experimental
+ */
+fn __validate_tool_format_parity(pair, requested, parity, override_reason) {
+  let requested_format = __valid_tool_format(requested)
+  if requested_format == nil || pair == nil {
+    return
+  }
+  if override_reason != nil {
+    return
+  }
+  let catalog_parity = __catalog_parity(parity)
+  if catalog_parity == "native_only" && requested_format == "text" {
+    throw "agent_loop: tool_format \"text\" is unsupported for "
+      + pair.provider
+      + ":"
+      + pair.model
+      + " (catalog parity native_only — this model only does native tool calling). "
+      + "Pass tool_format_override_reason to force it deliberately."
+  }
+  if catalog_parity == "text_only" && requested_format == "native" {
+    throw "agent_loop: tool_format \"native\" is unsupported for "
+      + pair.provider
+      + ":"
+      + pair.model
+      + " (catalog parity text_only — this model only does text tool calling). "
+      + "Pass tool_format_override_reason to force it deliberately."
+  }
+}
+
 fn __optional_text(value) {
   if value == nil {
     return nil
@@ -284,6 +353,7 @@ pub fn agent_tool_format_resolution(options = nil) {
   let opts = options ?? {}
   let explicit = __explicit_tool_format(opts)
   if explicit != nil {
+    __validate_explicit_tool_format(explicit)
     let pair = __tool_format_pair(opts)
     var preferred = nil
     var parity = nil
@@ -297,6 +367,12 @@ pub fn agent_tool_format_resolution(options = nil) {
         parity = resolved_caps?.tool_mode_parity
       }
     }
+    __validate_tool_format_parity(
+      pair,
+      explicit,
+      parity,
+      __optional_text(opts?.tool_format_override_reason),
+    )
     return {
       tool_format: explicit,
       source: "explicit",

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -236,7 +236,8 @@ id = "devstral-small-2:24b"
 provider = "ollama"
 tool_format = "text"
 
-[aliases.ollama-devstral-small-2-native]
-id = "devstral-small-2:24b"
-provider = "ollama"
-tool_format = "native"
+# NOTE: there is intentionally no `ollama-devstral-small-2-native` alias.
+# Devstral Small 2 on Ollama is text-tool-only (see the `devstral-small-2*`
+# capability rule: native_tools = false). A `tool_format = "native"` pin here
+# would be silently half-supported — accepted by resolution but degraded to
+# the text protocol downstream — which the catalog validator now rejects.

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -834,10 +834,11 @@ id = "devstral-small-2:24b"
 provider = "ollama"
 tool_format = "text"
 
-[aliases.ollama-devstral-small-2-native]
-id = "devstral-small-2:24b"
-provider = "ollama"
-tool_format = "native"
+# NOTE: there is intentionally no `ollama-devstral-small-2-native` alias.
+# Devstral Small 2 on Ollama is text-tool-only (see the `devstral-small-2*`
+# capability rule: native_tools = false). A `tool_format = "native"` pin here
+# would be silently half-supported — accepted by resolution but degraded to
+# the text protocol downstream — which the catalog validator now rejects.
 
 # --- source: 30-aliases/tool-calling.toml ---
 # ── Alias tool-calling probe state ───────────────────────────────────────────

--- a/crates/harn-vm/src/llm/tools/parse/native_json.rs
+++ b/crates/harn-vm/src/llm/tools/parse/native_json.rs
@@ -20,10 +20,20 @@ pub(crate) fn parse_native_json_tool_calls(
     };
 
     for item in items {
+        // Two envelope shapes carry a tool call:
+        //   1. OpenAI native: `{"function":{"name":..,"arguments":..}}`.
+        //   2. JSON-RPC / MCP-ish flat: `{"name":..,"arguments"|"parameters":..}`
+        //      — value models emit this when they ignore the text format and
+        //      reach for a generic function-call envelope. Read `name` +
+        //      `arguments`/`parameters` from whichever object actually carries
+        //      them (the nested `function`, else the item itself).
+        let Some(item_obj) = item.as_object() else {
+            continue;
+        };
         let func = item
             .get("function")
-            .and_then(|function| function.as_object());
-        let Some(func) = func else { continue };
+            .and_then(|function| function.as_object())
+            .unwrap_or(item_obj);
         let name = func
             .get("name")
             .and_then(|name| name.as_str())
@@ -41,7 +51,8 @@ pub(crate) fn parse_native_json_tool_calls(
             continue;
         }
         // OpenAI format encodes arguments as a JSON string; others as an object.
-        let arguments = match func.get("arguments") {
+        // The flat JSON-RPC/MCP envelope sometimes names the slot `parameters`.
+        let arguments = match func.get("arguments").or_else(|| func.get("parameters")) {
             Some(serde_json::Value::String(raw)) => match serde_json::from_str(raw) {
                 Ok(value) => value,
                 Err(error) => {
@@ -80,8 +91,9 @@ pub(crate) fn parse_native_json_tool_calls(
 /// Instead we walk every position where a JSON value can begin (`[` or `{`),
 /// let the boundary-safe `serde_json::Deserializer` attempt a parse, and accept
 /// the first candidate whose decoded value actually carries a tool call (an
-/// item with a `function` field). The Deserializer stops at the value's
-/// structural end, so trailing prose — including multi-byte UTF-8
+/// item with a `function` object, or a flat `name` + `arguments`/`parameters`
+/// envelope — see the acceptance check below). The Deserializer stops at the
+/// value's structural end, so trailing prose — including multi-byte UTF-8
 /// (emoji/accents/CJK) — is ignored without the old O(n^2) backward byte scan
 /// that panicked on mid-codepoint slicing.
 fn find_native_json_items(text: &str) -> Option<Vec<serde_json::Value>> {
@@ -102,11 +114,24 @@ fn find_native_json_items(text: &str) -> Option<Vec<serde_json::Value>> {
             continue;
         };
         // Only accept JSON that looks like a native tool-call payload. This
-        // skips incidental prose JSON (config snippets, examples) without a
-        // `function` field and keeps scanning for the real call.
+        // skips incidental prose JSON (config snippets, examples) and keeps
+        // scanning for the real call. Two payload shapes qualify:
+        //   - OpenAI native: an item with an object `function` field.
+        //   - flat JSON-RPC/MCP: an item with a string `name` AND an
+        //     `arguments`/`parameters` object — the generic function-call
+        //     envelope value models reach for when ignoring the text format.
+        // Requiring the args object (not just a bare `name`) keeps prose JSON
+        // that merely has a `name` key (config, package.json) from matching.
         if items.iter().any(|item| {
             item.get("function")
                 .is_some_and(serde_json::Value::is_object)
+                || (item.get("name").is_some_and(serde_json::Value::is_string)
+                    && (item
+                        .get("arguments")
+                        .is_some_and(serde_json::Value::is_object)
+                        || item
+                            .get("parameters")
+                            .is_some_and(serde_json::Value::is_object)))
         }) {
             return Some(items);
         }

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -310,10 +310,95 @@ pub(crate) fn scan_heredoc(src: &str, start: usize) -> Result<HeredocSpan, Hered
         if bytes.get(pos) == Some(&b'\n') {
             pos += 1;
         } else {
-            return Err(HeredocError::Unterminated { tag });
+            // Last physical line, no trailing newline, not the closing tag.
+            return unterminated_or_implicit_close(src, content_start, tag);
         }
     }
-    Err(HeredocError::Unterminated { tag })
+    unterminated_or_implicit_close(src, content_start, tag)
+}
+
+/// Recover a heredoc whose closing tag the model botched (indented, misspelled,
+/// or omitted) but which is otherwise a complete, structurally-closed call.
+///
+/// Value models routinely write `new_body: <<EOF\n...body...\n})` — the call's
+/// own `}`/`)` close it, but the `EOF` line is missing. The corpus shows ~2,400
+/// of these "sloppy terminator" shapes against ~1 genuine max-token truncation,
+/// so dropping them all wastes a turn the model usually repeats verbatim.
+///
+/// The distinguisher is sharp: we treat the body as implicitly closed ONLY when
+/// its final non-blank line is a pure structural call-tail — after leading
+/// whitespace, nothing but `}` / `)` / `]` / `,` AND at least one `)`. That `)`
+/// is the tool call's own closing paren, which an escape-free heredoc *body*
+/// would not place on a standalone final line. A bare `}`-only final line
+/// (ordinary Go/Rust code) is ambiguous and is left to error, and a body cut
+/// off mid-token (no structural tail at all) still reports `Unterminated`. So a
+/// genuinely truncated/unclosed body never silently dispatches.
+fn unterminated_or_implicit_close(
+    src: &str,
+    content_start: usize,
+    tag: String,
+) -> Result<HeredocSpan, HeredocError> {
+    let body = &src[content_start..];
+    // Find the last non-blank line and where it starts within `body`.
+    let mut last_line_start = body.len();
+    for (offset, line) in line_starts(body) {
+        if !line.trim().is_empty() {
+            last_line_start = offset;
+        }
+    }
+    if last_line_start >= body.len() {
+        return Err(HeredocError::Unterminated { tag });
+    }
+    let last_line = body[last_line_start..].trim_end();
+    let after_ws = last_line.trim_start();
+    let is_call_tail = !after_ws.is_empty()
+        && after_ws.contains(')')
+        && after_ws
+            .chars()
+            .all(|ch| matches!(ch, '}' | ')' | ']' | ',' | ' ' | '\t'));
+    if !is_call_tail {
+        return Err(HeredocError::Unterminated { tag });
+    }
+    // Body content ends just before the structural call-tail line; `end` points
+    // at the start of that line so the outer parser consumes the `})`/`)` close.
+    let content_abs_end = content_start + last_line_start;
+    let raw = &src[content_start..content_abs_end];
+    let stripped = raw.strip_suffix('\n').unwrap_or(raw);
+    let stripped = stripped.strip_suffix('\r').unwrap_or(stripped);
+    tracing::debug!(
+        target: "harn::tool_parse",
+        "recovered heredoc with botched/missing closing tag (implicit close at call tail)"
+    );
+    Ok(HeredocSpan {
+        content: content_start..content_start + stripped.len(),
+        end: content_abs_end,
+        escaped: false,
+    })
+}
+
+/// Yield `(byte_offset_within_s, line_without_newline)` for each `\n`-delimited
+/// line of `s`, including a trailing line with no terminating newline.
+fn line_starts(s: &str) -> impl Iterator<Item = (usize, &str)> {
+    let mut start = 0usize;
+    let bytes = s.as_bytes();
+    std::iter::from_fn(move || {
+        if start > s.len() {
+            return None;
+        }
+        if start == s.len() {
+            // Emit nothing more once we've passed the end; a trailing newline
+            // means the final "line" is empty and is handled by the loop below.
+            return None;
+        }
+        let mut end = start;
+        while end < bytes.len() && bytes[end] != b'\n' {
+            end += 1;
+        }
+        let line = &s[start..end];
+        let offset = start;
+        start = end + 1; // skip the '\n'
+        Some((offset, line))
+    })
 }
 
 /// Scan a JSON/string-escaped heredoc body whose line breaks are the two

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -111,6 +111,34 @@ pub(crate) fn parse_text_tool_calls_with_tools(
         if let Some((body, after)) = match_tool_call_block(src, cursor, TEXT_TOOL_CALL_TAG)
             .or_else(|| match_tool_call_block(src, cursor, TEXT_TOOL_CALL_TAG_COMPACT))
         {
+            // Weak value models (DeepSeek) wrap THINKING/narration in
+            // `<assistant_prose>` *inside* `<tool_call>`, sometimes alongside a
+            // real call in the same wrapper. When the body opens with a known
+            // narration tag, peel the narration out as prose and recover any
+            // real call that follows — never report the narration as a parse
+            // error (which would waste the turn telling the model it erred).
+            if let Some(narration) = recover_tool_call_narration(body, tools_val) {
+                for prose in &narration.prose {
+                    assistant_prose_parts.push(prose.clone());
+                    canonical_parts.push(format!("<assistant_prose>\n{prose}\n</assistant_prose>"));
+                }
+                if let Some(call) = narration.call {
+                    let name = call
+                        .get("name")
+                        .and_then(|name| name.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let args = call
+                        .get("arguments")
+                        .cloned()
+                        .unwrap_or(serde_json::json!({}));
+                    canonical_parts
+                        .push(text_tool_call_block(&render_canonical_call(&name, &args)));
+                    calls.push(call);
+                }
+                cursor = after;
+                continue;
+            }
             match parse_single_tool_call(body, tools_val) {
                 Ok(call) => {
                     let name = call
@@ -933,6 +961,108 @@ fn parse_single_tool_call(
         ));
     }
     Ok(inner.calls.into_iter().next().expect("len == 1"))
+}
+
+/// Narration recovered from a `<tool_call>` wrapper that the body parser
+/// rejected: the assistant's prose plus any real call that shared the wrapper.
+struct ToolCallNarration {
+    prose: Vec<String>,
+    call: Option<serde_json::Value>,
+}
+
+/// Known *narration* tags a value model may wrap inside `<tool_call>` while it
+/// is only thinking out loud. Deliberately tiny and allowlisted: a narration
+/// tag is special precisely because it is NOT an attempted tool invocation, so
+/// it must never widen to cover unknown tags that look like calls (e.g.
+/// `<frobnicate>{...}</frobnicate>` stays a rejected unknown tool). Compact
+/// (tagless-underscore) spellings mirror the top-level `<assistant_prose>` /
+/// `<user_response>` aliases the parser already accepts.
+const NARRATION_TAGS: &[&str] = &["assistant_prose", "assistantprose", "thinking", "reasoning"];
+
+/// Reclassify a `<tool_call>` body that failed to parse as a call. Returns
+/// `Some` only when the body is narration the model mis-wrapped in tool-call
+/// tags, in which case the surrounding turn should NOT be reported as a parse
+/// error:
+///
+/// * The body opens with a known narration tag (`<assistant_prose>…`). Peel off
+///   every leading narration block as prose; if a real `name({ ... })` / nested
+///   tool call follows in the same wrapper, recover it too.
+/// * The body is bare prose — no inner `<tag>` and no recoverable call (e.g.
+///   `<tool_call>Reading the file.</tool_call>`). Treat the text as narration.
+///
+/// Returns `None` for anything that looks like an attempted (but malformed or
+/// unknown) tool call so the caller surfaces the existing actionable error and
+/// the #3132/6b970d61 unknown-tag discipline is preserved.
+fn recover_tool_call_narration(
+    body: &str,
+    tools_val: Option<&VmValue>,
+) -> Option<ToolCallNarration> {
+    let mut prose: Vec<String> = Vec::new();
+    let mut rest = body.trim();
+
+    // Peel leading narration blocks. `match_block` finds the matching close
+    // tag, so a narration block followed by a real call is split cleanly.
+    loop {
+        let opened = NARRATION_TAGS
+            .iter()
+            .find_map(|tag| match_block(rest, 0, tag).map(|matched| (tag, matched)));
+        match opened {
+            Some((_, (inner, after))) => {
+                let trimmed = inner.trim();
+                if !trimmed.is_empty() {
+                    prose.push(trimmed.to_string());
+                }
+                rest = rest[after..].trim_start();
+            }
+            None => break,
+        }
+    }
+
+    let remainder = rest.trim();
+    if !prose.is_empty() {
+        // Narration tag(s) present. Recover a real call from whatever follows,
+        // if any; ignore a parse failure on the remainder (it is trailing slop,
+        // not the model's intended action — the prose already carries the turn).
+        let call = if remainder.is_empty() {
+            None
+        } else {
+            parse_single_tool_call(remainder, tools_val).ok()
+        };
+        return Some(ToolCallNarration { prose, call });
+    }
+
+    // No narration tag. Only reclassify as prose when the body is plainly NOT
+    // an attempted tool call: it carries no inner `<tag>` (not an unknown-tool
+    // attempt like `<frobnicate>{...}`), no `{` JSON body (the Gemma-style
+    // `{ "name": …, "arguments": … }` shape), and no `name(` call head (so a
+    // bare call to an unknown/misspelled tool still surfaces its real error
+    // instead of being silently swallowed as prose).
+    if remainder.starts_with('<')
+        || remainder.starts_with('{')
+        || remainder.is_empty()
+        || looks_like_call_head(remainder)
+    {
+        return None;
+    }
+    Some(ToolCallNarration {
+        prose: vec![remainder.to_string()],
+        call: None,
+    })
+}
+
+/// True if `src` opens with a `name(` token — the head of a (possibly
+/// unknown-tool) call. Used to keep an attempted bare call out of the
+/// narration path so its real parse error still surfaces.
+fn looks_like_call_head(src: &str) -> bool {
+    let bytes = src.as_bytes();
+    let Some(name_len) = ident_length(bytes) else {
+        return false;
+    };
+    let mut idx = name_len;
+    while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    bytes.get(idx) == Some(&b'(')
 }
 
 fn known_tool_names_with_implicit(tools_val: Option<&VmValue>) -> BTreeSet<String> {

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -232,7 +232,27 @@ EOF
 }
 
 #[test]
-fn heredoc_unterminated_is_error() {
+fn heredoc_indented_closing_tag_terminates() {
+    // Shape 2 (indented terminator): the model indents the closing `EOF` to
+    // match the surrounding code. Leading whitespace before the tag on the
+    // close line must not prevent termination.
+    let tools = sample_tool_registry();
+    let text = "edit({\n    action: \"create\",\n    path: \"a.go\",\n    content: <<EOF\npackage main\n    EOF\n})";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["content"],
+        json!("package main")
+    );
+}
+
+#[test]
+fn heredoc_missing_tag_with_structural_close_recovers() {
+    // Shape 2 (sloppy terminator): the model wrote a complete, structurally
+    // closed call but botched/omitted the heredoc `EOF` tag. The trailing `})`
+    // is the call's own close, so the body is implicitly terminated there and
+    // the call dispatches rather than wasting a turn on parse_guidance. (~2,400
+    // of these in the corpus vs ~1 genuine truncation.)
     let tools = sample_tool_registry();
     let text = r#"edit({
     action: "create",
@@ -242,9 +262,58 @@ package main
 // no closing EOF tag
 })"#;
     let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "sloppy-terminator heredoc should recover, errors: {:?}",
+        result.errors
+    );
+    assert!(result.errors.is_empty(), "no errors: {:?}", result.errors);
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert_eq!(
+        content, "package main\n// no closing EOF tag",
+        "body ends just before the call tail"
+    );
+}
+
+#[test]
+fn heredoc_truncated_mid_body_is_error() {
+    // Negative: a genuinely truncated body (cut off mid-token, no structural
+    // call-tail line at the end) must still error loudly — never silently
+    // dispatch a half-written call. This is the ~1-in-the-corpus real
+    // max-token truncation that the implicit-close recovery deliberately leaves
+    // alone (no `)` on a standalone final line to anchor the close).
+    let tools = sample_tool_registry();
+    let text = r#"edit({
+    action: "create",
+    path: "main.go",
+    content: <<EOF
+package main
+
+func main() {
+    fmt.Println("hello"#;
+    let result = parse_bare_calls_in_body(text, Some(&tools));
     assert!(
         result.calls.is_empty(),
-        "unterminated heredoc should produce no calls"
+        "truncated heredoc should produce no calls, calls: {:?}",
+        result.calls
+    );
+    assert!(!result.errors.is_empty(), "should have parse error");
+}
+
+#[test]
+fn heredoc_code_body_with_bare_brace_close_stays_ambiguous() {
+    // Boundary: a body whose final standalone line is a bare `}` (ordinary
+    // Go/Rust block close) is ambiguous — it could be code or a botched call
+    // tail. With no `)` to anchor the call's own close, we do NOT guess; the
+    // call errors rather than risk truncating a legitimate body.
+    let tools = sample_tool_registry();
+    let text = "edit({\n    action: \"create\",\n    path: \"main.go\",\n    content: <<EOF\nfunc main() {\n    return\n}";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert!(
+        result.calls.is_empty(),
+        "bare-brace ambiguous close must not silently dispatch, calls: {:?}",
+        result.calls
     );
     assert!(!result.errors.is_empty(), "should have parse error");
 }
@@ -510,6 +579,45 @@ fn native_json_fallback_parses_pretty_printed_non_call_id() {
         json!("0"),
         "non-call_ id should be preserved"
     );
+}
+
+#[test]
+fn native_json_fallback_parses_flat_jsonrpc_envelope() {
+    // Bonus item 9: a flat JSON-RPC/MCP envelope `[{"name":..,"arguments":{..}}]`
+    // (name + args object at the TOP level, no nested `function`) should map to
+    // the same call as `read({ path: ".." })`.
+    let known = known_tools_set();
+    let text = r#"[{"name":"read","arguments":{"path":"main.go"}}]"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(calls.len(), 1, "should parse flat envelope: {calls:?}");
+    assert_eq!(calls[0]["name"], json!("read"));
+    assert_eq!(calls[0]["arguments"]["path"], json!("main.go"));
+}
+
+#[test]
+fn native_json_fallback_parses_flat_envelope_with_parameters_slot() {
+    // The flat envelope sometimes names the args slot `parameters`, and arrives
+    // as a single object rather than an array.
+    let known = known_tools_set();
+    let text = r#"{"name":"read","parameters":{"path":"lib.rs"}}"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(calls.len(), 1, "should parse single-object envelope");
+    assert_eq!(calls[0]["name"], json!("read"));
+    assert_eq!(calls[0]["arguments"]["path"], json!("lib.rs"));
+}
+
+#[test]
+fn native_json_fallback_ignores_prose_json_with_bare_name() {
+    // Negative: incidental prose JSON that merely has a `name` key (a
+    // package.json snippet, a config example) but no args/parameters object
+    // must NOT be hijacked as a tool call.
+    let known = known_tools_set();
+    let text = r#"Here is the config: {"name":"my-pkg","version":"1.0.0"}"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(calls.is_empty(), "prose JSON must not match: {calls:?}");
+    assert!(errors.is_empty(), "no errors for prose JSON: {errors:?}");
 }
 
 #[test]

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -343,6 +343,132 @@ fn tagged_parser_rejects_unknown_nested_xml_tool_with_sloppy_close() {
     );
 }
 
+// High-frequency DeepSeek shape: the model wraps its THINKING/narration in
+// `<assistant_prose>` *inside* `<tool_call>`. This is not a malformed call —
+// it took no action this turn. It must NOT be reported as a parse error
+// (which wastes the turn telling the model it erred); the text is preserved as
+// prose and the loop's normal no-tool-call nudge applies.
+#[test]
+fn tagged_parser_treats_wrapped_assistant_prose_as_narration_not_parse_error() {
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<assistant_prose>\nReading parser.go to understand ParseManifest.\n</assistant_prose>\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    assert!(result.calls.is_empty(), "narration emits no tool call");
+    assert!(
+        result.errors.is_empty(),
+        "narration wrapped in <tool_call> must not be a parse error: {:?}",
+        result.errors
+    );
+    assert!(
+        result.violations.is_empty(),
+        "narration wrapped in <tool_call> must not be a violation: {:?}",
+        result.violations
+    );
+    assert!(
+        !result
+            .errors
+            .iter()
+            .chain(result.violations.iter())
+            .any(|msg| msg.contains("could not be parsed")
+                || msg.contains("did not contain a bare")
+                || msg.contains("TRUNCATED")),
+        "no 'could not be parsed' diagnostic for narration: errors={:?} violations={:?}",
+        result.errors,
+        result.violations
+    );
+    assert_eq!(
+        result.prose, "Reading parser.go to understand ParseManifest.",
+        "narration text preserved as prose"
+    );
+}
+
+// A bare prose body (no inner tag, no call) the model wrapped in `<tool_call>`
+// is treated identically to `<assistant_prose>` — narration, not a parse error.
+#[test]
+fn tagged_parser_treats_bare_prose_tool_call_body_as_narration() {
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\nReading the file to understand the layout.\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    assert!(result.calls.is_empty(), "bare prose emits no tool call");
+    assert!(
+        result.errors.is_empty(),
+        "bare prose body must not be a parse error: {:?}",
+        result.errors
+    );
+    assert!(
+        result.violations.is_empty(),
+        "bare prose body must not be a violation: {:?}",
+        result.violations
+    );
+    assert_eq!(
+        result.prose, "Reading the file to understand the layout.",
+        "bare prose text preserved"
+    );
+}
+
+// Mixed shape: the SAME `<tool_call>` wrapper carries an `<assistant_prose>`
+// narration block AND a real call. Recover and dispatch the call; keep the
+// narration as prose; emit no parse error.
+#[test]
+fn tagged_parser_recovers_real_call_alongside_wrapped_prose() {
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<assistant_prose>\nReading parser.go first.\n</assistant_prose>\nrun({ command: \"cat parser.go\" })\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    assert!(
+        result.errors.is_empty(),
+        "mixed prose+call must not error: {:?}",
+        result.errors
+    );
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "the real call must be recovered (violations: {:?})",
+        result.violations
+    );
+    assert_eq!(result.calls[0]["name"], json!("run"));
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("cat parser.go")
+    );
+    assert_eq!(
+        result.prose, "Reading parser.go first.",
+        "narration preserved alongside the recovered call"
+    );
+    assert!(
+        result.canonical.contains("run({"),
+        "canonical replay should carry the recovered call: {}",
+        result.canonical
+    );
+}
+
+// Negative: an unknown inner tag that LOOKS like an attempted call must STILL
+// be rejected — the narration allowance is scoped to the narration allowlist,
+// it does not turn every unknown wrapped tag into silent prose.
+#[test]
+fn tagged_parser_still_rejects_unknown_wrapped_tag_as_not_narration() {
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<frobnicate>\n{ \"target\": \"prod\" }\n</frobnicate>\n</tool_call>";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+
+    assert!(result.calls.is_empty(), "unknown tool must not execute");
+    assert!(
+        result.prose.trim().is_empty(),
+        "an unknown attempted call is not narration: {:?}",
+        result.prose
+    );
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|error| error.contains("Unknown tool 'frobnicate'")),
+        "unknown inner tag must be rejected with an actionable error: {:?}",
+        result.errors
+    );
+}
+
 #[test]
 fn tagged_parser_recovers_mistral_tool_markers() {
     let tools = sample_tool_registry();

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -892,3 +892,104 @@ fn tagged_parser_closed_tool_call_unaffected_by_truncation_branch() {
         result.errors
     );
 }
+
+// ---------------------------------------------------------------------------
+// Shape 1: template literals + `+`-concatenated string fragments in a value.
+// ---------------------------------------------------------------------------
+
+// A multi-line backtick template literal as a value (Go-ish content) parses to
+// the literal body. (Single-line backticks were already covered; this guards
+// the multi-line body the corpus emits.)
+#[test]
+fn value_accepts_multiline_template_literal() {
+    let tools = sample_tool_registry();
+    let text =
+        "edit({ action: \"create\", path: \"a.go\", content: `package main\n\nfunc main() {}\n` })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["content"],
+        json!("package main\n\nfunc main() {}\n")
+    );
+}
+
+// Plain `+`-concatenation of two quoted strings collapses to one value.
+#[test]
+fn value_folds_string_concatenation() {
+    let tools = sample_tool_registry();
+    let text = "edit({ action: \"create\", path: \"a.txt\", content: \"hello \" + \"world\" })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["content"],
+        json!("hello world")
+    );
+}
+
+// The dominant corpus shape: a Go file body where a backtick struct tag forces
+// the model into ``…` + "`json:\"x\"`" + `…`` concatenation. The fragments
+// (template + quoted + template) must collapse into one content string with the
+// literal backtick struct tag preserved.
+#[test]
+fn value_folds_go_backtick_struct_tag_concatenation() {
+    let tools = sample_tool_registry();
+    let text = "edit({ action: \"create\", path: \"status.go\", content: `package main\n\ntype S struct {\n\tServices []ServiceStatus ` + \"`json:\\\"services\\\"`\" + ` // tail\n}\n` })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert!(
+        content.contains("`json:\"services\"`"),
+        "backtick struct tag must survive concatenation: {content:?}"
+    );
+    assert!(
+        content.starts_with("package main") && content.contains("type S struct {"),
+        "surrounding template fragments must be joined: {content:?}"
+    );
+}
+
+// Negative: a `+` whose right operand is NOT a string is malformed
+// concatenation — the parser must reject loudly, never guess.
+#[test]
+fn value_rejects_non_string_concatenation_operand() {
+    let tools = sample_tool_registry();
+    let text = "edit({ action: \"create\", path: \"a.txt\", content: \"x\" + 1 })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert!(
+        result.calls.is_empty(),
+        "non-string concat operand must not dispatch: {:?}",
+        result.calls
+    );
+    assert!(
+        !result.errors.is_empty(),
+        "should error: {:?}",
+        result.errors
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Shape 3: `=` accepted as a synonym for `:` as the object key/value separator.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_accepts_equals_as_key_value_separator() {
+    let tools = sample_tool_registry();
+    // `=` before a scalar and before a template body, mixed with a normal `:`.
+    let text = "edit({ action= \"create\", path: \"a.go\", content= `x` })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    assert_eq!(result.calls[0]["arguments"]["action"], json!("create"));
+    assert_eq!(result.calls[0]["arguments"]["path"], json!("a.go"));
+    assert_eq!(result.calls[0]["arguments"]["content"], json!("x"));
+}
+
+#[test]
+fn object_accepts_equals_before_heredoc_value() {
+    let tools = sample_tool_registry();
+    let text = "edit({\n    action: \"create\",\n    path: \"a.go\",\n    content= <<EOF\npackage main\nEOF\n})";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["content"],
+        json!("package main")
+    );
+}

--- a/crates/harn-vm/src/llm/tools/ts_value_parser.rs
+++ b/crates/harn-vm/src/llm/tools/ts_value_parser.rs
@@ -96,6 +96,26 @@ impl<'a> TsValueParser<'a> {
     }
 
     pub(super) fn parse_value(&mut self) -> Result<serde_json::Value, String> {
+        let value = self.parse_primary_value()?;
+        // String concatenation (`"a" + "b"` / `` `a` + "b" ``). Value models —
+        // notably Go, where backtick struct tags force JS-style concat like
+        // `` `...` + "`json:\"x\"`" + `...` `` — split a single code body into
+        // `+`-joined string/template fragments. TS would evaluate that to one
+        // string; tool arguments never evaluate expressions, so collapse the
+        // fragments into one string value here. Engages ONLY when the first
+        // operand already parsed as a string AND a `+` follows, so non-string
+        // values and well-formed single strings are untouched. Scoped to
+        // tool-call argument parsing — `TsValueParser` is private to the tools
+        // module and never parses general documents.
+        if matches!(value, serde_json::Value::String(_)) {
+            return self.fold_string_concatenation(value);
+        }
+        Ok(value)
+    }
+
+    /// Parse one primary value (object, array, string/template, heredoc,
+    /// keyword, or number) without considering a trailing `+` concatenation.
+    fn parse_primary_value(&mut self) -> Result<serde_json::Value, String> {
         self.skip_ws_and_comments();
         let c = self.peek().ok_or("unexpected end of input")?;
         match c {
@@ -120,6 +140,44 @@ impl<'a> TsValueParser<'a> {
                 "unexpected character `{}` starting a value",
                 other as char
             )),
+        }
+    }
+
+    /// Given an already-parsed leading string `head`, fold any `+`-joined
+    /// trailing string/template fragments into it. Each `+` must be followed
+    /// (after whitespace/comments) by another string-producing primary; if the
+    /// right operand is NOT a string the input is malformed concatenation
+    /// (e.g. `"a" + 1` or `"a" +` at EOF) and we error rather than guess. A
+    /// recovered concat collapses to one `String` value — canonicalized back to
+    /// a single quoted string on replay by `render_canonical_call`.
+    fn fold_string_concatenation(
+        &mut self,
+        head: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let serde_json::Value::String(mut acc) = head else {
+            return Ok(head);
+        };
+        loop {
+            // Peek past whitespace/comments without committing: only a `+`
+            // continues the concatenation. Anything else is the next structural
+            // token (`,`, `}`, `]`, `)`), which the caller handles.
+            let save = self.pos;
+            self.skip_ws_and_comments();
+            if self.peek() != Some(b'+') {
+                self.pos = save;
+                return Ok(serde_json::Value::String(acc));
+            }
+            self.advance(); // consume '+'
+            self.skip_ws_and_comments();
+            let rhs = self.parse_primary_value()?;
+            match rhs {
+                serde_json::Value::String(s) => acc.push_str(&s),
+                other => {
+                    return Err(format!(
+                        "expected a string fragment after `+` in string concatenation, got `{other}`"
+                    ));
+                }
+            }
         }
     }
 
@@ -152,8 +210,13 @@ impl<'a> TsValueParser<'a> {
             };
             self.skip_ws_and_comments();
             // TS shorthand `{ foo }` is legal but rare for our tool calls; we
-            // disallow it to keep the contract explicit.
-            if self.peek() != Some(b':') {
+            // disallow it to keep the contract explicit. Accept `=` as a synonym
+            // for `:`: value models (especially before a heredoc/template body,
+            // e.g. `{ new_body= <<EOF ... }`) reach for the assignment glyph they
+            // know from kwargs/struct-literal syntax. `=` is not a legal
+            // object-literal separator in TS, so there is no ambiguity to lose —
+            // canonicalized back to `:` on replay by `render_canonical_call`.
+            if !matches!(self.peek(), Some(b':') | Some(b'=')) {
                 return Err(format!(
                     "expected `:` after key `{key}` inside object literal"
                 ));

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -3165,10 +3165,6 @@ mod tests {
             default_tool_format("devstral-small-2:24b", "ollama"),
             "text"
         );
-        assert_eq!(
-            default_tool_format("ollama-devstral-small-2-native", "ollama"),
-            "native"
-        );
         // vLLM/SGLang-served Gemma 4 exposes OpenAI-compatible function calling,
         // so the local route declares native tools (matching every hosted gemma-4
         // sibling) rather than degrading to the text tool format.

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -898,6 +898,50 @@ async fn custom_compaction_summary(
     }
 }
 
+/// Marker the host emits inside a tool-output (or message) body to pin its
+/// live grounding — the current file view and just-edited window — so it
+/// survives a compaction pass. Burin renders this literal substring inside
+/// markdown headings (e.g. `## Exact current file text [no-compact]`,
+/// `## Edited region now reads (...) [no-compact]`) in
+/// `lib/tools/result-format.harn`. Compaction matches the substring; it does
+/// not invent a new vocabulary.
+pub(crate) const NO_COMPACT_MARKER: &str = "[no-compact]";
+
+/// Upper bound on how many of the most-recent pinned segments survive a
+/// compaction pass verbatim. A pin that could never be evicted would let a
+/// long session accumulate unbounded pinned snapshots (e.g. one edited-window
+/// per edit) and eventually overflow the context window — defeating the
+/// purpose of compaction. Keeping only the latest few preserves the agent's
+/// *current* grounding (the file it is editing now, emitted as the exact-text
+/// block plus the numbered-lines block in one or two adjacent outputs) while
+/// letting stale duplicates from earlier in the session compact normally.
+pub(crate) const MAX_PINNED_SEGMENTS: usize = 3;
+
+/// Whether a content body carries the host's `[no-compact]` pin marker.
+fn is_pinned_content(content: &str) -> bool {
+    content.contains(NO_COMPACT_MARKER)
+}
+
+/// Compute the set of message indices into `messages` that are pinned AND fall
+/// within the most-recent [`MAX_PINNED_SEGMENTS`] pinned bodies. Older pinned
+/// bodies are intentionally excluded so they compact normally (the bound).
+/// `content_of` extracts the body text to inspect for each message.
+fn latest_pinned_indices<'a, F>(
+    messages: impl Iterator<Item = &'a serde_json::Value>,
+    content_of: F,
+) -> std::collections::HashSet<usize>
+where
+    F: Fn(&serde_json::Value) -> Option<&str>,
+{
+    // Walk newest-first, collecting up to MAX_PINNED_SEGMENTS pinned indices.
+    let pinned: Vec<usize> = messages
+        .enumerate()
+        .filter(|(_, msg)| content_of(msg).is_some_and(is_pinned_content))
+        .map(|(idx, _)| idx)
+        .collect();
+    pinned.into_iter().rev().take(MAX_PINNED_SEGMENTS).collect()
+}
+
 /// Check whether a tool-result string should be preserved verbatim during
 /// observation masking. Uses content length as the primary heuristic:
 /// short results (< 500 chars) are kept since they're typically error messages,
@@ -938,6 +982,13 @@ fn observation_mask_compaction_with_callback(
     parts.push(format!(
         "[auto-compacted {archived_count} older messages via observation masking]"
     ));
+    // Pin the agent's most-recent live grounding: any archived body carrying
+    // the host's `[no-compact]` marker (the current file view / edited window)
+    // survives masking verbatim, bounded to the latest MAX_PINNED_SEGMENTS so a
+    // long session's stale snapshots still compact.
+    let pinned = latest_pinned_indices(old_messages.iter(), |msg| {
+        msg.get("content").and_then(|v| v.as_str())
+    });
     for (idx, msg) in old_messages.iter().enumerate() {
         let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("user");
         let content = msg
@@ -945,6 +996,10 @@ fn observation_mask_compaction_with_callback(
             .and_then(|v| v.as_str())
             .unwrap_or_default();
         if content.is_empty() {
+            continue;
+        }
+        if pinned.contains(&idx) {
+            parts.push(format!("[{role}] {content}"));
             continue;
         }
         if role == "assistant" {
@@ -1015,7 +1070,18 @@ async fn clamp_tool_outputs(
     if config.tool_output_max_chars == 0 {
         return Ok(());
     }
-    for message in messages.iter_mut() {
+    // Exempt the most-recent pinned tool-outputs (those carrying the host's
+    // `[no-compact]` marker) from length-clamping so the agent's live file view
+    // stays intact. Bounded to the latest MAX_PINNED_SEGMENTS so older pinned
+    // snapshots in the kept window still clamp and can't blow the budget.
+    let pinned = latest_pinned_indices(messages.iter(), |msg| {
+        if msg.get("role").and_then(|role| role.as_str()) == Some("tool") {
+            msg.get("content").and_then(|content| content.as_str())
+        } else {
+            None
+        }
+    });
+    for (idx, message) in messages.iter_mut().enumerate() {
         if message.get("role").and_then(|role| role.as_str()) != Some("tool") {
             continue;
         }
@@ -1023,6 +1089,9 @@ async fn clamp_tool_outputs(
             continue;
         };
         if content.len() <= config.tool_output_max_chars {
+            continue;
+        }
+        if pinned.contains(&idx) {
             continue;
         }
         let content = content.to_string();
@@ -1528,6 +1597,186 @@ mod tests {
             content.len(),
             big_len
         );
+        assert!(content.len() < 2000, "clamped near tool_output_max_chars");
+    }
+
+    /// (1) A pinned tool-output survives an observation-mask pass that evicts
+    /// (masks) the unpinned verbose outputs around it.
+    #[test]
+    fn observation_mask_preserves_pinned_live_file_view() {
+        let pinned_body = format!(
+            "## Edited region now reads (line 42, ±6 context) {}\n```\n{}\n```",
+            NO_COMPACT_MARKER,
+            (0..40)
+                .map(|i| format!("   {i}  let x = compute({i});"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        let verbose_unpinned = (0..60)
+            .map(|i| format!("verbose scan output line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // These are the ARCHIVED messages handed to the mask pass.
+        let archived = vec![
+            serde_json::json!({"role": "user", "content": verbose_unpinned}),
+            serde_json::json!({"role": "user", "content": pinned_body}),
+        ];
+        let summary = observation_mask_compaction(&archived, archived.len());
+        // Pinned live file view survives verbatim.
+        assert!(
+            summary.contains("Edited region now reads"),
+            "pinned heading survived: {summary}"
+        );
+        assert!(
+            summary.contains("let x = compute(39);"),
+            "pinned body survived verbatim"
+        );
+        // The unpinned verbose neighbor was masked.
+        assert!(summary.contains("masked]"), "unpinned output was masked");
+        assert!(!summary.contains("verbose scan output line 30"));
+    }
+
+    /// (2) A pinned large tool-output is NOT clamped, while an unpinned one of
+    /// the same size IS.
+    #[test]
+    fn clamp_exempts_pinned_tool_output() {
+        let pinned_big = format!(
+            "## Exact current file text {}\n{}",
+            NO_COMPACT_MARKER,
+            "x".repeat(4000)
+        );
+        let pinned_len = pinned_big.len();
+        let unpinned_big = "y".repeat(4000);
+        let unpinned_len = unpinned_big.len();
+        let mut messages = vec![
+            serde_json::json!({"role": "user", "content": "old task"}),
+            serde_json::json!({"role": "assistant", "content": "reply"}),
+            serde_json::json!({"role": "user", "content": "new task"}),
+            serde_json::json!({"role": "assistant", "content": "calling tools"}),
+            serde_json::json!({"role": "tool", "tool_call_id": "c0", "content": unpinned_big}),
+            serde_json::json!({"role": "tool", "tool_call_id": "c1", "content": pinned_big}),
+            serde_json::json!({"role": "user", "content": "continue"}),
+        ];
+        let config = AutoCompactConfig {
+            token_threshold: 1,
+            keep_last: 4,
+            tool_output_max_chars: 500,
+            ..Default::default()
+        };
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime
+            .block_on(auto_compact_messages(&mut messages, &config, None))
+            .expect("compaction succeeds");
+
+        let pinned_msg = messages
+            .iter()
+            .find(|m| m["tool_call_id"] == "c1")
+            .expect("pinned tool message kept");
+        assert_eq!(
+            pinned_msg["content"].as_str().map(str::len),
+            Some(pinned_len),
+            "pinned output must be intact (unclamped)"
+        );
+        let unpinned_msg = messages
+            .iter()
+            .find(|m| m["tool_call_id"] == "c0")
+            .expect("unpinned tool message kept");
+        assert!(
+            unpinned_msg["content"].as_str().map(str::len).unwrap() < unpinned_len,
+            "unpinned output of the same size must be clamped"
+        );
+    }
+
+    /// (3) Bounded policy: with MANY pinned outputs, only the latest
+    /// MAX_PINNED_SEGMENTS survive verbatim; older pinned duplicates compact —
+    /// so the pin can't prevent all compaction (and can't overflow the window
+    /// on a very long session).
+    #[test]
+    fn pin_bound_keeps_only_latest_segments() {
+        // Build 6 distinct pinned, oversized edited-window snapshots
+        // (gen 0 = oldest .. gen 5 = newest), each tagged with the marker and
+        // long enough that masking would otherwise truncate it.
+        let make = |gen: usize| {
+            let body = (0..40)
+                .map(|i| format!("marker-gen-{gen} body line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            serde_json::json!({
+                "role": "user",
+                "content": format!(
+                    "## Edited region now reads (gen {gen}) {}\n{}",
+                    NO_COMPACT_MARKER, body
+                ),
+            })
+        };
+        let archived: Vec<_> = (0..6).map(make).collect();
+
+        // Unit-level: the index selection keeps exactly the latest N.
+        let pinned = latest_pinned_indices(archived.iter(), |m| {
+            m.get("content").and_then(|c| c.as_str())
+        });
+        assert_eq!(
+            pinned.len(),
+            MAX_PINNED_SEGMENTS,
+            "only the latest MAX_PINNED_SEGMENTS are pinned"
+        );
+        assert!(pinned.contains(&5) && pinned.contains(&4) && pinned.contains(&3));
+        assert!(!pinned.contains(&0) && !pinned.contains(&1) && !pinned.contains(&2));
+
+        // End-to-end through the mask pass: the 3 newest snapshots survive
+        // verbatim; the 3 oldest are masked, proving the pin cannot defeat all
+        // compaction.
+        let summary = observation_mask_compaction(&archived, archived.len());
+        assert!(
+            summary.contains("marker-gen-5")
+                && summary.contains("marker-gen-4")
+                && summary.contains("marker-gen-3"),
+            "latest {MAX_PINNED_SEGMENTS} pinned snapshots survive verbatim: {summary}"
+        );
+        assert!(
+            !summary.contains("marker-gen-0")
+                && !summary.contains("marker-gen-1")
+                && !summary.contains("marker-gen-2"),
+            "older pinned snapshots are masked (bound enforced)"
+        );
+        assert!(summary.contains("masked]"), "older snapshots were masked");
+    }
+
+    /// (4) Regression: with NO pins, compaction behaves exactly as before.
+    #[test]
+    fn no_pins_preserves_prior_clamp_behavior() {
+        let big = "x".repeat(4000);
+        let big_len = big.len();
+        let mut messages = vec![
+            serde_json::json!({"role": "user", "content": "old task"}),
+            serde_json::json!({"role": "assistant", "content": "old reply"}),
+            serde_json::json!({"role": "user", "content": "new task"}),
+            serde_json::json!({"role": "assistant", "content": "calling tool"}),
+            serde_json::json!({"role": "tool", "tool_call_id": "call_1", "content": big}),
+        ];
+        let config = AutoCompactConfig {
+            token_threshold: 1,
+            keep_last: 2,
+            tool_output_max_chars: 500,
+            ..Default::default()
+        };
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let result = runtime
+            .block_on(auto_compact_messages(&mut messages, &config, None))
+            .expect("compaction succeeds");
+        assert!(result.is_some());
+        let tool_msg = messages
+            .iter()
+            .find(|m| m["role"] == "tool")
+            .expect("tool kept");
+        let content = tool_msg["content"].as_str().expect("string content");
+        assert!(content.len() < big_len, "unpinned output clamped as before");
         assert!(content.len() < 2000, "clamped near tool_output_max_chars");
     }
 }

--- a/crates/harn-vm/src/provider_catalog/tests.rs
+++ b/crates/harn-vm/src/provider_catalog/tests.rs
@@ -309,6 +309,104 @@ fn validation_rejects_duplicate_and_dangling_aliases() {
 }
 
 #[test]
+fn validation_rejects_alias_tool_format_not_native_or_text() {
+    // A typo / wrong value in an alias's tool_format pin must be caught at
+    // catalog-build time, not silently degraded at call time.
+    let mut catalog = artifact();
+    catalog.aliases[0].tool_format = Some("nativ".to_string());
+    let report = validate_artifact(&catalog);
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|message| message.contains("must be \"native\" or \"text\"")),
+        "expected invalid alias tool_format error, got {:?}",
+        report.errors
+    );
+}
+
+#[test]
+fn validation_rejects_alias_pinning_unservable_tool_format() {
+    // An alias may only pin a format the target model actually serves. Pin
+    // "native" on a text-only model -> hard error (this is the exact footgun
+    // that the shipped ollama-devstral-small-2-native alias had).
+    let mut catalog = artifact();
+    let alias_target = (
+        catalog.aliases[0].provider.clone(),
+        catalog.aliases[0].model_id.clone(),
+    );
+    let model = catalog
+        .models
+        .iter_mut()
+        .find(|m| m.provider == alias_target.0 && m.id == alias_target.1)
+        .expect("alias target model present in catalog");
+    model.tool_support.native = false;
+    model.tool_support.text = true;
+    catalog.aliases[0].tool_format = Some("native".to_string());
+    let report = validate_artifact(&catalog);
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|message| message.contains("does not support native tool calling")),
+        "expected unservable-native alias error, got {:?}",
+        report.errors
+    );
+
+    // Symmetric: pin "text" on a native-only model -> hard error.
+    let mut catalog = artifact();
+    let alias_target = (
+        catalog.aliases[0].provider.clone(),
+        catalog.aliases[0].model_id.clone(),
+    );
+    let model = catalog
+        .models
+        .iter_mut()
+        .find(|m| m.provider == alias_target.0 && m.id == alias_target.1)
+        .expect("alias target model present in catalog");
+    model.tool_support.native = true;
+    model.tool_support.text = false;
+    catalog.aliases[0].tool_format = Some("text".to_string());
+    let report = validate_artifact(&catalog);
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|message| message.contains("does not support text tool calling")),
+        "expected unservable-text alias error, got {:?}",
+        report.errors
+    );
+}
+
+#[test]
+fn validation_accepts_alias_pinning_servable_tool_format() {
+    // The happy path: an alias pinning a format the model serves validates.
+    let mut catalog = artifact();
+    let alias_target = (
+        catalog.aliases[0].provider.clone(),
+        catalog.aliases[0].model_id.clone(),
+    );
+    let model = catalog
+        .models
+        .iter_mut()
+        .find(|m| m.provider == alias_target.0 && m.id == alias_target.1)
+        .expect("alias target model present in catalog");
+    model.tool_support.native = true;
+    model.tool_support.text = true;
+    catalog.aliases[0].tool_format = Some("native".to_string());
+    let report = validate_artifact(&catalog);
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|message| message.contains("does not support")
+                || message.contains("must be \"native\" or \"text\"")),
+        "servable alias tool_format should validate, got {:?}",
+        report.errors
+    );
+}
+
+#[test]
 fn overlay_merge_surfaces_private_model() {
     let _guard = install_overlay(
         r#"

--- a/crates/harn-vm/src/provider_catalog/validation.rs
+++ b/crates/harn-vm/src/provider_catalog/validation.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::*;
 
@@ -165,6 +165,17 @@ pub fn validate_artifact(artifact: &ProviderCatalogArtifact) -> ProviderCatalogV
         }
     }
 
+    // Index models by (provider, id) so alias tool_format can be checked
+    // against the target model's declared tool support. An alias is the one
+    // place a harness author can pin `native` / `text` per model, so a typo
+    // or a format the model can't serve must be caught at catalog-build time
+    // rather than silently degrading at call time.
+    let model_by_pair: BTreeMap<(&str, &str), &CatalogModel> = artifact
+        .models
+        .iter()
+        .map(|model| ((model.provider.as_str(), model.id.as_str()), model))
+        .collect();
+
     let dedicated_pairs: BTreeSet<(&str, &str)> = artifact
         .models
         .iter()
@@ -177,6 +188,29 @@ pub fn validate_artifact(artifact: &ProviderCatalogArtifact) -> ProviderCatalogV
                 "alias {} targets {}/{} without a catalog row",
                 alias.name, alias.provider, alias.model_id
             ));
+        }
+        if let Some(format) = alias.tool_format.as_deref() {
+            if format != "native" && format != "text" {
+                result.errors.push(format!(
+                    "alias {} declares tool_format {:?}; must be \"native\" or \"text\"",
+                    alias.name, format
+                ));
+            } else if let Some(model) =
+                model_by_pair.get(&(alias.provider.as_str(), alias.model_id.as_str()))
+            {
+                if format == "native" && !model.tool_support.native {
+                    result.errors.push(format!(
+                        "alias {} pins tool_format \"native\" but model {}/{} does not support native tool calling",
+                        alias.name, alias.provider, alias.model_id
+                    ));
+                }
+                if format == "text" && !model.tool_support.text {
+                    result.errors.push(format!(
+                        "alias {} pins tool_format \"text\" but model {}/{} does not support text tool calling",
+                        alias.name, alias.provider, alias.model_id
+                    ));
+                }
+            }
         }
         if is_tier_alias(&alias.name)
             && dedicated_pairs.contains(&(alias.provider.as_str(), alias.model_id.as_str()))

--- a/crates/harn-vm/tests/tool_calling_bootcamp.rs
+++ b/crates/harn-vm/tests/tool_calling_bootcamp.rs
@@ -1,0 +1,479 @@
+#![recursion_limit = "256"]
+//! Tool-calling boot camp: a deterministic, zero-live-call battery that proves
+//! Harn abstracts away provider/model tool-calling quirks behind a single
+//! `tool_format` knob, with the north-star invariant:
+//!
+//!   every provider/model config input is either REJECTED with a clear error,
+//!   OR accepted and resolves to a format the model can actually serve —
+//!   never silently half-supported.
+//!
+//! The battery exercises the REAL resolution layer harness authors hit:
+//!   - `agent_tool_format_resolution(opts)` / `agent_tool_format(opts)`
+//!     (`std/agent/options`), which the agent-loop preset machinery and
+//!     preflight all route through.
+//!   - `provider_capabilities(provider, model)` / `provider_capabilities_install`
+//!     (the capability matrix), used to set up synthetic parity cells so the
+//!     hard-reject path is covered without touching the shipped catalog.
+//!
+//! Design: a pairwise-covering sample over the axes
+//!   {capability-profile × requested-format × config-source}
+//! kept to a few dozen cases. Each case asserts exactly one of:
+//!   (a) resolution REJECTS (throws) with a message naming `tool_format`, or
+//!   (b) resolution ACCEPTS and returns a concrete `native`/`text` that the
+//!       capability matrix says the model serves.
+//! No case is allowed to resolve to a format the matrix marks impossible, and
+//! no case is allowed to resolve to a non-`{native,text}` string.
+//!
+//! Run with:
+//!   CARGO_TARGET_DIR=/tmp/harn-target-bootcamp \
+//!     cargo test -p harn-vm --test tool_calling_bootcamp
+
+use harn_vm::value::VmError;
+
+/// Run one Harn snippet through a fresh VM with the full stdlib registered,
+/// returning Ok(stdout) or Err(error-string). A `throw` inside the snippet
+/// surfaces as Err here, which is how we observe a "rejected" config.
+fn run(source: &str) -> Result<String, String> {
+    harn_vm::reset_thread_local_state();
+    let chunk = harn_vm::compile_source(source)?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())?;
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = harn_vm::Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                vm.execute(&chunk)
+                    .await
+                    .map_err(|e: VmError| format!("{e:?}"))?;
+                Ok(vm.output().to_string())
+            })
+            .await
+    })
+}
+
+/// `log()` lines emitted by the snippet, stripped of the `[harn] ` prefix.
+fn lines(source: &str) -> Result<Vec<String>, String> {
+    run(source).map(|raw| {
+        raw.lines()
+            .filter_map(|l| l.strip_prefix("[harn] ").map(str::to_string))
+            .collect()
+    })
+}
+
+/// Resolve `tool_format` for a single `(provider, model, requested)` cell and
+/// echo the outcome. `requested` of `"auto"`/`""` means "omit / auto".
+fn resolve_snippet(provider: &str, model: &str, requested: &str) -> String {
+    let requested = if requested.is_empty() {
+        "auto"
+    } else {
+        requested
+    };
+    let opts =
+        format!(r#"{{model: "{model}", provider: "{provider}", tool_format: "{requested}"}}"#);
+    format!(
+        r#"
+import {{ agent_tool_format_resolution, agent_tool_format }} from "std/agent/options"
+pipeline main(task) {{
+  let r = agent_tool_format_resolution({opts})
+  log("tool_format=" + to_string(r.tool_format))
+  log("source=" + to_string(r.source))
+  log("effective=" + to_string(agent_tool_format({opts})))
+}}
+"#
+    )
+}
+
+/// Outcome of resolving one cell.
+enum Outcome {
+    /// Rejected: resolution threw. The carried string is the error text.
+    Rejected(String),
+    /// Accepted: resolution returned a concrete format string.
+    Accepted { tool_format: String },
+}
+
+fn resolve(provider: &str, model: &str, requested: &str) -> Outcome {
+    match lines(&resolve_snippet(provider, model, requested)) {
+        Err(err) => Outcome::Rejected(err),
+        Ok(out) => Outcome::Accepted {
+            tool_format: accepted_field(&out, "tool_format"),
+        },
+    }
+}
+
+/// Pull a `key=value` line emitted by a resolve snippet.
+fn accepted_field(out: &[String], key: &str) -> String {
+    out.iter()
+        .find_map(|l| l.strip_prefix(&format!("{key}=")))
+        .unwrap_or("")
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 1 — reject-or-work-well over the requested-format axis.
+//
+// A requested `tool_format` is one of: omitted/auto, native, text, or an
+// invalid token (typo / wrong value). Every accepted resolution must yield a
+// concrete `native` or `text`; every invalid token must be rejected.
+// ---------------------------------------------------------------------------
+
+/// The requested-format axis. `None` = omitted/auto.
+const REQUESTED_FORMATS: &[&str] = &[
+    "auto",     // explicit auto sentinel
+    "",         // omitted (treated as auto)
+    "native",   // valid
+    "text",     // valid
+    "NATIVE",   // valid but uppercase — must normalize, not reject
+    " text ",   // valid but padded — must normalize, not reject
+    "nativ",    // typo — must reject
+    "json",     // wrong value — must reject
+    "tool_use", // wrong value (Anthropic wire term) — must reject
+    "xml",      // wrong value — must reject
+];
+
+/// Representative real catalog cells spanning the capability profiles:
+///   - anthropic native-tools frontier
+///   - ollama text-only local (devstral)
+///   - llamacpp qwen3.6 native
+const REAL_CELLS: &[(&str, &str)] = &[
+    ("anthropic", "claude-sonnet-4-6"),
+    ("ollama", "devstral-small-2:24b"),
+    ("llamacpp", "qwen3.6-35b-a3b-ud-q4-k-xl"),
+];
+
+fn is_invalid_token(requested: &str) -> bool {
+    let norm = requested.trim().to_lowercase();
+    !matches!(norm.as_str(), "" | "auto" | "native" | "text")
+}
+
+#[test]
+fn requested_format_axis_rejects_or_resolves_concretely() {
+    for &(provider, model) in REAL_CELLS {
+        let (native_ok, text_ok, parity) = capability_facts(provider, model);
+        for &requested in REQUESTED_FORMATS {
+            let outcome = resolve(provider, model, requested);
+            let label = format!("{provider}:{model} requested={requested:?} (parity={parity})");
+            let norm = requested.trim().to_lowercase();
+            // A valid token can still be an impossible *side* for this cell:
+            // requesting "native" on a native_tools=false model, or "text" on
+            // a text_tool_wire_format_supported=false model, is a hard reject
+            // (the matrix says that side does not work) — never a silent
+            // degrade. The invalid-token cases reject on syntax alone.
+            let requests_impossible_side =
+                (norm == "native" && !native_ok) || (norm == "text" && !text_ok);
+            if is_invalid_token(requested) {
+                match outcome {
+                    Outcome::Rejected(err) => assert!(
+                        err.contains("tool_format"),
+                        "{label}: rejection should name tool_format; got {err}"
+                    ),
+                    Outcome::Accepted { tool_format, .. } => panic!(
+                        "{label}: invalid token silently accepted as {tool_format:?} \
+                         (reject-or-work-well violation)"
+                    ),
+                }
+            } else if requests_impossible_side {
+                match outcome {
+                    Outcome::Rejected(_) => {}
+                    Outcome::Accepted { tool_format, .. } => panic!(
+                        "{label}: requested an impossible side but was accepted as \
+                         {tool_format:?} (silent half-support)"
+                    ),
+                }
+            } else {
+                match outcome {
+                    Outcome::Rejected(err) => {
+                        panic!("{label}: serviceable request unexpectedly rejected: {err}")
+                    }
+                    Outcome::Accepted { tool_format, .. } => assert!(
+                        tool_format == "native" || tool_format == "text",
+                        "{label}: accepted but resolved to non-concrete {tool_format:?}"
+                    ),
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 2 — accepted format never contradicts the capability matrix.
+//
+// For each real cell, an accepted explicit request must match what the matrix
+// reports as servable: a model whose matrix says native_tools=false and
+// text_tool_wire_format_supported=true must NOT silently accept "native" as a
+// working config when parity marks it impossible — and must always be able to
+// serve "text". This is the "consistent across formats" gate.
+// ---------------------------------------------------------------------------
+
+/// Read the capability facts the resolver keys off for a cell.
+fn capability_facts(provider: &str, model: &str) -> (bool, bool, String) {
+    let src = format!(
+        r#"
+pipeline main(task) {{
+  let c = provider_capabilities("{provider}", "{model}")
+  log("native=" + to_string(c.native_tools))
+  log("text=" + to_string(c.text_tool_wire_format_supported))
+  log("parity=" + to_string(c.tool_mode_parity))
+}}
+"#
+    );
+    let out = lines(&src).expect("capability lookup");
+    (
+        accepted_field(&out, "native") == "true",
+        accepted_field(&out, "text") == "true",
+        accepted_field(&out, "parity"),
+    )
+}
+
+#[test]
+fn accepted_format_is_consistent_with_capability_matrix() {
+    for &(provider, model) in REAL_CELLS {
+        let (native_ok, text_ok, parity) = capability_facts(provider, model);
+        // A text-only model (no native tools) must always accept and resolve
+        // "text", and its auto resolution must land on "text".
+        if text_ok && !native_ok {
+            if let Outcome::Accepted { tool_format, .. } = resolve(provider, model, "text") {
+                assert_eq!(
+                    tool_format, "text",
+                    "{provider}:{model}: text-capable model dropped explicit text request"
+                );
+            } else {
+                panic!("{provider}:{model}: text-capable model rejected a text request");
+            }
+            // Auto must pick the servable side, not silently choose native.
+            if let Outcome::Accepted { tool_format, .. } = resolve(provider, model, "auto") {
+                assert_eq!(
+                    tool_format, "text",
+                    "{provider}:{model}: auto resolved to {tool_format:?} on a text-only model \
+                     (parity={parity})"
+                );
+            }
+        }
+        // A native-capable model must accept and resolve "native".
+        if native_ok {
+            if let Outcome::Accepted { tool_format, .. } = resolve(provider, model, "native") {
+                assert_eq!(
+                    tool_format, "native",
+                    "{provider}:{model}: native-capable model dropped explicit native request"
+                );
+            } else {
+                panic!("{provider}:{model}: native-capable model rejected a native request");
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 3 — hard parity (`*_only`) rejects the impossible side.
+//
+// Synthetic capability cells with `native_only` / `text_only` parity exercise
+// the hard-reject path that no shipped model currently has. A request for the
+// side the matrix marks impossible MUST be rejected, not degraded.
+// ---------------------------------------------------------------------------
+
+/// Install a synthetic capability rule with the given parity, then resolve
+/// while forcing the requested side with an explicit override reason.
+fn resolve_with_parity_and_override(
+    model: &str,
+    parity: &str,
+    native_tools: bool,
+    requested: &str,
+) -> Outcome {
+    resolve_with_parity_impl(model, parity, native_tools, requested, true)
+}
+
+/// Install a synthetic capability rule with the given parity, then resolve.
+fn resolve_with_parity(model: &str, parity: &str, native_tools: bool, requested: &str) -> Outcome {
+    resolve_with_parity_impl(model, parity, native_tools, requested, false)
+}
+
+/// Shared body: install a synthetic capability rule under provider `bootcamp`
+/// with the given derived/declared parity, then resolve `requested` against it.
+/// When `with_override` is set, a `tool_format_override_reason` is supplied to
+/// exercise the deliberate-force escape hatch. The install + resolve share one
+/// snippet so the override is live during resolution; the trailing
+/// `provider_capabilities_clear()` resets process-wide capability state.
+fn resolve_with_parity_impl(
+    model: &str,
+    parity: &str,
+    native_tools: bool,
+    requested: &str,
+    with_override: bool,
+) -> Outcome {
+    let preferred = if native_tools { "native" } else { "text" };
+    let install = format!(
+        r#"
+[[provider.bootcamp]]
+model_match = "{model}*"
+native_tools = {native_tools}
+preferred_tool_format = "{preferred}"
+text_tool_wire_format_supported = true
+tool_mode_parity = "{parity}"
+"#
+    );
+    let override_line = if with_override {
+        r#"tool_format_override_reason: "probe: deliberately forcing the marked-impossible side","#
+    } else {
+        ""
+    };
+    let src = format!(
+        r#"
+import {{ agent_tool_format_resolution }} from "std/agent/options"
+pipeline main(task) {{
+  provider_capabilities_install({install:?})
+  let r = agent_tool_format_resolution({{
+    model: "{model}",
+    provider: "bootcamp",
+    tool_format: "{requested}",
+    {override_line}
+  }})
+  log("tool_format=" + to_string(r.tool_format))
+  log("source=" + to_string(r.source))
+  provider_capabilities_clear()
+}}
+"#
+    );
+    match lines(&src) {
+        Err(err) => Outcome::Rejected(err),
+        Ok(out) => Outcome::Accepted {
+            tool_format: accepted_field(&out, "tool_format"),
+        },
+    }
+}
+
+#[test]
+fn native_only_parity_rejects_text_request() {
+    // native_only: the model can only do native tool calling. Asking for text
+    // must be rejected, while native must be accepted.
+    match resolve_with_parity("bootcamp-native-only-model", "native_only", true, "text") {
+        Outcome::Rejected(err) => assert!(
+            err.contains("text") && err.contains("native_only"),
+            "expected native_only rejection naming text; got {err}"
+        ),
+        Outcome::Accepted { tool_format, .. } => panic!(
+            "native_only model accepted text request as {tool_format:?} \
+             (silent half-support)"
+        ),
+    }
+    match resolve_with_parity("bootcamp-native-only-model", "native_only", true, "native") {
+        Outcome::Accepted { tool_format, .. } => assert_eq!(tool_format, "native"),
+        Outcome::Rejected(err) => panic!("native_only model rejected its own native side: {err}"),
+    }
+}
+
+#[test]
+fn text_only_parity_rejects_native_request() {
+    // text_only: the model can only do text tool calling. Asking for native
+    // must be rejected, while text must be accepted.
+    match resolve_with_parity("bootcamp-text-only-model", "text_only", false, "native") {
+        Outcome::Rejected(err) => assert!(
+            err.contains("native") && err.contains("text_only"),
+            "expected text_only rejection naming native; got {err}"
+        ),
+        Outcome::Accepted { tool_format, .. } => panic!(
+            "text_only model accepted native request as {tool_format:?} \
+             (silent half-support)"
+        ),
+    }
+    match resolve_with_parity("bootcamp-text-only-model", "text_only", false, "text") {
+        Outcome::Accepted { tool_format, .. } => assert_eq!(tool_format, "text"),
+        Outcome::Rejected(err) => panic!("text_only model rejected its own text side: {err}"),
+    }
+}
+
+#[test]
+fn override_reason_forces_marked_impossible_side() {
+    // The escape hatch: a probe/matrix harness may deliberately force the
+    // catalog-marked-impossible side by recording a reason. This stays within
+    // "never SILENTLY half-supported" — the override is explicit and recorded,
+    // not a silent quirk. Both directions must now ACCEPT.
+    match resolve_with_parity_and_override(
+        "bootcamp-text-only-forced",
+        "text_only",
+        false,
+        "native",
+    ) {
+        Outcome::Accepted { tool_format, .. } => assert_eq!(
+            tool_format, "native",
+            "override reason should force the requested native side on a text_only model"
+        ),
+        Outcome::Rejected(err) => {
+            panic!("override reason failed to unlock the forced native side: {err}")
+        }
+    }
+    match resolve_with_parity_and_override(
+        "bootcamp-native-only-forced",
+        "native_only",
+        true,
+        "text",
+    ) {
+        Outcome::Accepted { tool_format, .. } => assert_eq!(tool_format, "text"),
+        Outcome::Rejected(err) => {
+            panic!("override reason failed to unlock the forced text side: {err}")
+        }
+    }
+}
+
+#[test]
+fn unreliable_parity_warns_but_does_not_reject() {
+    // *_unreliable is recoverable, not impossible: the requested side still
+    // works (with a warning the harness author can act on), so resolution must
+    // ACCEPT it rather than reject. This is the boundary between the warn path
+    // and the hard-reject path.
+    match resolve_with_parity(
+        "bootcamp-native-unreliable-model",
+        "native_unreliable",
+        true,
+        "native",
+    ) {
+        Outcome::Accepted { tool_format, .. } => assert_eq!(
+            tool_format, "native",
+            "native_unreliable should still honor an explicit native request"
+        ),
+        Outcome::Rejected(err) => {
+            panic!("native_unreliable wrongly hard-rejected the recoverable side: {err}")
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 4 — config-source axis: the knob behaves identically whether the
+// format is pinned via explicit option or resolved from the catalog.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_and_catalog_paths_agree_on_servable_cells() {
+    for &(provider, model) in REAL_CELLS {
+        let (native_ok, text_ok, _) = capability_facts(provider, model);
+        let auto = match resolve(provider, model, "auto") {
+            Outcome::Accepted { tool_format, .. } => tool_format,
+            Outcome::Rejected(err) => panic!("{provider}:{model}: auto resolution failed: {err}"),
+        };
+        // Whatever auto picks, an explicit pin of the same value must resolve
+        // identically and be a format the matrix says is servable.
+        if !auto.is_empty() {
+            let explicit = match resolve(provider, model, &auto) {
+                Outcome::Accepted { tool_format, .. } => tool_format,
+                Outcome::Rejected(err) => {
+                    panic!("{provider}:{model}: explicit {auto:?} rejected though auto chose it: {err}")
+                }
+            };
+            assert_eq!(
+                auto, explicit,
+                "{provider}:{model}: auto and explicit disagree ({auto} vs {explicit})"
+            );
+            let servable = match auto.as_str() {
+                "native" => native_ok,
+                "text" => text_ok,
+                _ => false,
+            };
+            assert!(
+                servable,
+                "{provider}:{model}: auto chose {auto:?} which the matrix marks unservable"
+            );
+        }
+    }
+}

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -2432,7 +2432,9 @@ public let harnProviderCatalogJSON = #"""
       "id": "gpt-oss-120b",
       "name": "GPT-OSS 120B (Cerebras)",
       "provider": "cerebras",
-      "aliases": [],
+      "aliases": [
+        "cerebras-gpt-oss"
+      ],
       "context_window": 131072,
       "logical_model": "openai-gpt-oss-120b",
       "equivalence_group": "openai-gpt-oss-120b",
@@ -2588,7 +2590,9 @@ public let harnProviderCatalogJSON = #"""
       "id": "zai-glm-4.7",
       "name": "Z.ai GLM 4.7 (Cerebras)",
       "provider": "cerebras",
-      "aliases": [],
+      "aliases": [
+        "cerebras-glm"
+      ],
       "context_window": 131072,
       "modalities": {
         "input": [
@@ -4883,8 +4887,7 @@ public let harnProviderCatalogJSON = #"""
       "provider": "ollama",
       "aliases": [
         "devstral-small-2",
-        "ollama-devstral-small-2",
-        "ollama-devstral-small-2-native"
+        "ollama-devstral-small-2"
       ],
       "context_window": 262144,
       "runtime_context_window": 32768,
@@ -7681,6 +7684,18 @@ public let harnProviderCatalogJSON = #"""
   ],
   "aliases": [
     {
+      "name": "cerebras-glm",
+      "model_id": "zai-glm-4.7",
+      "provider": "cerebras",
+      "tool_format": "text"
+    },
+    {
+      "name": "cerebras-gpt-oss",
+      "model_id": "gpt-oss-120b",
+      "provider": "cerebras",
+      "tool_format": "text"
+    },
+    {
       "name": "cohere",
       "model_id": "command-a-plus-05-2026",
       "provider": "cohere"
@@ -7906,12 +7921,6 @@ public let harnProviderCatalogJSON = #"""
       "model_id": "devstral-small-2:24b",
       "provider": "ollama",
       "tool_format": "text"
-    },
-    {
-      "name": "ollama-devstral-small-2-native",
-      "model_id": "devstral-small-2:24b",
-      "provider": "ollama",
-      "tool_format": "native"
     },
     {
       "name": "ollama-gemma4",

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -2432,9 +2432,7 @@ public let harnProviderCatalogJSON = #"""
       "id": "gpt-oss-120b",
       "name": "GPT-OSS 120B (Cerebras)",
       "provider": "cerebras",
-      "aliases": [
-        "cerebras-gpt-oss"
-      ],
+      "aliases": [],
       "context_window": 131072,
       "logical_model": "openai-gpt-oss-120b",
       "equivalence_group": "openai-gpt-oss-120b",
@@ -2590,9 +2588,7 @@ public let harnProviderCatalogJSON = #"""
       "id": "zai-glm-4.7",
       "name": "Z.ai GLM 4.7 (Cerebras)",
       "provider": "cerebras",
-      "aliases": [
-        "cerebras-glm"
-      ],
+      "aliases": [],
       "context_window": 131072,
       "modalities": {
         "input": [
@@ -7683,18 +7679,6 @@ public let harnProviderCatalogJSON = #"""
     }
   ],
   "aliases": [
-    {
-      "name": "cerebras-glm",
-      "model_id": "zai-glm-4.7",
-      "provider": "cerebras",
-      "tool_format": "text"
-    },
-    {
-      "name": "cerebras-gpt-oss",
-      "model_id": "gpt-oss-120b",
-      "provider": "cerebras",
-      "tool_format": "text"
-    },
     {
       "name": "cohere",
       "model_id": "command-a-plus-05-2026",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -2168,7 +2168,9 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "id": "gpt-oss-120b",
       "name": "GPT-OSS 120B (Cerebras)",
       "provider": "cerebras",
-      "aliases": [],
+      "aliases": [
+        "cerebras-gpt-oss"
+      ],
       "context_window": 131072,
       "logical_model": "openai-gpt-oss-120b",
       "equivalence_group": "openai-gpt-oss-120b",
@@ -2324,7 +2326,9 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "id": "zai-glm-4.7",
       "name": "Z.ai GLM 4.7 (Cerebras)",
       "provider": "cerebras",
-      "aliases": [],
+      "aliases": [
+        "cerebras-glm"
+      ],
       "context_window": 131072,
       "modalities": {
         "input": [
@@ -4619,8 +4623,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "ollama",
       "aliases": [
         "devstral-small-2",
-        "ollama-devstral-small-2",
-        "ollama-devstral-small-2-native"
+        "ollama-devstral-small-2"
       ],
       "context_window": 262144,
       "runtime_context_window": 32768,
@@ -7417,6 +7420,18 @@ export const harnProviderCatalog: HarnProviderCatalog = {
   ],
   "aliases": [
     {
+      "name": "cerebras-glm",
+      "model_id": "zai-glm-4.7",
+      "provider": "cerebras",
+      "tool_format": "text"
+    },
+    {
+      "name": "cerebras-gpt-oss",
+      "model_id": "gpt-oss-120b",
+      "provider": "cerebras",
+      "tool_format": "text"
+    },
+    {
       "name": "cohere",
       "model_id": "command-a-plus-05-2026",
       "provider": "cohere"
@@ -7642,12 +7657,6 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "model_id": "devstral-small-2:24b",
       "provider": "ollama",
       "tool_format": "text"
-    },
-    {
-      "name": "ollama-devstral-small-2-native",
-      "model_id": "devstral-small-2:24b",
-      "provider": "ollama",
-      "tool_format": "native"
     },
     {
       "name": "ollama-gemma4",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -2168,9 +2168,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "id": "gpt-oss-120b",
       "name": "GPT-OSS 120B (Cerebras)",
       "provider": "cerebras",
-      "aliases": [
-        "cerebras-gpt-oss"
-      ],
+      "aliases": [],
       "context_window": 131072,
       "logical_model": "openai-gpt-oss-120b",
       "equivalence_group": "openai-gpt-oss-120b",
@@ -2326,9 +2324,7 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "id": "zai-glm-4.7",
       "name": "Z.ai GLM 4.7 (Cerebras)",
       "provider": "cerebras",
-      "aliases": [
-        "cerebras-glm"
-      ],
+      "aliases": [],
       "context_window": 131072,
       "modalities": {
         "input": [
@@ -7419,18 +7415,6 @@ export const harnProviderCatalog: HarnProviderCatalog = {
     }
   ],
   "aliases": [
-    {
-      "name": "cerebras-glm",
-      "model_id": "zai-glm-4.7",
-      "provider": "cerebras",
-      "tool_format": "text"
-    },
-    {
-      "name": "cerebras-gpt-oss",
-      "model_id": "gpt-oss-120b",
-      "provider": "cerebras",
-      "tool_format": "text"
-    },
     {
       "name": "cohere",
       "model_id": "command-a-plus-05-2026",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -1914,9 +1914,7 @@
       "id": "gpt-oss-120b",
       "name": "GPT-OSS 120B (Cerebras)",
       "provider": "cerebras",
-      "aliases": [
-        "cerebras-gpt-oss"
-      ],
+      "aliases": [],
       "context_window": 131072,
       "logical_model": "openai-gpt-oss-120b",
       "equivalence_group": "openai-gpt-oss-120b",
@@ -2072,9 +2070,7 @@
       "id": "zai-glm-4.7",
       "name": "Z.ai GLM 4.7 (Cerebras)",
       "provider": "cerebras",
-      "aliases": [
-        "cerebras-glm"
-      ],
+      "aliases": [],
       "context_window": 131072,
       "modalities": {
         "input": [
@@ -7165,18 +7161,6 @@
     }
   ],
   "aliases": [
-    {
-      "name": "cerebras-glm",
-      "model_id": "zai-glm-4.7",
-      "provider": "cerebras",
-      "tool_format": "text"
-    },
-    {
-      "name": "cerebras-gpt-oss",
-      "model_id": "gpt-oss-120b",
-      "provider": "cerebras",
-      "tool_format": "text"
-    },
     {
       "name": "cohere",
       "model_id": "command-a-plus-05-2026",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -1914,7 +1914,9 @@
       "id": "gpt-oss-120b",
       "name": "GPT-OSS 120B (Cerebras)",
       "provider": "cerebras",
-      "aliases": [],
+      "aliases": [
+        "cerebras-gpt-oss"
+      ],
       "context_window": 131072,
       "logical_model": "openai-gpt-oss-120b",
       "equivalence_group": "openai-gpt-oss-120b",
@@ -2070,7 +2072,9 @@
       "id": "zai-glm-4.7",
       "name": "Z.ai GLM 4.7 (Cerebras)",
       "provider": "cerebras",
-      "aliases": [],
+      "aliases": [
+        "cerebras-glm"
+      ],
       "context_window": 131072,
       "modalities": {
         "input": [
@@ -4365,8 +4369,7 @@
       "provider": "ollama",
       "aliases": [
         "devstral-small-2",
-        "ollama-devstral-small-2",
-        "ollama-devstral-small-2-native"
+        "ollama-devstral-small-2"
       ],
       "context_window": 262144,
       "runtime_context_window": 32768,
@@ -7163,6 +7166,18 @@
   ],
   "aliases": [
     {
+      "name": "cerebras-glm",
+      "model_id": "zai-glm-4.7",
+      "provider": "cerebras",
+      "tool_format": "text"
+    },
+    {
+      "name": "cerebras-gpt-oss",
+      "model_id": "gpt-oss-120b",
+      "provider": "cerebras",
+      "tool_format": "text"
+    },
+    {
       "name": "cohere",
       "model_id": "command-a-plus-05-2026",
       "provider": "cohere"
@@ -7388,12 +7403,6 @@
       "model_id": "devstral-small-2:24b",
       "provider": "ollama",
       "tool_format": "text"
-    },
-    {
-      "name": "ollama-devstral-small-2-native",
-      "model_id": "devstral-small-2:24b",
-      "provider": "ollama",
-      "tool_format": "native"
     },
     {
       "name": "ollama-gemma4",


### PR DESCRIPTION
Batches five individually-tested cheap-model-hardening fixes onto `main` ahead of the v0.8.88 release. Each was developed off an older base (v0.8.86); this PR re-bases them onto current `main` (v0.8.87) as one cohesive change and verifies they coexist.

## Components

1. **Recover more sloppy text tool-call shapes from value models** (`fec37774`) — broadens the tagged-call parser tolerance for malformed text tool calls emitted by value models. Touches `parse/tagged.rs`, `ts_value_parser.rs`.
2. **Treat `<tool_call>`-wrapped narration as prose, not a parse error** (`acc19cd3`) — when a `<tool_call>` block is actually narration rather than a real call, treat it as assistant prose instead of surfacing a parse error. Touches `parse/tagged.rs`.
3. **Accept code-bearing tool-call argument value shapes from value models** (`28a0650f`) — extends the argument-value grammar to accept code-bearing shapes value models produce. Touches `parse/syntax.rs`, `parse/native_json.rs`, `ts_value_parser.rs`.
4. **Tool-calling boot camp: reject-or-work-well for `tool_format`** (`dee34314`) — reject-or-work-well validation for the `tool_format` axis against the capability matrix, with an `options.harn` surface and provider-catalog validation. Includes a new `tool_calling_bootcamp.rs` integration test. Touches `options.harn`, `provider_catalog/validation.rs`, `catalog_sources/30-aliases/aliases.toml` (source) + regenerated `providers.toml` / `spec/provider-catalog/*` artifacts.
5. **Honor `[no-compact]` pin in transcript compaction** (`cd36fe42`) — compaction now preserves transcript entries pinned with `[no-compact]`. Touches `orchestration/compaction.rs`.

## Verification (combined — all five integrated)

- `cargo build -p harn-vm`: clean.
- `cargo test -p harn-vm --lib`: **3394 passed, 0 failed**. The three parser-touching components (parser tolerance, narration-as-prose, code-bearing args) coexist with no test interactions.
- `cargo test -p harn-vm --test tool_calling_bootcamp`: **7 passed, 0 failed**.
- `cargo fmt --all --check`: clean.
- `cargo clippy -p harn-vm`: clean.
- `harn fmt --check` / `harn check` on `options.harn`: ok.
- `harn providers build-config --check` + `harn providers validate --check-artifacts`: generated provider-catalog artifacts are in sync (no drift against v0.8.87 base).

Five `changelog.d/` fragments are included (one per fix); they will be folded at release time. This is the feature PR — the v0.8.88 version bump / Release PR is handled separately.