### PR TITLE
fix(agent): recover from empty/malformed tool name instead of aborting the run

### DIFF
--- a/changelog.d/3194.fixed.md
+++ b/changelog.d/3194.fixed.md
@@ -1,0 +1,7 @@
+- `harn-vm` agent loop: an empty or malformed tool-call name no longer aborts
+  the whole run. `host_agent_dispatch_tool_call` previously threw a runtime
+  error on a blank `tool_name`, terminating `agent_loop` — so a single malformed
+  function-call element from a model (common on some native-tool/MoE providers)
+  could wipe an entire run. The empty/malformed-name case now routes through the
+  existing recoverable denied-tool path, re-injecting actionable retry feedback,
+  exactly as an unknown-but-named tool already does.

--- a/conformance/tests/scenarios/agent_loop_empty_tool_name_recovers.expected
+++ b/conformance/tests/scenarios/agent_loop_empty_tool_name_recovers.expected
@@ -1,0 +1,9 @@
+loop.status=done
+empty.ok=false
+empty.status=error
+empty.error_category=schema_validation
+missing.ok=false
+missing.status=error
+missing.error_category=schema_validation
+good.ok=true
+good.status=ok

--- a/conformance/tests/scenarios/agent_loop_empty_tool_name_recovers.harn
+++ b/conformance/tests/scenarios/agent_loop_empty_tool_name_recovers.harn
@@ -1,0 +1,79 @@
+/**
+ * An empty / missing / non-string tool name is a RECOVERABLE parse slip, not a
+ * terminal harness error.
+ *
+ * Regression: `__host_agent_dispatch_tool_call` used to `Err(...)` on an empty
+ * `call.name`, which propagates out of `agent_loop` and aborts the entire run.
+ * A model that emits one nameless/malformed tool call would have its whole
+ * session terminated, wrongly scoring a fixable slip as a hard failure. The
+ * unknown-but-named path was already recoverable (the loop re-injects the
+ * `schema_validation` denied-tool result and lets the model retry); this aligns
+ * the unnamed path with it.
+ *
+ * Part A: drive `agent_loop` with a nameless tool call on turn 1 followed by a
+ * `##DONE##` text turn. The loop must reach `done` (it recovers + retries),
+ * not abort.
+ *
+ * Part B: call the dispatch primitive directly with an empty / missing name and
+ * assert it returns the recoverable error envelope (ok=false, status=error,
+ * error_category=schema_validation) instead of throwing.
+ */
+import { agent_dispatch_tool_call } from "std/agent/primitives"
+import { llm_text, with_llm_script } from "std/testing"
+
+fn one_tool() {
+  let r = tool_registry()
+  return tool_define(
+    r,
+    "echo",
+    "Echo back the message",
+    {
+      handler: { args -> return "echoed:" + to_string(args?.msg ?? "") },
+      parameters: {msg: {type: "string"}},
+    },
+  )
+}
+
+fn run_loop_with_empty_name() {
+  return with_llm_script(
+    [{tool_calls: [{id: "bad-1", name: "", arguments: {}}]}, llm_text("##DONE##")],
+    { ->
+      let result = agent_loop(
+        "do something",
+        nil,
+        {
+          provider: "mock",
+          tools: one_tool(),
+          tool_format: "native",
+          max_iterations: 4,
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+        },
+      )
+      return result.status
+    },
+  )
+}
+
+/**
+ * Turn 1: a malformed call with an empty name — the loop must NOT abort.
+ * Turn 2: the model recovers and finishes.
+ */
+pipeline default() {
+  // Part A: the whole run survives a nameless tool call and reaches `done`.
+  __io_println("loop.status=" + run_loop_with_empty_name())
+  // Part B: the dispatch primitive returns a recoverable envelope, not a throw.
+  let empty = agent_dispatch_tool_call({name: "", arguments: {}}, one_tool(), {})
+  __io_println("empty.ok=" + to_string(empty?.ok))
+  __io_println("empty.status=" + to_string(empty?.status))
+  __io_println("empty.error_category=" + to_string(empty?.error_category))
+  let missing = agent_dispatch_tool_call({arguments: {}}, one_tool(), {})
+  __io_println("missing.ok=" + to_string(missing?.ok))
+  __io_println("missing.status=" + to_string(missing?.status))
+  __io_println("missing.error_category=" + to_string(missing?.error_category))
+  // A well-formed call against the same registry still executes normally:
+  // the recovery path must not have broken the happy path.
+  let good = agent_dispatch_tool_call({name: "echo", arguments: {msg: "hi"}}, one_tool(), {})
+  __io_println("good.ok=" + to_string(good?.ok))
+  __io_println("good.status=" + to_string(good?.status))
+}

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -767,14 +767,6 @@ async fn host_agent_dispatch_tool_call(
         )))
         }
     };
-    let mut tool_name = match call.get("name") {
-        Some(VmValue::String(name)) if !name.trim().is_empty() => name.to_string(),
-        _ => {
-            return Err(VmError::Runtime(
-                "__host_agent_dispatch_tool_call: call.name must be a non-empty string".to_string(),
-            ))
-        }
-    };
     let tool_id = ["id", "tool_call_id", "call_id"]
         .iter()
         .find_map(|key| match call.get(*key) {
@@ -786,6 +778,29 @@ async fn host_agent_dispatch_tool_call(
         .get("arguments")
         .map(helpers::vm_value_to_json)
         .unwrap_or(serde_json::Value::Null);
+    let mut tool_name = match call.get("name") {
+        Some(VmValue::String(name)) if !name.trim().is_empty() => name.to_string(),
+        // An empty/missing/non-string tool name is a recoverable parse slip,
+        // not a terminal harness error: the model emitted a malformed call and
+        // can fix it on the next turn. Surface it through the same
+        // schema-validation denied-tool envelope the loop already re-injects
+        // for bad arguments (a hard `Err` here aborts the whole agent_loop,
+        // wrongly tanking a run over one fixable slip). The unknown-but-named
+        // path is already recoverable this way; align the unnamed path with it.
+        _ => {
+            let denied = agent_primitive_denied_tool(
+                "<unnamed>",
+                &tool_id,
+                &raw_args,
+                "Tool call is missing a name. Emit one tool call per turn as \
+                 `name({ ... })` using a non-empty tool name from the allowed \
+                 list, then retry.",
+                crate::agent_events::ToolCallErrorCategory::SchemaValidation,
+                None,
+            );
+            return Ok(json_to_vm_value(&denied));
+        }
+    };
     let mut tool_args = tools::normalize_tool_args(&tool_name, &raw_args);
     let session_id = agent_primitive_option_str(options, "session_id")
         .or_else(current_agent_session_id)


### PR DESCRIPTION
## Problem (harness-robustness / parse-recovery)

`host_agent_dispatch_tool_call` (`crates/harn-vm/src/llm/agent_host_primitives.rs`) threw a **hard** `VmError::Runtime("call.name must be a non-empty string")` whenever a model emitted a tool call with an empty / missing / non-string `name`. That error propagates straight out of `agent_loop` and **terminates the entire run**.

The `name({ ... })` text tool-call format occasionally drops the name on cheap models — a fixable parse slip. Aborting the whole session over it wrongly scores a recoverable slip as a terminal failure and tanks convergence.

This is an asymmetry: the **unknown-but-named** tool path was already recoverable (the loop re-injects a `schema_validation` denied-tool result and lets the model retry), but the **unnamed** path threw.

## Fix

Surface the empty/malformed name through the same recoverable denied-tool envelope the loop already re-injects for bad arguments:
- `ok=false, status=error, error_category=schema_validation`
- an actionable message telling the model to emit `name({ ... })` with a non-empty tool name and retry.

The loop then re-injects feedback and the model fixes the call on the next turn instead of the session aborting. Minimal, in the existing recoverable path; the well-formed happy path is unchanged. Batch dispatch inherits the fix (it delegates per-call to the same function).

## Verification

- New conformance scenario `agent_loop_empty_tool_name_recovers`:
  - drives `agent_loop` with a nameless call on turn 1 → run reaches `done` (previously aborted);
  - calls `agent_dispatch_tool_call` directly with empty and missing names → both return the recoverable `schema_validation` envelope;
  - a well-formed call against the same registry still executes (`ok=true, status=ok`).
- Full `make conformance` walk: **1595 passed, 0 failed**.
- `cargo clippy -p harn-vm` clean; `cargo test -p harn-vm` green.
- Confirmed against Burin Code's pinned runtime: a Burin pipeline regression test that drives `agent_loop` with an empty-name call **fails** (hard abort) on the current pinned `v0.8.92` binary and **passes** (recovers via `feedback_injected`) on this patched binary. The Burin-side regression test lands with the follow-up Harn repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)