### PR TITLE
harn-cli: share one Markdown pipe-escaping helper

### DIFF
--- a/changelog.d/dry-md-escape.changed.md
+++ b/changelog.d/dry-md-escape.changed.md
@@ -1,0 +1,5 @@
+- **Internal: unified the Markdown table-cell pipe escaping used by the CLI
+  report commands.** The eval summary, provider-matrix, provider-support, and
+  diagnostics-catalog commands each carried a private copy of the same
+  `|`-escaping helper; they now share `crate::format::escape_md`. No behavior
+  change to any rendered report.

--- a/crates/harn-cli/src/commands/check/provider_matrix.rs
+++ b/crates/harn-cli/src/commands/check/provider_matrix.rs
@@ -7,6 +7,7 @@ use harn_vm::provider_catalog::{CatalogModel, ModelToolEmpiricalParity, Provider
 
 use crate::cli::CheckOutputFormat;
 use crate::commands::tool_mode_parity::{self, ToolModeParityOverlay};
+use crate::format::escape_md;
 use crate::json_envelope::{to_string_pretty, JsonEnvelope};
 
 pub(crate) const PROVIDER_MATRIX_SCHEMA_VERSION: u32 = 1;
@@ -120,7 +121,7 @@ pub(crate) fn generate_markdown(
         out.push_str(&format!(
             "| `{}` | `{}` | `{}` | `{}` | {} | {} | {} | {} | {} | {} |\n",
             model.provider,
-            escape_markdown_pipes(&model.id),
+            escape_md(&model.id),
             recommended_tool_format_cell(model),
             parity_cell(model),
             empirical
@@ -459,10 +460,6 @@ fn markdown_cell(value: &str) -> String {
     } else {
         format!("`{value}`")
     }
-}
-
-fn escape_markdown_pipes(value: &str) -> String {
-    value.replace('|', "\\|")
 }
 
 #[cfg(test)]

--- a/crates/harn-cli/src/commands/diagnostics_catalog.rs
+++ b/crates/harn-cli/src/commands/diagnostics_catalog.rs
@@ -16,6 +16,8 @@ use std::fmt::Write as _;
 use harn_parser::diagnostic_codes::{Category, Code, RegistryEntry};
 use serde::Serialize;
 
+use crate::format::escape_md;
+
 /// JSON sidecar schema version. Increment on any breaking shape change.
 pub const SCHEMA_VERSION: u32 = 1;
 
@@ -240,7 +242,7 @@ impl Renderer {
                     "| [`{}`](#{}) | {} | {} | {} |",
                     entry.identifier,
                     code_anchor(entry.identifier),
-                    escape_pipe(entry.summary),
+                    escape_md(entry.summary),
                     repair_cell,
                     safety_cell,
                 )
@@ -464,10 +466,6 @@ fn category_anchor(category: Category) -> String {
 
 fn code_anchor(identifier: &str) -> String {
     identifier.to_lowercase()
-}
-
-fn escape_pipe(value: &str) -> String {
-    value.replace('|', "\\|")
 }
 
 /// Drop the leading `#` heading line from a markdown chunk plus any

--- a/crates/harn-cli/src/commands/eval_coding_agent.rs
+++ b/crates/harn-cli/src/commands/eval_coding_agent.rs
@@ -61,6 +61,7 @@ use crate::commands::tool_mode_parity::{
 };
 use crate::dispatch;
 use crate::env_guard::ScopedEnvVar;
+use crate::format::escape_md;
 #[cfg(test)]
 use live_verify::{coding_agent_live_verify_cases, tool_format_override_warning_line};
 use live_verify::{
@@ -1251,14 +1252,14 @@ fn render_markdown(summary: &EvalSummary) -> String {
         let tool_sequence = if run.tool_sequence.is_empty() {
             "-".to_string()
         } else {
-            run.tool_sequence.join(", ").replace('|', "\\|")
+            escape_md(&run.tool_sequence.join(", "))
         };
         out.push_str(&format!(
             "| `{}` | `{}` | `{}` | `{}` | `{}` | `{}` | `{}` | {} | {} | {} | {:.6} | {} | `{}` |\n",
             run.fixture_id,
             run.run_id,
             run.selector.provider,
-            run.selector.model.replace('|', "\\|"),
+            escape_md(&run.selector.model),
             run.tool_format,
             run.fixture_tool_sequence,
             tool_sequence,
@@ -1403,7 +1404,7 @@ fn render_rollup_table(out: &mut String, title: &str, rollups: &[RollupReport]) 
     for rollup in rollups {
         out.push_str(&format!(
             "| `{}` | {} | {} | {} | {} | {:.6} |\n",
-            rollup.key.replace('|', "\\|"),
+            escape_md(&rollup.key),
             rollup.passed_runs,
             rollup.failed_runs,
             rollup.skipped_runs,
@@ -1507,7 +1508,7 @@ fn comparison_evidence_links(comparison: &FormatComparison) -> String {
 fn markdown_link(label: &str, target: &str) -> String {
     format!(
         "[{}]({})",
-        label.replace('|', "\\|"),
+        escape_md(label),
         target
             .replace(' ', "%20")
             .replace('(', "%28")

--- a/crates/harn-cli/src/commands/eval_context.rs
+++ b/crates/harn-cli/src/commands/eval_context.rs
@@ -36,6 +36,7 @@ use harn_vm::orchestration::{
 use crate::cli::EvalContextArgs;
 use crate::dispatch;
 use crate::env_guard::ScopedEnvVar;
+use crate::format::escape_md;
 
 /// Env var the embedded `cli/eval/context` script reads to pick up the
 /// pre-serialised `ContextEvalReport`. The Rust shim does all the
@@ -243,10 +244,6 @@ fn legacy_render_markdown(report: &ContextEvalReport) -> String {
         ));
     }
     out
-}
-
-fn escape_md(value: &str) -> String {
-    value.replace('|', "\\|")
 }
 
 // ─── Dispatch (.harn) render path ────────────────────────────────────────

--- a/crates/harn-cli/src/commands/eval_skill_gate.rs
+++ b/crates/harn-cli/src/commands/eval_skill_gate.rs
@@ -10,6 +10,7 @@ use harn_vm::orchestration::{
 };
 
 use crate::cli::EvalSkillGateArgs;
+use crate::format::escape_md;
 
 pub async fn run(args: EvalSkillGateArgs) -> i32 {
     let manifest = match load_skill_gate_manifest(&args.manifest) {
@@ -179,8 +180,4 @@ fn variant_row(variant: &SkillGateVariantReport) -> String {
         variant.context.delta_tokens,
         escape_md(&variant.failures.join("; "))
     )
-}
-
-fn escape_md(value: &str) -> String {
-    value.replace('|', "\\|")
 }

--- a/crates/harn-cli/src/commands/provider_support.rs
+++ b/crates/harn-cli/src/commands/provider_support.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::cli::ProvidersSupportArgs;
+use crate::format::escape_md;
 
 pub(crate) const PROVIDER_SUPPORT_SCHEMA_VERSION: u32 = 1;
 const DEFAULT_NOTES_PATH: &str = "crates/harn-cli/data/provider_support_notes.toml";
@@ -934,7 +935,9 @@ fn yes_no(value: bool) -> &'static str {
 }
 
 fn markdown_escape(value: &str) -> String {
-    value.replace('|', "\\|").replace('\n', " ")
+    // Pipes would end the table column; newlines would break the row. Share
+    // the pipe escaping with the other report commands and collapse newlines.
+    escape_md(value).replace('\n', " ")
 }
 
 fn write_file(path: &Path, body: &str) -> Result<(), String> {

--- a/crates/harn-cli/src/format.rs
+++ b/crates/harn-cli/src/format.rs
@@ -61,6 +61,14 @@ pub(crate) fn format_duration_ms(duration_ms: u64) -> String {
     }
 }
 
+/// Escape the `|` characters in `value` so it can sit inside a single Markdown
+/// table cell without prematurely ending the column. Several report commands
+/// (eval summaries, provider matrices, diagnostics catalogs) build Markdown
+/// tables and had each grown a private copy of this; keep the escaping uniform.
+pub(crate) fn escape_md(value: &str) -> String {
+    value.replace('|', "\\|")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,5 +102,12 @@ mod tests {
         assert_eq!(format_duration_ms(500), "500ms");
         assert_eq!(format_duration_ms(1_500), "1.5s");
         assert_eq!(format_duration_ms(90_000), "1.5m");
+    }
+
+    #[test]
+    fn escape_md_escapes_only_pipes() {
+        assert_eq!(escape_md("a|b|c"), "a\\|b\\|c");
+        assert_eq!(escape_md("no pipes here"), "no pipes here");
+        assert_eq!(escape_md(""), "");
     }
 }


### PR DESCRIPTION
## What

A DRY pass over `harn-cli`'s report commands. Six commands that emit Markdown tables had each grown a private copy of the same "escape `|` so it doesn't end the table column" helper:

- `eval_skill_gate.rs` — `fn escape_md`
- `eval_context.rs` — `fn escape_md`
- `check/provider_matrix.rs` — `fn escape_markdown_pipes`
- `diagnostics_catalog.rs` — `fn escape_pipe`
- `provider_support.rs` — `fn markdown_escape` (also collapses newlines)
- `eval_coding_agent.rs` — several inline `value.replace('|', "\\|")` calls

Consolidated them into a single `crate::format::escape_md`, which is the existing home for shared CLI formatting helpers (`format_timestamp_rfc3339`, `format_duration_ms`, …). `provider_support`'s `markdown_escape` keeps its extra newline-collapse by composing on top of the shared escaper, so its output is unchanged.

## Tests

- Added a unit test for `escape_md` in `format.rs`.
- `cargo fmt -p harn-cli --check`: clean.
- `cargo clippy -p harn-cli --all-targets` with `RUSTFLAGS="-D warnings"`: clean.
- `cargo test -p harn-cli`: all suites pass.

No behavior change to any rendered report — pure consolidation. Includes a `changelog.d/` fragment.

https://claude.ai/code/session_015XYNBPFcGcBzkWDqN54VY1

---
_Generated by [Claude Code](https://claude.ai/code/session_015XYNBPFcGcBzkWDqN54VY1)_