### PR TITLE
pg/anthropic: revert nil→OID0 bind, fix anthropic tool_choice, reject non-finite float binds

### DIFF
--- a/changelog.d/anthropic-tool-choice.fixed.md
+++ b/changelog.d/anthropic-tool-choice.fixed.md
@@ -1,0 +1,6 @@
+- Fixed the direct Anthropic provider sending `tool_choice` as a bare string
+  (the OpenAI wire shape), which Anthropic rejected with HTTP 400
+  (`tool_choice: Input should be an object`) and broke tool-using agent loops on
+  `--provider anthropic`. Harn's tool-choice modes are now mapped to Anthropic's
+  object form (`auto`/`any`/`none`/specific-tool), and OpenAI-style
+  `{"type":"function",...}` and bare-name inputs are normalized too.

--- a/changelog.d/pg-nil-bind-revert-untyped-null.fixed.md
+++ b/changelog.d/pg-nil-bind-revert-untyped-null.fixed.md
@@ -1,0 +1,13 @@
+- **Reverted the v0.8.89 "untyped NULL (OID 0)" Postgres `nil` bind.** Binding
+  `nil` as an unspecified-type NULL (OID 0) so Postgres infers the slot type
+  from context is incompatible with sqlx's binary wire protocol: when a query
+  mixes a `nil` param with non-null typed params, Postgres re-infers the whole
+  parameter-type list from the OID-0 slot during `Parse`, and the inferred
+  types no longer match the client-declared OIDs sqlx encodes the non-null
+  params with — yielding `incorrect binary data format in bind parameter N` /
+  `insufficient data left in message` (and `could not determine data type` in
+  genuinely ambiguous contexts). `nil` once again binds as `None::<String>`
+  (Postgres TEXT), the long-stable behavior. The narrow cache-poisoning /
+  typed-column cases the OID-0 change targeted are handled at the query layer by
+  binding a concrete cast (`$n::text::int`, a `::text` cast, or a non-null
+  sentinel) — the correct place to disambiguate a NULL's intended type.

--- a/changelog.d/pg-non-finite-float-bind.fixed.md
+++ b/changelog.d/pg-non-finite-float-bind.fixed.md
@@ -1,0 +1,6 @@
+- Fixed the Postgres hostlib binding a non-finite `Float` (NaN/Infinity) raw:
+  a direct `float8` bind stored NaN/Infinity (which breaks downstream JSON), and
+  a non-finite float on the jsonb path serialized to a silent JSON `null`.
+  `pg_query`/`pg_execute` (and the introspection/advisory helpers) now reject a
+  non-finite float — directly bound or nested in a list/dict — with a clear
+  error before it reaches the database. Finite-float binds are unchanged.

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -282,7 +282,14 @@ impl AnthropicProvider {
             }
         }
         if let Some(ref tc) = opts.tool_choice {
-            body["tool_choice"] = tc.clone();
+            // Anthropic requires `tool_choice` to be an OBJECT (e.g.
+            // `{"type":"auto"}`); a bare string like `"auto"` — which is the
+            // OpenAI wire shape that most callers and the harn agent loop emit —
+            // returns HTTP 400 (`tool_choice: Input should be an object`).
+            // Normalize harn's internal tool-choice modes to Anthropic's shape.
+            if let Some(normalized) = normalize_anthropic_tool_choice(tc) {
+                body["tool_choice"] = normalized;
+            }
         }
         match &opts.output_format {
             crate::llm::api::OutputFormat::Text => {}
@@ -360,6 +367,78 @@ fn sanitize_anthropic_tool_for_request(tool: &serde_json::Value) -> serde_json::
         object.remove("namespaces");
     }
     tool
+}
+
+/// Map a caller-supplied `tool_choice` value to Anthropic's object form.
+///
+/// Anthropic's Messages API requires `tool_choice` to be an object with a
+/// `type` of `auto` | `any` | `tool` | `none` (and `name` for `tool`); a bare
+/// string returns HTTP 400. Callers and the harn agent loop, however, speak the
+/// OpenAI dialect (bare strings `"auto"` / `"none"` / `"required"`, or a
+/// `{"type":"function","function":{"name":...}}` object), so we translate here.
+///
+/// Mapping (mirrors how the OpenAI providers interpret the same modes):
+/// - `"auto"` / `{"type":"auto"}` → `{"type":"auto"}`
+/// - `"required"` / `"any"` / `{"type":"required"}` / `{"type":"any"}` → `{"type":"any"}`
+/// - `"none"` / `{"type":"none"}` → `{"type":"none"}` (tools stay in the request
+///   but Claude won't call them — same semantics as OpenAI's `"none"`)
+/// - a specific tool: bare name string, `{"type":"tool","name":N}`, or the
+///   OpenAI `{"type":"function","function":{"name":N}}` → `{"type":"tool","name":N}`
+///
+/// Returns `None` only when the value can't be interpreted at all (e.g. a JSON
+/// `null`), in which case the caller leaves `tool_choice` unset. Any
+/// `disable_parallel_tool_use` flag on an object input is preserved.
+fn normalize_anthropic_tool_choice(value: &serde_json::Value) -> Option<serde_json::Value> {
+    let attach_parallel = |mut obj: serde_json::Value, src: &serde_json::Value| {
+        if let Some(flag) = src.get("disable_parallel_tool_use") {
+            if let Some(map) = obj.as_object_mut() {
+                map.insert("disable_parallel_tool_use".to_string(), flag.clone());
+            }
+        }
+        obj
+    };
+
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "auto" => Some(serde_json::json!({"type": "auto"})),
+            "any" | "required" => Some(serde_json::json!({"type": "any"})),
+            "none" => Some(serde_json::json!({"type": "none"})),
+            // A bare, non-keyword string names a specific tool to force.
+            other => Some(serde_json::json!({"type": "tool", "name": other})),
+        },
+        serde_json::Value::Object(_) => {
+            let ty = value.get("type").and_then(|t| t.as_str());
+            match ty {
+                Some("auto") => Some(attach_parallel(serde_json::json!({"type": "auto"}), value)),
+                Some("any") | Some("required") => {
+                    Some(attach_parallel(serde_json::json!({"type": "any"}), value))
+                }
+                Some("none") => Some(attach_parallel(serde_json::json!({"type": "none"}), value)),
+                // Anthropic native: `{"type":"tool","name":...}`.
+                Some("tool") => {
+                    let name = value.get("name").and_then(|n| n.as_str());
+                    name.map(|name| {
+                        attach_parallel(serde_json::json!({"type": "tool", "name": name}), value)
+                    })
+                }
+                // OpenAI native: `{"type":"function","function":{"name":...}}`.
+                Some("function") => {
+                    let name = value
+                        .get("function")
+                        .and_then(|f| f.get("name"))
+                        .and_then(|n| n.as_str());
+                    name.map(|name| {
+                        attach_parallel(serde_json::json!({"type": "tool", "name": name}), value)
+                    })
+                }
+                // Unknown / unset `type` on an object: fall back to letting
+                // Claude decide rather than forwarding a shape Anthropic rejects.
+                _ => Some(serde_json::json!({"type": "auto"})),
+            }
+        }
+        // Null or any other JSON scalar: treat as "no tool_choice".
+        _ => None,
+    }
 }
 
 fn force_json_via_tool_use(body: &mut serde_json::Value, schema: &serde_json::Value, model: &str) {
@@ -666,6 +745,89 @@ mod tests {
         assert!(
             tool_names.contains(&"lookup"),
             "the caller's tool is preserved, not dropped: {tool_names:?}"
+        );
+    }
+
+    #[test]
+    fn tool_choice_string_modes_become_anthropic_objects() {
+        // The OpenAI/agent-loop wire shape is a bare string. Anthropic 400s on
+        // a bare string, so each mode must be rewritten to its object form.
+        for (input, expected) in [
+            ("auto", serde_json::json!({"type": "auto"})),
+            ("any", serde_json::json!({"type": "any"})),
+            ("required", serde_json::json!({"type": "any"})),
+            ("none", serde_json::json!({"type": "none"})),
+        ] {
+            let mut payload = base_payload();
+            payload.tool_choice = Some(serde_json::json!(input));
+            let body = AnthropicProvider::build_request_body(&payload);
+            assert_eq!(
+                body["tool_choice"], expected,
+                "tool_choice \"{input}\" must serialize to an object"
+            );
+            assert!(
+                body["tool_choice"].is_object(),
+                "Anthropic rejects a non-object tool_choice"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_choice_bare_string_names_a_specific_tool() {
+        // A non-keyword bare string is treated as "force this tool by name".
+        let mut payload = base_payload();
+        payload.tool_choice = Some(serde_json::json!("read_file"));
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert_eq!(
+            body["tool_choice"],
+            serde_json::json!({"type": "tool", "name": "read_file"})
+        );
+    }
+
+    #[test]
+    fn tool_choice_openai_function_object_maps_to_anthropic_tool() {
+        // OpenAI's specific-tool shape is `{"type":"function","function":{...}}`.
+        let mut payload = base_payload();
+        payload.tool_choice = Some(serde_json::json!({
+            "type": "function",
+            "function": {"name": "read_file"},
+        }));
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert_eq!(
+            body["tool_choice"],
+            serde_json::json!({"type": "tool", "name": "read_file"})
+        );
+    }
+
+    #[test]
+    fn tool_choice_already_anthropic_object_is_preserved() {
+        // Callers that already speak Anthropic must pass through unchanged,
+        // including the optional disable_parallel_tool_use flag.
+        let mut payload = base_payload();
+        payload.tool_choice = Some(serde_json::json!({
+            "type": "tool",
+            "name": "read_file",
+            "disable_parallel_tool_use": true,
+        }));
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert_eq!(
+            body["tool_choice"],
+            serde_json::json!({
+                "type": "tool",
+                "name": "read_file",
+                "disable_parallel_tool_use": true,
+            })
+        );
+    }
+
+    #[test]
+    fn tool_choice_null_leaves_field_unset() {
+        let mut payload = base_payload();
+        payload.tool_choice = Some(serde_json::Value::Null);
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert!(
+            body.get("tool_choice").is_none(),
+            "a null tool_choice must not be forwarded"
         );
     }
 

--- a/crates/harn-vm/src/stdlib/postgres/advisory.rs
+++ b/crates/harn-vm/src/stdlib/postgres/advisory.rs
@@ -142,13 +142,13 @@ async fn take_xact_lock(tx_id: &str, key: &LockKey) -> Result<(), VmError> {
     let result = match key {
         LockKey::Single(value) => {
             let params = [VmValue::Int(*value)];
-            bind_params(query("SELECT pg_advisory_xact_lock($1)"), &params)
+            bind_params(query("SELECT pg_advisory_xact_lock($1)"), &params)?
                 .execute(&mut **tx)
                 .await
         }
         LockKey::Pair(a, b) => {
             let params = [VmValue::Int(i64::from(*a)), VmValue::Int(i64::from(*b))];
-            bind_params(query("SELECT pg_advisory_xact_lock($1, $2)"), &params)
+            bind_params(query("SELECT pg_advisory_xact_lock($1, $2)"), &params)?
                 .execute(&mut **tx)
                 .await
         }

--- a/crates/harn-vm/src/stdlib/postgres/introspect.rs
+++ b/crates/harn-vm/src/stdlib/postgres/introspect.rs
@@ -559,7 +559,7 @@ fn prune_subtree<'a>(
     pruned: &'a mut Vec<VmValue>,
 ) -> Pin<Box<dyn Future<Output = Result<(), VmError>> + Send + 'a>> {
     Box::pin(async move {
-        let rows = bind_params(query(PARTITION_CHILDREN_SQL), &[VmValue::Int(parent_oid)])
+        let rows = bind_params(query(PARTITION_CHILDREN_SQL), &[VmValue::Int(parent_oid)])?
             .fetch_all(pool)
             .await
             .map_err(|error| runtime_error(format!("{builtin}: {error}")))?;
@@ -608,7 +608,7 @@ async fn resolve_regclass_oid(
     let row = bind_params(
         query("SELECT ($1::regclass)::oid::bigint AS oid"),
         &[VmValue::String(std::sync::Arc::from(qualified))],
-    )
+    )?
     .fetch_one(pool)
     .await
     .map_err(|error| runtime_error(format!("{builtin}: {error}")))?;
@@ -628,7 +628,7 @@ async fn existing_partition_names(
              WHERE inh.inhparent = ($1::regclass)::oid",
         ),
         &[VmValue::String(std::sync::Arc::from(qualified))],
-    )
+    )?
     .fetch_all(pool)
     .await
     .map_err(|error| runtime_error(format!("{builtin}: {error}")))?;
@@ -755,7 +755,7 @@ async fn rows_to_list(
     params: &[VmValue],
     builtin: &'static str,
 ) -> Result<VmValue, VmError> {
-    let rows = bind_params(query(AssertSqlSafe(sql)), params)
+    let rows = bind_params(query(AssertSqlSafe(sql)), params)?
         .fetch_all(pool)
         .await
         .map_err(|error| runtime_error(format!("{builtin}: {error}")))?;

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -8,20 +8,15 @@ use std::time::Duration;
 
 use sqlx_core::column::Column;
 use sqlx_core::connection::Connection;
-use sqlx_core::encode::{Encode, IsNull};
-use sqlx_core::error::BoxDynError;
 use sqlx_core::executor::Executor;
 use sqlx_core::query::{query, Query};
 use sqlx_core::row::Row;
 use sqlx_core::sql_str::AssertSqlSafe;
 use sqlx_core::transaction::Transaction;
 use sqlx_core::type_info::TypeInfo;
-use sqlx_core::types::Type;
 use sqlx_core::value::ValueRef;
-use sqlx_postgres::types::Oid;
 use sqlx_postgres::{
-    PgArgumentBuffer, PgArguments, PgConnectOptions, PgPool, PgPoolOptions, PgQueryResult, PgRow,
-    PgSslMode, PgTypeInfo, Postgres,
+    PgArguments, PgConnectOptions, PgPool, PgPoolOptions, PgQueryResult, PgRow, PgSslMode, Postgres,
 };
 use tokio::sync::Mutex;
 
@@ -945,52 +940,6 @@ async fn apply_transaction_settings(
     Ok(())
 }
 
-/// A NULL bind that declares Postgres type OID `0` (unspecified) in the
-/// `Parse` message, so the server infers the parameter's type from the query
-/// context (a cast like `$1::integer`, the target column, etc.) — exactly as a
-/// bare SQL `NULL` does.
-///
-/// Why this exists: `None::<String>` (the obvious way to bind a typed NULL)
-/// declares OID `25` (TEXT) because `Option::<T>::produces()` falls back to
-/// `T::type_info()` for the `None` case. sqlx caches prepared statements keyed
-/// by SQL string on the pooled connection AND sends params in binary with the
-/// client-declared OIDs in `Parse`, so a TEXT-declared NULL caused two
-/// production bugs:
-///   1. Type-cache poisoning: once `$1` is parsed as TEXT (from a NULL), a
-///      later non-null `i64` in the same slot is sent as 8 binary bytes that
-///      Postgres UTF-8-validates against the cached TEXT type →
-///      `invalid byte sequence for encoding "UTF8": 0x00`.
-///   2. Wrong NULL typing: `($1::integer)` / `($1::jsonb)` with a TEXT NULL →
-///      `column is of type integer but expression is of type text`.
-///
-/// `PgTypeInfo::with_oid(Oid(0))` resolves to OID `0` in `Parse`
-/// (see `sqlx_postgres::connection::resolve::try_oid` →
-/// `PgType::DeclareWithOid`), which Postgres treats as "infer from context".
-/// The encoded value is a `-1` length (NULL), so no binary bytes are sent and
-/// the parameter format is irrelevant.
-struct UntypedNull;
-
-impl Type<Postgres> for UntypedNull {
-    fn type_info() -> PgTypeInfo {
-        PgTypeInfo::with_oid(Oid(0))
-    }
-}
-
-impl Encode<'_, Postgres> for UntypedNull {
-    fn encode_by_ref(&self, _buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        // Write no bytes; the caller records a `-1` length to mark SQL NULL.
-        Ok(IsNull::Yes)
-    }
-
-    fn produces(&self) -> Option<PgTypeInfo> {
-        Some(PgTypeInfo::with_oid(Oid(0)))
-    }
-
-    fn size_hint(&self) -> usize {
-        0
-    }
-}
-
 /// Error message for a non-finite float that can't be safely bound to Postgres.
 fn non_finite_float_error() -> VmError {
     runtime_error(
@@ -1028,7 +977,7 @@ pub(super) fn bind_params<'q>(
         // a float8 column or emitting invalid JSON.
         reject_non_finite_floats(param)?;
         query = match param {
-            VmValue::Nil => query.bind(UntypedNull),
+            VmValue::Nil => query.bind(None::<String>),
             VmValue::Bool(value) => query.bind(*value),
             VmValue::Int(value) => query.bind(*value),
             VmValue::Float(value) => query.bind(*value),
@@ -2100,129 +2049,16 @@ mod tests {
         assert_eq!(row.get("amount").unwrap().display(), "12345.6789");
     }
 
-    /// Opens a single-connection pool against the test database so that every
-    /// query reuses the same physical connection (and therefore the same
-    /// prepared-statement cache), which is required to exercise the
-    /// type-cache-poisoning path.
+    /// Opens a single-connection pool against the test database so every query
+    /// reuses the same physical connection (and prepared-statement cache).
     async fn open_single_conn_pool(url: &str) -> VmValue {
         let mut options = BTreeMap::new();
         options.insert("max_connections".to_string(), VmValue::Int(1));
-        options.insert(
-            "application_name".to_string(),
-            s("harn-postgres-untyped-null-test"),
-        );
+        options.insert("application_name".to_string(), s("harn-postgres-bind-test"));
         let ctx = crate::vm::AsyncBuiltinCtx::for_test(crate::Vm::new());
         open_pool(&ctx, &s(url), Some(&options), false)
             .await
             .expect("open single-connection pool")
-    }
-
-    /// Regression for prepared-statement TYPE-CACHE POISONING.
-    ///
-    /// Before the fix, binding `VmValue::Nil` declared OID 25 (TEXT) in the
-    /// `Parse` message. On a single pooled connection, `SELECT $1::bigint`
-    /// would be prepared with `$1` cached as TEXT during the first (NULL) call;
-    /// the second call binding a real `i64` then sent 8 binary bytes that
-    /// Postgres UTF-8-validated against the cached TEXT type, producing
-    /// `invalid byte sequence for encoding "UTF8": 0x00`.
-    ///
-    /// After the fix the NULL declares OID 0 (unspecified), so Postgres infers
-    /// `bigint` from the cast and both calls succeed.
-    #[tokio::test(flavor = "current_thread")]
-    async fn nil_bind_does_not_poison_prepared_statement_cache_when_env_url_is_set() {
-        let Ok(url) = std::env::var("HARN_TEST_POSTGRES_URL") else {
-            return;
-        };
-        reset_postgres_state();
-        let handle = open_single_conn_pool(&url).await;
-
-        // Same SQL string both times so the cached prepared statement is reused.
-        let sql = "select $1::bigint as v";
-
-        // 1) NULL first — this is what poisoned the cache as TEXT before.
-        let null_row = query_rows(&handle, sql, &[VmValue::Nil], QueryRouting::Primary)
-            .await
-            .expect("nil bind for $1::bigint should succeed")
-            .remove(0);
-        assert!(
-            matches!(null_row.as_dict().unwrap().get("v"), Some(VmValue::Nil)),
-            "NULL bigint should decode to Nil"
-        );
-
-        // 2) Non-null int, reusing the cached statement on the same connection.
-        let int_row = query_rows(&handle, sql, &[VmValue::Int(42)], QueryRouting::Primary)
-            .await
-            .expect("int bind after nil must not hit the 0x00 UTF8 error")
-            .remove(0);
-        assert_eq!(
-            int_row.as_dict().unwrap().get("v").unwrap().as_int(),
-            Some(42),
-            "second call should return the bound integer"
-        );
-    }
-
-    /// Regression for WRONG NULL TYPING on typed columns.
-    ///
-    /// Before the fix, binding `VmValue::Nil` directly into typed columns
-    /// (`INSERT ... VALUES ($1, $2)` where `i integer, j jsonb`) declared the
-    /// params as TEXT, so Postgres rejected the statement with
-    /// `column "i" is of type integer but expression is of type text`.
-    /// After the fix the NULLs declare OID 0 (unspecified), so Postgres infers
-    /// each parameter's type from the target column and stores SQL NULL.
-    ///
-    /// (A typed cast like `$1::integer` happens to mask this because a `text`
-    /// NULL casts to integer cleanly — but production `.harn` code that binds a
-    /// bare `$n` into a typed column hit the error, so we reproduce the
-    /// no-cast form here.)
-    #[tokio::test(flavor = "current_thread")]
-    async fn nil_bind_into_typed_columns_inserts_sql_null_when_env_url_is_set() {
-        let Ok(url) = std::env::var("HARN_TEST_POSTGRES_URL") else {
-            return;
-        };
-        reset_postgres_state();
-        let handle = open_single_conn_pool(&url).await;
-
-        execute_stmt(
-            &handle,
-            "create temporary table harn_untyped_null_test(i integer, j jsonb) on commit preserve rows",
-            &[],
-        )
-        .await
-        .expect("create temp table");
-        execute_stmt(&handle, "truncate table harn_untyped_null_test", &[])
-            .await
-            .expect("truncate temp table");
-
-        // Bare `$1`/`$2` into typed columns: a properly-inferred NULL must not
-        // raise `is of type integer but expression is of type text`.
-        execute_stmt(
-            &handle,
-            "insert into harn_untyped_null_test(i, j) values ($1, $2)",
-            &[VmValue::Nil, VmValue::Nil],
-        )
-        .await
-        .expect("nil binds into typed columns must insert cleanly");
-
-        let row = query_rows(
-            &handle,
-            "select i, j, (i is null) as i_is_null, (j is null) as j_is_null from harn_untyped_null_test",
-            &[],
-            QueryRouting::Primary,
-        )
-        .await
-        .expect("select back inserted row")
-        .remove(0);
-        let row = row.as_dict().unwrap();
-        assert!(
-            matches!(row.get("i"), Some(VmValue::Nil)),
-            "integer column should be SQL NULL"
-        );
-        assert!(
-            matches!(row.get("j"), Some(VmValue::Nil)),
-            "jsonb column should be SQL NULL"
-        );
-        assert_eq!(row.get("i_is_null").unwrap().display(), "true");
-        assert_eq!(row.get("j_is_null").unwrap().display(), "true");
     }
 
     #[test]
@@ -3204,8 +3040,7 @@ pg_close(db)
                 .expect_err("non-finite float must be rejected");
             assert!(
                 err.to_string().contains("non-finite float"),
-                "error should name the cause: {}",
-                err.to_string()
+                "error should name the cause: {err}"
             );
         }
 
@@ -3244,8 +3079,7 @@ pg_close(db)
             .expect_err("non-finite float8 bind must be rejected before sqlx");
             assert!(
                 err.to_string().contains("non-finite float"),
-                "error should be the guard's, not a raw sqlx error: {}",
-                err.to_string()
+                "error should be the guard's, not a raw sqlx error: {err}"
             );
         }
 
@@ -3261,8 +3095,7 @@ pg_close(db)
         .expect_err("non-finite float in jsonb path must be rejected");
         assert!(
             err.to_string().contains("non-finite float"),
-            "jsonb path should hit the same guard: {}",
-            err.to_string()
+            "jsonb path should hit the same guard: {err}"
         );
 
         // 3) A finite float still round-trips unchanged.

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -751,7 +751,7 @@ pub(super) async fn query_rows(
             let tx = tx
                 .as_mut()
                 .ok_or_else(|| runtime_error("pg_query: transaction is closed"))?;
-            let query = bind_params(query(AssertSqlSafe(sql)), params);
+            let query = bind_params(query(AssertSqlSafe(sql)), params)?;
             let rows = query
                 .fetch_all(&mut **tx)
                 .await
@@ -764,7 +764,7 @@ pub(super) async fn query_rows(
     let record = pool_record_from_handle(target, "pg_query")?;
     let pool = pool_for_routing(&record, routing, "pg_query")?;
     let (probe, _) = enter_circuit(&record.circuit, "pg_query")?;
-    let query = bind_params(query(AssertSqlSafe(sql)), params);
+    let query = bind_params(query(AssertSqlSafe(sql)), params)?;
     let result = query.fetch_all(pool.as_ref()).await;
     match result {
         Ok(rows) => {
@@ -803,7 +803,7 @@ pub(super) async fn execute_stmt(
         let tx = tx
             .as_mut()
             .ok_or_else(|| runtime_error("pg_execute: transaction is closed"))?;
-        let result = bind_params(query(AssertSqlSafe(sql)), params)
+        let result = bind_params(query(AssertSqlSafe(sql)), params)?
             .execute(&mut **tx)
             .await
             .map_err(|error| runtime_error(format!("pg_execute: {error}")))?;
@@ -811,7 +811,7 @@ pub(super) async fn execute_stmt(
     }
     let record = pool_record_from_handle(target, "pg_execute")?;
     let (probe, _) = enter_circuit(&record.circuit, "pg_execute")?;
-    let result = bind_params(query(AssertSqlSafe(sql)), params)
+    let result = bind_params(query(AssertSqlSafe(sql)), params)?
         .execute(record.pool.as_ref())
         .await;
     match result {
@@ -935,7 +935,7 @@ async fn apply_transaction_settings(
         let tx = tx
             .as_mut()
             .ok_or_else(|| runtime_error("pg_transaction: transaction is closed"))?;
-        bind_params(query(sql), &params)
+        bind_params(query(sql), &params)?
             .execute(&mut **tx)
             .await
             .map_err(|error| {
@@ -991,11 +991,42 @@ impl Encode<'_, Postgres> for UntypedNull {
     }
 }
 
+/// Error message for a non-finite float that can't be safely bound to Postgres.
+fn non_finite_float_error() -> VmError {
+    runtime_error(
+        "pg bind: non-finite float (NaN/Infinity) cannot be bound to a Postgres parameter",
+    )
+}
+
+/// Reject a non-finite `VmValue::Float` anywhere inside a value that will be
+/// bound. Direct `float8` binds of NaN/Infinity are legal for the column type
+/// but corrupt any downstream JSON, and a non-finite float that falls through
+/// to the jsonb (`vm_value_to_json`) path serializes to a JSON `null`
+/// (serde_json's representation of non-finite f64), silently dropping the
+/// value. We reject both up front with a clear error instead.
+fn reject_non_finite_floats(value: &VmValue) -> Result<(), VmError> {
+    match value {
+        VmValue::Float(f) if !f.is_finite() => Err(non_finite_float_error()),
+        VmValue::List(list) => list.iter().try_for_each(reject_non_finite_floats),
+        VmValue::Dict(dict) => dict.values().try_for_each(reject_non_finite_floats),
+        VmValue::StructInstance { .. } => value
+            .struct_fields_map()
+            .unwrap_or_default()
+            .values()
+            .try_for_each(reject_non_finite_floats),
+        _ => Ok(()),
+    }
+}
+
 pub(super) fn bind_params<'q>(
     mut query: Query<'q, Postgres, PgArguments>,
     params: &'q [VmValue],
-) -> Query<'q, Postgres, PgArguments> {
+) -> Result<Query<'q, Postgres, PgArguments>, VmError> {
     for param in params {
+        // Guard every param (including floats nested in the jsonb path) before
+        // it reaches sqlx, so NaN/Infinity fail cleanly rather than corrupting
+        // a float8 column or emitting invalid JSON.
+        reject_non_finite_floats(param)?;
         query = match param {
             VmValue::Nil => query.bind(UntypedNull),
             VmValue::Bool(value) => query.bind(*value),
@@ -1007,7 +1038,7 @@ pub(super) fn bind_params<'q>(
             value => query.bind(sqlx_core::types::Json(vm_value_to_json(value))),
         };
     }
-    query
+    Ok(query)
 }
 
 pub(super) fn row_to_value(row: PgRow) -> Result<VmValue, VmError> {
@@ -3145,5 +3176,108 @@ pg_close(db)
         assert_ne!(key_a, key_b, "same salt for distinct tenants");
         assert_eq!(key_none, 0, "no-tenant scope should produce zero salt");
         assert_ne!(key_a, 0);
+    }
+
+    /// `reject_non_finite_floats` must catch a non-finite float wherever it
+    /// hides — bound directly, or nested in a list/dict that takes the jsonb
+    /// path — while leaving finite floats and float-free values alone. No DB
+    /// required: this is the pure guard that `bind_params` calls per param.
+    #[test]
+    fn non_finite_float_guard_catches_direct_and_nested() {
+        // Finite scalars and collections pass.
+        assert!(reject_non_finite_floats(&VmValue::Float(1.5)).is_ok());
+        assert!(reject_non_finite_floats(&VmValue::Float(0.0)).is_ok());
+        assert!(reject_non_finite_floats(&VmValue::Int(7)).is_ok());
+        assert!(reject_non_finite_floats(&VmValue::Nil).is_ok());
+        assert!(
+            reject_non_finite_floats(&VmValue::List(std::sync::Arc::new(vec![
+                VmValue::Float(1.0),
+                VmValue::Int(2),
+            ])))
+            .is_ok()
+        );
+        assert!(reject_non_finite_floats(&dict(&[("amount", VmValue::Float(3.25))])).is_ok());
+
+        // Direct non-finite binds are rejected.
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let err = reject_non_finite_floats(&VmValue::Float(bad))
+                .expect_err("non-finite float must be rejected");
+            assert!(
+                err.to_string().contains("non-finite float"),
+                "error should name the cause: {}",
+                err.to_string()
+            );
+        }
+
+        // Nested in a list (jsonb path) — rejected.
+        let list = VmValue::List(std::sync::Arc::new(vec![
+            VmValue::Int(1),
+            VmValue::Float(f64::NAN),
+        ]));
+        assert!(reject_non_finite_floats(&list).is_err());
+
+        // Nested in a dict (jsonb path) — rejected.
+        let nested = dict(&[("ratio", VmValue::Float(f64::INFINITY))]);
+        assert!(reject_non_finite_floats(&nested).is_err());
+    }
+
+    /// Live regression: binding a non-finite float must fail cleanly with the
+    /// guard's error rather than corrupting a `float8` column or emitting
+    /// invalid JSON on the jsonb path. Gated on `HARN_TEST_POSTGRES_URL`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn non_finite_float_bind_errors_cleanly_when_env_url_is_set() {
+        let Ok(url) = std::env::var("HARN_TEST_POSTGRES_URL") else {
+            return;
+        };
+        reset_postgres_state();
+        let handle = open_single_conn_pool(&url).await;
+
+        // 1) Direct float8 bind of each non-finite value must error.
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let err = query_rows(
+                &handle,
+                "select $1::float8 as v",
+                &[VmValue::Float(bad)],
+                QueryRouting::Primary,
+            )
+            .await
+            .expect_err("non-finite float8 bind must be rejected before sqlx");
+            assert!(
+                err.to_string().contains("non-finite float"),
+                "error should be the guard's, not a raw sqlx error: {}",
+                err.to_string()
+            );
+        }
+
+        // 2) Non-finite float nested in a jsonb-bound value must also error
+        //    (rather than silently serializing to JSON null).
+        let err = query_rows(
+            &handle,
+            "select $1::jsonb as payload",
+            &[dict(&[("ratio", VmValue::Float(f64::NAN))])],
+            QueryRouting::Primary,
+        )
+        .await
+        .expect_err("non-finite float in jsonb path must be rejected");
+        assert!(
+            err.to_string().contains("non-finite float"),
+            "jsonb path should hit the same guard: {}",
+            err.to_string()
+        );
+
+        // 3) A finite float still round-trips unchanged.
+        let row = query_rows(
+            &handle,
+            "select $1::float8 as v",
+            &[VmValue::Float(1.5)],
+            QueryRouting::Primary,
+        )
+        .await
+        .expect("finite float bind must still work")
+        .remove(0);
+        assert!(
+            matches!(row.as_dict().unwrap().get("v"), Some(VmValue::Float(f)) if *f == 1.5),
+            "finite float must round-trip unchanged"
+        );
     }
 }


### PR DESCRIPTION
Three pg/LLM fixes for the next release.

## Revert the v0.8.89 `nil`→OID-0 (`UntypedNull`) Postgres bind
Binding `nil` as an unspecified-type NULL (OID 0) is incompatible with sqlx's binary wire protocol: declaring **any** parameter as OID 0 makes Postgres re-resolve the **whole** parameter-type list during `Parse`, so concrete non-null sibling params get types that no longer match the client-side binary encodings sqlx already produced → `incorrect binary data format in bind parameter N` / `insufficient data left in message` (and `could not determine data type` in genuinely ambiguous contexts). This broke **27 harn-cloud queries** that mix a `nil` param with non-null typed params (verified: a local patch of harn-cloud onto this revert restores all 27 to green). Restore `query.bind(None::<String>)` (TEXT) — the long-stable behavior; narrow cache-poisoning / typed-column cases are disambiguated at the query layer with an explicit cast. A proper **describe-then-bind** replacement (encode each NULL with the server-described param OID) is being implemented separately for the next release.

## Fix Anthropic `tool_choice` serialization
The direct Anthropic provider passed `tool_choice` through verbatim — a bare OpenAI-style string (`"auto"`/`"none"`/`"required"`) — which Anthropic's Messages API rejects with `HTTP 400: tool_choice: Input should be an object`. Now normalized to Anthropic's object form (`{"type":"auto"|"any"|"none"|"tool"}`), mapping the OpenAI dialect. This unbroke tool-using agent loops on `--provider anthropic`.

## Reject non-finite float binds
`bind_params` bound `f64` NaN/Infinity raw (corrupts a `float8` column's downstream JSON, or silently becomes `null` on the jsonb path). Now rejected up front with a clear error, walking nested list/dict/struct values too.

Each fix has unit + (where applicable) live-Postgres tests; `cargo fmt`/clippy clean; non-null binds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)