### PR TITLE
fix(hostlib/ast): preserve invalid-UTF-8 bytes in AST edits (no silent U+FFFD rewrite)

### DIFF
--- a/changelog.d/ast-edit-utf8-preserve.fixed.md
+++ b/changelog.d/ast-edit-utf8-preserve.fixed.md
@@ -1,0 +1,10 @@
+- AST edit builtins (`ast.apply_node`, `ast.batch_apply`,
+  `ast.insert_at_anchor`) no longer corrupt invalid-UTF-8 bytes. The read path
+  decoded the whole file with `String::from_utf8_lossy` and the callers wrote
+  the decoded buffer back, so any non-UTF-8 byte anywhere in the file (e.g. a
+  Latin-1 byte or a `\x80` in a comment or byte-string) was silently rewritten
+  to the 3-byte U+FFFD encoding — even in regions the edit never touched. The
+  edit pipeline now reads, parses (tree-sitter over raw bytes), splices, and
+  writes raw bytes, so bytes outside the edited span pass through verbatim.
+  Lossy decoding is retained only for display-only previews/diagnostics and the
+  read-only `ast.search` text bindings.

--- a/crates/harn-hostlib/src/ast/apply_node.rs
+++ b/crates/harn-hostlib/src/ast/apply_node.rs
@@ -49,12 +49,12 @@ use crate::tools::args::{
 use crate::tools::permissions::enforce_path_scope;
 
 use super::edit_common::{
-    collect_target_spans, first_syntax_error, format_query_error, read_source,
+    collect_target_spans, first_syntax_error, format_query_error, lossy_str, read_source,
     resolve_target_capture, select_spans, sha256_hex, splice, write_source, SelectFailure,
     Selector, Span,
 };
 use super::language::{Language, TEXT_PATCH_FALLBACK};
-use super::parse::parse_source;
+use super::parse::parse_bytes;
 
 const BUILTIN: &str = "hostlib_ast_apply_node";
 const DEFAULT_TARGET_CAPTURE: &str = "target";
@@ -140,12 +140,12 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         }
     };
 
-    let tree = parse_source(&source, language).map_err(|err| HostlibError::Backend {
+    let tree = parse_bytes(&source, language).map_err(|err| HostlibError::Backend {
         builtin: BUILTIN,
         message: err.to_string(),
     })?;
 
-    let spans = collect_target_spans(&query, &tree, source.as_bytes(), target_index);
+    let spans = collect_target_spans(&query, &tree, &source, target_index);
     if spans.is_empty() {
         return Ok(no_match_response(
             &path_str,
@@ -174,7 +174,12 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     if validate {
         if let Some(detail) = first_syntax_error(&patched, language) {
-            return Ok(syntax_error_response(&path_str, &patched, &detail, &chosen));
+            return Ok(syntax_error_response(
+                &path_str,
+                &lossy_str(&patched),
+                &detail,
+                &chosen,
+            ));
         }
     }
 
@@ -198,8 +203,8 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
 fn applied_response(
     path: &str,
-    before: &str,
-    after: &str,
+    before: &[u8],
+    after: &[u8],
     chosen: &[Span],
     replacement: &str,
     dry_run: bool,
@@ -220,15 +225,9 @@ fn applied_response(
                         .collect(),
                 )),
             ),
-            (
-                "before_sha256".to_string(),
-                str_value(sha256_hex(before.as_bytes())),
-            ),
-            (
-                "after_sha256".to_string(),
-                str_value(sha256_hex(after.as_bytes())),
-            ),
-            ("preview".to_string(), str_value(after)),
+            ("before_sha256".to_string(), str_value(sha256_hex(before))),
+            ("after_sha256".to_string(), str_value(sha256_hex(after))),
+            ("preview".to_string(), str_value(lossy_str(after))),
         ]
         .into_iter()
         .collect(),
@@ -546,6 +545,58 @@ mod tests {
         assert!(s(field(&result, "preview")).contains("{ 2 }"));
         let on_disk = std::fs::read_to_string(file.path()).expect("read");
         assert_eq!(on_disk, source);
+    }
+
+    fn write_temp_bytes(extension: &str, source: &[u8]) -> NamedTempFile {
+        let mut file = tempfile::Builder::new()
+            .suffix(&format!(".{extension}"))
+            .tempfile()
+            .expect("temp file");
+        file.write_all(source).expect("write source");
+        file
+    }
+
+    #[test]
+    fn preserves_invalid_utf8_bytes_outside_edited_span() {
+        // A valid-UTF-8 edit target sitting next to an invalid byte (0x80)
+        // in a comment. Lossy-decoding the whole file on read and writing
+        // the decoded string back would rewrite 0x80 to the 3-byte U+FFFD
+        // encoding, even though the edit never touches the comment.
+        let mut source: Vec<u8> = b"// header byte: ".to_vec();
+        source.push(0x80);
+        source.extend_from_slice(b"\nfn foo() { let x = 1; }\n");
+        assert!(
+            std::str::from_utf8(&source).is_err(),
+            "fixture must be non-UTF8"
+        );
+
+        let file = write_temp_bytes("rs", &source);
+        let path = file.path().to_string_lossy().to_string();
+        let result = invoke(dict(&[
+            ("path", vm_string(&path)),
+            (
+                "query",
+                vm_string("(let_declaration value: (integer_literal) @target)"),
+            ),
+            ("replacement", vm_string("2")),
+        ]));
+        assert_eq!(s(field(&result, "result")), "applied");
+
+        let on_disk = std::fs::read(file.path()).expect("read raw bytes");
+        // The targeted edit landed...
+        assert!(
+            String::from_utf8_lossy(&on_disk).contains("let x = 2"),
+            "edit should apply"
+        );
+        // ...and the untouched invalid byte survived verbatim — no U+FFFD.
+        assert!(
+            on_disk.contains(&0x80),
+            "invalid byte must be preserved, not rewritten to U+FFFD"
+        );
+        assert!(
+            !on_disk.windows(3).any(|w| w == [0xEF, 0xBF, 0xBD]),
+            "no U+FFFD replacement bytes should be introduced"
+        );
     }
 
     #[test]

--- a/crates/harn-hostlib/src/ast/batch_apply.rs
+++ b/crates/harn-hostlib/src/ast/batch_apply.rs
@@ -58,12 +58,12 @@ use crate::tools::args::{
 use crate::tools::permissions::enforce_path_scope;
 
 use super::edit_common::{
-    collect_target_spans, first_syntax_error, format_query_error, read_source,
+    collect_target_spans, first_syntax_error, format_query_error, lossy_str, read_source,
     resolve_target_capture, select_spans, sha256_hex, splice, write_source, SelectFailure,
     Selector,
 };
 use super::language::Language;
-use super::parse::parse_source;
+use super::parse::parse_bytes;
 
 const BUILTIN: &str = "hostlib_ast_batch_apply";
 const DEFAULT_TARGET_CAPTURE: &str = "target";
@@ -304,12 +304,12 @@ fn apply_one(path_str: &str, cfg: &FileJob<'_>) -> Result<FileOutcome, HostlibEr
         Err(detail) => return Ok(FileOutcome::failure("no_match", detail)),
     };
 
-    let tree = match parse_source(&source, language) {
+    let tree = match parse_bytes(&source, language) {
         Ok(tree) => tree,
         Err(err) => return Ok(FileOutcome::failure("parse_error", err.to_string())),
     };
 
-    let spans = collect_target_spans(&query, &tree, source.as_bytes(), target_index);
+    let spans = collect_target_spans(&query, &tree, &source, target_index);
     if spans.is_empty() {
         return Ok(unchanged(&source, "no_match", 0, None));
     }
@@ -348,10 +348,10 @@ fn apply_one(path_str: &str, cfg: &FileJob<'_>) -> Result<FileOutcome, HostlibEr
             return Ok(FileOutcome {
                 result: "syntax_error",
                 match_count: chosen.len(),
-                before_sha: Some(sha256_hex(source.as_bytes())),
-                after_sha: Some(sha256_hex(patched.as_bytes())),
+                before_sha: Some(sha256_hex(&source)),
+                after_sha: Some(sha256_hex(&patched)),
                 changed: false,
-                preview: Some(patched),
+                preview: Some(lossy_str(&patched)),
                 details: Some(detail),
             });
         }
@@ -368,10 +368,10 @@ fn apply_one(path_str: &str, cfg: &FileJob<'_>) -> Result<FileOutcome, HostlibEr
     Ok(FileOutcome {
         result: "applied",
         match_count: chosen.len(),
-        before_sha: Some(sha256_hex(source.as_bytes())),
-        after_sha: Some(sha256_hex(patched.as_bytes())),
+        before_sha: Some(sha256_hex(&source)),
+        after_sha: Some(sha256_hex(&patched)),
         changed,
-        preview: Some(patched),
+        preview: Some(lossy_str(&patched)),
         details: None,
     })
 }
@@ -382,12 +382,12 @@ fn apply_one(path_str: &str, cfg: &FileJob<'_>) -> Result<FileOutcome, HostlibEr
 /// so echoing its full source back for every non-matching file would bloat
 /// a large batch's response for nothing.
 fn unchanged(
-    source: &str,
+    source: &[u8],
     result: &'static str,
     match_count: usize,
     details: Option<String>,
 ) -> FileOutcome {
-    let sha = sha256_hex(source.as_bytes());
+    let sha = sha256_hex(source);
     FileOutcome {
         result,
         match_count,

--- a/crates/harn-hostlib/src/ast/edit_common.rs
+++ b/crates/harn-hostlib/src/ast/edit_common.rs
@@ -13,7 +13,7 @@ use tree_sitter::{Node, Query, QueryCursor, QueryError, QueryErrorKind, Tree};
 use crate::error::HostlibError;
 
 use super::language::Language;
-use super::parse::parse_source;
+use super::parse::parse_bytes;
 
 /// A matched, replaceable byte span plus its 0-based row/col coordinates
 /// and the original text it covers. Shared by every query-driven edit
@@ -164,12 +164,19 @@ fn insert_span(into: &mut BTreeMap<(usize, usize), Span>, node: Node<'_>, source
 /// processed in reverse start order so earlier byte offsets stay valid as
 /// later ones are rewritten; whitespace and trivia outside each span are
 /// preserved verbatim (the format-preserving guarantee).
-pub(super) fn splice(source: &str, chosen: &[Span], replacement: &str) -> String {
+///
+/// Operates on raw bytes so that bytes outside the edited spans — including
+/// any invalid-UTF-8 bytes elsewhere in the file — are copied through
+/// untouched. The span offsets must index `source` directly (they come from
+/// a tree parsed over these same raw bytes via [`parse_bytes`]).
+pub(super) fn splice(source: &[u8], chosen: &[Span], replacement: &str) -> Vec<u8> {
     let mut by_start: Vec<&Span> = chosen.iter().collect();
     by_start.sort_by_key(|s| std::cmp::Reverse(s.start_byte));
-    let mut out = source.to_string();
+    let mut out = source.to_vec();
     for span in by_start {
-        out.replace_range(span.start_byte..span.end_byte, replacement);
+        let end = span.end_byte.min(out.len());
+        let start = span.start_byte.min(end);
+        out.splice(start..end, replacement.bytes());
     }
     out
 }
@@ -228,8 +235,8 @@ pub(super) fn format_query_error(err: &QueryError) -> String {
 /// any ERROR / MISSING node, return a short human-readable diagnostic
 /// pinpointing the first offender. Returns `None` when the source
 /// parses cleanly.
-pub(super) fn first_syntax_error(source: &str, language: Language) -> Option<String> {
-    let tree = parse_source(source, language).ok()?;
+pub(super) fn first_syntax_error(source: &[u8], language: Language) -> Option<String> {
+    let tree = parse_bytes(source, language).ok()?;
     let root = tree.root_node();
     if !root.has_error() {
         return None;
@@ -266,14 +273,13 @@ pub(super) fn first_syntax_error(source: &str, language: Language) -> Option<Str
     Some("post-edit source has parse errors".into())
 }
 
-pub(super) fn node_text(node: Node<'_>, source: &str) -> String {
-    let bytes = source.as_bytes();
-    let start = node.start_byte().min(bytes.len());
-    let end = node.end_byte().min(bytes.len());
+pub(super) fn node_text(node: Node<'_>, source: &[u8]) -> String {
+    let start = node.start_byte().min(source.len());
+    let end = node.end_byte().min(source.len());
     if start >= end {
         return String::new();
     }
-    std::str::from_utf8(&bytes[start..end])
+    std::str::from_utf8(&source[start..end])
         .map(|s| s.to_string())
         .unwrap_or_default()
 }
@@ -290,12 +296,18 @@ pub(super) fn sha256_hex(bytes: &[u8]) -> String {
 /// Read `path` through staged-fs when `session_id` is set, otherwise
 /// fall back to the real filesystem. Truncates to `max_bytes` (`0` is
 /// unlimited). `builtin` names the caller for error reporting.
+///
+/// Returns the **raw bytes** verbatim — no lossy UTF-8 decoding. The edit
+/// primitives parse, splice, and write these same bytes, so any invalid
+/// UTF-8 elsewhere in the file survives a targeted edit untouched. Decoding
+/// to a `String` here would silently rewrite every invalid byte in the file
+/// to U+FFFD on write-back, even in regions the edit never touched.
 pub(super) fn read_source(
     builtin: &'static str,
     path: &Path,
     session_id: Option<&str>,
     max_bytes: usize,
-) -> Result<String, HostlibError> {
+) -> Result<Vec<u8>, HostlibError> {
     let bytes = if let Some(result) = crate::fs::read(path, session_id) {
         result.map_err(|err| HostlibError::Backend {
             builtin,
@@ -307,26 +319,34 @@ pub(super) fn read_source(
             message: format!("read `{}`: {err}", path.display()),
         })?
     };
-    let slice = if max_bytes == 0 || bytes.len() <= max_bytes {
-        &bytes[..]
+    if max_bytes != 0 && bytes.len() > max_bytes {
+        Ok(bytes[..max_bytes].to_vec())
     } else {
-        &bytes[..max_bytes]
-    };
-    Ok(String::from_utf8_lossy(slice).into_owned())
+        Ok(bytes)
+    }
+}
+
+/// Best-effort UTF-8 view of raw source bytes for display/heuristic use
+/// (response previews, indent detection). Lossy decoding is safe here
+/// because the result never feeds back into byte offsets or the write
+/// path — only [`splice`]/[`write_source`] over the raw bytes do.
+pub(super) fn lossy_str(source: &[u8]) -> String {
+    String::from_utf8_lossy(source).into_owned()
 }
 
 /// Write `contents` to `path`. Routes through staged-fs when active;
 /// otherwise captures an auto-snapshot (#1722 fallback) and writes
 /// directly. Creates the parent directory if it doesn't exist.
+///
+/// Takes raw bytes so the byte-preserving edit path can write back the
+/// original (possibly non-UTF-8) bytes outside the edited span verbatim.
 pub(super) fn write_source(
     builtin: &'static str,
     path: &Path,
-    contents: &str,
+    contents: &[u8],
     session_id: Option<&str>,
 ) -> Result<(), HostlibError> {
-    if crate::fs::stage_write_or_none(builtin, path, contents.as_bytes(), true, true, session_id)?
-        .is_some()
-    {
+    if crate::fs::stage_write_or_none(builtin, path, contents, true, true, session_id)?.is_some() {
         return Ok(());
     }
     crate::fs_snapshot::auto_capture_for_write(builtin, path);

--- a/crates/harn-hostlib/src/ast/insert_at_anchor.rs
+++ b/crates/harn-hostlib/src/ast/insert_at_anchor.rs
@@ -52,11 +52,11 @@ use crate::tools::args::{
 use crate::tools::permissions::enforce_path_scope;
 
 use super::edit_common::{
-    first_syntax_error, format_query_error, read_source, resolve_target_capture, sha256_hex,
-    write_source,
+    first_syntax_error, format_query_error, lossy_str, read_source, resolve_target_capture,
+    sha256_hex, write_source,
 };
 use super::language::{Language, TEXT_PATCH_FALLBACK};
-use super::parse::parse_source;
+use super::parse::parse_bytes;
 
 const BUILTIN: &str = "hostlib_ast_insert_at_anchor";
 const DEFAULT_TARGET_CAPTURE: &str = "anchor";
@@ -176,12 +176,12 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         }
     };
 
-    let tree = parse_source(&source, language).map_err(|err| HostlibError::Backend {
+    let tree = parse_bytes(&source, language).map_err(|err| HostlibError::Backend {
         builtin: BUILTIN,
         message: err.to_string(),
     })?;
 
-    let anchors = collect_anchors(&query, &tree, source.as_bytes(), target_index);
+    let anchors = collect_anchors(&query, &tree, &source, target_index);
     if anchors.is_empty() {
         return Ok(no_match_response(
             &path_str,
@@ -227,7 +227,11 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     if validate {
         if let Some(detail) = first_syntax_error(&patched, language) {
-            return Ok(syntax_error_response(&path_str, &patched, &detail));
+            return Ok(syntax_error_response(
+                &path_str,
+                &lossy_str(&patched),
+                &detail,
+            ));
         }
     }
 
@@ -335,13 +339,13 @@ struct InsertionPlan {
 }
 
 fn build_insertion(
-    source: &str,
+    source: &[u8],
     anchor: Node<'_>,
     position: Position,
     language: Language,
     indent_override: Option<&str>,
 ) -> Result<InsertionPlan, String> {
-    let bytes = source.as_bytes();
+    let bytes = source;
     let anchor_indent = line_indent(bytes, anchor.start_byte());
 
     match position {
@@ -514,13 +518,16 @@ fn line_indent(bytes: &[u8], byte: usize) -> String {
 
 /// Detect the file's prevailing indent unit so child insertions feel
 /// native. Override > language default > heuristic scan.
-fn indent_unit(source: &str, language: Language, override_unit: Option<&str>) -> String {
+fn indent_unit(source: &[u8], language: Language, override_unit: Option<&str>) -> String {
     if let Some(unit) = override_unit {
         if !unit.is_empty() {
             return unit.to_string();
         }
     }
-    if let Some(unit) = scan_indent_unit(source) {
+    // Indent detection is a display/formatting heuristic, so a lossy view
+    // of the raw bytes is fine here — it never feeds back into byte offsets
+    // or the write path.
+    if let Some(unit) = scan_indent_unit(&lossy_str(source)) {
         return unit;
     }
     language_default_indent(language).to_string()
@@ -587,12 +594,16 @@ fn reindent_lines(body: &str, indent: &str) -> String {
     out
 }
 
-fn splice_insert(source: &str, byte: usize, text: &str) -> String {
-    let mut out = String::with_capacity(source.len() + text.len());
+/// Insert `text` at byte offset `byte` in the raw `source` bytes. Operates
+/// on bytes so any non-UTF-8 bytes elsewhere in the file pass through the
+/// insertion untouched (`byte` is a tree-sitter offset over these same raw
+/// bytes via [`parse_bytes`]).
+fn splice_insert(source: &[u8], byte: usize, text: &str) -> Vec<u8> {
     let cut = byte.min(source.len());
-    out.push_str(&source[..cut]);
-    out.push_str(text);
-    out.push_str(&source[cut..]);
+    let mut out = Vec::with_capacity(source.len() + text.len());
+    out.extend_from_slice(&source[..cut]);
+    out.extend_from_slice(text.as_bytes());
+    out.extend_from_slice(&source[cut..]);
     out
 }
 
@@ -603,8 +614,8 @@ fn splice_insert(source: &str, byte: usize, text: &str) -> String {
 #[allow(clippy::too_many_arguments)]
 fn applied_response(
     path: &str,
-    before: &str,
-    after: &str,
+    before: &[u8],
+    after: &[u8],
     anchor: &AnchorSpan,
     insertion_byte: usize,
     inserted_text: &str,
@@ -622,9 +633,9 @@ fn applied_response(
         ("indent", str_value(target_indent)),
         ("inserted_text", str_value(inserted_text)),
         ("anchor", anchor_to_value(anchor)),
-        ("before_sha256", str_value(sha256_hex(before.as_bytes()))),
-        ("after_sha256", str_value(sha256_hex(after.as_bytes()))),
-        ("preview", str_value(after)),
+        ("before_sha256", str_value(sha256_hex(before))),
+        ("after_sha256", str_value(sha256_hex(after))),
+        ("preview", str_value(lossy_str(after))),
     ])
 }
 
@@ -800,6 +811,59 @@ mod tests {
         assert!(
             alpha < beta && beta < gamma,
             "beta must land between alpha and gamma:\n{preview}"
+        );
+    }
+
+    fn write_temp_bytes(extension: &str, source: &[u8]) -> NamedTempFile {
+        let mut file = tempfile::Builder::new()
+            .suffix(&format!(".{extension}"))
+            .tempfile()
+            .expect("temp file");
+        file.write_all(source).expect("write source");
+        file
+    }
+
+    #[test]
+    fn preserves_invalid_utf8_bytes_outside_insertion() {
+        // An invalid byte (0x80) lives in a comment far from the insertion
+        // anchor. Reading the file lossily and writing the decoded buffer
+        // back would rewrite 0x80 to U+FFFD even though the insert never
+        // touches that region.
+        let mut source: Vec<u8> = b"// header byte: ".to_vec();
+        source.push(0x80);
+        source.extend_from_slice(b"\nfn alpha() {\n    1\n}\n");
+        assert!(
+            std::str::from_utf8(&source).is_err(),
+            "fixture must be non-UTF8"
+        );
+
+        let file = write_temp_bytes("rs", &source);
+        let path = file.path().to_string_lossy().to_string();
+        let result = invoke(dict(&[
+            ("path", vm_string(&path)),
+            (
+                "query",
+                vm_string(
+                    "(function_item name: (identifier) @name (#eq? @name \"alpha\")) @anchor",
+                ),
+            ),
+            ("position", vm_string("after")),
+            ("content", vm_string("fn beta() {\n    2\n}")),
+        ]));
+        assert_eq!(s(field(&result, "result")), "applied");
+
+        let on_disk = std::fs::read(file.path()).expect("read raw bytes");
+        assert!(
+            String::from_utf8_lossy(&on_disk).contains("fn beta()"),
+            "insert should apply"
+        );
+        assert!(
+            on_disk.contains(&0x80),
+            "invalid byte must be preserved, not rewritten to U+FFFD"
+        );
+        assert!(
+            !on_disk.windows(3).any(|w| w == [0xEF, 0xBF, 0xBD]),
+            "no U+FFFD replacement bytes should be introduced"
         );
     }
 

--- a/crates/harn-hostlib/src/ast/parse.rs
+++ b/crates/harn-hostlib/src/ast/parse.rs
@@ -89,6 +89,15 @@ pub(super) fn read_source(path: &str, max_bytes: usize) -> Result<String, Hostli
 /// Build a parser, point it at `language`'s grammar, and parse `source`.
 /// Tree-sitter parser construction is cheap; we don't bother pooling.
 pub(super) fn parse_source(source: &str, language: Language) -> Result<Tree, HostlibError> {
+    parse_bytes(source.as_bytes(), language)
+}
+
+/// Parse raw `source` bytes for `language`. The byte offsets in the
+/// returned tree index `source` directly, so the AST edit primitives can
+/// splice on the original bytes and preserve any non-UTF-8 bytes verbatim
+/// (lossy decoding the source first would corrupt them — see the
+/// byte-preserving edit path in `edit_common`).
+pub(super) fn parse_bytes(source: &[u8], language: Language) -> Result<Tree, HostlibError> {
     let ts_language = language
         .ts_language()
         .ok_or_else(|| HostlibError::Backend {

--- a/crates/harn-hostlib/src/ast/search.rs
+++ b/crates/harn-hostlib/src/ast/search.rs
@@ -48,7 +48,7 @@ use crate::tools::args::{
 };
 use crate::tools::permissions::enforce_path_scope;
 
-use super::edit_common::{format_query_error, node_text, read_source};
+use super::edit_common::{format_query_error, lossy_str, node_text, read_source};
 use super::language::{Language, TEXT_PATCH_FALLBACK};
 use super::parse::parse_source;
 
@@ -85,7 +85,8 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
                     ))
                 }
             };
-            (read_source(BUILTIN, &path, None, 0)?, language)
+            // Read-only search: lossy decode is fine, no bytes are written back.
+            (lossy_str(&read_source(BUILTIN, &path, None, 0)?), language)
         }
         (None, Some(src)) => {
             // Inline source carries no extension, so a language is required.
@@ -235,7 +236,7 @@ fn collect_matches(query: &Query, tree: &Tree, source: &str) -> Vec<SearchMatch>
             if !captures.iter().any(|c| c.name == name) {
                 captures.push(CaptureBinding {
                     name: name.to_string(),
-                    text: node_text(capture.node, source),
+                    text: node_text(capture.node, source_bytes),
                     span,
                 });
             }


### PR DESCRIPTION
## Problem

The AST edit builtins (`ast.apply_node`, `ast.batch_apply`, `ast.insert_at_anchor`) read the target file with `String::from_utf8_lossy` (`edit_common.rs::read_source`) and then wrote the *whole decoded buffer* back to disk.

Any invalid-UTF-8 byte **anywhere** in the file — a Latin-1 byte, a `\x80` in a comment or byte-string, mojibake — was silently rewritten to the 3-byte U+FFFD encoding on write-back, **even in regions the edit never touched**. The model only observed its targeted span succeeding, so this was irreversible, silent, model-invisible byte-level data loss.

Trigger frequency is low (only files that already contain invalid UTF-8), but the impact is high: silent, irreversible whole-file encoding corruption the agent cannot see.

### Code path (before)

- `read_source` returned `String::from_utf8_lossy(slice).into_owned()` — already U+FFFD-substituted.
- `splice` / `splice_insert` rebuilt the output from that lossy `String` (only the chosen span was replaced; every untouched region came from the lossy buffer).
- `write_source` wrote the whole lossy `String` back via staged-fs or `std::fs::write` — no original-bytes path preserved. Fired on **both** the staged-fs and direct-fs paths.

## Fix

The edit pipeline is now byte-oriented end to end:

- `read_source` returns the **raw bytes** verbatim (no lossy decode).
- New `parse::parse_bytes` parses tree-sitter over the raw bytes, so span byte offsets index the original bytes directly.
- `splice` / `splice_insert` operate on `&[u8]` → `Vec<u8>`; bytes outside the edited span are copied through untouched.
- `write_source` takes `&[u8]` and writes raw bytes.

Lossy decoding is retained **only** for display-only surfaces where nothing is written back: response previews / syntax-error diagnostics (via the new `lossy_str` helper) and the read-only `ast.search` text bindings.

## Tests

Adds Rust regression tests in `apply_node` and `insert_at_anchor` that write a fixture containing a `0x80` byte in a comment, run an edit that never touches it, and assert the byte survives with no U+FFFD (`EF BF BD`) bytes introduced. Both tests **fail** against the prior lossy-read behavior (verified by temporarily reinstating the lossy round-trip) and pass with this fix.

`cargo test -p harn-hostlib` (308 lib + integration tests) green; `cargo clippy -p harn-hostlib` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)