### PR TITLE
Fix native no-progress feedback wording

### DIFF
--- a/changelog.d/native-no-progress-feedback.fixed.md
+++ b/changelog.d/native-no-progress-feedback.fixed.md
@@ -1,0 +1,3 @@
+- **Agent-loop no-progress feedback now respects native tool mode.** Native-tool
+  runs are nudged to use the provider tool channel instead of receiving
+  text-mode `<tool_call>` and `<user_response>` syntax.

--- a/conformance/tests/agents/agent_loop_no_progress_feedback_modes.expected
+++ b/conformance/tests/agents/agent_loop_no_progress_feedback_modes.expected
@@ -1,0 +1,11 @@
+text.status=done
+text.has_streak=true
+text.has_tool_call_tag=true
+text.has_user_response_tag=true
+text.no_native_channel=true
+native.status=done
+native.has_streak=true
+native.has_native_channel=true
+native.has_native_tool=true
+native.no_tool_call_tag=true
+native.no_user_response_tag=true

--- a/conformance/tests/agents/agent_loop_no_progress_feedback_modes.harn
+++ b/conformance/tests/agents/agent_loop_no_progress_feedback_modes.harn
@@ -1,0 +1,85 @@
+import { llm_text, with_llm_script } from "std/testing"
+import { agent_loop } from "../../../crates/harn-stdlib/src/stdlib/agent/loop.harn"
+
+fn note_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note.",
+    {
+      handler: { args -> "wrote " + args.path },
+      parameters: {path: {type: "string", description: "Path to write"}},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+  return tools
+}
+
+fn messages_for_streak_retry(calls) {
+  return json_stringify(calls[2].messages)
+}
+
+pipeline default() {
+  with_llm_script(
+    [
+      llm_text("The context appears consistent."),
+      llm_text("The surrounding details remain aligned."),
+      llm_text("<user_response>done</user_response>\n<done>##DONE##</done>"),
+    ],
+    { ->
+      let text_result = agent_loop(
+        "Write notes.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "text",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          max_iterations: 4,
+          max_nudges: 4,
+          tools: note_tools(),
+        },
+      )
+      let text_retry = messages_for_streak_retry(llm_mock_calls())
+      __io_println("text.status=" + text_result.status)
+      __io_println("text.has_streak=" + to_string(contains(text_retry, "no_progress_streak")))
+      __io_println("text.has_tool_call_tag=" + to_string(contains(text_retry, "<tool_call>")))
+      __io_println("text.has_user_response_tag=" + to_string(contains(text_retry, "<user_response>")))
+      __io_println("text.no_native_channel=" + to_string(!contains(text_retry, "provider tool channel")))
+    },
+  )
+  with_llm_script(
+    [
+      llm_text("The context appears consistent."),
+      llm_text("The surrounding details remain aligned."),
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let native_result = agent_loop(
+        "Write notes.txt.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          done_judge: nil,
+          max_iterations: 4,
+          max_nudges: 4,
+          tools: note_tools(),
+        },
+      )
+      let native_retry = messages_for_streak_retry(llm_mock_calls())
+      __io_println("native.status=" + native_result.status)
+      __io_println("native.has_streak=" + to_string(contains(native_retry, "no_progress_streak")))
+      __io_println(
+        "native.has_native_channel=" + to_string(contains(native_retry, "provider tool channel")),
+      )
+      __io_println("native.has_native_tool=" + to_string(contains(native_retry, "native tool")))
+      __io_println("native.no_tool_call_tag=" + to_string(!contains(native_retry, "<tool_call>")))
+      __io_println("native.no_user_response_tag=" + to_string(!contains(native_retry, "<user_response>")))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1445,9 +1445,13 @@ fn __next_progress_count(made_progress, turns_since_progress) {
  * double-injected; this streak nudge is the fallback for pure-prose churn.
  * Depth is `turns_since_progress`.
  */
-fn __progress_nudge_text(depth, has_tools) {
+fn __progress_nudge_text(depth, has_tools, tool_mode = "text") {
   let action = if has_tools {
-    "Emit exactly one well-formed <tool_call> now, or state your final answer in <user_response> and stop."
+    if tool_mode == "native" {
+      "Call exactly one native tool through the provider tool channel now, or give your final answer and stop."
+    } else {
+      "Emit exactly one well-formed <tool_call> now, or state your final answer in <user_response> and stop."
+    }
   } else {
     "Make concrete progress in your reply now, or state your final answer and stop."
   }
@@ -2967,10 +2971,11 @@ fn __agent_loop_run(message, session, initial_opts) {
           && turns_since_progress <= turn_max_nudges
           && !(outcome?.nudged_this_turn ?? false) {
           let has_tools = len(opts?.tools?.tools ?? []) > 0
+          let tool_mode = agent_tool_call_paradigm(turn_opts).kind
           agent_session_inject_feedback(
             session.session_id,
             "no_progress_streak",
-            __progress_nudge_text(turns_since_progress, has_tools),
+            __progress_nudge_text(turns_since_progress, has_tools, tool_mode),
           )
           agent_emit_event(
             session.session_id,


### PR DESCRIPTION
## Summary

- Fixes Harn agent-loop no-progress feedback so native-tool runs are nudged toward the provider tool channel instead of text-mode `<tool_call>` tags.
- Adds a conformance regression covering text and native feedback wording.
- Adds a changelog fragment.

## Root Cause

The fallback no-progress nudge always emitted text-tool syntax whenever tools were available. In native-tool hosts, that message injected the wrong protocol into the model feedback loop and could trigger malformed text-mode tool attempts.

## Validation

- `harn fmt --check conformance/tests/agents/agent_loop_no_progress_feedback_modes.harn`
- `harn test conformance --filter agent_loop_no_progress_feedback_modes`
- `harn test conformance --filter agent_loop_text_mode_action_nudges`
- Pre-commit hooks: CI ratchets, markdownlint, staged Harn fmt/lint, highlight keyword sync
