### PR TITLE
Auto-continue on length-truncated tool calls instead of burning the turn

### DIFF
--- a/changelog.d/truncation-auto-continue.fixed.md
+++ b/changelog.d/truncation-auto-continue.fixed.md
@@ -1,0 +1,20 @@
+- **A tool call that the provider cut off mid-emit when the model hit its
+  output-token cap is now auto-continued with a raised cap instead of burning
+  the turn.** When a value model exhausts `max_tokens` partway through a tool
+  call, the provider returns a length-truncation stop reason (`length` for
+  OpenAI/OpenRouter/Ollama, `max_tokens` for Anthropic) and the partial output
+  carries a truncated, unparseable call. The agent loop previously treated that
+  as a malformed/missing call and dropped the turn to parse-guidance — a
+  silent-corruption class that wastes a turn even on capable models that were
+  mid-correct-action. The loop now detects this specific condition
+  deterministically (no model cooperation, no abuse surface): a length
+  truncation that resolved zero usable tool calls AND shows a partial-call
+  signal (a parser truncation diagnostic or a tool-call opener prefix) is
+  re-issued with a higher output cap so the model can finish the call. The
+  re-issue is bounded (two continuations by default, each clamped to a ceiling)
+  and does not consume a loop iteration; once the cap is exhausted the loop
+  falls back to the existing parse-guidance path, so it can never loop forever.
+  The gate keys on the normalized finish reason, so it generalizes across
+  providers, and it fires ONLY on a real length truncation — a clean stop with
+  a genuinely malformed call still flows through the parse-tolerance and
+  reasoning-leak paths unchanged, with no overlap.

--- a/conformance/tests/agents/agent_loop_truncation_auto_continue.expected
+++ b/conformance/tests/agents/agent_loop_truncation_auto_continue.expected
@@ -1,0 +1,9 @@
+done
+write_note
+3
+true
+done
+true
+done
+3
+true

--- a/conformance/tests/agents/agent_loop_truncation_auto_continue.harn
+++ b/conformance/tests/agents/agent_loop_truncation_auto_continue.harn
@@ -1,0 +1,123 @@
+import { llm_text, with_llm_script } from "std/testing"
+
+/**
+ * A value model that hits the output-token cap mid-emit returns a
+ * length-truncation stop_reason with a partial, unparseable tool call. The loop
+ * must AUTO-CONTINUE (re-issue with a raised cap) instead of burning the turn on
+ * parse-guidance — but only on a real length truncation, and bounded so it can't
+ * loop forever. A clean stop with a malformed call must NOT trigger it (that is
+ * the parse-tolerance / reasoning-leak domain).
+ */
+fn note_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note.",
+    {
+      handler: { args -> "wrote " + to_string(args?.path) },
+      parameters: {path: {type: "string", description: "Path to write"}},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+  return tools
+}
+
+/**
+ * A tagged tool-call cut off mid-heredoc: the parser surfaces a TRUNCATED
+ * diagnostic and zero calls. `stop_reason: "length"` marks the token-cap cause.
+ */
+fn truncated_turn() {
+  return {text: "<tool_call>\nwrite_note({ path: \"a.txt\", body: <<EOF\nhello", stop_reason: "length"}
+}
+
+pipeline default() {
+  // (a) Length truncation + incomplete call -> auto-continue. The re-issue
+  // consumes the next scripted turn (a complete call), dispatches it, then the
+  // loop finishes. The continuation must NOT carry parse-guidance — the whole
+  // point is that we did not burn the turn.
+  with_llm_script(
+    [
+      truncated_turn(),
+      llm_text("<tool_call>\nwrite_note({ path: \"a.txt\" })\n</tool_call>"),
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Write a.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "text",
+          loop_until_done: true,
+          max_iterations: 5,
+          max_nudges: 5,
+          tools: note_tools(),
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(result.tools.successful[0])
+      __io_println(len(calls))
+      __io_println(!contains(json_stringify(calls[1].messages), "parse_guidance"))
+    },
+  )
+  // (b) Still truncated after the cap -> fall back to parse-guidance, no
+  // infinite loop. Two continuations are allowed (default cap), so the third
+  // truncated result falls through; its successor call carries parse-guidance.
+  with_llm_script(
+    [
+      truncated_turn(),
+      truncated_turn(),
+      truncated_turn(),
+      llm_text("<tool_call>\nwrite_note({ path: \"a.txt\" })\n</tool_call>"),
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Write a.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "text",
+          loop_until_done: true,
+          max_iterations: 8,
+          max_nudges: 8,
+          tools: note_tools(),
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(contains(json_stringify(calls[3].messages), "parse_guidance"))
+    },
+  )
+  // (c) Clean stop + malformed call -> NOT auto-continue. The same truncated
+  // body but with `stop_reason: "stop"` is the #3137/#3142 domain: parse-guidance
+  // fires immediately on the next call and the continuation count is not inflated.
+  with_llm_script(
+    [
+      {text: "<tool_call>\nwrite_note({ path: \"a.txt\", body: <<EOF\nhello", stop_reason: "stop"},
+      llm_text("<tool_call>\nwrite_note({ path: \"a.txt\" })\n</tool_call>"),
+      llm_text("<done>##DONE##</done>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Write a.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "text",
+          loop_until_done: true,
+          max_iterations: 5,
+          max_nudges: 5,
+          tools: note_tools(),
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(len(calls))
+      __io_println(contains(json_stringify(calls[1].messages), "parse_guidance"))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -186,6 +186,141 @@ fn __invoke_llm(message, turn_system, llm_opts) {
 
 // -------------------------------------------------------------------------------------------------
 
+// Length-truncation auto-continue.
+//
+// When a value model hits the output-token cap mid-emit, the provider returns a
+// length-truncation stop_reason (`length` for OpenAI/OpenRouter/Ollama,
+// `max_tokens` for Anthropic) and the partial output often holds a TRUNCATED,
+// unparseable tool call. Treating that as a malformed/missing call burns the
+// turn on parse-guidance even though the model was mid-correct-action — a
+// silent-corruption class that hurts even capable models.
+//
+// Instead we detect the specific condition deterministically (no model
+// cooperation, no abuse surface) and re-issue the completion with a RAISED cap
+// so the model can finish the call. The retry is invisible to the rest of the
+// loop body: it does not consume an iteration or run stall/parse accounting.
+// Bounded to a small number of continuations; if still truncated after the cap
+// we return the last result and the existing parse-guidance path takes over.
+//
+// The gate (`__host_agent_truncated_tool_call`) fires ONLY on a real length
+// truncation with zero usable calls AND a partial-call signal, so it never
+// double-handles the clean-stop-but-malformed (#3137) or reasoning-leak (#3142)
+// cases — those stop with `end_turn`/`stop`, not `length`/`max_tokens`.
+
+// -------------------------------------------------------------------------------------------------
+
+fn __autocontinue_max_continuations(llm_opts) {
+  let configured = llm_opts?.truncation_auto_continue_max
+  if type_of(configured) == "int" && configured >= 0 {
+    return configured
+  }
+  return 2
+}
+
+/**
+ * Compute the raised output-token cap for an auto-continue retry. An unset cap
+ * (`<= 0`) means the provider's own default truncated us, so jump to an
+ * explicit base. A set cap doubles. Both are clamped to a ceiling so a
+ * misconfigured model can't request an unbounded body.
+ */
+fn __autocontinue_raised_cap(current, llm_opts) {
+  let base = if type_of(llm_opts?.truncation_auto_continue_base) == "int"
+    && llm_opts.truncation_auto_continue_base > 0 {
+    llm_opts.truncation_auto_continue_base
+  } else {
+    16384
+  }
+  let ceiling = if type_of(llm_opts?.truncation_auto_continue_ceiling) == "int"
+    && llm_opts.truncation_auto_continue_ceiling > 0 {
+    llm_opts.truncation_auto_continue_ceiling
+  } else {
+    32768
+  }
+  let raised = if type_of(current) == "int" && current > 0 {
+    current * 2
+  } else {
+    base
+  }
+  if raised > ceiling {
+    return ceiling
+  }
+  return raised
+}
+
+/**
+ * Detect whether `call` is a length-truncated turn that resolved no usable
+ * tool call but looks like it was mid-call — the one condition where
+ * re-issuing with a raised cap is the right move.
+ */
+fn __autocontinue_should_continue(call, turn_opts) {
+  if !(call?.ok ?? false) {
+    return false
+  }
+  let llm_result = call?.value
+  if type_of(llm_result) != "dict" {
+    return false
+  }
+  let raw_text = llm_result?.text ?? ""
+  let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools)
+  let tool_calls = __resolve_tool_calls(llm_result, parsed)
+  let has_parse_errors = len(parsed?.tool_parse_errors ?? []) > 0
+  return __host_agent_truncated_tool_call(
+    llm_result?.stop_reason,
+    raw_text,
+    len(tool_calls),
+    has_parse_errors,
+  )
+}
+
+/**
+ * Call the LLM, and on a length-truncated turn with an incomplete tool call,
+ * AUTO-CONTINUE by re-issuing with a raised output cap (bounded). Returns the
+ * same `{ok, value, ...}` shape `__invoke_llm` returns; callers consume the
+ * final (hopefully complete) result and run their normal parse/stall/dispatch
+ * accounting on it. Falls back to the last truncated result once the cap is
+ * exhausted, so the existing parse-guidance path still fires.
+ */
+fn __invoke_llm_with_autocontinue(
+  message,
+  turn_system,
+  llm_opts,
+  turn_opts,
+  session_id,
+  iteration_index,
+) {
+  var call = __invoke_llm(message, turn_system, llm_opts)
+  let max_continuations = __autocontinue_max_continuations(llm_opts)
+  var attempts = 0
+  var cap = llm_opts?.max_tokens ?? 0
+  while attempts < max_continuations && __autocontinue_should_continue(call, turn_opts) {
+    let raised = __autocontinue_raised_cap(cap, llm_opts)
+    // No headroom left to raise — re-issuing would just truncate again at the
+    // same cap, so stop and let parse-guidance take the turn.
+    if type_of(cap) == "int" && cap > 0 && raised <= cap {
+      break
+    }
+    attempts = attempts + 1
+    agent_emit_event(
+      session_id,
+      "llm_auto_continue",
+      {
+        iteration: iteration_index + 1,
+        attempt: attempts,
+        max_continuations: max_continuations,
+        previous_max_tokens: cap,
+        raised_max_tokens: raised,
+        stop_reason: call?.value?.stop_reason ?? "",
+      },
+    )
+    cap = raised
+    let retry_opts = llm_opts + {max_tokens: raised, _truncation_auto_continue_attempt: attempts}
+    call = __invoke_llm(message, turn_system, retry_opts)
+  }
+  return call
+}
+
+// -------------------------------------------------------------------------------------------------
+
 // Tool middleware seam — composable tool_caller (mirrors __invoke_llm).
 //
 // Each tool dispatch is funneled through `tool_caller(envelope, next)` when
@@ -2207,7 +2342,14 @@ fn __agent_loop_run(message, session, initial_opts) {
         _iteration: iteration_index + 1,
         _system_fragments: turn_prompt.fragments,
       }
-      let call = __invoke_llm(message, turn_prompt.system, llm_opts)
+      let call = __invoke_llm_with_autocontinue(
+        message,
+        turn_prompt.system,
+        llm_opts,
+        turn_opts,
+        session.session_id,
+        iteration_index,
+      )
       if !call.ok {
         let failure_config = __agent_loop_consecutive_failure_config(budget)
         if __agent_loop_tracks_failure(call?.error, failure_config) {

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -785,6 +785,79 @@ pub(crate) fn canonical_provider_stop_reason(last_llm_stop_reason: Option<&str>)
     }
 }
 
+/// True when a provider stop_reason means "I ran out of output-token budget
+/// mid-emit", i.e. the response was cut off rather than completed.
+///
+/// Keys on the normalized condition, not one wire format: OpenAI / OpenRouter /
+/// Ollama (`/v1` finish_reason + native `done_reason`) report `length`;
+/// Anthropic reports `max_tokens`. Both canonicalize to `max_tokens` via
+/// [`canonical_provider_stop_reason`], so we reuse that mapping as the single
+/// source of truth — a new provider that adopts either spelling is covered for
+/// free.
+pub(crate) fn is_length_truncation(stop_reason: Option<&str>) -> bool {
+    canonical_provider_stop_reason(stop_reason) == "max_tokens"
+}
+
+/// True when the model's text looks like it was mid-tool-call when the stream
+/// was cut off: it contains a text-tool-call opener (the `<tool_call>` tag or a
+/// bare `name(` shape) but the turn resolved ZERO usable tool calls. This is the
+/// "truncated, unparseable tool call" fingerprint — distinct from a model that
+/// simply ran long on prose with no tool intent.
+///
+/// Deliberately permissive on the *prefix* side (any opener) but strict on the
+/// *outcome* side (zero calls dispatched): a turn that landed even one tool call
+/// made real progress and is not a truncation casualty.
+fn text_has_tool_call_prefix(text: &str) -> bool {
+    if text.contains(super::tools::TEXT_TOOL_CALL_OPEN)
+        || text.contains(super::tools::TEXT_TOOL_CALL_OPEN_COMPACT)
+    {
+        return true;
+    }
+    // Bare `name(` shape at the start of any line — the text-tool wire format
+    // the agent loop reads back. We only need a cheap structural sniff here;
+    // the authoritative parse already ran and produced zero calls, so this just
+    // decides whether continuing is worthwhile.
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if let Some(ident) = super::tools::ident_length(trimmed.as_bytes()) {
+            if trimmed.as_bytes().get(ident) == Some(&b'(') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Decide whether the agent loop should AUTO-CONTINUE (re-issue the completion
+/// with a raised output cap) instead of burning the turn on parse-guidance.
+///
+/// Fires only when ALL hold:
+///   1. `stop_reason` is a length truncation (the response was cut off), AND
+///   2. the turn resolved ZERO usable tool calls, AND
+///   3. there is a partial tool-call signal — either the parser emitted a
+///      diagnostic (e.g. "unterminated heredoc") or the raw text carries a
+///      tool-call opener prefix.
+///
+/// A clean stop with a genuinely malformed call returns `false` here: that is
+/// the parse-tolerance / narration-as-prose domain (#3137) and the
+/// reasoning-leak domain (#3142), which this must NOT double-handle. The
+/// length-truncation gate is what keeps the two from colliding — those cases
+/// stop with `end_turn`/`stop`, never `length`/`max_tokens`.
+pub(crate) fn truncated_tool_call_should_continue(
+    stop_reason: Option<&str>,
+    text: &str,
+    tool_call_count: i64,
+    has_parse_errors: bool,
+) -> bool {
+    if !is_length_truncation(stop_reason) {
+        return false;
+    }
+    if tool_call_count > 0 {
+        return false;
+    }
+    has_parse_errors || text_has_tool_call_prefix(text)
+}
+
 fn last_assistant_text(snapshot: &VmValue) -> Option<String> {
     let messages_value = dict_get(snapshot, "messages")?;
     let messages = list_items(messages_value);
@@ -1248,6 +1321,41 @@ fn host_agent_session_record_usage_builtin(
     out.insert("tokens_used".to_string(), VmValue::Int(totals.0));
     out.insert("cost_usd".to_string(), VmValue::Float(totals.1));
     Ok(VmValue::Dict(std::sync::Arc::new(out)))
+}
+
+/// Deterministic "should the loop auto-continue this truncated turn?" gate.
+///
+/// Returns `true` only when the provider cut the response off mid-emit
+/// (`stop_reason` is a length truncation), the turn resolved zero usable tool
+/// calls, and there is a partial tool-call signal (a parser diagnostic or a
+/// tool-call opener in the text). Returns `false` on clean stops — including a
+/// cleanly-finished-but-malformed call — so it never overlaps the
+/// parse-tolerance (#3137) or reasoning-leak (#3142) paths.
+#[harn_builtin(
+    sig = "__host_agent_truncated_tool_call(stop_reason: string|nil, text: string, tool_call_count: int, has_parse_errors: bool) -> bool",
+    category = "agent.host",
+    runtime_only = true
+)]
+fn host_agent_truncated_tool_call_builtin(
+    args: &[VmValue],
+    _out: &mut String,
+) -> Result<VmValue, VmError> {
+    let stop_reason = match args.first() {
+        Some(VmValue::String(s)) if !s.is_empty() => Some(s.to_string()),
+        _ => None,
+    };
+    let text = args.get(1).map(|v| v.display()).unwrap_or_default();
+    let tool_call_count = match args.get(2) {
+        Some(VmValue::Int(i)) => *i,
+        _ => 0,
+    };
+    let has_parse_errors = matches!(args.get(3), Some(VmValue::Bool(true)));
+    Ok(VmValue::Bool(truncated_tool_call_should_continue(
+        stop_reason.as_deref(),
+        &text,
+        tool_call_count,
+        has_parse_errors,
+    )))
 }
 
 /// Drain pending runtime-feedback notes for a session (no-op shim).
@@ -2203,6 +2311,23 @@ fn build_agent_event(
             kind: "tool_parse_error_feedback".to_string(),
             content: get_string("error_summary"),
         }),
+        // `llm_auto_continue` fires when a length-truncated turn with an
+        // incomplete tool call is re-issued with a raised output cap instead of
+        // burning the turn on parse-guidance. Engine-emitted (not user
+        // feedback), surfaced on the FeedbackInjected stream like the sibling
+        // corrections above so operators can see the recovery. `content`
+        // summarizes the cap raise: "<previous>->-<raised> (attempt N/max)".
+        "llm_auto_continue" => Ok(AgentEvent::FeedbackInjected {
+            session_id: session_id.to_string(),
+            kind: "llm_auto_continue".to_string(),
+            content: format!(
+                "{}->{} (attempt {}/{})",
+                get_usize("previous_max_tokens"),
+                get_usize("raised_max_tokens"),
+                get_usize("attempt"),
+                get_usize("max_continuations"),
+            ),
+        }),
         other => Err(VmError::Runtime(format!(
             "{HOST_AGENT_EMIT_EVENT}: unsupported event type `{other}`"
         ))),
@@ -3111,6 +3236,7 @@ const HOST_SESSION_BUILTINS: &[&VmBuiltinDef] = &[
     &HOST_AGENT_SESSION_RECORD_USAGE_BUILTIN_DEF,
     &HOST_AGENT_SESSION_DRAIN_FEEDBACK_BUILTIN_DEF,
     &HOST_AGENT_SESSION_TOTALS_BUILTIN_DEF,
+    &HOST_AGENT_TRUNCATED_TOOL_CALL_BUILTIN_DEF,
     &HOST_AGENT_SESSION_INJECT_FEEDBACK_BUILTIN_DEF,
     &HOST_AGENT_SESSION_POST_EVENT_BUILTIN_DEF,
     &HOST_AGENT_SESSION_APPLY_REMINDER_POST_TURN_BUILTIN_DEF,
@@ -3148,8 +3274,9 @@ mod tests {
 
     use super::{
         agent_turn_made_no_llm_call, assistant_message_from_llm_result, canonical_acp_stop_reason,
-        canonical_provider_stop_reason, initial_user_content, last_assistant_text,
-        tool_result_message_for_provider, vm_to_json,
+        canonical_provider_stop_reason, initial_user_content, is_length_truncation,
+        last_assistant_text, text_has_tool_call_prefix, tool_result_message_for_provider,
+        truncated_tool_call_should_continue, vm_to_json,
     };
     use std::collections::BTreeMap;
 
@@ -3389,6 +3516,107 @@ mod tests {
             canonical_acp_stop_reason("budget_exhausted", 50, 50, Some("refusal")),
             "max_turn_requests"
         );
+    }
+
+    #[test]
+    fn length_truncation_recognized_across_provider_spellings() {
+        // Keyed on the normalized condition, not one wire format.
+        assert!(is_length_truncation(Some("length"))); // OpenAI/OpenRouter/Ollama
+        assert!(is_length_truncation(Some("max_tokens"))); // Anthropic
+        assert!(is_length_truncation(Some("LENGTH"))); // case-insensitive
+        assert!(!is_length_truncation(Some("stop")));
+        assert!(!is_length_truncation(Some("end_turn")));
+        assert!(!is_length_truncation(Some("tool_use")));
+        assert!(!is_length_truncation(Some("refusal")));
+        assert!(!is_length_truncation(None));
+    }
+
+    #[test]
+    fn truncated_tool_call_prefix_detection_covers_both_wire_shapes() {
+        // Tagged opener.
+        assert!(text_has_tool_call_prefix(
+            "let me edit\n<tool_call>\nedit({ path: \"a.rs\", body: <<EOF\nfn"
+        ));
+        // Bare `name(` at line start.
+        assert!(text_has_tool_call_prefix(
+            "I'll write the file.\nwrite_file({ path: \"a.rs\", contents: <<EOF\nfn main"
+        ));
+        // Pure prose with no call shape — not a truncated call.
+        assert!(!text_has_tool_call_prefix(
+            "Here is a long explanation of the algorithm that just kept going"
+        ));
+        // A bare ident with no opening paren is not a call prefix.
+        assert!(!text_has_tool_call_prefix(
+            "write_file is the tool you want"
+        ));
+    }
+
+    #[test]
+    fn auto_continue_fires_on_length_truncation_with_partial_call() {
+        // (a) finish_reason == length + truncated tool-call prefix with zero
+        // resolved calls -> auto-continue.
+        let truncated_body = "edit({ path: \"a.rs\", body: <<EOF\nfn main() {";
+        // Via a parser diagnostic (unterminated heredoc).
+        assert!(truncated_tool_call_should_continue(
+            Some("length"),
+            truncated_body,
+            0,
+            true,
+        ));
+        // Via the text prefix alone, even with no parser diagnostic surfaced.
+        assert!(truncated_tool_call_should_continue(
+            Some("max_tokens"),
+            truncated_body,
+            0,
+            false,
+        ));
+    }
+
+    #[test]
+    fn auto_continue_does_not_fire_when_calls_resolved() {
+        // A length truncation that still landed a usable tool call made real
+        // progress; do not re-issue.
+        assert!(!truncated_tool_call_should_continue(
+            Some("length"),
+            "edit({ path: \"a.rs\", body: <<EOF\nfn main() {}\nEOF })",
+            1,
+            false,
+        ));
+    }
+
+    #[test]
+    fn auto_continue_does_not_fire_on_clean_stop_with_malformed_call() {
+        // (c) Clean stop + malformed call -> NOT auto-continue. This is the
+        // #3137/#3142 domain (parse-tolerance / reasoning-leak); the
+        // length-truncation gate is what keeps the two from colliding.
+        let malformed = "edit({ path: \"a.rs\" body \"oops\" })";
+        assert!(!truncated_tool_call_should_continue(
+            Some("stop"),
+            malformed,
+            0,
+            true,
+        ));
+        assert!(!truncated_tool_call_should_continue(
+            Some("end_turn"),
+            malformed,
+            0,
+            true,
+        ));
+        assert!(!truncated_tool_call_should_continue(
+            None, malformed, 0, true
+        ));
+    }
+
+    #[test]
+    fn auto_continue_does_not_fire_on_length_truncated_prose() {
+        // A model that simply ran long on prose with no tool intent should not
+        // trigger a continuation: there is no partial-call signal.
+        assert!(!truncated_tool_call_should_continue(
+            Some("length"),
+            "Here is a very long explanation that ran past the token cap",
+            0,
+            false,
+        ));
     }
 }
 

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use messages::{build_assistant_response_message, normalize_tool_args}
 pub(crate) use native::{
     apply_tool_search_native_injection_typed, extract_deferred_tool_names, vm_tools_to_native,
 };
+pub(crate) use parse::ident_length;
 pub(crate) use parse::parse_text_tool_calls_with_tools;
 pub(crate) use parse::StreamingToolCallDetector;
 #[cfg(test)]

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -125,6 +125,7 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__host_agent_session_replace_messages",
     "__host_agent_session_set_active_skills",
     "__host_agent_session_totals",
+    "__host_agent_truncated_tool_call",
     "__host_autonomy_budget_check",
     "__host_drain_file_edits",
     "__host_fire_session_hook",


### PR DESCRIPTION
## Problem

When a value model hits its output-token cap mid-emit, the provider returns a length-truncation stop reason (`length` for OpenAI/OpenRouter/Ollama, `max_tokens` for Anthropic) and the partial output often carries a **truncated, unparseable tool call**. The agent loop treated that as a malformed/missing call and dropped the turn to parse-guidance (or a no-tool-call nudge) — burning the turn even though the model was mid-correct-action. This is a **silent-corruption class** that wastes turns even on capable models.

## Fix

Detect the specific condition deterministically (no model cooperation, no abuse surface) and re-issue the completion with a **raised output cap** so the model can finish the call.

**The seam.** The loop already surfaces the provider's raw `stop_reason` on `llm_result`. The decision lives in two places:

- `is_length_truncation` / `truncated_tool_call_should_continue` in `crates/harn-vm/src/llm/agent_session_host.rs` are the single deterministic source of truth, exposed to the loop as the `__host_agent_truncated_tool_call` builtin. They key on the **normalized** finish reason (reusing the existing `canonical_provider_stop_reason` mapping, so a new provider adopting either spelling is covered for free) and fire **only** when the turn was length-truncated, resolved **zero usable tool calls**, AND shows a partial-call signal — a parser truncation diagnostic (`tool_parse_errors`) or a tool-call opener prefix (`<tool_call>` / bare `name(`) in the text.
- `__invoke_llm_with_autocontinue` in `crates/harn-stdlib/src/stdlib/agent/loop.harn` wraps the LLM call. On the gate it re-issues with a doubled/based cap (clamped to a ceiling), **bounded to two continuations by default**, **without consuming a loop iteration**. Once the cap is exhausted it returns the last truncated result and the **existing parse-guidance path takes over**, so it can never loop forever. Emits an `llm_auto_continue` event per retry.

## Cap / fallback design

- Cap: `max_tokens` doubles each continuation (or jumps to a 16384 base if unset), clamped to a 32768 ceiling. All three are overridable via `truncation_auto_continue_{max,base,ceiling}` opts.
- Bound: 2 continuations by default. If the cap can't be raised any further (no headroom), it stops immediately.
- Fallback: after the bound, the unchanged downstream `__maybe_inject_parse_error_feedback` fires exactly as before.

## No whac-a-mole overlap with #3137 / #3142

The length-truncation gate is what keeps the paths separate. #3137 (parse-tolerance / narration-as-prose) and #3142 (reasoning-channel leak) are **clean-stop** cases — they stop with `end_turn`/`stop`, never `length`/`max_tokens` — so `truncated_tool_call_should_continue` returns `false` on them and they flow through the existing handling unchanged. A clean stop with a genuinely malformed call is explicitly tested to NOT auto-continue.

## Tests (deterministic, no live LLM)

- 6 new unit tests in `agent_session_host`: cross-provider spellings, prefix detection for both wire shapes, fires on truncation+partial-call, does **not** fire when a call resolved / on a clean malformed call / on length-truncated prose.
- New conformance fixture `agent_loop_truncation_auto_continue` exercises the loop end-to-end with the mock provider: (a) one auto-continue then success with **no** parse-guidance on the continuation; (b) fallback to parse-guidance after the cap with **no infinite loop**; (c) clean stop + malformed call does **not** auto-continue (call count not inflated, parse-guidance fires immediately).

Verified: `RUSTFLAGS="-D warnings" cargo build -p harn-vm`, `cargo test -p harn-vm --lib llm::` (861 pass), builtin registry/signature drift tests, `cargo fmt --check`, `cargo clippy -p harn-vm`, `harn fmt --check` + `harn check` on the touched `.harn`, and the full 204-test agents conformance category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)