### PR TITLE
Gate release drift check on CHANGELOG content, not tip-parenting

### DIFF
--- a/.github/workflows/release-pr-drift-check.yml
+++ b/.github/workflows/release-pr-drift-check.yml
@@ -10,12 +10,16 @@ name: Release PR drift check
 # lies about what's in the artifact.
 #
 # This workflow posts a `release-pr-drift-check` check_run on each
-# release PR's head SHA. It fails whenever the release branch is not
-# parented at current `origin/main`, or when the pin-time `## Unreleased`
-# body (read from the release branch's merge-base with `main`) differs
-# from the current `main` `## Unreleased` body. Remediation: rerun
-# `release_harn.harn` from `burin-labs/harn-bump-fleet` — that re-pins
-# on fresh `main`, runs the smart-subtract, and force-pushes the PR.
+# release PR's head SHA. It fails when the pin-time `## Unreleased` body
+# (read from the release branch's merge-base with `main`) differs from
+# the current `main` `## Unreleased` body — the one case where the merge
+# would publish a CHANGELOG that lies about the artifact. Mere commit
+# distance from `main` is benign and passes: the merge queue rebases the
+# release PR onto `main` before it lands (so no main commit is omitted)
+# and the crate publishes from the frozen pin tag regardless. Remediation
+# for real drift: rerun `release_harn.harn` from `burin-labs/harn-bump-fleet`
+# — that re-pins on fresh `main`, runs the smart-subtract, and force-pushes
+# the PR.
 #
 # Wire `release-pr-drift-check` as a required status check on a ruleset
 # scoped to PRs from `release/v*` head refs so branch protection
@@ -155,56 +159,35 @@ jobs:
             git fetch origin "$ref" --quiet || true
             pin=$(git merge-base "$sha" origin/main)
             main_sha=$(git rev-parse origin/main)
+            behind=$(git rev-list --count "$pin..origin/main" || echo 0)
+
+            # The only release-time hazard when `main` advances under a pinned
+            # release PR is a *lying CHANGELOG*: if new bullets landed under
+            # `## Unreleased` after the pin, GitHub's automatic 3-way merge can
+            # fold them into the renamed `## v$ver` section and publish notes
+            # claiming work the artifact does not contain. Mere commit distance
+            # is benign — the merge queue rebases the PR onto `main` before it
+            # lands (so non-CHANGELOG commits are never omitted), and the tag the
+            # crate publishes from is frozen at the pin regardless. So gate on
+            # `## Unreleased` *content* drift, not on tip-parenting: a release PR
+            # that is behind `main` but whose pin-time `## Unreleased` still
+            # matches `main` is safe to merge and need not be re-pinned.
+            pin_body=$(git show "$pin:CHANGELOG.md" | extract_unreleased)
+            main_body=$(git show origin/main:CHANGELOG.md | extract_unreleased)
 
             summary_file=$(mktemp)
-            if [ "$pin" != "$main_sha" ]; then
-              new_commits=$(git log --oneline -50 "$pin..origin/main" || true)
+            if [ "$pin_body" = "$main_body" ]; then
               cat > "$summary_file" <<EOF
-          This release PR is parented at \`$pin\`, but current \`origin/main\` is
-          \`$main_sha\`. Merging this PR would publish \`v$ver\` from a stale
-          main snapshot and omit commits that are already on \`main\`, even if
-          the merge is textually clean.
-
-          **Remediation:** rerun the release harness from \`harn-bump-fleet\`:
-
-          \`\`\`
-          harn run release_harn.harn -- --mode ship-pr --agent --yes-live-release
-          \`\`\`
-
-          The harness re-pins on fresh \`origin/main\`, smart-subtracts the
-          pin-time bullets, and force-pushes a clean release PR.
+          \`main\`'s \`## Unreleased\` matches the pin this release branch is parented at,
+          so merging \`v$ver\` cannot silently absorb newer release notes.
 
           - Release branch: \`$ref\`
           - Pin SHA: \`$pin\`
           - Current main: \`$main_sha\`
-          - Background: [burin-labs/harn-bump-fleet#39](https://github.com/burin-labs/harn-bump-fleet/issues/39)
-
-          <details><summary>Commits on <code>main</code> after the release pin</summary>
-
-          \`\`\`text
-          $new_commits
-          \`\`\`
-
-          </details>
+          - Commits behind \`main\`: $behind (benign — the merge queue rebases the PR onto \`main\` before it lands)
           EOF
-              post_check "$sha" failure "Release PR is behind current main" "$summary_file"
-              drift_detected=1
-              echo "::error title=PR #$pr ($ref) — stale release pin::pin $pin is behind origin/main $main_sha; rerun release_harn.harn."
-              continue
-            fi
-
-            pin_body=$(git show "$pin:CHANGELOG.md" | extract_unreleased)
-            main_body=$(git show origin/main:CHANGELOG.md | extract_unreleased)
-
-            if [ "$pin_body" = "$main_body" ]; then
-              cat > "$summary_file" <<EOF
-          \`main\`'s \`## Unreleased\` matches the pin the release branch is parented at.
-
-          - Release branch: \`$ref\`
-          - Pin SHA: \`$pin\`
-          EOF
-              post_check "$sha" success "No drift detected" "$summary_file"
-              echo "::notice title=PR #$pr ($ref)::No CHANGELOG drift detected at pin $pin."
+              post_check "$sha" success "No CHANGELOG drift" "$summary_file"
+              echo "::notice title=PR #$pr ($ref)::No CHANGELOG ## Unreleased drift at pin $pin (behind main by $behind)."
             else
               # Cap the diff so the check_run summary stays well under the
               # 64KB GitHub limit even on a large CHANGELOG diff.


### PR DESCRIPTION
## Problem
The `Release PR drift check` hard-fails whenever a `release/v*` PR is not parented at the **exact tip** of `origin/main`. In an active repo, `main` advances during the ~30-min release run + CI + merge-queue wait, so the check fails on benign commit distance and **every release needs a manual re-pin** (rebase + force-push). This bit the v0.8.90 and v0.8.91 releases.

## Root cause
The real hazard is narrow (see the workflow's own header): GitHub's automatic 3-way merge can fold bullets that landed under `## Unreleased` **after** the pin into the renamed `## vX.Y.Z` section, publishing notes that lie about the artifact. That is already fully detected by the existing `## Unreleased` **content** comparison. The extra tip-parent check is redundant and overstrict:
- The **merge queue rebases** the release PR onto `main` before it lands, so no `main` commit is omitted from the merge.
- The crate **publishes from the frozen pin tag** regardless of later `main` commits.

So "behind `main`" with an unchanged `## Unreleased` is safe.

## Fix
Gate solely on `## Unreleased` content drift. A release PR behind `main` whose pin-time `## Unreleased` still matches `main` now **passes** (with a note of how many commits behind); only genuine release-note divergence fails and asks for a re-pin. Header comment + summaries updated to match.

Validated: `## Unreleased` content for the in-flight v0.8.91 PR (#3165) matches `main` (1 commit behind) — i.e. exactly the benign case this turns green. YAML + `bash -n` + the repo's Actions-workflow pre-commit check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)