### PR TITLE
fix(harn-vm): precise, actionable tool-call parser feedback (D2/D3/D5/D8)

### DIFF
--- a/changelog.d/toolcall-feedback-quality.fixed.md
+++ b/changelog.d/toolcall-feedback-quality.fixed.md
@@ -1,0 +1,21 @@
+- `harn-vm` tool-call parser feedback is now precise about what went wrong and
+  how to fix it, so cheap coding models stop re-emitting the same broken turn:
+  - Source/test code emitted where a tool call was expected (`it(...)`,
+    `expect(...)`, `describe(...)`, `assertServiceCount(...)`, …) no longer
+    reports a misleading `Unknown tool 'it'`. The feedback now names the real
+    cause — code outside a heredoc/`content` envelope — and tells the model to
+    wrap it.
+  - The "Unknown tool" available-tools list is no longer capped at 20 names
+    (which could hide the very tool the model needed). It lists every tool, and
+    appends an explicit `…and N more` only for a pathologically large registry —
+    never silently truncating. The highest-frequency misses (`read`, `write`,
+    `list`, `search`, …) now carry a canonical alias hint, e.g. `read` →
+    `look({ intent: "read" })`. Genuine close-miss typos still get the
+    `Did you mean '<tool>'?` suggestion. Applies to both the bare-TS and
+    native-JSON tool-call parsers.
+  - A denied/permission-gated tool result now carries an actionable `next_step`
+    ("do not retry the same call; make progress with allowed tools, or ask for
+    permission") instead of a bare `{"error":"permission_denied"}`.
+  - Object-literal tool-call parse errors now include a short `Raw:` preview of
+    the offending span (mirroring the native-JSON parser), so the model can tell
+    which of several on-screen calls failed.

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -15,10 +15,21 @@ pub(super) fn stable_hash(val: &serde_json::Value) -> u64 {
 }
 
 pub(super) fn denied_tool_result(tool_name: &str, reason: impl Into<String>) -> serde_json::Value {
+    let reason = reason.into();
+    // A bare `{"error":"permission_denied", ...}` tells the model what was
+    // blocked but not what to do instead, so it tends to retry the same denied
+    // call. Add a generic, capability-gate-appropriate next step: don't repeat
+    // the call, find another way to make progress, or ask for the permission.
+    let next_step = format!(
+        "The `{tool_name}` tool is not permitted right now. Do not retry the same call. \
+         Make progress with the tools you are allowed to use, or if this capability is \
+         essential, briefly tell the user what you need permission for and why."
+    );
     serde_json::json!({
         "error": "permission_denied",
         "tool": tool_name,
-        "reason": reason.into(),
+        "reason": reason,
+        "next_step": next_step,
     })
 }
 
@@ -510,6 +521,31 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
     use tokio::sync::Mutex;
+
+    // D5: a permission denial must tell the model what to do instead, not just
+    // report `{"error":"permission_denied"}`. The bare object made the model
+    // retry the same blocked call; the `next_step` field gives it an out.
+    #[test]
+    fn denied_tool_result_includes_actionable_next_step() {
+        let result = denied_tool_result("run", "shell access is disabled");
+        assert_eq!(result["error"], serde_json::json!("permission_denied"));
+        assert_eq!(result["tool"], serde_json::json!("run"));
+        assert_eq!(
+            result["reason"],
+            serde_json::json!("shell access is disabled")
+        );
+        let next = result["next_step"]
+            .as_str()
+            .expect("denial should carry a next_step string");
+        assert!(
+            next.contains("Do not retry"),
+            "next_step should steer the model off a retry loop: {next}"
+        );
+        assert!(
+            next.contains("run"),
+            "next_step should name the denied tool: {next}"
+        );
+    }
 
     fn tools_dict(entries: Vec<(&str, BTreeMap<String, VmValue>)>) -> VmValue {
         let list: Vec<VmValue> = entries

--- a/crates/harn-vm/src/llm/tools/parse/bare.rs
+++ b/crates/harn-vm/src/llm/tools/parse/bare.rs
@@ -4,7 +4,7 @@ use super::native_json::parse_native_json_tool_calls;
 use super::syntax::{
     collapse_blank_lines, has_object_literal_arg_start, ident_length, parse_object_literal_from,
     parse_ts_call_from, strip_empty_fences, strip_thinking_tags, strip_tool_call_wrappers,
-    unwrap_exact_code_wrapper,
+    unknown_tool_feedback, unwrap_exact_code_wrapper,
 };
 use super::TextToolParseResult;
 use crate::llm::tools::collect_tool_schemas;
@@ -247,12 +247,7 @@ pub(crate) fn parse_bare_calls_in_body(
                                 }
                             }
                         } else if object_arg_start {
-                            let available: Vec<_> = known.iter().take(20).cloned().collect();
-                            errors.push(format!(
-                                "Unknown tool '{}'. Available tools: [{}]",
-                                name_str,
-                                available.join(", ")
-                            ));
+                            errors.push(unknown_tool_feedback(name_str, &known));
                             i = k + name_len + 1;
                             at_line_start = false;
                             continue;

--- a/crates/harn-vm/src/llm/tools/parse/native_json.rs
+++ b/crates/harn-vm/src/llm/tools/parse/native_json.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use super::syntax::preview_str;
+use super::syntax::{preview_str, unknown_tool_feedback};
 
 /// Detect and parse OpenAI-style native function calling JSON that a model
 /// emitted as raw text. Matches `[{"id":...,"function":{"name":"...",
@@ -42,12 +42,7 @@ pub(crate) fn parse_native_json_tool_calls(
             continue;
         }
         if !known_tools.contains(name) {
-            let available: Vec<_> = known_tools.iter().take(20).cloned().collect();
-            errors.push(format!(
-                "Unknown tool '{}'. Available tools: [{}]",
-                name,
-                available.join(", ")
-            ));
+            errors.push(unknown_tool_feedback(name, known_tools));
             continue;
         }
         // OpenAI format encodes arguments as a JSON string; others as an object.

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -1,6 +1,150 @@
+use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
 use super::super::ts_value_parser::TsValueParser;
+
+/// Identifiers a model commonly emits as raw source/test code at the start of a
+/// line — `it(...)`, `expect(...)`, `describe(...)`, `assertServiceCount(...)`,
+/// etc. When one of these appears where a tool call is expected, the real cause
+/// is "code emitted outside a heredoc/content envelope," NOT "the model called
+/// an unknown tool." Naming the wrong cause (`Unknown tool 'it'`) gives the
+/// model no signal to re-wrap the body, so several eval transcripts show it
+/// re-emitting the same code and re-failing. We treat a name as source code
+/// when it is one of these well-known non-tool identifiers.
+const SOURCE_CODE_IDENTIFIERS: &[&str] = &[
+    // JS/TS test frameworks (jest, mocha, vitest, jasmine).
+    "it",
+    "test",
+    "describe",
+    "expect",
+    "beforeEach",
+    "afterEach",
+    "beforeAll",
+    "afterAll",
+    "suite",
+    "context",
+    // Common assertion helpers (custom + library).
+    "assert",
+    "assertEquals",
+    "assertEqual",
+    "assertTrue",
+    "assertFalse",
+    "assertThat",
+    "require",
+    // Generic source-ish calls models leak as bare lines.
+    "console",
+    "print",
+    "println",
+    "printf",
+    "fmt",
+    "func",
+    "function",
+    "return",
+    "if",
+    "for",
+    "while",
+    "class",
+    "def",
+];
+
+/// True when `name` is a project-specific custom assertion the model is likely
+/// writing as test source (e.g. `assertServiceCount(...)`). We match the common
+/// `assert*`/`expect*`/`check*`/`verify*` test-helper prefixes (camelCase, so
+/// the char after the prefix is uppercase) to catch the long tail of bespoke
+/// helpers without hardcoding every project's names.
+fn looks_like_test_helper(name: &str) -> bool {
+    for prefix in ["assert", "expect", "check", "verify", "should", "mock"] {
+        if let Some(rest) = name.strip_prefix(prefix) {
+            if rest.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// True when `name` looks like the model's own source/test code rather than a
+/// (mistyped) tool call. Used to route the feedback to the heredoc-envelope
+/// message instead of a misleading "Unknown tool" message.
+pub(super) fn looks_like_source_code(name: &str) -> bool {
+    SOURCE_CODE_IDENTIFIERS.contains(&name) || looks_like_test_helper(name)
+}
+
+/// High-frequency tool-name misses where the right answer is always the same
+/// canonical call. The #1 real miss across eval transcripts is `read` (271×),
+/// where the answer is `look({ intent: "read" })`. Sourced here as a small
+/// static table because the canonical replacement is a full call shape, not a
+/// rename the live registry can express.
+fn tool_alias_hint(name: &str) -> Option<&'static str> {
+    match name {
+        "read" | "read_file" | "readFile" | "cat" | "open" => {
+            Some("Use `look({ intent: \"read\", ... })` to read a file.")
+        }
+        "write" | "write_file" | "writeFile" => {
+            Some("Use `edit({ action: \"create\", ... })` to write a file.")
+        }
+        "list" | "ls" | "list_files" => {
+            Some("Use `look({ intent: \"list\", ... })` to list files.")
+        }
+        "search" | "grep" | "find" => {
+            Some("Use `look({ intent: \"search\", ... })` to search the codebase.")
+        }
+        _ => None,
+    }
+}
+
+/// Render the full available-tool list, sorted and never silently truncated.
+/// The previous `known.iter().take(20)` cap could hide the very tool the model
+/// needed (225 transcripts), so we list every tool. If the registry is ever
+/// pathologically large we keep the head and append an explicit `…and N more`
+/// marker rather than dropping names without a trace.
+fn render_available_tools(known: &BTreeSet<String>) -> String {
+    const CAP: usize = 60;
+    if known.len() <= CAP {
+        return known.iter().cloned().collect::<Vec<_>>().join(", ");
+    }
+    let head = known.iter().take(CAP).cloned().collect::<Vec<_>>();
+    format!("{}, …and {} more", head.join(", "), known.len() - CAP)
+}
+
+/// Build the model-facing feedback for a name that parsed like a tool call
+/// (`name({ ... })`) but is not a registered tool. Routes to the most
+/// actionable message: a close-miss typo suggestion, a known-alias hint
+/// (e.g. `read` → `look`), a "this is source code, wrap it in a heredoc"
+/// message when the name looks like the model's own code, or a plain
+/// unknown-tool listing. Shared by the bare and native-JSON parsers so both
+/// surfaces give the same precise {what/why/how-to-fix} guidance.
+pub(super) fn unknown_tool_feedback(name: &str, known: &BTreeSet<String>) -> String {
+    let available = render_available_tools(known);
+
+    // Genuine close-miss typo (e.g. `edt` → `edit`): keep the existing
+    // suggestion behavior, which is the most likely intent.
+    if let Some(suggestion) = crate::value::closest_match(name, known.iter().map(String::as_str)) {
+        return format!(
+            "Unknown tool '{name}'. Did you mean '{suggestion}'? \
+             Tool calls must be one of: [{available}]."
+        );
+    }
+
+    // High-frequency alias where the real tool is a specific call shape.
+    if let Some(hint) = tool_alias_hint(name) {
+        return format!("Unknown tool '{name}'. {hint} Tool calls must be one of: [{available}].");
+    }
+
+    // Not close to any real tool AND it looks like the model's own source/test
+    // code: name the real cause so the model re-wraps it instead of re-emitting
+    // the same code as a "tool call."
+    if looks_like_source_code(name) {
+        return format!(
+            "`{name}(...)` looks like source code, not a tool call. If this is file \
+             content, wrap it in a heredoc or a string `content` value (e.g. \
+             `edit({{ action: \"create\", path: ..., content: <<EOF ... EOF }})`). \
+             Tool calls must be one of: [{available}]."
+        );
+    }
+
+    format!("Unknown tool '{name}'. Tool calls must be one of: [{available}].")
+}
 
 /// Strip leaked thinking tags from model output. Some models (Qwen, Gemma)
 /// emit `</think>` or `<think>` markers in their response text when the
@@ -144,15 +288,21 @@ pub(super) fn parse_object_literal_from(
     let mut parser = TsValueParser::new(text);
     parser.skip_ws_and_comments();
     let value = parser.parse_value().map_err(|error| {
+        // Include a short preview of the offending span so the model can tell
+        // which of several on-screen calls failed (the native-JSON parser
+        // already shows `Raw: …`; mirror it here for object-literal failures).
         format!(
             "TOOL CALL PARSE ERROR: `{name}{{...}}` — {error}. \
-             Tool arguments must be a TypeScript object literal."
+             Tool arguments must be a TypeScript object literal. Raw: {}",
+            preview_str(text, 200)
         )
     })?;
     match value {
         serde_json::Value::Object(map) => Ok((serde_json::Value::Object(map), parser.position())),
         other => Err(format!(
-            "TOOL CALL PARSE ERROR: `{name}{{...}}` — expected an object literal argument, got `{other}`."
+            "TOOL CALL PARSE ERROR: `{name}{{...}}` — expected an object literal argument, \
+             got `{other}`. Raw: {}",
+            preview_str(text, 200)
         )),
     }
 }
@@ -679,9 +829,14 @@ pub(crate) fn parse_ts_call_from(
         serde_json::Value::Object(serde_json::Map::new())
     } else {
         parser.parse_value().map_err(|error| {
+            // Preview the offending arg span so the model can tell which call
+            // failed when several appear on screen (mirrors the native-JSON
+            // `Raw: …` snippet).
             format!(
                 "TOOL CALL PARSE ERROR: `{name}(...)` — {error}. \
-                 Tool arguments must be a TypeScript object literal: `{{ key: value, key: value }}`."
+                 Tool arguments must be a TypeScript object literal: `{{ key: value, key: value }}`. \
+                 Raw: {}",
+                preview_str(&text[paren_open + 1..], 200)
             )
         })?
     };

--- a/crates/harn-vm/src/llm/tools/tests/core_parser.rs
+++ b/crates/harn-vm/src/llm/tools/tests/core_parser.rs
@@ -245,12 +245,89 @@ fn reports_unknown_tool_names() {
         result.errors[0]
     );
     assert!(
-        result.errors[0].contains("Available tools:"),
+        result.errors[0].contains("Tool calls must be one of:"),
         "error should list available tools: {}",
         result.errors[0]
     );
     assert_eq!(result.calls.len(), 1, "valid edit call should still parse");
     assert_eq!(result.calls[0]["name"], json!("edit"));
+}
+
+// D3: the available-tool list must never be silently truncated. With a small
+// registry every tool name must appear; with a huge one we append an explicit
+// "…and N more" marker rather than dropping names without a trace.
+#[test]
+fn unknown_tool_lists_every_available_tool() {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body("fictitious_tool({ x: 1 })", Some(&tools));
+    assert_eq!(result.errors.len(), 1);
+    let msg = &result.errors[0];
+    // sample_tool_registry has `edit` and `run`; both must be listed.
+    assert!(msg.contains("edit"), "should list edit: {msg}");
+    assert!(msg.contains("run"), "should list run: {msg}");
+    assert!(
+        !msg.contains("and") || !msg.contains("more"),
+        "small registry must not truncate: {msg}"
+    );
+}
+
+// D3: the #1 real miss is `read`, where the answer is always
+// `look({ intent: "read" })`. The alias hint must name that.
+#[test]
+fn unknown_read_suggests_look_alias() {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body("read({ path: \"a.go\" })", Some(&tools));
+    assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+    let msg = &result.errors[0];
+    assert!(
+        msg.contains("look(") && msg.contains("intent"),
+        "read should be aliased to look({{intent:\"read\"}}): {msg}"
+    );
+}
+
+// D2: when the model emits its own test/source code (`it(...)`,
+// `expect(...)`, `assertServiceCount(...)`) where a tool call is expected, the
+// feedback must name the real cause — code outside a heredoc/content envelope —
+// not blame the model for an "unknown tool", so it knows to re-wrap it.
+#[test]
+fn code_emitted_outside_heredoc_reports_envelope_cause() {
+    let tools = sample_tool_registry();
+    for snippet in [
+        "it({ x: 1 })",
+        "expect({ x: 1 })",
+        "describe({ x: 1 })",
+        "assertServiceCount({ x: 1 })",
+    ] {
+        let result = parse_bare_calls_in_body(snippet, Some(&tools));
+        assert_eq!(result.errors.len(), 1, "{snippet}: {:?}", result.errors);
+        let msg = &result.errors[0];
+        assert!(
+            msg.contains("looks like source code"),
+            "{snippet} should report the source-code cause: {msg}"
+        );
+        assert!(
+            msg.contains("heredoc") || msg.contains("content"),
+            "{snippet} should tell the model to wrap it: {msg}"
+        );
+        assert!(
+            !msg.contains("Unknown tool"),
+            "{snippet} must not blame an unknown tool: {msg}"
+        );
+    }
+}
+
+// A genuine close-miss typo must still get the existing suggestion behavior,
+// not be misrouted to the source-code message.
+#[test]
+fn close_miss_typo_still_suggests_real_tool() {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body("edt({ action: \"create\" })", Some(&tools));
+    assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+    let msg = &result.errors[0];
+    assert!(
+        msg.contains("Did you mean 'edit'"),
+        "edt should suggest edit: {msg}"
+    );
 }
 
 #[test]
@@ -441,6 +518,29 @@ fn reports_bare_scalar_argument_as_needing_object_wrapper() {
     assert!(
         err.contains("object literal") || err.contains("{ key: value }"),
         "diagnostic should nudge towards object literal syntax: {err}"
+    );
+}
+
+// D8: a parse failure inside the argument object must include a short `Raw:`
+// preview of the offending span, so the model can tell which of several
+// on-screen calls failed (the native-JSON path already showed `Raw:`).
+#[test]
+fn object_literal_parse_error_includes_raw_preview() {
+    let tools = sample_tool_registry();
+    // `action:` with no value is a malformed object literal that fails the
+    // value parser, exercising the `parse_ts_call_from` error path.
+    let text = "edit({ action: })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert!(result.calls.is_empty());
+    assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+    let err = &result.errors[0];
+    assert!(
+        err.contains("Raw:"),
+        "parse error should include a Raw: preview: {err}"
+    );
+    assert!(
+        err.contains("action"),
+        "Raw: preview should echo the offending span: {err}"
     );
 }
 

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -685,8 +685,29 @@ fn native_json_fallback_reports_unknown_tools() {
         errors[0]
     );
     assert!(
-        errors[0].contains("Available tools:"),
+        errors[0].contains("Tool calls must be one of:"),
         "error should list available tools: {}",
+        errors[0]
+    );
+}
+
+// D3: the native-JSON parser must give the same alias hint as the bare parser
+// for the high-frequency `read` miss (answer is always `look`).
+#[test]
+fn native_json_unknown_read_suggests_look_alias() {
+    // A registry that has `look` (the real reader) but not `read`, so `read`
+    // is an unknown name that should be aliased to `look`.
+    let known: std::collections::BTreeSet<String> = ["edit", "look", "run"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let text = r#"[{"function":{"name":"read","arguments":"{}"}}]"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert_eq!(calls.len(), 0);
+    assert_eq!(errors.len(), 1, "errors: {errors:?}");
+    assert!(
+        errors[0].contains("look(") && errors[0].contains("intent"),
+        "read should be aliased to look: {}",
         errors[0]
     );
 }


### PR DESCRIPTION
## What

Two error-quality audits over ~2260 Burin coding-agent eval transcripts found that the `harn-vm` tool-call parser's **model-facing feedback** misdirects cheap models, so they re-emit the same broken turn instead of self-correcting. This fixes the wording at the source. All four are pure feedback-text changes — no change to what parses.

### D2 [134 transcripts] — code-as-tool-call misblamed as "Unknown tool"
When a model emits source/test code it means as file content but doesn't wrap in a heredoc/`content` value (`it(...)`, `expect(...)`, `describe(...)`, `assertServiceCount(...)`), the scanner reported `Unknown tool 'it'`. That blames the model for calling an unknown tool when the real cause is "code emitted outside a heredoc/content envelope" — and gives no signal to re-wrap. Transcripts show the model re-emitting the same code and re-failing.

**Now:** when the name is not close to any real tool AND looks like the model's own source/test code, the feedback names the real cause and tells it to wrap the body in a heredoc/`content` value.

### D3 [225 transcripts] — truncated tool list, no alias hint
The "Unknown tool" available-tools list was `known.iter().take(20)` with no "…+N more" and no closest-match/alias hint, so it could omit the very tool the model needed. The #1 real miss is `read` (271×) where the answer is always `look({ intent: "read" })`.

**Now:** lists every tool (explicit `…and N more` only for a pathologically large registry — never silent truncation), and adds a canonical alias map for the top misses (`read`→`look({intent:"read"})`, `write`→`edit`, `list`/`search`→`look`). Genuine close-miss typos still get the `Did you mean '<tool>'?` suggestion (now powered by the shared `closest_match` helper).

### D5 [MED] — denied tool result has no "what to do instead"
A denied/permission-gated tool reached the model as a bare `{"error":"permission_denied","tool":X,"reason":R}`, so it retried the same blocked call.

**Now:** adds an actionable `next_step` field ("do not retry the same call; make progress with allowed tools, or ask for permission").

### D8 [MED] — object-literal parse error omits body preview
The text-format object-literal parse error omitted a body preview, leaving the model guessing which of several on-screen calls failed (the native-JSON parser already shows `Raw: …`).

**Now:** includes a short `Raw:` preview of the offending span (both the `name({...})` and `name(...)` arg paths).

## How

The unknown-tool feedback is now one shared helper (`unknown_tool_feedback`) in `parse/syntax.rs`, used by both the bare-TS (`parse/bare.rs`) and native-JSON (`parse/native_json.rs`) parsers, so both surfaces give identical {what/why/how-to-fix} guidance.

## Tests

New unit tests assert each new message:
- code-as-tool-call (`it`/`expect`/`describe`/`assertServiceCount`) yields the heredoc-envelope message and never says "Unknown tool"
- `read` yields the `look({intent:...})` alias (bare and native-JSON parsers)
- a small registry's tool list is never truncated
- a close-miss typo (`edt`) still suggests `edit`
- an object-literal parse error includes a `Raw:` preview
- a denied tool result carries an actionable `next_step`

`cargo test -p harn-vm --lib` passes (3516 single-threaded); `cargo fmt`/`cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)