### PR TITLE
pg hostlib: sqlx migration ledger, untyped-null bind fix, migration advisory-lock + checksum hardening

### DIFF
--- a/changelog.d/harn-pg-migrate-sqlx-ledger.added.md
+++ b/changelog.d/harn-pg-migrate-sqlx-ledger.added.md
@@ -1,0 +1,15 @@
+- **`pg_migrate` gained an SQLx-compatible ledger mode (`ledger: "sqlx"`).**
+  The Postgres builtin can now read and write SQLx's own `_sqlx_migrations`
+  table byte-for-byte: it keys migrations off the integer version prefix of
+  each filename, sorts ascending by that numeric version, applies only
+  forward files (`*.up.sql` / `*.sql`, skipping `*.down.sql`), records the
+  same `version, description, success, checksum (SHA-384), execution_time`
+  rows SQLx does, and takes SQLx's per-database advisory lock
+  (`0x3d32ad9e * crc32(current_database())`) so a Harn migration and a
+  concurrent `sqlx migrate run` serialize against each other. It is
+  idempotent against a SQLx-migrated database (applies zero rows, checksums
+  byte-identical), refuses to run on a dirty ledger, errors on checksum
+  drift naming the version, and warn-and-skips duplicate versions. The
+  default `ledger: "harn"` path (the native `harn_migrations` SHA-256
+  ledger) is unchanged. This lets harn-cloud retire its bespoke Rust
+  `run_migrations()` in favor of `pg_migrate`.

--- a/changelog.d/pg-migrate-advisory-lock-and-drift.fixed.md
+++ b/changelog.d/pg-migrate-advisory-lock-and-drift.fixed.md
@@ -1,0 +1,16 @@
+- **`pg_migrate` advisory lock now actually serializes, and the harn ledger
+  verifies checksums.** Two correctness bugs in the `std/postgres` migration
+  runner are fixed. (1) The Postgres advisory lock was taken, all migration
+  work done, and the unlock run on *different* pooled connections. Because
+  `pg_advisory_lock` is session-scoped (tied to one backend), concurrent
+  `pg_migrate` callers did not mutually exclude, and the unlock usually ran on
+  a connection that never held the lock — a no-op that leaked a session lock on
+  a recycled connection. The runner now pins a single connection for
+  lock → migrate → unlock (matching `sqlx migrate`), in both `harn` and `sqlx`
+  ledger modes. (2) The default `harn` ledger wrote a SHA-256 checksum per
+  migration but never read it back, so an edited (already-applied) migration
+  file was silently skipped with no drift detection. The runner now re-hashes
+  each already-applied file and errors with `checksum mismatch for migration
+  <name>` when it differs from the recorded checksum, mirroring the `sqlx`
+  mode's SHA-384 check. `pg_advisory_unlock`'s boolean result is now checked
+  and a `false` (lock not held) is logged.

--- a/changelog.d/postgres-nil-bind-untyped-null.fixed.md
+++ b/changelog.d/postgres-nil-bind-untyped-null.fixed.md
@@ -1,0 +1,13 @@
+- **Postgres `nil` bind parameters no longer pin the TEXT type.** The
+  `std/postgres` client previously bound a `nil` argument as `None::<String>`,
+  which declared Postgres type OID `25` (TEXT) in the wire `Parse` message.
+  Because sqlx caches prepared statements per pooled connection and sends
+  params in binary, this caused two production failures: prepared-statement
+  type-cache poisoning (a slot first seen as `nil` was cached as TEXT, so a
+  later non-null integer was UTF-8-validated against TEXT and failed with
+  `invalid byte sequence for encoding "UTF8": 0x00`), and wrong NULL typing
+  (binding `nil` into an `integer`/`jsonb` column or cast failed with
+  `column is of type integer but expression is of type text`). `nil` now binds
+  as a Postgres NULL with type OID `0` (unspecified), so the server infers the
+  parameter's type from the query context — the cast, the target column — just
+  like a bare SQL `NULL`. Non-null binds are unchanged.

--- a/crates/harn-vm/src/stdlib/postgres/migrate.rs
+++ b/crates/harn-vm/src/stdlib/postgres/migrate.rs
@@ -15,15 +15,16 @@
 //!   mutually exclude. This lets Harn apply an existing SQLx migration
 //!   history idempotently without forking it.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
+use sqlx_core::connection::Connection;
 use sqlx_core::executor::Executor;
 use sqlx_core::row::Row;
 use sqlx_core::sql_str::AssertSqlSafe;
-use sqlx_postgres::PgPool;
+use sqlx_postgres::{PgConnection, PgPool};
 
 use crate::value::{VmError, VmValue};
 
@@ -131,27 +132,47 @@ async fn run_harn(
     let entries = discover_migrations(dir)?;
 
     let started = Instant::now();
-    acquire_lock(pool.clone(), MIGRATION_LOCK_KEY).await?;
+    // Pin a SINGLE connection for the whole run. `pg_advisory_lock` is
+    // session-scoped, so the lock, every read/write, and the unlock must run
+    // on the same backend or there is no mutual exclusion (and the unlock
+    // would no-op on a connection that never held the lock, leaking it). This
+    // mirrors sqlx-migrate, which acquires one `PoolConnection` for
+    // lock -> migrate -> unlock.
+    let mut conn = pool.acquire().await.map_err(|error| {
+        runtime_error(format!("pg_migrate: acquire connection failed: {error}"))
+    })?;
+
+    acquire_lock(&mut conn, MIGRATION_LOCK_KEY).await?;
     let result = async {
-        ensure_migrations_table(pool.clone(), table_name.clone()).await?;
-        let applied = applied_set(pool.clone(), table_name.clone()).await?;
+        ensure_migrations_table(&mut conn, &table_name).await?;
+        let applied = applied_set(&mut conn, &table_name).await?;
 
         let mut applied_now = Vec::new();
         let mut skipped = Vec::new();
-        for entry in entries.iter().cloned() {
-            if applied.contains(&entry.name) {
+        for entry in entries.iter() {
+            if let Some(existing) = applied.get(&entry.name) {
+                // Already applied: re-hash the on-disk file and compare to the
+                // recorded SHA-256 so drift (an edited migration) is caught.
+                let checksum = sha256_file(&entry.path)?;
+                if &checksum != existing {
+                    return Err(runtime_error(format!(
+                        "pg_migrate: checksum mismatch for migration {}; the \
+                         recorded checksum differs from the file on disk",
+                        entry.name
+                    )));
+                }
                 skipped.push(entry.name.clone());
                 continue;
             }
             if !dry_run {
-                apply_one(pool.clone(), table_name.clone(), entry.clone()).await?;
+                apply_one(&mut conn, &table_name, entry).await?;
             }
             applied_now.push(entry.name.clone());
         }
         Ok::<_, VmError>((applied_now, skipped))
     }
     .await;
-    release_lock(pool.clone(), MIGRATION_LOCK_KEY).await;
+    release_lock(&mut conn, MIGRATION_LOCK_KEY).await;
     let (applied_now, skipped) = result?;
 
     let available: Vec<String> = entries.iter().map(|entry| entry.name.clone()).collect();
@@ -214,7 +235,7 @@ fn discover_migrations(dir: &Path) -> Result<Vec<MigrationEntry>, VmError> {
     Ok(entries)
 }
 
-async fn ensure_migrations_table(pool: Arc<PgPool>, table: String) -> Result<(), VmError> {
+async fn ensure_migrations_table(conn: &mut PgConnection, table: &str) -> Result<(), VmError> {
     let sql = format!(
         "CREATE TABLE IF NOT EXISTS \"{table}\" (\
              name TEXT PRIMARY KEY,\
@@ -222,26 +243,34 @@ async fn ensure_migrations_table(pool: Arc<PgPool>, table: String) -> Result<(),
              checksum BYTEA NOT NULL\
          )"
     );
-    pool.as_ref()
-        .execute(AssertSqlSafe(sql))
+    conn.execute(AssertSqlSafe(sql))
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: ensure table failed: {error}")))?;
     Ok(())
 }
 
-async fn applied_set(pool: Arc<PgPool>, table: String) -> Result<BTreeSet<String>, VmError> {
-    let sql = format!("SELECT name FROM \"{table}\"");
+/// Read the full ledger as `name -> stored SHA-256 checksum` so already-applied
+/// migrations can be re-hashed and checked for drift.
+async fn applied_set(
+    conn: &mut PgConnection,
+    table: &str,
+) -> Result<BTreeMap<String, Vec<u8>>, VmError> {
+    let sql = format!("SELECT name, checksum FROM \"{table}\"");
     let rows = sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(sql))
-        .fetch_all(pool.as_ref())
+        .fetch_all(conn)
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: select applied failed: {error}")))?;
     Ok(rows
         .iter()
-        .map(|row| row.get::<String, _>(0))
-        .collect::<BTreeSet<_>>())
+        .map(|row| (row.get::<String, _>(0), row.get::<Vec<u8>, _>(1)))
+        .collect::<BTreeMap<_, _>>())
 }
 
-async fn apply_one(pool: Arc<PgPool>, table: String, entry: MigrationEntry) -> Result<(), VmError> {
+async fn apply_one(
+    conn: &mut PgConnection,
+    table: &str,
+    entry: &MigrationEntry,
+) -> Result<(), VmError> {
     let sql = std::fs::read_to_string(&entry.path).map_err(|error| {
         runtime_error(format!(
             "pg_migrate: could not read {}: {error}",
@@ -250,7 +279,9 @@ async fn apply_one(pool: Arc<PgPool>, table: String, entry: MigrationEntry) -> R
     })?;
     let checksum = sha256(&sql);
 
-    let mut tx = pool
+    // Per-migration transaction started from the pinned connection (so it runs
+    // on the same backend that holds the advisory lock).
+    let mut tx = conn
         .begin()
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: begin failed: {error}")))?;
@@ -275,20 +306,52 @@ async fn apply_one(pool: Arc<PgPool>, table: String, entry: MigrationEntry) -> R
     })
 }
 
-async fn acquire_lock(pool: Arc<PgPool>, key: i64) -> Result<(), VmError> {
+/// Take the session-scoped advisory lock on the PINNED connection. Holding it
+/// on the pool would be meaningless: the next pool checkout is a different
+/// backend that never acquired the lock.
+async fn acquire_lock(conn: &mut PgConnection, key: i64) -> Result<(), VmError> {
     sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT pg_advisory_lock($1)")
         .bind(key)
-        .execute(pool.as_ref())
+        .execute(conn)
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: advisory lock failed: {error}")))?;
     Ok(())
 }
 
-async fn release_lock(pool: Arc<PgPool>, key: i64) {
-    let _ = sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT pg_advisory_unlock($1)")
+/// Release the session-scoped advisory lock on the same pinned connection that
+/// took it. `pg_advisory_unlock` returns whether a lock was actually released;
+/// since the connection is pinned this is normally `true`, so a `false` (or a
+/// query error) signals something unexpected and is logged.
+async fn release_lock(conn: &mut PgConnection, key: i64) {
+    match sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT pg_advisory_unlock($1)")
         .bind(key)
-        .execute(pool.as_ref())
-        .await;
+        .fetch_optional(conn)
+        .await
+    {
+        Ok(Some(row)) => {
+            let released: bool = row.get::<bool, _>(0);
+            if !released {
+                tracing::warn!(
+                    lock_key = key,
+                    "pg_migrate: pg_advisory_unlock returned false; the advisory \
+                     lock was not held by this connection"
+                );
+            }
+        }
+        Ok(None) => {
+            tracing::warn!(
+                lock_key = key,
+                "pg_migrate: pg_advisory_unlock returned no row"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                lock_key = key,
+                %error,
+                "pg_migrate: releasing advisory lock failed"
+            );
+        }
+    }
 }
 
 fn sha256(text: &str) -> Vec<u8> {
@@ -296,6 +359,16 @@ fn sha256(text: &str) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
     hasher.finalize().to_vec()
+}
+
+fn sha256_file(path: &Path) -> Result<Vec<u8>, VmError> {
+    let sql = std::fs::read_to_string(path).map_err(|error| {
+        runtime_error(format!(
+            "pg_migrate: could not read {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(sha256(&sql))
 }
 
 fn validate_table_name(name: &str) -> Result<(), VmError> {
@@ -457,10 +530,17 @@ async fn run_sqlx(
     let migrations = discover_sqlx_migrations(dir)?;
 
     let started = Instant::now();
-    let lock_id = sqlx_lock_id(pool.clone()).await?;
-    acquire_lock(pool.clone(), lock_id).await?;
-    let result = run_sqlx_locked(pool.clone(), &table_name, dry_run, &migrations).await;
-    release_lock(pool.clone(), lock_id).await;
+    // Pin one connection for lock -> migrate -> unlock, exactly like
+    // sqlx-migrate. The advisory lock is session-scoped, so it only mutually
+    // excludes when held on the same backend that does the work.
+    let mut conn = pool.acquire().await.map_err(|error| {
+        runtime_error(format!("pg_migrate: acquire connection failed: {error}"))
+    })?;
+
+    let lock_id = sqlx_lock_id(&mut conn).await?;
+    acquire_lock(&mut conn, lock_id).await?;
+    let result = run_sqlx_locked(&mut conn, &table_name, dry_run, &migrations).await;
+    release_lock(&mut conn, lock_id).await;
     let (applied_now, skipped) = result?;
 
     let available: Vec<String> = migrations.iter().map(|m| m.name.clone()).collect();
@@ -475,15 +555,15 @@ async fn run_sqlx(
 }
 
 async fn run_sqlx_locked(
-    pool: Arc<PgPool>,
+    conn: &mut PgConnection,
     table: &str,
     dry_run: bool,
     migrations: &[SqlxMigration],
 ) -> Result<(Vec<String>, Vec<String>), VmError> {
-    ensure_sqlx_migrations_table(pool.clone(), table).await?;
+    ensure_sqlx_migrations_table(conn, table).await?;
 
     // Refuse to proceed on a dirty ledger (a failed migration).
-    if let Some(version) = sqlx_dirty_version(pool.clone(), table).await? {
+    if let Some(version) = sqlx_dirty_version(conn, table).await? {
         return Err(runtime_error(format!(
             "pg_migrate: dirty migration {version}; the ledger has a failed \
              migration recorded — resolve it before re-running"
@@ -491,7 +571,7 @@ async fn run_sqlx_locked(
     }
 
     // version -> checksum of everything already recorded.
-    let applied = sqlx_applied(pool.clone(), table).await?;
+    let applied = sqlx_applied(conn, table).await?;
 
     let mut applied_now = Vec::new();
     let mut skipped = Vec::new();
@@ -509,7 +589,7 @@ async fn run_sqlx_locked(
             continue;
         }
         if !dry_run {
-            apply_sqlx_one(pool.clone(), table, migration).await?;
+            apply_sqlx_one(conn, table, migration).await?;
         }
         applied_now.push(migration.name.clone());
     }
@@ -518,7 +598,7 @@ async fn run_sqlx_locked(
 }
 
 /// EXACT schema match for SQLx 0.9 `_sqlx_migrations`.
-async fn ensure_sqlx_migrations_table(pool: Arc<PgPool>, table: &str) -> Result<(), VmError> {
+async fn ensure_sqlx_migrations_table(conn: &mut PgConnection, table: &str) -> Result<(), VmError> {
     let sql = format!(
         "CREATE TABLE IF NOT EXISTS \"{table}\" (\
              version BIGINT PRIMARY KEY,\
@@ -529,27 +609,29 @@ async fn ensure_sqlx_migrations_table(pool: Arc<PgPool>, table: &str) -> Result<
              execution_time BIGINT NOT NULL\
          )"
     );
-    pool.as_ref()
-        .execute(AssertSqlSafe(sql))
+    conn.execute(AssertSqlSafe(sql))
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: ensure sqlx table failed: {error}")))?;
     Ok(())
 }
 
-async fn sqlx_dirty_version(pool: Arc<PgPool>, table: &str) -> Result<Option<i64>, VmError> {
+async fn sqlx_dirty_version(conn: &mut PgConnection, table: &str) -> Result<Option<i64>, VmError> {
     let sql =
         format!("SELECT version FROM \"{table}\" WHERE success = false ORDER BY version LIMIT 1");
     let row = sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(sql))
-        .fetch_optional(pool.as_ref())
+        .fetch_optional(conn)
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: dirty check failed: {error}")))?;
     Ok(row.map(|row| row.get::<i64, _>(0)))
 }
 
-async fn sqlx_applied(pool: Arc<PgPool>, table: &str) -> Result<HashMap<i64, Vec<u8>>, VmError> {
+async fn sqlx_applied(
+    conn: &mut PgConnection,
+    table: &str,
+) -> Result<HashMap<i64, Vec<u8>>, VmError> {
     let sql = format!("SELECT version, checksum FROM \"{table}\" ORDER BY version");
     let rows = sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(sql))
-        .fetch_all(pool.as_ref())
+        .fetch_all(conn)
         .await
         .map_err(|error| {
             runtime_error(format!("pg_migrate: select applied (sqlx) failed: {error}"))
@@ -561,7 +643,7 @@ async fn sqlx_applied(pool: Arc<PgPool>, table: &str) -> Result<HashMap<i64, Vec
 }
 
 async fn apply_sqlx_one(
-    pool: Arc<PgPool>,
+    conn: &mut PgConnection,
     table: &str,
     migration: &SqlxMigration,
 ) -> Result<(), VmError> {
@@ -579,8 +661,9 @@ async fn apply_sqlx_one(
     let start = Instant::now();
 
     if no_tx {
-        // Run the migration SQL then record it, no wrapping transaction.
-        pool.as_ref()
+        // Run the migration SQL then record it, no wrapping transaction, on
+        // the pinned connection that holds the advisory lock.
+        (&mut *conn)
             .execute(AssertSqlSafe(sql))
             .await
             .map_err(|error| {
@@ -589,9 +672,9 @@ async fn apply_sqlx_one(
                     migration.version, migration.name
                 ))
             })?;
-        sqlx_insert_row(pool.as_ref(), table, migration, &checksum).await?;
+        sqlx_insert_row(&mut *conn, table, migration, &checksum).await?;
     } else {
-        let mut tx = pool
+        let mut tx = conn
             .begin()
             .await
             .map_err(|error| runtime_error(format!("pg_migrate: begin failed: {error}")))?;
@@ -619,7 +702,7 @@ async fn apply_sqlx_one(
     sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(update))
         .bind(elapsed_nanos)
         .bind(migration.version)
-        .execute(pool.as_ref())
+        .execute(&mut *conn)
         .await
         .map_err(|error| {
             runtime_error(format!(
@@ -664,9 +747,9 @@ where
 /// `0x3d32ad9e * crc32_iso_hdlc(current_database())`. Computing it the same
 /// way means a Harn `pg_migrate(ledger: "sqlx")` and a concurrent
 /// `sqlx migrate run` take the SAME lock and serialize against each other.
-async fn sqlx_lock_id(pool: Arc<PgPool>) -> Result<i64, VmError> {
+async fn sqlx_lock_id(conn: &mut PgConnection) -> Result<i64, VmError> {
     let row = sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT current_database()")
-        .fetch_one(pool.as_ref())
+        .fetch_one(conn)
         .await
         .map_err(|error| {
             runtime_error(format!("pg_migrate: current_database() failed: {error}"))

--- a/crates/harn-vm/src/stdlib/postgres/migrate.rs
+++ b/crates/harn-vm/src/stdlib/postgres/migrate.rs
@@ -1,13 +1,21 @@
 //! `pg_migrate(pool, opts)` — apply `.sql` files from a directory and
 //! track the applied set in a configurable migration ledger table.
 //!
-//! Each migration file is identified by its name (e.g. `0001_init.sql`)
-//! and runs in its own transaction. The runner takes a process-wide
-//! Postgres advisory lock so two concurrent callers serialize cleanly,
-//! and computes a SHA-256 of the file contents at apply time for drift
-//! detection.
+//! Two ledger formats are supported via `ledger`:
+//!
+//! - `ledger: "harn"` (default) — the native Harn ledger. Each migration
+//!   file is identified by its name (e.g. `0001_init.sql`) and runs in its
+//!   own transaction. The runner takes a process-wide Postgres advisory
+//!   lock so two concurrent callers serialize cleanly, and computes a
+//!   SHA-256 of the file contents at apply time for drift detection.
+//! - `ledger: "sqlx"` — byte-for-byte compatible with SQLx's
+//!   `_sqlx_migrations` table. Versions are the integer prefix of each
+//!   filename, checksums are SHA-384 of the raw file, and the advisory
+//!   lock id matches SQLx's so `harn` and a concurrent `sqlx migrate`
+//!   mutually exclude. This lets Harn apply an existing SQLx migration
+//!   history idempotently without forking it.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -28,6 +36,39 @@ const MIGRATION_LOCK_KEY: i64 = 0x4861_726E_4D67_7201;
 
 const DEFAULT_TABLE: &str = "harn_migrations";
 
+/// SQLx's canonical ledger table name. The `ledger: "sqlx"` mode always
+/// targets this table so a Harn-driven migration is indistinguishable
+/// from a `sqlx migrate run`.
+const SQLX_TABLE: &str = "_sqlx_migrations";
+
+/// Which ledger format to read/write.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Ledger {
+    /// Native Harn ledger (`name TEXT PK`, SHA-256). Default.
+    Harn,
+    /// SQLx-compatible `_sqlx_migrations` ledger (`version BIGINT PK`,
+    /// SHA-384).
+    Sqlx,
+}
+
+impl Ledger {
+    fn parse(opts: &BTreeMap<String, VmValue>) -> Result<Self, VmError> {
+        match opts.get("ledger") {
+            None => Ok(Ledger::Harn),
+            Some(VmValue::String(s)) => match s.as_ref() {
+                "harn" => Ok(Ledger::Harn),
+                "sqlx" => Ok(Ledger::Sqlx),
+                other => Err(runtime_error(format!(
+                    "pg_migrate: unknown ledger `{other}`; expected \"harn\" or \"sqlx\""
+                ))),
+            },
+            Some(_) => Err(runtime_error(
+                "pg_migrate: option `ledger` must be a string (\"harn\" or \"sqlx\")",
+            )),
+        }
+    }
+}
+
 pub(super) async fn run(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let pool_handle = args.first().ok_or_else(|| {
         runtime_error("pg_migrate: pool handle is required as the first argument")
@@ -43,20 +84,54 @@ pub(super) async fn run(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     let pool_id = handle_id(Some(pool_handle), HANDLE_POOL, "pg_migrate")?;
     let pool = pool_by_id(&pool_id)?;
     let dir = dir_arg(&opts, "dir")?;
-    let table_name = opts
-        .get("table")
-        .and_then(|v| match v {
-            VmValue::String(s) => Some(s.to_string()),
-            _ => None,
-        })
-        .unwrap_or_else(|| DEFAULT_TABLE.to_string());
+    let ledger = Ledger::parse(&opts)?;
+
+    // In sqlx mode the ledger table name is fixed; an explicit `table`
+    // that disagrees is a hard error so callers do not believe they wrote
+    // somewhere they did not.
+    let table_name = match ledger {
+        Ledger::Sqlx => {
+            if let Some(VmValue::String(s)) = opts.get("table") {
+                if s.as_ref() != SQLX_TABLE {
+                    return Err(runtime_error(format!(
+                        "pg_migrate: ledger \"sqlx\" always uses table `{SQLX_TABLE}`; \
+                         remove the conflicting `table: \"{s}\"`"
+                    )));
+                }
+            }
+            SQLX_TABLE.to_string()
+        }
+        Ledger::Harn => opts
+            .get("table")
+            .and_then(|v| match v {
+                VmValue::String(s) => Some(s.to_string()),
+                _ => None,
+            })
+            .unwrap_or_else(|| DEFAULT_TABLE.to_string()),
+    };
     validate_table_name(&table_name)?;
     let dry_run = matches!(opts.get("dry_run"), Some(VmValue::Bool(true)));
 
-    let entries = discover_migrations(&dir)?;
+    match ledger {
+        Ledger::Harn => run_harn(pool, &dir, table_name, dry_run).await,
+        Ledger::Sqlx => run_sqlx(pool, &dir, table_name, dry_run).await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harn ledger (default; unchanged behavior)
+// ---------------------------------------------------------------------------
+
+async fn run_harn(
+    pool: Arc<PgPool>,
+    dir: &Path,
+    table_name: String,
+    dry_run: bool,
+) -> Result<VmValue, VmError> {
+    let entries = discover_migrations(dir)?;
 
     let started = Instant::now();
-    acquire_lock(pool.clone()).await?;
+    acquire_lock(pool.clone(), MIGRATION_LOCK_KEY).await?;
     let result = async {
         ensure_migrations_table(pool.clone(), table_name.clone()).await?;
         let applied = applied_set(pool.clone(), table_name.clone()).await?;
@@ -76,47 +151,18 @@ pub(super) async fn run(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         Ok::<_, VmError>((applied_now, skipped))
     }
     .await;
-    release_lock(pool.clone()).await;
+    release_lock(pool.clone(), MIGRATION_LOCK_KEY).await;
     let (applied_now, skipped) = result?;
 
-    let mut response = BTreeMap::new();
-    response.insert(
-        "applied".to_string(),
-        VmValue::List(std::sync::Arc::new(
-            applied_now
-                .into_iter()
-                .map(|name| VmValue::String(std::sync::Arc::from(name)))
-                .collect(),
-        )),
-    );
-    response.insert(
-        "skipped".to_string(),
-        VmValue::List(std::sync::Arc::new(
-            skipped
-                .into_iter()
-                .map(|name| VmValue::String(std::sync::Arc::from(name)))
-                .collect(),
-        )),
-    );
-    response.insert(
-        "available".to_string(),
-        VmValue::List(std::sync::Arc::new(
-            entries
-                .iter()
-                .map(|entry| VmValue::String(std::sync::Arc::from(entry.name.clone())))
-                .collect(),
-        )),
-    );
-    response.insert("dry_run".to_string(), VmValue::Bool(dry_run));
-    response.insert(
-        "duration_ms".to_string(),
-        VmValue::Int(started.elapsed().as_millis() as i64),
-    );
-    response.insert(
-        "table".to_string(),
-        VmValue::String(std::sync::Arc::from(table_name.as_str())),
-    );
-    Ok(VmValue::Dict(std::sync::Arc::new(response)))
+    let available: Vec<String> = entries.iter().map(|entry| entry.name.clone()).collect();
+    Ok(build_response(
+        applied_now,
+        skipped,
+        available,
+        dry_run,
+        started.elapsed().as_millis() as i64,
+        &table_name,
+    ))
 }
 
 fn dir_arg(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<PathBuf, VmError> {
@@ -229,18 +275,18 @@ async fn apply_one(pool: Arc<PgPool>, table: String, entry: MigrationEntry) -> R
     })
 }
 
-async fn acquire_lock(pool: Arc<PgPool>) -> Result<(), VmError> {
+async fn acquire_lock(pool: Arc<PgPool>, key: i64) -> Result<(), VmError> {
     sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT pg_advisory_lock($1)")
-        .bind(MIGRATION_LOCK_KEY)
+        .bind(key)
         .execute(pool.as_ref())
         .await
         .map_err(|error| runtime_error(format!("pg_migrate: advisory lock failed: {error}")))?;
     Ok(())
 }
 
-async fn release_lock(pool: Arc<PgPool>) {
+async fn release_lock(pool: Arc<PgPool>, key: i64) {
     let _ = sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT pg_advisory_unlock($1)")
-        .bind(MIGRATION_LOCK_KEY)
+        .bind(key)
         .execute(pool.as_ref())
         .await;
 }
@@ -272,4 +318,485 @@ fn validate_table_name(name: &str) -> Result<(), VmError> {
         }
     }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Shared response shape
+// ---------------------------------------------------------------------------
+
+fn build_response(
+    applied_now: Vec<String>,
+    skipped: Vec<String>,
+    available: Vec<String>,
+    dry_run: bool,
+    duration_ms: i64,
+    table_name: &str,
+) -> VmValue {
+    fn str_list(items: Vec<String>) -> VmValue {
+        VmValue::List(Arc::new(
+            items
+                .into_iter()
+                .map(|name| VmValue::String(Arc::from(name)))
+                .collect(),
+        ))
+    }
+
+    let mut response = BTreeMap::new();
+    response.insert("applied".to_string(), str_list(applied_now));
+    response.insert("skipped".to_string(), str_list(skipped));
+    response.insert("available".to_string(), str_list(available));
+    response.insert("dry_run".to_string(), VmValue::Bool(dry_run));
+    response.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
+    response.insert("table".to_string(), VmValue::String(Arc::from(table_name)));
+    VmValue::Dict(Arc::new(response))
+}
+
+// ---------------------------------------------------------------------------
+// SQLx-compatible ledger (`_sqlx_migrations`)
+// ---------------------------------------------------------------------------
+
+/// A forward SQLx migration parsed from a filename.
+#[derive(Clone, Debug)]
+struct SqlxMigration {
+    /// Integer version prefix (`splitn(2, '_')[0]` parsed as i64).
+    version: i64,
+    /// Filename with the type suffix trimmed and `_` -> ` `.
+    description: String,
+    /// The original filename (for diagnostics / the result lists).
+    name: String,
+    path: PathBuf,
+}
+
+/// Discover forward (`*.up.sql` / non-`.down`) SQLx migrations, parse their
+/// versions/descriptions, sort numerically by version, and dedupe duplicate
+/// versions with a warn-and-skip (mirrors harn-cloud's `handled` set). An
+/// un-parseable integer prefix is a hard error (SQLx behavior).
+fn discover_sqlx_migrations(dir: &Path) -> Result<Vec<SqlxMigration>, VmError> {
+    if !dir.exists() {
+        return Err(runtime_error(format!(
+            "pg_migrate: directory does not exist: {}",
+            dir.display()
+        )));
+    }
+    let read_dir = std::fs::read_dir(dir).map_err(|error| {
+        runtime_error(format!(
+            "pg_migrate: could not read directory {}: {error}",
+            dir.display()
+        ))
+    })?;
+
+    let mut parsed: Vec<SqlxMigration> = Vec::new();
+    for entry in read_dir.filter_map(|entry| entry.ok()) {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+
+        // Mirror sqlx's `resolve_blocking`: <VERSION>_<DESC>.<DIR>.sql.
+        let parts: Vec<&str> = name.splitn(2, '_').collect();
+        if parts.len() != 2 || !parts[1].ends_with(".sql") {
+            // Not of the recognized format; ignore (matches sqlx).
+            continue;
+        }
+        // Skip down migrations.
+        if parts[1].ends_with(".down.sql") {
+            continue;
+        }
+
+        let version: i64 = parts[0].parse().map_err(|_| {
+            runtime_error(format!(
+                "pg_migrate: error parsing migration filename {name:?}; \
+                 expected integer version prefix (e.g. `01_foo.sql`)"
+            ))
+        })?;
+
+        // Trim the type suffix, then `_` -> ` ` (matches sqlx).
+        let suffix = if parts[1].ends_with(".up.sql") {
+            ".up.sql"
+        } else {
+            ".sql"
+        };
+        let description = parts[1].trim_end_matches(suffix).replace('_', " ");
+
+        parsed.push(SqlxMigration {
+            version,
+            description,
+            name,
+            path,
+        });
+    }
+
+    // SQLx sorts migrations by `version` (the `Ord` impl on `Migration`
+    // orders on `version` first); numeric, not lexicographic.
+    parsed.sort_by(|a, b| a.version.cmp(&b.version).then(a.name.cmp(&b.name)));
+
+    // Dedupe duplicate versions: first one wins, warn-and-skip the rest.
+    let mut seen: HashSet<i64> = HashSet::new();
+    let mut deduped = Vec::with_capacity(parsed.len());
+    for migration in parsed {
+        if !seen.insert(migration.version) {
+            tracing::warn!(
+                version = migration.version,
+                description = %migration.description,
+                file = %migration.name,
+                "pg_migrate: skipping migration with duplicate version (another file \
+                 already claimed this prefix); fix by renaming one of the files",
+            );
+            continue;
+        }
+        deduped.push(migration);
+    }
+
+    Ok(deduped)
+}
+
+async fn run_sqlx(
+    pool: Arc<PgPool>,
+    dir: &Path,
+    table_name: String,
+    dry_run: bool,
+) -> Result<VmValue, VmError> {
+    let migrations = discover_sqlx_migrations(dir)?;
+
+    let started = Instant::now();
+    let lock_id = sqlx_lock_id(pool.clone()).await?;
+    acquire_lock(pool.clone(), lock_id).await?;
+    let result = run_sqlx_locked(pool.clone(), &table_name, dry_run, &migrations).await;
+    release_lock(pool.clone(), lock_id).await;
+    let (applied_now, skipped) = result?;
+
+    let available: Vec<String> = migrations.iter().map(|m| m.name.clone()).collect();
+    Ok(build_response(
+        applied_now,
+        skipped,
+        available,
+        dry_run,
+        started.elapsed().as_millis() as i64,
+        &table_name,
+    ))
+}
+
+async fn run_sqlx_locked(
+    pool: Arc<PgPool>,
+    table: &str,
+    dry_run: bool,
+    migrations: &[SqlxMigration],
+) -> Result<(Vec<String>, Vec<String>), VmError> {
+    ensure_sqlx_migrations_table(pool.clone(), table).await?;
+
+    // Refuse to proceed on a dirty ledger (a failed migration).
+    if let Some(version) = sqlx_dirty_version(pool.clone(), table).await? {
+        return Err(runtime_error(format!(
+            "pg_migrate: dirty migration {version}; the ledger has a failed \
+             migration recorded — resolve it before re-running"
+        )));
+    }
+
+    // version -> checksum of everything already recorded.
+    let applied = sqlx_applied(pool.clone(), table).await?;
+
+    let mut applied_now = Vec::new();
+    let mut skipped = Vec::new();
+    for migration in migrations {
+        if let Some(existing) = applied.get(&migration.version) {
+            let checksum = sha384_file(&migration.path)?;
+            if existing != &checksum {
+                return Err(runtime_error(format!(
+                    "pg_migrate: checksum mismatch for migration {} ({}); the \
+                     recorded checksum differs from the file on disk",
+                    migration.version, migration.name
+                )));
+            }
+            skipped.push(migration.name.clone());
+            continue;
+        }
+        if !dry_run {
+            apply_sqlx_one(pool.clone(), table, migration).await?;
+        }
+        applied_now.push(migration.name.clone());
+    }
+
+    Ok((applied_now, skipped))
+}
+
+/// EXACT schema match for SQLx 0.9 `_sqlx_migrations`.
+async fn ensure_sqlx_migrations_table(pool: Arc<PgPool>, table: &str) -> Result<(), VmError> {
+    let sql = format!(
+        "CREATE TABLE IF NOT EXISTS \"{table}\" (\
+             version BIGINT PRIMARY KEY,\
+             description TEXT NOT NULL,\
+             installed_on TIMESTAMPTZ NOT NULL DEFAULT now(),\
+             success BOOLEAN NOT NULL,\
+             checksum BYTEA NOT NULL,\
+             execution_time BIGINT NOT NULL\
+         )"
+    );
+    pool.as_ref()
+        .execute(AssertSqlSafe(sql))
+        .await
+        .map_err(|error| runtime_error(format!("pg_migrate: ensure sqlx table failed: {error}")))?;
+    Ok(())
+}
+
+async fn sqlx_dirty_version(pool: Arc<PgPool>, table: &str) -> Result<Option<i64>, VmError> {
+    let sql =
+        format!("SELECT version FROM \"{table}\" WHERE success = false ORDER BY version LIMIT 1");
+    let row = sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(sql))
+        .fetch_optional(pool.as_ref())
+        .await
+        .map_err(|error| runtime_error(format!("pg_migrate: dirty check failed: {error}")))?;
+    Ok(row.map(|row| row.get::<i64, _>(0)))
+}
+
+async fn sqlx_applied(pool: Arc<PgPool>, table: &str) -> Result<HashMap<i64, Vec<u8>>, VmError> {
+    let sql = format!("SELECT version, checksum FROM \"{table}\" ORDER BY version");
+    let rows = sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(sql))
+        .fetch_all(pool.as_ref())
+        .await
+        .map_err(|error| {
+            runtime_error(format!("pg_migrate: select applied (sqlx) failed: {error}"))
+        })?;
+    Ok(rows
+        .iter()
+        .map(|row| (row.get::<i64, _>(0), row.get::<Vec<u8>, _>(1)))
+        .collect())
+}
+
+async fn apply_sqlx_one(
+    pool: Arc<PgPool>,
+    table: &str,
+    migration: &SqlxMigration,
+) -> Result<(), VmError> {
+    let sql = std::fs::read_to_string(&migration.path).map_err(|error| {
+        runtime_error(format!(
+            "pg_migrate: could not read {}: {error}",
+            migration.path.display()
+        ))
+    })?;
+    let checksum = sha384(&sql);
+    // SQLx opts out of the wrapping transaction when the file starts with
+    // a `-- no-transaction` comment.
+    let no_tx = sql.starts_with("-- no-transaction");
+
+    let start = Instant::now();
+
+    if no_tx {
+        // Run the migration SQL then record it, no wrapping transaction.
+        pool.as_ref()
+            .execute(AssertSqlSafe(sql))
+            .await
+            .map_err(|error| {
+                runtime_error(format!(
+                    "pg_migrate: applying {} ({}): {error}",
+                    migration.version, migration.name
+                ))
+            })?;
+        sqlx_insert_row(pool.as_ref(), table, migration, &checksum).await?;
+    } else {
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|error| runtime_error(format!("pg_migrate: begin failed: {error}")))?;
+        (&mut *tx)
+            .execute(AssertSqlSafe(sql))
+            .await
+            .map_err(|error| {
+                runtime_error(format!(
+                    "pg_migrate: applying {} ({}): {error}",
+                    migration.version, migration.name
+                ))
+            })?;
+        sqlx_insert_row(&mut *tx, table, migration, &checksum).await?;
+        tx.commit().await.map_err(|error| {
+            runtime_error(format!(
+                "pg_migrate: commit {} ({}) failed: {error}",
+                migration.version, migration.name
+            ))
+        })?;
+    }
+
+    // Backfill `execution_time` (nanos) the way SQLx does. Best-effort.
+    let elapsed_nanos = start.elapsed().as_nanos() as i64;
+    let update = format!("UPDATE \"{table}\" SET execution_time = $1 WHERE version = $2");
+    sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(update))
+        .bind(elapsed_nanos)
+        .bind(migration.version)
+        .execute(pool.as_ref())
+        .await
+        .map_err(|error| {
+            runtime_error(format!(
+                "pg_migrate: record execution_time for {} failed: {error}",
+                migration.version
+            ))
+        })?;
+
+    Ok(())
+}
+
+/// Insert the success row exactly as SQLx does, with `execution_time = -1`.
+async fn sqlx_insert_row<'c, E>(
+    executor: E,
+    table: &str,
+    migration: &SqlxMigration,
+    checksum: &[u8],
+) -> Result<(), VmError>
+where
+    E: Executor<'c, Database = sqlx_postgres::Postgres>,
+{
+    let insert = format!(
+        "INSERT INTO \"{table}\" (version, description, success, checksum, execution_time) \
+         VALUES ($1, $2, TRUE, $3, -1)"
+    );
+    sqlx_core::query::query::<sqlx_postgres::Postgres>(AssertSqlSafe(insert))
+        .bind(migration.version)
+        .bind(migration.description.clone())
+        .bind(checksum.to_vec())
+        .execute(executor)
+        .await
+        .map_err(|error| {
+            runtime_error(format!(
+                "pg_migrate: record {} ({}) failed: {error}",
+                migration.version, migration.name
+            ))
+        })?;
+    Ok(())
+}
+
+/// SQLx's per-database advisory lock id:
+/// `0x3d32ad9e * crc32_iso_hdlc(current_database())`. Computing it the same
+/// way means a Harn `pg_migrate(ledger: "sqlx")` and a concurrent
+/// `sqlx migrate run` take the SAME lock and serialize against each other.
+async fn sqlx_lock_id(pool: Arc<PgPool>) -> Result<i64, VmError> {
+    let row = sqlx_core::query::query::<sqlx_postgres::Postgres>("SELECT current_database()")
+        .fetch_one(pool.as_ref())
+        .await
+        .map_err(|error| {
+            runtime_error(format!("pg_migrate: current_database() failed: {error}"))
+        })?;
+    let database_name = row.get::<String, _>(0);
+    Ok(generate_sqlx_lock_id(&database_name))
+}
+
+/// Port of sqlx-postgres `generate_lock_id`:
+/// `0x3d32ad9e * (CRC_32_ISO_HDLC(name) as i64)`. We compute the CRC inline
+/// so we do not need the `crc` crate as a dependency.
+fn generate_sqlx_lock_id(database_name: &str) -> i64 {
+    0x3d32ad9e * (crc32_iso_hdlc(database_name.as_bytes()) as i64)
+}
+
+/// CRC-32/ISO-HDLC (a.k.a. the standard zlib CRC-32): reflected, polynomial
+/// 0xEDB88320, init/xorout 0xFFFFFFFF. Identical to what `crc::CRC_32_ISO_HDLC`
+/// and `crc32fast` compute.
+fn crc32_iso_hdlc(bytes: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in bytes {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+fn sha384(text: &str) -> Vec<u8> {
+    use sha2::{Digest, Sha384};
+    Sha384::digest(text.as_bytes()).to_vec()
+}
+
+fn sha384_file(path: &Path) -> Result<Vec<u8>, VmError> {
+    let sql = std::fs::read_to_string(path).map_err(|error| {
+        runtime_error(format!(
+            "pg_migrate: could not read {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(sha384(&sql))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// CRC-32/ISO-HDLC must match the canonical check value (the standard
+    /// "123456789" test vector for CRC-32 is 0xCBF43926).
+    #[test]
+    fn crc32_iso_hdlc_matches_check_vector() {
+        assert_eq!(crc32_iso_hdlc(b"123456789"), 0xCBF4_3926);
+        assert_eq!(crc32_iso_hdlc(b""), 0x0000_0000);
+    }
+
+    /// The lock id must be computed exactly like sqlx-postgres'
+    /// `generate_lock_id`: `0x3d32ad9e * (crc32 as i64)`.
+    #[test]
+    fn sqlx_lock_id_matches_sqlx_formula() {
+        let db = "harn_cloud";
+        let expected = 0x3d32ad9e_i64 * (crc32_iso_hdlc(db.as_bytes()) as i64);
+        assert_eq!(generate_sqlx_lock_id(db), expected);
+        // Never overflows i64 for any database name (0x3d32ad9e * u32::MAX
+        // < i64::MAX), so plain multiply is safe and matches sqlx.
+        assert!(generate_sqlx_lock_id("postgres") != 0);
+    }
+
+    /// SHA-384 of the file content is a 48-byte digest, distinct from the
+    /// SHA-256 used by the harn ledger.
+    #[test]
+    fn sha384_is_48_bytes_and_differs_from_sha256() {
+        let sql = "CREATE TABLE t (id INT);";
+        let s384 = sha384(sql);
+        let s256 = sha256(sql);
+        assert_eq!(s384.len(), 48);
+        assert_eq!(s256.len(), 32);
+        assert_ne!(s384[..32], s256[..]);
+    }
+
+    /// Version/description parsing mirrors sqlx: integer prefix, suffix
+    /// trimmed, `_` -> ` `. Numeric (not lexicographic) sort, dedupe.
+    #[test]
+    fn discover_sqlx_parses_versions_descriptions_and_sorts_numerically() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("20260419170000_bootstrap.up.sql"), "SELECT 1").unwrap();
+        std::fs::write(dir.join("20260419170000_bootstrap.down.sql"), "SELECT 0").unwrap();
+        std::fs::write(dir.join("9_early_thing.up.sql"), "SELECT 2").unwrap();
+        std::fs::write(dir.join("100_later_thing.sql"), "SELECT 3").unwrap();
+        // A non-migration file is ignored.
+        std::fs::write(dir.join("README.md"), "ignore me").unwrap();
+
+        let migrations = discover_sqlx_migrations(dir).expect("discover");
+        let versions: Vec<i64> = migrations.iter().map(|m| m.version).collect();
+        // Numeric ascending: 9 < 100 < 20260419170000 (lexicographic would
+        // sort "100" before "20260419170000" before "9").
+        assert_eq!(versions, vec![9, 100, 20260419170000]);
+        assert_eq!(migrations[0].description, "early thing");
+        assert_eq!(migrations[1].description, "later thing");
+        assert_eq!(migrations[2].description, "bootstrap");
+        // `.down.sql` was skipped.
+        assert!(migrations.iter().all(|m| !m.name.ends_with(".down.sql")));
+    }
+
+    /// A non-integer version prefix is a hard error (matches sqlx).
+    #[test]
+    fn discover_sqlx_errors_on_non_integer_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("notanumber_thing.up.sql"), "SELECT 1").unwrap();
+        let err = discover_sqlx_migrations(dir).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("integer version prefix"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// Duplicate versions warn-and-skip (first wins).
+    #[test]
+    fn discover_sqlx_dedupes_duplicate_versions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("5_first.up.sql"), "SELECT 1").unwrap();
+        std::fs::write(dir.join("5_second.up.sql"), "SELECT 2").unwrap();
+        let migrations = discover_sqlx_migrations(dir).expect("discover");
+        assert_eq!(migrations.len(), 1);
+        assert_eq!(migrations[0].version, 5);
+        // First by (version, name) ordering wins: "5_first" < "5_second".
+        assert_eq!(migrations[0].name, "5_first.up.sql");
+    }
 }

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -8,15 +8,20 @@ use std::time::Duration;
 
 use sqlx_core::column::Column;
 use sqlx_core::connection::Connection;
+use sqlx_core::encode::{Encode, IsNull};
+use sqlx_core::error::BoxDynError;
 use sqlx_core::executor::Executor;
 use sqlx_core::query::{query, Query};
 use sqlx_core::row::Row;
 use sqlx_core::sql_str::AssertSqlSafe;
 use sqlx_core::transaction::Transaction;
 use sqlx_core::type_info::TypeInfo;
+use sqlx_core::types::Type;
 use sqlx_core::value::ValueRef;
+use sqlx_postgres::types::Oid;
 use sqlx_postgres::{
-    PgArguments, PgConnectOptions, PgPool, PgPoolOptions, PgQueryResult, PgRow, PgSslMode, Postgres,
+    PgArgumentBuffer, PgArguments, PgConnectOptions, PgPool, PgPoolOptions, PgQueryResult, PgRow,
+    PgSslMode, PgTypeInfo, Postgres,
 };
 use tokio::sync::Mutex;
 
@@ -940,13 +945,59 @@ async fn apply_transaction_settings(
     Ok(())
 }
 
+/// A NULL bind that declares Postgres type OID `0` (unspecified) in the
+/// `Parse` message, so the server infers the parameter's type from the query
+/// context (a cast like `$1::integer`, the target column, etc.) — exactly as a
+/// bare SQL `NULL` does.
+///
+/// Why this exists: `None::<String>` (the obvious way to bind a typed NULL)
+/// declares OID `25` (TEXT) because `Option::<T>::produces()` falls back to
+/// `T::type_info()` for the `None` case. sqlx caches prepared statements keyed
+/// by SQL string on the pooled connection AND sends params in binary with the
+/// client-declared OIDs in `Parse`, so a TEXT-declared NULL caused two
+/// production bugs:
+///   1. Type-cache poisoning: once `$1` is parsed as TEXT (from a NULL), a
+///      later non-null `i64` in the same slot is sent as 8 binary bytes that
+///      Postgres UTF-8-validates against the cached TEXT type →
+///      `invalid byte sequence for encoding "UTF8": 0x00`.
+///   2. Wrong NULL typing: `($1::integer)` / `($1::jsonb)` with a TEXT NULL →
+///      `column is of type integer but expression is of type text`.
+///
+/// `PgTypeInfo::with_oid(Oid(0))` resolves to OID `0` in `Parse`
+/// (see `sqlx_postgres::connection::resolve::try_oid` →
+/// `PgType::DeclareWithOid`), which Postgres treats as "infer from context".
+/// The encoded value is a `-1` length (NULL), so no binary bytes are sent and
+/// the parameter format is irrelevant.
+struct UntypedNull;
+
+impl Type<Postgres> for UntypedNull {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::with_oid(Oid(0))
+    }
+}
+
+impl Encode<'_, Postgres> for UntypedNull {
+    fn encode_by_ref(&self, _buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
+        // Write no bytes; the caller records a `-1` length to mark SQL NULL.
+        Ok(IsNull::Yes)
+    }
+
+    fn produces(&self) -> Option<PgTypeInfo> {
+        Some(PgTypeInfo::with_oid(Oid(0)))
+    }
+
+    fn size_hint(&self) -> usize {
+        0
+    }
+}
+
 pub(super) fn bind_params<'q>(
     mut query: Query<'q, Postgres, PgArguments>,
     params: &'q [VmValue],
 ) -> Query<'q, Postgres, PgArguments> {
     for param in params {
         query = match param {
-            VmValue::Nil => query.bind(None::<String>),
+            VmValue::Nil => query.bind(UntypedNull),
             VmValue::Bool(value) => query.bind(*value),
             VmValue::Int(value) => query.bind(*value),
             VmValue::Float(value) => query.bind(*value),
@@ -2016,6 +2067,131 @@ mod tests {
             .display()
             .contains("2024-01-02"));
         assert_eq!(row.get("amount").unwrap().display(), "12345.6789");
+    }
+
+    /// Opens a single-connection pool against the test database so that every
+    /// query reuses the same physical connection (and therefore the same
+    /// prepared-statement cache), which is required to exercise the
+    /// type-cache-poisoning path.
+    async fn open_single_conn_pool(url: &str) -> VmValue {
+        let mut options = BTreeMap::new();
+        options.insert("max_connections".to_string(), VmValue::Int(1));
+        options.insert(
+            "application_name".to_string(),
+            s("harn-postgres-untyped-null-test"),
+        );
+        let ctx = crate::vm::AsyncBuiltinCtx::for_test(crate::Vm::new());
+        open_pool(&ctx, &s(url), Some(&options), false)
+            .await
+            .expect("open single-connection pool")
+    }
+
+    /// Regression for prepared-statement TYPE-CACHE POISONING.
+    ///
+    /// Before the fix, binding `VmValue::Nil` declared OID 25 (TEXT) in the
+    /// `Parse` message. On a single pooled connection, `SELECT $1::bigint`
+    /// would be prepared with `$1` cached as TEXT during the first (NULL) call;
+    /// the second call binding a real `i64` then sent 8 binary bytes that
+    /// Postgres UTF-8-validated against the cached TEXT type, producing
+    /// `invalid byte sequence for encoding "UTF8": 0x00`.
+    ///
+    /// After the fix the NULL declares OID 0 (unspecified), so Postgres infers
+    /// `bigint` from the cast and both calls succeed.
+    #[tokio::test(flavor = "current_thread")]
+    async fn nil_bind_does_not_poison_prepared_statement_cache_when_env_url_is_set() {
+        let Ok(url) = std::env::var("HARN_TEST_POSTGRES_URL") else {
+            return;
+        };
+        reset_postgres_state();
+        let handle = open_single_conn_pool(&url).await;
+
+        // Same SQL string both times so the cached prepared statement is reused.
+        let sql = "select $1::bigint as v";
+
+        // 1) NULL first — this is what poisoned the cache as TEXT before.
+        let null_row = query_rows(&handle, sql, &[VmValue::Nil], QueryRouting::Primary)
+            .await
+            .expect("nil bind for $1::bigint should succeed")
+            .remove(0);
+        assert!(
+            matches!(null_row.as_dict().unwrap().get("v"), Some(VmValue::Nil)),
+            "NULL bigint should decode to Nil"
+        );
+
+        // 2) Non-null int, reusing the cached statement on the same connection.
+        let int_row = query_rows(&handle, sql, &[VmValue::Int(42)], QueryRouting::Primary)
+            .await
+            .expect("int bind after nil must not hit the 0x00 UTF8 error")
+            .remove(0);
+        assert_eq!(
+            int_row.as_dict().unwrap().get("v").unwrap().as_int(),
+            Some(42),
+            "second call should return the bound integer"
+        );
+    }
+
+    /// Regression for WRONG NULL TYPING on typed columns.
+    ///
+    /// Before the fix, binding `VmValue::Nil` directly into typed columns
+    /// (`INSERT ... VALUES ($1, $2)` where `i integer, j jsonb`) declared the
+    /// params as TEXT, so Postgres rejected the statement with
+    /// `column "i" is of type integer but expression is of type text`.
+    /// After the fix the NULLs declare OID 0 (unspecified), so Postgres infers
+    /// each parameter's type from the target column and stores SQL NULL.
+    ///
+    /// (A typed cast like `$1::integer` happens to mask this because a `text`
+    /// NULL casts to integer cleanly — but production `.harn` code that binds a
+    /// bare `$n` into a typed column hit the error, so we reproduce the
+    /// no-cast form here.)
+    #[tokio::test(flavor = "current_thread")]
+    async fn nil_bind_into_typed_columns_inserts_sql_null_when_env_url_is_set() {
+        let Ok(url) = std::env::var("HARN_TEST_POSTGRES_URL") else {
+            return;
+        };
+        reset_postgres_state();
+        let handle = open_single_conn_pool(&url).await;
+
+        execute_stmt(
+            &handle,
+            "create temporary table harn_untyped_null_test(i integer, j jsonb) on commit preserve rows",
+            &[],
+        )
+        .await
+        .expect("create temp table");
+        execute_stmt(&handle, "truncate table harn_untyped_null_test", &[])
+            .await
+            .expect("truncate temp table");
+
+        // Bare `$1`/`$2` into typed columns: a properly-inferred NULL must not
+        // raise `is of type integer but expression is of type text`.
+        execute_stmt(
+            &handle,
+            "insert into harn_untyped_null_test(i, j) values ($1, $2)",
+            &[VmValue::Nil, VmValue::Nil],
+        )
+        .await
+        .expect("nil binds into typed columns must insert cleanly");
+
+        let row = query_rows(
+            &handle,
+            "select i, j, (i is null) as i_is_null, (j is null) as j_is_null from harn_untyped_null_test",
+            &[],
+            QueryRouting::Primary,
+        )
+        .await
+        .expect("select back inserted row")
+        .remove(0);
+        let row = row.as_dict().unwrap();
+        assert!(
+            matches!(row.get("i"), Some(VmValue::Nil)),
+            "integer column should be SQL NULL"
+        );
+        assert!(
+            matches!(row.get("j"), Some(VmValue::Nil)),
+            "jsonb column should be SQL NULL"
+        );
+        assert_eq!(row.get("i_is_null").unwrap().display(), "true");
+        assert_eq!(row.get("j_is_null").unwrap().display(), "true");
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -2381,6 +2381,87 @@ pg_close(db)
         });
     }
 
+    /// Harn-ledger drift detection (C-2): apply a migration, then edit the
+    /// file body on disk and re-run. The runner must re-hash the on-disk file,
+    /// see it no longer matches the recorded SHA-256, and error naming the
+    /// migration — never silently skip an edited (already-applied) file.
+    #[test]
+    fn migrate_harn_detects_checksum_drift_when_env_url_is_set() {
+        if std::env::var("HARN_TEST_POSTGRES_URL").is_err() {
+            return;
+        }
+        reset_postgres_state();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        let migration_path = dir.join("0001_create_widgets.sql");
+        std::fs::write(
+            &migration_path,
+            "CREATE TABLE widgets (id INT PRIMARY KEY, label TEXT NOT NULL)",
+        )
+        .unwrap();
+
+        let schema = format!("harn_pg_drift_{}", uuid::Uuid::new_v4().simple());
+        let migration_dir = dir.to_string_lossy().into_owned();
+
+        // First run: apply the migration cleanly into a fresh schema. The
+        // schema persists in the shared DB for the second run below.
+        let apply_source = format!(
+            r#"
+import "std/postgres"
+
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_execute(admin, "CREATE SCHEMA \"{schema}\"", [])
+pg_close(admin)
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+let first = pg_migrate(db, {{dir: "{migration_dir}"}})
+__io_println(len(first.applied))
+pg_close(db)
+"#,
+        );
+        let out = run_harn_source(&apply_source);
+        assert_eq!(out.trim(), "1", "first run should apply exactly one file");
+
+        // Edit the migration body on disk *after* it was recorded. A clean
+        // re-run would normally skip an already-applied file; here the changed
+        // body must trip the checksum check.
+        std::fs::write(
+            &migration_path,
+            "CREATE TABLE widgets (id INT PRIMARY KEY, label TEXT NOT NULL, extra INT)",
+        )
+        .unwrap();
+
+        let rerun_source = format!(
+            r#"
+import "std/postgres"
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+let second = pg_migrate(db, {{dir: "{migration_dir}"}})
+__io_println(len(second.applied))
+pg_close(db)
+"#,
+        );
+        let err = run_harn_source_expect_err(&rerun_source);
+        assert!(
+            err.contains("checksum mismatch") && err.contains("0001_create_widgets.sql"),
+            "expected harn checksum-mismatch error naming the migration, got: {err}"
+        );
+
+        // Clean up the scratch schema.
+        let cleanup = format!(
+            r#"
+import "std/postgres"
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_close(admin)
+"#,
+        );
+        run_harn_source(&cleanup);
+    }
+
     /// `pg_migrate` against the canonical `harn-cloud-store/migrations/`
     /// directory. Opt-in via `HARN_TEST_CLOUD_MIGRATIONS_DIR`; verifies
     /// that the runner consumes the full ledger without errors.

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -2276,6 +2276,412 @@ pg_close(db)
         });
     }
 
+    /// Build a synthetic SQLx-style migrations directory (with `.up.sql`
+    /// and ignorable `.down.sql` siblings) and return (tmpdir, dir-string).
+    /// Keep the `TempDir` alive for the duration of the test.
+    fn sqlx_synthetic_migrations() -> (tempfile::TempDir, String) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        let files: &[(&str, &str)] = &[
+            (
+                "20260419170000_bootstrap.up.sql",
+                "CREATE TABLE widgets (id INT PRIMARY KEY, label TEXT NOT NULL)",
+            ),
+            ("20260419170000_bootstrap.down.sql", "DROP TABLE widgets"),
+            (
+                "20260423100000_seed_widget.up.sql",
+                "INSERT INTO widgets (id, label) VALUES (1, 'alpha')",
+            ),
+            (
+                "20260423100000_seed_widget.down.sql",
+                "DELETE FROM widgets WHERE id = 1",
+            ),
+            (
+                "20260424000000_add_gadgets.up.sql",
+                "CREATE TABLE gadgets (id INT PRIMARY KEY)",
+            ),
+            ("20260424000000_add_gadgets.down.sql", "DROP TABLE gadgets"),
+        ];
+        for (name, body) in files {
+            std::fs::write(dir.join(name), body).unwrap();
+        }
+        let s = dir.to_string_lossy().into_owned();
+        (tmp, s)
+    }
+
+    fn run_harn_source(source: &str) -> String {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let local = tokio::task::LocalSet::new();
+            local
+                .run_until(async {
+                    let chunk = compile_source(source).expect("compile source");
+                    let mut vm = Vm::new();
+                    register_vm_stdlib(&mut vm);
+                    vm.execute(&chunk).await.expect("execute source");
+                    vm.output().to_string()
+                })
+                .await
+        })
+    }
+
+    fn run_harn_source_expect_err(source: &str) -> String {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let local = tokio::task::LocalSet::new();
+            local
+                .run_until(async {
+                    let chunk = compile_source(source).expect("compile source");
+                    let mut vm = Vm::new();
+                    register_vm_stdlib(&mut vm);
+                    let err = vm
+                        .execute(&chunk)
+                        .await
+                        .expect_err("expected source to error");
+                    format!("{err:?}")
+                })
+                .await
+        })
+    }
+
+    /// SQLx ledger mode applies all forward files into `_sqlx_migrations`
+    /// with the exact 6-column schema, 48-byte SHA-384 checksums, and
+    /// `success = true`.
+    #[test]
+    fn migrate_sqlx_applies_into_sqlx_migrations_table_when_env_url_is_set() {
+        if std::env::var("HARN_TEST_POSTGRES_URL").is_err() {
+            return;
+        }
+        reset_postgres_state();
+        let (_tmp, dir) = sqlx_synthetic_migrations();
+        let schema = format!("harn_pg_sqlx_{}", uuid::Uuid::new_v4().simple());
+        let source = format!(
+            r#"
+import "std/postgres"
+
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_execute(admin, "CREATE SCHEMA \"{schema}\"", [])
+pg_close(admin)
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+
+let result = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(result.applied))
+__io_println(len(result.available))
+__io_println(result.table)
+
+let cols = pg_query(db, "SELECT column_name FROM information_schema.columns WHERE table_schema=$1 AND table_name='_sqlx_migrations' ORDER BY column_name", ["{schema}"])
+__io_println(len(cols))
+
+let rows = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations", [])
+__io_println(rows.c)
+
+let badlen = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations WHERE octet_length(checksum) <> 48", [])
+__io_println(badlen.c)
+
+let failed = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations WHERE success = false", [])
+__io_println(failed.c)
+
+let versions = pg_query(db, "SELECT version FROM _sqlx_migrations ORDER BY version", [])
+__io_println(len(versions))
+
+pg_execute(db, "DROP SCHEMA \"{schema}\" CASCADE", [])
+pg_close(db)
+"#,
+        );
+        let out = run_harn_source(&source);
+        let lines: Vec<&str> = out.lines().collect();
+        // applied=3, available=3, table name, 6 columns, 3 rows, 0 bad
+        // checksum lengths, 0 failed, 3 versions.
+        assert_eq!(
+            lines,
+            vec!["3", "3", "_sqlx_migrations", "6", "3", "0", "0", "3"],
+            "unexpected output: {out}"
+        );
+    }
+
+    /// SQLx ledger mode is idempotent: a second run applies 0, skips all,
+    /// and leaves the row count unchanged.
+    #[test]
+    fn migrate_sqlx_is_idempotent_when_env_url_is_set() {
+        if std::env::var("HARN_TEST_POSTGRES_URL").is_err() {
+            return;
+        }
+        reset_postgres_state();
+        let (_tmp, dir) = sqlx_synthetic_migrations();
+        let schema = format!("harn_pg_sqlxidem_{}", uuid::Uuid::new_v4().simple());
+        let source = format!(
+            r#"
+import "std/postgres"
+
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_execute(admin, "CREATE SCHEMA \"{schema}\"", [])
+pg_close(admin)
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+
+let first = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(first.applied))
+__io_println(len(first.skipped))
+
+let count1 = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations", [])
+__io_println(count1.c)
+
+let second = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(second.applied))
+__io_println(len(second.skipped))
+
+let count2 = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations", [])
+__io_println(count2.c)
+
+pg_execute(db, "DROP SCHEMA \"{schema}\" CASCADE", [])
+pg_close(db)
+"#,
+        );
+        let out = run_harn_source(&source);
+        let lines: Vec<&str> = out.lines().collect();
+        // first: applied 3 skipped 0, count 3; second: applied 0 skipped 3,
+        // count still 3.
+        assert_eq!(
+            lines,
+            vec!["3", "0", "3", "0", "3", "3"],
+            "unexpected output: {out}"
+        );
+    }
+
+    /// No-fork against a "real" SQLx ledger: pre-seed `_sqlx_migrations`
+    /// with rows whose checksums are computed the SAME way SQLx does
+    /// (SHA-384 of the file body) — exactly what `sqlx migrate run` would
+    /// have written — then run `pg_migrate(ledger: "sqlx")`. It must apply
+    /// 0 and the checksums stay byte-identical.
+    #[test]
+    fn migrate_sqlx_no_fork_against_preseeded_ledger_when_env_url_is_set() {
+        if std::env::var("HARN_TEST_POSTGRES_URL").is_err() {
+            return;
+        }
+        reset_postgres_state();
+        let (_tmp, dir) = sqlx_synthetic_migrations();
+
+        // Compute SHA-384 the same way sqlx (and our runner) does: over the
+        // file body read as a string.
+        let checksum_hex = |name: &str| -> String {
+            use sha2::{Digest, Sha384};
+            let body =
+                std::fs::read_to_string(std::path::Path::new(&dir).join(name)).expect("read file");
+            let digest = Sha384::digest(body.as_bytes());
+            digest.iter().map(|b| format!("{b:02x}")).collect()
+        };
+        let bootstrap_sum = checksum_hex("20260419170000_bootstrap.up.sql");
+        let seed_sum = checksum_hex("20260423100000_seed_widget.up.sql");
+        let gadgets_sum = checksum_hex("20260424000000_add_gadgets.up.sql");
+
+        let schema = format!("harn_pg_sqlxnofork_{}", uuid::Uuid::new_v4().simple());
+        let source = format!(
+            r#"
+import "std/postgres"
+
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_execute(admin, "CREATE SCHEMA \"{schema}\"", [])
+pg_close(admin)
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+
+// Replicate exactly what `sqlx migrate run` would have written, including
+// the schema and the three rows with SHA-384 checksums, then create the
+// objects those migrations would have created.
+pg_execute(db, "CREATE TABLE _sqlx_migrations (version BIGINT PRIMARY KEY, description TEXT NOT NULL, installed_on TIMESTAMPTZ NOT NULL DEFAULT now(), success BOOLEAN NOT NULL, checksum BYTEA NOT NULL, execution_time BIGINT NOT NULL)", [])
+pg_execute(db, "CREATE TABLE widgets (id INT PRIMARY KEY, label TEXT NOT NULL)", [])
+pg_execute(db, "INSERT INTO widgets (id, label) VALUES (1, 'alpha')", [])
+pg_execute(db, "CREATE TABLE gadgets (id INT PRIMARY KEY)", [])
+pg_execute(db, "INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time) VALUES (20260419170000, 'bootstrap', TRUE, decode('{bootstrap_sum}', 'hex'), 1)", [])
+pg_execute(db, "INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time) VALUES (20260423100000, 'seed widget', TRUE, decode('{seed_sum}', 'hex'), 1)", [])
+pg_execute(db, "INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time) VALUES (20260424000000, 'add gadgets', TRUE, decode('{gadgets_sum}', 'hex'), 1)", [])
+
+let before = pg_query_one(db, "SELECT md5(string_agg(encode(checksum,'hex'), ',' ORDER BY version)) AS h FROM _sqlx_migrations", [])
+
+let result = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(result.applied))
+__io_println(len(result.skipped))
+
+let after = pg_query_one(db, "SELECT md5(string_agg(encode(checksum,'hex'), ',' ORDER BY version)) AS h FROM _sqlx_migrations", [])
+if before.h == after.h {{ __io_println("checksums-identical") }} else {{ __io_println("checksums-CHANGED") }}
+
+let count = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations", [])
+__io_println(count.c)
+
+pg_execute(db, "DROP SCHEMA \"{schema}\" CASCADE", [])
+pg_close(db)
+"#,
+        );
+        let out = run_harn_source(&source);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(
+            lines,
+            vec!["0", "3", "checksums-identical", "3"],
+            "unexpected output: {out}"
+        );
+    }
+
+    /// Checksum-mismatch detection: corrupt one recorded checksum then run;
+    /// the runner must error and name the offending version.
+    #[test]
+    fn migrate_sqlx_detects_checksum_mismatch_when_env_url_is_set() {
+        if std::env::var("HARN_TEST_POSTGRES_URL").is_err() {
+            return;
+        }
+        reset_postgres_state();
+        let (_tmp, dir) = sqlx_synthetic_migrations();
+        let schema = format!("harn_pg_sqlxmismatch_{}", uuid::Uuid::new_v4().simple());
+        let source = format!(
+            r#"
+import "std/postgres"
+
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_execute(admin, "CREATE SCHEMA \"{schema}\"", [])
+pg_close(admin)
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+
+let first = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(first.applied))
+
+// Corrupt the recorded checksum for the first migration.
+pg_execute(db, "UPDATE _sqlx_migrations SET checksum = decode('deadbeef', 'hex') WHERE version = 20260419170000", [])
+
+let second = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(second.applied))
+
+pg_execute(db, "DROP SCHEMA \"{schema}\" CASCADE", [])
+pg_close(db)
+"#,
+        );
+        let err = run_harn_source_expect_err(&source);
+        assert!(
+            err.contains("checksum mismatch") && err.contains("20260419170000"),
+            "expected checksum-mismatch error naming the version, got: {err}"
+        );
+    }
+
+    /// Dirty-ledger detection: a `success = false` row blocks the run.
+    #[test]
+    fn migrate_sqlx_detects_dirty_ledger_when_env_url_is_set() {
+        if std::env::var("HARN_TEST_POSTGRES_URL").is_err() {
+            return;
+        }
+        reset_postgres_state();
+        let (_tmp, dir) = sqlx_synthetic_migrations();
+        let schema = format!("harn_pg_sqlxdirty_{}", uuid::Uuid::new_v4().simple());
+        let source = format!(
+            r#"
+import "std/postgres"
+
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_execute(admin, "CREATE SCHEMA \"{schema}\"", [])
+pg_close(admin)
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+
+pg_execute(db, "CREATE TABLE _sqlx_migrations (version BIGINT PRIMARY KEY, description TEXT NOT NULL, installed_on TIMESTAMPTZ NOT NULL DEFAULT now(), success BOOLEAN NOT NULL, checksum BYTEA NOT NULL, execution_time BIGINT NOT NULL)", [])
+pg_execute(db, "INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time) VALUES (20260419170000, 'bootstrap', FALSE, decode('deadbeef', 'hex'), -1)", [])
+
+let result = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(result.applied))
+
+pg_execute(db, "DROP SCHEMA \"{schema}\" CASCADE", [])
+pg_close(db)
+"#,
+        );
+        let err = run_harn_source_expect_err(&source);
+        assert!(
+            err.contains("dirty migration") && err.contains("20260419170000"),
+            "expected dirty-ledger error naming the version, got: {err}"
+        );
+    }
+
+    /// SQLx ledger mode against the canonical harn-cloud `migrations/`
+    /// directory: applies the full forward history, then a second run is a
+    /// no-op (every version skipped, no checksum drift). This is the
+    /// retire-`migrations.rs` acceptance test. Opt-in via
+    /// `HARN_TEST_CLOUD_MIGRATIONS_DIR`.
+    #[test]
+    fn migrate_sqlx_applies_real_cloud_dir_and_is_idempotent_when_env_set() {
+        if std::env::var("HARN_TEST_POSTGRES_URL").is_err() {
+            return;
+        }
+        let Ok(dir) = std::env::var("HARN_TEST_CLOUD_MIGRATIONS_DIR") else {
+            return;
+        };
+        if !std::path::Path::new(&dir).exists() {
+            return;
+        }
+        reset_postgres_state();
+        let schema = format!("harn_pg_sqlxcloud_{}", uuid::Uuid::new_v4().simple());
+        let source = format!(
+            r#"
+import "std/postgres"
+
+let admin = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(admin, "DROP SCHEMA IF EXISTS \"{schema}\" CASCADE", [])
+pg_execute(admin, "CREATE SCHEMA \"{schema}\"", [])
+pg_close(admin)
+
+let db = pg_pool("env:HARN_TEST_POSTGRES_URL", {{max_connections: 1}})
+pg_execute(db, "SET search_path TO \"{schema}\"", [])
+
+let first = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(first.applied))
+__io_println(len(first.skipped))
+
+let count1 = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations", [])
+__io_println(count1.c)
+
+let badlen = pg_query_one(db, "SELECT count(*)::int8 AS c FROM _sqlx_migrations WHERE octet_length(checksum) <> 48", [])
+__io_println(badlen.c)
+
+let second = pg_migrate(db, {{dir: "{dir}", ledger: "sqlx"}})
+__io_println(len(second.applied))
+__io_println(len(second.skipped))
+
+pg_execute(db, "DROP SCHEMA \"{schema}\" CASCADE", [])
+pg_close(db)
+"#,
+        );
+        let out = run_harn_source(&source);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 6, "unexpected output: {out}");
+        let applied: usize = lines[0].parse().expect("applied count");
+        let skipped_first: usize = lines[1].parse().expect("skipped count");
+        let count: usize = lines[2].parse().expect("row count");
+        let bad_checksums: usize = lines[3].parse().expect("bad checksum count");
+        let applied_second: usize = lines[4].parse().expect("second applied");
+        let skipped_second: usize = lines[5].parse().expect("second skipped");
+        assert!(applied > 0, "no migrations applied: {out}");
+        assert_eq!(skipped_first, 0, "first run should skip nothing: {out}");
+        assert_eq!(count, applied, "ledger rows != applied: {out}");
+        assert_eq!(bad_checksums, 0, "all checksums must be 48 bytes: {out}");
+        assert_eq!(applied_second, 0, "second run must apply nothing: {out}");
+        assert_eq!(
+            skipped_second, applied,
+            "second run must skip everything: {out}"
+        );
+    }
+
     /// Confirms `duration_ms` lives on every real execute result. The
     /// synthetic `Instant` path is covered by
     /// `execute_result_value_includes_duration`.

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -39,7 +39,7 @@ pipeline default() {
 | `pg_savepoint(tx, name)` | `bool` | Create a savepoint inside an open transaction. |
 | `pg_release_savepoint(tx, name)` | `bool` | Release a previously created savepoint. |
 | `pg_rollback_to_savepoint(tx, name)` | `bool` | Roll work back to a savepoint while keeping the outer transaction open. |
-| `pg_migrate(pool, {dir, table?, dry_run?})` | `PgMigrateResult` | Apply `.sql` files from a directory; track the applied set in `harn_migrations` (override via `table`). |
+| `pg_migrate(pool, {dir, ledger?, table?, dry_run?})` | `PgMigrateResult` | Apply `.sql` files from a directory; track the applied set in `harn_migrations` (override via `table`). Pass `ledger: "sqlx"` to read/write SQLx's `_sqlx_migrations` ledger instead. |
 | `pg_close(pool)` | `bool` | Close and unregister a pool handle. |
 | `pg_stmt_cache_clear(pool)` | `PgStmtCacheClearResult` | Clear prepared-statement caches on idle primary and replica connections without closing the pool. |
 | `pg.jsonb.path(pool, document, jsonpath)` | `list<any>` | Run `jsonb_path_query($1::jsonb, $2::jsonpath)` with bound operands. |
@@ -313,6 +313,46 @@ For richer migration tooling — multi-statement `.down` files, baselines,
 or branching — keep using SQLx CLI, Sqitch, or Flyway and call
 `pg_migrate` only when your `.harn` pipeline is the authoritative
 schema owner.
+
+### SQLx-compatible ledger
+
+Pass `ledger: "sqlx"` to apply an existing SQLx migration history into
+SQLx's own `_sqlx_migrations` table, byte-for-byte compatibly:
+
+```harn
+let pool = pg_pool("env:DATABASE_URL", {max_connections: 1})
+let result = pg_migrate(pool, {dir: "./migrations", ledger: "sqlx"})
+```
+
+In this mode `pg_migrate`:
+
+- Always targets the `_sqlx_migrations` table (the default
+  `ledger: "harn"` continues to use `harn_migrations`). Passing a `table`
+  that disagrees with `_sqlx_migrations` is an error.
+- Identifies each migration by the **integer version prefix** of its
+  filename (`splitn(_)[0]`, e.g. `20260419170000_bootstrap.up.sql` →
+  `20260419170000`) rather than the full name, sorts ascending by that
+  numeric version, and applies only forward files (`*.up.sql` / `*.sql`,
+  skipping `*.down.sql`). A non-integer prefix is a hard error.
+- Computes a **SHA-384** checksum of the raw file (the same digest SQLx
+  records), so a migration already applied by `sqlx migrate run` is
+  recognized and skipped — running `pg_migrate(ledger: "sqlx")` against a
+  SQLx-migrated database applies zero rows.
+- Records rows exactly as SQLx does
+  (`version, description, success=TRUE, checksum, execution_time`).
+- Takes the **same per-database advisory lock** SQLx uses
+  (`0x3d32ad9e * crc32(current_database())`), so a Harn migration and a
+  concurrent `sqlx migrate run` serialize against each other instead of
+  racing.
+- Refuses to run when the ledger has a failed (`success = false`)
+  migration (a "dirty" ledger), and errors if a file's checksum differs
+  from the recorded one (drift detection), naming the offending version.
+- Honors a leading `-- no-transaction` comment by running the migration
+  outside a wrapping transaction, matching SQLx.
+
+This is the path to retire a Rust `run_migrations()` that called
+`sqlx_core::migrate::Migrator`: point `pg_migrate(ledger: "sqlx")` at the
+same `migrations/` directory and the two are interchangeable.
 
 ## Typed rows from migrations
 


### PR DESCRIPTION
Four self-contained pg-hostlib improvements, each tested against live Postgres.

## 1. `pg_migrate(ledger: "sqlx")` — SQLx-compatible migration ledger
Applies migrations against SQLx's `_sqlx_migrations` (version BIGINT PK, SHA-384 checksum, 6-col schema, `0x3d32ad9e * crc32_iso_hdlc(db)` lock id) with byte-identical semantics: idempotent, errors on dirty/checksum drift, never forks history. Verified by applying harn-cloud's real 111 migrations (applied 111 → re-run skips 111, checksums byte-identical vs a SQLx-seeded ledger). Default `ledger:"harn"` path unchanged. Unblocks harn-cloud retiring its Rust SQLx runner.

## 2. Report Postgres event-log backend kind
`EventLogBackendKind::Postgres` so host-provided Postgres event logs report the correct backend instead of borrowing the SQLite label.

## 3. Bind nil pg params as untyped NULL (OID 0) — root-cause fix
`bind_params` bound `VmValue::Nil` as `None::<String>` → Postgres TEXT (OID 25). With sqlx's binary param format + per-connection prepared-statement cache, a slot first bound NULL (cached TEXT) then a non-null int sent int8 binary into a text slot → `invalid byte sequence for encoding "UTF8": 0x00`; nil into an int/jsonb column → `is of type integer but expression is of type text`. Now binds via an `UntypedNull` declaring OID 0 so Postgres infers the slot type from context, exactly like a bare SQL NULL. Non-null binds unchanged. Repro tests fail before / pass after; full postgres module green.

## 4. Migration runner hardening (security audit C-1/C-2/L-3)
- **C-1:** advisory lock + all migration steps now run on ONE pinned connection (was the pool, so the session-scoped lock never serialized concurrent callers and the unlock no-op'd on a recycled connection, leaking the lock). Both ledger modes.
- **C-2:** harn-mode now re-hashes already-applied files and errors on checksum drift (was stored-but-never-verified despite the doc claim). sqlx mode already verified SHA-384.
- **L-3:** `release_lock` inspects the unlock result and warns if the lock wasn't held.

Tests: 16 migrate tests (harn + sqlx modes) green incl. a drift-detection test proven to catch the bug; full postgres module green; `cargo fmt`/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)