### PR TITLE
fix(agent): recoverable schema/arg rejections coach retry-with-correction, not "permission denied — do not retry"

### DIFF
--- a/changelog.d/recoverable-schema-feedback.fixed.md
+++ b/changelog.d/recoverable-schema-feedback.fixed.md
@@ -1,0 +1,8 @@
+Agent tool feedback: a recoverable schema/argument-validation rejection (a tool
+call missing a required parameter, or a malformed empty tool name) now returns a
+retry-positive `invalid_arguments` result that coaches the model to re-call the
+tool with the named correction, instead of the `permission_denied` "Do not retry
+the same call" denial body. The denial body is now reserved for true
+policy/permission denials. Cheap models were giving up after one fixable mistake
+— observed across ~26 recent eval transcripts as a false-FAIL pass-rate
+deflation.

--- a/crates/harn-vm/src/agent_events/tests.rs
+++ b/crates/harn-vm/src/agent_events/tests.rs
@@ -552,6 +552,24 @@ fn tool_call_error_category_from_internal_collapses_transient_family() {
 }
 
 #[test]
+fn only_schema_validation_is_recoverable() {
+    // Recoverable == the model can fix the call itself and retry (bad/missing
+    // args, malformed tool name). Everything else — permission denials,
+    // tool/transport errors, timeouts — is NOT something a retry-with-correction
+    // fixes, so it must not get retry-positive feedback.
+    assert!(ToolCallErrorCategory::SchemaValidation.is_recoverable());
+    for category in ToolCallErrorCategory::ALL {
+        if matches!(category, ToolCallErrorCategory::SchemaValidation) {
+            continue;
+        }
+        assert!(
+            !category.is_recoverable(),
+            "{category:?} must not be treated as recoverable"
+        );
+    }
+}
+
+#[test]
 fn tool_call_update_event_omits_error_category_when_none() {
     let event = AgentEvent::ToolCallUpdate {
         session_id: "s".into(),

--- a/crates/harn-vm/src/agent_events/tool.rs
+++ b/crates/harn-vm/src/agent_events/tool.rs
@@ -90,6 +90,17 @@ impl ToolCallErrorCategory {
         Self::Unknown,
     ];
 
+    /// Whether a rejection in this category is RECOVERABLE by the model on its
+    /// own — i.e. the call failed because of a fixable slip (bad/missing
+    /// arguments, malformed tool name) and re-issuing it *with the correction*
+    /// is the right next move. Distinguished from a true policy/permission
+    /// denial, where the model must NOT retry and should pivot or ask. Used by
+    /// the dispatch primitive to pick a retry-positive vs. don't-retry feedback
+    /// body for the model-facing tool result.
+    pub fn is_recoverable(self) -> bool {
+        matches!(self, Self::SchemaValidation)
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::SchemaValidation => "schema_validation",

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -213,7 +213,19 @@ fn agent_primitive_denied_tool(
     denial: Option<&crate::agent_events::ToolDenial>,
 ) -> serde_json::Value {
     let reason = reason.into();
-    let mut result = agent_tools::denied_tool_result(tool_name, reason.clone());
+    // Split the inner result body by category. A RECOVERABLE rejection
+    // (`SchemaValidation` — bad/missing arguments or an empty tool name) must
+    // coach a retry *with the correction* via `recoverable_tool_result`
+    // (`error: "invalid_arguments"`), never the permission-denial body. Reusing
+    // `denied_tool_result` here was the live convergence bug: cheap models read
+    // "permission_denied / Do not retry the same call" after one fixable arg
+    // mistake and gave up (false FAIL across ~26 recent eval transcripts). True
+    // policy/permission denials keep the don't-retry `denied_tool_result` body.
+    let mut result = if category.is_recoverable() {
+        agent_tools::recoverable_tool_result(tool_name, reason.clone())
+    } else {
+        agent_tools::denied_tool_result(tool_name, reason.clone())
+    };
     // Mirror the structured denial onto the inner tool result so it rides
     // along in the transcript the model sees, and onto the envelope so a
     // host harness reading the dispatch outcome can fail or pivot early
@@ -1868,6 +1880,85 @@ mod security_gate_tests {
         assert_eq!(descriptor["schemaChanged"], true);
 
         assert!(tool_descriptor_for(Some(&catalog), "unknown_tool").is_none());
+    }
+}
+
+#[cfg(test)]
+mod denied_tool_routing_tests {
+    //! `agent_primitive_denied_tool` must pick its model-facing result body by
+    //! category: RECOVERABLE rejections (schema/argument validation, malformed
+    //! tool name) coach a retry-with-correction, while TRUE policy/permission
+    //! denials keep the don't-retry body. Reverting the split (sending every
+    //! category through `denied_tool_result`) fails the recoverable assertions.
+    use super::agent_primitive_denied_tool;
+    use crate::agent_events::ToolCallErrorCategory;
+
+    #[test]
+    fn schema_validation_missing_param_yields_invalid_arguments_retry_positive() {
+        let envelope = agent_primitive_denied_tool(
+            "edit",
+            "call_1",
+            &serde_json::json!({ "content": "x" }),
+            "Tool 'edit' is missing required parameter(s): path. \
+             Provide all required parameters and try again.",
+            ToolCallErrorCategory::SchemaValidation,
+            None,
+        );
+        // Envelope-level category is still schema_validation for the wire...
+        assert_eq!(envelope["error_category"], "schema_validation");
+        // ...but the inner model-facing result is retry-positive, NOT a denial.
+        let result = &envelope["result"];
+        assert_eq!(result["error"], serde_json::json!("invalid_arguments"));
+        assert_ne!(result["error"], serde_json::json!("permission_denied"));
+        let next = result["next_step"].as_str().expect("next_step");
+        assert!(
+            !next.contains("Do not retry"),
+            "schema rejection must be retry-positive: {next}"
+        );
+        assert!(
+            next.contains("Re-call") && next.contains("edit") && next.contains("path"),
+            "next_step should re-call the named tool with the missing param: {next}"
+        );
+    }
+
+    #[test]
+    fn empty_tool_name_yields_recoverable_retry_positive_feedback() {
+        let envelope = agent_primitive_denied_tool(
+            "<unnamed>",
+            "call_2",
+            &serde_json::json!({}),
+            "Tool call is missing a name. Emit one tool call per turn as \
+             `name({ ... })` using a non-empty tool name from the allowed list, then retry.",
+            ToolCallErrorCategory::SchemaValidation,
+            None,
+        );
+        let result = &envelope["result"];
+        assert_eq!(result["error"], serde_json::json!("invalid_arguments"));
+        let next = result["next_step"].as_str().expect("next_step");
+        assert!(
+            !next.contains("Do not retry"),
+            "empty-name slip must be retry-positive: {next}"
+        );
+    }
+
+    #[test]
+    fn permission_denied_keeps_do_not_retry_body() {
+        let envelope = agent_primitive_denied_tool(
+            "run",
+            "call_3",
+            &serde_json::json!({ "command": "rm -rf /" }),
+            "shell access is disabled by policy",
+            ToolCallErrorCategory::PermissionDenied,
+            None,
+        );
+        assert_eq!(envelope["error_category"], "permission_denied");
+        let result = &envelope["result"];
+        assert_eq!(result["error"], serde_json::json!("permission_denied"));
+        let next = result["next_step"].as_str().expect("next_step");
+        assert!(
+            next.contains("Do not retry the same call"),
+            "true denial must still steer off a retry loop: {next}"
+        );
     }
 }
 

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -20,6 +20,13 @@ pub(super) fn denied_tool_result(tool_name: &str, reason: impl Into<String>) -> 
     // blocked but not what to do instead, so it tends to retry the same denied
     // call. Add a generic, capability-gate-appropriate next step: don't repeat
     // the call, find another way to make progress, or ask for the permission.
+    //
+    // RESERVED FOR TRUE POLICY/PERMISSION DENIALS (capability gate, sandbox /
+    // command policy, host rejection). The "Do not retry the same call" wording
+    // is *correct* there — the call is blocked and re-issuing it identically
+    // will be blocked again. Recoverable rejections (bad/missing arguments, an
+    // empty tool name) must NOT use this body: see `recoverable_tool_result`,
+    // which coaches a retry *with the correction* instead.
     let next_step = format!(
         "The `{tool_name}` tool is not permitted right now. Do not retry the same call. \
          Make progress with the tools you are allowed to use, or if this capability is \
@@ -31,6 +38,69 @@ pub(super) fn denied_tool_result(tool_name: &str, reason: impl Into<String>) -> 
         "reason": reason,
         "next_step": next_step,
     })
+}
+
+/// Build the tool-result body for a RECOVERABLE rejection — a schema /
+/// argument-validation failure or a malformed (empty) tool name. Unlike
+/// [`denied_tool_result`], this is explicitly retry-POSITIVE: the model made a
+/// fixable slip, so the guidance tells it to re-call the same tool *with the
+/// correction*, naming the specific missing/invalid parameter(s) when the
+/// `reason` carries them.
+///
+/// Using `error: "invalid_arguments"` (NOT `permission_denied`) is load-bearing
+/// — it keeps `is_denied_tool_result` from misclassifying a fixable mistake as a
+/// hard denial, and it stops cheap models from giving up after one correctable
+/// error (observed live: a model called `edit` without `path`, read
+/// `permission_denied / do not retry`, then made zero further edits and timed
+/// out into a false FAIL; ~26 recent eval transcripts show this pattern).
+pub(super) fn recoverable_tool_result(
+    tool_name: &str,
+    reason: impl Into<String>,
+) -> serde_json::Value {
+    let reason = reason.into();
+    // The validator phrases missing params as
+    // "... missing required parameter(s): path, mode. ...". Pull the named
+    // params out so the next_step can be concretely actionable instead of
+    // generic. Falls back to a generic-but-still-retry-positive nudge when no
+    // parameter list is present (e.g. the empty-tool-name slip).
+    let missing_params = extract_missing_params(&reason);
+    let next_step = match (tool_name, missing_params.as_deref()) {
+        ("<unnamed>", _) => "This was a malformed tool call (no tool name). It is fixable — \
+             emit exactly one tool call this turn as `name({ ... })` using a non-empty tool \
+             name from the allowed list, with all required parameters."
+            .to_string(),
+        (name, Some(params)) => format!(
+            "This is a fixable argument error, not a permission denial. \
+             Re-call `{name}` with the missing required parameter(s): {params}."
+        ),
+        (name, None) => format!(
+            "This is a fixable argument error, not a permission denial. \
+             Re-call `{name}` with corrected arguments per the reason above."
+        ),
+    };
+    serde_json::json!({
+        "error": "invalid_arguments",
+        "tool": tool_name,
+        "reason": reason,
+        "next_step": next_step,
+    })
+}
+
+/// Extract the named missing parameters from a validator `reason` of the form
+/// `"Tool 'x' is missing required parameter(s): a, b. ..."`. Returns the
+/// comma-separated parameter list (e.g. `"a, b"`) when present, else `None`.
+fn extract_missing_params(reason: &str) -> Option<String> {
+    let marker = "missing required parameter(s):";
+    let start = reason.find(marker)? + marker.len();
+    let tail = reason[start..].trim_start();
+    // The list runs up to the sentence-ending period the validator appends.
+    let end = tail.find('.').unwrap_or(tail.len());
+    let params = tail[..end].trim();
+    if params.is_empty() {
+        None
+    } else {
+        Some(params.to_string())
+    }
 }
 
 pub(super) fn render_tool_result(value: &serde_json::Value) -> String {
@@ -545,6 +615,92 @@ mod tests {
             next.contains("run"),
             "next_step should name the denied tool: {next}"
         );
+    }
+
+    // A RECOVERABLE schema/argument rejection must coach a retry WITH the
+    // correction — `error: "invalid_arguments"` (not permission_denied) and a
+    // next_step that re-calls the tool naming the missing param. Reverting the
+    // recoverable/denied split (routing this through `denied_tool_result`) makes
+    // every assertion below fail: the error flips to permission_denied and the
+    // next_step says "Do not retry the same call".
+    #[test]
+    fn recoverable_tool_result_coaches_retry_with_named_missing_param() {
+        let result = recoverable_tool_result(
+            "edit",
+            "Tool 'edit' is missing required parameter(s): path. \
+             Provide all required parameters and try again.",
+        );
+        assert_eq!(result["error"], serde_json::json!("invalid_arguments"));
+        assert_ne!(result["error"], serde_json::json!("permission_denied"));
+        assert_eq!(result["tool"], serde_json::json!("edit"));
+        let next = result["next_step"]
+            .as_str()
+            .expect("recoverable result should carry a next_step string");
+        assert!(
+            !next.contains("Do not retry"),
+            "recoverable next_step must be retry-positive, not a don't-retry denial: {next}"
+        );
+        assert!(
+            next.contains("Re-call") && next.contains("edit"),
+            "next_step should tell the model to re-call the named tool: {next}"
+        );
+        assert!(
+            next.contains("path"),
+            "next_step should name the specific missing parameter: {next}"
+        );
+    }
+
+    // The empty/malformed tool-name slip (harn#3194) is also recoverable: it
+    // must get retry-positive feedback, never the permission-denial body.
+    #[test]
+    fn recoverable_tool_result_handles_empty_tool_name() {
+        let result = recoverable_tool_result(
+            "<unnamed>",
+            "Tool call is missing a name. Emit one tool call per turn as \
+             `name({ ... })` using a non-empty tool name from the allowed list, then retry.",
+        );
+        assert_eq!(result["error"], serde_json::json!("invalid_arguments"));
+        let next = result["next_step"]
+            .as_str()
+            .expect("recoverable result should carry a next_step string");
+        assert!(
+            !next.contains("Do not retry"),
+            "empty-name feedback must be retry-positive: {next}"
+        );
+        assert!(
+            next.contains("fixable") && next.contains("name"),
+            "next_step should frame the missing name as a fixable slip: {next}"
+        );
+    }
+
+    #[test]
+    fn recoverable_tool_result_is_not_a_denial() {
+        // The loop keys flow control off `is_denied_tool_result`; a fixable
+        // argument error must NOT trip the denial detector.
+        let result = recoverable_tool_result(
+            "edit",
+            "Tool 'edit' is missing required parameter(s): path. \
+             Provide all required parameters and try again.",
+        );
+        assert!(
+            !is_denied_tool_result(&result),
+            "recoverable invalid_arguments result must not read as a denial"
+        );
+        assert!(!is_denied_tool_result(&serde_json::Value::String(
+            result.to_string()
+        )));
+    }
+
+    #[test]
+    fn extract_missing_params_pulls_named_list() {
+        assert_eq!(
+            extract_missing_params(
+                "Tool 'edit' is missing required parameter(s): path, mode. \
+                 Provide all required parameters and try again."
+            ),
+            Some("path, mode".to_string())
+        );
+        assert_eq!(extract_missing_params("Tool call is missing a name."), None);
     }
 
     fn tools_dict(entries: Vec<(&str, BTreeMap<String, VmValue>)>) -> VmValue {


### PR DESCRIPTION
## What

A recoverable schema-validation rejection — a tool call missing a required parameter, or a malformed empty tool name — was being shown to the model through `denied_tool_result`, the **same** body used for true policy/permission denials. That body's `next_step` says `error: "permission_denied" … Do not retry the same call`.

This PR makes the model-facing tool feedback **category-aware**: recoverable rejections now get a distinct retry-positive body, while true policy/permission denials keep the don't-retry wording.

- New `recoverable_tool_result` → `error: "invalid_arguments"` (NOT `permission_denied`) with a retry-POSITIVE `next_step` that names the specific missing parameter(s) parsed out of the validator reason, e.g. *"This is a fixable argument error, not a permission denial. Re-call `edit` with the missing required parameter(s): path."*
- `ToolCallErrorCategory::is_recoverable()` classifies `SchemaValidation` as recoverable; `agent_primitive_denied_tool` routes recoverable categories to the new body, everything else to `denied_tool_result`.
- Fixes **both** schema-validation gates: the missing-required-param gate at dispatch and the empty/malformed tool-name slip (harn#3194). True-denial paths are untouched — `deny_tool_call` (PermissionDenied) and the bridge/handler `ToolRejected` results keep `permission_denied` + "Do not retry the same call".
- `invalid_arguments` is intentionally **not** matched by `is_denied_tool_result`, so a fixable argument error no longer trips the loop's denial flow control.

Composes with the D5 next_step work (#3199): this splits that single denial body into recoverable-vs-denial variants.

## Why

The schema-validation gate's own comment says *"the model can fix the arguments and retry"*, but the natural-language feedback the model read contradicted that. Cheap models read "permission_denied / Do not retry the same call" after **one fixable mistake** and gave up. Observed live: a model called `edit` without `path`, got the denial, made zero further edits, and **timed out into a false FAIL**. This pattern appears across **~26 recent eval transcripts** and systematically deflates the measured pass-rate.

## Tests

New/extended `harn-vm` tests assert:
- (a) a missing-required-parameter `edit` rejection yields `invalid_arguments` + a retry-positive `next_step` naming the missing param (`path`), no "Do not retry";
- (b) an empty/malformed tool name yields recoverable retry-positive feedback;
- (c) a true permission denial still yields `permission_denied` + "Do not retry the same call".

Each recoverable assertion was verified to **FAIL** when the recoverable/denied split is reverted (the true-denial assertion still passes). `cargo fmt` + `cargo clippy` clean; `llm::agent*` and `agent_events::` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)