### PR TITLE
fix(tools): stop silently dropping valid agent tool calls (two parser bugs)

### DIFF
--- a/changelog.d/toolcall-parse-dropped-calls.fixed.md
+++ b/changelog.d/toolcall-parse-dropped-calls.fixed.md
@@ -1,0 +1,11 @@
+- **Agent tool-call parser no longer silently drops valid calls in two cases.**
+  A single stray/unmatched backtick in model prose used to flip the bare-call
+  scanner's inline-code flag for the rest of the response, suppressing every
+  later bare `name({ ... })` tool call and stalling the agent loop; the flag now
+  resets at each newline (Markdown inline code never spans lines). And the
+  native-JSON fallback now accepts the flat OpenAI on-the-wire envelope whose
+  `arguments`/`parameters` value is a JSON *string*
+  (`{"name":"read","arguments":"{\"path\":\"a\"}"}`, common from local
+  llama.cpp/vLLM/Ollama OpenAI-mimic templates) — the acceptance gate previously
+  required an object and dropped the call even though the extractor already
+  decoded the string.

--- a/crates/harn-vm/src/llm/tools/parse/bare.rs
+++ b/crates/harn-vm/src/llm/tools/parse/bare.rs
@@ -305,6 +305,11 @@ pub(crate) fn parse_bare_calls_in_body(
 
         if bytes[i] == b'\n' {
             at_line_start = true;
+            // Markdown inline code spans never cross a newline. Reset the
+            // flag here so a single stray/unmatched backtick in prose can't
+            // flip `in_inline_code` true for the rest of the response and
+            // silently suppress every later bare tool call.
+            in_inline_code = false;
         } else if !bytes[i].is_ascii_whitespace() {
             at_line_start = false;
         }

--- a/crates/harn-vm/src/llm/tools/parse/native_json.rs
+++ b/crates/harn-vm/src/llm/tools/parse/native_json.rs
@@ -118,20 +118,25 @@ fn find_native_json_items(text: &str) -> Option<Vec<serde_json::Value>> {
         // scanning for the real call. Two payload shapes qualify:
         //   - OpenAI native: an item with an object `function` field.
         //   - flat JSON-RPC/MCP: an item with a string `name` AND an
-        //     `arguments`/`parameters` object — the generic function-call
-        //     envelope value models reach for when ignoring the text format.
-        // Requiring the args object (not just a bare `name`) keeps prose JSON
+        //     `arguments`/`parameters` slot that is an object OR a string —
+        //     the generic function-call envelope value models reach for when
+        //     ignoring the text format. The slot is a JSON STRING in OpenAI's
+        //     on-the-wire shape (`{"name":"read","arguments":"{\"path\":..}"}`),
+        //     which local llama.cpp/vLLM/Ollama OpenAI-mimic templates commonly
+        //     emit; the downstream extractor already decodes that string, so the
+        //     gate must accept it too or the call silently vanishes.
+        // Requiring the args slot (not just a bare `name`) keeps prose JSON
         // that merely has a `name` key (config, package.json) from matching.
+        let args_slot_present = |item: &serde_json::Value, key: &str| {
+            item.get(key)
+                .is_some_and(|slot| slot.is_object() || slot.is_string())
+        };
         if items.iter().any(|item| {
             item.get("function")
                 .is_some_and(serde_json::Value::is_object)
                 || (item.get("name").is_some_and(serde_json::Value::is_string)
-                    && (item
-                        .get("arguments")
-                        .is_some_and(serde_json::Value::is_object)
-                        || item
-                            .get("parameters")
-                            .is_some_and(serde_json::Value::is_object)))
+                    && (args_slot_present(item, "arguments")
+                        || args_slot_present(item, "parameters")))
         }) {
             return Some(items);
         }

--- a/crates/harn-vm/src/llm/tools/tests/core_parser.rs
+++ b/crates/harn-vm/src/llm/tools/tests/core_parser.rs
@@ -125,6 +125,28 @@ fn ignores_tool_name_mentions_inside_inline_code_spans() {
 }
 
 #[test]
+fn unbalanced_backtick_in_prose_does_not_suppress_later_bare_call() {
+    // Regression: a single stray/unmatched backtick in prose used to flip the
+    // scanner's `in_inline_code` flag true for the REST of the response, so
+    // every later bare tool call was silently skipped and the agent loop
+    // stalled. The flag must reset at each newline (inline code never spans
+    // lines), so the call on the following line still parses.
+    let tools = sample_tool_registry();
+    let text =
+        "The file is `src/main.rs (note path).\nedit({ action: \"create\", path: \"real.go\" })\n";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "stray backtick must not suppress the later call: {:?}",
+        result.calls
+    );
+    assert_eq!(result.calls[0]["name"], json!("edit"));
+    assert_eq!(result.calls[0]["arguments"]["path"], json!("real.go"));
+}
+
+#[test]
 fn recovers_single_inline_wrapped_tool_call_when_it_is_the_entire_response() {
     let tools = sample_tool_registry();
     let text = r#"`edit({ action: "create", path: "wrapped.go" })`"#;

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -596,6 +596,26 @@ fn native_json_fallback_parses_flat_jsonrpc_envelope() {
 }
 
 #[test]
+fn native_json_fallback_parses_flat_envelope_with_string_encoded_arguments() {
+    // Regression: OpenAI's on-the-wire flat shape encodes `arguments` as a JSON
+    // STRING (`{"name":"read","arguments":"{\"path\":\"a\"}"}`), which local
+    // llama.cpp/vLLM/Ollama OpenAI-mimic templates commonly emit. The
+    // acceptance gate used to require an args OBJECT, so this call silently
+    // vanished even though the downstream extractor already decodes the string.
+    let known = known_tools_set();
+    let text = r#"{"name":"read","arguments":"{\"path\":\"a\"}"}"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(
+        calls.len(),
+        1,
+        "string-encoded arguments must parse: {calls:?}"
+    );
+    assert_eq!(calls[0]["name"], json!("read"));
+    assert_eq!(calls[0]["arguments"]["path"], json!("a"));
+}
+
+#[test]
 fn native_json_fallback_parses_flat_envelope_with_parameters_slot() {
     // The flat envelope sometimes names the args slot `parameters`, and arrives
     // as a single object rather than an array.


### PR DESCRIPTION
## Summary

An adversarial audit empirically reproduced two confirmed bugs in Harn's agent tool-call parser that **silently drop valid tool calls** — a capable model emits a real call, the harness sees none, and the agent loop stalls. Both are the same bug class (silently-dropped tool calls), so they ship together.

### Bug 1 (high impact) — unbalanced backtick in prose suppresses all later bare calls
`crates/harn-vm/src/llm/tools/parse/bare.rs`

The bare-call scanner's `in_inline_code` flag was toggled by every backtick byte but **never reset on newline**, while the detection guard is `at_line_start && !in_inline_code`. So a single stray/unmatched backtick anywhere in the model's prose flipped `in_inline_code` true for the rest of the response, and every later bare `name({ ... })` call was skipped.

Repro: `"The file is \`src/main.rs (note path).\nedit({...})\n"` parsed **0** calls; the same with a balanced backtick parsed 1.

Fix: reset `in_inline_code = false` when a newline is consumed (Markdown inline code never spans newlines), matching how `at_line_start` is already handled there.

### Bug 2 (narrow) — flat native-JSON envelope with string-encoded `arguments` is dropped
`crates/harn-vm/src/llm/tools/parse/native_json.rs`

The native-JSON acceptance gate required `arguments`/`parameters` to be an **object**, but the downstream extractor already handles `Value::String(raw)` (OpenAI encodes args as a JSON string). So the on-the-wire shape `{"name":"read","arguments":"{\"path\":\"a\"}"}` — common from local llama.cpp/vLLM/Ollama OpenAI-mimic templates — failed the gate and vanished.

Fix: accept the `arguments`/`parameters` slot when it is an object **or** a string. The negative case (prose JSON like `{"name":"my-pkg","version":"1.0.0"}` with no args slot) still does not match.

## Tests

Two focused regression tests, each failing before the fix and passing after:

- `unbalanced_backtick_in_prose_does_not_suppress_later_bare_call` (core_parser.rs)
- `native_json_fallback_parses_flat_envelope_with_string_encoded_arguments` (heredoc_and_messages.rs)

Verified by stashing only the two source fixes: both new tests FAILED, then PASS once restored.

## Verification

`cargo test -p harn-vm` — all 3506 lib tests + integration tests pass, 0 failures. Pre-commit clippy + rustfmt + pre-push checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)