### PR TITLE
harn-vm: detect structured-output truncation for Gemini/Vertex (MAX_TOKENS casing)

### DIFF
--- a/changelog.d/3175.fixed.md
+++ b/changelog.d/3175.fixed.md
@@ -1,0 +1,6 @@
+- Structured-output truncation is now detected for Gemini/Vertex responses,
+  which report `MAX_TOKENS` (uppercase). `llm_call`'s structured-output error
+  path previously used a case-sensitive `length`/`max_tokens` literal match and
+  mislabeled a truncated Gemini response as "did not contain parseable JSON".
+  It now reuses the canonical, case-insensitive `is_length_truncation`
+  classifier (single source of truth shared with the agent/ACP path).

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -146,7 +146,15 @@ pub(crate) fn structured_output_errors(
         }
     }
     if let Some(stop_reason) = dict.get("stop_reason").map(VmValue::display) {
-        if matches!(stop_reason.as_str(), "length" | "max_tokens") {
+        // Reuse the single canonical truncation classifier instead of a
+        // partial, case-sensitive literal match. The hand-rolled
+        // `matches!(.., "length" | "max_tokens")` missed Gemini/Vertex, which
+        // report `MAX_TOKENS` (uppercase) — those native responses passed their
+        // raw `finishReason` through unnormalized, so a truncated structured
+        // output was misreported as "did not contain parseable JSON" rather
+        // than a token-limit hit. `is_length_truncation` is case-insensitive
+        // and covers `length`/`max_tokens`/`MAX_TOKENS`/etc. for free.
+        if super::agent_session_host::is_length_truncation(Some(stop_reason.as_str())) {
             errors.push("response hit the token limit before producing complete JSON".to_string());
         }
     }
@@ -1076,6 +1084,37 @@ mod schema_stream_abort_retry_tests {
         routing::extract_routing_policy(Some(&options))
             .expect("routing policy extracts")
             .expect("routing policy present")
+    }
+
+    // Regression: a truncated structured-output response must be reported as a
+    // token-limit hit regardless of provider stop_reason spelling. Gemini /
+    // Vertex pass `MAX_TOKENS` (uppercase) through unnormalized; the previous
+    // case-sensitive `matches!(.., "length" | "max_tokens")` missed it and
+    // mislabeled the failure as "did not contain parseable JSON".
+    #[test]
+    fn structured_output_truncation_detected_case_insensitively() {
+        let opts = api::options::base_opts("fake");
+        for spelling in ["max_tokens", "MAX_TOKENS", "length", "LENGTH"] {
+            let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                "stop_reason".to_string(),
+                VmValue::String(std::sync::Arc::from(spelling)),
+            )])));
+            let errors = structured_output_errors(&dict, &opts);
+            assert!(
+                errors.iter().any(|e| e.contains("hit the token limit")),
+                "spelling {spelling:?} should be flagged as truncation, got: {errors:?}"
+            );
+        }
+        // A non-truncation stop_reason must NOT add the token-limit error.
+        let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            "stop_reason".to_string(),
+            VmValue::String(std::sync::Arc::from("stop")),
+        )])));
+        let errors = structured_output_errors(&dict, &opts);
+        assert!(
+            !errors.iter().any(|e| e.contains("hit the token limit")),
+            "non-truncation stop must not add token-limit error, got: {errors:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3175.

## What

`structured_output_errors` (`crates/harn-vm/src/llm/call.rs`) decided whether a
structured-output response was truncated at the token limit with a hand-rolled,
**case-sensitive** literal match:

```rust
if matches!(stop_reason.as_str(), "length" | "max_tokens") { ... }
```

Anthropic (`max_tokens`) and OpenAI/OpenRouter/Ollama (`length`) matched, but
**Gemini and Vertex report `MAX_TOKENS` (uppercase)** and pass their raw
`finishReason` through unnormalized (`providers/gemini.rs:446`,
`providers/vertex.rs:295`; the repo's own fixtures use `"finishReason": "STOP"`).
So a truncated Gemini/Vertex structured-output response was mislabeled
`"response did not contain parseable JSON"` instead of the actionable
token-limit message the `llm_call` schema-retry loop needs.

## Fix

Route the check through the existing `is_length_truncation()` /
`canonical_provider_stop_reason()` helper in `agent_session_host.rs`, which is
already documented as the "single source of truth," is case-insensitive, and has
an explicit `MAX_TOKENS` test. This also removes a DRY drift — `call.rs` had
reimplemented a partial subset of that classifier.

## Test

Adds `structured_output_truncation_detected_case_insensitively`, which asserts
`max_tokens` / `MAX_TOKENS` / `length` / `LENGTH` are all flagged and `stop` is
not. Verified red against the old `matches!` literal, green with the canonical
helper.

Found during an adversarial provider/tool-format bug-hunt for Burin's direct
use of Harn (also surfaced #3176 fenced-JSON near-miss drops and #3177 a
missing OpenRouter deepseek-chat capability row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)