### PR TITLE
harn-serve: make -p harn-serve green — register pg.* builtins for tests via dev-dep

### DIFF
--- a/changelog.d/3222.fixed.md
+++ b/changelog.d/3222.fixed.md
@@ -1,0 +1,7 @@
+- **harn-serve:** the `@budget(pg_queries)` integration test
+  (`pg_query_budget_rejects_third_query_as_429_via_dispatch`) now registers the
+  `pg.*` builtins it exercises via a `harn-vm`/`postgres` dev-dependency, so
+  `cargo nextest run -p harn-serve` is green in isolation. Previously the test
+  only passed under a `--workspace` run that happened to unify `harn-vm/postgres`
+  on; running the crate alone hit `Undefined builtin: pg_mock_pool`. The library
+  build stays lean (`default-features = false`, no `sqlx` in the non-dev graph).

--- a/crates/harn-serve/Cargo.toml
+++ b/crates/harn-serve/Cargo.toml
@@ -83,6 +83,18 @@ features = ["use_pem", "aws_lc_rs"]
 [dev-dependencies]
 async-compression = { version = "0.4", features = ["tokio", "gzip"] }
 filetime = "0.2"
+# harn-serve depends on harn-vm with `default-features = false` (lean embedding
+# — see lean-embedding.yml), so the `pg.*` builtins are off in the library
+# build. A handful of integration tests (e.g. the `@budget(pg_queries)` gate in
+# tests/limits_loadgen.rs) drive a `pg_mock_pool` against the dispatch core and
+# need those builtins registered. Re-declaring harn-vm here with `postgres`
+# turns it on for harn-serve's OWN test/bench builds only: cargo merges normal +
+# dev dependency features for test targets, while the library build and every
+# downstream embedder still see the lean `default-features = false` view. This
+# makes `cargo nextest run -p harn-serve` green in isolation without the test
+# silently relying on workspace-wide feature unification (which masked the gap:
+# it passed under `--workspace` but failed under `-p harn-serve`).
+harn-vm = { path = "../harn-vm", version = "0.8", default-features = false, features = ["postgres"] }
 futures-util = "0.3"
 hex = "0.4"
 tempfile = "3"


### PR DESCRIPTION
## Fix the pre-existing `-p harn-serve` test failure (full ownership)

`cargo nextest run -p harn-serve` failed on a clean `main`:

```
FAIL  harn-serve::limits_loadgen pg_query_budget_rejects_third_query_as_429_via_dispatch
  → Undefined builtin: pg_mock_pool
```

### Root cause
harn-serve depends on `harn-vm` with `default-features = false` for lean
embedding (asserted by `lean-embedding.yml`), so the `pg.*` builtins
(`pg_mock_pool`, `pg_query`) are **off** in harn-serve's own build. The test
that drives those builtins isn't feature-gated, so it only passed because
`cargo nextest run --workspace` (what CI runs) unifies `harn-vm/postgres` **on**
transitively. Run the crate in isolation and the builtin is undefined → the test
every local/agent run quietly stepped around.

### Fix — and why not the obvious alternative
Re-declare `harn-vm` as a **dev-dependency** with `features = ["postgres"]`.
Cargo merges normal + dev-dependency features for test/bench targets only, so the
builtins are registered for harn-serve's tests while the **library** build and
every downstream embedder keep the lean `default-features = false` view.

I deliberately did **not** `#[cfg(feature = "vm-postgres")]`-gate the test (the
tempting one-liner): nothing in the workspace enables harn-serve's own
`vm-postgres` feature, so a cfg-gate would compile the test **out** of the
`--workspace` CI run — silently *narrowing* coverage. The dev-dep keeps the test
compiled and running under **both** `-p harn-serve` and `--workspace`.

### Verification
- `cargo nextest run -p harn-serve` (isolated): **470/470 pass, 0 skipped** (was 1 failed).
- `cargo tree -p harn-serve -e no-dev -i sqlx-postgres` → empty: `sqlx-postgres`
  absent from the non-dev dep graph, so lean embedding is preserved.
- `cargo tree -p harn-serve -i sqlx-postgres` (with dev): present via the dev-dep, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
