### PR TITLE
Stop release tooling from reflowing already-published CHANGELOG sections

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -43,6 +43,18 @@
     // GitHub PR/issue templates are forms, not prose docs — they lead with
     // an HTML comment and h2 sections, which trips MD041 (first-line-h1).
     ".github/pull_request_template.md",
-    ".github/ISSUE_TEMPLATE/**/*.md"
+    ".github/ISSUE_TEMPLATE/**/*.md",
+    // CHANGELOG.md (and the pre-0.x archives) is machine-assembled by the
+    // release tooling from `changelog.d/*` fragments and is append-only
+    // published history. Linting the assembled file for MD013 line-length
+    // flagged long lines in already-published `## vX.Y.Z` sections, which drove
+    // the release recovery agent to rewrap them — tripping
+    // `scripts/check_changelog_no_retroactive_edits.harn` ("sections for
+    // already-published versions were modified"). The fragments themselves are
+    // still linted as `*.md`, so line-length is enforced at the source; the
+    // assembled history must not be reflowed. (harn-bump-fleet release_harn.harn
+    // runs `make lint-md` post-assembly.)
+    "CHANGELOG.md",
+    "CHANGELOG-pre-*.md"
   ]
 }

--- a/changelog.d/changelog-md013-published-exempt.fixed.md
+++ b/changelog.d/changelog-md013-published-exempt.fixed.md
@@ -1,0 +1,6 @@
+Release tooling no longer reflows already-published `CHANGELOG.md` sections.
+`make lint-md` previously linted the assembled `CHANGELOG.md` (and `CHANGELOG-pre-*.md`
+archives) under MD013 line-length, so long lines in published `## vX.Y.Z` sections were
+flagged and rewrapped during a release — tripping the retroactive-edit guard. Those
+machine-assembled, append-only files are now excluded from markdownlint; the
+`changelog.d/*` fragments are still linted at the source.


### PR DESCRIPTION
## Problem
During the 0.8.9x release train, `release_harn` twice rewrapped text inside **already-published** `## vX.Y.Z` sections of `CHANGELOG.md`, tripping `scripts/check_changelog_no_retroactive_edits.harn` ("CHANGELOG.md sections for already-published versions were modified") and forcing a manual splice of main's verbatim published sections.

## Root cause
The fragment-fold assembly (in `harn-bump-fleet`) is byte-safe — it splices the new section via offset slices and never re-emits published sections. The reflow came from the **post-assembly markdown lint**:
- `harn-bump-fleet`'s `release_harn.harn` runs `make -s lint-md` as a generated-content check.
- harn's `Makefile` `lint-md` = `npx markdownlint-cli2 "**/*.md"` — lints the **entire** `CHANGELOG.md`.
- `.markdownlint-cli2.jsonc` enforces MD013 `line_length: 120` with **no CHANGELOG exemption**, so any published-section prose line >120 chars is flagged.
- On failure, the release recovery agent rewraps the offending lines — including lines in published sections → trips the retroactive-edit guard.

## Fix
Exclude the machine-assembled, append-only changelog files (`CHANGELOG.md`, `CHANGELOG-pre-*.md`) from markdownlint via `ignores`. The `changelog.d/*` fragments are still linted as `*.md`, so MD013 line-length is enforced **at the source** (where wrapping a fragment is harmless), while the assembled published history is never reflowed.

The retroactive-edit guard and the `release-pr-drift-check.yml` Unreleased-content guard are unchanged — they still catch *real* published-section drift.

## Verify
`npx markdownlint-cli2 "**/*.md"`: **0 errors**, and the discovery line now shows `!CHANGELOG.md !CHANGELOG-pre-*.md` excluded. Pre-commit markdown hook passes. Changelog fragment added.

(Addresses the internal release-tooling task; no matching GitHub issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)