### PR TITLE
Stop reasoning from leaking into message channel on tool-call turns

### DIFF
--- a/changelog.d/reasoning-channel-leak.fixed.md
+++ b/changelog.d/reasoning-channel-leak.fixed.md
@@ -1,0 +1,14 @@
+- **Reasoning-only turns that also call a tool no longer leak the model's
+  private chain-of-thought into the visible message channel.** OpenAI-compatible
+  normalization (both the non-streaming `normalize_openai_message_text` and the
+  streaming transport path) promoted a turn's extracted reasoning into `.text`
+  whenever the content channel was empty — intended for models that legitimately
+  answer inside the reasoning channel. But gpt-oss / harmony models route their
+  analysis channel into `reasoning_content` and emit a tool call with no
+  committed content, so that promotion surfaced their intermediate
+  chain-of-thought ("We need to inspect parser.rs first…") as the assistant
+  message. That contaminated both the user-facing transcript and the
+  transcript-mined eval grader. Promotion is now suppressed when the turn
+  carries a tool call (the tool call is the action, the reasoning is not a final
+  answer); the reasoning stays under `thinking`. Reasoning-as-answer promotion
+  on tool-call-free clean stops is unchanged.

--- a/crates/harn-vm/src/llm/api/openai_normalize.rs
+++ b/crates/harn-vm/src/llm/api/openai_normalize.rs
@@ -139,7 +139,20 @@ pub(super) fn normalize_openai_message_text(
     // final answer. Keep `text` empty and expose only the partial trace via
     // `thinking`, so the caller can emit a clean truncation signal instead.
     let truncated = finish_reason == Some("length");
-    if !truncated && text.is_empty() && !extracted_thinking.is_empty() {
+    // When the message also carries a tool call, the reasoning is intermediate
+    // chain-of-thought (the tool call is the real action), not a final answer.
+    // gpt-oss / harmony models route their analysis channel into
+    // `reasoning_content` and emit a tool call with empty content; promoting
+    // that reasoning into `.text` leaks the model's private chain-of-thought
+    // into the user-facing assistant message AND into the transcript the eval
+    // grader mines, contaminating both. Keep `.text` empty and surface the
+    // reasoning only via `thinking`. Only promote reasoning-as-answer when the
+    // turn has no tool call to act on.
+    let has_tool_call = message
+        .get("tool_calls")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|calls| !calls.is_empty());
+    if !truncated && !has_tool_call && text.is_empty() && !extracted_thinking.is_empty() {
         text = extracted_thinking.clone();
     }
     (text, extracted_thinking)
@@ -273,6 +286,34 @@ mod tests {
         let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
         assert_eq!(visible, "the answer is 42");
         assert_eq!(thinking, "the answer is 42");
+    }
+
+    #[test]
+    fn normalize_openai_message_text_does_not_promote_reasoning_when_tool_call_present() {
+        // gpt-oss / harmony models route their analysis channel into
+        // `reasoning_content` and emit a tool call with empty content. The
+        // reasoning is intermediate chain-of-thought, NOT a final answer — the
+        // tool call is the action. Promoting it into `.text` would leak the
+        // model's private CoT into the user-facing message and into the
+        // transcript the eval grader mines, contaminating the meter stick.
+        let message = serde_json::json!({
+            "content": "",
+            "reasoning_content": "We need to write unit tests for the parser. First inspect parser.rs.",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "look", "arguments": "{\"path\":\"parser.rs\"}"}
+            }]
+        });
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("tool_calls"));
+        assert_eq!(
+            visible, "",
+            "reasoning leaked into visible text on a tool-call turn"
+        );
+        assert_eq!(
+            thinking,
+            "We need to write unit tests for the parser. First inspect parser.rs."
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -1155,7 +1155,15 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
     // final answer. Leave `text` empty and expose the partial trace only via
     // `thinking`, mirroring `openai_normalize::normalize_openai_message_text`.
     let truncated = stop_reason.as_deref() == Some("length");
-    if !truncated && text.is_empty() && !thinking_text.is_empty() {
+    // When the turn also carries a tool call, the reasoning is intermediate
+    // chain-of-thought (the tool call is the real action), not a final answer.
+    // gpt-oss / harmony models stream their analysis channel into the reasoning
+    // delta and emit a tool call with no committed content; promoting that
+    // reasoning into `.text` leaks private chain-of-thought into the user-facing
+    // assistant message AND the transcript the eval grader mines. Keep `.text`
+    // empty and surface the reasoning only via `thinking`, mirroring
+    // `openai_normalize::normalize_openai_message_text`.
+    if !truncated && tool_calls.is_empty() && text.is_empty() && !thinking_text.is_empty() {
         text = thinking_text.clone();
         blocks
             .push(serde_json::json!({"type": "output_text", "text": text, "visibility": "public"}));
@@ -1949,6 +1957,42 @@ mod streaming_tool_call_tests {
         assert_eq!(result.stop_reason.as_deref(), Some("stop"));
         assert_eq!(result.text, "the answer is 42");
         assert_eq!(result.thinking.as_deref(), Some("the answer is 42"));
+
+        clear_session_sinks(&session_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn openai_stream_reasoning_does_not_leak_into_text_when_tool_call_present() {
+        // gpt-oss / harmony streaming: the analysis channel arrives as
+        // `reasoning` deltas, the model emits a tool call, and no `content`
+        // delta is committed. The reasoning is intermediate chain-of-thought,
+        // not a final answer — the tool call is the action. It must NOT be
+        // promoted into `.text` (that would leak private CoT into the
+        // user-facing message and into the transcript the eval grader mines);
+        // it stays under `.thinking`.
+        let body = concat!(
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\"We need to inspect\"}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"reasoning\":\" parser.rs first.\"}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"function\":{\"name\":\"look\",\"arguments\":\"{\\\"path\\\":\\\"parser.rs\\\"}\"}}]}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"finish_reason\":\"tool_calls\",\"delta\":{}}],\"usage\":{\"prompt_tokens\":4,\"completion_tokens\":6}}\n",
+            "data: [DONE]\n",
+        );
+        let session_id = fresh_session_id("oai-reason-toolcall");
+        let (result, _events) = drive(body.as_bytes(), &session_id, false).await;
+
+        assert_eq!(result.stop_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(
+            result.text, "",
+            "reasoning leaked into visible text on a tool-call turn: {:?}",
+            result.text
+        );
+        assert_eq!(
+            result.thinking.as_deref(),
+            Some("We need to inspect parser.rs first."),
+            "reasoning trace must survive under thinking"
+        );
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0]["name"], "look");
 
         clear_session_sinks(&session_id);
     }


### PR DESCRIPTION
## Problem

Cheap/local reasoning models (notably **gpt-oss / harmony** via Cerebras) were leaking their private chain-of-thought into the **visible assistant message channel**, contaminating both the user-facing transcript and the transcript-mined eval grader that the meter stick depends on.

### Evidence (real eval data)

Scanning all `~/.burin-evals` transcripts: across **899 cheap/local-model eval summaries**, the gpt-oss-120b raw `provider_call_response` records carry the analysis channel in BOTH `thinking` AND `text`, e.g.:

```
text:     'We need to write unit tests for command parser. First inspect src/server/command_parser.cpp.'
thinking: 'We need to write unit tests for command parser. First inspect src/server/command_parser.cpp.'
tool_calls: [{"name": "look", ...}]   # the real action
```

That `text` becomes an assistant `{type:"message", role:"assistant"}` record, which is exactly what `scripts/analyze-eval-transcripts.harn` (transcript miner) and `scripts/grade-compaction-run.harn` (LLM compaction judge, reads `request_snapshot.messages`) ingest — so the grader reads model reasoning. A transcript-mined grader that reads reasoning is a contaminated meter stick.

## Root cause

`normalize_openai_message_text` (non-streaming) and the streaming transport path both promote a turn's extracted reasoning into `.text` whenever the content channel is empty. That promotion is correct for models that legitimately answer *inside* the reasoning channel (e.g. minimax), but wrong for harmony models: they route the analysis channel into `reasoning_content` and emit a **tool call** with no committed content. The reasoning is intermediate CoT, not a final answer — the tool call is the action.

## Fix

Suppress the reasoning→`.text` promotion when the turn carries a tool call. The reasoning still survives under `thinking` (private). Reasoning-as-answer promotion on tool-call-free clean stops is unchanged. Applied identically to both the non-streaming and streaming paths.

This is the correct owning layer per the Burin/Harn split: parsing the LLM wire response into message-vs-thought is Harn's job. Burin's grounding/loop layers have **no** reasoning handling and rely entirely on Harn to have already separated it.

## Tests

- `normalize_openai_message_text_does_not_promote_reasoning_when_tool_call_present` (non-streaming)
- `openai_stream_reasoning_does_not_leak_into_text_when_tool_call_present` (streaming)

Each: a reasoning-only message/stream carrying a tool call asserts `.text` stays empty and the reasoning routes to `thinking`. The existing `..._promotes_reasoning_on_clean_stop` controls still pass (tool-call-free promotion unchanged).

## Verification

- `RUSTFLAGS="-D warnings" cargo build -p harn-vm` — clean
- `cargo test -p harn-vm --lib llm::api::` — 145 passed, 0 failed
- `cargo fmt -p harn-vm --check` — clean
- `cargo clippy -p harn-vm --lib` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)