### PR TITLE
feat(stdlib): cache-aware cost helpers in std/eval/stats

### DIFF
--- a/changelog.d/std-eval-cost.added.md
+++ b/changelog.d/std-eval-cost.added.md
@@ -1,0 +1,3 @@
+Added `estimate_cost_usd` and `realized_trial_cost_usd` to `std/eval/stats`: cache-aware token→USD cost estimation
+(cache-read/write tokens are billed at their own rates and not re-charged at the full input rate) plus cached-replay
+realized-cost accounting. Lets eval harnesses drop their own hand-rolled LLM cost math.

--- a/conformance/tests/stdlib/eval_stats.harn
+++ b/conformance/tests/stdlib/eval_stats.harn
@@ -31,6 +31,28 @@ pipeline test(task) {
   assert_eq(round(skip_rate(rows) * 1000), 250)
   assert_eq(round(timeout_rate(rows) * 1000), 63)
   assert_eq(cost_per_solved(rows), 5.0)
+  // estimate_cost_usd: cache-aware token->USD. 1M billable input @ $3 + 1M
+  // output @ $15 = 18.0; cache-read tokens bill at their own rate and are not
+  // re-charged at the input rate.
+  assert_eq(estimate_cost_usd(nil, {inputTokens: 1000000}), nil)
+  assert_eq(
+    estimate_cost_usd(
+      {inputPerMTok: 3.0, outputPerMTok: 15.0},
+      {inputTokens: 1000000, outputTokens: 1000000},
+    ),
+    18.0,
+  )
+  assert_eq(
+    estimate_cost_usd(
+      {inputPerMTok: 3.0, outputPerMTok: 15.0, cacheReadPerMTok: 0.3},
+      {inputTokens: 1000000, cacheReadTokens: 1000000},
+    ),
+    0.3,
+  )
+  // realized_trial_cost_usd: a cached replay realizes $0; otherwise pass-through.
+  assert_eq(realized_trial_cost_usd(0.42, true), 0.0)
+  assert_eq(realized_trial_cost_usd(0.42, false), 0.42)
+  assert_eq(realized_trial_cost_usd(nil, true), nil)
   assert_eq(worst_group(rows), {group: "rust", pass_rate: 0.0, cases: 2})
   let aggregate = aggregate_trials(
     "agg-a",

--- a/crates/harn-stdlib/src/stdlib/stdlib_eval_stats.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_eval_stats.harn
@@ -644,6 +644,63 @@ pub fn cost_per_solved(rows: list) {
 }
 
 /**
+ * Estimate USD model cost from a pricing descriptor and token usage, or nil
+ * when pricing is unknown.
+ *
+ * `pricing` carries per-million-token rates (`inputPerMTok`, `outputPerMTok`,
+ * and optional `cacheReadPerMTok` / `cacheWritePerMTok`, each defaulting to the
+ * input rate when absent). `usage` carries token counts (`inputTokens`,
+ * `outputTokens`, `cacheReadTokens`, and `cacheWriteTokens` — the
+ * `cacheCreationInputTokens` alias is also honored). Cache-read and cache-write
+ * tokens are billed at their own rates and subtracted from the billable input
+ * so they are never double-charged at the full input rate. Returns the total
+ * rounded to 6 decimal places.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: estimate_cost_usd(pricing, usage)
+ */
+pub fn estimate_cost_usd(pricing, usage: dict) {
+  if pricing == nil {
+    return nil
+  }
+  let input_tokens = to_float(usage?.inputTokens ?? 0) ?? 0.0
+  let output_tokens = to_float(usage?.outputTokens ?? 0) ?? 0.0
+  let cache_read_tokens = to_float(usage?.cacheReadTokens ?? 0) ?? 0.0
+  let cache_write_tokens = to_float(usage?.cacheWriteTokens ?? usage?.cacheCreationInputTokens ?? 0) ?? 0.0
+  let billable_input_tokens = max(input_tokens - cache_read_tokens - cache_write_tokens, 0.0)
+  let input_cost = billable_input_tokens / 1000000.0 * (to_float(pricing?.inputPerMTok ?? 0) ?? 0.0)
+  let output_cost = output_tokens / 1000000.0 * (to_float(pricing?.outputPerMTok ?? 0) ?? 0.0)
+  let cache_read_cost = cache_read_tokens / 1000000.0
+    * (to_float(pricing?.cacheReadPerMTok ?? pricing?.inputPerMTok ?? 0) ?? 0.0)
+  let cache_write_cost = cache_write_tokens / 1000000.0
+    * (to_float(pricing?.cacheWritePerMTok ?? pricing?.inputPerMTok ?? 0) ?? 0.0)
+  return __round_digits(input_cost + output_cost + cache_read_cost + cache_write_cost, 6)
+}
+
+/**
+ * Realized trial cost after cache-trajectory replay accounting. A cached replay
+ * re-runs a previously-recorded trajectory at no model cost, so its realized
+ * cost is 0.0 even though `derived_cost_usd` reflects the original (uncached)
+ * spend. With no replay (or unknown derived cost) the derived value passes
+ * through unchanged.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: realized_trial_cost_usd(derived_cost_usd, cache_replay)
+ */
+pub fn realized_trial_cost_usd(derived_cost_usd, cache_replay: bool) {
+  if cache_replay && derived_cost_usd != nil {
+    return 0.0
+  }
+  return derived_cost_usd
+}
+
+/**
  * Return the group with the lowest macro pass@1.
  *
  * @effects: []


### PR DESCRIPTION
## What

Adds two pure functions to **`std/eval/stats`**, ported out of Burin's eval harness:

- **`estimate_cost_usd(pricing, usage)`** — cache-aware token→USD estimation. Cache-read/write tokens are billed at their own per-MTok rates (defaulting to the input rate when absent) and subtracted from the billable input so they're never double-charged at the full input rate. Returns nil when pricing is unknown, else the total rounded to 6 dp.
- **`realized_trial_cost_usd(derived_cost_usd, cache_replay)`** — a cached-trajectory replay re-runs at no model cost, so its realized cost is `0.0`; otherwise the derived cost passes through.

## Why

Pure, generically-useful LLM-cost math any token-tracking eval harness needs. Sits alongside the existing cost *aggregation* (`cost_per_solved`) in `std/eval/stats`, and lets Burin (and other harnesses) drop hand-rolled copies. Companion to the `std/eval/agreement` port (#3209).

## Verification

- Conformance extended in `conformance/tests/stdlib/eval_stats.harn`: `nil` on unknown pricing; `1M input @ $3 + 1M output @ $15 = 18.0`; 1M cache-read tokens bill at `$0.3` (own rate, not re-charged at input). `harn test conformance --filter eval_stats` → PASS.
- HARN-STD-101 stdlib metadata backfilled; `make lint-harn` gate clean locally (0 occurrences); `harn fmt --check` clean; changelog fragment markdownlint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)