### PR TITLE
feat(catalog): add Claude Fable 5 (claude-fable-5) provider support

### DIFF
--- a/changelog.d/fable-5-catalog.added.md
+++ b/changelog.d/fable-5-catalog.added.md
@@ -1,0 +1,5 @@
+Claude Fable 5 (`claude-fable-5`, released 2026-06-09) in the provider catalog: model entry
+($10/$50 per MTok, 1M context, SWE-bench Pro 80.3), a `fable` alias, `claude-fable-*` /
+`claude-mythos-*` capability rules (adaptive-only thinking, no assistant prefill), and
+generation parsing for the fable/mythos families so the Opus 4.7+ request guards
+(sampling-param strip, adaptive-thinking rewrite, prefill removal, always-on thinking) apply.

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -169,6 +169,110 @@ top_k_supported = false
 # --- source: 20-providers/00-anthropic.toml ---
 # ---------- Anthropic (Claude) ------------------------------------------------
 
+# Claude Fable 5 / Mythos 5 — the Mythos-class tier above Opus (launched
+# 2026-06-09). Same surface as Opus 4.7+: adaptive thinking only (and on
+# this family thinking is always on — an explicit `disabled` is a 400, so
+# the request builder must omit the field), interleaved thinking, no
+# assistant prefill, sampling params rejected. No version_min: every
+# fable/mythos id is Mythos-class. Without these rows the ids would fall
+# through to the permissive `claude-*` catch-all at the bottom of this
+# file, which wrongly grants `thinking_modes = ["enabled"]` and prefill.
+[[provider.anthropic]]
+model_match = "claude-fable-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
+[[provider.anthropic]]
+model_match = "claude-mythos-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
+[[provider.anthropic]]
+model_match = "anthropic/claude-fable-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
+[[provider.anthropic]]
+model_match = "anthropic/claude-mythos-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
 # Claude 4.7+ uses adaptive thinking instead of explicit budgets.
 [[provider.anthropic]]
 model_match = "claude-haiku-*"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/00-anthropic.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/00-anthropic.toml
@@ -1,5 +1,109 @@
 # ---------- Anthropic (Claude) ------------------------------------------------
 
+# Claude Fable 5 / Mythos 5 — the Mythos-class tier above Opus (launched
+# 2026-06-09). Same surface as Opus 4.7+: adaptive thinking only (and on
+# this family thinking is always on — an explicit `disabled` is a 400, so
+# the request builder must omit the field), interleaved thinking, no
+# assistant prefill, sampling params rejected. No version_min: every
+# fable/mythos id is Mythos-class. Without these rows the ids would fall
+# through to the permissive `claude-*` catch-all at the bottom of this
+# file, which wrongly grants `thinking_modes = ["enabled"]` and prefill.
+[[provider.anthropic]]
+model_match = "claude-fable-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
+[[provider.anthropic]]
+model_match = "claude-mythos-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
+[[provider.anthropic]]
+model_match = "anthropic/claude-fable-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
+[[provider.anthropic]]
+model_match = "anthropic/claude-mythos-*"
+native_tools = true
+preferred_tool_format = "native"
+defer_loading = true
+tool_search = ["bm25", "regex"]
+max_tools = 10000
+prompt_caching = true
+vision = true
+audio_supported = true
+pdf_supported = true
+files_api_supported = true
+structured_output = "tool_use"
+thinking_modes = ["adaptive"]
+interleaved_thinking_supported = true
+vision_supported = true
+prefers_xml_scaffolding = true
+prefers_markdown_scaffolding = false
+structured_output_mode = "xml_tagged"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = true
+thinking_block_style = "thinking_blocks"
+
 # Claude 4.7+ uses adaptive thinking instead of explicit budgets.
 [[provider.anthropic]]
 model_match = "claude-haiku-*"

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -14,6 +14,12 @@ provider = "anthropic"
 id = "claude-opus-4-8"
 provider = "anthropic"
 
+# Fable is the Mythos-class tier above Opus, not an Opus successor — the
+# `opus` alias intentionally stays on claude-opus-4-8.
+[aliases.fable]
+id = "claude-fable-5"
+provider = "anthropic"
+
 [aliases.haiku]
 id = "claude-haiku-4-5-20251001"
 provider = "anthropic"

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/00-anthropic.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/00-anthropic.toml
@@ -211,3 +211,31 @@ complementary_with = ["openai-gpt", "google-gemini", "qwen", "deepseek", "kimi"]
 # Fast mode (research preview): 2x standard pricing, ~2.5x output tok/s.
 fast_mode = { param = "speed", value = "fast", beta_header = "fast-mode-2026-02-01", otps_speedup = 2.5, status = "research_preview", pricing = { input_per_mtok = 10.00, output_per_mtok = 50.00, cache_read_per_mtok = 1.00, cache_write_per_mtok = 12.50 }, note = "Claude API + Managed Agents only (not Bedrock/Vertex/Foundry); excluded from Batch and Priority Tier. Switching speed invalidates the prompt cache. Waitlist/account-manager gated." }
 
+# Claude Fable 5 (released 2026-06-09) — Anthropic's most capable widely
+# released model: the first generally available Mythos-class model, a new
+# tier *above* Opus (Opus 4.8 stays current and keeps the `opus` alias;
+# nothing is superseded). Same request surface as Opus 4.7/4.8 — adaptive
+# thinking only, sampling params rejected, no assistant prefill — plus one
+# new constraint: an explicit `thinking: {type: "disabled"}` is also a 400
+# (thinking is always on; omit the field instead, which our request
+# builder already does for the Disabled config). Safety classifiers can
+# decline requests with stop_reason="refusal"; the `fallbacks` beta
+# retries on Opus 4.8. No fast mode tier. The 1M-token context window is
+# the model's only tier (there is no 200k standard tier to mirror, so
+# this row intentionally departs from the 200k convention used by the
+# Opus/Sonnet rows above). Pricing per the Anthropic pricing page:
+# $10 / $50 per MTok in/out (cache read 0.1x, 5-min cache write 1.25x);
+# Batch API 50% discount applies. SWE-bench Verified not published for
+# Fable 5 itself at launch (only for Mythos Preview), so it is omitted.
+[models."claude-fable-5"]
+name = "Claude Fable 5"
+provider = "anthropic"
+context_window = 1000000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 10.00, output_per_mtok = 50.00, cache_read_per_mtok = 1.00, cache_write_per_mtok = 12.50 }
+tier = "frontier"
+open_weight = false
+strengths = ["reasoning", "coding", "long_context", "agentic"]
+benchmarks = { swe_bench_pro = 80.3 }
+complementary_with = ["openai-gpt", "google-gemini", "qwen", "deepseek", "kimi"]
+

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -612,6 +612,12 @@ provider = "anthropic"
 id = "claude-opus-4-8"
 provider = "anthropic"
 
+# Fable is the Mythos-class tier above Opus, not an Opus successor — the
+# `opus` alias intentionally stays on claude-opus-4-8.
+[aliases.fable]
+id = "claude-fable-5"
+provider = "anthropic"
+
 [aliases.haiku]
 id = "claude-haiku-4-5-20251001"
 provider = "anthropic"
@@ -1128,6 +1134,34 @@ benchmarks = { swe_bench_verified = 88.6, swe_bench_pro = 69.2 }
 complementary_with = ["openai-gpt", "google-gemini", "qwen", "deepseek", "kimi"]
 # Fast mode (research preview): 2x standard pricing, ~2.5x output tok/s.
 fast_mode = { param = "speed", value = "fast", beta_header = "fast-mode-2026-02-01", otps_speedup = 2.5, status = "research_preview", pricing = { input_per_mtok = 10.00, output_per_mtok = 50.00, cache_read_per_mtok = 1.00, cache_write_per_mtok = 12.50 }, note = "Claude API + Managed Agents only (not Bedrock/Vertex/Foundry); excluded from Batch and Priority Tier. Switching speed invalidates the prompt cache. Waitlist/account-manager gated." }
+
+# Claude Fable 5 (released 2026-06-09) — Anthropic's most capable widely
+# released model: the first generally available Mythos-class model, a new
+# tier *above* Opus (Opus 4.8 stays current and keeps the `opus` alias;
+# nothing is superseded). Same request surface as Opus 4.7/4.8 — adaptive
+# thinking only, sampling params rejected, no assistant prefill — plus one
+# new constraint: an explicit `thinking: {type: "disabled"}` is also a 400
+# (thinking is always on; omit the field instead, which our request
+# builder already does for the Disabled config). Safety classifiers can
+# decline requests with stop_reason="refusal"; the `fallbacks` beta
+# retries on Opus 4.8. No fast mode tier. The 1M-token context window is
+# the model's only tier (there is no 200k standard tier to mirror, so
+# this row intentionally departs from the 200k convention used by the
+# Opus/Sonnet rows above). Pricing per the Anthropic pricing page:
+# $10 / $50 per MTok in/out (cache read 0.1x, 5-min cache write 1.25x);
+# Batch API 50% discount applies. SWE-bench Verified not published for
+# Fable 5 itself at launch (only for Mythos Preview), so it is omitted.
+[models."claude-fable-5"]
+name = "Claude Fable 5"
+provider = "anthropic"
+context_window = 1000000
+capabilities = ["tools", "streaming", "prompt_caching", "thinking"]
+pricing = { input_per_mtok = 10.00, output_per_mtok = 50.00, cache_read_per_mtok = 1.00, cache_write_per_mtok = 12.50 }
+tier = "frontier"
+open_weight = false
+strengths = ["reasoning", "coding", "long_context", "agentic"]
+benchmarks = { swe_bench_pro = 80.3 }
+complementary_with = ["openai-gpt", "google-gemini", "qwen", "deepseek", "kimi"]
 
 # --- source: 60-models/10-openai-gemini-mistral.toml ---
 # OpenAI ─ pricing pages: https://platform.openai.com/docs/pricing.

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -24,15 +24,20 @@ thread_local! {
 /// Parse the (major, minor) generation out of a Claude model ID. Handles
 /// both dash-separated names like `claude-opus-4-7` / `claude-sonnet-4-6`
 /// and dotted variants like `claude-opus-4.7` (OpenRouter, some proxies),
-/// plus dated IDs like `claude-haiku-4-5-20251001`.
+/// plus dated IDs like `claude-haiku-4-5-20251001` and single-component
+/// generations like `claude-fable-5` → (5, 0).
 ///
-/// Returns `None` if the ID isn't a known Claude shape (e.g. `gpt-4o`).
+/// Returns `None` if the ID isn't a known Claude shape (e.g. `gpt-4o`),
+/// including non-numeric tails like `claude-mythos-preview`.
 pub(crate) fn claude_generation(model: &str) -> Option<(u32, u32)> {
     let lower = model.to_lowercase();
     if !lower.starts_with("claude-") && !lower.contains("/claude-") {
         return None;
     }
-    for family in ["opus", "sonnet", "haiku"] {
+    // fable/mythos (the Mythos-class tier above Opus, generation 5+) share
+    // the Opus 4.7+ request surface, so the >= (4, 6) / (4, 7) guards below
+    // must fire for them too.
+    for family in ["opus", "sonnet", "haiku", "fable", "mythos"] {
         let needle = format!("{family}-");
         if let Some(idx) = lower.find(&needle) {
             return parse_major_minor_tail(&lower[idx + needle.len()..]);
@@ -552,6 +557,47 @@ mod tests {
         assert!(claude_model_supports_tool_search("claude-opus-4-0"));
         assert!(claude_model_supports_tool_search("claude-sonnet-4-6"));
         assert!(claude_model_supports_tool_search("claude-sonnet-4-0"));
+    }
+
+    #[test]
+    fn fable_and_mythos_parse_generation_and_inherit_guards() {
+        // Fable/Mythos 5 (launched 2026-06-09) share the Opus 4.7+ request
+        // surface; the generation parser must recognize the families or none
+        // of the >= (4, 6) / (4, 7) guards (prefill removal, sampling strip,
+        // adaptive-thinking rewrite) fire for them.
+        assert_eq!(claude_generation("claude-fable-5"), Some((5, 0)));
+        assert_eq!(claude_generation("claude-mythos-5"), Some((5, 0)));
+        assert_eq!(claude_generation("anthropic/claude-fable-5"), Some((5, 0)));
+        // Mythos Preview has no numeric generation — stays unrecognized.
+        assert_eq!(claude_generation("claude-mythos-preview"), None);
+        assert!(claude_model_supports_tool_search("claude-fable-5"));
+    }
+
+    #[test]
+    fn fable_thinking_payloads_match_always_on_surface() {
+        // Extended-thinking budgets are a 400 on Fable — rewritten to adaptive.
+        let mut payload = base_payload();
+        payload.model = "claude-fable-5".to_string();
+        payload.thinking = ThinkingConfig::Enabled {
+            budget_tokens: Some(4096),
+        };
+        let body = AnthropicProvider::build_request_body(&payload);
+        assert_eq!(body["thinking"], serde_json::json!({ "type": "adaptive" }));
+
+        // Thinking is always on for Fable, and an explicit
+        // `thinking: {type: "disabled"}` is also a 400 — a Disabled config
+        // must leave the field out of the payload entirely.
+        let mut payload2 = base_payload();
+        payload2.model = "claude-fable-5".to_string();
+        payload2.thinking = ThinkingConfig::Disabled;
+        payload2.temperature = Some(0.0);
+        let body2 = AnthropicProvider::build_request_body(&payload2);
+        assert!(body2.get("thinking").is_none());
+        // Sampling params are rejected on the 4.7+ surface — stripped.
+        assert!(
+            body2.get("temperature").is_none(),
+            "temperature must be stripped for claude-fable-5"
+        );
     }
 
     #[test]

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -12,6 +12,10 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 
 | Provider | Model pattern | Version min | Thinking | Vision | Audio | PDF | Video | Streaming | Files API | JSON schema | Prompt | Output mode | Prefill | Role | Tool prompt | Thinking blocks | Default tools | Native tools | Text tools | Parity | Tools | Cache |
 |---|---|---|---|---:|---:|---:|---:|---:|---:|---|---|---|---:|---|---|---|---|---:|---:|---|---:|---:|
+| `anthropic` | `claude-fable-*` | `any` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `claude-mythos-*` | `any` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-fable-*` | `any` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `anthropic` | `anthropic/claude-mythos-*` | `any` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
 | `anthropic` | `claude-haiku-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
 | `anthropic` | `claude-opus-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
 | `anthropic` | `claude-sonnet-*` | `>=4.7` | `adaptive` | yes | yes | yes | no | yes | yes | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
@@ -151,6 +155,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `anthropic` | `claude-3-5-sonnet-20240620` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `anthropic` | `claude-3-5-sonnet-20241022` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `anthropic` | `claude-3-opus-20240229` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `anthropic` | `claude-fable-5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `anthropic` | `claude-haiku-4-5-20251001` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `anthropic` | `claude-opus-4-1-20250805` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `anthropic` | `claude-opus-4-20250514` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -1494,6 +1494,101 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "claude-fable-5",
+      "name": "Claude Fable 5",
+      "provider": "anthropic",
+      "aliases": [
+        "fable"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 10.0,
+        "output_per_mtok": 50.0,
+        "cache_read_per_mtok": 1.0,
+        "cache_write_per_mtok": 12.5
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "anthropic-claude",
+      "lineage": "claude-sonnet-opus",
+      "complementary_with": [
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "long_context",
+        "agentic"
+      ],
+      "benchmarks": {
+        "swe_bench_pro": 80.3
+      }
+    },
+    {
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
       "provider": "anthropic",
@@ -7718,6 +7813,11 @@ public let harnProviderCatalogJSON = #"""
       "name": "devstral-small-2",
       "model_id": "devstral-small-2:24b",
       "provider": "ollama"
+    },
+    {
+      "name": "fable",
+      "model_id": "claude-fable-5",
+      "provider": "anthropic"
     },
     {
       "name": "frontier",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -1230,6 +1230,101 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "claude-fable-5",
+      "name": "Claude Fable 5",
+      "provider": "anthropic",
+      "aliases": [
+        "fable"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 10.0,
+        "output_per_mtok": 50.0,
+        "cache_read_per_mtok": 1.0,
+        "cache_write_per_mtok": 12.5
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "anthropic-claude",
+      "lineage": "claude-sonnet-opus",
+      "complementary_with": [
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "long_context",
+        "agentic"
+      ],
+      "benchmarks": {
+        "swe_bench_pro": 80.3
+      }
+    },
+    {
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
       "provider": "anthropic",
@@ -7454,6 +7549,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "devstral-small-2",
       "model_id": "devstral-small-2:24b",
       "provider": "ollama"
+    },
+    {
+      "name": "fable",
+      "model_id": "claude-fable-5",
+      "provider": "anthropic"
     },
     {
       "name": "frontier",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -976,6 +976,101 @@
       ]
     },
     {
+      "id": "claude-fable-5",
+      "name": "Claude Fable 5",
+      "provider": "anthropic",
+      "aliases": [
+        "fable"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "audio",
+          "pdf"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": [
+          "bm25",
+          "regex"
+        ],
+        "max_tools": 10000
+      },
+      "structured_output": "tool_use",
+      "format_preferences": {
+        "prefers_xml_scaffolding": true,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "xml_tagged",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": true,
+        "thinking_block_style": "thinking_blocks"
+      },
+      "reasoning": {
+        "modes": [
+          "adaptive"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": true,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 10.0,
+        "output_per_mtok": 50.0,
+        "cache_read_per_mtok": 1.0,
+        "cache_write_per_mtok": 12.5
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "tool_search",
+        "vision",
+        "audio",
+        "pdf",
+        "files",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "anthropic-claude",
+      "lineage": "claude-sonnet-opus",
+      "complementary_with": [
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "long_context",
+        "agentic"
+      ],
+      "benchmarks": {
+        "swe_bench_pro": 80.3
+      }
+    },
+    {
       "id": "claude-haiku-4-5-20251001",
       "name": "Claude Haiku 4.5",
       "provider": "anthropic",
@@ -7200,6 +7295,11 @@
       "name": "devstral-small-2",
       "model_id": "devstral-small-2:24b",
       "provider": "ollama"
+    },
+    {
+      "name": "fable",
+      "model_id": "claude-fable-5",
+      "provider": "anthropic"
     },
     {
       "name": "frontier",


### PR DESCRIPTION
## Summary

Adds comprehensive catalog support for **Claude Fable 5** (`claude-fable-5`), Anthropic's Mythos-class tier above Opus, GA today (2026-06-09).

- **Model entry** in `60-models/00-anthropic.toml`: $10/$50 per MTok (cache read $1.00, 5-min write $12.50), `context_window = 1000000` — the 1M window is the model's *only* tier, so this row intentionally departs from the 200k standard-tier convention used by the Opus/Sonnet rows (comment explains). SWE-bench Pro 80.3; Verified is unpublished for Fable itself at launch, so omitted rather than guessed. No `fast_mode` (Opus-only feature). Nothing is superseded — Opus 4.8 stays current.
- **`fable` alias**; `opus` intentionally stays on `claude-opus-4-8` (new tier, not an Opus successor).
- **Capability rules** for `claude-fable-*` / `claude-mythos-*` (+ `anthropic/`-prefixed variants): adaptive-only thinking, interleaved thinking, no assistant prefill. Without these, the ids fell through to the `claude-*` catch-all which wrongly grants `thinking_modes = ["enabled"]` and prefill.
- **`claude_generation()`** now recognizes the `fable`/`mythos` families (`claude-fable-5` → (5, 0)), so the existing ≥4.6/≥4.7 request guards fire: budget→adaptive rewrite, sampling-param strip, prefill removal. Fable additionally 400s on an explicit `thinking: {type: "disabled"}`; the request builder already omits the field for the Disabled config — now pinned by a regression test.
- Regenerated `providers.toml` / `capabilities.toml` / `spec/provider-catalog/*` via `providers build-config|export`; `providers validate --check-artifacts` passes.

Source: [Anthropic models overview](https://platform.claude.com/docs/en/about-claude/models/overview), [Introducing Claude Fable 5 and Claude Mythos 5](https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5), [pricing](https://platform.claude.com/docs/en/about-claude/pricing).

## Test plan

- `cargo test -p harn-vm --lib` — anthropic provider, fast_mode, provider_catalog, capabilities suites (118 passed) incl. two new tests: `fable_and_mythos_parse_generation_and_inherit_guards`, `fable_thinking_payloads_match_always_on_surface`
- `harn providers validate --check-artifacts` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)