### PR TITLE
fix(llm): honor catalog stream_timeout on the shared transport, surface mid-stream SSE failures, retry zero-token empty completions

### DIFF
--- a/changelog.d/openai-transport-stream-timeout.fixed.md
+++ b/changelog.d/openai-transport-stream-timeout.fixed.md
@@ -1,0 +1,22 @@
+- **The OpenAI-compatible transport now honors the model catalog's
+  `stream_timeout`, surfaces mid-stream failures, and retries zero-token empty
+  completions.** Three gaps turned provider stalls into silent empty agent
+  turns (observed live in Burin Code eval-meter work: an OpenRouter call hung
+  133s and returned `output_tokens=0` as a "success"): (1) the catalog's
+  `stream_timeout` (seconds) was projected into config dicts but consumed by
+  no transport — it now feeds the shared whole-request deadline
+  (`explicit timeout option > HARN_LLM_TIMEOUT > stream_timeout > 120s
+  default`) for every provider on the common `resolve_timeout` seam, both
+  streaming and non-streaming, so slow local models with `stream_timeout =
+  900.0` get their budget and hung remote calls are bounded; (2) a mid-body
+  SSE read failure (including that deadline firing mid-stream) was silently
+  swallowed, returning a truncated zero-token success — it now surfaces as
+  the same transient stream-error class other timeouts use, so the existing
+  retry machinery picks it up; (3) a wire-level "success" carrying zero output
+  tokens, no content, no thinking, and no tool calls is now retried once
+  built-in (more with `llm_retries`) as a transient provider hiccup, with an
+  `empty_completion_retry` observability entry and `EmptyCompletionRetry`
+  trace event; if it stays empty after the budget, the result is returned
+  unchanged. Token-cap truncations (`stop_reason` length/max_tokens) are
+  excluded from the retry, and mock/fake providers only retry on explicit
+  opt-in so scripted tests stay deterministic.

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -202,6 +202,39 @@ fn is_empty_completion_retry_error(err: &VmError) -> bool {
     lower.contains("completion_tokens=") && lower.contains("delivered no content")
 }
 
+/// A wire-level "success" that carries nothing at all: zero output tokens, no
+/// text, no thinking, no tool calls, and no server-side tool-search activity.
+/// Observed live (OpenRouter): a provider stall that ends with an empty 200
+/// flows back into the agent loop as an empty assistant turn the loop has to
+/// burn an iteration recovering from. Treated as a transient provider hiccup
+/// and retried in [`observed_llm_call`].
+///
+/// Token-cap truncations (`stop_reason` length/max_tokens) are excluded — a
+/// deterministic cap would just re-truncate on every retry, mirroring the
+/// `done_reason == "length"` carve-out on the Ollama NDJSON path.
+fn is_zero_token_empty_completion(result: &super::api::LlmResult) -> bool {
+    let truncated = matches!(
+        result
+            .stop_reason
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("length" | "max_tokens")
+    );
+    let has_tool_search_block = result.blocks.iter().any(|block| {
+        matches!(
+            block.get("type").and_then(|value| value.as_str()),
+            Some("tool_search_query") | Some("tool_search_result")
+        )
+    });
+    result.output_tokens == 0
+        && result.text.is_empty()
+        && result.tool_calls.is_empty()
+        && result.thinking.as_deref().unwrap_or("").is_empty()
+        && !truncated
+        && !has_tool_search_block
+}
+
 /// Extract retry-after delay from an error message if present.
 ///
 /// Supports both forms defined by RFC 7231 §7.1.3:
@@ -908,6 +941,29 @@ async fn run_detector_loop(
 pub(crate) const DEFAULT_LLM_CALL_RETRIES: usize = 0;
 pub(crate) const DEFAULT_LLM_CALL_BACKOFF_MS: u64 = 250;
 
+/// Built-in retry budget for zero-token empty completions. Applies even when
+/// the caller's transient-retry budget is 0 (the fail-fast `llm_call`
+/// default), mirroring the transport's unconditional single retry for the
+/// Ollama empty-content parser bug: an empty 200 is clearly a provider
+/// hiccup, and most live callers (e.g. the Burin agent loop) retry only on
+/// *errors*, so an empty Ok would otherwise sail through untouched.
+const EMPTY_COMPLETION_BUILTIN_RETRIES: usize = 1;
+
+/// Effective retry budget for zero-token empty completions: the caller's
+/// transient budget, floored at [`EMPTY_COMPLETION_BUILTIN_RETRIES`] for real
+/// providers. Deterministic in-process providers (mock/fake) replay scripted
+/// turns — a built-in silent retry would consume turns tests rely on — so
+/// they only honor an explicit `llm_retries` opt-in.
+fn empty_completion_retry_budget(retry_config: &LlmRetryConfig, provider: &str) -> usize {
+    if crate::llm::providers::MockProvider::should_intercept(provider)
+        || crate::llm::fake::FakeLlmProvider::should_intercept(provider)
+    {
+        retry_config.retries
+    } else {
+        retry_config.retries.max(EMPTY_COMPLETION_BUILTIN_RETRIES)
+    }
+}
+
 pub(crate) struct LlmRetryConfig {
     /// Maximum number of retries for transient errors (429, 5xx, connection).
     pub retries: usize,
@@ -933,8 +989,13 @@ fn llm_retry_backoff_ms(
     if crate::llm::providers::MockProvider::should_intercept(provider) {
         return 0;
     }
-    extract_retry_after_ms(error)
-        .unwrap_or_else(|| retry_config.backoff_ms.saturating_mul(1 << attempt.min(4)))
+    extract_retry_after_ms(error).unwrap_or_else(|| base_retry_backoff_ms(retry_config, attempt))
+}
+
+/// Exponential backoff base shared by the error-retry and empty-completion
+/// retry paths (no `retry-after` hint available on the latter).
+fn base_retry_backoff_ms(retry_config: &LlmRetryConfig, attempt: usize) -> u64 {
+    retry_config.backoff_ms.saturating_mul(1 << attempt.min(4))
 }
 
 // ---------------------------------------------------------------------------
@@ -1061,6 +1122,74 @@ pub(crate) async fn observed_llm_call(
 
         match llm_result {
             Ok(result) => {
+                // Zero-token empty "success" (no content, no thinking, no tool
+                // calls): a provider hiccup, not an answer. Retry within the
+                // empty-completion budget; once exhausted, fall through and
+                // return the result unchanged so callers see today's shape
+                // rather than a novel error.
+                if is_zero_token_empty_completion(&result)
+                    && attempt < empty_completion_retry_budget(retry_config, &opts.provider)
+                {
+                    annotate_current_span(&[
+                        ("status", serde_json::json!("retrying")),
+                        ("retry_reason", serde_json::json!("empty_completion")),
+                        ("attempt", serde_json::json!(attempt)),
+                    ]);
+                    let detail = format!(
+                        "provider {} model {} returned a zero-token empty completion (no content, thinking, or tool calls)",
+                        opts.provider, opts.model
+                    );
+                    append_llm_observability_entry(
+                        "empty_completion_retry",
+                        serde_json::Map::from_iter([
+                            (
+                                "iteration".to_string(),
+                                serde_json::json!(iteration.unwrap_or(0)),
+                            ),
+                            ("attempt".to_string(), serde_json::json!(attempt + 1)),
+                            ("provider".to_string(), serde_json::json!(opts.provider)),
+                            ("model".to_string(), serde_json::json!(opts.model)),
+                            ("error".to_string(), serde_json::json!(detail.clone())),
+                        ]),
+                    );
+                    super::trace::emit_agent_event(
+                        super::trace::AgentTraceEvent::EmptyCompletionRetry {
+                            iteration: iteration.unwrap_or(0),
+                            attempt: attempt + 1,
+                            error: detail.clone(),
+                        },
+                    );
+                    if let Some(b) = bridge {
+                        b.send_call_end(
+                            &call_id,
+                            "llm",
+                            "llm_call",
+                            duration_ms,
+                            "retrying",
+                            serde_json::json!({
+                                "error": detail,
+                                "retryable": true,
+                                "attempt": attempt,
+                                "user_visible": user_visible,
+                            }),
+                        );
+                    }
+                    attempt += 1;
+                    let backoff =
+                        if crate::llm::providers::MockProvider::should_intercept(&opts.provider) {
+                            0
+                        } else {
+                            base_retry_backoff_ms(retry_config, attempt)
+                        };
+                    crate::events::log_warn(
+                        "llm",
+                        &format!("{detail}; retrying in {backoff}ms (attempt {attempt})"),
+                    );
+                    if backoff > 0 {
+                        crate::clock_mock::sleep(std::time::Duration::from_millis(backoff)).await;
+                    }
+                    continue;
+                }
                 annotate_current_span(&[
                     ("status", serde_json::json!("ok")),
                     ("input_tokens", serde_json::json!(result.input_tokens)),
@@ -1666,6 +1795,204 @@ mod retry_tests {
     #[test]
     fn retry_after_malformed_returns_none() {
         assert_eq!(parse_retry_after("retry-after: soon-ish"), None);
+    }
+}
+
+#[cfg(test)]
+mod empty_completion_retry_tests {
+    //! Zero-token empty-completion retry coverage. A provider stall can end
+    //! with an empty HTTP 200 (observed live on OpenRouter: 133s hang,
+    //! `output_tokens=0`), which is not an error at the wire level —
+    //! `observed_llm_call` must treat it as a transient hiccup and retry,
+    //! and must return the empty result unchanged once the budget is spent.
+    //! Driven through `FakeLlmProvider` (an empty scripted stream produces
+    //! exactly the zero-token empty shape) so the full retry loop runs
+    //! without network I/O.
+
+    use super::*;
+    use crate::llm::fake::{
+        install_fake_llm_script, FakeLlmEvent, FakeLlmScript, FakeLlmTurn, FakeStopReason,
+    };
+    use crate::llm::trace::{peek_agent_trace, reset_agent_trace_state, AgentTraceEvent};
+
+    fn fake_opts() -> crate::llm::api::LlmCallOptions {
+        let mut opts = crate::llm::api::options::base_opts("fake");
+        opts.model = "fake-stream".to_string();
+        opts.native_tools = None;
+        opts.tools = None;
+        opts.tool_choice = None;
+        opts.provider_overrides = None;
+        opts
+    }
+
+    fn current_thread_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+    }
+
+    fn empty_turn() -> FakeLlmTurn {
+        FakeLlmTurn::stream(vec![FakeLlmEvent::Done(FakeStopReason::EndTurn)])
+    }
+
+    fn retry_config(retries: usize) -> LlmRetryConfig {
+        LlmRetryConfig {
+            retries,
+            backoff_ms: 0,
+        }
+    }
+
+    #[test]
+    fn empty_completion_retries_then_succeeds_on_second_attempt() {
+        current_thread_runtime().block_on(async {
+            reset_agent_trace_state();
+            let _guard = install_fake_llm_script(FakeLlmScript::new().push(empty_turn()).push(
+                FakeLlmTurn::stream(vec![
+                    FakeLlmEvent::Token("recovered".into()),
+                    FakeLlmEvent::Done(FakeStopReason::EndTurn),
+                ]),
+            ));
+            let result = observed_llm_call(
+                &fake_opts(),
+                None,
+                None,
+                &retry_config(1),
+                None,
+                false,
+                false,
+                None,
+            )
+            .await
+            .expect("empty completion retry should recover");
+            assert_eq!(result.text, "recovered");
+
+            let retries: Vec<usize> = peek_agent_trace()
+                .iter()
+                .filter_map(|event| match event {
+                    AgentTraceEvent::EmptyCompletionRetry { attempt, .. } => Some(*attempt),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                retries,
+                vec![1],
+                "expected exactly one EmptyCompletionRetry trace event"
+            );
+            reset_agent_trace_state();
+            // _guard drop asserts both scripted turns were consumed.
+        });
+    }
+
+    #[test]
+    fn empty_completion_returns_result_unchanged_after_budget_exhausted() {
+        current_thread_runtime().block_on(async {
+            reset_agent_trace_state();
+            let _guard =
+                install_fake_llm_script(FakeLlmScript::new().push(empty_turn()).push(empty_turn()));
+            let result = observed_llm_call(
+                &fake_opts(),
+                None,
+                None,
+                &retry_config(1),
+                None,
+                false,
+                false,
+                None,
+            )
+            .await
+            .expect("exhausted empty-completion retries must return Ok, not a new error");
+            assert!(result.text.is_empty());
+            assert!(result.tool_calls.is_empty());
+            assert_eq!(result.output_tokens, 0);
+            reset_agent_trace_state();
+        });
+    }
+
+    #[test]
+    fn fake_provider_without_retry_budget_does_not_silently_retry() {
+        // Mock/fake providers replay scripted turns, so the built-in
+        // empty-completion floor must not apply to them — only an explicit
+        // budget. One scripted turn, zero retries: the guard would panic on
+        // drop if a hidden retry consumed a second turn.
+        current_thread_runtime().block_on(async {
+            let _guard = install_fake_llm_script(FakeLlmScript::new().push(empty_turn()));
+            let result = observed_llm_call(
+                &fake_opts(),
+                None,
+                None,
+                &retry_config(0),
+                None,
+                false,
+                false,
+                None,
+            )
+            .await
+            .expect("empty completion without budget returns as today");
+            assert!(result.text.is_empty());
+        });
+    }
+
+    #[test]
+    fn builtin_empty_retry_budget_floors_real_providers_only() {
+        let zero = retry_config(0);
+        assert_eq!(empty_completion_retry_budget(&zero, "openrouter"), 1);
+        assert_eq!(empty_completion_retry_budget(&zero, "fake"), 0);
+        assert_eq!(empty_completion_retry_budget(&zero, "mock"), 0);
+        let three = retry_config(3);
+        assert_eq!(empty_completion_retry_budget(&three, "openrouter"), 3);
+        assert_eq!(empty_completion_retry_budget(&three, "fake"), 3);
+    }
+
+    fn empty_result() -> crate::llm::api::LlmResult {
+        crate::llm::api::LlmResult {
+            text: String::new(),
+            tool_calls: Vec::new(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            cache_supported: true,
+            model: "test-model".to_string(),
+            provider: "openrouter".to_string(),
+            thinking: None,
+            thinking_summary: None,
+            stop_reason: Some("stop".to_string()),
+            served_fast: false,
+            blocks: Vec::new(),
+            logprobs: Vec::new(),
+            telemetry: crate::llm::api::ProviderTelemetry::default(),
+        }
+    }
+
+    #[test]
+    fn zero_token_empty_completion_predicate_edges() {
+        assert!(is_zero_token_empty_completion(&empty_result()));
+
+        // Token-cap truncation is deterministic — not a retryable hiccup.
+        let mut truncated = empty_result();
+        truncated.stop_reason = Some("length".to_string());
+        assert!(!is_zero_token_empty_completion(&truncated));
+        let mut truncated_upper = empty_result();
+        truncated_upper.stop_reason = Some("MAX_TOKENS".to_string());
+        assert!(!is_zero_token_empty_completion(&truncated_upper));
+
+        // Any delivered payload disqualifies.
+        let mut with_text = empty_result();
+        with_text.text = "hi".to_string();
+        assert!(!is_zero_token_empty_completion(&with_text));
+        let mut with_tokens = empty_result();
+        with_tokens.output_tokens = 3;
+        assert!(!is_zero_token_empty_completion(&with_tokens));
+        let mut with_thinking = empty_result();
+        with_thinking.thinking = Some("hmm".to_string());
+        assert!(!is_zero_token_empty_completion(&with_thinking));
+        let mut with_tool_call = empty_result();
+        with_tool_call.tool_calls = vec![serde_json::json!({"id": "t1", "name": "look"})];
+        assert!(!is_zero_token_empty_completion(&with_tool_call));
+        let mut with_tool_search = empty_result();
+        with_tool_search.blocks = vec![serde_json::json!({"type": "tool_search_query"})];
+        assert!(!is_zero_token_empty_completion(&with_tool_search));
     }
 }
 

--- a/crates/harn-vm/src/llm/api/options.rs
+++ b/crates/harn-vm/src/llm/api/options.rs
@@ -444,19 +444,40 @@ pub(crate) struct LlmCallOptions {
         Option<crate::llm::structural_experiments::AppliedStructuralExperiment>,
 }
 
-/// Resolve effective request timeout: explicit value > `HARN_LLM_TIMEOUT` env > 120s default.
-fn resolve_timeout(explicit: Option<u64>) -> u64 {
-    explicit.unwrap_or_else(|| {
-        std::env::var("HARN_LLM_TIMEOUT")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(120)
-    })
+/// Resolve effective request timeout: explicit value > `HARN_LLM_TIMEOUT` env >
+/// model-catalog `stream_timeout` > 120s default.
+///
+/// `stream_timeout` (fractional seconds in the model catalog) was previously
+/// only projected into the config dict for pipelines — no transport consumed
+/// it, so a slow local model with `stream_timeout = 900.0` was still cut off
+/// (and a hung remote provider only bounded) by the generic 120s default.
+/// It now feeds the same whole-request deadline every provider applies via
+/// `reqwest::RequestBuilder::timeout`, which covers both the non-streaming
+/// response read and the streamed body.
+fn resolve_timeout(explicit: Option<u64>, model: &str) -> u64 {
+    let env = std::env::var("HARN_LLM_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok());
+    resolve_timeout_from(explicit, env, catalog_stream_timeout_secs(model))
+}
+
+/// Pure precedence core of [`resolve_timeout`], split out for tests.
+fn resolve_timeout_from(explicit: Option<u64>, env: Option<u64>, catalog: Option<u64>) -> u64 {
+    explicit.or(env).or(catalog).unwrap_or(120)
+}
+
+/// Model-catalog `stream_timeout` (fractional seconds) for `model`, rounded
+/// up to whole seconds. `None` when the model is unknown or carries no value.
+fn catalog_stream_timeout_secs(model: &str) -> Option<u64> {
+    crate::llm_config::model_catalog_entry(model)
+        .and_then(|entry| entry.stream_timeout)
+        .filter(|secs| secs.is_finite() && *secs > 0.0)
+        .map(|secs| secs.ceil() as u64)
 }
 
 impl LlmCallOptions {
     pub(crate) fn resolve_timeout(&self) -> u64 {
-        resolve_timeout(self.timeout)
+        resolve_timeout(self.timeout, &self.model)
     }
 
     pub(crate) fn anthropic_beta_features_for_request(&self) -> Vec<String> {
@@ -558,7 +579,7 @@ pub(crate) struct LlmRequestPayload {
 
 impl LlmRequestPayload {
     pub(crate) fn resolve_timeout(&self) -> u64 {
-        resolve_timeout(self.timeout)
+        resolve_timeout(self.timeout, &self.model)
     }
 
     pub(crate) fn emit_reminder_lifecycle(&self) {
@@ -734,9 +755,49 @@ pub(crate) fn base_opts(provider: &str) -> LlmCallOptions {
 
 #[cfg(test)]
 mod tests {
-    use super::{base_opts, LlmRequestPayload, ThinkingConfig};
+    use super::{
+        base_opts, catalog_stream_timeout_secs, resolve_timeout_from, LlmRequestPayload,
+        ThinkingConfig,
+    };
 
     fn assert_send<T: Send>() {}
+
+    #[test]
+    fn resolve_timeout_precedence_explicit_then_env_then_catalog_then_default() {
+        // Explicit always wins.
+        assert_eq!(resolve_timeout_from(Some(7), Some(60), Some(300)), 7);
+        // Operator env override beats the catalog hint.
+        assert_eq!(resolve_timeout_from(None, Some(60), Some(300)), 60);
+        // Catalog `stream_timeout` replaces the hardcoded default.
+        assert_eq!(resolve_timeout_from(None, None, Some(300)), 300);
+        // No `stream_timeout` -> behavior unchanged (120s default, no new
+        // deadline tighter than today).
+        assert_eq!(resolve_timeout_from(None, None, None), 120);
+    }
+
+    #[test]
+    fn catalog_stream_timeout_resolves_from_model_catalog_overlay() {
+        crate::llm_config::set_user_overrides(None);
+        let mut overlay = crate::llm_config::ProvidersConfig::default();
+        let model: crate::llm_config::ModelDef = toml::from_str(
+            "name = \"Acme Slow\"\nprovider = \"acme\"\ncontext_window = 8192\nstream_timeout = 330.5\n",
+        )
+        .expect("model def parses");
+        overlay.models.insert("acme/slow-model".to_string(), model);
+        crate::llm_config::set_user_overrides(Some(overlay));
+
+        assert_eq!(catalog_stream_timeout_secs("acme/slow-model"), Some(331));
+
+        crate::llm_config::clear_user_overrides();
+    }
+
+    #[test]
+    fn catalog_stream_timeout_absent_for_unknown_model() {
+        assert_eq!(
+            catalog_stream_timeout_secs("model-that-does-not-exist-xyz"),
+            None
+        );
+    }
 
     #[test]
     fn request_payload_is_send_safe_and_drops_vm_local_fields() {

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -739,7 +739,27 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
     // UI only see the real response.
     let mut oai_thinking_splitter = ThinkingStreamSplitter::new();
 
-    while let Ok(Some(line)) = lines.next_line().await {
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            // Clean EOF without `[DONE]` stays a normal stop: Anthropic ends
+            // streams with `message_stop` (no `[DONE]` sentinel) and some
+            // OpenAI-compatible servers close the connection cleanly.
+            Ok(None) => break,
+            Err(error) => {
+                // A mid-body read failure (the whole-request reqwest timeout
+                // from `resolve_timeout`, a connection reset, ...) used to be
+                // swallowed here, silently truncating the stream and returning
+                // a zero-token "success" that the agent loop accepted as an
+                // empty assistant turn (observed live: an OpenRouter call hung
+                // 133s and came back with output_tokens=0). Surface it in the
+                // same transient stream-error class other transports use so
+                // the existing retry machinery picks it up.
+                return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+                    format!("{provider} stream error (mid-stream read): {error}"),
+                ))));
+            }
+        };
         let data = if let Some(d) = line.strip_prefix("data: ") {
             d
         } else {
@@ -2137,6 +2157,106 @@ mod streaming_tool_call_tests {
             "coalescing must cap the burst — got {pending_updates} pending updates from 20 deltas"
         );
         clear_session_sinks(&session_id);
+    }
+}
+
+#[cfg(test)]
+mod sse_read_error_tests {
+    //! Mid-stream read failures must surface as transient errors, not as a
+    //! silently truncated zero-token "success". The whole-request reqwest
+    //! timeout (`resolve_timeout`, now fed by the model catalog's
+    //! `stream_timeout`) materializes as exactly such a body-read error, so
+    //! these tests drive `consume_sse_lines` with an erroring byte stream —
+    //! the same shape `reqwest::Response::bytes_stream()` produces when the
+    //! deadline fires mid-body.
+
+    use super::*;
+
+    /// Reader whose underlying stream yields some SSE bytes and then an
+    /// io error, mimicking a reqwest total-timeout firing mid-stream.
+    fn erroring_reader(
+        head: &'static [u8],
+        error: std::io::Error,
+    ) -> tokio::io::BufReader<impl tokio::io::AsyncBufRead + Unpin> {
+        let chunks: Vec<Result<&'static [u8], std::io::Error>> = vec![Ok(head), Err(error)];
+        tokio::io::BufReader::new(tokio_util::io::StreamReader::new(tokio_stream::iter(
+            chunks,
+        )))
+    }
+
+    #[tokio::test]
+    async fn mid_stream_timeout_surfaces_as_retryable_error_not_empty_success() {
+        let reader = erroring_reader(
+            b"data: {\"choices\":[{\"delta\":{\"content\":\"par\"}}]}\n",
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "operation timed out"),
+        );
+        let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let err = consume_sse_lines(
+            reader,
+            "openrouter",
+            "test-model",
+            false,
+            delta_tx,
+            None,
+            None,
+        )
+        .await
+        .expect_err("mid-stream read failure must not return a truncated success");
+        let message = err.to_string();
+        assert!(
+            message.contains("openrouter stream error (mid-stream read)"),
+            "message was: {message}"
+        );
+        assert!(
+            crate::llm::agent_observe::is_retryable_llm_error(&err),
+            "mid-stream timeout must classify as transient/retryable; message was: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mid_stream_connection_reset_is_also_retryable() {
+        let reader = erroring_reader(
+            b"data: {\"choices\":[{\"delta\":{\"content\":\"par\"}}]}\n",
+            std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "connection reset by peer",
+            ),
+        );
+        let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let err = consume_sse_lines(
+            reader,
+            "llamacpp",
+            "test-model",
+            false,
+            delta_tx,
+            None,
+            None,
+        )
+        .await
+        .expect_err("mid-stream reset must surface as an error");
+        assert!(
+            crate::llm::agent_observe::is_retryable_llm_error(&err),
+            "mid-stream reset must classify as transient/retryable; got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn clean_eof_without_done_sentinel_still_returns_ok() {
+        // Anthropic ends streams with `message_stop` (no `[DONE]`), and some
+        // OpenAI-compatible servers close cleanly without the sentinel; a
+        // clean EOF must keep returning the accumulated result.
+        let body: &[u8] = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":1}}\n",
+        )
+        .as_bytes();
+        let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let reader = tokio::io::BufReader::new(body);
+        let result = consume_sse_lines(reader, "openai", "test-model", false, delta_tx, None, None)
+            .await
+            .expect("clean EOF without [DONE] parses");
+        assert_eq!(result.text, "hello");
+        assert_eq!(result.stop_reason.as_deref(), Some("stop"));
     }
 }
 


### PR DESCRIPTION
Live evidence (Burin Code eval-meter work, 2026-06-09): an OpenRouter call
hung 133,430 ms and then flowed back into the agent loop as a "successful"
completion with output_tokens=0 / input_tokens=0 — an empty assistant turn
the loop had to burn an iteration recovering from. Three transport gaps
compounded into that failure:

1. The model catalog's `stream_timeout` (seconds) was consumed by no
   transport at all — `rg stream_timeout` only hit test fixtures and the
   config-dict projection — so the only bound on the OpenAI-compatible
   path (OpenRouter, llamacpp, vLLM, LM Studio, ...) was the generic 120s
   default, and slow local models with `stream_timeout = 900.0` got cut
   off by it. `resolve_timeout` (the one seam every provider's
   `reqwest .timeout()` flows through, streaming and non-streaming) now
   resolves: explicit timeout option > HARN_LLM_TIMEOUT env > catalog
   `stream_timeout` > 120s default. Whole-request deadline semantics,
   matching the existing timeout machinery; absent stream_timeout is
   byte-for-byte unchanged behavior.

2. `consume_sse_lines` ran `while let Ok(Some(line))`, so a mid-body read
   failure — including exactly that reqwest deadline firing mid-stream —
   was silently swallowed and returned as a truncated zero-token success.
   It now surfaces as "<provider> stream error (mid-stream read): ..."
   which classifies into the same transient timeout/network class other
   transports use, so the existing retry machinery picks it up. Clean EOF
   without a [DONE] sentinel still returns Ok (Anthropic message_stop,
   OpenAI-compat servers that close cleanly).

3. A wire-level 200 carrying zero output tokens, no text, no thinking,
   and no tool calls is now retried in observed_llm_call as a transient
   provider hiccup: once built-in for real providers (mirroring the
   transport's unconditional Ollama empty-content retry), more with
   llm_retries; mock/fake only on explicit opt-in so scripted tests stay
   deterministic. Emits the existing empty_completion_retry observability
   entry + EmptyCompletionRetry trace event. Token-cap truncations
   (stop_reason length/max_tokens) are excluded, and a completion that
   stays empty after the budget is returned unchanged — no new error
   shape for the loop to handle.

Verified: cargo test -p harn-vm --lib llm (981 passed), cargo build -p
harn-vm, cargo fmt --check, cargo clippy -p harn-vm --all-targets
-D warnings.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
