### PR TITLE
Extend flow narrowing to full reference-path + match parity

### DIFF
--- a/changelog.d/flow-path-narrowing.added.md
+++ b/changelog.d/flow-path-narrowing.added.md
@@ -1,10 +1,28 @@
 - **Flow-sensitive type refinement now narrows reference paths and
-  `if`-expression branches.** `type_of(entry.arguments) == "list"` and
-  `entry.arguments != nil` narrow the property path itself (any identifier-
-  rooted chain of constant `.` / `?.` accesses), not just bare variables, so a
-  guarded path flows into a typed parameter without a defensive `?? []`
-  coercion. The same refinements now also apply inside an `if`/`else` used as
-  an expression for its value — matching the ternary — so
-  `let xs = if type_of(p) == "list" { p } else { [] }` infers `list` instead of
-  widening back to `list?`. Path narrowing is dropped when the base variable or
-  the path is reassigned.
+  `if`-expression branches, at parity with bare-variable narrowing.** Every
+  refinement form that narrowed a variable now also narrows an *identifier-
+  rooted reference path* — a chain of constant `.`/`?.` property accesses and
+  constant `[…]` subscripts (`entry.arguments`, `cfg.opts.mode`, `xs[0]`,
+  `m["k"]`):
+  - `type_of(path) == "T"`, `path != nil`, and a bare `if path` (truthiness)
+    narrow the path; a path whose type is the top type (`unknown`/`any`, e.g. a
+    `json_parse` / `llm_call` boundary field) narrows to the tested kind.
+  - `schema_is(path, S)` / `is_type(path, S)` and `path.has("k")` narrow the
+    path.
+  - A tagged-shape-union discriminant narrows the object path
+    (`o.msg.kind == "ping"` narrows `o.msg`), gated so it never mangles a
+    `dict`/`unknown` object.
+  - `match type_of(subject) { "T" -> … }` now narrows the subject — variable
+    **or** path — in each arm (previously this narrowed nothing, even for a
+    bare variable).
+  - The `unknown`-exhaustiveness lint (incomplete `type_of` chain reaching
+    `unreachable()` / `throw`) now also covers `unknown`-typed paths.
+  - An `if`/`else` used as an expression now narrows its branches like the
+    ternary, so `let xs = if type_of(p) == "list" { p } else { [] }` infers
+    `list` rather than widening back to `list?`.
+
+  Narrowing is dropped when the base variable or path is reassigned. A
+  *dynamic* subscript (`xs[i]` with a non-literal index) is intentionally never
+  narrowed — it is not a stable reference. This is a static type-checker
+  feature: the runtime is dynamically typed and `type_of` always reflects the
+  concrete value, so no runtime change is needed.

--- a/conformance/tests/types/path_narrowing_advanced.expected
+++ b/conformance/tests/types/path_narrowing_advanced.expected
@@ -1,0 +1,4 @@
+[harn] s:hi
+[harn] i:7
+[harn] 42
+[harn] 0

--- a/conformance/tests/types/path_narrowing_advanced.harn
+++ b/conformance/tests/types/path_narrowing_advanced.harn
@@ -1,0 +1,27 @@
+/**
+ * Reference-path narrowing reaches parity with variable narrowing:
+ * `match type_of(path)` narrows each arm, and a tagged-shape-union
+ * discriminant narrows the object path. Both flow into typed positions
+ * without coercion, and run correctly.
+ */
+pipeline test(task) {
+  fn describe(o: {val: string | int}) -> string {
+    return match type_of(o.val) {
+      "string" -> { "s:${o.val}" }
+      "int" -> { "i:${o.val}" }
+      _ -> { "?" }
+    }
+  }
+  type Ping = {kind: "ping", ttl: int}
+  type Pong = {kind: "pong", lat: int}
+  fn latency(o: {msg: Ping | Pong}) -> int {
+    if o.msg.kind == "pong" {
+      return o.msg.lat
+    }
+    return 0
+  }
+  log(describe({val: "hi"}))
+  log(describe({val: 7}))
+  log(latency({msg: {kind: "pong", lat: 42}}))
+  log(latency({msg: {kind: "ping", ttl: 9}}))
+}

--- a/crates/harn-parser/src/typechecker/inference/decls.rs
+++ b/crates/harn-parser/src/typechecker/inference/decls.rs
@@ -204,6 +204,7 @@ impl TypeChecker {
                         value_type.as_ref(),
                         &mut arm_scope,
                     );
+                    self.narrow_match_subject(value, &arm.pattern, &mut arm_scope);
                     if !self.collect_block_returns(&arm.body, &mut arm_scope, out) {
                         return false;
                     }
@@ -543,6 +544,7 @@ impl TypeChecker {
                             value_type.as_ref(),
                             &mut arm_scope,
                         );
+                        self.narrow_match_subject(value, &arm.pattern, &mut arm_scope);
                         self.body_cannot_fall_through(&arm.body, &arm_scope)
                     })
             }
@@ -643,7 +645,7 @@ impl TypeChecker {
                 then_body,
                 else_body,
             } => {
-                let refs = Self::extract_refinements(condition, scope);
+                let refs = self.extract_refinements(condition, scope);
                 let mut then_scope = scope.child();
                 refs.apply_truthy(&mut then_scope);
                 for stmt in then_body {
@@ -681,6 +683,7 @@ impl TypeChecker {
                         value_type.as_ref(),
                         &mut arm_scope,
                     );
+                    self.narrow_match_subject(value, &arm.pattern, &mut arm_scope);
                     for stmt in &arm.body {
                         self.check_return_type(stmt, expected, expected_span, &mut arm_scope);
                     }
@@ -727,7 +730,7 @@ impl TypeChecker {
                 }
             }
             Node::WhileLoop { condition, body } => {
-                let refs = Self::extract_refinements(condition, scope);
+                let refs = self.extract_refinements(condition, scope);
                 let mut loop_scope = scope.child();
                 refs.apply_truthy(&mut loop_scope);
                 for stmt in body {
@@ -756,7 +759,7 @@ impl TypeChecker {
                 condition,
                 else_body,
             } => {
-                let refs = Self::extract_refinements(condition, scope);
+                let refs = self.extract_refinements(condition, scope);
                 let mut else_scope = scope.child();
                 refs.apply_falsy(&mut else_scope);
                 for stmt in else_body {

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -22,7 +22,8 @@ use super::super::binary_ops::{infer_binary_op_type, merge_shape_fields};
 use super::super::schema_inference::schema_type_expr_from_node;
 use super::super::scope::{builtin_return_type, InferredType, PathNarrowing, TypeScope};
 use super::super::union::{
-    narrow_to_single, reference_path_key, remove_from_union, simplify_union,
+    intersect_types, narrow_to_single, reference_path_key, reference_path_key_for_subscript,
+    remove_from_union, simplify_union, subtract_type,
 };
 use super::super::{is_gradual_type_name, TypeChecker};
 
@@ -133,6 +134,7 @@ impl TypeChecker {
         for arm in arms {
             let mut arm_scope = scope.child();
             self.define_match_pattern_bindings(&arm.pattern, value_type.as_ref(), &mut arm_scope);
+            self.narrow_match_subject(value, &arm.pattern, &mut arm_scope);
             if let Some(arm_type) = self.infer_block_type(&arm.body, &arm_scope) {
                 arm_types.push(arm_type);
             }
@@ -594,7 +596,7 @@ impl TypeChecker {
                 true_expr,
                 false_expr,
             } => {
-                let refs = Self::extract_refinements(condition, scope);
+                let refs = self.extract_refinements(condition, scope);
 
                 let mut true_scope = scope.child();
                 refs.apply_truthy(&mut true_scope);
@@ -980,7 +982,7 @@ impl TypeChecker {
                 // value (`let x = if type_of(p) == "list" { p } else { ... }`)
                 // must see `p` narrowed inside the matching branch, otherwise
                 // the result type widens back to the un-narrowed union.
-                let refs = Self::extract_refinements(condition, scope);
+                let refs = self.extract_refinements(condition, scope);
                 let mut then_scope = scope.child();
                 refs.apply_truthy(&mut then_scope);
                 let then_type = self.infer_block_type(then_body, &then_scope);
@@ -1093,21 +1095,38 @@ impl TypeChecker {
     }
 
     /// Re-apply a [`PathNarrowing`] directive to a reference path's natural
-    /// type. `Keep`/`Remove` reuse the same union helpers that variable
-    /// `type_of` narrowing uses, treating a non-union type as a one-member
-    /// union. When the directive matches nothing (a statically dead branch),
-    /// the natural type is returned unchanged rather than over-narrowing.
+    /// type. The directives reuse the same type algebra that variable
+    /// narrowing uses (`narrow_to_single`/`remove_from_union` for `type_of`,
+    /// `intersect_types`/`subtract_type` for schema checks), treating a
+    /// non-union type as a one-member union. A top type (`unknown`/`any`)
+    /// narrows straight to the tested kind on `Keep`, mirroring variable
+    /// `unknown` narrowing. When a directive matches nothing (a statically
+    /// dead branch) the natural type is returned unchanged rather than
+    /// over-narrowing.
     fn apply_path_narrowing(natural: InferredType, narrowing: &PathNarrowing) -> InferredType {
         let ty = natural?;
-        let members: Vec<TypeExpr> = match &ty {
+        match narrowing {
+            PathNarrowing::Keep(tag) => {
+                if matches!(&ty, TypeExpr::Named(n) if is_gradual_type_name(n)) {
+                    return Some(TypeExpr::Named(tag.clone()));
+                }
+                let members = Self::as_union_members(&ty);
+                narrow_to_single(&members, tag).or(Some(ty))
+            }
+            PathNarrowing::Remove(tag) => {
+                let members = Self::as_union_members(&ty);
+                remove_from_union(&members, tag).or(Some(ty))
+            }
+            PathNarrowing::Intersect(schema) => intersect_types(&ty, schema).or(Some(ty)),
+            PathNarrowing::Subtract(schema) => subtract_type(&ty, schema).or(Some(ty)),
+        }
+    }
+
+    fn as_union_members(ty: &TypeExpr) -> Vec<TypeExpr> {
+        match ty {
             TypeExpr::Union(members) => members.clone(),
             other => vec![other.clone()],
-        };
-        let narrowed = match narrowing {
-            PathNarrowing::Keep(tag) => narrow_to_single(&members, tag),
-            PathNarrowing::Remove(tag) => remove_from_union(&members, tag),
-        };
-        narrowed.or(Some(ty))
+        }
     }
 
     pub(super) fn infer_property_type_from_type(
@@ -1217,7 +1236,17 @@ impl TypeChecker {
         optional: bool,
     ) -> InferredType {
         let obj_type = self.infer_type(object, scope)?;
-        self.infer_subscript_type_from_type(&obj_type, index, scope, optional)
+        let natural = self.infer_subscript_type_from_type(&obj_type, index, scope, optional);
+
+        // Flow-sensitive path narrowing on a constant-index subscript
+        // (`xs[0]`, `cfg["mode"]`) — same deferred mechanism as property
+        // paths; `reference_path_key` only keys constant indices.
+        if let Some(key) = reference_path_key_for_subscript(object, index) {
+            if let Some(narrowing) = scope.get_narrowed_path(&key) {
+                return Self::apply_path_narrowing(natural, narrowing);
+            }
+        }
+        natural
     }
 
     fn infer_subscript_type_from_type(

--- a/crates/harn-parser/src/typechecker/inference/flow.rs
+++ b/crates/harn-parser/src/typechecker/inference/flow.rs
@@ -81,15 +81,48 @@ fn resolve_named_alias_chain(ty: TypeExpr, scope: &TypeScope) -> TypeExpr {
     }
 }
 
-/// Extract `(var_name, property_name)` from a `Identifier.property` access.
-/// Returns `None` for nested accesses or non-identifier objects.
-fn extract_property_var(node: &SNode) -> Option<(String, String)> {
-    if let Node::PropertyAccess { object, property } = &node.node {
-        if let Node::Identifier(name) = &object.node {
-            return Some((name.clone(), property.clone()));
-        }
+/// Split a property access into its object node and property name, for both
+/// plain and optional access. Returns `None` for non-property-access nodes.
+/// Unlike a bare-identifier extractor this keeps the full object node, so the
+/// caller can narrow a reference path (`o.msg.kind`) as well as a variable.
+fn property_access_parts(node: &SNode) -> Option<(&SNode, String)> {
+    match &node.node {
+        Node::PropertyAccess { object, property }
+        | Node::OptionalPropertyAccess { object, property } => Some((object, property.clone())),
+        _ => None,
     }
-    None
+}
+
+/// The runtime kinds that `type_of(...)` can return and that the refinement
+/// logic knows how to map to a `TypeExpr` member kind. Kept in lockstep with
+/// `VmValue::type_name` so the narrower never accepts a tag the runtime can't
+/// produce. Shared by `if`/`guard` `type_of` narrowing and `match type_of(…)`
+/// arm narrowing.
+fn is_type_of_tag(tag: &str) -> bool {
+    const TAGS: &[&str] = &[
+        "int",
+        "string",
+        "float",
+        "bool",
+        "nil",
+        "list",
+        "dict",
+        "closure",
+        "bytes",
+        "generator",
+        "stream",
+        "iter",
+    ];
+    TAGS.contains(&tag)
+}
+
+/// The literal `TypeExpr` for a discriminant value, used to build the
+/// `{tag: literal}` schema that drives path-based discriminant narrowing.
+fn discriminant_literal_type(value: &DiscriminantValue) -> TypeExpr {
+    match value {
+        DiscriminantValue::Str(s) => TypeExpr::LitString(s.clone()),
+        DiscriminantValue::Int(v) => TypeExpr::LitInt(*v),
+    }
 }
 
 /// Walk an *optional*-access chain (`o?.a`, `o?[i]`, `o?.m()`, and nestings
@@ -208,7 +241,7 @@ impl TypeChecker {
         scope: &TypeScope,
     ) -> Refinements {
         self.lint_vacuous_condition(condition, scope);
-        Self::extract_refinements(condition, scope)
+        self.extract_refinements(condition, scope)
     }
 
     /// Walk a boolean condition reporting `HARN-LNT-058`. Two patterns fire:
@@ -246,7 +279,7 @@ impl TypeChecker {
         match &condition.node {
             Node::BinaryOp { op, left, right } if op == "&&" || op == "||" => {
                 self.lint_vacuous_condition(left, scope);
-                let left_ref = Self::extract_refinements(left, scope);
+                let left_ref = self.extract_refinements(left, scope);
                 let mut right_scope = scope.child();
                 if op == "&&" {
                     left_ref.apply_truthy(&mut right_scope);
@@ -381,20 +414,21 @@ impl TypeChecker {
 
     /// Extract bidirectional type refinements from a condition expression.
     pub(in crate::typechecker) fn extract_refinements(
+        &self,
         condition: &SNode,
         scope: &TypeScope,
     ) -> Refinements {
         match &condition.node {
             Node::BinaryOp { op, left, right } if op == "!=" || op == "==" => {
-                let nil_ref = Self::extract_nil_refinements(op, left, right, scope);
+                let nil_ref = self.extract_nil_refinements(op, left, right, scope);
                 if !nil_ref.is_empty() {
                     return nil_ref;
                 }
-                let typeof_ref = Self::extract_typeof_refinements(op, left, right, scope);
+                let typeof_ref = self.extract_typeof_refinements(op, left, right, scope);
                 if !typeof_ref.is_empty() {
                     return typeof_ref;
                 }
-                let tag_ref = Self::extract_discriminator_refinements(op, left, right, scope);
+                let tag_ref = self.extract_discriminator_refinements(op, left, right, scope);
                 if !tag_ref.is_empty() {
                     return tag_ref;
                 }
@@ -403,10 +437,10 @@ impl TypeChecker {
 
             // Logical AND: both operands must be truthy, so truthy refinements compose.
             Node::BinaryOp { op, left, right } if op == "&&" => {
-                let left_ref = Self::extract_refinements(left, scope);
+                let left_ref = self.extract_refinements(left, scope);
                 let mut right_scope = scope.child();
                 left_ref.apply_truthy(&mut right_scope);
-                let right_ref = Self::extract_refinements(right, &right_scope);
+                let right_ref = self.extract_refinements(right, &right_scope);
                 let mut truthy = left_ref.truthy;
                 truthy.extend(right_ref.truthy);
                 let mut truthy_paths = left_ref.truthy_paths;
@@ -425,10 +459,10 @@ impl TypeChecker {
 
             // Logical OR: both operands must be falsy for the whole to be falsy.
             Node::BinaryOp { op, left, right } if op == "||" => {
-                let left_ref = Self::extract_refinements(left, scope);
+                let left_ref = self.extract_refinements(left, scope);
                 let mut right_scope = scope.child();
                 left_ref.apply_falsy(&mut right_scope);
-                let right_ref = Self::extract_refinements(right, &right_scope);
+                let right_ref = self.extract_refinements(right, &right_scope);
                 let mut falsy = left_ref.falsy;
                 falsy.extend(right_ref.falsy);
                 let mut falsy_paths = left_ref.falsy_paths;
@@ -446,7 +480,7 @@ impl TypeChecker {
             }
 
             Node::UnaryOp { op, operand } if op == "!" => {
-                Self::extract_refinements(operand, scope).inverted()
+                self.extract_refinements(operand, scope).inverted()
             }
 
             // Bare identifier in condition position: narrow `T | nil` to `T`.
@@ -468,18 +502,35 @@ impl TypeChecker {
                 Refinements::empty()
             }
 
+            // Bare reference path in condition position (`if entry.arguments`,
+            // `if xs[0]`): a truthy value is non-nil, so remove `nil` from the
+            // path's type on the truthy branch. The falsy branch stays open —
+            // `false`/`0`/`""` are falsy without being `nil`.
+            Node::PropertyAccess { .. }
+            | Node::OptionalPropertyAccess { .. }
+            | Node::SubscriptAccess { .. }
+            | Node::OptionalSubscriptAccess { .. } => {
+                if let Some(key) = reference_path_key(condition) {
+                    return Refinements {
+                        truthy_paths: vec![(key, PathNarrowing::Remove("nil".into()))],
+                        ..Refinements::default()
+                    };
+                }
+                Refinements::empty()
+            }
+
             Node::MethodCall {
                 object,
                 method,
                 args,
             } if method == "has" && args.len() == 1 => {
-                Self::extract_has_refinements(object, args, scope)
+                self.extract_has_refinements(object, args, scope)
             }
 
             Node::FunctionCall { name, args, .. }
                 if (name == "schema_is" || name == "is_type") && args.len() == 2 =>
             {
-                Self::extract_schema_refinements(args, scope)
+                self.extract_schema_refinements(args, scope)
             }
 
             _ => Refinements::empty(),
@@ -488,6 +539,7 @@ impl TypeChecker {
 
     /// Extract nil-check refinements from `x != nil` / `x == nil` patterns.
     fn extract_nil_refinements(
+        &self,
         op: &str,
         left: &SNode,
         right: &SNode,
@@ -578,6 +630,7 @@ impl TypeChecker {
 
     /// Extract type_of refinements from `type_of(x) == "typename"` patterns.
     fn extract_typeof_refinements(
+        &self,
         op: &str,
         left: &SNode,
         right: &SNode,
@@ -594,25 +647,7 @@ impl TypeChecker {
             return Refinements::empty();
         };
 
-        // The runtime kinds that `type_of(...)` can return and that the
-        // refinement logic knows how to map to a `TypeExpr` member kind.
-        // Keep this in lockstep with `VmValue::type_name` so the
-        // narrower never accepts a tag that the runtime can't produce.
-        const KNOWN_TYPES: &[&str] = &[
-            "int",
-            "string",
-            "float",
-            "bool",
-            "nil",
-            "list",
-            "dict",
-            "closure",
-            "bytes",
-            "generator",
-            "stream",
-            "iter",
-        ];
-        if !KNOWN_TYPES.contains(&type_name.as_str()) {
+        if !is_type_of_tag(&type_name) {
             return Refinements::empty();
         }
 
@@ -622,11 +657,19 @@ impl TypeChecker {
         // `infer_property_access_type` re-applies to the path's natural type.
         let Node::Identifier(var_name) = &arg.node else {
             if let Some(key) = reference_path_key(arg) {
-                let eq_refs = Refinements {
+                let mut eq_refs = Refinements {
                     truthy_paths: vec![(key.clone(), PathNarrowing::Keep(type_name.clone()))],
-                    falsy_paths: vec![(key, PathNarrowing::Remove(type_name))],
+                    falsy_paths: vec![(key.clone(), PathNarrowing::Remove(type_name.clone()))],
                     ..Refinements::default()
                 };
+                // When the path is itself a top type, the `==` falsy branch
+                // can't subtract a concrete kind from it (it stays open), but
+                // we record the ruled-out tag so an exhaustive `type_of`
+                // chain on the path can be validated at `unreachable()` /
+                // `throw` — exactly as for an `unknown`-typed variable.
+                if self.path_type_is_top(arg, scope) {
+                    eq_refs.falsy_ruled_out = vec![(key, type_name)];
+                }
                 return if op == "==" {
                     eq_refs
                 } else {
@@ -713,33 +756,48 @@ impl TypeChecker {
 
     /// Extract refinements from `obj.<tag> == "value"` / `obj.<tag> == 7` style
     /// patterns where `obj` is a tagged shape union and `<tag>` is the union's
-    /// auto-detected discriminant field. Truthy narrows `obj` to the matching
-    /// variant; falsy narrows to the residual union.
+    /// auto-detected discriminant field. `obj` may be a bare variable or a
+    /// reference path (`o.msg.kind == "ping"`). Truthy narrows `obj` to the
+    /// matching variant; falsy narrows to the residual union. The
+    /// tagged-shape-union gate keeps this from narrowing arbitrary
+    /// `path.field == literal` comparisons (which would otherwise mangle a
+    /// `dict`/`unknown` object into a closed one-field shape).
     fn extract_discriminator_refinements(
+        &self,
         op: &str,
         left: &SNode,
         right: &SNode,
         scope: &TypeScope,
     ) -> Refinements {
         // Find which side is the property access and which is the literal.
-        let (var_name, tag_field, tag_value) = match (
-            extract_property_var(left),
+        let (obj_node, tag_field, tag_value) = match (
+            property_access_parts(left),
             discriminant_value_from_node(right),
         ) {
-            (Some((var, field)), Some(value)) => (var, field, value),
+            (Some((obj, field)), Some(value)) => (obj, field, value),
             _ => match (
-                extract_property_var(right),
+                property_access_parts(right),
                 discriminant_value_from_node(left),
             ) {
-                (Some((var, field)), Some(value)) => (var, field, value),
+                (Some((obj, field)), Some(value)) => (obj, field, value),
                 _ => return Refinements::empty(),
             },
         };
 
-        let Some(Some(raw_type)) = scope.get_var(&var_name).cloned() else {
-            return Refinements::empty();
+        // Resolve the object's type to a union of shapes. A bare variable
+        // reads from the scope (preserving the historical resolution path);
+        // a reference path is inferred (needs `&self`).
+        let resolved = if let Node::Identifier(name) = &obj_node.node {
+            let Some(Some(raw_type)) = scope.get_var(name).cloned() else {
+                return Refinements::empty();
+            };
+            resolve_named_alias_chain(raw_type, scope)
+        } else {
+            let Some(obj_type) = self.infer_type(obj_node, scope) else {
+                return Refinements::empty();
+            };
+            self.resolve_alias(&obj_type, scope)
         };
-        let resolved = resolve_named_alias_chain(raw_type, scope);
         let TypeExpr::Union(members) = resolved else {
             return Refinements::empty();
         };
@@ -755,16 +813,33 @@ impl TypeChecker {
             return Refinements::empty();
         };
 
-        let truthy = vec![(var_name.clone(), Some(matched))];
-        let falsy = match residual {
-            TypeExpr::Never => vec![(var_name, Some(TypeExpr::Never))],
-            other => vec![(var_name, Some(other))],
-        };
-
-        let eq_refs = Refinements {
-            truthy,
-            falsy,
-            ..Refinements::default()
+        let eq_refs = if let Node::Identifier(var_name) = &obj_node.node {
+            // Variable: store the resolved matched/residual types directly.
+            let falsy = match residual {
+                TypeExpr::Never => vec![(var_name.clone(), Some(TypeExpr::Never))],
+                other => vec![(var_name.clone(), Some(other))],
+            };
+            Refinements {
+                truthy: vec![(var_name.clone(), Some(matched))],
+                falsy,
+                ..Refinements::default()
+            }
+        } else if let Some(key) = reference_path_key(obj_node) {
+            // Path: defer via `{tag: literal}` intersect/subtract, which
+            // re-derives the matched variant / residual union from the path's
+            // natural type at read time.
+            let schema = TypeExpr::Shape(vec![ShapeField {
+                name: tag_field,
+                type_expr: discriminant_literal_type(&tag_value),
+                optional: false,
+            }]);
+            Refinements {
+                truthy_paths: vec![(key.clone(), PathNarrowing::Intersect(schema.clone()))],
+                falsy_paths: vec![(key, PathNarrowing::Subtract(schema))],
+                ..Refinements::default()
+            }
+        } else {
+            return Refinements::empty();
         };
         if op == "==" {
             eq_refs
@@ -773,63 +848,142 @@ impl TypeChecker {
         }
     }
 
-    /// Extract .has("key") refinements on shape types.
-    fn extract_has_refinements(object: &SNode, args: &[SNode], scope: &TypeScope) -> Refinements {
+    /// Extract `.has("key")` refinements: the presence check makes the named
+    /// field required on the truthy branch. Works on a bare variable (narrow
+    /// its `Shape` to make the field required) or a reference path (deferred
+    /// `Intersect` with a `{key: any}` schema, which `intersect_shapes` folds
+    /// into making the field required at read time).
+    fn extract_has_refinements(
+        &self,
+        object: &SNode,
+        args: &[SNode],
+        scope: &TypeScope,
+    ) -> Refinements {
+        let Node::StringLiteral(key) = &args[0].node else {
+            return Refinements::empty();
+        };
         if let Node::Identifier(var_name) = &object.node {
-            if let Node::StringLiteral(key) = &args[0].node {
-                if let Some(Some(TypeExpr::Shape(fields))) = scope.get_var(var_name) {
-                    if fields.iter().any(|f| f.name == *key && f.optional) {
-                        let narrowed_fields: Vec<ShapeField> = fields
-                            .iter()
-                            .map(|f| {
-                                if f.name == *key {
-                                    ShapeField {
-                                        name: f.name.clone(),
-                                        type_expr: f.type_expr.clone(),
-                                        optional: false,
-                                    }
-                                } else {
-                                    f.clone()
+            if let Some(Some(TypeExpr::Shape(fields))) = scope.get_var(var_name) {
+                if fields.iter().any(|f| f.name == *key && f.optional) {
+                    let narrowed_fields: Vec<ShapeField> = fields
+                        .iter()
+                        .map(|f| {
+                            if f.name == *key {
+                                ShapeField {
+                                    name: f.name.clone(),
+                                    type_expr: f.type_expr.clone(),
+                                    optional: false,
                                 }
-                            })
-                            .collect();
-                        return Refinements {
-                            truthy: vec![(
-                                var_name.clone(),
-                                Some(TypeExpr::Shape(narrowed_fields)),
-                            )],
-                            falsy: vec![],
-                            ..Refinements::default()
-                        };
-                    }
+                            } else {
+                                f.clone()
+                            }
+                        })
+                        .collect();
+                    return Refinements {
+                        truthy: vec![(var_name.clone(), Some(TypeExpr::Shape(narrowed_fields)))],
+                        ..Refinements::default()
+                    };
                 }
             }
+            return Refinements::empty();
+        }
+        if let Some(path_key) = reference_path_key(object) {
+            // `{key: any}` required: intersecting with the path's shape marks
+            // the field required (and drops `nil` members) at read time.
+            let schema = TypeExpr::Shape(vec![ShapeField {
+                name: key.clone(),
+                type_expr: TypeExpr::Named("any".into()),
+                optional: false,
+            }]);
+            return Refinements {
+                truthy_paths: vec![(path_key, PathNarrowing::Intersect(schema))],
+                ..Refinements::default()
+            };
         }
         Refinements::empty()
     }
 
-    fn extract_schema_refinements(args: &[SNode], scope: &TypeScope) -> Refinements {
-        let Node::Identifier(var_name) = &args[0].node else {
-            return Refinements::empty();
-        };
+    /// Extract `schema_is(x, S)` / `is_type(x, S)` refinements for a bare
+    /// variable (resolved intersect/subtract) or a reference path (deferred
+    /// `Intersect`/`Subtract` directives re-applied to the path's type).
+    fn extract_schema_refinements(&self, args: &[SNode], scope: &TypeScope) -> Refinements {
         let Some(schema_type) = schema_type_expr_from_node(&args[1], scope) else {
             return Refinements::empty();
         };
-        let Some(Some(var_type)) = scope.get_var(var_name).cloned() else {
-            return Refinements::empty();
+        if let Node::Identifier(var_name) = &args[0].node {
+            let Some(Some(var_type)) = scope.get_var(var_name).cloned() else {
+                return Refinements::empty();
+            };
+            let truthy = intersect_types(&var_type, &schema_type)
+                .map(|ty| vec![(var_name.clone(), Some(ty))])
+                .unwrap_or_default();
+            let falsy = subtract_type(&var_type, &schema_type)
+                .map(|ty| vec![(var_name.clone(), Some(ty))])
+                .unwrap_or_default();
+            return Refinements {
+                truthy,
+                falsy,
+                ..Refinements::default()
+            };
+        }
+        if let Some(key) = reference_path_key(&args[0]) {
+            return Refinements {
+                truthy_paths: vec![(key.clone(), PathNarrowing::Intersect(schema_type.clone()))],
+                falsy_paths: vec![(key, PathNarrowing::Subtract(schema_type))],
+                ..Refinements::default()
+            };
+        }
+        Refinements::empty()
+    }
+
+    /// Narrow the subject of a `match type_of(subject) { "tag" -> … }` arm.
+    /// When the match scrutinee is `type_of(subject)` and an arm matches a
+    /// single runtime-kind literal, the subject is narrowed to that kind in
+    /// the arm scope — the `match` counterpart of `if type_of(subject) == "T"`.
+    /// `subject` may be a variable (narrow its union, or a top type to the
+    /// tag) or a reference path (deferred `Keep`). A no-op for any other
+    /// scrutinee, so it is safe to call at every match-arm site.
+    pub(in crate::typechecker) fn narrow_match_subject(
+        &self,
+        value: &SNode,
+        pattern: &SNode,
+        scope: &mut TypeScope,
+    ) {
+        let Some(subject) = extract_type_of_arg(value) else {
+            return;
         };
+        // Only a single concrete runtime-kind literal narrows; or-patterns over
+        // several tags, wildcards, and non-literal patterns leave it un-narrowed.
+        let leaves = pattern_alternatives(pattern);
+        let [leaf] = leaves.as_slice() else {
+            return;
+        };
+        let Node::StringLiteral(tag) = &leaf.node else {
+            return;
+        };
+        if !is_type_of_tag(tag) {
+            return;
+        }
 
-        let truthy = intersect_types(&var_type, &schema_type)
-            .map(|ty| vec![(var_name.clone(), Some(ty))])
-            .unwrap_or_default();
-        let falsy = subtract_type(&var_type, &schema_type)
-            .map(|ty| vec![(var_name.clone(), Some(ty))])
-            .unwrap_or_default();
-
-        Refinements {
-            truthy,
-            falsy,
-            ..Refinements::default()
+        match &subject.node {
+            Node::Identifier(name) => {
+                let narrowed = match scope.get_var(name).cloned().flatten() {
+                    Some(TypeExpr::Union(members)) => narrow_to_single(&members, tag),
+                    Some(TypeExpr::Named(n)) if n == "unknown" || n == "any" => {
+                        Some(TypeExpr::Named(tag.clone()))
+                    }
+                    Some(other) => narrow_to_single(std::slice::from_ref(&other), tag),
+                    None => None,
+                };
+                if let Some(narrowed) = narrowed {
+                    scope.define_var(name, Some(narrowed));
+                }
+            }
+            _ => {
+                if let Some(key) = reference_path_key(subject) {
+                    scope.set_narrowed_path(&key, PathNarrowing::Keep(tag.clone()));
+                }
+            }
         }
     }
 
@@ -1331,11 +1485,21 @@ impl TypeChecker {
         "int", "string", "float", "bool", "nil", "list", "dict", "closure", "bytes",
     ];
 
-    /// Emit a warning if any `unknown`-typed variable in scope has been
-    /// partially narrowed via `type_of(v) == "T"` checks but the current
-    /// control-flow path reaches a never-returning site (`unreachable()`,
-    /// a function with `Never` return, or a `throw`) without covering every
-    /// concrete `type_of` variant.
+    /// Whether a reference node's type resolves to a top type (`unknown` /
+    /// `any`) — the precondition for path-based `type_of` exhaustiveness
+    /// tracking, mirroring the `unknown`-typed-variable case.
+    fn path_type_is_top(&self, node: &SNode, scope: &TypeScope) -> bool {
+        matches!(
+            self.infer_type(node, scope).map(|t| self.resolve_alias(&t, scope)),
+            Some(TypeExpr::Named(n)) if n == "unknown" || n == "any"
+        )
+    }
+
+    /// Emit a warning if any `unknown`-typed variable or reference path in
+    /// scope has been partially narrowed via `type_of(v) == "T"` checks but
+    /// the current control-flow path reaches a never-returning site
+    /// (`unreachable()`, a function with `Never` return, or a `throw`)
+    /// without covering every concrete `type_of` variant.
     ///
     /// The ruled-out set must be non-empty — reaching `throw`/`unreachable`
     /// without any narrowing isn't an exhaustiveness claim, so it stays
@@ -1351,12 +1515,18 @@ impl TypeChecker {
             if covered.is_empty() {
                 continue;
             }
-            // Only warn if `v` is still typed `unknown` at this point —
-            // if it was fully narrowed elsewhere the ruled-out set is stale.
-            if !matches!(
-                scope.get_var(&var_name),
-                Some(Some(TypeExpr::Named(n))) if n == "unknown"
-            ) {
+            // A path key (`o.x`, `xs[0]`) can't be re-typed from its string
+            // form, but the ledger entry only exists because the path was a
+            // top type at the guards; a fully-narrowed chain rules out all
+            // nine variants, leaving `missing` empty. A bare variable must
+            // still be `unknown` — otherwise the ruled-out set is stale.
+            let is_path = var_name.contains('.') || var_name.contains('[');
+            if !is_path
+                && !matches!(
+                    scope.get_var(&var_name),
+                    Some(Some(TypeExpr::Named(n))) if n == "unknown"
+                )
+            {
                 continue;
             }
             let missing: Vec<&str> = Self::UNKNOWN_CONCRETE_TYPES

--- a/crates/harn-parser/src/typechecker/inference/statements.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements.rs
@@ -1650,14 +1650,17 @@ impl TypeChecker {
                     }
                     scope.define_schema_binding(name, None);
                     scope.clear_unknown_ruled_out(name);
-                    // Reassigning the base drops any path narrowing that read
-                    // through it (`entry.arguments` is stale once `entry` is).
+                    // Reassigning the base drops any path narrowing (and path
+                    // exhaustiveness ledger) that read through it —
+                    // `entry.arguments` is stale once `entry` is.
                     scope.clear_narrowed_paths_rooted_at(name);
+                    scope.clear_unknown_ruled_out_paths_rooted_at(name);
                 } else if let Some(base) = Self::assignment_target_root(target) {
                     // Mutating a path (`entry.arguments = ...`, `o.a[i] = ...`)
                     // can invalidate any narrowing rooted at the same base, so
                     // conservatively drop them all.
                     scope.clear_narrowed_paths_rooted_at(base);
+                    scope.clear_unknown_ruled_out_paths_rooted_at(base);
                 }
             }
 
@@ -1890,6 +1893,9 @@ impl TypeChecker {
                             &mut arm_scope,
                         );
                     }
+                    // `match type_of(subject) { "T" -> … }` narrows the subject
+                    // in the arm — independent of the pattern-binding gate above.
+                    self.narrow_match_subject(value, &arm.pattern, &mut arm_scope);
                     if let Some(ref guard) = arm.guard {
                         self.check_node(guard, &mut arm_scope);
                     }
@@ -1902,7 +1908,7 @@ impl TypeChecker {
             Node::BinaryOp { op, left, right } => {
                 self.check_node(left, scope);
                 if op == "&&" || op == "||" {
-                    let refs = Self::extract_refinements(left, scope);
+                    let refs = self.extract_refinements(left, scope);
                     let mut right_scope = scope.child();
                     if op == "&&" {
                         refs.apply_truthy(&mut right_scope);

--- a/crates/harn-parser/src/typechecker/scope.rs
+++ b/crates/harn-parser/src/typechecker/scope.rs
@@ -325,6 +325,15 @@ impl TypeScope {
             .insert(var_name.to_string(), Vec::new());
     }
 
+    /// Drop ruled-out sets for every reference *path* rooted at `base` (used
+    /// on reassignment of the base, alongside [`Self::clear_unknown_ruled_out`]
+    /// for the base itself). Current-scope only, matching the path-narrowing
+    /// invalidation, since both are applied into the same branch scope.
+    pub(super) fn clear_unknown_ruled_out_paths_rooted_at(&mut self, base: &str) {
+        self.unknown_ruled_out
+            .retain(|key, _| key == base || !path_key_rooted_at(key, base));
+    }
+
     /// Collect every function name visible through this scope chain.
     /// Used by the strict cross-module check to offer "did you mean"
     /// suggestions that span the whole lexical visibility set.
@@ -478,9 +487,8 @@ impl TypeScope {
     /// which is likewise current-scope-scoped, since narrowings are applied
     /// into the same branch scope they are invalidated from.
     pub(super) fn clear_narrowed_paths_rooted_at(&mut self, base: &str) {
-        let prefix = format!("{base}.");
         self.narrowed_paths
-            .retain(|key, _| key != base && !key.starts_with(&prefix));
+            .retain(|key, _| !path_key_rooted_at(key, base));
     }
 
     pub(super) fn define_var_mutable(&mut self, name: &str, ty: InferredType) {
@@ -587,15 +595,23 @@ impl TypeScope {
 /// `&self` (it never needs to project a property type), and re-deriving from
 /// the natural type each read keeps the result correct even as the base
 /// variable's own type is narrowed by other guards in the same flow.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(super) enum PathNarrowing {
     /// Keep only the union members whose runtime `type_of` equals this tag
-    /// (the truthy branch of `type_of(path) == "tag"`).
+    /// (the truthy branch of `type_of(path) == "tag"`). A top type
+    /// (`unknown`/`any`) narrows straight to the tag, mirroring variable
+    /// `unknown` narrowing.
     Keep(String),
     /// Remove the union members whose runtime `type_of` equals this tag
     /// (the falsy branch of `type_of(path) == "tag"`, and — with tag `"nil"`
-    /// — the truthy branch of `path != nil`).
+    /// — the truthy branch of `path != nil` and of a bare `if path`).
     Remove(String),
+    /// Intersect the path's type with a schema (the truthy branch of
+    /// `schema_is(path, S)` / `is_type(path, S)`, and `path.has("k")`).
+    Intersect(TypeExpr),
+    /// Subtract a schema from the path's type (the falsy branch of
+    /// `schema_is(path, S)` / `is_type(path, S)`).
+    Subtract(TypeExpr),
 }
 
 /// Bidirectional type refinements extracted from a condition.
@@ -682,4 +698,17 @@ pub(super) fn builtin_return_type(name: &str) -> InferredType {
 /// [`builtin_signatures`] registry.
 pub(super) fn is_builtin(name: &str) -> bool {
     builtin_signatures::is_builtin(name)
+}
+
+/// Whether a canonical reference-path `key` is rooted at `base` — i.e. it is
+/// `base` itself or extends it through a path separator (`.` for a property,
+/// `[` for a constant subscript). `xs` roots `xs`, `xs.a`, and `xs[0]`, but
+/// not `xsmore`. Used to invalidate every narrowing that reads through a
+/// variable when that variable (or a path under it) is reassigned.
+pub(super) fn path_key_rooted_at(key: &str, base: &str) -> bool {
+    if key == base {
+        return true;
+    }
+    key.strip_prefix(base)
+        .is_some_and(|rest| rest.starts_with('.') || rest.starts_with('['))
 }

--- a/crates/harn-parser/src/typechecker/tests/narrowing.rs
+++ b/crates/harn-parser/src/typechecker/tests/narrowing.rs
@@ -1182,3 +1182,189 @@ fn test_path_narrowing_invalidated_by_base_reassignment() {
         "expected `bad` binding to be rejected after base reassignment, got: {errs:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Path narrowing parity with variable narrowing: unknown paths, truthiness,
+// schema_is/has, constant subscripts, discriminators, and exhaustiveness.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_typeof_path_narrowing_unknown_field() {
+    // A path whose natural type is the top type narrows to the tested kind,
+    // mirroring `unknown`-typed variable narrowing.
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(o: {data: unknown}) {
+    if type_of(o.data) == "list" { let r: list = o.data }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_truthiness_narrowing_on_path() {
+    let errs = errors(
+        r"pipeline t(task) {
+  fn check(entry: {status: bool?}) {
+    if entry.status { let b: bool = entry.status }
+  }
+}",
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_schema_is_narrowing_on_path() {
+    let errs = errors(
+        r"pipeline t(task) {
+  type User = {id: string}
+  fn check(e: {profile: {id: string} | {err: string}}) {
+    if schema_is(e.profile, User) {
+      let u: {id: string} = e.profile
+    }
+  }
+}",
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_has_narrowing_on_path() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(o: {meta: {name?: string}}) {
+    if o.meta.has("name") { let n: string = o.meta.name }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_typeof_narrowing_on_constant_subscript() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(xs: list<string | int>) {
+    if type_of(xs[0]) == "string" { let s: string = xs[0] }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_dynamic_subscript_does_not_narrow() {
+    // A dynamic (non-literal) index is not a stable reference: it must NOT
+    // narrow, and the un-narrowed access must still be rejected (soundness).
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(xs: list<string | int>, i: int) {
+    if type_of(xs[i]) == "string" { let s: string = xs[i] }
+  }
+}"#,
+    );
+    assert!(
+        errs.iter().any(|e| e.contains("expected string")),
+        "dynamic index must not narrow, got: {errs:?}"
+    );
+}
+
+#[test]
+fn test_discriminator_narrowing_on_path() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  type Ping = {kind: "ping", ttl: int}
+  type Pong = {kind: "pong", lat: int}
+  fn check(o: {msg: Ping | Pong}) {
+    if o.msg.kind == "ping" { let p: Ping = o.msg }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_discriminator_on_path_is_gated_to_tagged_unions() {
+    // `path.field == literal` on a non-tagged-union object (here a `dict`)
+    // must NOT narrow the object into a closed one-field shape — other keys
+    // stay accessible.
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(o: {data: dict}) {
+    if o.data.status == "ok" {
+      let c = o.data.count
+    }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_match_type_of_narrows_variable() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(x: string | int) {
+    match type_of(x) {
+      "string" -> { let s: string = x }
+      "int" -> { let i: int = x }
+      _ -> {}
+    }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_match_type_of_narrows_path() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(o: {data: string | int}) {
+    match type_of(o.data) {
+      "string" -> { let s: string = o.data }
+      "int" -> { let i: int = o.data }
+      _ -> {}
+    }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_match_type_of_narrows_unknown() {
+    let errs = errors(
+        r#"pipeline t(task) {
+  fn check(v: unknown) -> string {
+    match type_of(v) {
+      "string" -> { return v }
+      _ -> { return "other" }
+    }
+  }
+}"#,
+    );
+    assert!(errs.is_empty(), "got: {errs:?}");
+}
+
+#[test]
+fn test_unknown_exhaustiveness_warns_on_path() {
+    // An incomplete `type_of(path)` chain on an `unknown` path that reaches
+    // `unreachable()` warns about the uncovered concrete kinds.
+    let warns = exhaustive_warns(
+        r#"pipeline t(task) {
+  fn check(o: {x: unknown}) -> string {
+    if type_of(o.x) == "string" { return "s" }
+    if type_of(o.x) == "int" { return "i" }
+    unreachable("incomplete")
+  }
+}"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .any(|w| w.contains("o.x") && w.contains("list")),
+        "expected path exhaustiveness warning naming uncovered kinds, got: {warns:?}"
+    );
+}

--- a/crates/harn-parser/src/typechecker/union.rs
+++ b/crates/harn-parser/src/typechecker/union.rs
@@ -154,13 +154,15 @@ pub(super) fn extract_type_of_arg(node: &SNode) -> Option<&SNode> {
 }
 
 /// Build the canonical dotted key for an identifier-rooted reference path:
-/// `a` → `"a"`, `a.b` / `a?.b` → `"a.b"`, `cfg.opts.mode` → `"cfg.opts.mode"`.
+/// `a` → `"a"`, `a.b` / `a?.b` → `"a.b"`, `cfg.opts.mode` → `"cfg.opts.mode"`,
+/// `xs[0]` → `"xs[0]"`, `m["k"]` → `"m[\"k\"]"`.
 ///
 /// Optional (`?.`) and plain (`.`) property links produce the same key — they
 /// address the same runtime value, so a guard on one narrows reads of the
-/// other. Returns `None` for anything that isn't a chain of constant property
-/// accesses rooted at a bare identifier (subscripts, method calls, computed
-/// keys), since those are not stable references we can re-narrow soundly.
+/// other. Subscripts are keyed only when the index is a literal (a *constant*
+/// reference): a dynamic index is not a stable reference and is deliberately
+/// left un-narrowable. Returns `None` for method calls, computed keys, or any
+/// non-identifier root.
 pub(super) fn reference_path_key(node: &SNode) -> Option<String> {
     match &node.node {
         Node::Identifier(name) => Some(name.clone()),
@@ -169,8 +171,26 @@ pub(super) fn reference_path_key(node: &SNode) -> Option<String> {
             let base = reference_path_key(object)?;
             Some(format!("{base}.{property}"))
         }
+        Node::SubscriptAccess { object, index }
+        | Node::OptionalSubscriptAccess { object, index } => {
+            reference_path_key_for_subscript(object, index)
+        }
         _ => None,
     }
+}
+
+/// Key for a subscript access given its `object` and `index` separately (the
+/// read-side `infer_subscript_access_type` has them split, not as one node).
+/// Keys only literal-int / literal-string indices — a dynamic index yields
+/// `None`.
+pub(super) fn reference_path_key_for_subscript(object: &SNode, index: &SNode) -> Option<String> {
+    let base = reference_path_key(object)?;
+    let seg = match &index.node {
+        Node::IntLiteral(n) => format!("[{n}]"),
+        Node::StringLiteral(s) => format!("[\"{s}\"]"),
+        _ => return None,
+    };
+    Some(format!("{base}{seg}"))
 }
 
 /// Width subtyping for `Shape ∩ Shape`. Pulled out of `intersect_types`

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -3918,6 +3918,10 @@ Narrowing rules for `unknown`:
   flow path, so an exhaustive chain ending in `unreachable()` / `throw`
   can be validated; see the "Exhaustive narrowing on `unknown`"
   subsection of "Flow-sensitive type refinement".
+- These rules apply equally when `x` is a *reference path* whose type is
+  `unknown` (e.g. an `unknown`-typed field reached via `o.data`), not
+  only a bare `unknown` variable — including the ruled-out tracking for
+  the exhaustiveness check.
 
 Interop between `any` and `unknown`:
 
@@ -4569,10 +4573,14 @@ fn describe(x: string | int) {
 
 #### Reference paths
 
-`type_of()` and nil checks narrow *reference paths* — an identifier
-followed by a chain of constant property accesses (`entry.arguments`,
-`cfg.opts.mode`) — not just bare variables. A guard on a path narrows
-later reads of that same path:
+Narrowing applies to *reference paths* — an identifier followed by a
+chain of constant property accesses and constant subscripts
+(`entry.arguments`, `cfg.opts.mode`, `xs[0]`, `m["k"]`) — not just bare
+variables. Every refinement form that narrows a variable also narrows a
+path: `type_of(path) == "T"`, `path != nil`, a bare `if path`
+(truthiness, removes `nil`), `schema_is(path, S)` / `path.has("k")`, and
+a tagged-shape-union discriminant (`o.msg.kind == "ping"` narrows
+`o.msg`). A guard on a path narrows later reads of that same path:
 
 ```harn
 fn flags(entry: {arguments: list?}) -> list {
@@ -4585,9 +4593,16 @@ fn flags(entry: {arguments: list?}) -> list {
 
 Optional (`?.`) and plain (`.`) links address the same value, so they
 share a narrowing — `type_of(entry?.arguments) == "list"` narrows reads
-of both `entry?.arguments` and `entry.arguments`. The narrowing is
-dropped when the base variable or the path is reassigned, since the
-reference may then point at a different value.
+of both `entry?.arguments` and `entry.arguments`. A path whose type is
+the top type (`unknown`/`any`, common for `json_parse` / `llm_call`
+boundary fields) narrows to the tested kind, exactly as an
+`unknown`-typed variable does.
+
+The narrowing is dropped when the base variable or the path is
+reassigned, since the reference may then point at a different value. A
+*dynamic* subscript (`xs[i]` with a non-literal index) is deliberately
+never narrowed: it is not a stable reference, so a later `xs[i]` may
+read a different element.
 
 #### Truthiness
 
@@ -4668,6 +4683,20 @@ fn check(x: string | int) {
     "hello" -> { log(x) }  // x is `string`
     42 -> { log(x) }       // x is `int`
     _ -> {}
+  }
+}
+```
+
+Matching on `type_of(subject)` narrows the subject (variable or
+reference path) in each arm to the tested kind — the `match`
+counterpart of an `if type_of(subject) == "T"` chain:
+
+```harn
+fn describe(o: {val: string | int}) -> string {
+  return match type_of(o.val) {
+    "string" -> { o.val }  // o.val is `string`
+    "int" -> { to_string(o.val) }  // o.val is `int`
+    _ -> { "?" }
   }
 }
 ```

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -3916,6 +3916,10 @@ Narrowing rules for `unknown`:
   flow path, so an exhaustive chain ending in `unreachable()` / `throw`
   can be validated; see the "Exhaustive narrowing on `unknown`"
   subsection of "Flow-sensitive type refinement".
+- These rules apply equally when `x` is a *reference path* whose type is
+  `unknown` (e.g. an `unknown`-typed field reached via `o.data`), not
+  only a bare `unknown` variable — including the ruled-out tracking for
+  the exhaustiveness check.
 
 Interop between `any` and `unknown`:
 
@@ -4567,10 +4571,14 @@ fn describe(x: string | int) {
 
 #### Reference paths
 
-`type_of()` and nil checks narrow *reference paths* — an identifier
-followed by a chain of constant property accesses (`entry.arguments`,
-`cfg.opts.mode`) — not just bare variables. A guard on a path narrows
-later reads of that same path:
+Narrowing applies to *reference paths* — an identifier followed by a
+chain of constant property accesses and constant subscripts
+(`entry.arguments`, `cfg.opts.mode`, `xs[0]`, `m["k"]`) — not just bare
+variables. Every refinement form that narrows a variable also narrows a
+path: `type_of(path) == "T"`, `path != nil`, a bare `if path`
+(truthiness, removes `nil`), `schema_is(path, S)` / `path.has("k")`, and
+a tagged-shape-union discriminant (`o.msg.kind == "ping"` narrows
+`o.msg`). A guard on a path narrows later reads of that same path:
 
 ```harn
 fn flags(entry: {arguments: list?}) -> list {
@@ -4583,9 +4591,16 @@ fn flags(entry: {arguments: list?}) -> list {
 
 Optional (`?.`) and plain (`.`) links address the same value, so they
 share a narrowing — `type_of(entry?.arguments) == "list"` narrows reads
-of both `entry?.arguments` and `entry.arguments`. The narrowing is
-dropped when the base variable or the path is reassigned, since the
-reference may then point at a different value.
+of both `entry?.arguments` and `entry.arguments`. A path whose type is
+the top type (`unknown`/`any`, common for `json_parse` / `llm_call`
+boundary fields) narrows to the tested kind, exactly as an
+`unknown`-typed variable does.
+
+The narrowing is dropped when the base variable or the path is
+reassigned, since the reference may then point at a different value. A
+*dynamic* subscript (`xs[i]` with a non-literal index) is deliberately
+never narrowed: it is not a stable reference, so a later `xs[i]` may
+read a different element.
 
 #### Truthiness
 
@@ -4666,6 +4681,20 @@ fn check(x: string | int) {
     "hello" -> { log(x) }  // x is `string`
     42 -> { log(x) }       // x is `int`
     _ -> {}
+  }
+}
+```
+
+Matching on `type_of(subject)` narrows the subject (variable or
+reference path) in each arm to the tested kind — the `match`
+counterpart of an `if type_of(subject) == "T"` chain:
+
+```harn
+fn describe(o: {val: string | int}) -> string {
+  return match type_of(o.val) {
+    "string" -> { o.val }  // o.val is `string`
+    "int" -> { to_string(o.val) }  // o.val is `int`
+    _ -> { "?" }
   }
 }
 ```


### PR DESCRIPTION
## Summary

Follow-up to #3139 (reference-path + `if`-expression narrowing). Brings reference-path narrowing to **full parity with bare-variable narrowing** and closes the remaining flow-refinement gaps — all confirmed empirically against the prior build. Motivated by the question of whether the fixes cover every `type_of`-style refinement; this makes the answer yes.

A *reference path* is an identifier-rooted chain of constant `.`/`?.` property accesses and constant `[…]` subscripts (`entry.arguments`, `cfg.opts.mode`, `xs[0]`, `m["k"]`).

### What's added
- **`unknown`/`any` paths** narrow to the tested kind (the `json_parse`/`llm_call` boundary case), mirroring `unknown` variable narrowing.
- **Truthiness** (`if path`) removes `nil` from a path.
- **`schema_is(path, S)` / `path.has("k")`** narrow a path — via new deferred `Intersect`/`Subtract(TypeExpr)` directives re-applied to the path's natural type.
- **Constant-index subscripts** (`xs[0]`, `m["k"]`) are narrowable references. Dynamic indices (`xs[i]`) stay deliberately un-narrowable — not a stable reference — and the un-narrowed read still errors (soundness test included).
- **Discriminator-on-path** (`o.msg.kind == "ping"` narrows `o.msg`), gated on the object being a tagged shape union so a `dict`/`unknown` object is never mangled.
- **`match type_of(subject) { "T" -> … }`** narrows the subject — variable **or** path — in each arm. This previously narrowed nothing, even for a bare variable.
- **`unknown`-exhaustiveness lint** now covers `unknown`-typed paths.

### Mechanism
To gate discriminator-on-path on the object's actual type, the refinement extractors (`extract_refinements` + helpers) became `&self` methods so they can call `infer_type`/`resolve_alias`. `extract_property_var` is replaced by `property_access_parts` (keeps the full object node). Path narrowing stays deferred (`PathNarrowing` directives re-applied at read time), so it composes with base-variable narrowing and is invalidated on reassignment.

### Runtime vs static
This is a **static-checker** feature only. The Harn runtime is dynamically typed and erases narrowing entirely; `type_of` always reflects the concrete value, so there is no runtime counterpart to implement. (Verified: the VM enforces parameter annotations but has no concept of narrowed types.)

## Tests
- 12 new unit tests in `narrowing.rs` (unknown paths, truthiness, schema_is/has, constant + dynamic subscripts, discriminator + its gating, `match type_of` for var/path/unknown, path exhaustiveness warning).
- New `conformance/tests/types/path_narrowing_advanced.harn` (typechecks + runs).
- Full suite green: **470** harn-parser unit tests, **1587** conformance, 0 stdlib type errors, clippy clean.
- Spec updated (Reference paths, `match type_of`, `unknown` rules); mirror synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)