### PR TITLE
Add installed package eval discovery

### DIFF
--- a/changelog.d/3124.added.md
+++ b/changelog.d/3124.added.md
@@ -1,0 +1,5 @@
+- **Eval packs can now be discovered from installed packages (#3124).** Package
+  eval discovery includes the root package plus materialized dependencies under
+  `.harn/packages/<alias>/`, so `harn test package --evals` and root
+  `eval_pack://...` trigger handlers can run published eval packs through the
+  existing package-manager install path.

--- a/crates/harn-cli/src/package/extensions.rs
+++ b/crates/harn-cli/src/package/extensions.rs
@@ -489,7 +489,7 @@ fn eval_pack_manifest_for_handler(
         0 => Err(trigger_error(
             trigger,
             format!(
-                "handler eval_pack://{target} did not match any [package].evals pack by id, name, or file stem",
+                "handler eval_pack://{target} did not match any package eval pack by id, name, or file stem",
             ),
         )),
         1 => Ok(matches.remove(0).1),

--- a/crates/harn-cli/src/package/extensions_tests.rs
+++ b/crates/harn-cli/src/package/extensions_tests.rs
@@ -994,6 +994,81 @@ run = "run.json"
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn collect_manifest_triggers_accepts_installed_eval_pack_handler_uri() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".harn/packages/installed-evals/evals")).unwrap();
+    let harn_file = write_trigger_project(
+        root,
+        r#"
+[package]
+name = "workspace"
+
+[[triggers]]
+id = "dependency-eval"
+kind = "cron"
+provider = "cron"
+match = { events = ["cron.tick"] }
+handler = "eval_pack://dependency-pack"
+schedule = "0 4 * * *"
+timezone = "UTC"
+"#,
+        None,
+    );
+    fs::write(
+        root.join(LOCK_FILE),
+        r#"
+version = 4
+generator_version = "0.8.90"
+protocol_artifact_version = "0.8.90"
+
+[[package]]
+name = "installed-evals"
+source = "path+file:///tmp/installed-evals"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join(".harn/packages/installed-evals/harn.toml"),
+        r#"
+[package]
+name = "installed-evals"
+version = "0.1.0"
+evals = ["evals/dependency.toml"]
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join(".harn/packages/installed-evals/evals/dependency.toml"),
+        r#"
+version = 1
+id = "dependency-pack"
+
+[metadata]
+model = "mock-model"
+commit = "commit-a"
+
+[[cases]]
+id = "case-a"
+run = "run.json"
+"#,
+    )
+    .unwrap();
+
+    let mut vm = test_vm();
+    let collected = collect_manifest_triggers(&mut vm, &load_runtime_extensions(&harn_file))
+        .await
+        .expect("trigger collection succeeds");
+
+    assert_eq!(collected.len(), 1);
+    assert!(matches!(
+        &collected[0].handler,
+        CollectedTriggerHandler::EvalPack { target, manifest, .. }
+            if target == "dependency-pack" && manifest.id == "dependency-pack"
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn collect_manifest_triggers_accepts_harn_provider_override() {
     let tmp = tempfile::tempdir().unwrap();
     let harn_file = write_trigger_project(

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -1507,13 +1507,38 @@ pub fn load_package_eval_pack_paths(anchor: Option<&Path>) -> Result<Vec<PathBuf
         ));
     };
 
+    let ctx = ManifestContext { manifest, dir };
+    let mut paths = eval_pack_paths_from_manifest(&ctx.manifest, &ctx.dir)?;
+    paths.extend(installed_package_eval_pack_paths(&ctx)?);
+    paths.sort();
+    paths.dedup();
+    if paths.is_empty() {
+        return Err(PackageError::Manifest(
+            "package declares no eval packs; add [package].evals, harn.eval.toml, or install a dependency that ships eval packs".to_string(),
+        ));
+    }
+    for path in &paths {
+        if !path.is_file() {
+            return Err(PackageError::Manifest(format!(
+                "eval pack does not exist: {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(paths)
+}
+
+fn eval_pack_paths_from_manifest(
+    manifest: &Manifest,
+    manifest_dir: &Path,
+) -> Result<Vec<PathBuf>, PackageError> {
     let declared = manifest
         .package
         .as_ref()
         .map(|package| package.evals.clone())
         .unwrap_or_default();
-    let mut paths = if declared.is_empty() {
-        let default_pack = dir.join("harn.eval.toml");
+    let paths = if declared.is_empty() {
+        let default_pack = manifest_dir.join("harn.eval.toml");
         if default_pack.is_file() {
             vec![default_pack]
         } else {
@@ -1527,17 +1552,11 @@ pub fn load_package_eval_pack_paths(anchor: Option<&Path>) -> Result<Vec<PathBuf
                 if path.is_absolute() {
                     path
                 } else {
-                    dir.join(path)
+                    manifest_dir.join(path)
                 }
             })
             .collect()
     };
-    paths.sort();
-    if paths.is_empty() {
-        return Err(PackageError::Manifest(
-            "package declares no eval packs; add [package].evals or harn.eval.toml".to_string(),
-        ));
-    }
     for path in &paths {
         if !path.is_file() {
             return Err(PackageError::Manifest(format!(
@@ -1545,6 +1564,36 @@ pub fn load_package_eval_pack_paths(anchor: Option<&Path>) -> Result<Vec<PathBuf
                 path.display()
             )));
         }
+    }
+    Ok(paths)
+}
+
+fn installed_package_eval_pack_paths(ctx: &ManifestContext) -> Result<Vec<PathBuf>, PackageError> {
+    let Some(lock) = LockFile::load(&ctx.lock_path())? else {
+        return Ok(Vec::new());
+    };
+    let mut paths = Vec::new();
+    let packages_dir = ctx.packages_dir();
+    for entry in &lock.packages {
+        validate_package_alias(&entry.name)?;
+        let package_dir = packages_dir.join(&entry.name);
+        if package_dir.is_dir() {
+            if let Some(manifest) = read_package_manifest_from_dir(&package_dir)? {
+                paths.extend(eval_pack_paths_from_manifest(&manifest, &package_dir)?);
+            }
+            continue;
+        }
+
+        let package_file = packages_dir.join(format!("{}.harn", entry.name));
+        if package_file.is_file() {
+            continue;
+        }
+
+        return Err(PackageError::Manifest(format!(
+            "installed package {} is missing under {}; run `harn install`",
+            entry.name,
+            packages_dir.display()
+        )));
     }
     Ok(paths)
 }
@@ -1694,6 +1743,7 @@ impl PackageWorkspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::package::test_support::TestWorkspace;
 
     #[test]
     fn rules_table_parses_camel_and_kebab_dir_keys() {
@@ -1745,6 +1795,161 @@ mod tests {
         let paths = load_package_eval_pack_paths(Some(&root.join("src/main.harn"))).unwrap();
 
         assert_eq!(paths, vec![root.join("evals/webhook.toml")]);
+    }
+
+    #[test]
+    fn package_eval_pack_paths_include_installed_package_evals() {
+        let dependency_tmp = tempfile::tempdir().unwrap();
+        let dependency = dependency_tmp.path().join("coding-pack");
+        fs::create_dir_all(dependency.join("evals")).unwrap();
+        fs::write(
+            dependency.join(MANIFEST),
+            r#"
+[package]
+name = "coding-pack"
+version = "0.1.0"
+evals = ["evals/coding.toml"]
+"#,
+        )
+        .unwrap();
+        fs::write(
+            dependency.join("evals/run.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "_type": "workflow_run",
+                "id": "run_1",
+                "workflow_id": "workflow_1",
+                "status": "completed",
+                "usage": {
+                    "total_duration_ms": 12,
+                    "total_cost": 0.01,
+                    "input_tokens": 3,
+                    "output_tokens": 4,
+                    "call_count": 1,
+                    "models": ["mock"]
+                },
+                "replay_fixture": {
+                    "_type": "replay_fixture",
+                    "expected_status": "completed"
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            dependency.join("evals/coding.toml"),
+            r#"
+version = 1
+id = "coding-pack"
+trials = 2
+
+[package]
+name = "coding-pack"
+version = "0.1.0"
+source = "path:test"
+templates = ["templates/rubric.harn.prompt"]
+
+[metadata]
+model = "mock-model"
+commit = "commit-a"
+
+[[cases]]
+id = "case-a"
+run = "run.json"
+rubrics = ["status"]
+
+[[rubrics]]
+id = "status"
+kind = "deterministic"
+
+[[rubrics.assertions]]
+kind = "run-status"
+expected = "completed"
+"#,
+        )
+        .unwrap();
+
+        let helper = dependency_tmp.path().join("helper-lib");
+        fs::create_dir_all(&helper).unwrap();
+        fs::write(
+            helper.join(MANIFEST),
+            r#"
+[package]
+name = "helper-lib"
+version = "0.1.0"
+"#,
+        )
+        .unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let root = project_tmp.path();
+        let workspace = TestWorkspace::new(root);
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            format!(
+                r#"
+[package]
+name = "workspace"
+version = "0.1.0"
+
+[dependencies]
+coding-pack = {{ path = "{}" }}
+helper-lib = {{ path = "{}" }}
+"#,
+                dependency.display(),
+                helper.display()
+            ),
+        )
+        .unwrap();
+
+        install_packages_in(workspace.env(), false, None, false).unwrap();
+
+        let paths = load_package_eval_pack_paths(Some(&root.join("src/main.harn"))).unwrap();
+        assert_eq!(
+            paths,
+            vec![root
+                .join(PKG_DIR)
+                .join("coding-pack")
+                .join("evals/coding.toml")]
+        );
+
+        harn_vm::event_log::reset_active_event_log();
+        let manifest = harn_vm::orchestration::load_eval_pack_manifest(&paths[0]).unwrap();
+        let package = manifest.package.as_ref().expect("package descriptor");
+        assert_eq!(package.name.as_deref(), Some("coding-pack"));
+        assert_eq!(package.templates, vec!["templates/rubric.harn.prompt"]);
+
+        let report = harn_vm::orchestration::evaluate_eval_pack_manifest_resumable(
+            &manifest,
+            Some(serde_json::json!({
+                "namespace": "installed-pack-evals",
+                "suite": "coding-pack",
+                "model": "mock-model",
+                "commit": "commit-a",
+                "branch": "main"
+            })),
+        )
+        .unwrap();
+        assert!(report.pass);
+        assert_eq!(report.trial_count, 2);
+        assert_eq!(report.run_state.ledger_rows_inserted, 2);
+        assert_eq!(report.stats_rows.len(), 1);
+        assert_eq!(report.stats_rows[0].trials, 2);
+        assert!(!report.stats_rows[0].case_fingerprint.is_empty());
+        assert_eq!(
+            report.harness_config_fingerprint,
+            report.stats_rows[0].harness_config_fingerprint
+        );
+
+        let ledger = harn_vm::orchestration::eval_ledger_read_report(Some(serde_json::json!({
+            "namespace": "installed-pack-evals",
+            "suite": "coding-pack",
+            "model": "mock-model",
+            "commit": "commit-a"
+        })))
+        .unwrap();
+        assert_eq!(ledger.rows.len(), 2);
+        harn_vm::event_log::reset_active_event_log();
     }
     #[test]
     fn preflight_severity_parsing_accepts_synonyms() {

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1551,7 +1551,9 @@ harn test package --evals
 ```
 
 Package eval discovery uses `[package].evals = ["evals/webhooks.toml"]` when
-present, otherwise it falls back to `harn.eval.toml` in the package root.
+present, otherwise it falls back to `harn.eval.toml` in the package root. After
+`harn install`, discovery also includes eval packs declared by materialized
+dependency packages under `.harn/packages/<alias>/`.
 
 Clarifying-question evals use an explicit fixture with
 `"eval_kind": "clarifying_question"`. The fixture checks persisted

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -6147,6 +6147,11 @@ version = "0.1.0"
 evals = ["evals/webhooks.toml"]
 ```
 
+After `harn install`, eval-pack discovery includes the root package plus
+materialized dependency packages under `.harn/packages/<alias>/`. Installed
+package eval packs are inert until a command or root trigger references them;
+installing a package does not install that package's own triggers.
+
 An eval pack is a TOML document with `version = 1`, package metadata, fixture
 references, rubrics, optional judge calibration, thresholds, cases, and optional
 persona timeout ladders:
@@ -6234,9 +6239,9 @@ Threshold severity controls deployment-gate behavior:
 | `warning` | Failure is reported but does not block |
 | `informational` | Failure is reported for comparison and dashboards only |
 
-Run a pack directly with `harn eval harn.eval.toml`, run package-declared packs
-with `harn test package --evals`, or run a ladder directly with `harn
-merge-captain ladder <manifest>`.
+Run a pack directly with `harn eval harn.eval.toml`, run root and installed
+package-declared packs with `harn test package --evals`, or run a ladder
+directly with `harn merge-captain ladder <manifest>`.
 
 Harn source may also declare an eval pack directly:
 
@@ -6320,12 +6325,13 @@ provenance. Lower-level ledger builtins also accept `split`, `case`,
 Declarative trigger manifests may bind a trigger directly to an eval pack with
 `handler = "eval_pack://<target>"`. A path-like target (`eval_pack://evals/a.toml`
 or an absolute path) loads that TOML/JSON pack relative to `harn.toml`; a bare
-target resolves by pack `id`, `name`, or file stem through `[package].evals` or
-the package's default `harn.eval.toml`. Dispatch runs the normalized manifest
-through the same `eval_pack_run` path as scripts, so cron ticks inherit trigger
-dedupe, retry, DLQ, replay/cancel, budget, and flow-control handling without a
-separate scheduler. Optional trigger-local `ledger = { ... }` or
-`eval_options = { ... }` fields are passed as the `eval_pack_run` options.
+target resolves by pack `id`, `name`, or file stem through the root package and
+installed package eval declarations (`[package].evals` or default
+`harn.eval.toml`). Dispatch runs the normalized manifest through the same
+`eval_pack_run` path as scripts, so cron ticks inherit trigger dedupe, retry,
+DLQ, replay/cancel, budget, and flow-control handling without a separate
+scheduler. Optional trigger-local `ledger = { ... }` or `eval_options = { ... }`
+fields are passed as the `eval_pack_run` options.
 
 Manifests may declare named partitions with a `split` block:
 

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -366,6 +366,10 @@ Run the eval packs shipped by a package:
 harn test package --evals
 ```
 
+After `harn install`, this also includes eval packs declared by installed
+dependency packages under `.harn/packages/<alias>/`. Dependency eval packs are
+passive until this command or a root `eval_pack://...` trigger references them.
+
 `[package].evals` is optional when the package root contains
 `harn.eval.toml`; otherwise declare one or more package-relative pack paths:
 

--- a/docs/src/triggers/manifest.md
+++ b/docs/src/triggers/manifest.md
@@ -99,12 +99,12 @@ dispatch time.
 
 `eval_pack://...` handlers run an eval pack through the same
 `eval_pack_run(manifest, options?)` path as scripts. A bare target resolves by
-pack `id`, `name`, or file stem from `[package].evals` or `harn.eval.toml`; a
-path-like target resolves relative to `harn.toml`. Cron bindings use the normal
-trigger substrate, so budget, retry, DLQ, replay/cancel, dedupe, and
-concurrency controls apply before the suite runs. Optional trigger-local
-`ledger = { ... }` or `eval_options = { ... }` fields are passed as
-`eval_pack_run` options.
+pack `id`, `name`, or file stem from root and installed package eval
+declarations (`[package].evals` or `harn.eval.toml`); a path-like target
+resolves relative to `harn.toml`. Cron bindings use the normal trigger
+substrate, so budget, retry, DLQ, replay/cancel, dedupe, and concurrency
+controls apply before the suite runs. Optional trigger-local `ledger = { ... }`
+or `eval_options = { ... }` fields are passed as `eval_pack_run` options.
 
 Local handlers and predicates resolve through the same module-export plumbing as
 the manifest hook loader:

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -6145,6 +6145,11 @@ version = "0.1.0"
 evals = ["evals/webhooks.toml"]
 ```
 
+After `harn install`, eval-pack discovery includes the root package plus
+materialized dependency packages under `.harn/packages/<alias>/`. Installed
+package eval packs are inert until a command or root trigger references them;
+installing a package does not install that package's own triggers.
+
 An eval pack is a TOML document with `version = 1`, package metadata, fixture
 references, rubrics, optional judge calibration, thresholds, cases, and optional
 persona timeout ladders:
@@ -6232,9 +6237,9 @@ Threshold severity controls deployment-gate behavior:
 | `warning` | Failure is reported but does not block |
 | `informational` | Failure is reported for comparison and dashboards only |
 
-Run a pack directly with `harn eval harn.eval.toml`, run package-declared packs
-with `harn test package --evals`, or run a ladder directly with `harn
-merge-captain ladder <manifest>`.
+Run a pack directly with `harn eval harn.eval.toml`, run root and installed
+package-declared packs with `harn test package --evals`, or run a ladder
+directly with `harn merge-captain ladder <manifest>`.
 
 Harn source may also declare an eval pack directly:
 
@@ -6318,12 +6323,13 @@ provenance. Lower-level ledger builtins also accept `split`, `case`,
 Declarative trigger manifests may bind a trigger directly to an eval pack with
 `handler = "eval_pack://<target>"`. A path-like target (`eval_pack://evals/a.toml`
 or an absolute path) loads that TOML/JSON pack relative to `harn.toml`; a bare
-target resolves by pack `id`, `name`, or file stem through `[package].evals` or
-the package's default `harn.eval.toml`. Dispatch runs the normalized manifest
-through the same `eval_pack_run` path as scripts, so cron ticks inherit trigger
-dedupe, retry, DLQ, replay/cancel, budget, and flow-control handling without a
-separate scheduler. Optional trigger-local `ledger = { ... }` or
-`eval_options = { ... }` fields are passed as the `eval_pack_run` options.
+target resolves by pack `id`, `name`, or file stem through the root package and
+installed package eval declarations (`[package].evals` or default
+`harn.eval.toml`). Dispatch runs the normalized manifest through the same
+`eval_pack_run` path as scripts, so cron ticks inherit trigger dedupe, retry,
+DLQ, replay/cancel, budget, and flow-control handling without a separate
+scheduler. Optional trigger-local `ledger = { ... }` or `eval_options = { ... }`
+fields are passed as the `eval_pack_run` options.
 
 Manifests may declare named partitions with a `split` block:
 


### PR DESCRIPTION
## Summary
- discover eval packs declared by installed Harn package dependencies through the existing lock/materialized package layout
- allow `eval_pack://...` trigger handlers to resolve installed dependency eval packs by id/name/file stem
- document installed package eval-pack behavior and add a changelog fragment

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target-16dd-3116 cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-16dd-3116 cargo test -p harn-cli package::manifest::tests::package_eval_pack_paths -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-16dd-3116 cargo test -p harn-cli package::extensions::tests::collect_manifest_triggers_accepts_eval_pack -- --nocapture`
- `make check-docs-snippets`
- pre-push targeted checks

Closes #3124.
Part of #3116.