### PR TITLE
Honor optional injected tool params

### DIFF
--- a/changelog.d/optional-tool-param-injection.fixed.md
+++ b/changelog.d/optional-tool-param-injection.fixed.md
@@ -1,0 +1,4 @@
+- **Tool middleware optional parameter injection.** `tool_inject_param(...,
+  {required: false})` now also marks the injected parameter fragment optional,
+  preventing provider-facing tool schemas from accidentally requiring stripped
+  middleware-only fields such as `_nl_intent`.

--- a/conformance/tests/scenarios/tool_middleware_primitives.expected
+++ b/conformance/tests/scenarios/tool_middleware_primitives.expected
@@ -9,3 +9,8 @@ true
 why
 true
 true
+true
+false
+false
+true
+false

--- a/conformance/tests/scenarios/tool_middleware_primitives.harn
+++ b/conformance/tests/scenarios/tool_middleware_primitives.harn
@@ -94,4 +94,30 @@ pipeline default() {
   let edit_entry = added2.tools[0]
   __io_println(contains(edit_entry.parameters.properties.keys(), "reason"))
   __io_println(contains(edit_entry.parameters.required, "reason"))
+  // (5) Optional injected params must remain optional in both the full
+  // JSON-schema shape and the bare shorthand shape. Provider-facing schema
+  // projection reads the param fragment's `required` bit, so the injection
+  // helper must reflect opts.required there as well as in object.required.
+  let optional_full = tools_use_middleware(
+    tools2,
+    { entry -> tool_inject_param(entry, "note", {type: "string"}, {required: false}) },
+  )
+  let optional_full_entry = optional_full.tools[0]
+  __io_println(contains(optional_full_entry.parameters.properties.keys(), "note"))
+  __io_println(contains(optional_full_entry.parameters.required, "note"))
+  __io_println(optional_full_entry.parameters.properties.note.required)
+  var tools3 = tool_registry()
+  tools3 = tool_define(
+    tools3,
+    "read",
+    "Read a file",
+    {handler: { _ -> "" }, parameters: {path: {type: "string"}}, returns: {type: "string"}},
+  )
+  let optional_bare = tools_use_middleware(
+    tools3,
+    { entry -> tool_inject_param(entry, "note", {type: "string"}, {required: false}) },
+  )
+  let optional_bare_entry = optional_bare.tools[0]
+  __io_println(contains(optional_bare_entry.parameters.keys(), "note"))
+  __io_println(optional_bare_entry.parameters.note.required)
 }

--- a/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/tool_middleware.harn
@@ -318,6 +318,11 @@ pub fn tool_inject_param(entry, name, schema_fragment, opts = nil) {
   }
   let cfg = __tool_mw_dict(opts)
   let required = cfg?.required ?? true
+  let fragment = if type_of(schema_fragment) == "dict" && schema_fragment?.required == nil {
+    schema_fragment + {required: required}
+  } else {
+    schema_fragment
+  }
   let params = entry?.parameters
   if type_of(params) == "dict" && contains(params.keys(), "type")
     && to_string(params.type) == "object" {
@@ -325,7 +330,7 @@ pub fn tool_inject_param(entry, name, schema_fragment, opts = nil) {
     if contains(props.keys(), name) {
       return entry
     }
-    let new_props = props + {[name]: schema_fragment}
+    let new_props = props + {[name]: fragment}
     let req_list = __tool_mw_list(params?.required)
     let new_req = if required && !contains(req_list, name) {
       req_list.push(name)
@@ -340,7 +345,7 @@ pub fn tool_inject_param(entry, name, schema_fragment, opts = nil) {
   if contains(bare.keys(), name) {
     return entry
   }
-  return entry + {parameters: bare + {[name]: schema_fragment}}
+  return entry + {parameters: bare + {[name]: fragment}}
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -718,7 +723,7 @@ pub fn with_audit_log(sink_or_options) {
     let receipt = if receipt_uri == nil {
       base_receipt
     } else {
-      base_receipt + {audit: __merge_audit(base_receipt?.audit, {receipt_uri: receipt_uri})}
+      base_receipt + {audit: __merge_audit(base_receipt.audit, {receipt_uri: receipt_uri})}
     }
     let enriched_result = if receipt_uri == nil {
       result


### PR DESCRIPTION
## Summary
- honor `tool_inject_param(..., { required: false })` in the injected parameter fragment itself
- cover optional injection for full JSON-schema and bare shorthand tool parameter shapes
- add a changelog fragment for the tool middleware fix

## Why
`harn-bump-fleet` issue #140 exposed a release-harness failure where middleware-only `_nl_intent` was projected as required. The binder strips `_nl_intent` before dispatch, so provider-facing schemas must preserve optional injected params.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-optional-tool-param cargo run --quiet --bin harn -- test conformance --filter tool_middleware_primitives`
- pre-push targeted checks (markdown, targeted Rust check, affected Harn fmt/lint, highlight sync)
