### PR TITLE
harn-serve: route-level SiteAuth hook + tenant/claims plumbing for SiteServer (#3212)

### DIFF
--- a/changelog.d/3212.added.md
+++ b/changelog.d/3212.added.md
@@ -1,0 +1,11 @@
+- **`harn serve site` now takes an embedder auth hook with tenant/claims plumbing (#3212).** New
+  `harn_serve::SiteAuth` trait (`async fn authenticate(&self, parts, route) -> SiteAuthOutcome`),
+  installed via `SiteServerConfig::with_auth(Arc<dyn SiteAuth>)`, runs on every matched route before
+  the body is read. `Allow(SiteAuthContext { tenant_id, scopes, context })` threads the tenant into
+  the dispatch (trust records, spans, `harness.tenant.id()`), checks the route's `@scopes` against
+  the hook-granted scopes (refusing with the canonical `forbidden` envelope), and installs the
+  opaque embedder `context` as an ambient scope a `HostCallBridge` can read via
+  `harn_serve::current_auth_context()` for the duration of the dispatch; `Deny(response)` returns
+  the embedder-shaped response verbatim. `AuthRequest` gains a `granted_scopes` field so transports
+  that own credential resolution compose with the dispatch-level scope check, and `CallRequest`
+  gains the `auth_context` carrier. Without a hook, behavior is unchanged. Fixes #3212.

--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -791,8 +791,7 @@ fn script_http_auth_request(
         path: path.to_string(),
         body,
         headers: script_normalized_headers(headers),
-        validated_oauth: None,
-        tenant_id: None,
+        ..AuthRequest::default()
     }
 }
 

--- a/crates/harn-serve/src/adapter.rs
+++ b/crates/harn-serve/src/adapter.rs
@@ -128,6 +128,7 @@ mod tests {
             progress: None,
             tenant_id: None,
             request_id: None,
+            auth_context: None,
         }
     }
 

--- a/crates/harn-serve/src/adapters/a2a/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tasks.rs
@@ -120,6 +120,7 @@ impl A2aServer {
                 progress: None,
                 tenant_id: None,
                 request_id: Some(task.id.clone()),
+                auth_context: None,
             })
             .await;
 

--- a/crates/harn-serve/src/adapters/a2a/tests/protocol.rs
+++ b/crates/harn-serve/src/adapters/a2a/tests/protocol.rs
@@ -767,8 +767,7 @@ fn auth_request_with_bearer(token: &str) -> AuthRequest {
             "authorization".to_string(),
             format!("Bearer {token}"),
         )]),
-        validated_oauth: None,
-        tenant_id: None,
+        ..AuthRequest::default()
     }
 }
 

--- a/crates/harn-serve/src/adapters/acp/auth.rs
+++ b/crates/harn-serve/src/adapters/acp/auth.rs
@@ -63,8 +63,7 @@ pub(super) fn acp_auth_request_for_method(
             .map(|value| value.as_bytes().to_vec())
             .unwrap_or_default(),
         headers: harn_auth_headers(meta),
-        validated_oauth: None,
-        tenant_id: None,
+        ..AuthRequest::default()
     };
 
     match method {

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -55,6 +55,10 @@ async fn recv_json(rx: &mut mpsc::UnboundedReceiver<String>) -> serde_json::Valu
     serde_json::from_str(&line).expect("ACP JSON line")
 }
 
+/// Only the hostlib-gated rollback/redo test builds transcript
+/// messages by hand; gate the helper identically so a featureless
+/// `clippy --all-targets -D warnings` run stays clean.
+#[cfg(feature = "hostlib")]
 fn make_acp_test_message(role: &str, content: &str) -> VmValue {
     VmValue::Dict(Arc::new(BTreeMap::from([
         ("role".to_string(), VmValue::String(Arc::from(role))),

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -315,8 +315,7 @@ impl McpServer {
                 path: String::new(),
                 body: line.into_bytes(),
                 headers: BTreeMap::new(),
-                validated_oauth: None,
-                tenant_id: None,
+                ..AuthRequest::default()
             };
             self.clone()
                 .handle_stdio_message(request, session.clone(), auth, tx.clone())

--- a/crates/harn-serve/src/adapters/mcp/schema.rs
+++ b/crates/harn-serve/src/adapters/mcp/schema.rs
@@ -38,6 +38,7 @@ pub(super) fn build_call_request(
         progress,
         tenant_id: None,
         request_id,
+        auth_context: None,
     })
 }
 

--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -67,10 +67,11 @@
 //! value as JSON, `nil` sends nothing). This reuses the exact subprotocol
 //! negotiation and idle-keepalive machinery the other WS routes use.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use axum::body::{to_bytes, Bytes};
 use axum::extract::ws::WebSocketUpgrade;
 use axum::extract::{
@@ -82,6 +83,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::any;
 use axum::{Json, Router};
 use base64::Engine;
+use harn_vm::TenantId;
 use ipnet::IpNet;
 use serde_json::{json, Map, Value};
 
@@ -94,14 +96,74 @@ use crate::http_codec::{
 use crate::tls::HttpTlsConfig;
 use crate::ws::{ws_accept, WsConfig, WsMessage, WsSession};
 use crate::{
-    CallArguments, CallRequest, DispatchCore, ExportCatalog, RouteSpec, TransportConfig,
-    DEFAULT_HTTP_BODY_LIMIT_BYTES,
+    CallArguments, CallRequest, DispatchCore, DispatchError, ExportCatalog, RouteSpec,
+    TransportConfig, DEFAULT_HTTP_BODY_LIMIT_BYTES,
 };
 
 /// Adapter identifier stamped on every [`CallRequest`] this host issues,
 /// so trust records and span attributes attribute the dispatch to the
 /// site host rather than one of the protocol adapters.
 const SITE_ADAPTER: &str = "site";
+
+/// Embedder-supplied per-request authenticator for the site surface
+/// (#3212). Installed with [`SiteServerConfig::with_auth`]; without one
+/// the adapter behaves exactly as before — no edge auth, every dispatch
+/// tenant-less, and `@scopes` enforced only by the configured
+/// [`crate::AuthPolicy`].
+///
+/// The hook runs once per matched route, after routing but before the
+/// request body is buffered, so it sees the request head
+/// ([`axum::http::request::Parts`]: method, URI, headers, extensions)
+/// plus the matched [`RouteSpec`]. That is enough for the embedder
+/// auth schemes harn-cloud needs: bearer API keys, cookie sessions,
+/// token-in-path public routes, worker enrollment tokens.
+#[async_trait]
+pub trait SiteAuth: Send + Sync {
+    async fn authenticate(
+        &self,
+        parts: &axum::http::request::Parts,
+        route: &RouteSpec,
+    ) -> SiteAuthOutcome;
+}
+
+/// Decision returned by [`SiteAuth::authenticate`].
+pub enum SiteAuthOutcome {
+    /// Admit the request under the given identity. The route's
+    /// `@scopes` are then checked against [`SiteAuthContext::scopes`];
+    /// a route with no `@scopes` admits any allowed request.
+    Allow(SiteAuthContext),
+    /// Refuse the request. The embedder-shaped response (401/403/redirect/
+    /// whatever) is returned to the client verbatim.
+    Deny(Box<Response>),
+}
+
+/// Identity resolved by an embedder's [`SiteAuth`] hook.
+#[derive(Clone, Debug, Default)]
+pub struct SiteAuthContext {
+    /// Tenant the credential is bound to. Threaded into the dispatch
+    /// (`CallRequest::tenant_id`) so trust records, span attributes,
+    /// and the `.harn` callee's `harness.tenant.id()` all see it.
+    /// `None` admits the request tenant-less (public routes).
+    pub tenant_id: Option<TenantId>,
+    /// Scopes the credential carries. Checked against the route's
+    /// `@scopes` at admission and unioned into the authenticated
+    /// principal (via [`AuthRequest::granted_scopes`]) so the
+    /// dispatch-level scope check agrees with the edge.
+    pub scopes: BTreeSet<String>,
+    /// Opaque embedder context (e.g. the API-key record or session
+    /// claims). Never interpreted by harn-serve; surfaced to the
+    /// embedder's [`harn_vm::HostCallBridge`] for the duration of the
+    /// dispatch via [`crate::current_auth_context`].
+    pub context: Option<Value>,
+}
+
+impl SiteAuthOutcome {
+    /// Convenience constructor: wrap an embedder response in the
+    /// boxed `Deny` variant.
+    pub fn deny(response: Response) -> Self {
+        Self::Deny(Box::new(response))
+    }
+}
 
 /// Listener options for [`SiteServer::run_http`].
 #[derive(Clone, Debug)]
@@ -125,6 +187,10 @@ pub struct SiteServerConfig {
     /// `client_ip` is the direct transport peer — the only spoof-proof
     /// choice when the server is not strictly behind a known proxy.
     pub trusted_proxies: Vec<IpNet>,
+    /// Embedder auth hook consulted on every matched route. `None`
+    /// (the default) keeps the historic behavior: no edge auth and
+    /// tenant-less dispatch.
+    pub auth: Option<Arc<dyn SiteAuth>>,
 }
 
 impl SiteServerConfig {
@@ -133,6 +199,7 @@ impl SiteServerConfig {
             core,
             transport: TransportConfig::default_enabled(),
             trusted_proxies: Vec::new(),
+            auth: None,
         }
     }
 
@@ -143,6 +210,14 @@ impl SiteServerConfig {
 
     pub fn with_trusted_proxies(mut self, trusted_proxies: Vec<IpNet>) -> Self {
         self.trusted_proxies = trusted_proxies;
+        self
+    }
+
+    /// Install an embedder [`SiteAuth`] hook. Every matched route then
+    /// authenticates through it before the body is read or anything is
+    /// dispatched.
+    pub fn with_auth(mut self, auth: Arc<dyn SiteAuth>) -> Self {
+        self.auth = Some(auth);
         self
     }
 }
@@ -165,10 +240,11 @@ impl SiteServer {
             core,
             transport,
             trusted_proxies,
+            auth,
         } = self.config;
         let catalog = Arc::new(core.catalog().clone());
         let runtime = Arc::new(DispatchRuntime::start("SITE", Arc::new(core)));
-        build_site_router(&catalog, runtime, &transport, trusted_proxies)
+        build_site_router(&catalog, runtime, &transport, trusted_proxies, auth)
     }
 
     /// Bind the configured socket and serve until the process exits.
@@ -191,28 +267,42 @@ impl SiteServer {
     }
 }
 
+/// Resolved dispatch target for one mounted `(path, method)` pair: the
+/// function to invoke plus the route metadata the auth hook and the
+/// scope admission check need without re-consulting the catalog.
+#[derive(Clone)]
+struct SiteRoute {
+    function: String,
+    /// The function's declared [`RouteSpec`] (method may be `*`),
+    /// handed to the embedder's [`SiteAuth`] hook.
+    spec: RouteSpec,
+    /// `@scopes(...)` declared on the function; empty means no scope
+    /// requirement (public, as far as scopes are concerned).
+    required_scopes: BTreeSet<String>,
+}
+
 /// State shared by every site route handler: the dispatch executor plus
 /// the method→function table for each mounted path.
 #[derive(Clone)]
 struct SiteState {
     runtime: Arc<DispatchRuntime>,
-    /// `path → (method → function name)`. `method` is uppercased; `"*"`
-    /// is the any-method fallback consulted when no exact method matches.
-    routes: Arc<BTreeMap<String, BTreeMap<String, String>>>,
+    /// `path → (method → route)`. `method` is uppercased; `"*"` is the
+    /// any-method fallback consulted when no exact method matches.
+    routes: Arc<BTreeMap<String, BTreeMap<String, SiteRoute>>>,
     /// Reverse-proxy CIDR ranges trusted for forwarded-header parsing;
     /// empty means `client_ip` is always the direct peer.
     trusted_proxies: Arc<Vec<IpNet>>,
+    /// Embedder auth hook; `None` means no edge auth (historic
+    /// behavior).
+    auth: Option<Arc<dyn SiteAuth>>,
 }
 
 impl SiteState {
     /// Resolve the handler for a `(path, method)` pair, honouring the
-    /// `*` any-method fallback. Returns the function name to dispatch.
-    fn resolve(&self, path: &str, method: &Method) -> Option<&str> {
+    /// `*` any-method fallback.
+    fn resolve(&self, path: &str, method: &Method) -> Option<&SiteRoute> {
         let methods = self.routes.get(path)?;
-        methods
-            .get(method.as_str())
-            .or_else(|| methods.get("*"))
-            .map(String::as_str)
+        methods.get(method.as_str()).or_else(|| methods.get("*"))
     }
 }
 
@@ -224,18 +314,24 @@ fn build_site_router(
     runtime: Arc<DispatchRuntime>,
     transport: &TransportConfig,
     trusted_proxies: Vec<IpNet>,
+    auth: Option<Arc<dyn SiteAuth>>,
 ) -> Result<Router, String> {
-    let mut routes: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    let mut routes: BTreeMap<String, BTreeMap<String, SiteRoute>> = BTreeMap::new();
     for function in catalog.functions.values() {
-        let Some(RouteSpec { method, path }) = function.route.as_ref() else {
+        let Some(spec @ RouteSpec { method, path }) = function.route.as_ref() else {
             continue;
         };
         let by_method = routes.entry(path.clone()).or_default();
-        if let Some(existing) = by_method.insert(method.clone(), function.name.clone()) {
+        let entry = SiteRoute {
+            function: function.name.clone(),
+            spec: spec.clone(),
+            required_scopes: function.required_scopes.clone(),
+        };
+        if let Some(existing) = by_method.insert(method.clone(), entry) {
             return Err(format!(
-                "route conflict: {method} {path} is claimed by both `{existing}` and \
+                "route conflict: {method} {path} is claimed by both `{}` and \
                  `{}`; give one of them a distinct @route(...)",
-                function.name
+                existing.function, function.name
             ));
         }
     }
@@ -252,6 +348,7 @@ fn build_site_router(
         runtime,
         routes: Arc::new(routes),
         trusted_proxies: Arc::new(trusted_proxies),
+        auth,
     };
 
     let mut router: Router<SiteState> = Router::new();
@@ -297,8 +394,34 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
 
     let method = parts.method.clone();
     let route_template = matched_path.unwrap_or_else(|| parts.uri.path().to_string());
-    let Some(function) = state.resolve(&route_template, &method).map(str::to_string) else {
+    let Some(route) = state.resolve(&route_template, &method).cloned() else {
         return method_not_allowed(&state, &route_template);
+    };
+    let function = route.function.clone();
+    let request_id = fresh_request_id();
+
+    // Embedder auth runs on the request head, before the body is
+    // buffered: an unauthenticated caller never costs a body read or a
+    // dispatch. `Deny` short-circuits with the embedder's response
+    // verbatim; `Allow` is then checked against the route's `@scopes`
+    // (a route without `@scopes` has no scope requirement).
+    let auth_context = match state.auth.as_ref() {
+        None => None,
+        Some(hook) => match hook.authenticate(&parts, &route.spec).await {
+            SiteAuthOutcome::Deny(response) => return *response,
+            SiteAuthOutcome::Allow(context) => {
+                if !route.required_scopes.is_subset(&context.scopes) {
+                    return axum_response_from_dispatch_error(
+                        DispatchError::Forbidden {
+                            required: route.required_scopes.clone(),
+                            granted: context.scopes,
+                        },
+                        &request_id,
+                    );
+                }
+                Some(context)
+            }
+        },
     };
 
     let wants_upgrade = is_websocket_upgrade(&parts.headers);
@@ -326,7 +449,6 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
         }
     };
 
-    let request_id = fresh_request_id();
     let req_value = build_request_value(
         &method,
         &parts.uri,
@@ -338,12 +460,19 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
         peer,
         &state.trusted_proxies,
     );
-    let auth = AuthRequest::from_http(
+    let mut auth = AuthRequest::from_http(
         &method,
         parts.uri.path(),
         body_bytes.to_vec(),
         &parts.headers,
     );
+    // The hook-resolved scopes feed the dispatch-level scope check too,
+    // so a configured `AuthPolicy` (or the allow-all default) agrees
+    // with the admission decision made above instead of re-denying a
+    // route the embedder explicitly allowed.
+    if let Some(context) = auth_context.as_ref() {
+        auth.granted_scopes = context.scopes.clone();
+    }
 
     let call = CallRequest {
         adapter: SITE_ADAPTER.to_string(),
@@ -358,8 +487,13 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
         cancel_token: None,
         agent_session_id: None,
         progress: None,
-        tenant_id: None,
+        tenant_id: auth_context
+            .as_ref()
+            .and_then(|context| context.tenant_id.clone()),
         request_id: Some(request_id.clone()),
+        auth_context: auth_context
+            .as_ref()
+            .and_then(|context| context.context.clone()),
     };
 
     let response = match state.runtime.call(call).await {
@@ -375,7 +509,7 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
     // surface, not silently 101 a plain GET.
     if wants_upgrade {
         if let Some(spec) = classify_ws_upgrade(&response) {
-            return upgrade_websocket(&mut parts, state.runtime, spec).await;
+            return upgrade_websocket(&mut parts, state.runtime, spec, auth_context).await;
         }
     }
 
@@ -438,6 +572,7 @@ async fn upgrade_websocket(
     parts: &mut axum::http::request::Parts,
     runtime: Arc<DispatchRuntime>,
     spec: harn_vm::WsUpgradeSpec,
+    auth_context: Option<SiteAuthContext>,
 ) -> Response {
     let config = ws_config_from_spec(&spec);
     let on_message = spec.on_message.clone();
@@ -450,8 +585,9 @@ async fn upgrade_websocket(
     ws_accept(config, headers, upgrade, move |session| {
         let runtime = runtime.clone();
         let on_message = on_message.clone();
+        let auth_context = auth_context.clone();
         async move {
-            drive_ws_session(session, runtime, on_message).await;
+            drive_ws_session(session, runtime, on_message, auth_context).await;
         }
     })
     .await
@@ -476,10 +612,16 @@ fn ws_config_from_spec(spec: &harn_vm::WsUpgradeSpec) -> WsConfig {
 /// return value back. When the envelope named no handler the socket is
 /// inbound-only — frames are drained and discarded (suiting server-push
 /// handlers that never read from the client).
+///
+/// `auth_context` is the identity the [`SiteAuth`] hook resolved for
+/// the upgrade request; every frame dispatched over the socket carries
+/// the same tenant / scopes / embedder context, since the frames belong
+/// to the connection that was admitted.
 async fn drive_ws_session(
     session: WsSession,
     runtime: Arc<DispatchRuntime>,
     on_message: Option<String>,
+    auth_context: Option<SiteAuthContext>,
 ) {
     let Some(handler) = on_message else {
         while let Ok(Some(_)) = session.recv().await {}
@@ -494,11 +636,18 @@ async fn drive_ws_session(
                 "data_base64": base64::engine::general_purpose::STANDARD.encode(bytes),
             }),
         };
+        let auth = AuthRequest {
+            granted_scopes: auth_context
+                .as_ref()
+                .map(|context| context.scopes.clone())
+                .unwrap_or_default(),
+            ..AuthRequest::default()
+        };
         let call = CallRequest {
             adapter: SITE_ADAPTER.to_string(),
             function: handler.clone(),
             arguments: CallArguments::Positional(vec![message_value]),
-            auth: AuthRequest::default(),
+            auth,
             caller: SITE_ADAPTER.to_string(),
             replay_key: None,
             trace_id: None,
@@ -507,8 +656,13 @@ async fn drive_ws_session(
             cancel_token: None,
             agent_session_id: None,
             progress: None,
-            tenant_id: None,
+            tenant_id: auth_context
+                .as_ref()
+                .and_then(|context| context.tenant_id.clone()),
             request_id: Some(fresh_request_id()),
+            auth_context: auth_context
+                .as_ref()
+                .and_then(|context| context.context.clone()),
         };
         match runtime.call(call).await {
             Ok(response) => {

--- a/crates/harn-serve/src/auth.rs
+++ b/crates/harn-serve/src/auth.rs
@@ -51,6 +51,14 @@ pub struct AuthRequest {
     /// transports that own tenant resolution. `None` means defer to
     /// the auth method.
     pub tenant_id: Option<TenantId>,
+    /// Scopes the transport granted ahead of authentication (e.g. a
+    /// [`crate::SiteAuth`] hook that resolved the credential in the
+    /// embedder's own store). Unioned into the authenticated
+    /// principal's `granted_scopes` before the per-route scope check,
+    /// mirroring how `tenant_id` lets a transport own tenant
+    /// resolution. Empty (the default) defers entirely to the
+    /// configured auth methods.
+    pub granted_scopes: BTreeSet<String>,
 }
 
 impl AuthRequest {
@@ -370,6 +378,13 @@ impl AuthPolicy {
         if let Some(override_tenant) = request.tenant_id.clone() {
             principal.tenant_id = Some(override_tenant);
         }
+
+        // Same story for scopes: a transport-side authenticator that
+        // already resolved the credential contributes the scopes it
+        // granted, on top of whatever the configured method granted.
+        principal
+            .granted_scopes
+            .extend(request.granted_scopes.iter().cloned());
 
         if !required.is_subset(&principal.granted_scopes) {
             return AuthorizationDecision::MissingScope {
@@ -771,8 +786,7 @@ mod tests {
             path: "/mcp".to_string(),
             body: body.to_vec(),
             headers: BTreeMap::from([("authorization".to_string(), authorization)]),
-            validated_oauth: None,
-            tenant_id: None,
+            ..AuthRequest::default()
         };
 
         let decision = policy.authorize(&request).await;
@@ -971,8 +985,7 @@ mod tests {
             path: "/mcp".to_string(),
             body: body.to_vec(),
             headers: BTreeMap::from([("authorization".to_string(), authorization)]),
-            validated_oauth: None,
-            tenant_id: None,
+            ..AuthRequest::default()
         };
 
         let decision = policy
@@ -1080,6 +1093,27 @@ mod tests {
             panic!("expected Authorized");
         };
         assert_eq!(principal.tenant_id, Some(TenantId::new("policy-default")));
+    }
+
+    /// A transport that resolved scopes itself (e.g. a `SiteAuth` hook
+    /// backed by the embedder's API-key store) passes them in via
+    /// `AuthRequest.granted_scopes`; they union into the principal so
+    /// the per-route scope check honours them even under an allow-all
+    /// policy with no configured methods.
+    #[tokio::test]
+    async fn transport_granted_scopes_extend_the_principal() {
+        let policy = AuthPolicy::allow_all();
+        let request = AuthRequest {
+            granted_scopes: scopes(&["personas:read"]),
+            ..AuthRequest::default()
+        };
+        let decision = policy
+            .authorize_with_scopes(&request, &scopes(&["personas:read"]))
+            .await;
+        let AuthorizationDecision::Authorized(principal) = decision else {
+            panic!("expected Authorized");
+        };
+        assert_eq!(principal.granted_scopes, scopes(&["personas:read"]));
     }
 
     #[tokio::test]

--- a/crates/harn-serve/src/auth_context.rs
+++ b/crates/harn-serve/src/auth_context.rs
@@ -1,0 +1,81 @@
+//! Ambient embedder auth context threaded into a dispatch by transports
+//! whose [`crate::SiteAuth`] (or equivalent) hook resolved per-request
+//! authentication state the host-call bridge needs to see.
+//!
+//! The value is opaque to harn-serve: a `serde_json::Value` the embedder
+//! produced at admission (e.g. the API-key record, session claims, or a
+//! worker-token descriptor). `DispatchCore` installs it for the duration
+//! of the `.harn` invocation — on the same OS thread the VM (and
+//! therefore any [`harn_vm::HostCallBridge`]) runs on — so a bridge
+//! implementation can recover it with [`current_auth_context`] while
+//! handling a `host_call` issued by the dispatched handler.
+//!
+//! The scope is stack-shaped, mirroring [`harn_vm::enter_tenant`] /
+//! [`harn_vm::enter_request_id`], so nested dispatches restore the outer
+//! context on return.
+
+use std::cell::RefCell;
+use std::sync::Arc;
+
+thread_local! {
+    static ACTIVE_AUTH_CONTEXT_STACK: RefCell<Vec<Arc<serde_json::Value>>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// RAII guard returned by [`enter_auth_context`]. Popping the stack on
+/// drop keeps the ambient scope balanced even when the dispatched
+/// callable panics or returns an error.
+#[must_use = "dropping the guard immediately pops the auth-context scope"]
+pub struct AuthContextScopeGuard {
+    _private: (),
+}
+
+impl Drop for AuthContextScopeGuard {
+    fn drop(&mut self) {
+        ACTIVE_AUTH_CONTEXT_STACK.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+/// Push `context` onto the ambient stack for the lifetime of the
+/// returned guard. The innermost entry wins for [`current_auth_context`].
+pub fn enter_auth_context(context: serde_json::Value) -> AuthContextScopeGuard {
+    ACTIVE_AUTH_CONTEXT_STACK.with(|stack| stack.borrow_mut().push(Arc::new(context)));
+    AuthContextScopeGuard { _private: () }
+}
+
+/// Currently-active embedder auth context, or `None` when the dispatch
+/// was admitted without one. The innermost [`enter_auth_context`] scope
+/// wins.
+pub fn current_auth_context() -> Option<Arc<serde_json::Value>> {
+    ACTIVE_AUTH_CONTEXT_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_scopes_shadow_and_restore() {
+        assert!(current_auth_context().is_none());
+        let outer = enter_auth_context(serde_json::json!({"who": "outer"}));
+        assert_eq!(
+            current_auth_context().as_deref(),
+            Some(&serde_json::json!({"who": "outer"}))
+        );
+        {
+            let _inner = enter_auth_context(serde_json::json!({"who": "inner"}));
+            assert_eq!(
+                current_auth_context().as_deref(),
+                Some(&serde_json::json!({"who": "inner"}))
+            );
+        }
+        assert_eq!(
+            current_auth_context().as_deref(),
+            Some(&serde_json::json!({"who": "outer"}))
+        );
+        drop(outer);
+        assert!(current_auth_context().is_none());
+    }
+}

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -138,6 +138,15 @@ pub struct CallRequest {
     /// the caller. `None` for tests / in-process callers with no
     /// ingress to mint against.
     pub request_id: Option<String>,
+    /// Opaque embedder auth context resolved at admission (e.g. by a
+    /// [`crate::SiteAuth`] hook): the API-key record, session claims,
+    /// or whatever else the embedder's host-call bridge needs to see
+    /// for this request. harn-serve never interprets it; `invoke_*`
+    /// installs it as an ambient scope on the VM thread so a
+    /// [`harn_vm::HostCallBridge`] can recover it via
+    /// [`crate::current_auth_context`] for the duration of the
+    /// dispatch. `None` (the default) installs nothing.
+    pub auth_context: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -489,6 +498,7 @@ impl DispatchCore {
         let tenant_id = request.tenant_id.clone();
         let budget = function.budget.clone();
         let request_id = request.request_id.clone();
+        let auth_context = request.auth_context.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -500,6 +510,7 @@ impl DispatchCore {
                 let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
                 let _budget_guard = budget.as_ref().and_then(BudgetSpec::install);
                 let _request_id_guard = request_id.map(harn_vm::enter_request_id);
+                let _auth_context_guard = auth_context.map(crate::enter_auth_context);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -568,6 +579,7 @@ impl DispatchCore {
         let tenant_id = request.tenant_id.clone();
         let budget = function.budget.clone();
         let request_id = request.request_id.clone();
+        let auth_context = request.auth_context.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -579,6 +591,7 @@ impl DispatchCore {
                 let _tenant_guard = tenant_id.map(harn_vm::enter_tenant);
                 let _budget_guard = budget.as_ref().and_then(BudgetSpec::install);
                 let _request_id_guard = request_id.map(harn_vm::enter_request_id);
+                let _auth_context_guard = auth_context.map(crate::enter_auth_context);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -838,6 +851,7 @@ pub fn greet(name: string) -> string {
                 progress: None,
                 tenant_id: None,
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect("dispatch");
@@ -880,6 +894,7 @@ pipeline default(task) {
                 progress: None,
                 tenant_id: None,
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect("dispatch");
@@ -939,6 +954,7 @@ pub fn greet(name: string) -> string {
                 progress: None,
                 tenant_id: None,
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect("dispatch");
@@ -977,6 +993,7 @@ pub fn inspect(upload: string) -> string {
             progress: None,
             tenant_id: None,
             request_id: None,
+            auth_context: None,
         };
 
         let first = core
@@ -1030,6 +1047,7 @@ pub fn greet(name: string) -> string {
                 progress: None,
                 tenant_id: None,
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect("dispatch");
@@ -1080,6 +1098,7 @@ pub fn spin() -> string {
                 progress: None,
                 tenant_id: None,
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect("dispatch");
@@ -1141,6 +1160,7 @@ pub fn whoami(harness: Harness) -> string {
                 progress: None,
                 tenant_id: None,
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect("dispatch");
@@ -1190,6 +1210,7 @@ pub fn whoami(harness: Harness) -> string {
                 progress: None,
                 tenant_id: None,
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect_err("missing tenant should error");
@@ -1253,6 +1274,7 @@ pub fn whoami(harness: Harness) -> string {
                 progress: None,
                 tenant_id: Some(harn_vm::TenantId::new("override-tenant")),
                 request_id: None,
+                auth_context: None,
             })
             .await
             .expect("dispatch");

--- a/crates/harn-serve/src/http_codec.rs
+++ b/crates/harn-serve/src/http_codec.rs
@@ -53,8 +53,7 @@ impl AuthRequest {
             path: path.to_string(),
             body,
             headers: normalize_headers(headers),
-            validated_oauth: None,
-            tenant_id: None,
+            ..Self::default()
         }
     }
 }
@@ -809,6 +808,7 @@ mod tests {
             progress: None,
             tenant_id: None,
             request_id: None,
+            auth_context: None,
         };
         core.dispatch(request).await.map(|response| response.value)
     }
@@ -1107,6 +1107,7 @@ pub fn handler() -> dict {
             progress: None,
             tenant_id: None,
             request_id,
+            auth_context: None,
         };
         core.dispatch(request).await.map(|response| response.value)
     }

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -3,6 +3,7 @@
 mod adapter;
 pub mod adapters;
 mod auth;
+mod auth_context;
 mod core;
 pub mod embed;
 mod error;
@@ -50,13 +51,16 @@ pub use adapters::api::{ApiHttpServeOptions, ApiServer, ApiServerConfig};
 pub use adapters::mcp::{
     McpHttpServeOptions, McpServer, McpServerConfig, McpStdioServer, MCP_PROTOCOL_VERSION,
 };
-pub use adapters::site::{SiteHttpServeOptions, SiteServer, SiteServerConfig};
+pub use adapters::site::{
+    SiteAuth, SiteAuthContext, SiteAuthOutcome, SiteHttpServeOptions, SiteServer, SiteServerConfig,
+};
 pub use adapters::worker::{run_job_from_files, run_job_once, run_job_once_with, JobRunOutcome};
 pub use auth::{
     AllowlistOutcome, ApiKeyAuthConfig, ApiKeyEntry, AuthMethodConfig, AuthPolicy, AuthRequest,
     AuthenticatedPrincipal, AuthorizationDecision, HmacAuthConfig, McpAllowlist, McpAllowlistTools,
     OAuth21AuthConfig, OAuthClaims, ACP_LOCAL_NONE_METHOD_ID,
 };
+pub use auth_context::{current_auth_context, enter_auth_context, AuthContextScopeGuard};
 pub use core::{
     CallArguments, CallRequest, CallResponse, DispatchCore, DispatchCoreConfig, NoopVmConfigurator,
     VmConfigurator,

--- a/crates/harn-serve/tests/limits_loadgen.rs
+++ b/crates/harn-serve/tests/limits_loadgen.rs
@@ -44,6 +44,7 @@ fn synth_request(function: &str) -> CallRequest {
         progress: None,
         tenant_id: None,
         request_id: None,
+        auth_context: None,
     }
 }
 

--- a/crates/harn-serve/tests/site_auth.rs
+++ b/crates/harn-serve/tests/site_auth.rs
@@ -1,0 +1,331 @@
+//! Embedder auth hook conformance for `harn serve site` (#3212).
+//!
+//! Exercises the [`harn_serve::SiteAuth`] route-level hook end-to-end
+//! through a real router: the no-hook default is unchanged, an `Allow`
+//! threads tenant + scopes into the dispatch (so `@scopes` admission and
+//! `harness.tenant.id()` agree with the embedder), a scope shortfall is
+//! refused with the canonical `forbidden` envelope, a `Deny` response
+//! passes through verbatim, and the opaque embedder context is visible
+//! to a [`harn_vm::HostCallBridge`] for the duration of the dispatch.
+//!
+//! All cases drive the router through `tower::ServiceExt::oneshot`,
+//! mirroring `tests/site_hosting.rs`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::request::Parts;
+use axum::http::{Request, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router};
+use harn_serve::{
+    current_auth_context, DispatchCore, DispatchCoreConfig, DispatchError, NoReplayCache,
+    RouteSpec, SiteAuth, SiteAuthContext, SiteAuthOutcome, SiteServer, SiteServerConfig,
+    VmConfigurator,
+};
+use harn_vm::{HostCallBridge, TenantId, Vm, VmError, VmValue};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+/// One script backs every case: a public route, a `@scopes`-guarded
+/// route that also reports the bound tenant, and a route that asks the
+/// embedder's host-call bridge for the ambient auth context.
+const SITE_SCRIPT: &str = r#"
+@route("GET", "/public")
+pub fn open_route(req: dict) -> dict {
+  return http_ok({ "ok": true })
+}
+
+@scopes("personas:read")
+@route("GET", "/scoped")
+pub fn scoped_route(harness: Harness, req: dict) -> dict {
+  return http_ok({ "tenant": harness.tenant.try_id() })
+}
+
+@route("GET", "/ctx")
+pub fn ctx_route(req: dict) -> dict {
+  return http_ok({ "ctx": host_call("embedder.auth_context", {}) })
+}
+"#;
+
+/// `SiteAuth` hook that always admits with a fixed identity.
+struct AllowAuth {
+    tenant: Option<&'static str>,
+    scopes: &'static [&'static str],
+    context: Option<Value>,
+}
+
+#[async_trait::async_trait]
+impl SiteAuth for AllowAuth {
+    async fn authenticate(&self, _parts: &Parts, _route: &RouteSpec) -> SiteAuthOutcome {
+        SiteAuthOutcome::Allow(SiteAuthContext {
+            tenant_id: self.tenant.map(TenantId::new),
+            scopes: self.scopes.iter().map(|scope| scope.to_string()).collect(),
+            context: self.context.clone(),
+        })
+    }
+}
+
+/// `SiteAuth` hook that always refuses with an embedder-shaped response.
+struct DenyAuth;
+
+#[async_trait::async_trait]
+impl SiteAuth for DenyAuth {
+    async fn authenticate(&self, _parts: &Parts, _route: &RouteSpec) -> SiteAuthOutcome {
+        SiteAuthOutcome::deny(
+            (
+                StatusCode::UNAUTHORIZED,
+                [("x-embedder-deny", "1")],
+                Json(json!({ "error": "custom_embedder_denial" })),
+            )
+                .into_response(),
+        )
+    }
+}
+
+/// `SiteAuth` hook that authenticates off the request head: a bearer
+/// header gates admission, and the matched route template is echoed
+/// into the context — proof the hook sees both `Parts` and `RouteSpec`.
+struct HeaderAuth;
+
+#[async_trait::async_trait]
+impl SiteAuth for HeaderAuth {
+    async fn authenticate(&self, parts: &Parts, route: &RouteSpec) -> SiteAuthOutcome {
+        let authorized = parts
+            .headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            == Some("Bearer letmein");
+        if !authorized {
+            return SiteAuthOutcome::deny(
+                (StatusCode::UNAUTHORIZED, Json(json!({ "error": "no_key" }))).into_response(),
+            );
+        }
+        SiteAuthOutcome::Allow(SiteAuthContext {
+            tenant_id: None,
+            scopes: ["personas:read".to_string()].into(),
+            context: Some(json!({ "route": route.path, "method": route.method })),
+        })
+    }
+}
+
+/// Host-call bridge that hands the ambient embedder auth context back
+/// to the `.harn` handler as a JSON string (or `"absent"`).
+struct ContextEchoBridge;
+
+impl HostCallBridge for ContextEchoBridge {
+    fn dispatch(
+        &self,
+        capability: &str,
+        operation: &str,
+        _params: &BTreeMap<String, VmValue>,
+    ) -> Result<Option<VmValue>, VmError> {
+        if capability != "embedder" || operation != "auth_context" {
+            return Ok(None);
+        }
+        let rendered = current_auth_context()
+            .map(|context| context.to_string())
+            .unwrap_or_else(|| "absent".to_string());
+        Ok(Some(VmValue::String(Arc::from(rendered.as_str()))))
+    }
+}
+
+/// `VmConfigurator` that installs [`ContextEchoBridge`] on the dispatch
+/// thread, the way an embedder wires its host-call bridge in.
+struct BridgeConfigurator;
+
+impl VmConfigurator for BridgeConfigurator {
+    fn configure(&self, _vm: &mut Vm) -> Result<(), DispatchError> {
+        harn_vm::set_host_call_bridge(Arc::new(ContextEchoBridge));
+        Ok(())
+    }
+}
+
+fn build_core(path: &Path, configurator: Option<Arc<dyn VmConfigurator>>) -> DispatchCore {
+    let mut config = DispatchCoreConfig::for_script(path);
+    // An HTTP host must re-run its handler on every request.
+    config.replay_cache = Arc::new(NoReplayCache);
+    if let Some(configurator) = configurator {
+        config.vm_configurator = configurator;
+    }
+    DispatchCore::new(config).expect("dispatch core")
+}
+
+/// Write the shared script to a temp dir and build a site router over
+/// it, optionally with an auth hook and a VM configurator. The temp dir
+/// is returned so it outlives the router.
+fn site_router(
+    auth: Option<Arc<dyn SiteAuth>>,
+    configurator: Option<Arc<dyn VmConfigurator>>,
+) -> (tempfile::TempDir, Router) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(&path, SITE_SCRIPT).expect("write script");
+    let mut config = SiteServerConfig::new(build_core(&path, configurator));
+    if let Some(auth) = auth {
+        config = config.with_auth(auth);
+    }
+    let router = SiteServer::new(config).router().expect("site router");
+    (dir, router)
+}
+
+async fn get(router: Router, uri: &str) -> Response {
+    router
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+async fn read_json(response: Response) -> (StatusCode, Value) {
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, value)
+}
+
+/// (a) Without a hook the adapter behaves exactly as before: public
+/// routes serve, and a `@scopes` route is refused by the dispatch-level
+/// check because the allow-all policy grants no scopes.
+#[tokio::test]
+async fn default_without_hook_is_unchanged() {
+    let (_dir, router) = site_router(None, None);
+    let (status, body) = read_json(get(router.clone(), "/public").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+
+    let (status, body) = read_json(get(router, "/scoped").await).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["code"], "forbidden");
+}
+
+/// (b) An `Allow` carrying tenant + scopes admits the scoped route and
+/// the dispatch runs under that tenant (`harness.tenant` sees it).
+#[tokio::test]
+async fn allow_with_tenant_and_scopes_reaches_scoped_route() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["personas:read", "sessions:write"],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(get(router, "/scoped").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["tenant"], "acme");
+}
+
+/// (c) An `Allow` whose scopes do not cover the route's `@scopes` is
+/// refused at admission with the canonical `forbidden` envelope.
+#[tokio::test]
+async fn allow_with_missing_scopes_yields_canonical_403() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["sessions:read"],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(get(router, "/scoped").await).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["code"], "forbidden");
+    assert_eq!(body["details"]["kind"], "forbidden");
+    assert_eq!(body["details"]["missing_scopes"][0], "personas:read");
+    assert_eq!(body["details"]["granted_scopes"][0], "sessions:read");
+    assert!(body["request_id"].as_str().is_some());
+}
+
+/// (d) A `Deny` returns the embedder's response verbatim — status,
+/// headers, and body untouched.
+#[tokio::test]
+async fn deny_passes_embedder_response_through_verbatim() {
+    let (_dir, router) = site_router(Some(Arc::new(DenyAuth)), None);
+    let response = get(router, "/public").await;
+    assert_eq!(response.headers()["x-embedder-deny"], "1");
+    let (status, body) = read_json(response).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "custom_embedder_denial");
+}
+
+/// (e) A route with no `@scopes` plus an `Allow` with no tenant and no
+/// scopes serves fine — public routes need only the hook's blessing.
+#[tokio::test]
+async fn public_route_admits_tenantless_scopeless_allow() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &[],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(get(router, "/public").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+}
+
+/// The opaque embedder context rides the dispatch onto the VM thread,
+/// where the embedder's host-call bridge recovers it via
+/// `current_auth_context()` while serving a handler's `host_call`.
+#[tokio::test]
+async fn auth_context_is_visible_to_the_host_call_bridge() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &[],
+        context: Some(json!({ "key_id": "k_123", "session": "s_9" })),
+    });
+    let (_dir, router) = site_router(Some(hook), Some(Arc::new(BridgeConfigurator)));
+    let (status, body) = read_json(get(router, "/ctx").await).await;
+    assert_eq!(status, StatusCode::OK);
+    let echoed: Value =
+        serde_json::from_str(body["ctx"].as_str().expect("bridge echoes a string")).unwrap();
+    assert_eq!(echoed, json!({ "key_id": "k_123", "session": "s_9" }));
+}
+
+/// Without an `Allow`-supplied context the bridge sees no ambient
+/// value: nothing leaks across requests on the shared dispatch thread.
+#[tokio::test]
+async fn absent_auth_context_is_absent_at_the_bridge() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &[],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), Some(Arc::new(BridgeConfigurator)));
+    let (status, body) = read_json(get(router, "/ctx").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ctx"], "absent");
+}
+
+/// The hook authenticates off the request head and sees the matched
+/// route: a bearer header gates admission, and the `RouteSpec` handed
+/// to the hook round-trips through the context into the bridge.
+#[tokio::test]
+async fn hook_sees_request_head_and_matched_route() {
+    let (_dir, router) = site_router(
+        Some(Arc::new(HeaderAuth)),
+        Some(Arc::new(BridgeConfigurator)),
+    );
+
+    let denied = get(router.clone(), "/ctx").await;
+    let (status, body) = read_json(denied).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "no_key");
+
+    let allowed = router
+        .oneshot(
+            Request::builder()
+                .uri("/ctx")
+                .header("authorization", "Bearer letmein")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, body) = read_json(allowed).await;
+    assert_eq!(status, StatusCode::OK);
+    let echoed: Value =
+        serde_json::from_str(body["ctx"].as_str().expect("bridge echoes a string")).unwrap();
+    assert_eq!(echoed, json!({ "route": "/ctx", "method": "GET" }));
+}


### PR DESCRIPTION
Fixes #3212 (HS-1) — the mandatory gap for harn-cloud's gateway retirement (#496a): `SiteServer` hardcoded `tenant_id: None` with no embedder auth.

## API
- `trait SiteAuth { async fn authenticate(&self, parts: &Parts, route: &RouteSpec) -> SiteAuthOutcome }`
- `SiteAuthOutcome::{Allow(SiteAuthContext), Deny(Box<Response>)}`; `SiteAuthContext { tenant_id: Option<TenantId>, scopes: BTreeSet<String>, context: Option<serde_json::Value> }`
- `SiteServerConfig::with_auth(Arc<dyn SiteAuth>)` — default (no hook) = prior behavior, existing users unchanged.

## Flow
Hook runs after route match, **before body buffering**, on `Parts` + the matched `RouteSpec`. `Deny` → embedder response verbatim. `Allow` → the route's `@scopes` are checked against the embedder claims (`required ⊆ granted`; shortfall → the canonical `DispatchError::Forbidden` 403 with `details.missing_scopes`, shared with all adapters). On pass: `CallRequest.tenant_id`, `AuthRequest.granted_scopes` (unioned into the principal so core admission agrees with the edge), and an opaque `auth_context` flow into dispatch; a stack-shaped thread-local ambient (`enter_auth_context`, alongside the existing tenant/request-id guards) makes the context readable by a synchronous `HostCallBridge` during any `host_call`. WS `on_message` frames inherit the upgrade request's resolved identity.

## Tests
8 new in `tests/site_auth.rs` (default-unchanged; allow-with-tenant reaches scoped route + dispatch sees tenant; missing scopes → canonical 403; deny verbatim; public route with tenantless allow; auth-context visible/absent at the bridge; hook sees head+route) + 2 unit. `cargo nextest -p harn-serve`: 461 run / 460 pass (sole failure = documented pre-existing `pg_query_budget...`, identical on clean main). fmt/clippy/`check -p harn-cli` clean; changelog fragment added.

Unblocks: harn-cloud #496a (move the gateway HTTP host onto harn-serve; deletes the un-ported axum bulk; ~66k → ~8–12k LOC residual). Related: #3213 (SSE streaming), #3214 (raw/binary bodies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)