### PR TITLE
Make provider-catalog artifact generation hermetic

### DIFF
--- a/changelog.d/hermetic-provider-catalog-gen.fixed.md
+++ b/changelog.d/hermetic-provider-catalog-gen.fixed.md
@@ -1,0 +1,12 @@
+- **`harn providers export` / `providers validate --check-artifacts` now
+  generate the `spec/provider-catalog/*` artifacts hermetically.** Generation
+  reads only the compiled-in embedded provider config and capability matrix,
+  ignoring the developer's `~/.config/harn/providers.toml`, environment
+  overrides (`HARN_PROVIDERS_CONFIG`, `HARN_DEFAULT_PROVIDER`, `HARN_LLM_*`),
+  the process runtime-catalog overlay, and ambient thread-local user overrides.
+  Previously, artifact generation merged the effective (home/env-aware) config,
+  so a developer's personal aliases/providers could leak into the shipped
+  catalog and clean CI would then flag the artifacts as drifted. Runtime catalog
+  presentation is unchanged and still reflects the host's live configuration; an
+  explicit `--overlay` file remains honored because it is a declared,
+  reproducible input rather than ambient machine state.

--- a/crates/harn-cli/src/commands/providers/artifacts.rs
+++ b/crates/harn-cli/src/commands/providers/artifacts.rs
@@ -1,13 +1,19 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use harn_vm::llm_config::ProvidersConfig;
 use serde_json::json;
 
 use crate::cli::{ProvidersExportArgs, ProvidersValidateArgs};
 
 pub(crate) fn run_validate(args: &ProvidersValidateArgs) -> Result<(), String> {
-    apply_overlay(args.overlay.as_deref())?;
-    let artifact = harn_vm::provider_catalog::artifact();
+    let overlay = load_overlay(args.overlay.as_deref())?;
+    // Generation is hermetic: validate the artifact built from the compiled-in
+    // embedded catalog (plus any explicit `--overlay`), never the developer's
+    // home config or environment. Otherwise a personal
+    // `~/.config/harn/providers.toml` would leak aliases/providers into the
+    // catalog we validate and ship.
+    let artifact = harn_vm::provider_catalog::artifact_embedded(overlay.as_ref());
     let logical = harn_vm::provider_catalog::validate_artifact(&artifact);
     let schema = harn_vm::provider_catalog::schema_value();
     let artifact_value = serde_json::to_value(&artifact)
@@ -16,7 +22,7 @@ pub(crate) fn run_validate(args: &ProvidersValidateArgs) -> Result<(), String> {
     validate_against_schema(&schema, &artifact_value, &mut schema_errors)?;
     let mut drift = Vec::new();
     if args.check_artifacts {
-        drift = artifact_drift(&args.artifact_dir)?;
+        drift = artifact_drift(&args.artifact_dir, overlay.as_ref())?;
     }
 
     if args.json {
@@ -58,8 +64,10 @@ pub(crate) fn run_validate(args: &ProvidersValidateArgs) -> Result<(), String> {
 }
 
 pub(crate) fn run_export(args: &ProvidersExportArgs) -> Result<(), String> {
-    apply_overlay(args.overlay.as_deref())?;
-    let artifacts = generated_artifacts()?;
+    let overlay = load_overlay(args.overlay.as_deref())?;
+    // Export from the embedded catalog only (plus any explicit `--overlay`) so
+    // the checked-in artifacts are a pure function of the source tree.
+    let artifacts = generated_artifacts(overlay.as_ref())?;
     if args.check {
         let drift = artifact_drift_from(&args.output_dir, &artifacts)?;
         if drift.is_empty() {
@@ -87,16 +95,19 @@ pub(crate) fn run_export(args: &ProvidersExportArgs) -> Result<(), String> {
     Ok(())
 }
 
-fn apply_overlay(path: Option<&Path>) -> Result<(), String> {
+/// Parse an explicit `--overlay` providers.toml file into a config to merge on
+/// top of the embedded catalog. Returning the parsed overlay (instead of
+/// installing it via `set_user_overrides`) keeps generation hermetic: only this
+/// declared overlay influences the artifacts, never ambient thread-local state.
+fn load_overlay(path: Option<&Path>) -> Result<Option<ProvidersConfig>, String> {
     let Some(path) = path else {
-        return Ok(());
+        return Ok(None);
     };
     let src = fs::read_to_string(path)
         .map_err(|error| format!("failed to read overlay {}: {error}", path.display()))?;
     let overlay = harn_vm::llm_config::parse_config_toml(&src)
         .map_err(|error| format!("failed to parse overlay {}: {error}", path.display()))?;
-    harn_vm::llm_config::set_user_overrides(Some(overlay));
-    Ok(())
+    Ok(Some(overlay))
 }
 
 fn validate_against_schema(
@@ -121,11 +132,13 @@ struct GeneratedArtifact {
     body: String,
 }
 
-fn generated_artifacts() -> Result<Vec<GeneratedArtifact>, String> {
+fn generated_artifacts(
+    overlay: Option<&ProvidersConfig>,
+) -> Result<Vec<GeneratedArtifact>, String> {
     Ok(vec![
         GeneratedArtifact {
             relative_path: "provider-catalog.json",
-            body: harn_vm::provider_catalog::artifact_json()
+            body: harn_vm::provider_catalog::artifact_json_embedded(overlay)
                 .map_err(|error| format!("failed to generate catalog JSON: {error}"))?,
         },
         GeneratedArtifact {
@@ -135,19 +148,19 @@ fn generated_artifacts() -> Result<Vec<GeneratedArtifact>, String> {
         },
         GeneratedArtifact {
             relative_path: "harn-provider-catalog.ts",
-            body: harn_vm::provider_catalog::typescript_binding()
+            body: harn_vm::provider_catalog::typescript_binding_embedded(overlay)
                 .map_err(|error| format!("failed to generate TypeScript binding: {error}"))?,
         },
         GeneratedArtifact {
             relative_path: "HarnProviderCatalog.swift",
-            body: harn_vm::provider_catalog::swift_binding()
+            body: harn_vm::provider_catalog::swift_binding_embedded(overlay)
                 .map_err(|error| format!("failed to generate Swift binding: {error}"))?,
         },
     ])
 }
 
-fn artifact_drift(dir: &Path) -> Result<Vec<String>, String> {
-    artifact_drift_from(dir, &generated_artifacts()?)
+fn artifact_drift(dir: &Path, overlay: Option<&ProvidersConfig>) -> Result<Vec<String>, String> {
+    artifact_drift_from(dir, &generated_artifacts(overlay)?)
 }
 
 fn artifact_drift_from(dir: &Path, artifacts: &[GeneratedArtifact]) -> Result<Vec<String>, String> {
@@ -168,7 +181,7 @@ mod tests {
 
     #[test]
     fn generated_artifacts_include_downstream_bindings() {
-        let artifacts = generated_artifacts().expect("artifacts generate");
+        let artifacts = generated_artifacts(None).expect("artifacts generate");
         let names: Vec<_> = artifacts
             .iter()
             .map(|artifact| artifact.relative_path)
@@ -182,7 +195,8 @@ mod tests {
     #[test]
     fn generated_catalog_validates_against_schema() {
         let schema = harn_vm::provider_catalog::schema_value();
-        let artifact = serde_json::to_value(harn_vm::provider_catalog::artifact()).unwrap();
+        let artifact =
+            serde_json::to_value(harn_vm::provider_catalog::artifact_embedded(None)).unwrap();
         let mut errors = Vec::new();
         validate_against_schema(&schema, &artifact, &mut errors).expect("schema compiles");
         assert!(errors.is_empty(), "schema errors: {errors:?}");

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1079,6 +1079,31 @@ pub(crate) fn effective_config() -> ProvidersConfig {
     effective_config_with_user_overrides(user_overrides.as_ref())
 }
 
+/// Provider config built purely from the compiled-in `EMBEDDED_PROVIDERS_TOML`
+/// snapshot, ignoring every ambient layer: the developer's
+/// `~/.config/harn/providers.toml`, `HARN_PROVIDERS_CONFIG`, the process
+/// runtime-catalog overlay, and thread-local user overrides.
+///
+/// This is the hermetic source of truth for *generating* the checked-in
+/// `spec/provider-catalog/*` artifacts. Artifact generation must be a pure
+/// function of the source tree so a developer's personal aliases/providers
+/// never leak into shipped artifacts (which then makes clean CI flag drift).
+/// Runtime catalog presentation must keep using [`effective_config`] /
+/// [`effective_config_with_user_overrides`], which legitimately reflect the
+/// host's live configuration.
+///
+/// An optional explicit overlay (e.g. a `--overlay` file named on the command
+/// line) is merged on top of the embedded base. Unlike the home file and env
+/// layers, that overlay is a declared, reproducible input rather than ambient
+/// machine state, so it is safe to honor while staying hermetic.
+pub fn embedded_config(explicit_overlay: Option<&ProvidersConfig>) -> ProvidersConfig {
+    let mut config = default_config();
+    if let Some(overlay) = explicit_overlay {
+        config.merge_from(overlay);
+    }
+    config
+}
+
 pub(crate) fn effective_config_with_user_overrides(
     user_overrides: Option<&ProvidersConfig>,
 ) -> ProvidersConfig {

--- a/crates/harn-vm/src/provider_catalog.rs
+++ b/crates/harn-vm/src/provider_catalog.rs
@@ -39,7 +39,9 @@ mod tests;
 mod types;
 mod validation;
 
-pub use bindings::{swift_binding, typescript_binding};
+pub use bindings::{
+    swift_binding, swift_binding_embedded, typescript_binding, typescript_binding_embedded,
+};
 pub use remote::{refresh_runtime_catalog, CatalogRefreshOptions, CatalogRefreshReport};
 pub use schema::{schema_json, schema_value};
 pub use types::*;
@@ -165,6 +167,30 @@ pub fn artifact() -> ProviderCatalogArtifact {
     artifact_from_config(&config, CatalogCapabilityOverrides::CurrentThread)
 }
 
+/// Build the catalog artifact hermetically: from the compiled-in embedded
+/// provider config and embedded capability matrix only, ignoring the
+/// developer's `~/.config/harn/providers.toml`, environment overrides
+/// (`HARN_PROVIDERS_CONFIG`, `HARN_DEFAULT_PROVIDER`, `HARN_LLM_*`), the
+/// process runtime-catalog overlay, and any thread-local user overrides.
+///
+/// This is what `harn providers export` / `providers validate
+/// --check-artifacts` use so the checked-in `spec/provider-catalog/*` artifacts
+/// are a pure function of the source tree. Do NOT use this for live runtime
+/// catalog presentation — use [`artifact`] / [`artifact_with_overrides`] there,
+/// which legitimately reflect the host's configuration.
+///
+/// `explicit_overlay` is an optional declared overlay (e.g. a `--overlay` file
+/// named on the command line); it is reproducible input, not ambient machine
+/// state, so it is merged on top of the embedded base while staying hermetic.
+pub fn artifact_embedded(
+    explicit_overlay: Option<&llm_config::ProvidersConfig>,
+) -> ProviderCatalogArtifact {
+    let config = llm_config::embedded_config(explicit_overlay);
+    // `Explicit(None)` consults only the built-in capability matrix, never the
+    // thread-local capability user-overrides the CLI may have installed.
+    artifact_from_config(&config, CatalogCapabilityOverrides::Explicit(None))
+}
+
 /// Build a catalog artifact for a runtime that has captured explicit provider
 /// and capability overlays. `None` means no override for that layer; unlike
 /// `artifact()`, this does not read thread-local user overrides implicitly.
@@ -233,7 +259,19 @@ fn artifact_from_config(
 }
 
 pub fn artifact_json() -> Result<String, serde_json::Error> {
-    serde_json::to_string_pretty(&artifact()).map(|mut text| {
+    artifact_to_json(&artifact())
+}
+
+/// Hermetic counterpart of [`artifact_json`] for generating the checked-in
+/// `provider-catalog.json` artifact. See [`artifact_embedded`].
+pub fn artifact_json_embedded(
+    explicit_overlay: Option<&llm_config::ProvidersConfig>,
+) -> Result<String, serde_json::Error> {
+    artifact_to_json(&artifact_embedded(explicit_overlay))
+}
+
+fn artifact_to_json(artifact: &ProviderCatalogArtifact) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(artifact).map(|mut text| {
         text.push('\n');
         text
     })

--- a/crates/harn-vm/src/provider_catalog/bindings.rs
+++ b/crates/harn-vm/src/provider_catalog/bindings.rs
@@ -1,25 +1,51 @@
 use super::*;
 
 pub fn typescript_binding() -> Result<String, serde_json::Error> {
-    let json = artifact_json()?;
-    Ok(format!(
+    Ok(typescript_binding_from_json(&artifact_json()?))
+}
+
+/// Hermetic counterpart of [`typescript_binding`] for generating the
+/// checked-in `harn-provider-catalog.ts` artifact. See [`artifact_embedded`].
+pub fn typescript_binding_embedded(
+    explicit_overlay: Option<&crate::llm_config::ProvidersConfig>,
+) -> Result<String, serde_json::Error> {
+    Ok(typescript_binding_from_json(&artifact_json_embedded(
+        explicit_overlay,
+    )?))
+}
+
+fn typescript_binding_from_json(json: &str) -> String {
+    format!(
         "{}{}{}{}{}",
         generated_header("//", "typescript"),
         TYPESCRIPT_TYPES,
         "\nexport const harnProviderCatalog: HarnProviderCatalog = ",
         json.trim_end(),
         ";\n",
-    ) + TYPESCRIPT_COMPAT_EXPORTS)
+    ) + TYPESCRIPT_COMPAT_EXPORTS
 }
 
 pub fn swift_binding() -> Result<String, serde_json::Error> {
-    let json = artifact_json()?;
-    Ok(format!(
+    Ok(swift_binding_from_json(&artifact_json()?))
+}
+
+/// Hermetic counterpart of [`swift_binding`] for generating the checked-in
+/// `HarnProviderCatalog.swift` artifact. See [`artifact_embedded`].
+pub fn swift_binding_embedded(
+    explicit_overlay: Option<&crate::llm_config::ProvidersConfig>,
+) -> Result<String, serde_json::Error> {
+    Ok(swift_binding_from_json(&artifact_json_embedded(
+        explicit_overlay,
+    )?))
+}
+
+fn swift_binding_from_json(json: &str) -> String {
+    format!(
         "{}{}\npublic let harnProviderCatalogJSON = #\"\"\"\n{}\"\"\"#\n",
         generated_header("//", "swift"),
         SWIFT_TYPES,
         json
-    ))
+    )
 }
 
 fn generated_header(comment: &str, language: &str) -> String {

--- a/crates/harn-vm/src/provider_catalog/tests.rs
+++ b/crates/harn-vm/src/provider_catalog/tests.rs
@@ -597,3 +597,99 @@ fast_mode = { param = "speed", value = "fast", status = "turbo", pricing = { inp
         report.warnings
     );
 }
+
+/// A providers.toml overlay declaring a provider/alias/model that a developer
+/// might carry in their personal `~/.config/harn/providers.toml`. Generation
+/// must never bake any of this into the shipped catalog artifacts.
+const POLLUTING_OVERLAY: &str = r#"
+[providers.leakco]
+display_name = "Leak Co"
+base_url = "https://leak.example/v1"
+auth_style = "bearer"
+auth_env = "LEAK_API_KEY"
+chat_endpoint = "/chat/completions"
+
+[aliases]
+leak-alias = { id = "leak/model", provider = "leakco", tool_format = "text" }
+
+[models."leak/model"]
+name = "Leak Model"
+provider = "leakco"
+context_window = 8192
+"#;
+
+fn catalog_mentions_leak(artifact: &ProviderCatalogArtifact) -> bool {
+    artifact.providers.iter().any(|p| p.id == "leakco")
+        || artifact.aliases.iter().any(|a| a.name == "leak-alias")
+        || artifact.models.iter().any(|m| m.id == "leak/model")
+}
+
+#[test]
+fn embedded_artifact_generation_is_hermetic_against_ambient_overlay() {
+    // Baseline generated with no ambient config at all.
+    llm_config::clear_user_overrides();
+    let baseline = artifact_embedded(None);
+    let baseline_json = artifact_json_embedded(None).expect("baseline json");
+    let baseline_ts = typescript_binding_embedded(None).expect("baseline ts");
+    let baseline_swift = swift_binding_embedded(None).expect("baseline swift");
+
+    assert!(
+        !catalog_mentions_leak(&baseline),
+        "baseline embedded catalog should not contain leak fixtures"
+    );
+
+    // Install an ambient overlay — the in-test proxy for a polluting
+    // `~/.config/harn/providers.toml` / `HARN_PROVIDERS_CONFIG`. Hermetic
+    // generation must ignore it entirely, so output stays byte-identical.
+    {
+        let _guard = install_overlay(POLLUTING_OVERLAY);
+
+        // Sanity-check the contrast: the *runtime* catalog DOES reflect the
+        // ambient overlay, so this is a genuine hermetic fork, not a no-op.
+        assert!(
+            catalog_mentions_leak(&artifact()),
+            "runtime artifact() must still reflect the ambient overlay"
+        );
+
+        let polluted = artifact_embedded(None);
+        assert!(
+            !catalog_mentions_leak(&polluted),
+            "embedded catalog leaked ambient overlay aliases/providers/models"
+        );
+        assert_eq!(
+            artifact_json_embedded(None).expect("polluted json"),
+            baseline_json,
+            "embedded provider-catalog.json must be byte-identical with/without ambient overlay"
+        );
+        assert_eq!(
+            typescript_binding_embedded(None).expect("polluted ts"),
+            baseline_ts,
+            "embedded TypeScript binding must be byte-identical with/without ambient overlay"
+        );
+        assert_eq!(
+            swift_binding_embedded(None).expect("polluted swift"),
+            baseline_swift,
+            "embedded Swift binding must be byte-identical with/without ambient overlay"
+        );
+    }
+
+    // After dropping the overlay, generation is unchanged.
+    assert_eq!(
+        artifact_json_embedded(None).expect("cleared json"),
+        baseline_json
+    );
+}
+
+#[test]
+fn embedded_artifact_honors_explicit_declared_overlay() {
+    llm_config::clear_user_overrides();
+    let overlay = llm_config::parse_config_toml(POLLUTING_OVERLAY).expect("overlay parses");
+    // An *explicit* declared overlay (e.g. a `--overlay` file named on the
+    // command line) is reproducible input, not ambient machine state, so the
+    // hermetic generator merges it on top of the embedded base.
+    let artifact = artifact_embedded(Some(&overlay));
+    assert!(
+        catalog_mentions_leak(&artifact),
+        "explicit overlay should be merged into the embedded catalog"
+    );
+}


### PR DESCRIPTION
## The bug

`harn providers export` and `harn providers validate --check-artifacts`
generated the `spec/provider-catalog/*` artifacts from the **effective**
provider config, which merges the developer's `~/.config/harn/providers.toml`
home file (gated only by `should_load_home_config()`, which keys on
`!cfg!(test)`) plus environment overrides (`HARN_PROVIDERS_CONFIG`,
`HARN_DEFAULT_PROVIDER`, `HARN_LLM_*`). Artifact generation was therefore **not
a pure function of the source tree**: a developer with personal
aliases/providers in their home config baked them into the shipped catalog, and
clean CI then flagged the committed artifacts as drifted. This caused a real CI
failure when two personal `cerebras-*` aliases leaked into the catalog.

## The fix

Add a dedicated hermetic entry point and route **only** the artifact
export/validate command handlers through it. Runtime catalog presentation is
left untouched.

- `llm_config::embedded_config(explicit_overlay)` builds the provider config
  from the compiled-in `EMBEDDED_PROVIDERS_TOML` only — no home file, no env
  overrides, no runtime-catalog overlay, no ambient thread-local user overrides.
- `provider_catalog::artifact_embedded` / `artifact_json_embedded` /
  `typescript_binding_embedded` / `swift_binding_embedded` build from that
  embedded config plus `CatalogCapabilityOverrides::Explicit(None)` so the
  capability matrix is the built-in one too. `schema_value` / `schema_json` are
  pure constants and need no embedded variant.
- `providers export` and `validate --check-artifacts` (artifacts.rs) call the
  embedded generators. The `--overlay` flag is honored by passing the parsed
  overlay **explicitly** (a declared, reproducible input) instead of installing
  it as an ambient `set_user_overrides`. This automatically covers the Makefile
  `gen-provider-catalog` / `check-provider-catalog` path.

### Caller classification (what is NOT changed)

Runtime presentation / hashing / docs keep reflecting the live host config:
`provider_catalog::artifact()` / `artifact_with_overrides()` in `harn-serve`,
`workflow_bundle::current_provider_catalog_hash_blake3`, `pack.rs` SBOM, and the
`provider-matrix` / `provider-support` doc generators.

## Tests

- `embedded_artifact_generation_is_hermetic_against_ambient_overlay`: installs a
  polluting overlay (in-test proxy for a personal `~/.config/harn/providers.toml`),
  asserts the runtime `artifact()` **does** surface it (genuine fork, not a
  no-op), and asserts the embedded JSON/TypeScript/Swift outputs are
  byte-identical with vs without the overlay and never contain the leak fixtures.
- `embedded_artifact_honors_explicit_declared_overlay`: proves an explicit
  `--overlay` is still merged into the embedded base.

## Local verification (with the polluting home file present)

- `providers validate --check-artifacts` → PASS
- `make check-provider-catalog` → PASS
- `providers export` byte-identical with vs without a bogus
  `HARN_PROVIDERS_CONFIG` + `HARN_DEFAULT_PROVIDER`; bogus alias never leaks;
  output matches committed `spec/provider-catalog/*` (no artifact bytes changed)
- `cargo test -p harn-vm --lib provider_catalog` (23 pass) and
  `cargo test -p harn-cli --lib providers` (12 pass)
- `cargo fmt --check` and `cargo clippy -D warnings` on harn-vm + harn-cli clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)