### PR TITLE
harn-serve: @job Vm-configure hook for embedder host builtins (#3207)

### DIFF
--- a/changelog.d/3207.added.md
+++ b/changelog.d/3207.added.md
@@ -1,0 +1,6 @@
+- **The `@job` one-shot driver can now register embedder-defined host builtins (#3207.)** New
+  `harn_serve::run_job_once_with(.., configure: impl FnOnce(&mut Vm))` hands the embedder the
+  fully-built job VM after the standard stdlib + store/metadata registration and before the job
+  entrypoint runs, so a host builtin (e.g. a `sandbox_exec` bridge) can coexist with — or override —
+  the standard ones and be callable from the `@job` `.harn` code. `run_job_once` is unchanged and
+  delegates to the new variant with a no-op closure. Fixes #3207.

--- a/crates/harn-serve/src/adapters/worker.rs
+++ b/crates/harn-serve/src/adapters/worker.rs
@@ -117,6 +117,33 @@ pub async fn run_job_once(
     job_name: &str,
     request: serde_json::Value,
 ) -> Result<JobRunOutcome, DispatchError> {
+    run_job_once_with(script_path, job_name, request, |_vm| {}).await
+}
+
+/// Like [`run_job_once`], but lets the embedder inject extra VM state via a
+/// `configure` closure that runs on the fully-built job VM.
+///
+/// The closure receives `&mut Vm` *after* the standard registration
+/// (`register_vm_stdlib` + `register_store_builtins` +
+/// `register_metadata_builtins` + source-dir/harness wiring) and *before*
+/// the job module is loaded and the entrypoint executes. This lets an
+/// embedder register host-defined builtins (e.g. a `sandbox_exec` that
+/// bridges to a cloud-sandbox adapter) that coexist with the standard
+/// ones, so the `@job` closure can call them.
+///
+/// Ordering guarantees:
+/// - Standard stdlib + store/metadata builtins are registered first, so
+///   embedder builtins may *extend* the surface the job sees.
+/// - Embedder builtins are registered last, so a name collision *overrides*
+///   the standard builtin (`register_builtin` replaces by name).
+/// - The closure runs before `load_module_exports`, so the job module's
+///   captured globals resolve against the embedder-augmented VM.
+pub async fn run_job_once_with(
+    script_path: &Path,
+    job_name: &str,
+    request: serde_json::Value,
+    configure: impl FnOnce(&mut Vm),
+) -> Result<JobRunOutcome, DispatchError> {
     // A one-shot process owns its trigger registry / dispatcher state, so
     // start from a clean slate. (No-op the first time; defends against a
     // second call in the same process — e.g. tests.)
@@ -179,6 +206,10 @@ pub async fn run_job_once(
     harn_vm::register_metadata_builtins(&mut vm, &base_dir);
     vm.set_source_dir(&base_dir);
     vm.set_harness(harn_vm::Harness::real());
+
+    // Let the embedder register host-defined builtins on the fully-built VM
+    // before the job module loads. See `run_job_once_with` docs for ordering.
+    configure(&mut vm);
 
     let exports = vm
         .load_module_exports(script_path)
@@ -408,6 +439,49 @@ pub fn scan(event: TriggerEvent) -> dict {
                 let result = outcome.result.expect("result");
                 assert_eq!(result["status"], serde_json::json!("ok"));
                 assert_eq!(result["echo"], request);
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn configure_hook_registers_callable_host_builtin() {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let dir = tempfile::tempdir().expect("tempdir");
+                let script = write_script(
+                    dir.path(),
+                    r#"
+import "std/triggers"
+
+@job("scan")
+pub fn scan(event: TriggerEvent) -> dict {
+  let req = event.provider_payload.raw
+  return {status: "ok", host: host_echo(req.repo)}
+}
+"#,
+                )
+                .await;
+
+                let request = serde_json::json!({"repo": "burin-labs/harn"});
+                let outcome = run_job_once_with(&script, "scan", request, |vm| {
+                    // An embedder-defined builtin, injected via the configure
+                    // hook on the fully-built job VM. The `@job` closure calls
+                    // it by bare name, exactly like the stdlib builtins.
+                    vm.register_builtin("host_echo", |args, _out| {
+                        let x = args.first().map(|a| a.display()).unwrap_or_default();
+                        Ok(harn_vm::VmValue::String(std::sync::Arc::from(
+                            format!("host:{x}").as_str(),
+                        )))
+                    });
+                })
+                .await
+                .expect("run job");
+
+                assert_eq!(outcome.status, DispatchStatus::Succeeded);
+                let result = outcome.result.expect("result");
+                assert_eq!(result["status"], serde_json::json!("ok"));
+                assert_eq!(result["host"], serde_json::json!("host:burin-labs/harn"));
             })
             .await;
     }

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -51,7 +51,7 @@ pub use adapters::mcp::{
     McpHttpServeOptions, McpServer, McpServerConfig, McpStdioServer, MCP_PROTOCOL_VERSION,
 };
 pub use adapters::site::{SiteHttpServeOptions, SiteServer, SiteServerConfig};
-pub use adapters::worker::{run_job_from_files, run_job_once, JobRunOutcome};
+pub use adapters::worker::{run_job_from_files, run_job_once, run_job_once_with, JobRunOutcome};
 pub use auth::{
     AllowlistOutcome, ApiKeyAuthConfig, ApiKeyEntry, AuthMethodConfig, AuthPolicy, AuthRequest,
     AuthenticatedPrincipal, AuthorizationDecision, HmacAuthConfig, McpAllowlist, McpAllowlistTools,


### PR DESCRIPTION
Fixes #3207.

Adds `run_job_once_with(script_path, job_name, request, configure: impl FnOnce(&mut Vm)) -> Result<JobRunOutcome, DispatchError>` to the harn-serve `@job` one-shot driver, letting an embedder register host-defined builtins into the job VM. `run_job_once` is unchanged and now delegates to `run_job_once_with(.., |_vm| {})`.

The `configure(&mut vm)` runs **after** standard registration (`register_vm_stdlib` + store + metadata + source-dir/harness) and **before** `load_module_exports`/dispatch — so embedder builtins coexist with the stdlib (and override by name, since `register_builtin` replaces). Re-exported from the crate root; `run_job_from_files` untouched.

## Why
Unblocks the harn-cloud factory `scan_worker` port onto the `@job` surface: harn-cloud can inject a `sandbox_*` builtin that bridges to its Rust cloud-sandbox adapter (the ~10-12kLOC remote-provisioning orchestration that stays Rust). See harn-cloud `docs/factory/worker-dispatch-as-job-port.md`.

## Test
`configure_hook_registers_callable_host_builtin`: registers a `host_echo(x)` builtin via the hook, runs a `@job("scan")` that calls it, asserts the job output reflects it — proves the closure runs and the builtin is callable from the job.

`cargo fmt --check`, `cargo nextest run -p harn-serve` (new test + 5/5 worker tests pass), `clippy -p harn-serve --lib -D warnings` clean. Changelog fragment added. (One pre-existing unrelated harn-serve failure `pg_query_budget_...` confirmed identical on origin/main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)