### PR TITLE
Add scheduled eval trigger handlers

### DIFF
--- a/changelog.d/3122.added.md
+++ b/changelog.d/3122.added.md
@@ -1,0 +1,3 @@
+- Added cron-bindable eval-pack trigger handlers via `eval_pack://...`,
+  including trigger budget, retry, replay, DLQ, cancellation, ledger, docs, and
+  conformance coverage.

--- a/conformance/tests/triggers/trigger_harness_scheduled_eval_suite.expected
+++ b/conformance/tests/triggers/trigger_harness_scheduled_eval_suite.expected
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/triggers/trigger_harness_scheduled_eval_suite.harn
+++ b/conformance/tests/triggers/trigger_harness_scheduled_eval_suite.harn
@@ -1,0 +1,10 @@
+pipeline test(task) {
+  let result = trigger_test_harness("scheduled_eval_suite")
+  __io_println(result.ok)
+  __io_println(result.details.first_status == "succeeded")
+  __io_println(result.details.ledger_rows == 1)
+  __io_println(result.details.ledger_commit == "commit-a")
+  __io_println(result.details.second_status == "skipped")
+  __io_println(result.details.second_budget == "daily_budget_exceeded")
+  __io_println(result.details.skip_stage == "budget")
+}

--- a/crates/harn-cli/src/commands/dump_trigger_quickref.rs
+++ b/crates/harn-cli/src/commands/dump_trigger_quickref.rs
@@ -151,12 +151,13 @@ fn generate_file() -> String {
     out.push_str("[exports]\nhandlers = \"lib.harn\"\n\n");
     out.push_str("[[triggers]]\n");
     out.push_str("id = \"github-prs\"\nkind = \"webhook\"\nprovider = \"github\"\nmatch = { path = \"/hooks/github\", events = [\"pull_request.opened\"] }\nhandler = \"handlers::on_pull_request\"\nwhen = \"handlers::should_handle\"\ndedupe_key = \"event.dedupe_key\"\nretry = { max = 7, backoff = \"svix\" }\nbudget = { daily_cost_usd = 5.00, max_concurrent = 4 }\nsecrets = { signing_secret = \"github/webhook-secret\" }\n\n");
-    out.push_str("[[triggers]]\nid = \"weekday-digest\"\nkind = \"cron\"\nprovider = \"cron\"\nschedule = \"0 9 * * 1-5\"\ntimezone = \"America/Los_Angeles\"\nhandler = \"handlers::send_digest\"\n```\n\n");
+    out.push_str("[[triggers]]\nid = \"weekday-digest\"\nkind = \"cron\"\nprovider = \"cron\"\nmatch = { events = [\"cron.tick\"] }\nschedule = \"0 9 * * 1-5\"\ntimezone = \"America/Los_Angeles\"\nhandler = \"handlers::send_digest\"\n\n");
+    out.push_str("[[triggers]]\nid = \"nightly-regression\"\nkind = \"cron\"\nprovider = \"cron\"\nmatch = { events = [\"cron.tick\"] }\nschedule = \"0 3 * * *\"\ntimezone = \"UTC\"\nhandler = \"eval_pack://scheduled-regression\"\nbudget = { daily_cost_usd = 0.25, on_budget_exhausted = \"retry_later\" }\nconcurrency = { max = 1 }\n```\n\n");
     out.push_str("Key fields: `id`, `kind`, `provider`, `handler`, `path` or `match.path`, `match.events`, `when`, `dedupe_key`, `retry`, `budget`, `secrets`, `schedule`, `timezone`, and provider-specific config tables such as `poll`.\n\n");
     out.push_str("Audit a project before deploy with `harn routes <root> --json`; it reports each declarative trigger's route path, handler module, budgets, inferred host capabilities, vendor-lock disclosure, and prompt/template overhead without executing handler code.\n\n");
 
     out.push_str("## Handler variants\n\n");
-    out.push_str("`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; `SpawnToPool` and `ReminderInject` ship today, more variants will plug into the same syntax over time.\n\n");
+    out.push_str("`handler:` accepts a closure (in-process), an `a2a://`, `worker://`, or `eval_pack://` URI string, or a handler-variant dict. `eval_pack://<target>` resolves a bare target from `[package].evals` by id/name/file stem or a path-like target relative to `harn.toml`, then dispatches through `eval_pack_run(manifest, options?)` under the trigger's normal budget, retry, DLQ, replay/cancel, and flow-control rules. The dict form covers compositions that need more than a single callable; `SpawnToPool` and `ReminderInject` ship today, more variants will plug into the same syntax over time.\n\n");
     out.push_str("```harn\n");
     out.push_str("import { SpawnToPool } from \"std/triggers\"\n");
     out.push_str("import { pool_create } from \"std/lifecycle/pool\"\n\n");

--- a/crates/harn-cli/src/commands/mcp/serve/util.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/util.rs
@@ -60,6 +60,13 @@ pub(super) fn handler_json(handler: &CollectedTriggerHandler) -> JsonValue {
             "name": binding.name,
             "entry_workflow": binding.entry_workflow,
         }),
+        CollectedTriggerHandler::EvalPack {
+            target, manifest, ..
+        } => json!({
+            "kind": "eval_pack",
+            "target": target,
+            "pack_id": manifest.id.clone(),
+        }),
     }
 }
 

--- a/crates/harn-cli/src/commands/orchestrator/harness/routing.rs
+++ b/crates/harn-cli/src/commands/orchestrator/harness/routing.rs
@@ -503,6 +503,7 @@ pub(super) fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
         CollectedTriggerHandler::A2a { .. } => "a2a",
         CollectedTriggerHandler::Worker { .. } => "worker",
         CollectedTriggerHandler::Persona { .. } => "persona",
+        CollectedTriggerHandler::EvalPack { .. } => "eval_pack",
     }
 }
 

--- a/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
+++ b/crates/harn-cli/src/commands/orchestrator/inspect_data.rs
@@ -768,6 +768,7 @@ fn handler_kind(handler: &CollectedTriggerHandler) -> &'static str {
         CollectedTriggerHandler::A2a { .. } => "a2a",
         CollectedTriggerHandler::Worker { .. } => "worker",
         CollectedTriggerHandler::Persona { .. } => "persona",
+        CollectedTriggerHandler::EvalPack { .. } => "eval_pack",
     }
 }
 

--- a/crates/harn-cli/src/commands/routes.rs
+++ b/crates/harn-cli/src/commands/routes.rs
@@ -189,33 +189,29 @@ fn describe_trigger(
     cache: &mut ModuleCache,
 ) -> Result<RouteTrigger, String> {
     let handler_uri = parse_trigger_handler_uri(trigger).map_err(|error| error.to_string())?;
+    use TriggerHandlerUri::*;
     let mut capabilities = BTreeSet::new();
     let mut module = None;
     let mut vendor_locked = false;
     let mut framework_overhead_tokens = 0u64;
-    let handler = match &handler_uri {
-        TriggerHandlerUri::Local(reference) => {
+    let (handler, dispatch_capability) = match &handler_uri {
+        Local(reference) => {
             let local = analyze_local_function(trigger, reference, manifest_dir, cache)?;
             module = local.module;
             capabilities.extend(local.capabilities);
             vendor_locked |= local.vendor_locked;
             framework_overhead_tokens =
                 framework_overhead_tokens.saturating_add(local.framework_overhead_tokens);
-            reference.function_name.clone()
+            (reference.function_name.clone(), None)
         }
-        TriggerHandlerUri::A2a { target, .. } => {
-            capabilities.insert("worker.dispatch".to_string());
-            format!("a2a://{target}")
-        }
-        TriggerHandlerUri::Worker { queue } => {
-            capabilities.insert("worker.dispatch".to_string());
-            format!("worker://{queue}")
-        }
-        TriggerHandlerUri::Persona { name } => {
-            capabilities.insert("persona.dispatch".to_string());
-            format!("persona://{name}")
-        }
+        A2a { target, .. } => (format!("a2a://{target}"), Some("worker.dispatch")),
+        Worker { queue } => (format!("worker://{queue}"), Some("worker.dispatch")),
+        Persona { name } => (format!("persona://{name}"), Some("persona.dispatch")),
+        EvalPack { target } => (format!("eval_pack://{target}"), Some("eval.dispatch")),
     };
+    if let Some(capability) = dispatch_capability {
+        capabilities.insert(capability.to_string());
+    }
 
     if let Some(when_raw) = trigger.when.as_deref() {
         let reference = parse_local_trigger_ref(when_raw, "when", trigger)

--- a/crates/harn-cli/src/commands/trigger/ops.rs
+++ b/crates/harn-cli/src/commands/trigger/ops.rs
@@ -720,6 +720,7 @@ fn handler_kind(binding: &harn_vm::triggers::registry::TriggerBinding) -> &'stat
         TriggerHandlerSpec::A2a { .. } => "a2a",
         TriggerHandlerSpec::Worker { .. } => "worker",
         TriggerHandlerSpec::Persona { .. } => "persona",
+        TriggerHandlerSpec::EvalPack { .. } => "eval_pack",
         TriggerHandlerSpec::AutoResume { .. } => "auto_resume",
         TriggerHandlerSpec::SpawnToPool { .. } => "spawn_to_pool",
         TriggerHandlerSpec::ReminderInject { .. } => "reminder_inject",
@@ -733,6 +734,7 @@ fn handler_label(binding: &harn_vm::triggers::registry::TriggerBinding) -> Strin
         TriggerHandlerSpec::A2a { target, .. } => target.clone(),
         TriggerHandlerSpec::Worker { queue } => queue.clone(),
         TriggerHandlerSpec::Persona { binding } => binding.name.clone(),
+        TriggerHandlerSpec::EvalPack { target, .. } => target.clone(),
         TriggerHandlerSpec::AutoResume { worker_id } => worker_id.clone(),
         TriggerHandlerSpec::SpawnToPool { pool, .. } => pool.clone(),
         TriggerHandlerSpec::ReminderInject { target, .. } => target.kind().to_string(),
@@ -748,6 +750,7 @@ fn target_uri(binding: &harn_vm::triggers::registry::TriggerBinding) -> String {
         TriggerHandlerSpec::A2a { target, .. } => format!("a2a://{target}"),
         TriggerHandlerSpec::Worker { queue } => format!("worker://{queue}"),
         TriggerHandlerSpec::Persona { binding } => format!("persona://{}", binding.name),
+        TriggerHandlerSpec::EvalPack { target, .. } => format!("eval_pack://{target}"),
         TriggerHandlerSpec::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
         TriggerHandlerSpec::SpawnToPool { pool, .. } => format!("pool://{pool}"),
         TriggerHandlerSpec::ReminderInject { target, .. } => match target {

--- a/crates/harn-cli/src/package/extensions.rs
+++ b/crates/harn-cli/src/package/extensions.rs
@@ -205,6 +205,15 @@ pub async fn collect_manifest_triggers(
                 let binding = persona_runtime_binding_for_handler(extensions, trigger, &name)?;
                 CollectedTriggerHandler::Persona { binding }
             }
+            TriggerHandlerUri::EvalPack { target } => {
+                let manifest = eval_pack_manifest_for_handler(trigger, &target)?;
+                let ledger_options = eval_pack_ledger_options_for_handler(trigger)?;
+                CollectedTriggerHandler::EvalPack {
+                    target,
+                    manifest: Box::new(manifest),
+                    ledger_options,
+                }
+            }
         };
 
         let collected_when = if let Some(when_raw) = &trigger.when {
@@ -437,6 +446,92 @@ fn persona_runtime_binding_for_handler(
     Ok(persona_runtime_binding(name, persona))
 }
 
+fn eval_pack_manifest_for_handler(
+    trigger: &ResolvedTriggerConfig,
+    target: &str,
+) -> Result<harn_vm::orchestration::EvalPackManifest, PackageError> {
+    if eval_pack_target_is_path(target) {
+        let path = resolve_eval_pack_target_path(&trigger.manifest_dir, target);
+        return harn_vm::orchestration::load_eval_pack_manifest(&path).map_err(|error| {
+            trigger_error(
+                trigger,
+                format!(
+                    "handler eval_pack://{target} failed to load eval pack {}: {error}",
+                    path.display()
+                ),
+            )
+        });
+    }
+
+    let paths = load_package_eval_pack_paths(Some(&trigger.manifest_path))
+        .map_err(|error| trigger_error(trigger, error))?;
+    let mut matches = Vec::new();
+    for path in paths {
+        let manifest = harn_vm::orchestration::load_eval_pack_manifest(&path).map_err(|error| {
+            trigger_error(
+                trigger,
+                format!(
+                    "failed to load package eval pack {}: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        let file_stem = path.file_stem().and_then(|stem| stem.to_str());
+        if manifest.id == target
+            || manifest.name.as_deref() == Some(target)
+            || file_stem == Some(target)
+        {
+            matches.push((path, manifest));
+        }
+    }
+
+    match matches.len() {
+        0 => Err(trigger_error(
+            trigger,
+            format!(
+                "handler eval_pack://{target} did not match any [package].evals pack by id, name, or file stem",
+            ),
+        )),
+        1 => Ok(matches.remove(0).1),
+        _ => Err(trigger_error(
+            trigger,
+            format!("handler eval_pack://{target} matched multiple package eval packs"),
+        )),
+    }
+}
+
+fn eval_pack_target_is_path(target: &str) -> bool {
+    target.contains('/')
+        || target.contains('\\')
+        || target.ends_with(".toml")
+        || target.ends_with(".json")
+}
+
+fn resolve_eval_pack_target_path(manifest_dir: &Path, target: &str) -> PathBuf {
+    let path = PathBuf::from(target);
+    if path.is_absolute() {
+        path
+    } else {
+        manifest_dir.join(path)
+    }
+}
+
+fn eval_pack_ledger_options_for_handler(
+    trigger: &ResolvedTriggerConfig,
+) -> Result<Option<serde_json::Value>, PackageError> {
+    let value = trigger
+        .kind_specific
+        .get("eval_options")
+        .or_else(|| trigger.kind_specific.get("ledger"));
+    value
+        .map(|value| {
+            serde_json::to_value(value).map_err(|error| {
+                trigger_error(trigger, format!("invalid eval ledger options: {error}"))
+            })
+        })
+        .transpose()
+}
+
 /// Lower a manifest persona entry into the runtime binding. Centralised so
 /// every call site (`harn persona` CLI, trigger registration, etc.) carries
 /// the same shape — stages included.
@@ -598,6 +693,30 @@ pub fn manifest_trigger_binding_spec(
                 "entry_workflow": binding.entry_workflow,
             }),
         ),
+        CollectedTriggerHandler::EvalPack {
+            target,
+            manifest,
+            ledger_options,
+        } => {
+            let pack_id = manifest.id.clone();
+            let harness_config_fingerprint =
+                harn_vm::orchestration::eval_pack_harness_config_fingerprint(manifest.as_ref())
+                    .ok();
+            (
+                harn_vm::TriggerHandlerSpec::EvalPack {
+                    target: target.clone(),
+                    manifest,
+                    ledger_options: ledger_options.clone(),
+                },
+                serde_json::json!({
+                    "kind": "eval_pack",
+                    "target": target,
+                    "pack_id": pack_id,
+                    "harness_config_fingerprint": harness_config_fingerprint,
+                    "ledger_options": ledger_options,
+                }),
+            )
+        }
     };
 
     let when_raw = trigger

--- a/crates/harn-cli/src/package/extensions_tests.rs
+++ b/crates/harn-cli/src/package/extensions_tests.rs
@@ -928,6 +928,72 @@ secrets = { signing_secret = "github/webhook-secret" }
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn collect_manifest_triggers_accepts_eval_pack_handler_uri() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("evals")).unwrap();
+    let harn_file = write_trigger_project(
+        tmp.path(),
+        r#"
+[package]
+name = "workspace"
+evals = ["evals/nightly.toml"]
+
+[[triggers]]
+id = "nightly-eval"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "eval_pack://nightly"
+schedule = "0 3 * * *"
+timezone = "UTC"
+budget = { daily_cost_usd = 0.50, max_concurrent = 1 }
+ledger = { namespace = "nightly-trigger" }
+"#,
+        None,
+    );
+    fs::write(
+        tmp.path().join("evals/nightly.toml"),
+        r#"
+version = 1
+id = "nightly"
+trials = 1
+
+[metadata]
+model = "mock-model"
+commit = "commit-a"
+branch = "main"
+
+[[cases]]
+id = "case-a"
+run = "run.json"
+"#,
+    )
+    .unwrap();
+
+    let mut vm = test_vm();
+    let collected = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+        .await
+        .expect("trigger collection succeeds");
+
+    assert_eq!(collected.len(), 1);
+    assert!(matches!(
+        &collected[0].handler,
+        CollectedTriggerHandler::EvalPack {
+            target,
+            manifest,
+            ledger_options,
+        } if target == "nightly"
+            && manifest.id == "nightly"
+            && ledger_options.as_ref().and_then(|value| value.get("namespace")).and_then(|value| value.as_str())
+                == Some("nightly-trigger")
+    ));
+    let binding = manifest_trigger_binding_spec(collected.into_iter().next().unwrap());
+    assert_eq!(binding.handler.kind(), "eval_pack");
+    assert_eq!(binding.daily_cost_usd, Some(0.50));
+    assert_eq!(binding.max_concurrent, Some(1));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn collect_manifest_triggers_accepts_harn_provider_override() {
     let tmp = tempfile::tempdir().unwrap();
     let harn_file = write_trigger_project(

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -596,6 +596,9 @@ pub enum TriggerHandlerUri {
     Persona {
         name: String,
     },
+    EvalPack {
+        target: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1357,6 +1360,11 @@ pub enum CollectedTriggerHandler {
     },
     Persona {
         binding: harn_vm::PersonaRuntimeBinding,
+    },
+    EvalPack {
+        target: String,
+        manifest: Box<harn_vm::orchestration::EvalPackManifest>,
+        ledger_options: Option<serde_json::Value>,
     },
 }
 

--- a/crates/harn-cli/src/package/validation.rs
+++ b/crates/harn-cli/src/package/validation.rs
@@ -403,6 +403,17 @@ pub(crate) fn parse_trigger_handler_uri(
             name: name.to_string(),
         });
     }
+    if let Some(target) = raw.strip_prefix("eval_pack://") {
+        if target.is_empty() {
+            return Err(trigger_error(
+                trigger,
+                "handler eval_pack:// target cannot be empty",
+            ));
+        }
+        return Ok(TriggerHandlerUri::EvalPack {
+            target: target.to_string(),
+        });
+    }
     if raw.contains("://") {
         return Err(trigger_error(
             trigger,

--- a/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/action_graph.rs
@@ -70,6 +70,10 @@ pub(super) fn dispatch_success_outcome(
         }
         DispatchUri::A2a { .. } => "completed",
         DispatchUri::Local { .. } => "success",
+        DispatchUri::EvalPack { .. } => match result.get("pass").and_then(|v| v.as_bool()) {
+            Some(false) => "eval_failed",
+            _ => "eval_passed",
+        },
         DispatchUri::AutoResume { .. } => "resumed",
         // SpawnToPool reports the same accept/reject distinction we record
         // on the dispatch metadata so observers (run viewer, audit log) can
@@ -248,6 +252,10 @@ pub(super) fn dispatch_node_metadata(
     if let DispatchUri::Persona { name } = route {
         metadata.insert("persona".to_string(), serde_json::json!(name));
     }
+    if let DispatchUri::EvalPack { target, pack_id } = route {
+        metadata.insert("eval_pack_target".to_string(), serde_json::json!(target));
+        metadata.insert("eval_pack_id".to_string(), serde_json::json!(pack_id));
+    }
     if let DispatchUri::SpawnToPool {
         pool,
         priority_from,
@@ -327,6 +335,35 @@ pub(super) fn dispatch_success_metadata(
             }
             if let Some(status) = result.get("status").and_then(|value| value.as_str()) {
                 metadata.insert("status".to_string(), serde_json::json!(status));
+            }
+        }
+        DispatchUri::EvalPack { target, pack_id } => {
+            metadata.insert("eval_pack_target".to_string(), serde_json::json!(target));
+            metadata.insert("eval_pack_id".to_string(), serde_json::json!(pack_id));
+            for field in [
+                "pass",
+                "total",
+                "passed",
+                "failed",
+                "blocking_failed",
+                "trial_count",
+            ] {
+                if let Some(value) = result.get(field).cloned() {
+                    metadata.insert(field.to_string(), value);
+                }
+            }
+            if let Some(run_state) = result.get("run_state").and_then(|value| value.as_object()) {
+                for field in [
+                    "ledger_rows_inserted",
+                    "ledger_rows_duplicate",
+                    "executed_cells",
+                    "skipped_cells",
+                    "all_skipped",
+                ] {
+                    if let Some(value) = run_state.get(field).cloned() {
+                        metadata.insert(field.to_string(), value);
+                    }
+                }
             }
         }
         DispatchUri::SpawnToPool { pool, .. } => {

--- a/crates/harn-vm/src/triggers/dispatcher/audit.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/audit.rs
@@ -322,6 +322,7 @@ impl Dispatcher {
         route: &DispatchUri,
         event: &TriggerEvent,
         replay_of_event_id: Option<&String>,
+        stage: DispatchSkipStage,
         reason: &str,
     ) -> Result<(), DispatchError> {
         self.append_topic_event(
@@ -348,12 +349,45 @@ impl Dispatcher {
             route,
             event,
             replay_of_event_id,
-            DispatchSkipStage::Predicate,
+            stage,
             serde_json::json!({
                 "deferred": true,
                 "reason": reason,
                 "retry_at": next_budget_reset_rfc3339(binding),
             }),
+        )
+        .await
+    }
+
+    pub(super) async fn append_trigger_budget_exhausted_event(
+        &self,
+        binding: &TriggerBinding,
+        route: &DispatchUri,
+        event: &TriggerEvent,
+        replay_of_event_id: Option<&String>,
+        reason: &str,
+        expected_cost_usd_micros: u64,
+    ) -> Result<(), DispatchError> {
+        self.append_lifecycle_event(
+            "trigger.budget_exceeded",
+            event,
+            binding,
+            serde_json::json!({
+                "trigger_id": binding.id.as_str(),
+                "event_id": event.id.0,
+                "handler_kind": route.kind(),
+                "target_uri": route.target_uri(),
+                "reason": reason,
+                "strategy": binding.on_budget_exhausted.as_str(),
+                "expected_cost_usd": crate::triggers::micros_to_usd(expected_cost_usd_micros),
+                "cost_usd": crate::triggers::micros_to_usd(expected_cost_usd_micros),
+                "daily_limit_usd": binding.daily_cost_usd,
+                "hourly_limit_usd": binding.hourly_cost_usd,
+                "cost_today_usd": crate::triggers::micros_to_usd(binding.metrics.cost_today_usd_micros.load(Ordering::Relaxed)),
+                "cost_hour_usd": crate::triggers::micros_to_usd(binding.metrics.cost_hour_usd_micros.load(Ordering::Relaxed)),
+                "replay_of_event_id": replay_of_event_id,
+            }),
+            replay_of_event_id,
         )
         .await
     }

--- a/crates/harn-vm/src/triggers/dispatcher/circuits.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/circuits.rs
@@ -110,6 +110,7 @@ impl Dispatcher {
         route: &DispatchUri,
         event: &TriggerEvent,
         replay_of_event_id: Option<&String>,
+        source_node_id: &str,
         final_error: &str,
     ) -> Result<(), DispatchError> {
         let dlq_entry = DlqEntry {
@@ -163,7 +164,7 @@ impl Dispatcher {
                 metadata: dlq_node_metadata(binding, event, 0, final_error),
             }],
             vec![RunActionGraphEdgeRecord {
-                from_id: format!("predicate:{}:{}", binding.binding_key(), event.id.0),
+                from_id: source_node_id.to_string(),
                 to_id: format!("dlq:{}:{}", binding.binding_key(), event.id.0),
                 kind: ACTION_GRAPH_EDGE_KIND_DLQ_MOVE.to_string(),
                 label: Some("budget exhausted".to_string()),

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -30,7 +30,9 @@ use crate::vm::Vm;
 
 use self::uri::DispatchUri;
 use super::registry::{
-    binding_autonomy_budget_would_exceed, matching_bindings, note_autonomous_decision, AgentScope,
+    binding_autonomy_budget_would_exceed, binding_budget_would_exceed, matching_bindings,
+    micros_to_usd, note_autonomous_decision, note_binding_budget_cost,
+    note_orchestrator_budget_cost, orchestrator_budget_would_exceed, usd_to_micros, AgentScope,
     TargetExpr, TriggerBinding, TriggerBudgetExhaustionStrategy, TriggerHandlerSpec,
 };
 use super::{
@@ -728,6 +730,7 @@ impl Dispatcher {
                         &route,
                         &event,
                         replay_of_event_id.as_ref(),
+                        &predicate_node_id,
                         &final_error,
                     )
                     .await?;
@@ -773,6 +776,7 @@ impl Dispatcher {
                         &route,
                         &event,
                         replay_of_event_id.as_ref(),
+                        DispatchSkipStage::Predicate,
                         evaluation.reason.as_deref().unwrap_or("budget_exhausted"),
                     )
                     .await?;
@@ -865,6 +869,20 @@ impl Dispatcher {
             }
 
             source_node_id = predicate_node_id;
+        }
+
+        if let Some(outcome) = self
+            .handle_dispatch_budget_exhaustion(
+                binding,
+                &route,
+                &event,
+                replay_of_event_id.as_ref(),
+                &source_node_id,
+                autonomy_tier,
+            )
+            .await?
+        {
+            return Ok(outcome);
         }
 
         if autonomy_tier == AutonomyTier::ActAuto {
@@ -1229,7 +1247,8 @@ impl Dispatcher {
             match result {
                 Ok(dispatch_result) => {
                     let result = dispatch_result.output;
-                    let dispatch_metadata = dispatch_result.metadata;
+                    let mut dispatch_metadata = dispatch_result.metadata;
+                    self.note_dispatch_result_cost(binding, &result, &mut dispatch_metadata);
                     let attempt_record = DispatchAttemptRecord {
                         trigger_id: binding.id.as_str().to_string(),
                         binding_key: binding.binding_key(),
@@ -1990,6 +2009,196 @@ impl Dispatcher {
         })
     }
 
+    async fn handle_dispatch_budget_exhaustion(
+        &self,
+        binding: &TriggerBinding,
+        route: &DispatchUri,
+        event: &TriggerEvent,
+        replay_of_event_id: Option<&String>,
+        source_node_id: &str,
+        autonomy_tier: AutonomyTier,
+    ) -> Result<Option<DispatchOutcome>, DispatchError> {
+        let expected_cost_usd_micros = 0;
+        let Some(reason) = binding_budget_would_exceed(binding, expected_cost_usd_micros)
+            .or_else(|| orchestrator_budget_would_exceed(expected_cost_usd_micros))
+        else {
+            return Ok(None);
+        };
+        self.append_trigger_budget_exhausted_event(
+            binding,
+            route,
+            event,
+            replay_of_event_id,
+            reason,
+            expected_cost_usd_micros,
+        )
+        .await?;
+
+        if binding.on_budget_exhausted == TriggerBudgetExhaustionStrategy::Warn {
+            return Ok(None);
+        }
+
+        match binding.on_budget_exhausted {
+            TriggerBudgetExhaustionStrategy::Fail => {
+                let final_error = format!("trigger budget exhausted: {reason}");
+                self.move_budget_exhausted_to_dlq(
+                    binding,
+                    route,
+                    event,
+                    replay_of_event_id,
+                    source_node_id,
+                    &final_error,
+                )
+                .await?;
+                finish_in_flight(
+                    binding.id.as_str(),
+                    binding.version,
+                    TriggerDispatchOutcome::Dlq,
+                )
+                .await
+                .map_err(|error| DispatchError::Registry(error.to_string()))?;
+                decrement_in_flight(&self.state);
+                self.append_dispatch_trust_record(
+                    binding,
+                    route,
+                    event,
+                    replay_of_event_id,
+                    autonomy_tier,
+                    TrustOutcome::Failure,
+                    "dlq",
+                    0,
+                    Some(final_error.clone()),
+                )
+                .await?;
+                Ok(Some(DispatchOutcome {
+                    trigger_id: binding.id.as_str().to_string(),
+                    binding_key: binding.binding_key(),
+                    event_id: event.id.0.clone(),
+                    attempt_count: 0,
+                    status: DispatchStatus::Dlq,
+                    handler_kind: route.kind().to_string(),
+                    target_uri: route.target_uri(),
+                    replay_of_event_id: replay_of_event_id.cloned(),
+                    result: None,
+                    error: Some(final_error),
+                }))
+            }
+            TriggerBudgetExhaustionStrategy::RetryLater => {
+                self.append_budget_deferred_event(
+                    binding,
+                    route,
+                    event,
+                    replay_of_event_id,
+                    DispatchSkipStage::Budget,
+                    reason,
+                )
+                .await?;
+                finish_in_flight(
+                    binding.id.as_str(),
+                    binding.version,
+                    TriggerDispatchOutcome::Dispatched,
+                )
+                .await
+                .map_err(|error| DispatchError::Registry(error.to_string()))?;
+                decrement_in_flight(&self.state);
+                self.append_dispatch_trust_record(
+                    binding,
+                    route,
+                    event,
+                    replay_of_event_id,
+                    autonomy_tier,
+                    TrustOutcome::Denied,
+                    "waiting",
+                    0,
+                    Some(reason.to_string()),
+                )
+                .await?;
+                Ok(Some(DispatchOutcome {
+                    trigger_id: binding.id.as_str().to_string(),
+                    binding_key: binding.binding_key(),
+                    event_id: event.id.0.clone(),
+                    attempt_count: 0,
+                    status: DispatchStatus::Waiting,
+                    handler_kind: route.kind().to_string(),
+                    target_uri: route.target_uri(),
+                    replay_of_event_id: replay_of_event_id.cloned(),
+                    result: Some(serde_json::json!({
+                        "deferred": true,
+                        "reason": reason,
+                    })),
+                    error: None,
+                }))
+            }
+            TriggerBudgetExhaustionStrategy::False => {
+                self.append_skipped_outbox_event(
+                    binding,
+                    route,
+                    event,
+                    replay_of_event_id,
+                    DispatchSkipStage::Budget,
+                    serde_json::json!({
+                        "budget": reason,
+                    }),
+                )
+                .await?;
+                finish_in_flight(
+                    binding.id.as_str(),
+                    binding.version,
+                    TriggerDispatchOutcome::Dispatched,
+                )
+                .await
+                .map_err(|error| DispatchError::Registry(error.to_string()))?;
+                decrement_in_flight(&self.state);
+                self.append_dispatch_trust_record(
+                    binding,
+                    route,
+                    event,
+                    replay_of_event_id,
+                    autonomy_tier,
+                    TrustOutcome::Denied,
+                    "skipped",
+                    0,
+                    Some(reason.to_string()),
+                )
+                .await?;
+                Ok(Some(DispatchOutcome {
+                    trigger_id: binding.id.as_str().to_string(),
+                    binding_key: binding.binding_key(),
+                    event_id: event.id.0.clone(),
+                    attempt_count: 0,
+                    status: DispatchStatus::Skipped,
+                    handler_kind: route.kind().to_string(),
+                    target_uri: route.target_uri(),
+                    replay_of_event_id: replay_of_event_id.cloned(),
+                    result: Some(serde_json::json!({
+                        "skipped": true,
+                        "budget": reason,
+                    })),
+                    error: None,
+                }))
+            }
+            TriggerBudgetExhaustionStrategy::Warn => Ok(None),
+        }
+    }
+
+    fn note_dispatch_result_cost(
+        &self,
+        binding: &TriggerBinding,
+        result: &serde_json::Value,
+        metadata: &mut BTreeMap<String, serde_json::Value>,
+    ) {
+        let cost_usd_micros = dispatch_result_cost_usd_micros(result);
+        if cost_usd_micros == 0 {
+            return;
+        }
+        note_binding_budget_cost(binding, cost_usd_micros);
+        note_orchestrator_budget_cost(cost_usd_micros);
+        metadata.insert(
+            "cost_usd".to_string(),
+            serde_json::json!(micros_to_usd(cost_usd_micros)),
+        );
+    }
+
     async fn dispatch_once(
         &self,
         binding: &TriggerBinding,
@@ -2137,6 +2346,32 @@ impl Dispatcher {
                     output: serde_json::to_value(receipt)
                         .map_err(|error| DispatchError::Serde(error.to_string()))?,
                     metadata: route.dispatch_boundary_metadata(),
+                })
+            }
+            DispatchUri::EvalPack { target, pack_id } => {
+                let TriggerHandlerSpec::EvalPack {
+                    manifest,
+                    ledger_options,
+                    ..
+                } = &binding.handler
+                else {
+                    return Err(DispatchError::Local(format!(
+                        "trigger '{}' resolved to an eval_pack dispatch URI but does not carry an eval_pack manifest",
+                        binding.id.as_str()
+                    )));
+                };
+                let report = crate::orchestration::evaluate_eval_pack_manifest_resumable(
+                    manifest,
+                    ledger_options.clone(),
+                )
+                .map_err(|error| DispatchError::Local(error.to_string()))?;
+                let mut metadata = route.dispatch_boundary_metadata();
+                metadata.insert("eval_pack_target".to_string(), serde_json::json!(target));
+                metadata.insert("eval_pack_id".to_string(), serde_json::json!(pack_id));
+                Ok(DispatchCallResult {
+                    output: serde_json::to_value(report)
+                        .map_err(|error| DispatchError::Serde(error.to_string()))?,
+                    metadata,
                 })
             }
             DispatchUri::AutoResume { worker_id } => {
@@ -3072,6 +3307,61 @@ impl Dispatcher {
             .await?;
         Ok(json_value_to_gate(&vm_value_to_json(&value)))
     }
+}
+
+fn dispatch_result_cost_usd_micros(result: &serde_json::Value) -> u64 {
+    for field in ["cost_usd", "costUsd", "total_cost_usd", "totalCostUsd"] {
+        if let Some(cost) = result.get(field).and_then(json_usd_micros) {
+            return cost;
+        }
+    }
+
+    let stats_rows_cost = result
+        .get("stats_rows")
+        .and_then(|rows| rows.as_array())
+        .map(|rows| {
+            rows.iter().fold(0_u64, |acc, row| {
+                acc.saturating_add(
+                    row.get("total_cost_usd")
+                        .or_else(|| row.get("totalCostUsd"))
+                        .and_then(json_usd_micros)
+                        .unwrap_or_default(),
+                )
+            })
+        })
+        .unwrap_or_default();
+    if stats_rows_cost > 0 {
+        return stats_rows_cost;
+    }
+
+    result
+        .get("cases")
+        .and_then(|cases| cases.as_array())
+        .map(|cases| {
+            cases.iter().fold(0_u64, |case_acc, case| {
+                let trial_cost = case
+                    .get("trials")
+                    .and_then(|trials| trials.as_array())
+                    .map(|trials| {
+                        trials.iter().fold(0_u64, |trial_acc, trial| {
+                            trial_acc.saturating_add(
+                                trial
+                                    .get("cost_usd")
+                                    .or_else(|| trial.get("costUsd"))
+                                    .and_then(json_usd_micros)
+                                    .unwrap_or_default(),
+                            )
+                        })
+                    })
+                    .unwrap_or_default();
+                case_acc.saturating_add(trial_cost)
+            })
+        })
+        .unwrap_or_default()
+}
+
+fn json_usd_micros(value: &serde_json::Value) -> Option<u64> {
+    value.as_f64().map(usd_to_micros)
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/tests/dispatch.rs
@@ -113,6 +113,118 @@ pub fn local_fn(event: TriggerEvent) -> dict {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn eval_pack_handler_runs_from_cron_tick_and_sheds_after_budget() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            crate::reset_thread_local_state();
+            let dir = tempfile::tempdir().expect("tempdir");
+            let log = install_default_for_base_dir(dir.path()).expect("install event log");
+            let manifest = crate::triggers::test_util::scheduled_eval_manifest(dir.path())
+                .expect("scheduled eval manifest normalizes");
+
+            let mut vm = Vm::new();
+            register_vm_stdlib(&mut vm);
+            vm.set_source_dir(dir.path());
+            install_manifest_triggers(vec![TriggerBindingSpec {
+                id: "nightly-eval".to_string(),
+                source: TriggerBindingSource::Manifest,
+                kind: "cron".to_string(),
+                provider: ProviderId::from("cron"),
+                autonomy_tier: crate::AutonomyTier::Suggest,
+                handler: TriggerHandlerSpec::EvalPack {
+                    target: "scheduled-eval".to_string(),
+                    manifest: Box::new(manifest),
+                    ledger_options: None,
+                },
+                dispatch_priority: crate::WorkerQueuePriority::Normal,
+                when: None,
+                when_budget: None,
+                retry: TriggerRetryConfig::default(),
+                match_events: vec!["cron.tick".to_string()],
+                dedupe_key: None,
+                dedupe_retention_days: crate::triggers::DEFAULT_INBOX_RETENTION_DAYS,
+                filter: None,
+                daily_cost_usd: Some(0.10),
+                hourly_cost_usd: None,
+                max_autonomous_decisions_per_hour: None,
+                max_autonomous_decisions_per_day: None,
+                on_budget_exhausted: crate::TriggerBudgetExhaustionStrategy::False,
+                max_concurrent: None,
+                flow_control: crate::triggers::TriggerFlowControlConfig {
+                    concurrency: Some(crate::triggers::TriggerConcurrencyConfig {
+                        key: None,
+                        max: 1,
+                    }),
+                    ..Default::default()
+                },
+                aggregation: None,
+                manifest_path: None,
+                package_name: Some("workspace".to_string()),
+                definition_fingerprint: "fp:scheduled-eval".to_string(),
+            }])
+            .await
+            .expect("install eval trigger");
+
+            let dispatcher = Dispatcher::with_event_log(vm, log.clone());
+            let first = dispatcher
+                .dispatch_event(crate::triggers::test_util::scheduled_eval_cron_tick(
+                    "nightly-eval",
+                    "tick-1",
+                ))
+                .await
+                .expect("first tick dispatches");
+
+            assert_eq!(first.len(), 1);
+            assert_eq!(first[0].status, DispatchStatus::Succeeded);
+            let report = first[0].result.as_ref().expect("eval report");
+            assert_eq!(report["pack_id"], serde_json::json!("scheduled-eval"));
+            assert_eq!(report["pass"], serde_json::json!(true));
+            assert_eq!(
+                report["run_state"]["ledger_rows_inserted"],
+                serde_json::json!(1)
+            );
+
+            let ledger = crate::orchestration::eval_ledger_read_report(Some(serde_json::json!({
+                "namespace": "scheduled-eval",
+            })))
+            .expect("ledger read");
+            assert_eq!(ledger.rows.len(), 1);
+            assert_eq!(ledger.rows[0].suite, "scheduled-eval");
+            assert_eq!(ledger.rows[0].provenance.commit, "commit-a");
+
+            let second = dispatcher
+                .dispatch_event(crate::triggers::test_util::scheduled_eval_cron_tick(
+                    "nightly-eval",
+                    "tick-2",
+                ))
+                .await
+                .expect("second tick sheds");
+            assert_eq!(second.len(), 1);
+            assert_eq!(second[0].status, DispatchStatus::Skipped);
+            assert_eq!(
+                second[0].result,
+                Some(serde_json::json!({
+                    "skipped": true,
+                    "budget": "daily_budget_exceeded",
+                }))
+            );
+
+            let outbox = read_topic(log.clone(), "trigger.outbox").await;
+            let skipped = outbox
+                .iter()
+                .find(|(_, event)| event.kind == "dispatch_skipped")
+                .expect("budget-shed tick emits skipped outbox record");
+            assert_eq!(skipped.1.payload["skip_stage"], serde_json::json!("budget"));
+            assert_eq!(
+                skipped.1.payload["detail"]["budget"],
+                serde_json::json!("daily_budget_exceeded")
+            );
+        })
+        .await;
+}
+
 #[tokio::test(start_paused = true, flavor = "current_thread")]
 async fn a2a_handler_returns_inline_result_and_emits_a2a_action_graph() {
     let local = tokio::task::LocalSet::new();

--- a/crates/harn-vm/src/triggers/dispatcher/types.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/types.rs
@@ -342,6 +342,7 @@ pub(super) struct DispatchCallResult {
 
 #[derive(Clone, Debug)]
 pub(super) enum DispatchSkipStage {
+    Budget,
     Predicate,
     FlowControl,
 }
@@ -391,6 +392,7 @@ impl DispatchError {
 impl DispatchSkipStage {
     pub(super) fn as_str(&self) -> &'static str {
         match self {
+            Self::Budget => "budget",
             Self::Predicate => "predicate",
             Self::FlowControl => "flow_control",
         }

--- a/crates/harn-vm/src/triggers/dispatcher/uri.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/uri.rs
@@ -36,6 +36,10 @@ pub enum DispatchUri {
     Persona {
         name: String,
     },
+    EvalPack {
+        target: String,
+        pack_id: String,
+    },
     AutoResume {
         worker_id: String,
     },
@@ -104,6 +108,17 @@ impl DispatchUri {
                 name: name.to_string(),
             });
         }
+        if let Some(target) = raw.strip_prefix("eval_pack://") {
+            if target.is_empty() {
+                return Err(DispatchUriError::MissingTarget {
+                    scheme: "eval_pack".to_string(),
+                });
+            }
+            return Ok(Self::EvalPack {
+                target: target.to_string(),
+                pack_id: target.to_string(),
+            });
+        }
         if let Some(pool) = raw.strip_prefix("pool://") {
             if pool.is_empty() {
                 return Err(DispatchUriError::MissingTarget {
@@ -130,6 +145,7 @@ impl DispatchUri {
             Self::A2a { .. } => "a2a",
             Self::Worker { .. } => "worker",
             Self::Persona { .. } => "persona",
+            Self::EvalPack { .. } => "eval_pack",
             Self::AutoResume { .. } => "auto_resume",
             Self::SpawnToPool { .. } => "spawn_to_pool",
             Self::ReminderInject { .. } => "reminder_inject",
@@ -143,6 +159,7 @@ impl DispatchUri {
             Self::A2a { target, .. } => format!("a2a://{target}"),
             Self::Worker { queue } => format!("worker://{queue}"),
             Self::Persona { name } => format!("persona://{name}"),
+            Self::EvalPack { target, .. } => format!("eval_pack://{target}"),
             Self::AutoResume { worker_id } => format!("auto_resume://{worker_id}"),
             Self::SpawnToPool { pool, .. } => format!("pool://{pool}"),
             Self::ReminderInject {
@@ -168,6 +185,7 @@ impl DispatchUri {
             Self::A2a { .. } => "federated_a2a",
             Self::Worker { .. } => "event_log_worker_queue",
             Self::Persona { .. } => "persona_runtime",
+            Self::EvalPack { .. } => "local_process",
             Self::AutoResume { .. } => "local_process",
             Self::SpawnToPool { .. } => "local_process",
             Self::ReminderInject { .. } => "local_process",
@@ -181,6 +199,7 @@ impl DispatchUri {
             Self::A2a { .. } => "remote",
             Self::Worker { .. } => "queued",
             Self::Persona { .. } => "managed_persona",
+            Self::EvalPack { .. } => "in_process",
             Self::AutoResume { .. } => "in_process",
             Self::SpawnToPool { .. } => "pool_queued",
             Self::ReminderInject { .. } => "in_process",
@@ -233,6 +252,12 @@ impl From<&TriggerHandlerSpec> for DispatchUri {
             },
             TriggerHandlerSpec::Persona { binding } => Self::Persona {
                 name: binding.name.clone(),
+            },
+            TriggerHandlerSpec::EvalPack {
+                target, manifest, ..
+            } => Self::EvalPack {
+                target: target.clone(),
+                pack_id: manifest.id.clone(),
             },
             TriggerHandlerSpec::AutoResume { worker_id } => Self::AutoResume {
                 worker_id: worker_id.clone(),

--- a/crates/harn-vm/src/triggers/registry.rs
+++ b/crates/harn-vm/src/triggers/registry.rs
@@ -151,6 +151,11 @@ pub enum TriggerHandlerSpec {
     Persona {
         binding: crate::PersonaRuntimeBinding,
     },
+    EvalPack {
+        target: String,
+        manifest: Box<crate::orchestration::EvalPackManifest>,
+        ledger_options: Option<serde_json::Value>,
+    },
     AutoResume {
         worker_id: String,
     },
@@ -287,6 +292,16 @@ impl std::fmt::Debug for TriggerHandlerSpec {
                 .debug_struct("Persona")
                 .field("name", &binding.name)
                 .finish(),
+            Self::EvalPack {
+                target,
+                manifest,
+                ledger_options,
+            } => f
+                .debug_struct("EvalPack")
+                .field("target", target)
+                .field("pack_id", &manifest.id)
+                .field("ledger_options", ledger_options)
+                .finish(),
             Self::AutoResume { worker_id } => f
                 .debug_struct("AutoResume")
                 .field("worker_id", worker_id)
@@ -341,6 +356,7 @@ impl TriggerHandlerSpec {
             Self::A2a { .. } => "a2a",
             Self::Worker { .. } => "worker",
             Self::Persona { .. } => "persona",
+            Self::EvalPack { .. } => "eval_pack",
             Self::AutoResume { .. } => "auto_resume",
             Self::SpawnToPool { .. } => "spawn_to_pool",
             Self::ReminderInject { .. } => "reminder_inject",
@@ -747,6 +763,25 @@ pub fn note_orchestrator_budget_cost(cost_usd_micros: u64) {
     });
 }
 
+pub(crate) fn note_binding_budget_cost(binding: &TriggerBinding, cost_usd_micros: u64) {
+    if cost_usd_micros == 0 {
+        return;
+    }
+    reset_binding_budget_windows(binding);
+    binding
+        .metrics
+        .cost_total_usd_micros
+        .fetch_add(cost_usd_micros, Ordering::Relaxed);
+    binding
+        .metrics
+        .cost_today_usd_micros
+        .fetch_add(cost_usd_micros, Ordering::Relaxed);
+    binding
+        .metrics
+        .cost_hour_usd_micros
+        .fetch_add(cost_usd_micros, Ordering::Relaxed);
+}
+
 pub fn orchestrator_budget_would_exceed(expected_cost_usd_micros: u64) -> Option<&'static str> {
     ORCHESTRATOR_BUDGET.with(|slot| {
         let mut state = slot.borrow_mut();
@@ -1135,7 +1170,10 @@ pub(crate) fn matching_bindings(event: &super::TriggerEvent) -> Vec<Arc<TriggerB
                     continue;
                 }
                 if !binding.match_events.is_empty()
-                    && !binding.match_events.iter().any(|kind| kind == &event.kind)
+                    && !binding
+                        .match_events
+                        .iter()
+                        .any(|kind| trigger_event_kind_matches(event, kind))
                 {
                     continue;
                 }
@@ -1151,6 +1189,16 @@ pub(crate) fn matching_bindings(event: &super::TriggerEvent) -> Vec<Arc<TriggerB
         });
         bindings
     })
+}
+
+fn trigger_event_kind_matches(event: &super::TriggerEvent, expected: &str) -> bool {
+    if expected == event.kind {
+        return true;
+    }
+    expected
+        .strip_prefix(event.provider.as_str())
+        .and_then(|rest| rest.strip_prefix('.'))
+        .is_some_and(|kind| kind == event.kind)
 }
 
 pub async fn install_manifest_triggers(

--- a/crates/harn-vm/src/triggers/test_util/mod.rs
+++ b/crates/harn-vm/src/triggers/test_util/mod.rs
@@ -21,8 +21,8 @@ use crate::connectors::{
     RawInbound, TriggerBinding as ConnectorTriggerBinding,
 };
 use crate::event_log::{
-    install_memory_for_current_thread, AnyEventLog, EventLog, FileEventLog, LogEvent,
-    MemoryEventLog, Topic,
+    install_default_for_base_dir, install_memory_for_current_thread, AnyEventLog, EventLog,
+    FileEventLog, LogEvent, MemoryEventLog, Topic,
 };
 use crate::secrets::{
     RotationHandle, SecretBytes, SecretError, SecretId, SecretMeta, SecretProvider,
@@ -62,6 +62,7 @@ pub const TRIGGER_TEST_FIXTURES: &[&str] = &[
     "rate_limit_throttles",
     "replay_binding_gc_fallback",
     "replay_refires_from_dlq",
+    "scheduled_eval_suite",
     "webhook_dedupe_blocks_duplicates",
     "webhook_verifies_hmac",
 ];
@@ -242,6 +243,7 @@ impl TriggerTestHarness {
             "rate_limit_throttles" => self.rate_limit_throttles().await,
             "replay_binding_gc_fallback" => self.replay_binding_gc_fallback().await,
             "replay_refires_from_dlq" => self.replay_refires_from_dlq().await,
+            "scheduled_eval_suite" => self.scheduled_eval_suite().await,
             "webhook_dedupe_blocks_duplicates" => self.webhook_dedupe_blocks_duplicates().await,
             "webhook_verifies_hmac" => self.webhook_verifies_hmac().await,
             _ => Err(format!(
@@ -1073,6 +1075,129 @@ impl TriggerTestHarness {
         })
     }
 
+    async fn scheduled_eval_suite(self) -> Result<TriggerHarnessResult, String> {
+        let guard = ScopedTriggerHarnessState::new("scheduled-eval-suite")?;
+        let log = install_default_for_base_dir(guard.path()).map_err(|error| error.to_string())?;
+        let manifest = scheduled_eval_manifest(guard.path())?;
+
+        let mut vm = crate::Vm::new();
+        crate::register_vm_stdlib(&mut vm);
+        vm.set_source_dir(guard.path());
+
+        install_manifest_triggers(vec![TriggerBindingSpec {
+            id: "nightly-eval".to_string(),
+            source: TriggerBindingSource::Manifest,
+            kind: "cron".to_string(),
+            provider: ProviderId::from("cron"),
+            autonomy_tier: crate::AutonomyTier::Suggest,
+            handler: TriggerHandlerSpec::EvalPack {
+                target: "scheduled-eval".to_string(),
+                manifest: Box::new(manifest),
+                ledger_options: None,
+            },
+            dispatch_priority: crate::WorkerQueuePriority::Normal,
+            when: None,
+            when_budget: None,
+            retry: TriggerRetryConfig::default(),
+            match_events: vec!["cron.tick".to_string()],
+            dedupe_key: None,
+            dedupe_retention_days: DEFAULT_INBOX_RETENTION_DAYS,
+            filter: None,
+            daily_cost_usd: Some(0.10),
+            hourly_cost_usd: None,
+            max_autonomous_decisions_per_hour: None,
+            max_autonomous_decisions_per_day: None,
+            on_budget_exhausted: crate::TriggerBudgetExhaustionStrategy::False,
+            max_concurrent: None,
+            flow_control: crate::triggers::TriggerFlowControlConfig {
+                concurrency: Some(crate::triggers::TriggerConcurrencyConfig { key: None, max: 1 }),
+                ..Default::default()
+            },
+            aggregation: None,
+            manifest_path: None,
+            package_name: Some("workspace".to_string()),
+            definition_fingerprint: "fp:scheduled-eval".to_string(),
+        }])
+        .await
+        .map_err(|error| error.to_string())?;
+
+        let dispatcher = crate::triggers::Dispatcher::with_event_log(vm, log.clone());
+        let first = dispatcher
+            .dispatch_event(scheduled_eval_cron_tick("nightly-eval", "tick-1"))
+            .await
+            .map_err(|error| error.to_string())?;
+        let second = dispatcher
+            .dispatch_event(scheduled_eval_cron_tick("nightly-eval", "tick-2"))
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let ledger = crate::orchestration::eval_ledger_read_report(Some(json!({
+            "namespace": "scheduled-eval",
+        })))
+        .map_err(|error| error.to_string())?;
+        let outbox = read_log_topic(log, crate::TRIGGER_OUTBOX_TOPIC).await?;
+        let skipped = outbox
+            .iter()
+            .find(|(_, event)| event.kind == "dispatch_skipped");
+
+        let first_status = first
+            .first()
+            .map(|outcome| outcome.status.as_str())
+            .unwrap_or("missing");
+        let second_status = second
+            .first()
+            .map(|outcome| outcome.status.as_str())
+            .unwrap_or("missing");
+        let second_budget = second
+            .first()
+            .and_then(|outcome| outcome.result.as_ref())
+            .and_then(|result| result.get("budget"))
+            .and_then(JsonValue::as_str)
+            .unwrap_or("");
+        let skip_stage = skipped
+            .and_then(|(_, event)| event.payload.get("skip_stage"))
+            .and_then(JsonValue::as_str)
+            .unwrap_or("");
+
+        let report = first
+            .first()
+            .and_then(|outcome| outcome.result.as_ref())
+            .cloned()
+            .unwrap_or(JsonValue::Null);
+        let ok = first_status == "succeeded"
+            && report.get("pack_id").and_then(JsonValue::as_str) == Some("scheduled-eval")
+            && report.get("pass").and_then(JsonValue::as_bool) == Some(true)
+            && ledger.rows.len() == 1
+            && ledger.rows[0].provenance.commit == "commit-a"
+            && second_status == "skipped"
+            && second_budget == "daily_budget_exceeded"
+            && skip_stage == "budget";
+
+        Ok(TriggerHarnessResult {
+            fixture: "scheduled_eval_suite".to_string(),
+            ok,
+            stub: false,
+            summary: "cron triggers can dispatch eval packs and shed later ticks on spent budget"
+                .to_string(),
+            emitted: Vec::new(),
+            attempts: Vec::new(),
+            dlq: Vec::new(),
+            alerts: Vec::new(),
+            bindings: snapshot_trigger_bindings(),
+            notes: Vec::new(),
+            details: json!({
+                "first_status": first_status,
+                "second_status": second_status,
+                "second_budget": second_budget,
+                "skip_stage": skip_stage,
+                "ledger_rows": ledger.rows.len(),
+                "ledger_commit": ledger.rows.first().map(|row| row.provenance.commit.clone()),
+                "pack_id": report.get("pack_id").cloned().unwrap_or(JsonValue::Null),
+                "pass": report.get("pass").cloned().unwrap_or(JsonValue::Null),
+            }),
+        })
+    }
+
     async fn multi_tenant_isolation_stub(self) -> Result<TriggerHarnessResult, String> {
         let tenant_a = synthetic_event("tenant.event", "tenant-a", Some("tenant-a"));
         let tenant_b = synthetic_event("tenant.event", "tenant-b", Some("tenant-b"));
@@ -1473,6 +1598,120 @@ impl SecretProvider for EmptySecretProvider {
     fn supports_versions(&self) -> bool {
         false
     }
+}
+
+struct ScopedTriggerHarnessState {
+    path: PathBuf,
+}
+
+impl ScopedTriggerHarnessState {
+    fn new(label: &str) -> Result<Self, String> {
+        clear_dispatcher_state_for_harness();
+        let path =
+            std::env::temp_dir().join(format!("harn-trigger-harness-{label}-{}", Uuid::new_v4()));
+        fs::create_dir_all(&path).map_err(|error| error.to_string())?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for ScopedTriggerHarnessState {
+    fn drop(&mut self) {
+        clear_dispatcher_state_for_harness();
+        crate::event_log::reset_active_event_log();
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn clear_dispatcher_state_for_harness() {
+    crate::triggers::clear_dispatcher_state();
+    clear_trigger_registry();
+}
+
+pub(crate) fn scheduled_eval_cron_tick(trigger_id: &str, dedupe_key: &str) -> TriggerEvent {
+    let tick_at = OffsetDateTime::from_unix_timestamp(1).expect("valid timestamp");
+    TriggerEvent::new(
+        ProviderId::from("cron"),
+        "tick",
+        Some(tick_at),
+        dedupe_key,
+        None,
+        BTreeMap::new(),
+        ProviderPayload::Known(KnownProviderPayload::Cron(
+            crate::triggers::CronEventPayload {
+                cron_id: Some(trigger_id.to_string()),
+                schedule: Some("0 3 * * *".to_string()),
+                tick_at,
+                raw: json!({"timezone": "UTC"}),
+            },
+        )),
+        SignatureStatus::Verified,
+    )
+}
+
+pub(crate) fn scheduled_eval_manifest(
+    base_dir: &std::path::Path,
+) -> Result<crate::orchestration::EvalPackManifest, String> {
+    let payload = json!({
+        "id": "scheduled-eval",
+        "base_dir": base_dir.display().to_string(),
+        "trials": 1,
+        "metadata": {
+            "model": "mock-model",
+            "commit": "commit-a",
+            "branch": "main",
+            "tool_format": "native-json",
+            "pipeline_rev": "rev-a",
+            "ledger_namespace": "scheduled-eval"
+        },
+        "fixtures": [{
+            "id": "pass-run",
+            "kind": "run-record",
+            "inline": {
+                "_type": "workflow_run",
+                "id": "run_pass",
+                "workflow_id": "workflow_1",
+                "task": "demo",
+                "status": "completed",
+                "usage": {
+                    "total_duration_ms": 1000,
+                    "total_cost": 0.25,
+                    "input_tokens": 3,
+                    "output_tokens": 4,
+                    "call_count": 1,
+                    "models": ["mock"]
+                },
+                "replay_fixture": {
+                    "_type": "replay_fixture",
+                    "expected_status": "completed",
+                    "stage_assertions": []
+                }
+            }
+        }],
+        "rubrics": [{
+            "id": "completed",
+            "kind": "deterministic",
+            "assertions": [{"kind": "run-status", "expected": "completed"}]
+        }],
+        "cases": [{"id": "pass-case", "run": "pass-run", "rubrics": ["completed"]}]
+    });
+    crate::orchestration::normalize_eval_pack_manifest_value(&crate::stdlib::json_to_vm_value(
+        &payload,
+    ))
+    .map_err(|error| error.to_string())
+}
+
+async fn read_log_topic(
+    log: Arc<AnyEventLog>,
+    topic: &str,
+) -> Result<Vec<(u64, LogEvent)>, String> {
+    let topic = Topic::new(topic).map_err(|error| error.to_string())?;
+    log.read_range(&topic, None, usize::MAX)
+        .await
+        .map_err(|error| error.to_string())
 }
 
 pub async fn run_trigger_harness_fixture(fixture: &str) -> Result<TriggerHarnessResult, String> {

--- a/docs/llm/harn-triggers-quickref.md
+++ b/docs/llm/harn-triggers-quickref.md
@@ -36,9 +36,21 @@ secrets = { signing_secret = "github/webhook-secret" }
 id = "weekday-digest"
 kind = "cron"
 provider = "cron"
+match = { events = ["cron.tick"] }
 schedule = "0 9 * * 1-5"
 timezone = "America/Los_Angeles"
 handler = "handlers::send_digest"
+
+[[triggers]]
+id = "nightly-regression"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+schedule = "0 3 * * *"
+timezone = "UTC"
+handler = "eval_pack://scheduled-regression"
+budget = { daily_cost_usd = 0.25, on_budget_exhausted = "retry_later" }
+concurrency = { max = 1 }
 ```
 
 Key fields: `id`, `kind`, `provider`, `handler`, `path` or `match.path`, `match.events`, `when`, `dedupe_key`, `retry`, `budget`, `secrets`, `schedule`, `timezone`, and provider-specific config tables such as `poll`.
@@ -47,7 +59,7 @@ Audit a project before deploy with `harn routes <root> --json`; it reports each 
 
 ## Handler variants
 
-`handler:` accepts a closure (in-process), an `a2a://` or `worker://` URI string, or a handler-variant dict. The dict form covers compositions that need more than a single callable; `SpawnToPool` and `ReminderInject` ship today, more variants will plug into the same syntax over time.
+`handler:` accepts a closure (in-process), an `a2a://`, `worker://`, or `eval_pack://` URI string, or a handler-variant dict. `eval_pack://<target>` resolves a bare target from `[package].evals` by id/name/file stem or a path-like target relative to `harn.toml`, then dispatches through `eval_pack_run(manifest, options?)` under the trigger's normal budget, retry, DLQ, replay/cancel, and flow-control rules. The dict form covers compositions that need more than a single callable; `SpawnToPool` and `ReminderInject` ship today, more variants will plug into the same syntax over time.
 
 ```harn
 import { SpawnToPool } from "std/triggers"

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -6317,6 +6317,16 @@ provenance. Lower-level ledger builtins also accept `split`, `case`,
 `eval_ledger_read`, `eval_ledger_append_rows`,
 `eval_ledger_prior_commit_rows`, and `eval_ledger_resolve_resume_plan`.
 
+Declarative trigger manifests may bind a trigger directly to an eval pack with
+`handler = "eval_pack://<target>"`. A path-like target (`eval_pack://evals/a.toml`
+or an absolute path) loads that TOML/JSON pack relative to `harn.toml`; a bare
+target resolves by pack `id`, `name`, or file stem through `[package].evals` or
+the package's default `harn.eval.toml`. Dispatch runs the normalized manifest
+through the same `eval_pack_run` path as scripts, so cron ticks inherit trigger
+dedupe, retry, DLQ, replay/cancel, budget, and flow-control handling without a
+separate scheduler. Optional trigger-local `ledger = { ... }` or
+`eval_options = { ... }` fields are passed as the `eval_pack_run` options.
+
 Manifests may declare named partitions with a `split` block:
 
 ```toml

--- a/docs/src/triggers.md
+++ b/docs/src/triggers.md
@@ -104,8 +104,11 @@ Predicate evaluation is safety-defaulted:
 - `when_budget.max_cost_usd`, `tokens_max`, and `timeout` cap a single
   predicate evaluation
 - `budget.daily_cost_usd` applies to aggregate predicate spend for the trigger
-  across the current UTC day
-- if either budget is exceeded, the predicate short-circuits to `false`
+  and to handler results that report `cost_usd`, `total_cost_usd`, or eval-pack
+  `stats_rows[*].total_cost_usd`, across the current UTC day
+- if a predicate budget is exceeded, the predicate short-circuits to `false`;
+  if aggregate trigger spend is already exhausted before a handler starts, the
+  dispatcher applies `budget.on_budget_exhausted`
 - replay caches predicate `llm_call(...)` responses so `trigger_replay(...)`
   can deterministically re-evaluate the predicate without hitting a live
   provider

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -57,7 +57,7 @@ that agent.
 
 ## Handler URI schemes
 
-Harn currently accepts three handler forms:
+Harn currently accepts these handler forms:
 
 - local function:
   `handler = "on_event"` or `handler = "handlers::on_event"`
@@ -65,6 +65,8 @@ Harn currently accepts three handler forms:
   `handler = "a2a://reviewer.prod/triage"`
 - worker queue dispatch:
   `handler = "worker://triage-queue"`
+- eval-pack dispatch:
+  `handler = "eval_pack://nightly-regression"`
 
 Unsupported URI schemes fail fast at load time.
 
@@ -94,6 +96,15 @@ in-process HTTPS.
 That scalar priority becomes the default queue priority when the dispatcher
 enqueues the job. An explicit event header `priority` still overrides it at
 dispatch time.
+
+`eval_pack://...` handlers run an eval pack through the same
+`eval_pack_run(manifest, options?)` path as scripts. A bare target resolves by
+pack `id`, `name`, or file stem from `[package].evals` or `harn.eval.toml`; a
+path-like target resolves relative to `harn.toml`. Cron bindings use the normal
+trigger substrate, so budget, retry, DLQ, replay/cancel, dedupe, and
+concurrency controls apply before the suite runs. Optional trigger-local
+`ledger = { ... }` or `eval_options = { ... }` fields are passed as
+`eval_pack_run` options.
 
 Local handlers and predicates resolve through the same module-export plumbing as
 the manifest hook loader:

--- a/examples/triggers/README.md
+++ b/examples/triggers/README.md
@@ -4,6 +4,7 @@ These examples show ready-to-customize `[[triggers]]` shapes. Each directory
 contains `harn.toml`, `lib.harn`, `README.md`, and `SKILL.md` unless noted:
 
 - `cron-daily-digest/`: cron schedule + local handler
+- `scheduled-eval-suite/`: cron schedule + direct eval-pack handler
 - `context-maintenance/`: lifecycle hooks for non-blocking context refresh and crystallization
 - `github-new-issue/`: webhook trigger + local predicate + local handler
 - `a2a-reviewer-fanout/`: a2a-push trigger + remote A2A handler

--- a/examples/triggers/scheduled-eval-suite/README.md
+++ b/examples/triggers/scheduled-eval-suite/README.md
@@ -1,0 +1,12 @@
+# Scheduled eval suite
+
+Cron trigger that runs an eval pack directly through `eval_pack://scheduled-regression`.
+The dispatcher applies the trigger budget, retry, dedupe, DLQ, replay, and
+concurrency controls before calling `eval_pack_run`.
+
+## Verify
+
+```sh
+harn check lib.harn
+harn test package --evals
+```

--- a/examples/triggers/scheduled-eval-suite/SKILL.md
+++ b/examples/triggers/scheduled-eval-suite/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: scheduled-eval-suite
+short: Run an eval pack from a cron trigger.
+description: Cron trigger example that binds directly to an eval pack handler.
+when-to-use: Use when scheduling regression evals through Harn triggers.
+---
+# Scheduled eval suite
+
+Customize `harn.eval.toml`, keep `handler = "eval_pack://scheduled-regression"`,
+and tune `budget` / `concurrency` in `harn.toml` for the expected eval cost.

--- a/examples/triggers/scheduled-eval-suite/fixtures/pass-run.json
+++ b/examples/triggers/scheduled-eval-suite/fixtures/pass-run.json
@@ -1,0 +1,41 @@
+{
+  "_type": "run_record",
+  "id": "scheduled-regression-smoke",
+  "workflow_id": "run",
+  "workflow_name": "scheduled_regression",
+  "task": "scheduled eval smoke",
+  "status": "completed",
+  "started_at": "2026-04-22T00:00:00Z",
+  "finished_at": "2026-04-22T00:00:01Z",
+  "usage": {
+    "total_duration_ms": 1000,
+    "total_cost": 0.01,
+    "input_tokens": 1,
+    "output_tokens": 1,
+    "call_count": 1,
+    "models": ["mock"]
+  },
+  "stages": [
+    {
+      "id": "stage_1",
+      "node_id": "run",
+      "kind": "stage",
+      "status": "completed",
+      "outcome": "success",
+      "started_at": "2026-04-22T00:00:00Z",
+      "finished_at": "2026-04-22T00:00:01Z",
+      "visible_text": "scheduled eval smoke passed"
+    }
+  ],
+  "completed_nodes": ["run"],
+  "replay_fixture": {
+    "_type": "replay_fixture",
+    "id": "scheduled-regression-smoke-fixture",
+    "source_run_id": "scheduled-regression-smoke",
+    "workflow_id": "run",
+    "workflow_name": "scheduled_regression",
+    "created_at": "2026-04-22T00:00:01Z",
+    "expected_status": "completed",
+    "stage_assertions": []
+  }
+}

--- a/examples/triggers/scheduled-eval-suite/harn.eval.toml
+++ b/examples/triggers/scheduled-eval-suite/harn.eval.toml
@@ -1,0 +1,22 @@
+version = 1
+id = "scheduled-regression"
+name = "Scheduled regression suite"
+trials = 1
+
+[metadata]
+model = "mock-model"
+commit = "example-commit"
+branch = "main"
+tool_format = "replay"
+pipeline_rev = "docs-example"
+ledger_namespace = "scheduled-regression"
+
+[[rubrics]]
+id = "completed"
+kind = "deterministic"
+assertions = [{ kind = "run-status", expected = "completed" }]
+
+[[cases]]
+id = "smoke"
+run = "fixtures/pass-run.json"
+rubrics = ["completed"]

--- a/examples/triggers/scheduled-eval-suite/harn.toml
+++ b/examples/triggers/scheduled-eval-suite/harn.toml
@@ -1,0 +1,16 @@
+[package]
+name = "scheduled-eval-suite"
+evals = ["harn.eval.toml"]
+
+[[triggers]]
+id = "nightly-regression"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "eval_pack://scheduled-regression"
+schedule = "0 3 * * *"
+timezone = "UTC"
+dedupe_key = "event.dedupe_key"
+budget = { daily_cost_usd = 0.25, on_budget_exhausted = "retry_later" }
+concurrency = { max = 1 }
+ledger = { namespace = "scheduled-regression" }

--- a/examples/triggers/scheduled-eval-suite/lib.harn
+++ b/examples/triggers/scheduled-eval-suite/lib.harn
@@ -1,0 +1,3 @@
+fn main(_harness: Harness) {
+  log("scheduled eval suite uses eval_pack://scheduled-regression")
+}

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -6315,6 +6315,16 @@ provenance. Lower-level ledger builtins also accept `split`, `case`,
 `eval_ledger_read`, `eval_ledger_append_rows`,
 `eval_ledger_prior_commit_rows`, and `eval_ledger_resolve_resume_plan`.
 
+Declarative trigger manifests may bind a trigger directly to an eval pack with
+`handler = "eval_pack://<target>"`. A path-like target (`eval_pack://evals/a.toml`
+or an absolute path) loads that TOML/JSON pack relative to `harn.toml`; a bare
+target resolves by pack `id`, `name`, or file stem through `[package].evals` or
+the package's default `harn.eval.toml`. Dispatch runs the normalized manifest
+through the same `eval_pack_run` path as scripts, so cron ticks inherit trigger
+dedupe, retry, DLQ, replay/cancel, budget, and flow-control handling without a
+separate scheduler. Optional trigger-local `ledger = { ... }` or
+`eval_options = { ... }` fields are passed as the `eval_pack_run` options.
+
 Manifests may declare named partitions with a `split` block:
 
 ```toml


### PR DESCRIPTION
## Summary
- add `eval_pack://...` trigger handlers so cron bindings can run eval packs through the existing dispatcher path
- inherit trigger budget accounting, DLQ/retry/replay/cancel metadata, and provider-qualified cron event matching
- add the canonical scheduled eval example, docs/spec updates, conformance coverage, and changelog fragment

Closes #3122

## Verification
- `cargo test -q -p harn-vm eval_pack_handler_runs_from_cron_tick_and_sheds_after_budget`
- `cargo test -q -p harn-cli collect_manifest_triggers_accepts_eval_pack_handler_uri`
- `cargo run --quiet --bin harn -- test conformance --filter trigger_harness_scheduled_eval_suite`
- `cargo run --quiet --bin harn -- check examples/triggers/scheduled-eval-suite/lib.harn`
- `(cd examples/triggers/scheduled-eval-suite && cargo run --quiet --bin harn -- test package --evals)`
- `make check-trigger-examples`
- `make check-docs-snippets`
- `make check-language-spec`
- `make check-trigger-quickref`
- `make lint-test-patterns`
- `git diff --check`
- `make test`