### PR TITLE
Improve code-index grounding: same-turn freshness (recall ranking left as-is, with canary)

### DIFF
--- a/changelog.d/codeindex-same-turn-freshness.fixed.md
+++ b/changelog.d/codeindex-same-turn-freshness.fixed.md
@@ -1,0 +1,14 @@
+- **Incremental project scans now detect same-instant edits that the
+  modification-time heuristic alone misses.** `scan_incremental`'s automatic
+  delta computation (the path taken when no explicit `changed_paths` signal is
+  supplied) compared only `mtime > previous_mtime`. Millisecond mtime
+  granularity collides on same-turn/same-second writes — and on
+  coarse-granularity filesystems — so a file an agent wrote and then re-scanned
+  in the same instant was silently treated as unchanged, leaving the index
+  serving pre-edit symbol facts and feeding fuzzy-match-stale loops on weak
+  local models. The delta now also flags a file as modified when its byte size
+  differs from the cached record, an mtime-independent signal that catches the
+  overwhelmingly common add/remove edit for free (the file metadata is already
+  read for the mtime check). Length-preserving same-instant edits still rely on
+  the explicit `changed_paths` bypass the agent loop already threads through
+  after its own writes.

--- a/crates/harn-hostlib/src/scanner/mod.rs
+++ b/crates/harn-hostlib/src/scanner/mod.rs
@@ -448,13 +448,23 @@ fn compute_delta(
         let mut out = Vec::new();
         for entry in current {
             if let Some(prev) = cached_files.get(entry.relative_path.as_str()) {
-                let mtime = std::fs::metadata(&entry.absolute_path)
-                    .ok()
+                let meta = std::fs::metadata(&entry.absolute_path).ok();
+                let mtime = meta
+                    .as_ref()
                     .and_then(|m| m.modified().ok())
                     .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
                     .map(|d| d.as_millis() as i64)
                     .unwrap_or(0);
-                if mtime > prev.last_modified_unix_ms {
+                let size = meta.as_ref().map(|m| m.len()).unwrap_or(prev.size_bytes);
+                // A newer mtime is the cheap common signal, but mtime
+                // granularity collides on same-turn/same-second edits (and on
+                // coarse-granularity filesystems), silently dropping the edit.
+                // A changed byte size is an mtime-independent modification
+                // signal that catches the overwhelmingly common add/remove edit
+                // for free — `meta.len()` is already in hand. Without it, an
+                // agent that writes a file and re-scans in the same instant
+                // keeps reading the pre-edit symbol facts.
+                if mtime > prev.last_modified_unix_ms || size != prev.size_bytes {
                     out.push(entry.relative_path.clone());
                 }
             }
@@ -756,6 +766,8 @@ fn delta_to_value(delta: &ScanDelta) -> VmValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use filetime::{set_file_mtime, FileTime};
+    use std::fs;
 
     #[test]
     fn builtin_option_defaults_match_request_schemas() {
@@ -766,5 +778,115 @@ mod tests {
 
         assert!(scan_project.include_git_history);
         assert!(!scan_incremental.include_git_history);
+    }
+
+    fn symbol_names(scan: &IncrementalScan) -> Vec<String> {
+        scan.result.symbols.iter().map(|s| s.name.clone()).collect()
+    }
+
+    /// Regression guard: an agent that writes a file and re-scans in the same
+    /// instant must see its own edit. `compute_delta`'s mtime comparison
+    /// collides on same-millisecond/same-second writes (and on
+    /// coarse-granularity filesystems), so the size-change fallback is what
+    /// keeps same-turn index freshness honest. Before the fallback this
+    /// returned the pre-edit symbol set, feeding fuzzy-match-stale loops on
+    /// cheap local models.
+    #[test]
+    fn scan_incremental_detects_same_mtime_size_changing_edit() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        let file = dir.path().join("src/lib.rs");
+        fs::write(&file, "pub fn old_symbol() {}\n").unwrap();
+
+        // Canonicalize so the snapshot token matches across calls.
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        let token = canonical.to_string_lossy().to_string();
+        let opts = ScanProjectOptions::default();
+
+        let first = scan_incremental(&token, None, opts.clone());
+        let cached_mtime = first
+            .result
+            .files
+            .iter()
+            .find(|r| r.relative_path == "src/lib.rs")
+            .expect("seed file indexed")
+            .last_modified_unix_ms;
+        assert!(symbol_names(&first).iter().any(|n| n == "old_symbol"));
+
+        // Add a symbol (byte size grows), then force the mtime back to the
+        // cached value to simulate a same-instant edit the OS couldn't
+        // distinguish by mtime.
+        fs::write(
+            &file,
+            "pub fn old_symbol() {}\npub fn brand_new_symbol() {}\n",
+        )
+        .unwrap();
+        let secs = cached_mtime / 1000;
+        let nanos = ((cached_mtime % 1000) * 1_000_000) as u32;
+        set_file_mtime(&file, FileTime::from_unix_time(secs, nanos)).unwrap();
+
+        let second = scan_incremental(&token, None, opts);
+        let names = symbol_names(&second);
+        assert!(
+            names.iter().any(|n| n == "brand_new_symbol"),
+            "same-mtime size-changing edit must be reindexed, got {names:?} (delta.modified={:?})",
+            second.delta.modified,
+        );
+    }
+
+    /// Companion guard: even when an edit changes nothing the scanner can
+    /// cheaply detect (same mtime AND same byte size — e.g. a length-preserving
+    /// one-character swap), passing the explicit `changed_paths` signal still
+    /// forces the reindex. The agent loop threads its own write through this
+    /// bypass, so freshness never depends on mtime/size heuristics for the
+    /// agent's own edits.
+    #[test]
+    fn scan_incremental_changed_paths_bypasses_metadata_heuristics() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        let file = dir.path().join("src/lib.rs");
+        // 23 bytes.
+        fs::write(&file, "pub fn alpha_name() {}\n").unwrap();
+
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        let token = canonical.to_string_lossy().to_string();
+        let opts = ScanProjectOptions::default();
+
+        let first = scan_incremental(&token, None, opts.clone());
+        let cached_mtime = first
+            .result
+            .files
+            .iter()
+            .find(|r| r.relative_path == "src/lib.rs")
+            .expect("seed file indexed")
+            .last_modified_unix_ms;
+        assert!(symbol_names(&first).iter().any(|n| n == "alpha_name"));
+
+        // Length-preserving rename (same 23 bytes), same forced mtime: neither
+        // the size nor the mtime heuristic can see this.
+        fs::write(&file, "pub fn omega_name() {}\n").unwrap();
+        let secs = cached_mtime / 1000;
+        let nanos = ((cached_mtime % 1000) * 1_000_000) as u32;
+        set_file_mtime(&file, FileTime::from_unix_time(secs, nanos)).unwrap();
+
+        // Without an explicit signal the heuristics legitimately miss this
+        // rare length-preserving same-instant case...
+        let heuristic_only = scan_incremental(&token, None, opts.clone());
+        assert!(
+            !heuristic_only
+                .delta
+                .modified
+                .contains(&"src/lib.rs".to_string()),
+            "documenting the heuristic's known blind spot",
+        );
+
+        // ...but the explicit changed-path signal the agent loop passes after
+        // its own write forces the reindex regardless.
+        let explicit = scan_incremental(&token, Some(&["src/lib.rs".to_string()]), opts);
+        assert!(
+            symbol_names(&explicit).iter().any(|n| n == "omega_name"),
+            "explicit changed_paths must always reindex, got {:?}",
+            symbol_names(&explicit),
+        );
     }
 }

--- a/crates/harn-hostlib/tests/code_index.rs
+++ b/crates/harn-hostlib/tests/code_index.rs
@@ -384,3 +384,140 @@ fn empty_workspace_returns_empty_responses() {
     ));
     assert!(extract_list(imps_of.get("importers").unwrap()).is_empty());
 }
+
+// === Recall@K canary for the substring `query` scorer ===
+//
+// `run_query` ranks hits by raw substring `match_count` (desc, path asc) — no
+// IDF or length normalization. This gold fixture pins what that scorer actually
+// recovers so a future scorer change has to MEASURE against it rather than
+// churn the load-bearing index blindly.
+//
+// Findings these assertions lock in (see PR investigation):
+//   * Rare-symbol localization — the cheap-model grounding pain point — already
+//     achieves recall@5 = 1.0 under raw count. There are few matching files and
+//     they all fit in the top-K, so the scorer is NOT the bottleneck here.
+//   * The one demonstrable count-scorer blind spot is recall@1 for a symbol
+//     DEFINITION when a non-definition file mentions the symbol more times
+//     (e.g. a test that repeats it). The definition is ranked 2nd, not buried —
+//     recall@3 recovers it. A length/IDF-normalized scorer was prototyped and
+//     REGRESSED other cases (common-token recall@5 1.0 -> 0.5) with no rare-
+//     symbol gain, so the scorer is intentionally left as raw count.
+
+/// Build a workspace where a rare symbol is defined once but mentioned many
+/// times in a non-definition test file, plus several single-mention callers and
+/// unrelated noise files. Mirrors the realistic "localize the definition" task.
+fn write_recall_workspace() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("tests")).unwrap();
+
+    // Definition file: the symbol appears twice (decl + impl).
+    fs::write(
+        root.join("src/retry_budget.rs"),
+        "pub struct RetryBudget { remaining: u32 }\nimpl RetryBudget { pub fn new() -> Self { RetryBudget { remaining: 3 } } }\n",
+    )
+    .unwrap();
+    // Non-definition test file mentions the symbol many times (high raw count).
+    fs::write(
+        root.join("tests/retry_budget_test.rs"),
+        "let b = RetryBudget::new();\n".repeat(20),
+    )
+    .unwrap();
+    // Single-mention callers.
+    for i in 0..6 {
+        fs::write(
+            root.join(format!("src/caller{i}.rs")),
+            "fn run() { let b = RetryBudget::new(); }\n",
+        )
+        .unwrap();
+    }
+    // Noise files without the symbol.
+    for i in 0..8 {
+        fs::write(root.join(format!("src/noise{i}.rs")), "fn unrelated() {}\n").unwrap();
+    }
+    dir
+}
+
+fn query_ranked_paths(registry: &BuiltinRegistry, needle: &str) -> Vec<String> {
+    let response = call(
+        registry,
+        "hostlib_code_index_query",
+        dict(&[
+            ("needle", VmValue::String(Arc::from(needle))),
+            ("max_results", VmValue::Int(100)),
+        ]),
+    );
+    let response = extract_dict(&response);
+    extract_list(response.get("results").unwrap())
+        .iter()
+        .map(|hit| extract_str(extract_dict(hit).get("path").unwrap()))
+        .collect()
+}
+
+fn recall_at_k(ranked: &[String], expected: &[&str], k: usize) -> f64 {
+    let top = &ranked[..ranked.len().min(k)];
+    let hit = expected
+        .iter()
+        .filter(|e| top.iter().any(|p| p == *e))
+        .count();
+    hit as f64 / expected.len() as f64
+}
+
+#[test]
+fn query_recall_gold_fixture_rare_symbol_and_definition_burial() {
+    let dir = write_recall_workspace();
+    let (registry, _) = build_registry();
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Arc::from(dir.path().to_string_lossy().to_string())),
+        )]),
+    );
+
+    let ranked = query_ranked_paths(&registry, "RetryBudget");
+
+    // Rare-symbol recall: every file that references the symbol is a relevant
+    // localization target, and they all surface within the top-K. recall@5 is
+    // perfect — the count scorer is not the rare-symbol grounding bottleneck.
+    let all_refs = [
+        "src/retry_budget.rs",
+        "tests/retry_budget_test.rs",
+        "src/caller0.rs",
+        "src/caller1.rs",
+        "src/caller2.rs",
+        "src/caller3.rs",
+        "src/caller4.rs",
+        "src/caller5.rs",
+    ];
+    assert_eq!(
+        recall_at_k(&ranked, &["src/retry_budget.rs"], 5),
+        1.0,
+        "definition must be within top-5 under raw count, got order {ranked:?}"
+    );
+    assert_eq!(
+        ranked.len(),
+        all_refs.len(),
+        "every referencing file returns (no false drops), got {ranked:?}"
+    );
+
+    // Documented blind spot: the high-mention test file outranks the
+    // definition, so recall@1 for the *definition* is 0. recall@3 recovers it.
+    // If a scorer change flips these, this canary forces a re-measure.
+    assert_eq!(
+        ranked[0], "tests/retry_budget_test.rs",
+        "raw count ranks the most-mentions file first, got {ranked:?}"
+    );
+    assert_eq!(
+        recall_at_k(&ranked, &["src/retry_budget.rs"], 1),
+        0.0,
+        "known recall@1 definition-burial under raw count, order {ranked:?}"
+    );
+    assert_eq!(
+        recall_at_k(&ranked, &["src/retry_budget.rs"], 3),
+        1.0,
+        "definition recovered by recall@3, order {ranked:?}"
+    );
+}


### PR DESCRIPTION
Two GROUNDING-QUALITY investigations on the harn code index — the foundation cheap local models lean on hardest. Both hypotheses were surfaced grounded; both were verified deterministically before any change. No LLM/eval loops.

## Issue 2 — same-turn index freshness (FIXED)

**Confirmed bug.** `crates/harn-hostlib/src/scanner/mod.rs::compute_delta` (the automatic delta path, taken when no explicit `changed_paths` is supplied) compared only `mtime > prev.last_modified_unix_ms`. Both sides are `as_millis() as i64`, so millisecond mtime granularity collides on same-turn/same-second writes (and on coarse-granularity filesystems). A deterministic test (`filetime`-forced same-ms mtime) proved that an edit adding a symbol in the same instant is **silently dropped** — `modified` delta empty, the scan keeps serving pre-edit symbols. That is the fuzzy-match-stale loop on weak local models.

**Fix.** `compute_delta` now also flags a file as modified when its byte size differs from the cached record — an mtime-independent signal that catches the overwhelmingly common add/remove edit for free (`meta.len()` is already read for the mtime check). Length-preserving same-instant edits (e.g. a same-byte-count rename) still rely on the explicit `changed_paths` bypass the agent loop already threads after its own writes.

**Scope note.** The agent's *own-edit* reindex path (`lib/index/edit.harn` → `host_codeindex_reindex_file` → `code_index::reindex_file` → `ingest`) is content-hash based (`content_hash == hash` short-circuit) and was never subject to the mtime bug. This fixes the separate scanner-snapshot subsystem (`scan_incremental`, used by context-refresh / librarian).

**Tests.** Two regression guards in `scanner::tests`:
- `scan_incremental_detects_same_mtime_size_changing_edit` — the fix.
- `scan_incremental_changed_paths_bypasses_metadata_heuristics` — documents the length-preserving blind spot and that the explicit signal always wins.

## Issue 1 — recall ranking IDF/length normalization (INVESTIGATED, NOT CHANGED)

**Confirmed current scoring** (`builtins.rs::run_query`): ranks hits by raw substring `count as f64`, sorted `match_count` desc then path asc — no IDF, no length normalization.

```rust
let count = count_matches(&text, &needle, case_sensitive);
...
hits.push(Hit { path: ..., score: count as f64, match_count: count });
hits.sort_by(|a, b| b.match_count.cmp(&a.match_count).then_with(|| a.path.cmp(&b.path)));
```

**Measured on a deterministic gold fixture** (rare symbol defined once, mentioned 20x in a non-definition test file, 6 single-mention callers, 8 noise files):
- **Rare-symbol recall@5 = 1.0** under raw count — few matching files, all within top-K. The scorer is *not* the rare-symbol grounding bottleneck.
- The only blind spot: **recall@1 for the definition = 0.0** (the 20-mention test file outranks the 2-mention definition). recall@3 already recovers it (= 1.0) — the definition is ranked 2nd, not buried.
- A length-normalized prototype **regressed** the common-token case (recall@5 1.0 → 0.5) and pulled in tiny noise files, with no rare-symbol gain. IDF is meaningless here — `run_query` takes a single substring needle, so there's no cross-term frequency signal to exploit.

Per the load-bearing-index guidance, the win was ambiguous/negative, so **the scorer is intentionally left as raw count** and pinned by a `recall@K` canary test (`query_recall_gold_fixture_rare_symbol_and_definition_burial` in `tests/code_index.rs`) that locks in the measured numbers — any future scorer change must re-measure against it rather than churn blindly.

## Verify

- `RUSTFLAGS="-D warnings" cargo build -p harn-hostlib` — clean
- `cargo test -p harn-hostlib` — 304 lib + all integration tests pass (incl. the 3 new ones)
- `cargo fmt --check` — clean
- `cargo clippy -p harn-hostlib --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)