### PR TITLE
[harn-lint] Anchor complexity + naming spans to the declaration name

### DIFF
--- a/changelog.d/lint-name-anchored-span.fixed.md
+++ b/changelog.d/lint-name-anchored-span.fixed.md
@@ -1,0 +1,4 @@
+- Lint: `cyclomatic-complexity` (HARN-LNT-002) and `naming-convention`
+  diagnostics now underline just the keyword + declaration name
+  (`fn run_agent`, `struct Bad`) instead of carpeting carets across the
+  entire function/type body.

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -515,6 +515,57 @@ impl<'a> Linter<'a> {
         });
     }
 
+    /// Narrow a declaration span (which covers the whole `fn`/`pipeline`/`tool`
+    /// node, signature through body) down to just the keyword + name on the
+    /// signature's first line, so name-anchored lints underline `fn run_agent`
+    /// instead of carpeting hundreds of columns across the entire function.
+    ///
+    /// The AST does not carry a separate identifier span, so we recover it from
+    /// the source: scan forward from the decl span's start for the `name`
+    /// identifier as a whole word and end the narrow span just past it. Falls
+    /// back to the original span when the source is unavailable or the name
+    /// can't be located (e.g. synthetic nodes), preserving prior behavior.
+    pub(super) fn name_anchored_span(&self, name: &str, span: Span) -> Span {
+        let Some(source) = self.source else {
+            return span;
+        };
+        if name.is_empty() || span.start >= span.end {
+            return span;
+        }
+        // Confine the search to the first line of the decl so we never grab a
+        // same-named token from the body.
+        let scan_end = source[span.start..span.end]
+            .find('\n')
+            .map_or(span.end, |nl| span.start + nl);
+        let Some(haystack) = source.get(span.start..scan_end) else {
+            return span;
+        };
+        let mut search_from = 0;
+        while let Some(rel) = haystack[search_from..].find(name) {
+            let match_start = search_from + rel;
+            let match_end = match_start + name.len();
+            let prev_ok = match_start == 0
+                || !haystack[..match_start]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| c.is_alphanumeric() || c == '_');
+            let next_ok = !haystack[match_end..]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+            if prev_ok && next_ok {
+                return Span::with_offsets(
+                    span.start,
+                    span.start + match_end,
+                    span.line,
+                    span.column,
+                );
+            }
+            search_from = match_start + 1;
+        }
+        span
+    }
+
     /// Score the body of a function/tool and emit a
     /// `cyclomatic-complexity` warning if it exceeds the configured
     /// threshold. No-op when the enclosing decl carries
@@ -534,7 +585,7 @@ impl<'a> Linter<'a> {
             message: format!(
                 "function `{name}` has cyclomatic complexity {complexity} (> {threshold})"
             ),
-            span,
+            span: self.name_anchored_span(name, span),
             severity: LintSeverity::Warning,
             suggestion: Some(format!(
                 "split `{name}` into smaller helpers, or mark it `@complexity(allow)` if the branching is intrinsic; threshold configurable via `[lint].complexity_threshold` in `harn.toml`"
@@ -551,7 +602,7 @@ impl<'a> Linter<'a> {
             code: Code::LintNamingConvention,
             rule: "naming-convention".into(),
             message: format!("function `{name}` should use snake_case"),
-            span,
+            span: self.name_anchored_span(name, span),
             severity: LintSeverity::Warning,
             suggestion: Some(format!(
                 "rename `{name}` to snake_case (for example `{}`)",
@@ -569,7 +620,7 @@ impl<'a> Linter<'a> {
             code: Code::LintNamingConvention,
             rule: "naming-convention".into(),
             message: format!("{kind} `{name}` should use PascalCase"),
-            span,
+            span: self.name_anchored_span(name, span),
             severity: LintSeverity::Warning,
             suggestion: Some(format!(
                 "rename `{name}` to PascalCase (for example `{}`)",

--- a/crates/harn-lint/src/tests/complexity.rs
+++ b/crates/harn-lint/src/tests/complexity.rs
@@ -182,6 +182,67 @@ pipeline default(task) {
 }
 
 #[test]
+fn test_cyclomatic_complexity_span_anchors_to_name_not_whole_function() {
+    // Regression for HARN-LNT-002 underlining the entire function (signature
+    // through body, hundreds of columns) instead of pointing at the name. The
+    // diagnostic span must cover only `fn complicated_runner` on the first line.
+    let source = r#"
+fn complicated_runner(x: int, y: int, z: int, label: string, extra: bool) -> int {
+  if x > 0 { log("1") }
+  if x > 1 { log("2") }
+  if x > 2 { log("3") }
+  if x > 3 { log("4") }
+  if x > 4 { log("5") }
+  if x > 5 { log("6") }
+  if x > 6 { log("7") }
+  if x > 7 { log("8") }
+  if x > 8 { log("9") }
+  if x > 9 { log("10") }
+  if x > 10 { log("11") }
+  if x > 11 { log("12") }
+  if x > 12 { log("13") }
+  if x > 13 { log("14") }
+  if x > 14 { log("15") }
+  if x > 15 { log("16") }
+  if x > 16 { log("17") }
+  if x > 17 { log("18") }
+  if x > 18 { log("19") }
+  if x > 19 { log("20") }
+  if x > 20 { log("21") }
+  if x > 21 { log("22") }
+  if x > 22 { log("23") }
+  if x > 23 { log("24") }
+  if x > 24 { log("25") }
+  if x > 25 { log("26") }
+  0
+}
+
+pipeline default(task) {
+  complicated_runner(10, 1, 2, "a", true)
+}
+"#;
+    let diags = lint_source(source);
+    let warning = diags
+        .iter()
+        .find(|d| d.rule == "cyclomatic-complexity")
+        .expect("expected a cyclomatic-complexity warning");
+    let underlined = &source[warning.span.start..warning.span.end];
+    assert_eq!(
+        underlined, "fn complicated_runner",
+        "complexity diagnostic must underline only the keyword + name, got: {underlined:?}"
+    );
+    // The span must not bleed past the first line into the giant body.
+    assert_eq!(
+        warning.span.line, warning.span.end_line,
+        "name-anchored span must stay on a single line"
+    );
+    assert!(
+        !underlined.contains('\n'),
+        "name-anchored span must not span the whole multi-line function"
+    );
+}
+
+#[test]
 fn test_cyclomatic_complexity_allow_attribute_suppresses() {
     // Intentionally branchy parser-style function; `@complexity(allow)`
     // must silence the warning even when the score is above threshold.

--- a/crates/harn-lint/src/tests/naming_types.rs
+++ b/crates/harn-lint/src/tests/naming_types.rs
@@ -18,6 +18,47 @@ fn BadName() {
 }
 
 #[test]
+fn test_naming_convention_span_anchors_to_function_name() {
+    // The name lint should underline `fn BadName`, not the whole multi-line
+    // function declaration (same HARN-LNT-002-class span bug).
+    let source = "
+fn BadName(a: int, b: int, c: string) -> int {
+  return a
+}
+";
+    let diags = lint_source(source);
+    let warning = diags
+        .iter()
+        .find(|d| d.rule == "naming-convention")
+        .expect("expected naming-convention warning");
+    let underlined = &source[warning.span.start..warning.span.end];
+    assert_eq!(
+        underlined, "fn BadName",
+        "function name lint must underline only keyword + name, got: {underlined:?}"
+    );
+}
+
+#[test]
+fn test_naming_convention_span_anchors_to_type_name() {
+    let source = "
+struct bad_name {
+  value: int
+  other: string
+}
+";
+    let diags = lint_source(source);
+    let warning = diags
+        .iter()
+        .find(|d| d.rule == "naming-convention")
+        .expect("expected naming-convention warning");
+    let underlined = &source[warning.span.start..warning.span.end];
+    assert_eq!(
+        underlined, "struct bad_name",
+        "type name lint must underline only keyword + name, got: {underlined:?}"
+    );
+}
+
+#[test]
 fn test_naming_convention_flags_non_pascal_case_type() {
     let diags = lint_source(
         r"


### PR DESCRIPTION
## Problem

The cyclomatic-complexity lint (`HARN-LNT-002`) underlined the **entire**
function — signature through body, hundreds of caret columns long — instead
of pointing at the function name. `naming-convention` (function and type name
lints) had the same whole-declaration-underline bug.

## Root cause

`crates/harn-lint/src/linter/walk.rs` passed `snode.span` (the whole
`fn`/`pipeline`/`tool`/type node, declaration through body) into
`check_cyclomatic_complexity`, `lint_function_name`, and `lint_type_name`.
Those built the diagnostic with that wide span, so the renderer drew one
caret per column across the whole node.

## Fix

The AST (`Node::FnDecl`/`ToolDecl`/`Pipeline`/type decls) carries only
`name: String`, no separate identifier span — threading a name span through
the parser/typechecker/visitor would be a large, risky change for a
diagnostic-quality fix. Instead, a small shared `name_anchored_span` helper
recovers a tight span from source: it scans the decl span's **first line**
for `name` as a whole word and ends the diagnostic span just past it, so the
underline covers exactly `fn run_agent` / `struct Bad`. It falls back to the
original span when the source is unavailable or the name can't be located
(synthetic nodes), preserving prior behavior.

Applied consistently to the complexity lint and the function/type name lints
(the latter cover `fn`/`tool`/`struct`/`enum`/`interface`/`type`).

## Tests

- `complexity.rs`: new `test_cyclomatic_complexity_span_anchors_to_name_not_whole_function`
  asserts the emitted span underlines exactly `fn complicated_runner` (not the
  multi-line body) for a function with a long signature.
- `naming_types.rs`: new `test_naming_convention_span_anchors_to_function_name`
  and `..._to_type_name` assert `fn BadName` / `struct bad_name`.

`cargo build -p harn-lint`, `cargo test -p harn-lint` (283 passed, incl. the 3
new tests), `cargo clippy -p harn-lint --all-targets` (clean), and
`cargo fmt -p harn-lint --check` all pass. Changelog fragment:
`changelog.d/lint-name-anchored-span.fixed.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)