### PR TITLE
harn-serve: @stream routes + SiteStreamProvider for host-streamed SSE bodies (#3213)

### DIFF
--- a/changelog.d/3213.added.md
+++ b/changelog.d/3213.added.md
@@ -1,0 +1,14 @@
+- **`harn serve site` can now host-stream response bodies (SSE/chunked) on `@stream` routes
+  (#3213).** The dispatch boundary is JSON in/out, so a `.harn` handler's response is always
+  buffered — wrong for SSE. A routed `pub fn` carrying the new bare `@stream` attribute therefore
+  never buffers the request body and never dispatches into the VM: after admission (the `SiteAuth`
+  hook plus the route's `@scopes`, which the adapter now enforces itself for stream routes since no
+  `CallRequest` exists to back-stop them) the adapter calls the embedder's new
+  `harn_serve::SiteStreamProvider` (`async fn open(&self, route, auth: Option<&SiteAuthContext>,
+  request: Value) -> Response`), installed via `SiteServerConfig::with_stream_provider`, and
+  forwards its streaming `Response` unbuffered — keep-alive and client-disconnect propagation come
+  from the returned `Sse`/stream body. The provider receives the same request-head dict a `.harn`
+  handler would see (`method`, `path`, `route`, `path_params`, `query`, `headers`, `client_ip`,
+  `remote_addr`), minus any body. Declaring a `@stream` route without a provider fails at
+  router-build time; a malformed `@stream(...)` or one without an HTTP route is diagnosed
+  (`HARN-SRV-009` / `HARN-SRV-010`). Non-stream routes are unchanged. Fixes #3213.

--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -56,6 +56,19 @@
 //! status/headers/SSE/304 semantics come for free and stay identical to
 //! every other harn-serve surface.
 //!
+//! ## Streamed bodies (`@stream`)
+//!
+//! The dispatch boundary is JSON in/out, so a `.harn` handler's response
+//! is fully buffered before it is rendered — fine for pages and APIs,
+//! wrong for SSE. A route whose export carries the bare `@stream`
+//! attribute therefore never dispatches into the VM: after the
+//! [`SiteAuth`] hook and the route's `@scopes` admit the request, the
+//! adapter hands the request head to the embedder's
+//! [`SiteStreamProvider`] (installed with
+//! [`SiteServerConfig::with_stream_provider`]) and forwards its
+//! streaming `Response` — an SSE or chunked body — unbuffered. See the
+//! trait docs for the contract.
+//!
 //! ## WebSockets
 //!
 //! When a handler returns an `http_upgrade_ws(req, options)` envelope and
@@ -165,6 +178,48 @@ impl SiteAuthOutcome {
     }
 }
 
+/// Embedder-supplied responder for `@stream` routes (#3213).
+///
+/// The host-call bridge is synchronous request/response (JSON in, JSON
+/// out), so a `.harn` handler can never *stream* a body — yet SSE/
+/// chunked endpoints are real surfaces an embedder needs to host on the
+/// same router, behind the same admission. The seam: a route whose
+/// `.harn` export carries the `@stream` marker (see [`crate::exports`])
+/// never buffers the request body and never dispatches into the VM.
+/// After routing and admission — the [`SiteAuth`] hook plus the route's
+/// `@scopes` — the adapter calls the provider installed with
+/// [`SiteServerConfig::with_stream_provider`], and forwards whatever
+/// streaming [`Response`] it returns (an [`axum::response::sse::Sse`],
+/// a `Body::from_stream`, …) to the client unbuffered. Keep-alive and
+/// client-disconnect propagation are axum's: when the client goes away
+/// the response body stream is dropped, cancelling the source.
+///
+/// The `.harn` function under a `@stream` route is a declaration-only
+/// stub — it owns the route, its `@scopes`, and its docs, while the
+/// stream source lives in embedder Rust (where the event store is).
+#[async_trait]
+pub trait SiteStreamProvider: Send + Sync {
+    /// Open the stream for one admitted request.
+    ///
+    /// * `route` — the matched function's declared [`RouteSpec`].
+    /// * `auth` — the identity the [`SiteAuth`] hook resolved (tenant,
+    ///   scopes, opaque context); `None` when no hook is installed.
+    /// * `request` — the request head as the same JSON dict a `.harn`
+    ///   handler would receive (`method`, `path`, `route`,
+    ///   `path_params`/`params`, `query`, `headers`, `client_ip`,
+    ///   `remote_addr`), minus any body — a stream route never reads
+    ///   one.
+    ///
+    /// Errors are just responses: shape a 404/410/500 the same way a
+    /// success is shaped, and return it.
+    async fn open(
+        &self,
+        route: &RouteSpec,
+        auth: Option<&SiteAuthContext>,
+        request: Value,
+    ) -> Response;
+}
+
 /// Listener options for [`SiteServer::run_http`].
 #[derive(Clone, Debug)]
 pub struct SiteHttpServeOptions {
@@ -191,6 +246,10 @@ pub struct SiteServerConfig {
     /// (the default) keeps the historic behavior: no edge auth and
     /// tenant-less dispatch.
     pub auth: Option<Arc<dyn SiteAuth>>,
+    /// Embedder responder for `@stream` routes. Required when the
+    /// script declares any — building the router fails loudly otherwise,
+    /// since the route would have no body source.
+    pub stream_provider: Option<Arc<dyn SiteStreamProvider>>,
 }
 
 impl SiteServerConfig {
@@ -200,6 +259,7 @@ impl SiteServerConfig {
             transport: TransportConfig::default_enabled(),
             trusted_proxies: Vec::new(),
             auth: None,
+            stream_provider: None,
         }
     }
 
@@ -218,6 +278,13 @@ impl SiteServerConfig {
     /// dispatched.
     pub fn with_auth(mut self, auth: Arc<dyn SiteAuth>) -> Self {
         self.auth = Some(auth);
+        self
+    }
+
+    /// Install the embedder [`SiteStreamProvider`] that answers the
+    /// script's `@stream` routes.
+    pub fn with_stream_provider(mut self, provider: Arc<dyn SiteStreamProvider>) -> Self {
+        self.stream_provider = Some(provider);
         self
     }
 }
@@ -241,10 +308,18 @@ impl SiteServer {
             transport,
             trusted_proxies,
             auth,
+            stream_provider,
         } = self.config;
         let catalog = Arc::new(core.catalog().clone());
         let runtime = Arc::new(DispatchRuntime::start("SITE", Arc::new(core)));
-        build_site_router(&catalog, runtime, &transport, trusted_proxies, auth)
+        build_site_router(
+            &catalog,
+            runtime,
+            &transport,
+            trusted_proxies,
+            auth,
+            stream_provider,
+        )
     }
 
     /// Bind the configured socket and serve until the process exits.
@@ -279,6 +354,9 @@ struct SiteRoute {
     /// `@scopes(...)` declared on the function; empty means no scope
     /// requirement (public, as far as scopes are concerned).
     required_scopes: BTreeSet<String>,
+    /// `@stream` marker: after admission, hand the request head to the
+    /// [`SiteStreamProvider`] instead of dispatching into the VM.
+    stream: bool,
 }
 
 /// State shared by every site route handler: the dispatch executor plus
@@ -295,6 +373,10 @@ struct SiteState {
     /// Embedder auth hook; `None` means no edge auth (historic
     /// behavior).
     auth: Option<Arc<dyn SiteAuth>>,
+    /// Embedder stream provider answering `@stream` routes. Present
+    /// whenever the catalog declares one (router construction enforces
+    /// it).
+    stream_provider: Option<Arc<dyn SiteStreamProvider>>,
 }
 
 impl SiteState {
@@ -315,17 +397,28 @@ fn build_site_router(
     transport: &TransportConfig,
     trusted_proxies: Vec<IpNet>,
     auth: Option<Arc<dyn SiteAuth>>,
+    stream_provider: Option<Arc<dyn SiteStreamProvider>>,
 ) -> Result<Router, String> {
     let mut routes: BTreeMap<String, BTreeMap<String, SiteRoute>> = BTreeMap::new();
     for function in catalog.functions.values() {
         let Some(spec @ RouteSpec { method, path }) = function.route.as_ref() else {
             continue;
         };
+        // A `@stream` route has no body source without a provider;
+        // refusing to start beats serving a route that can only 500.
+        if function.stream && stream_provider.is_none() {
+            return Err(format!(
+                "route {method} {path} (`{}`) is marked @stream but no stream provider is \
+                 configured; install one with SiteServerConfig::with_stream_provider(...)",
+                function.name
+            ));
+        }
         let by_method = routes.entry(path.clone()).or_default();
         let entry = SiteRoute {
             function: function.name.clone(),
             spec: spec.clone(),
             required_scopes: function.required_scopes.clone(),
+            stream: function.stream,
         };
         if let Some(existing) = by_method.insert(method.clone(), entry) {
             return Err(format!(
@@ -349,6 +442,7 @@ fn build_site_router(
         routes: Arc::new(routes),
         trusted_proxies: Arc::new(trusted_proxies),
         auth,
+        stream_provider,
     };
 
     let mut router: Router<SiteState> = Router::new();
@@ -423,6 +517,54 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
             }
         },
     };
+
+    // `@stream` routes hand off to the embedder's provider right after
+    // admission: no body buffering (a stream route never reads one) and
+    // no VM dispatch — the provider's streaming Response is forwarded
+    // unbuffered, so SSE keep-alive and client-disconnect propagation
+    // are whatever the provider's `Sse`/stream body gives axum.
+    if route.stream {
+        // A @stream route never builds a `CallRequest`, so the
+        // dispatch-level `AuthPolicy` scope check cannot back-stop it
+        // the way it does for plain routes. With a hook installed the
+        // admission above already compared `@scopes` against the
+        // hook-granted set; without one, no identity means no granted
+        // scopes, and any scope requirement refuses — matching the
+        // allow-all default a plain route would hit at dispatch.
+        if auth_context.is_none() && !route.required_scopes.is_empty() {
+            return axum_response_from_dispatch_error(
+                DispatchError::Forbidden {
+                    required: route.required_scopes.clone(),
+                    granted: BTreeSet::new(),
+                },
+                &request_id,
+            );
+        }
+        let Some(provider) = state.stream_provider.as_ref() else {
+            // Unreachable: router construction refuses a @stream route
+            // without a provider. Shape a loud 500 rather than panic.
+            return axum_response_from_dispatch_error(
+                DispatchError::Execution(format!(
+                    "@stream route {route_template} has no stream provider"
+                )),
+                &request_id,
+            );
+        };
+        let request = build_request_value(
+            &method,
+            &parts.uri,
+            &route_template,
+            raw_params.as_ref(),
+            &query,
+            &parts.headers,
+            &[],
+            peer,
+            &state.trusted_proxies,
+        );
+        return provider
+            .open(&route.spec, auth_context.as_ref(), request)
+            .await;
+    }
 
     let wants_upgrade = is_websocket_upgrade(&parts.headers);
 

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -56,6 +56,15 @@ pub struct ExportedFunction {
     /// through the trigger dispatcher (retry / DLQ / budget / cancel all
     /// come free from the dispatcher). See [`JobSpec`].
     pub job: Option<JobSpec>,
+    /// `true` when the function carries a `@stream` attribute alongside
+    /// its HTTP route. A streaming route never buffers the request body
+    /// and never dispatches into the VM: after the site adapter's
+    /// admission checks (the embedder's `SiteAuth` hook plus `@scopes`)
+    /// it hands the request head to the embedder-registered
+    /// `SiteStreamProvider`, which returns a live SSE/chunked response.
+    /// The `.harn` function body is a declaration-only stub for such
+    /// routes — the stream source lives in embedder Rust.
+    pub stream: bool,
 }
 
 /// A `.harn` worker/job entrypoint declared with `@job("name")`.
@@ -187,6 +196,13 @@ pub const RETRY_BAD_ARGS: &str = "HARN-SRV-007";
 /// `@schedule` / `@queue` / `@retry` appears without a `@job` attribute.
 /// Those modifiers only mean something on a job, so they are ignored.
 pub const JOB_MODIFIER_WITHOUT_JOB: &str = "HARN-SRV-008";
+/// `@stream` carries arguments — it is a bare marker. The marker is
+/// dropped, so the route dispatches into the VM like any other handler.
+pub const STREAM_BAD_ARGS: &str = "HARN-SRV-009";
+/// `@stream` appears on a declaration without an HTTP route (no
+/// `@route(...)`, no `handler_*` convention, or a pipeline). Streaming
+/// only means something on a routed `pub fn`, so it is ignored.
+pub const STREAM_WITHOUT_ROUTE: &str = "HARN-SRV-010";
 
 impl std::fmt::Display for ExportDiagnostic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -246,6 +262,8 @@ impl ExportCatalog {
             }
 
             let (limits, budget) = limits_and_budget_from_attributes(attrs);
+            let route = route_from_attributes(attrs, name, &mut diagnostics);
+            let stream = stream_from_attributes(attrs, name, route.as_ref(), &mut diagnostics);
             functions.insert(
                 name.clone(),
                 ExportedFunction {
@@ -260,7 +278,8 @@ impl ExportCatalog {
                     required_scopes: scopes_from_attributes(attrs, name, &mut diagnostics),
                     limits,
                     budget,
-                    route: route_from_attributes(attrs, name, &mut diagnostics),
+                    route,
+                    stream,
                     job: job_from_attributes(attrs, name, &mut diagnostics),
                 },
             );
@@ -284,6 +303,9 @@ impl ExportCatalog {
             }
             let required_scopes = scopes_from_attributes(attrs, name, &mut diagnostics);
             let (limits, budget) = limits_and_budget_from_attributes(attrs);
+            // Pipelines never carry a route, so a `@stream` on one is
+            // inert — diagnose it the same way as on an unrouted fn.
+            let stream = stream_from_attributes(attrs, name, None, &mut diagnostics);
             functions
                 .entry(name.clone())
                 .or_insert_with(|| ExportedFunction {
@@ -302,6 +324,7 @@ impl ExportCatalog {
                     // HTTP route. Only `pub fn` handlers participate in
                     // `harn serve site`.
                     route: None,
+                    stream,
                     job: job_from_attributes(attrs, name, &mut diagnostics),
                 });
         }
@@ -524,6 +547,52 @@ fn normalize_route_path(path: &str) -> String {
     } else {
         format!("/{trimmed}")
     }
+}
+
+/// Resolve the `@stream` marker on a declaration.
+///
+/// `@stream` is a bare attribute: it takes no arguments and only means
+/// something on a declaration that resolved an HTTP route. A
+/// well-formed marker turns the route into a streaming route — the site
+/// adapter skips body buffering and VM dispatch and hands the request
+/// head to the embedder's `SiteStreamProvider` after admission. A
+/// malformed or unrouted `@stream` records a `HARN-SRV-*` diagnostic
+/// and returns `false`, so the author sees the mistake instead of a
+/// route that silently dispatches a stub handler (or a marker that
+/// silently does nothing).
+fn stream_from_attributes(
+    attrs: &[Attribute],
+    fn_name: &str,
+    route: Option<&RouteSpec>,
+    diagnostics: &mut Vec<ExportDiagnostic>,
+) -> bool {
+    let Some(attr) = attrs.iter().find(|attr| attr.name == "stream") else {
+        return false;
+    };
+    if route.is_none() {
+        diagnostics.push(ExportDiagnostic {
+            code: STREAM_WITHOUT_ROUTE,
+            line: attr.span.line,
+            message: format!(
+                "`@stream` on `{fn_name}` has no effect without an HTTP route \
+                 (`@route(...)` or the `handler_*` convention); ignoring it"
+            ),
+        });
+        return false;
+    }
+    if !attr.args.is_empty() {
+        diagnostics.push(ExportDiagnostic {
+            code: STREAM_BAD_ARGS,
+            line: attr.span.line,
+            message: format!(
+                "`@stream` on `{fn_name}` takes no arguments, found {}; marker dropped — \
+                 the route dispatches as a plain handler",
+                attr.args.len()
+            ),
+        });
+        return false;
+    }
+    true
 }
 
 /// Resolve the worker/job binding a `pub fn` declares with `@job(...)`.
@@ -1218,5 +1287,59 @@ pub fn scan(event: TriggerEvent) -> dict { return {ok: true} }
         assert_eq!(retry.backoff, RetryBackoff::Svix);
         let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
         assert_eq!(codes, vec![RETRY_BAD_ARGS]);
+    }
+
+    #[test]
+    fn stream_attribute_marks_routed_functions_only() {
+        let catalog = catalog_from_source(
+            r#"
+@stream
+@route("GET", "/events")
+pub fn events(req: dict) -> dict { return http_ok({}) }
+
+@stream
+pub fn handler_feed(req: dict) -> dict { return http_ok({}) }
+
+@route("GET", "/plain")
+pub fn plain(req: dict) -> dict { return http_ok({}) }
+"#,
+        );
+        assert!(
+            catalog.diagnostics().is_empty(),
+            "unexpected diagnostics: {:?}",
+            catalog.diagnostics()
+        );
+        // Works with an explicit @route and with the handler_* convention.
+        assert!(catalog.function("events").expect("events").stream);
+        assert!(catalog.function("handler_feed").expect("feed").stream);
+        // A routed fn without the marker is a plain dispatch route.
+        assert!(!catalog.function("plain").expect("plain").stream);
+    }
+
+    #[test]
+    fn stream_with_args_is_diagnosed_and_dropped() {
+        let catalog = catalog_from_source(
+            r#"
+@stream("sse")
+@route("GET", "/events")
+pub fn events(req: dict) -> dict { return http_ok({}) }
+"#,
+        );
+        assert!(!catalog.function("events").expect("events").stream);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![STREAM_BAD_ARGS]);
+    }
+
+    #[test]
+    fn stream_without_route_is_diagnosed_and_ignored() {
+        let catalog = catalog_from_source(
+            r"
+@stream
+pub fn helper(req: dict) -> dict { return req }
+",
+        );
+        assert!(!catalog.function("helper").expect("helper").stream);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![STREAM_WITHOUT_ROUTE]);
     }
 }

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -53,6 +53,7 @@ pub use adapters::mcp::{
 };
 pub use adapters::site::{
     SiteAuth, SiteAuthContext, SiteAuthOutcome, SiteHttpServeOptions, SiteServer, SiteServerConfig,
+    SiteStreamProvider,
 };
 pub use adapters::worker::{run_job_from_files, run_job_once, run_job_once_with, JobRunOutcome};
 pub use auth::{

--- a/crates/harn-serve/tests/site_streaming.rs
+++ b/crates/harn-serve/tests/site_streaming.rs
@@ -1,0 +1,287 @@
+//! Host-streamed response bodies through `harn serve site` (#3213).
+//!
+//! Exercises the `@stream` route marker + [`harn_serve::SiteStreamProvider`]
+//! seam end-to-end through a real router: an admitted request on a
+//! `@stream` route reaches the embedder's provider (which sees the
+//! matched route, the hook-resolved identity, and the request head) and
+//! the provider's SSE body streams back verbatim; admission — the
+//! [`harn_serve::SiteAuth`] hook and the route's `@scopes` — still gates
+//! the route, refusing *before* the provider is consulted; a non-stream
+//! route on the same script dispatches into the VM unchanged; and a
+//! script that declares a `@stream` route refuses to build a router
+//! without a provider.
+//!
+//! All cases drive the router through `tower::ServiceExt::oneshot`,
+//! mirroring `tests/site_auth.rs`.
+
+use std::convert::Infallible;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::request::Parts;
+use axum::http::{Request, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router};
+use harn_serve::{
+    DispatchCore, DispatchCoreConfig, NoReplayCache, RouteSpec, SiteAuth, SiteAuthContext,
+    SiteAuthOutcome, SiteServer, SiteServerConfig, SiteStreamProvider,
+};
+use harn_vm::TenantId;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+/// One script backs every case: a `@scopes`-guarded `@stream` route and
+/// a plain dispatch route. The stream route's body is a declaration-only
+/// stub — if it ever runs, the VM dispatched where the provider should
+/// have answered, and the assertions below catch the buffered sentinel.
+const SITE_SCRIPT: &str = r#"
+@stream
+@scopes("events:read")
+@route("GET", "/topics/{topic}/events")
+pub fn topic_events(req: dict) -> dict {
+  return http_ok({ "buffered_stub": true })
+}
+
+@route("GET", "/plain")
+pub fn plain(req: dict) -> dict {
+  return http_ok({ "plain": true })
+}
+"#;
+
+/// Test provider: emits three SSE events and ends. The first event
+/// echoes what the provider was given (route, tenant, path params,
+/// query), so one body read proves the whole contract.
+struct ThreeEventProvider {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl SiteStreamProvider for ThreeEventProvider {
+    async fn open(
+        &self,
+        route: &RouteSpec,
+        auth: Option<&SiteAuthContext>,
+        request: Value,
+    ) -> Response {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let opened = json!({
+            "route": { "method": route.method, "path": route.path },
+            "tenant": auth.and_then(|context| context.tenant_id.as_ref()).map(|t| t.0.clone()),
+            "topic": request["path_params"]["topic"],
+            "since": request["query"]["since"],
+        });
+        let events = vec![
+            Event::default().event("opened").data(opened.to_string()),
+            Event::default().data("two"),
+            Event::default().data("three"),
+        ];
+        let stream = futures::stream::iter(events.into_iter().map(Ok::<_, Infallible>));
+        Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response()
+    }
+}
+
+/// `SiteAuth` hook that always admits with a fixed identity.
+struct AllowAuth {
+    tenant: Option<&'static str>,
+    scopes: &'static [&'static str],
+}
+
+#[async_trait::async_trait]
+impl SiteAuth for AllowAuth {
+    async fn authenticate(&self, _parts: &Parts, _route: &RouteSpec) -> SiteAuthOutcome {
+        SiteAuthOutcome::Allow(SiteAuthContext {
+            tenant_id: self.tenant.map(TenantId::new),
+            scopes: self.scopes.iter().map(|scope| scope.to_string()).collect(),
+            context: None,
+        })
+    }
+}
+
+/// `SiteAuth` hook that always refuses with an embedder-shaped response.
+struct DenyAuth;
+
+#[async_trait::async_trait]
+impl SiteAuth for DenyAuth {
+    async fn authenticate(&self, _parts: &Parts, _route: &RouteSpec) -> SiteAuthOutcome {
+        SiteAuthOutcome::deny(
+            (
+                StatusCode::UNAUTHORIZED,
+                [("x-embedder-deny", "1")],
+                Json(json!({ "error": "custom_embedder_denial" })),
+            )
+                .into_response(),
+        )
+    }
+}
+
+fn build_core(path: &Path) -> DispatchCore {
+    let mut config = DispatchCoreConfig::for_script(path);
+    // An HTTP host must re-run its handler on every request.
+    config.replay_cache = Arc::new(NoReplayCache);
+    DispatchCore::new(config).expect("dispatch core")
+}
+
+/// Write the shared script to a temp dir and build a site router over it
+/// with the counting provider, optionally behind an auth hook. The temp
+/// dir is returned so it outlives the router.
+fn streaming_router(
+    auth: Option<Arc<dyn SiteAuth>>,
+) -> (tempfile::TempDir, Router, Arc<AtomicUsize>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(&path, SITE_SCRIPT).expect("write script");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut config = SiteServerConfig::new(build_core(&path)).with_stream_provider(Arc::new(
+        ThreeEventProvider {
+            calls: calls.clone(),
+        },
+    ));
+    if let Some(auth) = auth {
+        config = config.with_auth(auth);
+    }
+    let router = SiteServer::new(config).router().expect("site router");
+    (dir, router, calls)
+}
+
+async fn get(router: Router, uri: &str) -> Response {
+    router
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+async fn read_body(response: Response) -> (StatusCode, String) {
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// The happy path: an admitted request on the `@stream` route receives
+/// the provider's three SSE events — and the first event proves the
+/// provider saw the matched route, the hook's tenant, the captured path
+/// param, and the query string. The `.harn` stub body never runs.
+#[tokio::test]
+async fn stream_route_delivers_provider_sse_events() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["events:read"],
+    });
+    let (_dir, router, calls) = streaming_router(Some(hook));
+    let response = get(router, "/topics/deploys/events?since=42").await;
+    assert_eq!(
+        response.headers()["content-type"].to_str().unwrap(),
+        "text/event-stream"
+    );
+    let (status, body) = read_body(response).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    // Three events arrived, in order, SSE-framed.
+    assert!(
+        body.contains("event: opened"),
+        "missing first event: {body}"
+    );
+    assert!(body.contains("data: two"), "missing second event: {body}");
+    assert!(body.contains("data: three"), "missing third event: {body}");
+    assert!(
+        !body.contains("buffered_stub"),
+        "the .harn stub body must never dispatch for a @stream route: {body}"
+    );
+
+    // The first event echoes the provider's inputs.
+    let opened_line = body
+        .lines()
+        .find(|line| line.starts_with("data: {"))
+        .expect("opened event data line");
+    let opened: Value = serde_json::from_str(opened_line.trim_start_matches("data: ")).unwrap();
+    assert_eq!(opened["route"]["method"], "GET");
+    assert_eq!(opened["route"]["path"], "/topics/{topic}/events");
+    assert_eq!(opened["tenant"], "acme");
+    assert_eq!(opened["topic"], "deploys");
+    assert_eq!(opened["since"], "42");
+}
+
+/// A `SiteAuth` `Deny` gates the stream route exactly as it gates a
+/// dispatch route: the embedder response comes back verbatim and the
+/// provider is never consulted.
+#[tokio::test]
+async fn auth_deny_refuses_stream_route_before_provider_opens() {
+    let (_dir, router, calls) = streaming_router(Some(Arc::new(DenyAuth)));
+    let response = get(router, "/topics/deploys/events").await;
+    assert_eq!(response.headers()["x-embedder-deny"], "1");
+    let (status, body) = read_body(response).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(body.contains("custom_embedder_denial"));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+/// An admitted identity whose scopes do not cover the route's `@scopes`
+/// is refused with the canonical `forbidden` envelope — again before the
+/// provider is consulted.
+#[tokio::test]
+async fn scope_shortfall_yields_403_before_provider_opens() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["events:write"],
+    });
+    let (_dir, router, calls) = streaming_router(Some(hook));
+    let (status, body) = read_body(get(router, "/topics/deploys/events").await).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let envelope: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(envelope["code"], "forbidden");
+    assert_eq!(envelope["details"]["missing_scopes"][0], "events:read");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+/// A non-stream route on the same script is untouched by the provider:
+/// it dispatches into the VM and renders its buffered JSON reply.
+#[tokio::test]
+async fn non_stream_route_still_dispatches_into_the_vm() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &[],
+    });
+    let (_dir, router, calls) = streaming_router(Some(hook));
+    let (status, body) = read_body(get(router, "/plain").await).await;
+    assert_eq!(status, StatusCode::OK);
+    let value: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(value["plain"], true);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+/// A `@stream` route never builds a `CallRequest`, so the dispatch-level
+/// scope check cannot back-stop its `@scopes`. The adapter enforces them
+/// itself: with no hook installed there is no identity and no granted
+/// scopes, so a scoped stream route refuses with the canonical 403
+/// before the provider opens — same outcome a scoped plain route gets
+/// from the allow-all default at dispatch.
+#[tokio::test]
+async fn scoped_stream_route_without_hook_is_refused_at_admission() {
+    let (_dir, router, calls) = streaming_router(None);
+    let (status, body) = read_body(get(router, "/topics/deploys/events").await).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let envelope: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(envelope["code"], "forbidden");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+/// Declaring a `@stream` route without installing a provider is a
+/// configuration error surfaced at router-build time, not a 500 at
+/// request time.
+#[tokio::test]
+async fn stream_route_without_provider_refuses_to_build() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(&path, SITE_SCRIPT).expect("write script");
+    let config = SiteServerConfig::new(build_core(&path));
+    let error = SiteServer::new(config).router().expect_err("must refuse");
+    assert!(
+        error.contains("@stream") && error.contains("with_stream_provider"),
+        "unhelpful error: {error}"
+    );
+}


### PR DESCRIPTION
Fixes #3213 (HS-2). Second harn-serve capability for harn-cloud's gateway retirement (#496a): SSE/streaming routes couldn't migrate because the dispatch buffers full bodies (and its JSON envelope can't carry a live stream).

## Design: declarative `@stream` + embedder provider
- `@stream` route attribute (exports collector): the `.harn` fn stays a declaration-only stub owning the route + `@scopes` + docs; the adapter skips body buffering AND VM dispatch entirely, going straight to the embedder's provider after admission. (A dispatch-result `{"stream":true}` marker was rejected: it would pay a full VM dispatch just to learn the route streams, and the result envelope can't return a stream handle.)
- `trait SiteStreamProvider { async fn open(&self, route: &RouteSpec, auth: Option<&SiteAuthContext>, request: Value) -> Response }`, installed via `SiteServerConfig::with_stream_provider`. `request` = the same head dict a `.harn` handler gets (no body).

## Admission composes with HS-1
routing → `SiteAuth` hook (Deny verbatim; provider never consulted) → `@scopes ⊆ granted` (canonical 403) → provider. Closed a subtle gap: stream routes never build a `CallRequest`, so the dispatch-level AuthPolicy can't back-stop `@scopes` — the adapter itself refuses a scoped stream route when no hook is installed (test-covered). Disconnect/keep-alive come free from the returned axum `Sse` body. `@stream` with no provider fails at router-build; malformed/unrouted `@stream` get diagnostics HARN-SRV-009/010.

## Tests (9, all pass)
SSE delivery (3 events; provider sees route/tenant/path-param/query; stub body never runs), auth-deny before open (verbatim 401, provider count 0), scope-shortfall 403 before open, scoped-without-hook refused, non-stream route still dispatches into the VM, no-provider refuses to build + 3 exports units. `nextest -p harn-serve`: 469/470 (sole failure = documented pre-existing `pg_query_budget...`). fmt/clippy clean; changelog added.

Unblocks harn-cloud's 5 SSE/streaming carve-out groups (supervision stream, task event streams). Remaining capability: #3214 (raw/binary bodies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)